### PR TITLE
Wait for DETACH DATABASE to release tables in three integration tests

### DIFF
--- a/tests/integration/test_drop_database_replica/test.py
+++ b/tests/integration/test_drop_database_replica/test.py
@@ -189,7 +189,7 @@ def test_drop_database_replica(started_cluster, with_tables: bool):
         f"CREATE DATABASE db ENGINE = Replicated('{zk_path}'"
         + r", '{shard}', '{replica}')"
     )
-    node4.query("DETACH DATABASE db")
+    node4.query("DETACH DATABASE db SYNC")
     node4.query(
         f"INSERT INTO system.zookeeper(name, path, value) VALUES ('active', '{zk_path}/replicas/s2|r2', '{node4_uuid}')",
     )

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -155,9 +155,9 @@ def test_drop_replica(start_cluster):
         "SYSTEM DROP REPLICA 'node_1_1' FROM ZKPATH '/clickhouse/tables/test'"
     )
 
-    node_1_1.query("DETACH DATABASE test")
+    node_1_1.query("DETACH DATABASE test SYNC")
     for i in range(1, 5):
-        node_1_1.query("DETACH DATABASE test{}".format(i))
+        node_1_1.query("DETACH DATABASE test{} SYNC".format(i))
 
     assert "does not exist" in node_1_3.query_and_get_error(
         "SYSTEM DROP REPLICA 'node_1_1' FROM TABLE test.test_table"

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1389,7 +1389,7 @@ def test_replicated_table_structure_alter(started_cluster):
     )
 
     competing_node.query("CREATE TABLE table_structure.mem (n int) ENGINE=Memory")
-    dummy_node.query("DETACH DATABASE table_structure")
+    dummy_node.query("DETACH DATABASE table_structure SYNC")
 
     settings = {"distributed_ddl_task_timeout": 0}
     main_node.query(
@@ -1398,7 +1398,7 @@ def test_replicated_table_structure_alter(started_cluster):
     )
 
     competing_node.query("SYSTEM SYNC DATABASE REPLICA table_structure")
-    competing_node.query("DETACH DATABASE table_structure")
+    competing_node.query("DETACH DATABASE table_structure SYNC")
 
     main_node.query(
         "ALTER TABLE table_structure.rmt ADD COLUMN m int", settings=settings


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/93064
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/93064

Three integration tests intermittently fail with `Code: 219 ... Database <db> cannot be
detached, because some tables are still in use. Retry later.` thrown from
`DatabaseAtomic::assertCanBeDetached` (`src/Databases/DatabaseAtomic.cpp:521`).

Root cause: non-SYNC `DETACH DATABASE` is best-effort by contract, and these tests assume it is
atomic. `assertCanBeDetached` throws if any table of the database still has a live refcount. The
engine already has the deterministic wait, `waitDetachedTableNotInUse`, but
`executeToDatabaseImpl` calls it only under `query.sync`
(`src/Interpreters/InterpreterDropQuery.cpp:779-790`). Stateless CI installs
`tests/config/users.d/database_atomic_drop_detach_sync.xml`
(`database_atomic_wait_for_drop_and_detach_synchronously=1`); the integration helpers install no
such profile and run at the server default of 0. Hence the failures are confined to the
integration suite, and 16 of the 17 integration occurrences in 180 days are sanitizer builds,
where the holder's window is wider.

Code 219 is intended behaviour of the asynchronous form and is pinned in-tree:
`01107_atomic_db_detach_attach.sh:19` sets the setting to 0 to provoke it and asserts it. So
this is a test-side defect, and the change asks for the wait the engine already implements
rather than altering it.

I added `SYNC` to the five `DETACH DATABASE` statements with observed CI failures:
`test_drop_replica` (11 hits/180d), `test_replicated_table_structure_alter` (4), and
`test_drop_database_replica:192` (2, both stacks confirm that line is the thrower). All 21
non-SYNC sites under `tests/integration/` were enumerated; the other 16 are excluded because
they have zero CIDB hits in 180 days, already pass
`database_atomic_wait_for_drop_and_detach_synchronously`, or sit inside the existing
`detach_database_with_retry` helper, whose docstring documents a different holder.

Validation: with a holder injected the way `01107` does it, the DETACH returns 219 without
`SYNC` and succeeds with it, 10/10 on `Atomic` and on `Replicated`. The three tests pass 42/42
runs. Each `DETACH` in `test_drop_replica` measures ~0.115 s over 25 measurements, so the wait
costs nothing when no table is held, and it is cancellable and shutdown-aware.

CI report for the master failure:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=91b700711adf0a07172e1046c8d8f013f1e0b82c&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1356` (included in `26.8` and later)
- Backported to: `26.7.11.17`, `26.6.9.17`, `26.3.33.106`
<!-- ch-version-info:end -->