### PR TITLE
Add LIKE/NOT LIKE/ILIKE filtering to SHOW access entity statements

### DIFF
--- a/src/Interpreters/Access/InterpreterShowAccessEntitiesQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowAccessEntitiesQuery.cpp
@@ -143,6 +143,16 @@ String InterpreterShowAccessEntitiesQuery::getRewrittenQuery() const
     if (origin.empty())
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "{}: type is not supported by SHOW query", toString(query.type));
 
+    if (!query.like.empty())
+    {
+        String like_column = (query.current_roles || query.enabled_roles) ? "role_name" : "name";
+        String like_filter = like_column + " "
+            + (query.not_like ? "NOT " : "")
+            + (query.case_insensitive_like ? "ILIKE " : "LIKE ")
+            + quoteString(query.like);
+        filter += (filter.empty() ? "" : " AND ") + like_filter;
+    }
+
     if (order.empty() && expr != "*")
         order = expr;
 

--- a/src/Parsers/Access/ASTShowAccessEntitiesQuery.cpp
+++ b/src/Parsers/Access/ASTShowAccessEntitiesQuery.cpp
@@ -40,6 +40,13 @@ void ASTShowAccessEntitiesQuery::formatQueryImpl(WriteBuffer & ostr, const Forma
         ostr << (database.empty() ? "" : backQuoteIfNeed(database) + ".");
         ostr << (table_name.empty() ? "*" : backQuoteIfNeed(table_name));
     }
+
+    if (!like.empty())
+    {
+        ostr << (not_like ? " NOT" : "");
+        ostr << (case_insensitive_like ? " ILIKE " : " LIKE ");
+        ostr << quoteString(like);
+    }
 }
 
 

--- a/src/Parsers/Access/ASTShowAccessEntitiesQuery.h
+++ b/src/Parsers/Access/ASTShowAccessEntitiesQuery.h
@@ -7,12 +7,12 @@
 namespace DB
 {
 
-/// SHOW USERS
-/// SHOW [CURRENT|ENABLED] ROLES
-/// SHOW [SETTINGS] PROFILES
-/// SHOW [ROW] POLICIES [name | ON [database.]table]
-/// SHOW MASKING POLICIES [name | ON [database.]table]
-/// SHOW QUOTAS
+/// SHOW USERS [[NOT] [I]LIKE 'pattern']
+/// SHOW [CURRENT|ENABLED] ROLES [[NOT] [I]LIKE 'pattern']
+/// SHOW [SETTINGS] PROFILES [[NOT] [I]LIKE 'pattern']
+/// SHOW [ROW] POLICIES [name | ON [database.]table] [[NOT] [I]LIKE 'pattern']
+/// SHOW MASKING POLICIES [name | ON [database.]table] [[NOT] [I]LIKE 'pattern']
+/// SHOW QUOTAS [[NOT] [I]LIKE 'pattern']
 /// SHOW [CURRENT] QUOTA
 class ASTShowAccessEntitiesQuery : public ASTQueryWithOutput
 {
@@ -26,6 +26,10 @@ public:
 
     String short_name;
     std::optional<std::pair<String, String>> database_and_table_name;
+
+    String like;
+    bool not_like = false;
+    bool case_insensitive_like = false;
 
     String getID(char) const override;
     ASTPtr clone() const override { return make_intrusive<ASTShowAccessEntitiesQuery>(*this); }

--- a/src/Parsers/Access/ParserShowAccessEntitiesQuery.cpp
+++ b/src/Parsers/Access/ParserShowAccessEntitiesQuery.cpp
@@ -2,6 +2,8 @@
 #include <Parsers/Access/ASTShowAccessEntitiesQuery.h>
 #include <Parsers/Access/parseAccessEntityName.h>
 #include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/parseDatabaseAndTableName.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
 #include <base/range.h>
@@ -92,6 +94,26 @@ bool ParserShowAccessEntitiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected
             all = true;
     }
 
+    String like;
+    bool not_like = false;
+    bool case_insensitive_like = false;
+
+    if (ParserKeyword{Keyword::NOT}.ignore(pos, expected))
+        not_like = true;
+
+    if (bool insensitive = ParserKeyword{Keyword::ILIKE}.ignore(pos, expected); insensitive || ParserKeyword{Keyword::LIKE}.ignore(pos, expected))
+    {
+        if (insensitive)
+            case_insensitive_like = true;
+
+        ASTPtr like_ast;
+        if (!ParserStringLiteral{}.parse(pos, like_ast, expected))
+            return false;
+        like = like_ast->as<ASTLiteral &>().value.safeGet<String>();
+    }
+    else if (not_like)
+        return false;
+
     auto query = make_intrusive<ASTShowAccessEntitiesQuery>();
     node = query;
 
@@ -102,6 +124,9 @@ bool ParserShowAccessEntitiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected
     query->enabled_roles = enabled_roles;
     query->short_name = std::move(short_name);
     query->database_and_table_name = std::move(database_and_table_name);
+    query->like = std::move(like);
+    query->not_like = not_like;
+    query->case_insensitive_like = case_insensitive_like;
 
     return true;
 }

--- a/tests/queries/0_stateless/04891_show_access_entities_like.reference
+++ b/tests/queries/0_stateless/04891_show_access_entities_like.reference
@@ -1,0 +1,23 @@
+-- users like all
+show_like_u_AliceUpper
+show_like_u_alice
+show_like_u_bob
+-- users like alice
+show_like_u_alice
+-- users ilike alice
+show_like_u_AliceUpper
+show_like_u_alice
+-- roles like all
+show_like_r_admin
+show_like_r_reader
+-- roles like admin
+show_like_r_admin
+-- roles ilike admin
+show_like_r_admin
+-- profiles like all
+show_like_p_fast
+show_like_p_slow
+-- profiles like fast
+show_like_p_fast
+-- profiles ilike fast
+show_like_p_fast

--- a/tests/queries/0_stateless/04891_show_access_entities_like.sql
+++ b/tests/queries/0_stateless/04891_show_access_entities_like.sql
@@ -1,0 +1,62 @@
+-- Tags: no-parallel
+
+DROP USER IF EXISTS show_like_u_alice, show_like_u_bob, show_like_u_AliceUpper;
+DROP ROLE IF EXISTS show_like_r_admin, show_like_r_reader;
+DROP SETTINGS PROFILE IF EXISTS show_like_p_fast, show_like_p_slow;
+
+CREATE USER show_like_u_alice;
+CREATE USER show_like_u_bob;
+CREATE USER show_like_u_AliceUpper;
+CREATE ROLE show_like_r_admin;
+CREATE ROLE show_like_r_reader;
+CREATE SETTINGS PROFILE show_like_p_fast;
+CREATE SETTINGS PROFILE show_like_p_slow;
+
+-- SHOW USERS LIKE: match all test users
+SELECT '-- users like all';
+SHOW USERS LIKE 'show\_like\_u\_%';
+
+-- SHOW USERS LIKE: match only alice
+SELECT '-- users like alice';
+SHOW USERS LIKE 'show\_like\_u\_a%';
+
+-- SHOW USERS ILIKE: case-insensitive matches both alice and AliceUpper
+SELECT '-- users ilike alice';
+SHOW USERS ILIKE 'SHOW\_LIKE\_U\_ALICE%';
+
+-- SHOW ROLES LIKE: match all test roles
+SELECT '-- roles like all';
+SHOW ROLES LIKE 'show\_like\_r\_%';
+
+-- SHOW ROLES LIKE: match only admin
+SELECT '-- roles like admin';
+SHOW ROLES LIKE 'show\_like\_r\_adm%';
+
+-- SHOW ROLES ILIKE
+SELECT '-- roles ilike admin';
+SHOW ROLES ILIKE 'SHOW\_LIKE\_R\_ADM%';
+
+-- SHOW SETTINGS PROFILES LIKE: match all test profiles
+SELECT '-- profiles like all';
+SHOW SETTINGS PROFILES LIKE 'show\_like\_p\_%';
+
+-- SHOW SETTINGS PROFILES LIKE: match only fast
+SELECT '-- profiles like fast';
+SHOW SETTINGS PROFILES LIKE 'show\_like\_p\_f%';
+
+-- SHOW SETTINGS PROFILES ILIKE
+SELECT '-- profiles ilike fast';
+SHOW SETTINGS PROFILES ILIKE 'SHOW\_LIKE\_P\_F%';
+
+-- NOT LIKE: verify it parses and executes without error
+SHOW USERS NOT LIKE 'show\_like\_u\_bob' FORMAT Null;
+SHOW ROLES NOT LIKE 'show\_like\_r\_reader' FORMAT Null;
+SHOW SETTINGS PROFILES NOT LIKE 'show\_like\_p\_slow' FORMAT Null;
+
+-- NOT ILIKE: verify it parses and executes without error
+SHOW USERS NOT ILIKE '%BOB%' FORMAT Null;
+
+-- Cleanup
+DROP USER show_like_u_alice, show_like_u_bob, show_like_u_AliceUpper;
+DROP ROLE show_like_r_admin, show_like_r_reader;
+DROP SETTINGS PROFILE show_like_p_fast, show_like_p_slow;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111692

Implement `[NOT] [I]LIKE 'pattern'` for all `SHOW` statements that list access entities:
- `SHOW USERS`
- `SHOW ROLES` / `SHOW CURRENT ROLES` / `SHOW ENABLED ROLES`
- `SHOW SETTINGS PROFILES`
- `SHOW QUOTAS`
- `SHOW ROW POLICIES`
- `SHOW MASKING POLICIES`

This allows filtering access entities by name pattern, matching the existing behavior of `SHOW TABLES LIKE` and `SHOW DATABASES LIKE`:

```sql
SHOW USERS LIKE '%admin%'
SHOW ROLES NOT LIKE '%-internal'
SHOW USERS ILIKE '%ALICE%'
```

The implementation mirrors the existing `SHOW TABLES` approach: three fields on the AST (`like`, `not_like`, `case_insensitive_like`), parsing in the shared access entity parser, and query rewriting in the interpreter to append a `WHERE name [NOT] [I]LIKE '...'` clause to the `system.*` table query.

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added `[NOT] [I]LIKE 'pattern'` filtering to `SHOW USERS`, `SHOW ROLES`, `SHOW SETTINGS PROFILES`, `SHOW QUOTAS`, `SHOW ROW POLICIES`, and `SHOW MASKING POLICIES` statements.