### PR TITLE
Reject Delta Lake partition column absent from the table schema

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -846,12 +846,14 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
 std::optional<size_t> TableSnapshot::getTotalRows() const
 {
     std::lock_guard lock(mutex);
+    initOrUpdateSchemaIfChanged();
     return getSnapshotStats().total_rows;
 }
 
 std::optional<size_t> TableSnapshot::getTotalBytes() const
 {
     std::lock_guard lock(mutex);
+    initOrUpdateSchemaIfChanged();
     return getSnapshotStats().total_bytes;
 }
 
@@ -1015,6 +1017,12 @@ void TableSnapshot::initOrUpdateSchemaIfChanged() const
 
         auto read_schema = getReadSchemaFromSnapshot(state->scan.get(), state->engine.get());
         auto partition_columns = getPartitionColumnsFromSnapshot(state->snapshot.get());
+
+        /// Both names are logical here; the rename to physical names happens later, on copies.
+        for (const auto & column_name : partition_columns)
+            if (!table_schema.tryGetByName(column_name))
+                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS,
+                    "Partition column {} is not present in the table schema", column_name);
 
         LOG_TRACE(
             log, "Table logical schema: {}, read schema: {}, "

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -843,17 +843,29 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
     };
 }
 
+void TableSnapshot::validatePartitionColumnsForStats() const
+{
+    if (schema.has_value())
+        return;
+
+    auto state = getKernelSnapshotState();
+    if (getPartitionColumnsFromSnapshot(state->snapshot.get()).empty())
+        return;
+
+    initOrUpdateSchemaIfChanged();
+}
+
 std::optional<size_t> TableSnapshot::getTotalRows() const
 {
     std::lock_guard lock(mutex);
-    initOrUpdateSchemaIfChanged();
+    validatePartitionColumnsForStats();
     return getSnapshotStats().total_rows;
 }
 
 std::optional<size_t> TableSnapshot::getTotalBytes() const
 {
     std::lock_guard lock(mutex);
-    initOrUpdateSchemaIfChanged();
+    validatePartitionColumnsForStats();
     return getSnapshotStats().total_bytes;
 }
 
@@ -1010,19 +1022,19 @@ void TableSnapshot::initOrUpdateSchemaIfChanged() const
     if (!schema.has_value())
     {
         auto state = getKernelSnapshotState();
+        auto partition_columns = getPartitionColumnsFromSnapshot(state->snapshot.get());
         auto [table_schema, physical_names_map] = getTableSchemaFromSnapshot(state->snapshot.get(), state->engine.get());
 
         if (table_schema.empty())
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Table schema cannot be empty");
-
-        auto read_schema = getReadSchemaFromSnapshot(state->scan.get(), state->engine.get());
-        auto partition_columns = getPartitionColumnsFromSnapshot(state->snapshot.get());
 
         /// Both names are logical here; the rename to physical names happens later, on copies.
         for (const auto & column_name : partition_columns)
             if (!table_schema.tryGetByName(column_name))
                 throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS,
                     "Partition column {} is not present in the table schema", column_name);
+
+        auto read_schema = getReadSchemaFromSnapshot(state->scan.get(), state->engine.get());
 
         LOG_TRACE(
             log, "Table logical schema: {}, read schema: {}, "

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -843,29 +843,15 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
     };
 }
 
-void TableSnapshot::validatePartitionColumnsForStats() const
-{
-    if (schema.has_value())
-        return;
-
-    auto state = getKernelSnapshotState();
-    if (getPartitionColumnsFromSnapshot(state->snapshot.get()).empty())
-        return;
-
-    initOrUpdateSchemaIfChanged();
-}
-
 std::optional<size_t> TableSnapshot::getTotalRows() const
 {
     std::lock_guard lock(mutex);
-    validatePartitionColumnsForStats();
     return getSnapshotStats().total_rows;
 }
 
 std::optional<size_t> TableSnapshot::getTotalBytes() const
 {
     std::lock_guard lock(mutex);
-    validatePartitionColumnsForStats();
     return getSnapshotStats().total_bytes;
 }
 
@@ -1022,19 +1008,19 @@ void TableSnapshot::initOrUpdateSchemaIfChanged() const
     if (!schema.has_value())
     {
         auto state = getKernelSnapshotState();
-        auto partition_columns = getPartitionColumnsFromSnapshot(state->snapshot.get());
         auto [table_schema, physical_names_map] = getTableSchemaFromSnapshot(state->snapshot.get(), state->engine.get());
 
         if (table_schema.empty())
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Table schema cannot be empty");
+
+        auto read_schema = getReadSchemaFromSnapshot(state->scan.get(), state->engine.get());
+        auto partition_columns = getPartitionColumnsFromSnapshot(state->snapshot.get());
 
         /// Both names are logical here; the rename to physical names happens later, on copies.
         for (const auto & column_name : partition_columns)
             if (!table_schema.tryGetByName(column_name))
                 throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS,
                     "Partition column {} is not present in the table schema", column_name);
-
-        auto read_schema = getReadSchemaFromSnapshot(state->scan.get(), state->engine.get());
 
         LOG_TRACE(
             log, "Table logical schema: {}, read schema: {}, "

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -121,6 +121,9 @@ private:
 
     void initOrUpdateSnapshot() const TSA_REQUIRES(mutex);
     void initOrUpdateSchemaIfChanged() const TSA_REQUIRES(mutex);
+    /// Row and byte counts come from the snapshot's file statistics and need no converted
+    /// schema, so a table whose column types ClickHouse cannot represent still reports them.
+    void validatePartitionColumnsForStats() const TSA_REQUIRES(mutex);
 
     SnapshotStats getSnapshotStats() const TSA_REQUIRES(mutex);
     SnapshotStats getSnapshotStatsImpl() const TSA_REQUIRES(mutex);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -121,9 +121,6 @@ private:
 
     void initOrUpdateSnapshot() const TSA_REQUIRES(mutex);
     void initOrUpdateSchemaIfChanged() const TSA_REQUIRES(mutex);
-    /// Row and byte counts come from the snapshot's file statistics and need no converted
-    /// schema, so a table whose column types ClickHouse cannot represent still reports them.
-    void validatePartitionColumnsForStats() const TSA_REQUIRES(mutex);
 
     SnapshotStats getSnapshotStats() const TSA_REQUIRES(mutex);
     SnapshotStats getSnapshotStatsImpl() const TSA_REQUIRES(mutex);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -344,7 +344,7 @@ struct DeltaLakeMetadataImpl
                                 if (!name_and_type)
                                 {
                                     throw Exception(
-                                        ErrorCodes::LOGICAL_ERROR,
+                                        ErrorCodes::INCORRECT_DATA,
                                         "No such column in schema: {} (schema: {})",
                                         partition_name, file_schema.toNamesAndTypesDescription());
                                 }
@@ -594,7 +594,7 @@ struct DeltaLakeMetadataImpl
                         if (!name_and_type)
                         {
                             throw Exception(
-                                ErrorCodes::LOGICAL_ERROR,
+                                ErrorCodes::INCORRECT_DATA,
                                 "No such column in schema: {} (schema: {})",
                                 partition_name, file_schema.toString());
                         }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -43,6 +43,7 @@
 #include <DataTypes/NestedUtils.h>
 
 #include <boost/algorithm/string/case_conv.hpp>
+#include <fmt/ranges.h>
 #include <parquet/file_reader.h>
 #include <parquet/arrow/reader.h>
 #include <Poco/JSON/Array.h>
@@ -301,7 +302,7 @@ struct DeltaLakeMetadataImpl
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to extract `fields` field");
 
                 auto current_schema = parseMetadata(fields_object);
-                validatePartitionColumns(metadata_object, fields_object, current_schema);
+                validatePartitionColumns(metadata_object, fields_object);
                 if (file_schema.empty())
                 {
                     file_schema = current_schema;
@@ -412,29 +413,27 @@ struct DeltaLakeMetadataImpl
 
     /// `partitionColumns` carries logical names, while a parsed schema is keyed by physical
     /// ones, so the declared set is recovered from the schema fields rather than from it.
-    NameSet getDeclaredLogicalNames(const Poco::JSON::Object::Ptr & schema_json) const
+    /// Ordered, so that the name list reported on rejection is deterministic.
+    NameOrderedSet getDeclaredLogicalNames(const Poco::JSON::Object::Ptr & schema_json) const
     {
-        NameSet declared;
+        NameOrderedSet declared;
         const auto fields = schema_json->get("fields").extract<Poco::JSON::Array::Ptr>();
         for (size_t i = 0; i < fields->size(); ++i)
             declared.insert(fields->getObject(static_cast<UInt32>(i))->getValue<String>("name"));
         return declared;
     }
 
-    void validatePartitionColumn(
-        const String & partition_name, const NameSet & declared, const NamesAndTypesList & parsed_schema) const
+    void validatePartitionColumn(const String & partition_name, const NameOrderedSet & declared) const
     {
         if (!declared.contains(partition_name))
             throw Exception(
                 ErrorCodes::INCORRECT_DATA,
-                "No such column in schema: {} (schema: {})",
-                partition_name, parsed_schema.toNamesAndTypesDescription());
+                "Partition column '{}' is not declared in the table schema (declared columns: {})",
+                partition_name, fmt::join(declared, ", "));
     }
 
     void validatePartitionColumns(
-        const Poco::JSON::Object::Ptr & metadata_json,
-        const Poco::JSON::Object::Ptr & schema_json,
-        const NamesAndTypesList & parsed_schema) const
+        const Poco::JSON::Object::Ptr & metadata_json, const Poco::JSON::Object::Ptr & schema_json) const
     {
         if (!metadata_json->isArray("partitionColumns"))
             return;
@@ -445,8 +444,7 @@ struct DeltaLakeMetadataImpl
 
         const auto declared = getDeclaredLogicalNames(schema_json);
         for (size_t i = 0; i < partition_columns->size(); ++i)
-            validatePartitionColumn(
-                partition_columns->getElement<String>(static_cast<UInt32>(i)), declared, parsed_schema);
+            validatePartitionColumn(partition_columns->getElement<String>(static_cast<UInt32>(i)), declared);
     }
 
 
@@ -605,8 +603,7 @@ struct DeltaLakeMetadataImpl
                         const auto declared = getDeclaredLogicalNames(object);
                         for (const auto & partition_name : partition_names.safeGet<Array>())
                             if (!partition_name.isNull())
-                                validatePartitionColumn(
-                                    partition_name.safeGet<String>(), declared, current_schema);
+                                validatePartitionColumn(partition_name.safeGet<String>(), declared);
                     }
                 }
                 if (file_schema.empty())

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -301,6 +301,7 @@ struct DeltaLakeMetadataImpl
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to extract `fields` field");
 
                 auto current_schema = parseMetadata(fields_object);
+                validatePartitionColumns(metadata_object, fields_object, current_schema);
                 if (file_schema.empty())
                 {
                     file_schema = current_schema;
@@ -407,6 +408,45 @@ struct DeltaLakeMetadataImpl
             schema.push_back({physical_name, DB::DeltaLakeMetadata::getFieldType(field, "type", is_nullable)});
         }
         return schema;
+    }
+
+    /// `partitionColumns` carries logical names, while a parsed schema is keyed by physical
+    /// ones, so the declared set is recovered from the schema fields rather than from it.
+    NameSet getDeclaredLogicalNames(const Poco::JSON::Object::Ptr & schema_json) const
+    {
+        NameSet declared;
+        const auto fields = schema_json->get("fields").extract<Poco::JSON::Array::Ptr>();
+        for (size_t i = 0; i < fields->size(); ++i)
+            declared.insert(fields->getObject(static_cast<UInt32>(i))->getValue<String>("name"));
+        return declared;
+    }
+
+    void validatePartitionColumn(
+        const String & partition_name, const NameSet & declared, const NamesAndTypesList & parsed_schema) const
+    {
+        if (!declared.contains(partition_name))
+            throw Exception(
+                ErrorCodes::INCORRECT_DATA,
+                "No such column in schema: {} (schema: {})",
+                partition_name, parsed_schema.toNamesAndTypesDescription());
+    }
+
+    void validatePartitionColumns(
+        const Poco::JSON::Object::Ptr & metadata_json,
+        const Poco::JSON::Object::Ptr & schema_json,
+        const NamesAndTypesList & parsed_schema) const
+    {
+        if (!metadata_json->isArray("partitionColumns"))
+            return;
+
+        const auto partition_columns = metadata_json->get("partitionColumns").extract<Poco::JSON::Array::Ptr>();
+        if (partition_columns->size() == 0)
+            return;
+
+        const auto declared = getDeclaredLogicalNames(schema_json);
+        for (size_t i = 0; i < partition_columns->size(); ++i)
+            validatePartitionColumn(
+                partition_columns->getElement<String>(static_cast<UInt32>(i)), declared, parsed_schema);
     }
 
 
@@ -543,6 +583,9 @@ struct DeltaLakeMetadataImpl
         auto partition_values_column_raw = res_block.getByName("add.partitionValues").column;
         const auto & partition_values_column = assert_cast<const ColumnMap &>(*partition_values_column_raw);
 
+        /// A checkpoint written before this column existed simply carries no partition names.
+        const auto * partition_columns_column = res_block.findByName("metaData.partitionColumns");
+
         for (size_t i = 0; i < path_column.size(); ++i)
         {
             const auto metadata = String(schema_column.getDataAt(i));
@@ -553,6 +596,19 @@ struct DeltaLakeMetadataImpl
                 const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
 
                 auto current_schema = parseMetadata(object);
+                if (partition_columns_column)
+                {
+                    Field partition_names;
+                    partition_columns_column->column->get(i, partition_names);
+                    if (!partition_names.isNull())
+                    {
+                        const auto declared = getDeclaredLogicalNames(object);
+                        for (const auto & partition_name : partition_names.safeGet<Array>())
+                            if (!partition_name.isNull())
+                                validatePartitionColumn(
+                                    partition_name.safeGet<String>(), declared, current_schema);
+                    }
+                }
                 if (file_schema.empty())
                 {
                     file_schema = current_schema;

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
@@ -9,6 +9,8 @@ BAD_ARGUMENTS
 BAD_ARGUMENTS
 -- delta-kernel reader: no row or byte statistics are published either
 1	1
+-- delta-kernel reader: an unpartitioned table still publishes statistics
+0	0
 -- legacy reader: json log branch
 INCORRECT_DATA
 -- legacy reader: checkpoint branch

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
@@ -7,5 +7,9 @@ BAD_ARGUMENTS
 BAD_ARGUMENTS
 -- delta-kernel reader: an explicit schema does not answer count() from statistics
 BAD_ARGUMENTS
--- legacy reader
+-- delta-kernel reader: no row or byte statistics are published either
+1	1
+-- legacy reader: json log branch
+INCORRECT_DATA
+-- legacy reader: checkpoint branch
 INCORRECT_DATA

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
@@ -1,0 +1,11 @@
+-- control: a declared partition column reads fine on both readers
+4	4	1
+4	4	1
+-- delta-kernel reader: rejected with or without a predicate
+BAD_ARGUMENTS
+BAD_ARGUMENTS
+BAD_ARGUMENTS
+-- delta-kernel reader: an explicit schema does not answer count() from statistics
+BAD_ARGUMENTS
+-- legacy reader
+INCORRECT_DATA

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
@@ -5,11 +5,8 @@
 BAD_ARGUMENTS
 BAD_ARGUMENTS
 BAD_ARGUMENTS
--- delta-kernel reader: an explicit schema does not answer count() from statistics
-BAD_ARGUMENTS
--- delta-kernel reader: no row or byte statistics are published either
-1	1
--- delta-kernel reader: an unpartitioned table still publishes statistics
+-- delta-kernel reader: a table with an unsupported column type still publishes statistics
+0	0
 0	0
 -- legacy reader: json log branch
 INCORRECT_DATA

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
@@ -9,6 +9,8 @@ BAD_ARGUMENTS
 BAD_ARGUMENTS
 -- legacy reader: json log branch
 INCORRECT_DATA
+-- legacy reader: json log branch, unknown partitionValues key
+INCORRECT_DATA
 -- legacy reader: checkpoint branch
 INCORRECT_DATA
 -- legacy reader: json log branch, partitionColumns with no add action to resolve

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
@@ -5,9 +5,6 @@
 BAD_ARGUMENTS
 BAD_ARGUMENTS
 BAD_ARGUMENTS
--- delta-kernel reader: a table with an unsupported column type still publishes statistics
-0	0
-0	0
 -- legacy reader: json log branch
 INCORRECT_DATA
 -- legacy reader: checkpoint branch

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.reference
@@ -1,6 +1,8 @@
 -- control: a declared partition column reads fine on both readers
 4	4	1
 4	4	1
+-- control: a column-mapped partition column is declared under its logical name
+3	1
 -- delta-kernel reader: rejected with or without a predicate
 BAD_ARGUMENTS
 BAD_ARGUMENTS
@@ -8,4 +10,8 @@ BAD_ARGUMENTS
 -- legacy reader: json log branch
 INCORRECT_DATA
 -- legacy reader: checkpoint branch
+INCORRECT_DATA
+-- legacy reader: json log branch, partitionColumns with no add action to resolve
+INCORRECT_DATA
+-- legacy reader: checkpoint branch, partitionColumns with no add action to resolve
 INCORRECT_DATA

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-msan
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/114462
+# A partition column that the table schema does not declare must raise a catchable
+# error on both Delta readers, not abort the server on assert-enabled builds.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+DIR="${CLICKHOUSE_TMP:?}/${CLICKHOUSE_TEST_UNIQUE_NAME:?}"
+rm -rf "$DIR"
+
+# "good" declares the partition column 'p' in the schema, "bad" omits it.
+DATA="p=1/part-00000-c000.snappy.parquet"
+for T in good bad; do
+    mkdir -p "$DIR/$T/_delta_log" "$DIR/$T/p=1"
+    $CLICKHOUSE_LOCAL -q "
+        INSERT INTO FUNCTION file('$DIR/$T/$DATA', Parquet, 'id Int64, s String')
+        SELECT number, toString(number) FROM numbers(5)
+        SETTINGS engine_file_truncate_on_insert = 1"
+done
+
+python3 - "$DIR" "$DATA" <<'EOF'
+import json, os, sys
+
+directory, data = sys.argv[1], sys.argv[2]
+field = lambda name, type_: {"name": name, "type": type_, "nullable": True, "metadata": {}}
+fields = {"good": [field("id", "long"), field("s", "string"), field("p", "string")],
+          "bad": [field("id", "long"), field("s", "string")]}
+
+for table, schema_fields in fields.items():
+    table_dir = os.path.join(directory, table)
+    actions = [
+        {"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}},
+        {"metaData": {"id": "114462",
+                      "format": {"provider": "parquet", "options": {}},
+                      "schemaString": json.dumps({"type": "struct", "fields": schema_fields}),
+                      "partitionColumns": ["p"],
+                      "configuration": {}, "createdTime": 1600000000000}},
+        {"add": {"path": data, "partitionValues": {"p": "1"},
+                 "size": os.path.getsize(os.path.join(table_dir, data)),
+                 "modificationTime": 1600000000000, "dataChange": True,
+                 "stats": json.dumps({"numRecords": 5})}},
+    ]
+    with open(os.path.join(table_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
+        for action in actions:
+            log.write(json.dumps(action) + "\n")
+EOF
+
+echo '-- control: a declared partition column reads fine on both readers'
+$CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3"
+$CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3 SETTINGS allow_delta_kernel_rs = 0"
+
+echo '-- delta-kernel reader: rejected with or without a predicate'
+$CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null" 2>&1 | grep -oF "BAD_ARGUMENTS"
+$CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') WHERE id > 3 FORMAT Null" 2>&1 | grep -oF "BAD_ARGUMENTS"
+$CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') WHERE id > 3 FORMAT Null SETTINGS delta_lake_enable_engine_predicate = 0" 2>&1 | grep -oF "BAD_ARGUMENTS"
+
+echo '-- delta-kernel reader: an explicit schema does not answer count() from statistics'
+$CLICKHOUSE_LOCAL --multiquery "
+CREATE TABLE t (\`id\` Int64, \`s\` String) ENGINE = DeltaLakeLocal('$DIR/bad');
+SELECT count() FROM t;
+" 2>&1 | grep -oF "BAD_ARGUMENTS"
+
+echo '-- legacy reader'
+$CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
+
+rm -rf "$DIR"

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
@@ -71,6 +71,38 @@ $CLICKHOUSE_LOCAL -q "
     SETTINGS engine_file_truncate_on_insert = 1"
 echo '{"version":1,"size":1}' > "$DIR/ckpt/_delta_log/_last_checkpoint"
 
+# "variant" has no partition columns at all, and one column of a type ClickHouse cannot
+# represent yet. Statistics come from the snapshot's file stats, so they stay available.
+mkdir -p "$DIR/variant/_delta_log"
+$CLICKHOUSE_LOCAL -q "
+    INSERT INTO FUNCTION file('$DIR/variant/part-00000-c000.snappy.parquet', Parquet, 'id Int64')
+    SELECT number FROM numbers(7)
+    SETTINGS engine_file_truncate_on_insert = 1"
+python3 - "$DIR/variant" <<'EOF'
+import json, os, sys
+
+table_dir = sys.argv[1]
+data = "part-00000-c000.snappy.parquet"
+fields = [{"name": "id", "type": "long", "nullable": True, "metadata": {}},
+          {"name": "v", "type": "variant", "nullable": True, "metadata": {}}]
+actions = [
+    {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7,
+                  "readerFeatures": ["variantType"], "writerFeatures": ["variantType"]}},
+    {"metaData": {"id": "114462-variant",
+                  "format": {"provider": "parquet", "options": {}},
+                  "schemaString": json.dumps({"type": "struct", "fields": fields}),
+                  "partitionColumns": [],
+                  "configuration": {}, "createdTime": 1600000000000}},
+    {"add": {"path": data, "partitionValues": {},
+             "size": os.path.getsize(os.path.join(table_dir, data)),
+             "modificationTime": 1600000000000, "dataChange": True,
+             "stats": json.dumps({"numRecords": 7})}},
+]
+with open(os.path.join(table_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
+    for action in actions:
+        log.write(json.dumps(action) + "\n")
+EOF
+
 echo '-- control: a declared partition column reads fine on both readers'
 $CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3"
 $CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3 SETTINGS allow_delta_kernel_rs = 0"
@@ -91,6 +123,12 @@ $CLICKHOUSE_LOCAL --multiquery "
 CREATE TABLE t2 (\`id\` Int64, \`s\` String) ENGINE = DeltaLakeLocal('$DIR/bad');
 SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't2';
 " 2>&1 | grep -E "^1\s+1$|BAD_ARGUMENTS"
+
+echo '-- delta-kernel reader: an unpartitioned table still publishes statistics'
+$CLICKHOUSE_LOCAL --multiquery "
+CREATE TABLE t3 (\`id\` Int64) ENGINE = DeltaLakeLocal('$DIR/variant');
+SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't3';
+" 2>&1 | grep -E "^0\s+0$|NOT_IMPLEMENTED"
 
 echo '-- legacy reader: json log branch'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
@@ -47,7 +47,29 @@ for table, schema_fields in fields.items():
     with open(os.path.join(table_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
         for action in actions:
             log.write(json.dumps(action) + "\n")
+
+with open(os.path.join(directory, "bad_schema.json"), "w") as out:
+    out.write(json.dumps({"type": "struct", "fields": fields["bad"]}))
 EOF
+
+# "ckpt" reaches the legacy reader's checkpoint branch instead of its JSON log branch:
+# a _last_checkpoint makes the reader parse the checkpoint parquet, whose single row
+# carries both the schema without 'p' and the add action keyed by 'p'.
+BAD_SCHEMA=$(cat "$DIR/bad_schema.json")
+mkdir -p "$DIR/ckpt/_delta_log" "$DIR/ckpt/p=1"
+$CLICKHOUSE_LOCAL -q "
+    INSERT INTO FUNCTION file('$DIR/ckpt/$DATA', Parquet, 'id Int64, s String')
+    SELECT number, toString(number) FROM numbers(5)
+    SETTINGS engine_file_truncate_on_insert = 1"
+$CLICKHOUSE_LOCAL -q "
+    INSERT INTO FUNCTION file('$DIR/ckpt/_delta_log/00000000000000000001.checkpoint.parquet', Parquet,
+        'add Tuple(path Nullable(String), partitionValues Map(String, Nullable(String)),
+                   size Nullable(Int64), modificationTime Nullable(Int64), dataChange Nullable(Bool)),
+         metaData Tuple(schemaString Nullable(String))')
+    SELECT ('$DATA', map('p', '1'), toInt64($(stat -c%s "$DIR/ckpt/$DATA")), toInt64(1600000000000), true),
+           tuple('$BAD_SCHEMA')
+    SETTINGS engine_file_truncate_on_insert = 1"
+echo '{"version":1,"size":1}' > "$DIR/ckpt/_delta_log/_last_checkpoint"
 
 echo '-- control: a declared partition column reads fine on both readers'
 $CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3"
@@ -64,7 +86,16 @@ CREATE TABLE t (\`id\` Int64, \`s\` String) ENGINE = DeltaLakeLocal('$DIR/bad');
 SELECT count() FROM t;
 " 2>&1 | grep -oF "BAD_ARGUMENTS"
 
-echo '-- legacy reader'
+echo '-- delta-kernel reader: no row or byte statistics are published either'
+$CLICKHOUSE_LOCAL --multiquery "
+CREATE TABLE t2 (\`id\` Int64, \`s\` String) ENGINE = DeltaLakeLocal('$DIR/bad');
+SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't2';
+" 2>&1 | grep -E "^1\s+1$|BAD_ARGUMENTS"
+
+echo '-- legacy reader: json log branch'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
+
+echo '-- legacy reader: checkpoint branch'
+$CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/ckpt') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
 
 rm -rf "$DIR"

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
@@ -71,50 +71,6 @@ $CLICKHOUSE_LOCAL -q "
     SETTINGS engine_file_truncate_on_insert = 1"
 echo '{"version":1,"size":1}' > "$DIR/ckpt/_delta_log/_last_checkpoint"
 
-# "variant" and "variant_p" are both well formed and declare a column of a type ClickHouse
-# cannot represent yet; "variant_p" additionally partitions by a declared column. Row and
-# byte counts come from the snapshot's file statistics, so neither table needs a converted
-# schema to report them.
-mkdir -p "$DIR/variant/_delta_log" "$DIR/variant_p/_delta_log" "$DIR/variant_p/p=1"
-$CLICKHOUSE_LOCAL -q "
-    INSERT INTO FUNCTION file('$DIR/variant/part-00000-c000.snappy.parquet', Parquet, 'id Int64')
-    SELECT number FROM numbers(7)
-    SETTINGS engine_file_truncate_on_insert = 1"
-$CLICKHOUSE_LOCAL -q "
-    INSERT INTO FUNCTION file('$DIR/variant_p/$DATA', Parquet, 'id Int64')
-    SELECT number FROM numbers(7)
-    SETTINGS engine_file_truncate_on_insert = 1"
-python3 - "$DIR" "$DATA" <<'EOF'
-import json, os, sys
-
-directory, data = sys.argv[1], sys.argv[2]
-field = lambda name, type_: {"name": name, "type": type_, "nullable": True, "metadata": {}}
-variant = field("v", "variant")
-tables = {
-    "variant": ([field("id", "long"), variant], [], "part-00000-c000.snappy.parquet", {}),
-    "variant_p": ([field("id", "long"), field("p", "string"), variant], ["p"], data, {"p": "1"}),
-}
-
-for table, (schema_fields, partition_columns, path, partition_values) in tables.items():
-    table_dir = os.path.join(directory, table)
-    actions = [
-        {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7,
-                      "readerFeatures": ["variantType"], "writerFeatures": ["variantType"]}},
-        {"metaData": {"id": "114462-" + table,
-                      "format": {"provider": "parquet", "options": {}},
-                      "schemaString": json.dumps({"type": "struct", "fields": schema_fields}),
-                      "partitionColumns": partition_columns,
-                      "configuration": {}, "createdTime": 1600000000000}},
-        {"add": {"path": path, "partitionValues": partition_values,
-                 "size": os.path.getsize(os.path.join(table_dir, path)),
-                 "modificationTime": 1600000000000, "dataChange": True,
-                 "stats": json.dumps({"numRecords": 7})}},
-    ]
-    with open(os.path.join(table_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
-        for action in actions:
-            log.write(json.dumps(action) + "\n")
-EOF
-
 echo '-- control: a declared partition column reads fine on both readers'
 $CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3"
 $CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3 SETTINGS allow_delta_kernel_rs = 0"
@@ -123,16 +79,6 @@ echo '-- delta-kernel reader: rejected with or without a predicate'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null" 2>&1 | grep -oF "BAD_ARGUMENTS"
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') WHERE id > 3 FORMAT Null" 2>&1 | grep -oF "BAD_ARGUMENTS"
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') WHERE id > 3 FORMAT Null SETTINGS delta_lake_enable_engine_predicate = 0" 2>&1 | grep -oF "BAD_ARGUMENTS"
-
-echo '-- delta-kernel reader: a table with an unsupported column type still publishes statistics'
-$CLICKHOUSE_LOCAL --multiquery "
-CREATE TABLE t3 (\`id\` Int64) ENGINE = DeltaLakeLocal('$DIR/variant');
-SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't3';
-" 2>&1 | grep -E "^0\s+0$|NOT_IMPLEMENTED"
-$CLICKHOUSE_LOCAL --multiquery "
-CREATE TABLE t4 (\`id\` Int64) ENGINE = DeltaLakeLocal('$DIR/variant_p');
-SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't4';
-" 2>&1 | grep -E "^0\s+0$|NOT_IMPLEMENTED"
 
 echo '-- legacy reader: json log branch'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
@@ -59,6 +59,27 @@ for table, schema_fields in fields.items():
 with open(os.path.join(directory, "bad_schema.json"), "w") as out:
     out.write(json.dumps({"type": "struct", "fields": fields["bad"]}))
 
+# "add_only" leaves partitionColumns empty, so the metaData check passes it and only the
+# later partitionValues lookup can reject its unknown key.
+add_only_dir = os.path.join(directory, "add_only")
+os.makedirs(os.path.join(add_only_dir, "_delta_log"))
+os.makedirs(os.path.join(add_only_dir, "p=1"))
+os.link(os.path.join(directory, "bad", data), os.path.join(add_only_dir, data))
+with open(os.path.join(add_only_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
+    for action in [
+        {"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}},
+        {"metaData": {"id": "114462-add-only",
+                      "format": {"provider": "parquet", "options": {}},
+                      "schemaString": json.dumps({"type": "struct", "fields": fields["bad"]}),
+                      "partitionColumns": [],
+                      "configuration": {}, "createdTime": 1600000000000}},
+        {"add": {"path": data, "partitionValues": {"p": "1"},
+                 "size": os.path.getsize(os.path.join(add_only_dir, data)),
+                 "modificationTime": 1600000000000, "dataChange": True,
+                 "stats": json.dumps({"numRecords": 5})}},
+    ]:
+        log.write(json.dumps(action) + "\n")
+
 # "empty" carries no add action at all, so only a metaData-time check can reject it.
 os.makedirs(os.path.join(directory, "empty", "_delta_log"))
 with open(os.path.join(directory, "empty", "_delta_log", "00000000000000000000.json"), "w") as log:
@@ -145,6 +166,9 @@ $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') WHERE id > 3 FORM
 
 echo '-- legacy reader: json log branch'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
+
+echo '-- legacy reader: json log branch, unknown partitionValues key'
+$CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/add_only') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
 
 echo '-- legacy reader: checkpoint branch'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/ckpt') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
@@ -22,10 +22,18 @@ for T in good bad; do
         SETTINGS engine_file_truncate_on_insert = 1"
 done
 
-python3 - "$DIR" "$DATA" <<'EOF'
+# "mapped" declares 'p' but stores it under a column-mapping physical name.
+MAPPED_DATA="col_pppp=1/part-00000-c000.snappy.parquet"
+mkdir -p "$DIR/mapped/_delta_log" "$DIR/mapped/col_pppp=1"
+$CLICKHOUSE_LOCAL -q "
+    INSERT INTO FUNCTION file('$DIR/mapped/$MAPPED_DATA', Parquet, 'col_iiii Int64')
+    SELECT number FROM numbers(3)
+    SETTINGS engine_file_truncate_on_insert = 1"
+
+python3 - "$DIR" "$DATA" "$MAPPED_DATA" <<'EOF'
 import json, os, sys
 
-directory, data = sys.argv[1], sys.argv[2]
+directory, data, mapped_data = sys.argv[1], sys.argv[2], sys.argv[3]
 field = lambda name, type_: {"name": name, "type": type_, "nullable": True, "metadata": {}}
 fields = {"good": [field("id", "long"), field("s", "string"), field("p", "string")],
           "bad": [field("id", "long"), field("s", "string")]}
@@ -50,6 +58,46 @@ for table, schema_fields in fields.items():
 
 with open(os.path.join(directory, "bad_schema.json"), "w") as out:
     out.write(json.dumps({"type": "struct", "fields": fields["bad"]}))
+
+# "empty" carries no add action at all, so only a metaData-time check can reject it.
+os.makedirs(os.path.join(directory, "empty", "_delta_log"))
+with open(os.path.join(directory, "empty", "_delta_log", "00000000000000000000.json"), "w") as log:
+    for action in [
+        {"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}},
+        {"metaData": {"id": "114462-empty",
+                      "format": {"provider": "parquet", "options": {}},
+                      "schemaString": json.dumps({"type": "struct", "fields": fields["bad"]}),
+                      "partitionColumns": ["p"],
+                      "configuration": {}, "createdTime": 1600000000000}},
+    ]:
+        log.write(json.dumps(action) + "\n")
+
+# "mapped" is well formed: 'p' is declared, and column mapping stores it as 'col_pppp'.
+# partitionColumns holds the logical name, so a check against physical names would
+# wrongly reject this table.
+mapped_dir = os.path.join(directory, "mapped")
+mapped = lambda name, type_, physical, id_: {
+    "name": name, "type": type_, "nullable": True,
+    "metadata": {"delta.columnMapping.physicalName": physical, "delta.columnMapping.id": id_}}
+with open(os.path.join(mapped_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
+    for action in [
+        {"protocol": {"minReaderVersion": 2, "minWriterVersion": 5,
+                      "readerFeatures": ["columnMapping"], "writerFeatures": ["columnMapping"]}},
+        {"metaData": {"id": "114462-mapped",
+                      "format": {"provider": "parquet", "options": {}},
+                      "schemaString": json.dumps({"type": "struct", "fields": [
+                          mapped("id", "long", "col_iiii", 1),
+                          mapped("p", "string", "col_pppp", 2)]}),
+                      "partitionColumns": ["p"],
+                      "configuration": {"delta.columnMapping.mode": "name",
+                                        "delta.columnMapping.maxColumnId": "2"},
+                      "createdTime": 1600000000000}},
+        {"add": {"path": mapped_data, "partitionValues": {"col_pppp": "1"},
+                 "size": os.path.getsize(os.path.join(mapped_dir, mapped_data)),
+                 "modificationTime": 1600000000000, "dataChange": True,
+                 "stats": json.dumps({"numRecords": 3})}},
+    ]:
+        log.write(json.dumps(action) + "\n")
 EOF
 
 # "ckpt" reaches the legacy reader's checkpoint branch instead of its JSON log branch:
@@ -71,9 +119,24 @@ $CLICKHOUSE_LOCAL -q "
     SETTINGS engine_file_truncate_on_insert = 1"
 echo '{"version":1,"size":1}' > "$DIR/ckpt/_delta_log/_last_checkpoint"
 
+# "ckpt_empty" is the checkpoint counterpart of "empty": its single row carries the
+# malformed metaData and no add action, so only a metaData-time check can reject it.
+mkdir -p "$DIR/ckpt_empty/_delta_log"
+$CLICKHOUSE_LOCAL -q "
+    INSERT INTO FUNCTION file('$DIR/ckpt_empty/_delta_log/00000000000000000001.checkpoint.parquet', Parquet,
+        'add Tuple(path Nullable(String), partitionValues Map(String, Nullable(String)),
+                   size Nullable(Int64), modificationTime Nullable(Int64), dataChange Nullable(Bool)),
+         metaData Tuple(schemaString Nullable(String), partitionColumns Array(Nullable(String)))')
+    SELECT (NULL, map(), NULL, NULL, NULL), tuple('$BAD_SCHEMA', ['p'])
+    SETTINGS engine_file_truncate_on_insert = 1"
+echo '{"version":1,"size":1}' > "$DIR/ckpt_empty/_delta_log/_last_checkpoint"
+
 echo '-- control: a declared partition column reads fine on both readers'
 $CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3"
 $CLICKHOUSE_LOCAL -q "SELECT id, s, p FROM deltaLakeLocal('$DIR/good') WHERE id > 3 SETTINGS allow_delta_kernel_rs = 0"
+
+echo '-- control: a column-mapped partition column is declared under its logical name'
+$CLICKHOUSE_LOCAL -q "SELECT sum(col_iiii), any(col_pppp) FROM deltaLakeLocal('$DIR/mapped') SETTINGS allow_delta_kernel_rs = 0"
 
 echo '-- delta-kernel reader: rejected with or without a predicate'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null" 2>&1 | grep -oF "BAD_ARGUMENTS"
@@ -85,5 +148,11 @@ $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null SETTI
 
 echo '-- legacy reader: checkpoint branch'
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/ckpt') FORMAT Null SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
+
+echo '-- legacy reader: json log branch, partitionColumns with no add action to resolve'
+$CLICKHOUSE_LOCAL -q "DESCRIBE TABLE deltaLakeLocal('$DIR/empty') SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
+
+echo '-- legacy reader: checkpoint branch, partitionColumns with no add action to resolve'
+$CLICKHOUSE_LOCAL -q "DESCRIBE TABLE deltaLakeLocal('$DIR/ckpt_empty') SETTINGS allow_delta_kernel_rs = 0" 2>&1 | grep -oF "INCORRECT_DATA"
 
 rm -rf "$DIR"

--- a/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
+++ b/tests/queries/0_stateless/04877_delta_lake_partition_column_not_in_schema.sh
@@ -71,36 +71,48 @@ $CLICKHOUSE_LOCAL -q "
     SETTINGS engine_file_truncate_on_insert = 1"
 echo '{"version":1,"size":1}' > "$DIR/ckpt/_delta_log/_last_checkpoint"
 
-# "variant" has no partition columns at all, and one column of a type ClickHouse cannot
-# represent yet. Statistics come from the snapshot's file stats, so they stay available.
-mkdir -p "$DIR/variant/_delta_log"
+# "variant" and "variant_p" are both well formed and declare a column of a type ClickHouse
+# cannot represent yet; "variant_p" additionally partitions by a declared column. Row and
+# byte counts come from the snapshot's file statistics, so neither table needs a converted
+# schema to report them.
+mkdir -p "$DIR/variant/_delta_log" "$DIR/variant_p/_delta_log" "$DIR/variant_p/p=1"
 $CLICKHOUSE_LOCAL -q "
     INSERT INTO FUNCTION file('$DIR/variant/part-00000-c000.snappy.parquet', Parquet, 'id Int64')
     SELECT number FROM numbers(7)
     SETTINGS engine_file_truncate_on_insert = 1"
-python3 - "$DIR/variant" <<'EOF'
+$CLICKHOUSE_LOCAL -q "
+    INSERT INTO FUNCTION file('$DIR/variant_p/$DATA', Parquet, 'id Int64')
+    SELECT number FROM numbers(7)
+    SETTINGS engine_file_truncate_on_insert = 1"
+python3 - "$DIR" "$DATA" <<'EOF'
 import json, os, sys
 
-table_dir = sys.argv[1]
-data = "part-00000-c000.snappy.parquet"
-fields = [{"name": "id", "type": "long", "nullable": True, "metadata": {}},
-          {"name": "v", "type": "variant", "nullable": True, "metadata": {}}]
-actions = [
-    {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7,
-                  "readerFeatures": ["variantType"], "writerFeatures": ["variantType"]}},
-    {"metaData": {"id": "114462-variant",
-                  "format": {"provider": "parquet", "options": {}},
-                  "schemaString": json.dumps({"type": "struct", "fields": fields}),
-                  "partitionColumns": [],
-                  "configuration": {}, "createdTime": 1600000000000}},
-    {"add": {"path": data, "partitionValues": {},
-             "size": os.path.getsize(os.path.join(table_dir, data)),
-             "modificationTime": 1600000000000, "dataChange": True,
-             "stats": json.dumps({"numRecords": 7})}},
-]
-with open(os.path.join(table_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
-    for action in actions:
-        log.write(json.dumps(action) + "\n")
+directory, data = sys.argv[1], sys.argv[2]
+field = lambda name, type_: {"name": name, "type": type_, "nullable": True, "metadata": {}}
+variant = field("v", "variant")
+tables = {
+    "variant": ([field("id", "long"), variant], [], "part-00000-c000.snappy.parquet", {}),
+    "variant_p": ([field("id", "long"), field("p", "string"), variant], ["p"], data, {"p": "1"}),
+}
+
+for table, (schema_fields, partition_columns, path, partition_values) in tables.items():
+    table_dir = os.path.join(directory, table)
+    actions = [
+        {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7,
+                      "readerFeatures": ["variantType"], "writerFeatures": ["variantType"]}},
+        {"metaData": {"id": "114462-" + table,
+                      "format": {"provider": "parquet", "options": {}},
+                      "schemaString": json.dumps({"type": "struct", "fields": schema_fields}),
+                      "partitionColumns": partition_columns,
+                      "configuration": {}, "createdTime": 1600000000000}},
+        {"add": {"path": path, "partitionValues": partition_values,
+                 "size": os.path.getsize(os.path.join(table_dir, path)),
+                 "modificationTime": 1600000000000, "dataChange": True,
+                 "stats": json.dumps({"numRecords": 7})}},
+    ]
+    with open(os.path.join(table_dir, "_delta_log", "00000000000000000000.json"), "w") as log:
+        for action in actions:
+            log.write(json.dumps(action) + "\n")
 EOF
 
 echo '-- control: a declared partition column reads fine on both readers'
@@ -112,22 +124,14 @@ $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') FORMAT Null" 2>&1
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') WHERE id > 3 FORMAT Null" 2>&1 | grep -oF "BAD_ARGUMENTS"
 $CLICKHOUSE_LOCAL -q "SELECT * FROM deltaLakeLocal('$DIR/bad') WHERE id > 3 FORMAT Null SETTINGS delta_lake_enable_engine_predicate = 0" 2>&1 | grep -oF "BAD_ARGUMENTS"
 
-echo '-- delta-kernel reader: an explicit schema does not answer count() from statistics'
-$CLICKHOUSE_LOCAL --multiquery "
-CREATE TABLE t (\`id\` Int64, \`s\` String) ENGINE = DeltaLakeLocal('$DIR/bad');
-SELECT count() FROM t;
-" 2>&1 | grep -oF "BAD_ARGUMENTS"
-
-echo '-- delta-kernel reader: no row or byte statistics are published either'
-$CLICKHOUSE_LOCAL --multiquery "
-CREATE TABLE t2 (\`id\` Int64, \`s\` String) ENGINE = DeltaLakeLocal('$DIR/bad');
-SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't2';
-" 2>&1 | grep -E "^1\s+1$|BAD_ARGUMENTS"
-
-echo '-- delta-kernel reader: an unpartitioned table still publishes statistics'
+echo '-- delta-kernel reader: a table with an unsupported column type still publishes statistics'
 $CLICKHOUSE_LOCAL --multiquery "
 CREATE TABLE t3 (\`id\` Int64) ENGINE = DeltaLakeLocal('$DIR/variant');
 SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't3';
+" 2>&1 | grep -E "^0\s+0$|NOT_IMPLEMENTED"
+$CLICKHOUSE_LOCAL --multiquery "
+CREATE TABLE t4 (\`id\` Int64) ENGINE = DeltaLakeLocal('$DIR/variant_p');
+SELECT total_rows IS NULL, total_bytes IS NULL FROM system.tables WHERE name = 't4';
 " 2>&1 | grep -E "^0\s+0$|NOT_IMPLEMENTED"
 
 echo '-- legacy reader: json log branch'


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/114462


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` when reading a Delta Lake table whose `metaData.partitionColumns` names a column that `metaData.schemaString` does not declare. Such metadata is now rejected with `BAD_ARGUMENTS` on the delta-kernel reader and `INCORRECT_DATA` on the legacy reader, whenever the table or its schema is read from a snapshot, not only when the query carries a predicate.


### Description

Requested by @ PedroTadim in #114462.

`partitionColumns` and `schemaString` are independent fields of externally supplied metadata and
nothing cross-checked them, so a mismatch was reported as `LOGICAL_ERROR`, which aborts on debug
and sanitizer builds. Paimon already threw `BAD_ARGUMENTS` here.

- delta-kernel reader: validate in `TableSnapshot::initOrUpdateSchemaIfChanged`, where both values
  first exist, beside the existing empty-schema rejection. Previously an unfiltered `SELECT *`
  succeeded and only a predicate threw, since `PartitionPruner` is built only when a filter
  exists. That site keeps `LOGICAL_ERROR`, now a genuine internal invariant.
- legacy reader: `LOGICAL_ERROR` -> `INCORRECT_DATA` where an `add` action's `partitionValues`
  names an undeclared key, in the JSON-log and checkpoint branches. It also validates
  `partitionColumns` where `metaData` is loaded, in both branches, so a snapshot with no `add`
  action to resolve is rejected too. That check compares logical names: a parsed legacy schema
  is keyed by column-mapping physical names, so comparing against it would reject well formed
  column-mapped tables.

Iceberg is unaffected: it resolves partitions by numeric `source_id` field ids, not by name.
Change-data-feed reads go through `TableChanges`, which resolves no partition name, and are out of
scope.

Behaviour change: such a table was readable without a predicate, and on the legacy reader also with
no `add` action; it is now rejected for every query that reads it. It is malformed per the Delta
protocol.

One case is left alone, unchanged from master: on a table with an explicit column list a bare
`count()` is answered from transaction-log row counts, which resolve no column name, so it is not
rejected, while reading any column from it is.

Validated with the new stateless test `04877`: every failure arm fails on a targeted revert of the
line it covers, including a well formed column-mapped control that must keep reading. Also 50/50
randomized runs and the `delta_lake` suite.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1554` (included in `26.8` and later)
<!-- ch-version-info:end -->