### PR TITLE
Do not let a post-run coverage diagnostic discard a finished test run's exit code

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -6221,9 +6221,6 @@ ORDER BY (test_name, callee_offset)
             clickhouse_execute(args, "SYSTEM SET COVERAGE TEST ''")
         except Exception as e:
             print("Cannot flush final coverage: ", str(e))
-        cov_rows = int(clickhouse_execute(args, "SELECT count() FROM system.coverage_log FINAL") or 0)
-        cov_tests = int(clickhouse_execute(args, "SELECT uniq(test_name) FROM system.coverage_log FINAL") or 0)
-        print(f"system.coverage_log: {cov_rows} rows, {cov_tests} distinct tests")
         try:
             ic_rows = int(
                 clickhouse_execute(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`NightlyCoverage` shards exit 1 after every test has already passed. CIDB gets a pseudo-test row
`clickhouse-test` / FAIL whose whole context is `clickhouse-test exited with code 1`, while the
report shows the shard `OK` with `Failed: 0`. On master: 83 such rows in 30 days, 26 nights, all 8
shards, 6 of them on one nightly.

Cause: `main()`'s post-run coverage block printed one diagnostic line built from two `FINAL`
aggregates over `system.coverage_log`, the only two statements in that block outside a
`try/except`. `clickhouse_execute` defaults to `timeout=30` and re-raises after 5 retries, and the
aggregates sit at that cap: the job's own exporter runs the same aggregate over the same
23.4-25.4M rows in 20-29s. The `TimeoutError` propagates out of `main()`, so
`sys.exit(exit_code.value)` never runs and Python exits 1 with every result already collected.
That costs a red job for a non-failure, and an exit status that no longer separates a test failure
from a teardown timeout.

The statement is deleted rather than guarded because in this job it is a vestigial duplicate:
`CoverageExporter.do()` re-runs the identical aggregate about 30s later, prints a strict superset
of the numbers, and raises when the row count is zero. Nothing reads `cov_rows`/`cov_tests`. A
local run drops the export stage, so it loses the line rather than seeing it duplicated.

Validated locally: the extracted block exits 1 before the change and 0 after, with negative
controls confirming the probe is specific to this timeout. Every remaining `clickhouse_execute` in
the post-run block is now guarded (checked by AST). The pre-run block is untouched: it is meant to
fail the run when coverage is broken. Two siblings are left alone: `coverage_indirect_calls` is
redundant the same way but already guarded, and `reportCoverage` is unguarded but no CI job passes
`--report-coverage`.

CI report, shard 3/8 of the 2026-08-13 nightly:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3da3cf323b91553960bdf55780a3b94e9deb5793&name_0=NightlyCoverage&name_1=Stateless%20tests%20%28amd_llvm_coverage_per_test%2C%20per_test_coverage%2C%203%2F8%29