### PR TITLE
Do not consult the query context when building a CAST

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -132,7 +132,6 @@ find $ROOT_PATH/src/Functions -type f | xargs grep -l 'ContextPtr [a-z_]*;' | gr
 FUNCTIONS_WITH_CONTEXT_EXCEPTIONS=(
     # It is OK to have WithContext for derived classes from IFunctionOverloadResolver
     -e /FunctionJoinGet.cpp
-    -e /CastOverloadResolver.cpp
     -e /reverse.cpp
     -e /formatRow.cpp
     # Store global context

--- a/src/Functions/CastOverloadResolver.cpp
+++ b/src/Functions/CastOverloadResolver.cpp
@@ -52,14 +52,20 @@ static void validateNestedTypesForAccurateCastOrNull(const DataTypePtr & type)
     }
 }
 
+struct FunctionConvertSettings;
+using FunctionConvertSettingsPtr = std::shared_ptr<const FunctionConvertSettings>;
+
+FunctionConvertSettingsPtr createFunctionConvertSettings(
+    const ContextPtr & context,
+    FormatSettings::DateTimeOverflowBehavior date_time_overflow_behavior);
+
 FunctionBasePtr createFunctionBaseCast(
-    ContextPtr context,
+    const FunctionConvertSettingsPtr & settings,
     const char * name,
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & return_type,
     std::optional<CastDiagnostic> diagnostic,
-    CastType cast_type,
-    FormatSettings::DateTimeOverflowBehavior date_time_overflow_behavior);
+    CastType cast_type);
 
 /// If `target` is a `DateTime` or `DateTime64` (possibly wrapped in `Nullable` and/or `LowCardinality`)
 /// without an explicit time zone, return a copy of it with the given time zone substituted.
@@ -124,7 +130,7 @@ static String getExplicitTimeZoneOfDateTimeArgument(const DataTypePtr & source)
   * Cast preserves nullability according to setting `cast_keep_nullable`,
   * i.e. Cast(toNullable(toInt8(1)) as Int32) will be Nullable(Int32(1)) if `cast_keep_nullable` == 1.
   */
-class CastOverloadResolverImpl final : public IFunctionOverloadResolver, private WithContext
+class CastOverloadResolverImpl final : public IFunctionOverloadResolver
 {
 public:
     static const char * getNameImpl(CastType cast_type, bool internal)
@@ -148,12 +154,12 @@ public:
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
 
     explicit CastOverloadResolverImpl(ContextPtr context_, CastType cast_type_, bool internal_, std::optional<CastDiagnostic> diagnostic_, bool keep_nullable_, const DataTypeValidationSettings & data_type_validation_settings_)
-        : WithContext(context_)
-        , cast_type(cast_type_)
+        : cast_type(cast_type_)
         , internal(internal_)
         , diagnostic(std::move(diagnostic_))
         , keep_nullable(keep_nullable_)
         , data_type_validation_settings(data_type_validation_settings_)
+        , convert_settings(createFunctionConvertSettings(context_, FormatSettings::DateTimeOverflowBehavior::Ignore))
     {
     }
 
@@ -185,20 +191,20 @@ public:
         arguments.emplace_back().type = std::make_unique<DataTypeString>();
 
         return createFunctionBaseCast(
-            context_, getNameImpl(cast_type, true), arguments, to, diagnostic, cast_type, FormatSettings::DateTimeOverflowBehavior::Saturate);
+            createFunctionConvertSettings(context_, FormatSettings::DateTimeOverflowBehavior::Saturate),
+            getNameImpl(cast_type, true), arguments, to, diagnostic, cast_type);
     }
 
 protected:
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
     {
         return createFunctionBaseCast(
-            getContext(),
+            convert_settings,
             getNameImpl(cast_type, internal),
             arguments,
             return_type,
             diagnostic,
-            cast_type,
-            FormatSettings::DateTimeOverflowBehavior::Ignore);
+            cast_type);
     }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
@@ -260,6 +266,9 @@ private:
     std::optional<CastDiagnostic> diagnostic;
     bool keep_nullable;
     DataTypeValidationSettings data_type_validation_settings;
+    /// Snapshot taken while the constructing context is alive: the cast this resolver builds may
+    /// be executed after that context is gone (stored default or mutation expressions).
+    FunctionConvertSettingsPtr convert_settings;
 };
 
 

--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -3205,14 +3205,20 @@ FunctionCast::WrapperType FunctionCast::prepareImpl(const DataTypePtr & from_typ
 
 }
 
+FunctionConvertSettingsPtr createFunctionConvertSettings(
+    const ContextPtr & context,
+    FormatSettings::DateTimeOverflowBehavior date_time_overflow_behavior)
+{
+    return std::make_shared<const FunctionConvertSettings>(context, date_time_overflow_behavior);
+}
+
 FunctionBasePtr createFunctionBaseCast(
-    ContextPtr context,
+    const FunctionConvertSettingsPtr & settings,
     const char * name,
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & return_type,
     std::optional<CastDiagnostic> diagnostic,
-    CastType cast_type,
-    FormatSettings::DateTimeOverflowBehavior date_time_overflow_behavior)
+    CastType cast_type)
 {
     DataTypes data_types(arguments.size());
 
@@ -3258,7 +3264,7 @@ FunctionBasePtr createFunctionBaseCast(
     }
 
     return std::make_unique<detail::FunctionCast>(
-        context, name, std::move(monotonicity), data_types, return_type, diagnostic, cast_type, date_time_overflow_behavior);
+        *settings, name, std::move(monotonicity), data_types, return_type, diagnostic, cast_type);
 }
 
 

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -154,6 +154,8 @@ struct FunctionConvertSettings
     }
 };
 
+using FunctionConvertSettingsPtr = std::shared_ptr<const FunctionConvertSettings>;
+
 namespace detail
 {
 
@@ -4909,15 +4911,14 @@ public:
     using MonotonicityForRange = std::function<Monotonicity(const IDataType &, const Field &, const Field &)>;
     using WrapperType = std::function<ColumnPtr(ColumnsWithTypeAndName &, const DataTypePtr &, const ColumnNullable *, size_t)>;
 
-    FunctionCast(ContextPtr context
+    FunctionCast(const FunctionConvertSettings & settings_
             , const char * cast_name_
             , MonotonicityForRange && monotonicity_for_range_
             , const DataTypes & argument_types_
             , const DataTypePtr & return_type_
             , std::optional<CastDiagnostic> diagnostic_
-            , CastType cast_type_
-            , FormatSettings::DateTimeOverflowBehavior date_time_overflow_behavior)
-        : settings(context, date_time_overflow_behavior)
+            , CastType cast_type_)
+        : settings(settings_)
         , cast_name(cast_name_)
         , monotonicity_for_range(std::move(monotonicity_for_range_))
         , argument_types(argument_types_)
@@ -5127,21 +5128,17 @@ private:
 }
 
 
+/// `context` may be nullptr.
+FunctionConvertSettingsPtr createFunctionConvertSettings(
+    const ContextPtr & context,
+    FormatSettings::DateTimeOverflowBehavior date_time_overflow_behavior);
+
 FunctionBasePtr createFunctionBaseCast(
-    ContextPtr context,
+    const FunctionConvertSettingsPtr & settings,
     const char * name,
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & return_type,
     std::optional<CastDiagnostic> diagnostic,
     CastType cast_type);
-
-FunctionBasePtr createFunctionBaseCast(
-    ContextPtr context,
-    const char * name,
-    const ColumnsWithTypeAndName & arguments,
-    const DataTypePtr & return_type,
-    std::optional<CastDiagnostic> diagnostic,
-    CastType cast_type,
-    FormatSettings::DateTimeOverflowBehavior date_time_overflow_behavior);
 
 }

--- a/tests/queries/0_stateless/04527_cast_resolver_expired_context.reference
+++ b/tests/queries/0_stateless/04527_cast_resolver_expired_context.reference
@@ -1,0 +1,24 @@
+-- MATERIALIZED default evaluated on the insert pipeline
+::1	::1
+not an ip	::
+-- MATERIALIZED default whose cast overflows
+2020-01-01	2020-01-01 00:00:00
+2149-06-06	2013-04-29 17:31:44
+-- MATERIALIZE COLUMN rebuilds the default on a mutation thread
+16	120
+-- mutation expression containing casts
+16	120
+-- the settings the resolver snapshots stay in effect
+2013-04-29 17:31:44
+2106-02-06 00:00:00
+2013-04-29 17:31:44
+Nullable(Int32)
+Int32
+::
+DateTime(\'Europe/Amsterdam\')
+-- argument wrappers and boundaries
+7	7
+0	0
+Nullable(Int64)
+1	1	1
+\N	-128	\N

--- a/tests/queries/0_stateless/04527_cast_resolver_expired_context.reference
+++ b/tests/queries/0_stateless/04527_cast_resolver_expired_context.reference
@@ -6,7 +6,9 @@ not an ip	::
 2149-06-06	2013-04-29 17:31:44
 -- MATERIALIZE COLUMN rebuilds the default on a mutation thread
 16	120
+16	16120
 -- mutation expression containing casts
+16	-16
 16	120
 -- the settings the resolver snapshots stay in effect
 2013-04-29 17:31:44

--- a/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
+++ b/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
@@ -1,3 +1,5 @@
+SET enable_analyzer = 1;
+
 SELECT '-- MATERIALIZED default evaluated on the insert pipeline';
 DROP TABLE IF EXISTS t_cast_expired_insert;
 CREATE TABLE t_cast_expired_insert (s String, ip IPv6 MATERIALIZED toIPv6OrDefault(s)) ENGINE = MergeTree ORDER BY tuple();

--- a/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
+++ b/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
@@ -8,7 +8,11 @@ SELECT s, ip FROM t_cast_expired_insert ORDER BY s;
 
 SELECT '-- MATERIALIZED default whose cast overflows';
 DROP TABLE IF EXISTS t_cast_expired_overflow;
-CREATE TABLE t_cast_expired_overflow (d Date, dt DateTime('UTC') MATERIALIZED toDateTimeOrDefault(d, 'UTC')) ENGINE = MergeTree ORDER BY tuple();
+-- Spell the conversion as an explicit `CAST` rather than `toDateTimeOrDefault`. Whether a
+-- `to<Type>OrDefault` function reads `date_time_overflow_behavior` from the query context at all
+-- depends on #109946, which is currently reverted on master and re-landed by #114912, so an
+-- `OrDefault` spelling would make the expected value of this arm swing with that revert.
+CREATE TABLE t_cast_expired_overflow (d Date, dt DateTime('UTC') MATERIALIZED CAST(d AS DateTime('UTC'))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_cast_expired_overflow (d) VALUES ('2149-06-07'), ('2020-01-01');
 SELECT d, dt FROM t_cast_expired_overflow ORDER BY d;
 

--- a/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
+++ b/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
@@ -11,15 +11,22 @@ INSERT INTO t_cast_expired_overflow (d) VALUES ('2149-06-07'), ('2020-01-01');
 SELECT d, dt FROM t_cast_expired_overflow ORDER BY d;
 
 SELECT '-- MATERIALIZE COLUMN rebuilds the default on a mutation thread';
-DROP TABLE IF EXISTS t_cast_expired_mutation;
-CREATE TABLE t_cast_expired_mutation (a String, m Int64 MATERIALIZED toInt64OrDefault(a), b Int64) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t_cast_expired_mutation (a, b) SELECT toString(number), number FROM numbers(16);
-ALTER TABLE t_cast_expired_mutation MATERIALIZE COLUMN m SETTINGS mutations_sync = 2;
-SELECT count(), sum(m) FROM t_cast_expired_mutation;
+DROP TABLE IF EXISTS t_cast_expired_materialize;
+CREATE TABLE t_cast_expired_materialize (a String, m Int64 MATERIALIZED toInt64OrDefault(a)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_cast_expired_materialize (a) SELECT toString(number) FROM numbers(16);
+-- Metadata-only: the stored bytes still hold the old expression's values.
+ALTER TABLE t_cast_expired_materialize MODIFY COLUMN m Int64 MATERIALIZED toInt64OrDefault(a) + 1000;
+SELECT count(), sum(m) FROM t_cast_expired_materialize;
+ALTER TABLE t_cast_expired_materialize MATERIALIZE COLUMN m SETTINGS mutations_sync = 2;
+SELECT count(), sum(m) FROM t_cast_expired_materialize;
 
 SELECT '-- mutation expression containing casts';
-ALTER TABLE t_cast_expired_mutation UPDATE b = toInt64OrDefault(a) WHERE toInt8OrDefault(a) >= 0 SETTINGS mutations_sync = 2;
-SELECT count(), sum(b) FROM t_cast_expired_mutation;
+DROP TABLE IF EXISTS t_cast_expired_update;
+CREATE TABLE t_cast_expired_update (a String, b Int64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_cast_expired_update SELECT toString(number), -1 FROM numbers(16);
+SELECT count(), sum(b) FROM t_cast_expired_update;
+ALTER TABLE t_cast_expired_update UPDATE b = toInt64OrDefault(a) WHERE toInt8OrDefault(a) >= 0 SETTINGS mutations_sync = 2;
+SELECT count(), sum(b) FROM t_cast_expired_update;
 
 SELECT '-- the settings the resolver snapshots stay in effect';
 SELECT CAST(toDate('2149-06-07') AS DateTime('UTC')) SETTINGS date_time_overflow_behavior = 'ignore';
@@ -40,4 +47,5 @@ SELECT accurateCastOrNull('', 'Int8'), accurateCastOrNull('-128', 'Int8'), accur
 
 DROP TABLE t_cast_expired_insert;
 DROP TABLE t_cast_expired_overflow;
-DROP TABLE t_cast_expired_mutation;
+DROP TABLE t_cast_expired_materialize;
+DROP TABLE t_cast_expired_update;

--- a/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
+++ b/tests/queries/0_stateless/04527_cast_resolver_expired_context.sql
@@ -1,0 +1,43 @@
+SELECT '-- MATERIALIZED default evaluated on the insert pipeline';
+DROP TABLE IF EXISTS t_cast_expired_insert;
+CREATE TABLE t_cast_expired_insert (s String, ip IPv6 MATERIALIZED toIPv6OrDefault(s)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_cast_expired_insert (s) VALUES ('::1'), ('not an ip');
+SELECT s, ip FROM t_cast_expired_insert ORDER BY s;
+
+SELECT '-- MATERIALIZED default whose cast overflows';
+DROP TABLE IF EXISTS t_cast_expired_overflow;
+CREATE TABLE t_cast_expired_overflow (d Date, dt DateTime('UTC') MATERIALIZED toDateTimeOrDefault(d, 'UTC')) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_cast_expired_overflow (d) VALUES ('2149-06-07'), ('2020-01-01');
+SELECT d, dt FROM t_cast_expired_overflow ORDER BY d;
+
+SELECT '-- MATERIALIZE COLUMN rebuilds the default on a mutation thread';
+DROP TABLE IF EXISTS t_cast_expired_mutation;
+CREATE TABLE t_cast_expired_mutation (a String, m Int64 MATERIALIZED toInt64OrDefault(a), b Int64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_cast_expired_mutation (a, b) SELECT toString(number), number FROM numbers(16);
+ALTER TABLE t_cast_expired_mutation MATERIALIZE COLUMN m SETTINGS mutations_sync = 2;
+SELECT count(), sum(m) FROM t_cast_expired_mutation;
+
+SELECT '-- mutation expression containing casts';
+ALTER TABLE t_cast_expired_mutation UPDATE b = toInt64OrDefault(a) WHERE toInt8OrDefault(a) >= 0 SETTINGS mutations_sync = 2;
+SELECT count(), sum(b) FROM t_cast_expired_mutation;
+
+SELECT '-- the settings the resolver snapshots stay in effect';
+SELECT CAST(toDate('2149-06-07') AS DateTime('UTC')) SETTINGS date_time_overflow_behavior = 'ignore';
+SELECT CAST(toDate('2149-06-07') AS DateTime('UTC')) SETTINGS date_time_overflow_behavior = 'saturate';
+SELECT CAST(toDate('2149-06-07') AS DateTime('UTC')) SETTINGS date_time_overflow_behavior = 'throw'; -- { serverError VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE }
+SELECT _CAST(toDate('2149-06-07'), 'DateTime(\'UTC\')') SETTINGS date_time_overflow_behavior = 'ignore';
+SELECT toTypeName(CAST(toNullable(toInt8(1)) AS Int32)) SETTINGS cast_keep_nullable = 1;
+SELECT toTypeName(CAST(toNullable(toInt8(1)) AS Int32)) SETTINGS cast_keep_nullable = 0;
+SELECT CAST('not an ip' AS IPv6) SETTINGS cast_ipv4_ipv6_default_on_conversion_error = 1;
+SELECT toTypeName(CAST(toDateTime('2020-01-01 00:00:00', 'Europe/Amsterdam') AS DateTime));
+
+SELECT '-- argument wrappers and boundaries';
+SELECT toInt64OrDefault(toNullable('x'), 7::Int64), toInt64OrDefault(toLowCardinality('x'), 7::Int64);
+SELECT accurateCastOrDefault(materialize('x'), 'Int64'), accurateCastOrDefault(CAST(NULL, 'Nullable(String)'), 'Int64');
+SELECT toTypeName(accurateCastOrNull(toLowCardinality(toNullable('42')), 'Int64'));
+SELECT toInt8OrDefault('', 1::Int8), toInt8OrDefault('999', 1::Int8), toInt64OrDefault('9223372036854775808', 1::Int64);
+SELECT accurateCastOrNull('', 'Int8'), accurateCastOrNull('-128', 'Int8'), accurateCastOrNull('128', 'Int8');
+
+DROP TABLE t_cast_expired_insert;
+DROP TABLE t_cast_expired_overflow;
+DROP TABLE t_cast_expired_mutation;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/485
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/2117
<!-- End of fixes issue link part, do not remove -->

<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109946
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `LOGICAL_ERROR: Context has expired` exception when a stored expression containing `accurateCastOrDefault` or a `to<Type>OrDefault` function is evaluated after the query that created it has finished, for example a `MATERIALIZED` column default on `INSERT` or a mutation expression.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/109946

`CastOverloadResolverImpl` inherited `WithContext`, which holds only a `weak_ptr<const Context>`, and its `buildImpl` passed `getContext()` to `createFunctionBaseCast`. That is safe only during analysis, while a caller still holds a strong `ContextPtr`.

#109946 made `FunctionCastOrDefault` store that resolver as a member and call `build()` at execute time. The `ActionsDAG` keeps the resolver alive but nothing keeps its context alive, and both affected paths build the DAG from a function-local `Context::createCopy` that dies on return (`inplaceBlockConversions.cpp:230` for materialized-column defaults, `MutationsInterpreter.cpp:1762` for mutations). Evaluating such an expression later throws `Context has expired`: an exception in release builds, a server abort under debug and sanitizers.

This captures the conversion settings in the resolver's constructor, while the context is provably alive, and has `buildImpl` consume that snapshot. `FunctionCast` used its `ContextPtr` for nothing but `settings(context, ...)`, so the snapshot moves one step earlier in the same call chain rather than being introduced. The resolver now holds no context at all, so the `WithContext` exception for this file in `various_checks.sh` is removed.

The two build paths keep their distinct `DateTimeOverflowBehavior`: `Saturate` for `createInternalCast`, `Ignore` for `buildImpl`. Sharing one snapshot between them would silently change date-time conversion.

Since a snapshot replaces a live context, every context-derived conversion setting was compared before and after and is byte-identical, including all three `date_time_overflow_behavior` modes, `cast_keep_nullable`, `precise_float_parsing`, the IPv4/IPv6 error settings and timezone substitution. `04510_accurateCastOrDefault_settings` from #109946 passes unchanged. The new test aborts a master server at `CastOverloadResolver.cpp:195` and passes with this change, 50/50 green under randomized settings.

The defect rides along with #109946, so it is present wherever that landed: 26.7 (#114689, merged); the 25.8, 26.3 and 26.5 backports are still open.

<details>
<summary>CI provenance</summary>

`Logical error: Context has expired`, STID `1805-460a`, first seen 2026-08-13 22:45:16 UTC, about four hours after #109946 merged. The frame pair `CastOverloadResolverImpl::buildImpl` + `Context has expired` has no earlier occurrence in the 90 days CIDB retains.

| when (UTC) | check | where |
|---|---|---|
| 2026-08-14 02:20:39 | [Stress test (arm_release)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=17d2798b962607ded301a9cab913c8ca70a33409&name_0=MasterCI&name_1=Stress%20test%20%28arm_release%29) | master, `17d2798b9626` |
| 2026-08-14 01:49:18 | [AST fuzzer (amd_debug, targeted)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114666&sha=dc79add25489c923c36b67be101b349bb964b190&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29) | unrelated PR |
| 2026-08-14 00:02:12 | [Stress test (amd_tsan)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114131&sha=06852ededde08f411d205aea05f6a78dbadaf55c&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29) | unrelated PR |
| 2026-08-13 22:50:06 | [AST fuzzer (amd_debug, targeted, old_compatibility)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100374&sha=50f4e25e8e3204407e724392592231c2ac54151c&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29) | unrelated PR |
| 2026-08-13 22:45:16 | [AST fuzzer (arm_asan_ubsan)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112679&sha=a2d3810c4df7a6d108a1a5b207e779cc41ae7e86&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29) | unrelated PR |

The master row is bucketed as STID `1805-4810` because an STID is a stack hash, but it carries both discriminating frames and `17d2798b9626` contains #109946.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114769&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114769](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114769+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1625` (included in `26.8` and later)
- Backported to: `26.7.7.82`, `26.6.5.112`
<!-- ch-version-info:end -->