### PR TITLE
Show file sizes next to artifact links in CI reports

### DIFF
--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -141,6 +141,14 @@
             text-decoration: none;
         }
 
+        /* File size shown next to a file link - same font size, but muted */
+        .file-size {
+            color: var(--text-color);
+            font-weight: normal;
+            opacity: 0.7;
+            white-space: nowrap;
+        }
+
         .external-link {
             color: var(--file-link-color);
             font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -753,6 +761,37 @@
         return `${formattedSeconds}.${formattedMilliseconds}`;
     }
 
+    // Human-readable file size, e.g. 1288490189 -> "1.2 GiB". Returns an empty
+    // string for an unknown size so that callers can just skip rendering it.
+    function formatFileSize(sizeInBytes) {
+        if (sizeInBytes === null || sizeInBytes === undefined) {
+            return '';
+        }
+        const size = parseFloat(sizeInBytes);
+        if (isNaN(size) || size < 0) {
+            return '';
+        }
+        const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+        let unitIdx = 0;
+        let value = size;
+        while (value >= 1024 && unitIdx < units.length - 1) {
+            value /= 1024;
+            unitIdx++;
+        }
+        // Bytes are whole, everything else gets one decimal place.
+        return `${unitIdx === 0 ? Math.round(value) : value.toFixed(1)} ${units[unitIdx]}`;
+    }
+
+    // Appends " (1.2 GiB)" to a file link element, if the size is known.
+    function appendFileSize(linkElement, sizeInBytes) {
+        const text = formatFileSize(sizeInBytes);
+        if (!text) return;
+        const sizeElement = document.createElement('span');
+        sizeElement.className = 'file-size';
+        sizeElement.textContent = ` (${text})`;
+        linkElement.appendChild(sizeElement);
+    }
+
     // Function to determine status class based on value
     function getStatusClass(status) {
         const lowerStatus = status.toLowerCase();
@@ -866,7 +905,7 @@
         statusContainer.appendChild(widget);
     }
 
-    function addFileLinksWidget(links) {
+    function addFileLinksWidget(links, link_sizes = {}) {
         if (!Array.isArray(links) || links.length === 0) return;
 
         const statusContainer = document.getElementById('status-container');
@@ -882,6 +921,7 @@
             fileLink.target = '_blank';
             fileLink.className = 'file-link';
             fileLink.textContent = link.includes(base_url) ? "Report" : link.split('/').pop();
+            appendFileSize(fileLink, (link_sizes || {})[link]);
 
             // Wrap each link in its own line for spacing
             const line = document.createElement('div');
@@ -1980,7 +2020,7 @@
                         statusEl.href = '#';
                         statusEl.addEventListener('click', (e) => {
                             e.preventDefault();
-                            toggleInfoRow(row, result.info, result.results, result.links);
+                            toggleInfoRow(row, result.info, result.results, result.links, result.ext?.link_sizes);
                         });
                     }
                     td.appendChild(statusEl);
@@ -2052,7 +2092,7 @@
 
             // unfold all for preview mode (nest_level = 0 in this case)
             if (nest_level === 0 && result.results.length > 0) {
-                toggleInfoRow(row, result.info, result.results, result.links);
+                toggleInfoRow(row, result.info, result.results, result.links, result.ext?.link_sizes);
             }
 
         });
@@ -2061,7 +2101,7 @@
     /**
      * Toggles an additional row below the clicked row to display the "info" text.
      */
-    function toggleInfoRow(row, infoText, sub_results = [], links = []) {
+    function toggleInfoRow(row, infoText, sub_results = [], links = [], link_sizes = {}) {
         let nextRow = row.nextElementSibling;
 
         // Check if the next row is already an "info" row
@@ -2106,7 +2146,6 @@
                     let linkElement = document.createElement('a');
                     linkElement.href = link;
                     linkElement.target = "_blank"; // Open in a new tab
-                    linkElement.style.display = "block"; // Each link on a new line
 
                     if (!link.includes(base_url)) {
                         // External link: Show file name
@@ -2114,7 +2153,12 @@
                     } else {
                         linkElement.textContent = "Report";
                     }
-                    linksContainer.appendChild(linkElement);
+                    appendFileSize(linkElement, (link_sizes || {})[link]);
+
+                    // Each link, with its size, on a new line
+                    const line = document.createElement('div');
+                    line.appendChild(linkElement);
+                    linksContainer.appendChild(line);
                 });
 
                 infoCell.appendChild(linksContainer);
@@ -2431,7 +2475,7 @@
         let statusWidget = addStatusWidget(result.name, result.status, result.start_time, result.duration);
         addLabelsWidget(result.ext);
         if (nameParams.length > 1) {
-            addFileLinksWidget(result.links);
+            addFileLinksWidget(result.links, result.ext?.link_sizes);
             if (nameParams.length === 2) {
                 addStatisticsWidget(nameParams[1], result.duration * 1000)
             }
@@ -2621,11 +2665,18 @@
             // Rewrite links: replace origin+bucket prefix with proxy base URL.
             // privateBaseUrl is e.g. https://proxy/bucket-name, extract /bucket-name
             const bucketPath = new URL(privateBaseUrl).pathname;
+            const re = new RegExp('^https?://[^/]+' + bucketPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+            const rewriteLink = link => link.replace(re, privateBaseUrl);
             if (Array.isArray(copy.links)) {
-                copy.links = copy.links.map(link => {
-                    const re = new RegExp('^https?://[^/]+' + bucketPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-                    return link.replace(re, privateBaseUrl);
+                copy.links = copy.links.map(rewriteLink);
+            }
+            // ext.link_sizes is keyed by link, so its keys need the same rewrite
+            if (copy.ext && copy.ext.link_sizes) {
+                const link_sizes = {};
+                Object.entries(copy.ext.link_sizes).forEach(([link, size]) => {
+                    link_sizes[rewriteLink(link)] = size;
                 });
+                copy.ext = Object.assign({}, copy.ext, {link_sizes});
             }
             return copy;
         });

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -192,6 +192,8 @@ class Result(MetaClasses.Serializable):
             files=files or [],
             links=links or [],
         )
+        for link in result.links:
+            result._record_link_size(link)
         if isinstance(labels, str):
             labels = [labels]
         for label in labels or []:
@@ -360,10 +362,24 @@ class Result(MetaClasses.Serializable):
         self._dump_if_persisted()
         return self
 
-    def set_link(self, link) -> "Result":
+    def set_link(self, link, size=None) -> "Result":
         self.links.append(link)
+        self._record_link_size(link, size)
         self._dump_if_persisted()
         return self
+
+    def _record_link_size(self, link, size=None):
+        """Remember the size in bytes of the object a link points to.
+
+        Stored in ``ext["link_sizes"]`` as a ``{link: bytes}`` map and rendered by
+        ``json.html`` next to the link, e.g. ``clickhouse-common-static.deb (1.2 GiB)``.
+        When ``size`` is not given it is taken from the uploads this process made,
+        so links to files uploaded by praktika get their size for free.
+        """
+        if size is None:
+            size = S3.get_uploaded_size(link)
+        if size is not None:
+            self.ext.setdefault("link_sizes", {})[link] = size
 
     def _add_job_summary_to_info(self):
         if not self.info:
@@ -1323,6 +1339,7 @@ class _ResultS3:
                     _uploaded_file_link[file] = file_link
 
                 result.links.append(file_link)
+                result._record_link_size(file_link)
             except Exception as e:
                 traceback.print_exc()
                 print(f"ERROR: Failed to upload file [{file}] for result [{result.name}]")

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -4,7 +4,7 @@ import mimetypes
 import os
 import time
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 from urllib.parse import quote, urlencode
 
 from ._environment import _Environment
@@ -25,6 +25,17 @@ except ImportError:
 
 class S3:
     _boto3_client = None
+
+    # Size in bytes of every object this process has uploaded, keyed by the
+    # public URL returned by `copy_file_to_s3`. `Result.set_link` consults it so
+    # that reports can render the size next to a link without a HEAD request
+    # (the report page and the artifact bucket are different origins and neither
+    # bucket allows cross-origin requests).
+    _uploaded_object_sizes: Dict[str, int] = {}
+
+    @classmethod
+    def get_uploaded_size(cls, url) -> Optional[int]:
+        return cls._uploaded_object_sizes.get(url)
 
     @classmethod
     def _get_boto3_client(cls):
@@ -119,6 +130,7 @@ class S3:
             BOTO3_AVAILABLE and cls._get_boto3_client()
         ), "boto3 is required for S3 uploads (the AWS CLI fallback is deprecated)"
 
+        uploaded = False
         try:
             s3_full_path_clean = str(s3_full_path).removeprefix("s3://")
             bucket, key = s3_full_path_clean.split("/", maxsplit=1)
@@ -156,6 +168,7 @@ class S3:
 
             # Retry on transient credential failures
             cls._retry_on_no_credentials(_upload)
+            uploaded = True
 
         except NoCredentialsError as e:
             print(
@@ -182,7 +195,11 @@ class S3:
         bucket = s3_path.split("/")[0]
         endpoint = Settings.S3_BUCKET_TO_HTTP_ENDPOINT[bucket]
         assert endpoint
-        return quote(f"https://{s3_full_path}".replace(bucket, endpoint), safe=":/?&=")
+        url = quote(f"https://{s3_full_path}".replace(bucket, endpoint), safe=":/?&=")
+        if uploaded:
+            # The object is uploaded as is, so its size is the local file size.
+            cls._uploaded_object_sizes[url] = os.path.getsize(local_path)
+        return url
 
     @classmethod
     def put(

--- a/ci/tests/test_result_link_sizes.py
+++ b/ci/tests/test_result_link_sizes.py
@@ -1,0 +1,106 @@
+"""
+Reports render the size of a file next to the link to it, e.g.
+`clickhouse-common-static_26.8.1.1332_amd64.deb (1.2 GiB)`.
+
+The size cannot be fetched by the report page itself: the page and the artifact
+bucket are different origins and neither bucket allows cross-origin requests.
+So it is recorded at upload time - `S3.copy_file_to_s3` remembers the size of
+every object it uploads, and `Result` stores it in `ext["link_sizes"]`, keyed by
+the link, for `json.html` to render.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.result import Result
+from ci.praktika.s3 import S3
+
+DEB = "https://clickhouse-builds.s3.amazonaws.com/REFs/master/abc/build_amd_debug/clickhouse-common-static_26.8.1.1332_amd64.deb"
+REPORT = "https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=abc"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry(monkeypatch):
+    """Every test starts with an empty upload registry."""
+    monkeypatch.setattr(S3, "_uploaded_object_sizes", {})
+
+
+def test_set_link_takes_size_from_the_upload():
+    S3._uploaded_object_sizes[DEB] = 1288490189
+    result = Result("Build (amd, debug)", Result.Status.OK).set_link(DEB)
+    assert result.ext["link_sizes"] == {DEB: 1288490189}
+
+
+def test_set_link_accepts_an_explicit_size():
+    result = Result("job", Result.Status.OK).set_link(DEB, size=100)
+    assert result.ext["link_sizes"] == {DEB: 100}
+
+
+def test_link_without_a_known_size_is_not_recorded():
+    """A link that is not a file (a link to another report) has no size."""
+    result = Result("job", Result.Status.OK).set_link(REPORT)
+    assert result.links == [REPORT]
+    assert "link_sizes" not in result.ext
+
+
+def test_create_from_takes_sizes_from_the_uploads():
+    S3._uploaded_object_sizes[DEB] = 42
+    result = Result.create_from(
+        name="job", status=Result.Status.OK, links=[DEB, REPORT]
+    )
+    assert result.ext["link_sizes"] == {DEB: 42}
+
+
+def test_sizes_survive_serialization():
+    result = Result("job", Result.Status.OK).set_link(DEB, size=1288490189)
+    restored = Result.from_dict(json.loads(json.dumps(Result.to_dict(result))))
+    assert restored.ext["link_sizes"] == {DEB: 1288490189}
+
+
+def test_upload_records_the_size_of_the_uploaded_object(tmp_path, monkeypatch):
+    pytest.importorskip("boto3")
+    from ci.praktika import s3 as s3_module
+
+    class _FakeS3Client:
+        def upload_file(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(S3, "_boto3_client", _FakeS3Client())
+    monkeypatch.setattr(
+        s3_module.StorageUsage, "add_uploaded", classmethod(lambda cls, path: None)
+    )
+
+    local_file = tmp_path / "clickhouse-server.deb"
+    local_file.write_bytes(b"x" * 12345)
+
+    url = S3.copy_file_to_s3("clickhouse-builds/REFs/master/abc", str(local_file))
+    assert S3.get_uploaded_size(url) == 12345
+
+
+def test_failed_upload_does_not_record_a_size(tmp_path, monkeypatch):
+    pytest.importorskip("boto3")
+    from botocore.exceptions import ClientError
+
+    from ci.praktika import s3 as s3_module
+
+    class _FailingS3Client:
+        def upload_file(self, *args, **kwargs):
+            raise ClientError({"Error": {"Code": "AccessDenied"}}, "PutObject")
+
+    monkeypatch.setattr(S3, "_boto3_client", _FailingS3Client())
+    monkeypatch.setattr(
+        s3_module.StorageUsage, "add_uploaded", classmethod(lambda cls, path: None)
+    )
+
+    local_file = tmp_path / "clickhouse-server.deb"
+    local_file.write_bytes(b"x" * 12345)
+
+    url = S3.copy_file_to_s3(
+        "clickhouse-builds/REFs/master/abc", str(local_file), no_strict=True
+    )
+    assert S3.get_uploaded_size(url) is None


### PR DESCRIPTION
Praktika reports link to files — build artifacts, job logs, uploaded reports — without saying how large they are. A link to `clickhouse-common-static_26.8.1.1332_amd64.deb` gives no hint whether it is 300 KiB or 1.2 GiB, which matters when deciding what to download from a report such as
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1bfa2815c410fb75b3fe6cfa4ef7877d82b63ea6&name_0=MasterCI

Now every link to an uploaded file shows its size: `clickhouse-common-static_26.8.1.1332_amd64.deb (1.2 GiB)`, in both places file links appear — the widget on a job page and the expanded info row of any result.

The size cannot be fetched by the report page itself: it is served from `s3.amazonaws.com/clickhouse-test-reports`, build artifacts live on `clickhouse-builds.s3.amazonaws.com`, and neither bucket sends `Access-Control-Allow-Origin`, so a cross-origin `HEAD` request is blocked by the browser. Instead the size is recorded at upload time: `copy_file_to_s3` remembers the size of every object it uploads, and `Result` stores it in `ext["link_sizes"]` as a `{link: bytes}` map for `json.html` to render. This costs about 0.3% of a gzipped report.

Links with no recorded size — a link to another report, or any report produced before this change — render exactly as before. `json.html` has to be deployed for existing report URLs to pick up the rendering change.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1383` (included in `26.8` and later)
<!-- ch-version-info:end -->