### PR TITLE
Add test: Truncated `Array` elements stream: `CANNOT_READ_ALL_DATA` branch has no test

### DIFF
--- a/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.reference
+++ b/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.reference
@@ -1,1 +1,4 @@
 Arrays offsets are not monotonically increasing (starting at 0, value 2): (in file/uri (fd = 0)): While executing Native: data for INSERT was parsed from stdin. (INCORRECT_DATA
+Cannot read all array values: read just 1 of 2: (in file/uri (fd = 0)): While executing Native: data for INSERT was parsed from stdin. (CANNOT_READ_ALL_DATA
+Cannot read array values: elements column is empty while the last offset is 2: (in file/uri (fd = 0)): While executing Native: data for INSERT was parsed from stdin. (INCORRECT_DATA
+0

--- a/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.sh
+++ b/tests/queries/0_stateless/03533_column_array_insert_broken_offsets.sh
@@ -14,3 +14,20 @@ $CLICKHOUSE_CLIENT 'create table array_deserialize_offsets (val Array(String)) e
   $CLICKHOUSE_LOCAL "select * from values('val UInt64', (2),(1)) format Native" | tail -c+14
   # We do not even need array values, offsets should be checked before reading them
 } | $CLICKHOUSE_CLIENT 'insert into array_deserialize_offsets format Native' |& grep -o 'Arrays offsets are not monotonically increasing (starting at 0, value 2).*INCORRECT_DATA'
+
+{
+  # Native header
+  $CLICKHOUSE_LOCAL "select * from values('val Array(String)', (['foo','fooo']),(['bar','barr'])) format Native" | head -c20
+  # Monotonic offsets (1, 2) followed by a single value, so one value is missing
+  $CLICKHOUSE_LOCAL "select * from values('val UInt64', (1),(2)) format Native" | tail -c+14
+  printf '\x03foo'
+} | $CLICKHOUSE_CLIENT 'insert into array_deserialize_offsets format Native' |& grep -o 'Cannot read all array values: read just 1 of 2.*CANNOT_READ_ALL_DATA'
+
+{
+  # Native header
+  $CLICKHOUSE_LOCAL "select * from values('val Array(String)', (['foo','fooo']),(['bar','barr'])) format Native" | head -c20
+  # Monotonic offsets (1, 2) with no values at all
+  $CLICKHOUSE_LOCAL "select * from values('val UInt64', (1),(2)) format Native" | tail -c+14
+} | $CLICKHOUSE_CLIENT 'insert into array_deserialize_offsets format Native' |& grep -o 'Cannot read array values: elements column is empty while the last offset is 2.*INCORRECT_DATA'
+
+$CLICKHOUSE_CLIENT 'select count() from array_deserialize_offsets'


### PR DESCRIPTION
_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #109212](https://github.com/ClickHouse/ClickHouse/pull/109212).
That PR: (1) Moves the `Array` offsets monotonicity check in `SerializationArray::deserializeOffsetsBinaryBulk` from `settings.native_format` to `!settings.position_independent_encoding`, and rescopes the scan to values appended by the current call (starting one element early); adds a second consistency …

**1. Truncated `Array` elements stream: `CANNOT_READ_ALL_DATA` branch has no test**
  `src/DataTypes/Serializations/SerializationArray.cpp:537`, `src/DataTypes/Serializations/SerializationArray.cpp:545`
  **Risk:** `SerializationArray::deserializeBinaryBulkWithMultipleStreams` restructured the offsets/elements consistency check into a nested `if`: the `!nested_column->empty()` arm (`SerializationArray.cpp:536-538`) throws `CANNOT_READ_ALL_DATA`, the new `!settings.position_independent_encoding` arm throws …
  **Unique vs PR tests:** The PR's gtest covers decreasing offsets and the empty-elements case by calling the serialization directly; nothing covers a short-but-non-empty elements column, and nothing exercises either new/restructured branch through `NativeReader` from SQL.

cc @groeneai (author of #109212), @alexey-milovidov (merged/approved #109212) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1315` (included in `26.8` and later)
<!-- ch-version-info:end -->