### PR TITLE
Restores quantized sub-column read for vector search

### DIFF
--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -406,6 +406,21 @@ void attachQuantizeSerializationIfNeeded(ColumnDescription & column)
 
 }
 
+void attachQuantizeSerializations(NamesAndTypesList & columns, const ColumnsDescription & metadata)
+{
+    for (auto & column : columns)
+    {
+        /// Same type only: a dropped and re-added column would throw in the helper.
+        const auto * column_in_metadata = metadata.tryGet(column.name);
+        if (!column_in_metadata || !column_in_metadata->codec || !column_in_metadata->type->equals(*column.type))
+            continue;
+
+        /// The customization lands on the shared type instance, i.e. on column.type itself.
+        ColumnDescription column_with_codec(column.name, column.type, column_in_metadata->codec, {});
+        attachQuantizeSerializationIfNeeded(column_with_codec);
+    }
+}
+
 void ColumnsDescription::add(ColumnDescription column, const String & after_column, bool first, bool add_subcolumns)
 {
     if (has(column.name))

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -329,6 +329,9 @@ struct DefaultExpressionsInfo
     NameSet insert_time_default_columns;
 };
 
+/// Restore the Quantized(...) subcolumns on columns parsed from a part's columns.txt.
+void attachQuantizeSerializations(NamesAndTypesList & columns, const ColumnsDescription & metadata);
+
 void getDefaultExpressionInfoInto(const ASTColumnDeclaration & col_decl, const DataTypePtr & data_type, DefaultExpressionsInfo & info);
 
 /// Validate default expressions and corresponding types compatibility, i.e.

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2452,6 +2452,9 @@ void IMergeTreeDataPart::loadColumns(bool require, bool load_metadata_version)
 
         for (auto & column : loaded_columns)
             setVersionToAggregateFunctions(column.type, true);
+
+        if (!info.isPatch())
+            attachQuantizeSerializations(loaded_columns, getMetadataSnapshot()->getColumns());
     }
     else
     {

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_subcolumn_read_bytes.reference
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_subcolumn_read_bytes.reference
@@ -1,0 +1,1 @@
+codes_read_is_small	1	codebook_read_is_small	1

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_subcolumn_read_bytes.sql
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_subcolumn_read_bytes.sql
@@ -1,0 +1,53 @@
+-- Ensure that quantized sub column read does not fetch the full column.
+
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS quantize_subcolumn_read_bytes;
+
+CREATE TABLE quantize_subcolumn_read_bytes
+(
+    id UInt32,
+    vec Array(Float32) CODEC(Quantized('product', 64, 8, 8))
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0;
+
+-- 8 code bytes per vector against 256 bytes of full-precision data.
+INSERT INTO quantize_subcolumn_read_bytes
+SELECT number, arrayMap(j -> toFloat32(sipHash64(number, j) % 2000 / 1000.0 - 1.0), range(64))
+FROM numbers(30000);
+
+-- A fresh part reads correctly even with the bug, so the reload is what makes this a test.
+DETACH TABLE quantize_subcolumn_read_bytes;
+ATTACH TABLE quantize_subcolumn_read_bytes;
+
+SELECT sum(cityHash64(vec.quantized)) FROM quantize_subcolumn_read_bytes
+SETTINGS log_comment = '02354_codes' FORMAT Null;
+
+SELECT sum(cityHash64(vec.product_quantization_codebook)) FROM quantize_subcolumn_read_bytes
+SETTINGS log_comment = '02354_codebook' FORMAT Null;
+
+SELECT sum(cityHash64(vec)) FROM quantize_subcolumn_read_bytes
+SETTINGS log_comment = '02354_full' FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- Compare against the full-column read, not absolute bytes, so nothing needs retuning later.
+WITH
+    (SELECT read_bytes FROM system.query_log
+     WHERE current_database = currentDatabase() AND event_date >= yesterday()
+       AND type = 'QueryFinish' AND log_comment = '02354_codes'
+     ORDER BY event_time_microseconds DESC LIMIT 1) AS codes,
+    (SELECT read_bytes FROM system.query_log
+     WHERE current_database = currentDatabase() AND event_date >= yesterday()
+       AND type = 'QueryFinish' AND log_comment = '02354_codebook'
+     ORDER BY event_time_microseconds DESC LIMIT 1) AS codebook,
+    (SELECT read_bytes FROM system.query_log
+     WHERE current_database = currentDatabase() AND event_date >= yesterday()
+       AND type = 'QueryFinish' AND log_comment = '02354_full'
+     ORDER BY event_time_microseconds DESC LIMIT 1) AS full_column
+SELECT
+    'codes_read_is_small', codes > 0 AND codes * 4 < full_column,
+    'codebook_read_is_small', codebook > 0 AND codebook * 4 < full_column;
+
+DROP TABLE quantize_subcolumn_read_bytes SYNC;


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/114762

### Changelog category
- Experimental Feature

### Changelog entry 
- Restores quantized sub-column read for vector search ( introduced in 26.7 )


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1459` (included in `26.8` and later)
<!-- ch-version-info:end -->