### PR TITLE
Fix presentation URL in `clickhouse-git-import` help

### DIFF
--- a/programs/git-import/git-import.cpp
+++ b/programs/git-import/git-import.cpp
@@ -173,7 +173,7 @@ clickhouse-client --query "INSERT INTO git.commits FORMAT TSV" < commits.tsv
 clickhouse-client --query "INSERT INTO git.file_changes FORMAT TSV" < file_changes.tsv
 clickhouse-client --query "INSERT INTO git.line_changes FORMAT TSV" < line_changes.tsv
 
-Check out this presentation: https://presentations.clickhouse.com/matemarketing_2020/
+Check out this presentation: https://presentations.clickhouse.com/2020-matemarketing/
 )";
 
 namespace po = boost::program_options;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

The help message of `clickhouse-git-import` referenced the presentation at `https://presentations.clickhouse.com/matemarketing_2020/`. Replace it with `https://presentations.clickhouse.com/2020-matemarketing/`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1328` (included in `26.8` and later)
<!-- ch-version-info:end -->