### PR TITLE
Reject a Variant whose ORC branches read back as one type

### DIFF
--- a/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
@@ -2,6 +2,8 @@
 
 #include <unordered_map>
 
+#include <fmt/ranges.h>
+
 #if USE_ORC
 
 #include <Common/assert_cast.h>
@@ -62,6 +64,33 @@ orc::CompressionKind getORCCompression(FormatSettings::ORCCompression method)
         return orc::CompressionKind::CompressionKind_ZLIB;
 
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported compression method");
+}
+
+/// Two ORC types get the same key exactly when `parseORCType` (NativeORCBlockInputFormat.cpp) reads
+/// them back as the same ClickHouse type: `BINARY` and `STRING` both read as `String`, and a nested
+/// `UNION` reads as a `Variant`, which sorts its branches, while ORC keeps them positional.
+/// A field name is length-prefixed so a name containing `:` or `,` cannot forge another key.
+String orcTypeDedupKey(const orc::Type & type)
+{
+    const auto kind = type.getKind();
+    if (kind == orc::TypeKind::BINARY || kind == orc::TypeKind::STRING)
+        return "string";
+    if (kind == orc::TypeKind::DECIMAL)
+        return fmt::format("decimal({},{})", type.getPrecision(), type.getScale());
+
+    std::vector<String> children;
+    for (size_t i = 0; i < type.getSubtypeCount(); ++i)
+    {
+        auto child = orcTypeDedupKey(*type.getSubtype(i));
+        if (kind == orc::TypeKind::STRUCT)
+            child = fmt::format("{}:{}:{}", type.getFieldName(i).size(), type.getFieldName(i), child);
+        children.push_back(std::move(child));
+    }
+    if (kind == orc::TypeKind::UNION)
+        std::sort(children.begin(), children.end());
+    /// Every remaining kind the writer emits is a parameterless primitive mapping to a distinct
+    /// ClickHouse type, so for those the kind alone is the key and there are no children.
+    return fmt::format("{}<{}>", static_cast<int>(kind), fmt::join(children, ","));
 }
 
 }
@@ -247,20 +276,22 @@ std::unique_ptr<orc::Type> ORCBlockOutputFormat::getORCType(const DataTypePtr & 
             /// ORC keeps one physical stream per union branch and identifies a branch only by its
             /// ORC type, so two variants that map to the same ORC type (e.g. `Int32` and `UInt32`,
             /// both ORC `int`) would produce a union with duplicate branches, which the reader
-            /// rejects. Reject such a `Variant` up front instead of writing an unreadable file.
-            std::unordered_map<String, String> variant_by_orc_type;
+            /// rejects. Branches whose ORC types merely read back as one ClickHouse type collide the
+            /// same way, so they are keyed by `orcTypeDedupKey` rather than by the ORC type itself.
+            std::unordered_map<String, std::pair<String, String>> variant_by_orc_type;
             /// A union child is addressed by its type name, the way a `Variant` subcolumn is
             /// (`v.Int32`). Iceberg has no union type, so no field id is expected to be found there.
             for (const auto & nested_type : variant_type.getVariants())
             {
                 auto child_type = getORCType(nested_type, Nested::concatenateName(column_path, nested_type->getName()));
-                auto [it, inserted] = variant_by_orc_type.emplace(child_type->toString(), nested_type->getName());
+                auto [it, inserted] = variant_by_orc_type.emplace(
+                    orcTypeDedupKey(*child_type), std::pair{nested_type->getName(), child_type->toString()});
                 if (!inserted)
                     throw Exception(
                         ErrorCodes::ILLEGAL_COLUMN,
-                        "Type {} is not supported for ORC output format: variants {} and {} are both written as ORC type '{}', "
-                        "and ORC unions with duplicate branch types cannot be read back",
-                        unwrapped->getName(), it->second, nested_type->getName(), it->first);
+                        "Type {} is not supported for ORC output format: variant {} is written as ORC type '{}' and variant {} as "
+                        "'{}', which are read back as the same type, and ORC unions with duplicate branch types cannot be read back",
+                        unwrapped->getName(), it->second.first, it->second.second, nested_type->getName(), child_type->toString());
                 union_type->addUnionChild(std::move(child_type));
             }
             result = std::move(union_type);

--- a/tests/queries/0_stateless/04512_orc_native_union_write.reference
+++ b/tests/queries/0_stateless/04512_orc_native_union_write.reference
@@ -8,3 +8,8 @@ v	Variant(Int32, String)
 42	Variant(Float64, Int32, String)
 hi	Variant(Float64, Int32, String)
 1000	334	333	333	166500	s1	s997
+v	Variant(Tuple(\n    binary Nullable(Int32)), Tuple(\n    string Nullable(Int32)))					
+v	Variant(Tuple(\n    `a:int,b` Nullable(Int32)), Tuple(\n    a Nullable(Int32),\n    b Nullable(Int32)))					
+1.5	Variant(Decimal(18, 2), Decimal(38, 2))
+2.5	Variant(Decimal(18, 2), Decimal(38, 2))
+v	Variant(Array(Variant(Float64, Int32)), Array(Variant(Int32, String)))					

--- a/tests/queries/0_stateless/04512_orc_native_union_write.reference
+++ b/tests/queries/0_stateless/04512_orc_native_union_write.reference
@@ -9,7 +9,7 @@ v	Variant(Int32, String)
 hi	Variant(Float64, Int32, String)
 1000	334	333	333	166500	s1	s997
 v	Variant(Tuple(\n    binary Nullable(Int32)), Tuple(\n    string Nullable(Int32)))					
-v	Variant(Tuple(\n    `a:int,b` Nullable(Int32)), Tuple(\n    a Nullable(Int32),\n    b Nullable(Int32)))					
+v	Variant(Tuple(\n    `a:3<>,b` Nullable(Int32)), Tuple(\n    a Nullable(Int32),\n    b Nullable(Int32)))					
 1.5	Variant(Decimal(18, 2), Decimal(38, 2))
 2.5	Variant(Decimal(18, 2), Decimal(38, 2))
 v	Variant(Array(Variant(Float64, Int32)), Array(Variant(Int32, String)))					

--- a/tests/queries/0_stateless/04512_orc_native_union_write.reference
+++ b/tests/queries/0_stateless/04512_orc_native_union_write.reference
@@ -13,3 +13,5 @@ v	Variant(Tuple(\n    `a:3<>,b` Nullable(Int32)), Tuple(\n    a Nullable(Int32),
 1.5	Variant(Decimal(18, 2), Decimal(38, 2))
 2.5	Variant(Decimal(18, 2), Decimal(38, 2))
 v	Variant(Array(Variant(Float64, Int32)), Array(Variant(Int32, String)))					
+v	Variant(Map(Int32, Nullable(String)), Map(String, Nullable(Int32)))					
+v	Variant(Tuple(\n    a Nullable(Int32),\n    b Nullable(String)), Tuple(\n    b Nullable(String),\n    a Nullable(Int32)))					

--- a/tests/queries/0_stateless/04512_orc_native_union_write.sql
+++ b/tests/queries/0_stateless/04512_orc_native_union_write.sql
@@ -103,9 +103,10 @@ INSERT INTO FUNCTION file(currentDatabase() || '_04512_names.orc', ORC, 'v Varia
 SELECT CAST(NULL, 'Variant(Tuple(binary Int32), Tuple(string Int32))');
 DESC file(currentDatabase() || '_04512_names.orc', ORC);
 
--- A field name may itself contain the punctuation that renders a struct field.
-INSERT INTO FUNCTION file(currentDatabase() || '_04512_punct.orc', ORC, 'v Variant(Tuple(`a:int,b` Int32), Tuple(a Int32, b Int32))')
-SELECT CAST(NULL, 'Variant(Tuple(`a:int,b` Int32), Tuple(a Int32, b Int32))');
+-- A struct field name may itself contain the punctuation that renders a field, including a rendered
+-- child key, so field names are length-framed and two distinct tuples cannot render one key.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_punct.orc', ORC, 'v Variant(Tuple(`a:3<>,b` Int32), Tuple(a Int32, b Int32))')
+SELECT CAST(NULL, 'Variant(Tuple(`a:3<>,b` Int32), Tuple(a Int32, b Int32))');
 DESC file(currentDatabase() || '_04512_punct.orc', ORC);
 
 INSERT INTO FUNCTION file(currentDatabase() || '_04512_dec.orc', ORC, 'v Variant(Decimal64(2), Decimal128(2))')

--- a/tests/queries/0_stateless/04512_orc_native_union_write.sql
+++ b/tests/queries/0_stateless/04512_orc_native_union_write.sql
@@ -57,3 +57,63 @@ SELECT 42::Int32::Variant(IPv4, Int32); -- { serverError ILLEGAL_COLUMN }
 -- only strips LowCardinality from top-level columns), so it cannot collide with a plain branch.
 INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(LowCardinality(String), String)')
 SELECT CAST(NULL, 'Variant(LowCardinality(String), String)'); -- { serverError ILLEGAL_COLUMN }
+
+-- Branches whose ORC types differ but which the reader parses back to the same ClickHouse type must
+-- be rejected too: ORC `binary` (Int128/UInt128/Int256/UInt256/Decimal256/IPv6) and ORC `string`
+-- (String/FixedString) both read as String. Such a file used to be written, and could then not be
+-- inferred at all.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(String, Int128)')
+SELECT CAST(NULL, 'Variant(String, Int128)'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(String, IPv6)')
+SELECT CAST(NULL, 'Variant(String, IPv6)'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(String, Decimal256(5))')
+SELECT CAST(NULL, 'Variant(String, Decimal256(5))'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(FixedString(3), Int128)')
+SELECT CAST(NULL, 'Variant(FixedString(3), Int128)'); -- { serverError ILLEGAL_COLUMN }
+
+-- The same collapse inside a container: branch types are compared recursively.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Array(String), Array(Int128))')
+SELECT CAST(NULL, 'Variant(Array(String), Array(Int128))'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Array(Array(String)), Array(Array(IPv6)))')
+SELECT CAST(NULL, 'Variant(Array(Array(String)), Array(Array(IPv6)))'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Array(Nullable(String)), Array(Nullable(Int128)))')
+SELECT CAST(NULL, 'Variant(Array(Nullable(String)), Array(Nullable(Int128)))'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Tuple(a String, b Int32), Tuple(a IPv6, b Int32))')
+SELECT CAST(NULL, 'Variant(Tuple(a String, b Int32), Tuple(a IPv6, b Int32))'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Map(String, String), Map(String, Int128))')
+SELECT CAST(NULL, 'Variant(Map(String, String), Map(String, Int128))'); -- { serverError ILLEGAL_COLUMN }
+
+-- Sibling branches that differ only inside a nested union. A Variant sorts its branches while an ORC
+-- union keeps them positional, so these two nested unions are rendered in different orders and are
+-- recognized as equivalent only because nested union branches are sorted before comparing.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Array(Variant(String, Int32)), Array(Variant(IPv6, Int32)))')
+SELECT CAST(NULL, 'Variant(Array(Variant(String, Int32)), Array(Variant(IPv6, Int32)))'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Tuple(a Variant(String, Int32)), Tuple(a Variant(IPv6, Int32)))')
+SELECT CAST(NULL, 'Variant(Tuple(a Variant(String, Int32)), Tuple(a Variant(IPv6, Int32)))'); -- { serverError ILLEGAL_COLUMN }
+
+-- A nested Variant whose own branches collapse is rejected at its own level.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Array(Variant(String, Int128)), Int32)')
+SELECT CAST(NULL, 'Variant(Array(Variant(String, Int128)), Int32)'); -- { serverError ILLEGAL_COLUMN }
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dup.orc', ORC, 'v Variant(Tuple(a Variant(String, IPv6)), Int32)')
+SELECT CAST(NULL, 'Variant(Tuple(a Variant(String, IPv6)), Int32)'); -- { serverError ILLEGAL_COLUMN }
+
+-- Branches that only look alike must still round-trip: a Tuple field name is significant, and so is
+-- decimal precision, so neither pair collapses to one type on read.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_names.orc', ORC, 'v Variant(Tuple(binary Int32), Tuple(string Int32))')
+SELECT CAST(NULL, 'Variant(Tuple(binary Int32), Tuple(string Int32))');
+DESC file(currentDatabase() || '_04512_names.orc', ORC);
+
+-- A field name may itself contain the punctuation that renders a struct field.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_punct.orc', ORC, 'v Variant(Tuple(`a:int,b` Int32), Tuple(a Int32, b Int32))')
+SELECT CAST(NULL, 'Variant(Tuple(`a:int,b` Int32), Tuple(a Int32, b Int32))');
+DESC file(currentDatabase() || '_04512_punct.orc', ORC);
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_dec.orc', ORC, 'v Variant(Decimal64(2), Decimal128(2))')
+      SELECT CAST(1.5::Decimal64(2), 'Variant(Decimal64(2), Decimal128(2))')
+UNION ALL SELECT CAST(2.5::Decimal128(2), 'Variant(Decimal64(2), Decimal128(2))');
+SELECT v, toTypeName(v) FROM file(currentDatabase() || '_04512_dec.orc', ORC) ORDER BY toString(v);
+
+-- Two nested unions that are genuinely distinct: sorting their branches must not merge them.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_nested_ok.orc', ORC, 'v Variant(Array(Variant(String, Int32)), Array(Variant(Float64, Int32)))')
+SELECT CAST(NULL, 'Variant(Array(Variant(String, Int32)), Array(Variant(Float64, Int32)))');
+DESC file(currentDatabase() || '_04512_nested_ok.orc', ORC);

--- a/tests/queries/0_stateless/04512_orc_native_union_write.sql
+++ b/tests/queries/0_stateless/04512_orc_native_union_write.sql
@@ -118,3 +118,14 @@ SELECT v, toTypeName(v) FROM file(currentDatabase() || '_04512_dec.orc', ORC) OR
 INSERT INTO FUNCTION file(currentDatabase() || '_04512_nested_ok.orc', ORC, 'v Variant(Array(Variant(String, Int32)), Array(Variant(Float64, Int32)))')
 SELECT CAST(NULL, 'Variant(Array(Variant(String, Int32)), Array(Variant(Float64, Int32)))');
 DESC file(currentDatabase() || '_04512_nested_ok.orc', ORC);
+
+-- Only the branches of a nested union are order-insensitive. The children of an ORC list, map or
+-- struct are positional, because their order is part of the Map or Tuple type, so branches that
+-- differ only in child order are different types and must round-trip.
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_map_pos.orc', ORC, 'v Variant(Map(Int32, String), Map(String, Int32))')
+SELECT CAST(NULL, 'Variant(Map(Int32, String), Map(String, Int32))');
+DESC file(currentDatabase() || '_04512_map_pos.orc', ORC);
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04512_tuple_pos.orc', ORC, 'v Variant(Tuple(a Int32, b String), Tuple(b String, a Int32))')
+SELECT CAST(NULL, 'Variant(Tuple(a Int32, b String), Tuple(b String, a Int32))');
+DESC file(currentDatabase() || '_04512_tuple_pos.orc', ORC);


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/114169
Related: https://github.com/ClickHouse/ClickHouse/pull/110085
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/114169

The native ORC writer accepted a `Variant` whose branches map to *different* ORC types but which the
reader parses back to the *same* type. The file was written, and reads fine with an explicit structure,
but inference on it failed, breaking the round-trip:

```
$ clickhouse local -q "SELECT NULL::Variant(String, Int128) FORMAT ORC" | clickhouse local --input-format ORC -q "SELECT * FROM table"
Code: 50. ORC union type 'uniontype<binary,string>' has branches with identical types (UNKNOWN_TYPE)
```

Root cause: the writer's duplicate-branch guard keyed its dedup map on the ORC type
(`child_type->toString()`), while the reader keys on the ClickHouse type each branch parses back to,
mapping both ORC `binary` and ORC `string` to `String`. Two different equivalence relations, so the
writer's guard passed where the reader's fired.

This keys the guard on a new `orcTypeDedupKey` helper, a recursive rendering of the ORC type that folds
`BINARY` into `STRING` and sorts nested `UNION` children (a nested union reads back as a `Variant`, which
sorts its branches, whereas ORC keeps them positional). `LIST`, `MAP` and `STRUCT` stay positional,
matching `Array`, `Map` and `Tuple`. The writer never emits `CHAR`/`VARCHAR`, so that is the only
collapse it can produce.

The reader was left alone: remapping ORC `binary` would change the inferred type of every existing ORC
`binary` column, and `uniontype<binary,string>` has no type to infer *to* anyway.

Validated on a debug build: 16 measured carriers (the 6 reported scalar pairings, `FixedString`, and the
same collapse through `Array`/`Tuple`/`Map` and nested unions) wrote and then failed inference before,
and are rejected at write time after. 7 positive controls still round-trip. Unreleased feature, so
nothing to break and no backport.

The `.cpp` adds 26 lines of code, within the 50 @ PedroTadim authorized.

Requested by @ PedroTadim in https://github.com/ClickHouse/ClickHouse/issues/114169#issuecomment-5265686354