### PR TITLE
Fix ANY/SEMI RIGHT JOIN with OR conditions emitting rows twice or losing matches

### DIFF
--- a/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
+++ b/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
@@ -492,18 +492,25 @@ void processMatch(
     {
         setUsed<need_filter>(added_columns.filter, i, added_columns.matched_rows);
         used_flags.template setUsed<join_features.need_flags, flag_per_row>(find_result);
-        /// setUsed already marked every row of the key's list, so addFoundRowAll does not need to call setUsedOnce on the rows it emits.
+        /// An ALL join emits a right row for each matching left row, so nothing is claimed here.
         addFoundRowAll<Map, join_features.add_missing>(mapped, added_columns, current_offset, known_rows, nullptr, is_last_disjunct);
     }
     else if constexpr ((join_features.is_any_join || join_features.is_semi_join) && join_features.right)
     {
-        /// Use first appeared left key + it needs left columns replication
-        bool used_once = used_flags.template setUsedOnce<join_features.need_flags, flag_per_row>(find_result);
-        if (used_once)
+        /// Each right row is emitted for exactly one left row, so the claimed rows must be the emitted
+        /// ones. With several disjuncts a right row is reachable through several keys, hence the claim
+        /// is taken per row by `addFoundRowAll`, which emits only what it claims.
+        if constexpr (flag_per_row)
         {
-            auto used_flags_opt = join_features.need_flags ? &used_flags : nullptr;
+            static_assert(join_features.need_flags, "RIGHT ANY/SEMI JOIN needs flags to claim the rows it emits");
+            if (addFoundRowAll<Map, join_features.add_missing>(mapped, added_columns, current_offset, known_rows, &used_flags, is_last_disjunct))
+                setUsed<need_filter>(added_columns.filter, i, added_columns.matched_rows);
+        }
+        /// A single disjunct reaches a right row through one key only, so claiming the key claims all of its rows.
+        else if (used_flags.template setUsedOnce<join_features.need_flags, flag_per_row>(find_result))
+        {
             setUsed<need_filter>(added_columns.filter, i, added_columns.matched_rows);
-            addFoundRowAll<Map, join_features.add_missing>(mapped, added_columns, current_offset, known_rows, used_flags_opt, is_last_disjunct);
+            addFoundRowAll<Map, join_features.add_missing>(mapped, added_columns, current_offset, known_rows, nullptr, is_last_disjunct);
         }
     }
     else if constexpr (join_features.is_any_join && join_features.inner)

--- a/src/Interpreters/HashJoin/KnownRowsHolder.h
+++ b/src/Interpreters/HashJoin/KnownRowsHolder.h
@@ -90,13 +90,16 @@ public:
     }
 };
 
+/// With `claim_flags` set, a row is appended only if this call wins its used flag, so it is emitted
+/// for exactly one left row; pass nullptr when a row may be emitted more than once (ALL joins).
+/// Returns whether anything was appended.
 template <typename Map, bool add_missing, bool flag_per_row, typename AddedColumns>
-void addFoundRowAll(
+bool addFoundRowAll(
     const typename Map::mapped_type & mapped,
     AddedColumns & added,
     IColumn::Offset & current_offset,
     KnownRowsHolder<flag_per_row> & known_rows [[maybe_unused]],
-    JoinStuff::JoinUsedFlags * used_flags [[maybe_unused]],
+    JoinStuff::JoinUsedFlags * claim_flags [[maybe_unused]],
     bool is_last_disjunct [[maybe_unused]])
 {
     if constexpr (add_missing)
@@ -105,26 +108,29 @@ void addFoundRowAll(
     if constexpr (flag_per_row)
     {
         std::vector<UInt64> new_known_rows;
+        bool any_row_added = false;
 
         for (const UInt64 ref_word : refsOf(mapped.word))
         {
-            if (!known_rows.isKnown(ref_word))
-            {
-                added.appendFromBlock(ref_word, false);
-                ++current_offset;
-                if (!is_last_disjunct)
-                    new_known_rows.push_back(ref_word);
+            if (known_rows.isKnown(ref_word))
+                continue;
 
-                if (used_flags)
-                {
-                    used_flags->JoinStuff::JoinUsedFlags::setUsedOnce<true, flag_per_row>(
-                        refWordBlockNo(ref_word), refWordRowNo(ref_word), 0);
-                }
-            }
+            if (claim_flags
+                && !claim_flags->JoinStuff::JoinUsedFlags::setUsedOnce<true, flag_per_row>(
+                    refWordBlockNo(ref_word), refWordRowNo(ref_word), 0))
+                continue;
+
+            added.appendFromBlock(ref_word, false);
+            ++current_offset;
+            any_row_added = true;
+            if (!is_last_disjunct)
+                new_known_rows.push_back(ref_word);
         }
 
         if (!is_last_disjunct)
             known_rows.add(std::cbegin(new_known_rows), std::cend(new_known_rows));
+
+        return any_row_added;
     }
     else if constexpr (AddedColumns::isLazy())
     {
@@ -132,6 +138,7 @@ void addFoundRowAll(
         /// (inline refs) and duplicate keys are both appended without dereferencing the node.
         added.appendFromBlock(mapped.word, false);
         current_offset += mapped.rows();
+        return true;
     }
     else
     {
@@ -142,6 +149,7 @@ void addFoundRowAll(
             added.appendFromBlock(ref_word, false);
             ++current_offset;
         }
+        return true;
     }
 }
 

--- a/tests/queries/0_stateless/04869_any_semi_right_join_or_conditions.reference
+++ b/tests/queries/0_stateless/04869_any_semi_right_join_or_conditions.reference
@@ -1,0 +1,21 @@
+one row per left row, no defaults
+1	3
+2	3
+3	3
+4	3
+count, distinct left rows, rows padded with defaults
+4	4	0
+swapped ANY LEFT JOIN
+1050	1050	50
+ANY RIGHT JOIN
+1050	1050	50
+SEMI RIGHT JOIN
+1000	1000
+swapped ANY LEFT JOIN, joined blocks split
+1050	1050	50
+SEMI RIGHT JOIN, joined blocks split
+1000	1000
+swapped ANY LEFT JOIN, residual condition
+1050	1050	50
+SEMI RIGHT JOIN, residual condition
+1000	1000

--- a/tests/queries/0_stateless/04869_any_semi_right_join_or_conditions.sql
+++ b/tests/queries/0_stateless/04869_any_semi_right_join_or_conditions.sql
@@ -1,0 +1,95 @@
+-- ANY/SEMI RIGHT JOIN emits every row of its right table at most once, and exactly once when the
+-- row has a match. With OR-ed conditions in ON a right row is reachable through several hash maps,
+-- so the row must be claimed per row and not per key.
+-- An ANY LEFT JOIN becomes an ANY RIGHT JOIN when the planner swaps the tables.
+
+DROP TABLE IF EXISTS t_or_left;
+DROP TABLE IF EXISTS t_or_head;
+DROP TABLE IF EXISTS t_or_inner;
+DROP TABLE IF EXISTS t_or_groups;
+DROP TABLE IF EXISTS t_or_probes;
+
+-- The sort keys pin the order the rows are stored and probed in, which the two focused cases below
+-- rely on to reproduce the failure.
+CREATE TABLE t_or_left (a1 Int32, b1 Int32) ENGINE = MergeTree ORDER BY a1;
+CREATE TABLE t_or_head (a2 Int32, b2 Int32, probe_order UInt8) ENGINE = MergeTree ORDER BY probe_order;
+CREATE TABLE t_or_inner (a2 Int32, b2 Int32, probe_order UInt8) ENGINE = MergeTree ORDER BY probe_order;
+
+INSERT INTO t_or_left VALUES (1, 2), (2, 2), (3, 2), (4, 2);
+-- (2, 3) matches all four left rows through the first condition, (7, 3) matches only the first
+-- left row and only through the second one, and is probed first.
+INSERT INTO t_or_head VALUES (7, 3, 0), (2, 3, 1);
+-- The same, but the row matched only through the second condition is not the first left row.
+INSERT INTO t_or_inner VALUES (6, 4, 0), (2, 3, 1);
+
+SELECT 'one row per left row, no defaults';
+SELECT a1, b2 FROM t_or_left ANY LEFT JOIN t_or_head ON b1 + 1 = a2 + 1 OR a1 + 4 = b2 + 2
+ORDER BY a1 SETTINGS max_threads = 1, query_plan_join_swap_table = 'true';
+
+SELECT 'count, distinct left rows, rows padded with defaults';
+SELECT count(), uniqExact(a1), countIf(b2 = 0) FROM
+(
+    SELECT a1, b2 FROM t_or_left ANY LEFT JOIN t_or_inner ON b1 + 1 = a2 + 1 OR a1 + 4 = b2 + 2
+) SETTINGS max_threads = 1, query_plan_join_swap_table = 'true';
+
+-- 100 groups of 10 left rows sharing `b1`, so that one probe row matches a whole group at once,
+-- while other probe rows match a single row of the group through the second condition.
+CREATE TABLE t_or_groups (a1 Int32, b1 Int32) ENGINE = MergeTree ORDER BY (b1, a1);
+CREATE TABLE t_or_probes (a2 Int32, b2 Int32) ENGINE = MergeTree ORDER BY a2;
+INSERT INTO t_or_groups SELECT number + 1, intDiv(number, 10) + 1 FROM numbers(1000);
+-- 50 more left rows that match no probe row at all: RIGHT ANY emits them once padded with
+-- defaults through the non-joined stream, RIGHT SEMI does not emit them.
+INSERT INTO t_or_groups SELECT number + 500000, 500000 FROM numbers(50);
+INSERT INTO t_or_probes SELECT number + 1, 100000 FROM numbers(100);
+INSERT INTO t_or_probes SELECT 200000, number * 10 + 1 FROM numbers(100);
+INSERT INTO t_or_probes SELECT 200000, number * 10 + 6 FROM numbers(100);
+
+SELECT 'swapped ANY LEFT JOIN';
+SELECT count(), uniqExact(a1), countIf(a2 = 0) FROM
+(
+    SELECT a1, a2 FROM t_or_groups ANY LEFT JOIN t_or_probes ON b1 = a2 OR a1 = b2
+) SETTINGS query_plan_join_swap_table = 'true';
+
+SELECT 'ANY RIGHT JOIN';
+SELECT count(), uniqExact(a1), countIf(a2 = 0) FROM
+(
+    SELECT a1, a2 FROM t_or_probes ANY RIGHT JOIN t_or_groups ON a2 = b1 OR b2 = a1
+) SETTINGS query_plan_join_swap_table = 'false';
+
+SELECT 'SEMI RIGHT JOIN';
+SELECT count(), uniqExact(a1) FROM
+(
+    SELECT a1, a2 FROM t_or_probes SEMI RIGHT JOIN t_or_groups ON a2 = b1 OR b2 = a1
+) SETTINGS query_plan_join_swap_table = 'false';
+
+SELECT 'swapped ANY LEFT JOIN, joined blocks split';
+SELECT count(), uniqExact(a1), countIf(a2 = 0) FROM
+(
+    SELECT a1, a2 FROM t_or_groups ANY LEFT JOIN t_or_probes ON b1 = a2 OR a1 = b2
+) SETTINGS query_plan_join_swap_table = 'true', max_joined_block_size_rows = 7;
+
+SELECT 'SEMI RIGHT JOIN, joined blocks split';
+SELECT count(), uniqExact(a1) FROM
+(
+    SELECT a1, a2 FROM t_or_probes SEMI RIGHT JOIN t_or_groups ON a2 = b1 OR b2 = a1
+) SETTINGS query_plan_join_swap_table = 'false', max_joined_block_size_rows = 7;
+
+-- A condition over both tables that survives as a residual is executed by another code path,
+-- which claims the rows after applying the residual filter.
+SELECT 'swapped ANY LEFT JOIN, residual condition';
+SELECT count(), uniqExact(a1), countIf(a2 = 0) FROM
+(
+    SELECT a1, a2 FROM t_or_groups ANY LEFT JOIN t_or_probes ON (b1 = a2 OR a1 = b2) AND a1 + a2 != -12345
+) SETTINGS query_plan_join_swap_table = 'true';
+
+SELECT 'SEMI RIGHT JOIN, residual condition';
+SELECT count(), uniqExact(a1) FROM
+(
+    SELECT a1, a2 FROM t_or_probes SEMI RIGHT JOIN t_or_groups ON (a2 = b1 OR b2 = a1) AND a1 + a2 != -12345
+) SETTINGS query_plan_join_swap_table = 'false';
+
+DROP TABLE t_or_left;
+DROP TABLE t_or_head;
+DROP TABLE t_or_inner;
+DROP TABLE t_or_groups;
+DROP TABLE t_or_probes;

--- a/tests/queries/0_stateless/04869_any_semi_right_join_or_conditions.sql
+++ b/tests/queries/0_stateless/04869_any_semi_right_join_or_conditions.sql
@@ -1,3 +1,5 @@
+-- Tags: no-old-analyzer
+
 -- ANY/SEMI RIGHT JOIN emits every row of its right table at most once, and exactly once when the
 -- row has a match. With OR-ed conditions in ON a right row is reachable through several hash maps,
 -- so the row must be claimed per row and not per key.


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/112640

`ANY RIGHT JOIN` and `SEMI RIGHT JOIN` emit every row of their right table at most once, and exactly once when the row has a match. With several OR-ed conditions in `ON` the claim for that was taken with a single CAS on the head row of the matched key's `RowRefList`, while `addFoundRowAll` then emitted every row of that list and discarded the result of the per-row `setUsedOnce` it called afterwards.

With `OR` a right row is reachable through several keys in several hash maps, so a per-key claim does not partition the right rows: a list whose head row was claimed through another condition was skipped whole, orphaning its other rows, and a list whose head row was still free re-emitted rows another left row had already taken. Some right rows then appeared twice and others lost their match — padded with defaults for `ANY RIGHT JOIN`, dropped entirely for `SEMI RIGHT JOIN` — varying from run to run with the probe order under `max_threads > 1`.

The claim is now taken per emitted row: `addFoundRowAll` claims a row before appending it and skips the rows whose CAS it loses, and returns whether it appended anything so the left row is filtered in only then. A single disjunct keeps the per-key claim, which is exact there, since one key owns all of its rows. The residual-condition path (`joinRightColumnsWithAdditionalFilter`) already claimed per row and is unchanged.

Besides writing `ANY RIGHT JOIN` / `SEMI RIGHT JOIN` directly, this is reached by a plain `ANY LEFT JOIN` whenever the planner swaps the tables (`query_plan_join_swap_table`, `auto` by default), which is how the issue was reported.

Measured on the reported query before and after, at `max_threads = 8`: 20 of 60 runs returned 5 or 6 rows for a 4-row left table, now 60/60 return 4. On a 1000-row shape, `SEMI RIGHT JOIN` returned 200 rows instead of 1000; `ANY LEFT JOIN` padded 416–736 rows with defaults although they had a match, and with `max_joined_block_size_rows = 7` also returned 1008 rows for 1000 left rows.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `ANY RIGHT JOIN` and `SEMI RIGHT JOIN` with several `OR`-ed conditions in the `ON` section returning some rows of the right table twice and losing the matches of others. A written `ANY LEFT JOIN` was affected too, because the planner may swap the tables and execute it as `ANY RIGHT JOIN`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.12` (included in `26.9` and later)
<!-- ch-version-info:end -->