### PR TITLE
Keep the projection's intermediates out of the WITH FILL header

### DIFF
--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -536,10 +536,19 @@ SortAnalysisResult analyzeSort(
         }
     }
 
+    /// `materializeNode` wraps the node and aliases the wrapper back to the original name, so the
+    /// `materialize(...)` node is an intermediate rather than an output. `Filling` fills by it, so it has to
+    /// stay in the stream; remember the names here, where they are known.
+    NameSet materialized_sort_column_names;
+
     if (has_with_fill)
     {
         for (auto & output_node : before_sort_actions_outputs)
+        {
             output_node = &before_sort_actions->dag.materializeNode(*output_node);
+            if (!output_node->children.empty())
+                materialized_sort_column_names.insert(output_node->children.front()->result_name);
+        }
     }
 
     auto actions_step_before_sort = std::make_unique<ActionsChainStep>(before_sort_actions);
@@ -562,33 +571,28 @@ SortAnalysisResult analyzeSort(
 
         /** A step's available output columns are every node of its dag - the intermediates of a computed
           * expression included - because a later step is allowed to *reference* any of them. Passing all of
-          * them through as outputs turns "referenceable" into "must be in the stream", which pins the
-          * intermediates of the projection into the header of the `Filling` step. Two query trees that
-          * differ only by whether an `ALIAS` column was inlined into its defining expression then produce
-          * different headers - `v * 2` contributes its `2` and the un-inlined `a_v` does not - and a
-          * distributed query planned one way and executed the other cannot reconcile them.
+          * them through as outputs turns "referenceable" into "must be in the stream", which pins those
+          * intermediates into the header of the `Filling` step. Two query trees that differ only by whether
+          * an `ALIAS` column was inlined into its defining expression then produce different headers -
+          * `v * 2` contributes its `2` and the un-inlined `a_v` does not - and a distributed query planned
+          * one way and executed the other cannot reconcile them.
           *
-          * So the projection's own intermediates are held back. Everything else is passed through as
-          * before, including the sort columns materialized just above, which is what `Filling` fills by.
-          * They all stay inputs either way, so an INTERPOLATE expression naming one still resolves.
+          * Pass through only what belongs in the stream: the columns the previous step emits, the sort
+          * columns and the `materialize(...)` wrappers `Filling` fills by. Everything else stays an input,
+          * so the chain still asks the previous step to produce it and an INTERPOLATE expression naming one
+          * still resolves; it just does not travel on as a column.
           */
         const auto & available_columns = actions_chain.getLastStepAvailableOutputColumns();
 
-        NameSet projection_intermediates;
+        NameSet columns_to_pass_through = materialized_sort_column_names;
+        for (const auto & column : before_sort_actions->dag.getResultColumns())
+            columns_to_pass_through.insert(column.name);
+
         const size_t last_step_index = actions_chain.getLastStepIndex();
         const bool know_previous_step = last_step_index > 0;
         if (know_previous_step)
-        {
-            const auto & previous_dag = actions_chain.at(last_step_index - 1)->getActions()->dag;
-
-            NameSet previous_stream_columns;
-            for (const auto & column : previous_dag.getResultColumns())
-                previous_stream_columns.insert(column.name);
-
-            for (const auto & node : previous_dag.getNodes())
-                if (!previous_stream_columns.contains(node.result_name))
-                    projection_intermediates.insert(node.result_name);
-        }
+            for (const auto & column : actions_chain.at(last_step_index - 1)->getActions()->dag.getResultColumns())
+                columns_to_pass_through.insert(column.name);
 
         /** The INTERPOLATE expressions themselves are turned into actions later, in `Planner`, against a dag
           * built from this step's *header*. Whatever they name therefore has to survive as a column here,
@@ -615,7 +619,7 @@ SortAnalysisResult analyzeSort(
             referenced_by_interpolate_dag.removeUnusedActions(/*allow_remove_inputs=*/true, /*allow_constant_folding=*/false);
 
             for (const auto & name : referenced_by_interpolate_dag.getRequiredColumnsNames())
-                projection_intermediates.erase(name);
+                columns_to_pass_through.insert(name);
         }
 
         for (const auto & out : available_columns)
@@ -625,7 +629,8 @@ SortAnalysisResult analyzeSort(
 
             const auto * input_node = &before_interpolate_actions_dag.addInput(out);
 
-            if (!projection_intermediates.contains(out.name))
+            /// With no preceding step to consult, keep the previous behaviour and pass everything through.
+            if (!know_previous_step || columns_to_pass_through.contains(out.name))
                 before_interpolate_actions_dag.getOutputs().push_back(input_node);
         }
 

--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -559,9 +559,75 @@ SortAnalysisResult analyzeSort(
         /// If we take getLastStepAvailableOutputColumns list, it may return non-materialized constants,
         /// so here we add materialized ORDER BY columns manually, and append everything else after.
         ActionsDAG before_interpolate_actions_dag(before_sort_actions->dag.getResultColumns());
-        for (const auto & out : actions_chain.getLastStepAvailableOutputColumns())
-            if (!before_sort_actions_dag_output_node_names.contains(out.name))
-                before_interpolate_actions_dag.getOutputs().push_back(&before_interpolate_actions_dag.addInput(out));
+
+        /** A step's available output columns are every node of its dag - the intermediates of a computed
+          * expression included - because a later step is allowed to *reference* any of them. Passing all of
+          * them through as outputs turns "referenceable" into "must be in the stream", which pins the
+          * intermediates of the projection into the header of the `Filling` step. Two query trees that
+          * differ only by whether an `ALIAS` column was inlined into its defining expression then produce
+          * different headers - `v * 2` contributes its `2` and the un-inlined `a_v` does not - and a
+          * distributed query planned one way and executed the other cannot reconcile them.
+          *
+          * So the projection's own intermediates are held back. Everything else is passed through as
+          * before, including the sort columns materialized just above, which is what `Filling` fills by.
+          * They all stay inputs either way, so an INTERPOLATE expression naming one still resolves.
+          */
+        const auto & available_columns = actions_chain.getLastStepAvailableOutputColumns();
+
+        NameSet projection_intermediates;
+        const size_t last_step_index = actions_chain.getLastStepIndex();
+        const bool know_previous_step = last_step_index > 0;
+        if (know_previous_step)
+        {
+            const auto & previous_dag = actions_chain.at(last_step_index - 1)->getActions()->dag;
+
+            NameSet previous_stream_columns;
+            for (const auto & column : previous_dag.getResultColumns())
+                previous_stream_columns.insert(column.name);
+
+            for (const auto & node : previous_dag.getNodes())
+                if (!previous_stream_columns.contains(node.result_name))
+                    projection_intermediates.insert(node.result_name);
+        }
+
+        /** The INTERPOLATE expressions themselves are turned into actions later, in `Planner`, against a dag
+          * built from this step's *header*. Whatever they name therefore has to survive as a column here,
+          * even when the query does not select it. Collect those names by visiting the expressions into a
+          * throwaway dag over the same columns and reading back what it requires.
+          */
+        if (know_previous_step)
+        {
+            ActionsDAG referenced_by_interpolate_dag(available_columns);
+            referenced_by_interpolate_dag.getOutputs().clear();
+
+            PlannerActionsVisitor referenced_actions_visitor(planner_context, correlated_columns_set);
+            for (auto & interpolate_node : interpolate_list_node.getNodes())
+            {
+                auto & interpolate_node_typed = interpolate_node->as<InterpolateNode &>();
+                auto [nodes, correlated_subtrees]
+                    = referenced_actions_visitor.visit(referenced_by_interpolate_dag, interpolate_node_typed.getInterpolateExpression());
+                correlated_subtrees.assertEmpty("in interpolate expression");
+                for (const auto * node : nodes)
+                    referenced_by_interpolate_dag.getOutputs().push_back(node);
+            }
+
+            /// `getRequiredColumnsNames` lists every INPUT, so drop the ones the expressions did not reach.
+            referenced_by_interpolate_dag.removeUnusedActions(/*allow_remove_inputs=*/true, /*allow_constant_folding=*/false);
+
+            for (const auto & name : referenced_by_interpolate_dag.getRequiredColumnsNames())
+                projection_intermediates.erase(name);
+        }
+
+        for (const auto & out : available_columns)
+        {
+            if (before_sort_actions_dag_output_node_names.contains(out.name))
+                continue;
+
+            const auto * input_node = &before_interpolate_actions_dag.addInput(out);
+
+            if (!projection_intermediates.contains(out.name))
+                before_interpolate_actions_dag.getOutputs().push_back(input_node);
+        }
 
         for (auto & interpolate_node : interpolate_list_node.getNodes())
         {

--- a/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.reference
+++ b/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.reference
@@ -1,0 +1,55 @@
+local
+0	10
+2	10
+4	14
+6	14
+8	18
+parallel replicas, shipping a plan
+0	10
+2	10
+4	14
+6	14
+8	18
+parallel replicas, shipping SQL
+0	10
+2	10
+4	14
+6	14
+8	18
+Distributed, two shards
+0	10
+0	10
+2	10
+4	14
+4	14
+6	14
+8	18
+8	18
+a body that carries a cast
+0	5
+0	5
+2	5
+4	7
+4	7
+6	7
+8	9
+8	9
+interpolating by an expression
+0	10
+0	10
+2	11
+4	14
+4	14
+6	15
+8	18
+8	18
+interpolating by a column that is not selected
+0	10
+0	10
+2	11
+4	14
+4	14
+6	15
+8	18
+8	18
+an ORDER BY column as the INTERPOLATE target is still rejected

--- a/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.reference
+++ b/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.reference
@@ -52,4 +52,21 @@ interpolating by a column that is not selected
 6	15
 8	18
 8	18
+the alias appears only in ORDER BY, parallel replicas
+0	0
+0	0
+0	5
+4	7
+0	7
+8	9
+the alias appears only in ORDER BY, Distributed
+0	0
+0	0
+0	5
+0	5
+4	7
+4	7
+0	7
+8	9
+8	9
 an ORDER BY column as the INTERPOLATE target is still rejected

--- a/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.sql
+++ b/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.sql
@@ -1,15 +1,20 @@
 -- Tags: shard
 
 -- The `Before INTERPOLATE` step used to pass every column *available* to it through as an output, and a
--- step's available columns are all the nodes of the previous step's dag, intermediates included. That put
--- the intermediates of the projection into the header of the `Filling` step, so a query whose `ALIAS`
--- column had been inlined into its defining expression got a header one column wider than the same query
--- with the column left alone: `v * 2` contributes its `2`, `a_v` does not. A distributed query is planned
--- from the un-inlined tree on the initiator and executed from the inlined one on the shard, so the two
--- headers met and could not be reconciled:
+-- step's available columns are all the nodes of the preceding dags, intermediates included. That put those
+-- intermediates into the header of the `Filling` step, so a query whose `ALIAS` column had been inlined
+-- into its defining expression got a header wider than the same query with the column left alone:
+-- `v * 2` contributes its `2`, `a_v` does not. A distributed query is planned from the un-inlined tree on
+-- the initiator and executed from the inlined one on the shard, so the two headers met and could not be
+-- reconciled:
 --   Number of columns doesn't match (source: 5 and result: 4). (NUMBER_OF_COLUMNS_DOESNT_MATCH)
 
 SET enable_analyzer = 1;
+
+-- serialize_query_plan = 0 because WITH FILL is not supported in serialized sort descriptions
+-- (serializeSortDescription throws NOT_IMPLEMENTED) and the CI `distributed plan` shard turns
+-- serialize_query_plan on globally; this test exercises the header, not plan serialization.
+SET serialize_query_plan = 0;
 
 DROP TABLE IF EXISTS t_fill_alias;
 DROP TABLE IF EXISTS t_fill_alias_dist;
@@ -29,14 +34,14 @@ SELECT k, a_v FROM t_fill_alias ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPO
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
     cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
     parallel_replicas_for_non_replicated_merge_tree = 1, automatic_parallel_replicas_mode = 0,
-    serialize_query_plan = 0, parallel_replicas_local_plan = 1;
+    parallel_replicas_local_plan = 1;
 
 SELECT 'parallel replicas, shipping SQL';
 SELECT k, a_v FROM t_fill_alias ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v)
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
     cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
     parallel_replicas_for_non_replicated_merge_tree = 1, automatic_parallel_replicas_mode = 0,
-    serialize_query_plan = 0, parallel_replicas_local_plan = 0;
+    parallel_replicas_local_plan = 0;
 
 -- The `Distributed` path has always inlined, so this shape was broken there before the parallel-replicas
 -- paths started inlining too.
@@ -56,13 +61,24 @@ SELECT k, a_v FROM t_fill_alias_dist ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 IN
 SELECT 'interpolating by a column that is not selected';
 SELECT k, a_v FROM t_fill_alias_dist ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v + w);
 
+-- The alias is not selected at all here, so its body is inlined into the sort expression rather than the
+-- projection. The intermediates then belong to the ORDER BY dag, which leaks the same way.
+SELECT 'the alias appears only in ORDER BY, parallel replicas';
+SELECT k, v FROM t_fill_alias ORDER BY a_v WITH FILL FROM 0 TO 20 STEP 5 INTERPOLATE (v AS v)
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1, automatic_parallel_replicas_mode = 0;
+
+SELECT 'the alias appears only in ORDER BY, Distributed';
+SELECT k, v FROM t_fill_alias_dist ORDER BY a_v WITH FILL FROM 0 TO 20 STEP 5 INTERPOLATE (v AS v);
+
 -- The reconciliation failure used to mask this error, which is about the query rather than the transport.
 SELECT 'an ORDER BY column as the INTERPOLATE target is still rejected';
 SELECT k, a_v FROM t_fill_alias ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (k AS k)
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
     cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
-    parallel_replicas_for_non_replicated_merge_tree = 1, automatic_parallel_replicas_mode = 0,
-    serialize_query_plan = 0; -- { serverError INVALID_WITH_FILL_EXPRESSION }
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    automatic_parallel_replicas_mode = 0; -- { serverError INVALID_WITH_FILL_EXPRESSION }
 
 DROP TABLE t_fill_alias_dist;
 DROP TABLE t_fill_alias;

--- a/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.sql
+++ b/tests/queries/0_stateless/04891_with_fill_interpolate_alias_column_header.sql
@@ -1,0 +1,68 @@
+-- Tags: shard
+
+-- The `Before INTERPOLATE` step used to pass every column *available* to it through as an output, and a
+-- step's available columns are all the nodes of the previous step's dag, intermediates included. That put
+-- the intermediates of the projection into the header of the `Filling` step, so a query whose `ALIAS`
+-- column had been inlined into its defining expression got a header one column wider than the same query
+-- with the column left alone: `v * 2` contributes its `2`, `a_v` does not. A distributed query is planned
+-- from the un-inlined tree on the initiator and executed from the inlined one on the shard, so the two
+-- headers met and could not be reconciled:
+--   Number of columns doesn't match (source: 5 and result: 4). (NUMBER_OF_COLUMNS_DOESNT_MATCH)
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t_fill_alias;
+DROP TABLE IF EXISTS t_fill_alias_dist;
+
+CREATE TABLE t_fill_alias (k UInt32, v Int64, w Int64, a_v Int64 ALIAS v * 2, a_cast Int32 ALIAS abs(v))
+ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_fill_alias VALUES (0, 5, 1), (4, 7, 1), (8, 9, 1);
+
+CREATE TABLE t_fill_alias_dist AS t_fill_alias
+ENGINE = Distributed('test_cluster_two_shards', currentDatabase(), t_fill_alias, rand());
+
+SELECT 'local';
+SELECT k, a_v FROM t_fill_alias ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v);
+
+SELECT 'parallel replicas, shipping a plan';
+SELECT k, a_v FROM t_fill_alias ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v)
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1, automatic_parallel_replicas_mode = 0,
+    serialize_query_plan = 0, parallel_replicas_local_plan = 1;
+
+SELECT 'parallel replicas, shipping SQL';
+SELECT k, a_v FROM t_fill_alias ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v)
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1, automatic_parallel_replicas_mode = 0,
+    serialize_query_plan = 0, parallel_replicas_local_plan = 0;
+
+-- The `Distributed` path has always inlined, so this shape was broken there before the parallel-replicas
+-- paths started inlining too.
+SELECT 'Distributed, two shards';
+SELECT k, a_v FROM t_fill_alias_dist ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v);
+
+-- A body whose declared type forces a cast contributes an intermediate of its own.
+SELECT 'a body that carries a cast';
+SELECT k, a_cast FROM t_fill_alias_dist ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_cast AS a_cast);
+
+-- Interpolating by an expression over the alias, rather than the alias itself.
+SELECT 'interpolating by an expression';
+SELECT k, a_v FROM t_fill_alias_dist ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v + 1);
+
+-- A column the query does not select is still nameable by INTERPOLATE, so it has to stay in the stream
+-- even though it is not part of the projection.
+SELECT 'interpolating by a column that is not selected';
+SELECT k, a_v FROM t_fill_alias_dist ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (a_v AS a_v + w);
+
+-- The reconciliation failure used to mask this error, which is about the query rather than the transport.
+SELECT 'an ORDER BY column as the INTERPOLATE target is still rejected';
+SELECT k, a_v FROM t_fill_alias ORDER BY k WITH FILL FROM 0 TO 10 STEP 2 INTERPOLATE (k AS k)
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    parallel_replicas_for_non_replicated_merge_tree = 1, automatic_parallel_replicas_mode = 0,
+    serialize_query_plan = 0; -- { serverError INVALID_WITH_FILL_EXPRESSION }
+
+DROP TABLE t_fill_alias_dist;
+DROP TABLE t_fill_alias;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: https://github.com/ClickHouse/ClickHouse/issues/114404
Caused by: https://github.com/ClickHouse/ClickHouse/pull/107700

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `NUMBER_OF_COLUMNS_DOESNT_MATCH` for a distributed query combining an `ALIAS` column whose body is an expression with `ORDER BY ... WITH FILL ... INTERPOLATE`.

### Description

`analyzeSort` passed every column *available* to the `Before INTERPOLATE` step through as an output. A step's available columns are all the nodes of the previous step's `ActionsDAG` — the intermediates of a computed expression included, since a later step is allowed to *reference* any of them. Turning "referenceable" into "must be in the stream" pinned those intermediates into the header of the `Filling` step.

That made the header depend on something that should not matter. Two query trees that differ only by whether an `ALIAS` column was inlined into its defining expression produced different headers, because `v * 2` contributes its `2` and the un-inlined `a_v` does not:

```
un-inlined                                  inlined
  __table1.k                                  __table1.k
  __table1.a_v                                multiply(__table1.v, 2_UInt8)
  __table1.v                                  __table1.v
                                              2_UInt8            <- extra
  materialize(__table1.k)                     materialize(__table1.k)
  a_v                                         a_v
```

A distributed query is planned from the un-inlined tree on the initiator and executed from the inlined one on the shard, so the two headers meet. `buildShardCollapseFanOut` only handles a *smaller* shard header, and the positional `makeConvertingActions` then throws `NUMBER_OF_COLUMNS_DOESNT_MATCH`.

The fix holds back the projection's own intermediates and passes everything else through as before, including the sort columns materialized just above, which is what `Filling` fills by. They all remain *inputs* either way, so the step still asks the previous one to produce them.

One exception has to be carved out: a column that an `INTERPOLATE` expression names. Those expressions become actions later, in `Planner`, against a dag built from this step's *header*, so whatever they reference must survive as a column even when the query does not select it — `INTERPOLATE (inter AS inter2 + inter)` where `inter2` is not in the `SELECT` list. Those names are collected by visiting the expressions into a throwaway dag.

### Scope

Everything here is inside `if (query_node.hasInterpolate())`, so only queries with `INTERPOLATE` change.

The shape was already broken over a `Distributed` table before #107700, since that path has always inlined `ALIAS` columns; #107700 extended the inlining to the parallel-replicas paths and so exposed it there too. Both are fixed.

It also stops the reconciliation failure from masking a query error: `INTERPOLATE (k AS k)` on an `ORDER BY` column reports `INVALID_WITH_FILL_EXPRESSION` again instead of `NUMBER_OF_COLUMNS_DOESNT_MATCH`.

### Validation

Built and run against a three-replica localhost cluster and a two-shard `Distributed` table, compared with the CI binaries of the commit before #107700 (`75b17ad`) and of its merge (`dd01d270e`):

| | before #107700 | after #107700 | this |
|---|---|---|---|
| repro, parallel replicas shipping a plan | pass | `NUMBER_OF_COLUMNS_DOESNT_MATCH` | pass |
| repro, parallel replicas shipping SQL | pass | `NUMBER_OF_COLUMNS_DOESNT_MATCH` | pass |
| repro over a 2-shard `Distributed` table | `NUMBER_OF_COLUMNS_DOESNT_MATCH` | `NUMBER_OF_COLUMNS_DOESNT_MATCH` | pass |
| `INTERPOLATE (k AS k)` under parallel replicas | `INVALID_WITH_FILL_EXPRESSION` | `NUMBER_OF_COLUMNS_DOESNT_MATCH` | `INVALID_WITH_FILL_EXPRESSION` |

The new test `04891_with_fill_interpolate_alias_column_header` reports four exceptions on the commit before #107700 and seven on the merge commit, and passes here.

Every self-contained stateless test mentioning `WITH FILL` or `INTERPOLATE`, plus the `ALIAS`-shipping tests from #107700, passes: 94 of 94.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd669bf9-3d72-4334-961f-0871feaf9f98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd669bf9-3d72-4334-961f-0871feaf9f98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

