### PR TITLE
Ask `@oranjeai` instead of `@groeneai` in the private repository

### DIFF
--- a/.claude/skills/continue-pr/SKILL.md
+++ b/.claude/skills/continue-pr/SKILL.md
@@ -22,6 +22,14 @@ Extract the PR number from `$0`. If not provided, use `AskUserQuestion` to ask f
 
 Validate that the PR number contains only digits. Reject any non-numeric input immediately — do not pass unvalidated input to shell commands or GraphQL queries.
 
+Determine which repository you are operating in — the public `ClickHouse/ClickHouse` or the private `ClickHouse/clickhouse-private`:
+
+```bash
+gh repo view --json nameWithOwner --jq .nameWithOwner   # or: git remote get-url origin
+```
+
+Remember it as `$REPO` and use it everywhere below instead of the literal `ClickHouse/ClickHouse` in `gh` commands, API URLs, and GraphQL `repository(owner:, name:)` arguments. The repository also decides whom to ask about unrelated CI failures (step 4, item 5): `@groeneai` in `ClickHouse/ClickHouse`, `@oranjeai` in `ClickHouse/clickhouse-private`.
+
 Fetch PR metadata using `gh` if available, otherwise use `WebFetch` on the GitHub API:
 
 ```bash
@@ -113,8 +121,8 @@ For each CI failure:
 
 4. If the only failure is "CH Inc sync", fix it using the /fix-sync skill.
 
-5. If you are confident that the failure is unrelated to the changes, post a comment, asking @groeneai to investigate the failure:
-   @groeneai, investigate the failure: <link> and provide a fix in a separate PR. If the fix is already in progress, link it here. 
+5. If you are confident that the failure is unrelated to the changes, post a comment, asking the reviewer for `$REPO` (step 1) — `@groeneai` in `ClickHouse/ClickHouse`, `@oranjeai` in `ClickHouse/clickhouse-private` — to investigate the failure:
+   @<reviewer>, investigate the failure: <link> and provide a fix in a separate PR. If the fix is already in progress, link it here. 
 
 6. **Repeat** until all failures are addressed or confirmed as known issues with links to open issues/PRs.
 


### PR DESCRIPTION
The `continue-pr` skill hardcoded `@groeneai` as the person to ping about CI failures that are unrelated to the pull request being worked on. That handle is only correct for `ClickHouse/ClickHouse`; when the skill runs in `ClickHouse/clickhouse-private`, the request should go to `@oranjeai` instead.

Step 1 now detects the repository (`gh repo view --json nameWithOwner`, falling back to `git remote get-url origin`), remembers it as `$REPO` for the `gh` commands, API URLs, and GraphQL arguments further down, and step 4 picks the reviewer from it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1297` (included in `26.8` and later)
<!-- ch-version-info:end -->