### PR TITLE
Fix spelling of 'prefetches' and 'prefetched' in documentation

### DIFF
--- a/docs/reference/system-tables/events.mdx
+++ b/docs/reference/system-tables/events.mdx
@@ -4097,7 +4097,7 @@ Number of buffers created for asynchronous reading from remote filesystem
 
 ### RemoteFSCancelledPrefetches {#remotefscancelledprefetches}
 
-Number of cancelled prefetches (because of seek)
+Number of cancelled prefecthes (because of seek)
 
 ### RemoteFSLazySeeks {#remotefslazyseeks}
 
@@ -4105,11 +4105,11 @@ Number of lazy seeks
 
 ### RemoteFSPrefetchedBytes {#remotefsprefetchedbytes}
 
-Number of bytes from prefetched buffer
+Number of bytes from prefecthed buffer
 
 ### RemoteFSPrefetchedReads {#remotefsprefetchedreads}
 
-Number of reads from prefetched buffer
+Number of reads from prefecthed buffer
 
 ### RemoteFSPrefetches {#remotefsprefetches}
 

--- a/docs/reference/system-tables/events.mdx
+++ b/docs/reference/system-tables/events.mdx
@@ -4097,7 +4097,7 @@ Number of buffers created for asynchronous reading from remote filesystem
 
 ### RemoteFSCancelledPrefetches {#remotefscancelledprefetches}
 
-Number of cancelled prefecthes (because of seek)
+Number of cancelled prefetches (because of seek)
 
 ### RemoteFSLazySeeks {#remotefslazyseeks}
 
@@ -4105,11 +4105,11 @@ Number of lazy seeks
 
 ### RemoteFSPrefetchedBytes {#remotefsprefetchedbytes}
 
-Number of bytes from prefecthed buffer
+Number of bytes from prefetched buffer
 
 ### RemoteFSPrefetchedReads {#remotefsprefetchedreads}
 
-Number of reads from prefecthed buffer
+Number of reads from prefetched buffer
 
 ### RemoteFSPrefetches {#remotefsprefetches}
 

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -927,10 +927,10 @@ The server successfully detected this situation and will download merged part fr
     \
     M(RemoteFSSeeks, "Total number of seeks for async buffer", ValueType::Number) \
     M(RemoteFSPrefetches, "Number of prefetches made with asynchronous reading from remote filesystem", ValueType::Number) \
-    M(RemoteFSCancelledPrefetches, "Number of cancelled prefecthes (because of seek)", ValueType::Number) \
+    M(RemoteFSCancelledPrefetches, "Number of cancelled prefetches (because of seek)", ValueType::Number) \
     M(RemoteFSUnusedPrefetches, "Number of prefetches pending at buffer destruction", ValueType::Number) \
-    M(RemoteFSPrefetchedReads, "Number of reads from prefecthed buffer", ValueType::Number) \
-    M(RemoteFSPrefetchedBytes, "Number of bytes from prefecthed buffer", ValueType::Bytes) \
+    M(RemoteFSPrefetchedReads, "Number of reads from prefetched buffer", ValueType::Number) \
+    M(RemoteFSPrefetchedBytes, "Number of bytes from prefetched buffer", ValueType::Bytes) \
     M(RemoteFSUnprefetchedReads, "Number of reads from unprefetched buffer", ValueType::Number) \
     M(RemoteFSUnprefetchedBytes, "Number of bytes from unprefetched buffer", ValueType::Bytes) \
     M(RemoteFSLazySeeks, "Number of lazy seeks", ValueType::Number) \


### PR DESCRIPTION
Corrected spelling of 'prefetches' and 'prefetched' in multiple sections.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1353` (included in `26.8` and later)
<!-- ch-version-info:end -->