### PR TITLE
Lazy-load part-level column statistics

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1541,6 +1541,7 @@ The server successfully detected this situation and will download merged part fr
     M(JemallocFailedDeallocationSampleTracking, "Total number of times tracking of jemalloc deallocation sample failed", ValueType::Number) \
     \
     M(LoadedStatisticsMicroseconds, "Elapsed time of loading statistics from parts", ValueType::Microseconds) \
+    M(LoadedStatisticsColumns, "Number of per-column statistics deserialized when loading statistics from parts.", ValueType::Number) \
     \
     M(RuntimeDataflowStatisticsInputBytes, "Collected statistics on the number of bytes replicas would read if the query was executed with parallel replicas", ValueType::Number) \
     M(RuntimeDataflowStatisticsOutputBytes, "Collected statistics on the number of bytes replicas would send to the initiator if the query was executed with parallel replicas", ValueType::Number) \

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -102,6 +102,7 @@ namespace ProfileEvents
     extern const Event LoadedPrimaryIndexFiles;
     extern const Event LoadedPrimaryIndexRows;
     extern const Event LoadedPrimaryIndexBytes;
+    extern const Event LoadedStatisticsColumns;
 }
 
 namespace DimensionalMetrics
@@ -1355,7 +1356,10 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesRead
 
             auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
             if (column_stat)
+            {
                 result.emplace(column_desc->name, std::move(column_stat));
+                ProfileEvents::increment(ProfileEvents::LoadedStatisticsColumns);
+            }
         }
         catch (Exception & e)
         {
@@ -1397,7 +1401,10 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & require
 
             auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
             if (column_stat)
+            {
                 result.emplace(column_desc->name, std::move(column_stat));
+                ProfileEvents::increment(ProfileEvents::LoadedStatisticsColumns);
+            }
         }
         catch (Exception & e)
         {
@@ -1434,33 +1441,107 @@ ColumnsStatistics IMergeTreeDataPart::loadStatistics(const Names & required_colu
     return loadStatisticsWide(required_columns_set);
 }
 
-Estimates IMergeTreeDataPart::getEstimates() const
+Names IMergeTreeDataPart::getColumnsWithStatistics() const
 {
-    std::lock_guard lock(estimates_mutex);
+    Names result;
 
-    if (estimates.has_value())
-        return *estimates;
+    /// Packed parts store column statistics in a single `statistics.packed` file
+    /// (indexed by `PackedFilesReader`). `checksums.files` has only the
+    /// top-level archive entry, so iterate the reader's file list instead.
+    if (auto * reader = getStatisticsPackedReader())
+    {
+        for (const auto & filename : reader->getFileNames())
+        {
+            if (filename.starts_with(STATS_FILE_PREFIX) && filename.ends_with(STATS_FILE_SUFFIX))
+            {
+                size_t prefix_len = STATS_FILE_PREFIX.size();
+                size_t suffix_len = STATS_FILE_SUFFIX.size();
+                String col_name = unescapeForFileName(filename.substr(prefix_len, filename.size() - prefix_len - suffix_len));
+                if (getColumnsDescription().has(col_name))
+                    result.push_back(std::move(col_name));
+            }
+        }
+        return result;
+    }
 
-    /// The raw statistics are transient, so load them in the default arena; only the cached
-    /// estimates map is long-lived (kept on the part until reload), so build it in the dedicated
-    /// arena, like the rest of the part's metadata.
-    auto statistics = loadStatistics();
+    /// Wide parts have one `statistics_<col>.stats` checksum entry per column.
+    for (const auto & [filename, _] : checksums.files)
+    {
+        if (filename.starts_with(STATS_FILE_PREFIX) && filename.ends_with(STATS_FILE_SUFFIX))
+        {
+            size_t prefix_len = STATS_FILE_PREFIX.size();
+            size_t suffix_len = STATS_FILE_SUFFIX.size();
+            String col_name = unescapeForFileName(filename.substr(prefix_len, filename.size() - prefix_len - suffix_len));
+            if (getColumnsDescription().has(col_name))
+                result.push_back(std::move(col_name));
+        }
+    }
+
+    return result;
+}
+
+Estimates IMergeTreeDataPart::getEstimates(const Names & required_columns) const
+{
+    /// Empty `required_columns` means "don't load statistics".
+    if (required_columns.empty())
+        return {};
+
+    auto collectResult = [&](const std::unordered_map<String, std::optional<Estimate>> & source) -> Estimates
+    {
+        Estimates result;
+        result.reserve(required_columns.size());
+        for (const auto & column_name : required_columns)
+            if (auto it = source.find(column_name); it != source.end() && it->second.has_value())
+                result.emplace(column_name, *it->second);
+        return result;
+    };
+
+    Names missing;
 
     {
-        ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
-        Estimates new_estimates;
-        for (const auto & [column_name, stats] : statistics)
-            new_estimates.emplace(column_name, stats->getEstimate());
-        estimates = std::move(new_estimates);
+        std::lock_guard lock(estimates_mutex);
+
+        for (const auto & column_name : required_columns)
+            if (!estimates.contains(column_name))
+                missing.push_back(column_name);
+
+        if (missing.empty())
+            return collectResult(estimates);
     }
-    return *estimates;
+
+    /// Load off the lock, then commit under the lock.
+    ColumnsStatistics statistics;
+    try
+    {
+        statistics = loadStatistics(missing);
+    }
+    catch (const Exception &)
+    {
+        /// Record nullopt for every failed column so it is not re-read on every query.
+        tryLogCurrentException(storage.log, fmt::format("Failed to load statistics for part {}", name));
+    }
+
+    std::lock_guard lock(estimates_mutex);
+    {
+        ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
+        for (const auto & column_name : missing)
+        {
+            if (auto it = statistics.find(column_name); it != statistics.end())
+                estimates.insert_or_assign(column_name, it->second->getEstimate());
+            else
+                estimates.insert_or_assign(column_name, std::nullopt);
+        }
+    }
+
+    return collectResult(estimates);
 }
 
 void IMergeTreeDataPart::setEstimates(const Estimates & new_estimates)
 {
     ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
     std::lock_guard lock(estimates_mutex);
-    estimates = new_estimates;
+    for (const auto & [col_name, estimate] : new_estimates)
+        estimates.insert_or_assign(col_name, estimate);
 }
 
 void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checksums, bool check_consistency, bool load_metadata_version)

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -239,7 +239,11 @@ public:
 
     ColumnsStatistics loadStatistics() const;
     ColumnsStatistics loadStatistics(const Names & required_columns) const;
-    Estimates getEstimates() const;
+    /// Returns column names that have statistics files in this part (packed or wide).
+    Names getColumnsWithStatistics() const;
+    /// Returns estimates for the requested columns, loading missing ones and caching them.
+    /// Empty `required_columns` means "don't load statistics" and returns an empty map.
+    Estimates getEstimates(const Names & required_columns) const;
     void setEstimates(const Estimates & new_estimates);
 
     /// Initialize columns (from columns.txt if exists, or create from column files if not).
@@ -881,10 +885,10 @@ private:
     /// inside are shared even when only some columns have the same kinds. Never null.
     PartSerializationsPtr serializations = SharedPartColumns::getEmptySerializations();
 
-    /// Small state of finalized statistics for suitable statistics types.
-    /// Lazily initialized on a first access.
+    /// Per-column entries: a value when statistics were loaded, or nullopt after a
+    /// deterministic miss, so the column is not re-probed on every query.
     mutable std::mutex estimates_mutex;
-    mutable std::optional<Estimates> estimates TSA_GUARDED_BY(estimates_mutex);
+    mutable std::unordered_map<String, std::optional<Estimate>> estimates TSA_GUARDED_BY(estimates_mutex);
 
     /// Reads part unique identifier (if exists) from uuid.txt
     void loadUUID();

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -840,10 +840,12 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByStatistics(
 
     RangesInDataParts res_parts;
     size_t total_parts_before = parts.size();
+    /// Load statistics only for the filter columns, known right after construction.
+    const Names candidate_columns = statistics_pruner.getCandidateColumns();
 
     for (const auto & part : parts)
     {
-        auto estimates = part.data_part->getEstimates();
+        auto estimates = part.data_part->getEstimates(candidate_columns);
         try
         {
             if (!statistics_pruner.checkPartCanMatch(estimates).can_be_true)

--- a/src/Storages/Statistics/StatisticsPartPruner.h
+++ b/src/Storages/Statistics/StatisticsPartPruner.h
@@ -25,7 +25,18 @@ public:
     /// Returns true if no columns with MinMax statistics are used in the filter, then all parts will match.
     bool isUseless() const { return useless; }
 
-    /// Get the list of column names used in the filter condition that have statistics.
+    /// Filter columns carrying MinMax/Basic statistics, known right after construction.
+    Names getCandidateColumns() const
+    {
+        Names result;
+        result.reserve(stats_column_name_to_type_map.size());
+        for (const auto & [name, _] : stats_column_name_to_type_map)
+            result.push_back(name);
+        return result;
+    }
+
+    /// Get the list of column names actually used by the built key conditions. Only meaningful
+    /// after `checkPartCanMatch` has run for at least one part; used for query-plan reporting.
     Names getUsedColumns() const { return {used_column_names.begin(), used_column_names.end()}; }
 
 private:

--- a/src/Storages/System/StorageSystemPartsColumns.cpp
+++ b/src/Storages/System/StorageSystemPartsColumns.cpp
@@ -137,11 +137,14 @@ void StorageSystemPartsColumns::processNextStorage(
         auto index_size_in_allocated_bytes = part->getIndexSizeInAllocatedBytes();
         std::optional<Estimates> estimates;
 
-        /// Lazy initialize statistics estimates if they are queried.
+        /// Load estimates for only the columns that have statistics.
         auto find_estimate = [&](const auto & column_name)
         {
             if (!estimates.has_value())
-                estimates = part->getEstimates();
+            {
+                Names statistics_columns = part->getColumnsWithStatistics();
+                estimates = part->getEstimates(statistics_columns);
+            }
 
             return estimates->find(column_name);
         };

--- a/tests/performance/statistics_lazy_loading.xml
+++ b/tests/performance/statistics_lazy_loading.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Part pruning loads statistics for only the filter columns instead of every column.
+  The table is detached and re-attached before each timed run to clear the per-part
+  estimates cache, otherwise only the first run would read statistics from disk and
+  the rest would hit the cache. The DETACH/ATTACH cost is fixed and identical on both
+  sides of the comparison, so it does not affect the relative difference.
+-->
+<test>
+
+    <create_query>
+        CREATE TABLE stats_lazy_bench (col_0 UInt64, col_1 UInt64, col_2 UInt64, col_3 UInt64, col_4 UInt64, col_5 UInt64, col_6 UInt64, col_7 UInt64, col_8 UInt64, col_9 UInt64, col_10 UInt64, col_11 UInt64, col_12 UInt64, col_13 UInt64, col_14 UInt64, col_15 UInt64, col_16 UInt64, col_17 UInt64, col_18 UInt64, col_19 UInt64, col_20 UInt64, col_21 UInt64, col_22 UInt64, col_23 UInt64, col_24 UInt64, col_25 UInt64, col_26 UInt64, col_27 UInt64, col_28 UInt64, col_29 UInt64, col_30 UInt64, col_31 UInt64, col_32 UInt64, col_33 UInt64, col_34 UInt64, col_35 UInt64, col_36 UInt64, col_37 UInt64, col_38 UInt64, col_39 UInt64, col_40 UInt64, col_41 UInt64, col_42 UInt64, col_43 UInt64, col_44 UInt64, col_45 UInt64, col_46 UInt64, col_47 UInt64, col_48 UInt64, col_49 UInt64, col_50 UInt64, col_51 UInt64, col_52 UInt64, col_53 UInt64, col_54 UInt64, col_55 UInt64, col_56 UInt64, col_57 UInt64, col_58 UInt64, col_59 UInt64, col_60 UInt64, col_61 UInt64, col_62 UInt64, col_63 UInt64, col_64 UInt64, col_65 UInt64, col_66 UInt64, col_67 UInt64, col_68 UInt64, col_69 UInt64, col_70 UInt64, col_71 UInt64, col_72 UInt64, col_73 UInt64, col_74 UInt64, col_75 UInt64, col_76 UInt64, col_77 UInt64, col_78 UInt64, col_79 UInt64, col_80 UInt64, col_81 UInt64, col_82 UInt64, col_83 UInt64, col_84 UInt64, col_85 UInt64, col_86 UInt64, col_87 UInt64, col_88 UInt64, col_89 UInt64, col_90 UInt64, col_91 UInt64, col_92 UInt64, col_93 UInt64, col_94 UInt64, col_95 UInt64, col_96 UInt64, col_97 UInt64, col_98 UInt64, col_99 UInt64)
+        ENGINE = MergeTree ORDER BY tuple()
+        SETTINGS min_bytes_for_wide_part = 0,
+                 auto_statistics_types = 'basic',
+                 refresh_statistics_interval = 0,
+                 max_bytes_to_merge_at_max_space_in_pool = 0,
+                 max_bytes_to_merge_at_min_space_in_pool = 0
+    </create_query>
+
+    <!-- Insert 50 parts; the filter columns have shifted ranges so pruning can skip parts. -->
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 0, number + 0, number + 0 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 100000, number + 100000, number + 100000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 200000, number + 200000, number + 200000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 300000, number + 300000, number + 300000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 400000, number + 400000, number + 400000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 500000, number + 500000, number + 500000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 600000, number + 600000, number + 600000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 700000, number + 700000, number + 700000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 800000, number + 800000, number + 800000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 900000, number + 900000, number + 900000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1000000, number + 1000000, number + 1000000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1100000, number + 1100000, number + 1100000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1200000, number + 1200000, number + 1200000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1300000, number + 1300000, number + 1300000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1400000, number + 1400000, number + 1400000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1500000, number + 1500000, number + 1500000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1600000, number + 1600000, number + 1600000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1700000, number + 1700000, number + 1700000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1800000, number + 1800000, number + 1800000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 1900000, number + 1900000, number + 1900000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2000000, number + 2000000, number + 2000000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2100000, number + 2100000, number + 2100000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2200000, number + 2200000, number + 2200000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2300000, number + 2300000, number + 2300000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2400000, number + 2400000, number + 2400000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2500000, number + 2500000, number + 2500000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2600000, number + 2600000, number + 2600000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2700000, number + 2700000, number + 2700000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2800000, number + 2800000, number + 2800000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 2900000, number + 2900000, number + 2900000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3000000, number + 3000000, number + 3000000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3100000, number + 3100000, number + 3100000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3200000, number + 3200000, number + 3200000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3300000, number + 3300000, number + 3300000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3400000, number + 3400000, number + 3400000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3500000, number + 3500000, number + 3500000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3600000, number + 3600000, number + 3600000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3700000, number + 3700000, number + 3700000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3800000, number + 3800000, number + 3800000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 3900000, number + 3900000, number + 3900000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4000000, number + 4000000, number + 4000000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4100000, number + 4100000, number + 4100000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4200000, number + 4200000, number + 4200000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4300000, number + 4300000, number + 4300000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4400000, number + 4400000, number + 4400000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4500000, number + 4500000, number + 4500000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4600000, number + 4600000, number + 4600000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4700000, number + 4700000, number + 4700000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4800000, number + 4800000, number + 4800000 FROM numbers(1000)</fill_query>
+    <fill_query>INSERT INTO stats_lazy_bench (col_0, col_1, col_2) SELECT number + 4900000, number + 4900000, number + 4900000 FROM numbers(1000)</fill_query>
+
+    <fill_query>ALTER TABLE stats_lazy_bench MATERIALIZE STATISTICS ALL SETTINGS mutations_sync=2</fill_query>
+
+    <fill_query>SYSTEM STOP MERGES stats_lazy_bench</fill_query>
+
+    <query type="shell"><![CDATA[
+        ${CLICKHOUSE_CLIENT} --query "
+            DETACH TABLE stats_lazy_bench;
+            ATTACH TABLE stats_lazy_bench;
+            SELECT count() FROM stats_lazy_bench WHERE col_0 > 1500000 AND col_1 > 1500000 AND col_2 > 1500000 SETTINGS use_statistics = 0, use_statistics_for_part_pruning = 1 FORMAT Null;
+        "
+    ]]></query>
+
+    <drop_query>DROP TABLE IF EXISTS stats_lazy_bench</drop_query>
+
+</test>

--- a/tests/queries/0_stateless/04209_stats_lazy_columns.reference
+++ b/tests/queries/0_stateless/04209_stats_lazy_columns.reference
@@ -1,0 +1,3 @@
+all_1_1_0	Wide
+all_2_2_0	Wide
+04209_part_lazy	2

--- a/tests/queries/0_stateless/04209_stats_lazy_columns.sql
+++ b/tests/queries/0_stateless/04209_stats_lazy_columns.sql
@@ -1,0 +1,42 @@
+SET enable_analyzer = 1;
+SET materialize_statistics_on_insert = 1;
+SET enable_parallel_replicas = 0;
+
+DROP TABLE IF EXISTS t_lazy;
+
+-- Wide-part table: the part-pruning path must load statistics only for the filter
+-- columns that carry them, not for every column of the part.
+CREATE TABLE t_lazy (a UInt64, b UInt64, c UInt64, d UInt64, e UInt64, k UInt64)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 0,
+         auto_statistics_types = 'basic',
+         refresh_statistics_interval = 0;
+
+INSERT INTO t_lazy SELECT number, number, number, number, number, number FROM numbers(1000);
+INSERT INTO t_lazy SELECT number + 2000000, number, number, number, number, number FROM numbers(1000);
+
+SELECT name, part_type FROM system.parts
+WHERE database = currentDatabase() AND table = 't_lazy' AND active
+ORDER BY table, name;
+
+-- INSERT pre-populates the per-part estimates cache; drop it so the SELECTs below
+-- measure real disk loads via `LoadedStatisticsColumns`.
+DETACH TABLE t_lazy;
+ATTACH TABLE t_lazy;
+
+-- Part pruning, filter on `a` -> 1 column x 2 wide parts = 2.
+SELECT count() FROM t_lazy WHERE a > 1000000
+SETTINGS use_statistics_for_part_pruning = 1, use_statistics = 0, log_comment = '04209_part_lazy'
+FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT log_comment, toUInt64(ProfileEvents['LoadedStatisticsColumns'])
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600
+  AND current_database = currentDatabase() AND type = 'QueryFinish'
+  AND log_comment IN ('04209_part_lazy')
+ORDER BY log_comment, event_time_microseconds DESC
+LIMIT 1 BY log_comment;
+
+DROP TABLE t_lazy;

--- a/tests/queries/0_stateless/04341_stats_lazy_deterministic_miss.reference
+++ b/tests/queries/0_stateless/04341_stats_lazy_deterministic_miss.reference
@@ -1,0 +1,4 @@
+first query warnings:
+1
+second query warnings:
+0

--- a/tests/queries/0_stateless/04341_stats_lazy_deterministic_miss.sh
+++ b/tests/queries/0_stateless/04341_stats_lazy_deterministic_miss.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tags: no-object-storage
+#
+# `no-object-storage`: the test corrupts the statistics payload directly inside
+# the part directory on the local disk. On object-storage disks the files in that
+# directory are pointer files, so overwriting them would not corrupt the statistics.
+#
+# Regression test for the deterministic-miss negative cache in
+# `IMergeTreeDataPart::getEstimates`: a metadata-declared column whose statistics
+# are unreadable (here: corrupted) must be probed at most once per part object.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# Suppress the corrupted-statistics error streaming to the client; it is asserted
+# below via `system.text_log` instead.
+export CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_stats_miss SYNC"
+
+${CLICKHOUSE_CLIENT} -q "
+CREATE TABLE t_stats_miss (a UInt64, b UInt64 STATISTICS(basic))
+ENGINE = MergeTree ORDER BY tuple()
+-- min_bytes_for_wide_part = 0 forces a Wide (non-Compact) part so every file is a
+-- separate on-disk entity; min_bytes_for_full_part_storage = 0 keeps the part in
+-- full-part storage so that statistics.packed is an independent file rather
+-- than being embedded inside data.packed. The Python corruption step below
+-- relies on both properties.
+SETTINGS min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0"
+
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_stats_miss SELECT number, number FROM numbers(1000) SETTINGS materialize_statistics_on_insert = 1"
+
+DATA_PATH=$(${CLICKHOUSE_CLIENT} -q "SELECT data_paths[1] FROM system.tables WHERE database = currentDatabase() AND table = 't_stats_miss'")
+PART=$(${CLICKHOUSE_CLIENT} -q "SELECT name FROM system.parts WHERE database = currentDatabase() AND table = 't_stats_miss' AND active LIMIT 1")
+
+# Zero out only column `b`'s blob in `statistics.packed`, leaving the index and
+# column `a`'s blob intact, so deserializing `b` deterministically fails.
+PACKED_FILE="${DATA_PATH}${PART}/statistics.packed"
+python3 - "$PACKED_FILE" <<'PY'
+import struct, sys
+
+path = sys.argv[1]
+data = bytearray(open(path, "rb").read())
+pos = 0
+pos += 1  # version (UInt8)
+num_files = struct.unpack_from("<Q", data, pos)[0]; pos += 8
+for _ in range(num_files):
+    shift = length = 0
+    while True:  # readVarUInt name length
+        byte = data[pos]; pos += 1
+        length |= (byte & 0x7F) << shift
+        if not (byte & 0x80):
+            break
+        shift += 7
+    name = bytes(data[pos:pos + length]); pos += length
+    offset = struct.unpack_from("<Q", data, pos)[0]; pos += 8
+    size = struct.unpack_from("<Q", data, pos)[0]; pos += 8
+    if name == b"statistics_b.stats":
+        for i in range(offset, offset + size):
+            data[i] = 0
+open(path, "wb").write(data)
+PY
+
+# Drop the per-part estimates cache populated during INSERT so the SELECTs below
+# load statistics for real.
+${CLICKHOUSE_CLIENT} -q "DETACH TABLE t_stats_miss"
+${CLICKHOUSE_CLIENT} -q "ATTACH TABLE t_stats_miss"
+
+QID1="${CLICKHOUSE_DATABASE}_stats_miss_1"
+QID2="${CLICKHOUSE_DATABASE}_stats_miss_2"
+
+# Both queries prune on `b`, so each asks the part for `b`'s statistics.
+for QID in "$QID1" "$QID2"; do
+    ${CLICKHOUSE_CLIENT} --query_id="$QID" -q "
+    SELECT count() FROM t_stats_miss WHERE b > 500
+    SETTINGS use_statistics_for_part_pruning = 1, use_statistics = 0,
+             enable_analyzer = 1, enable_parallel_replicas = 0
+    FORMAT Null"
+done
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+
+# The first query probes the corrupted blob once and logs; the second must find
+# `b` negatively cached and emit nothing.
+echo "first query warnings:"
+${CLICKHOUSE_CLIENT} -q "
+SELECT count() FROM system.text_log
+WHERE event_date >= yesterday() AND query_id = '${QID1}'
+  AND message LIKE '%while loading statistics for column b%'"
+echo "second query warnings:"
+${CLICKHOUSE_CLIENT} -q "
+SELECT count() FROM system.text_log
+WHERE event_date >= yesterday() AND query_id = '${QID2}'
+  AND message LIKE '%while loading statistics for column b%'"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_stats_miss SYNC"


### PR DESCRIPTION
When loading a part's statistics, the part currently loads statistics for every column via `getEstimates`, even when only a few columns are needed. On wide tables this performs a lot of pointless deserialization.

Related: https://github.com/ClickHouse/ClickHouse/pull/104691

  This change makes per-part statistics load lazily, only for the requested columns:

  - `IMergeTreeDataPart::getEstimates` now takes the set of requested columns, loads only the missing ones, and caches the result per column. A deterministic miss (no statistics declared, file absent, or corrupted) is recorded as a `nullopt` entry so the column is not re-probed on every query.
  - Part pruning asks for only the filter columns: `StatisticsPartPruner` exposes `getCandidateColumns` and `filterPartsByStatistics` passes them to `getEstimates`.
  - `system.parts_columns` discovers which columns have statistics via the new `getColumnsWithStatistics` and loads only those.

  A new `LoadedStatisticsColumns` profile event counts the per-column statistics that are actually deserialized.

  The performance test measures a 100-column wide table with 50 parts and a query filtering on 3 columns; part pruning loads 150 columns instead of 5000.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Part-level column statistics are now loaded lazily, only for the columns that are actually needed, reducing statistics deserialization on wide tables.
