### PR TITLE
Docs: Clarify `PREWHERE` behavior with `JOIN`

### DIFF
--- a/docs/reference/statements/select/index.mdx
+++ b/docs/reference/statements/select/index.mdx
@@ -32,9 +32,9 @@ SELECT [DISTINCT [ON (column1, column2, ...)]] expr_list
 [FORMAT format]
 ```
 
-All clauses are optional, except for the required list of expressions immediately after `SELECT` which is covered in more detail [below](#select-clause).
+The expression list immediately after `SELECT` is required; all other clauses are optional.
 
-Specifics of each optional clause are covered in separate sections, which are listed in the same order as they are executed (except for `SELECT` and `DISTINCT`, listed first for convenience: their expressions are evaluated only after the preceding clauses finish, as described [below](#select-clause)):
+`SELECT` and its optional clauses are covered in separate sections:
 
 - [WITH clause](/reference/statements/select/with)
 - [SELECT clause](#select-clause)

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -30,7 +30,7 @@ When `enable_analyzer = 1`, a `PREWHERE` condition in a query with a [`JOIN`](/r
 
 By contrast, a `WHERE` condition logically filters the joined result, although the optimizer may apply it before the join when doing so does not change the result. Using the same condition in `PREWHERE` and `WHERE` can therefore produce different results, particularly with outer joins.
 
-The following inner-join example uses a `PREWHERE` condition that references `table_2`:
+The following example creates two tables to demonstrate this difference:
 
 ```sql
 CREATE TABLE table_1
@@ -51,25 +51,9 @@ ORDER BY id;
 
 INSERT INTO table_1 VALUES (1, 'a'), (2, 'b'), (3, 'c');
 INSERT INTO table_2 VALUES (1, 'x'), (2, 'y'), (3, 'z');
-
-SELECT
-    table_1.id,
-    table_1.value,
-    table_2.value
-FROM table_1
-JOIN table_2 ON table_1.id = table_2.id
-PREWHERE table_2.id >= 2
-ORDER BY table_1.id;
 ```
 
-```text
-   ┌─id─┬─value─┬─table_2.value─┐
-1. │  2 │ b     │ y             │
-2. │  3 │ c     │ z             │
-   └────┴───────┴───────────────┘
-```
-
-With an outer join, moving the condition between `PREWHERE` and `WHERE` can change which rows are returned. Reusing the tables above, `PREWHERE` filters `table_2` before the `LEFT JOIN`, so the row from `table_1` with `id = 1` remains unmatched:
+In the first query, `PREWHERE` filters `table_2` before the `LEFT JOIN`, so the row from `table_1` with `id = 1` remains unmatched:
 
 ```sql
 SELECT

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -26,7 +26,7 @@ By default, `PREWHERE` is evaluated before `FINAL`, so `FROM ... FINAL` queries 
 
 ## `PREWHERE` with `JOIN` {#prewhere-with-join}
 
-When `enable_analyzer = 1`, a `PREWHERE` condition in a query with a [`JOIN`](/reference/statements/select/join) can directly reference columns from at most one table. ClickHouse applies the condition to that table's rows before they reach the join.
+A `PREWHERE` condition in a query with a [`JOIN`](/reference/statements/select/join) can directly reference columns from at most one table. ClickHouse applies the condition to that table's rows before they reach the join.
 
 By contrast, a `WHERE` condition logically filters the joined result, although the optimizer may apply it before the join when doing so does not change the result. Using the same condition in `PREWHERE` and `WHERE` can therefore produce different results, particularly with outer joins.
 

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -6,23 +6,68 @@ title: 'PREWHERE Clause'
 doc_type: 'reference'
 ---
 
-Prewhere is an optimization to apply filtering more efficiently. It is enabled by default even if `PREWHERE` clause is not specified explicitly. It works by automatically moving part of [WHERE](/reference/statements/select/where) condition to prewhere stage. The role of `PREWHERE` clause is only to control this optimization if you think that you know how to do it better than it happens by default.
+`PREWHERE` can make filtering more efficient by reducing the amount of data read. By default, ClickHouse applies this optimization, even when a query does not explicitly specify `PREWHERE`, by moving eligible conditions from [`WHERE`](/reference/statements/select/where) to `PREWHERE`. You can specify `PREWHERE` explicitly to control which conditions are applied at this stage.
 
-With prewhere optimization, at first only the columns necessary for executing prewhere expression are read. Then the other columns are read that are needed for running the rest of the query, but only those blocks where the prewhere expression is `true` at least for some rows. If there are a lot of blocks where prewhere expression is `false` for all rows and prewhere needs less columns than other parts of query, this often allows to read a lot less data from disk for query execution.
+With `PREWHERE`, ClickHouse first reads only the columns needed to evaluate the condition. It then reads the other columns required by the query only for blocks that contain at least one matching row. This can reduce the amount of data read when the condition uses fewer columns than the rest of the query and filters out many blocks.
 
-## Controlling Prewhere Manually {#controlling-prewhere-manually}
+## Controlling `PREWHERE` manually {#controlling-prewhere-manually}
 
-The clause has the same meaning as the `WHERE` clause. The difference is in which data is read from the table. When manually controlling `PREWHERE` for filtration conditions that are used by a minority of the columns in the query, but that provide strong data filtration. This reduces the volume of data to read.
+Specify `PREWHERE` manually when a condition references a small number of columns and filters out many rows. This can reduce the amount of data read for the remaining columns.
 
-A query may simultaneously specify `PREWHERE` and `WHERE`. In this case, `PREWHERE` precedes `WHERE`.
+A query can contain both `PREWHERE` and `WHERE`. In this case, `PREWHERE` is evaluated first.
 
-If the [optimize_move_to_prewhere](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) setting is set to 0, heuristics to automatically move parts of expressions from `WHERE` to `PREWHERE` are disabled.
+Set [`optimize_move_to_prewhere`](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) to `0` to prevent ClickHouse from automatically moving conditions from `WHERE` to `PREWHERE`.
 
-If query has [FINAL](/reference/statements/select/from#final-modifier) modifier, the `PREWHERE` optimization is not always correct. It is enabled only if both settings [optimize_move_to_prewhere](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) and [optimize_move_to_prewhere_if_final](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere_if_final) are turned on.
+For queries with the [`FINAL`](/reference/statements/select/from#final-modifier) modifier, ClickHouse moves conditions from `WHERE` to `PREWHERE` only when both [`optimize_move_to_prewhere`](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere) and [`optimize_move_to_prewhere_if_final`](/reference/settings/session-settings/optimize-move-to-prewhere#optimize_move_to_prewhere_if_final) are enabled.
 
 <Note>
-The `PREWHERE` section is executed before `FINAL`, so the results of `FROM ... FINAL` queries may be skewed when using `PREWHERE` with fields not in the `ORDER BY` section of a table.
+By default, `PREWHERE` is evaluated before `FINAL`, so `FROM ... FINAL` queries may produce unexpected results when `PREWHERE` references columns outside the table's `ORDER BY` key.
 </Note>
+
+## `PREWHERE` with `JOIN` {#prewhere-with-join}
+
+When `enable_analyzer = 1`, a `PREWHERE` condition in a query with a [`JOIN`](/reference/statements/select/join) can directly reference columns from at most one table. ClickHouse applies the condition to that table's rows before they reach the join.
+
+By contrast, a `WHERE` condition logically filters the joined result, although the optimizer may apply it before the join when doing so does not change the result. Using the same condition in `PREWHERE` and `WHERE` can therefore produce different results, particularly with outer joins.
+
+The following example uses a `PREWHERE` condition that references `table_2`:
+
+```sql
+CREATE TABLE table_1
+(
+    `id` UInt32,
+    `value` String
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+CREATE TABLE table_2
+(
+    `id` UInt32,
+    `value` String
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO table_1 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+INSERT INTO table_2 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+
+SELECT
+    table_1.id,
+    table_1.value,
+    table_2.value
+FROM table_1
+JOIN table_2 ON table_1.id = table_2.id
+PREWHERE table_2.id >= 2
+ORDER BY table_1.id;
+```
+
+```text
+   ┌─id─┬─value─┬─table_2.value─┐
+1. │  2 │ b     │ y             │
+2. │  3 │ c     │ z             │
+   └────┴───────┴───────────────┘
+```
 
 ## Limitations {#limitations}
 
@@ -51,13 +96,13 @@ WHERE (B = 0) AND (C = 'x');
 
 1 row in set. Elapsed: 0.074 sec. Processed 10.00 million rows, 168.89 MB (134.98 million rows/s., 2.28 GB/s.)
 
--- let's enable tracing to see which predicate are moved to PREWHERE
+-- Enable tracing to see which predicates are moved to PREWHERE.
 set send_logs_level='debug';
 
 MergeTreeWhereOptimizer: condition "B = 0" moved to PREWHERE  
--- Clickhouse moves automatically `B = 0` to PREWHERE, but it has no sense because B is always 0.
+-- ClickHouse automatically moves B = 0 to PREWHERE, but this condition does not filter any rows because B is always 0.
 
--- Let's move other predicate `C = 'x'` 
+-- Move the more selective C = 'x' predicate to PREWHERE.
 
 SELECT count()
 FROM mydata
@@ -66,5 +111,5 @@ WHERE B = 0;
 
 1 row in set. Elapsed: 0.069 sec. Processed 10.00 million rows, 158.89 MB (144.90 million rows/s., 2.30 GB/s.)
 
--- This query with manual `PREWHERE` processes slightly less data: 158.89 MB VS 168.89 MB
+-- The query with manually specified PREWHERE processes slightly less data: 158.89 MB instead of 168.89 MB.
 ```

--- a/docs/reference/statements/select/prewhere.mdx
+++ b/docs/reference/statements/select/prewhere.mdx
@@ -30,7 +30,7 @@ When `enable_analyzer = 1`, a `PREWHERE` condition in a query with a [`JOIN`](/r
 
 By contrast, a `WHERE` condition logically filters the joined result, although the optimizer may apply it before the join when doing so does not change the result. Using the same condition in `PREWHERE` and `WHERE` can therefore produce different results, particularly with outer joins.
 
-The following example uses a `PREWHERE` condition that references `table_2`:
+The following inner-join example uses a `PREWHERE` condition that references `table_2`:
 
 ```sql
 CREATE TABLE table_1
@@ -59,6 +59,47 @@ SELECT
 FROM table_1
 JOIN table_2 ON table_1.id = table_2.id
 PREWHERE table_2.id >= 2
+ORDER BY table_1.id;
+```
+
+```text
+   ┌─id─┬─value─┬─table_2.value─┐
+1. │  2 │ b     │ y             │
+2. │  3 │ c     │ z             │
+   └────┴───────┴───────────────┘
+```
+
+With an outer join, moving the condition between `PREWHERE` and `WHERE` can change which rows are returned. Reusing the tables above, `PREWHERE` filters `table_2` before the `LEFT JOIN`, so the row from `table_1` with `id = 1` remains unmatched:
+
+```sql
+SELECT
+    table_1.id,
+    table_1.value,
+    table_2.value
+FROM table_1
+LEFT JOIN table_2 ON table_1.id = table_2.id
+PREWHERE table_2.id >= 2
+ORDER BY table_1.id;
+```
+
+```text
+   ┌─id─┬─value─┬─table_2.value─┐
+1. │  1 │ a     │               │
+2. │  2 │ b     │ y             │
+3. │  3 │ c     │ z             │
+   └────┴───────┴───────────────┘
+```
+
+Using the same condition in `WHERE` filters the joined result, removing the row with `id = 1`:
+
+```sql
+SELECT
+    table_1.id,
+    table_1.value,
+    table_2.value
+FROM table_1
+LEFT JOIN table_2 ON table_1.id = table_2.id
+WHERE table_2.id >= 2
 ORDER BY table_1.id;
 ```
 


### PR DESCRIPTION
This follow-up documents how `PREWHERE` applies to one table in a query with a `JOIN`, and why the same condition can produce different results in `PREWHERE` and `WHERE`.  Clarifies the existing prose, fixes grammar, and adding a minimal runnable example with verified output.

Related: https://github.com/ClickHouse/ClickHouse/pull/114484
Related: https://github.com/ClickHouse/ClickHouse/pull/114661

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required for a documentation change.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1428` (included in `26.8` and later)
<!-- ch-version-info:end -->