### PR TITLE
Make the 04780 index-analysis allocation oracle the minimum of several runs

### DIFF
--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -54,21 +54,32 @@ $CLICKHOUSE_CLIENT -nm -q "
     INSERT INTO tokens SELECT 'v' || toString(number % 10) FROM numbers(1000);
 "
 
-# Sets ALLOC_BYTES to the bytes the server allocated while planning one query.
-# EXPLAIN runs index analysis without reading data, so the measurement is the matcher's cost.
+# Sets ALLOC_BYTES to the minimum bytes the server allocated while planning one query, over
+# several identical runs. EXPLAIN runs index analysis without reading data, so the measurement
+# is the matcher's cost.
+# A single run is not a stable oracle: whichever query happens to be the first to touch a cache
+# or spin up a thread pool absorbs a transient multi-megabyte allocation, and the dotted arm
+# always runs first in the loop below, so such a one-off inflates the ratio arbitrarily
+# (observed in CI: a 4216780-byte dotted arm against a 22224-byte control). A genuine quadratic
+# regression is deterministic and shows up in every run, so the minimum keeps discriminating.
+ALLOC_RUNS=3
 alloc_bytes_for() {
     local table="$1" unit="$2"
-    local query_id="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
-    $CLICKHOUSE_CLIENT --query_id "$query_id" --max_query_size 1048576 --max_execution_time 300 -q "
-        SELECT count() FROM (
-            EXPLAIN indexes = 1
-            SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1
-        )" >/dev/null
+    local query_id_prefix="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
+    local run
+    for run in $(seq 1 $ALLOC_RUNS); do
+        $CLICKHOUSE_CLIENT --query_id "${query_id_prefix}-${run}" --max_query_size 1048576 --max_execution_time 300 -q "
+            SELECT count() FROM (
+                EXPLAIN indexes = 1
+                SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1
+            )" >/dev/null
+    done
     $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log" >/dev/null
     ALLOC_BYTES=$($CLICKHOUSE_CLIENT -q "
-        SELECT ProfileEvents['MemoryAllocatedWithoutCheckBytes']
+        SELECT min(ProfileEvents['MemoryAllocatedWithoutCheckBytes'])
         FROM system.query_log
-        WHERE current_database = currentDatabase() AND query_id = '${query_id}' AND type = 'QueryFinish'")
+        WHERE current_database = currentDatabase() AND startsWith(query_id, '${query_id_prefix}-') AND type = 'QueryFinish'
+        HAVING count() = ${ALLOC_RUNS}")
     [ -n "$ALLOC_BYTES" ] && [ "$ALLOC_BYTES" -gt 0 ]
 }
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/104948

`04780_json_subcolumn_index_match_not_quadratic` compares `MemoryAllocatedWithoutCheckBytes` of a dotted-constant `EXPLAIN indexes = 1` against a no-dots control with a 150% threshold, measuring each arm with a single query. A single run is not a stable oracle: whichever query happens to be the first to touch a cache or spin up a thread pool absorbs a transient multi-megabyte allocation, and the dotted arm always runs first in the loop, so such a one-off lands on it and inflates the ratio arbitrarily. Locally the effect is easy to see: the first query after a server start reports 8–22 MB in this counter against a ~2.8 MB steady state for the identical query.

The test failed this way on at least 6 unrelated PRs since 2026-08-12 (e.g. `Stateless tests (amd_asan_ubsan, distributed plan, parallel)` on https://github.com/ClickHouse/ClickHouse/pull/104948 at commit 81300c20: `longidx index analysis over a constant with 100000 dots allocated 4216780 bytes, more than 150% of the no-dots control (22224 bytes)` — reruns passed; CIDB shows the same failure on #106011, #108522, #114475, #96130, #114476).

Measure each arm three times and take the minimum: a genuine quadratic regression is deterministic and shows up in every run, so the oracle keeps discriminating (the minimum can only remove one-sided transient noise), while a one-off transient can no longer fail the test. Verified against the current master binary: the modified test passes repeatedly.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1329` (included in `26.8` and later)
- Backported to: `26.7.8.10`, `26.6.6.13`
<!-- ch-version-info:end -->