### PR TITLE
Read a subcolumn of an `ALIAS` parent through a `Merge` table instead of a default

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -22,6 +22,7 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/getLeastSupertype.h>
 #include <DataTypes/IDataType.h>
+#include <DataTypes/NestedUtils.h>
 #include <Databases/IDatabase.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -148,6 +149,23 @@ StoragePtr tableForRead(const DatabasePtr & database, const String & table_name,
         return table;
 
     return database->getTableForRead(table_name, table, local_context);
+}
+
+/// `ColumnsDescription` registers no subcolumns for an ALIAS column, so a name like `arr.size0`
+/// never resolves through the subcolumn index even though the alias expression can produce it.
+bool isSubcolumnOfAliasColumn(const ColumnsDescription & storage_columns, const String & name)
+{
+    for (auto [parent_name, subcolumn_name] : Nested::getAllColumnAndSubcolumnPairs(name))
+    {
+        const auto * parent = storage_columns.tryGet(String(parent_name));
+        if (!parent || parent->default_desc.kind != ColumnDefaultKind::Alias)
+            continue;
+
+        if (parent->type->tryGetSubcolumnType(subcolumn_name))
+            return true;
+    }
+
+    return false;
 }
 
 }
@@ -1286,6 +1304,8 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
         /// This happens when merge() is used over tables with different schemas and the processing
         /// stage is above FetchColumns (e.g., for distributed/remote tables where the full query
         /// is sent to the child for processing).
+        auto storage_columns = storage_snapshot_->metadata->getColumns();
+
         std::unordered_map<std::string, QueryTreeNodePtr> column_name_to_node;
         for (const auto & column_name : required_column_names)
         {
@@ -1293,6 +1313,10 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
                 continue;
 
             if (storage_snapshot_->tryGetColumn(get_column_options, column_name))
+                continue;
+
+            /// The child can produce this value, so it must not be replaced by a default.
+            if (isSubcolumnOfAliasColumn(storage_columns, column_name))
                 continue;
 
             auto merge_column = merge_storage_snapshot->tryGetColumn(
@@ -1306,8 +1330,6 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
                 std::make_shared<ConstantNode>(merge_column->type->getDefault(), merge_column->type));
         }
 
-        auto storage_columns = storage_snapshot_->metadata->getColumns();
-
         bool with_aliases = /* common_processed_stage == QueryProcessingStage::FetchColumns && */ !storage_columns.getAliases().empty();
         if (with_aliases)
         {
@@ -1317,34 +1339,41 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
                 /// Try to resolve column, including subcolumns (e.g. JSON sub-paths like json.x).
                 auto resolved_pair = storage_snapshot_->tryGetColumn(get_column_options, column);
 
-                /// Skip columns that don't exist in this table. It may happen when we use merge over tables with different schemas.
-                if (!resolved_pair)
-                    continue;
-
                 const auto column_default = storage_columns.getDefault(column);
                 bool is_alias = column_default && column_default->kind == ColumnDefaultKind::Alias;
+
+                /// Such a name resolves through neither lookup above, and the analyzer turns it into
+                /// `getSubcolumn` over the alias expression, so the alias branch handles it.
+                bool is_subcolumn_of_alias = !resolved_pair && !is_alias && isSubcolumnOfAliasColumn(storage_columns, column);
+
+                /// Skip columns that don't exist in this table. It may happen when we use merge over tables with different schemas.
+                if (!resolved_pair && !is_subcolumn_of_alias)
+                    continue;
 
                 QueryTreeNodePtr column_node;
 
                 // Replace all references to ALIAS columns in the query by expressions.
-                if (is_alias)
+                if (is_alias || is_subcolumn_of_alias)
                 {
                     QueryTreeNodePtr fake_node = std::make_shared<IdentifierNode>(Identifier{column});
 
                     QueryAnalysisPass query_analysis_pass(modified_query_info.table_expression);
                     query_analysis_pass.run(fake_node, modified_context);
 
+                    /// An ALIAS column resolves to a ColumnNode carrying its expression, a subcolumn
+                    /// of one to a FunctionNode that owns no expression of its own.
                     auto * resolved_column = fake_node->as<ColumnNode>();
+                    if (is_subcolumn_of_alias ? !fake_node->as<FunctionNode>() : (!resolved_column || !resolved_column->getExpression()))
+                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Alias column {} is not resolved", column);
+
+                    auto column_type = fake_node->getResultType();
 
                     column_node = fake_node;
                     ApplyAliasColumnExpressionsVisitor visitor(replacement_table_expression);
                     visitor.visit(column_node);
 
-                    if (!resolved_column || !resolved_column->getExpression())
-                        throw Exception(ErrorCodes::LOGICAL_ERROR, "Alias column is not resolved");
-
                     column_name_to_node.emplace(column, column_node);
-                    aliases.push_back({ .name = column, .type = resolved_column->getResultType(), .expression = column_node->toAST() });
+                    aliases.push_back({ .name = column, .type = column_type, .expression = column_node->toAST() });
                 }
                 else
                 {

--- a/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.reference
+++ b/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.reference
@@ -1,0 +1,14 @@
+array size0	5	5
+array size0 subcolumns on	5	5
+array size0 with parent	5	5
+array size0 with other column	5	0
+array size0 via merge()	5	5
+tuple element	1	1
+string size	5	5
+nullable null	1	1
+nested element	4	4
+row policy	10	10
+materialized parent	3	3
+default parent	4	4
+missing column	1	3
+missing column	2	0

--- a/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.reference
+++ b/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.reference
@@ -3,6 +3,9 @@ array size0 subcolumns on	5	5
 array size0 with parent	5	5
 array size0 with other column	5	0
 array size0 via merge()	5	5
+dep alias size0	9	9
+dep alias size0 with parent	9	9
+dep alias size0 with dep	9	7	11
 tuple element	1	1
 string size	5	5
 nullable null	1	1

--- a/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.sql
+++ b/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.sql
@@ -1,0 +1,122 @@
+-- Tags: no-old-analyzer
+--       no-old-analyzer: the old analyzer never resolves a subcolumn of an ALIAS parent, so every
+--       arm would raise UNKNOWN_IDENTIFIER; the explicit `SETTINGS enable_analyzer = 0` arm below
+--       is what covers it.
+
+-- Each arm prints the value read through the Merge table next to the same value read straight from
+-- the child. They must agree, and the truth must differ from the type default, or a broken read
+-- returning the default would still pass.
+
+DROP TABLE IF EXISTS t_arr;
+DROP TABLE IF EXISTS m_arr;
+CREATE TABLE t_arr (n UInt64, tiny UInt8, arr Array(UInt8) ALIAS [1, 2, 3, 4, 5]) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_arr (n, tiny) VALUES (77, 0);
+CREATE TABLE m_arr (arr Array(UInt8), tiny UInt8, n UInt64) ENGINE = Merge(currentDatabase(), '^t_arr$');
+
+SELECT 'array size0', (SELECT arr.size0 FROM m_arr) AS through_merge, (SELECT arr.size0 FROM t_arr) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'array size0 subcolumns on', (SELECT arr.size0 FROM m_arr) AS through_merge, (SELECT arr.size0 FROM t_arr) AS direct SETTINGS optimize_functions_to_subcolumns = 1;
+
+-- The subcolumn and its parent in one row: both must describe the same value.
+SELECT 'array size0 with parent', arr.size0, length(arr) FROM m_arr SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'array size0 with other column', arr.size0, tiny FROM m_arr SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'array size0 via merge()', (SELECT arr.size0 FROM merge(currentDatabase(), '^t_arr$')) AS through_merge, (SELECT arr.size0 FROM t_arr) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+
+-- The old analyzer never resolved the name; it must keep failing loudly rather than start guessing.
+SELECT arr.size0 FROM m_arr SETTINGS enable_analyzer = 0, optimize_functions_to_subcolumns = 0; -- { serverError UNKNOWN_IDENTIFIER }
+
+DROP TABLE IF EXISTS t_tup;
+DROP TABLE IF EXISTS m_tup;
+CREATE TABLE t_tup (n UInt64, tup Tuple(a UInt8, b UInt8) ALIAS tuple(1, 2)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_tup (n) VALUES (1);
+CREATE TABLE m_tup (tup Tuple(a UInt8, b UInt8), n UInt64) ENGINE = Merge(currentDatabase(), '^t_tup$');
+SELECT 'tuple element', (SELECT tup.a FROM m_tup) AS through_merge, (SELECT tup.a FROM t_tup) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+
+DROP TABLE IF EXISTS t_str;
+DROP TABLE IF EXISTS m_str;
+CREATE TABLE t_str (n UInt64, s String ALIAS 'hello') ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_str (n) VALUES (1);
+CREATE TABLE m_str (s String, n UInt64) ENGINE = Merge(currentDatabase(), '^t_str$');
+SELECT 'string size', (SELECT s.size FROM m_str) AS through_merge, (SELECT s.size FROM t_str) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+
+-- The alias value is NULL, so the truth is 1 and cannot be confused with the UInt8 default.
+DROP TABLE IF EXISTS t_null;
+DROP TABLE IF EXISTS m_null;
+CREATE TABLE t_null (n UInt64, v Nullable(UInt64) ALIAS CAST(NULL, 'Nullable(UInt64)')) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_null (n) VALUES (1);
+CREATE TABLE m_null (v Nullable(UInt64), n UInt64) ENGINE = Merge(currentDatabase(), '^t_null$');
+SELECT 'nullable null', (SELECT v.null FROM m_null) AS through_merge, (SELECT v.null FROM t_null) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+
+DROP TABLE IF EXISTS t_nest;
+DROP TABLE IF EXISTS m_nest;
+CREATE TABLE t_nest (n UInt64, tup Tuple(a Tuple(b UInt8), c UInt8) ALIAS tuple(tuple(4), 9)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nest (n) VALUES (1);
+CREATE TABLE m_nest (tup Tuple(a Tuple(b UInt8), c UInt8), n UInt64) ENGINE = Merge(currentDatabase(), '^t_nest$');
+SELECT 'nested element', (SELECT tup.a.b FROM m_nest) AS through_merge, (SELECT tup.a.b FROM t_nest) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+
+-- Map has no readable subcolumn on the Merge table either, so this stays a loud error.
+DROP TABLE IF EXISTS t_map;
+DROP TABLE IF EXISTS m_map;
+CREATE TABLE t_map (n UInt64, mp Map(String, UInt8) ALIAS map('k', 1)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_map (n) VALUES (1);
+CREATE TABLE m_map (mp Map(String, UInt8), n UInt64) ENGINE = Merge(currentDatabase(), '^t_map$');
+SELECT mp.size0 FROM m_map SETTINGS optimize_functions_to_subcolumns = 0; -- { serverError NO_SUCH_COLUMN_IN_TABLE }
+
+-- A row policy on the child must still bound which rows the subcolumn is computed over.
+DROP TABLE IF EXISTS t_pol;
+DROP TABLE IF EXISTS m_pol;
+CREATE TABLE t_pol (n UInt64, arr Array(UInt8) ALIAS [1, 2, 3, 4, 5]) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_pol (n) VALUES (1), (2), (3);
+CREATE TABLE m_pol (arr Array(UInt8), n UInt64) ENGINE = Merge(currentDatabase(), '^t_pol$');
+DROP ROW POLICY IF EXISTS p_04738 ON t_pol;
+CREATE ROW POLICY p_04738 ON t_pol USING n > 1 TO ALL;
+SELECT 'row policy', (SELECT sum(arr.size0) FROM m_pol) AS through_merge, (SELECT sum(arr.size0) FROM t_pol) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+DROP ROW POLICY p_04738 ON t_pol;
+
+-- Parents whose subcolumns are registered were already correct and must stay untouched.
+DROP TABLE IF EXISTS t_mat;
+DROP TABLE IF EXISTS m_mat;
+CREATE TABLE t_mat (n UInt64, arr Array(UInt8) MATERIALIZED [1, 2, 3]) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_mat (n) VALUES (1);
+CREATE TABLE m_mat (arr Array(UInt8), n UInt64) ENGINE = Merge(currentDatabase(), '^t_mat$');
+SELECT 'materialized parent', (SELECT arr.size0 FROM m_mat) AS through_merge, (SELECT arr.size0 FROM t_mat) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+
+DROP TABLE IF EXISTS t_def;
+DROP TABLE IF EXISTS m_def;
+CREATE TABLE t_def (n UInt64, arr Array(UInt8) DEFAULT [1, 2, 3, 4]) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_def (n) VALUES (1);
+CREATE TABLE m_def (arr Array(UInt8), n UInt64) ENGINE = Merge(currentDatabase(), '^t_def$');
+SELECT 'default parent', (SELECT arr.size0 FROM m_def) AS through_merge, (SELECT arr.size0 FROM t_def) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+
+-- A child that really lacks the column still gets the type default, which is what makes Merge over
+-- differing schemas work. t_miss_b has no arr; only t_miss_a contributes a value.
+DROP TABLE IF EXISTS t_miss_a;
+DROP TABLE IF EXISTS t_miss_b;
+DROP TABLE IF EXISTS m_miss;
+CREATE TABLE t_miss_a (n UInt64, arr Array(UInt8), al UInt8 ALIAS 9) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_miss_a (n, arr) VALUES (1, [1, 2, 3]);
+CREATE TABLE t_miss_b (n UInt64, al UInt8 ALIAS 9) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_miss_b (n) VALUES (2);
+CREATE TABLE m_miss (n UInt64, arr Array(UInt8)) ENGINE = Merge(currentDatabase(), '^t_miss_');
+SELECT 'missing column', n, arr.size0 FROM m_miss ORDER BY n SETTINGS optimize_functions_to_subcolumns = 0;
+
+DROP TABLE IF EXISTS t_arr;
+DROP TABLE IF EXISTS m_arr;
+DROP TABLE IF EXISTS t_tup;
+DROP TABLE IF EXISTS m_tup;
+DROP TABLE IF EXISTS t_str;
+DROP TABLE IF EXISTS m_str;
+DROP TABLE IF EXISTS t_null;
+DROP TABLE IF EXISTS m_null;
+DROP TABLE IF EXISTS t_nest;
+DROP TABLE IF EXISTS m_nest;
+DROP TABLE IF EXISTS t_map;
+DROP TABLE IF EXISTS m_map;
+DROP TABLE IF EXISTS t_pol;
+DROP TABLE IF EXISTS m_pol;
+DROP TABLE IF EXISTS t_mat;
+DROP TABLE IF EXISTS m_mat;
+DROP TABLE IF EXISTS t_def;
+DROP TABLE IF EXISTS m_def;
+DROP TABLE IF EXISTS t_miss_a;
+DROP TABLE IF EXISTS t_miss_b;
+DROP TABLE IF EXISTS m_miss;

--- a/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.sql
+++ b/tests/queries/0_stateless/04738_merge_subcolumn_of_alias_parent.sql
@@ -24,6 +24,19 @@ SELECT 'array size0 via merge()', (SELECT arr.size0 FROM merge(currentDatabase()
 -- The old analyzer never resolved the name; it must keep failing loudly rather than start guessing.
 SELECT arr.size0 FROM m_arr SETTINGS enable_analyzer = 0, optimize_functions_to_subcolumns = 0; -- { serverError UNKNOWN_IDENTIFIER }
 
+-- Here the alias expression reads a physical column, so the child must be asked for `dep`.
+-- `dep + 2` keeps the size0 truth (9), `dep` (7) and `first` (11) distinct: with a plain
+-- `range(dep)` the truth would equal `dep`, and a read landing on `dep` would look correct.
+DROP TABLE IF EXISTS t_dep;
+DROP TABLE IF EXISTS m_dep;
+CREATE TABLE t_dep (first UInt64, tiny UInt8, dep UInt64, arr Array(UInt64) ALIAS range(dep + 2)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_dep (first, tiny, dep) VALUES (11, 0, 7);
+CREATE TABLE m_dep (arr Array(UInt64), tiny UInt8, dep UInt64, first UInt64) ENGINE = Merge(currentDatabase(), '^t_dep$');
+
+SELECT 'dep alias size0', (SELECT arr.size0 FROM m_dep) AS through_merge, (SELECT arr.size0 FROM t_dep) AS direct SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'dep alias size0 with parent', arr.size0, length(arr) FROM m_dep SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'dep alias size0 with dep', arr.size0, dep, first FROM m_dep SETTINGS optimize_functions_to_subcolumns = 0;
+
 DROP TABLE IF EXISTS t_tup;
 DROP TABLE IF EXISTS m_tup;
 CREATE TABLE t_tup (n UInt64, tup Tuple(a UInt8, b UInt8) ALIAS tuple(1, 2)) ENGINE = MergeTree ORDER BY tuple();
@@ -101,6 +114,8 @@ SELECT 'missing column', n, arr.size0 FROM m_miss ORDER BY n SETTINGS optimize_f
 
 DROP TABLE IF EXISTS t_arr;
 DROP TABLE IF EXISTS m_arr;
+DROP TABLE IF EXISTS t_dep;
+DROP TABLE IF EXISTS m_dep;
 DROP TABLE IF EXISTS t_tup;
 DROP TABLE IF EXISTS m_tup;
 DROP TABLE IF EXISTS t_str;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112975
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix reading a subcolumn (`.size0`, `.null`, a tuple element, `String.size`) through a `Merge` table when the underlying table declares the parent column as `ALIAS`. Such a read returned the type default, and when the parent was selected in the same query it could return the value of an unrelated column.

### Description

Selecting `arr.size0` from a `Merge` table returns `0` when the child declares `arr` as an `ALIAS` column, while the same query against the child returns the correct `5`:

```sql
CREATE TABLE ag (n UInt64, arr Array(UInt8) ALIAS [1,2,3,4,5]) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO ag (n) VALUES (77);
CREATE TABLE mg (arr Array(UInt8), n UInt64) ENGINE = Merge(currentDatabase(), '^ag$');
SELECT arr.size0 FROM mg;  -- 0, should be 5
```

Root cause: `ColumnsDescription::add` registers no subcolumns for an `ALIAS` column, because the value has to be extracted after the expression is evaluated. So `arr.size0` does not resolve against the child, but does against the `Merge` table, where `arr` is ordinary. `ReadFromMerge::getModifiedQueryInfo` reads that as "the child does not have this column": it substitutes a constant default, and its `with_aliases` loop skips the column, so the child is never asked for the data. With the parent also selected, alias expansion put the alias's dependency column in the child read list, and the misaligned read surfaced that value under the subcolumn's name.

The analyzer already implements the extract-after-evaluation contract, turning such a name into `getSubcolumn` over the alias expression. This teaches both guards to recognise the case and route it to the existing alias branch with the full identifier, adding no new carrier.

Also wrong for `Tuple.a`, `String.size` and `Nullable.null` (a NULL read back as non-NULL), under `optimize_functions_to_subcolumns` 0 and 1, and it mis-scoped a row policy. `Map` subcolumns raise `NO_SUCH_COLUMN_IN_TABLE` before and after. The old analyzer raises `UNKNOWN_IDENTIFIER` and is unchanged, hence the `no-old-analyzer` tag. `MATERIALIZED` and `DEFAULT` parents were already correct, and the default substitution for a child genuinely lacking a column is preserved; both have test arms.

A mistyped child (`String ALIAS` under an `Array(UInt8)` Merge column) stays as it is, because `String` has no `size0`. That conversion case is #112975.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1454` (included in `26.8` and later)
<!-- ch-version-info:end -->