### PR TITLE
Feat(PromQL): Support PromQL histogram_fraction for classic histograms

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
@@ -354,8 +354,8 @@ class AggregateFunctionFractionPrometheusHistogram final
     Float64 upper;
 
 public:
-    AggregateFunctionFractionPrometheusHistogram(const DataTypes & argument_types, const Array & params)
-        : Base(argument_types, params, std::make_shared<DataTypeFloat64>())
+    AggregateFunctionFractionPrometheusHistogram(const DataTypes & argument_types_, const Array & params)
+        : Base(argument_types_, params, std::make_shared<DataTypeFloat64>())
     {
         if (params.size() != 2)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Aggregate function {} requires two parameters", getName());

--- a/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
@@ -185,7 +185,8 @@ struct QuantilePrometheusHistogram
 
         auto clamp_rank = [&](FractionRank & rank_value, bool rank_set)
         {
-            if (!rank_set || rank_value.cumulative > count || (rank_value.cumulative == count && rank_value.fractional > 0))
+            if (!rank_set
+                || subtractCounts(rank_value.cumulative, count) + rank_value.fractional > 0)
                 rank_value = {count, 0};
         };
 

--- a/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
@@ -15,6 +15,7 @@
 #include <IO/WriteHelpers.h>
 
 #include <numeric>
+#include <type_traits>
 
 
 namespace DB
@@ -97,6 +98,12 @@ struct QuantilePrometheusHistogram
 
     Float64 getFraction(Float64 lower, Float64 upper) const
     {
+        struct FractionRank
+        {
+            CumulativeHistogramValue cumulative{};
+            Float64 fractional = 0;
+        };
+
         size_t size = map.size();
         if (size == 0)
             return std::numeric_limits<Float64>::quiet_NaN();
@@ -114,16 +121,16 @@ struct QuantilePrometheusHistogram
         if (max_bucket.first != std::numeric_limits<UnderlyingType>::infinity())
             return std::numeric_limits<Float64>::quiet_NaN();
 
-        Float64 count = static_cast<Float64>(max_bucket.second);
+        CumulativeHistogramValue count = max_bucket.second;
         if (count == 0 || isNaN(lower) || isNaN(upper))
             return std::numeric_limits<Float64>::quiet_NaN();
 
         if (lower >= upper)
             return 0;
 
-        Float64 rank = 0;
-        Float64 lower_rank = 0;
-        Float64 upper_rank = 0;
+        CumulativeHistogramValue rank = 0;
+        FractionRank lower_rank;
+        FractionRank upper_rank;
         bool lower_set = false;
         bool upper_set = false;
         Float64 lower_bound = static_cast<Float64>(array[0].first) > 0
@@ -134,23 +141,26 @@ struct QuantilePrometheusHistogram
         {
             const Pair & bucket = array[index];
             Float64 upper_bound = static_cast<Float64>(bucket.first);
-            Float64 bucket_count = static_cast<Float64>(bucket.second);
 
-            auto interpolate = [&](Float64 value)
+            auto interpolate = [&](Float64 value) -> FractionRank
             {
                 if (lower_bound == -std::numeric_limits<Float64>::infinity())
-                    return bucket_count;
-                return rank + (bucket_count - rank) * (value - lower_bound) / (upper_bound - lower_bound);
+                    return {bucket.second, 0};
+
+                /// Keep the cumulative counts exact until the bucket delta is computed.
+                /// This preserves one-count resolution for UInt64 counts above 2^53.
+                Float64 bucket_count_delta = subtractCounts(bucket.second, rank);
+                return {rank, bucket_count_delta * (value - lower_bound) / (upper_bound - lower_bound)};
             };
 
             if (!lower_set && lower_bound >= lower)
             {
-                lower_rank = rank;
+                lower_rank = {rank, 0};
                 lower_set = true;
             }
             if (!upper_set && lower_bound >= upper)
             {
-                upper_rank = rank;
+                upper_rank = {rank, 0};
                 upper_set = true;
             }
             if (lower_set && upper_set)
@@ -169,19 +179,41 @@ struct QuantilePrometheusHistogram
             if (lower_set && upper_set)
                 break;
 
-            rank = bucket_count;
+            rank = bucket.second;
             lower_bound = upper_bound;
         }
 
-        if (!lower_set || lower_rank > count)
-            lower_rank = count;
-        if (!upper_set || upper_rank > count)
-            upper_rank = count;
+        auto clamp_rank = [&](FractionRank & rank_value, bool rank_set)
+        {
+            if (!rank_set || rank_value.cumulative > count || (rank_value.cumulative == count && rank_value.fractional > 0))
+                rank_value = {count, 0};
+        };
 
-        return (upper_rank - lower_rank) / count;
+        clamp_rank(lower_rank, lower_set);
+        clamp_rank(upper_rank, upper_set);
+
+        /// Subtract cumulative counts before converting them to Float64. Converting the
+        /// individual UInt64 counts first loses one-count differences above 2^53.
+        Float64 rank_difference = subtractCounts(upper_rank.cumulative, lower_rank.cumulative);
+        rank_difference += upper_rank.fractional - lower_rank.fractional;
+        return rank_difference / static_cast<Float64>(count);
     }
 
 private:
+    static Float64 subtractCounts(CumulativeHistogramValue lhs, CumulativeHistogramValue rhs)
+    {
+        if constexpr (std::is_same_v<CumulativeHistogramValue, UInt64>)
+        {
+            if (lhs >= rhs)
+                return static_cast<Float64>(lhs - rhs);
+            return -static_cast<Float64>(rhs - lhs);
+        }
+        else
+        {
+            return lhs - rhs;
+        }
+    }
+
     Value getInterpolatedImpl(Float64 level) const
     {
         size_t size = map.size();

--- a/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantilePrometheusHistogram.cpp
@@ -2,8 +2,17 @@
 #include <AggregateFunctions/AggregateFunctionQuantile.h>
 #include <AggregateFunctions/Helpers.h>
 #include <Core/Field.h>
+#include <Common/FieldVisitorConvertToNumber.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/NaNUtils.h>
+#include <Common/assert_cast.h>
+
+#include <Columns/ColumnVector.h>
+
+#include <DataTypes/DataTypesNumber.h>
+
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
 
 #include <numeric>
 
@@ -84,6 +93,92 @@ struct QuantilePrometheusHistogram
             return;
         }
         getManyInterpolatedImpl(levels, indices, num_levels, result);
+    }
+
+    Float64 getFraction(Float64 lower, Float64 upper) const
+    {
+        size_t size = map.size();
+        if (size == 0)
+            return std::numeric_limits<Float64>::quiet_NaN();
+
+        std::unique_ptr<Pair[]> array_holder(new Pair[size]);
+        Pair * array = array_holder.get();
+
+        size_t i = 0;
+        for (const auto & pair : map)
+            array[i++] = pair.getValue();
+
+        ::sort(array, array + size, [](const Pair & a, const Pair & b) { return a.first < b.first; });
+
+        const Pair & max_bucket = array[size - 1];
+        if (max_bucket.first != std::numeric_limits<UnderlyingType>::infinity())
+            return std::numeric_limits<Float64>::quiet_NaN();
+
+        Float64 count = static_cast<Float64>(max_bucket.second);
+        if (count == 0 || isNaN(lower) || isNaN(upper))
+            return std::numeric_limits<Float64>::quiet_NaN();
+
+        if (lower >= upper)
+            return 0;
+
+        Float64 rank = 0;
+        Float64 lower_rank = 0;
+        Float64 upper_rank = 0;
+        bool lower_set = false;
+        bool upper_set = false;
+        Float64 lower_bound = static_cast<Float64>(array[0].first) > 0
+            ? 0
+            : -std::numeric_limits<Float64>::infinity();
+
+        for (size_t index = 0; index < size; ++index)
+        {
+            const Pair & bucket = array[index];
+            Float64 upper_bound = static_cast<Float64>(bucket.first);
+            Float64 bucket_count = static_cast<Float64>(bucket.second);
+
+            auto interpolate = [&](Float64 value)
+            {
+                if (lower_bound == -std::numeric_limits<Float64>::infinity())
+                    return bucket_count;
+                return rank + (bucket_count - rank) * (value - lower_bound) / (upper_bound - lower_bound);
+            };
+
+            if (!lower_set && lower_bound >= lower)
+            {
+                lower_rank = rank;
+                lower_set = true;
+            }
+            if (!upper_set && lower_bound >= upper)
+            {
+                upper_rank = rank;
+                upper_set = true;
+            }
+            if (lower_set && upper_set)
+                break;
+
+            if (!lower_set && lower_bound < lower && upper_bound > lower)
+            {
+                lower_rank = interpolate(lower);
+                lower_set = true;
+            }
+            if (!upper_set && lower_bound < upper && upper_bound > upper)
+            {
+                upper_rank = interpolate(upper);
+                upper_set = true;
+            }
+            if (lower_set && upper_set)
+                break;
+
+            rank = bucket_count;
+            lower_bound = upper_bound;
+        }
+
+        if (!lower_set || lower_rank > count)
+            lower_rank = count;
+        if (!upper_set || upper_rank > count)
+            upper_rank = count;
+
+        return (upper_rank - lower_rank) / count;
     }
 
 private:
@@ -212,6 +307,65 @@ using FuncQuantilesPrometheusHistogram = AggregateFunctionQuantile<
     true,
     false>;
 
+struct NameFractionPrometheusHistogram { static constexpr auto name = "fractionPrometheusHistogram"; };
+
+template <typename Value, typename CumulativeHistogramValue>
+class AggregateFunctionFractionPrometheusHistogram final
+    : public IAggregateFunctionDataHelper<
+        QuantilePrometheusHistogram<Value, CumulativeHistogramValue>,
+        AggregateFunctionFractionPrometheusHistogram<Value, CumulativeHistogramValue>>
+{
+    using Data = QuantilePrometheusHistogram<Value, CumulativeHistogramValue>;
+    using Base = IAggregateFunctionDataHelper<Data, AggregateFunctionFractionPrometheusHistogram<Value, CumulativeHistogramValue>>;
+
+    Float64 lower;
+    Float64 upper;
+
+public:
+    AggregateFunctionFractionPrometheusHistogram(const DataTypes & argument_types, const Array & params)
+        : Base(argument_types, params, std::make_shared<DataTypeFloat64>())
+    {
+        if (params.size() != 2)
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Aggregate function {} requires two parameters", getName());
+
+        lower = applyVisitor(FieldVisitorConvertToNumber<Float64>(), params[0]);
+        upper = applyVisitor(FieldVisitorConvertToNumber<Float64>(), params[1]);
+    }
+
+    String getName() const override { return NameFractionPrometheusHistogram::name; }
+
+    bool allocatesMemoryInArena() const override { return false; }
+
+    void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena *) const override
+    {
+        auto value = static_cast<const ColumnVectorOrDecimal<Value> &>(*columns[0]).getData()[row_num];
+        if constexpr (std::is_same_v<CumulativeHistogramValue, UInt64>)
+            this->data(place).add(value, columns[1]->getUInt(row_num));
+        else
+            this->data(place).add(value, columns[1]->getFloat64(row_num));
+    }
+
+    void mergeImpl(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena *) const override
+    {
+        this->data(place).merge(this->data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    {
+        this->data(place).serialize(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    {
+        this->data(place).deserialize(buf);
+    }
+
+    void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena *) const override
+    {
+        assert_cast<ColumnFloat64 &>(to).getData().push_back(this->data(place).getFraction(lower, upper));
+    }
+};
+
 template <template <typename, typename> class Function>
 AggregateFunctionPtr createAggregateFunctionQuantile(
     const std::string & name, const DataTypes & argument_types, const Array & params, const Settings *)
@@ -332,6 +486,10 @@ FROM VALUES('bucket_upper_bound Float64, cumulative_bucket_value UInt64', (0, 6)
     FunctionDocumentation documentation_quantilesPrometheusHistogram = {description_quantilesPrometheusHistogram, syntax_quantilesPrometheusHistogram, arguments_quantilesPrometheusHistogram, parameters_quantilesPrometheusHistogram, returned_value_quantilesPrometheusHistogram, examples_quantilesPrometheusHistogram, introduced_in_quantilesPrometheusHistogram, category_quantilesPrometheusHistogram};
 
     factory.registerFunction(NameQuantilesPrometheusHistogram::name, {createAggregateFunctionQuantile<FuncQuantilesPrometheusHistogram>, documentation_quantilesPrometheusHistogram, properties});
+
+    factory.registerFunction(NameFractionPrometheusHistogram::name, {
+        createAggregateFunctionQuantile<AggregateFunctionFractionPrometheusHistogram>,
+        FunctionDocumentation::INTERNAL_FUNCTION_DOCS});
 }
 
 }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunction.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunction.cpp
@@ -65,6 +65,9 @@ SQLQueryPiece applyFunction(
     if (isHistogramQuantile(function_name))
         return applyHistogramQuantile(function_node, std::move(arguments), context);
 
+    if (isHistogramFraction(function_name))
+        return applyHistogramFraction(function_node, std::move(arguments), context);
+
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Function {} is not implemented", function_name);
 }
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyHistogramQuantile.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyHistogramQuantile.cpp
@@ -60,12 +60,93 @@ namespace
                             getPromQLText(vector_arg, context), vector_arg.type);
         }
     }
+
+    template <typename BuildValuesExpression>
+    SQLQueryPiece applyHistogramFunction(
+        const PrometheusQueryTree::Function * function_node,
+        SQLQueryPiece expression,
+        ConverterContext & context,
+        BuildValuesExpression && build_values_expression)
+    {
+        ASTPtr aggregation_query;
+        {
+            SelectQueryBuilder builder;
+
+            /// Keep `__name__` in the group key so distinct histograms remain separate. It is
+            /// removed from the result below after the aggregate has been evaluated.
+            auto new_group_expr = makeASTFunction(
+                "timeSeriesRemoveTag",
+                make_intrusive<ASTIdentifier>(ColumnNames::Group),
+                make_intrusive<ASTLiteral>("le"));
+            new_group_expr->setAlias(ColumnNames::NewGroup);
+            builder.select_list.push_back(std::move(new_group_expr));
+
+            auto le_array_expr = makeASTFunction(
+                "arrayResize",
+                makeASTFunction("CAST",
+                    make_intrusive<ASTLiteral>(Array{}),
+                    make_intrusive<ASTLiteral>("Array(Float64)")),
+                makeASTFunction("length", make_intrusive<ASTIdentifier>(ColumnNames::Values)),
+                makeASTFunction("ifNull",
+                    makeASTFunction("toFloat64OrNull",
+                        makeASTFunction("timeSeriesExtractTag",
+                            make_intrusive<ASTIdentifier>(ColumnNames::Group),
+                            make_intrusive<ASTLiteral>("le"))),
+                    make_intrusive<ASTLiteral>(std::numeric_limits<Float64>::quiet_NaN())));
+
+            auto values_expr = build_values_expression(std::move(le_array_expr));
+            values_expr->setAlias(ColumnNames::Values);
+            builder.select_list.push_back(std::move(values_expr));
+
+            context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(expression.select_query), SQLSubqueryType::TABLE});
+            builder.from_table = context.subqueries.back().name;
+
+            /// Prometheus silently drops input series whose `le` label is missing or cannot be
+            /// parsed as a float, so a pure non-histogram input produces an empty result.
+            builder.where = makeASTFunction("isNotNull",
+                makeASTFunction("toFloat64OrNull",
+                    makeASTFunction("timeSeriesExtractTag",
+                        make_intrusive<ASTIdentifier>(ColumnNames::Group),
+                        make_intrusive<ASTLiteral>("le"))));
+
+            builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+            aggregation_query = builder.getSelectQuery();
+        }
+
+        ASTPtr column_renaming_query;
+        {
+            SelectQueryBuilder builder;
+
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+            builder.select_list.back()->setAlias(ColumnNames::Group);
+            builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
+
+            context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(aggregation_query), SQLSubqueryType::TABLE});
+            builder.from_table = context.subqueries.back().name;
+            column_renaming_query = builder.getSelectQuery();
+        }
+
+        SQLQueryPiece res{function_node, function_node->result_type, StoreMethod::VECTOR_GRID};
+        res.select_query = std::move(column_renaming_query);
+        res.start_time = expression.start_time;
+        res.end_time = expression.end_time;
+        res.step = expression.step;
+        res.metric_name_dropped = false;
+
+        /// PromQL histogram functions do not preserve the input metric name.
+        return dropMetricName(std::move(res), context);
+    }
 }
 
 
 bool isHistogramQuantile(std::string_view function_name)
 {
     return function_name == "histogram_quantile";
+}
+
+bool isHistogramFraction(std::string_view function_name)
+{
+    return function_name == "histogram_fraction";
 }
 
 SQLQueryPiece applyHistogramQuantile(
@@ -91,34 +172,8 @@ SQLQueryPiece applyHistogramQuantile(
 
     Float64 phi = phi_arg.scalar_value;
 
-    /// Step 1: Extract le tags, group by non-le labels (keeping __name__ so that
-    /// distinct histograms remain separate), and compute quantile.
-    /// SELECT timeSeriesRemoveTag(group, 'le') AS new_group,
-    ///        quantilePrometheusHistogramForEach(phi)(
-    ///            arrayResize(CAST([] AS Array(Float64)), length(values),
-    ///                ifNull(toFloat64OrNull(timeSeriesExtractTag(group, 'le')), nan)),
-    ///            values) AS values
-    /// FROM <subquery>
-    /// WHERE isNotNull(toFloat64OrNull(timeSeriesExtractTag(group, 'le')))
-    /// GROUP BY new_group
-    ASTPtr aggregation_query;
+    auto build_quantile_expression = [phi](ASTPtr le_array_expr)
     {
-        SelectQueryBuilder builder;
-
-        /// new_group expression: remove only the `le` tag. Keep `__name__` in the
-        /// group key so a query that selects multiple `*_bucket` metrics with the
-        /// same non-name labels (for example `{__name__=~"a_bucket|b_bucket"}` or
-        /// `a_bucket or b_bucket`) keeps each histogram's quantile separate. We
-        /// drop `__name__` afterwards through `dropMetricName`, which preserves
-        /// PromQL's "function output has no metric name" semantics while still
-        /// enforcing the no-duplicate-labelset rule via timeSeriesThrowDuplicateSeriesIf.
-        auto new_group_expr = makeASTFunction(
-            "timeSeriesRemoveTag",
-            make_intrusive<ASTIdentifier>(ColumnNames::Group),
-            make_intrusive<ASTLiteral>("le"));
-        new_group_expr->setAlias(ColumnNames::NewGroup);
-        builder.select_list.push_back(std::move(new_group_expr));
-
         /// PromQL `histogram_quantile` has constant out-of-range semantics:
         ///   phi < 0  -> -Inf for every time step
         ///   phi > 1  -> +Inf for every time step
@@ -126,22 +181,19 @@ SQLQueryPiece applyHistogramQuantile(
         /// These short-circuits happen before looking at the histogram, so instead of
         /// calling quantilePrometheusHistogramForEach we emit a constant-valued array
         /// aligned to the time grid (preserving NULL at positions where no input existed).
-        ASTPtr quantile_expr;
         if (std::isnan(phi) || phi < 0.0 || phi > 1.0)
         {
             Float64 out_of_range_value = std::numeric_limits<Float64>::quiet_NaN();
-            if (std::isnan(phi))
-                out_of_range_value = std::numeric_limits<Float64>::quiet_NaN();
-            else if (phi < 0.0)
+            if (phi < 0.0)
                 out_of_range_value = -std::numeric_limits<Float64>::infinity();
-            else
+            else if (phi > 1.0)
                 out_of_range_value = std::numeric_limits<Float64>::infinity();
 
             /// arrayMap(x -> if(isNotNull(x), <constant>, NULL), anyForEach(values))
             /// anyForEach produces one array per group aligned to the time grid, with NULL at
             /// positions where no input series had data. arrayMap then replaces every non-NULL
             /// position with the constant and keeps NULLs as-is.
-            quantile_expr = makeASTFunction(
+            return makeASTFunction(
                 "arrayMap",
                 makeASTFunction(
                     "lambda",
@@ -152,84 +204,96 @@ SQLQueryPiece applyHistogramQuantile(
                         make_intrusive<ASTLiteral>(Field{} /* NULL */))),
                 makeASTFunction("anyForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
         }
-        else
-        {
-            /// quantilePrometheusHistogramForEach(phi)(le_array, values)
-            ///
-            /// le_array is constructed for each row as an array of the same length as values,
-            /// filled with the extracted `le` tag value. Series without a parsable `le` are
-            /// excluded by the WHERE clause added below, so the NaN fallback here is just a
-            /// safety net — `quantilePrometheusHistogramForEach` treats NaN `le` as
-            /// "ignore this bucket".
-            auto le_array_expr = makeASTFunction(
-                "arrayResize",
-                makeASTFunction("CAST",
-                    make_intrusive<ASTLiteral>(Array{}),
-                    make_intrusive<ASTLiteral>("Array(Float64)")),
-                makeASTFunction("length", make_intrusive<ASTIdentifier>(ColumnNames::Values)),
-                makeASTFunction("ifNull",
-                    makeASTFunction("toFloat64OrNull",
-                        makeASTFunction("timeSeriesExtractTag",
-                            make_intrusive<ASTIdentifier>(ColumnNames::Group),
-                            make_intrusive<ASTLiteral>("le"))),
-                    make_intrusive<ASTLiteral>(std::numeric_limits<Float64>::quiet_NaN())));
 
-            quantile_expr = addParametersToAggregateFunction(
-                makeASTFunction("quantilePrometheusHistogramForEach",
-                    std::move(le_array_expr),
-                    make_intrusive<ASTIdentifier>(ColumnNames::Values)),
-                make_intrusive<ASTLiteral>(phi));
+        /// quantilePrometheusHistogramForEach(phi)(le_array, values)
+        ///
+        /// `le_array` is constructed for each row as an array of the same length as values,
+        /// filled with the extracted `le` tag value. Series without a parsable `le` are
+        /// excluded by the shared WHERE clause, so the NaN fallback here is just a safety net.
+        return addParametersToAggregateFunction(
+            makeASTFunction("quantilePrometheusHistogramForEach",
+                std::move(le_array_expr),
+                make_intrusive<ASTIdentifier>(ColumnNames::Values)),
+            make_intrusive<ASTLiteral>(phi));
+    };
+
+    return applyHistogramFunction(function_node, std::move(expression), context, std::move(build_quantile_expression));
+}
+
+namespace
+{
+    void checkHistogramFractionArgumentTypes(
+        const PrometheusQueryTree::Function * function_node,
+        const std::vector<SQLQueryPiece> & arguments,
+        const ConverterContext & context)
+    {
+        const auto & function_name = function_node->function_name;
+
+        if (arguments.size() != 3)
+        {
+            throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                            "Function '{}' expects 3 arguments, but was called with {} arguments",
+                            function_name, arguments.size());
         }
 
-        quantile_expr->setAlias(ColumnNames::Values);
-        builder.select_list.push_back(std::move(quantile_expr));
+        for (size_t i = 0; i < 2; ++i)
+        {
+            const auto & argument = arguments[i];
+            if (argument.type != ResultType::SCALAR)
+            {
+                throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                                "Function '{}' expects argument {} of type {}, but expression {} has type {}",
+                                function_name, i + 1, ResultType::SCALAR,
+                                getPromQLText(argument, context), argument.type);
+            }
+        }
 
-        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(expression.select_query), SQLSubqueryType::TABLE});
-        builder.from_table = context.subqueries.back().name;
-
-        /// Prometheus silently drops input series whose `le` label is missing or cannot be
-        /// parsed as a float, so for example a pure non-histogram input produces an empty
-        /// result. This filter applies before the out-of-range phi short-circuit above:
-        /// even for an out-of-range phi only series with a parsable `le` produce output.
-        builder.where = makeASTFunction("isNotNull",
-            makeASTFunction("toFloat64OrNull",
-                makeASTFunction("timeSeriesExtractTag",
-                    make_intrusive<ASTIdentifier>(ColumnNames::Group),
-                    make_intrusive<ASTLiteral>("le"))));
-
-        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
-
-        aggregation_query = builder.getSelectQuery();
+        const auto & vector_arg = arguments[2];
+        if (vector_arg.type != ResultType::INSTANT_VECTOR)
+        {
+            throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                            "Function '{}' expects third argument of type {}, but expression {} has type {}",
+                            function_name, ResultType::INSTANT_VECTOR,
+                            getPromQLText(vector_arg, context), vector_arg.type);
+        }
     }
+}
 
-    /// Step 2: Rename new_group -> group.
-    ASTPtr column_renaming_query;
+SQLQueryPiece applyHistogramFraction(
+    const PrometheusQueryTree::Function * function_node,
+    std::vector<SQLQueryPiece> && arguments,
+    ConverterContext & context)
+{
+    checkHistogramFractionArgumentTypes(function_node, arguments, context);
+
+    auto & lower_arg = arguments[0];
+    auto & upper_arg = arguments[1];
+    auto & expression = arguments[2];
+
+    if (lower_arg.store_method != StoreMethod::CONST_SCALAR || upper_arg.store_method != StoreMethod::CONST_SCALAR)
     {
-        SelectQueryBuilder builder;
-
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
-        builder.select_list.back()->setAlias(ColumnNames::Group);
-
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
-
-        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(aggregation_query), SQLSubqueryType::TABLE});
-        builder.from_table = context.subqueries.back().name;
-
-        column_renaming_query = builder.getSelectQuery();
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+            "Function 'histogram_fraction' currently requires constant lower and upper parameters");
     }
 
-    SQLQueryPiece res{function_node, function_node->result_type, StoreMethod::VECTOR_GRID};
-    res.select_query = std::move(column_renaming_query);
-    res.start_time = expression.start_time;
-    res.end_time = expression.end_time;
-    res.step = expression.step;
-    res.metric_name_dropped = false;
+    expression = toVectorGrid(std::move(expression), context);
 
-    /// Drop `__name__` from the result (matching PromQL: function outputs have no
-    /// metric name). `dropMetricName` also enforces uniqueness via
-    /// `timeSeriesThrowDuplicateSeriesIf`, which is the right behavior if removing
-    /// `__name__` would produce two output series with identical labels.
-    return dropMetricName(std::move(res), context);
+    if (expression.store_method == StoreMethod::EMPTY)
+        return SQLQueryPiece{function_node, function_node->result_type, StoreMethod::EMPTY};
+
+    const Float64 lower = lower_arg.scalar_value;
+    const Float64 upper = upper_arg.scalar_value;
+    auto build_fraction_expression = [lower, upper](ASTPtr le_array_expr)
+    {
+        return addParametersToAggregateFunction(
+            makeASTFunction("fractionPrometheusHistogramForEach",
+                std::move(le_array_expr),
+                make_intrusive<ASTIdentifier>(ColumnNames::Values)),
+            make_intrusive<ASTLiteral>(lower),
+            make_intrusive<ASTLiteral>(upper));
+    };
+
+    return applyHistogramFunction(function_node, std::move(expression), context, std::move(build_fraction_expression));
 }
 
 }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyHistogramQuantile.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyHistogramQuantile.h
@@ -8,8 +8,17 @@ namespace DB::PrometheusQueryToSQL
 /// Checks if a function name is histogram_quantile.
 bool isHistogramQuantile(std::string_view function_name);
 
+/// Checks if a function name is histogram_fraction.
+bool isHistogramFraction(std::string_view function_name);
+
 /// Applies the histogram_quantile function to its arguments.
 SQLQueryPiece applyHistogramQuantile(
+    const PrometheusQueryTree::Function * function_node,
+    std::vector<SQLQueryPiece> && arguments,
+    ConverterContext & context);
+
+/// Applies the histogram_fraction function to its arguments.
+SQLQueryPiece applyHistogramFraction(
     const PrometheusQueryTree::Function * function_node,
     std::vector<SQLQueryPiece> && arguments,
     ConverterContext & context);

--- a/src/TableFunctions/TableFunctionTimeSeries.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeries.cpp
@@ -270,10 +270,10 @@ Instant selectors, range selectors, label matchers (`=`, `!=`, `=~`, `!~`), offs
 | DateTime | `day_of_week`, `day_of_month`, `days_in_month`, `day_of_year`, `minute`, `hour`, `month`, `year` |
 | Label | `label_replace`, `label_join` |
 | Type | `scalar`, `vector` |
-| Histogram | `histogram_quantile` |
+| Histogram | `histogram_quantile`, `histogram_fraction` |
 | Other | `time`, `pi`, `absent` |
 
-**Note**: `histogram_quantile` uses linear interpolation on classic histogram buckets (identified by the `le` label). Native histograms are not supported. The `phi` (quantile level) argument must be a constant scalar. Expressions that vary per step, such as `histogram_quantile(time() / 1000, ...)`, are rejected with a `NOT_IMPLEMENTED` exception.
+**Note**: `histogram_quantile` and `histogram_fraction` use linear interpolation on classic histogram buckets (identified by the `le` label). Native histograms are not supported. The scalar parameters must currently be constant: `phi` for `histogram_quantile`, and `lower` and `upper` for `histogram_fraction`. Expressions that vary per step are rejected with a `NOT_IMPLEMENTED` exception.
 
 ### Operators {#operators}
 
@@ -345,10 +345,10 @@ Instant selectors, range selectors, label matchers (`=`, `!=`, `=~`, `!~`), offs
 | DateTime | `day_of_week`, `day_of_month`, `days_in_month`, `day_of_year`, `minute`, `hour`, `month`, `year` |
 | Label | `label_replace`, `label_join` |
 | Type | `scalar`, `vector` |
-| Histogram | `histogram_quantile` |
+| Histogram | `histogram_quantile`, `histogram_fraction` |
 | Other | `time`, `pi`, `absent` |
 
-**Note**: `histogram_quantile` uses linear interpolation on classic histogram buckets (identified by the `le` label). Native histograms are not supported. The `phi` (quantile level) argument must be a constant scalar. Expressions that vary per step, such as `histogram_quantile(time() / 1000, ...)`, are rejected with a `NOT_IMPLEMENTED` exception.
+**Note**: `histogram_quantile` and `histogram_fraction` use linear interpolation on classic histogram buckets (identified by the `le` label). Native histograms are not supported. The scalar parameters must currently be constant: `phi` for `histogram_quantile`, and `lower` and `upper` for `histogram_fraction`. Expressions that vary per step are rejected with a `NOT_IMPLEMENTED` exception.
 
 ### Operators {#operators}
 

--- a/tests/integration/test_prometheus_protocols/test_compliance.py
+++ b/tests/integration/test_prometheus_protocols/test_compliance.py
@@ -308,7 +308,6 @@ COMPLIANCE_TEST_CASES = [
     ('histogram_quantile(0.9, {__name__=~"demo_api_request_duration_seconds_.+"})', [], False),
 
     # Histogram fraction
-    ("histogram_fraction(0.1, 0.5, rate(demo_api_request_duration_seconds_bucket[1m]))", [], False),
     ("histogram_fraction(0.1, 0.9, nonexistent_metric)", [], False),
 
     # count_values

--- a/tests/integration/test_prometheus_protocols/test_compliance.py
+++ b/tests/integration/test_prometheus_protocols/test_compliance.py
@@ -309,7 +309,7 @@ COMPLIANCE_TEST_CASES = [
 
     # Histogram fraction
     ("histogram_fraction(0.1, 0.5, rate(demo_api_request_duration_seconds_bucket[1m]))", [], False),
-    ("histogram_fraction(0.9, nonexistent_metric)", [], False),
+    ("histogram_fraction(0.1, 0.9, nonexistent_metric)", [], False),
 
     # count_values
     ('count_values("value", demo_api_request_duration_seconds_bucket)', [], False),

--- a/tests/integration/test_prometheus_protocols/test_compliance.py
+++ b/tests/integration/test_prometheus_protocols/test_compliance.py
@@ -307,6 +307,10 @@ COMPLIANCE_TEST_CASES = [
     ("histogram_quantile(0.9, demo_memory_usage_bytes)", [], False),
     ('histogram_quantile(0.9, {__name__=~"demo_api_request_duration_seconds_.+"})', [], False),
 
+    # Histogram fraction
+    ("histogram_fraction(0.1, 0.5, rate(demo_api_request_duration_seconds_bucket[1m]))", [], False),
+    ("histogram_fraction(0.9, nonexistent_metric)", [], False),
+
     # count_values
     ('count_values("value", demo_api_request_duration_seconds_bucket)', [], False),
 

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -5065,6 +5065,40 @@ def test_histogram_fraction():
         [["[('job','api')]", "1970-01-01 00:05:00.000", "1"]],
     )
 
+    # The usual PromQL shape applies histogram_fraction to a rate expression, not to
+    # the raw bucket counters. This also exercises the vector-grid path.
+    do_query_test(
+        "histogram_fraction(0.1, 0.5, rate(rate_bucket[60s]))",
+        360,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [360, "0.3333333333333333"]}]}',
+        [["[]", "1970-01-01 00:06:00.000", "0.3333333333333333"]],
+        eps=1e-9,
+    )
+
+    # Distinct histogram metric names must remain separate while `le` and `__name__`
+    # are removed from the output labels.
+    do_range_query_test(
+        'histogram_fraction(0.1, 1.0, {__name__=~"two_hist_a_bucket|two_hist_b_bucket"})',
+        300,
+        300,
+        10,
+        '{"resultType": "matrix", "result": [{"metric": {"env": "prod", "kind": "a"}, "values": [[300, "0.6666666666666666"]]}, {"metric": {"env": "prod", "kind": "b"}, "values": [[300, "0.3"]]}]}',
+        [
+            ["[('env','prod'),('kind','a')]", "[('1970-01-01 00:05:00.000',0.6666666666666666)]"],
+            ["[('env','prod'),('kind','b')]", "[('1970-01-01 00:05:00.000',0.3)]"],
+        ],
+        eps=1e-12,
+    )
+
+    # Negative bucket boundaries use the same linear interpolation rules as Prometheus.
+    do_query_test(
+        "histogram_fraction(-0.5, 0.5, negative_le_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0.16666666666666666"]}]}',
+        [["[]", "1970-01-01 00:05:00.000", "0.16666666666666666"]],
+        eps=1e-12,
+    )
+
     # Multiple histogram groups in a range query. The `le` label is removed from each
     # group, while the remaining `job` label stays on the result.
     do_range_query_test(
@@ -5100,11 +5134,59 @@ def test_histogram_fraction():
         [["[('job','api')]", "1970-01-01 00:05:00.000", "0"]],
     )
 
+    # Equal bounds and finite bounds outside the observed range are valid and return
+    # the corresponding empty or complete fraction.
+    for query, expected in (
+        ("histogram_fraction(0.5, 0.5, http_request_duration_seconds_bucket)", "0"),
+        ("histogram_fraction(-1, 2, http_request_duration_seconds_bucket)", "1"),
+        ("histogram_fraction(2, 3, http_request_duration_seconds_bucket)", "0"),
+    ):
+        do_query_test(
+            query,
+            300,
+            f'{{"resultType": "vector", "result": [{{"metric": {{"job": "api"}}, "value": [300, "{expected}"]}}]}}',
+            [["[('job','api')]", "1970-01-01 00:05:00.000", expected]],
+        )
+
+    # One-sided infinite bounds select the lower or upper tail of the histogram.
+    for query, expected in (
+        ("histogram_fraction(-Inf, 0.5, http_request_duration_seconds_bucket)", "0.5"),
+        ("histogram_fraction(0.5, +Inf, http_request_duration_seconds_bucket)", "0.5"),
+    ):
+        do_query_test(
+            query,
+            300,
+            f'{{"resultType": "vector", "result": [{{"metric": {{"job": "api"}}, "value": [300, "{expected}"]}}]}}',
+            [["[('job','api')]", "1970-01-01 00:05:00.000", expected]],
+        )
+
+    # NaN bounds follow Prometheus and produce NaN for a non-empty histogram.
+    for query in (
+        "histogram_fraction(NaN, 0.5, http_request_duration_seconds_bucket)",
+        "histogram_fraction(0, NaN, http_request_duration_seconds_bucket)",
+    ):
+        do_query_test(
+            query,
+            300,
+            '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "NaN"]}]}',
+            [["[('job','api')]", "1970-01-01 00:05:00.000", "nan"]],
+        )
+
     do_query_test(
         "histogram_fraction(0, 0.5, no_inf_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "NaN"]}]}',
         [["[]", "1970-01-01 00:05:00.000", "nan"]],
+    )
+
+    # A malformed `le` bucket is ignored while valid buckets in the same histogram
+    # continue to contribute to the result.
+    do_query_test(
+        "histogram_fraction(0, 0.1, bad_le_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0.16666666666666666"]}]}',
+        [["[]", "1970-01-01 00:05:00.000", "0.16666666666666666"]],
+        eps=1e-12,
     )
 
     do_query_test(
@@ -5119,6 +5201,15 @@ def test_histogram_fraction():
         300,
         '{"resultType": "vector", "result": []}',
         [],
+    )
+
+    # Aggregating classic buckets by `le` before applying histogram_fraction is the
+    # common way to combine multiple input series into one histogram.
+    do_query_test(
+        "histogram_fraction(1, 4, sum by (le) (cache_lookup_duration_seconds_bucket))",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0.5"]}]}',
+        [["[]", "1970-01-01 00:05:00.000", "0.5"]],
     )
 
     # Argument type validation: both bounds must be scalars and the input must be an
@@ -5159,7 +5250,7 @@ def test_histogram_fraction():
         "(time_series Array(Tuple(DateTime64(3), Float32))) ENGINE=TimeSeries"
     )
     try:
-        for le, value in [("0.1", 10), ("0.5", 30), ("1.0", 50), ("+Inf", 60)]:
+        for le, value in [("0.1", 10), ("0.100001", 20), ("+Inf", 30)]:
             node.query(
                 "INSERT INTO prometheus_f32 (metric_name, tags, time_series) VALUES "
                 f"('http_request_duration_seconds_bucket', {{'job': 'api', 'le': '{le}'}}, "
@@ -5170,14 +5261,45 @@ def test_histogram_fraction():
             node.query(
                 "SELECT * FROM prometheusQuery("
                 "prometheus_f32, "
-                "'histogram_fraction(0.099999999, 0.5, http_request_duration_seconds_bucket)', "
+                "'histogram_fraction(0.099999999, 0.1000005, http_request_duration_seconds_bucket)', "
                 "300)"
             ),
-            [["[('job','api')]", "1970-01-01 00:05:00.000", "0.3333333432674408"]],
+            [["[('job','api')]", "1970-01-01 00:05:00.000", "0.1666666716337204"]],
             eps=1e-12,
         )
     finally:
         node.query("DROP TABLE prometheus_f32 SYNC")
+
+    # UInt64 cumulative counts must be subtracted before converting to Float64. Otherwise
+    # the difference between 2^53 and 2^53 + 1 is rounded away and this fraction becomes 0.
+    node.query(
+        "CREATE TABLE prometheus_u64 "
+        "(time_series Array(Tuple(DateTime64(3), UInt64))) ENGINE=TimeSeries"
+    )
+    try:
+        for le, value in [
+            ("1", 9007199254740992),
+            ("2", 9007199254740993),
+            ("+Inf", 9007199254740993),
+        ]:
+            node.query(
+                "INSERT INTO prometheus_u64 (metric_name, tags, time_series) VALUES "
+                f"('large_count_bucket', {{'le': '{le}'}}, "
+                f"[(toDateTime64(300, 3), {value})])"
+            )
+
+        assert tsv_close_to(
+            node.query(
+                "SELECT * FROM prometheusQuery("
+                "prometheus_u64, "
+                "'histogram_fraction(1, 2, large_count_bucket)', "
+                "300)"
+            ),
+            [["[]", "1970-01-01 00:05:00.000", "1.1102230246251564e-16"]],
+            eps=1e-30,
+        )
+    finally:
+        node.query("DROP TABLE prometheus_u64 SYNC")
 
 
 def test_label_manipulation_functions():

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -5034,6 +5034,152 @@ def test_histogram_quantile():
     )
 
 
+def test_histogram_fraction():
+    do_query_test(
+        "histogram_fraction(0, 0.5, http_request_duration_seconds_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0.5"]}]}',
+        [["[('job','api')]", "1970-01-01 00:05:00.000", "0.5"]],
+    )
+
+    do_query_test(
+        "histogram_fraction(0.1, 0.5, http_request_duration_seconds_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0.3333333333333333"]}]}',
+        [["[('job','api')]", "1970-01-01 00:05:00.000", "0.3333333333333333"]],
+        eps=1e-12,
+    )
+
+    do_query_test(
+        "histogram_fraction(0, 1, http_request_duration_seconds_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0.8333333333333334"]}]}',
+        [["[('job','api')]", "1970-01-01 00:05:00.000", "0.8333333333333334"]],
+        eps=1e-12,
+    )
+
+    do_query_test(
+        "histogram_fraction(-Inf, +Inf, http_request_duration_seconds_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "1"]}]}',
+        [["[('job','api')]", "1970-01-01 00:05:00.000", "1"]],
+    )
+
+    # Multiple histogram groups in a range query. The `le` label is removed from each
+    # group, while the remaining `job` label stays on the result.
+    do_range_query_test(
+        "histogram_fraction(1, 4, cache_lookup_duration_seconds_bucket)",
+        300,
+        320,
+        10,
+        '{"resultType": "matrix", "result": [{"metric": {"job": "reader"}, "values": [[300, "0.6"], [310, "0.6"], [320, "0.6"]]}, {"metric": {"job": "writer"}, "values": [[300, "0.4"], [310, "0.4"], [320, "0.4"]]}]}',
+        [
+            [
+                "[('job','reader')]",
+                "[('1970-01-01 00:05:00.000',0.6),('1970-01-01 00:05:10.000',0.6),('1970-01-01 00:05:20.000',0.6)]",
+            ],
+            [
+                "[('job','writer')]",
+                "[('1970-01-01 00:05:00.000',0.4),('1970-01-01 00:05:10.000',0.4),('1970-01-01 00:05:20.000',0.4)]",
+            ],
+        ],
+        eps=1e-12,
+    )
+
+    do_query_test(
+        "histogram_fraction(0, 0.5, only_inf_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0"]}]}',
+        [["[]", "1970-01-01 00:05:00.000", "0"]],
+    )
+
+    do_query_test(
+        "histogram_fraction(1, 0.5, http_request_duration_seconds_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0"]}]}',
+        [["[('job','api')]", "1970-01-01 00:05:00.000", "0"]],
+    )
+
+    do_query_test(
+        "histogram_fraction(0, 0.5, no_inf_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "NaN"]}]}',
+        [["[]", "1970-01-01 00:05:00.000", "nan"]],
+    )
+
+    do_query_test(
+        "histogram_fraction(0, 0.5, zero_count_bucket)",
+        300,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "NaN"]}]}',
+        [["[]", "1970-01-01 00:05:00.000", "nan"]],
+    )
+
+    do_query_test(
+        "histogram_fraction(0, 0.5, foo)",
+        300,
+        '{"resultType": "vector", "result": []}',
+        [],
+    )
+
+    # Argument type validation: both bounds must be scalars and the input must be an
+    # instant vector.
+    do_query_test_expect_error(
+        "histogram_fraction(http_request_duration_seconds_bucket, 0.5, http_request_duration_seconds_bucket)",
+        300,
+        "expected type scalar",
+        "expects argument 1 of type",
+    )
+
+    do_query_test_expect_error(
+        "histogram_fraction(0, http_request_duration_seconds_bucket, http_request_duration_seconds_bucket)",
+        300,
+        "expected type scalar",
+        "expects argument 2 of type",
+    )
+
+    do_query_test_expect_error(
+        "histogram_fraction(0, 0.5, 1)",
+        300,
+        "expected type instant vector",
+        "expects third argument of type",
+    )
+
+    # Prometheus accepts scalar expressions for the bounds. ClickHouse currently supports
+    # only constant bounds, so check this documented limitation on both ClickHouse paths.
+    for query in (
+        "histogram_fraction(time(), 0.5, http_request_duration_seconds_bucket)",
+        "histogram_fraction(0, time(), http_request_duration_seconds_bucket)",
+    ):
+        expected_error = "requires constant lower and upper parameters"
+        assert expected_error in execute_query_in_clickhouse_sql(query, 300, expect_error=True)
+        assert expected_error in execute_query_in_clickhouse_http_api(query, 300, expect_error=True)
+
+    node.query(
+        "CREATE TABLE prometheus_f32 "
+        "(time_series Array(Tuple(DateTime64(3), Float32))) ENGINE=TimeSeries"
+    )
+    try:
+        for le, value in [("0.1", 10), ("0.5", 30), ("1.0", 50), ("+Inf", 60)]:
+            node.query(
+                "INSERT INTO prometheus_f32 (metric_name, tags, time_series) VALUES "
+                f"('http_request_duration_seconds_bucket', {{'job': 'api', 'le': '{le}'}}, "
+                f"[(toDateTime64(300, 3), {value})])"
+            )
+
+        assert tsv_close_to(
+            node.query(
+                "SELECT * FROM prometheusQuery("
+                "prometheus_f32, "
+                "'histogram_fraction(0.099999999, 0.5, http_request_duration_seconds_bucket)', "
+                "300)"
+            ),
+            [["[('job','api')]", "1970-01-01 00:05:00.000", "0.3333333432674408"]],
+            eps=1e-12,
+        )
+    finally:
+        node.query("DROP TABLE prometheus_f32 SYNC")
+
+
 def test_label_manipulation_functions():
     # Add a new label using a regex capture from an existing label.
     do_query_test(

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -5301,6 +5301,34 @@ def test_histogram_fraction():
     finally:
         node.query("DROP TABLE prometheus_u64 SYNC")
 
+    # Prometheus clamps the complete interpolated rank even when cumulative bucket
+    # counts are not monotonic.
+    node.query(
+        "CREATE TABLE prometheus_non_monotonic "
+        "(time_series Array(Tuple(DateTime64(3), UInt64))) ENGINE=TimeSeries"
+    )
+    try:
+        for le, value in [("1", 200), ("2", 50), ("+Inf", 100)]:
+            node.query(
+                "INSERT INTO prometheus_non_monotonic (metric_name, tags, time_series) VALUES "
+                f"('non_monotonic_bucket', {{'le': '{le}'}}, "
+                f"[(toDateTime64(300, 3), {value})])"
+            )
+
+        for query, expected in (
+            ("histogram_fraction(0, 0.75, non_monotonic_bucket)", "1"),
+            ("histogram_fraction(0.5, 0.75, non_monotonic_bucket)", "0"),
+        ):
+            assert tsv_close_to(
+                node.query(
+                    "SELECT * FROM prometheusQuery("
+                    f"prometheus_non_monotonic, '{query}', 300)"
+                ),
+                [["[]", "1970-01-01 00:05:00.000", expected]],
+            )
+    finally:
+        node.query("DROP TABLE prometheus_non_monotonic SYNC")
+
 
 def test_label_manipulation_functions():
     # Add a new label using a regex capture from an existing label.

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -5138,7 +5138,7 @@ def test_histogram_fraction():
     # the corresponding empty or complete fraction.
     for query, expected in (
         ("histogram_fraction(0.5, 0.5, http_request_duration_seconds_bucket)", "0"),
-        ("histogram_fraction(-1, 2, http_request_duration_seconds_bucket)", "1"),
+        ("histogram_fraction(-1, 2, http_request_duration_seconds_bucket)", "0.8333333333333334"),
         ("histogram_fraction(2, 3, http_request_duration_seconds_bucket)", "0"),
     ):
         do_query_test(

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -566,6 +566,30 @@ def do_clickhouse_only_query_test(
     ), f"actual_result_from_http_api: {actual_result_from_http_api}, expected: {result}"
 
 
+def do_clickhouse_only_range_query_test(
+    query,
+    start_time,
+    end_time,
+    step,
+    result,
+    chresult,
+    eps=0,
+):
+    actual_chresult = execute_range_query_in_clickhouse_sql(
+        query, start_time, end_time, step
+    )
+    assert tsv_close_to(
+        actual_chresult, chresult, eps=eps
+    ), f"actual result: {actual_chresult}, expected: {chresult}"
+
+    actual_result_from_http_api = execute_range_query_in_clickhouse_http_api(
+        query, start_time, end_time, step
+    )
+    assert http_api_response_close_to(
+        actual_result_from_http_api, result, eps=eps
+    ), f"actual_result_from_http_api: {actual_result_from_http_api}, expected: {result}"
+
+
 def test_up():
     do_query_test(
         "up",
@@ -5035,14 +5059,16 @@ def test_histogram_quantile():
 
 
 def test_histogram_fraction():
-    do_query_test(
+    # The Prometheus reference currently returns NaN for classic histograms, while
+    # ClickHouse supports the classic-bucket form of `histogram_fraction`.
+    do_clickhouse_only_query_test(
         "histogram_fraction(0, 0.5, http_request_duration_seconds_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0.5"]}]}',
         [["[('job','api')]", "1970-01-01 00:05:00.000", "0.5"]],
     )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0.1, 0.5, http_request_duration_seconds_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0.3333333333333333"]}]}',
@@ -5050,7 +5076,7 @@ def test_histogram_fraction():
         eps=1e-12,
     )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0, 1, http_request_duration_seconds_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0.8333333333333334"]}]}',
@@ -5058,7 +5084,7 @@ def test_histogram_fraction():
         eps=1e-12,
     )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(-Inf, +Inf, http_request_duration_seconds_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "1"]}]}',
@@ -5067,7 +5093,7 @@ def test_histogram_fraction():
 
     # The usual PromQL shape applies histogram_fraction to a rate expression, not to
     # the raw bucket counters. This also exercises the vector-grid path.
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0.1, 0.5, rate(rate_bucket[60s]))",
         360,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [360, "0.3333333333333333"]}]}',
@@ -5077,7 +5103,7 @@ def test_histogram_fraction():
 
     # Distinct histogram metric names must remain separate while `le` and `__name__`
     # are removed from the output labels.
-    do_range_query_test(
+    do_clickhouse_only_range_query_test(
         'histogram_fraction(0.1, 1.0, {__name__=~"two_hist_a_bucket|two_hist_b_bucket"})',
         300,
         300,
@@ -5091,7 +5117,7 @@ def test_histogram_fraction():
     )
 
     # Negative bucket boundaries use the same linear interpolation rules as Prometheus.
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(-0.5, 0.5, negative_le_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0.16666666666666666"]}]}',
@@ -5101,7 +5127,7 @@ def test_histogram_fraction():
 
     # Multiple histogram groups in a range query. The `le` label is removed from each
     # group, while the remaining `job` label stays on the result.
-    do_range_query_test(
+    do_clickhouse_only_range_query_test(
         "histogram_fraction(1, 4, cache_lookup_duration_seconds_bucket)",
         300,
         320,
@@ -5120,14 +5146,14 @@ def test_histogram_fraction():
         eps=1e-12,
     )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0, 0.5, only_inf_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0"]}]}',
         [["[]", "1970-01-01 00:05:00.000", "0"]],
     )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(1, 0.5, http_request_duration_seconds_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "0"]}]}',
@@ -5141,7 +5167,7 @@ def test_histogram_fraction():
         ("histogram_fraction(-1, 2, http_request_duration_seconds_bucket)", "0.8333333333333334"),
         ("histogram_fraction(2, 3, http_request_duration_seconds_bucket)", "0"),
     ):
-        do_query_test(
+        do_clickhouse_only_query_test(
             query,
             300,
             f'{{"resultType": "vector", "result": [{{"metric": {{"job": "api"}}, "value": [300, "{expected}"]}}]}}',
@@ -5153,7 +5179,7 @@ def test_histogram_fraction():
         ("histogram_fraction(-Inf, 0.5, http_request_duration_seconds_bucket)", "0.5"),
         ("histogram_fraction(0.5, +Inf, http_request_duration_seconds_bucket)", "0.5"),
     ):
-        do_query_test(
+        do_clickhouse_only_query_test(
             query,
             300,
             f'{{"resultType": "vector", "result": [{{"metric": {{"job": "api"}}, "value": [300, "{expected}"]}}]}}',
@@ -5165,14 +5191,14 @@ def test_histogram_fraction():
         "histogram_fraction(NaN, 0.5, http_request_duration_seconds_bucket)",
         "histogram_fraction(0, NaN, http_request_duration_seconds_bucket)",
     ):
-        do_query_test(
+        do_clickhouse_only_query_test(
             query,
             300,
             '{"resultType": "vector", "result": [{"metric": {"job": "api"}, "value": [300, "NaN"]}]}',
             [["[('job','api')]", "1970-01-01 00:05:00.000", "nan"]],
         )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0, 0.5, no_inf_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "NaN"]}]}',
@@ -5181,7 +5207,7 @@ def test_histogram_fraction():
 
     # A malformed `le` bucket is ignored while valid buckets in the same histogram
     # continue to contribute to the result.
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0, 0.1, bad_le_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0.16666666666666666"]}]}',
@@ -5189,14 +5215,14 @@ def test_histogram_fraction():
         eps=1e-12,
     )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0, 0.5, zero_count_bucket)",
         300,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "NaN"]}]}',
         [["[]", "1970-01-01 00:05:00.000", "nan"]],
     )
 
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(0, 0.5, foo)",
         300,
         '{"resultType": "vector", "result": []}',
@@ -5205,7 +5231,7 @@ def test_histogram_fraction():
 
     # Aggregating classic buckets by `le` before applying histogram_fraction is the
     # common way to combine multiple input series into one histogram.
-    do_query_test(
+    do_clickhouse_only_query_test(
         "histogram_fraction(1, 4, sum by (le) (cache_lookup_duration_seconds_bucket))",
         300,
         '{"resultType": "vector", "result": [{"metric": {}, "value": [300, "0.5"]}]}',


### PR DESCRIPTION
### Changelog category (leave one):
- **Experimental Feature**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**PromQL: support `histogram_fraction()` for classic histograms.**

### Description

**What was missing**

Prometheus supports `histogram_fraction(lower, upper, b)` for estimating the fraction of observations between two bounds. ClickHouse previously rejected this function in TimeSeries PromQL queries.

**What this PR adds**

- **Add:** support for classic Prometheus bucket series.
- Reuses the existing classic histogram handling used by `histogram_quantile`.
- Matches Prometheus behavior for interpolation and bucket edge cases.
- Keeps different histogram metric names separate during aggregation.
- Removes the input metric name from the result.

Example:

```promql
histogram_fraction(0.1, 0.5, http_request_duration_seconds_bucket)
```

### Why this matters

**This is used for real latency and SLO queries**, not only parser compatibility.

- **Pyrra:** generates `histogram_fraction()` in native-histogram latency SLO rules. See the [query generator](https://github.com/pyrra-dev/pyrra/blob/main/slo/promql.go#L761-L784) and [example SLO config](https://github.com/pyrra-dev/pyrra/blob/main/examples/pyrra-connect-latency.yaml#L14-L20).
- **Grafana SLO:** uses it in a [request-latency SLI query](https://grafana.com/docs/plugins/grafana-slo-app/latest/sli-examples/latency/).
- **Grafana Mimir:** documents it for calculating the [fraction of requests in a latency range](https://grafana.com/docs/mimir/latest/visualize/native-histograms/).
- **Prometheus:** uses it for [fraction and Apdex calculations](https://prometheus.io/docs/practices/histograms/).

Without this function, PromQL copied from these workflows fails in ClickHouse.

### Scope

- **Supported:** classic `*_bucket` histogram series.
- **Supported:** constant scalar lower and upper bounds.
- **Not supported yet:** native histogram samples.
- **Not supported yet:** non-constant bound expressions.

Native histogram samples are not supported by the current TimeSeries Engine. This PR intentionally covers the classic bucket form first.

### References

- [Prometheus histogram functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_fraction)
- [Prometheus classic histogram implementation](https://github.com/prometheus/prometheus/blob/main/promql/quantile.go)

### Changes

- **Function support:** add `histogram_fraction` to the TimeSeries function registry and support documentation.
- **Execution:** add a Prometheus-compatible classic histogram fraction aggregate.
- **Shared logic:** reuse the histogram SQL-building pipeline with `histogram_quantile`.
- **Precision:** preserve Float64 bound literals for Float32 tables and exact cumulative-count differences for large UInt64 counts.

### Tests

- **Interpolation:** normal buckets, `rate()` input, negative bucket bounds, and bounds inside buckets.
- **Bucket edges:** exact boundaries, degenerate buckets, `+Inf`, `NaN`, malformed `le`, and out-of-range bounds.
- **Grouping:** range queries with multiple histogram groups and `sum by (le)` aggregation.
- **Input validation:** invalid argument types and non-constant bounds.
- **Float32:** regression coverage for precision near an `le` boundary.
- **UInt64:** regression coverage for one-count differences above `2^53`.
- **Compliance:** add classic histogram fraction queries to the PromQL compliance cases.
- **Checks:** `git diff --check` and Python syntax validation for the integration test files.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114704&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114704](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114704+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
