### PR TITLE
Add test: Duplicate TLS argument rejection and positional-arity stripping untested

### DIFF
--- a/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.reference
+++ b/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.reference
@@ -1,0 +1,2 @@
+PostgreSQL
+PostgreSQL

--- a/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
+++ b/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
@@ -3,21 +3,21 @@
 
 -- A TLS parameter of a PostgreSQL source given twice in the trailing key-value arguments must be
 -- rejected, and the trailing arguments must not count towards the positional ones.
+-- The database name comes from the CLICKHOUSE_DATABASE_1 macro: the flaky check runs this test
+-- many times in parallel, and a fixed name collides across runs.
 
 DROP TABLE IF EXISTS t_04869;
-DROP DATABASE IF EXISTS db_04869;
-DROP TABLE IF EXISTS t_04869;
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
 
 SELECT * FROM postgresql('127.0.0.1:1', 'd', 't', 'u', 'p', sslmode = 'require', sslmode = 'disable') ORDER BY 1; -- { serverError BAD_ARGUMENTS }
-CREATE DATABASE db_04869 ENGINE = PostgreSQL('127.0.0.1:1', 'd', 'u', 'p', sslmode = 'require', sslmode = 'disable'); -- { serverError BAD_ARGUMENTS }
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = PostgreSQL('127.0.0.1:1', 'd', 'u', 'p', sslmode = 'require', sslmode = 'disable'); -- { serverError BAD_ARGUMENTS }
 CREATE TABLE t_04869 (x Int32) ENGINE = PostgreSQL('127.0.0.1:1', 'd', 't', 'u', 'p', sslrootcert_pem = 'a', sslrootcert_pem = 'b'); -- { serverError BAD_ARGUMENTS }
 
-CREATE DATABASE db_04869 ENGINE = PostgreSQL('127.0.0.1:1', 'd', 'u', 'p', 'sch', 1, sslmode = 'require');
-SELECT engine FROM system.databases WHERE name = 'db_04869' ORDER BY 1;
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = PostgreSQL('127.0.0.1:1', 'd', 'u', 'p', 'sch', 1, sslmode = 'require');
+SELECT engine FROM system.databases WHERE name = '{CLICKHOUSE_DATABASE_1:String}' ORDER BY 1;
 
 CREATE TABLE t_04869 (x Int32) ENGINE = PostgreSQL('127.0.0.1:1', 'd', 't', 'u', 'p', 'sch', sslmode = 'require');
 SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = 't_04869' ORDER BY 1;
 
 DROP TABLE t_04869;
-DROP DATABASE db_04869;
-DROP TABLE IF EXISTS t_04869;
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};

--- a/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
+++ b/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, need-query-parameters
 -- no-fasttest: the PostgreSQL integration is not available in the fast test build.
 
 -- A TLS parameter of a PostgreSQL source given twice in the trailing key-value arguments must be

--- a/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
+++ b/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
@@ -1,0 +1,23 @@
+-- Tags: no-fasttest
+-- no-fasttest: the PostgreSQL integration is not available in the fast test build.
+
+-- A TLS parameter of a PostgreSQL source given twice in the trailing key-value arguments must be
+-- rejected, and the trailing arguments must not count towards the positional ones.
+
+DROP TABLE IF EXISTS t_04869;
+DROP DATABASE IF EXISTS db_04869;
+DROP TABLE IF EXISTS t_04869;
+
+SELECT * FROM postgresql('127.0.0.1:1', 'd', 't', 'u', 'p', sslmode = 'require', sslmode = 'disable') ORDER BY 1; -- { serverError BAD_ARGUMENTS }
+CREATE DATABASE db_04869 ENGINE = PostgreSQL('127.0.0.1:1', 'd', 'u', 'p', sslmode = 'require', sslmode = 'disable'); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE t_04869 (x Int32) ENGINE = PostgreSQL('127.0.0.1:1', 'd', 't', 'u', 'p', sslrootcert_pem = 'a', sslrootcert_pem = 'b'); -- { serverError BAD_ARGUMENTS }
+
+CREATE DATABASE db_04869 ENGINE = PostgreSQL('127.0.0.1:1', 'd', 'u', 'p', 'sch', 1, sslmode = 'require');
+SELECT engine FROM system.databases WHERE name = 'db_04869' ORDER BY 1;
+
+CREATE TABLE t_04869 (x Int32) ENGINE = PostgreSQL('127.0.0.1:1', 'd', 't', 'u', 'p', 'sch', sslmode = 'require');
+SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = 't_04869' ORDER BY 1;
+
+DROP TABLE t_04869;
+DROP DATABASE db_04869;
+DROP TABLE IF EXISTS t_04869;

--- a/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
+++ b/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
@@ -14,7 +14,7 @@ CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = PostgreSQL('127.0.0.
 CREATE TABLE t_04869 (x Int32) ENGINE = PostgreSQL('127.0.0.1:1', 'd', 't', 'u', 'p', sslrootcert_pem = 'a', sslrootcert_pem = 'b'); -- { serverError BAD_ARGUMENTS }
 
 CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = PostgreSQL('127.0.0.1:1', 'd', 'u', 'p', 'sch', 1, sslmode = 'require');
-SELECT engine FROM system.databases WHERE name = '{CLICKHOUSE_DATABASE_1:String}' ORDER BY 1;
+SELECT engine FROM system.databases WHERE name = {CLICKHOUSE_DATABASE_1:String} ORDER BY 1;
 
 CREATE TABLE t_04869 (x Int32) ENGINE = PostgreSQL('127.0.0.1:1', 'd', 't', 'u', 'p', 'sch', sslmode = 'require');
 SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = 't_04869' ORDER BY 1;


### PR DESCRIPTION
_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #110615](https://github.com/ClickHouse/ClickHouse/pull/110615).
That PR: (1) Adds TLS/SSL to every PostgreSQL integration: `sslmode` plus certificate/key either as server-local paths (`sslrootcert`/`sslcert`/`sslkey`, config-only) or as literal contents (`*_pem`, accepted from SQL, materialized into `TemporarySecretFile` and masked as secrets). New code: …

**1. Duplicate TLS argument rejection and positional-arity stripping untested**
  `src/Storages/StoragePostgreSQL.cpp:726`, `src/Databases/PostgreSQL/DatabasePostgreSQL.cpp:573`
  **Risk:** `StoragePostgreSQL::extractSSLParamsFromArguments` strips trailing TLS `key = value` pairs and rejects repeats at `StoragePostgreSQL.cpp:726-727`; the stripped list then feeds the arity check at `DatabasePostgreSQL.cpp:573`. Risk if broken: a repeated `sslmode = 'require', sslmode = 'disable'` …
  **Unique vs PR tests:** 04820 formats queries with distinct TLS keys and checks masking plus path rejection; 04846 checks query-tree masking; test_postgresql_ssl exercises real handshakes through named collections. None repeats a TLS key (the `specified more than once` branch) and none combines the maximum positional …
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: the PostgreSQL integration is not built in the fast test build; the PR's own 04820 uses the same tag

cc @alexey-milovidov (author of #110615) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)