### PR TITLE
Do not prune with an invalid polygon in pointInPolygon key analysis

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3331,6 +3331,43 @@ KeyCondition::RPNElement::RPNElement(Function function_, std::vector<size_t> key
 }
 
 
+/// Whether `shell` plus the hole rings in arguments 2..num_args-1 of `pointInPolygon` assemble into
+/// a valid polygon. A hole argument that is not a constant ring of two-element numeric tuples
+/// yields false, so an unrecognized shape is never taken for a hole-free polygon.
+static bool holesAreValidForShell(
+    const RPNBuilderFunctionTreeNode & func, size_t num_args, const KeyCondition::RPNElement::Polygon::RingT & shell)
+{
+    boost::geometry::model::polygon<KeyCondition::RPNElement::Polygon::PointT> polygon;
+    polygon.outer().assign(shell.begin(), shell.end());
+
+    for (size_t i = 2; i < num_args; ++i)
+    {
+        Field hole_value;
+        DataTypePtr hole_type;
+        if (!func.getArgumentAt(i).tryGetConstant(hole_value, hole_type) || !WhichDataType(hole_type).isArray())
+            return false;
+
+        auto & hole = polygon.inners().emplace_back();
+        for (const auto & elem : hole_value.safeGet<Array>())
+        {
+            if (elem.getType() != Field::Types::Tuple)
+                return false;
+
+            const auto & elem_tuple = elem.safeGet<Tuple>();
+            if (elem_tuple.size() != 2)
+                return false;
+
+            auto x = applyVisitor(FieldVisitorConvertToNumber<Float64>(), elem_tuple[0]);
+            auto y = applyVisitor(FieldVisitorConvertToNumber<Float64>(), elem_tuple[1]);
+            hole.emplace_back(x, y);
+        }
+    }
+
+    boost::geometry::correct(polygon);
+    return boost::geometry::is_valid(polygon);
+}
+
+
 /** This helper rewrites comparisons of the form "integer_key <op> Float64_literal" into semantically equivalent
   * integer-key predicates so that pruning can stay exact.
   *
@@ -3658,6 +3695,12 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             /// `correct` does not make a ring valid, and `intersects` below only agrees with the
             /// algorithm the function evaluates for a ring that is. Prune only from a valid one.
             if (!boost::geometry::is_valid(out.polygon->ring))
+                return false;
+
+            /// Holes are not stored, so `intersects` below tests the shell alone. That over-
+            /// approximates the function only while the assembled shape is valid: for an invalid
+            /// one the function can report a point the shell excludes.
+            if (num_args > 2 && !holesAreValidForShell(func, num_args, out.polygon->ring))
                 return false;
 
             /// Store bounding box of the polygon so that we can quickly reject blocks/parts and avoid

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3655,6 +3655,11 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             }
             boost::geometry::correct(out.polygon->ring);
 
+            /// `correct` does not make a ring valid, and `intersects` below only agrees with the
+            /// algorithm the function evaluates for a ring that is. Prune only from a valid one.
+            if (!boost::geometry::is_valid(out.polygon->ring))
+                return false;
+
             /// Store bounding box of the polygon so that we can quickly reject blocks/parts and avoid
             /// costly `intersects` checks
             boost::geometry::envelope(out.polygon->ring, out.polygon->bbox);

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
@@ -7,6 +7,7 @@ extra rows	0
 invalid hole, dense	3556	3556
 invalid hole, lightweight	3556	3556
 invalid hole, lost rows	0
+hole outside shell, counts	4480	4480
 valid hole, dense	4480	4480
 valid hole forces key, dense	4480
 valid hole forces key, lightweight	4480

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
@@ -1,0 +1,12 @@
+bowtie 2-arg, dense	875	875	875
+bowtie 2-arg, lightweight	875	875	875
+bowtie 3-arg, dense	820	820
+bowtie 3-arg, lightweight	820	820
+lost rows	0
+extra rows	0
+degenerate ring, dense	8	8
+degenerate ring, lightweight	8	8
+valid ring, dense	1681	1681
+valid ring, lightweight	1681	1681
+valid ring prunes, dense	1
+valid ring prunes, lightweight	1

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
@@ -8,5 +8,7 @@ degenerate ring, dense	8	8
 degenerate ring, lightweight	8	8
 valid ring, dense	1681	1681
 valid ring, lightweight	1681	1681
+valid ring forces key, dense	1681
+valid ring forces key, lightweight	1681
 valid ring prunes, dense	1
 valid ring prunes, lightweight	1

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.reference
@@ -4,6 +4,12 @@ bowtie 3-arg, dense	820	820
 bowtie 3-arg, lightweight	820	820
 lost rows	0
 extra rows	0
+invalid hole, dense	3556	3556
+invalid hole, lightweight	3556	3556
+invalid hole, lost rows	0
+valid hole, dense	4480	4480
+valid hole forces key, dense	4480
+valid hole forces key, lightweight	4480
 degenerate ring, dense	8	8
 degenerate ring, lightweight	8	8
 valid ring, dense	1681	1681

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
@@ -115,15 +115,17 @@ SELECT 'valid ring, lightweight',
 -- A valid ring still builds an atom, so forcing the primary key must not raise.
 SELECT 'valid ring forces key, dense', count() FROM pip_pk
     WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
-    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0;
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0,
+        use_query_condition_cache = 0;
 
 SELECT 'valid ring forces key, lightweight', count() FROM pip_pk
     WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
-    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1;
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1,
+        use_query_condition_cache = 0;
 
--- Pruning must stay effective, not merely non-zero: this ring selects a quarter of the granules,
--- so a fourfold margin separates it from a regression that scans everything. The seek thresholds
--- are pinned because they merge accepted ranges across gaps and so inflate the count.
+-- Pruning must stay effective, not merely non-zero: this ring selects about 23% of the granules,
+-- the bound admits anything under 25%, and a ring that prunes nothing reads 100%. The seek
+-- thresholds inflate that count by merging ranges across gaps, the condition cache lowers it.
 SELECT 'valid ring prunes, dense',
     toUInt64(extract(explain, 'Granules: ([0-9]+)')) * 4 < toUInt64(extract(explain, 'Granules: [0-9]+/([0-9]+)'))
 FROM
@@ -131,7 +133,8 @@ FROM
     EXPLAIN indexes = 1
     SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
     SETTINGS use_lightweight_primary_key_index_analysis = 0,
-        merge_tree_min_rows_for_seek = 0, merge_tree_min_bytes_for_seek = 0
+        merge_tree_min_rows_for_seek = 0, merge_tree_min_bytes_for_seek = 0,
+        use_query_condition_cache = 0
 )
 WHERE explain LIKE '%Granules%';
 
@@ -142,7 +145,8 @@ FROM
     EXPLAIN indexes = 1
     SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
     SETTINGS use_lightweight_primary_key_index_analysis = 1,
-        merge_tree_min_rows_for_seek = 0, merge_tree_min_bytes_for_seek = 0
+        merge_tree_min_rows_for_seek = 0, merge_tree_min_bytes_for_seek = 0,
+        use_query_condition_cache = 0
 )
 WHERE explain LIKE '%Granules%';
 

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
@@ -111,6 +111,21 @@ SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8.
 SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)])
     SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1; -- { serverError INDEX_NOT_USED }
 
+-- Every hole argument takes part, and validity is a property of the assembly rather than of the
+-- rings: here the shell and both holes are individually valid, yet the second hole lies outside the
+-- shell, so the assembled polygon is not. Validating the rings one by one, or only the first hole,
+-- would build an atom here.
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)], [(20., 20.), (21., 20.), (21., 21.), (20., 21.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0; -- { serverError INDEX_NOT_USED }
+
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)], [(20., 20.), (21., 20.), (21., 21.), (20., 21.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1; -- { serverError INDEX_NOT_USED }
+
+SELECT 'hole outside shell, counts',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)], [(20., 20.), (21., 20.), (21., 21.), (20., 21.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 0),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)], [(20., 20.), (21., 20.), (21., 21.), (20., 21.)]));
+
 -- The same shell with a hole that keeps the assembled shape valid must keep both its result and its
 -- pruning, so that the check rejects invalid assemblies rather than every hole argument.
 SELECT 'valid hole, dense',

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
@@ -83,6 +83,51 @@ SELECT 'extra rows', count() FROM
     SELECT x, y FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
 );
 
+-- Hole rings are not stored, so pruning tests the shell alone. That is only an over-approximation
+-- of the function while the assembled shell-plus-holes shape is valid. Here the shell is valid and
+-- concave and the hole self-intersects: the function reports points inside the shell's notch, which
+-- the shell alone excludes, so the two counts diverged by 110 rows before the assembled shape was
+-- validated. A convex shell cannot expose this, having no notch outside its own outline.
+SELECT 'invalid hole, dense',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 0),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)]));
+
+SELECT 'invalid hole, lightweight',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 1),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)]));
+
+SELECT 'invalid hole, lost rows', count() FROM
+(
+    SELECT x, y FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)])
+    EXCEPT
+    SELECT x, y FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)])
+);
+
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0; -- { serverError INDEX_NOT_USED }
+
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (7., 7.), (7., 1.), (1., 7.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1; -- { serverError INDEX_NOT_USED }
+
+-- The same shell with a hole that keeps the assembled shape valid must keep both its result and its
+-- pruning, so that the check rejects invalid assemblies rather than every hole argument.
+SELECT 'valid hole, dense',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 0),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)]));
+
+SELECT 'valid hole forces key, dense', count() FROM pip_pk
+    WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0,
+        use_query_condition_cache = 0;
+
+SELECT 'valid hole forces key, lightweight', count() FROM pip_pk
+    WHERE pointInPolygon((x, y), [(0., 0.), (8., 0.), (8., 4.), (4., 4.), (4., 8.), (0., 8.)], [(1., 1.), (3., 1.), (3., 3.), (1., 3.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1,
+        use_query_condition_cache = 0;
+
 -- A ring with too few points is also rejected by `is_valid`, so it must stay consistent too.
 SELECT 'degenerate ring, dense',
     (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)])

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
@@ -54,6 +54,20 @@ SELECT 'bowtie 3-arg, lightweight',
         SETTINGS use_lightweight_primary_key_index_analysis = 1),
     (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)], [(1., 1.), (2., 1.), (2., 2.), (1., 2.)]));
 
+-- The atom must be DECLINED, not merely widened to a bound that happens to keep every matching
+-- row: with no key-range atom left, `force_primary_key` has no primary key use to force.
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0; -- { serverError INDEX_NOT_USED }
+
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1; -- { serverError INDEX_NOT_USED }
+
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)], [(1., 1.), (2., 1.), (2., 2.), (1., 2.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0; -- { serverError INDEX_NOT_USED }
+
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)], [(1., 1.), (2., 1.), (2., 2.), (1., 2.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1; -- { serverError INDEX_NOT_USED }
+
 -- No row is lost, and none is gained either: pruning must be an exact filter here.
 SELECT 'lost rows', count() FROM
 (
@@ -80,6 +94,12 @@ SELECT 'degenerate ring, lightweight',
         SETTINGS use_lightweight_primary_key_index_analysis = 1),
     (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)]));
 
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0; -- { serverError INDEX_NOT_USED }
+
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1; -- { serverError INDEX_NOT_USED }
+
 -- A valid polygon must keep both its result and its pruning: the check must not reject shapes
 -- that were being pruned correctly.
 SELECT 'valid ring, dense',
@@ -92,23 +112,37 @@ SELECT 'valid ring, lightweight',
         SETTINGS use_lightweight_primary_key_index_analysis = 1),
     (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)]));
 
+-- A valid ring still builds an atom, so forcing the primary key must not raise.
+SELECT 'valid ring forces key, dense', count() FROM pip_pk
+    WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 0;
+
+SELECT 'valid ring forces key, lightweight', count() FROM pip_pk
+    WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
+    SETTINGS force_primary_key = 1, use_lightweight_primary_key_index_analysis = 1;
+
+-- Pruning must stay effective, not merely non-zero: this ring selects a quarter of the granules,
+-- so a fourfold margin separates it from a regression that scans everything. The seek thresholds
+-- are pinned because they merge accepted ranges across gaps and so inflate the count.
 SELECT 'valid ring prunes, dense',
-    toUInt64(extract(explain, 'Granules: ([0-9]+)')) < toUInt64(extract(explain, 'Granules: [0-9]+/([0-9]+)'))
+    toUInt64(extract(explain, 'Granules: ([0-9]+)')) * 4 < toUInt64(extract(explain, 'Granules: [0-9]+/([0-9]+)'))
 FROM
 (
     EXPLAIN indexes = 1
     SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
-    SETTINGS use_lightweight_primary_key_index_analysis = 0
+    SETTINGS use_lightweight_primary_key_index_analysis = 0,
+        merge_tree_min_rows_for_seek = 0, merge_tree_min_bytes_for_seek = 0
 )
 WHERE explain LIKE '%Granules%';
 
 SELECT 'valid ring prunes, lightweight',
-    toUInt64(extract(explain, 'Granules: ([0-9]+)')) < toUInt64(extract(explain, 'Granules: [0-9]+/([0-9]+)'))
+    toUInt64(extract(explain, 'Granules: ([0-9]+)')) * 4 < toUInt64(extract(explain, 'Granules: [0-9]+/([0-9]+)'))
 FROM
 (
     EXPLAIN indexes = 1
     SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
-    SETTINGS use_lightweight_primary_key_index_analysis = 1
+    SETTINGS use_lightweight_primary_key_index_analysis = 1,
+        merge_tree_min_rows_for_seek = 0, merge_tree_min_bytes_for_seek = 0
 )
 WHERE explain LIKE '%Granules%';
 

--- a/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
+++ b/tests/queries/0_stateless/04897_point_in_polygon_primary_key_invalid_polygon.sql
@@ -1,0 +1,116 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
+-- Closes: https://github.com/ClickHouse/ClickHouse/issues/114630
+
+-- Primary key analysis of `pointInPolygon` must not prune with a polygon that
+-- `boost::geometry::is_valid` rejects: boost's predicate disagrees with the grid algorithm the
+-- function itself evaluates, so granules holding matching rows were dropped.
+-- `pip_pk` allows a key-range atom, `pip_nopk` holds the same rows and allows none, so the two
+-- counts must always agree. Both `KeyCondition::checkInHyperrectangle` overloads are exercised:
+-- `use_lightweight_primary_key_index_analysis` selects between them and `clickhouse-test`
+-- randomizes it, so every case pins it explicitly.
+
+-- EXPLAIN output may differ between old and new format
+SET explain_query_plan_default = 'legacy';
+
+DROP TABLE IF EXISTS pip_pk;
+DROP TABLE IF EXISTS pip_nopk;
+
+CREATE TABLE pip_pk   (x Float64, y Float64) ENGINE = MergeTree ORDER BY (x, y)
+    SETTINGS index_granularity = 8, index_granularity_bytes = 0;
+CREATE TABLE pip_nopk (x Float64, y Float64) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS index_granularity = 8, index_granularity_bytes = 0;
+
+INSERT INTO pip_pk SELECT (number % 100) * 0.1, (intDiv(number, 100) % 100) * 0.1 FROM numbers(10000);
+INSERT INTO pip_nopk SELECT * FROM pip_pk;
+
+-- Under the default `validate_polygons = 1` the function rejects the invalid ring while folding
+-- the constant, before any part is selected, so index analysis never sees it.
+SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)]); -- { serverError BAD_ARGUMENTS }
+
+SET validate_polygons = 0;
+
+-- Self-intersecting ("bowtie") ring, two-argument form.
+SELECT 'bowtie 2-arg, dense',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 0),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])),
+    (SELECT countIf(pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])) FROM pip_pk);
+
+SELECT 'bowtie 2-arg, lightweight',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 1),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])),
+    (SELECT countIf(pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])) FROM pip_pk);
+
+-- Same ring with a hole, three-argument form. It reaches the same analysis lambda (holes are
+-- ignored there), so it is affected identically.
+SELECT 'bowtie 3-arg, dense',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)], [(1., 1.), (2., 1.), (2., 2.), (1., 2.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 0),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)], [(1., 1.), (2., 1.), (2., 2.), (1., 2.)]));
+
+SELECT 'bowtie 3-arg, lightweight',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)], [(1., 1.), (2., 1.), (2., 2.), (1., 2.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 1),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)], [(1., 1.), (2., 1.), (2., 2.), (1., 2.)]));
+
+-- No row is lost, and none is gained either: pruning must be an exact filter here.
+SELECT 'lost rows', count() FROM
+(
+    SELECT x, y FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+    EXCEPT
+    SELECT x, y FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+);
+
+SELECT 'extra rows', count() FROM
+(
+    SELECT x, y FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+    EXCEPT
+    SELECT x, y FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (4., 4.), (4., 0.), (0., 4.)])
+);
+
+-- A ring with too few points is also rejected by `is_valid`, so it must stay consistent too.
+SELECT 'degenerate ring, dense',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 0),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)]));
+
+SELECT 'degenerate ring, lightweight',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 1),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(0., 0.), (1., 1.)]));
+
+-- A valid polygon must keep both its result and its pruning: the check must not reject shapes
+-- that were being pruned correctly.
+SELECT 'valid ring, dense',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 0),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)]));
+
+SELECT 'valid ring, lightweight',
+    (SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
+        SETTINGS use_lightweight_primary_key_index_analysis = 1),
+    (SELECT count() FROM pip_nopk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)]));
+
+SELECT 'valid ring prunes, dense',
+    toUInt64(extract(explain, 'Granules: ([0-9]+)')) < toUInt64(extract(explain, 'Granules: [0-9]+/([0-9]+)'))
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
+    SETTINGS use_lightweight_primary_key_index_analysis = 0
+)
+WHERE explain LIKE '%Granules%';
+
+SELECT 'valid ring prunes, lightweight',
+    toUInt64(extract(explain, 'Granules: ([0-9]+)')) < toUInt64(extract(explain, 'Granules: [0-9]+/([0-9]+)'))
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT count() FROM pip_pk WHERE pointInPolygon((x, y), [(1., 1.), (1., 5.), (5., 5.), (5., 1.)])
+    SETTINGS use_lightweight_primary_key_index_analysis = 1
+)
+WHERE explain LIKE '%Granules%';
+
+DROP TABLE pip_pk;
+DROP TABLE pip_nopk;


### PR DESCRIPTION
Do not prune with an invalid polygon in pointInPolygon key analysis

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114630   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed rows missing from the result of a `SELECT` filtered by `pointInPolygon` over a MergeTree primary key when the polygon argument is an invalid constant literal and `validate_polygons = 0`. Primary key analysis derived granule pruning from a polygon it never validated, and dropped granules holding matching rows.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114630


### Description

Two defects, both making primary key analysis prune from a polygon that disagrees with the one `pointInPolygon` evaluates.

**Invalid ring.** The constant ring was never checked with `boost::geometry::is_valid`, unlike `parseConstPolygon` and the GeoParquet pruning path. `bg::correct` does not repair a self-intersection, so the unusable ring reached `bg::intersects`, whose relate-based answer disagrees with the grid algorithm the function evaluates. On the reporter's reproducer: 849 rows against 875 for the same data with a key permitting no such atom, 26 lost. Both argument forms are affected, correcting the issue text: they reach the same lambda, as the reporter's own three-argument case (794 against 820) shows.

**Invalid assembly (found in review).** Holes are not stored, so the filter tests the shell alone, which over-approximates the function only while the assembled shell-plus-holes shape is valid. A valid *concave* shell with a self-intersecting hole loses rows: an L-shaped shell with a bowtie hole returned 3446 against 3556, the 110 missing rows all in the shell's notch, which the shell excludes but the assembly includes. A convex shell cannot expose this, having no notch outside its own outline.

Both are fixed by validating the shape the function itself validates and declining the atom otherwise, so no pruning happens and the scan returns the correct rows. This mirrors `GeoBbox.h`, which refuses a pruning bbox rather than throwing; index analysis must not raise user errors. Neither check is gated on `validate_polygons`: with validation enabled the query already fails earlier, so gating would keep the bug for exactly the users who can reach it. `force_primary_key = 1` now raises `INDEX_NOT_USED` on these shapes, no key atom being left to force.

<details>
<summary>Validation</summary>

Debug build, both directions, Build IDs asserted against the running servers.

| Case (`validate_polygons = 0`) | Before | After | Expected |
|---|---|---|---|
| bowtie ring, 2-arg, both modes | 849 | 875 | 875 |
| bowtie ring, 3-arg with hole, both modes | 794 | 820 | 820 |
| rows lost / gained | 26 / 0 | 0 / 0 | 0 / 0 |
| valid concave shell + bowtie hole, both modes | 3446 | 3556 | 3556 |
| rows lost, that case | 110 | 0 | 0 |
| degenerate 2-point ring | 8 | 8 | 8 |
| valid convex ring | 1681 | 1681 | 1681 |
| valid ring, granules | 289/1250 | 289/1250 | unchanged |
| valid shell + valid hole, granules | 85/1250 | 85/1250 | unchanged |
| invalid ring, granules | 188/1250 | 1250/1250 | no pruning |
| invalid assembly, granules | 733/1250 | 1250/1250 | no pruning |

Every shape newly declined is already rejected by the function under the default `validate_polygons = 1`, verified per shape, so pruning changes only under the explicit opt-out. Valid shapes keep pruning: interior hole, two disjoint holes, holes sharing a vertex, clockwise and explicitly-closed holes, concave shell with interior hole, and the existing with-holes minmax test.

The test fails on the unpatched binary with exactly the pre-fix counts and passes 50/50 randomized. Of 153 selected `polygon`, `key_condition`, `primary_key_index`, `geo_` and `minmax_index` tests, 15 failed and none is attributable: 9 fail identically unpatched, and 6 are order or sandbox-config flakes measured on both binaries.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1487` (included in `26.8` and later)
<!-- ch-version-info:end -->