### PR TITLE
Do not merge-sort a distributed gather whose sort description is all-constant

### DIFF
--- a/src/Processors/QueryPlan/GatherSendStep.cpp
+++ b/src/Processors/QueryPlan/GatherSendStep.cpp
@@ -6,6 +6,7 @@
 #include <Processors/QueryPlan/ExchangeLookup.h>
 #include <Processors/QueryPlan/LogicalExchangeStep.h>
 #include <Processors/Merges/MergingSortedTransform.h>
+#include <Columns/IColumn.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/Pipe.h>
 #include <IO/WriteHelpers.h>
@@ -23,6 +24,19 @@ namespace ErrorCodes
     extern const int SUPPORT_IS_DISABLED;
 }
 
+/// True when every key of `description` is constant in `header`, so all rows compare equal under it.
+static bool sortDescriptionIsAllConstant(const SortDescription & description, const Block & header)
+{
+    for (const auto & column_description : description)
+    {
+        const auto * column = header.findByName(column_description.column_name);
+        if (!column || !column->column || !isColumnConst(*column->column))
+            return false;
+    }
+
+    return true;
+}
+
 QueryPipelineBuilderPtr GatherSendStep::updatePipeline(QueryPipelineBuilders pipelines, const BuildQueryPipelineSettings & settings)
 {
     if (pipelines.size() != 1)
@@ -35,7 +49,11 @@ QueryPipelineBuilderPtr GatherSendStep::updatePipeline(QueryPipelineBuilders pip
     /// Cannot have multiple sinks writing to the same file concurrently. Merge-sort rather than plain
     /// resize(1) when order must be preserved, since `GatherReceiveStep` merge-sorts assuming each bucket's
     /// stream already arrives sorted.
-    if (maintain_sort_description && pipeline.getNumStreams() > 1)
+    /// An all-constant description orders nothing, so any interleaving satisfies it. The merge is skipped
+    /// there because it waits for every input to have data, which cannot complete while the streams share
+    /// one upstream producer blocked on a stream the merge is not reading.
+    if (maintain_sort_description && pipeline.getNumStreams() > 1
+        && !sortDescriptionIsAllConstant(*maintain_sort_description, *pipeline.getSharedHeader()))
     {
         pipeline.addTransform(
             std::make_shared<MergingSortedTransform>(

--- a/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.reference
+++ b/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.reference
@@ -2,6 +2,8 @@ constant key	20000
 const gather is const-sorted	1
 constant key, LowCardinality	20000
 constant key, Nullable	20000
+constant key behind identity	20000
+materialized key is not constant	20000
 column key	20000
 column gather is column-sorted	1
 mixed key	20000

--- a/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.reference
+++ b/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.reference
@@ -1,0 +1,6 @@
+constant key	20000
+constant key, LowCardinality	20000
+constant key, Nullable	20000
+column key	20000
+mixed key	20000
+values match local	1

--- a/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.reference
+++ b/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.reference
@@ -1,6 +1,8 @@
 constant key	20000
+const gather is const-sorted	1
 constant key, LowCardinality	20000
 constant key, Nullable	20000
 column key	20000
+column gather is column-sorted	1
 mixed key	20000
 values match local	1

--- a/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.sql
+++ b/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.sql
@@ -1,0 +1,92 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- A window `PARTITION BY <constant>` under make_distributed_plan=1 builds a `GatherSend` fragment whose
+-- sort description is entirely constant. Such a description orders nothing, so the fragment's
+-- order-preserving merge must not be used: it waits for every input stream to have data, which never
+-- completes while the streams share one blocked upstream scatter. Before the fix every query below with
+-- a constant partition key deadlocked until `receive_timeout` and then raised `Pipeline stuck`.
+
+DROP TABLE IF EXISTS t_const_window;
+
+CREATE TABLE t_const_window (a UInt32, v UInt32)
+ENGINE = MergeTree ORDER BY (a, v) SETTINGS index_granularity = 256;
+
+-- Several parts so the fragment reads with more than one stream and the scatter actually fans out.
+SYSTEM STOP MERGES t_const_window;
+INSERT INTO t_const_window SELECT number % 10, number FROM numbers(4000);
+INSERT INTO t_const_window SELECT number % 10, number + 10000000 FROM numbers(4000);
+INSERT INTO t_const_window SELECT number % 10, number + 20000000 FROM numbers(4000);
+INSERT INTO t_const_window SELECT number % 10, number + 30000000 FROM numbers(4000);
+INSERT INTO t_const_window SELECT number % 10, number + 40000000 FROM numbers(4000);
+
+-- Two buckets with four threads keeps several streams inside one fragment, which is what puts the
+-- merge and the scatter in the deadlocking state. max_rows_to_group_by must be 0, otherwise
+-- make_distributed_plan declines plans with an aggregation.
+SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0, enable_join_runtime_filters = 0,
+    distributed_plan_default_shuffle_join_bucket_count = 2, distributed_plan_default_reader_bucket_count = 2,
+    distributed_plan_optimize_exchanges = 1, max_threads = 4, max_rows_to_group_by = 0,
+    optimize_read_in_order = 0, optimize_sorting_by_input_stream_properties = 1, max_block_size = 1024;
+
+-- The window argument is a non-trivial expression on purpose: it keeps the window above the gather, so
+-- the fragment below the gather is the const-keyed sort. A plain `uniq(v)` is pushed below the gather
+-- instead and does not build the failing shape.
+SELECT 'constant key', count() FROM
+(
+    SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window
+);
+
+-- Constants wrapped in LowCardinality and Nullable reach the same shape.
+SELECT 'constant key, LowCardinality', count() FROM
+(
+    SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY toLowCardinality('c') ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window
+);
+
+SELECT 'constant key, Nullable', count() FROM
+(
+    SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY toNullable('c') ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window
+);
+
+-- Controls. A real column key, and a mixed key whose second component is a column, both order rows and
+-- must keep using the merge; they passed before the fix and must keep passing.
+SELECT 'column key', count() FROM
+(
+    SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY a ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window
+);
+
+SELECT 'mixed key', count() FROM
+(
+    SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c', a ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window
+);
+
+-- A constant partition key is one partition, so the distributed and local results must agree.
+SELECT 'values match local', d.h = l.h FROM
+(
+    SELECT sum(cityHash64(a, v, roll)) AS h FROM
+    (
+        SELECT a, v, sum(v) OVER (PARTITION BY 'c' ORDER BY a, v
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS roll
+        FROM t_const_window
+    )
+) AS d,
+(
+    SELECT sum(cityHash64(a, v, roll)) AS h FROM
+    (
+        SELECT a, v, sum(v) OVER (PARTITION BY 'c' ORDER BY a, v
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS roll
+        FROM t_const_window
+    ) SETTINGS make_distributed_plan = 0
+) AS l;
+
+DROP TABLE t_const_window;

--- a/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.sql
+++ b/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.sql
@@ -66,6 +66,23 @@ SELECT 'constant key, Nullable', count() FROM
     FROM t_const_window
 );
 
+-- A function that returns its argument column verbatim keeps the key constant, so the description is
+-- still all-constant after the const-strip. `materialize` is the opposite case: it converts to a full
+-- column, the strip keeps the key, and the sort really sorts, so that shape never reached the merge.
+SELECT 'constant key behind identity', count() FROM
+(
+    SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY identity('c') ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window
+);
+
+SELECT 'materialized key is not constant', count() FROM
+(
+    SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY materialize('c') ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window
+);
+
 -- Controls. A real column key, and a mixed key whose second component is a column, both order rows and
 -- must keep using the merge; they passed before the fix and must keep passing.
 SELECT 'column key', count() FROM

--- a/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.sql
+++ b/tests/queries/0_stateless/04888_distributed_plan_window_const_partition.sql
@@ -39,6 +39,18 @@ SELECT 'constant key', count() FROM
     FROM t_const_window
 );
 
+-- A constant partition key must build a gather whose sort description is nothing but that constant.
+-- `make_distributed_plan` is repeated inside because the outer `SETTINGS` propagates into the subquery,
+-- and the outer query must stay local: distributed it fails with `ReadFromStorage is not serializable`.
+SELECT 'const gather is const-sorted', count() > 0 FROM
+(
+    EXPLAIN SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window SETTINGS make_distributed_plan = 1
+)
+WHERE explain ILIKE '%GatherExchange (sorted by (''c''_String ASC))%'
+SETTINGS make_distributed_plan = 0;
+
 -- Constants wrapped in LowCardinality and Nullable reach the same shape.
 SELECT 'constant key, LowCardinality', count() FROM
 (
@@ -62,6 +74,17 @@ SELECT 'column key', count() FROM
         OVER (PARTITION BY a ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
     FROM t_const_window
 );
+
+-- A column partition key keeps a column in the gather's sort description, so this arm and the constant
+-- one above are distinguishable rather than both merely returning the same row count.
+SELECT 'column gather is column-sorted', count() > 0 FROM
+(
+    EXPLAIN SELECT uniq(modulo(v, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY a ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS roll
+    FROM t_const_window SETTINGS make_distributed_plan = 1
+)
+WHERE explain ILIKE '%GatherExchange (sorted by (a ASC))%'
+SETTINGS make_distributed_plan = 0;
 
 SELECT 'mixed key', count() FROM
 (


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113558
Related: https://github.com/ClickHouse/ClickHouse/issues/106237
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

With `make_distributed_plan = 1`, a window `PARTITION BY <constant>` builds a `GatherSend` fragment
whose sort description is entirely constant. `GatherSendStep::updatePipeline` adds an order-preserving
`MergingSortedTransform` for any non-empty description, and that merge waits for *every* input stream
to have data (`IMergingTransformBase::prepareInitializeInputs`). Hashing a constant key sends all rows
to one bucket, so the other branches are never fed and stay `NeedData` while the loaded branch is
`PortFull`. Neither side can move: the query deadlocks at zero CPU until `receive_timeout` and then
raises `Pipeline stuck` (a logical error, so the server aborts in debug and sanitizer builds).

An all-constant description orders nothing, so this change takes the `pipeline.resize(1)` branch that
already exists in that function. A `ResizeProcessor` pairs any waiting output with any ready input and
has no all-inputs barrier, which is why the code before
[4a1ab1e](https://github.com/ClickHouse/ClickHouse/commit/4a1ab1e3d94fb0d) - which replaced an
unconditional `resize(1)` with this conditional merge - could not wedge this way. Every row compares
equal under an all-constant description, so any interleaving is validly sorted and the contract
`GatherReceiveStep` relies on still holds. A description with at least one real column keeps the merge.

Related: https://github.com/ClickHouse/ClickHouse/pull/113558 (where this failure was reported)
Related: https://github.com/ClickHouse/ClickHouse/issues/106237 (context only, different mechanism)

Found by `AST fuzzer (amd_debug, targeted, old_compatibility)`:
[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113558&sha=b9fe1650232abf4fefc16992f3efcce44222bebc&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29).
The `BufferedShardByHashTransform` deadlock tracked in #106237 is a different mechanism: that
transform does not appear in the failing pipeline at all.

The new test `04888` fails on master with `Pipeline stuck` for a constant key, a `LowCardinality`
constant and a `Nullable` constant, and passes with this change. Its controls - a real column key, a
mixed constant-plus-column key, and the non-distributed plan - pass both before and after, so the
change is narrow. `04837_distributed_plan_window_partition_shuffle`, which pins the full distributed
plan for a column-keyed window, still passes.