### PR TITLE
Check PREWHERE column support inside lambda bodies

### DIFF
--- a/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
+++ b/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/LambdaNode.h>
 #include <Analyzer/Utils.h>
+#include <DataTypes/DataTypeFunction.h>
 #include <fmt/ranges.h>
 
 namespace DB
@@ -49,7 +51,22 @@ public:
             node = replacement_node;
 
         if (auto * function_node = node->as<FunctionNode>(); function_node && function_node->isResolved())
+        {
             rerunFunctionResolve(function_node, context);
+        }
+        else if (auto * lambda_node = node->as<LambdaNode>())
+        {
+            /// The lambda caches its own result type, so replacing a column inside its body leaves that
+            /// cache stale and the mismatch resurfaces later as a header type mismatch. Recompute it from
+            /// the rewritten body, keeping the argument types.
+            const auto * lambda_type = typeid_cast<const DataTypeFunction *>(lambda_node->getResultType().get());
+            if (!lambda_type)
+                throw Exception(ErrorCodes::LOGICAL_ERROR,
+                    "Lambda node {} result type is not a function type",
+                    lambda_node->formatASTForErrorMessage());
+
+            lambda_node->resolve(std::make_shared<DataTypeFunction>(lambda_type->getArgumentTypes(), lambda_node->getExpression()->getResultType()));
+        }
     }
 
     /// We want to re-run resolve for function _after_ its arguments are replaced
@@ -57,11 +74,15 @@ public:
 
     bool needChildVisit(QueryTreeNodePtr & /* parent */, QueryTreeNodePtr & child)
     {
-        /// Visit only expressions, but not subqueries
+        /// Visit only expressions, but not subqueries.
+        /// LAMBDA is an expression too: a matcher inside a lambda body (`arrayMap(x -> *, ...)`) is
+        /// rewritten by the same JOIN type corrections as one outside it, so the replacement must reach
+        /// it, otherwise the registered entry is never applied.
         return child->getNodeType() == QueryTreeNodeType::IDENTIFIER
             || child->getNodeType() == QueryTreeNodeType::LIST
             || child->getNodeType() == QueryTreeNodeType::FUNCTION
-            || child->getNodeType() == QueryTreeNodeType::COLUMN;
+            || child->getNodeType() == QueryTreeNodeType::COLUMN
+            || child->getNodeType() == QueryTreeNodeType::LAMBDA;
     }
 
 private:

--- a/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
+++ b/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
@@ -75,9 +75,8 @@ public:
         }
         else if (auto * lambda_node = node->as<LambdaNode>())
         {
-            /// The lambda caches its own result type, so replacing a column inside its body leaves that
-            /// cache stale and the mismatch resurfaces later as a header type mismatch. Recompute it from
-            /// the rewritten body, keeping the argument types.
+            /// The lambda caches a result type derived from its body, so recompute it from the
+            /// rewritten body, keeping the argument types.
             const auto * lambda_type = typeid_cast<const DataTypeFunction *>(lambda_node->getResultType().get());
             if (!lambda_type)
                 throw Exception(ErrorCodes::LOGICAL_ERROR,
@@ -107,7 +106,8 @@ public:
 private:
     const QueryTreeNodePtrWithHashMap<QueryTreeNodePtr> & replacement_map;
     const ContextPtr & context;
-    /// Nodes a replacement happened at or under. The tree being visited owns every entry.
+    /// Nodes a replacement happened at or under. Only tested for membership, and no node is
+    /// allocated during the visit, so a released address cannot be aliased by a node tested later.
     std::unordered_set<const IQueryTreeNode *> replaced_subtrees;
 };
 

--- a/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
+++ b/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
@@ -47,8 +47,23 @@ public:
 
     void visitImpl(QueryTreeNodePtr & node)
     {
+        bool subtree_replaced = false;
         if (auto replacement_node = findTransitiveReplacement(node, replacement_map))
+        {
             node = replacement_node;
+            subtree_replaced = true;
+        }
+
+        for (const auto & child : node->getChildren())
+            if (child && replaced_subtrees.contains(child.get()))
+                subtree_replaced = true;
+
+        /// A node nothing was replaced under keeps the types it was resolved with, and rebuilding it
+        /// goes through FunctionFactory, which does not own executable or WebAssembly UDFs.
+        if (!subtree_replaced)
+            return;
+
+        replaced_subtrees.insert(node.get());
 
         if (auto * function_node = node->as<FunctionNode>(); function_node && function_node->isResolved())
         {
@@ -92,6 +107,8 @@ public:
 private:
     const QueryTreeNodePtrWithHashMap<QueryTreeNodePtr> & replacement_map;
     const ContextPtr & context;
+    /// Nodes a replacement happened at or under. The tree being visited owns every entry.
+    std::unordered_set<const IQueryTreeNode *> replaced_subtrees;
 };
 
 }

--- a/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
+++ b/src/Analyzer/Resolve/ReplaceColumnsVisitor.h
@@ -52,6 +52,10 @@ public:
 
         if (auto * function_node = node->as<FunctionNode>(); function_node && function_node->isResolved())
         {
+            /// A lambda's parameter types are derived from its higher-order function's array
+            /// arguments, so replacing a column in one of those arguments invalidates them.
+            /// Re-derive them before rebuilding the function, which reads the lambda's type.
+            rerunLambdaArgumentsResolve(function_node, context);
             rerunFunctionResolve(function_node, context);
         }
         else if (auto * lambda_node = node->as<LambdaNode>())

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -9,6 +9,7 @@
 #include <Parsers/ASTFunction.h>
 
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeFunction.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeArray.h>
@@ -49,6 +50,7 @@
 #include <Analyzer/IdentifierNode.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/JoinNode.h>
+#include <Analyzer/LambdaNode.h>
 #include <Analyzer/QueryNode.h>
 #include <Analyzer/TableFunctionNode.h>
 #include <Analyzer/TableNode.h>
@@ -939,6 +941,56 @@ void replaceColumns(QueryTreeNodePtr & node,
     visitor.visit(node);
 }
 
+namespace
+{
+
+/// Retypes the columns of a lambda body that read the lambda's own parameters, after those
+/// parameter types changed, and re-resolves every function built on them.
+class RetypeLambdaArgumentColumnsVisitor : public InDepthQueryTreeVisitor<RetypeLambdaArgumentColumnsVisitor>
+{
+public:
+    RetypeLambdaArgumentColumnsVisitor(const LambdaArgumentsNode * arguments_, const ContextPtr & context_)
+        : arguments(arguments_)
+        , context(context_)
+    {}
+
+    void visitImpl(QueryTreeNodePtr & node)
+    {
+        if (auto * column_node = node->as<ColumnNode>())
+        {
+            if (column_node->getColumnSourceOrNull().get() != arguments)
+                return;
+
+            const auto & names = arguments->getNames();
+            auto it = std::find(names.begin(), names.end(), column_node->getColumnName());
+            if (it == names.end())
+                return;
+
+            column_node->setColumnType(arguments->getTypes()[it - names.begin()]);
+        }
+        else if (auto * function_node = node->as<FunctionNode>(); function_node && function_node->isResolved())
+        {
+            rerunLambdaArgumentsResolve(function_node, context);
+            rerunFunctionResolve(function_node, context);
+        }
+    }
+
+    /// Rebuild a function only after its arguments settled.
+    bool shouldTraverseTopToBottom() const { return false; }
+
+    static bool needChildVisit(QueryTreeNodePtr &, QueryTreeNodePtr & child)
+    {
+        auto child_node_type = child->getNodeType();
+        return child_node_type != QueryTreeNodeType::QUERY && child_node_type != QueryTreeNodeType::UNION;
+    }
+
+private:
+    const LambdaArgumentsNode * arguments;
+    const ContextPtr & context;
+};
+
+}
+
 void rerunFunctionResolve(FunctionNode * function_node, ContextPtr context)
 {
     if (!function_node->isResolved())
@@ -962,6 +1014,77 @@ void rerunFunctionResolve(FunctionNode * function_node, ContextPtr context)
     else if (function_node->isWindowFunction())
     {
         function_node->resolveAsWindowFunction(resolveAggregateFunction(*function_node, function_node->getFunctionName()));
+    }
+}
+
+void rerunLambdaArgumentsResolve(FunctionNode * function_node, ContextPtr context)
+{
+    if (!function_node->isResolved())
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Trying to rerun lambda arguments resolve of unresolved function '{}'", function_node->getFunctionName());
+
+    if (!function_node->isOrdinaryFunction())
+        return;
+
+    auto & argument_nodes = function_node->getArguments().getNodes();
+
+    std::vector<size_t> lambda_argument_indexes;
+    for (size_t i = 0; i < argument_nodes.size(); ++i)
+        if (argument_nodes[i]->as<LambdaNode>())
+            lambda_argument_indexes.push_back(i);
+
+    if (lambda_argument_indexes.empty())
+        return;
+
+    auto function = FunctionFactory::instance().tryGet(function_node->getFunctionName(), context);
+    if (!function || !function->isHigherOrderFunction())
+        return;
+
+    /// `getLambdaArgumentTypes` expects a placeholder DataTypeFunction of the right arity at every
+    /// lambda position and fills in the parameter types from the other arguments, exactly as
+    /// function resolution does. Deriving `Array(T) -> T` here instead would miss the
+    /// tuple-unpacking and LowCardinality handling each higher-order function applies.
+    DataTypes argument_types;
+    argument_types.reserve(argument_nodes.size());
+    for (const auto & argument_node : argument_nodes)
+    {
+        if (const auto * lambda_node = argument_node->as<LambdaNode>())
+            argument_types.push_back(std::make_shared<DataTypeFunction>(
+                DataTypes(lambda_node->getArguments().getNames().size(), nullptr), nullptr));
+        else
+            argument_types.push_back(argument_node->getResultType());
+    }
+
+    function->getLambdaArgumentTypes(argument_types);
+
+    for (size_t index : lambda_argument_indexes)
+    {
+        const auto * function_data_type = typeid_cast<const DataTypeFunction *>(argument_types[index].get());
+        if (!function_data_type)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Function '{}' expected function data type for lambda argument with index {}. Actual: {}",
+                function_node->getFunctionName(), index, argument_types[index]->getName());
+
+        auto & lambda_node = argument_nodes[index]->as<LambdaNode &>();
+        const auto & derived_argument_types = function_data_type->getArgumentTypes();
+        if (derived_argument_types.size() != lambda_node.getArguments().getNames().size())
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Function '{}' lambda argument with index {} arguments size mismatch. Actual: {}. Expected {}",
+                function_node->getFunctionName(), index,
+                derived_argument_types.size(), lambda_node.getArguments().getNames().size());
+
+        if (derived_argument_types == lambda_node.getArguments().getTypes())
+            continue;
+
+        lambda_node.getArguments().resolve(derived_argument_types);
+
+        /// The body reads the parameters through columns sourced from the arguments node, so those
+        /// columns and everything derived from them must be re-typed too.
+        RetypeLambdaArgumentColumnsVisitor retype_visitor(&lambda_node.getArguments(), context);
+        retype_visitor.visit(lambda_node.getExpression());
+
+        lambda_node.resolve(std::make_shared<DataTypeFunction>(
+            derived_argument_types, lambda_node.getExpression()->getResultType()));
     }
 }
 

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -1040,10 +1040,9 @@ void rerunLambdaArgumentsResolve(FunctionNode * function_node, ContextPtr contex
     if (!function || !function->isHigherOrderFunction())
         return;
 
-    /// `getLambdaArgumentTypes` expects a placeholder DataTypeFunction of the right arity at every
-    /// lambda position and fills in the parameter types from the other arguments, exactly as
-    /// function resolution does. Deriving `Array(T) -> T` here instead would miss the
-    /// tuple-unpacking and LowCardinality handling each higher-order function applies.
+    /// Each lambda position takes a placeholder DataTypeFunction of the right arity, which
+    /// `getLambdaArgumentTypes` fills in from the remaining arguments. Only the function itself knows
+    /// how, so the tuple-unpacking and LowCardinality cases are handled here for free.
     DataTypes argument_types;
     argument_types.reserve(argument_nodes.size());
     for (const auto & argument_node : argument_nodes)

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -973,6 +973,20 @@ public:
             rerunLambdaArgumentsResolve(function_node, context);
             rerunFunctionResolve(function_node, context);
         }
+        else if (auto * lambda_node = node->as<LambdaNode>())
+        {
+            /// A nested lambda whose own array argument did not change keeps its parameter types,
+            /// so re-resolving its higher-order function leaves the cached return type stale.
+            /// Recompute it from the body, which the bottom-up traversal has already settled.
+            const auto * lambda_type = typeid_cast<const DataTypeFunction *>(lambda_node->getResultType().get());
+            if (!lambda_type)
+                throw Exception(ErrorCodes::LOGICAL_ERROR,
+                    "Lambda node {} result type is not a function type",
+                    lambda_node->formatASTForErrorMessage());
+
+            lambda_node->resolve(std::make_shared<DataTypeFunction>(
+                lambda_type->getArgumentTypes(), lambda_node->getExpression()->getResultType()));
+        }
     }
 
     /// Rebuild a function only after its arguments settled.

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -967,8 +967,23 @@ public:
                 return;
 
             column_node->setColumnType(arguments->getTypes()[it - names.begin()]);
+            retyped_subtrees.insert(node.get());
+            return;
         }
-        else if (auto * function_node = node->as<FunctionNode>(); function_node && function_node->isResolved())
+
+        bool subtree_retyped = false;
+        for (const auto & child : node->getChildren())
+            if (child && retyped_subtrees.contains(child.get()))
+                subtree_retyped = true;
+
+        /// A node no parameter read was retyped under keeps the types it was resolved with, and
+        /// rebuilding it goes through FunctionFactory, which does not own executable or WebAssembly UDFs.
+        if (!subtree_retyped)
+            return;
+
+        retyped_subtrees.insert(node.get());
+
+        if (auto * function_node = node->as<FunctionNode>(); function_node && function_node->isResolved())
         {
             rerunLambdaArgumentsResolve(function_node, context);
             rerunFunctionResolve(function_node, context);
@@ -1001,6 +1016,8 @@ public:
 private:
     const LambdaArgumentsNode * arguments;
     const ContextPtr & context;
+    /// Nodes a parameter read was retyped at or under. The body being visited owns every entry.
+    std::unordered_set<const IQueryTreeNode *> retyped_subtrees;
 };
 
 }

--- a/src/Analyzer/Utils.cpp
+++ b/src/Analyzer/Utils.cpp
@@ -949,9 +949,13 @@ namespace
 class RetypeLambdaArgumentColumnsVisitor : public InDepthQueryTreeVisitor<RetypeLambdaArgumentColumnsVisitor>
 {
 public:
-    RetypeLambdaArgumentColumnsVisitor(const LambdaArgumentsNode * arguments_, const ContextPtr & context_)
+    RetypeLambdaArgumentColumnsVisitor(
+        const LambdaArgumentsNode * arguments_,
+        const ContextPtr & context_,
+        const std::unordered_set<size_t> & changed_argument_indexes_)
         : arguments(arguments_)
         , context(context_)
+        , changed_argument_indexes(changed_argument_indexes_)
     {}
 
     void visitImpl(QueryTreeNodePtr & node)
@@ -966,7 +970,13 @@ public:
             if (it == names.end())
                 return;
 
-            column_node->setColumnType(arguments->getTypes()[it - names.begin()]);
+            /// A parameter whose type is unchanged still reads the type it was resolved with, so
+            /// nothing above it needs rebuilding.
+            const size_t index = it - names.begin();
+            if (!changed_argument_indexes.contains(index))
+                return;
+
+            column_node->setColumnType(arguments->getTypes()[index]);
             retyped_subtrees.insert(node.get());
             return;
         }
@@ -1016,7 +1026,9 @@ public:
 private:
     const LambdaArgumentsNode * arguments;
     const ContextPtr & context;
-    /// Nodes a parameter read was retyped at or under. The body being visited owns every entry.
+    const std::unordered_set<size_t> & changed_argument_indexes;
+    /// Nodes a parameter read was retyped at or under. Only tested for membership, and no node is
+    /// allocated during the visit, so a released address cannot be aliased by a node tested later.
     std::unordered_set<const IQueryTreeNode *> retyped_subtrees;
 };
 
@@ -1103,14 +1115,24 @@ void rerunLambdaArgumentsResolve(FunctionNode * function_node, ContextPtr contex
                 function_node->getFunctionName(), index,
                 derived_argument_types.size(), lambda_node.getArguments().getNames().size());
 
-        if (derived_argument_types == lambda_node.getArguments().getTypes())
+        const auto & old_argument_types = lambda_node.getArguments().getTypes();
+        if (derived_argument_types == old_argument_types)
             continue;
+
+        std::unordered_set<size_t> changed_argument_indexes;
+        for (size_t i = 0; i < derived_argument_types.size(); ++i)
+        {
+            const auto & new_type = derived_argument_types[i];
+            const auto & old_type = i < old_argument_types.size() ? old_argument_types[i] : nullptr;
+            if (!old_type || !new_type || !old_type->equals(*new_type))
+                changed_argument_indexes.insert(i);
+        }
 
         lambda_node.getArguments().resolve(derived_argument_types);
 
         /// The body reads the parameters through columns sourced from the arguments node, so those
         /// columns and everything derived from them must be re-typed too.
-        RetypeLambdaArgumentColumnsVisitor retype_visitor(&lambda_node.getArguments(), context);
+        RetypeLambdaArgumentColumnsVisitor retype_visitor(&lambda_node.getArguments(), context, changed_argument_indexes);
         retype_visitor.visit(lambda_node.getExpression());
 
         lambda_node.resolve(std::make_shared<DataTypeFunction>(

--- a/src/Analyzer/Utils.h
+++ b/src/Analyzer/Utils.h
@@ -152,6 +152,12 @@ void replaceColumns(QueryTreeNodePtr & node,
   */
 void rerunFunctionResolve(FunctionNode * function_node, ContextPtr context);
 
+/** Re-derive the parameter types of the lambda arguments of a resolved function from its current
+  * arguments, and re-resolve the affected lambda bodies.
+  * This function should be called when the arguments of a higher-order function changed type.
+  */
+void rerunLambdaArgumentsResolve(FunctionNode * function_node, ContextPtr context);
+
 /// Just collect all identifiers from query tree
 NameSet collectIdentifiersFullNames(const QueryTreeNodePtr & node);
 

--- a/src/Planner/CollectTableExpressionData.cpp
+++ b/src/Planner/CollectTableExpressionData.cpp
@@ -290,6 +290,10 @@ public:
                 column_node->formatASTForErrorMessage(),
                 query_node->formatASTForErrorMessage());
 
+        /// A lambda parameter is bound by the lambda, not read from a table expression.
+        if (column_source->getNodeType() == QueryTreeNodeType::LAMBDA_ARGS)
+            return;
+
         auto * table_column_source = column_source->as<TableNode>();
         auto * table_function_column_source = column_source->as<TableFunctionNode>();
 
@@ -342,8 +346,7 @@ public:
     {
         auto child_node_type = child_node->getNodeType();
         return child_node_type != QueryTreeNodeType::QUERY &&
-               child_node_type != QueryTreeNodeType::UNION &&
-               child_node_type != QueryTreeNodeType::LAMBDA;
+               child_node_type != QueryTreeNodeType::UNION;
     }
 
 private:

--- a/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.reference
+++ b/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.reference
@@ -30,6 +30,26 @@ left join with join_use_nulls, right column inside a lambda body
 left join with join_use_nulls, right column outside a lambda
 1
 2
+left join with join_use_nulls, nested lambda over the right column
+1
+2
+nested lambda over the right column, without join_use_nulls
+1
+2
+nested arrayMap over the right column
+1
+2
+nested arrayFilter over the right column
+1
+2
+three lambdas deep over the right column
+1
+2
+nested lambda over a column of a single table
+10
+20
+lambda body reading both join inputs
+both join inputs outside a lambda, refused already
 left join with join_use_nulls, lambda parameter shadowing the right column
 1	100
 2	\N

--- a/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.reference
+++ b/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.reference
@@ -1,0 +1,35 @@
+unsupported column inside a lambda body, qualified
+unsupported column inside a lambda body, asterisk
+unsupported column outside a lambda, refused already
+higher-order function other than arrayMap
+array-joined alias inside a lambda body
+array-joined alias outside a lambda, refused already
+supported column inside a lambda body
+100
+300
+diverging types are fine in WHERE
+100
+300
+unrestricted storage, lambda body
+100
+lambda parameter shadowing a table column
+100
+lambda over a non-first table expression
+2	20	200
+left join, right column inside a lambda body
+1
+2
+left join, right column outside a lambda
+1
+2
+left join, right column in WHERE, filtered after the join
+1
+left join with join_use_nulls, right column inside a lambda body
+1
+2
+left join with join_use_nulls, right column outside a lambda
+1
+2
+left join with join_use_nulls, lambda parameter shadowing the right column
+1	100
+2	\N

--- a/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.reference
+++ b/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.reference
@@ -45,7 +45,19 @@ nested arrayFilter over the right column
 three lambdas deep over the right column
 1
 2
+left join with join_use_nulls, inner lambda capturing the outer parameter
+1
+2
+inner lambda capturing the outer parameter, without join_use_nulls
+1
+2
+outer parameter captured two lambdas down
+1
+2
 nested lambda over a column of a single table
+10
+20
+capture of the outer parameter over a column of a single table
 10
 20
 lambda body reading both join inputs

--- a/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.sql
+++ b/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.sql
@@ -111,6 +111,44 @@ SELECT 'left join with join_use_nulls, right column outside a lambda';
 SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
 PREWHERE b.y != 0 ORDER BY a.id SETTINGS join_use_nulls = 1;
 
+-- The parameter types of a nested lambda are derived from the array it iterates, so restoring a
+-- column inside that array must re-derive them. Every spelling and depth agrees with the
+-- non-lambda control above.
+SELECT 'left join with join_use_nulls, nested lambda over the right column';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(z -> arrayExists(y -> y != 0, [b.y]), [1]) ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+SELECT 'nested lambda over the right column, without join_use_nulls';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(z -> arrayExists(y -> y != 0, [b.y]), [1]) ORDER BY a.id SETTINGS join_use_nulls = 0;
+
+SELECT 'nested arrayMap over the right column';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(z -> (arrayMap(y -> y != 0, [b.y])[1]), [1]) ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+SELECT 'nested arrayFilter over the right column';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(z -> arrayFilter(y -> y != 0, [b.y]) != [], [1]) ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+SELECT 'three lambdas deep over the right column';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(w -> arrayExists(z -> arrayExists(y -> y != 0, [b.y]), [1]), [1])
+ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+-- Nothing is restored without a join, so the same nesting reads the column unchanged.
+SELECT 'nested lambda over a column of a single table';
+SELECT v FROM pw_lam_lj_a PREWHERE arrayExists(z -> arrayExists(y -> y != 0, [pw_lam_lj_a.v]), [1]) ORDER BY v;
+
+-- PREWHERE reads a single table expression, so a lambda body spanning both join inputs is
+-- refused like the non-lambda spelling instead of reaching the reader.
+SELECT 'lambda body reading both join inputs';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(z -> (a.id = 1) AND (b.y != 0), [1]) ORDER BY a.id; -- { serverError ILLEGAL_PREWHERE }
+
+SELECT 'both join inputs outside a lambda, refused already';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE (a.id = 1) AND (b.y != 0) ORDER BY a.id; -- { serverError ILLEGAL_PREWHERE }
+
 -- A lambda parameter is bound by the lambda, so sharing a name and a type with the
 -- substituted join column must not make the restoration rewrite it.
 SELECT 'left join with join_use_nulls, lambda parameter shadowing the right column';

--- a/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.sql
+++ b/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.sql
@@ -135,9 +135,30 @@ SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
 PREWHERE arrayExists(w -> arrayExists(z -> arrayExists(y -> y != 0, [b.y]), [1]), [1])
 ORDER BY a.id SETTINGS join_use_nulls = 1;
 
+-- An inner lambda that only captures an outer parameter keeps its own parameter types, so its
+-- cached return type is the single stale part and has to be recomputed on its own.
+SELECT 'left join with join_use_nulls, inner lambda capturing the outer parameter';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(x -> arrayExists(y -> (y = 1) AND (x != 0), [1]), [b.y])
+ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+SELECT 'inner lambda capturing the outer parameter, without join_use_nulls';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(x -> arrayExists(y -> (y = 1) AND (x != 0), [1]), [b.y])
+ORDER BY a.id SETTINGS join_use_nulls = 0;
+
+SELECT 'outer parameter captured two lambdas down';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(x -> arrayExists(w -> arrayExists(y -> (y = 1) AND (x != 0), [1]), [1]), [b.y])
+ORDER BY a.id SETTINGS join_use_nulls = 1;
+
 -- Nothing is restored without a join, so the same nesting reads the column unchanged.
 SELECT 'nested lambda over a column of a single table';
 SELECT v FROM pw_lam_lj_a PREWHERE arrayExists(z -> arrayExists(y -> y != 0, [pw_lam_lj_a.v]), [1]) ORDER BY v;
+
+SELECT 'capture of the outer parameter over a column of a single table';
+SELECT v FROM pw_lam_lj_a
+PREWHERE arrayExists(x -> arrayExists(y -> (y = 1) AND (x != 0), [1]), [pw_lam_lj_a.v]) ORDER BY v;
 
 -- PREWHERE reads a single table expression, so a lambda body spanning both join inputs is
 -- refused like the non-lambda spelling instead of reaching the reader.

--- a/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.sql
+++ b/tests/queries/0_stateless/04879_prewhere_lambda_body_column_check.sql
@@ -1,0 +1,130 @@
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS pw_lam_u32;
+DROP TABLE IF EXISTS pw_lam_nul;
+DROP TABLE IF EXISTS pw_lam_same_a;
+DROP TABLE IF EXISTS pw_lam_same_b;
+DROP TABLE IF EXISTS pw_lam_one;
+DROP TABLE IF EXISTS pw_lam_join_l;
+DROP TABLE IF EXISTS pw_lam_join_r;
+DROP TABLE IF EXISTS pw_lam_aj;
+DROP TABLE IF EXISTS pw_lam_lj_a;
+DROP TABLE IF EXISTS pw_lam_lj_b;
+
+-- Two Merge children declaring x with different types: the Merge contract excludes x
+-- from PREWHERE, so referencing it must be refused however it is spelled.
+CREATE TABLE pw_lam_u32 (x UInt32)           ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE pw_lam_nul (x Nullable(UInt32)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO pw_lam_u32 VALUES (100);
+INSERT INTO pw_lam_nul VALUES (300);
+
+SELECT 'unsupported column inside a lambda body, qualified';
+SELECT x FROM merge(currentDatabase(), '^pw_lam_u32$|^pw_lam_nul$') AS m
+PREWHERE (arrayMap(x -> m.x, [1])[1]) > 50 ORDER BY x; -- { serverError ILLEGAL_PREWHERE }
+
+SELECT 'unsupported column inside a lambda body, asterisk';
+SELECT * FROM merge(currentDatabase(), '^pw_lam_u32$|^pw_lam_nul$') AS m
+PREWHERE (arrayMap(x -> *, [1])[1]) > 50 ORDER BY x; -- { serverError ILLEGAL_PREWHERE }
+
+SELECT 'unsupported column outside a lambda, refused already';
+SELECT x FROM merge(currentDatabase(), '^pw_lam_u32$|^pw_lam_nul$') AS m
+PREWHERE m.x > 50 ORDER BY x; -- { serverError ILLEGAL_PREWHERE }
+
+SELECT 'higher-order function other than arrayMap';
+SELECT x FROM merge(currentDatabase(), '^pw_lam_u32$|^pw_lam_nul$') AS m
+PREWHERE arrayFilter(x -> m.x > 50, [1]) != []; -- { serverError ILLEGAL_PREWHERE }
+
+-- PREWHERE runs at the storage read, before ARRAY JOIN, so an array-joined value is not
+-- readable there. Both spellings must be refused alike.
+CREATE TABLE pw_lam_aj (x UInt32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO pw_lam_aj VALUES (100);
+
+SELECT 'array-joined alias inside a lambda body';
+SELECT x FROM pw_lam_aj ARRAY JOIN [1, 2] AS arr
+PREWHERE (arrayMap(y -> arr, [1])[1]) > 0 ORDER BY x; -- { serverError ILLEGAL_PREWHERE }
+
+SELECT 'array-joined alias outside a lambda, refused already';
+SELECT x FROM pw_lam_aj ARRAY JOIN [1, 2] AS arr
+PREWHERE arr > 0 ORDER BY x; -- { serverError ILLEGAL_PREWHERE }
+
+-- Children agreeing on the type keep x in the contract, so the lambda still reads it.
+CREATE TABLE pw_lam_same_a (x UInt32) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE pw_lam_same_b (x UInt32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO pw_lam_same_a VALUES (100);
+INSERT INTO pw_lam_same_b VALUES (300);
+
+SELECT 'supported column inside a lambda body';
+SELECT x FROM merge(currentDatabase(), '^pw_lam_same_a$|^pw_lam_same_b$') AS m
+PREWHERE (arrayMap(x -> m.x, [1])[1]) > 50 ORDER BY x;
+
+SELECT 'diverging types are fine in WHERE';
+SELECT x FROM merge(currentDatabase(), '^pw_lam_u32$|^pw_lam_nul$') AS m
+WHERE (arrayMap(x -> m.x, [1])[1]) > 50 ORDER BY x;
+
+-- A storage with no restriction admits every column.
+CREATE TABLE pw_lam_one (x UInt32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO pw_lam_one VALUES (100);
+
+SELECT 'unrestricted storage, lambda body';
+SELECT x FROM pw_lam_one PREWHERE (arrayMap(x -> pw_lam_one.x, [1])[1]) > 50 ORDER BY x;
+
+SELECT 'lambda parameter shadowing a table column';
+SELECT x FROM pw_lam_one PREWHERE (arrayMap(x -> x + 1, [1])[1]) > 0 ORDER BY x;
+
+-- A lambda referencing a column of the second table expression must resolve to that
+-- table instead of being pinned to the first one. PREWHERE filters before the JOIN.
+CREATE TABLE pw_lam_join_l (id UInt32, av UInt32) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE pw_lam_join_r (id UInt32, bv UInt32) ENGINE = MergeTree ORDER BY id;
+INSERT INTO pw_lam_join_l VALUES (1, 10), (2, 20);
+INSERT INTO pw_lam_join_r VALUES (1, 100), (2, 200);
+
+SELECT 'lambda over a non-first table expression';
+SELECT l.id, l.av, r.bv FROM pw_lam_join_l AS l JOIN pw_lam_join_r AS r ON l.id = r.id
+PREWHERE (arrayMap(y -> r.bv, [1])[1]) > 150 ORDER BY l.id;
+
+-- Issue #114206: a LEFT JOIN keeps left rows with no match, so the lambda spelling must agree
+-- with the non-lambda PREWHERE spelling below, not with the post-join WHERE spelling.
+CREATE TABLE pw_lam_lj_a (id UInt64, v UInt64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE pw_lam_lj_b (x UInt64, y UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO pw_lam_lj_a VALUES (1, 10), (2, 20);
+INSERT INTO pw_lam_lj_b VALUES (1, 100);
+
+SELECT 'left join, right column inside a lambda body';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(z -> b.y != 0, [1]) ORDER BY a.id;
+
+SELECT 'left join, right column outside a lambda';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE b.y != 0 ORDER BY a.id;
+
+SELECT 'left join, right column in WHERE, filtered after the join';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+WHERE arrayExists(z -> b.y != 0, [1]) ORDER BY a.id;
+
+-- join_use_nulls makes the right column Nullable, and PREWHERE must see its original type.
+-- Both spellings therefore agree with each other and with the join_use_nulls = 0 rows above.
+SELECT 'left join with join_use_nulls, right column inside a lambda body';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(z -> b.y != 0, [1]) ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+SELECT 'left join with join_use_nulls, right column outside a lambda';
+SELECT a.id FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE b.y != 0 ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+-- A lambda parameter is bound by the lambda, so sharing a name and a type with the
+-- substituted join column must not make the restoration rewrite it.
+SELECT 'left join with join_use_nulls, lambda parameter shadowing the right column';
+SELECT a.id, b.y FROM pw_lam_lj_a AS a LEFT JOIN pw_lam_lj_b AS b ON a.id = b.x
+PREWHERE arrayExists(y -> (y = 7) AND (b.y != 0), [toNullable(toUInt64(7))])
+ORDER BY a.id SETTINGS join_use_nulls = 1;
+
+DROP TABLE pw_lam_u32;
+DROP TABLE pw_lam_nul;
+DROP TABLE pw_lam_same_a;
+DROP TABLE pw_lam_same_b;
+DROP TABLE pw_lam_one;
+DROP TABLE pw_lam_aj;
+DROP TABLE pw_lam_join_l;
+DROP TABLE pw_lam_join_r;
+DROP TABLE pw_lam_lj_a;
+DROP TABLE pw_lam_lj_b;

--- a/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.reference
+++ b/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.reference
@@ -1,0 +1,14 @@
+udf outside a lambda
+1
+udf inside a lambda body
+1
+udf inside a lambda body, nested
+1
+udf beside a restored join column, join_use_nulls
+1
+udf before a restored join column, join_use_nulls
+1
+udf in a lambda whose parameter is a restored join column, join_use_nulls
+1
+udf in a retyped lambda body, restored column also read outside
+1

--- a/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.reference
+++ b/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.reference
@@ -12,3 +12,7 @@ udf in a lambda whose parameter is a restored join column, join_use_nulls
 1
 udf in a retyped lambda body, restored column also read outside
 1
+udf reads an unchanged parameter beside a restored one, join_use_nulls
+1
+builtin reads an unchanged parameter beside a restored one, join_use_nulls
+1

--- a/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.sh
+++ b/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -e
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+SCRIPTS_DIR=$CUR_DIR/scripts_udf
+
+# An executable UDF is resolved through UserDefinedExecutableFunctionFactory, not FunctionFactory,
+# so a function node the PREWHERE column restoration re-resolves cannot be rebuilt and the whole
+# query is refused with UNKNOWN_FUNCTION. Nothing is replaced in any of these expressions, so the
+# restoration must leave them alone whatever the surrounding shape is.
+
+DATA="
+    SET enable_analyzer = 1;
+    CREATE TABLE lam_udf_l (id UInt64, v UInt64) ENGINE = MergeTree ORDER BY tuple();
+    CREATE TABLE lam_udf_r (x UInt64, y UInt64) ENGINE = MergeTree ORDER BY tuple();
+    INSERT INTO lam_udf_l SELECT 1, 10;
+    INSERT INTO lam_udf_r SELECT 1, 100;
+"
+
+run() {
+    echo "$1"
+    $CLICKHOUSE_LOCAL --multiquery -q "$DATA $2" \
+        -- "--user_scripts_path=$SCRIPTS_DIR" \
+           "--user_defined_executable_functions_config=$SCRIPTS_DIR/function.xml" < /dev/null
+}
+
+run 'udf outside a lambda' "
+    SELECT id FROM lam_udf_l PREWHERE (test_function() = 'qwerty') AND (v > 0) ORDER BY id;"
+
+run 'udf inside a lambda body' "
+    SELECT id FROM lam_udf_l
+    PREWHERE (arrayMap(z -> test_function(), [1])[1]) = 'qwerty' ORDER BY id;"
+
+run 'udf inside a lambda body, nested' "
+    SELECT id FROM lam_udf_l
+    PREWHERE arrayExists(w -> (arrayMap(z -> test_function(), [1])[1]) = 'qwerty', [1]) ORDER BY id;"
+
+# A restored join column in the same PREWHERE re-resolves its own subtree. The udf sibling shares
+# no node with it, so it must stay untouched.
+run 'udf beside a restored join column, join_use_nulls' "
+    SELECT a.id FROM lam_udf_l AS a LEFT JOIN lam_udf_r AS b ON a.id = b.x
+    PREWHERE (b.y != 0) AND ((arrayMap(z -> test_function(), [1])[1]) = 'qwerty')
+    ORDER BY a.id SETTINGS join_use_nulls = 1;"
+
+run 'udf before a restored join column, join_use_nulls' "
+    SELECT a.id FROM lam_udf_l AS a LEFT JOIN lam_udf_r AS b ON a.id = b.x
+    PREWHERE ((arrayMap(z -> test_function(), [1])[1]) = 'qwerty') AND (b.y != 0)
+    ORDER BY a.id SETTINGS join_use_nulls = 1;"
+
+# Here the lambda's own parameter is the restored column, so its body IS retyped. The udf reads no
+# parameter, so it must still be left alone.
+run 'udf in a lambda whose parameter is a restored join column, join_use_nulls' "
+    SELECT a.id FROM lam_udf_l AS a LEFT JOIN lam_udf_r AS b ON a.id = b.x
+    PREWHERE arrayExists(x -> (test_function() = 'qwerty') AND (x != 0), [b.y])
+    ORDER BY a.id SETTINGS join_use_nulls = 1;"
+
+run 'udf in a retyped lambda body, restored column also read outside' "
+    SELECT a.id FROM lam_udf_l AS a LEFT JOIN lam_udf_r AS b ON a.id = b.x
+    PREWHERE arrayExists(x -> (test_function() = 'qwerty') AND (x != 0), [b.y]) AND (b.y > 0)
+    ORDER BY a.id SETTINGS join_use_nulls = 1;"

--- a/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.sh
+++ b/tests/queries/0_stateless/04889_prewhere_lambda_executable_udf.sh
@@ -28,6 +28,15 @@ run() {
            "--user_defined_executable_functions_config=$SCRIPTS_DIR/function.xml" < /dev/null
 }
 
+# udf_proxy echoes its argument, so unlike the nullary test_function it can read a lambda
+# parameter. It is declared in a separate config.
+run_proxy() {
+    echo "$1"
+    $CLICKHOUSE_LOCAL --multiquery -q "$DATA $2" \
+        -- "--user_scripts_path=$SCRIPTS_DIR" \
+           "--user_defined_executable_functions_config=$SCRIPTS_DIR/proxy.xml" < /dev/null
+}
+
 run 'udf outside a lambda' "
     SELECT id FROM lam_udf_l PREWHERE (test_function() = 'qwerty') AND (v > 0) ORDER BY id;"
 
@@ -61,4 +70,16 @@ run 'udf in a lambda whose parameter is a restored join column, join_use_nulls' 
 run 'udf in a retyped lambda body, restored column also read outside' "
     SELECT a.id FROM lam_udf_l AS a LEFT JOIN lam_udf_r AS b ON a.id = b.x
     PREWHERE arrayExists(x -> (test_function() = 'qwerty') AND (x != 0), [b.y]) AND (b.y > 0)
+    ORDER BY a.id SETTINGS join_use_nulls = 1;"
+
+# Only the second parameter of this lambda is restored, so the udf reading the first one keeps the
+# type it was resolved with and must be left alone. The builtin control takes the same shape.
+run_proxy 'udf reads an unchanged parameter beside a restored one, join_use_nulls' "
+    SELECT a.id FROM lam_udf_l AS a LEFT JOIN lam_udf_r AS b ON a.id = b.x
+    PREWHERE arrayExists((u, v) -> (udf_proxy(toString(u)) = '1') AND (v != 0), [1], [b.y])
+    ORDER BY a.id SETTINGS join_use_nulls = 1;"
+
+run_proxy 'builtin reads an unchanged parameter beside a restored one, join_use_nulls' "
+    SELECT a.id FROM lam_udf_l AS a LEFT JOIN lam_udf_r AS b ON a.id = b.x
+    PREWHERE arrayExists((u, v) -> (toString(u) = '1') AND (v != 0), [1], [b.y])
     ORDER BY a.id SETTINGS join_use_nulls = 1;"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/114206


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a logical error and a `NOT_FOUND_COLUMN_IN_BLOCK` error when a `PREWHERE` expression reads a table column inside a lambda body, e.g. `PREWHERE arrayMap(x -> t.c, [1])[1] > 0`. Such a column was never checked against the table expression's supported `PREWHERE` columns, so a `Merge` whose children declare it with different types built the filter against the wrong one rather than refusing it. Also fixes `UNKNOWN_FUNCTION` for a `PREWHERE` expression calling an executable or WebAssembly UDF that does not itself read a `JOIN` column.

### Description

`CollectPrewhereTableExpressionVisitor::needChildVisit` skipped `LAMBDA`, so a column read only inside a lambda body never reached `visitImpl`, the one place that picks the table expression `PREWHERE` reads from and enforces `supportedPrewhereColumns`. On master:

- A `Merge` whose children declare `x` as `UInt32` and `Nullable(UInt32)` excludes `x` from its contract, but the guard that would refuse it never runs. The filter is built against the root's type while a child reads another, so the lambda's `ColumnFunction` capture fails in the reader: `Cannot capture column N ... incompatible type`, a logical error, so an abort under sanitizers.
- With no column visited, `PREWHERE` is pinned to the first table expression, so a lambda over another fails `Code: 10` (#114206).

The fix descends into lambda bodies, skipping only the lambda's own parameters by testing for a `LAMBDA_ARGS` column source, as the sibling `CollectSourceColumnsVisitor` already does: a node type, not a function name, so all higher-order functions are covered.

Collecting those columns makes two latent omissions live. `ReplaceColumnsVisitor` never entered a lambda either, so the `JOIN` type substitution that `PREWHERE` must roll back survived inside a lambda and aborted at `join_use_nulls = 1`. Rolling it back also re-derives the lambda's parameter types from the array its higher-order function iterates.

It also rebuilt every function in the expression, replaced or not, through `FunctionFactory`, which does not own UDFs: hence the `UNKNOWN_FUNCTION`. It is now bounded to replaced subtrees, so a UDF reading a restored `JOIN` column stays refused as on master.

Reported by @ nikitamikhaylov on [#113768](https://github.com/ClickHouse/ClickHouse/pull/113768#issuecomment-5268962866): one `Server died` in that PR's unrelated Stress test (amd_msan), [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113768&sha=8f8aef10f381104c26153d7fb829b7e196825b0b&name_0=PR&name_1=Stress+test+%28amd_msan%29).

<details><summary>Validation</summary>

Reproducer (aborts on master, `ILLEGAL_PREWHERE` with this change):

```sql
CREATE TABLE t  (x UInt32)           ENGINE = MergeTree ORDER BY tuple();
CREATE TABLE t2 (x Nullable(UInt32)) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES (100);
INSERT INTO t2 VALUES (300);
SET enable_analyzer = 1;
SELECT x FROM merge(currentDatabase(), '^t') AS m
PREWHERE (arrayMap(x -> m.x, [1])[1]) > 50;
```

`04879_prewhere_lambda_body_column_check`: 29 arms A/B'd against a base build, 8 refusals and
21 row-returning. Every refusal and every `join_use_nulls` shape is paired with the same query
without a lambda, so each expected outcome is justified against master's own answer.

| arm | base | with this change |
|---|---|---|
| diverging child types, lambda reads `m.x` (also `*`, `arrayFilter`) | abort | `ILLEGAL_PREWHERE` |
| `ARRAY JOIN`ed alias inside a lambda | `Code: 10` | `ILLEGAL_PREWHERE` |
| lambda over the second table of a `JOIN` | `Code: 10` | resolves to that table |
| `LEFT JOIN`, right column in `arrayExists`, `join_use_nulls` 0 and 1 (#114206) | abort or `Code: 10` | `1` / `2` |
| the same four without a lambda | as after the change | unchanged |
| agreeing types; `WHERE`; unrestricted table; shadowed parameter | rows | unchanged |

`04889_prewhere_lambda_executable_udf` covers the UDF case in 9 arms, with a built-in control.

Five mutation arms, disjoint casualties: reverting `needChildVisit` re-introduces the abort and
the `Code: 10`; dropping the `LAMBDA_ARGS` guard breaks `04108`; reverting
`ReplaceColumnsVisitor` aborts in `ActionsDAG`; dropping either return-type refresh or the
parameter-type re-derivation aborts in planning or in `ColumnFunction::appendArgument`.

`04108`, `03036_prewhere_lambda_function`, `00729_prewhere_array_join` and
`02955_analyzer_using_functional_args` pass unchanged. Both new tests ran 50x, 0 failures:
`04879` under randomized settings, `04889` at `clickhouse-local` defaults.

</details>