### PR TITLE
Stop SeaweedFS deleting live object folders in stateless CI

### DIFF
--- a/ci/docker/stateless-test/Dockerfile
+++ b/ci/docker/stateless-test/Dockerfile
@@ -83,7 +83,7 @@ ENV NUM_TRIES=1
 
 # Keep SEAWEEDFS_VERSION in sync with the default in setup_seaweedfs.sh
 # to have the same binaries for local running scenario
-ARG SEAWEEDFS_VERSION=4.41
+ARG SEAWEEDFS_VERSION=4.42
 ARG TARGETARCH
 
 # Download SeaweedFS (the S3 server for stateless tests); the weed binary is a

--- a/ci/jobs/scripts/functional_tests/setup_seaweedfs.sh
+++ b/ci/jobs/scripts/functional_tests/setup_seaweedfs.sh
@@ -114,6 +114,9 @@ start_seaweedfs() {
   pwd
   mkdir -p ./seaweedfs_data
   weed version
+  # the filer's empty-folder cleaner deletes a folder without excluding a PUT
+  # arriving between its count and the delete, which destroys the object
+  export WEED_FILER_OPTIONS_S3_EMPTY_FOLDER_CLEANUP_DELAY=24h
   # weed server also runs master/volume/filer services (each also binds a gRPC
   # port at +10000); keep them next to the S3 port, away from the ports used by
   # clickhouse-server, keeper, azurite and redpanda

--- a/ci/jobs/scripts/functional_tests/setup_seaweedfs.sh
+++ b/ci/jobs/scripts/functional_tests/setup_seaweedfs.sh
@@ -69,7 +69,7 @@ find_os() {
 }
 
 download_seaweedfs() {
-  local seaweedfs_version=${SEAWEEDFS_VERSION:-4.41}
+  local seaweedfs_version=${SEAWEEDFS_VERSION:-4.42}
 
   wget "https://github.com/seaweedfs/seaweedfs/releases/download/${seaweedfs_version}/$(find_os)_$(find_arch).tar.gz" -O ./seaweedfs.tar.gz
   tar -xzf ./seaweedfs.tar.gz weed
@@ -114,9 +114,6 @@ start_seaweedfs() {
   pwd
   mkdir -p ./seaweedfs_data
   weed version
-  # the filer's empty-folder cleaner deletes a folder without excluding a PUT
-  # arriving between its count and the delete, which destroys the object
-  export WEED_FILER_OPTIONS_S3_EMPTY_FOLDER_CLEANUP_DELAY=24h
   # weed server also runs master/volume/filer services (each also binds a gRPC
   # port at +10000); keep them next to the S3 port, away from the ports used by
   # clickhouse-server, keeper, azurite and redpanda


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113828
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113828

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Since 2026-08-12, `s3 storage` stateless jobs intermittently failed an ordinary INSERT with
`Code: 499 ... Immediately after upload: Object ... suddenly disappeared (S3_ERROR)`.

Root cause is upstream and now fixed. SeaweedFS's filer listed a folder's children on a
non-recursive delete, returned early if it found any, then swept the children
unconditionally, so an object committed between the listing and the sweep lost its entry
after S3 had already answered 200. From a failing master run:

```
16:18:17.675651  EmptyFolderCleaner: deleting empty folder /buckets/test/test/jys
16:18:17.676290  PUT of the object SUCCEEDS, 282 bytes
16:18:17.678805  verifying HEAD -> 404
16:18:17.681060  WriteBufferFromS3: Nothing to abort   (so ClickHouse did not remove it)
```

I reported it as seaweedfs/seaweedfs#10779; it is fixed by seaweedfs/seaweedfs#10782
(sweep only on the recursive path) and seaweedfs/seaweedfs#10783 (restore a folder that
received an entry while it was deleted). Both are ancestors of the 4.42 tag, so this takes
4.42 and drops the cleanup-delay workaround the PR originally carried. Both pin sites move
together, as the Dockerfile comment requires.

Validated by running the shipped setup script's own sequence against 4.42 and 4.41,
identical except the binary: gateway up, bucket create, filer write probe, `filer.copy`,
then PUT, immediate HEAD, GET, ListObjectsV2 and DELETE over S3 all pass on both, so the
bump is not a regression on the CI path (134 upstream commits, several in `s3api`).

Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e9f46105394805fb1a160303c4f40b52ad053522&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F3%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1601` (included in `26.8` and later)
<!-- ch-version-info:end -->