### PR TITLE
Order the /play startup test's load-window keystroke by construction

### DIFF
--- a/tests/integration/test_play_reconcile_startup/reconcile_harness.js
+++ b/tests/integration/test_play_reconcile_startup/reconcile_harness.js
@@ -870,7 +870,9 @@ async function main() {
         const r = await runScenario(js, {
             href: base + '?tab=Scratch#' + stale_hash,
             historyState: { tabId: 't7', tabName: 'Scratch' },
-            openDelayMs: 30,
+            /// A zero-delay open leaves no wall-clock margin, so the load-window interaction below
+            /// holds only if it is ordered structurally rather than by timing.
+            openDelayMs: 0,
             duringLoad: (sandbox) => {
                 vm.runInContext(
                     "query_area.value = 'SELECT 999';" +

--- a/tests/integration/test_play_reconcile_startup/reconcile_harness.js
+++ b/tests/integration/test_play_reconcile_startup/reconcile_harness.js
@@ -469,8 +469,14 @@ async function runScenario(js, config) {
     /// (see the dirty-startup scenario): run `config.duringLoad(sandbox)` inside the `openDelayMs`
     /// window, before `reconcileStartup` takes over the workspace (`bootstrap_settled`).
     if (config.duringLoad) {
-        await sleep(config.duringLoadDelayMs || 5);
+        /// The bootstrap is synchronous and `IndexedDB.open` can only resolve through a
+        /// `setTimeout`, so yielding to microtasks alone keeps the interaction before the open.
+        await Promise.resolve();
+        if (vm.runInContext('bootstrap_settled', sandbox))
+            throw new Error('duringLoad ran after reconciliation settled: the load window closed early');
         config.duringLoad(sandbox);
+        if (!vm.runInContext('bootstrap_dirty', sandbox))
+            throw new Error('duringLoad did not mark the bootstrap workspace dirty');
     }
     /// Startup is asynchronous: `reconcileStartup` awaits IndexedDB and ends with the debounced
     /// `scheduleSave` (400 ms), whose `persist` writes the reconciled workspace back. Wait for

--- a/tests/integration/test_play_reconcile_startup/reconcile_harness.js
+++ b/tests/integration/test_play_reconcile_startup/reconcile_harness.js
@@ -266,7 +266,8 @@ function makeIndexedDB(seedTabs, seedMeta, openDelayMs) {
     const stores = new Map();
     stores.set('tabs', { keyPath: 'id', data: new Map((seedTabs || []).map(r => [r.id, structuredClone(r)])) });
     stores.set('meta', { keyPath: 'key', data: new Map(seedMeta ? [['state', structuredClone(seedMeta)]] : []) });
-    const stats = { persistCount: 0 };
+    /// `openFired` records that the load window has closed: the open callback below has run.
+    const stats = { persistCount: 0, openFired: false };
 
     function makeStoreHandle(name) {
         const s = stores.get(name);
@@ -293,6 +294,7 @@ function makeIndexedDB(seedTabs, seedMeta, openDelayMs) {
             /// `openDelayMs` lets a scenario make `IndexedDB.open` slower than any auto-run that
             /// races startup reconciliation (see the stale-reload-run-race scenario).
             setTimeout(() => {
+                stats.openFired = true;
                 req.result = {
                     objectStoreNames: { contains: (n) => stores.has(n) },
                     createObjectStore(n, opts) {
@@ -472,6 +474,8 @@ async function runScenario(js, config) {
         /// The bootstrap is synchronous and `IndexedDB.open` can only resolve through a
         /// `setTimeout`, so yielding to microtasks alone keeps the interaction before the open.
         await Promise.resolve();
+        if (stats.openFired)
+            throw new Error('duringLoad ran after the IndexedDB open completed: the load window closed early');
         if (vm.runInContext('bootstrap_settled', sandbox))
             throw new Error('duringLoad ran after reconciliation settled: the load window closed early');
         config.duringLoad(sandbox);

--- a/tests/integration/test_play_reconcile_startup/test.py
+++ b/tests/integration/test_play_reconcile_startup/test.py
@@ -81,13 +81,19 @@ def test_play_reconcile_startup(started_cluster, nodejs_container):
     assert code == 0, "harness failed:\n{}\n{}".format(out, err)
     assert "All scenarios passed" in out
     # The `run=1`-marker scenarios are the regression tests for scoping the URL
-    # marker to the tab that produced it; pin them by name so a harness edit
-    # that silently drops a scenario cannot pass as "all scenarios passed".
+    # marker to the tab that produced it, and the `dirty-startup-*` ones cover an
+    # edit that lands while the saved workspace is still loading; pin them by name
+    # so a harness edit that silently drops a scenario cannot pass as "all
+    # scenarios passed".
     for scenario in (
         "run-marker-per-tab",
         "legacy-popstate-clears-policy",
         "run-marker-kept-for-own-run",
         "run-marker-plain-load",
+        "dirty-startup-run-leak",
+        "dirty-startup-adopt-restamp",
+        "dirty-startup-allblank-edit-survives",
+        "dirty-startup-merge-entry-reowned",
     ):
         assert "PASS [{}]".format(scenario) in out, "scenario {} did not run:\n{}".format(
             scenario, out

--- a/tests/integration/test_play_reconcile_startup/test.py
+++ b/tests/integration/test_play_reconcile_startup/test.py
@@ -93,6 +93,7 @@ def test_play_reconcile_startup(started_cluster, nodejs_container):
         "dirty-startup-run-leak",
         "dirty-startup-adopt-restamp",
         "dirty-startup-allblank-edit-survives",
+        "dirty-startup-allblank-entry-reowned",
         "dirty-startup-merge-entry-reowned",
     ):
         assert "PASS [{}]".format(scenario) in out, "scenario {} did not run:\n{}".format(


### PR DESCRIPTION
Order the /play startup test's load-window keystroke by construction

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_play_reconcile_startup` can fail one assertion of `dirty-startup-merge-entry-reowned`
("the URL hash carries the live query, not the dropped blank tab stale hash", actual
`?tab=Scratch#U0VMRUNUIDExMQ==`) while the scenario's other five checks pass. No related open
issue found.

The Web UI is not at fault. The four `dirty-startup-*` scenarios must deliver their "user typed
while IndexedDB was still opening" keystroke inside the load window, but the harness expressed
that ordering as a duration: `await sleep(config.duringLoadDelayMs || 5)`. The fake
`IndexedDB.open` registers its `openDelayMs: 30` timer *during* page-script evaluation, while the
keystroke timer is registered only *after* evaluation returns, so the keystroke wins only while
`eval_end - open_call` stays under the measured 26-28 ms slack. Evaluating the 647 KB page script
takes 1-2 ms idle, up to 17 ms under CPU contention. When the keystroke loses,
`markBootstrapDirty` short-circuits on `bootstrap_settled`, `bootstrap_dirty` stays false, and
reconciliation runs the non-dirty named-URL path, for which the stale URL is the *correct* result.
The test was asserting the dirty contract against the non-dirty path.

Yielding only to microtasks before the interaction makes the ordering structural: the bootstrap is
synchronous, the open can resolve only through a `setTimeout`. Three premise assertions, one of
which is that the interaction precedes the fake open's completion, make a future ordering
regression fail loudly instead of being misattributed to `play.html`. The now-unreachable
`duringLoadDelayMs` key is removed.

So the suite can catch a reintroduction of the timing dependency,
`dirty-startup-merge-entry-reowned` opens IndexedDB with zero delay; the other three keep the
30 ms open so the timer path stays covered. `test.py`
also pins all five `dirty-startup-*` names, as it already did for `run-marker-*`: dropping any of
them used to still report "All scenarios passed".

No new test file, and no assertion weakened. All 84 checks pass, and the fix repairs all four
`duringLoad` scenarios.

<details>
<summary>Validation</summary>

Simulating a slow host (burn N ms of synchronous time after `indexedDB.open()` registers its
timer, still inside evaluation). The injection is **external**: each arm runs its own tree's
scenarios exactly as committed, no knob overridden.

| stall | before | after |
|---|---|---|
| 26 ms | 84 PASS | - |
| 30 ms | **3 FAIL** | 84 PASS |
| 40 ms | **3 FAIL** | 84 PASS |
| 400 ms | - | 84 PASS |

The boundary matches the independently measured 26-28 ms slack; after the change the ordering
holds at 16x that margin. On the runtime the test actually uses (`clickhouse/mysql-js-client`,
node v22.22.0, page over HTTP), stall 40 ms was 3/3 red with the reported signature verbatim and
is 3/3 green after.

The suite now detects its own regression: reverting just the microtask yield to the old `sleep(5)`
fails with `HARNESS ERROR: duringLoad ran after the IndexedDB open completed`, on both runtimes,
and at every post-registration stall from 0 to 400 ms (a stall makes both fake timers overdue, the
one case the workspace-state premises alone let through). Deleting any one `dirty-startup-*`
scenario now fails `test.py`, where each deletion previously reported "All scenarios passed".

Other arms: 20/20 consecutive unperturbed runs green with an invariant 84 PASS; keystroke forced
to 45 ms reproduces before and is green after; under 8 busy CPU loops 3/3 red before, 3/3 green
after. Counting evaluations shows the ordering assertion runs in all four scenarios and fires in
none of them unperturbed, so it is neither dead nor trigger-happy.

All four `duringLoad` carriers hold their premise after the change, and the adjacent timing knobs
(`stale-reload-run-race`'s `openDelayMs`, the `wasmInstantiateDelayMs`/`disableWasm` scenarios) are
deliberately untouched and stay green. Also checked against the in-flight `play.html` rewrite in
PR 114187: both globals the new assertions read survive there and all 17 dirty-startup checks pass
against its `play.html`.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1310` (included in `26.8` and later)
<!-- ch-version-info:end -->