### PR TITLE
Do not apply DROP fault injection to a refreshable view's cleanup DROP

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -217,7 +217,7 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
         /// table drops can break dependency invariants (e.g., a dependent table's drop is ignored
         /// while the table it depends on is dropped, since DROP DATABASE skips same-database
         /// dependency checks), leaving orphaned tables that prevent server restart.
-        if (!secondary_query && !is_refreshable_view && !is_drop_or_detach_database
+        if (!secondary_query && !internal && !is_refreshable_view && !is_drop_or_detach_database
             && settings[Setting::ignore_drop_queries_probability] != 0 && ast_drop_query.kind == ASTDropQuery::Kind::Drop
             && std::uniform_real_distribution<>(0.0, 1.0)(thread_local_rng) <= static_cast<double>(settings[Setting::ignore_drop_queries_probability]))
         {
@@ -270,7 +270,7 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
 
             query_to_send.if_empty = false;
 
-            return database->tryEnqueueReplicatedDDL(new_query_ptr, context_, {}, std::move(ddl_guard));
+            return database->tryEnqueueReplicatedDDL(new_query_ptr, context_, QueryFlags{ .internal = internal }, std::move(ddl_guard));
         }
 
         if (query.kind == ASTDropQuery::Kind::Detach)

--- a/src/Interpreters/InterpreterDropQuery.h
+++ b/src/Interpreters/InterpreterDropQuery.h
@@ -31,10 +31,17 @@ public:
 
     void extendQueryLogElemImpl(QueryLogElement & elem, const ASTPtr & ast, ContextPtr context_) const override;
 
+    void setInternal(bool internal_)
+    {
+        internal = internal_;
+    }
+
 private:
     AccessRightsElements getRequiredAccessForDDLOnCluster() const;
     ASTPtr query_ptr;
     ASTPtr current_query_ptr;
+    /// Is this a step of another statement rather than a DROP the user issued.
+    bool internal = false;
 
     BlockIO executeSingleDropQuery(const ASTPtr & drop_query_ptr);
     BlockIO executeToDatabase(const ASTDropQuery & query);

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -770,7 +770,9 @@ void StorageMaterializedView::dropTempTable(StorageID table_id, ContextMutablePt
     Stopwatch stopwatch;
     try
     {
-        InterpreterDropQuery(drop_query, refresh_context).execute();
+        InterpreterDropQuery drop_interpreter(drop_query, refresh_context);
+        drop_interpreter.setInternal(true);
+        drop_interpreter.execute();
     }
     catch (...)
     {

--- a/tests/queries/0_stateless/04887_refreshable_mv_cleanup_drop_not_ignored.reference
+++ b/tests/queries/0_stateless/04887_refreshable_mv_cleanup_drop_not_ignored.reference
@@ -1,0 +1,11 @@
+-- success path: the rotated-out target must be dropped, not leaked
+0
+1000
+-- failure path: the unpublished temporary target must be dropped too
+refresh_failed
+0
+-- Replicated database: the cleanup DROP is enqueued, not injected
+0
+1000
+-- a user DROP is still skipped: the setting keeps doing what it is for
+1

--- a/tests/queries/0_stateless/04887_refreshable_mv_cleanup_drop_not_ignored.sh
+++ b/tests/queries/0_stateless/04887_refreshable_mv_cleanup_drop_not_ignored.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-ordinary-database, no-replicated-database
+# no-ordinary-database: a refreshable materialized view rotates its target with CREATE OR REPLACE, which needs Atomic.
+# no-replicated-database: the last part of the test creates a Replicated database itself.
+
+# The DROP that a refreshable materialized view issues to clean up its rotated-out target
+# (StorageMaterializedView::dropTempTable) is a step of the refresh, not a user DROP, so
+# `ignore_drop_queries_probability` must not skip it. When it does, the old target survives
+# under its internal `.tmp.inner_id.<uuid>` name, still holding a full copy of the view's data,
+# outside the view's metadata and past a restart, and one leaks per refresh.
+#
+# The setting is pinned in a SETTINGS clause on the view's SELECT: that is what reaches the
+# background refresh context, whereas a session-level SET does not.
+#
+# Objects live in databases the test creates, torn down with DROP DATABASE, which is not
+# injected -- with the setting pinned, a plain DROP TABLE teardown would itself be skipped.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo '-- success path: the rotated-out target must be dropped, not leaked'
+
+db="${CLICKHOUSE_DATABASE}_ok"
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE ${db}"
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE ${db}.src (x UInt64) ENGINE = MergeTree ORDER BY x;
+    INSERT INTO ${db}.src SELECT number FROM numbers(1000);
+
+    CREATE MATERIALIZED VIEW ${db}.rmv
+        REFRESH EVERY 1 YEAR
+        (x UInt64) ENGINE = MergeTree ORDER BY x EMPTY
+        AS SELECT * FROM ${db}.src SETTINGS ignore_drop_queries_probability = 1;
+"
+
+# Refresh #1 rotates out the initial empty target; refresh #2 rotates out a populated one.
+${CLICKHOUSE_CLIENT} -q "
+    SYSTEM REFRESH VIEW ${db}.rmv;
+    SYSTEM WAIT VIEW ${db}.rmv;
+    SYSTEM REFRESH VIEW ${db}.rmv;
+    SYSTEM WAIT VIEW ${db}.rmv;
+"
+
+${CLICKHOUSE_CLIENT} -q "SELECT countIf(name LIKE '.tmp.%') FROM system.tables WHERE database = '${db}'"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${db}.rmv"
+
+echo '-- failure path: the unpublished temporary target must be dropped too'
+
+db_fail="${CLICKHOUSE_DATABASE}_fail"
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE ${db_fail}"
+# One row per block, so blocks land as parts in the temporary target before `throwIf` fires:
+# the refresh then fails with the target already created and populated, which is the cleanup
+# path taken from the catch branch rather than after a successful swap.
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE ${db_fail}.src (x UInt64) ENGINE = MergeTree ORDER BY x;
+    INSERT INTO ${db_fail}.src SELECT number FROM numbers(100);
+
+    CREATE MATERIALIZED VIEW ${db_fail}.rmv
+        REFRESH EVERY 1 YEAR
+        (x UInt64) ENGINE = MergeTree ORDER BY x EMPTY
+        AS SELECT throwIf(x = 50, 'stop') AS x FROM ${db_fail}.src
+        SETTINGS ignore_drop_queries_probability = 1, max_insert_block_size = 1,
+                 min_insert_block_size_rows = 1, min_insert_block_size_bytes = 1, max_block_size = 1;
+"
+${CLICKHOUSE_CLIENT} -q "SYSTEM REFRESH VIEW ${db_fail}.rmv"
+${CLICKHOUSE_CLIENT} -q "SYSTEM WAIT VIEW ${db_fail}.rmv" 2>&1 | grep -q 'REFRESH_FAILED' && echo 'refresh_failed'
+${CLICKHOUSE_CLIENT} -q "SELECT countIf(name LIKE '.tmp.%') FROM system.tables WHERE database = '${db_fail}'"
+
+echo '-- Replicated database: the cleanup DROP is enqueued, not injected'
+
+# The injection is checked before the query is enqueued for replication, so the leak is
+# reachable here too, and the fix must keep the DROP working through the enqueue path.
+db_repl="${CLICKHOUSE_DATABASE}_repl"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none -q "
+    CREATE DATABASE ${db_repl}
+        ENGINE = Replicated('/test/{database}/refreshable_mv_cleanup_drop', 'shard1', 'replica1');
+"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none -q "
+    CREATE TABLE ${db_repl}.src (x UInt64) ENGINE = MergeTree ORDER BY x;
+    INSERT INTO ${db_repl}.src SELECT number FROM numbers(1000);
+
+    CREATE MATERIALIZED VIEW ${db_repl}.rmv
+        REFRESH EVERY 1 YEAR
+        (x UInt64) ENGINE = ReplicatedMergeTree ORDER BY x EMPTY
+        AS SELECT * FROM ${db_repl}.src SETTINGS ignore_drop_queries_probability = 1;
+"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none -q "
+    SYSTEM REFRESH VIEW ${db_repl}.rmv;
+    SYSTEM WAIT VIEW ${db_repl}.rmv;
+    SYSTEM REFRESH VIEW ${db_repl}.rmv;
+    SYSTEM WAIT VIEW ${db_repl}.rmv;
+"
+${CLICKHOUSE_CLIENT} -q "SELECT countIf(name LIKE '.tmp.%') FROM system.tables WHERE database = '${db_repl}'"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${db_repl}.rmv"
+
+echo '-- a user DROP is still skipped: the setting keeps doing what it is for'
+
+${CLICKHOUSE_CLIENT} -q "
+    SET ignore_drop_queries_probability = 1;
+    CREATE TABLE ${db}.user_drop (a UInt64) ENGINE = MergeTree ORDER BY a;
+    INSERT INTO ${db}.user_drop SELECT number FROM numbers(10);
+    DROP TABLE ${db}.user_drop;
+"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = '${db}' AND name = 'user_drop'"
+
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${db}"
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${db_fail}"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none -q "DROP DATABASE ${db_repl}"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/114420
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a refreshable materialized view leaking its rotated-out target table when `ignore_drop_queries_probability` is enabled. The `DROP` a refresh issues to clean up the previous target is a step of the refresh, not a `DROP` the user asked for, so the fault injection no longer applies to it.

### Description

Follow-up to #114420, requested by @ tiandiwonder in https://github.com/ClickHouse/ClickHouse/pull/114420#discussion_r3772879738.

`ignore_drop_queries_probability` makes a `DROP TABLE` silently do nothing (or become a `TRUNCATE`) so the stress suite exercises "the table you dropped is still there". It must only affect `DROP`s the user issued.

**Root cause.** After a refresh swaps in a new target, `StorageMaterializedView::dropTempTable` drops the rotated-out one via `InterpreterDropQuery(drop_query, refresh_context)`. `createRefreshContext` never marks that context internal, so the gate treated the cleanup `DROP` as a user `DROP`. Its existing refreshable-view exemption does not cover this: that test inspects the table *being dropped*, which here is the inner target, not the view. Both refresh exits are affected. When it fires, the old target survives as `.tmp.inner_id.<uuid>` still holding a full copy of the view's data, outside the view's metadata and surviving restart.

**The change.** `InterpreterDropQuery` gains an `internal` member mirroring the one `InterpreterCreateQuery` already has, `dropTempTable` sets it, and the shared `refresh_context` is untouched. Marking that context instead would break the refresh outright in a `Replicated` database: the publishing `RENAME` runs on it, and `DatabaseReplicated` rejects a non-initial query unless the interpreter also passes `flags.internal`, which neither the Rename nor the Drop interpreter did. That is why #114420's one-liner was safe there and is not here. `QueryFlags{ .internal = internal }` at the replicated enqueue is behaviour-neutral for every other `DROP`, since all its members default to false. The interpreter's other policy branches (`ON CLUSTER` dispatch, access and dependency checks) deliberately keep applying.

**Validation.** New test `04887_refreshable_mv_cleanup_drop_not_ignored`: three positive arms (success path, failure path, `Replicated` database) leak on master and are clean with the fix; a fourth asserts a genuine user `DROP` is still skipped. 50 randomized runs plus 50 with `ignore_drop_queries_probability=0.2` were green, as were `04247`, `04796`, `04218` and `04327`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1485` (included in `26.8` and later)
<!-- ch-version-info:end -->