### PR TITLE
Docs: add service:delete and organization:create-service console permissions

### DIFF
--- a/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
@@ -54,7 +54,7 @@ Ensure users who will log into the console have a minimum of Organization > Acce
 <Info>
 **Data Sources tab access**
 
-To access the **Data Sources** tab, the role currently requires the `Manage and Delete Selected Services` permission.
+To access the **Data Sources** tab, the role currently requires the `Manage selected services` permission.
 </Info>
 
 <Image img="/images/cloud/guides/control_plane/manage_custom_roles/5_custom_role.webp" size="md"/>

--- a/docs/products/cloud/reference/security/console-roles.mdx
+++ b/docs/products/cloud/reference/security/console-roles.mdx
@@ -49,6 +49,7 @@ The table below describes the ClickHouse console and SQL console permissions. Mo
 | **Organization** ([more info](/products/cloud/guides/security/cloud-access-management/manage-cloud-users)) | Organization-level permissions |
 | control-plane:organization:view | View organization details and read-only metadata. |
 | control-plane:organization:manage | Manage organization settings and users. |
+| control-plane:organization:create-service | Create new services in the organization. |
 | **Billing** ([more info](/products/cloud/reference/billing/billing-overview)) | Billing and invoice management |
 | control-plane:organization:manage-billing | Manage billing settings, payment methods, and invoices. |
 | control-plane:organization:view-billing | View billing usage and invoices. |
@@ -62,6 +63,7 @@ The table below describes the ClickHouse console and SQL console permissions. Mo
 | **Service (general)** | General service-level permissions |
 | control-plane:service:view | View service-level metadata, settings, and status. |
 | control-plane:service:manage | Manage service configuration and lifecycle operations. |
+| control-plane:service:delete | Delete a service. |
 | **Backups** ([more info](/products/cloud/features/backups/overview)) | Service backups and restore points |
 | control-plane:service:view-backups | View backups and restore points for a service. |
 | control-plane:service:manage-backups | Create, manage, and restore service backups. |
@@ -76,7 +78,7 @@ The table below describes the ClickHouse console and SQL console permissions. Mo
 | control-plane:service:view-private-endpoints | View private endpoint configuration for a service. |
 | control-plane:service:manage-private-endpoints | Create and manage private endpoints and private networking. |
 | **ClickPipes** ([more info](/integrations/clickpipes/home)) | ClickPipes integration |
-| control-plane:service:manage-clickpipes | Manage ClickPipes integration and related settings. Accessing the **Data Sources** tab currently requires `control-plane:service:manage` ("Manage and Delete Selected Services"). |
+| control-plane:service:manage-clickpipes | Manage ClickPipes integration and related settings. Accessing the **Data Sources** tab currently requires `control-plane:service:manage` ("Manage selected services") as well. |
 | **Scaling** ([more info](/products/cloud/features/autoscaling/overview)) | Scaling and autoscaling configuration |
 | control-plane:service:view-scaling-config | View scaling configuration and autoscaling settings for a service. |
 | control-plane:service:manage-scaling-config | Modify scaling configuration and trigger scaling operations. |


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Summary

Adds two Cloud console permissions to the console permission reference. Both were carved out of a broader parent permission and were not documented:

- `control-plane:organization:create-service`, split out of `organization:manage`
- `control-plane:service:delete`, split out of `service:manage`

Splitting `service:delete` out also renames the role editor label for `service:manage` from "Manage and delete selected services" to "Manage selected services". The docs quoted the old label in two places, which would have contradicted the new `service:delete` row by implying `service:manage` still covers deletion, so both are corrected: the ClickPipes row on this page and the **Data Sources** tab note in the custom roles guide.

### Test plan

Docs-only change, no code paths touched.

- Render `/cloud/security/console-roles` and confirm the two new rows appear under **Organization** and **Service (general)**.
- Render the custom roles guide and confirm the **Data Sources** callout names the current label.

### Edge cases

- `grep` confirms no occurrence of the old `Manage and Delete Selected Services` label remains in the English docs.
- Only the English sources are edited. The `ja`, `ru`, `zh`, `ar`, `pt-BR`, `ko`, `fr`, and `es` copies use a machine-translation structure (`<div id=...>` wrappers rather than `{#anchor}` headings) and look pipeline-generated, so they are expected to pick this up on the next regeneration rather than being hand-edited here.
- Both permissions sit behind system feature flags that are currently off in production. While a flag is off, the child permission is hidden in the role editor and the parent still covers the behavior, so this describes the post-rollout state and should land after the flags reach full rollout.
- `service:manage` is still described as covering "lifecycle operations". Deletion is arguably a lifecycle operation, so that phrase is a little loose now that `service:delete` exists, but the separate row resolves it in context and a negative disclaimer on one row would break the table's one-line style.

### Risks

Low. Documentation text only, no build or runtime impact. The main risk is timing rather than correctness: until the feature flags are fully rolled out, these pages describe labels and a permission split that are not yet visible in the console.
