### PR TITLE
Text index: fix read mode of LIKE/ILIKE with an index built on a container

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -899,6 +899,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     bool has_map_keys_column = hasIndexForColumn(fmt::format("mapKeys({})", index_column_name));
     bool has_map_values_column = hasIndexForColumn(fmt::format("mapValues({})", index_column_name));
 
+    bool candidate_for_exact_mode = true;
     if (traverseMapElementValueNode(index_column_node, value_field))
     {
         has_index_column = true;
@@ -906,11 +907,13 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
         /// If we use index on `mapValues(m)` for `func(m['key'], 'value')`, we can use direct read only as a hint
         /// because we have to match the specific key to the value and therefore execute a real filter.
         direct_read_mode = getHintOrNoneMode();
+        candidate_for_exact_mode = false;
     }
     else if (tryMatchNodeToJSONIndex(index_column_node, header, "JSONAllValues"))
     {
         has_index_column = true;
         direct_read_mode = getHintOrNoneMode();
+        candidate_for_exact_mode = false;
         bool is_special_text_index_function = function_name == "hasAnyTokens" || function_name == "hasAllTokens";
 
         /// Convert non-string values to their text representation to match the format produced by `JSONAllValues`.
@@ -934,6 +937,7 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
             {
                 has_index_column = true;
                 direct_read_mode = getHintOrNoneMode();
+                candidate_for_exact_mode = false;
             }
         }
     }
@@ -1271,10 +1275,12 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
             auto patterns = stringLikeToPatterns(value_field, false);
             if (patterns.size() == 1)
             {
+                const auto pattern_read_mode = candidate_for_exact_mode ? TextIndexDirectReadMode::Exact : getHintOrNoneMode();
+
                 out.function = RPNElement::FUNCTION_LIKE;
                 out.text_search_queries.emplace_back(
                     std::make_shared<TextSearchQuery>(
-                        function_name, TextSearchMode::Any, TextIndexDirectReadMode::Exact, VectorWithMemoryTracking<String>(), std::move(patterns)));
+                        function_name, TextSearchMode::Any, pattern_read_mode, VectorWithMemoryTracking<String>(), std::move(patterns)));
                 return true;
             }
         }
@@ -1300,10 +1306,12 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
         auto patterns = stringLikeToPatterns(value_field, true);
         if (patterns.size() == 1)
         {
+            const auto pattern_read_mode = candidate_for_exact_mode ? TextIndexDirectReadMode::Exact : getHintOrNoneMode();
+
             out.function = RPNElement::FUNCTION_LIKE;
             out.text_search_queries.emplace_back(
                 std::make_shared<TextSearchQuery>(
-                    function_name, TextSearchMode::Any, TextIndexDirectReadMode::Exact, VectorWithMemoryTracking<String>(), std::move(patterns)));
+                    function_name, TextSearchMode::Any, pattern_read_mode, VectorWithMemoryTracking<String>(), std::move(patterns)));
             return true;
         }
         return false;

--- a/tests/queries/0_stateless/02346_text_index_function_like.reference
+++ b/tests/queries/0_stateless/02346_text_index_function_like.reference
@@ -116,3 +116,23 @@ Granules: 1024/4096
 Description: text GRANULARITY 100000000
 Parts: 2/4
 Granules: 2048/4096
+The optimization is only a hint for an index built on a container
+-- Index on mapValues
+[1]
+[1]
+[1]
+[1]
+1	1
+-- Index on mapValues with the array tokenizer
+[1]
+[1]
+[1]
+[1]
+-- Index on JSONAllValues
+[1]
+[1]
+[1]
+[1]
+[1]
+[1]
+1	1

--- a/tests/queries/0_stateless/02346_text_index_function_like.sql
+++ b/tests/queries/0_stateless/02346_text_index_function_like.sql
@@ -341,3 +341,101 @@ SELECT trimLeft(explain) AS explain FROM (
 LIMIT 2, 3;
 
 DROP TABLE tab;
+
+SELECT 'The optimization is only a hint for an index built on a container';
+
+-- When the index is built on `mapValues(m)` or `JSONAllValues(json)` but the predicate reads a single
+-- element out of it, the dictionary scan only proves a match somewhere in the container, not at the
+-- requested key or path. The original condition must therefore still be evaluated on every surviving row.
+
+SET use_skip_indexes_on_data_read = 1;
+SET query_plan_direct_read_from_text_index = 1;
+SET query_plan_text_index_add_hint = 1;
+SET use_text_index_like_evaluation_by_dictionary_scan = 1;
+
+SELECT '-- Index on mapValues';
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    attributes Map(String, String),
+    INDEX idx mapValues(attributes) TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree
+ORDER BY (id);
+
+INSERT INTO tab VALUES
+    (1, {'a': 'foobar value', 'b': 'other value'}),
+    (2, {'a': 'other value', 'b': 'foobar value'}),
+    (3, {'a': 'nothing', 'b': 'nothing'});
+
+SELECT groupArray(id) FROM tab WHERE attributes['a'] LIKE '%foobar%';
+SELECT groupArray(id) FROM tab WHERE attributes['a'] LIKE '%foobar%' SETTINGS use_skip_indexes = 0;
+
+SELECT groupArray(id) FROM tab WHERE attributes['a'] ILIKE '%FOOBAR%';
+SELECT groupArray(id) FROM tab WHERE attributes['a'] ILIKE '%FOOBAR%' SETTINGS use_skip_indexes = 0;
+
+-- The index is used as a hint, so the original condition must still be part of the plan.
+SELECT countIf(explain LIKE '%\_\_text_index\_%') > 0, countIf(explain LIKE '%FUNCTION like(%') > 0
+FROM (EXPLAIN actions = 1 SELECT count() FROM tab WHERE attributes['a'] LIKE '%foobar%');
+
+DROP TABLE tab;
+
+SELECT '-- Index on mapValues with the array tokenizer';
+
+-- The array tokenizer stores each map value as a whole token, which does not make the match exact
+-- either: the token still only proves that some value of the map matches.
+
+CREATE TABLE tab
+(
+    id UInt32,
+    attributes Map(String, String),
+    INDEX idx mapValues(attributes) TYPE text(tokenizer = array)
+)
+ENGINE = MergeTree
+ORDER BY (id);
+
+INSERT INTO tab VALUES
+    (1, {'a': 'foobar value', 'b': 'other value'}),
+    (2, {'a': 'other value', 'b': 'foobar value'}),
+    (3, {'a': 'nothing', 'b': 'nothing'});
+
+SELECT groupArray(id) FROM tab WHERE attributes['a'] LIKE '%foobar%';
+SELECT groupArray(id) FROM tab WHERE attributes['a'] LIKE '%foobar%' SETTINGS use_skip_indexes = 0;
+
+SELECT groupArray(id) FROM tab WHERE attributes['a'] ILIKE '%FOOBAR%';
+SELECT groupArray(id) FROM tab WHERE attributes['a'] ILIKE '%FOOBAR%' SETTINGS use_skip_indexes = 0;
+
+DROP TABLE tab;
+
+SELECT '-- Index on JSONAllValues';
+
+CREATE TABLE tab
+(
+    id UInt32,
+    data JSON,
+    INDEX idx JSONAllValues(data) TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree
+ORDER BY (id);
+
+INSERT INTO tab VALUES (1, '{"a": "foobar value", "b": "other value"}');
+INSERT INTO tab VALUES (2, '{"a": "other value", "b": "foobar value"}');
+INSERT INTO tab VALUES (3, '{"a": "nothing", "b": "nothing"}');
+
+SELECT groupArray(id) FROM tab WHERE data.a LIKE '%foobar%';
+SELECT groupArray(id) FROM tab WHERE data.a LIKE '%foobar%' SETTINGS use_skip_indexes = 0;
+
+SELECT groupArray(id) FROM tab WHERE data.a::String LIKE '%foobar%';
+SELECT groupArray(id) FROM tab WHERE data.a::String LIKE '%foobar%' SETTINGS use_skip_indexes = 0;
+
+SELECT groupArray(id) FROM tab WHERE data.a ILIKE '%FOOBAR%';
+SELECT groupArray(id) FROM tab WHERE data.a ILIKE '%FOOBAR%' SETTINGS use_skip_indexes = 0;
+
+-- The index is used as a hint, so the original condition must still be part of the plan.
+SELECT countIf(explain LIKE '%\_\_text_index\_%') > 0, countIf(explain LIKE '%FUNCTION like(%') > 0
+FROM (EXPLAIN actions = 1 SELECT count() FROM tab WHERE data.a LIKE '%foobar%');
+
+DROP TABLE tab;


### PR DESCRIPTION
Evaluating `LIKE`/`ILIKE` by scanning the text index dictionary always used an exact direct read, which removes the original condition from the query plan. That is only valid when a matching dictionary token proves the predicate, which is not the case when the index is built on a container while the predicate reads a single element out of it: with an index on `mapValues(m)`, `m['a'] LIKE '%foobar%'` also returned rows whose match is under another key. However, it may produce correct result due to the data, but it's not guaranteed.

To ensure for producing correct results, we need to use `HINT` mode when a text index built on a container (Map or JSON).

It is better to be safe than sorry.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix text index evaluation of `LIKE/ILIKE` operator built on Map or JSON containers.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1313` (included in `26.8` and later)
<!-- ch-version-info:end -->