### PR TITLE
Fix flaky 04780_json_subcolumn_index_match_not_quadratic

### DIFF
--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.reference
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.reference
@@ -3,5 +3,4 @@ longidx OK
 withjson OK
 tokens OK
 0
-Parts: 0 | Granules: 0
 Granules: 0/1000

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -6,8 +6,8 @@
 # name embeds the text of a folded constant, so a large dotted constant made index analysis
 # quadratic in the constant's length.
 # Each arm compares a dotted constant against a no-dots constant of the same length. The oracle is
-# the allocated-bytes counter rather than wall clock: it is exactly reproducible, whereas the
-# ~2.6s planning delta is smaller than debug-build client startup jitter.
+# the query's peak memory rather than wall clock: it is stable to within a fraction of a percent
+# across repeats, whereas the planning delta is smaller than debug-build client startup jitter.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -16,9 +16,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 set -e
 
 REPEATS=100000
-# Measured on a debug build with the untracked-memory limit pinned to 0: the dotted arm allocates
-# 1.00002x the control while the matcher is linear in the constant's length, and 1296x-2386x of it
-# while quadratic, so 1.5 discriminates by orders of magnitude on both sides.
+# The dotted arm peaks at 1.0002x the control while the matcher is linear in the constant's
+# length and at 2.7x while quadratic, on both debug and sanitizer builds. The control peak also
+# scales with the constant, so the quadratic ratio stays near 2.7x as REPEATS grows.
 MAX_RATIO_PERCENT=150
 
 LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))
@@ -54,23 +54,19 @@ $CLICKHOUSE_CLIENT -nm -q "
     INSERT INTO tokens SELECT 'v' || toString(number % 10) FROM numbers(1000);
 "
 
-# Sets ALLOC_BYTES to the bytes the server allocated while planning one query.
+# Sets ALLOC_BYTES to the peak memory the server tracked while planning one query.
 # EXPLAIN runs index analysis without reading data, so the measurement is the matcher's cost.
 alloc_bytes_for() {
     local table="$1" unit="$2"
     local tag="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
-    # The counter records each allocation only while max_untracked_memory is 0; otherwise it records
-    # deferred batches sized by concurrent load. The leading statement shares the server thread, so
-    # its own detach drains the balance deferred before the measured statement's scope existed.
-    $CLICKHOUSE_CLIENT --max_untracked_memory 0 --max_query_size 1048576 --max_execution_time 300 -nm -q "
-        SELECT 1;
+    $CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 300 -nm -q "
         SELECT count() FROM (
             EXPLAIN indexes = 1
             SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1
         ) SETTINGS log_comment = '${tag}'" >/dev/null
     $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log" >/dev/null
     ALLOC_BYTES=$($CLICKHOUSE_CLIENT -q "
-        SELECT ProfileEvents['MemoryAllocatedWithoutCheckBytes']
+        SELECT memory_usage
         FROM system.query_log
         WHERE current_database = currentDatabase() AND log_comment = '${tag}' AND type = 'QueryFinish'")
     [ -n "$ALLOC_BYTES" ] && [ "$ALLOC_BYTES" -gt 0 ]

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -16,9 +16,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 set -e
 
 REPEATS=100000
-# The dotted arm peaks at 1.0002x the control while the matcher is linear in the constant's
-# length and at 2.7x while quadratic, on both debug and sanitizer builds. The control peak also
-# scales with the constant, so the quadratic ratio stays near 2.7x as REPEATS grows.
+# The dotted arm peaks at 1.0001x the control while the matcher is linear in the constant's
+# length and at 2.4x while quadratic, on both debug and sanitizer builds. The control peak also
+# scales with the constant, so the quadratic ratio stays above 2x as REPEATS grows.
 MAX_RATIO_PERCENT=150
 
 LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))
@@ -59,7 +59,9 @@ $CLICKHOUSE_CLIENT -nm -q "
 alloc_bytes_for() {
     local table="$1" unit="$2"
     local tag="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
-    $CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 300 -nm -q "
+    # The limit is pinned to 0 so that every allocation reaches the query tracker immediately.
+    # Otherwise the peak reflects deferred batches whose flush points depend on concurrent load.
+    $CLICKHOUSE_CLIENT --max_untracked_memory 0 --max_query_size 1048576 --max_execution_time 300 -nm -q "
         SELECT count() FROM (
             EXPLAIN indexes = 1
             SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -16,9 +16,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 set -e
 
 REPEATS=100000
-# Measured on a debug build: pre-fix the dotted arm allocates 2.8x-3.0x the control in every arm,
-# post-fix 1.0003x. 1.5 sits an order of magnitude away from the fixed behavior and ~1.9x below
-# the regression, so it discriminates with margin on both sides.
+# Measured on a debug build with the untracked-memory limit pinned to 0: the dotted arm allocates
+# 1.00002x the control while the matcher is linear in the constant's length, and 1296x-2386x of it
+# while quadratic, so 1.5 discriminates by orders of magnitude on both sides.
 MAX_RATIO_PERCENT=150
 
 LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -58,17 +58,21 @@ $CLICKHOUSE_CLIENT -nm -q "
 # EXPLAIN runs index analysis without reading data, so the measurement is the matcher's cost.
 alloc_bytes_for() {
     local table="$1" unit="$2"
-    local query_id="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
-    $CLICKHOUSE_CLIENT --query_id "$query_id" --max_query_size 1048576 --max_execution_time 300 -q "
+    local tag="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
+    # The counter records each allocation only while max_untracked_memory is 0; otherwise it records
+    # deferred batches sized by concurrent load. The leading statement shares the server thread, so
+    # its own detach drains the balance deferred before the measured statement's scope existed.
+    $CLICKHOUSE_CLIENT --max_untracked_memory 0 --max_query_size 1048576 --max_execution_time 300 -nm -q "
+        SELECT 1;
         SELECT count() FROM (
             EXPLAIN indexes = 1
             SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1
-        )" >/dev/null
+        ) SETTINGS log_comment = '${tag}'" >/dev/null
     $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log" >/dev/null
     ALLOC_BYTES=$($CLICKHOUSE_CLIENT -q "
         SELECT ProfileEvents['MemoryAllocatedWithoutCheckBytes']
         FROM system.query_log
-        WHERE current_database = currentDatabase() AND query_id = '${query_id}' AND type = 'QueryFinish'")
+        WHERE current_database = currentDatabase() AND log_comment = '${tag}' AND type = 'QueryFinish'")
     [ -n "$ALLOC_BYTES" ] && [ "$ALLOC_BYTES" -gt 0 ]
 }
 
@@ -93,7 +97,7 @@ $CLICKHOUSE_CLIENT -nm -q "
     SET enable_json_type = 1;
     SELECT count() FROM withjson WHERE position(repeat('a.', 100), s) = 1;
     SELECT trimLeft(explain) FROM (
-        EXPLAIN indexes = 1 SELECT count() FROM withjson WHERE j.absent_path = 'zzz'
+        EXPLAIN indexes = 1, actions = 0 SELECT count() FROM withjson WHERE j.absent_path = 'zzz'
     ) WHERE explain LIKE '%Granules:%';
 "
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113289
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Requested in https://github.com/ClickHouse/ClickHouse/pull/112705#issuecomment-5276141544.
Related: https://github.com/ClickHouse/ClickHouse/pull/113289, which added the test.

Two independent test defects. The engine fix itself is fine.

**1. The oracle read a counter that does not exist on sanitizer builds.**
`ProfileEvents['MemoryAllocatedWithoutCheckBytes']` is written only from the allocation paths that
skip the memory-limit check, whose only non-Darwin producer is `src/Common/malloc.cpp`, compiled
under `#if USE_JEMALLOC`. jemalloc is disabled for every sanitizer except UBSan, and the
throwing `operator new` goes through `CurrentMemoryTracker::allocThrow` instead, so on
`asan_ubsan`, `tsan` and `msan` the counter has no writer: on an ASAN build a query peaking at
76 MB reports 256 bytes through it. The test's `-gt 0` guard then aborted the first arm, which is
the `no query_log row for plain dotted arm` failure.

The test now reads `system.query_log.memory_usage`. Peak memory is tracked by `operator new`
accounting, which is not sanitizer-gated, so it is defined on every flavour. The untracked-memory
limit stays pinned to 0 so allocations reach the query tracker immediately, not in deferred batches
whose flush points depend on concurrent load.

**2. The last `EXPLAIN` asserted a master-only default.** `Parts: 0 | Granules: 0` comes from
`describeActions`, gated by `actions`, which only master force-enables
(`set_default_pretty_explain_settings`, absent from 26.5 and 26.6), so the two open backports of
#113289 fail deterministically. Fixed by requesting `actions = 0` and dropping that line.
`Granules: 0/1000`, the pruning under test, comes from `describeIndexes` and is unaffected.

I could not confirm the 150% bound is too tight under sanitizers. It is sound on a quantity that
measures the matcher, so it stays.

Validation: 80 of 80 runs pass on debug and ASAN with randomization on and off, and 10 of 10 on
ASAN under six concurrent load generators. On a pre-#113289 binary the oracle reddens on all four
arms at 2.372x to 2.483x, against 1.0001x with the fix present.
