### PR TITLE
PostgreSQL: allow an empty TLS contents override when the collection stores no credential

### DIFF
--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -636,8 +636,12 @@ postgres::ConnectionSSLParams StoragePostgreSQL::getSSLParams(const NamedCollect
         /// An empty contents override never replaces the stored credential with another one - it can
         /// only silently drop whatever form of it the collection carries, a path or the contents
         /// alike. Checked before the empty fast path below so a credential the collection stores in
-        /// the contents form is protected too.
-        if (named_collection.isQueryOverridden(contents_key) && named_collection.getOrDefault<String>(contents_key, "").empty())
+        /// the contents form is protected too. When the collection stores no credential at all
+        /// (neither the path - a query cannot override it, so `value` is the collection's own - nor
+        /// the contents, read in its pre-override form), there is nothing to drop and the empty
+        /// override stays the no-op it is for the direct arguments.
+        if (named_collection.isQueryOverridden(contents_key) && named_collection.getOrDefault<String>(contents_key, "").empty()
+            && (!value.empty() || !named_collection.getValueBeforeQueryOverride(contents_key).value_or("").empty()))
             throw Exception(
                 ErrorCodes::BAD_ARGUMENTS,
                 "`{}` cannot be overridden with an empty `{}`", key, contents_key);

--- a/tests/integration/test_postgresql_ssl/test.py
+++ b/tests/integration/test_postgresql_ssl/test.py
@@ -857,6 +857,17 @@ def test_path_overrides_are_rejected(started_cluster):
     assert "cannot be overridden with an empty" in error
 
 
+def test_empty_override_without_stored_credential_is_noop(started_cluster):
+    # The rejection covers exactly the overrides that would drop a credential the collection
+    # carries. On a collection with no TLS keys at all there is nothing to drop, so an empty
+    # override stays the no-op it is for the direct arguments (`pg_ssl` stores no `ssl*` keys).
+    for key in ["sslrootcert_pem", "sslcert_pem", "sslkey_pem"]:
+        assert (
+            node.query(f"SELECT count() FROM postgresql(pg_ssl, sslmode='require', {key}='')").strip()
+            == "10"
+        )
+
+
 def test_tls_credentials_are_masked(started_cluster):
     # The credential contents are secrets: they must not show up in the stored table
     # definition nor in `system.query_log`. The key is the most sensitive of the


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113947
Related: https://github.com/ClickHouse/ClickHouse/pull/110615

Port of the #113947 narrowing (MySQL) to `StoragePostgreSQL::getSSLParams`. An empty `ssl*_pem` query override is rejected only when it would actually drop a TLS credential the named collection carries — a path (a query cannot override path keys, so the value read is the collection's own) or contents, read in the pre-override form via `NamedCollection::getValueBeforeQueryOverride`. On a collection with no TLS keys at all, the empty override stays the no-op it is for the direct arguments, instead of throwing `BAD_ARGUMENTS`.

The rejection cases are unchanged and remain covered by `test_path_overrides_are_rejected` and `test_tls_credentials_in_sql_named_collection`; the new `test_empty_override_without_stored_credential_is_noop` covers the no-op case (it fails without the code change).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix of the unreleased #110615: an empty `ssl*_pem` override on a PostgreSQL named collection without TLS credentials is a no-op again instead of an error.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1375` (included in `26.8` and later)
<!-- ch-version-info:end -->