### PR TITLE
Update CLAUDE.md around tests and recurring bad habits

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -182,3 +182,9 @@ ARM machines in CI are not slow. They are similar to x86 in performance.
 Use `tmp` subdirectory in the current directory for temporary files (logs, downloads, scripts, etc.), do not use `/tmp`. Create the directory if needed.
 
 Always use YYYY-MM-DD (ISO) date format. Never write in the American date style. Never omit the year in dates. Never use the relative time (like xxx days ago).
+
+Do not try/catch exceptions to fall-back to a less-optimized case. Let the exceptions propagate.
+
+Prefer functional (.sql/.sh) tests over unit (gtest) tests whenever possible. Unit tests are larger, too specific, and they are difficult to maintain.
+
+When you want to test changes in CI, you can write and run a throwaway script, but you don't need to commit it in the repository, because we don't have automated CI tests.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -183,8 +183,8 @@ Use `tmp` subdirectory in the current directory for temporary files (logs, downl
 
 Always use YYYY-MM-DD (ISO) date format. Never write in the American date style. Never omit the year in dates. Never use the relative time (like xxx days ago).
 
-Do not try/catch exceptions to fall-back to a less-optimized case. Let the exceptions propagate.
+Do not try/catch exceptions to fall back to a less-optimized case. Let the exceptions propagate.
 
 Prefer functional (.sql/.sh) tests over unit (gtest) tests whenever possible. Unit tests are larger, too specific, and they are difficult to maintain.
 
-When you want to test changes in CI, you can write and run a throwaway script, but you don't need to commit it in the repository, because we don't have automated CI tests.
+When you want to test changes in the CI scripts, you can write and run a throwaway test, but you don't need to commit it to the repository, because we don't have automated CI tests.


### PR DESCRIPTION
Adds three notes to `.claude/CLAUDE.md`:

- Do not use try/catch to fall back to a less-optimized case; let exceptions propagate.
- Prefer functional (`.sql`/`.sh`) tests over unit (`gtest`) tests whenever possible.
- Throwaway scripts used to test changes in CI do not need to be committed.

Split out of https://github.com/ClickHouse/ClickHouse/pull/114675 so that the documentation change is reviewed separately from the removal of `ci/tests`.

Related: https://github.com/ClickHouse/ClickHouse/pull/114675

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1387` (included in `26.8` and later)
<!-- ch-version-info:end -->