### PR TITLE
Keep two refreshable-MV tests runnable on a Replicated database

### DIFF
--- a/tests/queries/0_stateless/04501_distributed_query_client_version_internal_contexts.sql
+++ b/tests/queries/0_stateless/04501_distributed_query_client_version_internal_contexts.sql
@@ -18,7 +18,10 @@ CREATE TABLE dst (s UInt64) ENGINE = MergeTree ORDER BY s;
 
 -- The refresh runs in a background context; `prefer_localhost_replica = 0` forces the read of the
 -- Distributed table through `RemoteQueryExecutor` so the version guard is exercised.
-CREATE MATERIALIZED VIEW mv REFRESH EVERY 1 YEAR TO dst AS
+-- APPEND keeps this fixture creatable on a Replicated database, which refuses a non-APPEND
+-- refreshable view over a non-replicated target; `all_replicas = 1` keeps the refresh on the replica
+-- this client is connected to, and AFTER with EMPTY leaves `SYSTEM REFRESH VIEW` the only refresh.
+CREATE MATERIALIZED VIEW mv REFRESH AFTER 1 YEAR SETTINGS all_replicas = 1 APPEND TO dst EMPTY AS
     SELECT sum(x) AS s FROM src_dist SETTINGS prefer_localhost_replica = 0;
 
 SYSTEM REFRESH VIEW mv;

--- a/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.sh
+++ b/tests/queries/0_stateless/04661_refreshable_mv_cancel_during_planning.sh
@@ -10,10 +10,16 @@ $CLICKHOUSE_CLIENT -q "
 # `k IN (subquery)` over the primary key materializes the set during query planning
 # (ReadFromMergeTree::buildIndexes -> KeyCondition -> FutureSetFromSubquery::buildOrderedSetInplace),
 # so the refresh blocks in a nested pipeline that it does not own an executor for yet.
+# append keeps this fixture creatable on a Replicated database, which refuses a non-append
+# refreshable view over a non-replicated inner table; `all_replicas = 1` with a relative period and
+# `empty` leaves the explicit local `system refresh view` below as the only refresh anywhere.
 $CLICKHOUSE_CLIENT -q "
-    create materialized view rmv refresh every 1 second (k UInt64) engine MergeTree order by k as
+    create materialized view rmv refresh after 1 year settings all_replicas = 1 append
+        (k UInt64) engine MergeTree order by k empty as
         select k from src where k in (select number from numbers(120) where sleepEachRow(1) = 0)
         settings max_block_size = 1;"
+
+$CLICKHOUSE_CLIENT -q "system refresh view rmv"
 
 # Wait until the refresh is inside that nested pipeline. Fail hard on timeout: a drop that never
 # meets a blocked refresh returns quickly for the wrong reason, and the test would then match the


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112247


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04501_distributed_query_client_version_internal_contexts` and
`04661_refreshable_mv_cancel_during_planning` each create a non-APPEND refreshable
materialized view over a non-replicated target. On the `DBReplicated` test arm the server
refuses that shape by design (`Code: 36 ... refreshable materialized view, no APPEND,
replicated database, non-replicated table ... Refusing to create`), so the CREATE always
fails and neither test reaches its assertions. This is not intermittent: every run of both
tests on that arm carries the refusal, master included.

The failures were invisible because the functional-test diagnostics rerun rebuilds the
command without the job's own `--replicated-database` flag, so the failure does not
reproduce, is labelled flaky, and is reported green on the coverage job. That half is a
separate defect, tracked in #112247.

I did not add `no-replicated-database`. Both covered sites are APPEND-independent, so an
APPEND fixture keeps the tests running on every flavour instead of skipping them, which is
what commit `e73f3f142e5f` established for this refusal. Each test switches to
`APPEND` with `all_replicas = 1` (`SYSTEM REFRESH VIEW`, `system.processes` and a
non-replicated target are all replica-local, so the refresh has to stay on the connected
replica), a relative `AFTER 1 YEAR` period, and `EMPTY`. 04661 additionally triggers its
one refresh explicitly, which also removes the cross-replica concurrency its old
`every 1 second` schedule had.

Two test files, no source change. Validated locally against a 3-server Replicated cluster
built from `tests/config/install.sh --db-replicated`: both tests fail before the change and
pass after it, and reverting each test's covered site (the initiator version fill in
`createRefreshContext`; the early `executing_query_status` publication in
`refreshTask`) makes the corresponding test fail again, so neither fixture passes
vacuously. 100/100 randomized runs green on the Replicated arm and 100/100 on the ordinary
one, with no skips.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1413` (included in `26.8` and later)
<!-- ch-version-info:end -->