### PR TITLE
Raise the log-wait timeout in `test_keeper_session_loss_direct_read` to fix flakiness

### DIFF
--- a/tests/integration/test_storage_kafka/test_keeper_session_loss_direct_read.py
+++ b/tests/integration/test_storage_kafka/test_keeper_session_loss_direct_read.py
@@ -73,9 +73,14 @@ def test_direct_read_from_inactive_table_is_not_a_logical_error(kafka_cluster):
             # minute), runs `partialShutdown` and, since Keeper is unreachable, fails to
             # reactivate: from this line on the table stays inactive while the network
             # partition holds.
+            # The nominal detection latency is bounded by the check period plus the
+            # Keeper connection timeouts, but on an overloaded CI host (sanitizer
+            # builds, busy schedule pool) it has been seen exceeding 180 seconds, so
+            # the timeout is generous. The wait returns as soon as the line appears,
+            # so a healthy run does not pay for the margin.
             instance.wait_for_log_line(
                 f"{kafka_table}.*Failed to establish a new ZK connection. Will try again",
-                timeout=180,
+                timeout=600,
             )
 
             error = instance.query_and_get_error(


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Raise the log-wait timeout in the integration test `test_storage_kafka/test_keeper_session_loss_direct_read.py` to fix its flakiness.

The test waits for the `StorageKafka2` activation task to notice the expired Keeper session after a network partition. The task's check period is one minute, and on an overloaded CI host (sanitizer builds, busy schedule pool) the log line has been seen missing the 180-second window, failing the test with `retry_failed`. `wait_for_log_line` returns as soon as the line appears, so a healthy run does not pay for the extra margin.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1305` (included in `26.8` and later)
<!-- ch-version-info:end -->