### PR TITLE
Docs: Clarify `PREWHERE` behavior with `JOIN`

### DIFF
--- a/docs/reference/statements/select/index.mdx
+++ b/docs/reference/statements/select/index.mdx
@@ -71,7 +71,7 @@ FROM table
 
 ## SELECT Clause {#select-clause}
 
-[Expressions](/reference/syntax#expressions) in the `SELECT` clause define the columns returned by the query. ClickHouse may evaluate them at different stages depending on the query plan. Aggregate functions and their arguments are processed during [`GROUP BY`](/reference/statements/select/group-by) aggregation.
+[Expressions](/reference/syntax#expressions) specified in the `SELECT` clause are calculated after all the operations in the clauses described above are finished. These expressions work as if they apply to separate rows in the result. If expressions in the `SELECT` clause contain aggregate functions, then ClickHouse processes aggregate functions and expressions used as their arguments during the [GROUP BY](/reference/statements/select/group-by) aggregation.
 
 If you want to include all columns in the result, use the asterisk (`*`) symbol. For example, `SELECT * FROM ...`.
 

--- a/docs/reference/statements/select/index.mdx
+++ b/docs/reference/statements/select/index.mdx
@@ -178,3 +178,94 @@ You can put an asterisk in any part of a query instead of an expression. When th
 - When there is strong filtration on a small number of columns using `PREWHERE`.
 - In subqueries (since columns that aren't needed for the external query are excluded from subqueries).
 
+In all other cases, we do not recommend using the asterisk, since it only gives you the drawbacks of a columnar DBMS instead of the advantages. In other words using the asterisk is not recommended.
+
+### Extreme Values {#extreme-values}
+
+In addition to results, you can also get minimum and maximum values for the results columns. To do this, set the **extremes** setting to 1. Minimums and maximums are calculated for numeric types, dates, and dates with times. For other columns, the default values are output.
+
+An extra two rows are calculated – the minimums and maximums, respectively. These extra two rows are output in `XML`, `JSON*`, `TabSeparated*`, `CSV*`, `Vertical`, `Template` and `Pretty*` [formats](/reference/formats/index), separate from the other rows. They are not output for other formats.
+
+In `JSON*` and `XML` formats, the extreme values are output in a separate 'extremes' field. In `TabSeparated*`, `CSV*` and `Vertical` formats, the row comes after the main result, and after 'totals' if present. It is preceded by an empty row (after the other data). In `Pretty*` formats, the row is output as a separate table after the main result, and after `totals` if present. In `Template` format the extreme values are output according to specified template.
+
+Extreme values are calculated for rows before `LIMIT`, but after `LIMIT BY`. However, when using `LIMIT offset, size`, the rows before `offset` are included in `extremes`. In stream requests, the result may also include a small number of rows that passed through `LIMIT`.
+
+### Notes {#notes}
+
+You can use synonyms (`AS` aliases) in any part of a query.
+
+The `GROUP BY`, `ORDER BY`, and `LIMIT BY` clauses can support positional arguments. To enable this, switch on the [enable_positional_arguments](/reference/settings/session-settings/enable-positional-arguments#enable_positional_arguments) setting. Then, for example, `ORDER BY 1,2` will be sorting rows in the table on the first and then the second column.
+
+## Implementation Details {#implementation-details}
+
+If the query omits the `DISTINCT`, `GROUP BY` and `ORDER BY` clauses and the `IN` and `JOIN` subqueries, the query will be completely stream processed, using O(1) amount of RAM. Otherwise, the query might consume a lot of RAM if the appropriate restrictions are not specified:
+
+- `max_memory_usage`
+- `max_rows_to_group_by`
+- `max_rows_to_sort`
+- `max_rows_in_distinct`
+- `max_bytes_in_distinct`
+- `max_rows_in_set`
+- `max_bytes_in_set`
+- `max_rows_in_join`
+- `max_bytes_in_join`
+- `max_bytes_before_external_sort`
+- `max_bytes_ratio_before_external_sort`
+- `max_bytes_before_external_group_by`
+- `max_bytes_ratio_before_external_group_by`
+
+For more information, see the section "Settings". It is possible to use external sorting (saving temporary tables to a disk) and external aggregation.
+
+## SELECT modifiers {#select-modifiers}
+
+You can use the following modifiers in `SELECT` queries.
+
+| Modifier                            | Description                                                                                                                                                                                                                                                                                                                                                                              |
+|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`APPLY`](/reference/statements/select/apply_modifier)     | Allows you to invoke some function for each row returned by an outer table expression of a query.                                                                                                                                                                                                                                                                                        |
+| [`EXCEPT`](/reference/statements/select/except_modifier)   | Specifies the names of one or more columns to exclude from the result. All matching column names are omitted from the output.                                                                                                                                                                                                                                                            |
+| [`REPLACE`](/reference/statements/select/replace_modifier) | Specifies one or more [expression aliases](/reference/syntax#expression-aliases). Each alias must match a column name from the `SELECT *` statement. In the output column list, the column that matches the alias is replaced by the expression in that `REPLACE`. This modifier does not change the names or order of columns. However, it can change the value and the value type. |
+
+### Modifier Combinations {#modifier-combinations}
+
+You can use each modifier separately or combine them.
+
+**Examples:**
+
+Using the same modifier multiple times.
+
+```sql
+SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) FROM columns_transformers;
+```
+
+```response
+┌─max(length(toString(j)))─┬─max(length(toString(k)))─┐
+│                        2 │                        3 │
+└──────────────────────────┴──────────────────────────┘
+```
+
+Using multiple modifiers in a single query.
+
+```sql
+SELECT * REPLACE(i + 1 AS i) EXCEPT (j) APPLY(sum) from columns_transformers;
+```
+
+```response
+┌─sum(plus(i, 1))─┬─sum(k)─┐
+│             222 │    347 │
+└─────────────────┴────────┘
+```
+
+## SETTINGS in SELECT Query {#settings-in-select-query}
+
+You can specify the necessary settings right in the `SELECT` query. The setting value is applied only to this query and is reset to default or previous value after the query is executed.
+
+Other ways to make settings see [here](/concepts/features/configuration/settings/overview).
+
+For boolean settings set to true, you can use a shorthand syntax by omitting the value assignment. When only the setting name is specified, it is automatically set to `1` (true).
+
+**Example**
+
+```sql
+SELECT * FROM some_table SETTINGS optimize_read_in_order=1, cast_keep_nullable=1;
+```

--- a/docs/reference/statements/select/index.mdx
+++ b/docs/reference/statements/select/index.mdx
@@ -34,7 +34,7 @@ SELECT [DISTINCT [ON (column1, column2, ...)]] expr_list
 
 All clauses are optional, except for the required list of expressions immediately after `SELECT` which is covered in more detail [below](#select-clause).
 
-Specifics of each optional clause are covered in separate sections, which are listed in the same order as they are executed (except for `SELECT` and `DISTINCT`, listed first for convenience: their expressions are evaluated only after the preceding clauses finish, as described [below](#select-clause)):
+Specifics of each optional clause are covered in separate sections:
 
 - [WITH clause](/reference/statements/select/with)
 - [SELECT clause](#select-clause)

--- a/docs/reference/statements/select/index.mdx
+++ b/docs/reference/statements/select/index.mdx
@@ -32,9 +32,9 @@ SELECT [DISTINCT [ON (column1, column2, ...)]] expr_list
 [FORMAT format]
 ```
 
-All clauses are optional, except for the required list of expressions immediately after `SELECT` which is covered in more detail [below](#select-clause).
+The expression list immediately after `SELECT` is required; all other clauses are optional.
 
-Specifics of each optional clause are covered in separate sections:
+`SELECT` and its optional clauses are covered in separate sections:
 
 - [WITH clause](/reference/statements/select/with)
 - [SELECT clause](#select-clause)
@@ -71,7 +71,7 @@ FROM table
 
 ## SELECT Clause {#select-clause}
 
-[Expressions](/reference/syntax#expressions) specified in the `SELECT` clause are calculated after all the operations in the clauses described above are finished. These expressions work as if they apply to separate rows in the result. If expressions in the `SELECT` clause contain aggregate functions, then ClickHouse processes aggregate functions and expressions used as their arguments during the [GROUP BY](/reference/statements/select/group-by) aggregation.
+[Expressions](/reference/syntax#expressions) in the `SELECT` clause define the columns returned by the query. ClickHouse may evaluate them at different stages depending on the query plan. Aggregate functions and their arguments are processed during [`GROUP BY`](/reference/statements/select/group-by) aggregation.
 
 If you want to include all columns in the result, use the asterisk (`*`) symbol. For example, `SELECT * FROM ...`.
 
@@ -178,94 +178,3 @@ You can put an asterisk in any part of a query instead of an expression. When th
 - When there is strong filtration on a small number of columns using `PREWHERE`.
 - In subqueries (since columns that aren't needed for the external query are excluded from subqueries).
 
-In all other cases, we do not recommend using the asterisk, since it only gives you the drawbacks of a columnar DBMS instead of the advantages. In other words using the asterisk is not recommended.
-
-### Extreme Values {#extreme-values}
-
-In addition to results, you can also get minimum and maximum values for the results columns. To do this, set the **extremes** setting to 1. Minimums and maximums are calculated for numeric types, dates, and dates with times. For other columns, the default values are output.
-
-An extra two rows are calculated – the minimums and maximums, respectively. These extra two rows are output in `XML`, `JSON*`, `TabSeparated*`, `CSV*`, `Vertical`, `Template` and `Pretty*` [formats](/reference/formats/index), separate from the other rows. They are not output for other formats.
-
-In `JSON*` and `XML` formats, the extreme values are output in a separate 'extremes' field. In `TabSeparated*`, `CSV*` and `Vertical` formats, the row comes after the main result, and after 'totals' if present. It is preceded by an empty row (after the other data). In `Pretty*` formats, the row is output as a separate table after the main result, and after `totals` if present. In `Template` format the extreme values are output according to specified template.
-
-Extreme values are calculated for rows before `LIMIT`, but after `LIMIT BY`. However, when using `LIMIT offset, size`, the rows before `offset` are included in `extremes`. In stream requests, the result may also include a small number of rows that passed through `LIMIT`.
-
-### Notes {#notes}
-
-You can use synonyms (`AS` aliases) in any part of a query.
-
-The `GROUP BY`, `ORDER BY`, and `LIMIT BY` clauses can support positional arguments. To enable this, switch on the [enable_positional_arguments](/reference/settings/session-settings/enable-positional-arguments#enable_positional_arguments) setting. Then, for example, `ORDER BY 1,2` will be sorting rows in the table on the first and then the second column.
-
-## Implementation Details {#implementation-details}
-
-If the query omits the `DISTINCT`, `GROUP BY` and `ORDER BY` clauses and the `IN` and `JOIN` subqueries, the query will be completely stream processed, using O(1) amount of RAM. Otherwise, the query might consume a lot of RAM if the appropriate restrictions are not specified:
-
-- `max_memory_usage`
-- `max_rows_to_group_by`
-- `max_rows_to_sort`
-- `max_rows_in_distinct`
-- `max_bytes_in_distinct`
-- `max_rows_in_set`
-- `max_bytes_in_set`
-- `max_rows_in_join`
-- `max_bytes_in_join`
-- `max_bytes_before_external_sort`
-- `max_bytes_ratio_before_external_sort`
-- `max_bytes_before_external_group_by`
-- `max_bytes_ratio_before_external_group_by`
-
-For more information, see the section "Settings". It is possible to use external sorting (saving temporary tables to a disk) and external aggregation.
-
-## SELECT modifiers {#select-modifiers}
-
-You can use the following modifiers in `SELECT` queries.
-
-| Modifier                            | Description                                                                                                                                                                                                                                                                                                                                                                              |
-|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`APPLY`](/reference/statements/select/apply_modifier)     | Allows you to invoke some function for each row returned by an outer table expression of a query.                                                                                                                                                                                                                                                                                        |
-| [`EXCEPT`](/reference/statements/select/except_modifier)   | Specifies the names of one or more columns to exclude from the result. All matching column names are omitted from the output.                                                                                                                                                                                                                                                            |
-| [`REPLACE`](/reference/statements/select/replace_modifier) | Specifies one or more [expression aliases](/reference/syntax#expression-aliases). Each alias must match a column name from the `SELECT *` statement. In the output column list, the column that matches the alias is replaced by the expression in that `REPLACE`. This modifier does not change the names or order of columns. However, it can change the value and the value type. |
-
-### Modifier Combinations {#modifier-combinations}
-
-You can use each modifier separately or combine them.
-
-**Examples:**
-
-Using the same modifier multiple times.
-
-```sql
-SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) FROM columns_transformers;
-```
-
-```response
-┌─max(length(toString(j)))─┬─max(length(toString(k)))─┐
-│                        2 │                        3 │
-└──────────────────────────┴──────────────────────────┘
-```
-
-Using multiple modifiers in a single query.
-
-```sql
-SELECT * REPLACE(i + 1 AS i) EXCEPT (j) APPLY(sum) from columns_transformers;
-```
-
-```response
-┌─sum(plus(i, 1))─┬─sum(k)─┐
-│             222 │    347 │
-└─────────────────┴────────┘
-```
-
-## SETTINGS in SELECT Query {#settings-in-select-query}
-
-You can specify the necessary settings right in the `SELECT` query. The setting value is applied only to this query and is reset to default or previous value after the query is executed.
-
-Other ways to make settings see [here](/concepts/features/configuration/settings/overview).
-
-For boolean settings set to true, you can use a shorthand syntax by omitting the value assignment. When only the setting name is specified, it is automatically set to `1` (true).
-
-**Example**
-
-```sql
-SELECT * FROM some_table SETTINGS optimize_read_in_order=1, cast_keep_nullable=1;
-```

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -452,9 +452,21 @@ The columns specified in `USING` must have the same names in both subqueries, an
 
 The `USING` clause specifies one or more columns to join, which establishes the equality of these columns. The list of columns is set without brackets. More complex join conditions are not supported.
 
+### Syntax Limitations {#syntax-limitations}
+
+For multiple `JOIN` clauses in a single `SELECT` query:
+
+- Taking all the columns via `*` is available only if tables are joined, not subqueries.
+- The `PREWHERE` clause is not available.
+- The `USING` clause is not available.
+
+For `ON`, `WHERE`, and `GROUP BY` clauses:
+
+- Arbitrary expressions cannot be used in `ON`, `WHERE`, and `GROUP BY` clauses, but you can define an expression in a `SELECT` clause and then use it in these clauses via an alias.
+
 ### Performance {#performance}
 
-A `WHERE` condition logically filters the result of a `JOIN`, but the optimizer may apply it before the join when doing so does not change the result.
+When running a `JOIN`, there is no optimization of the order of execution in relation to other stages of the query. The join (a search in the right table) is run before filtering in `WHERE` and before aggregation.
 
 Each time a query is run with the same `JOIN`, the subquery is run again because the result is not cached. To avoid this, use the special [Join](/reference/engines/table-engines/special/join) table engine, which is a prepared array for joining that is always in RAM.
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -454,10 +454,7 @@ The `USING` clause specifies one or more columns to join, which establishes the 
 
 ### Syntax Limitations {#syntax-limitations}
 
-For multiple `JOIN` clauses in a single `SELECT` query:
-
-- Taking all the columns via `*` is available only if tables are joined, not subqueries.
-- The `USING` clause is not available.
+When a `SELECT` query contains multiple `JOIN` clauses, `*` can select all columns only when joining tables, not subqueries.
 
 For `ON`, `WHERE`, and `GROUP BY` clauses:
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -452,17 +452,9 @@ The columns specified in `USING` must have the same names in both subqueries, an
 
 The `USING` clause specifies one or more columns to join, which establishes the equality of these columns. The list of columns is set without brackets. More complex join conditions are not supported.
 
-### Syntax Limitations {#syntax-limitations}
-
-When a `SELECT` query contains multiple `JOIN` clauses, `*` can select all columns only when joining tables, not subqueries.
-
-For `ON`, `WHERE`, and `GROUP BY` clauses:
-
-- Arbitrary expressions cannot be used in `ON`, `WHERE`, and `GROUP BY` clauses, but you can define an expression in a `SELECT` clause and then use it in these clauses via an alias.
-
 ### Performance {#performance}
 
-When running a `JOIN`, there is no optimization of the order of execution in relation to other stages of the query. The join (a search in the right table) is run before filtering in `WHERE` and before aggregation.
+A `WHERE` condition logically filters the result of a `JOIN`, but the optimizer may apply it before the join when doing so does not change the result.
 
 Each time a query is run with the same `JOIN`, the subquery is run again because the result is not cached. To avoid this, use the special [Join](/reference/engines/table-engines/special/join) table engine, which is a prepared array for joining that is always in RAM.
 

--- a/docs/reference/statements/select/join.mdx
+++ b/docs/reference/statements/select/join.mdx
@@ -457,7 +457,6 @@ The `USING` clause specifies one or more columns to join, which establishes the 
 For multiple `JOIN` clauses in a single `SELECT` query:
 
 - Taking all the columns via `*` is available only if tables are joined, not subqueries.
-- The `PREWHERE` clause is not available.
 - The `USING` clause is not available.
 
 For `ON`, `WHERE`, and `GROUP BY` clauses:

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -28,7 +28,7 @@ The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... F
 
 With the analyzer enabled, a `PREWHERE` condition can directly reference columns from no more than one table in a [`JOIN`](/reference/statements/select/join). ClickHouse applies the condition to that table's rows before they reach the join.
 
-In the following example, the `PREWHERE` condition filters `table_2` before it is joined with `table_1`:
+The following example uses a `PREWHERE` condition that references `table_2`:
 
 ```sql
 CREATE TABLE table_1

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -24,11 +24,11 @@ If query has [FINAL](/reference/statements/select/from#final-modifier) modifier,
 The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
 </Note>
 
-## PREWHERE with JOIN {#prewhere-with-join}
+## `PREWHERE` with `JOIN` {#prewhere-with-join}
 
-With the analyzer enabled (the default), a `PREWHERE` condition can directly reference columns from only one of the tables in a [JOIN](/reference/statements/select/join). The condition is associated with that table and is applied to its rows before they reach the join.
+With the analyzer enabled, a `PREWHERE` condition can directly reference columns from no more than one table in a [`JOIN`](/reference/statements/select/join). ClickHouse applies the condition to that table's rows before they reach the join.
 
-The following example attaches the `PREWHERE` condition to `table_2`:
+In the following example, the `PREWHERE` condition filters `table_2` before it is joined with `table_1`:
 
 ```sql
 CREATE TABLE table_1

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -71,7 +71,7 @@ ORDER BY table_1.id;
 
 ## Limitations {#limitations}
 
-Support for `PREWHERE` depends on the table engine. It is supported by tables from the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family.
+Not every table engine supports `PREWHERE`. All engines in the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family do.
 
 ## Example {#example}
 

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -21,12 +21,14 @@ If the [optimize_move_to_prewhere](/reference/settings/session-settings/optimize
 If query has [FINAL](/reference/statements/select/from#final-modifier) modifier, the `PREWHERE` optimization is not always correct. It is enabled only if both settings [optimize_move_to_prewhere](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) and [optimize_move_to_prewhere_if_final](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere_if_final) are turned on.
 
 <Note>
-The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
+The `PREWHERE` section is normally executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
 </Note>
 
 ## `PREWHERE` with `JOIN` {#prewhere-with-join}
 
 With the analyzer enabled, a `PREWHERE` condition can directly reference columns from no more than one table in a [`JOIN`](/reference/statements/select/join). ClickHouse applies the condition to that table's rows before they reach the join.
+
+In contrast, a `WHERE` condition filters the result of the join. The optimizer may apply it before the join when doing so does not change the result. Moving the same condition between `PREWHERE` and `WHERE` can therefore produce different results, particularly for outer joins.
 
 The following example uses a `PREWHERE` condition that references `table_2`:
 

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -6,11 +6,11 @@ title: 'PREWHERE Clause'
 doc_type: 'reference'
 ---
 
-Prewhere is an optimization to apply filtering more efficiently. It is enabled by default even if `PREWHERE` clause is not specified explicitly. It works by automatically moving part of [WHERE](/reference/statements/select/where) condition to prewhere stage. The role of `PREWHERE` clause is only to control this optimization if you think that you know how to do it better than it happens by default.
+`PREWHERE` is an optimization that can reduce the amount of data read by filtering rows before reading all the columns required by a query. ClickHouse can apply it automatically by moving eligible conditions from [`WHERE`](/reference/statements/select/where) to `PREWHERE`. You can specify `PREWHERE` explicitly to control which conditions are applied at this stage.
 
-With prewhere optimization, at first only the columns necessary for executing prewhere expression are read. Then the other columns are read that are needed for running the rest of the query, but only those blocks where the prewhere expression is `true` at least for some rows. If there are a lot of blocks where prewhere expression is `false` for all rows and prewhere needs less columns than other parts of query, this often allows to read a lot less data from disk for query execution.
+With `PREWHERE`, ClickHouse first reads only the columns needed to evaluate the condition. It then reads the other columns required by the query only for blocks that contain at least one matching row. This can reduce the amount of data read when the condition uses fewer columns than the rest of the query and filters out many blocks.
 
-## Controlling Prewhere Manually {#controlling-prewhere-manually}
+## Controlling `PREWHERE` Manually {#controlling-prewhere-manually}
 
 Use `PREWHERE` when the filtering conditions reference a small number of columns but strongly reduce the number of rows. This reduces the volume of data read for the remaining columns.
 

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -12,7 +12,7 @@ With prewhere optimization, at first only the columns necessary for executing pr
 
 ## Controlling Prewhere Manually {#controlling-prewhere-manually}
 
-The clause is normally evaluated while ClickHouse reads data from a table. Use `PREWHERE` when the filtering conditions reference a small number of columns but strongly reduce the number of rows. This reduces the volume of data read for the remaining columns.
+Use `PREWHERE` when the filtering conditions reference a small number of columns but strongly reduce the number of rows. This reduces the volume of data read for the remaining columns.
 
 A query may simultaneously specify `PREWHERE` and `WHERE`. In this case, `PREWHERE` precedes `WHERE`.
 
@@ -21,12 +21,12 @@ If the [optimize_move_to_prewhere](/reference/settings/session-settings/optimize
 If query has [FINAL](/reference/statements/select/from#final-modifier) modifier, the `PREWHERE` optimization is not always correct. It is enabled only if both settings [optimize_move_to_prewhere](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) and [optimize_move_to_prewhere_if_final](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere_if_final) are turned on.
 
 <Note>
-The `PREWHERE` section is normally executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
+By default, the `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
 </Note>
 
 ## `PREWHERE` with `JOIN` {#prewhere-with-join}
 
-With the analyzer enabled, a `PREWHERE` condition can directly reference columns from no more than one table in a [`JOIN`](/reference/statements/select/join). ClickHouse applies the condition to that table's rows before they reach the join.
+When `enable_analyzer = 1`, a `PREWHERE` condition can directly reference columns from no more than one table in a [`JOIN`](/reference/statements/select/join). ClickHouse applies the condition to that table's rows before they reach the join.
 
 In contrast, a `WHERE` condition filters the result of the join. The optimizer may apply it before the join when doing so does not change the result. Moving the same condition between `PREWHERE` and `WHERE` can therefore produce different results, particularly for outer joins.
 
@@ -71,7 +71,7 @@ ORDER BY table_1.id;
 
 ## Limitations {#limitations}
 
-`PREWHERE` is only supported by tables from the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family.
+Support for `PREWHERE` depends on the table engine. It is supported by tables from the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family.
 
 ## Example {#example}
 

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -12,7 +12,7 @@ With prewhere optimization, at first only the columns necessary for executing pr
 
 ## Controlling Prewhere Manually {#controlling-prewhere-manually}
 
-The clause has the same meaning as the `WHERE` clause. The difference is in which data is read from the table. When manually controlling `PREWHERE` for filtration conditions that are used by a minority of the columns in the query, but that provide strong data filtration. This reduces the volume of data to read.
+The clause is normally evaluated while ClickHouse reads data from a table. Use `PREWHERE` when the filtering conditions reference a small number of columns but strongly reduce the number of rows. This reduces the volume of data read for the remaining columns.
 
 A query may simultaneously specify `PREWHERE` and `WHERE`. In this case, `PREWHERE` precedes `WHERE`.
 
@@ -23,6 +23,49 @@ If query has [FINAL](/reference/statements/select/from#final-modifier) modifier,
 <Note>
 The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
 </Note>
+
+## PREWHERE with JOIN {#prewhere-with-join}
+
+In queries that use [JOIN](/reference/statements/select/join), all columns in the `PREWHERE` condition must come from the same table. ClickHouse applies the condition while reading that table, before joining it with the other tables.
+
+In this example, `PREWHERE` filters `table_2` before the two tables are joined:
+
+```sql
+CREATE TABLE table_1
+(
+    `id` UInt32,
+    `value` String
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+CREATE TABLE table_2
+(
+    `id` UInt32,
+    `value` String
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO table_1 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+INSERT INTO table_2 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+
+SELECT
+    table_1.id,
+    table_1.value,
+    table_2.value
+FROM table_1
+JOIN table_2 ON table_1.id = table_2.id
+PREWHERE table_2.id >= 2
+ORDER BY table_1.id;
+```
+
+```text
+   ┌─id─┬─value─┬─table_2.value─┐
+1. │  2 │ b     │ y             │
+2. │  3 │ c     │ z             │
+   └────┴───────┴───────────────┘
+```
 
 ## Limitations {#limitations}
 

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -73,9 +73,9 @@ ORDER BY table_1.id;
 
 All table engines in the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family support `PREWHERE`; support varies for other table engines.
 
-## Reducing data reads with `PREWHERE` {#example}
+## Using `PREWHERE` explicitly {#example}
 
-The following example compares automatically and manually selected `PREWHERE` conditions.
+The following example specifies a selective condition in `PREWHERE`:
 
 ```sql
 CREATE TABLE mydata
@@ -94,44 +94,12 @@ FROM numbers(10000000);
 
 SELECT count()
 FROM mydata
-WHERE (B = 0) AND (C = 'x');
-```
-
-```text
-1 row in set. Elapsed: 0.074 sec. Processed 10.00 million rows, 168.89 MB (134.98 million rows/s., 2.28 GB/s.)
-```
-
-Enable debug-level logging to see which predicates ClickHouse moves to `PREWHERE`:
-
-```sql
-SET send_logs_level = 'debug';
-```
-
-Run the query again:
-
-```sql
-SELECT count()
-FROM mydata
-WHERE (B = 0) AND (C = 'x');
-```
-
-```text
-MergeTreeWhereOptimizer: condition "B = 0" moved to PREWHERE
-```
-
-ClickHouse automatically moves `B = 0` to `PREWHERE`. This condition does not filter any rows because `B` is always `0`.
-
-Move the more selective `C = 'x'` condition to `PREWHERE` manually:
-
-```sql
-SELECT count()
-FROM mydata
 PREWHERE C = 'x'
 WHERE B = 0;
 ```
 
 ```text
-1 row in set. Elapsed: 0.069 sec. Processed 10.00 million rows, 158.89 MB (144.90 million rows/s., 2.30 GB/s.)
+   ┌─count()─┐
+1. │    1001 │
+   └─────────┘
 ```
-
-The manual `PREWHERE` query processes slightly less data: 158.89 MB instead of 168.89 MB.

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -26,9 +26,9 @@ The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... F
 
 ## PREWHERE with JOIN {#prewhere-with-join}
 
-In queries that use [JOIN](/reference/statements/select/join), all columns in the `PREWHERE` condition must come from the same table. ClickHouse applies the condition while reading that table, before joining it with the other tables.
+With the analyzer enabled (the default), a `PREWHERE` condition can directly reference columns from only one of the tables in a [JOIN](/reference/statements/select/join). The condition is associated with that table and is applied to its rows before they reach the join.
 
-In this example, `PREWHERE` filters `table_2` before the two tables are joined:
+The following example attaches the `PREWHERE` condition to `table_2`:
 
 ```sql
 CREATE TABLE table_1

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -1,34 +1,34 @@
 ---
-description: 'Documentation for PREWHERE Clause'
+description: 'Documentation for the `PREWHERE` clause in ClickHouse'
 sidebarTitle: 'PREWHERE'
 slug: /sql-reference/statements/select/prewhere
 title: 'PREWHERE Clause'
 doc_type: 'reference'
 ---
 
-`PREWHERE` is an optimization that can reduce the amount of data read by filtering rows before reading all the columns required by a query. ClickHouse can apply it automatically by moving eligible conditions from [`WHERE`](/reference/statements/select/where) to `PREWHERE`. You can specify `PREWHERE` explicitly to control which conditions are applied at this stage.
+`PREWHERE` can reduce the amount of data read by filtering rows before ClickHouse reads all the columns required by a query. ClickHouse can apply this optimization automatically by moving eligible conditions from [`WHERE`](/reference/statements/select/where) to `PREWHERE`. You can also specify `PREWHERE` explicitly to control which conditions are applied at this stage.
 
-With `PREWHERE`, ClickHouse first reads only the columns needed to evaluate the condition. It then reads the other columns required by the query only for blocks that contain at least one matching row. This can reduce the amount of data read when the condition uses fewer columns than the rest of the query and filters out many blocks.
+With `PREWHERE`, ClickHouse first reads only the columns needed to evaluate the condition. It reads the remaining columns only for blocks that contain at least one matching row. This is most effective when the condition uses fewer columns than the rest of the query and filters out many blocks.
 
-## Controlling `PREWHERE` Manually {#controlling-prewhere-manually}
+## Controlling `PREWHERE` manually {#controlling-prewhere-manually}
 
-Use `PREWHERE` when the filtering conditions reference a small number of columns but strongly reduce the number of rows. This reduces the volume of data read for the remaining columns.
+Specify `PREWHERE` manually when a condition references a small number of columns and filters out many rows.
 
-A query may simultaneously specify `PREWHERE` and `WHERE`. In this case, `PREWHERE` precedes `WHERE`.
+A query can contain both `PREWHERE` and `WHERE`; `PREWHERE` is evaluated first.
 
-If the [optimize_move_to_prewhere](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) setting is set to 0, heuristics to automatically move parts of expressions from `WHERE` to `PREWHERE` are disabled.
+Set [`optimize_move_to_prewhere`](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) to `0` to prevent ClickHouse from automatically moving conditions from `WHERE` to `PREWHERE`.
 
-If query has [FINAL](/reference/statements/select/from#final-modifier) modifier, the `PREWHERE` optimization is not always correct. It is enabled only if both settings [optimize_move_to_prewhere](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) and [optimize_move_to_prewhere_if_final](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere_if_final) are turned on.
+For queries with the [`FINAL`](/reference/statements/select/from#final-modifier) modifier, ClickHouse moves conditions from `WHERE` to `PREWHERE` only when both [`optimize_move_to_prewhere`](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) and [`optimize_move_to_prewhere_if_final`](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere_if_final) are enabled.
 
 <Note>
-By default, the `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
+By default, `PREWHERE` is evaluated before `FINAL`. In queries that use `FROM ... FINAL`, applying `PREWHERE` to columns outside the table's `ORDER BY` key can produce different results than applying the same condition after `FINAL`.
 </Note>
 
 ## `PREWHERE` with `JOIN` {#prewhere-with-join}
 
-When `enable_analyzer = 1`, a `PREWHERE` condition can directly reference columns from no more than one table in a [`JOIN`](/reference/statements/select/join). ClickHouse applies the condition to that table's rows before they reach the join.
+When `enable_analyzer = 1`, a `PREWHERE` condition in a [`JOIN`](/reference/statements/select/join) can directly reference columns from at most one table. ClickHouse applies the condition to that table's rows before they reach the join.
 
-In contrast, a `WHERE` condition filters the result of the join. The optimizer may apply it before the join when doing so does not change the result. Moving the same condition between `PREWHERE` and `WHERE` can therefore produce different results, particularly for outer joins.
+By contrast, a `WHERE` condition logically filters the joined result, although the optimizer may apply it before the join when doing so does not change the result. Using the same condition in `PREWHERE` and `WHERE` can therefore produce different results, particularly with outer joins.
 
 The following example uses a `PREWHERE` condition that references `table_2`:
 
@@ -71,9 +71,11 @@ ORDER BY table_1.id;
 
 ## Limitations {#limitations}
 
-Not every table engine supports `PREWHERE`. All engines in the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family do.
+All table engines in the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family support `PREWHERE`; support varies for other table engines.
 
-## Example {#example}
+## Reducing data reads with `PREWHERE` {#example}
+
+The following example compares automatically and manually selected `PREWHERE` conditions.
 
 ```sql
 CREATE TABLE mydata
@@ -87,29 +89,49 @@ ORDER BY A AS
 SELECT
     number,
     0,
-    if(number between 1000 and 2000, 'x', toString(number))
+    if(number BETWEEN 1000 AND 2000, 'x', toString(number))
 FROM numbers(10000000);
 
 SELECT count()
 FROM mydata
 WHERE (B = 0) AND (C = 'x');
+```
 
+```text
 1 row in set. Elapsed: 0.074 sec. Processed 10.00 million rows, 168.89 MB (134.98 million rows/s., 2.28 GB/s.)
+```
 
--- let's enable tracing to see which predicate are moved to PREWHERE
-set send_logs_level='debug';
+Enable debug-level logging to see which predicates ClickHouse moves to `PREWHERE`:
 
-MergeTreeWhereOptimizer: condition "B = 0" moved to PREWHERE  
--- Clickhouse moves automatically `B = 0` to PREWHERE, but it has no sense because B is always 0.
+```sql
+SET send_logs_level = 'debug';
+```
 
--- Let's move other predicate `C = 'x'` 
+Run the query again:
 
+```sql
+SELECT count()
+FROM mydata
+WHERE (B = 0) AND (C = 'x');
+```
+
+```text
+MergeTreeWhereOptimizer: condition "B = 0" moved to PREWHERE
+```
+
+ClickHouse automatically moves `B = 0` to `PREWHERE`. This condition does not filter any rows because `B` is always `0`.
+
+Move the more selective `C = 'x'` condition to `PREWHERE` manually:
+
+```sql
 SELECT count()
 FROM mydata
 PREWHERE C = 'x'
 WHERE B = 0;
-
-1 row in set. Elapsed: 0.069 sec. Processed 10.00 million rows, 158.89 MB (144.90 million rows/s., 2.30 GB/s.)
-
--- This query with manual `PREWHERE` processes slightly less data: 158.89 MB VS 168.89 MB
 ```
+
+```text
+1 row in set. Elapsed: 0.069 sec. Processed 10.00 million rows, 158.89 MB (144.90 million rows/s., 2.30 GB/s.)
+```
+
+The manual `PREWHERE` query processes slightly less data: 158.89 MB instead of 168.89 MB.

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -71,11 +71,9 @@ ORDER BY table_1.id;
 
 ## Limitations {#limitations}
 
-All table engines in the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family support `PREWHERE`; support varies for other table engines.
+`PREWHERE` is only supported by tables from the [*MergeTree](/reference/engines/table-engines/mergetree-family/index) family.
 
-## Using `PREWHERE` explicitly {#example}
-
-The following example specifies a selective condition in `PREWHERE`:
+## Example {#example}
 
 ```sql
 CREATE TABLE mydata
@@ -94,12 +92,24 @@ FROM numbers(10000000);
 
 SELECT count()
 FROM mydata
+WHERE (B = 0) AND (C = 'x');
+
+1 row in set. Elapsed: 0.074 sec. Processed 10.00 million rows, 168.89 MB (134.98 million rows/s., 2.28 GB/s.)
+
+-- Enable tracing to see which predicates are moved to PREWHERE.
+SET send_logs_level = 'debug';
+
+MergeTreeWhereOptimizer: condition "B = 0" moved to PREWHERE
+-- ClickHouse automatically moves `B = 0` to PREWHERE, but this does not filter any rows because B is always 0.
+
+-- Move the more selective `C = 'x'` predicate to PREWHERE.
+
+SELECT count()
+FROM mydata
 PREWHERE C = 'x'
 WHERE B = 0;
-```
 
-```text
-   ┌─count()─┐
-1. │    1001 │
-   └─────────┘
+1 row in set. Elapsed: 0.069 sec. Processed 10.00 million rows, 158.89 MB (144.90 million rows/s., 2.30 GB/s.)
+
+-- The query with manual PREWHERE processes slightly less data: 158.89 MB instead of 168.89 MB.
 ```


### PR DESCRIPTION
This clarifies how `PREWHERE` behaves in queries with `JOIN`. It removes the misleading claim that `SELECT` clauses follow a single execution order, clearly states the single-table restriction, and adds a runnable minimal example with expected output.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required for a documentation change.
