### PR TITLE
AST fuzzer: do not create a view that duplicates a non-parallel sink

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -46,6 +46,8 @@
     M(ASTFuzzerQueries, "Number of fuzzed queries attempted by the server-side AST fuzzer.", ValueType::Number) \
     M(ASTFuzzerSkippedBackupRestore, "Number of fuzzed BACKUP/RESTORE queries the server-side AST fuzzer skipped instead of executing.", ValueType::Number) \
     M(ASTFuzzerSkippedReplicatedDDLInternal, "Number of times the server-side AST fuzzer skipped fuzzing because an internal replicated-database DDL execution (a live ZooKeeperMetadataTransaction) was in flight on the context.", ValueType::Number) \
+    M(ASTFuzzerSkippedSharedNonParallelTarget, "Number of fuzzed CREATE MATERIALIZED VIEW queries the server-side AST fuzzer skipped instead of executing, because the new view would have made one INSERT build two sinks for a storage that accepts only one write() per INSERT.", ValueType::Number) \
+    M(ASTFuzzerSkipCheckFailed, "Number of times the server-side AST fuzzer could not decide whether a fuzzed CREATE MATERIALIZED VIEW would duplicate a non-parallel sink, and executed the query anyway.", ValueType::Number) \
     M(QueryTimeMicroseconds, "Total time of all queries.", ValueType::Microseconds) \
     M(SelectQueryTimeMicroseconds, "Total time of SELECT queries.", ValueType::Microseconds) \
     M(InsertQueryTimeMicroseconds, "Total time of INSERT queries.", ValueType::Microseconds) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -47,7 +47,7 @@
     M(ASTFuzzerSkippedBackupRestore, "Number of fuzzed BACKUP/RESTORE queries the server-side AST fuzzer skipped instead of executing.", ValueType::Number) \
     M(ASTFuzzerSkippedReplicatedDDLInternal, "Number of times the server-side AST fuzzer skipped fuzzing because an internal replicated-database DDL execution (a live ZooKeeperMetadataTransaction) was in flight on the context.", ValueType::Number) \
     M(ASTFuzzerSkippedSharedNonParallelTarget, "Number of fuzzed CREATE MATERIALIZED VIEW queries the server-side AST fuzzer skipped instead of executing, because the new view would have made one INSERT build two sinks for a storage that accepts only one write() per INSERT.", ValueType::Number) \
-    M(ASTFuzzerSkipCheckFailed, "Number of times the server-side AST fuzzer could not decide whether a fuzzed CREATE MATERIALIZED VIEW would duplicate a non-parallel sink, and executed the query anyway.", ValueType::Number) \
+    M(ASTFuzzerSharedNonParallelTargetCheckUndecided, "Number of times the server-side AST fuzzer could not decide whether a fuzzed CREATE MATERIALIZED VIEW would duplicate a non-parallel sink, and executed the query anyway.", ValueType::Number) \
     M(QueryTimeMicroseconds, "Total time of all queries.", ValueType::Microseconds) \
     M(SelectQueryTimeMicroseconds, "Total time of SELECT queries.", ValueType::Microseconds) \
     M(InsertQueryTimeMicroseconds, "Total time of INSERT queries.", ValueType::Microseconds) \

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -937,47 +937,75 @@ bool InsertDependenciesBuilder::forwardedInsertHidesDependentView(const StorageP
 }
 
 
-bool InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
+InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
     const StorageID & source, const StorageID & new_view_target, ContextPtr context)
 {
     const auto & catalog = DatabaseCatalog::instance();
 
-    /// A cycle leaves the reachable set unknown, so the whole answer is unknown.
-    bool cyclic = false;
+    /// Set whenever a branch cannot be resolved, so that an otherwise negative answer is reported as
+    /// unknown instead of as safe.
+    bool undecided = false;
 
     StorageIDSet active;
     /// Keyed on the edge, not on the node: whether a view is pushed to depends on which parent it was
     /// reached from, so memoizing a view by name alone would carry the verdict for a stale edge over to
     /// the live one.
     std::unordered_set<String> walked_edges;
+    /// Length-prefixed, because a database or table name may itself contain any separator.
+    auto edge_key = [](const StorageIDMaybeEmpty & node)
+    { return fmt::format("{}:{}:{}:{}:", node.database_name.size(), node.database_name, node.table_name.size(), node.table_name); };
+
+    /// `parent` is empty at the root of a pipeline, where there is no edge to validate. `resolved`
+    /// carries a storage that must be walked as handed over rather than looked up: a proxy renames the
+    /// storage it wraps to the proxy's own id, so a lookup would return the proxy again. `insert_root`
+    /// marks a storage an `INSERT` itself targets, the only position at which
+    /// `noPushingToViewsOnInserts()` suppresses the dependent views.
+    struct Node
+    {
+        StorageIDMaybeEmpty id;
+        StorageIDMaybeEmpty parent;
+        StoragePtr resolved = nullptr;
+        bool insert_root = false;
+        size_t depth = 0;
+    };
 
     /// Collects into `sinks` the storages that accept a single `write()` per `INSERT` and for which a write
-    /// into `id` builds a sink, over the edges `collectAllDependencies` follows. `parent` is the node `id`
-    /// was reached from; it is empty at the root of a pipeline, where there is no edge to validate.
-    std::function<void(const StorageIDMaybeEmpty &, const StorageIDMaybeEmpty &, StorageIDSet &)> collect
-        = [&](const StorageIDMaybeEmpty & id, const StorageIDMaybeEmpty & parent, StorageIDSet & sinks)
+    /// into `node.id` builds a sink, over the edges `collectAllDependencies` follows.
+    std::function<void(const Node &, StorageIDSet &)> collect = [&](const Node & node, StorageIDSet & sinks)
     {
         /// A view chain is bounded only by the catalog.
         checkStackSize();
 
-        if (active.contains(id))
+        if (node.depth > max_insert_forwarding_depth)
         {
-            cyclic = true;
+            undecided = true;
             return;
         }
-        /// Length-prefixed, because a database or table name may itself contain any separator.
-        auto edge_key = [](const StorageIDMaybeEmpty & node)
-        {
-            return fmt::format("{}:{}:{}:{}:", node.database_name.size(), node.database_name, node.table_name.size(), node.table_name);
-        };
-        if (!walked_edges.insert(edge_key(id) + edge_key(parent)).second)
-            return;
-        active.insert(id);
-        SCOPE_EXIT({ active.erase(id); });
 
-        auto storage = catalog.tryGetTable(id, context);
+        StoragePtr storage = node.resolved;
+        bool holds_active_entry = false;
         if (!storage)
-            return;
+        {
+            if (active.contains(node.id))
+            {
+                undecided = true;
+                return;
+            }
+            if (!walked_edges.insert(edge_key(node.id) + edge_key(node.parent)).second)
+                return;
+            storage = catalog.tryGetTable(node.id, context);
+            if (!storage)
+            {
+                undecided = true;
+                return;
+            }
+            active.insert(node.id);
+            holds_active_entry = true;
+        }
+        SCOPE_EXIT({
+            if (holds_active_entry)
+                active.erase(node.id);
+        });
 
         if (auto * materialized_view = dynamic_cast<StorageMaterializedView *>(storage.get()))
         {
@@ -985,11 +1013,11 @@ bool InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
             /// hold; a view reached over such an edge is not pushed to by this `INSERT`.
             auto metadata = storage->getInMemoryMetadataPtr(context, false);
             StorageIDMaybeEmpty select_table_id = metadata->getSelectQuery().select_table_id;
-            if (!parent.empty() && select_table_id != parent)
+            if (!node.parent.empty() && select_table_id != node.parent)
                 return;
 
             /// A view is written *through* to its target, never *to*.
-            collect(materialized_view->getTargetTableId(), id, sinks);
+            collect({materialized_view->getTargetTableId(), node.id}, sinks);
             return;
         }
 
@@ -998,13 +1026,17 @@ bool InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
         if (dynamic_cast<const StorageWindowView *>(storage.get()))
             return;
 
-        /// Dependent views are registered against the table the view's `SELECT` named, so they are looked
-        /// up before any forwarding hop is resolved.
-        for (const auto & view_id : catalog.getDependentViews(id))
-            collect(view_id, id, sinks);
+        /// Dependent views belong to the id, and a proxy hop revisits an id whose views were already
+        /// taken. A storage that consumes from a queue is written by its background consumer, so a
+        /// direct `INSERT` into it builds the root sink alone.
+        if (!node.resolved && (!node.insert_root || !storage->noPushingToViewsOnInserts()))
+        {
+            for (const auto & view_id : catalog.getDependentViews(node.id))
+                collect({view_id, node.id}, sinks);
+        }
 
-        /// A `Buffer` accumulates the rows and a `Distributed` sends them on: the write that reaches the
-        /// destination is a separate `INSERT`, whose sinks are not part of this one.
+        /// A `Buffer` and a `Distributed` forward the rows into an `INSERT` of their own, whose sinks this
+        /// walk does not model: a branch that reaches one of them ends here.
         if (dynamic_cast<const StorageBuffer *>(storage.get()) || dynamic_cast<const StorageDistributed *>(storage.get()))
             return;
 
@@ -1013,13 +1045,18 @@ bool InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
         if (const auto * alias = dynamic_cast<const StorageAlias *>(storage.get()))
         {
             if (auto target = alias->tryGetTargetTable())
-                collect(target->getStorageID(), {}, sinks);
+                collect({target->getStorageID(), {}, nullptr, true, node.depth + 1}, sinks);
+            else
+                undecided = true;
             return;
         }
         if (const auto * proxy = dynamic_cast<const StorageProxy *>(storage.get()))
         {
+            /// Resolving a lazy proxy materializes and starts up the storage it wraps.
             if (auto nested = proxy->getNested())
-                collect(nested->getStorageID(), {}, sinks);
+                collect({node.id, node.parent, nested, node.insert_root, node.depth + 1}, sinks);
+            else
+                undecided = true;
             return;
         }
 
@@ -1028,20 +1065,21 @@ bool InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
     };
 
     StorageIDSet reachable_now;
-    collect(source, {}, reachable_now);
-    if (cyclic || reachable_now.empty())
-        return false;
+    collect({source, {}, nullptr, true}, reachable_now);
+    if (reachable_now.empty())
+        return undecided ? DuplicateNonParallelSinkVerdict::Undecided : DuplicateNonParallelSinkVerdict::NotHazardous;
 
     walked_edges.clear();
     StorageIDSet reachable_from_new_view;
-    collect(new_view_target, {}, reachable_from_new_view);
-    if (cyclic)
-        return false;
+    collect({new_view_target, {}}, reachable_from_new_view);
 
+    /// Every collected sink was reached over live edges, so a sink in both sets is positive proof even
+    /// when some other branch stayed unresolved.
     for (const auto & sink_id : reachable_from_new_view)
         if (reachable_now.contains(sink_id))
-            return true;
-    return false;
+            return DuplicateNonParallelSinkVerdict::Hazardous;
+
+    return undecided ? DuplicateNonParallelSinkVerdict::Undecided : DuplicateNonParallelSinkVerdict::NotHazardous;
 }
 
 

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -2,6 +2,7 @@
 #include <Interpreters/InterpreterInsertQuery.h>
 
 #include <Common/MemoryTracker.h>
+#include <Common/checkStackSize.h>
 #include <Access/Common/AccessType.h>
 #include <Access/Common/AccessFlags.h>
 #include <Processors/ResizeProcessor.h>
@@ -932,6 +933,114 @@ bool InsertDependenciesBuilder::forwardedInsertHidesDependentView(const StorageP
     /// A concrete local target: its dependent views are visible to `collectAllDependencies`, so the
     /// hazard scan over `storages` checks them (and whether their targets actually deduplicate)
     /// directly - nothing is hidden.
+    return false;
+}
+
+
+bool InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
+    const StorageID & source, const StorageID & new_view_target, ContextPtr context)
+{
+    const auto & catalog = DatabaseCatalog::instance();
+
+    /// A cycle leaves the reachable set unknown, so the whole answer is unknown.
+    bool cyclic = false;
+
+    StorageIDSet active;
+    /// Keyed on the edge, not on the node: whether a view is pushed to depends on which parent it was
+    /// reached from, so memoizing a view by name alone would carry the verdict for a stale edge over to
+    /// the live one.
+    std::unordered_set<String> walked_edges;
+
+    /// Collects into `sinks` the storages that accept a single `write()` per `INSERT` and for which a write
+    /// into `id` builds a sink, over the edges `collectAllDependencies` follows. `parent` is the node `id`
+    /// was reached from; it is empty at the root of a pipeline, where there is no edge to validate.
+    std::function<void(const StorageIDMaybeEmpty &, const StorageIDMaybeEmpty &, StorageIDSet &)> collect
+        = [&](const StorageIDMaybeEmpty & id, const StorageIDMaybeEmpty & parent, StorageIDSet & sinks)
+    {
+        /// A view chain is bounded only by the catalog.
+        checkStackSize();
+
+        if (active.contains(id))
+        {
+            cyclic = true;
+            return;
+        }
+        /// Length-prefixed, because a database or table name may itself contain any separator.
+        auto edge_key = [](const StorageIDMaybeEmpty & node)
+        {
+            return fmt::format("{}:{}:{}:{}:", node.database_name.size(), node.database_name, node.table_name.size(), node.table_name);
+        };
+        if (!walked_edges.insert(edge_key(id) + edge_key(parent)).second)
+            return;
+        active.insert(id);
+        SCOPE_EXIT({ active.erase(id); });
+
+        auto storage = catalog.tryGetTable(id, context);
+        if (!storage)
+            return;
+
+        if (auto * materialized_view = dynamic_cast<StorageMaterializedView *>(storage.get()))
+        {
+            /// `ALTER ... MODIFY QUERY` and a reused table name leave dependency edges that no longer
+            /// hold; a view reached over such an edge is not pushed to by this `INSERT`.
+            auto metadata = storage->getInMemoryMetadataPtr(context, false);
+            StorageIDMaybeEmpty select_table_id = metadata->getSelectQuery().select_table_id;
+            if (!parent.empty() && select_table_id != parent)
+                return;
+
+            /// A view is written *through* to its target, never *to*.
+            collect(materialized_view->getTargetTableId(), id, sinks);
+            return;
+        }
+
+        /// A window view is pushed its own inner storage; its external target is written by the separate
+        /// `INSERT` that `StorageWindowView::fire` runs.
+        if (dynamic_cast<const StorageWindowView *>(storage.get()))
+            return;
+
+        /// Dependent views are registered against the table the view's `SELECT` named, so they are looked
+        /// up before any forwarding hop is resolved.
+        for (const auto & view_id : catalog.getDependentViews(id))
+            collect(view_id, id, sinks);
+
+        /// A `Buffer` accumulates the rows and a `Distributed` sends them on: the write that reaches the
+        /// destination is a separate `INSERT`, whose sinks are not part of this one.
+        if (dynamic_cast<const StorageBuffer *>(storage.get()) || dynamic_cast<const StorageDistributed *>(storage.get()))
+            return;
+
+        /// An `Alias` runs a nested `INSERT` into its target per sink and a proxy hands the write to the
+        /// storage it wraps, so the target's sink is built as the root of that nested write.
+        if (const auto * alias = dynamic_cast<const StorageAlias *>(storage.get()))
+        {
+            if (auto target = alias->tryGetTargetTable())
+                collect(target->getStorageID(), {}, sinks);
+            return;
+        }
+        if (const auto * proxy = dynamic_cast<const StorageProxy *>(storage.get()))
+        {
+            if (auto nested = proxy->getNested())
+                collect(nested->getStorageID(), {}, sinks);
+            return;
+        }
+
+        if (!storage->supportsParallelInsert())
+            sinks.insert(storage->getStorageID());
+    };
+
+    StorageIDSet reachable_now;
+    collect(source, {}, reachable_now);
+    if (cyclic || reachable_now.empty())
+        return false;
+
+    walked_edges.clear();
+    StorageIDSet reachable_from_new_view;
+    collect(new_view_target, {}, reachable_from_new_view);
+    if (cyclic)
+        return false;
+
+    for (const auto & sink_id : reachable_from_new_view)
+        if (reachable_now.contains(sink_id))
+            return true;
     return false;
 }
 

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -955,23 +955,25 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
     auto edge_key = [](const StorageIDMaybeEmpty & node)
     { return fmt::format("{}:{}:{}:{}:", node.database_name.size(), node.database_name, node.table_name.size(), node.table_name); };
 
-    /// `parent` is empty at the root of a pipeline, where there is no edge to validate. `resolved`
-    /// carries a storage that must be walked as handed over rather than looked up: a proxy renames the
-    /// storage it wraps to the proxy's own id, so a lookup would return the proxy again. `insert_root`
-    /// marks a storage an `INSERT` itself targets, the only position at which
-    /// `noPushingToViewsOnInserts()` suppresses the dependent views.
+    /// `parent` is empty at the root of a branch, where there is no edge to validate. `resolved` carries
+    /// a storage to walk as handed over rather than looked up: a proxy renames the storage it wraps to
+    /// the proxy's own id, so a lookup would return the proxy again.
     struct Node
     {
         StorageIDMaybeEmpty id;
         StorageIDMaybeEmpty parent;
         StoragePtr resolved = nullptr;
-        bool insert_root = false;
         size_t depth = 0;
     };
 
-    /// Collects into `sinks` the storages that accept a single `write()` per `INSERT` and for which a write
+    /// Counted rather than collected: two live edges reaching one such sink within a single branch
+    /// already build two sinks on it, with no second branch involved.
+    using SinkCounts = std::
+        unordered_map<StorageIDMaybeEmpty, size_t, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual>;
+
+    /// Counts in `sinks` the storages that accept a single `write()` per `INSERT` and for which a write
     /// into `node.id` builds a sink, over the edges `collectAllDependencies` follows.
-    std::function<void(const Node &, StorageIDSet &)> collect = [&](const Node & node, StorageIDSet & sinks)
+    std::function<void(const Node &, SinkCounts &)> collect = [&](const Node & node, SinkCounts & sinks)
     {
         /// A view chain is bounded only by the catalog.
         checkStackSize();
@@ -1027,9 +1029,8 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
             return;
 
         /// Dependent views belong to the id, and a proxy hop revisits an id whose views were already
-        /// taken. A storage that consumes from a queue is written by its background consumer, so a
-        /// direct `INSERT` into it builds the root sink alone.
-        if (!node.resolved && (!node.insert_root || !storage->noPushingToViewsOnInserts()))
+        /// taken.
+        if (!node.resolved)
         {
             for (const auto & view_id : catalog.getDependentViews(node.id))
                 collect({view_id, node.id}, sinks);
@@ -1045,7 +1046,7 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
         if (const auto * alias = dynamic_cast<const StorageAlias *>(storage.get()))
         {
             if (auto target = alias->tryGetTargetTable())
-                collect({target->getStorageID(), {}, nullptr, true, node.depth + 1}, sinks);
+                collect({target->getStorageID(), {}, nullptr, node.depth + 1}, sinks);
             else
                 undecided = true;
             return;
@@ -1054,29 +1055,27 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
         {
             /// Resolving a lazy proxy materializes and starts up the storage it wraps.
             if (auto nested = proxy->getNested())
-                collect({node.id, node.parent, nested, node.insert_root, node.depth + 1}, sinks);
+                collect({node.id, node.parent, nested, node.depth + 1}, sinks);
             else
                 undecided = true;
             return;
         }
 
         if (!storage->supportsParallelInsert())
-            sinks.insert(storage->getStorageID());
+            ++sinks[storage->getStorageID()];
     };
 
-    StorageIDSet reachable_now;
-    collect({source, {}, nullptr, true}, reachable_now);
-    if (reachable_now.empty())
-        return undecided ? DuplicateNonParallelSinkVerdict::Undecided : DuplicateNonParallelSinkVerdict::NotHazardous;
+    SinkCounts reachable_now;
+    collect({source, {}}, reachable_now);
 
     walked_edges.clear();
-    StorageIDSet reachable_from_new_view;
+    SinkCounts reachable_from_new_view;
     collect({new_view_target, {}}, reachable_from_new_view);
 
-    /// Every collected sink was reached over live edges, so a sink in both sets is positive proof even
-    /// when some other branch stayed unresolved.
-    for (const auto & sink_id : reachable_from_new_view)
-        if (reachable_now.contains(sink_id))
+    /// Every count was reached over live edges and `walked_edges` admits each edge once, so two counts
+    /// are two distinct sinks: positive proof even when some other branch stayed unresolved.
+    for (const auto & [sink_id, count] : reachable_from_new_view)
+        if (count >= 2 || reachable_now.contains(sink_id))
             return DuplicateNonParallelSinkVerdict::Hazardous;
 
     return undecided ? DuplicateNonParallelSinkVerdict::Undecided : DuplicateNonParallelSinkVerdict::NotHazardous;

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -1057,7 +1057,13 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
         if (!node.resolved)
         {
             for (const auto & view_id : catalog.getDependentViews(node.id))
+            {
                 collect({view_id, node.id}, sinks);
+                /// Everything past this point either counts a further sink or resolves a storage, and
+                /// resolving one may throw; neither can change an answer that is already proven.
+                if (proven)
+                    return;
+            }
         }
 
         /// A `Buffer` and a `Distributed` forward the rows into an `INSERT` of their own, whose sinks this
@@ -1098,14 +1104,24 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
             proven = true;
     };
 
+    /// Resolving a storage runs the code that materializes it, which may throw. A throw says nothing
+    /// about the branches already walked, so it degrades the answer to unknown rather than discarding
+    /// a duplicate the walk had already proven.
     SinkCounts reachable_now;
-    collect({source, {}}, reachable_now);
-
-    baseline = &reachable_now;
-    count_per_path = true;
-    path_edges.clear();
     SinkCounts reachable_from_new_view;
-    collect({new_view_target, {}}, reachable_from_new_view);
+    try
+    {
+        collect({source, {}}, reachable_now);
+
+        baseline = &reachable_now;
+        count_per_path = true;
+        path_edges.clear();
+        collect({new_view_target, {}}, reachable_from_new_view);
+    }
+    catch (...)
+    {
+        undecided = true;
+    }
 
     if (proven)
         return DuplicateNonParallelSinkVerdict::Hazardous;

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -780,6 +780,10 @@ private:
 /// below are willing to follow. A longer chain (or a cycle of aliases) fails closed.
 static constexpr size_t max_insert_forwarding_depth = 16;
 
+/// Maximum number of nodes `insertWouldDuplicateNonParallelSink` visits before failing closed. Its walk
+/// counts each path separately, so a graph whose branches reconverge costs more than its node count.
+static constexpr size_t max_duplicate_sink_walk_visits = 10000;
+
 bool InsertDependenciesBuilder::storageDeduplicatesBlocksOnInsert(const StoragePtr & storage, size_t depth)
 {
     if (depth > max_insert_forwarding_depth)
@@ -947,13 +951,23 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
     bool undecided = false;
 
     StorageIDSet active;
+    /// Admits each edge once, within the current path or within the whole walk per `count_per_path`.
     /// Keyed on the edge, not on the node: whether a view is pushed to depends on which parent it was
-    /// reached from, so memoizing a view by name alone would carry the verdict for a stale edge over to
-    /// the live one.
-    std::unordered_set<String> walked_edges;
+    /// reached from, so memoizing a view by name alone would carry a stale edge's verdict to the live one.
+    std::unordered_set<String> path_edges;
     /// Length-prefixed, because a database or table name may itself contain any separator.
     auto edge_key = [](const StorageIDMaybeEmpty & node)
     { return fmt::format("{}:{}:{}:{}:", node.database_name.size(), node.database_name, node.table_name.size(), node.table_name); };
+
+    size_t visits = 0;
+
+    /// A proven duplicate ends the walk: no further count can change that answer.
+    bool proven = false;
+
+    /// Whether an edge is admitted once per path rather than once per walk. Counting per path is what
+    /// proves a duplicate below a convergence, and it costs a path enumeration, so only the walk that
+    /// decides pays for it.
+    bool count_per_path = false;
 
     /// `parent` is empty at the root of a branch, where there is no edge to validate. `resolved` carries
     /// a storage to walk as handed over rather than looked up: a proxy renames the storage it wraps to
@@ -971,6 +985,9 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
     using SinkCounts = std::
         unordered_map<StorageIDMaybeEmpty, size_t, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual>;
 
+    /// The sinks the source reaches without the new view, once the first walk has collected them.
+    const SinkCounts * baseline = nullptr;
+
     /// Counts in `sinks` the storages that accept a single `write()` per `INSERT` and for which a write
     /// into `node.id` builds a sink, over the edges `collectAllDependencies` follows.
     std::function<void(const Node &, SinkCounts &)> collect = [&](const Node & node, SinkCounts & sinks)
@@ -978,7 +995,10 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
         /// A view chain is bounded only by the catalog.
         checkStackSize();
 
-        if (node.depth > max_insert_forwarding_depth)
+        if (proven)
+            return;
+
+        if (node.depth > max_insert_forwarding_depth || ++visits > max_duplicate_sink_walk_visits)
         {
             undecided = true;
             return;
@@ -986,6 +1006,7 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
 
         StoragePtr storage = node.resolved;
         bool holds_active_entry = false;
+        String walked_edge;
         if (!storage)
         {
             if (active.contains(node.id))
@@ -993,7 +1014,8 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
                 undecided = true;
                 return;
             }
-            if (!walked_edges.insert(edge_key(node.id) + edge_key(node.parent)).second)
+            walked_edge = edge_key(node.id) + edge_key(node.parent);
+            if (!path_edges.insert(walked_edge).second)
                 return;
             storage = catalog.tryGetTable(node.id, context);
             if (!storage)
@@ -1007,6 +1029,8 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
         SCOPE_EXIT({
             if (holds_active_entry)
                 active.erase(node.id);
+            if (count_per_path && !walked_edge.empty())
+                path_edges.erase(walked_edge);
         });
 
         if (auto * materialized_view = dynamic_cast<StorageMaterializedView *>(storage.get()))
@@ -1061,22 +1085,30 @@ InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict InsertDependenciesBui
             return;
         }
 
-        if (!storage->supportsParallelInsert())
-            ++sinks[storage->getStorageID()];
+        if (storage->supportsParallelInsert())
+            return;
+
+        /// Every count is reached over a live edge admitted once per path, so a second count is a second
+        /// path and therefore a second sink: positive proof even when another branch stayed unresolved.
+        /// A sink the source already reaches proves the same. Both only once `baseline` holds the set the
+        /// source reaches without this view, since a duplicate already in that set is not its doing.
+        auto sink_id = storage->getStorageID();
+        size_t reached = ++sinks[sink_id];
+        if (baseline && (reached >= 2 || baseline->contains(sink_id)))
+            proven = true;
     };
 
     SinkCounts reachable_now;
     collect({source, {}}, reachable_now);
 
-    walked_edges.clear();
+    baseline = &reachable_now;
+    count_per_path = true;
+    path_edges.clear();
     SinkCounts reachable_from_new_view;
     collect({new_view_target, {}}, reachable_from_new_view);
 
-    /// Every count was reached over live edges and `walked_edges` admits each edge once, so two counts
-    /// are two distinct sinks: positive proof even when some other branch stayed unresolved.
-    for (const auto & [sink_id, count] : reachable_from_new_view)
-        if (count >= 2 || reachable_now.contains(sink_id))
-            return DuplicateNonParallelSinkVerdict::Hazardous;
+    if (proven)
+        return DuplicateNonParallelSinkVerdict::Hazardous;
 
     return undecided ? DuplicateNonParallelSinkVerdict::Undecided : DuplicateNonParallelSinkVerdict::NotHazardous;
 }

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -169,17 +169,28 @@ public:
     /// insert single-stream when this probe reports true and that setting is disabled.
     static bool forwardedInsertHidesDependentView(const StoragePtr & storage, size_t depth = 0);
 
+    enum class DuplicateNonParallelSinkVerdict : uint8_t
+    {
+        NotHazardous,
+        Hazardous,
+        Undecided,
+    };
+
     /// Whether adding a materialized view from `source` to `new_view_target` would make one
     /// `INSERT INTO source` build two sinks for the same storage while that storage accepts only one
     /// `write()` per `INSERT` (`IStorage::supportsParallelInsert() == false`). Both the graph already
     /// reachable from `source` and the branch `new_view_target` starts are walked over the edges
     /// `collectAllDependencies` follows (a view's own target plus `getDependentViews`), validating each
     /// view hop against a stale dependency the way `observePath` does. Capability is tested only on
-    /// concrete sinks - a view is written *through*, never *to* - `Alias` and proxy hops are resolved to
-    /// their target, and a `Buffer` or a `Distributed` ends a branch because it forwards the write into
-    /// a separate `INSERT` whose sinks do not belong to this query. Returns false whenever the answer is
-    /// not known here: an unresolvable table, or a cycle.
-    static bool insertWouldDuplicateNonParallelSink(const StorageID & source, const StorageID & new_view_target, ContextPtr context);
+    /// concrete sinks - a view is written *through*, never *to* - and `Alias` and proxy hops are resolved
+    /// to the storage they hand the write to, which materializes and starts up a lazily loaded one.
+    /// A `Buffer` or a `Distributed` ends a branch: the write it forwards runs as an `INSERT` of its own,
+    /// whose sinks this walk does not model, so a topology mixing a forwarded and a direct branch into one
+    /// such storage is outside the answer. `Undecided` is reported instead of `NotHazardous` whenever a
+    /// branch could not be resolved (an unresolvable table, a cycle, or a chain deeper than
+    /// `max_insert_forwarding_depth`) and no duplicated sink was proven.
+    static DuplicateNonParallelSinkVerdict
+    insertWouldDuplicateNonParallelSink(const StorageID & source, const StorageID & new_view_target, ContextPtr context);
 
     /// Whether inserting into `storage` reaches a `Buffer` or a `Distributed`, whose final write runs in a
     /// context other than this query's, so this query's deduplication settings (`deduplicate_insert` /

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -169,6 +169,18 @@ public:
     /// insert single-stream when this probe reports true and that setting is disabled.
     static bool forwardedInsertHidesDependentView(const StoragePtr & storage, size_t depth = 0);
 
+    /// Whether adding a materialized view from `source` to `new_view_target` would make one
+    /// `INSERT INTO source` build two sinks for the same storage while that storage accepts only one
+    /// `write()` per `INSERT` (`IStorage::supportsParallelInsert() == false`). Both the graph already
+    /// reachable from `source` and the branch `new_view_target` starts are walked over the edges
+    /// `collectAllDependencies` follows (a view's own target plus `getDependentViews`), validating each
+    /// view hop against a stale dependency the way `observePath` does. Capability is tested only on
+    /// concrete sinks - a view is written *through*, never *to* - `Alias` and proxy hops are resolved to
+    /// their target, and a `Buffer` or a `Distributed` ends a branch because it forwards the write into
+    /// a separate `INSERT` whose sinks do not belong to this query. Returns false whenever the answer is
+    /// not known here: an unresolvable table, or a cycle.
+    static bool insertWouldDuplicateNonParallelSink(const StorageID & source, const StorageID & new_view_target, ContextPtr context);
+
     /// Whether inserting into `storage` reaches a `Buffer` or a `Distributed`, whose final write runs in a
     /// context other than this query's, so this query's deduplication settings (`deduplicate_insert` /
     /// `insert_deduplicate` / `deduplicate_blocks_in_dependent_materialized_views`) never govern it.

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -184,6 +184,10 @@ public:
     /// A `Buffer` or a `Distributed` ends a branch, since the write it forwards runs as an `INSERT` of
     /// its own whose sinks are not modelled here; a topology mixing a forwarded and a direct branch
     /// into one such storage is outside the answer.
+    /// It describes the catalog as of this call, where a view appears only once its `CREATE` has
+    /// executed, so two creations of the same view that are both still unregistered are each answered
+    /// as though the other did not exist. A caller that must not build such a pair twice has to hold a
+    /// reservation from here through its own dependency registration.
     static DuplicateNonParallelSinkVerdict
     insertWouldDuplicateNonParallelSink(const StorageID & source, const StorageID & new_view_target, ContextPtr context);
 

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -177,22 +177,13 @@ public:
     };
 
     /// Whether adding a materialized view from `source` to `new_view_target` would make one
-    /// `INSERT INTO source` build two sinks for the same storage while that storage accepts only one
-    /// `write()` per `INSERT` (`IStorage::supportsParallelInsert() == false`) - either one sink from each
-    /// side, or two within the new branch alone. Both the graph already reachable from `source` and the
-    /// branch `new_view_target` starts are walked over the edges `collectAllDependencies` follows (a
-    /// view's own target plus `getDependentViews`), validating each view hop against a stale dependency
-    /// the way `observePath` does. Dependent views are taken at every node, including one whose
-    /// `noPushingToViewsOnInserts()` holds and whose views only its background consumer's insert builds, so
-    /// there the walk is a superset: it errs towards `Hazardous`, never past a real one.
-    /// Capability is tested only on concrete sinks - a view is written *through*, never *to* - and `Alias`
-    /// and proxy hops are resolved to the storage they hand the write to, which materializes and starts up
-    /// a lazily loaded one.
-    /// A `Buffer` or a `Distributed` ends a branch: the write it forwards runs as an `INSERT` of its own,
-    /// whose sinks this walk does not model, so a topology mixing a forwarded and a direct branch into one
-    /// such storage is outside the answer. `Undecided` is reported instead of `NotHazardous` whenever a
-    /// branch could not be resolved (an unresolvable table, a cycle, or a chain deeper than
-    /// `max_insert_forwarding_depth`) and no duplicated sink was proven.
+    /// `INSERT INTO source` build two sinks for one storage that accepts a single `write()` per
+    /// `INSERT` (`IStorage::supportsParallelInsert() == false`).
+    /// The answer is one-sided: it errs towards `Hazardous`, never past a real one. `Undecided` means
+    /// a branch could not be resolved and no duplicate was proven, so the caller should proceed.
+    /// A `Buffer` or a `Distributed` ends a branch, since the write it forwards runs as an `INSERT` of
+    /// its own whose sinks are not modelled here; a topology mixing a forwarded and a direct branch
+    /// into one such storage is outside the answer.
     static DuplicateNonParallelSinkVerdict
     insertWouldDuplicateNonParallelSink(const StorageID & source, const StorageID & new_view_target, ContextPtr context);
 

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -178,10 +178,14 @@ public:
 
     /// Whether adding a materialized view from `source` to `new_view_target` would make one
     /// `INSERT INTO source` build two sinks for the same storage while that storage accepts only one
-    /// `write()` per `INSERT` (`IStorage::supportsParallelInsert() == false`). Both the graph already
-    /// reachable from `source` and the branch `new_view_target` starts are walked over the edges
-    /// `collectAllDependencies` follows (a view's own target plus `getDependentViews`), validating each
-    /// view hop against a stale dependency the way `observePath` does. Capability is tested only on
+    /// `write()` per `INSERT` (`IStorage::supportsParallelInsert() == false`) - either one sink from each
+    /// side, or two within the new branch alone. Both the graph already reachable from `source` and the
+    /// branch `new_view_target` starts are walked over the edges `collectAllDependencies` follows (a
+    /// view's own target plus `getDependentViews`), validating each view hop against a stale dependency
+    /// the way `observePath` does. Dependent views are taken at every node, including one whose
+    /// `noPushingToViewsOnInserts()` holds and which a direct `INSERT` writes alone, so at such a node the
+    /// walk is a superset: it also covers that storage's background consumer, whose insert does push to
+    /// the views, and it errs towards `Hazardous` rather than past a real one. Capability is tested only on
     /// concrete sinks - a view is written *through*, never *to* - and `Alias` and proxy hops are resolved
     /// to the storage they hand the write to, which materializes and starts up a lazily loaded one.
     /// A `Buffer` or a `Distributed` ends a branch: the write it forwards runs as an `INSERT` of its own,

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -183,11 +183,11 @@ public:
     /// branch `new_view_target` starts are walked over the edges `collectAllDependencies` follows (a
     /// view's own target plus `getDependentViews`), validating each view hop against a stale dependency
     /// the way `observePath` does. Dependent views are taken at every node, including one whose
-    /// `noPushingToViewsOnInserts()` holds and which a direct `INSERT` writes alone, so at such a node the
-    /// walk is a superset: it also covers that storage's background consumer, whose insert does push to
-    /// the views, and it errs towards `Hazardous` rather than past a real one. Capability is tested only on
-    /// concrete sinks - a view is written *through*, never *to* - and `Alias` and proxy hops are resolved
-    /// to the storage they hand the write to, which materializes and starts up a lazily loaded one.
+    /// `noPushingToViewsOnInserts()` holds and whose views only its background consumer's insert builds, so
+    /// there the walk is a superset: it errs towards `Hazardous`, never past a real one.
+    /// Capability is tested only on concrete sinks - a view is written *through*, never *to* - and `Alias`
+    /// and proxy hops are resolved to the storage they hand the write to, which materializes and starts up
+    /// a lazily loaded one.
     /// A `Buffer` or a `Distributed` ends a branch: the write it forwards runs as an `INSERT` of its own,
     /// whose sinks this walk does not model, so a topology mixing a forwarded and a direct branch into one
     /// such storage is outside the answer. `Undecided` is reported instead of `NotHazardous` whenever a

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -72,7 +72,9 @@
 #include <Interpreters/SelectQueryOptions.h>
 #include <Interpreters/TransactionLog.h>
 #include <Interpreters/executeQuery.h>
+#include <Databases/DDLDependencyVisitor.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/InsertDependenciesBuilder.h>
 #include <Interpreters/QueryMetadataCache.h>
 #include <Common/ProfileEvents.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
@@ -128,6 +130,8 @@ namespace ProfileEvents
     extern const Event ASTFuzzerQueries;
     extern const Event ASTFuzzerSkippedBackupRestore;
     extern const Event ASTFuzzerSkippedReplicatedDDLInternal;
+    extern const Event ASTFuzzerSkippedSharedNonParallelTarget;
+    extern const Event ASTFuzzerSkipCheckFailed;
     extern const Event QueryParseMicroseconds;
 }
 
@@ -2268,6 +2272,42 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
         catch (...) // Ok: skip fuzzed ASTs that are too deeply nested
         {
             continue;
+        }
+
+        /// Fuzzing a `CREATE MATERIALIZED VIEW` renames the view but keeps its external `TO`, so the new
+        /// view shares both source and target with the one it was derived from. One `INSERT` then builds
+        /// two sinks for that target, which cannot complete if the target takes only one `write()` per
+        /// `INSERT`: the second sink waits out `lock_acquire_timeout`.
+        if (const auto * create = fuzzed_ast->as<ASTCreateQuery>(); create && create->is_materialized_view_with_external_target())
+        {
+            bool skip = false;
+            try
+            {
+                /// Both ids come from the extractor that registers the dependency edges this question is
+                /// asked about, so the two cannot disagree. The fuzzer moves the source as well as the name.
+                auto deps = getDependenciesFromCreateQuery(
+                    context->getGlobalContext(),
+                    {create->getDatabase(), create->getTable()},
+                    fuzzed_ast,
+                    context->getCurrentDatabase());
+                if (deps.mv_from_dependency && deps.mv_to_dependency)
+                    skip = InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
+                        *deps.mv_from_dependency, *deps.mv_to_dependency, context);
+            }
+            catch (...) // Ok: an undecided check must not suppress fuzzing
+            {
+                ProfileEvents::increment(ProfileEvents::ASTFuzzerSkipCheckFailed);
+            }
+
+            if (skip)
+            {
+                /// The name was recorded before this point and later mutations retarget table references
+                /// to the recorded names, so a name no table backs has to be withdrawn.
+                auto [fuzzer, lock] = getGlobalASTFuzzer();
+                fuzzer->notifyQueryFailed(fuzzed_ast);
+                ProfileEvents::increment(ProfileEvents::ASTFuzzerSkippedSharedNonParallelTarget);
+                continue;
+            }
         }
 
         /// Drop any SETTINGS that would override the fuzz-context resource caps below; otherwise a

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -2280,7 +2280,8 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
         /// `INSERT`: the second sink waits out `lock_acquire_timeout`.
         if (const auto * create = fuzzed_ast->as<ASTCreateQuery>(); create && create->is_materialized_view_with_external_target())
         {
-            bool skip = false;
+            using Verdict = InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict;
+            auto verdict = Verdict::Undecided;
             try
             {
                 /// Both ids come from the extractor that registers the dependency edges this question is
@@ -2291,15 +2292,18 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
                     fuzzed_ast,
                     context->getCurrentDatabase());
                 if (deps.mv_from_dependency && deps.mv_to_dependency)
-                    skip = InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
+                    verdict = InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
                         *deps.mv_from_dependency, *deps.mv_to_dependency, context);
             }
             catch (...) // Ok: an undecided check must not suppress fuzzing
             {
-                ProfileEvents::increment(ProfileEvents::ASTFuzzerSkipCheckFailed);
+                verdict = Verdict::Undecided;
             }
 
-            if (skip)
+            if (verdict == Verdict::Undecided)
+                ProfileEvents::increment(ProfileEvents::ASTFuzzerSkipCheckFailed);
+
+            if (verdict == Verdict::Hazardous)
             {
                 /// The name was recorded before this point and later mutations retarget table references
                 /// to the recorded names, so a name no table backs has to be withdrawn.

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -107,7 +107,9 @@
 #include <exception>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <random>
+#include <unordered_set>
 
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -2170,6 +2172,59 @@ std::pair<std::shared_ptr<QueryFuzzer>, std::unique_lock<std::mutex>> getGlobalA
 }
 
 
+/// Holds one (source, target) pair for the span in which a fuzzed `CREATE MATERIALIZED VIEW` on that
+/// pair is being decided and executed. A second holder of the same pair is refused.
+/// The duplicate-sink question is answered from the catalog, where a view appears only once its
+/// `CREATE` has executed, so two holders would each be told the target is reached once and each would
+/// build one of the two sinks. Scoped to the pair, because two views from one source onto different
+/// targets never share a sink.
+class FuzzedViewPairLock
+{
+public:
+    FuzzedViewPairLock(const StorageID & source, const StorageID & target)
+        : key(fmt::format(
+              "{}:{}:{}:{}:{}:{}:{}:{}",
+              source.database_name.size(), source.database_name,
+              source.table_name.size(), source.table_name,
+              target.database_name.size(), target.database_name,
+              target.table_name.size(), target.table_name))
+    {
+        std::lock_guard lock(mutex());
+        held = held_keys().insert(key).second;
+    }
+
+    ~FuzzedViewPairLock()
+    {
+        if (!held)
+            return;
+        std::lock_guard lock(mutex());
+        held_keys().erase(key);
+    }
+
+    FuzzedViewPairLock(const FuzzedViewPairLock &) = delete;
+    FuzzedViewPairLock & operator=(const FuzzedViewPairLock &) = delete;
+
+    bool acquired() const { return held; }
+
+private:
+    /// Length-prefixed, because a database or table name may itself contain any separator.
+    String key;
+    bool held = false;
+
+    static std::mutex & mutex()
+    {
+        static std::mutex m;
+        return m;
+    }
+
+    static std::unordered_set<String> & held_keys()
+    {
+        static std::unordered_set<String> keys;
+        return keys;
+    }
+};
+
+
 static bool isReadOnlyQuery(const ASTPtr & ast)
 {
     auto kind = ast->getQueryKind();
@@ -2276,6 +2331,9 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
 
         /// A storage taking one `write()` per `INSERT` cannot serve two sinks of the same `INSERT`: the
         /// second waits out `lock_acquire_timeout`. Such a view is withdrawn instead of executed.
+        /// Outlives the block below: the answer holds only while no other thread is creating a view on
+        /// the same pair, so the reservation has to span this iteration's execution too.
+        std::optional<FuzzedViewPairLock> view_pair_lock;
         if (const auto * create = fuzzed_ast->as<ASTCreateQuery>(); create && create->is_materialized_view_with_external_target())
         {
             using Verdict = InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict;
@@ -2290,8 +2348,13 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
                     fuzzed_ast,
                     context->getCurrentDatabase());
                 if (deps.mv_from_dependency && deps.mv_to_dependency)
-                    verdict = InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
-                        *deps.mv_from_dependency, *deps.mv_to_dependency, context);
+                {
+                    view_pair_lock.emplace(*deps.mv_from_dependency, *deps.mv_to_dependency);
+                    verdict = view_pair_lock->acquired()
+                        ? InsertDependenciesBuilder::insertWouldDuplicateNonParallelSink(
+                              *deps.mv_from_dependency, *deps.mv_to_dependency, context)
+                        : Verdict::Hazardous;
+                }
             }
             catch (...) // Ok: an undecided check must not suppress fuzzing
             {

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -2303,8 +2303,8 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
 
             if (verdict == Verdict::Hazardous)
             {
-                /// The name was recorded before this point and later mutations retarget table references
-                /// to the recorded names, so a name no table backs has to be withdrawn.
+                /// The fuzzer retargets table references to the names in its live-name registry, so a
+                /// name no table backs must leave that registry.
                 auto [fuzzer, lock] = getGlobalASTFuzzer();
                 fuzzer->notifyQueryFailed(fuzzed_ast);
                 ProfileEvents::increment(ProfileEvents::ASTFuzzerSkippedSharedNonParallelTarget);

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -2274,10 +2274,8 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
             continue;
         }
 
-        /// Fuzzing a `CREATE MATERIALIZED VIEW` renames the view but keeps its external `TO`, so the new
-        /// view shares both source and target with the one it was derived from. One `INSERT` then builds
-        /// two sinks for that target, which cannot complete if the target takes only one `write()` per
-        /// `INSERT`: the second sink waits out `lock_acquire_timeout`.
+        /// A storage taking one `write()` per `INSERT` cannot serve two sinks of the same `INSERT`: the
+        /// second waits out `lock_acquire_timeout`. Such a view is withdrawn instead of executed.
         if (const auto * create = fuzzed_ast->as<ASTCreateQuery>(); create && create->is_materialized_view_with_external_target())
         {
             using Verdict = InsertDependenciesBuilder::DuplicateNonParallelSinkVerdict;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -131,7 +131,7 @@ namespace ProfileEvents
     extern const Event ASTFuzzerSkippedBackupRestore;
     extern const Event ASTFuzzerSkippedReplicatedDDLInternal;
     extern const Event ASTFuzzerSkippedSharedNonParallelTarget;
-    extern const Event ASTFuzzerSkipCheckFailed;
+    extern const Event ASTFuzzerSharedNonParallelTargetCheckUndecided;
     extern const Event QueryParseMicroseconds;
 }
 
@@ -2299,7 +2299,7 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
             }
 
             if (verdict == Verdict::Undecided)
-                ProfileEvents::increment(ProfileEvents::ASTFuzzerSkipCheckFailed);
+                ProfileEvents::increment(ProfileEvents::ASTFuzzerSharedNonParallelTargetCheckUndecided);
 
             if (verdict == Verdict::Hazardous)
             {

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
@@ -1,0 +1,10 @@
+hazardous_clone_skipped	1
+insert_completed	1
+safe_target_not_skipped	1
+safe_target_executed	1
+lazy_proxy_engine	TableProxy
+lazy_proxy_clone_skipped	1
+lazy_proxy_insert_completed	1
+undecided_counted	1
+undecided_not_skipped	1
+alive

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
@@ -8,4 +8,7 @@ lazy_proxy_insert_completed	1
 undecided_counted	1
 undecided_executed_nonzero	1
 undecided_not_skipped	1
+queue_source_clone_skipped	1
+queue_source_safe_target_not_skipped	1
+queue_source_safe_target_executed	1
 alive

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
@@ -1,13 +1,13 @@
 hazardous_clone_skipped	1
 insert_completed	1
-safe_target_not_skipped	1
 safe_target_executed	1
+safe_target_not_skipped	1
 lazy_proxy_engine	TableProxy
 lazy_proxy_clone_skipped	1
 lazy_proxy_insert_completed	1
 undecided_counted	1
 undecided_executed_nonzero	1
 queue_source_clone_skipped	1
-queue_source_safe_target_not_skipped	1
 queue_source_safe_target_executed	1
+queue_source_safe_target_not_skipped	1
 alive

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
@@ -7,7 +7,6 @@ lazy_proxy_clone_skipped	1
 lazy_proxy_insert_completed	1
 undecided_counted	1
 undecided_executed_nonzero	1
-undecided_not_skipped	1
 queue_source_clone_skipped	1
 queue_source_safe_target_not_skipped	1
 queue_source_safe_target_executed	1

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.reference
@@ -6,5 +6,6 @@ lazy_proxy_engine	TableProxy
 lazy_proxy_clone_skipped	1
 lazy_proxy_insert_completed	1
 undecided_counted	1
+undecided_executed_nonzero	1
 undecided_not_skipped	1
 alive

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
@@ -1,0 +1,181 @@
+-- Tags: no-ordinary-database, no-parallel
+-- no-parallel: reads the server-global ProfileEvents counters
+-- ASTFuzzerSkippedSharedNonParallelTarget, ASTFuzzerSkipCheckFailed and ASTFuzzerQueries, so no
+-- other test may run fuzzed queries against the same server while this one measures the deltas.
+-- The counters are bumped in the query-finish callback, after the query's own ProfileEvents
+-- snapshot is taken, so system.query_log carries none of them and per-query_id attribution
+-- (the 04339 pattern, which does not need the tag) is not available here.
+
+-- The serverfuzz/stress profile sets ast_fuzzer_runs server-wide, which would make every statement
+-- here fire the fuzzer and pollute the counters. Pin the baseline to 0 so only statements with an
+-- explicit SETTINGS ast_fuzzer_runs > 0 fire it.
+SET ast_fuzzer_runs = 0;
+SET ast_fuzzer_any_query = 0;
+SET send_logs_level = 'fatal';
+
+DROP TABLE IF EXISTS fuzz_src;
+DROP TABLE IF EXISTS fuzz_log;
+DROP TABLE IF EXISTS fuzz_mt;
+DROP TABLE IF EXISTS fuzz_events;
+
+CREATE TABLE fuzz_events (label String, skipped Int64, undecided Int64, executed Int64) ENGINE = Memory;
+
+-- sumIf over the (possibly absent) rows yields 0 before an event has ever fired, so the delta
+-- arithmetic below is well defined on a fresh server. One scan keeps the three values consistent.
+CREATE TABLE fuzz_src (k Int) ENGINE = Null;
+CREATE TABLE fuzz_log (k Int) ENGINE = TinyLog;
+
+INSERT INTO fuzz_events
+SELECT 'before',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+-- Fuzzing a CREATE MATERIALIZED VIEW renames the view but keeps its external TO, so the clone
+-- shares both source and target with this view. One INSERT INTO fuzz_src would then build two
+-- sinks for fuzz_log, which takes a single write() per INSERT and holds its lock from pipeline
+-- build to finish: the second sink waits out lock_acquire_timeout and the INSERT never completes.
+-- The clone is stochastic (most die on a name collision first), so drive enough runs and assert a
+-- positive delta rather than an exact count.
+CREATE MATERIALIZED VIEW fuzz_mv TO fuzz_log AS SELECT k FROM fuzz_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+
+INSERT INTO fuzz_events
+SELECT 'after_hazard',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+SELECT 'hazardous_clone_skipped',
+      (SELECT skipped FROM fuzz_events WHERE label = 'after_hazard')
+    - (SELECT skipped FROM fuzz_events WHERE label = 'before') > 0;
+
+-- The counter and the wedge are separate claims: assert the INSERT itself completes. Without the
+-- skip it waits out lock_acquire_timeout on the target instead of returning, so pin that timeout
+-- (and the async-insert wait it feeds) low enough that a regression fails the test quickly.
+INSERT INTO fuzz_src SETTINGS lock_acquire_timeout = 5, wait_for_async_insert_timeout = 10 VALUES (1);
+SELECT 'insert_completed', count() FROM fuzz_log;
+
+-- Positive control: two views on one MergeTree target is supported and must keep being fuzzed, so
+-- the executed counter advances while the skip counter stays put. This also proves both counters
+-- are live under these settings, so the assertion above is not reading a dead counter.
+CREATE TABLE fuzz_mt (k Int) ENGINE = MergeTree ORDER BY k;
+CREATE MATERIALIZED VIEW fuzz_mv_mt TO fuzz_mt AS SELECT k FROM fuzz_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+
+INSERT INTO fuzz_events
+SELECT 'after_safe',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+SELECT 'safe_target_not_skipped',
+      (SELECT skipped FROM fuzz_events WHERE label = 'after_safe')
+    - (SELECT skipped FROM fuzz_events WHERE label = 'after_hazard') = 0;
+
+SELECT 'safe_target_executed',
+      (SELECT executed FROM fuzz_events WHERE label = 'after_safe')
+    - (SELECT executed FROM fuzz_events WHERE label = 'after_hazard') > 0;
+
+DROP TABLE fuzz_mv_mt;
+DROP TABLE fuzz_mv;
+DROP TABLE fuzz_mt;
+DROP TABLE fuzz_log;
+DROP TABLE fuzz_src;
+DROP TABLE fuzz_events;
+
+-- The hazard reached through a lazily loaded table. DETACH/ATTACH DATABASE replaces every plain
+-- table with a proxy that renames the storage it wraps to the proxy's own id, so a walk that
+-- re-entered by id would read the hop as a cycle and report the whole graph as safe.
+DROP DATABASE IF EXISTS 04876_lazy;
+CREATE DATABASE 04876_lazy ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+CREATE TABLE 04876_lazy.src (k Int) ENGINE = Null;
+CREATE TABLE 04876_lazy.tgt (k Int) ENGINE = TinyLog;
+DETACH DATABASE 04876_lazy;
+ATTACH DATABASE 04876_lazy;
+SELECT 'lazy_proxy_engine', engine FROM system.tables WHERE database = '04876_lazy' AND name = 'tgt';
+
+CREATE TABLE fuzz_events (label String, skipped Int64, undecided Int64, executed Int64) ENGINE = Memory;
+INSERT INTO fuzz_events
+SELECT 'before_lazy',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+CREATE MATERIALIZED VIEW 04876_lazy.mv TO 04876_lazy.tgt AS SELECT k FROM 04876_lazy.src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+
+INSERT INTO fuzz_events
+SELECT 'after_lazy',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+SELECT 'lazy_proxy_clone_skipped',
+      (SELECT skipped FROM fuzz_events WHERE label = 'after_lazy')
+    - (SELECT skipped FROM fuzz_events WHERE label = 'before_lazy') > 0;
+
+INSERT INTO 04876_lazy.src SETTINGS lock_acquire_timeout = 5, wait_for_async_insert_timeout = 10 VALUES (1);
+SELECT 'lazy_proxy_insert_completed', count() FROM 04876_lazy.tgt;
+
+DROP DATABASE 04876_lazy;
+DROP TABLE fuzz_events;
+
+-- An undecided answer is counted rather than silently read as safe: the dependent view's own
+-- target is detached, so that branch cannot be resolved, and the query is still fuzzed.
+DROP TABLE IF EXISTS und_src;
+DROP TABLE IF EXISTS und_mt;
+DROP TABLE IF EXISTS und_gone;
+
+CREATE TABLE und_src (k Int) ENGINE = Null;
+CREATE TABLE und_mt (k Int) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE und_gone (k Int) ENGINE = TinyLog;
+CREATE MATERIALIZED VIEW und_mv_gone TO und_gone AS SELECT k FROM und_mt;
+DETACH TABLE und_gone;
+
+CREATE TABLE fuzz_events (label String, skipped Int64, undecided Int64, executed Int64) ENGINE = Memory;
+INSERT INTO fuzz_events
+SELECT 'before_undecided',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+CREATE MATERIALIZED VIEW und_mv TO und_mt AS SELECT k FROM und_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+
+INSERT INTO fuzz_events
+SELECT 'after_undecided',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+-- Every fuzzed CREATE here hits the unresolvable branch, so each executed query must contribute an
+-- undecided verdict. Compared against the executed count rather than against zero: this same
+-- counter also fires when the dependency extractor throws on a shape the fuzzer injected, which
+-- happens on a few runs regardless, so a `> 0` assertion would hold even with the exits uncounted.
+SELECT 'undecided_counted',
+      (SELECT undecided FROM fuzz_events WHERE label = 'after_undecided')
+    - (SELECT undecided FROM fuzz_events WHERE label = 'before_undecided')
+   >= (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
+    - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided');
+
+SELECT 'undecided_not_skipped',
+      (SELECT skipped FROM fuzz_events WHERE label = 'after_undecided')
+    - (SELECT skipped FROM fuzz_events WHERE label = 'before_undecided') = 0;
+
+ATTACH TABLE und_gone;
+DROP TABLE und_mv;
+DROP TABLE und_mv_gone;
+DROP TABLE und_gone;
+DROP TABLE und_mt;
+DROP TABLE und_src;
+DROP TABLE fuzz_events;
+
+SELECT 'alive';

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
@@ -1,10 +1,19 @@
--- Tags: no-ordinary-database, no-parallel, log-engine, no-replicated-database
+-- Tags: no-ordinary-database, no-parallel, log-engine, no-replicated-database, no-fasttest
+-- no-fasttest: the queue-source section below needs the Kafka engine, which the fast-test build
+-- does not have.
 -- no-parallel: reads the server-global ProfileEvents counters
--- ASTFuzzerSkippedSharedNonParallelTarget, ASTFuzzerSkipCheckFailed and ASTFuzzerQueries, so no
--- other test may run fuzzed queries against the same server while this one measures the deltas.
+-- ASTFuzzerSkippedSharedNonParallelTarget, ASTFuzzerSharedNonParallelTargetCheckUndecided and
+-- ASTFuzzerQueries, so no other test may run fuzzed queries against the same server while this one
+-- measures the deltas.
 -- The counters are bumped in the query-finish callback, after the query's own ProfileEvents
 -- snapshot is taken, so system.query_log carries none of them and per-query_id attribution
 -- (the 04339 pattern, which does not need the tag) is not available here.
+-- The tag is what makes the deltas attributable, and it is load-bearing rather than cosmetic: it
+-- serializes only within one clickhouse-test process, while the stress runner drives several against
+-- one server. Measured under a concurrent fuzzing process, every claim that a delta was exactly zero
+-- failed 15 of 15 runs, so those are bounded by this section's own executed delta instead and then
+-- held 30 of 30. The undecided-versus-executed comparison remains same-window by nature: a foreign
+-- decided query inflates only the executed side, so it too relies on the tag.
 -- log-engine: the whole oracle rests on the target NOT supporting parallel insert, which
 -- --replace-log-memory-with-mergetree rewrites away (it also rewrites the Memory fixture).
 -- no-replicated-database: for the lazy_load_tables section below, plus a DETACH TABLE inside the
@@ -37,7 +46,7 @@ CREATE TABLE fuzz_log (k Int) ENGINE = TinyLog;
 INSERT INTO fuzz_events
 SELECT 'before',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
-       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
@@ -53,7 +62,7 @@ SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
 INSERT INTO fuzz_events
 SELECT 'after_hazard',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
-       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
@@ -77,13 +86,19 @@ SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
 INSERT INTO fuzz_events
 SELECT 'after_safe',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
-       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
+-- Bounded rather than pinned to zero: `no-parallel` only serializes within one clickhouse-test
+-- process, while the stress runner drives several against one server, and a foreign fuzzed query can
+-- only inflate these server-global counters. A skip delta below the executed delta still shows this
+-- section's own queries were executed rather than withdrawn, which is the claim.
 SELECT 'safe_target_not_skipped',
       (SELECT skipped FROM fuzz_events WHERE label = 'after_safe')
-    - (SELECT skipped FROM fuzz_events WHERE label = 'after_hazard') = 0;
+    - (SELECT skipped FROM fuzz_events WHERE label = 'after_hazard')
+    < (SELECT executed FROM fuzz_events WHERE label = 'after_safe')
+    - (SELECT executed FROM fuzz_events WHERE label = 'after_hazard');
 
 SELECT 'safe_target_executed',
       (SELECT executed FROM fuzz_events WHERE label = 'after_safe')
@@ -110,7 +125,7 @@ WHERE database = {CLICKHOUSE_DATABASE_1:String} AND name = 'tgt';
 INSERT INTO fuzz_events
 SELECT 'before_lazy',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
-       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
@@ -122,7 +137,7 @@ SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
 INSERT INTO fuzz_events
 SELECT 'after_lazy',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
-       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
@@ -151,7 +166,7 @@ DETACH TABLE und_gone;
 INSERT INTO fuzz_events
 SELECT 'before_undecided',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
-       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
@@ -161,14 +176,16 @@ SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
 INSERT INTO fuzz_events
 SELECT 'after_undecided',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
-       toInt64(sumIf(value, event = 'ASTFuzzerSkipCheckFailed')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
 -- Every fuzzed CREATE here hits the unresolvable branch, so each executed query must contribute an
--- undecided verdict. Compared against the executed count rather than against zero: this same
--- counter also fires when the dependency extractor throws on a shape the fuzzer injected, which
--- happens on a few runs regardless, so a `> 0` assertion would hold even with the exits uncounted.
+-- undecided verdict. Compared against the executed count rather than against zero: this same counter
+-- also fires when the dependency extractor throws on a shape the fuzzer injected, which happens on a
+-- few runs regardless, so a `> 0` assertion would hold even with the exits uncounted. Not a fixed
+-- floor either: the fuzz loop stops early on some runs (both deltas measured 30 on 18 of 20 runs and
+-- 14 on the other two), and it is their equality that is the claim.
 SELECT 'undecided_counted',
       (SELECT undecided FROM fuzz_events WHERE label = 'after_undecided')
     - (SELECT undecided FROM fuzz_events WHERE label = 'before_undecided')
@@ -181,9 +198,12 @@ SELECT 'undecided_executed_nonzero',
       (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
     - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided') > 0;
 
+-- Bounded, not pinned to zero, for the same reason as safe_target_not_skipped above.
 SELECT 'undecided_not_skipped',
       (SELECT skipped FROM fuzz_events WHERE label = 'after_undecided')
-    - (SELECT skipped FROM fuzz_events WHERE label = 'before_undecided') = 0;
+    - (SELECT skipped FROM fuzz_events WHERE label = 'before_undecided')
+    < (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
+    - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided');
 
 ATTACH TABLE und_gone;
 DROP TABLE und_mv;
@@ -191,6 +211,72 @@ DROP TABLE und_mv_gone;
 DROP TABLE und_gone;
 DROP TABLE und_mt;
 DROP TABLE und_src;
+
+-- A queue engine sets `noPushingToViewsOnInserts`, so a direct INSERT into it pushes to no view -
+-- but its background consumer inserts with `no_destination`, which does build a sink for every
+-- dependent view. The dependent views of such a source are therefore walked like any other: a
+-- clone sharing the TinyLog target has to be skipped. Kafka is used because it is the queue
+-- carrier constructible without a live broker; the same override is on Kafka2, FileLog, NATS and
+-- RabbitMQ. The skip is decided at CREATE time, so no broker is needed here.
+DROP TABLE IF EXISTS q_src;
+DROP TABLE IF EXISTS q_log;
+DROP TABLE IF EXISTS q_mt;
+
+CREATE TABLE q_log (k Int) ENGINE = TinyLog;
+CREATE TABLE q_src (k Int) ENGINE = Kafka
+    SETTINGS kafka_broker_list = 'localhost:9092', kafka_topic_list = '04876_q',
+             kafka_group_name = '04876_q', kafka_format = 'CSV';
+
+INSERT INTO fuzz_events
+SELECT 'before_queue',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+CREATE MATERIALIZED VIEW q_mv TO q_log AS SELECT k FROM q_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+
+INSERT INTO fuzz_events
+SELECT 'after_queue',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+SELECT 'queue_source_clone_skipped',
+      (SELECT skipped FROM fuzz_events WHERE label = 'after_queue')
+    - (SELECT skipped FROM fuzz_events WHERE label = 'before_queue') > 0;
+
+-- Control: the same queue source over a parallel-capable target must keep being fuzzed, so a
+-- positive above is not every queue-sourced view being reported hazardous.
+CREATE TABLE q_mt (k Int) ENGINE = MergeTree ORDER BY k;
+CREATE MATERIALIZED VIEW q_mv_mt TO q_mt AS SELECT k FROM q_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+
+INSERT INTO fuzz_events
+SELECT 'after_queue_safe',
+       toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
+       toInt64(sumIf(value, event = 'ASTFuzzerSharedNonParallelTargetCheckUndecided')),
+       toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
+FROM system.events;
+
+SELECT 'queue_source_safe_target_not_skipped',
+      (SELECT skipped FROM fuzz_events WHERE label = 'after_queue_safe')
+    - (SELECT skipped FROM fuzz_events WHERE label = 'after_queue')
+    < (SELECT executed FROM fuzz_events WHERE label = 'after_queue_safe')
+    - (SELECT executed FROM fuzz_events WHERE label = 'after_queue');
+
+SELECT 'queue_source_safe_target_executed',
+      (SELECT executed FROM fuzz_events WHERE label = 'after_queue_safe')
+    - (SELECT executed FROM fuzz_events WHERE label = 'after_queue') > 0;
+
+DROP TABLE q_mv_mt;
+DROP TABLE q_mv;
+DROP TABLE q_mt;
+DROP TABLE q_src;
+DROP TABLE q_log;
+
 DROP TABLE fuzz_events;
 
 SELECT 'alive';

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
@@ -27,16 +27,21 @@ SET send_logs_level = 'fatal';
 -- then becomes a TRUNCATE, so fuzz_events would survive its own DROP and the next CREATE would fail.
 SET ignore_drop_queries_probability = 0;
 
--- A materialized view does not disappear with its source table, and a run that fails is retried
--- against the same database, so every object the file creates is dropped up front rather than
--- relying only on the unconditional drops at the end of each section.
---
-DROP TABLE IF EXISTS fuzz_mv;
-DROP TABLE IF EXISTS fuzz_mv_mt;
-DROP TABLE IF EXISTS fuzz_src;
-DROP TABLE IF EXISTS fuzz_log;
-DROP TABLE IF EXISTS fuzz_mt;
+-- Every fixture a fuzzed statement can touch lives in a SECOND database that this file drops and
+-- recreates up front. Two reasons, both measured:
+--   * a clone survives its own statement (`fuzz_mv__fuzz_29`, `q_mv_mt__fuzz_16` ...) and no fixed
+--     DROP list can name it; 8-17 such views were left behind by a single clean pass. They are
+--     created in the database of the VIEW, not of the connection, so dropping that database removes
+--     all of them at once.
+--   * a leftover clone whose TO target is later dropped turns the next run's INSERT into
+--     `Code: 60 UNKNOWN_TABLE`. With a fixed --database the runner neither creates nor drops the
+--     per-test database, so without this reset the second run in one database failed (measured:
+--     first failure at run 2 of 8, in 3 of 4 trials).
+-- `fuzz_events` stays in the test's own database: nothing fuzzed writes to it, and keeping the
+-- counter bookkeeping outside the reset database means a reset cannot discard the deltas.
 DROP TABLE IF EXISTS fuzz_events;
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} SYNC;
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- One table for every section: each row is keyed by its own label, and creating it once keeps the
 -- fixture independent of whether a DROP in between was honoured.
@@ -44,8 +49,8 @@ CREATE TABLE fuzz_events (label String, skipped Int64, undecided Int64, executed
 
 -- sumIf over the (possibly absent) rows yields 0 before an event has ever fired, so the delta
 -- arithmetic below is well defined on a fresh server. One scan keeps the three values consistent.
-CREATE TABLE fuzz_src (k Int) ENGINE = Null;
-CREATE TABLE fuzz_log (k Int) ENGINE = TinyLog;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_src (k Int) ENGINE = Null;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_log (k Int) ENGINE = TinyLog;
 
 INSERT INTO fuzz_events
 SELECT 'before',
@@ -60,8 +65,12 @@ FROM system.events;
 -- build to finish: the second sink waits out lock_acquire_timeout and the INSERT never completes.
 -- The clone is stochastic (most die on a name collision first), so drive enough runs and assert a
 -- positive delta rather than an exact count.
-CREATE MATERIALIZED VIEW fuzz_mv TO fuzz_log AS SELECT k FROM fuzz_src
-SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+-- Microsecond boundary from the SERVER, stored in the fixture's `executed` slot: every clone this
+-- section logs starts after it, and every row an earlier run left behind starts before it.
+INSERT INTO fuzz_events SELECT 'hazard_boundary', 0, 0, toUnixTimestamp64Micro(now64(6));
+
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_mv TO {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_log AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1, log_comment = '04876_hazard';
 
 INSERT INTO fuzz_events
 SELECT 'after_hazard',
@@ -74,18 +83,35 @@ SELECT 'hazardous_clone_skipped',
       (SELECT skipped FROM fuzz_events WHERE label = 'after_hazard')
     - (SELECT skipped FROM fuzz_events WHERE label = 'before') > 0;
 
+SYSTEM FLUSH LOGS query_log;
+
+INSERT INTO fuzz_events
+SELECT 'hazard_own_clones', 0, 0, count(DISTINCT query_id)
+FROM system.query_log
+WHERE event_date >= today() - 1
+  AND toUnixTimestamp64Micro(event_time_microseconds)
+      >= (SELECT executed FROM fuzz_events WHERE label = 'hazard_boundary')
+  AND current_database = currentDatabase()
+  AND log_comment = '04876_hazard'
+  AND query LIKE '%fuzz\_mv\_\_fuzz%'
+SETTINGS enable_parallel_replicas = 0;
+
 -- The counter and the wedge are separate claims: assert the INSERT itself completes. Without the
 -- skip it waits out lock_acquire_timeout on the target instead of returning, so pin that timeout
 -- (and the async-insert wait it feeds) low enough that a regression fails the test quickly.
-INSERT INTO fuzz_src SETTINGS lock_acquire_timeout = 5, wait_for_async_insert_timeout = 10 VALUES (1);
-SELECT 'insert_completed', count() FROM fuzz_log;
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_src SETTINGS lock_acquire_timeout = 5, wait_for_async_insert_timeout = 10 VALUES (1);
+SELECT 'insert_completed', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_log;
 
 -- Positive control: two views on one MergeTree target is supported and must keep being fuzzed, so
 -- the executed counter advances while the skip counter stays put. This also proves both counters
 -- are live under these settings, so the assertion above is not reading a dead counter.
-CREATE TABLE fuzz_mt (k Int) ENGINE = MergeTree ORDER BY k;
-CREATE MATERIALIZED VIEW fuzz_mv_mt TO fuzz_mt AS SELECT k FROM fuzz_src
-SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_mt (k Int) ENGINE = MergeTree ORDER BY k;
+-- Microsecond boundary from the SERVER, stored in the fixture's `executed` slot: every clone this
+-- section logs starts after it, and every row an earlier run left behind starts before it.
+INSERT INTO fuzz_events SELECT 'safe_boundary', 0, 0, toUnixTimestamp64Micro(now64(6));
+
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_mv_mt TO {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_mt AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.fuzz_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1, log_comment = '04876_safe';
 
 INSERT INTO fuzz_events
 SELECT 'after_safe',
@@ -94,35 +120,51 @@ SELECT 'after_safe',
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
--- Bounded rather than pinned to zero: `no-parallel` only serializes within one clickhouse-test
--- process, while the stress runner drives several against one server, and a foreign fuzzed query can
--- only inflate these server-global counters. A skip delta below the executed delta still shows this
--- section's own queries were executed rather than withdrawn, which is the claim.
-SELECT 'safe_target_not_skipped',
-      (SELECT skipped FROM fuzz_events WHERE label = 'after_safe')
-    - (SELECT skipped FROM fuzz_events WHERE label = 'after_hazard')
-    < (SELECT executed FROM fuzz_events WHERE label = 'after_safe')
-    - (SELECT executed FROM fuzz_events WHERE label = 'after_hazard');
+-- Attributable to THIS fixture rather than to the server-global counters. The skip event is
+-- incremented in the query-finish callback and the loop then `continue`s, while `ASTFuzzerQueries` is
+-- incremented only on the execution path, so a foreign hazardous fuzz raises the skip side of a
+-- relative comparison without raising the executed side and a foreign skip can satisfy it outright.
+-- What is claimed here is about this section's OWN clones, and that is directly observable in
+-- query_log: a withdrawn clone never reaches execution and is therefore never logged, while an
+-- executed one always is. The database, the log_comment and the boundary timestamp together exclude
+-- both a foreign process and an earlier run of this same file.
+SYSTEM FLUSH LOGS query_log;
 
+INSERT INTO fuzz_events
+SELECT 'safe_own_clones', 0, 0, count(DISTINCT query_id)
+FROM system.query_log
+WHERE event_date >= today() - 1
+  AND toUnixTimestamp64Micro(event_time_microseconds)
+      >= (SELECT executed FROM fuzz_events WHERE label = 'safe_boundary')
+  AND current_database = currentDatabase()
+  AND log_comment = '04876_safe'
+  AND query LIKE '%fuzz\_mv\_mt\_\_fuzz%'
+SETTINGS enable_parallel_replicas = 0;
+
+-- Executed, not withdrawn: a clone of the safe-target view reached execution.
 SELECT 'safe_target_executed',
-      (SELECT executed FROM fuzz_events WHERE label = 'after_safe')
-    - (SELECT executed FROM fuzz_events WHERE label = 'after_hazard') > 0;
+      (SELECT executed FROM fuzz_events WHERE label = 'safe_own_clones') > 0;
 
-DROP TABLE fuzz_mv_mt;
-DROP TABLE fuzz_mv;
-DROP TABLE fuzz_mt;
-DROP TABLE fuzz_log;
-DROP TABLE fuzz_src;
+-- And not skipped, stated against THIS file's other section rather than a server-global delta: the
+-- hazardous section withdraws almost every clone it generates while the safe section executes almost
+-- all of its own, so the safe section's own logged-clone count must exceed the hazardous section's.
+-- Both sides are counted from this file's own query_log rows, so a foreign fuzzing process cannot
+-- move either one. Measured margin over 5 trials: hazard 1-7 of 30, safe 29-30 of 30.
+SELECT 'safe_target_not_skipped',
+      (SELECT executed FROM fuzz_events WHERE label = 'safe_own_clones')
+    > (SELECT executed FROM fuzz_events WHERE label = 'hazard_own_clones');
+
+
 
 -- The hazard reached through a lazily loaded table. DETACH/ATTACH DATABASE replaces every plain
 -- table with a proxy that renames the storage it wraps to the proxy's own id, so a walk that
 -- re-entered by id would read the hop as a cycle and report the whole graph as safe.
 -- Dropped SYNC rather than plain: an Atomic database dropped asynchronously can still hold its
 -- metadata directory when the CREATE below runs.
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} SYNC;
-CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Atomic SETTINGS lazy_load_tables = 1;
-CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.src (k Int) ENGINE = Null;
-CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.tgt (k Int) ENGINE = TinyLog;
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_2:Identifier} SYNC;
+CREATE DATABASE {CLICKHOUSE_DATABASE_2:Identifier} ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+CREATE TABLE {CLICKHOUSE_DATABASE_2:Identifier}.src (k Int) ENGINE = Null;
+CREATE TABLE {CLICKHOUSE_DATABASE_2:Identifier}.tgt (k Int) ENGINE = TinyLog;
 -- The DETACH/ATTACH pair is what replaces every table with a proxy, and it is load-bearing:
 -- `lazy_load_tables = 1` alone leaves `tgt` reported as `TinyLog` (measured), so the proxy hop this
 -- section exists to exercise is never reached without it.
@@ -133,10 +175,10 @@ CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.tgt (k Int) ENGINE = TinyLog;
 -- recovery is available: a detached database appears in neither system.databases nor
 -- system.detached_tables, and `ATTACH DATABASE IF NOT EXISTS` on a never-created name throws
 -- `Code: 336`. Keeping the interval empty is therefore the whole guarantee.
-DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
-ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+DETACH DATABASE {CLICKHOUSE_DATABASE_2:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_2:Identifier};
 SELECT 'lazy_proxy_engine', engine FROM system.tables
-WHERE database = {CLICKHOUSE_DATABASE_1:String} AND name = 'tgt';
+WHERE database = {CLICKHOUSE_DATABASE_2:String} AND name = 'tgt';
 
 INSERT INTO fuzz_events
 SELECT 'before_lazy',
@@ -145,9 +187,9 @@ SELECT 'before_lazy',
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
-CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.mv
-TO {CLICKHOUSE_DATABASE_1:Identifier}.tgt
-AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.src
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_2:Identifier}.mv
+TO {CLICKHOUSE_DATABASE_2:Identifier}.tgt
+AS SELECT k FROM {CLICKHOUSE_DATABASE_2:Identifier}.src
 SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
 
 INSERT INTO fuzz_events
@@ -161,31 +203,25 @@ SELECT 'lazy_proxy_clone_skipped',
       (SELECT skipped FROM fuzz_events WHERE label = 'after_lazy')
     - (SELECT skipped FROM fuzz_events WHERE label = 'before_lazy') > 0;
 
-INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.src
+INSERT INTO {CLICKHOUSE_DATABASE_2:Identifier}.src
 SETTINGS lock_acquire_timeout = 5, wait_for_async_insert_timeout = 10 VALUES (1);
-SELECT 'lazy_proxy_insert_completed', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.tgt;
+SELECT 'lazy_proxy_insert_completed', count() FROM {CLICKHOUSE_DATABASE_2:Identifier}.tgt;
 
-DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+DROP DATABASE {CLICKHOUSE_DATABASE_2:Identifier};
 
 -- An undecided answer is counted rather than silently read as safe: the dependent view's own
 -- target is detached, so that branch cannot be resolved, and the query is still fuzzed.
-DROP TABLE IF EXISTS und_mv;
-DROP TABLE IF EXISTS und_mv_gone;
-DROP TABLE IF EXISTS und_src;
-DROP TABLE IF EXISTS und_mt;
-DROP TABLE IF EXISTS und_gone;
-
-CREATE TABLE und_src (k Int) ENGINE = Null;
-CREATE TABLE und_mt (k Int) ENGINE = MergeTree ORDER BY k;
-CREATE TABLE und_gone (k Int) ENGINE = TinyLog;
-CREATE MATERIALIZED VIEW und_mv_gone TO und_gone AS SELECT k FROM und_mt;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.und_src (k Int) ENGINE = Null;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.und_mt (k Int) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.und_gone (k Int) ENGINE = TinyLog;
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.und_mv_gone TO {CLICKHOUSE_DATABASE_1:Identifier}.und_gone AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.und_mt;
 -- Dropped rather than detached. Either makes the dependent view's target unresolvable, so the walk
 -- reports undecided identically (measured: 30 undecided of 30 runs both ways), but a detached table
 -- is invisible to DROP and its metadata file survives, so a run that failed anywhere inside the
 -- detached interval left `und_gone` undroppable and the next run in the same database hit
 -- `already exists (detached)`. The interval here spans a 30-run fuzz loop, which is the widest
 -- window in the file; DROP leaves nothing to recover.
-DROP TABLE und_gone;
+DROP TABLE {CLICKHOUSE_DATABASE_1:Identifier}.und_gone;
 
 INSERT INTO fuzz_events
 SELECT 'before_undecided',
@@ -199,7 +235,7 @@ FROM system.events;
 -- starts before it.
 INSERT INTO fuzz_events SELECT 'undecided_boundary', 0, 0, toUnixTimestamp64Micro(now64(6));
 
-CREATE MATERIALIZED VIEW und_mv TO und_mt AS SELECT k FROM und_src
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.und_mv TO {CLICKHOUSE_DATABASE_1:Identifier}.und_mt AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.und_src
 SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1, log_comment = '04876_undecided';
 
 INSERT INTO fuzz_events
@@ -240,10 +276,6 @@ SELECT 'undecided_counted',
 SELECT 'undecided_executed_nonzero',
       (SELECT executed FROM fuzz_events WHERE label = 'undecided_own_clones') > 0;
 
-DROP TABLE und_mv;
-DROP TABLE und_mv_gone;
-DROP TABLE und_mt;
-DROP TABLE und_src;
 
 -- A queue engine sets `noPushingToViewsOnInserts`, so a direct INSERT into it pushes to no view -
 -- but its background consumer inserts with `no_destination`, which does build a sink for every
@@ -251,14 +283,8 @@ DROP TABLE und_src;
 -- clone sharing the TinyLog target has to be skipped. Kafka is used because it is the queue
 -- carrier constructible without a live broker; the same override is on Kafka2, FileLog, NATS and
 -- RabbitMQ. The skip is decided at CREATE time, so no broker is needed here.
-DROP TABLE IF EXISTS q_mv;
-DROP TABLE IF EXISTS q_mv_mt;
-DROP TABLE IF EXISTS q_src;
-DROP TABLE IF EXISTS q_log;
-DROP TABLE IF EXISTS q_mt;
-
-CREATE TABLE q_log (k Int) ENGINE = TinyLog;
-CREATE TABLE q_src (k Int) ENGINE = Kafka
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.q_log (k Int) ENGINE = TinyLog;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.q_src (k Int) ENGINE = Kafka
     SETTINGS kafka_broker_list = 'localhost:9092', kafka_topic_list = '04876_q',
              kafka_group_name = '04876_q', kafka_format = 'CSV';
 
@@ -269,8 +295,11 @@ SELECT 'before_queue',
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
-CREATE MATERIALIZED VIEW q_mv TO q_log AS SELECT k FROM q_src
-SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+-- Boundary for this section's own clones, as in the sections above.
+INSERT INTO fuzz_events SELECT 'queue_boundary', 0, 0, toUnixTimestamp64Micro(now64(6));
+
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.q_mv TO {CLICKHOUSE_DATABASE_1:Identifier}.q_log AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.q_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1, log_comment = '04876_queue';
 
 INSERT INTO fuzz_events
 SELECT 'after_queue',
@@ -283,11 +312,27 @@ SELECT 'queue_source_clone_skipped',
       (SELECT skipped FROM fuzz_events WHERE label = 'after_queue')
     - (SELECT skipped FROM fuzz_events WHERE label = 'before_queue') > 0;
 
+SYSTEM FLUSH LOGS query_log;
+
+INSERT INTO fuzz_events
+SELECT 'queue_own_clones', 0, 0, count(DISTINCT query_id)
+FROM system.query_log
+WHERE event_date >= today() - 1
+  AND toUnixTimestamp64Micro(event_time_microseconds)
+      >= (SELECT executed FROM fuzz_events WHERE label = 'queue_boundary')
+  AND current_database = currentDatabase()
+  AND log_comment = '04876_queue'
+  AND query LIKE '%q\_mv\_\_fuzz%'
+SETTINGS enable_parallel_replicas = 0;
+
 -- Control: the same queue source over a parallel-capable target must keep being fuzzed, so a
 -- positive above is not every queue-sourced view being reported hazardous.
-CREATE TABLE q_mt (k Int) ENGINE = MergeTree ORDER BY k;
-CREATE MATERIALIZED VIEW q_mv_mt TO q_mt AS SELECT k FROM q_src
-SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.q_mt (k Int) ENGINE = MergeTree ORDER BY k;
+-- Boundary for this section's own clones, as in the safe-target section above.
+INSERT INTO fuzz_events SELECT 'queue_safe_boundary', 0, 0, toUnixTimestamp64Micro(now64(6));
+
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.q_mv_mt TO {CLICKHOUSE_DATABASE_1:Identifier}.q_mt AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.q_src
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1, log_comment = '04876_qsafe';
 
 INSERT INTO fuzz_events
 SELECT 'after_queue_safe',
@@ -296,22 +341,31 @@ SELECT 'after_queue_safe',
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
-SELECT 'queue_source_safe_target_not_skipped',
-      (SELECT skipped FROM fuzz_events WHERE label = 'after_queue_safe')
-    - (SELECT skipped FROM fuzz_events WHERE label = 'after_queue')
-    < (SELECT executed FROM fuzz_events WHERE label = 'after_queue_safe')
-    - (SELECT executed FROM fuzz_events WHERE label = 'after_queue');
+-- Same fixture-attributable form as the safe-target section: a foreign fuzz can only move the
+-- server-global counters, never this section's own logged clones.
+SYSTEM FLUSH LOGS query_log;
+
+INSERT INTO fuzz_events
+SELECT 'queue_safe_own_clones', 0, 0, count(DISTINCT query_id)
+FROM system.query_log
+WHERE event_date >= today() - 1
+  AND toUnixTimestamp64Micro(event_time_microseconds)
+      >= (SELECT executed FROM fuzz_events WHERE label = 'queue_safe_boundary')
+  AND current_database = currentDatabase()
+  AND log_comment = '04876_qsafe'
+  AND query LIKE '%q\_mv\_mt\_\_fuzz%'
+SETTINGS enable_parallel_replicas = 0;
 
 SELECT 'queue_source_safe_target_executed',
-      (SELECT executed FROM fuzz_events WHERE label = 'after_queue_safe')
-    - (SELECT executed FROM fuzz_events WHERE label = 'after_queue') > 0;
+      (SELECT executed FROM fuzz_events WHERE label = 'queue_safe_own_clones') > 0;
 
-DROP TABLE q_mv_mt;
-DROP TABLE q_mv;
-DROP TABLE q_mt;
-DROP TABLE q_src;
-DROP TABLE q_log;
+SELECT 'queue_source_safe_target_not_skipped',
+      (SELECT executed FROM fuzz_events WHERE label = 'queue_safe_own_clones')
+    > (SELECT executed FROM fuzz_events WHERE label = 'queue_own_clones');
 
+
+-- One statement removes every fixture AND every fuzz clone, whatever the clones were named.
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier} SYNC;
 DROP TABLE fuzz_events;
 
 SELECT 'alive';

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
@@ -1,10 +1,14 @@
--- Tags: no-ordinary-database, no-parallel
+-- Tags: no-ordinary-database, no-parallel, log-engine, no-replicated-database
 -- no-parallel: reads the server-global ProfileEvents counters
 -- ASTFuzzerSkippedSharedNonParallelTarget, ASTFuzzerSkipCheckFailed and ASTFuzzerQueries, so no
 -- other test may run fuzzed queries against the same server while this one measures the deltas.
 -- The counters are bumped in the query-finish callback, after the query's own ProfileEvents
 -- snapshot is taken, so system.query_log carries none of them and per-query_id attribution
 -- (the 04339 pattern, which does not need the tag) is not available here.
+-- log-engine: the whole oracle rests on the target NOT supporting parallel insert, which
+-- --replace-log-memory-with-mergetree rewrites away (it also rewrites the Memory fixture).
+-- no-replicated-database: for the lazy_load_tables section below, plus a DETACH TABLE inside the
+-- test database.
 
 -- The serverfuzz/stress profile sets ast_fuzzer_runs server-wide, which would make every statement
 -- here fire the fuzzer and pollute the counters. Pin the baseline to 0 so only statements with an
@@ -12,12 +16,17 @@
 SET ast_fuzzer_runs = 0;
 SET ast_fuzzer_any_query = 0;
 SET send_logs_level = 'fatal';
+-- The stress runner appends this unconditionally; a DROP of a table that stores no data on disk
+-- then becomes a TRUNCATE, so fuzz_events would survive its own DROP and the next CREATE would fail.
+SET ignore_drop_queries_probability = 0;
 
 DROP TABLE IF EXISTS fuzz_src;
 DROP TABLE IF EXISTS fuzz_log;
 DROP TABLE IF EXISTS fuzz_mt;
 DROP TABLE IF EXISTS fuzz_events;
 
+-- One table for every section: each row is keyed by its own label, and creating it once keeps the
+-- fixture independent of whether a DROP in between was honoured.
 CREATE TABLE fuzz_events (label String, skipped Int64, undecided Int64, executed Int64) ENGINE = Memory;
 
 -- sumIf over the (possibly absent) rows yields 0 before an event has ever fired, so the delta
@@ -85,20 +94,19 @@ DROP TABLE fuzz_mv;
 DROP TABLE fuzz_mt;
 DROP TABLE fuzz_log;
 DROP TABLE fuzz_src;
-DROP TABLE fuzz_events;
 
 -- The hazard reached through a lazily loaded table. DETACH/ATTACH DATABASE replaces every plain
 -- table with a proxy that renames the storage it wraps to the proxy's own id, so a walk that
 -- re-entered by id would read the hop as a cycle and report the whole graph as safe.
-DROP DATABASE IF EXISTS 04876_lazy;
-CREATE DATABASE 04876_lazy ENGINE = Atomic SETTINGS lazy_load_tables = 1;
-CREATE TABLE 04876_lazy.src (k Int) ENGINE = Null;
-CREATE TABLE 04876_lazy.tgt (k Int) ENGINE = TinyLog;
-DETACH DATABASE 04876_lazy;
-ATTACH DATABASE 04876_lazy;
-SELECT 'lazy_proxy_engine', engine FROM system.tables WHERE database = '04876_lazy' AND name = 'tgt';
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Atomic SETTINGS lazy_load_tables = 1;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.src (k Int) ENGINE = Null;
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.tgt (k Int) ENGINE = TinyLog;
+DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
+SELECT 'lazy_proxy_engine', engine FROM system.tables
+WHERE database = {CLICKHOUSE_DATABASE_1:String} AND name = 'tgt';
 
-CREATE TABLE fuzz_events (label String, skipped Int64, undecided Int64, executed Int64) ENGINE = Memory;
 INSERT INTO fuzz_events
 SELECT 'before_lazy',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
@@ -106,7 +114,9 @@ SELECT 'before_lazy',
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
-CREATE MATERIALIZED VIEW 04876_lazy.mv TO 04876_lazy.tgt AS SELECT k FROM 04876_lazy.src
+CREATE MATERIALIZED VIEW {CLICKHOUSE_DATABASE_1:Identifier}.mv
+TO {CLICKHOUSE_DATABASE_1:Identifier}.tgt
+AS SELECT k FROM {CLICKHOUSE_DATABASE_1:Identifier}.src
 SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
 
 INSERT INTO fuzz_events
@@ -120,11 +130,11 @@ SELECT 'lazy_proxy_clone_skipped',
       (SELECT skipped FROM fuzz_events WHERE label = 'after_lazy')
     - (SELECT skipped FROM fuzz_events WHERE label = 'before_lazy') > 0;
 
-INSERT INTO 04876_lazy.src SETTINGS lock_acquire_timeout = 5, wait_for_async_insert_timeout = 10 VALUES (1);
-SELECT 'lazy_proxy_insert_completed', count() FROM 04876_lazy.tgt;
+INSERT INTO {CLICKHOUSE_DATABASE_1:Identifier}.src
+SETTINGS lock_acquire_timeout = 5, wait_for_async_insert_timeout = 10 VALUES (1);
+SELECT 'lazy_proxy_insert_completed', count() FROM {CLICKHOUSE_DATABASE_1:Identifier}.tgt;
 
-DROP DATABASE 04876_lazy;
-DROP TABLE fuzz_events;
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- An undecided answer is counted rather than silently read as safe: the dependent view's own
 -- target is detached, so that branch cannot be resolved, and the query is still fuzzed.
@@ -138,7 +148,6 @@ CREATE TABLE und_gone (k Int) ENGINE = TinyLog;
 CREATE MATERIALIZED VIEW und_mv_gone TO und_gone AS SELECT k FROM und_mt;
 DETACH TABLE und_gone;
 
-CREATE TABLE fuzz_events (label String, skipped Int64, undecided Int64, executed Int64) ENGINE = Memory;
 INSERT INTO fuzz_events
 SELECT 'before_undecided',
        toInt64(sumIf(value, event = 'ASTFuzzerSkippedSharedNonParallelTarget')),
@@ -165,6 +174,12 @@ SELECT 'undecided_counted',
     - (SELECT undecided FROM fuzz_events WHERE label = 'before_undecided')
    >= (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
     - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided');
+
+-- Lower bound for the comparison above, which two zeroes would otherwise satisfy without any
+-- query having been fuzzed at all.
+SELECT 'undecided_executed_nonzero',
+      (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
+    - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided') > 0;
 
 SELECT 'undecided_not_skipped',
       (SELECT skipped FROM fuzz_events WHERE label = 'after_undecided')

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
@@ -11,9 +11,7 @@
 -- The tag is what makes the deltas attributable, and it is load-bearing rather than cosmetic: it
 -- serializes only within one clickhouse-test process, while the stress runner drives several against
 -- one server. Measured under a concurrent fuzzing process, every claim that a delta was exactly zero
--- failed 15 of 15 runs, so those are bounded by this section's own executed delta instead and then
--- held 30 of 30. The undecided-versus-executed comparison remains same-window by nature: a foreign
--- decided query inflates only the executed side, so it too relies on the tag.
+-- failed 15 of 15 runs, so those are bounded by this section's own executed delta instead.
 -- log-engine: the whole oracle rests on the target NOT supporting parallel insert, which
 -- --replace-log-memory-with-mergetree rewrites away (it also rewrites the Memory fixture).
 -- no-replicated-database: for the lazy_load_tables section below, plus a DETACH TABLE inside the
@@ -171,7 +169,7 @@ SELECT 'before_undecided',
 FROM system.events;
 
 CREATE MATERIALIZED VIEW und_mv TO und_mt AS SELECT k FROM und_src
-SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1;
+SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1, log_comment = '04876_undecided';
 
 INSERT INTO fuzz_events
 SELECT 'after_undecided',
@@ -181,29 +179,30 @@ SELECT 'after_undecided',
 FROM system.events;
 
 -- Every fuzzed CREATE here hits the unresolvable branch, so each executed query must contribute an
--- undecided verdict. Compared against the executed count rather than against zero: this same counter
--- also fires when the dependency extractor throws on a shape the fuzzer injected, which happens on a
--- few runs regardless, so a `> 0` assertion would hold even with the exits uncounted. Not a fixed
--- floor either: the fuzz loop stops early on some runs (both deltas measured 30 on 18 of 20 runs and
--- 14 on the other two), and it is their equality that is the claim.
+-- undecided verdict. The right side counts this section's OWN clones out of query_log instead of a
+-- server-global counter: a withdrawn clone never reaches execution and so is never logged, while an
+-- executed one always is. A foreign fuzzing process can therefore only raise the left side, which
+-- makes the inequality one-sided in the safe direction rather than same-window.
+SYSTEM FLUSH LOGS query_log;
+
+INSERT INTO fuzz_events
+SELECT 'undecided_own_clones', 0, 0, count(DISTINCT query_id)
+FROM system.query_log
+WHERE event_date >= today() - 1
+  AND current_database = currentDatabase()
+  AND log_comment = '04876_undecided'
+  AND query LIKE '%und\_mv\_\_fuzz%'
+SETTINGS enable_parallel_replicas = 0;
+
 SELECT 'undecided_counted',
       (SELECT undecided FROM fuzz_events WHERE label = 'after_undecided')
     - (SELECT undecided FROM fuzz_events WHERE label = 'before_undecided')
-   >= (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
-    - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided');
+   >= (SELECT executed FROM fuzz_events WHERE label = 'undecided_own_clones');
 
 -- Lower bound for the comparison above, which two zeroes would otherwise satisfy without any
 -- query having been fuzzed at all.
 SELECT 'undecided_executed_nonzero',
-      (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
-    - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided') > 0;
-
--- Bounded, not pinned to zero, for the same reason as safe_target_not_skipped above.
-SELECT 'undecided_not_skipped',
-      (SELECT skipped FROM fuzz_events WHERE label = 'after_undecided')
-    - (SELECT skipped FROM fuzz_events WHERE label = 'before_undecided')
-    < (SELECT executed FROM fuzz_events WHERE label = 'after_undecided')
-    - (SELECT executed FROM fuzz_events WHERE label = 'before_undecided');
+      (SELECT executed FROM fuzz_events WHERE label = 'undecided_own_clones') > 0;
 
 ATTACH TABLE und_gone;
 DROP TABLE und_mv;

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
@@ -27,6 +27,11 @@ SET send_logs_level = 'fatal';
 -- then becomes a TRUNCATE, so fuzz_events would survive its own DROP and the next CREATE would fail.
 SET ignore_drop_queries_probability = 0;
 
+-- A materialized view does not disappear with its source table, and a run that fails is retried
+-- against the same database, so every object the file creates is dropped up front rather than
+-- relying only on the unconditional drops at the end of each section.
+DROP TABLE IF EXISTS fuzz_mv;
+DROP TABLE IF EXISTS fuzz_mv_mt;
 DROP TABLE IF EXISTS fuzz_src;
 DROP TABLE IF EXISTS fuzz_log;
 DROP TABLE IF EXISTS fuzz_mt;
@@ -151,6 +156,8 @@ DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- An undecided answer is counted rather than silently read as safe: the dependent view's own
 -- target is detached, so that branch cannot be resolved, and the query is still fuzzed.
+DROP TABLE IF EXISTS und_mv;
+DROP TABLE IF EXISTS und_mv_gone;
 DROP TABLE IF EXISTS und_src;
 DROP TABLE IF EXISTS und_mt;
 DROP TABLE IF EXISTS und_gone;
@@ -168,6 +175,11 @@ SELECT 'before_undecided',
        toInt64(sumIf(value, event = 'ASTFuzzerQueries'))
 FROM system.events;
 
+-- Microsecond boundary, taken from the SERVER and stored in the fixture's `executed` slot. Every
+-- clone this section logs starts after it, and every row an earlier run of this file left behind
+-- starts before it.
+INSERT INTO fuzz_events SELECT 'undecided_boundary', 0, 0, toUnixTimestamp64Micro(now64(6));
+
 CREATE MATERIALIZED VIEW und_mv TO und_mt AS SELECT k FROM und_src
 SETTINGS ast_fuzzer_runs = 30, ast_fuzzer_any_query = 1, log_comment = '04876_undecided';
 
@@ -183,12 +195,17 @@ FROM system.events;
 -- server-global counter: a withdrawn clone never reaches execution and so is never logged, while an
 -- executed one always is. A foreign fuzzing process can therefore only raise the left side, which
 -- makes the inequality one-sided in the safe direction rather than same-window.
+-- The database and log_comment predicates separate a foreign process; the boundary timestamp is
+-- what separates an earlier run of this same file, whose rows carry the same constant comment and,
+-- when the runner is given a fixed --database, the same database too.
 SYSTEM FLUSH LOGS query_log;
 
 INSERT INTO fuzz_events
 SELECT 'undecided_own_clones', 0, 0, count(DISTINCT query_id)
 FROM system.query_log
 WHERE event_date >= today() - 1
+  AND toUnixTimestamp64Micro(event_time_microseconds)
+      >= (SELECT executed FROM fuzz_events WHERE label = 'undecided_boundary')
   AND current_database = currentDatabase()
   AND log_comment = '04876_undecided'
   AND query LIKE '%und\_mv\_\_fuzz%'
@@ -217,6 +234,8 @@ DROP TABLE und_src;
 -- clone sharing the TinyLog target has to be skipped. Kafka is used because it is the queue
 -- carrier constructible without a live broker; the same override is on Kafka2, FileLog, NATS and
 -- RabbitMQ. The skip is decided at CREATE time, so no broker is needed here.
+DROP TABLE IF EXISTS q_mv;
+DROP TABLE IF EXISTS q_mv_mt;
 DROP TABLE IF EXISTS q_src;
 DROP TABLE IF EXISTS q_log;
 DROP TABLE IF EXISTS q_mt;

--- a/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
+++ b/tests/queries/0_stateless/04876_ast_fuzzer_skips_duplicate_non_parallel_sink.sql
@@ -30,6 +30,7 @@ SET ignore_drop_queries_probability = 0;
 -- A materialized view does not disappear with its source table, and a run that fails is retried
 -- against the same database, so every object the file creates is dropped up front rather than
 -- relying only on the unconditional drops at the end of each section.
+--
 DROP TABLE IF EXISTS fuzz_mv;
 DROP TABLE IF EXISTS fuzz_mv_mt;
 DROP TABLE IF EXISTS fuzz_src;
@@ -116,10 +117,22 @@ DROP TABLE fuzz_src;
 -- The hazard reached through a lazily loaded table. DETACH/ATTACH DATABASE replaces every plain
 -- table with a proxy that renames the storage it wraps to the proxy's own id, so a walk that
 -- re-entered by id would read the hop as a cycle and report the whole graph as safe.
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+-- Dropped SYNC rather than plain: an Atomic database dropped asynchronously can still hold its
+-- metadata directory when the CREATE below runs.
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} SYNC;
 CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Atomic SETTINGS lazy_load_tables = 1;
 CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.src (k Int) ENGINE = Null;
 CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.tgt (k Int) ENGINE = TinyLog;
+-- The DETACH/ATTACH pair is what replaces every table with a proxy, and it is load-bearing:
+-- `lazy_load_tables = 1` alone leaves `tgt` reported as `TinyLog` (measured), so the proxy hop this
+-- section exists to exercise is never reached without it.
+-- The two statements are adjacent so nothing that can fail sits inside the detached interval. That
+-- matters because a database left detached is invisible to `DROP DATABASE IF EXISTS` -- which then
+-- succeeds without removing anything while the metadata directory survives, so the next run's CREATE
+-- fails with `Code: 521 Cannot rename ...` (measured, with and without SYNC), and no SQL-level
+-- recovery is available: a detached database appears in neither system.databases nor
+-- system.detached_tables, and `ATTACH DATABASE IF NOT EXISTS` on a never-created name throws
+-- `Code: 336`. Keeping the interval empty is therefore the whole guarantee.
 DETACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 ATTACH DATABASE {CLICKHOUSE_DATABASE_1:Identifier};
 SELECT 'lazy_proxy_engine', engine FROM system.tables
@@ -166,7 +179,13 @@ CREATE TABLE und_src (k Int) ENGINE = Null;
 CREATE TABLE und_mt (k Int) ENGINE = MergeTree ORDER BY k;
 CREATE TABLE und_gone (k Int) ENGINE = TinyLog;
 CREATE MATERIALIZED VIEW und_mv_gone TO und_gone AS SELECT k FROM und_mt;
-DETACH TABLE und_gone;
+-- Dropped rather than detached. Either makes the dependent view's target unresolvable, so the walk
+-- reports undecided identically (measured: 30 undecided of 30 runs both ways), but a detached table
+-- is invisible to DROP and its metadata file survives, so a run that failed anywhere inside the
+-- detached interval left `und_gone` undroppable and the next run in the same database hit
+-- `already exists (detached)`. The interval here spans a 30-run fuzz loop, which is the widest
+-- window in the file; DROP leaves nothing to recover.
+DROP TABLE und_gone;
 
 INSERT INTO fuzz_events
 SELECT 'before_undecided',
@@ -221,10 +240,8 @@ SELECT 'undecided_counted',
 SELECT 'undecided_executed_nonzero',
       (SELECT executed FROM fuzz_events WHERE label = 'undecided_own_clones') > 0;
 
-ATTACH TABLE und_gone;
 DROP TABLE und_mv;
 DROP TABLE und_mv_gone;
-DROP TABLE und_gone;
 DROP TABLE und_mt;
 DROP TABLE und_src;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110166
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/110166

Reported by @ alexey-milovidov there: a `Stress test (arm_release)` hung check on an `INSERT` stuck in
`StorageLog::write`.
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110166&sha=c890bb8e35d0d9138c1fa770e1fd4a1db05f39bf&name_0=PR&name_1=Stress%20test%20%28arm_release%29

It is not lock contention under load. Fuzzing a `CREATE MATERIALIZED VIEW` renames the view but leaves its
external `TO` untouched, so the clone shares source *and* target with the original and one `INSERT` builds
two sinks for that target. `LogSink` holds the table's exclusive lock from pipeline build until
`onFinish`, so the second sink waits out `lock_acquire_timeout` and throws `Code: 159`; the `INSERT`
re-arms, the processlist never empties, and the hung check fails. Reproducible in 4 statements with no
concurrency and no fuzzer, on three build flavours.

This skips such a fuzzed query instead of creating the view. Whether it is hazardous is a sink-graph
question, so it is answered in `InsertDependenciesBuilder`, which owns that graph, and it errs only
towards skipping: safe shared-target fuzzing keeps running, and a sole writer of a non-parallel target is
unaffected. `Buffer` and `Distributed` end a branch, since the write they forward runs as an `INSERT` of
their own whose sinks this walk does not model. Anything the walk cannot decide executes normally and is
counted, so an undecided answer never suppresses fuzzing. Two `ProfileEvents` make both outcomes
attributable; the path is confined to `ast_fuzzer_runs > 0`.

A proven duplicate survives a later branch that throws while materializing a lazy storage. And since the
answer describes the catalog, where a view appears only once its `CREATE` has executed, the fuzzer
reserves the (source, target) pair across the decision and the create; the contract states that boundary.

Refusing two writers on one `Log`-family target at INSERT planning time is out of scope: that is
user-visible, and on #74080 the same topology was answered as unsupported.

<details><summary>Validation</summary>

Ground truth measured on a pre-fix binary by building the duplication by hand, against the predicate's
verdict on the same 9 topologies (agreement is 9/9):

| topology | wedges pre-fix | skipped |
|---|---|---|
| `src -> mv -> tgt(TinyLog)` | yes | yes |
| `src -> mvA -> mt(MergeTree) -> mvB -> lg(TinyLog)` | yes | yes |
| `Alias`-hidden: `mv TO Alias(mt)`, `mt -> mv2 -> lg` | yes | yes |
| deep cascade `mt1..mt8 -> lg` | yes | yes |
| `Alias(MergeTree) -> view -> Memory` | no | no |
| directly shared `Buffer` | no | no |
| directly shared `Distributed` | no | no |
| stale edge (`MODIFY QUERY` away from `mt`) | no | no |
| shared `MergeTree` | no | no |

Plus the hazard behind a lazily loaded table (`lazy_load_tables`, wedges pre-fix, skipped) and its
`MergeTree` counterpart (skipped in neither).

Through the real carrier (`--ast_fuzzer_runs=40 --ast_fuzzer_any_query=1`): pre-fix the `INSERT` fails
`Code: 159`; with the fix the hazardous arms are skipped, the insert completes, and the safe arms are
untouched. Removing the skip restores the failure; removing the name withdrawal makes 345 of 480 later
fuzzed queries name a view that was never created (0 with it).

`04876_ast_fuzzer_skips_duplicate_non_parallel_sink` states each claim against its own fixture's
query_log rows rather than server-global counters, so a concurrent fuzzing process cannot move them: 30/30
green under a deliberate adversary, 50/50 randomized green, 32 consecutive runs in one database with
nothing left behind, and eight mutations each flipping exactly their own assertion. It fails with the skip
removed (`Code: 159`) and with the proxy hop reverted.

</details>