### PR TITLE
Find a LowCardinality needle equal to the type's default value

### DIFF
--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -178,6 +178,10 @@ public:
     /// This is strange. Please remove this method as soon as possible.
     std::optional<UInt64> getOrFindValueIndex(std::string_view value) const override
     {
+        /// The reserved prefix slots are not in the reverse index, so match the default value here.
+        if (auto index = getNestedTypeDefaultValueIndex(); getRawColumnPtr()->getDataAt(index) == value)
+            return index;
+
         if (std::optional<UInt64> res = reverse_index.getIndex(value); res)
             return res;
 

--- a/src/Functions/LowCardinalityExecutionHelpers.h
+++ b/src/Functions/LowCardinalityExecutionHelpers.h
@@ -5,15 +5,37 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/IColumn.h>
+#include <Common/FieldAccurateComparison.h>
 #include <Core/Field.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/IDataType.h>
+#include <DataTypes/getLeastSupertype.h>
 #include <Interpreters/castColumn.h>
 
 #include <optional>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_CONVERT_TYPE;
+    extern const int CANNOT_PARSE_BOOL;
+    extern const int CANNOT_PARSE_DATE;
+    extern const int CANNOT_PARSE_DATETIME;
+    extern const int CANNOT_PARSE_IPV4;
+    extern const int CANNOT_PARSE_IPV6;
+    extern const int CANNOT_PARSE_NUMBER;
+    extern const int CANNOT_PARSE_TEXT;
+    extern const int CANNOT_PARSE_UUID;
+    extern const int DECIMAL_OVERFLOW;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NOT_IMPLEMENTED;
+    extern const int TOO_LARGE_STRING_SIZE;
+    extern const int UNKNOWN_ELEMENT_OF_ENUM;
+    extern const int VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE;
+}
 
 namespace LowCardinalityExecutionHelpers
 {
@@ -165,6 +187,58 @@ inline ColumnPtr dictionaryMatchesForSelectedIndexes(
     return sparse_matches;
 }
 
+/// Is [code] a cast declining its input, rather than a fault of the caller? Anything else (a memory
+/// limit, a logical error, a cancellation) is not an answer about the value and must propagate.
+inline bool isConstantCastDecline(int code)
+{
+    return code == ErrorCodes::CANNOT_CONVERT_TYPE
+        || code == ErrorCodes::CANNOT_PARSE_BOOL
+        || code == ErrorCodes::CANNOT_PARSE_DATE
+        || code == ErrorCodes::CANNOT_PARSE_DATETIME
+        || code == ErrorCodes::CANNOT_PARSE_IPV4
+        || code == ErrorCodes::CANNOT_PARSE_IPV6
+        || code == ErrorCodes::CANNOT_PARSE_NUMBER
+        || code == ErrorCodes::CANNOT_PARSE_TEXT
+        || code == ErrorCodes::CANNOT_PARSE_UUID
+        || code == ErrorCodes::DECIMAL_OVERFLOW
+        || code == ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT
+        || code == ErrorCodes::NOT_IMPLEMENTED
+        || code == ErrorCodes::TOO_LARGE_STRING_SIZE
+        || code == ErrorCodes::UNKNOWN_ELEMENT_OF_ENUM
+        || code == ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE;
+}
+
+/// Did [value] survive the cast that produced [image]? The cast alone cannot report loss, since it
+/// truncates UInt64(256) to UInt8(0) and succeeds, so compare the two in the type they meet in, where
+/// neither side's padding is a difference.
+inline bool targetTypeRepresentsValue(
+    const ColumnPtr & value, const DataTypePtr & value_type, const ColumnPtr & image, const DataTypePtr & image_type)
+{
+    try
+    {
+        /// Without a common type the pair only compares as numbers, so [value_type] is where they meet.
+        const auto common_type = tryGetLeastSupertype(DataTypes{value_type, image_type});
+        const auto compare_type = common_type ? makeNullable(common_type) : makeNullable(value_type);
+
+        const auto restored = castColumnAccurateOrNull({image, image_type, ""}, compare_type);
+        if (restored->empty() || restored->isNullAt(0))
+            return false;
+
+        const auto original = castColumnAccurateOrNull({value, value_type, ""}, compare_type);
+        if (original->empty() || original->isNullAt(0))
+            return false;
+
+        return accurateEquals((*restored)[0], (*original)[0]);
+    }
+    catch (const Exception & e)
+    {
+        if (!isConstantCastDecline(e.code()))
+            throw;
+
+        return false;
+    }
+}
+
 /// Returns false if the constant value is not present in the dictionary. If the constant is NULL,
 /// returns true and sets [dictionary_index] to the default LC null index, matching the existing
 /// Array(LowCardinality) index-function behavior.
@@ -183,13 +257,32 @@ inline __attribute__((always_inline)) bool dictionaryIndexForConstant(
         return true;
 
     auto value_type_without_low_cardinality = recursiveRemoveLowCardinality(value_type);
+    auto original_value = value;
+    auto cast_type = target_type;
     value = castColumn({value, value_type_without_low_cardinality, ""}, target_type);
 
     if (value->isNullable())
+    {
         value = assert_cast<const ColumnNullable &>(*value).getNestedColumnPtr();
+        cast_type = removeNullable(cast_type);
+    }
 
-    std::string_view elem = value->getDataAt(0);
-    if (auto maybe_index = low_cardinality_data.getDictionary().getOrFindValueIndex(elem))
+    const auto & dictionary = low_cardinality_data.getDictionary();
+
+    auto find_in_dictionary = [&](std::string_view elem) -> std::optional<UInt64>
+    {
+        /// The default slot holds its value whether or not any row references it, and the cast above
+        /// narrows without reporting loss, so UInt64(256) reaches it as UInt8(0). Answering from that
+        /// slot requires the constant to have survived the cast; one that did not equals no element.
+        if (elem == dictionary.getNestedNotNullableColumn()->getDataAt(dictionary.getNestedTypeDefaultValueIndex())
+            && !target_type->equals(*value_type_without_low_cardinality)
+            && !targetTypeRepresentsValue(original_value, value_type_without_low_cardinality, value, cast_type))
+            return {};
+
+        return dictionary.getOrFindValueIndex(elem);
+    };
+
+    if (auto maybe_index = find_in_dictionary(value->getDataAt(0)))
     {
         dictionary_index = *maybe_index;
         return true;

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -864,6 +864,14 @@ private:
         const auto & array_type  = assert_cast<const DataTypeArray &>(*arguments[0].type);
         const auto target_type = recursiveRemoveLowCardinality(array_type.getNestedType());
 
+        /// A float zero equals two byte-distinct dictionary entries, -0.0 and 0.0, and a single index
+        /// cannot denote both, so leave a zero needle to the path that compares values. The needle
+        /// type is narrowed only so that reading it as a float is total.
+        const auto needle_type = removeNullable(recursiveRemoveLowCardinality(arguments[1].type));
+        if (isFloat(removeNullable(target_type)) && (isNumber(needle_type) || isEnum(needle_type))
+            && !right_const->isNullAt(0) && right_const->getDataColumnPtr()->getFloat64(0) == 0.0)
+            return nullptr;
+
         UInt64 index = 0;
         UInt64 left_size = arguments[0].column->size();
         ResultColumnPtr col_result = ResultColumnType::create();

--- a/tests/queries/0_stateless/04881_low_cardinality_default_value_needle.reference
+++ b/tests/queries/0_stateless/04881_low_cardinality_default_value_needle.reference
@@ -1,0 +1,87 @@
+-- { echo }
+SET allow_suspicious_low_cardinality_types = 1;
+-- A needle equal to the element type's default value must be found. Every row prints the
+-- LowCardinality answer beside the same query over a plain array.
+SELECT has(CAST(['', 'a'], 'Array(LowCardinality(String))'), '') AS lc, has(CAST(['', 'a'], 'Array(String)'), '') AS oracle;
+1	1
+SELECT indexOf(materialize(CAST(['a', ''], 'Array(LowCardinality(String))')), '') AS lc, indexOf(materialize(CAST(['a', ''], 'Array(String)')), '') AS oracle;
+2	2
+SELECT countEqual(materialize(CAST(['', 'a', ''], 'Array(LowCardinality(String))')), '') AS lc, countEqual(materialize(CAST(['', 'a', ''], 'Array(String)')), '') AS oracle;
+2	2
+SELECT has(materialize(CAST([0, 5], 'Array(LowCardinality(UInt8))')), 0) AS lc, has(materialize(CAST([0, 5], 'Array(UInt8)')), 0) AS oracle;
+1	1
+SELECT has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(LowCardinality(FixedString(3)))')), CAST('', 'FixedString(3)')) AS lc, has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(FixedString(3))')), CAST('', 'FixedString(3)')) AS oracle;
+1	1
+-- An Enum needle compares to a FixedString element as a string, where the element type's own padding
+-- is not a difference.
+SELECT has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(LowCardinality(FixedString(3)))')), CAST('', 'Enum8('''' = 0, ''o'' = 1)')) AS lc, has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(FixedString(3))')), CAST('', 'Enum8('''' = 0, ''o'' = 1)')) AS oracle;
+1	1
+-- The Map key and value dictionaries are the second call site.
+SELECT mapContainsKey(materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(LowCardinality(String), String)')), '') AS lc, mapContainsKey(materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(String, String)')), '') AS oracle;
+1	1
+SELECT materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(LowCardinality(String), String)'))[''] AS lc, materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(String, String)'))[''] AS oracle;
+v_empty	v_empty
+SELECT mapContainsValue(materialize(CAST(map('k', '', 'j', 'v'), 'Map(String, LowCardinality(String))')), '') AS lc, mapContainsValue(materialize(CAST(map('k', '', 'j', 'v'), 'Map(String, String)')), '') AS oracle;
+1	1
+-- A constant the element type cannot represent equals no element, while one that survives the cast
+-- still finds the default element. The timezone is pinned because the cast to Date drops the
+-- needle's time of day and which day that lands on is offset-dependent.
+SELECT has(materialize(CAST([0, 5], 'Array(LowCardinality(UInt8))')), 256) AS lc, has(materialize(CAST([0, 5], 'Array(UInt8)')), 256) AS oracle;
+0	0
+SELECT mapContainsKey(materialize(CAST(map(0, 'a', 5, 'b'), 'Map(LowCardinality(UInt8), String)')), 256) AS lc, mapContainsKey(materialize(CAST(map(0, 'a', 5, 'b'), 'Map(UInt8, String)')), 256) AS oracle;
+0	0
+SELECT has(materialize(CAST([toDate('1970-01-01'), toDate('2020-01-01')], 'Array(LowCardinality(Date))')), toDateTime('1970-01-01 00:00:05')) AS lc, has(materialize(CAST([toDate('1970-01-01'), toDate('2020-01-01')], 'Array(Date)')), toDateTime('1970-01-01 00:00:05')) AS oracle SETTINGS session_timezone = 'UTC';
+0	0
+SELECT has(materialize(CAST([0, 5], 'Array(LowCardinality(UInt8))')), toUInt64(0)) AS widened_needle, has(materialize(CAST([0, 1.5], 'Array(LowCardinality(Float64))')), toUInt8(0)) AS integral_needle;
+1	1
+-- An IPv4 element represents a UInt32 needle exactly, and the two have no accurate cast between them,
+-- so representability is decided by comparing the needle against its own cast image.
+SELECT has(materialize(CAST([toIPv4('0.0.0.0'), toIPv4('1.2.3.4')], 'Array(LowCardinality(IPv4))')), toUInt32(0)) AS lc, has(materialize(CAST([toIPv4('0.0.0.0'), toIPv4('1.2.3.4')], 'Array(IPv4)')), toUInt32(0)) AS oracle;
+1	1
+-- A FixedString needle is padded to its own width and equality ignores that padding.
+SELECT has(materialize(CAST(['', 'xy'], 'Array(LowCardinality(String))')), CAST('', 'FixedString(4)')) AS lc, length(arrayFilter(x -> x = CAST('', 'FixedString(4)'), materialize(CAST(['', 'xy'], 'Array(String)')))) AS oracle;
+1	1
+-- -0.0 and 0.0 are equal but a text format stores them apart, so either zero as a needle must match
+-- either spelling, and a count must see both. stored_bits is asserted in the same row: if it ever
+-- reads 0 the array no longer holds -0.0 and the arm is void.
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, has(a, toFloat64(0)) AS positive_zero_needle, has(a, reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle, length(arrayFilter(x -> x = toFloat64(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[-0.0,1.5]}');
+[9223372036854775808,4609434218613702656]	1	1	1
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, indexOf(a, toFloat64(0)) AS positive_zero_needle, indexOf(a, reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle, indexOf(arrayMap(x -> toFloat64(x), a), toFloat64(0)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[1.5,-0.0]}');
+[4609434218613702656,9223372036854775808]	2	2	2
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, countEqual(a, toFloat64(0)) AS positive_zero_needle, countEqual(a, reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle, length(arrayFilter(x -> x = toFloat64(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[0.0,-0.0,1.5]}');
+[0,9223372036854775808,4609434218613702656]	2	2	2
+SELECT arrayMap(x -> reinterpretAsUInt32(x), a) AS stored_bits, has(a, toFloat32(0)) AS positive_zero_needle, has(a, reinterpretAsFloat32(toUInt32(2147483648))) AS negative_zero_needle, length(arrayFilter(x -> x = toFloat32(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float32))', '{"a":[-0.0,1.5]}');
+[2147483648,1069547520]	1	1	1
+-- A CAST array is folded onto the default slot, so its -0.0 element is stored as +0.0.
+SELECT arrayMap(x -> reinterpretAsUInt64(x), materialize(CAST([reinterpretAsFloat64(toUInt64(9223372036854775808)), 1.5], 'Array(LowCardinality(Float64))'))) AS stored_bits, has(materialize(CAST([reinterpretAsFloat64(toUInt64(9223372036854775808)), 1.5], 'Array(LowCardinality(Float64))')), toFloat64(0)) AS positive_zero_needle, has(materialize(CAST([reinterpretAsFloat64(toUInt64(9223372036854775808)), 1.5], 'Array(LowCardinality(Float64))')), reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle;
+[0,4609434218613702656]	1	1
+SELECT has(materialize(CAST([0, NULL, 1.5], 'Array(LowCardinality(Nullable(Float64)))')), reinterpretAsFloat64(toUInt64(9223372036854775808))) AS lc, length(arrayFilter(x -> x = reinterpretAsFloat64(toUInt64(9223372036854775808)), materialize(CAST([0, NULL, 1.5], 'Array(LowCardinality(Nullable(Float64)))')))) AS oracle;
+1	1
+-- An Enum needle reaches a float element through its underlying number, so it must be declined too.
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, has(a, CAST('z', 'Enum8(\'z\' = 0, \'o\' = 1)')) AS enum8_needle, indexOf(a, CAST('z', 'Enum8(\'z\' = 0, \'o\' = 1)')) AS enum8_index, countEqual(a, CAST('z', 'Enum16(\'z\' = 0, \'o\' = 1)')) AS enum16_count, length(arrayFilter(x -> x = toFloat64(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[-0.0,1.5]}');
+[9223372036854775808,4609434218613702656]	1	1	1	1
+-- Controls that must not move.
+SELECT has(materialize(CAST(['', 'a'], 'Array(LowCardinality(String))')), 'zzz') AS absent_needle, has(materialize(CAST(['a', 'b'], 'Array(LowCardinality(String))')), '') AS default_absent;
+0	0
+SELECT has(materialize(CAST(['', 'a'], 'Array(LowCardinality(String))')), materialize('')) AS non_const_needle, indexOfAssumeSorted(materialize(CAST(['', 'a'], 'Array(LowCardinality(String))')), '') AS assume_sorted;
+1	1
+-- Two answers that only the dictionary shortcut produces, so a build that stopped taking it would
+-- move them. Both disagree with the plain-array oracle printed beside them, and both are known
+-- defects of the value comparison tracked elsewhere, not of the lookup this test covers: a NaN is
+-- one dictionary entry but never equal to itself, and a negative needle is compared to an unsigned
+-- element as a raw number.
+SELECT has(materialize(CAST([nan, 1.5], 'Array(LowCardinality(Float64))')), nan) AS nan_needle, has(materialize(CAST([nan, 1.5], 'Array(Float64)')), nan) AS oracle;
+1	0
+SELECT has(materialize(CAST([0, 255], 'Array(LowCardinality(UInt8))')), toInt8(-1)) AS negative_needle, has(materialize(CAST([0, 255], 'Array(UInt8)')), toInt8(-1)) AS oracle;
+1	0
+-- LowCardinality(Nullable(T)): a NULL needle finds the NULL element and a default needle finds the default one.
+SELECT indexOf(materialize(CAST(['a', NULL, ''], 'Array(LowCardinality(Nullable(String)))')), NULL) AS null_needle, indexOf(materialize(CAST(['a', NULL, ''], 'Array(LowCardinality(Nullable(String)))')), '') AS default_needle;
+2	3
+-- Reached through a real table read rather than a constant-folded literal.
+DROP TABLE IF EXISTS t_04881;
+CREATE TABLE t_04881 (a Array(LowCardinality(String)), m Map(LowCardinality(String), String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04881 VALUES (['', 'a'], map('', 'v_empty', 'k', 'v_k')), (['x', 'y'], map('x', 'v_x', 'y', 'v_y'));
+SELECT a, has(a, '') AS has_empty, indexOf(a, '') AS idx_empty, mapContainsKey(m, '') AS key_empty, m[''] AS subscript_empty FROM t_04881 ORDER BY a;
+['','a']	1	1	1	v_empty
+['x','y']	0	0	0	
+DROP TABLE t_04881;

--- a/tests/queries/0_stateless/04881_low_cardinality_default_value_needle.sql
+++ b/tests/queries/0_stateless/04881_low_cardinality_default_value_needle.sql
@@ -1,0 +1,69 @@
+-- { echo }
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- A needle equal to the element type's default value must be found. Every row prints the
+-- LowCardinality answer beside the same query over a plain array.
+SELECT has(CAST(['', 'a'], 'Array(LowCardinality(String))'), '') AS lc, has(CAST(['', 'a'], 'Array(String)'), '') AS oracle;
+SELECT indexOf(materialize(CAST(['a', ''], 'Array(LowCardinality(String))')), '') AS lc, indexOf(materialize(CAST(['a', ''], 'Array(String)')), '') AS oracle;
+SELECT countEqual(materialize(CAST(['', 'a', ''], 'Array(LowCardinality(String))')), '') AS lc, countEqual(materialize(CAST(['', 'a', ''], 'Array(String)')), '') AS oracle;
+SELECT has(materialize(CAST([0, 5], 'Array(LowCardinality(UInt8))')), 0) AS lc, has(materialize(CAST([0, 5], 'Array(UInt8)')), 0) AS oracle;
+SELECT has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(LowCardinality(FixedString(3)))')), CAST('', 'FixedString(3)')) AS lc, has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(FixedString(3))')), CAST('', 'FixedString(3)')) AS oracle;
+-- An Enum needle compares to a FixedString element as a string, where the element type's own padding
+-- is not a difference.
+SELECT has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(LowCardinality(FixedString(3)))')), CAST('', 'Enum8('''' = 0, ''o'' = 1)')) AS lc, has(materialize(CAST([CAST('', 'FixedString(3)'), CAST('abc', 'FixedString(3)')], 'Array(FixedString(3))')), CAST('', 'Enum8('''' = 0, ''o'' = 1)')) AS oracle;
+
+-- The Map key and value dictionaries are the second call site.
+SELECT mapContainsKey(materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(LowCardinality(String), String)')), '') AS lc, mapContainsKey(materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(String, String)')), '') AS oracle;
+SELECT materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(LowCardinality(String), String)'))[''] AS lc, materialize(CAST(map('', 'v_empty', 'k', 'v_k'), 'Map(String, String)'))[''] AS oracle;
+SELECT mapContainsValue(materialize(CAST(map('k', '', 'j', 'v'), 'Map(String, LowCardinality(String))')), '') AS lc, mapContainsValue(materialize(CAST(map('k', '', 'j', 'v'), 'Map(String, String)')), '') AS oracle;
+
+-- A constant the element type cannot represent equals no element, while one that survives the cast
+-- still finds the default element. The timezone is pinned because the cast to Date drops the
+-- needle's time of day and which day that lands on is offset-dependent.
+SELECT has(materialize(CAST([0, 5], 'Array(LowCardinality(UInt8))')), 256) AS lc, has(materialize(CAST([0, 5], 'Array(UInt8)')), 256) AS oracle;
+SELECT mapContainsKey(materialize(CAST(map(0, 'a', 5, 'b'), 'Map(LowCardinality(UInt8), String)')), 256) AS lc, mapContainsKey(materialize(CAST(map(0, 'a', 5, 'b'), 'Map(UInt8, String)')), 256) AS oracle;
+SELECT has(materialize(CAST([toDate('1970-01-01'), toDate('2020-01-01')], 'Array(LowCardinality(Date))')), toDateTime('1970-01-01 00:00:05')) AS lc, has(materialize(CAST([toDate('1970-01-01'), toDate('2020-01-01')], 'Array(Date)')), toDateTime('1970-01-01 00:00:05')) AS oracle SETTINGS session_timezone = 'UTC';
+SELECT has(materialize(CAST([0, 5], 'Array(LowCardinality(UInt8))')), toUInt64(0)) AS widened_needle, has(materialize(CAST([0, 1.5], 'Array(LowCardinality(Float64))')), toUInt8(0)) AS integral_needle;
+-- An IPv4 element represents a UInt32 needle exactly, and the two have no accurate cast between them,
+-- so representability is decided by comparing the needle against its own cast image.
+SELECT has(materialize(CAST([toIPv4('0.0.0.0'), toIPv4('1.2.3.4')], 'Array(LowCardinality(IPv4))')), toUInt32(0)) AS lc, has(materialize(CAST([toIPv4('0.0.0.0'), toIPv4('1.2.3.4')], 'Array(IPv4)')), toUInt32(0)) AS oracle;
+
+-- A FixedString needle is padded to its own width and equality ignores that padding.
+SELECT has(materialize(CAST(['', 'xy'], 'Array(LowCardinality(String))')), CAST('', 'FixedString(4)')) AS lc, length(arrayFilter(x -> x = CAST('', 'FixedString(4)'), materialize(CAST(['', 'xy'], 'Array(String)')))) AS oracle;
+
+-- -0.0 and 0.0 are equal but a text format stores them apart, so either zero as a needle must match
+-- either spelling, and a count must see both. stored_bits is asserted in the same row: if it ever
+-- reads 0 the array no longer holds -0.0 and the arm is void.
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, has(a, toFloat64(0)) AS positive_zero_needle, has(a, reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle, length(arrayFilter(x -> x = toFloat64(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[-0.0,1.5]}');
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, indexOf(a, toFloat64(0)) AS positive_zero_needle, indexOf(a, reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle, indexOf(arrayMap(x -> toFloat64(x), a), toFloat64(0)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[1.5,-0.0]}');
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, countEqual(a, toFloat64(0)) AS positive_zero_needle, countEqual(a, reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle, length(arrayFilter(x -> x = toFloat64(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[0.0,-0.0,1.5]}');
+SELECT arrayMap(x -> reinterpretAsUInt32(x), a) AS stored_bits, has(a, toFloat32(0)) AS positive_zero_needle, has(a, reinterpretAsFloat32(toUInt32(2147483648))) AS negative_zero_needle, length(arrayFilter(x -> x = toFloat32(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float32))', '{"a":[-0.0,1.5]}');
+
+-- A CAST array is folded onto the default slot, so its -0.0 element is stored as +0.0.
+SELECT arrayMap(x -> reinterpretAsUInt64(x), materialize(CAST([reinterpretAsFloat64(toUInt64(9223372036854775808)), 1.5], 'Array(LowCardinality(Float64))'))) AS stored_bits, has(materialize(CAST([reinterpretAsFloat64(toUInt64(9223372036854775808)), 1.5], 'Array(LowCardinality(Float64))')), toFloat64(0)) AS positive_zero_needle, has(materialize(CAST([reinterpretAsFloat64(toUInt64(9223372036854775808)), 1.5], 'Array(LowCardinality(Float64))')), reinterpretAsFloat64(toUInt64(9223372036854775808))) AS negative_zero_needle;
+SELECT has(materialize(CAST([0, NULL, 1.5], 'Array(LowCardinality(Nullable(Float64)))')), reinterpretAsFloat64(toUInt64(9223372036854775808))) AS lc, length(arrayFilter(x -> x = reinterpretAsFloat64(toUInt64(9223372036854775808)), materialize(CAST([0, NULL, 1.5], 'Array(LowCardinality(Nullable(Float64)))')))) AS oracle;
+
+-- An Enum needle reaches a float element through its underlying number, so it must be declined too.
+SELECT arrayMap(x -> reinterpretAsUInt64(x), a) AS stored_bits, has(a, CAST('z', 'Enum8(\'z\' = 0, \'o\' = 1)')) AS enum8_needle, indexOf(a, CAST('z', 'Enum8(\'z\' = 0, \'o\' = 1)')) AS enum8_index, countEqual(a, CAST('z', 'Enum16(\'z\' = 0, \'o\' = 1)')) AS enum16_count, length(arrayFilter(x -> x = toFloat64(0), a)) AS oracle FROM format(JSONEachRow, 'a Array(LowCardinality(Float64))', '{"a":[-0.0,1.5]}');
+
+-- Controls that must not move.
+SELECT has(materialize(CAST(['', 'a'], 'Array(LowCardinality(String))')), 'zzz') AS absent_needle, has(materialize(CAST(['a', 'b'], 'Array(LowCardinality(String))')), '') AS default_absent;
+SELECT has(materialize(CAST(['', 'a'], 'Array(LowCardinality(String))')), materialize('')) AS non_const_needle, indexOfAssumeSorted(materialize(CAST(['', 'a'], 'Array(LowCardinality(String))')), '') AS assume_sorted;
+
+-- Two answers that only the dictionary shortcut produces, so a build that stopped taking it would
+-- move them. Both disagree with the plain-array oracle printed beside them, and both are known
+-- defects of the value comparison tracked elsewhere, not of the lookup this test covers: a NaN is
+-- one dictionary entry but never equal to itself, and a negative needle is compared to an unsigned
+-- element as a raw number.
+SELECT has(materialize(CAST([nan, 1.5], 'Array(LowCardinality(Float64))')), nan) AS nan_needle, has(materialize(CAST([nan, 1.5], 'Array(Float64)')), nan) AS oracle;
+SELECT has(materialize(CAST([0, 255], 'Array(LowCardinality(UInt8))')), toInt8(-1)) AS negative_needle, has(materialize(CAST([0, 255], 'Array(UInt8)')), toInt8(-1)) AS oracle;
+
+-- LowCardinality(Nullable(T)): a NULL needle finds the NULL element and a default needle finds the default one.
+SELECT indexOf(materialize(CAST(['a', NULL, ''], 'Array(LowCardinality(Nullable(String)))')), NULL) AS null_needle, indexOf(materialize(CAST(['a', NULL, ''], 'Array(LowCardinality(Nullable(String)))')), '') AS default_needle;
+
+-- Reached through a real table read rather than a constant-folded literal.
+DROP TABLE IF EXISTS t_04881;
+CREATE TABLE t_04881 (a Array(LowCardinality(String)), m Map(LowCardinality(String), String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04881 VALUES (['', 'a'], map('', 'v_empty', 'k', 'v_k')), (['x', 'y'], map('x', 'v_x', 'y', 'v_y'));
+SELECT a, has(a, '') AS has_empty, indexOf(a, '') AS idx_empty, mapContainsKey(m, '') AS key_empty, m[''] AS subscript_empty FROM t_04881 ORDER BY a;
+DROP TABLE t_04881;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112953
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes `has`, `indexOf`, `countEqual`, `mapContainsKey`, `mapContainsValue` and `Map` subscript returning "not found" for a constant `LowCardinality` needle equal to the element type's default value, such as an empty `String` or a zero number.

### Description

**The problem.** A constant needle equal to the element type's default value is never found in an `Array(LowCardinality(T))` or a `Map` with a `LowCardinality` key. No exception, so a `WHERE` on such a predicate silently drops rows:

```sql
CREATE TABLE t (a Array(LowCardinality(String))) ENGINE = Memory;
INSERT INTO t VALUES (['', 'a']);
SELECT has(a, '') FROM t;   -- 0, expected 1
```

Likewise for `0` over the numeric types, a NUL-padded `FixedString` and the `1970-01-01` `Date`, while `m['']` returns `''` instead of the stored value. Any non-default needle is correct. Reproduces on 26.5 to 26.7.

**Root cause.** A `LowCardinality` dictionary reserves prefix slots for the default and NULL values, and `ReverseIndex` is built with `num_prefix_rows_to_skip`, so the reserved slot is never indexed. `ColumnUnique::uniqueInsertData` compensates for that on the write path; the read path had no counterpart.

**The change.** `ColumnUnique::getOrFindValueIndex` now performs the same default-slot match as the write path. `ReverseIndex` is untouched, so no write behaviour moves.

That slot becoming reachable brings two equality details. The lookup casts the constant into the element type without reporting loss, so `UInt64(256)` arrived as `UInt8(0)` and would match the default; that slot now answers only if the element type can represent the constant. And a dictionary can hold `-0.0` and `0.0` as separate entries while the shortcut has room for one index, so a zero constant over a float element type is left to the value-comparing path, as `indexOfAssumeSorted` already is.

The new test covers both call sites. Lookup timing is unchanged.

**Overlap with #112953.** That open PR declines this same shortcut for every float element type, subsuming the float-zero decline here, and the two conflict textually; whichever merges second should keep the broader decline and drop this one, collapsing the duplicated representability predicate to one copy. Non-float types are independent of it.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.5.10`, `26.6.4.7`, `26.5.8.14`, `26.3.23.7`, `25.8.33.6`
<!-- ch-version-info:end -->