### PR TITLE
Fix flaky 02999_scalar_subqueries_bug_2

### DIFF
--- a/tests/queries/0_stateless/02999_scalar_subqueries_bug_2.sql
+++ b/tests/queries/0_stateless/02999_scalar_subqueries_bug_2.sql
@@ -2,6 +2,7 @@ drop table if exists source;
 drop table if exists target1;
 drop table if exists target2;
 drop table if exists v_heavy;
+drop table if exists t_as_select;
 
 
 create table source(type String) engine=MergeTree order by type;
@@ -13,6 +14,12 @@ select count(*) n from (select number from numbers(1e5) n1 cross join nums);
 create table target1(type String) engine=MergeTree order by type;
 create table target2(type String) engine=MergeTree order by type;
 
-set max_execution_time=2;
--- we should not execute scalar subquery here
-create materialized view vm_target2 to target2 as select * from source where type='two' and (select sum(sleepEachRow(0.1)) from numbers(30));
+-- A scalar subquery in a statement that is only analyzed, never executed, must not be
+-- evaluated, so `throwIf` never fires. This is checked with `throwIf` rather than with a
+-- timeout, because a timeout makes the test depend on machine load.
+create materialized view vm_target2 to target2 as select * from source where type='two' and (select throwIf(1));
+
+create table t_as_select engine=MergeTree order by tuple() empty as select * from source where type='two' and (select throwIf(1));
+
+-- But it is evaluated when the statement is actually executed.
+select * from source where type='two' and (select throwIf(1)) format Null; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Failure report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2485f1496f7dff85c6468cc59d1856cec0f92a9d&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29

Related: https://github.com/ClickHouse/ClickHouse/pull/111983
Related: https://github.com/ClickHouse/ClickHouse/pull/91744


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`02999_scalar_subqueries_bug_2` checked that the scalar subquery in a materialized view
definition is not executed at CREATE time by racing a 2 second `max_execution_time` against a
3 second `sleepEachRow`. That makes the test depend on machine load rather than on the property
under test, and it failed on master in `Stateless tests (amd_tsan, parallel)`:

```
Code: 159. DB::Exception: Timeout exceeded: maximum: 2000 ms. (TIMEOUT_EXCEEDED)
(query 10, line 17)
```

The diagnostics rerun passed 43/43 with the same randomized settings.

The scalar was not executed. The message carries no `elapsed ... ms` clause, while the in-sleep
deadline check (`sleep.cpp:168`) goes through `checkTimeLimit`, which always reports a non-zero
elapsed; the statement was cancelled while still pending, since every query including DDL is
registered with the `CancellationChecker` watchdog unconditionally (`ProcessList.cpp:381`). The
engine behaved correctly and only the clock failed. `max_execution_time` is not randomized by the
runner, so there is no setting to pin, and widening the bound was already tried on the structural
twin (#91744) without holding.

I removed the timing oracle and assert the property directly with `throwIf(1)`, following
@ alexey-milovidov's fix for that twin in #111983. If the scalar is not executed `throwIf` never
fires; if it ever is, the statement fails `FUNCTION_THROW_IF_VALUE_IS_NON_ZERO`.
`throwIf::isSuitableForConstantFolding` returns `false` (`throwIf.cpp:94`), the same guard
`sleepEachRow` relies on, so the mechanism the old oracle depended on is preserved, and the check
is now stronger: it detects execution at all, not only execution slower than 2 seconds. I also
cover `CREATE TABLE ... EMPTY AS SELECT`, which reaches a different analysis site, and added an
executed-position arm that must fail so the check has teeth. The reference file stays empty.

Validation: the new test is green 50/50 under `enable_analyzer=1` and 50/50 under `=0`, green
with 8 concurrent copies, and two mutations of the new oracle each redden it.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1338` (included in `26.8` and later)
<!-- ch-version-info:end -->