### PR TITLE
Check the table name length in `DatabaseOverlay`

### DIFF
--- a/src/Databases/DatabaseOverlay.cpp
+++ b/src/Databases/DatabaseOverlay.cpp
@@ -554,5 +554,17 @@ void DatabaseOverlay::checkMetadataFilenameAvailability(const String & table_nam
     }
 }
 
+void DatabaseOverlay::checkTableNameLength(const String & table_name) const
+{
+    /// The limit belongs to the member createTable writes to, which owns the metadata file.
+    for (const auto & db : databases)
+    {
+        if (db->isReadOnly())
+            continue;
+        db->checkTableNameLength(table_name);
+        return;
+    }
+}
+
 
 }

--- a/src/Databases/DatabaseOverlay.h
+++ b/src/Databases/DatabaseOverlay.h
@@ -99,6 +99,7 @@ public:
     void waitDatabaseStarted() const override;
     void stopLoading() override;
     void checkMetadataFilenameAvailability(const String & table_name) const override;
+    void checkTableNameLength(const String & table_name) const override;
 
 protected:
     ASTPtr getCreateDatabaseQueryImpl() const override TSA_REQUIRES(mutex);

--- a/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.reference
+++ b/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.reference
@@ -1,0 +1,13 @@
+--- long default_database: CREATE TABLE is rejected up front ---
+ARGUMENT_OUT_OF_BOUND
+--- long default_database: CREATE VIEW is rejected the same way ---
+ARGUMENT_OUT_OF_BOUND
+--- long default_database: RENAME TABLE to a rejected name is refused ---
+ARGUMENT_OUT_OF_BOUND
+--- short default_database: a name at exactly the limit still works ---
+boundary ok
+--- short default_database: the escaped length is what counts ---
+escaped ok
+ARGUMENT_OUT_OF_BOUND
+--- short default_database: an existing table still loads in a later run ---
+42

--- a/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.reference
+++ b/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.reference
@@ -2,8 +2,12 @@
 ARGUMENT_OUT_OF_BOUND
 --- long default_database: CREATE VIEW is rejected the same way ---
 ARGUMENT_OUT_OF_BOUND
---- long default_database: RENAME TABLE to a rejected name is refused ---
+--- rescue default_database: the source table is creatable ---
+source created
+--- rescue default_database: RENAME to a name over the limit is refused ---
 ARGUMENT_OUT_OF_BOUND
+--- rescue default_database: RENAME within the limit is still accepted ---
+rename accepted
 --- short default_database: a name at exactly the limit still works ---
 boundary ok
 --- short default_database: the escaped length is what counts ---
@@ -11,3 +15,6 @@ escaped ok
 ARGUMENT_OUT_OF_BOUND
 --- short default_database: an existing table still loads in a later run ---
 42
+--- long default_database: an over-limit name already on disk still loads ---
+attach accepted
+1	7

--- a/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.sh
+++ b/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `DatabaseOverlay` did not override `checkTableNameLength`, so in `clickhouse-local` a long
+# `--default_database` left the limit unchecked while the overlay forwarded the create to a real
+# on-disk database. The table was accepted and then could not be dropped, because the
+# `metadata_dropped` filename derived from the database name exceeds NAME_MAX.
+
+WORKING_FOLDER="${CLICKHOUSE_TMP}/04884_clickhouse_local_overlay_table_name_length"
+rm -rf "${WORKING_FOLDER}"
+mkdir -p "${WORKING_FOLDER}"
+
+# 214 characters saturates the per-table budget to 0, so every table name is rejected.
+LONG_DB=$(printf 'd%.0s' $(seq 1 214))
+
+echo "--- long default_database: CREATE TABLE is rejected up front ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/long_table" \
+    -q "CREATE TABLE tc (a UInt8) ENGINE = MergeTree ORDER BY a" \
+    -- --default_database="${LONG_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
+
+echo "--- long default_database: CREATE VIEW is rejected the same way ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/long_view" \
+    -q "CREATE VIEW v AS SELECT 1" \
+    -- --default_database="${LONG_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
+
+echo "--- long default_database: RENAME TABLE to a rejected name is refused ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/long_rename" \
+    -q "CREATE TABLE t0 (a UInt8) ENGINE = MergeTree ORDER BY a; RENAME TABLE t0 TO t1" \
+    -- --default_database="${LONG_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
+
+# The limit is read back through the overlay, so this arm follows the disk's real NAME_MAX.
+SHORT_DB="db04884"
+ALLOWED_LENGTH=$(${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/probe" \
+    -q "SELECT getMaxTableNameLengthForDatabase(currentDatabase())" \
+    -- --default_database="${SHORT_DB}" | tr -d '[:space:]')
+
+USE_S3_PLAIN_REWRITEABLE_AS_DB_DISK=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.disks WHERE name='disk_db_remote' AND type = 'ObjectStorage' AND object_storage_type='S3' AND metadata_type='PlainRewritable'" | tr -d '[:space:]')
+# When using s3_plain_rewriteable as a db_disk, minio doesn't allow the path segment to have more than 255 characters
+# Refer: https://github.com/minio/minio/blob/ddd9a84cd769e6bed67f5fe860f8f3c7527a6971/cmd/xl-storage.go#L154-L167
+if [ "${USE_S3_PLAIN_REWRITEABLE_AS_DB_DISK}" == "0" ]; then
+    echo "--- short default_database: a name at exactly the limit still works ---"
+    ALLOWED_NAME=$(printf 't%.0s' $(seq 1 "${ALLOWED_LENGTH}"))
+    ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/boundary" \
+        -q "CREATE TABLE ${ALLOWED_NAME} (a UInt8) ENGINE = MergeTree ORDER BY a; DROP TABLE ${ALLOWED_NAME}; SELECT 'boundary ok'" \
+        -- --default_database="${SHORT_DB}"
+
+    # escapeForFileName emits 3 bytes per non-word byte, so the check must measure the escaped name.
+    echo "--- short default_database: the escaped length is what counts ---"
+    ESCAPED_FIT=$(printf -- '-%.0s' $(seq 1 $((ALLOWED_LENGTH / 3))))
+    ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/escaped" \
+        -q "CREATE TABLE \`${ESCAPED_FIT}\` (a UInt8) ENGINE = MergeTree ORDER BY a; DROP TABLE \`${ESCAPED_FIT}\`; SELECT 'escaped ok'" \
+        -- --default_database="${SHORT_DB}"
+    ESCAPED_OVER=$(printf -- '-%.0s' $(seq 1 $((ALLOWED_LENGTH / 3 + 1))))
+    ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/escaped_over" \
+        -q "CREATE TABLE \`${ESCAPED_OVER}\` (a UInt8) ENGINE = MergeTree ORDER BY a" \
+        -- --default_database="${SHORT_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
+fi
+
+echo "--- short default_database: an existing table still loads in a later run ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/persist" \
+    -q "CREATE TABLE t (x UInt64) ENGINE = MergeTree ORDER BY x; INSERT INTO t VALUES (42)" \
+    -- --default_database="${SHORT_DB}"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/persist" \
+    -q "SELECT x FROM t" \
+    -- --default_database="${SHORT_DB}"
+
+rm -rf "${WORKING_FOLDER}"

--- a/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.sh
+++ b/tests/queries/0_stateless/04884_clickhouse_local_overlay_table_name_length.sh
@@ -13,8 +13,13 @@ WORKING_FOLDER="${CLICKHOUSE_TMP}/04884_clickhouse_local_overlay_table_name_leng
 rm -rf "${WORKING_FOLDER}"
 mkdir -p "${WORKING_FOLDER}"
 
+pad() { printf '%*s' "$1" '' | tr ' ' "${2:-d}"; }
+
 # 214 characters saturates the per-table budget to 0, so every table name is rejected.
-LONG_DB=$(printf 'd%.0s' $(seq 1 214))
+LONG_DB=$(pad 214)
+# 211 leaves a budget of exactly 2: long enough to hold t0, short enough that a 3-character
+# destination is refused while this database is the receiver.
+RESCUE_DB=$(pad 211)
 
 echo "--- long default_database: CREATE TABLE is rejected up front ---"
 ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/long_table" \
@@ -26,10 +31,24 @@ ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/long_view" \
     -q "CREATE VIEW v AS SELECT 1" \
     -- --default_database="${LONG_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
 
-echo "--- long default_database: RENAME TABLE to a rejected name is refused ---"
-${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/long_rename" \
-    -q "CREATE TABLE t0 (a UInt8) ENGINE = MergeTree ORDER BY a; RENAME TABLE t0 TO t1" \
-    -- --default_database="${LONG_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
+# RENAME reaches the check through its own call site, so the receiving database needs a nonzero
+# budget: the source name must be creatable for the rename to be the statement under test. Each
+# statement runs in its own process, because a `-q` list stops at the first error.
+echo "--- rescue default_database: the source table is creatable ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/rename_over" \
+    -q "CREATE TABLE t0 (a UInt8) ENGINE = MergeTree ORDER BY a; SELECT 'source created'" \
+    -- --default_database="${RESCUE_DB}"
+echo "--- rescue default_database: RENAME to a name over the limit is refused ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/rename_over" \
+    -q "RENAME TABLE t0 TO t01" \
+    -- --default_database="${RESCUE_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
+echo "--- rescue default_database: RENAME within the limit is still accepted ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/rename_in" \
+    -q "CREATE TABLE t0 (a UInt8) ENGINE = MergeTree ORDER BY a" \
+    -- --default_database="${RESCUE_DB}"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/rename_in" \
+    -q "RENAME TABLE t0 TO t9; SELECT 'rename accepted'" \
+    -- --default_database="${RESCUE_DB}"
 
 # The limit is read back through the overlay, so this arm follows the disk's real NAME_MAX.
 SHORT_DB="db04884"
@@ -37,27 +56,22 @@ ALLOWED_LENGTH=$(${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/probe" \
     -q "SELECT getMaxTableNameLengthForDatabase(currentDatabase())" \
     -- --default_database="${SHORT_DB}" | tr -d '[:space:]')
 
-USE_S3_PLAIN_REWRITEABLE_AS_DB_DISK=$(${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.disks WHERE name='disk_db_remote' AND type = 'ObjectStorage' AND object_storage_type='S3' AND metadata_type='PlainRewritable'" | tr -d '[:space:]')
-# When using s3_plain_rewriteable as a db_disk, minio doesn't allow the path segment to have more than 255 characters
-# Refer: https://github.com/minio/minio/blob/ddd9a84cd769e6bed67f5fe860f8f3c7527a6971/cmd/xl-storage.go#L154-L167
-if [ "${USE_S3_PLAIN_REWRITEABLE_AS_DB_DISK}" == "0" ]; then
-    echo "--- short default_database: a name at exactly the limit still works ---"
-    ALLOWED_NAME=$(printf 't%.0s' $(seq 1 "${ALLOWED_LENGTH}"))
-    ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/boundary" \
-        -q "CREATE TABLE ${ALLOWED_NAME} (a UInt8) ENGINE = MergeTree ORDER BY a; DROP TABLE ${ALLOWED_NAME}; SELECT 'boundary ok'" \
-        -- --default_database="${SHORT_DB}"
+echo "--- short default_database: a name at exactly the limit still works ---"
+ALLOWED_NAME=$(pad "${ALLOWED_LENGTH}" t)
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/boundary" \
+    -q "CREATE TABLE ${ALLOWED_NAME} (a UInt8) ENGINE = MergeTree ORDER BY a; DROP TABLE ${ALLOWED_NAME}; SELECT 'boundary ok'" \
+    -- --default_database="${SHORT_DB}"
 
-    # escapeForFileName emits 3 bytes per non-word byte, so the check must measure the escaped name.
-    echo "--- short default_database: the escaped length is what counts ---"
-    ESCAPED_FIT=$(printf -- '-%.0s' $(seq 1 $((ALLOWED_LENGTH / 3))))
-    ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/escaped" \
-        -q "CREATE TABLE \`${ESCAPED_FIT}\` (a UInt8) ENGINE = MergeTree ORDER BY a; DROP TABLE \`${ESCAPED_FIT}\`; SELECT 'escaped ok'" \
-        -- --default_database="${SHORT_DB}"
-    ESCAPED_OVER=$(printf -- '-%.0s' $(seq 1 $((ALLOWED_LENGTH / 3 + 1))))
-    ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/escaped_over" \
-        -q "CREATE TABLE \`${ESCAPED_OVER}\` (a UInt8) ENGINE = MergeTree ORDER BY a" \
-        -- --default_database="${SHORT_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
-fi
+# escapeForFileName emits 3 bytes per non-word byte, so the check must measure the escaped name.
+echo "--- short default_database: the escaped length is what counts ---"
+ESCAPED_FIT=$(pad $((ALLOWED_LENGTH / 3)) -)
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/escaped" \
+    -q "CREATE TABLE \`${ESCAPED_FIT}\` (a UInt8) ENGINE = MergeTree ORDER BY a; DROP TABLE \`${ESCAPED_FIT}\`; SELECT 'escaped ok'" \
+    -- --default_database="${SHORT_DB}"
+ESCAPED_OVER=$(pad $((ALLOWED_LENGTH / 3 + 1)) -)
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/escaped_over" \
+    -q "CREATE TABLE \`${ESCAPED_OVER}\` (a UInt8) ENGINE = MergeTree ORDER BY a" \
+    -- --default_database="${SHORT_DB}" 2>&1 | grep -o -m1 'ARGUMENT_OUT_OF_BOUND'
 
 echo "--- short default_database: an existing table still loads in a later run ---"
 ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/persist" \
@@ -66,5 +80,15 @@ ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/persist" \
 ${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/persist" \
     -q "SELECT x FROM t" \
     -- --default_database="${SHORT_DB}"
+
+# ATTACH carries the name past the check by design, and the budget here is 0, so this name is over
+# the limit. Reading it back in a later process asserts the load path does not reject it.
+echo "--- long default_database: an over-limit name already on disk still loads ---"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/attached" \
+    -q "ATTACH TABLE ta UUID '11111111-2222-3333-4444-555555555555' (a UInt8) ENGINE = MergeTree ORDER BY a; INSERT INTO ta VALUES (7); SELECT 'attach accepted'" \
+    -- --default_database="${LONG_DB}"
+${CLICKHOUSE_LOCAL} --path "${WORKING_FOLDER}/attached" \
+    -q "SELECT count(), sum(a) FROM ta" \
+    -- --default_database="${LONG_DB}"
 
 rm -rf "${WORKING_FOLDER}"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113019
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `clickhouse-local` accepting a `CREATE TABLE` whose name is too long for the configured `--default_database`, which produced a table that could not be dropped. `DatabaseOverlay` now checks the table name length like the on-disk database it writes to.

### Description

In `clickhouse-local` with a long `--default_database`, `CREATE TABLE` was accepted and the resulting table could then never be dropped:

```
$ clickhouse local --path=$D -q "CREATE TABLE tc (a UInt8) ENGINE=MergeTree ORDER BY a; DROP TABLE tc" \
    -- --default_database=<214 'd's>
Code: 1001. std::filesystem::filesystem_error: filesystem error: in rename: File name too long
  [".../store/<uuid>/tc.sql"] [".../metadata_dropped/<214 d's>.tc.<uuid>.sql"]
```

The end state survives restarts and has no SQL escape hatch: `DROP`, `DROP ... SYNC` and `DETACH` all fail the same way and the table stays in `system.tables`. The threshold is 212 characters of `--default_database`.

`IDatabase::checkTableNameLength` is a no-op default and only `DatabaseOnDisk` overrides it. `DatabaseOverlay` did not, so nothing was checked, while the overlay forwarded the create to a real `DatabaseAtomic` member carrying the same long name. `DROP` then builds `metadata_dropped/{db}.{table}.{uuid}.sql`, whose prefix alone exceeds `NAME_MAX`, so the per-table budget saturates to 0.

The fix overrides `checkTableNameLength` in `DatabaseOverlay`, delegating to the first non-read-only member, which is the same member `createTable` writes to. It copies the loop of the adjacent `checkMetadataFilenameAvailability`. No new setting, constant or arithmetic.

A real `DatabaseAtomic` with the same name already rejects this up front with `ARGUMENT_OUT_OF_BOUND`, so this makes the overlay consistent with the database that owns the file.

The change only affects rejection at DDL time; a table already on disk still attaches and reads, because both `CREATE` call sites are gated by `mode <= LoadingStrictnessLevel::CREATE`. It does not rescue tables already stranded on disk, which would mean changing the `metadata_dropped` naming convention.

Related: #113019, where this was found and measured.

<details>
<summary>Validation: zero regression window, and the object kinds covered</summary>

The delegated limit rejects exactly the names that already fail. Longest table name that survives CREATE+DROP today, versus the limit, measured at four database sizes:

| escaped db length | limit | longest working today | first failing today |
| --- | --- | --- | --- |
| 100 | 113 | 113 | 114 |
| 150 | 63 | 63 | 64 |
| 190 | 23 | 23 | 24 |
| 200 | 13 | 13 | 14 |

At every size, a name at the limit still works after the change and a name one over is now refused at CREATE instead of being accepted and stranded. `escapeForFileName` emits 3 bytes per non-word byte and the check measures the escaped name: 37 `-` characters (111 escaped bytes) work, 38 (114) do not, against the limit of 113.

All six object kinds routed through `InterpreterCreateQuery` reproduced the accepted-then-undroppable behaviour and are covered by the single override: `MergeTree`, `Log` and `Memory` tables, `VIEW`, `MATERIALIZED VIEW` and `DICTIONARY`.

`CREATE TEMPORARY TABLE` is not affected, since temporary tables never reach `metadata_dropped`.

In the only construction site today the overlay and its writable member share a name, so the delegated limit is the intended one. If a future overlay had a differently named writable member, delegating still gives the correct answer, because the limit follows the database that owns the file. `DatabaseOverlay` is currently built only by `clickhouse-local`; #86768 would add server-side consumers.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1484` (included in `26.8` and later)
<!-- ch-version-info:end -->