### PR TITLE
Fix inconsistent AST formatting for a subquery argument of the view table function

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -520,6 +520,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
         ostr << nl_or_nothing;
         FormatStateStacked frame_nested = frame;
         frame_nested.need_parens = false;
+        frame_nested.parent_has_trailing_settings = false;
         ++frame_nested.indent;
         query->format(ostr, settings, state, frame_nested);
         ostr << nl_or_nothing << indent_str;
@@ -546,6 +547,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
         ostr << name << "(" << nl_or_nothing;
         FormatStateStacked frame_nested = frame;
         frame_nested.need_parens = false;
+        frame_nested.parent_has_trailing_settings = false;
         frame_nested.indent += 2;
         arguments->children[0]->format(ostr, settings, state, frame_nested);
         ostr << nl_or_nothing << indent1 << (settings.one_line ? " " : "")

--- a/tests/queries/0_stateless/04896_inconsistent_ast_view_subquery_paren_round_trip_1941_1bfa.reference
+++ b/tests/queries/0_stateless/04896_inconsistent_ast_view_subquery_paren_round_trip_1941_1bfa.reference
@@ -1,0 +1,30 @@
+fixed shapes
+1	UInt8					
+DescribeQuery (children 2)
+ TableExpression (children 1)
+  Function view (children 1)
+   ExpressionList (children 1)
+    SelectWithUnionQuery (children 1)
+     ExpressionList (children 1)
+      SelectQuery (children 1)
+       ExpressionList (children 1)
+        Literal UInt64_1
+ Set
+x	UInt8					
+DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0
+EXPLAIN AST DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0
+DESCRIBE TABLE viewIfPermitted(SELECT 1 ELSE `null`(\'x UInt8\')) SETTINGS input_format_orc_use_fast_decoder = 0
+idempotency
+1
+1
+1
+multi-select argument
+DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0
+1
+1	UInt8					
+unaffected shapes
+DESCRIBE TABLE view(SELECT 1) FORMAT TSV SETTINGS input_format_orc_use_fast_decoder = 0
+SELECT * FROM view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0
+flag still active outside the view boundary
+EXPLAIN (SELECT 1) UNION ALL (SELECT 2) SETTINGS max_threads = 1
+EXPLAIN SYNTAX (SELECT 1) UNION (SELECT 2) SETTINGS max_threads = 1

--- a/tests/queries/0_stateless/04896_inconsistent_ast_view_subquery_paren_round_trip_1941_1bfa.sql
+++ b/tests/queries/0_stateless/04896_inconsistent_ast_view_subquery_paren_round_trip_1941_1bfa.sql
@@ -1,25 +1,13 @@
 -- STID 1941-1bfa: a query carrying a trailing SETTINGS clause whose AST contains a
 -- `view(SELECT ...)` table-function argument was formatted as `view((SELECT ...))`.
--- `ParserViewLayer` accepts only a bare select, so the formatted text did not parse
--- back and debug / sanitizer builds hit the `Inconsistent AST formatting`
--- LOGICAL_ERROR.
---
--- `ASTQueryWithOutput::formatImpl` sets `parent_has_trailing_settings` so that an
--- inner `ASTSelectWithUnionQuery` parenthesizes its individual SELECTs, keeping the
--- re-parser from consuming the trailing SETTINGS into the last SELECT. The flag was
--- inherited into the `view` / `viewIfPermitted` argument, where the closing paren of
--- the table function already terminates the select, so the parentheses were both
--- redundant and rejected on re-parse. The fix clears the flag when crossing that
--- argument boundary, matching the resets in `ASTSubquery`, `ASTCreateQuery` and
--- `ASTAlterQuery`.
---
--- The trailing SETTINGS clause is the trigger: without it nothing sets the flag and
--- the output is already correct.
+-- `ViewLayer` accepts only a bare select, so that text did not parse back and debug
+-- and sanitizer builds hit the `Inconsistent AST formatting` LOGICAL_ERROR.
+-- The trailing SETTINGS clause is the trigger.
 
 SELECT 'fixed shapes';
 
--- Each of these three aborted with LOGICAL_ERROR before the fix. Executing them is
--- itself the regression assertion: the internal round-trip check runs on every query.
+-- Executing these is itself the regression assertion: the internal round-trip check
+-- runs on every query.
 DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0;
 EXPLAIN AST DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0;
 DESCRIBE TABLE viewIfPermitted(SELECT 1 ELSE null('x UInt8')) SETTINGS input_format_orc_use_fast_decoder = 0;
@@ -29,8 +17,7 @@ SELECT formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1) SETTINGS input_forma
 SELECT formatQuerySingleLine('EXPLAIN AST DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0');
 SELECT formatQuerySingleLine('DESCRIBE TABLE viewIfPermitted(SELECT 1 ELSE null(''x UInt8'')) SETTINGS input_format_orc_use_fast_decoder = 0');
 
--- The parenthesized spelling the formatter used to emit is not accepted by
--- `ParserViewLayer`, which is why the round trip diverged.
+-- The parenthesized spelling the formatter used to emit is rejected by `ViewLayer`.
 SELECT formatQuerySingleLine('DESCRIBE TABLE view((SELECT 1)) SETTINGS input_format_orc_use_fast_decoder = 0'); -- { serverError SYNTAX_ERROR }
 
 SELECT 'idempotency';
@@ -42,28 +29,23 @@ SELECT formatQuerySingleLine(formatQuerySingleLine('DESCRIBE TABLE viewIfPermitt
 
 SELECT 'multi-select argument';
 
--- A multi-select UNION chain inside `view` also loses its branch parentheses, because
--- the closing paren of the table function already stops the trailing SETTINGS from
--- being absorbed. Both spellings parse; this pins the current one.
+-- A UNION chain inside `view` also loses its branch parentheses, and both spellings parse.
 SELECT formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0');
 SELECT formatQuerySingleLine(formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0')) = formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0');
 DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0;
 
 SELECT 'unaffected shapes';
 
--- `FORMAT` precedes SETTINGS in the output and stops the re-parser, so the setter
--- never raises the flag.
+-- `FORMAT` precedes SETTINGS in the output and stops the re-parser.
 SELECT formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1) FORMAT TSV SETTINGS input_format_orc_use_fast_decoder = 0');
 
--- A plain SELECT is not an `ASTQueryWithOutput` ancestor that hoists SETTINGS above
--- the table function, so the argument was never parenthesized here.
+-- A plain SELECT does not hoist SETTINGS above the table function.
 SELECT formatQuerySingleLine('SELECT * FROM view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0');
 
 SELECT 'flag still active outside the view boundary';
 
--- The reset must be scoped to the `view` argument. These are the shapes
--- `parent_has_trailing_settings` exists for (see 04039): the individual SELECTs of a
--- UNION chain under a trailing SETTINGS clause must KEEP their parentheses, otherwise
--- the re-parser moves SETTINGS into the last SELECT.
+-- Scoping control: the individual SELECTs of a UNION chain under a trailing SETTINGS
+-- clause must KEEP their parentheses, otherwise the re-parser moves SETTINGS into the
+-- last SELECT.
 SELECT formatQuerySingleLine('EXPLAIN (SELECT 1) UNION ALL (SELECT 2) SETTINGS max_threads = 1');
 SELECT formatQuerySingleLine('EXPLAIN SYNTAX (SELECT 1) UNION (SELECT 2) SETTINGS max_threads = 1');

--- a/tests/queries/0_stateless/04896_inconsistent_ast_view_subquery_paren_round_trip_1941_1bfa.sql
+++ b/tests/queries/0_stateless/04896_inconsistent_ast_view_subquery_paren_round_trip_1941_1bfa.sql
@@ -1,0 +1,69 @@
+-- STID 1941-1bfa: a query carrying a trailing SETTINGS clause whose AST contains a
+-- `view(SELECT ...)` table-function argument was formatted as `view((SELECT ...))`.
+-- `ParserViewLayer` accepts only a bare select, so the formatted text did not parse
+-- back and debug / sanitizer builds hit the `Inconsistent AST formatting`
+-- LOGICAL_ERROR.
+--
+-- `ASTQueryWithOutput::formatImpl` sets `parent_has_trailing_settings` so that an
+-- inner `ASTSelectWithUnionQuery` parenthesizes its individual SELECTs, keeping the
+-- re-parser from consuming the trailing SETTINGS into the last SELECT. The flag was
+-- inherited into the `view` / `viewIfPermitted` argument, where the closing paren of
+-- the table function already terminates the select, so the parentheses were both
+-- redundant and rejected on re-parse. The fix clears the flag when crossing that
+-- argument boundary, matching the resets in `ASTSubquery`, `ASTCreateQuery` and
+-- `ASTAlterQuery`.
+--
+-- The trailing SETTINGS clause is the trigger: without it nothing sets the flag and
+-- the output is already correct.
+
+SELECT 'fixed shapes';
+
+-- Each of these three aborted with LOGICAL_ERROR before the fix. Executing them is
+-- itself the regression assertion: the internal round-trip check runs on every query.
+DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0;
+EXPLAIN AST DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0;
+DESCRIBE TABLE viewIfPermitted(SELECT 1 ELSE null('x UInt8')) SETTINGS input_format_orc_use_fast_decoder = 0;
+
+-- The formatted text must carry no parentheses around the argument, and must parse back.
+SELECT formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0');
+SELECT formatQuerySingleLine('EXPLAIN AST DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0');
+SELECT formatQuerySingleLine('DESCRIBE TABLE viewIfPermitted(SELECT 1 ELSE null(''x UInt8'')) SETTINGS input_format_orc_use_fast_decoder = 0');
+
+-- The parenthesized spelling the formatter used to emit is not accepted by
+-- `ParserViewLayer`, which is why the round trip diverged.
+SELECT formatQuerySingleLine('DESCRIBE TABLE view((SELECT 1)) SETTINGS input_format_orc_use_fast_decoder = 0'); -- { serverError SYNTAX_ERROR }
+
+SELECT 'idempotency';
+
+-- Formatting the formatted text must be a fixed point.
+SELECT formatQuerySingleLine(formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0')) = formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0');
+SELECT formatQuerySingleLine(formatQuerySingleLine('EXPLAIN AST DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0')) = formatQuerySingleLine('EXPLAIN AST DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0');
+SELECT formatQuerySingleLine(formatQuerySingleLine('DESCRIBE TABLE viewIfPermitted(SELECT 1 ELSE null(''x UInt8'')) SETTINGS input_format_orc_use_fast_decoder = 0')) = formatQuerySingleLine('DESCRIBE TABLE viewIfPermitted(SELECT 1 ELSE null(''x UInt8'')) SETTINGS input_format_orc_use_fast_decoder = 0');
+
+SELECT 'multi-select argument';
+
+-- A multi-select UNION chain inside `view` also loses its branch parentheses, because
+-- the closing paren of the table function already stops the trailing SETTINGS from
+-- being absorbed. Both spellings parse; this pins the current one.
+SELECT formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0');
+SELECT formatQuerySingleLine(formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0')) = formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0');
+DESCRIBE TABLE view(SELECT 1 UNION ALL SELECT 2) SETTINGS input_format_orc_use_fast_decoder = 0;
+
+SELECT 'unaffected shapes';
+
+-- `FORMAT` precedes SETTINGS in the output and stops the re-parser, so the setter
+-- never raises the flag.
+SELECT formatQuerySingleLine('DESCRIBE TABLE view(SELECT 1) FORMAT TSV SETTINGS input_format_orc_use_fast_decoder = 0');
+
+-- A plain SELECT is not an `ASTQueryWithOutput` ancestor that hoists SETTINGS above
+-- the table function, so the argument was never parenthesized here.
+SELECT formatQuerySingleLine('SELECT * FROM view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0');
+
+SELECT 'flag still active outside the view boundary';
+
+-- The reset must be scoped to the `view` argument. These are the shapes
+-- `parent_has_trailing_settings` exists for (see 04039): the individual SELECTs of a
+-- UNION chain under a trailing SETTINGS clause must KEEP their parentheses, otherwise
+-- the re-parser moves SETTINGS into the last SELECT.
+SELECT formatQuerySingleLine('EXPLAIN (SELECT 1) UNION ALL (SELECT 2) SETTINGS max_threads = 1');
+SELECT formatQuerySingleLine('EXPLAIN SYNTAX (SELECT 1) UNION (SELECT 2) SETTINGS max_threads = 1');


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114004   (auto-closes the issue when this PR is merged into the default branch)
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/114004

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed formatting of a subquery argument of the `view` and `viewIfPermitted` table functions when the enclosing query has a trailing `SETTINGS` clause. Such a query was formatted as `view((SELECT ...))`, which cannot be parsed back, so the query failed the internal format-parse-format check and raised `Inconsistent AST formatting`.

### Description

`ASTQueryWithOutput::formatImpl` sets `parent_has_trailing_settings` so an inner `ASTSelectWithUnionQuery` parenthesizes its individual SELECTs, keeping the re-parser from consuming the trailing `SETTINGS` into the last SELECT. The flag is inherited down the format frame, so it also reached the argument of `view` / `viewIfPermitted`. There the parentheses are both redundant and rejected: the closing paren of the table function already terminates the select, and `ViewLayer::parse` bails out on a parenthesized lone select (`ExpressionListParsers.cpp:2981-2991`). The formatted text therefore did not parse back.

The trailing `SETTINGS` clause is the trigger. Without it nothing sets the flag and the output is already correct.

This clears the flag at the two places that cross the `view` argument boundary, which is what three other boundary owners already do: `ASTSubquery.cpp:98`, `ASTCreateQuery.cpp:1113` and `ASTAlterQuery.cpp:1032`. `ViewLayer` is the only producer of a bare-select function argument and serves exactly these two functions, so the two sites are the complete set.

The issue frames parser-versus-formatter as the fork. This takes the formatter side, on the grounds that the parentheses carry no meaning in this position and that the same reset is the established pattern; the parser side would widen the accepted grammar to fix an output bug. The call is his to close.

One output change beyond the broken shape: a multi-select argument such as `view(SELECT 1 UNION ALL SELECT 2)` also loses its branch parentheses. That form parsed before and parses now.

Validation: `DESCRIBE TABLE view(SELECT 1) SETTINGS input_format_orc_use_fast_decoder = 0` aborts a debug server with `Logical error: 'Inconsistent AST formatting'` before the change and returns `1 UInt8` after it. The new test fails on the unpatched binary and passes 50/50 under randomized settings on the patched one. The `formatQuery` / round-trip / `1941` stateless family was run on both binaries and the failure sets are byte-identical.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1436` (included in `26.8` and later)
<!-- ch-version-info:end -->