### PR TITLE
Pin enable_parallel_replicas off for 00673_subquery_prepared_set_performance

### DIFF
--- a/tests/queries/0_stateless/00673_subquery_prepared_set_performance.sql
+++ b/tests/queries/0_stateless/00673_subquery_prepared_set_performance.sql
@@ -1,3 +1,5 @@
+-- Random settings limits: enable_parallel_replicas=(0, 0)
+
 DROP TABLE IF EXISTS mergetree_00673;
 
 CREATE TABLE mergetree_00673 (x UInt64) ENGINE = MergeTree ORDER BY x;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113575
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`00673_subquery_prepared_set_performance` fails `TOO_DEEP_RECURSION` in `Stateless tests (amd_tsan, parallel)` on its 21-deep nested subquery. Reported by @ alexey-milovidov on #113575, whose own randomized-settings minimization pinned the culprit to `enable_parallel_replicas 1` + `parallel_replicas_for_non_replicated_merge_tree 1`.

Two facts compose. `tests/clickhouse-test:1772` is the only site that sets `enable_parallel_replicas`, and it is guarded by `automatic_parallel_replicas_mode == 2` (`:1769`, p=0.25), so the culprit pair appears only on mode-2 runs. And `STACK_SIZE_FREE_RATIO` is 20 under TSan versus 2 otherwise (`checkStackSize.cpp:150-157`), so the `maximum stack size: 8388608` in the message is the raw stack while the enforced ceiling is 419430 B. The overshoot is against that TSan-only 5% budget, not against 8 MB.

This is a CI signal problem rather than a user-facing one. Measured server-side at the byte ceiling a non-TSan build has (while still paying TSan-inflated frames), nesting is stopped by `max_subquery_depth` (default 100) with `TOO_DEEP_SUBQUERIES` at depth 100, and the stack itself is fine to depth 250. The deepest reachable query is depth 99. CIDB shows one row matching this signature in 180 days and none on master.

So this pins the one setting on the one test rather than changing planner recursion:

```
-- Random settings limits: enable_parallel_replicas=(0, 0)
```

I did not use `-- Tags: no-parallel-replicas`: the dedicated `ParallelReplicas` job is `amd_llvm_coverage` only (`job_configs.py:789`, `:795`), so it runs at ratio 2 and uses 8.6% of its ceiling. It cannot hit this limit, and the tag would skip the test there for no benefit. No SQL is changed and the test is not skipped anywhere.

<details><summary>Validation</summary>

CI-faithful TSan build (clang-22, `-DSANITIZE=thread`, Build ID `7d85b446...`). The enforced ceiling is the independent variable, calibrated with `ulimit -s 7000` into the window between the two arms' measured depth-21 usage (355408 < ceiling <= 362576), since CI's absolute byte count is not reproducible here (CI's frames measure ~18% wider on the same compiler).

| arm | result |
|---|---|
| pre-fix, culprit pair forced at the client, unmodified file | 5/5 `Code: 306`, control 5/5 pass |
| pre-fix, real runner, 50 randomized runs | 18 fail / 50; every failure `mode=2` + setting `1`, every pass mode-0 |
| directive parses (runner's own parser, real file) | `{'enable_parallel_replicas': (0, 0)}` |
| clamp changes the value (runner's own `apply_random_settings_limits`) | mode 2: `1` -> `0`; mode 0: absent both ways |
| post-fix, mode 2 forced, value read back | `epr_pre=1 epr_post=0 prnr=1`, 3/3 pass (same harness pre-fix: 5/5 fail) |
| negative control: corrupt the directive to `limitsX:` | unparsed, `epr_post=1`, 3/3 fail again |
| post-fix, real runner, 50 randomized runs | 50/50 pass, 6-12 runs drew mode 2, zero `306` |
| `--no-parallel-replicas` and `--no-random-settings` | run, not skipped |

The negative control matters because an unparsed `Random settings limits:` line is just a comment, and because ~75% of runs draw mode 0 and pass regardless of the directive.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1410` (included in `26.8` and later)
<!-- ch-version-info:end -->