### PR TITLE
Docs: expand the Managed Postgres autoscaling documentation

### DIFF
--- a/docs/products/managed-postgres/scaling.mdx
+++ b/docs/products/managed-postgres/scaling.mdx
@@ -143,15 +143,15 @@ ClickHouse Managed Postgres monitors disk usage and scales storage automatically
 
 If your instance is already at the largest available configuration, autoscaling can't go further. Free up disk space or contact [support](https://clickhouse.com/support/program).
 
-### Failover and connections {#autoscaling-failover}
+### Cutover and connections {#autoscaling-cutover}
 
-Storage isn't resized in place. Autoscaling follows the same [scaling process](#scaling-process) as a manual instance type change: a replacement server with more storage is provisioned, restored from the latest backup, catches up on WAL, and a controlled failover promotes it to the new primary. Instances with [high availability](/products/managed-postgres/high-availability) get replacement standbys at the new size as part of the same operation.
+Storage isn't resized in place. Autoscaling follows the same [scaling process](#scaling-process) as a manual instance type change: a replacement server with more storage is provisioned, restored from the latest backup, catches up on WAL, and a controlled cutover promotes it to the new primary. Instances with [high availability](/products/managed-postgres/high-availability) get replacement standbys at the new size as part of the same operation.
 
-The failover is the only step with downtime, typically under a minute. If a [maintenance window](/products/managed-postgres/upgrades#maintenance-windows) is configured, the cutover waits for it unless disk usage reaches 95%. During the cutover, open connections are dropped and in-flight transactions are rolled back. Your connection string doesn't change: DNS is updated to point at the new primary, and applications with standard reconnect logic recover automatically.
+The cutover is the only step with downtime, typically under a minute. If a [maintenance window](/products/managed-postgres/upgrades#maintenance-windows) is configured, the cutover waits for it unless disk usage reaches 95%. During the cutover, open connections are dropped and in-flight transactions are rolled back. Your connection string doesn't change: DNS is updated to point at the new primary, and applications with standard reconnect logic recover automatically.
 
 ### Read-only mode {#autoscaling-read-only}
 
-If writes fill the disk faster than autoscaling can complete, the instance switches to read-only mode to prevent complete disk exhaustion. Read-only mode triggers on remaining free space:
+If writes fill the disk faster than autoscaling can complete, the instance goes read-only to prevent full disk exhaustion. The trigger is remaining free space:
 
 | Total disk size | Read-only below | Writes resume above |
 |-----------------|-----------------|---------------------|
@@ -160,16 +160,7 @@ If writes fill the disk faster than autoscaling can complete, the instance switc
 | Up to 512 GB    | 7 GB free       | 10 GB free          |
 | Over 512 GB     | 2% free         | 3% free             |
 
-Reads keep working, while writes fail with the standard Postgres error `cannot execute INSERT in a read-only transaction`. If free space keeps shrinking, existing connections are terminated so that every session picks up the read-only setting. Read-only mode lifts automatically once free space rises above the recovery threshold, usually right after the scale-up cutover completes.
-
-### Example {#autoscaling-example}
-
-An instance with 1024 GB of storage runs a write-heavy workload:
-
-1. At 870 GB used (85%), you receive the storage notification.
-2. At 922 GB used (90%), autoscaling starts. A replacement server with 2048 GB of storage is provisioned and restored from the latest backup while your instance keeps serving traffic.
-3. Once the replacement has caught up, the failover runs, within your maintenance window if one is configured. Connections drop for under a minute, your application reconnects to the same hostname, and usage is back around 45%.
-4. If free space drops below 2% (about 20 GB) before the cutover completes, the instance goes read-only. Writes resume automatically once the cutover to the larger disk finishes.
+Reads keep working, while writes fail with the standard Postgres error `cannot execute INSERT in a read-only transaction`. Read-only mode lifts automatically once free space recovers, usually right after the scale-up cutover completes.
 
 ## Additional resources {#resources}
 

--- a/docs/products/managed-postgres/scaling.mdx
+++ b/docs/products/managed-postgres/scaling.mdx
@@ -135,7 +135,41 @@ This allows you to optimize the replication throughput separately from your Post
 
 ## Autoscaling {#autoscaling}
 
-At 90% disk usage your instance type will be adjusted to a larger instance type.
+ClickHouse Managed Postgres monitors disk usage and scales storage automatically so your instance doesn't run out of space:
+
+- **85% disk usage**: You receive a [notification](/products/managed-postgres/monitoring/notifications) through the cloud console and email.
+- **90% disk usage**: Autoscaling starts. Storage is increased to the next larger size available for your instance family. CPU and memory stay the same unless the current instance size doesn't support a larger disk, in which case the instance size is increased as well. [Read replicas](/products/managed-postgres/read-replicas) are scaled alongside the primary.
+- **95% disk usage**: The cutover skips any configured maintenance window and happens as soon as the new server is ready.
+
+If your instance is already at the largest available configuration, autoscaling can't go further. Free up disk space or contact [support](https://clickhouse.com/support/program).
+
+### Failover and connections {#autoscaling-failover}
+
+Storage isn't resized in place. Autoscaling follows the same [scaling process](#scaling-process) as a manual instance type change: a replacement server with more storage is provisioned, restored from the latest backup, catches up on WAL, and a controlled failover promotes it to the new primary. Instances with [high availability](/products/managed-postgres/high-availability) get replacement standbys at the new size as part of the same operation.
+
+The failover is the only step with downtime, typically under a minute. If a [maintenance window](/products/managed-postgres/upgrades#maintenance-windows) is configured, the cutover waits for it unless disk usage reaches 95%. During the cutover, open connections are dropped and in-flight transactions are rolled back. Your connection string doesn't change: DNS is updated to point at the new primary, and applications with standard reconnect logic recover automatically.
+
+### Read-only mode {#autoscaling-read-only}
+
+If writes fill the disk faster than autoscaling can complete, the instance switches to read-only mode to prevent complete disk exhaustion. Read-only mode triggers on remaining free space:
+
+| Total disk size | Read-only below | Writes resume above |
+|-----------------|-----------------|---------------------|
+| Up to 64 GB     | 1 GB free       | 2 GB free           |
+| Up to 128 GB    | 5 GB free       | 7 GB free           |
+| Up to 512 GB    | 7 GB free       | 10 GB free          |
+| Over 512 GB     | 2% free         | 3% free             |
+
+Reads keep working, while writes fail with the standard Postgres error `cannot execute INSERT in a read-only transaction`. If free space keeps shrinking, existing connections are terminated so that every session picks up the read-only setting. Read-only mode lifts automatically once free space rises above the recovery threshold, usually right after the scale-up cutover completes.
+
+### Example {#autoscaling-example}
+
+An instance with 1024 GB of storage runs a write-heavy workload:
+
+1. At 870 GB used (85%), you receive the storage notification.
+2. At 922 GB used (90%), autoscaling starts. A replacement server with 2048 GB of storage is provisioned and restored from the latest backup while your instance keeps serving traffic.
+3. Once the replacement has caught up, the failover runs, within your maintenance window if one is configured. Connections drop for under a minute, your application reconnects to the same hostname, and usage is back around 45%.
+4. If free space drops below 2% (about 20 GB) before the cutover completes, the instance goes read-only. Writes resume automatically once the cutover to the larger disk finishes.
 
 ## Additional resources {#resources}
 

--- a/docs/products/managed-postgres/scaling.mdx
+++ b/docs/products/managed-postgres/scaling.mdx
@@ -160,7 +160,7 @@ If writes fill the disk faster than autoscaling can complete, the instance goes 
 | Up to 512 GB    | 7 GB free       | 10 GB free          |
 | Over 512 GB     | 2% free         | 3% free             |
 
-Reads keep working, while writes fail with the standard Postgres error `cannot execute INSERT in a read-only transaction`. Read-only mode lifts automatically once free space recovers, usually right after the scale-up cutover completes.
+Reads keep working, while writes fail with the standard Postgres error `cannot execute INSERT in a read-only transaction`. If free space keeps shrinking, existing connections are terminated so that every session picks up the read-only setting; reads work again once clients reconnect. Read-only mode lifts automatically once free space recovers, usually right after the scale-up cutover completes.
 
 ### Example {#autoscaling-example}
 

--- a/docs/products/managed-postgres/scaling.mdx
+++ b/docs/products/managed-postgres/scaling.mdx
@@ -162,6 +162,15 @@ If writes fill the disk faster than autoscaling can complete, the instance goes 
 
 Reads keep working, while writes fail with the standard Postgres error `cannot execute INSERT in a read-only transaction`. Read-only mode lifts automatically once free space recovers, usually right after the scale-up cutover completes.
 
+### Example {#autoscaling-example}
+
+An instance with 1024 GB of storage runs a write-heavy workload:
+
+1. At 870 GB used (85%), you receive the storage notification.
+2. At 922 GB used (90%), autoscaling starts. A replacement server with 2048 GB of storage is provisioned and restored from the latest backup while your instance keeps serving traffic.
+3. Once the replacement has caught up, the cutover runs, within your maintenance window if one is configured. Connections drop for under a minute, your application reconnects to the same hostname, and usage is back around 45%.
+4. If free space drops below 2% (about 20 GB) before the cutover completes, the instance goes read-only. Writes resume automatically once the cutover to the larger disk finishes.
+
 ## Additional resources {#resources}
 
 - [Settings and configuration](/products/managed-postgres/settings)


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

## Summary

- Expand the one-line Autoscaling section in the Managed Postgres scaling docs with the behavior sourced from the Ubicloud codebase: the 85% storage notification, the 90% automatic scale-up, and the 95% maintenance-window bypass
- Document what autoscaling means for the cutover and client connections: same process as a manual instance change, connections dropped and in-flight transactions rolled back, DNS repointed to the new primary under the same hostname
- Document read-only mode: free-space trigger and recovery thresholds per disk size, the error writes receive, and automatic recovery after the scale-up
- Add a worked example scenario for a 1024 GB instance scaling to 2048 GB