### PR TITLE
Fix flaky 02572_query_views_log_background_thread

### DIFF
--- a/tests/queries/0_stateless/02572_query_views_log_background_thread.sh
+++ b/tests/queries/0_stateless/02572_query_views_log_background_thread.sh
@@ -22,7 +22,7 @@ ${CLICKHOUSE_CLIENT} --query="create materialized view mv_02572 to copy_02572 as
 start=$(date +%s)
 ${CLICKHOUSE_CLIENT} --query="insert into buffer_02572 values (1);"
 
-if [ $(( $(date +%s) - start )) -gt 6 ]; then  # clickhouse test cluster is overloaded, will skip
+if [ $(( $(date +%s) - start )) -le 6 ]; then  # if the insert was slow (overloaded runner), the background flush may already be done, so skip the check
     # ensure that the flush was not direct
     ${CLICKHOUSE_CLIENT} --ignore-error --query "select * from data_02572; select * from copy_02572;"
 fi


### PR DESCRIPTION

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Failure in [Stateless tests (amd_msan, WasmEdge, parallel, 2/3)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110892&sha=3cf26b73b27db84b1ae3b7957a8983a61112ff87&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29).

