### PR TITLE
Improve pruned statistics planning benchmark and comments

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -363,9 +363,9 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, const ActionsDAG::No
     {
         String table_display_name = reading->getStorageID().getTableName();
 
-        /// Run partition/PK analysis up front: statistics must be composed over the parts
-        /// surviving pruning, not over all active parts (issue #110281), and the index-based
-        /// fallback below needs the same analysis result anyway.
+        /// Analyze partition and primary-key ranges before estimating the relation so column
+        /// statistics come only from parts that can satisfy the query. Reuse the result for
+        /// the index-based fallback below.
         ReadFromMergeTree::AnalysisResultPtr analyzed_result = reading->getAnalyzedResult();
         if (!analyzed_result)
         {
@@ -374,25 +374,23 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, const ActionsDAG::No
                 = (settings[Setting::read_overflow_mode] == OverflowMode::THROW && settings[Setting::max_rows_to_read])
                 || (settings[Setting::read_overflow_mode_leaf] == OverflowMode::THROW && settings[Setting::max_rows_to_read_leaf]);
 
-            /// Join-order estimation needs these ranges before `optimizeReadInOrder` runs. Both variants
-            /// perform the same partition/PK/index analysis; the normal one memoizes its result for later
-            /// consumers. Since `optimizeReadInOrder` may exempt the final read from row limits, under
-            /// throwing limits analyze locally without checking them, then let the final read analyze and
-            /// memoize the ranges after its input order is known.
+            /// Range analysis normally enforces throwing read limits and memoizes its result.
+            /// At this stage, however, later planning may make the executed read exempt from those
+            /// limits. In that case use an estimation-only analysis; execution will analyze again
+            /// after its final read mode is known.
             analyzed_result = has_throwing_row_limit
                 ? reading->selectRangesToReadForEstimation()
                 : reading->selectRangesToRead();
         }
 
-        /// `has_exact_ranges` is a deterministic index-analysis result, not a confidence estimate.
-        /// If it selects zero rows, the read is provably empty. Early empty returns have no
-        /// `index_stats`, so preserve zero here instead of degrading to unknown in the fallback.
+        /// An exact empty range selection proves that the relation is empty. Other empty
+        /// analysis results can be placeholders for deferred work, so only propagate zero
+        /// when `has_exact_ranges` is set.
         if (analyzed_result && analyzed_result->has_exact_ranges && analyzed_result->selected_rows == 0)
             return RelationStats{.estimated_rows = 0, .table_name = table_display_name};
 
-        /// `STREAM` reads intentionally defer index analysis to `MergeTreeCommitOrderSequentialSource`,
-        /// so the empty `AnalysisResult` is not an exact empty relation. Do not expose its sentinel
-        /// zero as a join cardinality estimate.
+        /// `STREAM` defers range analysis until execution. Its placeholder result has zero
+        /// selected rows but does not mean that the relation is empty.
         if (reading->getQueryInfo().isStream() && analyzed_result && analyzed_result->selected_rows == 0)
         {
             return RelationStats{

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -337,7 +337,8 @@ public:
 
 
     AnalysisResultPtr selectRangesToRead(bool find_exact_ranges = false) const;
-    /// Analyze ranges for cardinality estimation without enforcing row limits or memoizing the result.
+    /// Analyze ranges only for an intermediate cardinality estimate, without enforcing row limits
+    /// or memoizing the result. The executed read analyzes again after its final mode is known.
     AnalysisResultPtr selectRangesToReadForEstimation() const;
 
     /// Analyze the ranges to read for a throwaway pre-plan estimate, without consulting or populating

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -922,11 +922,11 @@ ConditionSelectivityEstimatorPtr MergeTreeData::getConditionSelectivityEstimator
         cached = cached_estimator;
     }
 
-    /// The cached estimator is built by refreshStatistics() over all active parts.
-    /// Return it only if the query reads exactly that part set; a query pruned by
-    /// partition/PK analysis must compose statistics over the surviving parts
-    /// (issue #110281). The estimator is immutable once published, so the comparison
-    /// can run outside the mutex.
+    /// The cache contains statistics for the active-part snapshot seen by the last refresh.
+    /// Reuse it only when the query reads the same ordered parts. Otherwise load and merge
+    /// statistics for the parts left after partition and primary-key pruning. A changed active-part
+    /// sequence invalidates the full-set cache until a refresh publishes the new active snapshot.
+    /// The copied shared pointer keeps the cached snapshot alive after the mutex is released.
     if (cached && !cached->isStale(parts))
         return cached;
 

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -63,8 +63,10 @@ public:
     RelationProfile estimateRelationProfile(const StorageMetadataPtr & metadata, const std::vector<RPNBuilderTreeNode> & nodes) const;
     RelationProfile estimateRelationProfile() const;
 
+    /// Return true if the estimator was built from a different ordered sequence of data parts.
     bool isStale(const std::vector<DataPartPtr> & data_parts) const;
-    /// Same check against a query's analyzed part set, without materializing a parts vector.
+    /// Perform the same check against an analyzed query part set. Mark ranges are intentionally
+    /// ignored because the estimator contains whole-part statistics.
     bool isStale(const RangesInDataParts & parts) const;
 
     struct RPNElement

--- a/tests/performance/join_planning_pruned_statistics.xml
+++ b/tests/performance/join_planning_pruned_statistics.xml
@@ -1,10 +1,10 @@
 <test>
-    <!-- Planning cost of join-order estimation with column statistics composed over
-         pruned parts (issue #110281): EXPLAIN measures planning only.
+    <!-- Join-order planning cost when partition pruning changes the set of parts used
+         for column statistics (issue #110281): EXPLAIN measures planning only.
          fact_1000p_cached has refresh_statistics_interval = 1, so the background task
          warms the table-wide estimator cache during fill (the trailing sleep(2) gives
          it at least one full cycle); the other tables use interval = 0 (cache always
-         cold) to benchmark the per-part fold path. -->
+         cold) to benchmark loading and merging statistics from individual parts. -->
 
     <settings>
         <use_statistics>1</use_statistics>
@@ -13,11 +13,6 @@
         <materialize_statistics_on_insert>1</materialize_statistics_on_insert>
     </settings>
 
-    <create_query>
-        CREATE TABLE fact_100p (p UInt16, id UInt64)
-        ENGINE = MergeTree PARTITION BY p ORDER BY id
-        SETTINGS refresh_statistics_interval = 0
-    </create_query>
     <create_query>
         CREATE TABLE fact_1000p (p UInt16, id UInt64)
         ENGINE = MergeTree PARTITION BY p ORDER BY id
@@ -39,11 +34,9 @@
         SETTINGS refresh_statistics_interval = 0
     </create_query>
 
-    <fill_query>SYSTEM STOP MERGES fact_100p</fill_query>
     <fill_query>SYSTEM STOP MERGES fact_1000p</fill_query>
     <fill_query>SYSTEM STOP MERGES fact_1000p_cached</fill_query>
     <fill_query>SYSTEM STOP MERGES rmt_final_j</fill_query>
-    <fill_query>INSERT INTO fact_100p SELECT number % 100, number FROM numbers(1000000)</fill_query>
     <fill_query>INSERT INTO fact_1000p SELECT number % 1000, number FROM numbers(1000000)</fill_query>
     <fill_query>INSERT INTO fact_1000p_cached SELECT number % 1000, number FROM numbers(1000000)</fill_query>
     <fill_query>INSERT INTO dim_j SELECT number FROM numbers(100000)</fill_query>
@@ -53,13 +46,12 @@
     <!-- let the background refresh warm the estimator cache of fact_1000p_cached -->
     <fill_query>SELECT sleep(2) FORMAT Null</fill_query>
 
-    <!-- pruned predicate, cold cache: per-part statistics fold at 100 and 1000 parts -->
-    <query>EXPLAIN SELECT count() FROM fact_100p AS f INNER JOIN dim_j AS d ON f.id = d.id WHERE f.p = 5 SETTINGS use_statistics_cache = 0 FORMAT Null</query>
-    <query>EXPLAIN SELECT count() FROM fact_1000p AS f INNER JOIN dim_j AS d ON f.id = d.id WHERE f.p = 5 SETTINGS use_statistics_cache = 0 FORMAT Null</query>
+    <!-- cold cache after pruning: load and merge statistics from 950 of 1000 parts -->
+    <query>EXPLAIN SELECT count() FROM fact_1000p AS f INNER JOIN dim_j AS d ON f.id = d.id WHERE f.p &lt; 950 SETTINGS use_statistics_cache = 0 FORMAT Null</query>
     <!-- warm cache, unpruned: full-set hit exercises the O(parts) part-set comparison over 1000 parts -->
     <query>EXPLAIN SELECT count() FROM fact_1000p_cached AS f INNER JOIN dim_j AS d ON f.id = d.id SETTINGS use_statistics_cache = 1 FORMAT Null</query>
-    <!-- warm cache, pruned: size-mismatch bypass plus a one-part fold -->
-    <query>EXPLAIN SELECT count() FROM fact_1000p_cached AS f INNER JOIN dim_j AS d ON f.id = d.id WHERE f.p = 5 SETTINGS use_statistics_cache = 1 FORMAT Null</query>
+    <!-- warm cache bypass after pruning: load and merge statistics from 950 parts -->
+    <query>EXPLAIN SELECT count() FROM fact_1000p_cached AS f INNER JOIN dim_j AS d ON f.id = d.id WHERE f.p &lt; 950 SETTINGS use_statistics_cache = 1 FORMAT Null</query>
     <!-- unpruned, cold cache: full part-set estimation baseline -->
     <query>EXPLAIN SELECT count() FROM fact_1000p AS f INNER JOIN dim_j AS d ON f.id = d.id SETTINGS use_statistics_cache = 0 FORMAT Null</query>
     <!-- planning-only lazy FINAL join over a 200-part ReplacingMergeTree: guards the
@@ -68,7 +60,6 @@
     <!-- end-to-end execution of the same shape (kept separate; not a planning guard) -->
     <query>SELECT count() FROM rmt_final_j AS f FINAL INNER JOIN dim_j AS d ON f.id = d.id WHERE f.status = 'target' SETTINGS query_plan_optimize_lazy_final = 1, max_rows_for_lazy_final = 10000000, use_statistics_cache = 0</query>
 
-    <drop_query>DROP TABLE IF EXISTS fact_100p</drop_query>
     <drop_query>DROP TABLE IF EXISTS fact_1000p</drop_query>
     <drop_query>DROP TABLE IF EXISTS fact_1000p_cached</drop_query>
     <drop_query>DROP TABLE IF EXISTS dim_j</drop_query>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110283

### Summary

Follow up on review feedback from #110283:

- clarify the range-analysis, exact-empty, STREAM, and statistics-cache contracts;
- document what `ConditionSelectivityEstimator::isStale()` compares;
- remove cross-component implementation references from optimizer comments;
- make the performance workload exercise statistics from 950 of 1000 parts instead of producing noisy 2–3 ms measurements.

This PR does not change production behavior.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry:

Not for changelog.

### Testing

- `git diff --check`
- XML validation with `xmllint`
- local hostile diff review

The release performance comparison is left to CI.

🕵️‍♂️


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1587` (included in `26.8` and later)
<!-- ch-version-info:end -->