### PR TITLE
Optimize delayInsertOrThrowIfNeeded overhead

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6935,7 +6935,13 @@ size_t MergeTreeData::getNumberOfOutdatedPartsWithExpiredRemovalTime() const
 
 std::pair<size_t, size_t> MergeTreeData::getMaxPartsCountAndSizeForPartitionWithState(DataPartState state) const
 {
-    auto lock = readLockParts();
+    /// Take a snapshot of parts under the shared lock, then compute outside the lock
+    /// to reduce lock hold time under high-concurrency inserts.
+    DataPartsVector parts_snapshot;
+    {
+        auto lock = readLockParts();
+        parts_snapshot = getDataPartsVectorForInternalUsage({state}, lock);
+    }
 
     size_t cur_parts_count = 0;
     size_t cur_parts_size = 0;
@@ -6944,7 +6950,7 @@ std::pair<size_t, size_t> MergeTreeData::getMaxPartsCountAndSizeForPartitionWith
 
     const String * cur_partition_id = nullptr;
 
-    for (const auto & part : getDataPartsStateRange(state))
+    for (const auto & part : parts_snapshot)
     {
         if (!cur_partition_id || part->info.getPartitionId() != *cur_partition_id)
         {
@@ -7061,7 +7067,20 @@ void MergeTreeData::delayInsertOrThrowIfNeeded(Poco::Event * until, const Contex
             dead_blobs_over_threshold = dead_blobs_count - dead_blobs_to_delay_insert + 1;
     }
 
-    auto [parts_count_in_partition, size_of_partition] = getMaxPartsCountAndSizeForPartition();
+    size_t parts_count_in_partition = 0;
+    size_t size_of_partition = 0;
+    {
+        /// Smallest threshold that could trigger a throw or delay.
+        /// A zero parts_to_throw_insert means "throw on any part", so treat it as 1 to never skip.
+        UInt64 min_enabled_threshold = active_parts_to_throw_insert > 0 ? active_parts_to_throw_insert : 1;
+        if (active_parts_to_delay_insert > 0)
+            min_enabled_threshold = std::min(min_enabled_threshold, static_cast<UInt64>(active_parts_to_delay_insert));
+
+        /// parts_count_in_total is an O(1) upper bound on any single partition's part count,
+        /// so if it is below the threshold we can skip the O(N) per-partition scan.
+        if (parts_count_in_total >= min_enabled_threshold)
+            std::tie(parts_count_in_partition, size_of_partition) = getMaxPartsCountAndSizeForPartition();
+    }
     size_t average_part_size = parts_count_in_partition ? size_of_partition / parts_count_in_partition : 0;
     size_t active_parts_over_threshold = 0;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6935,13 +6935,7 @@ size_t MergeTreeData::getNumberOfOutdatedPartsWithExpiredRemovalTime() const
 
 std::pair<size_t, size_t> MergeTreeData::getMaxPartsCountAndSizeForPartitionWithState(DataPartState state) const
 {
-    /// Take a snapshot of parts under the shared lock, then compute outside the lock
-    /// to reduce lock hold time under high-concurrency inserts.
-    DataPartsVector parts_snapshot;
-    {
-        auto lock = readLockParts();
-        parts_snapshot = getDataPartsVectorForInternalUsage({state}, lock);
-    }
+    auto lock = readLockParts();
 
     size_t cur_parts_count = 0;
     size_t cur_parts_size = 0;
@@ -6950,7 +6944,7 @@ std::pair<size_t, size_t> MergeTreeData::getMaxPartsCountAndSizeForPartitionWith
 
     const String * cur_partition_id = nullptr;
 
-    for (const auto & part : parts_snapshot)
+    for (const auto & part : getDataPartsStateRange(state))
     {
         if (!cur_partition_id || part->info.getPartitionId() != *cur_partition_id)
         {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7070,8 +7070,7 @@ void MergeTreeData::delayInsertOrThrowIfNeeded(Poco::Event * until, const Contex
         if (active_parts_to_delay_insert > 0)
             min_enabled_threshold = std::min(min_enabled_threshold, static_cast<UInt64>(active_parts_to_delay_insert));
 
-        /// parts_count_in_total is an O(1) upper bound on any single partition's part count,
-        /// so if it is below the threshold we can skip the O(N) per-partition scan.
+        /// If total number of parts is less than minimal threshold, avoid iterating over parts under lock
         if (parts_count_in_total >= min_enabled_threshold)
             std::tie(parts_count_in_partition, size_of_partition) = getMaxPartsCountAndSizeForPartition();
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimized the insert backpressure path in `MergeTree` by short-circuiting the parts count check.

### Optimize
The per-partition scan is skipped when the O(1) total active part count is below the delay/throw thresholds, since it cannot change the outcome. This is the common case in healthy tables, so most inserts avoid the scan entirely.
## Benchmark

### Benchmark
One host, 20000 pre-filled active parts, 32 concurrent writers, 10000 single-row `INSERT`s per group with `async_insert=0`. Lock metrics from the built-in ProfileEvents `SharedPartsLockHoldMicroseconds` / `SharedPartsLocks`, diffed before/after each batch.

- All inserts succeed, part count below thresholds (the common case, parts_to_throw_insert=100000000`): **8.4x throughput** (231.7 -> 1955.4 QPS); total shared parts-lock hold time for the batch drops from 340.4 s to 0.13 s (13.2 -> 1.0 lock acquisitions per insert, 2577 us -> 12.5 us per acquisition). Every check that previously scanned 20000 parts under the lock now completes with a single atomic read.
- Half succeed, half rejected (`parts_to_throw_insert=25000`): **2.2x throughput**(349.6 -> 765.1 QPS), total lock hold halved (293.0 s -> 145.9 s).
- Every insert rejected (`parts_to_throw_insert=10000`, scan runs on both builds): parity within run-to-run variance (683.1 vs 657.6 QPS), as expected since both builds execute the identical scan once the thresholds are reached.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=114754&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114754](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114754+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.21` (included in `26.10` and later)
<!-- ch-version-info:end -->