### PR TITLE
Column IDs for MergeTree: the addressing refactor

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -1275,7 +1275,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
                 "`Poco::LRUCache<String, ColumnSize>` delegates inside each `IMergeTreeDataPart`, the "
                 "per-part `ColumnSize`/`IndexSize` maps, `MinMaxIndex`, `VersionMetadataOnDisk`, and the "
                 "`MergeTreeDataPart{Compact,Wide}` object itself), metadata shared across parts of a table "
-                "(`NamesAndTypesList`, `column_name_to_position`, the `serializations` map and "
+                "(`NamesAndTypesList`, `column_storage_key_to_position`, the `serializations` map and "
                 "`ColumnsSubstreams`, see `SharedPartColumns.h`) plus per-table metadata "
                 "(`StorageInMemoryMetadata` / `ColumnsDescription` / `VirtualColumnsDescription` clones "
                 "set up by `setProperties`, the `serialization_hints` aggregation, and the "

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -678,6 +678,7 @@
     M(1008, TEMPORARY_DATA_NOT_IN_CACHE) \
     M(1009, S3_OBJECT_CHANGED_DURING_READ) \
     M(1010, UNIQUE_KEY_DENSE_INDEX_UNREADABLE) \
+    M(1011, COLUMN_ID_MAPPING_MISSING) \
     /* See END */
 
 #ifdef APPLY_FOR_EXTERNAL_ERROR_CODES
@@ -694,7 +695,7 @@ namespace ErrorCodes
     APPLY_FOR_ERROR_CODES(M)
 #undef M
 
-    constexpr ErrorCode END = 1010;
+    constexpr ErrorCode END = 1011;
 
 #if !defined(CLICKHOUSE_PARSER_MINIMAL_BUILD)
     /** One `ErrorPairHolder` per error code, each holding two `Error` structs - the last message,

--- a/src/Common/JemallocMergeTreeArena.h
+++ b/src/Common/JemallocMergeTreeArena.h
@@ -12,7 +12,7 @@ namespace DB::JemallocMergeTreeArena
 ///     `ColumnSize`/`IndexSize` maps, `MinMaxIndex`, `VersionMetadataOnDisk`,
 ///     `index_granularity_info`, and the primary index / index-granularity arrays themselves.
 ///   - metadata shared across parts of a table (see `SharedPartColumns.h`): `NamesAndTypesList`,
-///     `column_name_to_position`, the `serializations` map and `ColumnsSubstreams`.
+///     `column_storage_key_to_position`, the `serializations` map and `ColumnsSubstreams`.
 ///   - per-table metadata: the `MergeTreeData` object's mutable schema state — `ColumnsDescription`,
 ///     `VirtualColumnsDescription`, `StorageInMemoryMetadata` clones, the `serialization_hints`
 ///     aggregation across active parts, and the `shared_part_columns_cache` populated from

--- a/src/Core/ColumnId.h
+++ b/src/Core/ColumnId.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <base/types.h>
+
+#include <functional>
+#include <unordered_set>
+#include <utility>
+
+
+namespace DB
+{
+
+/// Stable on-disk storage identifier of a column. A distinct type, and an explicit ctor, so that a
+/// logical column name (also a String) cannot cross into id space without being spelled out.
+/// Empty means "no id" -- the traditional name-as-file-name behavior.
+class ColumnId
+{
+public:
+    ColumnId() = default;
+    explicit ColumnId(String value_) : id(std::move(value_)) {}
+
+    const String & value() const { return id; }
+    bool empty() const { return id.empty(); }
+
+    bool operator==(const ColumnId & other) const { return id == other.id; }
+    bool operator!=(const ColumnId & other) const { return id != other.id; }
+
+private:
+    String id;
+};
+
+}
+
+namespace std
+{
+    template <>
+    struct hash<DB::ColumnId>
+    {
+        size_t operator()(const DB::ColumnId & column_id) const { return hash<String>()(column_id.value()); }
+    };
+}
+
+namespace DB
+{
+
+using ColumnIdSet = std::unordered_set<ColumnId>;
+
+}

--- a/src/Core/MergeTreeSerializationEnums.h
+++ b/src/Core/MergeTreeSerializationEnums.h
@@ -9,6 +9,7 @@ enum class MergeTreeSerializationInfoVersion : uint8_t
 {
     BASIC = 0,
     WITH_TYPES = 1,
+    WITH_COLUMN_IDS = 2,
 };
 
 enum class MergeTreeStringSerializationVersion : uint8_t

--- a/src/Core/NamesAndTypes.cpp
+++ b/src/Core/NamesAndTypes.cpp
@@ -4,6 +4,7 @@
 #include <Common/HashTable/HashMap.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/IDataType.h>
+#include <DataTypes/NestedUtils.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
 #include <IO/ReadHelpers.h>
@@ -13,6 +14,7 @@
 #include <IO/Operators.h>
 
 #include <boost/algorithm/string.hpp>
+#include <algorithm>
 #include <cstddef>
 
 namespace DB
@@ -21,6 +23,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int THERE_IS_NO_COLUMN;
+    extern const int UNKNOWN_FORMAT_VERSION;
 }
 
 NameAndTypePair::NameAndTypePair(
@@ -41,6 +44,21 @@ String NameAndTypePair::getNameInStorage() const
     return name.substr(0, *subcolumn_delimiter_position);
 }
 
+ColumnId NameAndTypePair::getColumnId() const
+{
+    if (column_id.empty())
+        return ColumnId{getNameInStorage()};
+
+    return column_id;
+}
+
+ColumnId NameAndTypePair::getStorageKey() const
+{
+    return isSubcolumn()
+        ? ColumnId{Nested::concatenateName(getColumnId().value(), getSubcolumnName())}
+        : getColumnId();
+}
+
 bool NameAndTypePair::operator<(const NameAndTypePair & rhs) const
 {
     return std::forward_as_tuple(name, type->getName()) < std::forward_as_tuple(rhs.name, rhs.type->getName());
@@ -48,6 +66,9 @@ bool NameAndTypePair::operator<(const NameAndTypePair & rhs) const
 
 bool NameAndTypePair::operator==(const NameAndTypePair & rhs) const
 {
+    /// Equality is intentionally logical (name + type) and ignores `column_id`:
+    /// callers compare schemas, not physical columns.  Two pairs that compare
+    /// equal may still refer to different on-disk columns after DROP + re-ADD.
     return name == rhs.name && type->equals(*rhs.type);
 }
 
@@ -65,6 +86,7 @@ String NameAndTypePair::dump() const
     out << "name: " << name << "\n"
         << "type: " << type->getName() << "\n"
         << "name in storage: " << getNameInStorage() << "\n"
+        << "column ID in storage: " << getColumnId().value() << "\n"
         << "type in storage: " << getTypeInStorage()->getName();
 
     return out.str();
@@ -87,11 +109,19 @@ void NameAndTypePair::setDelimiterAndTypeInStorage(const String & name_in_storag
     type_in_storage = type_in_storage_;
 }
 
-void NamesAndTypesList::readText(ReadBuffer & buf, bool check_eof)
+/// Under `FORMAT_VERSION_WITH_COLUMN_IDS` a name slot holds a column ID, not the logical name.
+UInt64 NamesAndTypesList::readText(ReadBuffer & buf, bool check_eof)
 {
     const DataTypeFactory & data_type_factory = DataTypeFactory::instance();
 
-    assertString("columns format version: 1\n", buf);
+    assertString("columns format version: ", buf);
+    UInt64 format_version = 0;
+    DB::readText(format_version, buf);
+    assertChar('\n', buf);
+
+    if (format_version != FORMAT_VERSION_WITH_NAMES && format_version != FORMAT_VERSION_WITH_COLUMN_IDS)
+        throw Exception(ErrorCodes::UNKNOWN_FORMAT_VERSION, "Unknown columns format version: {}", format_version);
+
     size_t count = 0;
     DB::readText(count, buf);
     assertString(" columns:\n", buf);
@@ -110,16 +140,26 @@ void NamesAndTypesList::readText(ReadBuffer & buf, bool check_eof)
 
     if (check_eof)
         assertEOF(buf);
+
+    return format_version;
 }
 
-void NamesAndTypesList::writeText(WriteBuffer & buf) const
+void NamesAndTypesList::writeText(WriteBuffer & buf, bool use_column_ids) const
 {
-    writeString("columns format version: 1\n", buf);
+    /// `use_column_ids` only permits the substitution; the version declares whether any column
+    /// actually took it, so the header cannot disagree with the tokens below it.
+    const auto substitutes_id = [&](const NameAndTypePair & column) { return use_column_ids && !column.column_id.empty(); };
+    const bool any_id_substituted = std::any_of(begin(), end(), substitutes_id);
+
+    writeString("columns format version: ", buf);
+    DB::writeText(any_id_substituted ? FORMAT_VERSION_WITH_COLUMN_IDS : FORMAT_VERSION_WITH_NAMES, buf);
+    writeChar('\n', buf);
     DB::writeText(size(), buf);
     writeString(" columns:\n", buf);
     for (const auto & it : *this)
     {
-        writeBackQuotedString(it.name, buf);
+        const auto & col_name = substitutes_id(it) ? it.column_id.value() : it.name;
+        writeBackQuotedString(col_name, buf);
         writeChar(' ', buf);
         writeString(it.type->getName(), buf);
         writeChar('\n', buf);
@@ -250,19 +290,20 @@ NamesAndTypesList NamesAndTypesList::eraseNames(const NameSet & names) const
 NamesAndTypesList NamesAndTypesList::addTypes(const Names & names) const
 {
     /// NOTE: It's better to make a map in `IStorage` than to create it here every time again.
-    HashMapWithSavedHash<std::string_view, const DataTypePtr *, StringViewHash> types;
+    HashMapWithSavedHash<std::string_view, const NameAndTypePair *, StringViewHash> pairs;
 
     for (const auto & column : *this)
-        types[column.name] = &column.type;
+        pairs[column.name] = &column;
 
     NamesAndTypesList res;
     for (const String & name : names)
     {
-        const auto * it = types.find(name);
-        if (it == types.end())
+        const auto * it = pairs.find(name);
+        if (it == pairs.end())
             throw Exception(ErrorCodes::THERE_IS_NO_COLUMN, "No column {}", name);
 
-        res.emplace_back(name, *it->getMapped());
+        /// Carry the source pair's stable storage ID so a resolved read binds the right on-disk column.
+        res.push_back(*it->getMapped());
     }
 
     return res;

--- a/src/Core/NamesAndTypes.cpp
+++ b/src/Core/NamesAndTypes.cpp
@@ -110,7 +110,7 @@ void NameAndTypePair::setDelimiterAndTypeInStorage(const String & name_in_storag
 }
 
 /// Under `FORMAT_VERSION_WITH_COLUMN_IDS` a name slot holds a column ID, not the logical name.
-UInt64 NamesAndTypesList::readText(ReadBuffer & buf, bool check_eof)
+UInt64 NamesAndTypesList::readText(ReadBuffer & buf, bool check_eof, bool allow_column_ids)
 {
     const DataTypeFactory & data_type_factory = DataTypeFactory::instance();
 
@@ -119,7 +119,11 @@ UInt64 NamesAndTypesList::readText(ReadBuffer & buf, bool check_eof)
     DB::readText(format_version, buf);
     assertChar('\n', buf);
 
-    if (format_version != FORMAT_VERSION_WITH_NAMES && format_version != FORMAT_VERSION_WITH_COLUMN_IDS)
+    /// A caller that did not ask for IDs would read them as names and denote the wrong columns, so
+    /// the version it cannot honour is as unknown to it as any other.
+    const bool known_version = format_version == FORMAT_VERSION_WITH_NAMES
+        || (allow_column_ids && format_version == FORMAT_VERSION_WITH_COLUMN_IDS);
+    if (!known_version)
         throw Exception(ErrorCodes::UNKNOWN_FORMAT_VERSION, "Unknown columns format version: {}", format_version);
 
     size_t count = 0;

--- a/src/Core/NamesAndTypes.cpp
+++ b/src/Core/NamesAndTypes.cpp
@@ -343,6 +343,22 @@ std::optional<NameAndTypePair> NamesAndTypesList::tryGetByName(const std::string
     return {};
 }
 
+std::optional<NameAndTypePair> NamesAndTypesList::tryGetByColumnId(const ColumnId & column_id) const
+{
+    for (const NameAndTypePair & column : *this)
+    {
+        if (column.getColumnId() == column_id)
+            return column;
+    }
+    return {};
+}
+
+ColumnId NamesAndTypesList::getColumnIdByName(const std::string & name) const
+{
+    auto column = tryGetByName(name);
+    return column ? column->getColumnId() : ColumnId{name};
+}
+
 size_t NamesAndTypesList::getPosByName(const std::string &name) const noexcept
 {
     size_t pos = 0;

--- a/src/Core/NamesAndTypes.h
+++ b/src/Core/NamesAndTypes.h
@@ -106,8 +106,10 @@ public:
     static constexpr UInt64 FORMAT_VERSION_WITH_NAMES = 1;
     static constexpr UInt64 FORMAT_VERSION_WITH_COLUMN_IDS = 2;
 
-    /// Returns the format version read, so the caller can check it against its own state.
-    UInt64 readText(ReadBuffer & buf, bool check_eof = true);
+    /// Returns the format version read. A caller that cannot resolve column IDs must not opt in:
+    /// under `FORMAT_VERSION_WITH_COLUMN_IDS` a name slot holds an ID, and read as a name it would
+    /// silently denote the wrong column, so the version is rejected unless it is asked for.
+    UInt64 readText(ReadBuffer & buf, bool check_eof = true, bool allow_column_ids = false);
     void writeText(WriteBuffer & buf, bool use_column_ids = false) const;
 
     String toString() const;

--- a/src/Core/NamesAndTypes.h
+++ b/src/Core/NamesAndTypes.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/ColumnId.h>
 #include <Core/Names.h>
 #include <DataTypes/IDataType.h>
 #include <base/types.h>
@@ -29,10 +30,19 @@ public:
     NameAndTypePair(const String & name_, const DataTypePtr & type_)
         : name(name_), type(type_), type_in_storage(type_) {}
 
+    NameAndTypePair(const String & name_, const DataTypePtr & type_, ColumnId column_id_)
+        : name(name_), type(type_), column_id(std::move(column_id_)), type_in_storage(type_) {}
+
     NameAndTypePair(const String & name_in_storage_, const String & subcolumn_name_,
         const DataTypePtr & type_in_storage_, const DataTypePtr & subcolumn_type_);
 
     String getNameInStorage() const;
+    /// Key for the part's whole-column-keyed maps -- `getColumnPosition`, `getColumnSize`,
+    /// `tryGetColumn` -- so a subcolumn reports its parent's id: it has no entry of its own there.
+    ColumnId getColumnId() const;
+    /// Key for `getSerialization`, the one part map that also holds subcolumn entries: the id for a
+    /// whole column, `"<id>.<subpath>"` for a subcolumn. A pure read -- the id must already be stamped.
+    ColumnId getStorageKey() const;
     String getSubcolumnName() const;
 
     bool isSubcolumn() const { return subcolumn_delimiter_position != std::nullopt; }
@@ -46,9 +56,14 @@ public:
     /// Can be used to convert "t.a.b.c" from meaning "column `t` in storage, subcolumn `a.b.c` inside it"
     /// to meaning "column `t.a.b` in storage, subcolumn `c` inside it".
     void setDelimiterAndTypeInStorage(const String & name_in_storage_, DataTypePtr type_in_storage_);
+    void setColumnId(ColumnId column_id_) { column_id = std::move(column_id_); }
 
     String name;
     DataTypePtr type;
+
+    /// Stable key of this column's on-disk files, stamped from the table's ColumnIdMapping
+    /// (see ColumnIdMapping.h). Empty means those files are named after `name` instead.
+    ColumnId column_id;
 
 private:
     DataTypePtr type_in_storage;
@@ -88,8 +103,12 @@ public:
     template <typename Iterator>
     NamesAndTypesList(Iterator begin, Iterator end) : ListWithMemoryTracking<NameAndTypePair>(begin, end) {}
 
-    void readText(ReadBuffer & buf, bool check_eof = true);
-    void writeText(WriteBuffer & buf) const;
+    static constexpr UInt64 FORMAT_VERSION_WITH_NAMES = 1;
+    static constexpr UInt64 FORMAT_VERSION_WITH_COLUMN_IDS = 2;
+
+    /// Returns the format version read, so the caller can check it against its own state.
+    UInt64 readText(ReadBuffer & buf, bool check_eof = true);
+    void writeText(WriteBuffer & buf, bool use_column_ids = false) const;
 
     String toString() const;
     static NamesAndTypesList parse(const String & s);

--- a/src/Core/NamesAndTypes.h
+++ b/src/Core/NamesAndTypes.h
@@ -154,6 +154,12 @@ public:
     /// Try to get column by name, returns empty optional if column not found
     std::optional<NameAndTypePair> tryGetByName(const std::string & name) const;
 
+    /// The same by column id, for a list that a data part keys by id rather than by name.
+    std::optional<NameAndTypePair> tryGetByColumnId(const ColumnId & column_id) const;
+
+    /// The id this list holds `name` under, or `name` itself when no column has it.
+    ColumnId getColumnIdByName(const std::string & name) const;
+
     /// Try to get column position by name, returns number of columns if column isn't found
     size_t getPosByName(const std::string & name) const noexcept;
 

--- a/src/DataTypes/NestedUtils.cpp
+++ b/src/DataTypes/NestedUtils.cpp
@@ -536,19 +536,26 @@ NamesAndTypesList collect(const NamesAndTypesList & names_and_types)
     return res;
 }
 
-NamesAndTypesList convertToSubcolumns(const NamesAndTypesList & names_and_types)
+NamesAndTypesList convertToSubcolumns(const NamesAndTypesList & names_and_types, bool skip_columns_with_id)
 {
     auto nested_types = getSubcolumnsOfNested(names_and_types);
     auto res = names_and_types;
 
     for (auto & name_type : res)
     {
+        if (skip_columns_with_id && !name_type.column_id.empty())
+            continue;
+
         if (!isArray(name_type.type))
             continue;
 
         auto split = splitName(name_type.name);
         if (split.second.empty())
             continue;
+
+        /// Rebuilding the pair below via the subcolumn ctor drops the stable storage ID; carry
+        /// it across so the reader still resolves the right on-disk stream after the remap.
+        const ColumnId column_id = name_type.column_id;
 
         if (name_type.isSubcolumn())
         {
@@ -565,7 +572,10 @@ NamesAndTypesList convertToSubcolumns(const NamesAndTypesList & names_and_types)
                 {
                     auto new_subcolumn = concatenateName(storage_split.second, name_type.getSubcolumnName());
                     if (auto subcolumn_type = it->second->tryGetSubcolumnType(new_subcolumn))
+                    {
                         name_type = NameAndTypePair{storage_split.first, new_subcolumn, it->second, subcolumn_type};
+                        name_type.column_id = column_id;
+                    }
                 }
             }
             continue;
@@ -573,7 +583,10 @@ NamesAndTypesList convertToSubcolumns(const NamesAndTypesList & names_and_types)
 
         auto it = nested_types.find(split.first);
         if (it != nested_types.end())
+        {
             name_type = NameAndTypePair{split.first, split.second, it->second, it->second->getSubcolumnType(split.second)};
+            name_type.column_id = column_id;
+        }
     }
 
     return res;

--- a/src/DataTypes/NestedUtils.h
+++ b/src/DataTypes/NestedUtils.h
@@ -93,7 +93,10 @@ namespace Nested
     NamesAndTypesList collect(const NamesAndTypesList & names_and_types);
 
     /// Convert old-style nested (single arrays with same prefix, `n.a`, `n.b`...) to subcolumns of data type Nested.
-    NamesAndTypesList convertToSubcolumns(const NamesAndTypesList & names_and_types);
+    /// When `skip_columns_with_id` is set, columns already carrying a stable `column_id` are left untouched:
+    /// with column IDs each flattened-Nested field is a standalone, ID-keyed on-disk column (no shared offsets),
+    /// so folding it back onto the Nested parent would misresolve its stream name.
+    NamesAndTypesList convertToSubcolumns(const NamesAndTypesList & names_and_types, bool skip_columns_with_id = false);
 
     /// Unwrap Nullable(Tuple(...)) into Tuple(...) by propagating the struct-level null map
     /// to each element. Scalar elements become Nullable(T), already-Nullable elements get merged

--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -458,6 +458,38 @@ String ISerialization::getFileNameForStream(const String & name_in_storage, cons
     return getNameForSubstreamPath(std::move(stream_name), path.begin(), path.end(), true, false, settings.escape_variant_substreams);
 }
 
+/// `getFileNameForStream` under the column's stable id, so a metadata-only RENAME leaves every
+/// stream file name alone. A column with no id resolves exactly as the name-based form does:
+/// `getColumnId()` falls back to the name, and the two agree whenever id and name are equal.
+String ISerialization::getFileNameForStreamByColumnId(const NameAndTypePair & column, const SubstreamPath & path, const StreamFileNameSettings & settings)
+{
+    const String column_id = column.getColumnId().value();
+    const String & logical_name = column.getNameInStorage();
+
+    String stream_name;
+    if (settings.share_nested_offsets && isPossibleOffsetsOfNested(path))
+    {
+        /// Flattened Nested siblings ("n.x", "n.y") share one offsets stream, under the Nested
+        /// parent's prefix -- taken from the id ("n.x" -> "n", "5.7" -> "5") because a rename cannot
+        /// move that. A counter id with no dot ("5") has no parent in it, so the name supplies one.
+        const auto nested_from_id = Nested::extractTableName(column_id);
+        const auto nested_from_logical = Nested::extractTableName(logical_name);
+        const bool id_is_nested = (column_id != nested_from_id);
+        const bool logical_is_nested = (logical_name != nested_from_logical);
+
+        if (id_is_nested)
+            stream_name = escapeForFileName(nested_from_id);
+        else if (logical_is_nested)
+            stream_name = escapeForFileName(nested_from_logical);
+        else
+            stream_name = escapeForFileName(column_id);
+    }
+    else
+        stream_name = escapeForFileName(column_id);
+
+    return getNameForSubstreamPath(std::move(stream_name), path.begin(), path.end(), true, false, settings.escape_variant_substreams);
+}
+
 String ISerialization::getFileNameForRenamedColumnStream(const String & name_from, const String & name_to, const String & file_name)
 {
     auto name_from_escaped = escapeForFileName(name_from);

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -715,6 +715,7 @@ public:
 
     static String getFileNameForStream(const NameAndTypePair & column, const SubstreamPath & path, const StreamFileNameSettings & settings);
     static String getFileNameForStream(const String & name_in_storage, const SubstreamPath & path, const StreamFileNameSettings & settings);
+    static String getFileNameForStreamByColumnId(const NameAndTypePair & column, const SubstreamPath & path, const StreamFileNameSettings & settings);
     static String getFileNameForRenamedColumnStream(const NameAndTypePair & column_from, const NameAndTypePair & column_to, const String & file_name);
     static String getFileNameForRenamedColumnStream(const String & name_from, const String & name_to, const String & file_name);
 

--- a/src/DataTypes/Serializations/SerializationInfo.cpp
+++ b/src/DataTypes/Serializations/SerializationInfo.cpp
@@ -7,6 +7,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Core/Block.h>
+#include <Core/NamesAndTypes.h>
 #include <base/EnumReflection.h>
 
 #include <Poco/JSON/JSON.h>
@@ -347,7 +348,7 @@ void SerializationInfo::fromJSON(const Poco::JSON::Object & object)
 {
     if (!object.has(KEY_KIND) || !object.has(KEY_NUM_DEFAULTS) || !object.has(KEY_NUM_ROWS))
         throw Exception(ErrorCodes::CORRUPTED_DATA,
-            "Missed field '{}' or '{}' or '{}' in SerializationInfo of columns",
+            "Missing field '{}' or '{}' or '{}' in SerializationInfo of columns",
             KEY_KIND, KEY_NUM_DEFAULTS, KEY_NUM_ROWS);
 
     data.num_rows = object.getValue<size_t>(KEY_NUM_ROWS);
@@ -434,6 +435,23 @@ MutableSerializationInfoPtr SerializationInfoByName::tryGet(const String & name)
     return it == end() ? nullptr : it->second;
 }
 
+SerializationPtr SerializationInfoByName::getSerialization(const NameAndTypePair & column) const
+{
+    /// Records are keyed by the stamped column id -- the column's name in a part without ids.
+    return getSerialization(column, column.getColumnId().value());
+}
+
+/// For the one caller whose key does not come from `column`: a reader holds the requested column's
+/// id but must build the serialization from the part's own pair.
+SerializationPtr SerializationInfoByName::getSerialization(const NameAndTypePair & column, const String & record_key) const
+{
+    auto it = find(record_key);
+    if (it == end())
+        return IDataType::getSerialization(column, settings);
+
+    return IDataType::getSerialization(column, *it->second);
+}
+
 void SerializationInfoByName::replaceData(const SerializationInfoByName & other)
 {
     for (const auto & [name, new_info] : other)
@@ -445,6 +463,33 @@ void SerializationInfoByName::replaceData(const SerializationInfoByName & other)
         else
             old_info = new_info->clone();
     }
+}
+
+void SerializationInfoByName::reKeyToColumnIds(const NamesAndTypesList & columns)
+{
+    if (empty())
+        return;
+
+    bool has_distinct_column_ids = std::any_of(columns.begin(), columns.end(),
+        [](const auto & column) { return !column.column_id.empty() && column.column_id.value() != column.name; });
+
+    if (!has_distinct_column_ids)
+        return;
+
+    std::unordered_map<String, String> id_by_name;
+    for (const auto & column : columns)
+        id_by_name.emplace(column.name, column.getColumnId().value());
+
+    /// Rebuild into a fresh map: re-keying in place would overwrite another
+    /// column's record when a logical name equals that column's ID (RENAME
+    /// keeps the ID, so the freed name can be re-added under a fresh one).
+    std::map<String, MutableSerializationInfoPtr> rekeyed;
+    for (auto & [name, info] : *this)
+    {
+        auto it = id_by_name.find(name);
+        rekeyed.emplace(it == id_by_name.end() ? name : it->second, std::move(info));
+    }
+    swap(rekeyed);
 }
 
 ISerialization::KindStack SerializationInfoByName::getKindStack(const String & column_name) const
@@ -526,7 +571,16 @@ SerializationInfoByName SerializationInfoByName::clone() const
     return res;
 }
 
-SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesAndTypesList & columns, const std::string & json_str)
+namespace
+{
+
+struct ParsedJSON
+{
+    Poco::JSON::Array::Ptr columns_array;
+    SerializationInfoSettings settings;
+};
+
+ParsedJSON parseJSONEnvelope(const std::string & json_str)
 {
     Poco::JSON::Parser parser;
     auto object = parser.parse(json_str).extract<Poco::JSON::Object::Ptr>();
@@ -575,7 +629,6 @@ SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesA
     MergeTreeMapSerializationVersion map_serialization_version = MergeTreeMapSerializationVersion::BASIC;
     if (version >= MergeTreeSerializationInfoVersion::WITH_TYPES)
     {
-        /// types_serialization_versions is mandatory in WITH_TYPES mode
         if (!type_versions_obj)
         {
             throw Exception(
@@ -624,33 +677,79 @@ SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesA
         map_serialization_version,
         propagate_types_serialization_versions_to_nested_types);
 
+    return {columns_array, settings};
+}
+
+using ColumnByRecordKey = std::unordered_map<String, const NameAndTypePair *>;
+
+ColumnByRecordKey indexByName(const NamesAndTypesList & columns)
+{
+    ColumnByRecordKey index;
+    index.reserve(columns.size());
+    for (const auto & column : columns)
+        index.emplace(column.name, &column);
+    return index;
+}
+
+/// A record in a file written with column ids is keyed by the stamped id, but a part activated
+/// mid-life still holds records written under the logical name. Ids claim keys first: a key equal to
+/// some column's id belongs to that id's owner, never to a same-named column.
+ColumnByRecordKey indexByColumnIdThenName(const NamesAndTypesList & columns)
+{
+    ColumnByRecordKey index;
+    index.reserve(columns.size());
+    for (const auto & column : columns)
+        index.emplace(column.getColumnId().value(), &column);
+
+    for (const auto & column : columns)
+    {
+        if (!column.column_id.empty() && column.column_id.value() != column.name)
+            index.emplace(column.name, &column);
+    }
+    return index;
+}
+
+/// Records are stored under each column's storage id, which for an unstamped column is its name --
+/// so this keys a name-written file exactly as that file keys it.
+/// A record with no matching column is corruption in a name-keyed file, but ordinary in an id-keyed
+/// one: a dropped column's record outlives the column, and only its id could have identified it.
+void readRecords(
+    const Poco::JSON::Array & records, const ColumnByRecordKey & column_by_key, bool skip_unknown_keys, SerializationInfoByName & infos)
+{
+    for (const auto & elem : records)
+    {
+        const auto & elem_object = elem.extract<Poco::JSON::Object::Ptr>();
+
+        if (!elem_object->has(KEY_NAME))
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "Missing field '{}' in serialization infos", KEY_NAME);
+
+        auto record_key = elem_object->getValue<String>(KEY_NAME);
+        auto it = column_by_key.find(record_key);
+
+        if (it == column_by_key.end())
+        {
+            if (skip_unknown_keys)
+                continue;
+
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "Found unexpected column '{}' in serialization infos", record_key);
+        }
+
+        const auto & column = *it->second;
+        auto info = column.type->createSerializationInfo(infos.getSettings());
+        info->fromJSON(*elem_object);
+        infos.emplace(column.getColumnId().value(), std::move(info));
+    }
+}
+
+} /// anonymous namespace
+
+SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesAndTypesList & columns, const std::string & json_str)
+{
+    auto [columns_array, settings] = parseJSONEnvelope(json_str);
+
     SerializationInfoByName infos(settings);
     if (columns_array)
-    {
-        std::unordered_map<std::string_view, const IDataType *> column_type_by_name;
-        for (const auto & [name, type] : columns)
-            column_type_by_name.emplace(name, type.get());
-
-        for (const auto & elem : *columns_array)
-        {
-            const auto & elem_object = elem.extract<Poco::JSON::Object::Ptr>();
-
-            if (!elem_object->has(KEY_NAME))
-                throw Exception(ErrorCodes::CORRUPTED_DATA,
-                    "Missed field '{}' in serialization infos", KEY_NAME);
-
-            auto name = elem_object->getValue<String>(KEY_NAME);
-            auto it = column_type_by_name.find(name);
-
-            if (it == column_type_by_name.end())
-                throw Exception(ErrorCodes::CORRUPTED_DATA,
-                    "Found unexpected column '{}' in serialization infos", name);
-
-            auto info = it->second->createSerializationInfo(infos.settings);
-            info->fromJSON(*elem_object);
-            infos.emplace(name, std::move(info));
-        }
-    }
+        readRecords(*columns_array, indexByName(columns), /*skip_unknown_keys=*/false, infos);
 
     return infos;
 }
@@ -660,6 +759,19 @@ SerializationInfoByName SerializationInfoByName::readJSON(const NamesAndTypesLis
     String json_str;
     readString(json_str, in);
     return readJSONFromString(columns, json_str);
+}
+
+SerializationInfoByName SerializationInfoByName::readJSONWithColumnIds(const NamesAndTypesList & columns, ReadBuffer & in)
+{
+    String json_str;
+    readString(json_str, in);
+    auto [columns_array, settings] = parseJSONEnvelope(json_str);
+
+    SerializationInfoByName infos(settings);
+    if (columns_array)
+        readRecords(*columns_array, indexByColumnIdThenName(columns), /*skip_unknown_keys=*/true, infos);
+
+    return infos;
 }
 
 }

--- a/src/DataTypes/Serializations/SerializationInfo.h
+++ b/src/DataTypes/Serializations/SerializationInfo.h
@@ -125,10 +125,20 @@ public:
     MutableSerializationInfoPtr tryGet(const String & name);
     ISerialization::KindStack getKindStack(const String & column_name) const;
 
+    /// Serialization of a part's column, from its own record if there is one.
+    SerializationPtr getSerialization(const NameAndTypePair & column) const;
+    SerializationPtr getSerialization(const NameAndTypePair & column, const String & record_key) const;
+
     /// Takes data from @other, but keeps current serialization kinds.
     /// If column exists in @other infos, but not in current infos,
     /// it's cloned to current infos.
     void replaceData(const SerializationInfoByName & other);
+
+    /// Re-keys records produced under logical names (write paths accumulate per-block
+    /// stats keyed by name) to the columns' stamped IDs — the canonical key of a part's
+    /// records (matches the on-disk key). The map must be name-keyed: on an ID-keyed map
+    /// a key that is one column's ID and another column's name would be re-bound wrongly.
+    void reKeyToColumnIds(const NamesAndTypesList & columns);
 
     void writeJSON(WriteBuffer & out) const;
 
@@ -141,6 +151,11 @@ public:
     bool needsPersistence() const;
 
     static SerializationInfoByName readJSON(const NamesAndTypesList & columns, ReadBuffer & in);
+
+    /// Reads infos of a part written with column IDs active: on-disk records are keyed by the same
+    /// token as that part's columns.txt, and stay keyed by column ID in memory. `columns` is the
+    /// part's stamped column list; a record no column of it claims (an orphan) is skipped.
+    static SerializationInfoByName readJSONWithColumnIds(const NamesAndTypesList & columns, ReadBuffer & in);
 
     static SerializationInfoByName readJSONFromString(const NamesAndTypesList & columns, const std::string & str);
 

--- a/src/DataTypes/Serializations/SerializationInfoTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationInfoTuple.cpp
@@ -205,7 +205,7 @@ void SerializationInfoTuple::fromJSON(const Poco::JSON::Object & object)
 
     if (!object.has("subcolumns"))
         throw Exception(ErrorCodes::CORRUPTED_DATA,
-            "Missed field 'subcolumns' in SerializationInfo of columns SerializationInfoTuple");
+            "Missing field 'subcolumns' in SerializationInfo of columns SerializationInfoTuple");
 
     auto subcolumns = object.getArray("subcolumns");
     if (elems.size() != subcolumns->size())

--- a/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
+++ b/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
@@ -1090,7 +1090,8 @@ std::shared_ptr<SerializationObjectSharedData::PathsDataGranules> SerializationO
                     EnumerateStreamsSettings enumerate_settings;
                     enumerate_settings.data_part_type = MergeTreeDataPartType::Compact;
                     enumerate_settings.use_specialized_prefixes_and_suffixes_substreams = true;
-                    order = getSubcolumnsDeserializationOrder("", subcolumns_substream_data, path_info.substreams, enumerate_settings, stream_file_name_settings);
+                    /// No column: a shared-data path's substreams are named relative to the path itself.
+                    order = getSubcolumnsDeserializationOrder({}, subcolumns_substream_data, path_info.substreams, enumerate_settings, stream_file_name_settings);
                 }
 
                 /// Finally, deserialize data of subcolumns in determined order.

--- a/src/DataTypes/Serializations/getSubcolumnsDeserializationOrder.cpp
+++ b/src/DataTypes/Serializations/getSubcolumnsDeserializationOrder.cpp
@@ -1,4 +1,5 @@
 #include <DataTypes/Serializations/getSubcolumnsDeserializationOrder.h>
+#include <Core/NamesAndTypes.h>
 #include <Common/Exception.h>
 
 namespace DB
@@ -10,7 +11,7 @@ namespace ErrorCodes
 }
 
 std::vector<size_t> getSubcolumnsDeserializationOrder(
-    const String & column_name,
+    const NameAndTypePair & column,
     const std::vector<ISerialization::SubstreamData> & subcolumns_data,
     const std::vector<String> & substreams_in_serialization_order,
     ISerialization::EnumerateStreamsSettings & enumerate_settings,
@@ -34,7 +35,7 @@ std::vector<size_t> getSubcolumnsDeserializationOrder(
             if (ISerialization::isEphemeralSubcolumn(substream_path, substream_path.size()))
                 return;
 
-            String substream_name = ISerialization::getFileNameForStream(column_name, substream_path, stream_file_name_settings);
+            String substream_name = ISerialization::getFileNameForStreamByColumnId(column, substream_path, stream_file_name_settings);
             auto it = substream_to_pos.find(substream_name);
             if (it == substream_to_pos.end())
             {
@@ -42,12 +43,12 @@ std::vector<size_t> getSubcolumnsDeserializationOrder(
                 auto stream_file_name_settings_copy = stream_file_name_settings;
                 if (ISerialization::tryToChangeStreamFileNameSettingsForNotFoundStream(substream_path, stream_file_name_settings_copy))
                 {
-                    substream_name = ISerialization::getFileNameForStream(column_name, substream_path, stream_file_name_settings_copy);
+                    substream_name = ISerialization::getFileNameForStreamByColumnId(column, substream_path, stream_file_name_settings_copy);
                     it = substream_to_pos.find(substream_name);
                 }
 
                 if (it == substream_to_pos.end())
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected substream {} for column {}", substream_name, column_name);
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected substream {} for column {}", substream_name, column.name);
             }
 
             substreams_positions.push_back(it->second);

--- a/src/DataTypes/Serializations/getSubcolumnsDeserializationOrder.h
+++ b/src/DataTypes/Serializations/getSubcolumnsDeserializationOrder.h
@@ -8,7 +8,7 @@ namespace DB
 /// subcolumns in order of their serialization, so we can avoid seeks back in the data files.
 /// This function determines this order.
 std::vector<size_t> getSubcolumnsDeserializationOrder(
-    const String & column_name,
+    const NameAndTypePair & column,
     const std::vector<ISerialization::SubstreamData> & subcolumns_data,
     const std::vector<String> & substreams_in_serialization_order,
     ISerialization::EnumerateStreamsSettings & enumerate_settings,

--- a/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_serialization_info.cpp
@@ -6,6 +6,8 @@
 #include <DataTypes/Serializations/SerializationInfo.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
 #include <Poco/JSON/Object.h>
 #include <Common/Exception.h>
@@ -310,6 +312,72 @@ TEST(SerializationInfoJSON, ChooseKindStackZeroRows)
 
     ISerialization::KindStack expected{ISerialization::Kind::DEFAULT};
     EXPECT_EQ(kind_stack, expected);
+}
+
+TEST(SerializationInfoColumnIds, ReKeyWhenNameEqualsOtherColumnsId)
+{
+    /// `d` was renamed from `b` and kept the column ID "b"; the freed name `b`
+    /// re-appears under the fresh ID "1".  Records accumulated under logical
+    /// names must re-key to their own column's ID in either column order.
+    auto settings = defaultSettings();
+    auto type = std::make_shared<DataTypeUInt64>();
+
+    NameAndTypePair col_d("d", type);
+    col_d.setColumnId(ColumnId{"b"});
+    NameAndTypePair col_b("b", type);
+    col_b.setColumnId(ColumnId{"1"});
+
+    for (const auto & columns : {NamesAndTypesList{col_d, col_b}, NamesAndTypesList{col_b, col_d}})
+    {
+        SerializationInfoByName infos(settings);
+        infos.emplace("d", std::make_shared<SerializationInfo>(
+            ISerialization::KindStack{ISerialization::Kind::DEFAULT, ISerialization::Kind::SPARSE}, settings, makeData(100, 96)));
+        infos.emplace("b", std::make_shared<SerializationInfo>(
+            ISerialization::KindStack{ISerialization::Kind::DEFAULT}, settings, makeData(200, 0)));
+
+        infos.reKeyToColumnIds(columns);
+
+        ASSERT_EQ(infos.size(), 2u);
+        auto info_d = infos.tryGet("b");
+        ASSERT_NE(info_d, nullptr);
+        EXPECT_EQ(info_d->getData().num_rows, 100u);
+        EXPECT_TRUE(ISerialization::hasKind(info_d->getKindStack(), ISerialization::Kind::SPARSE));
+        auto info_b = infos.tryGet("1");
+        ASSERT_NE(info_b, nullptr);
+        EXPECT_EQ(info_b->getData().num_rows, 200u);
+        EXPECT_FALSE(ISerialization::hasKind(info_b->getKindStack(), ISerialization::Kind::SPARSE));
+    }
+}
+
+TEST(SerializationInfoColumnIds, ReadJSONWithColumnIdsIdOwnsItsKey)
+{
+    /// Stored key "b" is column d's ID and column b's name at once; it must bind
+    /// to the ID's owner regardless of the columns' order.
+    auto type = std::make_shared<DataTypeUInt64>();
+    NameAndTypePair col_d("d", type);
+    col_d.setColumnId(ColumnId{"b"});
+    NameAndTypePair col_b("b", type);
+    col_b.setColumnId(ColumnId{"1"});
+
+    String json = R"({"version":0,"columns":[)"
+        R"({"name":"b","kind":"Sparse","num_rows":100,"num_defaults":96},)"
+        R"({"name":"1","kind":"Default","num_rows":200,"num_defaults":0}]})";
+
+    for (const auto & columns : {NamesAndTypesList{col_d, col_b}, NamesAndTypesList{col_b, col_d}})
+    {
+        ReadBufferFromString in(json);
+        auto infos = SerializationInfoByName::readJSONWithColumnIds(columns, in);
+
+        ASSERT_EQ(infos.size(), 2u);
+        auto info_d = infos.tryGet("b");
+        ASSERT_NE(info_d, nullptr);
+        EXPECT_EQ(info_d->getData().num_rows, 100u);
+        EXPECT_TRUE(ISerialization::hasKind(info_d->getKindStack(), ISerialization::Kind::SPARSE));
+        auto info_b = infos.tryGet("1");
+        ASSERT_NE(info_b, nullptr);
+        EXPECT_EQ(info_b->getData().num_rows, 200u);
+        EXPECT_FALSE(ISerialization::hasKind(info_b->getKindStack(), ISerialization::Kind::SPARSE));
+    }
 }
 
 }

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -1301,8 +1301,9 @@ void MutationsInterpreter::prepare(bool dry_run)
             if (const auto & merge_tree_data_part = source.getMergeTreeDataPart())
             {
                 /// Check if the type of this column is changed and there are projections that have this column in the primary key or indices
-                /// that depend on it. We should rebuild such projections and indices
-                const auto & column = merge_tree_data_part->tryGetColumn(command.column_name);
+                /// that depend on it. We should rebuild such projections and indices.
+                /// The part's stored pair (its on-disk type) may differ from the command's target.
+                auto column = merge_tree_data_part->tryGetColumnBySnapshotName(command.column_name, metadata_snapshot);
                 if (column && command.data_type && !column->type->equals(*command.data_type))
                 {
                     for (const auto & projection : metadata_snapshot->getProjections())

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -339,8 +339,10 @@ static bool projectionPartHasRequiredColumns(
 
     for (const auto & name : required_column_names)
     {
-        /// (1) Stored by the projection part.
-        if (projection_part.tryGetColumn(name))
+        /// (1) Stored by the projection part, resolved by its own name: `checkAlterIsPossible` has
+        /// rejected RENAME of a projection-referenced column since long before column IDs, so those
+        /// stored names never go stale.
+        if (projection_part.tryGetColumnByNameUnsafe(name))
             continue;
 
         /// (2) Virtual column, provided by the reading step.
@@ -349,7 +351,7 @@ static bool projectionPartHasRequiredColumns(
 
         /// (3) Drift: the parent part still stores the column, or it is not a stored table column,
         /// so the projection part is stale for it and must not be read.
-        if (parent_part.tryGetColumn(name)
+        if (parent_part.tryGetColumnBySnapshotName(name, parent_metadata)
             || !parent_table_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, name))
             return false;
 

--- a/src/Processors/TTL/TTLColumnAlgorithm.cpp
+++ b/src/Processors/TTL/TTLColumnAlgorithm.cpp
@@ -10,11 +10,13 @@ TTLColumnAlgorithm::TTLColumnAlgorithm(
     time_t current_time_,
     bool force_,
     const String & column_name_,
+    const ColumnId & column_id_,
     const ExpressionActionsPtr & default_expression_,
     const String & default_column_name_,
     bool is_compact_part_)
     : ITTLAlgorithm(ttl_expressions_, description_, old_ttl_info_, current_time_, force_)
     , column_name(column_name_)
+    , column_id(column_id_)
     , default_expression(default_expression_)
     , default_column_name(default_column_name_)
     , is_compact_part(is_compact_part_)
@@ -49,7 +51,7 @@ void TTLColumnAlgorithm::execute(Block & block)
     /// will logically read. Evaluate the DDL `DEFAULT` expression (matching the per-row slow
     /// path below), falling back to the type default only when the column has no `DEFAULT`.
     /// Filling the type default here would make a rebuilt projection materialize the type
-    /// default (e.g. `0`) while the base reads the DDL default (e.g. `-1`) via `expired_columns`.
+    /// default (e.g. `0`) while the base reads the DDL default (e.g. `-1`) via `expired_column_ids`.
     if (isMaxTTLExpired() && !is_compact_part)
     {
         auto result_column = column_with_type.column->cloneEmpty();
@@ -103,10 +105,10 @@ void TTLColumnAlgorithm::execute(Block & block)
 
 void TTLColumnAlgorithm::finalize(const MutableDataPartPtr & data_part) const
 {
-    data_part->ttl_infos.columns_ttl[column_name] = new_ttl_info;
+    data_part->ttl_infos.columns_ttl[column_id.value()] = new_ttl_info;
     data_part->ttl_infos.updatePartMinMaxTTL(new_ttl_info);
     if (is_fully_empty)
-        data_part->expired_columns.insert(column_name);
+        data_part->expired_column_ids.insert(column_id);
 }
 
 }

--- a/src/Processors/TTL/TTLColumnAlgorithm.h
+++ b/src/Processors/TTL/TTLColumnAlgorithm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Processors/TTL/ITTLAlgorithm.h>
+#include <Core/ColumnId.h>
 
 namespace DB
 {
@@ -17,6 +18,7 @@ public:
         time_t current_time_,
         bool force_,
         const String & column_name_,
+        const ColumnId & column_id_,
         const ExpressionActionsPtr & default_expression_,
         const String & default_column_name_,
         bool is_compact_part_
@@ -27,6 +29,8 @@ public:
 
 private:
     const String column_name;
+    /// Keys this column's entry in `columns_ttl`, while `column_name` addresses the block's columns.
+    const ColumnId column_id;
     const ExpressionActionsPtr default_expression;
     const String default_column_name;
 

--- a/src/Processors/Transforms/TTLCalcTransform.cpp
+++ b/src/Processors/Transforms/TTLCalcTransform.cpp
@@ -58,9 +58,11 @@ TTLCalcTransform::TTLCalcTransform(
     {
         for (const auto & [name, description] : metadata_snapshot_->getColumnTTLs())
         {
+            auto column_in_part = data_part->tryGetColumnBySnapshotName(name, metadata_snapshot_);
+            String ttl_key = column_in_part ? column_in_part->getColumnId().value() : name;
             algorithms.emplace_back(std::make_unique<TTLUpdateInfoAlgorithm>(
                 getExpressions(description, subqueries_for_sets, context), description,
-                TTLUpdateField::COLUMNS_TTL, name, old_ttl_infos.columns_ttl[name], current_time_, force_));
+                TTLUpdateField::COLUMNS_TTL, ttl_key, old_ttl_infos.columns_ttl[ttl_key], current_time_, force_));
         }
     }
 

--- a/src/Processors/Transforms/TTLTransform.cpp
+++ b/src/Processors/Transforms/TTLTransform.cpp
@@ -123,13 +123,16 @@ TTLTransform::TTLTransform(
             if (!expired_columns_map.contains(name))
             {
                 auto [default_expression, default_column_name] = build_default_expr(name);
+                auto column_in_part = data_part->tryGetColumnBySnapshotName(name, metadata_snapshot_);
+                auto column_id = column_in_part ? column_in_part->getColumnId() : ColumnId{name};
                 algorithms.emplace_back(std::make_unique<TTLColumnAlgorithm>(
                     getExpressions(description, subqueries_for_sets, context),
                     description,
-                    old_ttl_infos.columns_ttl[name],
+                    old_ttl_infos.columns_ttl[column_id.value()],
                     current_time_,
                     force_,
                     name,
+                    column_id,
                     default_expression,
                     default_column_name,
                     isCompactPart(data_part)));

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -43,6 +43,8 @@
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Storages/IStorage.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
+#include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/StorageDummy.h>
 #include <Common/Exception.h>
 #include <Common/randomSeed.h>
@@ -109,6 +111,7 @@ ColumnDescription & ColumnDescription::operator=(const ColumnDescription & other
     settings = other.settings;
     ttl = other.ttl ? other.ttl->clone() : nullptr;
     statistics = other.statistics;
+    column_id = other.column_id;
 
     return *this;
 }
@@ -132,6 +135,7 @@ ColumnDescription & ColumnDescription::operator=(ColumnDescription && other) ///
     other.ttl.reset();
 
     statistics = std::move(other.statistics);
+    column_id = std::move(other.column_id);
 
     return *this;
 }
@@ -301,6 +305,29 @@ void ColumnsDescription::invalidateGetCache() const
     get_cache.clear();
 }
 
+void ColumnsDescription::setColumnIds(const ColumnIdMapping & mapping)
+{
+    /// Stamp each column's id off the active mapping. An empty id means name-keyed (a non-stored
+    /// ALIAS / EPHEMERAL column, or a virtual column) -- legitimate to leave absent from the mapping.
+    /// A physically-stored, non-virtual column missing from the mapping is a schema/mapping desync:
+    /// fail loud rather than name-defaulting its id (which would silently defeat id resolution).
+    for (auto it = columns.begin(); it != columns.end(); ++it)
+    {
+        ColumnId id;
+        if (auto column_id = mapping.tryGetColumnId(it->name))
+            id = *column_id;
+        else if (const bool physically_stored = it->default_desc.kind != ColumnDefaultKind::Alias
+                     && it->default_desc.kind != ColumnDefaultKind::Ephemeral;
+                 physically_stored && !isVirtualColumn(it->name))
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Column '{}' is absent from the active column-ID mapping while stamping the schema; "
+                "the table schema and column-ID mapping have desynced", it->name);
+
+        columns.modify(it, [&](ColumnDescription & col) { col.column_id = id; });
+    }
+    invalidateGetCache();
+}
+
 ColumnsDescription::ColumnsDescription(std::initializer_list<ColumnDescription> ordinary)
 {
     for (auto && elem : ordinary)
@@ -318,7 +345,13 @@ ColumnsDescription ColumnsDescription::fromNamesAndTypes(NamesAndTypes ordinary)
 ColumnsDescription::ColumnsDescription(NamesAndTypesList ordinary, bool with_subcolumns)
 {
     for (auto & elem : ordinary)
-        add(ColumnDescription(std::move(elem.name), std::move(elem.type)), String(), false, with_subcolumns);
+    {
+        ColumnDescription column(std::move(elem.name), std::move(elem.type));
+        /// Preserve the stable storage ID so a description rebuilt from a stamped list
+        /// (e.g. a part's collected-Nested columns) keeps ID-keyed resolution.
+        column.column_id = elem.column_id;
+        add(std::move(column), String(), false, with_subcolumns);
+    }
 }
 
 ColumnsDescription::ColumnsDescription(NamesAndTypesList ordinary, NamesAndAliases aliases)
@@ -567,7 +600,7 @@ NamesAndTypesList ColumnsDescription::getOrdinary() const
     NamesAndTypesList ret;
     for (const auto & col : columns)
         if (col.default_desc.kind == ColumnDefaultKind::Default)
-            ret.emplace_back(col.name, col.type);
+            ret.push_back(NameAndTypePair(col.name, col.type, col.column_id));
     return ret;
 }
 
@@ -576,7 +609,7 @@ NamesAndTypesList ColumnsDescription::getInsertable() const
     NamesAndTypesList ret;
     for (const auto & col : columns)
         if (col.default_desc.kind == ColumnDefaultKind::Default || col.default_desc.kind == ColumnDefaultKind::Ephemeral)
-            ret.emplace_back(col.name, col.type);
+            ret.push_back(NameAndTypePair(col.name, col.type, col.column_id));
     return ret;
 }
 
@@ -585,7 +618,7 @@ NamesAndTypesList ColumnsDescription::getMaterialized() const
     NamesAndTypesList ret;
     for (const auto & col : columns)
         if (col.default_desc.kind == ColumnDefaultKind::Materialized)
-            ret.emplace_back(col.name, col.type);
+            ret.push_back(NameAndTypePair(col.name, col.type, col.column_id));
     return ret;
 }
 
@@ -594,7 +627,7 @@ NamesAndTypesList ColumnsDescription::getAliases() const
     NamesAndTypesList ret;
     for (const auto & col : columns)
         if (col.default_desc.kind == ColumnDefaultKind::Alias)
-            ret.emplace_back(col.name, col.type);
+            ret.push_back(NameAndTypePair(col.name, col.type, col.column_id));
     return ret;
 }
 
@@ -603,7 +636,7 @@ NamesAndTypesList ColumnsDescription::getEphemeral() const
     NamesAndTypesList ret;
         for (const auto & col : columns)
             if (col.default_desc.kind == ColumnDefaultKind::Ephemeral)
-                ret.emplace_back(col.name, col.type);
+                ret.push_back(NameAndTypePair(col.name, col.type, col.column_id));
     return ret;
 }
 
@@ -611,14 +644,24 @@ NamesAndTypesList ColumnsDescription::getAll() const
 {
     NamesAndTypesList ret;
     for (const auto & col : columns)
-        ret.emplace_back(col.name, col.type);
+        ret.push_back(NameAndTypePair(col.name, col.type, col.column_id));
     return ret;
 }
 
 NamesAndTypesList ColumnsDescription::getSubcolumns(const String & name_in_storage) const
 {
     auto range = subcolumns.get<1>().equal_range(name_in_storage);
-    return NamesAndTypesList(range.first, range.second);
+    auto parent = columns.get<1>().find(name_in_storage);
+    NamesAndTypesList ret;
+    for (auto it = range.first; it != range.second; ++it)
+    {
+        /// A subcolumn shares its parent column's stamped ID (streams live under the parent).
+        NameAndTypePair pair = *it;
+        if (parent != columns.get<1>().end())
+            pair.column_id = parent->column_id;
+        ret.push_back(std::move(pair));
+    }
+    return ret;
 }
 
 NamesAndTypesList ColumnsDescription::getNested(const String & column_name) const
@@ -626,7 +669,7 @@ NamesAndTypesList ColumnsDescription::getNested(const String & column_name) cons
     auto range = getNameRange(columns, column_name);
     NamesAndTypesList nested;
     for (auto & it = range.first; it != range.second; ++it)
-        nested.emplace_back(it->name, it->type);
+        nested.push_back(NameAndTypePair(it->name, it->type, it->column_id));
     return nested;
 }
 
@@ -642,8 +685,14 @@ void ColumnsDescription::addSubcolumnsToList(NamesAndTypesList & source_list) co
             continue;
 
         auto range = subcolumns.get<1>().equal_range(col.name);
-        if (range.first != range.second)
-            subcolumns_list.insert(subcolumns_list.end(), range.first, range.second);
+        for (auto jt = range.first; jt != range.second; ++jt)
+        {
+            /// A subcolumn shares its parent column's stamped ID (streams live under the parent).
+            NameAndTypePair pair = *jt;
+            if (it != columns.get<1>().end())
+                pair.column_id = it->column_id;
+            subcolumns_list.push_back(std::move(pair));
+        }
     }
 
     source_list.splice(source_list.end(), std::move(subcolumns_list));
@@ -807,7 +856,7 @@ NamesAndTypesList ColumnsDescription::getAllPhysical() const
     NamesAndTypesList ret;
     for (const auto & col : columns)
         if (col.default_desc.kind != ColumnDefaultKind::Alias && col.default_desc.kind != ColumnDefaultKind::Ephemeral)
-            ret.emplace_back(col.name, col.type);
+            ret.push_back(NameAndTypePair(col.name, col.type, col.column_id));
     return ret;
 }
 
@@ -824,13 +873,22 @@ std::optional<NameAndTypePair> ColumnsDescription::tryGetColumn(const GetColumns
 {
     auto it = columns.get<1>().find(column_name);
     if (it != columns.get<1>().end() && (defaultKindToGetKind(it->default_desc.kind) & options.kind))
-        return NameAndTypePair(it->name, it->type);
+        return NameAndTypePair(it->name, it->type, it->column_id);
 
     if (options.with_subcolumns)
     {
         auto jt = subcolumns.get<0>().find(column_name);
-        if (jt != subcolumns.get<0>().end() && (defaultKindToGetKind(columns.get<1>().find(jt->getNameInStorage())->default_desc.kind) & options.kind))
-            return *jt;
+        if (jt != subcolumns.get<0>().end())
+        {
+            auto parent = columns.get<1>().find(jt->getNameInStorage());
+            if (defaultKindToGetKind(parent->default_desc.kind) & options.kind)
+            {
+                /// A subcolumn shares its parent column's stamped ID (streams live under the parent).
+                NameAndTypePair pair = *jt;
+                pair.column_id = parent->column_id;
+                return pair;
+            }
+        }
 
         if (options.with_dynamic_subcolumns)
         {

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -27,6 +27,8 @@
 namespace DB
 {
 
+class ColumnIdMapping;
+
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
@@ -104,6 +106,11 @@ struct ColumnDescription
     SettingsChanges settings;
     ASTPtr ttl;
     ColumnStatisticsDescription statistics;
+
+    /// Stable on-disk storage ID, mirroring NameAndTypePair::column_id (empty ⇒ use `name`).
+    /// In-memory only -- column_ids.json is the on-disk source of truth, so neither writeText nor
+    /// the CREATE AST carries it, and `operator==` ignores it as NameAndTypePair::operator== does.
+    ColumnId column_id;
 
     ColumnDescription() = default;
     ColumnDescription(const ColumnDescription & other) { *this = other; }
@@ -191,6 +198,11 @@ public:
     bool hasSubcolumn(GetColumnsOptions::Kind kind, const String & column_name) const;
     const ColumnDescription & get(const String & column_name) const;
     const ColumnDescription * tryGet(const String & column_name) const;
+
+    /// Stamp each ColumnDescription's `column_id` from `mapping` (load / ALTER republish), so
+    /// every derived NameAndTypePair carries its ID for free. Columns not in the mapping keep
+    /// an empty ID (fall back to name).
+    void setColumnIds(const ColumnIdMapping & mapping);
 
     template <typename F>
     void modify(const String & column_name, F && f)

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -246,7 +246,9 @@ public:
     /// any locks.
     void setInMemoryMetadata(const StorageInMemoryMetadata & metadata_)
     {
-        metadata.set(std::make_unique<StorageInMemoryMetadata>(metadata_));
+        auto new_metadata = std::make_unique<StorageInMemoryMetadata>(metadata_);
+        new_metadata->syncColumnIdsFromMapping();
+        metadata.set(std::move(new_metadata));
     }
 
     VectorWithMemoryTracking<String> getAllRegisteredNames() const override;

--- a/src/Storages/MergeTree/ColumnIdHelper.cpp
+++ b/src/Storages/MergeTree/ColumnIdHelper.cpp
@@ -1,0 +1,22 @@
+#include <Storages/MergeTree/ColumnIdHelper.h>
+
+#include <Storages/MergeTree/ColumnIdMapping.h>
+
+namespace DB
+{
+
+ColumnId getColumnIdOrPartName(const NameAndTypePair & requested_column, const String & name_in_part)
+{
+    if (requested_column.column_id.empty())
+        return ColumnId{name_in_part};
+    return requested_column.getColumnId();
+}
+
+std::optional<String> tryGetCurrentColumnName(const NameAndTypePair & part_column, const ColumnIdMapping * mapping)
+{
+    if (mapping && !part_column.column_id.empty())
+        return mapping->tryGetColumnName(part_column.getColumnId());
+    return part_column.name;
+}
+
+}

--- a/src/Storages/MergeTree/ColumnIdHelper.h
+++ b/src/Storages/MergeTree/ColumnIdHelper.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <Core/NamesAndTypes.h>
+
+#include <optional>
+
+namespace DB
+{
+
+class ColumnIdMapping;
+
+/** Resolving a column across the domains that name it.
+  *
+  * A column ID is assigned once and never changes; a column NAME belongs to a domain and means nothing
+  * outside it. Four domains meet in MergeTree:
+  *
+  * - A DATA PART is immutable and, once the feature is active, ID-based throughout: `columns.txt` stores
+  *   IDs in the name slot and every stream file is named after one
+  *   (`ISerialization::getFileNameForStreamByColumnId`). No name is written down at all. The names a part
+  *   reports in memory are put there at load, by resolving those IDs through the mapping
+  *   (`IMergeTreeDataPart::remapColumnIdsToColumnNames`), so they are a cache of the schema as it stood
+  *   then -- right when loaded, stale as soon as a metadata-only RENAME lands, and never an identity.
+  *   Parts therefore match each other by ID: a merge or mutation pairs source columns with target columns
+  *   through IDs, never by comparing names.
+  * - The TABLE SCHEMA is the current, mutable truth. Names here change under DDL; IDs do not. The
+  *   metadata snapshot carries the `ColumnIdMapping`, which is the *only* translation between an ID and
+  *   a current name.
+  * - A STORAGE SNAPSHOT is what one query sees: schema columns plus virtuals. Pairs resolved from it
+  *   carry the ID, but also the schema's TYPE -- which is not the part's type when a MODIFY COLUMN has
+  *   not been materialised, so a snapshot pair must not be used to enumerate a part's streams.
+  * - A USER COMMAND (ALTER, mutation) names columns as typed, and one that targets parts outlives the
+  *   schema it was written against: a queued RENAME or DROP names its column as it stood BEFORE the
+  *   mutation, so the current snapshot may not have that name at all while the part still answers to it.
+  *   Translating a command to a part is therefore the ID path with a name fallback, which is what
+  *   `MutateTask::tryGetPartColumnForCommand` is; on the read path the same shape is
+  *   `getColumnIdOrPartName`, where the old name comes from the alter conversions instead.
+  *
+  * Hence the translation rules:
+  *
+  * - Entering a part from a request or the schema: resolve to the part's own pair by ID
+  *   (`IMergeTreeDataPart::tryGetColumnBySnapshotName` / `tryGetColumnByRequest`), then use THAT pair
+  *   for anything naming, sizing or deserialising the part's files.
+  * - Leaving a part for the schema -- a background operation writing metadata, per-column sizes, a
+  *   codec or TTL lookup: translate the part's ID through the snapshot's mapping
+  *   (`tryGetCurrentColumnName`) rather than trusting the name the part reports, which was resolved
+  *   against an older schema. No current name means the schema dropped the column and this part's copy
+  *   is an orphan.
+  * - Virtual columns (`_row_exists`, `_part_offset`) have no ID and appear in no mapping; they stay
+  *   name-keyed in every domain.
+  * - Before activation nothing is stamped, `NameAndTypePair::getColumnId` falls back to the name, and
+  *   every rule above degrades to the name lookup it replaced. That is why the feature is inert until a
+  *   table gets a mapping -- and why a name-keyed leftover on any of these paths goes unnoticed until it
+  *   is not.
+  */
+
+/// The key a part holds @requested_column under: its id, else @name_in_part. Not `getColumnId`, whose
+/// own fallback is the CURRENT name -- which a part left on the old name by a rename never answers to.
+ColumnId getColumnIdOrPartName(const NameAndTypePair & requested_column, const String & name_in_part);
+
+/// The name @part_column goes by in the CURRENT schema, through @mapping -- its own name when the part
+/// carries no ids. `nullopt` for an id the mapping no longer knows.
+std::optional<String> tryGetCurrentColumnName(const NameAndTypePair & part_column, const ColumnIdMapping * mapping);
+
+}

--- a/src/Storages/MergeTree/ColumnIdMapping.cpp
+++ b/src/Storages/MergeTree/ColumnIdMapping.cpp
@@ -1,0 +1,387 @@
+#include <Storages/MergeTree/ColumnIdMapping.h>
+
+#include <Storages/MergeTree/MergeTreeVirtualColumns.h>
+
+#include <Common/Exception.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Stringifier.h>
+
+#include <algorithm>
+#include <charconv>
+#include <sstream>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+constexpr auto KEY_ACTIVE = "active";
+constexpr auto KEY_NEXT_COLUMN_ID = "next_column_id";
+constexpr auto KEY_MAPPING = "mapping";
+
+UInt64 safeIncrementColumnId(UInt64 max_id)
+{
+    if (max_id == std::numeric_limits<UInt64>::max())
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Column ID counter overflow: the maximum value {} has been reached", max_id);
+    return max_id + 1;
+}
+
+/// The counter starts above every numeric column NAME as well, or a table that already has a column
+/// literally named "2" collides with the ID a later `ADD COLUMN` allocates.
+UInt64 getNextColumnId(const NamesAndTypesList & columns)
+{
+    UInt64 max_numeric_column_id = 0;
+    for (const auto & column : columns)
+        max_numeric_column_id = std::max(max_numeric_column_id, ColumnIdMapping::extractNumericCounter(column.name));
+    return safeIncrementColumnId(max_numeric_column_id);
+}
+
+UInt64 getNextColumnId(const std::unordered_map<String, String> & name_to_id)
+{
+    UInt64 max_numeric_column_id = 0;
+    for (const auto & [_, column_id] : name_to_id)
+        max_numeric_column_id = std::max(max_numeric_column_id, ColumnIdMapping::extractNumericCounter(column_id));
+    return safeIncrementColumnId(max_numeric_column_id);
+}
+
+[[noreturn]] void throwMissingColumnName(const String & column_name)
+{
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Column name '{}' is not found in `ColumnIdMapping`", column_name);
+}
+
+[[noreturn]] void throwMissingColumnId(const String & column_id)
+{
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Column ID '{}' is not found in `ColumnIdMapping`", column_id);
+}
+
+}
+
+UInt64 ColumnIdMapping::extractNumericCounter(const String & s)
+{
+    /// Every dot-separated numeric component counts, not just the first: a flattened Nested child id
+    /// is "<parent counter>.<child counter>" ("5.7"), and both halves come from this counter, so the
+    /// counter has to end up above both -- for a numeric column NAME at activation just the same.
+    UInt64 max_component = 0;
+    size_t component_begin = 0;
+    while (true)
+    {
+        const auto separator = s.find('.', component_begin);
+        const auto component_size = (separator == String::npos ? s.size() : separator) - component_begin;
+
+        UInt64 value = 0;
+        const auto * begin = s.data() + component_begin;
+        const auto * end = begin + component_size;
+        auto [ptr, ec] = std::from_chars(begin, end, value);
+        if (ec == std::errc() && ptr == end)
+            max_component = std::max(max_component, value);
+
+        if (separator == String::npos)
+            return max_component;
+        component_begin = separator + 1;
+    }
+}
+
+String ColumnIdMapping::getColumnId(const String & column_name) const
+{
+    auto it = name_to_id.find(column_name);
+    if (it == name_to_id.end())
+        throwMissingColumnName(column_name);
+
+    return it->second;
+}
+
+String ColumnIdMapping::getColumnIdOrDefault(const String & column_name) const
+{
+    auto it = name_to_id.find(column_name);
+    return it == name_to_id.end() ? column_name : it->second;
+}
+
+String ColumnIdMapping::getColumnName(const String & column_id) const
+{
+    auto it = id_to_name.find(column_id);
+    if (it == id_to_name.end())
+        throwMissingColumnId(column_id);
+
+    return it->second;
+}
+
+bool ColumnIdMapping::hasColumnName(const String & column_name) const
+{
+    return name_to_id.contains(column_name);
+}
+
+bool ColumnIdMapping::hasColumnId(const String & column_id) const
+{
+    return id_to_name.contains(column_id);
+}
+
+std::optional<ColumnId> ColumnIdMapping::tryGetColumnId(const String & column_name) const
+{
+    if (!hasColumnName(column_name))
+        return std::nullopt;
+    return ColumnId{getColumnId(column_name)};
+}
+
+std::optional<String> ColumnIdMapping::tryGetColumnName(const ColumnId & column_id) const
+{
+    if (!hasColumnId(column_id.value()))
+        return std::nullopt;
+    return getColumnName(column_id.value());
+}
+
+String ColumnIdMapping::allocateColumnId()
+{
+    active = true;
+    auto id = next_column_id;
+    next_column_id = safeIncrementColumnId(next_column_id);
+    return ::DB::toString(id);
+}
+
+void ColumnIdMapping::addColumn(const String & column_name, const String & column_id)
+{
+    if (name_to_id.contains(column_name))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name '{}' is already registered in `ColumnIdMapping`", column_name);
+
+    if (id_to_name.contains(column_id))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Column ID '{}' is already registered in `ColumnIdMapping`", column_id);
+
+    active = true;
+    name_to_id.emplace(column_name, column_id);
+    id_to_name.emplace(column_id, column_name);
+}
+
+void ColumnIdMapping::detachColumnName(std::unordered_map<String, String>::iterator it)
+{
+    const String column_id = it->second;
+    name_to_id.erase(it);
+
+    /// A second name can still hold the id -- that is the transient state `beginRename` leaves --
+    /// so the reverse entry is re-pointed at the survivor rather than erased.
+    for (const auto & [other_name, other_column_id] : name_to_id)
+    {
+        if (other_column_id == column_id)
+        {
+            id_to_name[column_id] = other_name;
+            return;
+        }
+    }
+    id_to_name.erase(column_id);
+}
+
+void ColumnIdMapping::removeColumn(const String & column_name)
+{
+    auto it = name_to_id.find(column_name);
+    if (it == name_to_id.end())
+        throwMissingColumnName(column_name);
+
+    detachColumnName(it);
+}
+
+/// Two phases, because `column_ids.json` and the catalog's metadata cannot be written atomically.
+/// Phase 1 adds the new name beside the old one, both pointing at the same id, and persists; the
+/// metadata commit follows; `finishRename` then drops the old name.
+///     phase 1:  { "b":"b", "name":"b" }    metadata still says "b"
+///     phase 2:  { "name":"b" }             metadata says "name"
+/// On restart, reconciliation drops mapping entries metadata does not name, which lands on the right
+/// state from either crash window: before the commit it keeps "b", after it keeps "name". A
+/// single-step rename would lose the id "b" outright if the crash fell between the two writes.
+void ColumnIdMapping::beginRename(const String & old_column_name, const String & new_column_name)
+{
+    auto it = name_to_id.find(old_column_name);
+    if (it == name_to_id.end())
+        throwMissingColumnName(old_column_name);
+
+    if (name_to_id.contains(new_column_name))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name '{}' is already registered in `ColumnIdMapping`", new_column_name);
+
+    auto column_id = it->second;
+
+    /// A name equal to a FOREIGN column's id would make every by-name resolution of an on-disk
+    /// artifact ambiguous, so a mutation could read or write the wrong streams. Disambiguating that
+    /// at each such site costs more than the feature is worth; the self-case is harmless.
+    if (id_to_name.contains(new_column_name) && new_column_name != column_id)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "Cannot rename column '{}' to '{}': the new name collides with an existing column ID",
+            old_column_name, new_column_name);
+
+    /// The reverse map stays on the old name, which is what the uncommitted metadata still says;
+    /// `finishRename` moves it once the commit is confirmed.
+    name_to_id.emplace(new_column_name, column_id);
+}
+
+void ColumnIdMapping::finishRename(const String & old_column_name)
+{
+    auto it = name_to_id.find(old_column_name);
+    /// `beginRename` registered the old name and nothing between the two phases removes it: the
+    /// planner only adds, and `AlterCommands::validate` rejects two renames of the same column.
+    if (it == name_to_id.end())
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "`finishRename` of column name '{}' without a matching `beginRename`", old_column_name);
+
+    detachColumnName(it);
+}
+
+Names ColumnIdMapping::columnNames() const
+{
+    Names names;
+    names.reserve(name_to_id.size());
+
+    for (const auto & [column_name, _] : name_to_id)
+        names.push_back(column_name);
+
+    return names;
+}
+
+ColumnIdMapping ColumnIdMapping::createIdentity(const NamesAndTypesList & columns)
+{
+    ColumnIdMapping mapping;
+    mapping.active = true;
+    mapping.next_column_id = getNextColumnId(columns);
+
+    for (const auto & column : columns)
+        mapping.addColumn(column.name, column.name);
+
+    return mapping;
+}
+
+void ColumnIdMapping::serialize(WriteBuffer & buf) const
+{
+    writeString(toString(), buf);
+}
+
+ColumnIdMapping ColumnIdMapping::deserialize(ReadBuffer & buf)
+{
+    String json;
+    readString(json, buf);
+    return fromString(json);
+}
+
+String ColumnIdMapping::toString() const
+{
+    Poco::JSON::Object json;
+    Poco::JSON::Object mapping_json;
+
+    std::vector<std::pair<String, String>> mapping_entries(name_to_id.begin(), name_to_id.end());
+    std::sort(mapping_entries.begin(), mapping_entries.end(), [](const auto & lhs, const auto & rhs)
+    {
+        return lhs.first < rhs.first;
+    });
+
+    for (const auto & [column_name, column_id] : mapping_entries)
+        mapping_json.set(column_name, column_id);
+
+    json.set(KEY_ACTIVE, active);
+    json.set(KEY_NEXT_COLUMN_ID, next_column_id);
+    json.set(KEY_MAPPING, mapping_json);
+
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    oss.exceptions(std::ios::failbit);
+    Poco::JSON::Stringifier::stringify(json, oss);
+    return oss.str();
+}
+
+ColumnIdMapping ColumnIdMapping::fromString(const String & str)
+{
+    Poco::JSON::Parser parser;
+    auto object = parser.parse(str).extract<Poco::JSON::Object::Ptr>();
+
+    ColumnIdMapping mapping;
+
+    if (object->has(KEY_ACTIVE))
+        mapping.active = object->getValue<bool>(KEY_ACTIVE);
+
+    if (object->has(KEY_NEXT_COLUMN_ID))
+        mapping.next_column_id = object->getValue<UInt64>(KEY_NEXT_COLUMN_ID);
+
+    if (!object->has(KEY_MAPPING))
+        return mapping;
+
+    auto mapping_object = object->getObject(KEY_MAPPING);
+    for (const auto & [column_name, column_id_value] : *mapping_object)
+    {
+        String column_id = column_id_value.convert<String>();
+        mapping.name_to_id.emplace(column_name, column_id);
+        mapping.id_to_name[column_id] = column_name;
+    }
+
+    /// A mid-rename file maps two names to one id, and the loop above let JSON key order pick the
+    /// reverse winner. Redo it on the lexicographically smallest name -- arbitrary but stable;
+    /// reconciliation drops the stale name right after startup anyway.
+    if (mapping.id_to_name.size() < mapping.name_to_id.size())
+    {
+        mapping.id_to_name.clear();
+        for (const auto & [column_name, column_id] : mapping.name_to_id)
+        {
+            auto it = mapping.id_to_name.find(column_id);
+            if (it == mapping.id_to_name.end() || column_name < it->second)
+                mapping.id_to_name[column_id] = column_name;
+        }
+    }
+
+    mapping.active = mapping.active || !mapping.name_to_id.empty();
+    if (!mapping.name_to_id.empty())
+        mapping.next_column_id = std::max(mapping.next_column_id, getNextColumnId(mapping.name_to_id));
+
+    return mapping;
+}
+
+void ColumnIdMapping::stampColumnIds(NamesAndTypesList & columns) const
+{
+    if (!active)
+        return;
+
+    for (auto & column : columns)
+    {
+        /// A read caller can pass a column already stamped with the part's real id (e.g.
+        /// getListOfStreamsForColumn, for subcolumn sizes); re-stamping from the live mapping would
+        /// clobber it after a DROP + re-ADD name reuse. Write-path columns arrive id-less.
+        if (!column.column_id.empty())
+            continue;
+
+        const auto name_in_storage = column.getNameInStorage();
+        if (auto id = tryGetColumnId(name_in_storage))
+            column.setColumnId(*id);
+        /// Virtual columns are not id-managed: persistent ones are stored by name, ephemeral
+        /// ones (e.g. `_part_offset`, `_part_data_version`) are materialized by the reader.
+        /// Leave them UNSTAMPED (empty id ≡ name-keyed on disk) for the name-resolution path.
+        else if (!isVirtualColumn(name_in_storage))
+            /// A real physical column absent from the active mapping is a schema/mapping
+            /// desync — a torn snapshot would otherwise stamp ids that no reader resolves
+            /// (write) or mis-resolve by a stale name (read). Fail loud instead.
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Column '{}' is absent from the active column-ID mapping while stamping a part; "
+                "the table schema and column-ID mapping have desynced", name_in_storage);
+    }
+}
+
+void ColumnIdMapping::stampColumnIdsLenient(NamesAndTypesList & columns) const
+{
+    if (!active)
+        return;
+
+    for (auto & column : columns)
+    {
+        const auto name_in_storage = column.getNameInStorage();
+        if (auto id = tryGetColumnId(name_in_storage))
+            column.setColumnId(*id);
+        /// Everything else (synthetic projection aggregates, not-yet-applied ALTER columns,
+        /// a projection part's parent-mapping-stamped columns) is left UNSTAMPED
+        /// (empty id ≡ name-keyed on disk). No throw.
+    }
+}
+
+}

--- a/src/Storages/MergeTree/ColumnIdMapping.cpp
+++ b/src/Storages/MergeTree/ColumnIdMapping.cpp
@@ -346,22 +346,16 @@ void ColumnIdMapping::stampColumnIds(NamesAndTypesList & columns) const
 
     for (auto & column : columns)
     {
-        /// A read caller can pass a column already stamped with the part's real id (e.g.
-        /// getListOfStreamsForColumn, for subcolumn sizes); re-stamping from the live mapping would
-        /// clobber it after a DROP + re-ADD name reuse. Write-path columns arrive id-less.
+        /// An id already on the pair is the part's own, and the mapping may hold a different one
+        /// for that name by now; the part's wins.
         if (!column.column_id.empty())
             continue;
 
         const auto name_in_storage = column.getNameInStorage();
         if (auto id = tryGetColumnId(name_in_storage))
             column.setColumnId(*id);
-        /// Virtual columns are not id-managed: persistent ones are stored by name, ephemeral
-        /// ones (e.g. `_part_offset`, `_part_data_version`) are materialized by the reader.
-        /// Leave them UNSTAMPED (empty id ≡ name-keyed on disk) for the name-resolution path.
+        /// A virtual column is outside the mapping by design, and stays name-keyed.
         else if (!isVirtualColumn(name_in_storage))
-            /// A real physical column absent from the active mapping is a schema/mapping
-            /// desync — a torn snapshot would otherwise stamp ids that no reader resolves
-            /// (write) or mis-resolve by a stale name (read). Fail loud instead.
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "Column '{}' is absent from the active column-ID mapping while stamping a part; "
                 "the table schema and column-ID mapping have desynced", name_in_storage);
@@ -375,12 +369,11 @@ void ColumnIdMapping::stampColumnIdsLenient(NamesAndTypesList & columns) const
 
     for (auto & column : columns)
     {
+        /// Anything outside the mapping -- a projection aggregate, a column an ALTER has not
+        /// applied yet -- stays unstamped rather than throwing.
         const auto name_in_storage = column.getNameInStorage();
         if (auto id = tryGetColumnId(name_in_storage))
             column.setColumnId(*id);
-        /// Everything else (synthetic projection aggregates, not-yet-applied ALTER columns,
-        /// a projection part's parent-mapping-stamped columns) is left UNSTAMPED
-        /// (empty id ≡ name-keyed on disk). No throw.
     }
 }
 

--- a/src/Storages/MergeTree/ColumnIdMapping.h
+++ b/src/Storages/MergeTree/ColumnIdMapping.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <Core/NamesAndTypes.h>
+
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+
+namespace DB
+{
+
+class ReadBuffer;
+class WriteBuffer;
+
+class ColumnIdMapping;
+using ColumnIdMappingPtr = std::shared_ptr<const ColumnIdMapping>;
+
+/// Bidirectional map between SQL column names and stable on-disk column IDs.
+///
+/// Existing columns get column_id == column_name at activation time.
+/// New columns added after activation get monotonically increasing numeric
+/// column IDs ("1", "2", ...) from a counter that never decreases; a flattened
+/// Nested child takes two of them, as "<group prefix>.<child counter>" ("5.7"),
+/// so that siblings share the group prefix their offsets stream is named from.
+/// RENAME only updates the mapping; the column ID (and therefore all
+/// on-disk filenames) stays unchanged.  DROP removes the entry but the
+/// counter is never recycled, so a subsequent ADD of the same column name
+/// gets a fresh column ID — this is the key invariant that makes
+/// DROP + re-ADD safe (old data files become orphans, not wrong-type reads).
+///
+/// Names not present in the mapping (virtual columns, `_row_exists`, etc.)
+/// pass through unchanged via `getColumnIdOrDefault`.
+///
+/// Thread safety: instances are immutable once published. The mapping is folded into
+/// the versioned `StorageInMemoryMetadata` (a `shared_ptr`-to-const field), so it is
+/// published atomically with the schema through the metadata `MultiVersion`.  Mutation
+/// methods (`addColumn`, `renameColumn`, ...) are only called on local copies inside
+/// engine `alter()` before that atomic publication.
+///
+/// Concurrency contract (no lock stops an ALTER from publishing a new mapping in the
+/// middle of a merge, mutation, SELECT, or part load):
+///  1. Parts speak only IDs. Any question about a specific part — stream names,
+///     columns.txt, serialization.json, minmax files — is answered from the part's
+///     stamped column IDs (`part->getColumns()`, each pair carrying `column_id`),
+///     never from the live mapping. In-memory structures loaded from ID-keyed disk
+///     files stay keyed by ID.
+///  2. An operation captures ONE mapping snapshot at entry and threads it (SELECTs
+///     via `StorageSnapshot`, merges/mutations via their context) — the same
+///     discipline as `metadata_snapshot`.
+///  3. The live mapping is read only at operation entry and in table-level actions
+///     under the alter lock; any other call is a defect.
+/// One stale snapshot is safe: IDs are stable under RENAME and never recycled, so a
+/// snapshot can lag only in names; every artifact of a part produced from one
+/// snapshot agrees by construction.
+class ColumnIdMapping
+{
+public:
+    bool isActive() const
+    {
+        return active;
+    }
+
+    const std::unordered_map<String, String> & getNameToId() const
+    {
+        return name_to_id;
+    }
+
+    UInt64 getNextColumnIdCounter() const
+    {
+        return next_column_id;
+    }
+
+    static UInt64 extractNumericCounter(const String & s);
+
+    /// An ID at or above the counter is unreadable here: a later `ADD COLUMN` gets handed the same
+    /// one.  A pre-activation ID (a bare column name) is never one.
+    bool isColumnIdAtOrAboveCounter(const String & column_id) const
+    {
+        return extractNumericCounter(column_id) >= next_column_id;
+    }
+
+    /// Throws if `column_name` is not in the mapping.
+    String getColumnId(const String & column_name) const;
+
+    /// Returns `column_name` itself when not in the mapping — safe default
+    /// for virtual columns, helper columns, and legacy (pre-activation) code paths.
+    String getColumnIdOrDefault(const String & column_name) const;
+
+    /// Reverse lookup: column ID -> column name. Throws if not found.
+    String getColumnName(const String & column_id) const;
+
+    bool hasColumnName(const String & column_name) const;
+    bool hasColumnId(const String & column_id) const;
+
+    /// Guard + lookup folded together for the pattern call sites repeat: translate a column
+    /// name to its (typed) id, or an id back to its column name. `nullopt` when unmapped.
+    std::optional<ColumnId> tryGetColumnId(const String & column_name) const;
+    std::optional<String> tryGetColumnName(const ColumnId & column_id) const;
+
+    /// Allocates the next numeric column ID and advances the counter.
+    /// Also sets `active = true` as a side effect (first allocation activates the mapping).
+    String allocateColumnId();
+
+    void addColumn(const String & column_name, const String & column_id);
+    void removeColumn(const String & column_name);
+
+    /// Two-phase rename for crash safety: `beginRename` before the metadata commit, `finishRename`
+    /// after it.  The mechanism and its crash windows are at `beginRename`'s definition.
+    void beginRename(const String & old_column_name, const String & new_column_name);
+    void finishRename(const String & old_column_name);
+
+    Names columnNames() const;
+
+    /// Ingress stamp for both write (new part) and read (query resolution): set `column_id` on each
+    /// `NameAndTypePair` that carries none yet (an existing one is a part-local id and is kept).
+    /// Throws `LOGICAL_ERROR` for a physical column the mapping does not hold.
+    /// Must be called before `convertToSubcolumns`, while a flattened-Nested field is still `n.x`.
+    void stampColumnIds(NamesAndTypesList & columns) const;
+
+    /// Lenient counterpart to `stampColumnIds` for callers whose columns are legitimately outside
+    /// the mapping (projection aggregates, a not-yet-applied schema): leaves those unstamped
+    /// instead of throwing.
+    void stampColumnIdsLenient(NamesAndTypesList & columns) const;
+
+    /// Identity mapping: every column gets column_id == column_name — the initial state of both a
+    /// new table and an existing one at activation.
+    static ColumnIdMapping createIdentity(const NamesAndTypesList & columns);
+
+    void serialize(WriteBuffer & buf) const;
+    static ColumnIdMapping deserialize(ReadBuffer & buf);
+
+    String toString() const;
+    static ColumnIdMapping fromString(const String & str);
+
+private:
+    /// Drop `it`'s forward entry and repair the reverse map.
+    void detachColumnName(std::unordered_map<String, String>::iterator it);
+
+    bool active = false;
+    UInt64 next_column_id = 1;
+    std::unordered_map<String, String> name_to_id;
+    std::unordered_map<String, String> id_to_name;
+};
+
+}

--- a/src/Storages/MergeTree/ColumnIdMappingStore.cpp
+++ b/src/Storages/MergeTree/ColumnIdMappingStore.cpp
@@ -1,0 +1,160 @@
+#include <Storages/MergeTree/ColumnIdMappingStore.h>
+
+#include <Core/MergeTreeSerializationEnums.h>
+#include <Core/Settings.h>
+#include <Disks/IDisk.h>
+#include <IO/ReadBufferFromFileBase.h>
+#include <IO/ReadHelpers.h>
+#include <IO/ReadSettings.h>
+#include <IO/WriteBufferFromFileBase.h>
+#include <Interpreters/Context.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace DB
+{
+
+namespace Setting
+{
+    extern const SettingsBool fsync_metadata;
+}
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+    extern const int SUPPORT_IS_DISABLED;
+}
+
+DiskColumnIdMappingStore::DiskColumnIdMappingStore(MergeTreeData & data_, LoggerPtr log_)
+    : data(data_)
+    , log(std::move(log_))
+{
+}
+
+std::optional<ColumnIdMapping> DiskColumnIdMappingStore::load()
+{
+    const auto column_ids_path = fs::path(data.getRelativeDataPath()) / MergeTreeData::COLUMN_IDS_FILE_NAME;
+
+    const DiskPtr authoritative_disk = getAuthoritativeDisk();
+    std::unique_ptr<ReadBufferFromFileBase> mapping_buf;
+    if (!authoritative_disk->isBroken())
+        mapping_buf = authoritative_disk->readFileIfExists(column_ids_path, getReadSettings());
+
+    /// This file, not `serialization_info_version`, is what makes a table use column IDs: the setting
+    /// defaults from the server config, so requiring a mapping on its say-so would refuse every table
+    /// that predates a change of that default. A mapping that really is gone is caught from the
+    /// evidence instead, by `IMergeTreeDataPart::loadColumns`.
+    if (!mapping_buf)
+        return {};
+
+    auto loaded_mapping = ColumnIdMapping::deserialize(*mapping_buf);
+    skipWhitespaceIfAny(*mapping_buf);
+    assertEOF(*mapping_buf);
+    return loaded_mapping;
+}
+
+/// One copy, not one per disk like `format_version.txt`: parts are self-describing (`columns.txt`
+/// stores the IDs), so no disk ever reads its own copy of the mapping.
+DiskPtr DiskColumnIdMappingStore::getAuthoritativeDisk() const
+{
+    const auto & disks = data.getStoragePolicy()->getDisks();
+    if (disks.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Storage policy for table {} has no disks to hold `{}`",
+            data.getStorageID().getNameForLogs(), MergeTreeData::COLUMN_IDS_FILE_NAME);
+
+    /// Only ever the first disk, never "wherever a copy turns up": a copy elsewhere cannot be proven
+    /// current at load time, and adopting a stale one resurrects DROP + re-ADD bytes under a reused
+    /// name. `MergeTreeData::checkAlterIsPossible` refuses the policy changes that would move it.
+    return disks.front();
+}
+
+void DiskColumnIdMappingStore::store(const ColumnIdMapping & mapping)
+{
+    const fs::path table_path = data.getRelativeDataPath();
+    const auto column_ids_path = table_path / MergeTreeData::COLUMN_IDS_FILE_NAME;
+    const auto column_ids_tmp_path = table_path / (String(MergeTreeData::COLUMN_IDS_FILE_NAME) + ".tmp");
+
+    auto disk = getAuthoritativeDisk();
+    if (disk->isBroken() || disk->isReadOnly() || disk->isWriteOnce())
+        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+            "Cannot store `{}` for table {}: disk `{}` is not writable. "
+            "Put a writable disk first in the policy.",
+            MergeTreeData::COLUMN_IDS_FILE_NAME, data.getStorageID().getNameForLogs(), disk->getName());
+
+    /// A crash between the write and the replace leaves either the previous file intact or only the
+    /// `.tmp` behind, so a reader never sees a torn one.
+    try
+    {
+        {
+            auto buf = disk->writeFile(column_ids_tmp_path, 4096, WriteMode::Rewrite, data.getContext()->getWriteSettings());
+            mapping.serialize(*buf);
+            buf->finalize();
+            if (data.getContext()->getSettingsRef()[Setting::fsync_metadata])
+                buf->sync();
+        }
+        disk->replaceFile(column_ids_tmp_path, column_ids_path);
+    }
+    catch (...)
+    {
+        try
+        {
+            disk->removeFileIfExists(column_ids_tmp_path);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+        throw;
+    }
+
+    /// Best-effort: drop any stale copy on the other disks (e.g. left by the old
+    /// multi-disk format) so exactly one authoritative copy exists.
+    for (const auto & other : data.getStoragePolicy()->getDisks())
+    {
+        if (other->getName() == disk->getName())
+            continue;
+        if (other->isBroken() || other->isReadOnly() || other->isWriteOnce())
+            continue;
+        try
+        {
+            other->removeFileIfExists(column_ids_path);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log, "Failed to remove stale column ID mapping copy");
+        }
+    }
+}
+
+/// Swept off every disk, not just the one `store` wrote to: a surviving inactive mapping makes a
+/// post-restart ALTER take the already-active path while parts still hold logical filenames.
+void DiskColumnIdMappingStore::remove() noexcept
+{
+    try
+    {
+        const auto column_ids_path = fs::path(data.getRelativeDataPath()) / MergeTreeData::COLUMN_IDS_FILE_NAME;
+        for (const auto & disk : data.getStoragePolicy()->getDisks())
+        {
+            if (disk->isBroken() || disk->isReadOnly() || disk->isWriteOnce())
+                continue;
+            try
+            {
+                disk->removeFileIfExists(column_ids_path);
+            }
+            catch (...)
+            {
+                tryLogCurrentException(log, "Failed to remove column ID mapping from disk");
+            }
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Failed to resolve the disks holding the column ID mapping");
+    }
+}
+
+}

--- a/src/Storages/MergeTree/ColumnIdMappingStore.cpp
+++ b/src/Storages/MergeTree/ColumnIdMappingStore.cpp
@@ -87,15 +87,24 @@ void DiskColumnIdMappingStore::store(const ColumnIdMapping & mapping)
 
     /// A crash between the write and the replace leaves either the previous file intact or only the
     /// `.tmp` behind, so a reader never sees a torn one.
+    const bool fsync_metadata = data.getContext()->getSettingsRef()[Setting::fsync_metadata];
     try
     {
         {
             auto buf = disk->writeFile(column_ids_tmp_path, 4096, WriteMode::Rewrite, data.getContext()->getWriteSettings());
             mapping.serialize(*buf);
             buf->finalize();
-            if (data.getContext()->getSettingsRef()[Setting::fsync_metadata])
+            if (fsync_metadata)
                 buf->sync();
         }
+
+        /// The rename itself needs the directory entry on the device: fsyncing only the file leaves
+        /// a window where the crash keeps the old name and loses the mapping this call reported
+        /// stored. The guard syncs the directory when it goes out of scope, after the replace.
+        SyncGuardPtr directory_sync_guard;
+        if (fsync_metadata)
+            directory_sync_guard = disk->getDirectorySyncGuard(table_path);
+
         disk->replaceFile(column_ids_tmp_path, column_ids_path);
     }
     catch (...)

--- a/src/Storages/MergeTree/ColumnIdMappingStore.cpp
+++ b/src/Storages/MergeTree/ColumnIdMappingStore.cpp
@@ -38,15 +38,17 @@ std::optional<ColumnIdMapping> DiskColumnIdMappingStore::load()
 {
     const auto column_ids_path = fs::path(data.getRelativeDataPath()) / MergeTreeData::COLUMN_IDS_FILE_NAME;
 
-    const DiskPtr authoritative_disk = getAuthoritativeDisk();
     std::unique_ptr<ReadBufferFromFileBase> mapping_buf;
-    if (!authoritative_disk->isBroken())
-        mapping_buf = authoritative_disk->readFileIfExists(column_ids_path, getReadSettings());
+    // Try to read the mapping from the first disk that has it
+    for (auto& disk : data.getStoragePolicy()->getDisks())
+    {
+        if (!disk->isBroken() && disk->existsFile(column_ids_path))
+        {
+            mapping_buf = disk->readFile(column_ids_path, getReadSettings());
+            break;
+        }
+    }
 
-    /// This file, not `serialization_info_version`, is what makes a table use column IDs: the setting
-    /// defaults from the server config, so requiring a mapping on its say-so would refuse every table
-    /// that predates a change of that default. A mapping that really is gone is caught from the
-    /// evidence instead, by `IMergeTreeDataPart::loadColumns`.
     if (!mapping_buf)
         return {};
 
@@ -56,8 +58,6 @@ std::optional<ColumnIdMapping> DiskColumnIdMappingStore::load()
     return loaded_mapping;
 }
 
-/// One copy, not one per disk like `format_version.txt`: parts are self-describing (`columns.txt`
-/// stores the IDs), so no disk ever reads its own copy of the mapping.
 DiskPtr DiskColumnIdMappingStore::getAuthoritativeDisk() const
 {
     const auto & disks = data.getStoragePolicy()->getDisks();
@@ -66,9 +66,6 @@ DiskPtr DiskColumnIdMappingStore::getAuthoritativeDisk() const
             "Storage policy for table {} has no disks to hold `{}`",
             data.getStorageID().getNameForLogs(), MergeTreeData::COLUMN_IDS_FILE_NAME);
 
-    /// Only ever the first disk, never "wherever a copy turns up": a copy elsewhere cannot be proven
-    /// current at load time, and adopting a stale one resurrects DROP + re-ADD bytes under a reused
-    /// name. `MergeTreeData::checkAlterIsPossible` refuses the policy changes that would move it.
     return disks.front();
 }
 
@@ -136,33 +133,6 @@ void DiskColumnIdMappingStore::store(const ColumnIdMapping & mapping)
         {
             tryLogCurrentException(log, "Failed to remove stale column ID mapping copy");
         }
-    }
-}
-
-/// Swept off every disk, not just the one `store` wrote to: a surviving inactive mapping makes a
-/// post-restart ALTER take the already-active path while parts still hold logical filenames.
-void DiskColumnIdMappingStore::remove() noexcept
-{
-    try
-    {
-        const auto column_ids_path = fs::path(data.getRelativeDataPath()) / MergeTreeData::COLUMN_IDS_FILE_NAME;
-        for (const auto & disk : data.getStoragePolicy()->getDisks())
-        {
-            if (disk->isBroken() || disk->isReadOnly() || disk->isWriteOnce())
-                continue;
-            try
-            {
-                disk->removeFileIfExists(column_ids_path);
-            }
-            catch (...)
-            {
-                tryLogCurrentException(log, "Failed to remove column ID mapping from disk");
-            }
-        }
-    }
-    catch (...)
-    {
-        tryLogCurrentException(log, "Failed to resolve the disks holding the column ID mapping");
     }
 }
 

--- a/src/Storages/MergeTree/ColumnIdMappingStore.h
+++ b/src/Storages/MergeTree/ColumnIdMappingStore.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <Disks/IStoragePolicy.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
+#include <Common/Logger.h>
+
+#include <memory>
+#include <optional>
+
+namespace DB
+{
+
+class MergeTreeData;
+
+/// A table's durable home for its column-ID mapping: persistence only, and the sole owner of WHERE
+/// the mapping lives.  One implementation per engine: a file on the storage policy for `MergeTree`,
+/// Keeper for a future `ReplicatedMergeTree`.  What to write is `ColumnIdMappingUpdate`'s business.
+class ColumnIdMappingStore
+{
+public:
+    virtual ~ColumnIdMappingStore() = default;
+
+    /// The stored mapping, `nullopt` when the table has none -- the answer for every table that never
+    /// opted into column IDs.  Returns it rather than publishing it.
+    virtual std::optional<ColumnIdMapping> load() = 0;
+
+    /// Store @mapping durably, wherever this table's mapping belongs.
+    virtual void store(const ColumnIdMapping & mapping) = 0;
+
+    /// Undo an activation that never committed.  Best-effort by contract.
+    virtual void remove() noexcept = 0;
+};
+
+using ColumnIdMappingStorePtr = std::unique_ptr<ColumnIdMappingStore>;
+
+/// `column_ids.json` on the table's storage policy.
+class DiskColumnIdMappingStore : public ColumnIdMappingStore
+{
+public:
+    DiskColumnIdMappingStore(MergeTreeData & data_, LoggerPtr log_);
+
+    std::optional<ColumnIdMapping> load() override;
+    void store(const ColumnIdMapping & mapping) override;
+    void remove() noexcept override;
+
+private:
+    /// The one disk that holds `column_ids.json`: the storage policy's first.
+    DiskPtr getAuthoritativeDisk() const;
+
+    MergeTreeData & data;
+    LoggerPtr log;
+};
+
+}

--- a/src/Storages/MergeTree/ColumnIdMappingStore.h
+++ b/src/Storages/MergeTree/ColumnIdMappingStore.h
@@ -26,9 +26,6 @@ public:
 
     /// Store @mapping durably, wherever this table's mapping belongs.
     virtual void store(const ColumnIdMapping & mapping) = 0;
-
-    /// Undo an activation that never committed.  Best-effort by contract.
-    virtual void remove() noexcept = 0;
 };
 
 using ColumnIdMappingStorePtr = std::unique_ptr<ColumnIdMappingStore>;
@@ -41,7 +38,6 @@ public:
 
     std::optional<ColumnIdMapping> load() override;
     void store(const ColumnIdMapping & mapping) override;
-    void remove() noexcept override;
 
 private:
     /// The one disk that holds `column_ids.json`: the storage policy's first.

--- a/src/Storages/MergeTree/ColumnsSubstreams.cpp
+++ b/src/Storages/MergeTree/ColumnsSubstreams.cpp
@@ -84,25 +84,38 @@ std::optional<size_t> ColumnsSubstreams::tryGetSubstreamPosition(size_t column_p
     return first_substream_positions[column_position] + it->second;
 }
 
-size_t ColumnsSubstreams::getSubstreamPosition(
+std::optional<size_t> ColumnsSubstreams::tryGetSubstreamPosition(
     size_t column_position,
     const NameAndTypePair & name_and_type,
     const ISerialization::SubstreamPath & substream_path,
     const MergeTreeSettingsPtr & storage_settings) const
 {
     ISerialization::StreamFileNameSettings stream_file_name_settings(*storage_settings);
-    auto substream = ISerialization::getFileNameForStream(name_and_type, substream_path, stream_file_name_settings);
+    auto substream = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, stream_file_name_settings);
     if (auto position = tryGetSubstreamPosition(column_position, substream))
-        return *position;
+        return position;
 
     /// To be able to read old parts after changes in stream file name settings, try to change settings and try to find it again.
     if (ISerialization::tryToChangeStreamFileNameSettingsForNotFoundStream(substream_path, stream_file_name_settings))
     {
-        substream = ISerialization::getFileNameForStream(name_and_type, substream_path, stream_file_name_settings);
-        if (auto position = tryGetSubstreamPosition(column_position, substream))
-            return *position;
+        substream = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, stream_file_name_settings);
+        return tryGetSubstreamPosition(column_position, substream);
     }
 
+    return std::nullopt;
+}
+
+size_t ColumnsSubstreams::getSubstreamPosition(
+    size_t column_position,
+    const NameAndTypePair & name_and_type,
+    const ISerialization::SubstreamPath & substream_path,
+    const MergeTreeSettingsPtr & storage_settings) const
+{
+    if (auto position = tryGetSubstreamPosition(column_position, name_and_type, substream_path, storage_settings))
+        return *position;
+
+    ISerialization::StreamFileNameSettings stream_file_name_settings(*storage_settings);
+    auto substream = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, stream_file_name_settings);
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot get position for substream {}: column {} with position {} doesn't have such substream", substream, name_and_type.name, column_position);
 }
 

--- a/src/Storages/MergeTree/ColumnsSubstreams.cpp
+++ b/src/Storages/MergeTree/ColumnsSubstreams.cpp
@@ -84,38 +84,25 @@ std::optional<size_t> ColumnsSubstreams::tryGetSubstreamPosition(size_t column_p
     return first_substream_positions[column_position] + it->second;
 }
 
-std::optional<size_t> ColumnsSubstreams::tryGetSubstreamPosition(
-    size_t column_position,
-    const NameAndTypePair & name_and_type,
-    const ISerialization::SubstreamPath & substream_path,
-    const MergeTreeSettingsPtr & storage_settings) const
-{
-    ISerialization::StreamFileNameSettings stream_file_name_settings(*storage_settings);
-    auto substream = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, stream_file_name_settings);
-    if (auto position = tryGetSubstreamPosition(column_position, substream))
-        return position;
-
-    /// To be able to read old parts after changes in stream file name settings, try to change settings and try to find it again.
-    if (ISerialization::tryToChangeStreamFileNameSettingsForNotFoundStream(substream_path, stream_file_name_settings))
-    {
-        substream = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, stream_file_name_settings);
-        return tryGetSubstreamPosition(column_position, substream);
-    }
-
-    return std::nullopt;
-}
-
 size_t ColumnsSubstreams::getSubstreamPosition(
     size_t column_position,
     const NameAndTypePair & name_and_type,
     const ISerialization::SubstreamPath & substream_path,
     const MergeTreeSettingsPtr & storage_settings) const
 {
-    if (auto position = tryGetSubstreamPosition(column_position, name_and_type, substream_path, storage_settings))
+    ISerialization::StreamFileNameSettings stream_file_name_settings(*storage_settings);
+    auto substream = ISerialization::getFileNameForStream(name_and_type, substream_path, stream_file_name_settings);
+    if (auto position = tryGetSubstreamPosition(column_position, substream))
         return *position;
 
-    ISerialization::StreamFileNameSettings stream_file_name_settings(*storage_settings);
-    auto substream = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, stream_file_name_settings);
+    /// To be able to read old parts after changes in stream file name settings, try to change settings and try to find it again.
+    if (ISerialization::tryToChangeStreamFileNameSettingsForNotFoundStream(substream_path, stream_file_name_settings))
+    {
+        substream = ISerialization::getFileNameForStream(name_and_type, substream_path, stream_file_name_settings);
+        if (auto position = tryGetSubstreamPosition(column_position, substream))
+            return *position;
+    }
+
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot get position for substream {}: column {} with position {} doesn't have such substream", substream, name_and_type.name, column_position);
 }
 

--- a/src/Storages/MergeTree/ColumnsSubstreams.h
+++ b/src/Storages/MergeTree/ColumnsSubstreams.h
@@ -48,6 +48,7 @@ public:
     size_t getSubstreamPosition(size_t column_position, const String & substream) const;
     std::optional<size_t> tryGetSubstreamPosition(size_t column_position, const String & substream) const;
     size_t getSubstreamPosition(size_t column_position, const NameAndTypePair & name_and_type, const ISerialization::SubstreamPath & substream_path, const MergeTreeSettingsPtr & storage_settings) const;
+    std::optional<size_t> tryGetSubstreamPosition(size_t column_position, const NameAndTypePair & name_and_type, const ISerialization::SubstreamPath & substream_path, const MergeTreeSettingsPtr & storage_settings) const;
     std::optional<size_t> tryGetSubstreamPosition(const String & substream) const;
     size_t getFirstSubstreamPosition(size_t column_position) const;
     size_t getLastSubstreamPosition(size_t column_position) const;

--- a/src/Storages/MergeTree/ColumnsSubstreams.h
+++ b/src/Storages/MergeTree/ColumnsSubstreams.h
@@ -48,7 +48,6 @@ public:
     size_t getSubstreamPosition(size_t column_position, const String & substream) const;
     std::optional<size_t> tryGetSubstreamPosition(size_t column_position, const String & substream) const;
     size_t getSubstreamPosition(size_t column_position, const NameAndTypePair & name_and_type, const ISerialization::SubstreamPath & substream_path, const MergeTreeSettingsPtr & storage_settings) const;
-    std::optional<size_t> tryGetSubstreamPosition(size_t column_position, const NameAndTypePair & name_and_type, const ISerialization::SubstreamPath & substream_path, const MergeTreeSettingsPtr & storage_settings) const;
     std::optional<size_t> tryGetSubstreamPosition(const String & substream) const;
     size_t getFirstSubstreamPosition(size_t column_position) const;
     size_t getLastSubstreamPosition(size_t column_position) const;

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -28,6 +28,8 @@
 #include <Parsers/parseQuery.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/Backup.h>
+#include <Storages/MergeTree/ColumnIdHelper.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
@@ -138,6 +140,7 @@ namespace ErrorCodes
     extern const int NO_FILE_IN_DATA_PART;
     extern const int EXPECTED_END_OF_FILE;
     extern const int CORRUPTED_DATA;
+    extern const int COLUMN_ID_MAPPING_MISSING;
     extern const int NOT_FOUND_EXPECTED_DATA_PART;
     extern const int BAD_SIZE_OF_FILE_IN_DATA_PART;
     extern const int BAD_TTL_FILE;
@@ -196,7 +199,7 @@ void IMergeTreeDataPart::MinMaxIndex::load(const IMergeTreeDataPart & part)
             continue;
         }
 
-        const String file_name = "minmax_" + getFileColumnName(column_name, part.checksums) + ".idx";
+        const String file_name = getFileName(getFileColumnName(part.minmaxColumnId(column_name), part.checksums));
 
         /// Treat missing columns as universe range so they don't prune; the file gets created on the next merge or mutation.
         auto file = part.readFileIfExists(file_name);
@@ -225,9 +228,16 @@ void IMergeTreeDataPart::MinMaxIndex::load(const IMergeTreeDataPart & part)
 }
 
 IMergeTreeDataPart::MinMaxIndex::WrittenFiles IMergeTreeDataPart::MinMaxIndex::store(
-    StorageMetadataPtr metadata_snapshot, IDataPartStorage & part_storage, Checksums & out_checksums, const MergeTreeSettingsPtr & storage_settings) const
+    StorageMetadataPtr metadata_snapshot, IDataPartStorage & part_storage, Checksums & out_checksums,
+    const MergeTreeSettingsPtr & storage_settings, const NamesAndTypesList & part_columns) const
 {
-    return store(MergeTreeData::getMinMaxColumns(metadata_snapshot->getPartitionKey(), storage_settings), part_storage, out_checksums, storage_settings);
+    auto minmax_columns = MergeTreeData::getMinMaxColumns(metadata_snapshot->getPartitionKey(), storage_settings);
+
+    /// The overload below names each file after the pair it is given, so hand it this part's ids.
+    for (auto & column : minmax_columns)
+        column.name = part_columns.getColumnIdByName(column.name).value();
+
+    return store(minmax_columns, part_storage, out_checksums, storage_settings);
 }
 
 IMergeTreeDataPart::MinMaxIndex::WrittenFiles IMergeTreeDataPart::MinMaxIndex::store(
@@ -253,7 +263,7 @@ IMergeTreeDataPart::MinMaxIndex::WrittenFiles IMergeTreeDataPart::MinMaxIndex::s
         if (!isNullableOrLowCardinalityNullable(column_type) && (hyperrectangle[i].left.isNull() || hyperrectangle[i].right.isNull()))
             break;
 
-        String file_name = "minmax_" + getFileColumnName(column_name, storage_settings, part_storage) + ".idx";
+        String file_name = getFileName(getFileColumnName(column_name, storage_settings, part_storage));
         auto serialization = column_type->getDefaultSerialization();
 
         auto out = part_storage.writeFile(file_name, 4096, {});
@@ -359,7 +369,7 @@ Names IMergeTreeDataPart::MinMaxIndex::getProbablyWrittenFiles(const IMergeTreeD
         minmax_columns.resize(hyperrectangle.size());
 
     return minmax_columns.getNames()
-        | std::views::transform([&](const auto & column_name) { return "minmax_" + getFileColumnName(column_name, data_settings, data_part_storage) + ".idx"; })
+        | std::views::transform([&](const auto & column_name) { return getFileName(getFileColumnName(part.minmaxColumnId(column_name), data_settings, data_part_storage)); })
         | std::ranges::to<Names>();
 }
 
@@ -371,11 +381,11 @@ String IMergeTreeDataPart::MinMaxIndex::getFileColumnName(const String & column_
 String IMergeTreeDataPart::MinMaxIndex::getFileColumnName(const String & column_name, const Checksums & checksums_)
 {
     String stream_name = escapeForFileName(column_name);
-    if (checksums_.files.contains("minmax_" + stream_name + ".idx"))
+    if (checksums_.files.contains(getFileName(stream_name)))
         return stream_name;
 
     auto hash = sipHash128String(stream_name);
-    if (checksums_.files.contains("minmax_" + hash + ".idx"))
+    if (checksums_.files.contains(getFileName(hash)))
         return hash;
     return stream_name;
 }
@@ -710,11 +720,12 @@ String IMergeTreeDataPart::getNewName(const MergeTreePartInfo & new_part_info) c
     return new_part_info.getPartNameV1();
 }
 
-std::optional<size_t> IMergeTreeDataPart::getColumnPosition(const String & column_name) const
+std::optional<size_t> IMergeTreeDataPart::getColumnPosition(const ColumnId & column_id) const
 {
-    const auto & column_name_to_position = shared_part_columns->column_name_to_position;
-    auto it = column_name_to_position.find(column_name);
-    if (it == column_name_to_position.end())
+    const auto & positions = shared_part_columns->column_storage_key_to_position;
+    /// An empty id is never a valid key, so it misses (nullopt).
+    auto it = positions.find(column_id.value());
+    if (it == positions.end())
         return {};
     return it->second;
 }
@@ -817,6 +828,9 @@ void IMergeTreeDataPart::setColumns(const NamesAndTypesList & new_columns, const
     /// reference to the cache in its destructor, so once it is in the member the part is
     /// responsible for it even when building the serializations fails and this part never finishes
     /// loading. The move-assignment returns the previously held reference.
+    ///
+    /// The bundle is interned per stored column list, IDs included, so every map inside it is keyed
+    /// by the stable storage ID.
     if (auto new_shared_part_columns = storage.getSharedPartColumnsForColumns(new_columns); shared_part_columns.get() != new_shared_part_columns.get())
         shared_part_columns = std::move(new_shared_part_columns);
 
@@ -856,29 +870,70 @@ StorageMetadataPtr IMergeTreeDataPart::getMetadataSnapshot() const
     return metadata_snapshot->projections.get(getProjectionName()).metadata;
 }
 
-NameAndTypePair IMergeTreeDataPart::getColumn(const String & column_name) const
+std::optional<NameAndTypePair> IMergeTreeDataPart::tryGetColumnByNameUnsafe(const String & column_name) const
 {
-    return getColumnsDescription().getColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name);
+    auto sub = getColumnsDescription().tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name);
+    if (!sub)
+        return {};
+
+    /// `ColumnsDescription` does not carry ids, so the id comes off the stored column list.
+    auto column = getColumns().tryGetByName(sub->getNameInStorage());
+    if (!column)
+        return sub;
+
+    sub->setColumnId(column->column_id);
+    return sub;
 }
 
-std::optional<NameAndTypePair> IMergeTreeDataPart::tryGetColumn(const String & column_name) const
+SerializationPtr IMergeTreeDataPart::tryGetSerializationByNameUnsafe(const String & column_name) const
 {
-    return getColumnsDescription().tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name);
+    /// Name-based resolver (see tryGetColumnByNameUnsafe).
+    auto pair = tryGetColumnByNameUnsafe(column_name);
+    if (!pair)
+        return nullptr;
+    return tryGetSerialization(pair->getStorageKey());
 }
 
-SerializationPtr IMergeTreeDataPart::getSerialization(const String & column_name) const
+std::optional<NameAndTypePair> IMergeTreeDataPart::tryGetColumn(const ColumnId & column_id) const
 {
-    auto serialization = tryGetSerialization(column_name);
+    if (auto position = getColumnPosition(column_id))
+        return *std::next(getColumns().begin(), *position);
+    return {};
+}
+
+/// These two are the crossing from schema or request space into this part's own space; the rules they
+/// implement are in `ColumnIdHelper.h`. A subcolumn has no id of its own, hence the second step.
+std::optional<NameAndTypePair> IMergeTreeDataPart::tryGetColumnBySnapshotName(
+    const String & current_name, const StorageMetadataPtr & snapshot) const
+{
+    auto snapshot_column = snapshot->getColumns().tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, current_name);
+    if (!snapshot_column)
+        return {};
+    return tryGetColumnByRequest(*snapshot_column);
+}
+
+std::optional<NameAndTypePair> IMergeTreeDataPart::tryGetColumnByRequest(const NameAndTypePair & requested) const
+{
+    auto column_in_part = tryGetColumn(requested.getColumnId());
+    if (!column_in_part || !requested.isSubcolumn())
+        return column_in_part;
+
+    return tryGetColumnByNameUnsafe(Nested::concatenateName(column_in_part->name, requested.getSubcolumnName()));
+}
+
+SerializationPtr IMergeTreeDataPart::getSerialization(const ColumnId & column_id) const
+{
+    auto serialization = tryGetSerialization(column_id);
     if (!serialization)
         throw Exception(ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
-            "There is no column or subcolumn {} in part {}", column_name, name);
+            "There is no column or subcolumn with id {} in part {}", column_id.value(), name);
 
     return serialization;
 }
 
-SerializationPtr IMergeTreeDataPart::tryGetSerialization(const String & column_name) const
+SerializationPtr IMergeTreeDataPart::tryGetSerialization(const ColumnId & column_id) const
 {
-    return serializations->tryGet(column_name);
+    return serializations->tryGet(column_id.value());
 }
 
 bool IMergeTreeDataPart::isMovingPart() const
@@ -1177,7 +1232,7 @@ String IMergeTreeDataPart::getColumnNameWithMinimumCompressedSize(const NamesAnd
         if (!hasColumnFiles(column))
             continue;
 
-        const auto size = getColumnSize(column.name).data_compressed;
+        const auto size = getColumnSize(column.getColumnId()).data_compressed;
         if (size < minimum_size)
         {
             minimum_size = size;
@@ -1217,13 +1272,19 @@ PackedFilesReader * IMergeTreeDataPart::getStatisticsPackedReader() const
     return statistics_reader.get();
 }
 
-static const ColumnDescription * getColumnForStatisticsFile(const String & filename, const ColumnsDescription & all_columns, const NameSet & required_columns)
+static const ColumnDescription * getColumnForStatisticsFile(
+    const String & filename, const ColumnsDescription & all_columns, const NamesAndTypesList & part_columns, const NameSet & required_columns)
 {
     chassert(filename.starts_with(STATS_FILE_PREFIX));
     chassert(filename.ends_with(STATS_FILE_SUFFIX));
 
     size_t num_chars_to_truncate = STATS_FILE_PREFIX.size() + STATS_FILE_SUFFIX.size();
-    String column_name = unescapeForFileName(filename.substr(STATS_FILE_PREFIX.size(), filename.size() - num_chars_to_truncate));
+    const ColumnId id_in_filename{unescapeForFileName(filename.substr(STATS_FILE_PREFIX.size(), filename.size() - num_chars_to_truncate))};
+
+    /// A dropped column's orphan file matches no id, so it passes through as a name and then fails
+    /// the lookups below -- which is how such a file gets skipped.
+    auto column_in_part = part_columns.tryGetByColumnId(id_in_filename);
+    const String column_name = column_in_part ? column_in_part->name : id_in_filename.value();
 
     /// `<col>.null` subcolumn may appear in required_columns when
     /// `optimize_functions_to_subcolumns=1`, keep stats for the parent column in that case.
@@ -1255,7 +1316,7 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesRead
         if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
             throw Exception(ErrorCodes::CORRUPTED_DATA, "File {} is not a statistics file", filename);
 
-        const auto * column_desc = getColumnForStatisticsFile(filename, getColumnsDescription(), required_columns);
+        const auto * column_desc = getColumnForStatisticsFile(filename, getColumnsDescription(), getColumns(), required_columns);
         if (!column_desc)
             continue;
 
@@ -1298,7 +1359,7 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & require
         if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
             continue;
 
-        const auto * column_desc = getColumnForStatisticsFile(filename, getColumnsDescription(), required_columns);
+        const auto * column_desc = getColumnForStatisticsFile(filename, getColumnsDescription(), getColumns(), required_columns);
         if (!column_desc)
             continue;
 
@@ -1403,6 +1464,7 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
         if (!isStoredOnReadonlyDisk())
             loadUUID();
 
+        tryPreloadChecksums();
         loadColumns(require_columns_checksums, load_metadata_version);
 
         bool has_broken_projections = false;
@@ -1925,7 +1987,7 @@ void IMergeTreeDataPart::writeColumns(const NamesAndTypesList & columns_, const 
 {
     writeMetadata("columns.txt", settings, [&columns_](auto & buffer)
     {
-        columns_.writeText(buffer);
+        columns_.writeText(buffer, /*use_column_ids=*/true);
     });
 }
 
@@ -1977,12 +2039,15 @@ CompressionCodecPtr IMergeTreeDataPart::detectDefaultCompressionCodec() const
     CompressionCodecPtr result = nullptr;
     for (const auto & part_column : getColumns())
     {
+        /// The codec is declared in the schema, which is keyed by current names.
+        auto current_name = tryGetCurrentColumnName(part_column, metadata_snapshot->column_id_mapping.get());
+
         /// It was compressed with default codec and it's not empty
-        auto column_size = getColumnSize(part_column.name);
-        if (column_size.data_compressed != 0 && !storage_columns.hasCompressionCodec(part_column.name))
+        auto column_size = getColumnSize(part_column.getColumnId());
+        if (column_size.data_compressed != 0 && current_name && !storage_columns.hasCompressionCodec(*current_name))
         {
             String path_to_data_file;
-            getSerialization(part_column.name)->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
+            getSerialization(part_column.getStorageKey())->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
             {
                 if (path_to_data_file.empty())
                 {
@@ -2059,23 +2124,33 @@ void IMergeTreeDataPart::loadPartitionAndMinMaxIndex()
             getDataPartStorage().getFullPath(), calculated_partition_id, info.getPartitionId());
 }
 
+bool IMergeTreeDataPart::tryPreloadChecksums()
+{
+    if (!checksums.empty())
+        return true;
+
+    auto buf = readFileIfExists("checksums.txt");
+    if (!buf)
+        return false;
+
+    if (checksums.read(*buf))
+    {
+        assertEOF(*buf);
+        bytes_on_disk = checksums.getTotalSizeOnDisk();
+        bytes_uncompressed_on_disk = checksums.getTotalSizeUncompressedOnDisk();
+    }
+    else
+        bytes_on_disk = getDataPartStorage().calculateTotalSizeOnDisk();
+
+    return true;
+}
+
 void IMergeTreeDataPart::loadChecksums(bool require)
 {
     /// Arena-agnostic: the real part-load callers (`loadColumnsChecksumsIndexes`, the projection load)
     /// already run inside the parts-arena scope, while transient checksum-only probes must stay on the
     /// default arenas. So the caller picks the arena rather than pinning it here.
-    if (auto buf = readFileIfExists("checksums.txt"))
-    {
-        if (checksums.read(*buf))
-        {
-            assertEOF(*buf);
-            bytes_on_disk = checksums.getTotalSizeOnDisk();
-            bytes_uncompressed_on_disk = checksums.getTotalSizeUncompressedOnDisk();
-        }
-        else
-            bytes_on_disk = getDataPartStorage().calculateTotalSizeOnDisk();
-    }
-    else
+    if (!tryPreloadChecksums())
     {
         if (require)
             throw Exception(ErrorCodes::NO_FILE_IN_DATA_PART, "No checksums.txt in part {}", name);
@@ -2143,9 +2218,9 @@ void IMergeTreeDataPart::loadRowsCount()
             /// Most trivial types
             if (column.type->isValueRepresentedByNumber()
                 && !column.type->haveSubtypes()
-                && getSerialization(column.name)->getKindStack() == ISerialization::KindStack{ISerialization::Kind::DEFAULT})
+                && getSerialization(column.getStorageKey())->getKindStack() == ISerialization::KindStack{ISerialization::Kind::DEFAULT})
             {
-                auto size = getColumnSize(column.name);
+                auto size = getColumnSize(column.getColumnId());
 
                 if (size.data_uncompressed == 0)
                     continue;
@@ -2202,11 +2277,11 @@ void IMergeTreeDataPart::loadRowsCount()
 
         for (const NameAndTypePair & column : getColumns())
         {
-            ColumnPtr column_col = column.type->createColumn(*getSerialization(column.name));
+            ColumnPtr column_col = column.type->createColumn(*getSerialization(column.getStorageKey()));
             if (!column_col->isFixedAndContiguous() || column_col->lowCardinality())
                 continue;
 
-            size_t column_size = getColumnSize(column.name).data_uncompressed;
+            size_t column_size = getColumnSize(column.getColumnId()).data_uncompressed;
             if (!column_size)
                 continue;
 
@@ -2355,6 +2430,63 @@ void IMergeTreeDataPart::loadUUID()
     }
 }
 
+/// Resolution stays in ID-space: an on-disk key is never reinterpreted as a current column name,
+/// or a dropped column's stale key could be re-bound to a live sibling's stream. A key that is no
+/// longer live keeps its slot -- compact ordinals must not shift -- under a placeholder name.
+NamesAndTypesList IMergeTreeDataPart::remapColumnIdsToColumnNames(
+    const NamesAndTypesList & loaded_columns,
+    const ColumnIdMapping & mapping) const
+{
+    /// A placeholder equal to a live column name would let callers mistake the orphan's
+    /// dropped-column bytes for that column's, so reserve both domains against it.
+    NameSet reserved_names;
+    for (const auto & column : loaded_columns)
+        reserved_names.insert(column.name);
+    const auto mapping_column_names = mapping.columnNames();
+    reserved_names.insert(mapping_column_names.begin(), mapping_column_names.end());
+
+    NamesAndTypesList remapped_columns;
+    for (const auto & column : loaded_columns)
+    {
+        /// The token in columns.txt IS this part's key for the column, whatever the mapping says
+        /// about it; only the column name has to be resolved.
+        auto remapped_column = column;
+        remapped_column.setColumnId(ColumnId{column.name});
+
+        /// A persistent virtual column is not managed by the mapping, and a column unknown to it
+        /// predates column ids -- both keep the token as their name.
+        if (!isPersistentVirtualColumn(column.name))
+        {
+            /// The counter only grows, and every load raises it past every ID in the mapping.
+            if (mapping.isColumnIdAtOrAboveCounter(column.name))
+                throw Exception(ErrorCodes::CORRUPTED_DATA,
+                    "Part {} of table {} lists column ID '{}' in columns.txt, at or above the table's next "
+                    "column ID counter ({}). The part cannot be attached here -- it most likely comes from "
+                    "another table -- because a later ADD COLUMN would be given that same ID and would read "
+                    "this part's data as its own.",
+                    name, storage.getStorageID().getNameForLogs(), column.name, mapping.getNextColumnIdCounter());
+
+            if (mapping.hasColumnId(column.name))
+                remapped_column.name = mapping.getColumnName(column.name);
+            else if (mapping.hasColumnName(column.name))
+            {
+                /// A dropped column's orphan stream, whose stale name a RENAME or DROP + re-ADD may
+                /// since have handed to a live column.
+                String placeholder = column.name;
+                do
+                    placeholder += "_";
+                while (reserved_names.contains(placeholder));
+                reserved_names.insert(placeholder);
+                remapped_column.name = placeholder;
+            }
+        }
+
+        remapped_columns.push_back(std::move(remapped_column));
+    }
+
+    return remapped_columns;
+}
+
 void IMergeTreeDataPart::loadColumns(bool require, bool load_metadata_version)
 {
     String path = fs::path(getDataPartStorage().getRelativePath()) / "columns.txt";
@@ -2362,12 +2494,35 @@ void IMergeTreeDataPart::loadColumns(bool require, bool load_metadata_version)
     NamesAndTypesList loaded_columns;
     bool is_readonly_storage = getDataPartStorage().isReadonly();
 
+    /// One mapping snapshot for the whole load: a concurrent column-ID ALTER between
+    /// two reads would make the remapped columns and the serialization infos disagree.
+    const auto column_id_mapping = storage.getActiveColumnIdMapping();
+
     if (auto in = readFileIfExists("columns.txt"))
     {
-        loaded_columns.readText(*in);
+        /// Unconditionally opted in: this is the caller that CAN resolve IDs, and a v2 file without a
+        /// mapping is diagnosed right below. Gating the opt-in on the mapping would bury that
+        /// diagnostic under `UNKNOWN_FORMAT_VERSION` in exactly the case it exists for.
+        const auto columns_format_version = loaded_columns.readText(*in, /*check_eof=*/true, /*allow_column_ids=*/true);
+
+        /// The IDs in the name slot resolve to nothing without the mapping, so the columns would
+        /// silently read as defaults under names like `1`. Its own error code so that
+        /// `MergeTreeData::loadDataPart` can tell it from a corrupt part.
+        if (columns_format_version == NamesAndTypesList::FORMAT_VERSION_WITH_COLUMN_IDS && !column_id_mapping)
+            throw Exception(ErrorCodes::COLUMN_ID_MAPPING_MISSING,
+                "Part {} was written under column IDs (columns.txt format version {}) but table {} has no active "
+                "column-ID mapping. The part belongs to another table, or the table's `column_ids.json` is gone -- "
+                "restore it from a backup, it cannot be rebuilt.",
+                name, columns_format_version, storage.getStorageID().getNameForLogs());
 
         for (auto & column : loaded_columns)
             setVersionToAggregateFunctions(column.type, true);
+
+        /// Only this branch: its columns are named by their on-disk token, which is what the remap
+        /// resolves. The other already holds ids and current names, and remapping would overwrite
+        /// each id with the name -- every stream would then be sought under a name no file carries.
+        if (column_id_mapping)
+            loaded_columns = remapColumnIdsToColumnNames(loaded_columns, *column_id_mapping);
     }
     else
     {
@@ -2378,7 +2533,14 @@ void IMergeTreeDataPart::loadColumns(bool require, bool load_metadata_version)
 
         auto metadata_snapshot = getMetadataSnapshot();
         /// If there is no file with a list of columns, write it down.
-        for (const auto & column : metadata_snapshot->getColumns().getAllPhysical())
+        auto columns_to_load = metadata_snapshot->getColumns().getAllPhysical();
+        /// Lenient: a projection part rebuilds its columns from projection metadata (synthetic
+        /// aggregates, `_parent_part_offset`) yet stamps against the PARENT table's mapping, where
+        /// those names are legitimately absent -- the strict stamp would wrongly throw.
+        if (column_id_mapping)
+            column_id_mapping->stampColumnIdsLenient(columns_to_load);
+
+        for (const auto & column : columns_to_load)
             if (getFileNameForColumn(column))
                 loaded_columns.push_back(column);
 
@@ -2391,7 +2553,12 @@ void IMergeTreeDataPart::loadColumns(bool require, bool load_metadata_version)
 
     SerializationInfoByName infos({});
     if (auto in = readFileIfExists(SERIALIZATION_FILE_NAME))
-        infos = SerializationInfoByName::readJSON(loaded_columns, *in);
+    {
+        if (column_id_mapping)
+            infos = SerializationInfoByName::readJSONWithColumnIds(loaded_columns, *in);
+        else
+            infos = SerializationInfoByName::readJSON(loaded_columns, *in);
+    }
 
     std::optional<int32_t> loaded_metadata_version;
     if (load_metadata_version)
@@ -2413,13 +2580,40 @@ void IMergeTreeDataPart::loadColumns(bool require, bool load_metadata_version)
     setColumns(loaded_columns, infos, *loaded_metadata_version);
 }
 
+/// `columns_substreams.txt` keys its columns by the name they had when the part was written, which a
+/// metadata-only RENAME leaves stale, while the substreams under them are id-keyed. Neither side of
+/// that comparison holds for an id part, so only check where the file is fully name-keyed.
+void IMergeTreeDataPart::validateSubstreamColumnNames(const ColumnsSubstreams & substreams) const
+{
+    if (!hasStampedColumnIds())
+        substreams.validateColumns(getColumns().getNames());
+}
+
+/// Fail closed before resolving a column's streams: an unstamped column on an id-keyed part would fall
+/// back to resolution by name, binding a foreign or absent file instead of reporting the miss.
+void IMergeTreeDataPart::checkColumnIdIsStamped(const NameAndTypePair & column) const
+{
+    /// Two kinds of columns are name-keyed by design and legitimately carry no id: virtual columns,
+    /// which the mapping never covers (a patch part consists of them), and a projection's synthetic
+    /// aggregates, which are not table columns at all.
+    if (!column.column_id.empty() || isVirtualColumn(column.name) || isProjectionPart())
+        return;
+
+    if (!hasStampedColumnIds())
+        return;
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR,
+        "Column {} of part {} has no stamped column ID, but the part was written with column IDs",
+        backQuoteIfNeed(column.name), name);
+}
+
 void IMergeTreeDataPart::setColumnsSubstreams(const ColumnsSubstreams & columns_substreams_)
 {
     /// The interned list is shared between parts and outlives the query, so it is not charged to it;
     /// see `setColumns`.
     MemoryTrackerBlockerInThread not_charged_to_the_query;
 
-    columns_substreams_.validateColumns(getColumns().getNames());
+    validateSubstreamColumnNames(columns_substreams_);
     /// Drop the interned list first, as in `setColumns`. Callers always pass a list of their own.
     chassert(&columns_substreams_ != columns_substreams.get());
     columns_substreams = SharedPartColumns::getEmptyColumnsSubstreams();
@@ -2441,7 +2635,7 @@ void IMergeTreeDataPart::moveMetadataToDedicatedArena()
     /// Re-home the members built outside the arena into it (copy under the scope, then adopt).
     reallocateByCopy(partition);
     reallocateByCopy(ttl_infos);
-    reallocateByCopy(expired_columns);
+    reallocateByCopy(expired_column_ids);
     /// The minmax index is re-homed at its population sites instead (`setMinMaxIndex`, the lazy
     /// `getMinMaxIndex` build, and the in-place merge/update sites in MergeTask): here it is either not
     /// yet populated (merge/mutation) or would be reset again later (zero-level virtual columns).
@@ -2461,8 +2655,9 @@ void IMergeTreeDataPart::loadColumnsSubstreams()
         /// (fixed in https://github.com/ClickHouse/ClickHouse/pull/102689) where renaming a column
         /// produced wrong substream names in columns_substreams.txt.
         /// For Wide parts this file is not mandatory, so we can safely discard it and proceed
-        /// as if it didn't exist.
-        if (part_type == MergeTreeDataPartType::Wide)
+        /// as if it didn't exist. Skipped for id-keyed parts, for the reason in
+        /// `validateSubstreamColumnNames`.
+        if (part_type == MergeTreeDataPartType::Wide && !hasStampedColumnIds())
         {
             auto [invalid_substream, invalid_column] = loaded_columns_substreams.findInvalidSubstreamName();
             if (!invalid_substream.empty())
@@ -2784,6 +2979,13 @@ IndexSize IMergeTreeDataPart::getIndexSizeFromFile() const
     return {};
 }
 
+/// Never the live mapping: after DROP + re-ADD that holds a fresh id while this part's file still
+/// carries the old one.
+String IMergeTreeDataPart::minmaxColumnId(const String & column_name) const
+{
+    return getColumns().getColumnIdByName(column_name).value();
+}
+
 void IMergeTreeDataPart::checkConsistencyBase() const
 {
     auto metadata_snapshot = getMetadataSnapshot();
@@ -2811,12 +3013,11 @@ void IMergeTreeDataPart::checkConsistencyBase() const
             {
                 for (const String & col_name : partition_key.expression->getRequiredColumns())
                 {
-                    if (!checksums.files.contains("minmax_" + escapeForFileName(col_name) + ".idx"))
-                        /// check hash one more time
-                        if (!checksums.files.contains("minmax_" + sipHash128String(escapeForFileName(col_name)) + ".idx"))
-                        {
-                            throw Exception(ErrorCodes::NO_FILE_IN_DATA_PART, "No minmax idx file checksum for column {}", col_name);
-                        }
+                    /// getFileColumnName returns whichever of the escaped / hashed variants the
+                    /// checksums hold, else the escaped one -- which is then absent, as required.
+                    auto file_column = MinMaxIndex::getFileColumnName(minmaxColumnId(col_name), checksums);
+                    if (!checksums.files.contains(MinMaxIndex::getFileName(file_column)))
+                        throw Exception(ErrorCodes::NO_FILE_IN_DATA_PART, "No minmax idx file checksum for column {}", col_name);
                 }
             }
         }
@@ -2873,16 +3074,21 @@ void IMergeTreeDataPart::checkConsistencyBase() const
 
             if (!parent_part)
             {
+                /// No checksums here to say which variant was written, so probe the filesystem. If
+                /// neither is there, the escaped one is re-checked so that it owns the error message.
+                auto try_file = [&](const String & file_name)
+                {
+                    try { check_file_not_empty(file_name); return true; }
+                    catch (Exception &) { return false; }
+                };
+
                 for (const String & col_name : partition_key.expression->getRequiredColumns())
-                    try
-                    {
-                        check_file_not_empty("minmax_" + escapeForFileName(col_name) + ".idx");
-                    }
-                    catch (Exception&)
-                    {
-                        /// check hash one more time
-                        check_file_not_empty("minmax_" + sipHash128String(escapeForFileName(col_name)) + ".idx");
-                    }
+                {
+                    auto escaped = escapeForFileName(minmaxColumnId(col_name));
+                    if (!try_file(MinMaxIndex::getFileName(escaped))
+                        && !try_file(MinMaxIndex::getFileName(sipHash128String(escaped))))
+                        check_file_not_empty(MinMaxIndex::getFileName(escaped));
+                }
             }
         }
     }
@@ -3051,14 +3257,14 @@ void IMergeTreeDataPart::calculateSecondaryIndicesSizesOnDisk() const
     secondary_index_sizes = std::make_shared<IndexSizeByName>(std::move(new_secondary_index_sizes));
 }
 
-ColumnSize IMergeTreeDataPart::getColumnSize(const String & column_name) const
+ColumnSize IMergeTreeDataPart::getColumnSize(const ColumnId & column_id) const
 {
     UniqueLock lock(columns_and_secondary_indices_sizes_mutex);
     if (!are_columns_and_secondary_indices_sizes_calculated && areChecksumsLoaded())
         calculateColumnsAndSecondaryIndicesSizesOnDiskUnlocked();
 
-    /// For some types of parts columns_size maybe not calculated
-    auto it = columns_sizes->find(column_name);
+    /// `columns_sizes` is keyed by storage id (see MergeTreeDataPartWide::calculateEachColumnSizes).
+    auto it = columns_sizes->find(column_id.value());
     if (it != columns_sizes->end())
         return it->second;
 
@@ -3073,15 +3279,20 @@ IMergeTreeDataPart::ColumnSizeByNameConstPtr IMergeTreeDataPart::getColumnSizes(
     return columns_sizes;
 }
 
-ColumnSize IMergeTreeDataPart::getSubcolumnSize(const String & subcolumn_name) const
+ColumnSize IMergeTreeDataPart::getSubcolumnSize(const NameAndTypePair & subcolumn) const
 {
+    /// Keyed by storage id: callers reach this from both name domains -- the part's own columns and
+    /// the current schema snapshot -- and a name key would serve one domain's size to the other once
+    /// a metadata-only rename moves the two apart.
+    const String cache_key = subcolumn.getStorageKey().value();
+
     /// First, check if we already calculated the size of this subcolumn and have it in cache.
-    if (auto size = subcolumns_sizes_cache.get(subcolumn_name))
+    if (auto size = subcolumns_sizes_cache.get(cache_key))
         return *size;
 
     /// If not, calculate the size of the subcolumn on disk and put it to cache.
-    auto size = calculateSubcolumnSize(subcolumn_name);
-    subcolumns_sizes_cache.add(subcolumn_name, size);
+    auto size = calculateSubcolumnSize(subcolumn);
+    subcolumns_sizes_cache.add(cache_key, size);
     return size;
 }
 
@@ -3173,8 +3384,9 @@ bool IMergeTreeDataPart::checkAllTTLCalculated(const StorageMetadataPtr & metada
 
     for (const auto & [column, desc] : metadata_snapshot->getColumnTTLs())
     {
-        /// Part has this column, but we don't calculated TTL for it
-        if (!ttl_infos.columns_ttl.contains(column) && getColumns().contains(column))
+        /// Part has this column, but we don't calculated TTL for it.
+        auto column_in_part = tryGetColumnBySnapshotName(column, metadata_snapshot);
+        if (column_in_part && !ttl_infos.columns_ttl.contains(column_in_part->getColumnId().value()))
             return false;
     }
 
@@ -3275,14 +3487,14 @@ std::optional<String> IMergeTreeDataPart::getStreamNameForColumn(
     const MergeTreeSettingsPtr & settings)
 {
     ISerialization::StreamFileNameSettings stream_file_name_settings(*settings);
-    auto stream_name = ISerialization::getFileNameForStream(column, substream_path, stream_file_name_settings);
+    auto stream_name = ISerialization::getFileNameForStreamByColumnId(column, substream_path, stream_file_name_settings);
     if (auto result_stream_name = getStreamNameOrHash(stream_name, extension, checksums_))
         return result_stream_name;
 
     /// To be able to read old parts after changes in stream file name settings, try to change settings and try to find it again.
     if (ISerialization::tryToChangeStreamFileNameSettingsForNotFoundStream(substream_path, stream_file_name_settings))
     {
-        stream_name = ISerialization::getFileNameForStream(column, substream_path, stream_file_name_settings);
+        stream_name = ISerialization::getFileNameForStreamByColumnId(column, substream_path, stream_file_name_settings);
         return getStreamNameOrHash(stream_name, extension, checksums_);
     }
 
@@ -3319,14 +3531,14 @@ std::optional<String> IMergeTreeDataPart::getStreamNameForColumn(
     const MergeTreeSettingsPtr & settings)
 {
     ISerialization::StreamFileNameSettings stream_file_name_settings(*settings);
-    auto stream_name = ISerialization::getFileNameForStream(column, substream_path, stream_file_name_settings);
+    auto stream_name = ISerialization::getFileNameForStreamByColumnId(column, substream_path, stream_file_name_settings);
     if (auto result_stream_name = getStreamNameOrHash(stream_name, extension, storage_))
         return result_stream_name;
 
     /// To be able to read old parts after changes in stream file name settings, try to change settings and try to find it again.
     if (ISerialization::tryToChangeStreamFileNameSettingsForNotFoundStream(substream_path, stream_file_name_settings))
     {
-        stream_name = ISerialization::getFileNameForStream(column, substream_path, stream_file_name_settings);
+        stream_name = ISerialization::getFileNameForStreamByColumnId(column, substream_path, stream_file_name_settings);
         return getStreamNameOrHash(stream_name, extension, storage_);
     }
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -47,6 +47,8 @@ class Block;
 struct ColumnSize;
 class DeserializationPrefixesCache;
 class MergeTreeData;
+class ColumnIdMapping;
+using ColumnIdMappingPtr = std::shared_ptr<const ColumnIdMapping>;
 struct FutureMergedMutatedPart;
 class IReservation;
 using ReservationPtr = std::unique_ptr<IReservation>;
@@ -120,6 +122,17 @@ enum class DataPartRemovalState : uint8_t
     REMOVE_RETRY,
 };
 
+/// Where one column stream's marks live: which marks file, and which entry of each mark. A Wide part
+/// keeps a marks file per stream with one entry per mark; a Compact part one file per part with an
+/// entry per column or substream. Always naming the stream lets callers cache loaders by that name.
+struct ColumnMarksLocation
+{
+    String marks_stream_name;
+    size_t index_in_mark;
+    /// Width of the marks file: how many entries every mark holds.
+    size_t columns_in_mark;
+};
+
 /// Description of the data part.
 /// Warning: `IStorage` must outlive all its `IMergeTreeDataPart`s. Whenever you hold a
 ///          MergeTreeDataPartPtr you must also hold the corresponding StoragePtr.
@@ -157,13 +170,14 @@ public:
     virtual bool isStoredOnRemoteDiskWithZeroCopySupport() const = 0;
 
     /// NOTE: Returns zeros if column files are not found in checksums.
-    /// Otherwise return information about column size on disk.
-    ColumnSize getColumnSize(const String & column_name) const;
+    /// Otherwise return information about column size on disk. Keyed by stable storage id.
+    ColumnSize getColumnSize(const ColumnId & column_id) const;
     ColumnSizeByNameConstPtr getColumnSizes() const;
-    /// Return the size of all files required to read the specified subcolumn.
-    ColumnSize getSubcolumnSize(const String & /*subcolumn_name*/) const;
+    /// Return the size of all files required to read the specified subcolumn. Takes the whole pair: a
+    /// subcolumn has no id of its own, so it is keyed by the parent's id plus its name (`getStorageKey`).
+    ColumnSize getSubcolumnSize(const NameAndTypePair & subcolumn) const;
 
-    virtual std::optional<time_t> getColumnModificationTime(const String & column_name) const = 0;
+    virtual std::optional<time_t> getColumnModificationTime(const ColumnId & column_id) const = 0;
 
     /// NOTE: Returns zeros if secondary indexes are not found in checksums.
     /// Otherwise return information about secondary index size on disk.
@@ -199,12 +213,18 @@ public:
     String getTypeName() const { return getType().toString(); }
 
     /// We could have separate method like setMetadata, but it's much more convenient to set it up with columns
+    /// `new_infos` must be keyed by the columns' stamped IDs (`getColumnId`); a caller holding
+    /// name-keyed writer stats runs `reKeyToColumnIds` first.
     void setColumns(const NamesAndTypesList & new_columns, const SerializationInfoByName & new_infos, int32_t new_metadata_version);
 
     void setColumnsSubstreams(const ColumnsSubstreams & columns_substreams_);
 
+    /// True when at least one of this part's columns carries a `column_id` (stamped at write /
+    /// merge time), i.e. this part's files are named by column IDs. Derived from `columns`.
+    bool hasStampedColumnIds() const { return shared_part_columns->has_stamped_column_ids; }
+
     /// Re-home the small, part-lifetime metadata that build paths may populate outside the
-    /// dedicated MergeTree arena (`partition`, `ttl_infos`, `expired_columns`, and for patch parts
+    /// dedicated MergeTree arena (`partition`, `ttl_infos`, `expired_column_ids`, and for patch parts
     /// `source_parts_set`) into that arena. A cheap copy of small objects; call once these members
     /// are final. `columns` / `serializations` are handled by `setColumns`, the minmax index by
     /// `setMinMaxIndex` / the population sites.
@@ -221,8 +241,21 @@ public:
     const ColumnsSubstreams & getColumnsSubstreams() const { return *columns_substreams; }
     StorageMetadataPtr getMetadataSnapshot() const;
 
-    NameAndTypePair getColumn(const String & name) const;
-    std::optional<NameAndTypePair> tryGetColumn(const String & column_name) const;
+    /// Return this part's own column carrying the given stable storage id (top-level; a subcolumn
+    /// shares its parent's id). The result is an id-carrying NameAndTypePair.
+    std::optional<NameAndTypePair> tryGetColumn(const ColumnId & column_id) const;
+
+    /// This part's own (sub)column for a name in @snapshot's schema: part-own name and type, subcolumn
+    /// preserved. `nullopt` if the snapshot lacks the name or this part lacks the column.
+    std::optional<NameAndTypePair> tryGetColumnBySnapshotName(const String & current_name, const StorageMetadataPtr & snapshot) const;
+    /// The same for a caller that already holds the resolved pair.
+    std::optional<NameAndTypePair> tryGetColumnByRequest(const NameAndTypePair & requested) const;
+
+    /// Unsafe: resolve by name off the part's OWN columns. The caller must hold a bare part-own name
+    /// (never a current/renamed name, which the part may not carry yet) and have no column id in
+    /// scope -- prefer the id overloads.
+    std::optional<NameAndTypePair> tryGetColumnByNameUnsafe(const String & column_name) const;
+    SerializationPtr tryGetSerializationByNameUnsafe(const String & column_name) const;
 
     /// Get sample column from part. For ordinary columns it just creates column using it's type.
     /// For columns with dynamic structure it reads sample column with 0 rows from the part.
@@ -232,8 +265,10 @@ public:
 
     const PartSerializations & getSerializations() const { return *serializations; }
 
-    SerializationPtr getSerialization(const String & column_name) const;
-    SerializationPtr tryGetSerialization(const String & column_name) const;
+    /// Serialization lookup by stable storage id (as produced by NameAndTypePair::getColumnId(),
+    /// subcolumns as "<id>.<subpath>" -- see NameAndTypePair::getStorageKey). No name->id resolution.
+    SerializationPtr getSerialization(const ColumnId & column_id) const;
+    SerializationPtr tryGetSerialization(const ColumnId & column_id) const;
 
     void remove();
 
@@ -253,6 +288,12 @@ public:
 
     /// Removes marks from cache for all columns in part.
     virtual void removeMarksFromCache(MarkCache * mark_cache) const = 0;
+
+    /// Locate the marks of one of @column's streams; an empty @substream_path asks for the stream
+    /// carrying the column itself. @column must be this part's own slot (see tryGetColumnBySnapshotName)
+    /// -- streams are addressed by its stamped id. `nullopt` if the part keeps no marks for that stream.
+    virtual std::optional<ColumnMarksLocation> getColumnMarksLocation(
+        const NameAndTypePair & column, const ISerialization::SubstreamPath & substream_path) const = 0;
 
     /// Loads index marks for secondary indices and saves them into the index mark cache.
     void loadIndexMarksToCache(MarkCache * index_mark_cache) const;
@@ -274,11 +315,10 @@ public:
 
     /// Returns column position in part structure or std::nullopt if it's missing in part.
     ///
-    /// NOTE: Doesn't take column renames into account, if some column renames
-    /// take place, you must take original name of column for this part from
-    /// storage and pass it to this method.
-    std::optional<size_t> getColumnPosition(const String & column_name) const;
-    const NameToNumber & getColumnPositions() const { return shared_part_columns->column_name_to_position; }
+    /// `column_id` is a storage key as produced by `NameAndTypePair::getColumnId`. An empty or
+    /// unknown id yields nullopt.
+    std::optional<size_t> getColumnPosition(const ColumnId & column_id) const;
+    const NameToNumber & getColumnPositions() const { return shared_part_columns->column_storage_key_to_position; }
 
     /// Returns the name of a column with minimum compressed size (as returned by getColumnSize()).
     /// If no checksums are present returns the name of the first physically existing column.
@@ -431,12 +471,17 @@ public:
 
         using WrittenFiles = std::vector<std::unique_ptr<WriteBufferFromFileBase>>;
 
-        [[nodiscard]] WrittenFiles store(StorageMetadataPtr metadata_snapshot, IDataPartStorage & part_storage, Checksums & checksums, const MergeTreeSettingsPtr & storage_settings) const;
+        /// Resolves the partition key's column ids against `part_columns` (see `NamesAndTypesList::getColumnIdByName`).
+        [[nodiscard]] WrittenFiles store(StorageMetadataPtr metadata_snapshot, IDataPartStorage & part_storage, Checksums & checksums, const MergeTreeSettingsPtr & storage_settings, const NamesAndTypesList & part_columns) const;
+        /// Names each file after the matching pair in `columns`, whose names must be column ids already.
         [[nodiscard]] WrittenFiles store(const NamesAndTypesList & columns, IDataPartStorage & part_storage, Checksums & checksums, const MergeTreeSettingsPtr & storage_settings) const;
 
         void update(const Block & block, const NamesAndTypesList & columns);
         void merge(const MinMaxIndex & other);
         Names getProbablyWrittenFiles(const IMergeTreeDataPart & part) const;
+        /// The only place a minmax file name is spelled. Its argument is an already resolved and
+        /// escaped key from one of the `getFileColumnName` overloads below, never a raw column name.
+        static String getFileName(const String & file_column_name) { return "minmax_" + file_column_name + ".idx"; }
         /// For Store
         static String getFileColumnName(const String & column_name, const MergeTreeSettingsPtr & storage_settings_, const IDataPartStorage & data_part_storage);
         /// For Load
@@ -458,8 +503,9 @@ public:
 
     Checksums checksums;
 
-    /// Columns with values, that all have been zeroed by expired ttl
-    NameSet expired_columns;
+    /// Columns with values, that all have been zeroed by expired ttl. Keyed by column ID, so
+    /// consumers match it against a part's own columns without resolving a column name.
+    ColumnIdSet expired_column_ids;
 
     NameSet invalidated_system_columns;
     bool isSystemColumnInvalidated(const String & column_name) const;
@@ -600,7 +646,11 @@ public:
         bool if_not_loaded = false,
         bool only_metadata = false);
 
-    /// If checksums.txt exists, reads file's checksums (and sizes) from it
+    /// Reads checksums (and sizes) from checksums.txt, without the recovery `loadChecksums` does.
+    /// False only when the file is absent -- i.e. exactly when that recovery is needed.
+    bool tryPreloadChecksums();
+
+    /// As above, but recovers by recalculating the checksums when checksums.txt is absent.
     void loadChecksums(bool require);
     bool areChecksumsLoaded() const { return !checksums.empty(); }
 
@@ -831,7 +881,14 @@ protected:
     virtual void calculateEachColumnSizes(ColumnSizeByName & each_columns_size, ColumnSize & total_size) const = 0;
 
     /// Calculate the size of all files required to read a specified subcolumn.
-    virtual ColumnSize calculateSubcolumnSize(const String & /*subcolumn_name*/) const { return {}; }
+    virtual ColumnSize calculateSubcolumnSize(const NameAndTypePair & /*subcolumn*/) const { return {}; }
+
+    /// Check `substreams`' column keys against this part's column names, where that comparison is
+    /// meaningful at all.
+    void validateSubstreamColumnNames(const ColumnsSubstreams & substreams) const;
+
+    /// Throws unless @column carries an id on a part whose files are named by ids.
+    void checkColumnIdIsStamped(const NameAndTypePair & column) const;
 
     std::optional<String> getRelativePathForDetachedPart(const String & prefix, bool broken) const;
 
@@ -854,7 +911,7 @@ private:
     mutable std::atomic<MergeTreeDataPartState> state{MergeTreeDataPartState::Temporary};
 
     /// Schema-derived metadata shared with all other parts of the table that store the same
-    /// columns: the column list, the name-to-position map (in compact parts order of columns
+    /// columns: the column list, the storage-key-to-position map (in compact parts order of columns
     /// is necessary) and the columns descriptions (for more convenient access to columns by
     /// name and getting subcolumns; the collected-nested variant is used while reading from
     /// wide parts). Cannot be changed after part initialization. Obtained from (and returned
@@ -870,7 +927,8 @@ private:
     /// Kept per-part: it holds the row/default counters of this part's data.
     SerializationInfoByName serialization_infos{{}};
 
-    /// Serializations for every columns and subcolumns by their names.
+    /// Serializations for every column and subcolumn, keyed by stable storage key (a subcolumn as
+    /// `"<id>.<subpath>"`, see `NameAndTypePair::getStorageKey`).
     /// Shared across parts of the table with the same serialization kinds; the per-column pieces
     /// inside are shared even when only some columns have the same kinds. Never null.
     PartSerializationsPtr serializations = SharedPartColumns::getEmptySerializations();
@@ -885,6 +943,13 @@ private:
 
     /// Reads columns names and types from columns.txt
     void loadColumns(bool require, bool load_metadata_version);
+
+    /// When a column ID mapping is active, every entry in the on-disk column list (columns.txt)
+    /// is a column ID rather than a current column name. Translate each back to its column name
+    /// and attach the column ID as metadata.
+    NamesAndTypesList remapColumnIdsToColumnNames(
+        const NamesAndTypesList & loaded_columns,
+        const ColumnIdMapping & mapping) const;
 
     /// Reads columns substreams from columns_substreams.txt.
     void loadColumnsSubstreams();
@@ -941,6 +1006,9 @@ private:
     void decrementStateMetric(MergeTreeDataPartState state) const;
 
     void checkConsistencyBase() const;
+
+    /// Id under which a partition-key column's `minmax_<id>.idx` is named in THIS part.
+    String minmaxColumnId(const String & column_name) const;
 
     /// Returns the name of projection for projection part, empty string for regular part.
     String getProjectionName() const;

--- a/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <Interpreters/Context_fwd.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/ColumnsSubstreams.h>
@@ -75,7 +76,11 @@ public:
 
     virtual const ColumnsSubstreams & getColumnsSubstreams() const = 0;
 
-    virtual std::optional<size_t> getColumnPosition(const String & column_name) const = 0;
+    /// Direct lookup by stable storage id (IMergeTreeDataPart::getColumnPosition).
+    virtual std::optional<size_t> getColumnPosition(const ColumnId & column_id) const = 0;
+
+    /// The part's own stored column carrying this id (id-carrying pair, part's on-disk type).
+    virtual std::optional<NameAndTypePair> tryGetColumn(const ColumnId & column_id) const = 0;
 
     /// Look up a (sub)column present in the part, if any.
     virtual std::optional<NameAndTypePair> tryGetColumn(const String & column_name) const = 0;
@@ -93,9 +98,11 @@ public:
     /// (size predictor falls back to a default estimate) and `getColumnSizes` returns null. The map is
     /// returned by shared pointer, not by value, so hot callers (e.g. the per-block dataflow-statistics
     /// callback) reuse the part's cached map instead of copying it on every block.
-    virtual ColumnSize getColumnSize(const String & column_name) const = 0;
+    /// Both take what the caller already resolved: an id, or the whole pair for a subcolumn, whose
+    /// id is its parent's.
+    virtual ColumnSize getColumnSize(const ColumnId & column_id) const = 0;
     virtual std::shared_ptr<const std::unordered_map<String, ColumnSize>> getColumnSizes() const = 0;
-    virtual ColumnSize getSubcolumnSize(const String & subcolumn_name) const = 0;
+    virtual ColumnSize getSubcolumnSize(const NameAndTypePair & subcolumn) const = 0;
 
     /// MergeTree settings governing how the part is read.
     virtual MergeTreeSettingsPtr getStorageSettings() const = 0;

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
@@ -145,12 +145,16 @@ PlainMarksByName IMergeTreeDataPartWriter::releaseCachedIndexMarks()
     return res;
 }
 
-SerializationPtr IMergeTreeDataPartWriter::getSerialization(const String & column_name) const
+SerializationPtr IMergeTreeDataPartWriter::getSerialization(const NameAndTypePair & column) const
 {
-    auto it = serializations.find(column_name);
+    /// `serializations` is keyed by stable storage id (see IMergeTreeDataPart::setColumns); the id
+    /// rides on the pair, so key off it directly -- no name->id resolution.
+    const String key = column.getStorageKey().value();
+
+    auto it = serializations.find(key);
     if (it == serializations.end())
         throw Exception(ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
-            "There is no column or subcolumn {} in part {}", column_name, data_part_name);
+            "There is no column or subcolumn {} in part {}", column.name, data_part_name);
 
     return it->second;
 }

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -81,7 +81,7 @@ public:
     virtual const ColumnsSubstreams & getColumnsSubstreams() const = 0;
 
 protected:
-    SerializationPtr getSerialization(const String & column_name) const;
+    SerializationPtr getSerialization(const NameAndTypePair & column) const;
 
     ASTPtr getCodecDescOrDefault(const String & column_name, CompressionCodecPtr default_codec) const;
 

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -7,6 +7,8 @@
 #include <Storages/MergeTree/MergeTreeReadTask.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
+#include <Storages/MergeTree/ColumnIdHelper.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <DataTypes/NestedUtils.h>
 #include <DataTypes/DataTypeNested.h>
 #include <DataTypes/Serializations/SerializationQuantizedVector.h>
@@ -65,7 +67,7 @@ IMergeTreeReader::IMergeTreeReader(
     , alter_conversions(data_part_info_for_read->getAlterConversions())
     , original_requested_columns(columns_)
     , converted_requested_columns((*storage_settings_)[MergeTreeSetting::share_nested_offsets]
-        ? Nested::convertToSubcolumns(columns_)
+        ? Nested::convertToSubcolumns(columns_, /*skip_columns_with_id=*/true)
         : columns_)
     , virtual_fields(virtual_fields_)
 {
@@ -83,7 +85,7 @@ IMergeTreeReader::IMergeTreeReader(
 
         if (column.isSubcolumn())
         {
-            NameAndTypePair requested_column_in_storage{column.getNameInStorage(), column.getTypeInStorage()};
+            NameAndTypePair requested_column_in_storage{column.getNameInStorage(), column.getTypeInStorage(), column.column_id};
             serializations_of_full_columns.emplace(column_to_read.getNameInStorage(), getSerializationInPart(requested_column_in_storage));
         }
     }
@@ -346,12 +348,8 @@ bool IMergeTreeReader::isSubcolumnOffsetsOfNested(const String & name_in_storage
     return nested_column && isNested(nested_column->type);
 }
 
-String IMergeTreeReader::getColumnNameInPart(const NameAndTypePair & required_column) const
-{
-    auto name_pair = getStorageAndSubcolumnNameInPart(required_column);
-    return Nested::concatenateName(name_pair.first, name_pair.second);
-}
-
+/// The rename-chain name path. Only id-less requests reach here: `tryResolveInPart` and
+/// `getColumnInPart` both answer an id-carrying request before consulting names.
 std::pair<String, String> IMergeTreeReader::getStorageAndSubcolumnNameInPart(const NameAndTypePair & required_column) const
 {
     auto name_in_storage = required_column.getNameInStorage();
@@ -368,14 +366,39 @@ std::pair<String, String> IMergeTreeReader::getStorageAndSubcolumnNameInPart(con
     return {name_in_storage, subcolumn_name};
 }
 
+std::optional<NameAndTypePair> IMergeTreeReader::tryResolveInPart(const NameAndTypePair & required_column) const
+{
+    /// An id-carrying request resolves by ID, never by name (see `ColumnIdHelper.h`): after DROP + ADD
+    /// the part can still list a same-named dead column of the old type.
+    if (!required_column.column_id.empty())
+    {
+        auto part_column = data_part_info_for_read->tryGetColumn(required_column.getColumnId());
+        if (!part_column || !required_column.isSubcolumn())
+            return part_column;
+
+        /// A subcolumn of an ID-identified parent (e.g. a Tuple element) has no ID of its own:
+        /// resolve it within the part's parent column.
+        return part_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical,
+            Nested::concatenateName(part_column->getNameInStorage(), required_column.getSubcolumnName()));
+    }
+
+    auto name_pair = getStorageAndSubcolumnNameInPart(required_column);
+    return part_columns.tryGetColumnOrSubcolumn(
+        GetColumnsOptions::AllPhysical, Nested::concatenateName(name_pair.first, name_pair.second));
+}
+
 NameAndTypePair IMergeTreeReader::getColumnInPart(const NameAndTypePair & required_column) const
 {
-    auto name_pair = getStorageAndSubcolumnNameInPart(required_column);
-    auto name_in_part = Nested::concatenateName(name_pair.first, name_pair.second);
-    auto column_in_part = part_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, name_in_part);
+    auto column_in_part = tryResolveInPart(required_column);
 
     if (!column_in_part)
     {
+        /// An id-carrying request has no rename chain to walk: the column is simply absent from
+        /// this part and reads as defaults of the requested (current) type.
+        if (!required_column.column_id.empty())
+            return required_column;
+
+        auto name_pair = getStorageAndSubcolumnNameInPart(required_column);
         /// If column is missing in part, return column with required type but with name that should be
         /// in part according to renames to avoid ambiguity in case of transitive renames.
         ///
@@ -386,20 +409,20 @@ NameAndTypePair IMergeTreeReader::getColumnInPart(const NameAndTypePair & requir
         return NameAndTypePair{name_pair.first, name_pair.second, required_column.getTypeInStorage(), required_column.type};
     }
 
+    /// A subcolumn resolves through the columns description, which drops IDs -- re-stamp so the
+    /// pair keeps addressing the part's ID-keyed maps.
+    if (!required_column.column_id.empty())
+        column_in_part->setColumnId(required_column.column_id);
+
     return *column_in_part;
 }
 
 SerializationPtr IMergeTreeReader::getSerializationInPart(const NameAndTypePair & required_column) const
 {
-    auto name_pair = getStorageAndSubcolumnNameInPart(required_column);
-    auto name_in_part = Nested::concatenateName(name_pair.first, name_pair.second);
-    auto column_in_part = part_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, name_in_part);
+    auto column_in_part = tryResolveInPart(required_column);
 
     if (!column_in_part)
-    {
-        NameAndTypePair missed_column{name_pair.first, name_pair.second, required_column.getTypeInStorage(), required_column.type};
-        return IDataType::getSerialization(missed_column);
-    }
+        return IDataType::getSerialization(getColumnInPart(required_column));
 
     const auto & infos = data_part_info_for_read->getSerializationInfos();
 
@@ -420,10 +443,11 @@ SerializationPtr IMergeTreeReader::getSerializationInPart(const NameAndTypePair 
         return serialization;
     }
 
-    if (auto it = infos.find(column_in_part->getNameInStorage()); it != infos.end())
-        return IDataType::getSerialization(*column_in_part, *it->second);
+    /// `column_in_part` can come from the columns description, which drops ids, so the key comes off
+    /// the request instead.
+    const String record_key = getColumnIdOrPartName(required_column, column_in_part->getNameInStorage()).value();
 
-    return IDataType::getSerialization(*column_in_part, infos.getSettings());
+    return infos.getSerialization(*column_in_part, record_key);
 }
 
 void IMergeTreeReader::performRequiredConversions(Columns & res_columns) const
@@ -440,13 +464,14 @@ void IMergeTreeReader::performRequiredConversions(Columns & res_columns) const
                             "Expected {}, got {}", num_columns, res_columns.size());
         }
 
-        /// We check types manually while iterating to avoid unnecessary copies
+        /// We check types manually while iterating to avoid unnecessary copies.
         Block copy_block;
         auto name_and_type = getColumns().begin();
         for (size_t pos = 0; pos < num_columns; ++pos, ++name_and_type)
         {
             if (res_columns[pos] == nullptr)
                 continue;
+            /// Already resolved against the part, by stamped column ID where there is one.
             const auto & column_in_part = columns_to_read[pos];
             if (column_in_part.type->equals(*name_and_type->type))
                 continue;
@@ -506,22 +531,24 @@ IMergeTreeReader::findColumnForOffsets(const NameAndTypePair & required_column) 
         return offsets_streams;
     };
 
-    auto required_name_in_storage = Nested::extractTableName(required_column.getNameInStorage());
-    auto required_offsets_streams = get_offsets_streams(getSerializationInPart(required_column), required_name_in_storage);
+    /// Which columns share an offsets stream is an id-space question -- that is how the stream is
+    /// named (see getFileNameForStreamByColumnId). The names built below only pair the two sides up.
+    auto required_id_prefix = Nested::extractTableName(required_column.getColumnId().value());
+    auto required_offsets_streams = get_offsets_streams(getSerializationInPart(required_column), required_id_prefix);
 
     size_t max_matched_streams = 0;
     std::optional<ColumnForOffsets> result;
 
-    /// Find column that has maximal number of matching
-    /// offsets columns with required_column.
-    for (const auto & part_column : Nested::convertToSubcolumns(data_part_info_for_read->getColumns()))
+    /// Find column that has maximal number of matching offsets columns with required_column. Match
+    /// the part's own flat columns: folding one onto its Nested parent would key the result by a
+    /// prefix the part has no slot under.
+    for (const auto & part_column : data_part_info_for_read->getColumns())
     {
-        auto name_in_storage = Nested::extractTableName(part_column.name);
-        if (name_in_storage != required_name_in_storage)
+        if (Nested::extractTableName(part_column.getColumnId().value()) != required_id_prefix)
             continue;
 
         auto serialization = data_part_info_for_read->getSerialization(part_column);
-        auto offsets_streams = get_offsets_streams(serialization, name_in_storage);
+        auto offsets_streams = get_offsets_streams(serialization, required_id_prefix);
         NameToIndexMap offsets_streams_map(offsets_streams.begin(), offsets_streams.end());
 
         size_t i = 0;
@@ -611,10 +638,15 @@ MergeTreeReaderPtr createMergeTreeReader(
     const ValueSizeMap & avg_value_size_hints,
     const ReadBufferFromFileBase::ProfileCallback & profile_callback)
 {
+    /// Stamp the requested columns with their storage ids off the snapshot, so the reader keys files by id.
+    NamesAndTypesList columns = columns_to_read;
+    if (const auto mapping = storage_snapshot->metadata->getActiveColumnIdMapping())
+        mapping->stampColumnIds(columns);
+
     if (read_info->isCompactPart())
         return createMergeTreeReaderCompact(
             read_info,
-            columns_to_read,
+            columns,
             storage_snapshot,
             storage_settings,
             mark_ranges,
@@ -629,7 +661,7 @@ MergeTreeReaderPtr createMergeTreeReader(
     if (read_info->isWidePart())
         return createMergeTreeReaderWide(
             read_info,
-            columns_to_read,
+            columns,
             storage_snapshot,
             storage_settings,
             mark_ranges,

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -196,8 +196,10 @@ private:
     friend class MergeTreeReaderTextIndex;
 
     /// Returns actual column name in part, which can differ from table metadata.
-    String getColumnNameInPart(const NameAndTypePair & required_column) const;
     std::pair<String, String> getStorageAndSubcolumnNameInPart(const NameAndTypePair & required_column) const;
+    /// Resolves a requested column against the part -- by stamped column ID when the request
+    /// carries one, else through the rename chain by name. Empty if the part has no such column.
+    std::optional<NameAndTypePair> tryResolveInPart(const NameAndTypePair & required_column) const;
     /// Returns actual column name and type in part, which can differ from table metadata.
     NameAndTypePair getColumnInPart(const NameAndTypePair & required_column) const;
     /// Returns actual serialization in part, which can differ from table metadata.

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -48,36 +48,33 @@ IMergedBlockOutputStream::IMergedBlockOutputStream(
 NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
     const MergeTreeDataPartPtr & data_part,
     NamesAndTypesList & columns,
-    const NameSet & empty_columns,
+    const ColumnIdSet & empty_column_ids,
     SerializationInfoByName & serialization_infos,
     MergeTreeData::DataPart::Checksums & checksums)
 {
     /// For compact part we have to override whole file with data, it's not
     /// worth it
-    if (empty_columns.empty() || isCompactPart(data_part))
+    if (empty_column_ids.empty() || isCompactPart(data_part))
         return {};
 
     /// A part must keep at least one physical column: `loadColumns` and `loadIndexGranularity`
     /// throw NO_FILE_IN_DATA_PART "No columns in part" for a zero-column part.
-    NameSet columns_to_remove = empty_columns;
+    ColumnIdSet ids_to_remove = empty_column_ids;
     size_t columns_kept = 0;
     for (const auto & column : columns)
-        columns_kept += !columns_to_remove.contains(column.name);
+        columns_kept += !ids_to_remove.contains(column.getColumnId());
 
     if (columns_kept == 0 && !columns.empty())
-        columns_to_remove.erase(columns.back().name);
+        ids_to_remove.erase(columns.back().getColumnId());
 
-    if (columns_to_remove.empty())
+    if (ids_to_remove.empty())
         return {};
-
-    for (const auto & column : columns_to_remove)
-        LOG_TRACE(data_part->storage.log, "Skipping expired/empty column {} for part {}", column, data_part->name);
 
     /// Collect counts for shared streams of different columns. As an example, Nested columns have shared stream with array sizes.
     std::map<String, size_t> stream_counts;
     for (const auto & column : columns)
     {
-        data_part->getSerialization(column.name)->enumerateStreams(
+        data_part->getSerialization(column.getStorageKey())->enumerateStreams(
             [&](const ISerialization::SubstreamPath & substream_path)
             {
                 auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(column, substream_path, ".bin", checksums, data_part->storage.getSettings());
@@ -88,15 +85,21 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
 
     NameSet remove_files;
     const String mrk_extension = data_part->getMarksFileExtension();
-    for (const auto & column_name : columns_to_remove)
+    for (const auto & column : columns)
     {
-        auto serialization = data_part->tryGetSerialization(column_name);
+        if (!ids_to_remove.contains(column.getColumnId()))
+            continue;
+
+        LOG_TRACE(data_part->storage.log, "Skipping expired/empty column {} for part {}", column.name, data_part->name);
+
+        auto serialization = data_part->tryGetSerialization(column.getStorageKey());
         if (!serialization)
             continue;
 
         ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
         {
-            auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(column_name, substream_path, ".bin", checksums, data_part->storage.getSettings());
+            auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+                column, substream_path, ".bin", checksums, data_part->storage.getSettings());
 
             /// Delete files if they are no longer shared with another column.
             if (stream_name && --stream_counts[*stream_name] == 0)
@@ -107,7 +110,7 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
         };
 
         serialization->enumerateStreams(callback);
-        serialization_infos.erase(column_name);
+        serialization_infos.erase(column.getStorageKey().value());
     }
 
     /// Remove files on disk and checksums
@@ -126,18 +129,7 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
     }
 
     /// Remove columns from columns array
-    for (const String & empty_column_name : columns_to_remove)
-    {
-        auto find_func = [&empty_column_name](const auto & pair) -> bool
-        {
-            return pair.name == empty_column_name;
-        };
-        auto remove_it
-            = std::find_if(columns.begin(), columns.end(), find_func);
-
-        if (remove_it != columns.end())
-            columns.erase(remove_it);
-    }
+    columns.remove_if([&](const auto & column) { return ids_to_remove.contains(column.getColumnId()); });
 
     return remove_files;
 }

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.h
@@ -68,13 +68,13 @@ public:
     }
 
 protected:
-    /// Remove all columns in @empty_columns, except that one column is always kept, because a
+    /// Remove all columns in @empty_column_ids, except that one column is always kept, because a
     /// part with no columns cannot be loaded. Also, clears checksums
     /// and columns array. Return set of removed files names.
     NameSet removeEmptyColumnsFromPart(
         const MergeTreeDataPartPtr & data_part,
         NamesAndTypesList & columns,
-        const NameSet & empty_columns,
+        const ColumnIdSet & empty_column_ids,
         SerializationInfoByName & serialization_infos,
         MergeTreeData::DataPart::Checksums & checksums);
 

--- a/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
@@ -56,9 +56,12 @@ public:
 
     const ColumnsSubstreams & getColumnsSubstreams() const override { return data_part->getColumnsSubstreams(); }
 
-    std::optional<size_t> getColumnPosition(const String & column_name) const override { return data_part->getColumnPosition(column_name); }
+    std::optional<size_t> getColumnPosition(const ColumnId & column_id) const override { return data_part->getColumnPosition(column_id); }
+    std::optional<NameAndTypePair> tryGetColumn(const ColumnId & column_id) const override { return data_part->tryGetColumn(column_id); }
 
-    std::optional<NameAndTypePair> tryGetColumn(const String & column_name) const override { return data_part->tryGetColumn(column_name); }
+    /// The name is one of the part's own, so resolving it against the part's columns is what the
+    /// caller means -- and it yields the id the size getters below need.
+    std::optional<NameAndTypePair> tryGetColumn(const String & column_name) const override { return data_part->tryGetColumnByNameUnsafe(column_name); }
 
     bool isSystemColumnInvalidated(const String & column_name) const override { return data_part->isSystemColumnInvalidated(column_name); }
 
@@ -71,14 +74,19 @@ public:
 
     String getParentPartName() const override { return data_part->getParentPartName(); }
 
-    ColumnSize getColumnSize(const String & column_name) const override { return data_part->getColumnSize(column_name); }
+    ColumnSize getColumnSize(const ColumnId & column_id) const override { return data_part->getColumnSize(column_id); }
 
     std::shared_ptr<const std::unordered_map<String, ColumnSize>> getColumnSizes() const override
     {
         return data_part->getColumnSizes();
     }
 
-    ColumnSize getSubcolumnSize(const String & subcolumn_name) const override { return data_part->getSubcolumnSize(subcolumn_name); }
+    ColumnSize getSubcolumnSize(const NameAndTypePair & subcolumn) const override
+    {
+        /// @subcolumn is a read request, so it needs resolving (`tryGetColumnByRequest`) before sizing.
+        auto subcolumn_in_part = data_part->tryGetColumnByRequest(subcolumn);
+        return subcolumn_in_part ? data_part->getSubcolumnSize(*subcolumn_in_part) : ColumnSize{};
+    }
 
     const MergeTreeDataPartChecksums & getChecksums() const override { return data_part->checksums; }
 
@@ -94,7 +102,7 @@ public:
 
     const SerializationInfoByName & getSerializationInfos() const override { return data_part->getSerializationInfos(); }
 
-    SerializationPtr getSerialization(const NameAndTypePair & column) const override { return data_part->getSerialization(column.name); }
+    SerializationPtr getSerialization(const NameAndTypePair & column) const override { return data_part->getSerialization(column.getStorageKey()); }
 
     String getTableName() const override { return data_part->storage.getStorageID().getNameForLogs(); }
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -7,9 +7,11 @@
 #include <Storages/ColumnsDescription.h>
 
 #include <memory>
+#include <unordered_set>
 #include <fmt/format.h>
 
 #include <Compression/CompressedWriteBuffer.h>
+#include <Core/ColumnId.h>
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
 #include <DataTypes/NestedUtils.h>
@@ -45,6 +47,7 @@
 #include <Processors/Transforms/TTLTransform.h>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Storages/MergeTree/FutureMergedMutatedPart.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeProjectionPartsTask.h>
@@ -317,27 +320,30 @@ private:
 
 static void addMissedColumnsToSerializationInfos(
     size_t num_rows_in_parts,
-    const Names & part_columns,
-    const ColumnsDescription & storage_columns,
+    const NamesAndTypesList & part_columns,
+    const NamesAndTypesList & storage_columns,
+    const ColumnsDescription & storage_columns_description,
     const SerializationInfo::Settings & info_settings,
     SerializationInfoByName & new_infos)
 {
-    NameSet part_columns_set(part_columns.begin(), part_columns.end());
+    /// Keyed by stamped column ID throughout: the part's column names may be stale after a
+    /// metadata-only RENAME, while IDs are stable.
+    ColumnIdSet part_column_ids;
+    for (const auto & column : part_columns)
+        part_column_ids.insert(column.getColumnId());
 
     for (const auto & column : storage_columns)
     {
-        if (part_columns_set.contains(column.name))
+        if (part_column_ids.contains(column.getColumnId()))
             continue;
 
-        if (column.default_desc.kind != ColumnDefaultKind::Default)
-            continue;
-
-        if (column.default_desc.expression)
+        if (auto default_desc = storage_columns_description.getDefault(column.name);
+            default_desc && (default_desc->kind != ColumnDefaultKind::Default || default_desc->expression))
             continue;
 
         auto new_info = column.type->createSerializationInfo(info_settings);
         new_info->addDefaults(num_rows_in_parts);
-        new_infos.emplace(column.name, std::move(new_info));
+        new_infos.emplace(column.getStorageKey().value(), std::move(new_info));
     }
 }
 
@@ -618,6 +624,8 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
 
     data_part_storage->beginTransaction();
 
+    /// `getAllPhysical()` below already carries the stamped ids (folded into the schema at metadata
+    /// publish via `setColumnIds`), so no separate stampColumnIds pass is needed here.
     global_ctx->storage_snapshot = std::make_shared<StorageSnapshot>(*global_ctx->data, global_ctx->metadata_snapshot);
     global_ctx->storage_columns = global_ctx->metadata_snapshot->getColumns().getAllPhysical();
     global_ctx->virtual_columns = global_ctx->metadata_snapshot->virtuals.getSampleBlock(VirtualsKind::All, VirtualsMaterializationPlace::Reader).getNamesAndTypesList();
@@ -680,14 +688,21 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     /// 2. Default expressions may introduce semantic changes if re-evaluated during merges, leading to
     ///    non-deterministic results across parts.
     {
+        /// Two vocabularies, asked two different questions below: a pending rename names its source
+        /// logically, while "does this column have data anywhere" is a question about column IDs.
         NameSet columns_present_in_parts;
+        ColumnIdSet column_ids_present_in_parts;
         columns_present_in_parts.reserve(global_ctx->storage_columns.size());
+        column_ids_present_in_parts.reserve(global_ctx->storage_columns.size());
 
-        /// Collect all column names that actually exist in the source parts
+        /// Collect what actually exists in the source parts.
         for (const auto & part : global_ctx->future_part->parts)
         {
             for (const auto & col : part->getColumns())
+            {
                 columns_present_in_parts.emplace(col.name);
+                column_ids_present_in_parts.emplace(col.getColumnId());
+            }
         }
 
         /// The only live values of a column may sit in the patch parts selected for this merge: a
@@ -735,11 +750,14 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         /// Any storage column not present in any part and without a default expression is considered expired
         for (const auto & storage_column : global_ctx->storage_columns)
         {
-            if (!columns_present_in_parts.contains(storage_column.name)
-                && !columns_present_in_patch_parts.contains(storage_column.name)
-                && !renamed_column_targets.contains(storage_column.name)
-                && !columns_desc.getDefault(storage_column.name))
-                global_ctx->new_data_part->expired_columns.emplace(storage_column.name);
+            /// Patch parts carry no IDs, and a rename target is by definition a name, so both of
+            /// those stay by name while base parts answer by ID.
+            bool present = column_ids_present_in_parts.contains(storage_column.getColumnId())
+                || columns_present_in_patch_parts.contains(storage_column.name)
+                || renamed_column_targets.contains(storage_column.name);
+
+            if (!present && !columns_desc.getDefault(storage_column.name))
+                global_ctx->new_data_part->expired_column_ids.emplace(storage_column.getColumnId());
         }
     }
 
@@ -773,17 +791,17 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     global_ctx->minmax_idx_columns = MergeTreeData::getMinMaxColumns(global_ctx->metadata_snapshot->getPartitionKey(), global_ctx->data_settings, has_block_columns ? MergeTreePartMinMaxIndexColumns::WITH_BLOCK_NUMBER_OFFSET : MergeTreePartMinMaxIndexColumns::PARTITION_KEY_ONLY);
     extractMergingAndGatheringColumns(exclude_index_names);
 
-    const auto & expired_columns = global_ctx->new_data_part->expired_columns;
-    if (!expired_columns.empty())
+    const auto & expired_column_ids = global_ctx->new_data_part->expired_column_ids;
+    if (!expired_column_ids.empty())
     {
-        global_ctx->gathering_columns = global_ctx->gathering_columns.eraseNames(expired_columns);
+        global_ctx->gathering_columns.remove_if([&](const auto & column) { return expired_column_ids.contains(column.getColumnId()); });
 
         auto filter_columns = [&](const NamesAndTypesList & input, NamesAndTypesList & expired_out)
         {
             NamesAndTypesList result;
             for (const auto & column : input)
             {
-                bool is_expired = expired_columns.contains(column.name);
+                bool is_expired = expired_column_ids.contains(column.getColumnId());
                 bool is_required_for_merge = global_ctx->merge_required_columns.contains(column.name);
 
                 if (is_expired)
@@ -896,6 +914,9 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     };
 
     SerializationInfoByName infos(global_ctx->storage_columns, info_settings);
+    /// Accumulate in the same key space the source parts and the new part use, so a source part's
+    /// records join directly and a record for a column no longer in the schema joins nothing.
+    infos.reKeyToColumnIds(global_ctx->storage_columns);
     global_ctx->alter_conversions.reserve(global_ctx->future_part->parts.size());
 
     for (const auto & part : global_ctx->future_part->parts)
@@ -906,7 +927,8 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
 
             addMissedColumnsToSerializationInfos(
                 part->rows_count,
-                part->getColumns().getNames(),
+                part->getColumns(),
+                global_ctx->storage_columns,
                 global_ctx->metadata_snapshot->getColumns(),
                 info_settings,
                 part_infos);
@@ -929,7 +951,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
 
     global_ctx->new_data_part->setColumns(global_ctx->storage_columns, infos, global_ctx->metadata_snapshot->getMetadataVersion());
 
-    /// partition / ttl_infos / minmax / expired_columns (and patch source parts) are populated
+    /// partition / ttl_infos / minmax / expired_column_ids (and patch source parts) are populated
     /// above interleaved with merge-only scratch, so they were allocated in the default arenas.
     /// Re-home them into the dedicated arena; the interleaved scratch stays out.
     global_ctx->new_data_part->moveMetadataToDedicatedArena();
@@ -1322,10 +1344,16 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::prepareProjectionsToMergeAndRe
     for (const auto & projection : projections)
     {
         const auto & required_columns = projection.getRequiredColumns();
+        /// A projection names its sources logically, so resolve each against the schema the merge
+        /// reads -- `storage_columns` carries the stamped ids and is filled before this runs.
         bool some_source_column_expired = std::any_of(
             required_columns.begin(),
             required_columns.end(),
-            [&](const String & name) { return global_ctx->new_data_part->expired_columns.contains(name); });
+            [&](const String & name)
+            {
+                return global_ctx->new_data_part->expired_column_ids.contains(
+                    global_ctx->storage_columns.getColumnIdByName(name));
+            });
 
         /// The IGNORE mode is checked here purely for backward compatibility.
         /// However, if the projection contains `_parent_part_offset`, it must still be rebuilt,
@@ -1359,8 +1387,11 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::prepareProjectionsToMergeAndRe
             {
                 for (const auto & column : projection_columns)
                 {
-                    if (!it->second->tryGetColumn(column.name)
-                        && (part->tryGetColumn(column.name)
+                    /// The projection part resolves by its own name: `MergeTreeData::checkAlterIsPossible`
+                    /// has always rejected RENAME of a projection-referenced column, so those stored names
+                    /// never go stale. The parent part must go through the snapshot -- it may be renamed.
+                    if (!it->second->tryGetColumnByNameUnsafe(column.name)
+                        && (part->tryGetColumnBySnapshotName(column.name, global_ctx->metadata_snapshot)
                             || !parent_table_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column.name)))
                     {
                         projection_part_misses_column = true;
@@ -1517,7 +1548,8 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::calculateProjectionForBlock(
     {
         auto result = projection_squash_plan.getHeader()->cloneWithColumns(squashed_chunk.detachColumns());
         auto tmp_part = MergeTreeDataWriter::writeTempProjectionPart(
-            *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context);
+            *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context,
+            global_ctx->metadata_snapshot->getActiveColumnIdMapping());
 
         tmp_part->finalize();
         tmp_part->part->getDataPartStorage().commitTransaction();
@@ -1559,7 +1591,8 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::finalizeProjections() const
         {
             auto result = projection_squash_plan.getHeader()->cloneWithColumns(squashed_chunk.detachColumns());
             auto temp_part = MergeTreeDataWriter::writeTempProjectionPart(
-                *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context);
+                *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context,
+                global_ctx->metadata_snapshot->getActiveColumnIdMapping());
 
             temp_part->finalize();
             temp_part->part->getDataPartStorage().commitTransaction();
@@ -1816,7 +1849,7 @@ bool MergeTask::VerticalMergeStage::prepareVerticalMergeForAllColumns() const
     ctx->use_prefetch = all_parts_on_remote_disks && storage_settings[MergeTreeSetting::vertical_merge_remote_filesystem_prefetch];
 
     if (ctx->use_prefetch && ctx->it_name_and_type != global_ctx->gathering_columns.end())
-        ctx->prepared_pipeline = createPipelineForReadingOneColumn(ctx->it_name_and_type->name);
+        ctx->prepared_pipeline = createPipelineForReadingOneColumn(*ctx->it_name_and_type);
 
     return false;
 }
@@ -1894,8 +1927,9 @@ private:
 };
 
 MergeTask::VerticalMergeRuntimeContext::PreparedColumnPipeline
-MergeTask::VerticalMergeStage::createPipelineForReadingOneColumn(const String & column_name) const
+MergeTask::VerticalMergeStage::createPipelineForReadingOneColumn(const NameAndTypePair & column) const
 {
+    const auto & column_name = column.name;
     /// Read from all parts
     std::vector<QueryPlanPtr> plans;
     size_t part_starting_offset = 0;
@@ -1963,7 +1997,10 @@ MergeTask::VerticalMergeStage::createPipelineForReadingOneColumn(const String & 
         else if (global_ctx->future_part->part_format.part_type == MergeTreeDataPartType::Compact)
             max_dynamic_subcolumns = (*merge_tree_settings)[MergeTreeSetting::merge_max_dynamic_subcolumns_in_compact_part].valueOrNullopt();
 
-        bool is_result_sparse = ISerialization::hasKind(global_ctx->new_data_part->getSerialization(column_name)->getKindStack(), ISerialization::Kind::SPARSE);
+        /// The gathering column carries its own storage key, which is how the fresh output part
+        /// keys its serializations.
+        bool is_result_sparse = ISerialization::hasKind(
+            global_ctx->new_data_part->getSerialization(column.getStorageKey())->getKindStack(), ISerialization::Kind::SPARSE);
         auto merge_step = std::make_unique<ColumnGathererStep>(
             merge_column_query_plan.getCurrentHeader(),
             RowsSourcesTemporaryFile::FILE_ID,
@@ -2018,11 +2055,11 @@ void MergeTask::VerticalMergeStage::prepareVerticalMergeForOneColumn() const
         /// Prepare next column pipeline to initiate prefetching
         auto next_column_it = std::next(ctx->it_name_and_type);
         if (next_column_it != global_ctx->gathering_columns.end())
-            ctx->prepared_pipeline = createPipelineForReadingOneColumn(next_column_it->name);
+            ctx->prepared_pipeline = createPipelineForReadingOneColumn(*next_column_it);
     }
     else
     {
-        column_pipepline = createPipelineForReadingOneColumn(column_name);
+        column_pipepline = createPipelineForReadingOneColumn(*ctx->it_name_and_type);
     }
 
     ctx->build_statistics_transforms = std::move(column_pipepline.build_statistics_transforms);

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -480,7 +480,7 @@ private:
         bool executeVerticalMergeForOneColumn() const;
         void finalizeVerticalMergeForOneColumn() const;
 
-        VerticalMergeRuntimeContext::PreparedColumnPipeline createPipelineForReadingOneColumn(const String & column_name) const;
+        VerticalMergeRuntimeContext::PreparedColumnPipeline createPipelineForReadingOneColumn(const NameAndTypePair & column) const;
 
         VerticalMergeRuntimeContextPtr ctx;
         GlobalRuntimeContextPtr global_ctx;

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -1,4 +1,6 @@
 #include <DataTypes/DataTypesNumber.h>
+#include <Storages/MergeTree/ColumnIdHelper.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/MergeTreeBlockReadUtils.h>
 #include <Storages/MergeTree/MergeTreeData.h>
@@ -106,7 +108,8 @@ bool injectRequiredColumnsRecursively(
         if (alter_conversions && alter_conversions->isColumnRenamed(column_name_in_part))
             column_name_in_part = alter_conversions->getColumnOldName(column_name_in_part);
 
-        auto column_in_part = data_part_info_for_reader.getColumns().tryGetByName(column_name_in_part);
+        auto column_in_part = data_part_info_for_reader.tryGetColumn(
+            getColumnIdOrPartName(*column_in_storage, column_name_in_part));
 
         bool share_nested = true;
         if (const auto * merge_tree = dynamic_cast<const MergeTreeData *>(&storage_snapshot->storage))
@@ -221,11 +224,16 @@ NameSet injectRequiredColumns(
         /// (to be resolvable by the StorageSnapshot). This handles cases where the table schema has changed
         /// since the part was created: columns may have been added (not in the part) or dropped (not in metadata).
         const auto & part_columns = data_part_info_for_reader.getColumns();
+        const auto column_id_mapping = storage_snapshot->metadata->getActiveColumnIdMapping();
+
         NamesAndTypesList available_columns;
         for (const auto & column : part_columns)
         {
-            if (storage_snapshot->tryGetColumn(options, column.name))
-                available_columns.push_back(column);
+            /// The name goes back to the caller to be resolved in the current schema, so a part column
+            /// that outlived a metadata-only RENAME has to be offered under its current name.
+            auto current_name = tryGetCurrentColumnName(column, column_id_mapping.get());
+            if (current_name && storage_snapshot->tryGetColumn(options, *current_name))
+                available_columns.emplace_back(*current_name, column.type, column.column_id);
         }
 
         if (available_columns.empty())
@@ -241,8 +249,8 @@ NameSet injectRequiredColumns(
 }
 
 MergeTreeBlockSizePredictor::MergeTreeBlockSizePredictor(
-    const DataPartPtr & data_part_, const Names & columns, const Block & sample_block, bool allow_subcolumns_sizes_calculation_)
-    : data_part(data_part_), allow_subcolumns_sizes_calculation(allow_subcolumns_sizes_calculation_)
+    const DataPartPtr & data_part_, const Names & columns, const Block & sample_block, const StorageMetadataPtr & storage_metadata_, bool allow_subcolumns_sizes_calculation_)
+    : data_part(data_part_), storage_metadata(storage_metadata_), allow_subcolumns_sizes_calculation(allow_subcolumns_sizes_calculation_)
 {
     number_of_rows_in_part = data_part->rows_count;
     /// Initialize with sample block until update won't called.
@@ -272,7 +280,7 @@ void MergeTreeBlockSizePredictor::initialize(const Block & sample_block, const C
         if (typeid_cast<const ColumnConst *>(column_data.get()))
             continue;
 
-        auto column_from_part = data_part->tryGetColumn(column_name);
+        auto column_from_part = data_part->tryGetColumnBySnapshotName(column_name, storage_metadata);
         if ((!column_from_part || !column_from_part->isSubcolumn()) && column_data->valuesHaveFixedSize())
         {
             size_t size_of_value = column_data->sizeOfValueIfFixed();
@@ -287,9 +295,12 @@ void MergeTreeBlockSizePredictor::initialize(const Block & sample_block, const C
             /// If column isn't fixed and doesn't have checksum, than take first
             ColumnSize column_size;
             if (info.is_subcolumn && allow_subcolumns_sizes_calculation)
-                column_size = data_part->getSubcolumnSize(column_name);
+                column_size = data_part->getSubcolumnSize(*column_from_part);
             else
-                column_size = data_part->getColumnSize(column_from_part ? column_from_part->getNameInStorage() : column_name);
+                /// A persistent virtual (`_row_exists`) is not in the schema, so it misses the resolver
+                /// above, yet the part does hold and size it -- under its name, as no mapping covers a
+                /// virtual. Hence the name key rather than nothing.
+                column_size = data_part->getColumnSize(column_from_part ? column_from_part->getColumnId() : ColumnId{column_name});
 
             info.bytes_per_row_global = column_size.data_uncompressed
                 ? static_cast<double>(column_size.data_uncompressed) / static_cast<double>(number_of_rows_in_part)

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
@@ -48,7 +48,7 @@ MergeTreeReadTaskColumns getReadTaskColumnsForMerge(
 
 struct MergeTreeBlockSizePredictor
 {
-    MergeTreeBlockSizePredictor(const DataPartPtr & data_part_, const Names & columns, const Block & sample_block, bool allow_subcolumns_sizes_calculation);
+    MergeTreeBlockSizePredictor(const DataPartPtr & data_part_, const Names & columns, const Block & sample_block, const StorageMetadataPtr & storage_metadata_, bool allow_subcolumns_sizes_calculation);
 
     /// Reset some values for correct statistics calculating
     void startBlock();
@@ -104,6 +104,8 @@ struct MergeTreeBlockSizePredictor
 
 protected:
     DataPartPtr data_part;
+    /// The op's pinned metadata snapshot (carries column ids).
+    StorageMetadataPtr storage_metadata;
 
     struct ColumnInfo
     {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -843,30 +843,10 @@ MergeTreeData::MergeTreeData(
 
 VirtualColumnsDescription MergeTreeData::createVirtuals(const KeyDescription * partition_key)
 {
-    VirtualColumnsDescription desc;
-
-    desc.addEphemeral("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of part", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_part_index", std::make_shared<DataTypeUInt64>(), "Sequential index of the part in the query result", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_part_starting_offset", std::make_shared<DataTypeUInt64>(), "Cumulative starting row of the part in the query result", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_part_uuid", std::make_shared<DataTypeUUID>(), "Unique part identifier (if enabled MergeTree setting assign_part_uuids)", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral(PartitionIdColumn::name, PartitionIdColumn::type, "Name of partition", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_sample_factor", std::make_shared<DataTypeFloat64>(), "Sample factor (from the query)", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_part_offset", std::make_shared<DataTypeUInt64>(), "Number of row in the part", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_part_granule_offset", std::make_shared<DataTypeUInt64>(), "Number of granule in the part", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral(PartDataVersionColumn::name, PartDataVersionColumn::type, "Data version of part (either min block number or mutation version)", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_disk_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Disk name", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_distance", std::make_shared<DataTypeFloat32>(), "Pre-computed distance for vector search queries", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_table", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "", VirtualsMaterializationPlace::Reader);
-    desc.addEphemeral("_database", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "", VirtualsMaterializationPlace::Reader);
-
-    if (partition_key && partition_key->sample_block.columns() > 0)
-        desc.addEphemeral(PartitionValueColumn::name, PartitionValueColumn::type(partition_key), "Value (a tuple) of a PARTITION BY expression", VirtualsMaterializationPlace::Reader);
-
-    desc.addPersistent(RowExistsColumn::name, RowExistsColumn::type, nullptr, "Persisted mask created by lightweight delete that show whether row exists or is deleted");
-    desc.addPersistent(BlockNumberColumn::name, BlockNumberColumn::type, BlockNumberColumn::codec, "Persisted original number of block that was assigned at insert");
-    desc.addPersistent(BlockOffsetColumn::name, BlockOffsetColumn::type, BlockOffsetColumn::codec, "Persisted original number of row in block that was assigned at insert");
-
-    return desc;
+    /// The set itself lives one layer down, in MergeTreeVirtualColumns, so that a predicate over it
+    /// -- `isVirtualColumn` -- is derived from the same registry rather than a second hardcoded list
+    /// that can drift from this one.
+    return getMergeTreeVirtuals(partition_key);
 }
 
 StoragePolicyPtr MergeTreeData::getStoragePolicy() const

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5,6 +5,8 @@
 #include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/ConditionTemplate.h>
 #include <Storages/MergeTree/Compaction/MergeSelectors/ManualMergeSelector.h>
+#include <Storages/MergeTree/ColumnIdHelper.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/PartitionCommands.h>
 #include <Common/CurrentThread.h>
@@ -955,6 +957,17 @@ static void checkKeyExpression(const ExpressionActions & expr, const Block & sam
                             "{} key contains nullable columns, "
                             "but merge tree setting `allow_nullable_key` is disabled", key_name);
     }
+}
+
+ColumnIdMappingPtr MergeTreeData::getActiveColumnIdMapping() const
+{
+    /// Off the live metadata, bypassing the per-query cache: a mapping change publishes a fresh
+    /// pointer, and a cached snapshot would hand out the pre-change one.
+    auto metadata = getInMemoryMetadataPtr(nullptr, /*bypass_metadata_cache=*/true);
+    const auto & mapping = metadata->column_id_mapping;
+    if (mapping && mapping->isActive())
+        return mapping;
+    return nullptr;
 }
 
 void MergeTreeData::checkProperties(
@@ -7721,10 +7734,14 @@ void MergeTreeData::addPartContributionToColumnAndSecondaryIndexSizes(const Data
 
 void MergeTreeData::addPartContributionToColumnAndSecondaryIndexSizesUnlocked(const DataPartPtr & part) const
 {
+    auto mapping = getActiveColumnIdMapping();
     for (const auto & column : part->getColumns())
     {
-        ColumnSize & total_column_size = column_sizes[column.name];
-        ColumnSize part_column_size = part->getColumnSize(column.name);
+        auto key = tryGetCurrentColumnName(column, mapping.get());
+        if (!key)
+            continue;
+        ColumnSize & total_column_size = column_sizes[*key];
+        ColumnSize part_column_size = part->getColumnSize(column.getColumnId());
         total_column_size.add(part_column_size);
     }
 
@@ -7776,6 +7793,8 @@ IStorage::ColumnSizeByName MergeTreeData::getColumnSizes(const Names & columns, 
         return result;
     }
 
+    auto metadata_snapshot = getInMemoryMetadataPtr(getContext(), false);
+
     /// Exact subcolumn sizes are derived per active part from the required substreams.
     /// Snapshot the parts under the lock and release it before the per-part size calculation,
     /// which reads part-local state and would otherwise block part commits and merges.
@@ -7790,9 +7809,9 @@ IStorage::ColumnSizeByName MergeTreeData::getColumnSizes(const Names & columns, 
     {
         for (const auto & col_name : subcolumn_names)
         {
-            auto column = part->tryGetColumn(col_name);
-            if (column && column->isSubcolumn())
-                result[col_name].add(part->getSubcolumnSize(col_name));
+            auto subcolumn = part->tryGetColumnBySnapshotName(col_name, metadata_snapshot);
+            if (subcolumn && subcolumn->isSubcolumn())
+                result[col_name].add(part->getSubcolumnSize(*subcolumn));
         }
     }
 
@@ -7806,10 +7825,15 @@ void MergeTreeData::removePartContributionToColumnAndSecondaryIndexSizes(const D
     if (!are_columns_and_secondary_indices_sizes_calculated)
         return;
 
+    auto mapping = getActiveColumnIdMapping();
     for (const auto & column : part->getColumns())
     {
-        ColumnSize & total_column_size = column_sizes[column.name];
-        ColumnSize part_column_size = part->getColumnSize(column.name);
+        /// Same key as the addition made, or the subtraction lands on another column's total.
+        auto key = tryGetCurrentColumnName(column, mapping.get());
+        if (!key)
+            continue;
+        ColumnSize & total_column_size = column_sizes[*key];
+        ColumnSize part_column_size = part->getColumnSize(column.getColumnId());
 
         auto log_subtract = [&](size_t & from, size_t value, const char * field)
         {

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -223,6 +223,7 @@ public:
     using PartitionIdToMinBlockPtr = std::shared_ptr<const PartitionIdToMinBlock>;
 
     constexpr static auto FORMAT_VERSION_FILE_NAME = "format_version.txt";
+    constexpr static auto COLUMN_IDS_FILE_NAME = "column_ids.json";
     constexpr static auto DETACHED_DIR_NAME = "detached";
     constexpr static auto MOVING_DIR_NAME = "moving";
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -699,6 +699,10 @@ public:
     /// Load the set of data parts from disk. Call once - immediately after the object is created.
     void loadDataParts(bool skip_sanity_checks, std::optional<std::unordered_set<std::string>> expected_parts);
 
+    /// The mapping only once it is active, i.e. parts are being written with IDs. An inactive mapping
+    /// (a leftover from a failed activation) must not make renames metadata-only.
+    ColumnIdMappingPtr getActiveColumnIdMapping() const;
+
     /// Check the set of data parts on disk and load if needed, assuming the data on disk can change under the hood.
     /// This method allows read-only replicas of tables on a shared storage.
     /// `refreshDataParts` is the background-task entry point: it reschedules itself afterwards.

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
@@ -130,13 +130,15 @@ MergeTreeDataPartWriterPtr createMergeTreeDataPartCompactWriter(
     const MergeTreeWriterSettings & writer_settings,
     MergeTreeIndexGranularityPtr computed_index_granularity)
 {
+    /// `column_positions` (the part's position map) is keyed by stable storage id; the columns_list
+    /// pairs carry the same id, so order by id.
     NamesAndTypesList ordered_columns_list;
     std::copy_if(columns_list.begin(), columns_list.end(), std::back_inserter(ordered_columns_list),
-        [&column_positions](const auto & column) { return column_positions.contains(column.name); });
+        [&column_positions](const auto & column) { return column_positions.contains(column.getColumnId().value()); });
 
     /// Order of writing is important in compact format
     ordered_columns_list.sort([&column_positions](const auto & lhs, const auto & rhs)
-        { return column_positions.at(lhs.name) < column_positions.at(rhs.name); });
+        { return column_positions.at(lhs.getColumnId().value()) < column_positions.at(rhs.getColumnId().value()); });
 
     return std::make_unique<MergeTreeDataPartWriterCompact>(
         data_part_name_, logger_name_, serializations_, data_part_storage_,
@@ -201,6 +203,11 @@ void MergeTreeDataPartCompact::loadIndexGranularityImpl(
     }
 }
 
+size_t MergeTreeDataPartCompact::getNumColumnsInMark() const
+{
+    return index_granularity_info.mark_type.with_substreams ? getColumnsSubstreams().getTotalSubstreams() : getColumns().size();
+}
+
 void MergeTreeDataPartCompact::loadIndexGranularity()
 {
     if (getColumns().empty())
@@ -209,7 +216,7 @@ void MergeTreeDataPartCompact::loadIndexGranularity()
     loadIndexGranularityImpl(
         index_granularity,
         index_granularity_info,
-        index_granularity_info.mark_type.with_substreams ? getColumnsSubstreams().getTotalSubstreams() : getColumns().size(),
+        getNumColumnsInMark(),
         getDataPartStorage(),
         *storage.getSettings());
 }
@@ -233,7 +240,7 @@ void MergeTreeDataPartCompact::loadMarksToCache(const Names & column_names, Mark
         /*save_marks_in_cache=*/ true,
         context->getReadSettings(),
         /*load_marks_threadpool_=*/ nullptr,
-        index_granularity_info.mark_type.with_substreams ? getColumnsSubstreams().getTotalSubstreams() : getColumns().size(),
+        getNumColumnsInMark(),
         context->getSettingsRef()[Setting::use_streaming_marks_compression]);
 
     loader.loadMarks();
@@ -249,9 +256,37 @@ void MergeTreeDataPartCompact::removeMarksFromCache(MarkCache * mark_cache) cons
     mark_cache->remove(key);
 }
 
+std::optional<ColumnMarksLocation> MergeTreeDataPartCompact::getColumnMarksLocation(
+    const NameAndTypePair & column, const ISerialization::SubstreamPath & substream_path) const
+{
+    checkColumnIdIsStamped(column);
+
+    auto column_position = getColumnPosition(column.getColumnId());
+    if (!column_position)
+        return std::nullopt;
+
+    if (!index_granularity_info.mark_type.with_substreams)
+    {
+        /// One mark per column, so only the stream carrying the column itself has marks here.
+        if (!substream_path.empty())
+            return std::nullopt;
+
+        return ColumnMarksLocation{
+            .marks_stream_name = DATA_FILE_NAME, .index_in_mark = *column_position, .columns_in_mark = getNumColumnsInMark()};
+    }
+
+    auto substream_position = getColumnsSubstreams().tryGetSubstreamPosition(
+        *column_position, column, substream_path, storage.getSettings());
+    if (!substream_position)
+        return std::nullopt;
+
+    return ColumnMarksLocation{
+        .marks_stream_name = DATA_FILE_NAME, .index_in_mark = *substream_position, .columns_in_mark = getNumColumnsInMark()};
+}
+
 bool MergeTreeDataPartCompact::hasColumnFiles(const NameAndTypePair & column) const
 {
-    if (!getColumnPosition(column.getNameInStorage()))
+    if (!getColumnPosition(column.getColumnId()))
         return false;
 
     auto bin_checksum = checksums.files.find(DATA_FILE_NAME_WITH_EXTENSION);
@@ -260,7 +295,7 @@ bool MergeTreeDataPartCompact::hasColumnFiles(const NameAndTypePair & column) co
     return (bin_checksum != checksums.files.end() && mrk_checksum != checksums.files.end());
 }
 
-std::optional<time_t> MergeTreeDataPartCompact::getColumnModificationTime(const String & /* column_name */) const
+std::optional<time_t> MergeTreeDataPartCompact::getColumnModificationTime(const ColumnId & /* column_id */) const
 {
     return getDataPartStorage().getFileLastModified(DATA_FILE_NAME_WITH_EXTENSION).epochTime();
 }

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.h
@@ -40,12 +40,15 @@ public:
 
     bool hasColumnFiles(const NameAndTypePair & column) const override;
 
-    std::optional<time_t> getColumnModificationTime(const String & column_name) const override;
+    std::optional<time_t> getColumnModificationTime(const ColumnId & column_id) const override;
 
     std::optional<String> getFileNameForColumn(const NameAndTypePair & /* column */) const override { return DATA_FILE_NAME; }
 
     void loadMarksToCache(const Names & column_names, MarkCache * mark_cache) const override;
     void removeMarksFromCache(MarkCache * mark_cache) const override;
+
+    std::optional<ColumnMarksLocation> getColumnMarksLocation(
+        const NameAndTypePair & column, const ISerialization::SubstreamPath & substream_path) const override;
 
     ~MergeTreeDataPartCompact() override;
 
@@ -60,6 +63,10 @@ protected:
     void doCheckConsistency(bool require_part_metadata) const override;
 
 private:
+     /// Entries every mark of this part's single marks file holds: one per substream when the part
+     /// was written with substream marks, one per column otherwise.
+     size_t getNumColumnsInMark() const;
+
      /// Loads marks index granularity into memory
      void loadIndexGranularity() override;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
@@ -203,7 +203,7 @@ ColumnSize MergeTreeDataPartWide::getColumnSizeImpl(
 
     if (column.type->hasDynamicSubcolumns() && !getColumnsSubstreams().empty())
     {
-        auto column_position = getColumnPosition(column.name);
+        auto column_position = getColumnPosition(column.getColumnId());
         if (!column_position)
             return size;
 
@@ -216,7 +216,7 @@ ColumnSize MergeTreeDataPartWide::getColumnSizeImpl(
     }
     else
     {
-        getSerialization(column.name)->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
+        getSerialization(column.getStorageKey())->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
         {
             auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(column, substream_path, DATA_FILE_EXTENSION, checksums, storage.getSettings());
 
@@ -234,13 +234,15 @@ ColumnSize MergeTreeDataPartWide::getColumnSizeImpl(
 }
 
 
-ColumnSize MergeTreeDataPartWide::calculateSubcolumnSize(const String & subcolumn_name) const
+ColumnSize MergeTreeDataPartWide::calculateSubcolumnSize(const NameAndTypePair & subcolumn) const
 {
     ColumnSize size;
     if (checksums.empty())
         return size;
 
-    for (const auto & stream : getListOfStreamsForColumn(getColumn(subcolumn_name)))
+    /// The caller resolved `subcolumn` against its own schema snapshot, so its id (inherited from the
+    /// parent -- a subcolumn has none of its own) is the stable key the on-disk streams use.
+    for (const auto & stream : getListOfStreamsForColumn(subcolumn))
         addStreamToColumnSize(stream, size);
 
     return size;
@@ -338,28 +340,32 @@ void MergeTreeDataPartWide::loadMarksToCache(const Names & column_names, MarkCac
 
     LOG_TEST(getLogger("MergeTreeDataPartWide"), "Loading marks into mark cache for columns {} of part {}", toString(column_names), name);
 
-    for (const auto & column_name : column_names)
+    NameSet requested(column_names.begin(), column_names.end());
+    for (const auto & column : getColumns())
     {
-        auto serialization = tryGetSerialization(column_name);
+        if (!requested.contains(column.name))
+            continue;
+
+        auto serialization = tryGetSerialization(column.getStorageKey());
         if (!serialization)
             continue;
 
         serialization->enumerateStreams([&](const auto & subpath)
         {
-            auto stream_name = getStreamNameForColumn(column_name, subpath, DATA_FILE_EXTENSION, checksums, storage.getSettings());
-            if (!stream_name)
+            auto marks_location = getColumnMarksLocation(column, subpath);
+            if (!marks_location)
                 return;
 
             loaders.emplace_back(std::make_unique<MergeTreeMarksLoader>(
                 info_for_read,
                 mark_cache,
-                index_granularity_info.getMarksFilePath(*stream_name),
+                index_granularity_info.getMarksFilePath(marks_location->marks_stream_name),
                 index_granularity->getMarksCount(),
                 index_granularity_info,
                 /*save_marks_in_cache=*/ true,
                 read_settings,
                 /*load_marks_threadpool=*/ nullptr,
-                /*num_columns_in_mark=*/ 1,
+                marks_location->columns_in_mark,
                 context->getSettingsRef()[Setting::use_streaming_marks_compression]));
 
             loaders.back()->startAsyncLoad();
@@ -375,19 +381,36 @@ void MergeTreeDataPartWide::removeMarksFromCache(MarkCache * mark_cache) const
     if (!mark_cache)
         return;
 
-    getSerializations().forEach([&](const String & column_name, const SerializationPtr & serialization)
+    /// Same resolution as loadMarksToCache, so the cache keys we evict match those insertion produced.
+    for (const auto & column : getColumns())
     {
+        auto serialization = tryGetSerialization(column.getStorageKey());
+        if (!serialization)
+            continue;
+
         serialization->enumerateStreams([&](const auto & subpath)
         {
-            auto stream_name = getStreamNameForColumn(column_name, subpath, DATA_FILE_EXTENSION, checksums, storage.getSettings());
-            if (!stream_name)
+            auto marks_location = getColumnMarksLocation(column, subpath);
+            if (!marks_location)
                 return;
 
-            auto mark_path = index_granularity_info.getMarksFilePath(*stream_name);
+            auto mark_path = index_granularity_info.getMarksFilePath(marks_location->marks_stream_name);
             auto key = MarkCache::hash(getDataPartStorage().getDiskName() + ":" + (fs::path(getRelativePathOfActivePart()) / mark_path).string());
             mark_cache->remove(key);
         });
-    });
+    }
+}
+
+std::optional<ColumnMarksLocation> MergeTreeDataPartWide::getColumnMarksLocation(
+    const NameAndTypePair & column, const ISerialization::SubstreamPath & substream_path) const
+{
+    checkColumnIdIsStamped(column);
+
+    auto stream_name = getStreamNameForColumn(column, substream_path, DATA_FILE_EXTENSION, checksums, storage.getSettings());
+    if (!stream_name)
+        return std::nullopt;
+
+    return ColumnMarksLocation{.marks_stream_name = std::move(*stream_name), .index_in_mark = 0, .columns_in_mark = 1};
 }
 
 bool MergeTreeDataPartWide::isStoredOnRemoteDisk() const
@@ -469,7 +492,7 @@ void MergeTreeDataPartWide::doCheckConsistency(bool require_part_metadata) const
                 settings.enumerate_dynamic_streams = false;
                 for (const auto & name_type : getColumns())
                 {
-                    auto serialization = getSerialization(name_type.name);
+                    auto serialization = getSerialization(name_type.getStorageKey());
                     auto data = ISerialization::SubstreamData(serialization)
                         .withType(name_type.type)
                         .withColumn(getColumnSample(name_type));
@@ -483,7 +506,7 @@ void MergeTreeDataPartWide::doCheckConsistency(bool require_part_metadata) const
                             throw Exception(
                                 ErrorCodes::NO_FILE_IN_DATA_PART,
                                 "No stream ({}{}) file checksum for column {} in part {}",
-                                ISerialization::getFileNameForStream(name_type, substream_path, ISerialization::StreamFileNameSettings(*storage.getSettings())),
+                                ISerialization::getFileNameForStreamByColumnId(name_type, substream_path, ISerialization::StreamFileNameSettings(*storage.getSettings())),
                                 DATA_FILE_EXTENSION,
                                 name_type.name,
                                 getDataPartStorage().getFullPath());
@@ -541,7 +564,7 @@ void MergeTreeDataPartWide::doCheckConsistency(bool require_part_metadata) const
             std::optional<UInt64> marks_size;
             for (const auto & name_type : getColumns())
             {
-                auto serialization = getSerialization(name_type.name);
+                auto serialization = getSerialization(name_type.getStorageKey());
                 auto data = ISerialization::SubstreamData(serialization)
                     .withType(name_type.type)
                     .withColumn(getColumnSample(name_type));
@@ -577,7 +600,7 @@ void MergeTreeDataPartWide::doCheckConsistency(bool require_part_metadata) const
 
 bool MergeTreeDataPartWide::hasColumnFiles(const NameAndTypePair & column) const
 {
-    auto serialization = tryGetSerialization(column.name);
+    auto serialization = tryGetSerialization(column.getStorageKey());
     if (!serialization)
         return false;
     auto marks_file_extension = index_granularity_info.mark_type.getFileExtension();
@@ -597,11 +620,15 @@ bool MergeTreeDataPartWide::hasColumnFiles(const NameAndTypePair & column) const
     return res;
 }
 
-std::optional<time_t> MergeTreeDataPartWide::getColumnModificationTime(const String & column_name) const
+std::optional<time_t> MergeTreeDataPartWide::getColumnModificationTime(const ColumnId & column_id) const
 {
     try
     {
-        auto stream_name = getStreamNameOrHash(column_name, DATA_FILE_EXTENSION, checksums);
+        /// Streams are named by the stamped column id; resolve the part's own pair for this id.
+        auto column = tryGetColumn(column_id);
+        if (!column)
+            return {};
+        auto stream_name = getStreamNameForColumn(*column, {}, DATA_FILE_EXTENSION, checksums, storage.getSettings());
         if (!stream_name)
             return {};
 
@@ -621,7 +648,7 @@ std::optional<String> MergeTreeDataPartWide::getFileNameForColumn(const NameAndT
     if (getSerializations().empty())
         return getStreamNameForColumn(column, {}, DATA_FILE_EXTENSION, getDataPartStorage(), storage.getSettings());
 
-    getSerialization(column.name)->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
+    getSerialization(column.getStorageKey())->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
     {
         if (!filename.has_value())
         {
@@ -642,7 +669,7 @@ void MergeTreeDataPartWide::calculateEachColumnSizes(ColumnSizeByName & each_col
     for (const auto & column : getColumns())
     {
         ColumnSize size = getColumnSizeImpl(column, &processed_substreams);
-        each_columns_size[column.name] = size;
+        each_columns_size[column.getColumnId().value()] = size;
         total_size.add(size);
 
 #ifndef NDEBUG
@@ -654,7 +681,7 @@ void MergeTreeDataPartWide::calculateEachColumnSizes(ColumnSizeByName & each_col
             && size.data_uncompressed != 0
             && column.type->isValueRepresentedByNumber()
             && !column.type->haveSubtypes()
-            && getSerialization(column.name)->getKindStack() == ISerialization::KindStack{ISerialization::Kind::DEFAULT})
+            && getSerialization(column.getStorageKey())->getKindStack() == ISerialization::KindStack{ISerialization::Kind::DEFAULT})
         {
             size_t rows_in_column = size.data_uncompressed / column.type->getSizeOfValueInMemory();
             if (rows_in_column != rows_count)

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.h
@@ -39,10 +39,13 @@ public:
 
     bool hasColumnFiles(const NameAndTypePair & column) const override;
 
-    std::optional<time_t> getColumnModificationTime(const String & column_name) const override;
+    std::optional<time_t> getColumnModificationTime(const ColumnId & column_id) const override;
 
     void loadMarksToCache(const Names & column_names, MarkCache * mark_cache) const override;
     void removeMarksFromCache(MarkCache * mark_cache) const override;
+
+    std::optional<ColumnMarksLocation> getColumnMarksLocation(
+        const NameAndTypePair & column, const ISerialization::SubstreamPath & substream_path) const override;
 
     static void loadIndexGranularityImpl(
         MergeTreeIndexGranularityPtr & index_granularity_ptr,
@@ -62,7 +65,7 @@ private:
 
     void calculateEachColumnSizes(ColumnSizeByName & each_columns_size, ColumnSize & total_size) const override;
 
-    ColumnSize calculateSubcolumnSize(const String & subcolumn_name) const override;
+    ColumnSize calculateSubcolumnSize(const NameAndTypePair & subcolumn) const override;
 
     void addStreamToColumnSize(const String & stream_name, ColumnSize & size) const;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -82,7 +82,7 @@ void MergeTreeDataPartWriterCompact::addStreams(const NameAndTypePair & name_and
     ISerialization::StreamCallback callback = [&](const auto & substream_path)
     {
         chassert(!substream_path.empty());
-        String stream_name = ISerialization::getFileNameForStream(name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
+        String stream_name = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
 
         /// Shared offsets for Nested type.
         if (compressed_streams.contains(stream_name))
@@ -140,7 +140,7 @@ void MergeTreeDataPartWriterCompact::addStreams(const NameAndTypePair & name_and
     enumerate_settings.map_buckets_coefficient = settings.map_buckets_coefficient;
     enumerate_settings.map_buckets_min_avg_size = settings.map_buckets_min_avg_size;
     enumerate_settings.data_part_type = MergeTreeDataPartType::Compact;
-    auto serialization = getSerialization(name_and_type.name);
+    auto serialization = getSerialization(name_and_type);
     auto substream_data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
     serialization->enumerateStreams(enumerate_settings, callback, substream_data);
 }
@@ -333,7 +333,7 @@ void MergeTreeDataPartWriterCompact::writeDataBlock(const Block & block, const G
             bool is_first_substream = true;
             auto stream_getter = [&, this](const ISerialization::SubstreamPath & substream_path) -> WriteBuffer *
             {
-                String stream_name = ISerialization::getFileNameForStream(*name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
+                String stream_name = ISerialization::getFileNameForStreamByColumnId(*name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
 
                 auto stream_it = compressed_streams.find(stream_name);
                 if (stream_it == compressed_streams.end())
@@ -384,13 +384,13 @@ void MergeTreeDataPartWriterCompact::writeDataBlock(const Block & block, const G
 
             auto stream_mark_getter = [&](const ISerialization::SubstreamPath & substream_path) -> MarkInCompressedFile
             {
-                String stream_name = ISerialization::getFileNameForStream(*name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
+                String stream_name = ISerialization::getFileNameForStreamByColumnId(*name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
                 return {plain_hashing.count(), compressed_streams[stream_name]->hashing_buf.offset()};
             };
 
             writeColumnSingleGranule(
                 block.getByName(name_and_type->name), block_sample.getByName(name_and_type->name),
-                getSerialization(name_and_type->name),
+                getSerialization(*name_and_type),
                 stream_getter, stream_mark_getter, granule.start_row, granule.rows_to_write, !data_written, getSerializationSettings());
 
             if (settings.compress_per_column_in_compact_parts)

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -721,13 +721,13 @@ void MergeTreeDataPartWriterOnDisk::initColumnsSubstreamsIfNeeded()
         columns_substreams.addColumn(name_and_type.name);
         serialize_settings.getter = [&](const ISerialization::SubstreamPath & substream_path)
         {
-            columns_substreams.addSubstreamToLastColumn(ISerialization::getFileNameForStream(name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings)));
+            columns_substreams.addSubstreamToLastColumn(ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings)));
             return &buf;
         };
         serialize_settings.stream_mark_getter = [&](const ISerialization::SubstreamPath &){ return MarkInCompressedFile(); };
 
         ISerialization::SerializeBinaryBulkStatePtr state;
-        auto serialization = getSerialization(name_and_type.name);
+        auto serialization = getSerialization(name_and_type);
         const auto & column = block_sample.getByName(name_and_type.name);
         serialization->serializeBinaryBulkStatePrefix(*column.column, serialize_settings, state);
         serialization->serializeBinaryBulkWithMultipleStreams(*column.column, column.column->size(), 0, serialize_settings, state);

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -150,7 +150,7 @@ void MergeTreeDataPartWriterWide::addStreams(
         if (ISerialization::isEphemeralSubcolumn(substream_path, substream_path.size()))
             return;
 
-        auto full_stream_name = ISerialization::getFileNameForStream(name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
+        auto full_stream_name = ISerialization::getFileNameForStreamByColumnId(name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
 
         String stream_name = replaceFileNameToHashIfNeeded(full_stream_name, *storage_settings, data_part_storage.get());
 
@@ -237,7 +237,7 @@ void MergeTreeDataPartWriterWide::addStreams(
         stream_name_to_full_name.emplace(stream_name, full_stream_name);
     };
 
-    auto serialization = getSerialization(name_and_type.name);
+    auto serialization = getSerialization(name_and_type);
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
     auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
@@ -247,7 +247,7 @@ const String & MergeTreeDataPartWriterWide::getStreamName(
     const NameAndTypePair & column,
     const ISerialization::SubstreamPath & substream_path) const
 {
-    auto full_stream_name = ISerialization::getFileNameForStream(column, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
+    auto full_stream_name = ISerialization::getFileNameForStreamByColumnId(column, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
     String stream_name = replaceFileNameToHashIfNeeded(full_stream_name, *storage_settings, data_part_storage.get());
 
     if (written_offset_substreams)
@@ -377,7 +377,7 @@ void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermut
     {
         auto & column = block_to_write.getByName(it->name);
 
-        if (!ISerialization::hasKind(getSerialization(it->name)->getKindStack(), ISerialization::Kind::SPARSE))
+        if (!ISerialization::hasKind(getSerialization(*it)->getKindStack(), ISerialization::Kind::SPARSE))
             column.column = recursiveRemoveSparse(column.column);
 
         if (permutation)
@@ -481,7 +481,7 @@ StreamsWithMarks MergeTreeDataPartWriterWide::getCurrentMarksForColumn(const Nam
         result.push_back(stream_with_mark);
     };
 
-    auto serialization = getSerialization(name_and_type.name);
+    auto serialization = getSerialization(name_and_type);
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
     auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);
@@ -496,7 +496,7 @@ void MergeTreeDataPartWriterWide::writeSingleGranule(
     ISerialization::SerializeBinaryBulkSettings & serialize_settings,
     const Granule & granule)
 {
-    const auto & serialization = getSerialization(name_and_type.name);
+    const auto & serialization = getSerialization(name_and_type);
 
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
     auto enumerate_settings = getEnumerateSettings(settings);
@@ -557,7 +557,7 @@ void MergeTreeDataPartWriterWide::writeColumn(
 
     const auto & [name, type] = name_and_type;
     auto [it, inserted] = serialization_states.emplace(name, nullptr);
-    auto serialization = getSerialization(name_and_type.name);
+    auto serialization = getSerialization(name_and_type);
 
     if (inserted)
     {
@@ -658,7 +658,7 @@ void MergeTreeDataPartWriterWide::writeColumn(
 void MergeTreeDataPartWriterWide::validateColumnOfFixedSize(const NameAndTypePair & name_type)
 {
     const auto & [name, type] = name_type;
-    const auto & serialization = getSerialization(name_type.name);
+    const auto & serialization = getSerialization(name_type);
 
     if (!type->isValueRepresentedByNumber() || type->haveSubtypes() || serialization->getKindStack() != ISerialization::KindStack{ISerialization::Kind::DEFAULT})
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot validate column of non fixed type {}", type->getName());
@@ -828,7 +828,7 @@ void MergeTreeDataPartWriterWide::finalizeIndexGranularity()
             if (!serialization_states.empty())
             {
                 serialize_settings.getter = createStreamGetter(*it, offset_substreams);
-                getSerialization(it->name)->serializeBinaryBulkStateSuffix(serialize_settings, serialization_states[it->name]);
+                getSerialization(*it)->serializeBinaryBulkStateSuffix(serialize_settings, serialization_states[it->name]);
             }
 
             if (write_final_mark)
@@ -879,7 +879,7 @@ void MergeTreeDataPartWriterWide::finishDataSerialization(bool sync)
     {
         if (column.type->isValueRepresentedByNumber()
             && !column.type->haveSubtypes()
-            && getSerialization(column.name)->getKindStack() == ISerialization::KindStack{ISerialization::Kind::DEFAULT})
+            && getSerialization(column)->getKindStack() == ISerialization::KindStack{ISerialization::Kind::DEFAULT})
         {
             validateColumnOfFixedSize(column);
         }
@@ -936,7 +936,7 @@ void MergeTreeDataPartWriterWide::writeFinalMark(const NameAndTypePair & name_an
         if (is_offsets)
             offset_substreams.insert(getStreamName(name_and_type, substream_path));
     };
-    auto serialization = getSerialization(name_and_type.name);
+    auto serialization = getSerialization(name_and_type);
     auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withColumn(block_sample.getByName(name_and_type.name).column);
     auto enumerate_settings = getEnumerateSettings(settings);
     serialization->enumerateStreams(enumerate_settings, callback, data);

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -18,6 +18,7 @@
 #include <Interpreters/PreparedSets.h>
 #include <Interpreters/InsertDeduplication.h>
 #include <Storages/MergeTree/DataPartStorageOnDiskFull.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeDataWriter.h>
 #include <Storages/MergeTree/MergeTreeIndexGranularity.h>
@@ -722,6 +723,11 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
     const auto & global_settings = context->getSettingsRef();
 
     auto columns = metadata_snapshot->getColumns().getAllPhysical().filter(block.getNames());
+    /// The mapping rides the pinned metadata_snapshot (folded there with the schema), so the
+    /// stamp is taken from the same schema version the part's columns come from.
+    const auto column_id_mapping = metadata_snapshot->getActiveColumnIdMapping();
+    if (column_id_mapping)
+        column_id_mapping->stampColumnIds(columns);
 
     /// Do not write _block_number and _block_offset for 0-level parts: block number is not known on this step.
     const auto minmax_columns = MergeTreeData::getMinMaxColumns(metadata_snapshot->getPartitionKey(), data_settings, MergeTreePartMinMaxIndexColumns::PARTITION_KEY_ONLY);
@@ -941,6 +947,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
             column.column = recursiveRemoveSparse(column.column);
     }
 
+    /// The stats above were accumulated under column names; `setColumns` wants the part's key space.
+    infos.reKeyToColumnIds(columns);
     new_data_part->setColumns(columns, infos, metadata_snapshot->getMetadataVersion());
     new_data_part->setSourcePartsSet(std::move(source_parts_set));
     new_data_part->rows_count = block.rows();
@@ -973,7 +981,10 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         updateTTL(context, ttl_entry, new_data_part->ttl_infos, new_data_part->ttl_infos.rows_where_ttl[ttl_entry.result_column], block, true);
 
     for (const auto & [name, ttl_entry] : metadata_snapshot->getColumnTTLs())
-        updateTTL(context, ttl_entry, new_data_part->ttl_infos, new_data_part->ttl_infos.columns_ttl[name], block, true);
+    {
+        const String ttl_key = columns.getColumnIdByName(name).value();
+        updateTTL(context, ttl_entry, new_data_part->ttl_infos, new_data_part->ttl_infos.columns_ttl[ttl_key], block, true);
+    }
 
     const auto & recompression_ttl_entries = metadata_snapshot->getRecompressionTTLs();
     for (const auto & ttl_entry : recompression_ttl_entries)
@@ -1047,7 +1058,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
             if (projection_block.rows())
             {
                 auto proj_temp_part
-                    = writeProjectionPart(data, projection_block, projection, new_data_part.get(), /*merge_is_needed=*/false, context);
+                    = writeProjectionPart(data, projection_block, projection, new_data_part.get(), /*merge_is_needed=*/false, context, column_id_mapping);
                 new_data_part->addProjectionPart(projection.name, std::move(proj_temp_part->part));
 
                 if (global_settings[Setting::finalize_projection_parts_synchronously])
@@ -1095,7 +1106,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
     const ProjectionDescription & projection,
     MergeTreeIndices indices,
     bool merge_is_needed,
-    bool try_adaptive_codec)
+    bool try_adaptive_codec,
+    ColumnIdMappingPtr column_id_mapping)
 {
     auto temp_part = std::make_unique<MergeTreeTemporaryPart>();
     const auto & metadata_snapshot = projection.metadata;
@@ -1117,6 +1129,11 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
     new_data_part->is_temp = is_temp;
 
     NamesAndTypesList columns = metadata_snapshot->getColumns().getAllPhysical().filter(block.getNames());
+    /// Projection columns are the projection's SELECT output (group-by keys plus synthetic
+    /// aggregates like `sum(c)`); the aggregates are never in the base table's column-ID mapping.
+    /// Use the lenient stamp rather than the strict base-table write stamp.
+    if (column_id_mapping)
+        column_id_mapping->stampColumnIdsLenient(columns);
     SerializationInfo::Settings settings
     {
         static_cast<double>((*data_settings)[MergeTreeSetting::ratio_of_defaults_for_sparse_serialization]),
@@ -1131,6 +1148,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
     SerializationInfoByName infos(columns, settings);
     infos.add(block);
 
+    /// The stats above were accumulated under column names; `setColumns` wants the part's key space.
+    infos.reKeyToColumnIds(columns);
     new_data_part->setColumns(columns, infos, metadata_snapshot->getMetadataVersion());
 
     projection_part_storage->createDirectories();
@@ -1236,7 +1255,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPart(
     const ProjectionDescription & projection,
     IMergeTreeDataPart * parent_part,
     bool merge_is_needed,
-    ContextPtr context)
+    ContextPtr context,
+    ColumnIdMappingPtr column_id_mapping)
 {
     const auto & query_settings = context->getSettingsRef();
     auto indices = collectSkipIndicesToMaterialize(
@@ -1255,7 +1275,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPart(
         projection,
         std::move(indices),
         merge_is_needed,
-        /*try_adaptive_codec=*/ false);
+        /*try_adaptive_codec=*/ false,
+        std::move(column_id_mapping));
 }
 
 /// This is used for projection materialization process which may contain multiple stages of
@@ -1266,7 +1287,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempProjectionPart(
     const ProjectionDescription & projection,
     IMergeTreeDataPart * parent_part,
     size_t block_num,
-    ContextPtr context)
+    ContextPtr context,
+    ColumnIdMappingPtr column_id_mapping)
 {
     const auto & table_settings = data.getSettings();
     auto indices = collectSkipIndicesToMaterialize(
@@ -1286,7 +1308,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempProjectionPart(
         projection,
         std::move(indices),
         /*merge_is_needed=*/ true,
-        /*try_adaptive_codec=*/ true);
+        /*try_adaptive_codec=*/ true,
+        std::move(column_id_mapping));
 
     new_part->part->temp_projection_block_number = block_num;
     return new_part;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.h
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.h
@@ -115,7 +115,8 @@ public:
         const ProjectionDescription & projection,
         IMergeTreeDataPart * parent_part,
         bool merge_is_needed,
-        ContextPtr context);
+        ContextPtr context,
+        ColumnIdMappingPtr column_id_mapping);
 
     /// For mutation: MATERIALIZE PROJECTION.
     static MergeTreeTemporaryPartPtr writeTempProjectionPart(
@@ -124,7 +125,8 @@ public:
         const ProjectionDescription & projection,
         IMergeTreeDataPart * parent_part,
         size_t block_num,
-        ContextPtr context);
+        ContextPtr context,
+        ColumnIdMappingPtr column_id_mapping);
 
     static Block mergeBlock(
         Block && block,
@@ -152,7 +154,8 @@ private:
         const ProjectionDescription & projection,
         MergeTreeIndices indices,
         bool merge_is_needed,
-        bool try_adaptive_codec);
+        bool try_adaptive_codec,
+        ColumnIdMappingPtr column_id_mapping);
 
     MergeTreeData & data;
     LoggerPtr log;

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -440,17 +440,16 @@ void MergeTreePrefetchedReadPool::fillPerPartStatistics()
 
         part_stat.approx_size_of_mark = read_info.approx_size_of_mark;
 
-        auto update_stat_for_column = [&](const auto & column_name)
+        /// The task columns are resolved against the current schema, so ask the part by id, the same
+        /// way `MergeTreeReadPoolBase::getSizeOfColumns` does. A column the part does not hold reports
+        /// zero, which is what the missing-column branch this replaced contributed.
+        auto update_stat_for_column = [&](const NameAndTypePair & column)
         {
             size_t column_size = 0;
-            auto column = read_info.data_part_info->tryGetColumn(column_name);
-            if (column)
-            {
-                if (column->isSubcolumn() && settings[Setting::allow_calculating_subcolumns_sizes_for_merge_tree_reading])
-                    column_size = read_info.data_part_info->getSubcolumnSize(column_name).data_compressed;
-                else
-                    column_size = read_info.data_part_info->getColumnSize(column->getNameInStorage()).data_compressed;
-            }
+            if (column.isSubcolumn() && settings[Setting::allow_calculating_subcolumns_sizes_for_merge_tree_reading])
+                column_size = read_info.data_part_info->getSubcolumnSize(column).data_compressed;
+            else
+                column_size = read_info.data_part_info->getColumnSize(column.getColumnId()).data_compressed;
 
             part_stat.estimated_memory_usage_for_single_prefetch += std::min<size_t>(column_size, settings[Setting::prefetch_buffer_size]);
             ++part_stat.required_readers_num;
@@ -462,11 +461,11 @@ void MergeTreePrefetchedReadPool::fillPerPartStatistics()
         /// But here we make a more approximate lowering (because we do not have loaded marks yet),
         /// while in adjustBufferSize it will be presize.
         for (const auto & column : read_info.task_columns.columns)
-            update_stat_for_column(column.name);
+            update_stat_for_column(column);
 
         for (const auto & pre_columns : read_info.task_columns.pre_columns)
             for (const auto & column : pre_columns)
-                update_stat_for_column(column.name);
+                update_stat_for_column(column);
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -100,7 +100,8 @@ MergeTreeReadPoolBase::MergeTreeReadPoolBase(
 {
 }
 
-static size_t getSizeOfColumns(const IMergeTreeDataPart & part, const Names & columns_to_read, const Settings & settings)
+static size_t getSizeOfColumns(
+    const IMergeTreeDataPart & part, const Names & columns_to_read, const ColumnsDescription & snapshot_columns, const Settings & settings)
 {
     /// For compact parts we don't know individual column sizes, let's use whole part size as approximation
     if (part.getType() == MergeTreeDataPartType::Compact)
@@ -109,13 +110,13 @@ static size_t getSizeOfColumns(const IMergeTreeDataPart & part, const Names & co
     size_t data_compressed_size = 0;
     for (const auto & col_name : columns_to_read)
     {
-        auto column = part.tryGetColumn(col_name);
-        if (column)
+        auto column = snapshot_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, col_name);
+        if (auto column_in_part = column ? part.tryGetColumnByRequest(*column) : std::nullopt)
         {
-            if (column->isSubcolumn() && settings[Setting::allow_calculating_subcolumns_sizes_for_merge_tree_reading])
-                data_compressed_size += part.getSubcolumnSize(col_name).data_compressed;
+            if (column_in_part->isSubcolumn() && settings[Setting::allow_calculating_subcolumns_sizes_for_merge_tree_reading])
+                data_compressed_size += part.getSubcolumnSize(*column_in_part).data_compressed;
             else
-                data_compressed_size += part.getColumnSize(column->getNameInStorage()).data_compressed;
+                data_compressed_size += part.getColumnSize(column_in_part->getColumnId()).data_compressed;
         }
     }
 
@@ -135,12 +136,12 @@ static size_t getSizeOfColumns(const IMergeTreeDataPart & part, const Names & co
 
 /// Columns from different prewhere steps are read independently, so it makes sense to use the heaviest set of columns among them as an estimation.
 static Names
-getHeaviestSetOfColumnsAmongPrewhereSteps(const IMergeTreeDataPart & part, const NamesAndTypesLists & prewhere_steps_columns, const Settings & settings)
+getHeaviestSetOfColumnsAmongPrewhereSteps(const IMergeTreeDataPart & part, const NamesAndTypesLists & prewhere_steps_columns, const ColumnsDescription & snapshot_columns, const Settings & settings)
 {
     const auto it = std::ranges::max_element(
         prewhere_steps_columns,
         [&](const auto & lhs, const auto & rhs)
-        { return getSizeOfColumns(part, lhs.getNames(), settings) < getSizeOfColumns(part, rhs.getNames(), settings); });
+        { return getSizeOfColumns(part, lhs.getNames(), snapshot_columns, settings) < getSizeOfColumns(part, rhs.getNames(), snapshot_columns, settings); });
     return it->getNames();
 }
 
@@ -149,6 +150,7 @@ calculateMinMarksPerTask(
     const RangesInDataPart & part,
     const Names & columns_to_read,
     const NamesAndTypesLists & prewhere_steps_columns,
+    const ColumnsDescription & snapshot_columns,
     const MergeTreeReadPoolBase::PoolSettings & pool_settings,
     const Settings & settings)
 {
@@ -166,9 +168,9 @@ calculateMinMarksPerTask(
             /// Which means in turn that for most of the rows we will read only the columns from prewhere clause.
             /// So it makes sense to use only them for the estimation.
             const auto & columns = settings[Setting::merge_tree_determine_task_size_by_prewhere_columns] && !prewhere_steps_columns.empty()
-                ? getHeaviestSetOfColumnsAmongPrewhereSteps(*part.data_part, prewhere_steps_columns, settings)
+                ? getHeaviestSetOfColumnsAmongPrewhereSteps(*part.data_part, prewhere_steps_columns, snapshot_columns, settings)
                 : columns_to_read;
-            const size_t part_compressed_bytes = getSizeOfColumns(*part.data_part, columns, settings);
+            const size_t part_compressed_bytes = getSizeOfColumns(*part.data_part, columns, snapshot_columns, settings);
 
             avg_mark_bytes = std::max<size_t>(part_compressed_bytes / part_marks_count, 1);
             const auto & min_bytes_per_task = settings[Setting::merge_tree_min_bytes_per_task_for_remote_reading];
@@ -190,7 +192,7 @@ calculateMinMarksPerTask(
         }
         else
         {
-            avg_mark_bytes = std::max<size_t>(getSizeOfColumns(*part.data_part, columns_to_read, settings) / part_marks_count, 1);
+            avg_mark_bytes = std::max<size_t>(getSizeOfColumns(*part.data_part, columns_to_read, snapshot_columns, settings) / part_marks_count, 1);
         }
     }
 
@@ -293,23 +295,27 @@ MergeTreeReadPoolBase::buildReadTaskInfo(const RangesInDataPart & part_with_rang
         }
 
         Block sample_block_from_part;
+        const auto & snapshot_columns = storage_snapshot->metadata->getColumns();
         for (const auto & column_name : all_column_names)
         {
-            if (auto column_in_part = data_part->tryGetColumn(column_name))
-                sample_block_from_part.insert(ColumnWithTypeAndName(column_in_part->type->createColumn(), column_in_part->type, column_in_part->name));
+            /// Resolved through the snapshot, so the part is asked by the current schema's id.
+            auto snapshot_column = snapshot_columns.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column_name);
+            if (snapshot_column && data_part->getColumnPosition(snapshot_column->getColumnId()))
+                sample_block_from_part.insert(ColumnWithTypeAndName(snapshot_column->type->createColumn(), snapshot_column->type, snapshot_column->name));
         }
 
         read_task_info.shared_size_predictor = std::make_unique<MergeTreeBlockSizePredictor>(
             data_part,
             Names(all_column_names.begin(), all_column_names.end()),
             sample_block_from_part,
+            storage_snapshot->metadata,
             settings[Setting::allow_calculating_subcolumns_sizes_for_merge_tree_reading]);
     }
 
     read_task_info.deserialization_prefixes_cache = std::make_shared<DeserializationPrefixesCache>();
 
     std::tie(read_task_info.min_marks_per_task, read_task_info.approx_size_of_mark)
-        = calculateMinMarksPerTask(part_with_ranges, column_names, read_task_info.task_columns.pre_columns, pool_settings, settings);
+        = calculateMinMarksPerTask(part_with_ranges, column_names, read_task_info.task_columns.pre_columns, storage_snapshot->metadata->getColumns(), pool_settings, settings);
     return read_task_info;
 }
 

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -78,7 +78,9 @@ void MergeTreeReaderCompact::fillColumnPositions()
     for (size_t i = 0; i < columns_num; ++i)
     {
         auto & column_to_read = columns_to_read[i];
-        auto position = data_part_info_for_read->getColumnPosition(column_to_read.getNameInStorage());
+        /// A miss (id absent from this part -- DROP + re-ADD reused the name under a fresh id, or a
+        /// new column) leaves the slot empty and defaults are filled downstream.
+        auto position = data_part_info_for_read->getColumnPosition(column_to_read.getColumnId());
 
         /// Column was dropped by a pending mutation or invalidated. Don't read stale data;
         if (position.has_value() && (isColumnDroppedByPendingMutation(i) || isSystemColumnInvalidated(i)))
@@ -161,6 +163,10 @@ void MergeTreeReaderCompact::findPositionForMissedNested(size_t pos)
     NameAndTypePair column_in_storage{column.getNameInStorage(), column.getTypeInStorage()};
 
     auto column_to_read_with_subcolumns = getColumnConvertedToSubcolumnOfNested(column_in_storage);
+
+    /// Both rebuilds above drop the column id, while `findColumnForOffsets` matches in id space.
+    column_to_read_with_subcolumns.setColumnId(column.getColumnId());
+
     auto column_for_offsets = findColumnForOffsets(column_to_read_with_subcolumns);
 
     if (!column_for_offsets)
@@ -170,6 +176,8 @@ void MergeTreeReaderCompact::findPositionForMissedNested(size_t pos)
     {
         /// Read offsets from antoher array from the same Nested column.
         column = {column_for_offsets->column.name, column.getSubcolumnName(), column.getTypeInStorage(), column.type};
+        /// The stream to read is the donor's, and this rebuild drops the id that names it.
+        column.setColumnId(column_for_offsets->column.getColumnId());
     }
     else
     {
@@ -177,7 +185,7 @@ void MergeTreeReaderCompact::findPositionForMissedNested(size_t pos)
         partially_read_columns.insert(column.name);
     }
 
-    column_positions[pos] = data_part_info_for_read->getColumnPosition(column_for_offsets->column.name);
+    column_positions[pos] = data_part_info_for_read->getColumnPosition(column_for_offsets->column.getColumnId());
     serializations_of_full_columns[column.getNameInStorage()] = column_for_offsets->serialization;
 }
 
@@ -377,7 +385,10 @@ void MergeTreeReaderCompact::initSubcolumnsDeserializationOrder()
     enumerate_settings.use_specialized_prefixes_and_suffixes_substreams = true;
     for (const auto & [column, subcolumns_indexes] : column_to_subcolumns_indexes)
     {
-        auto pos = data_part_info_for_read->getColumnPosition(column);
+        /// `column` is a name-in-storage grouping key (used below to query the name-indexed
+        /// part_columns); resolve the part slot by the id carried on the grouped read columns.
+        const auto & first_column = columns_to_read[subcolumns_indexes.front()];
+        auto pos = data_part_info_for_read->getColumnPosition(first_column.getColumnId());
         auto & deserialization_order = subcolumns_deserialization_order[column];
         /// If there is no such column in the part, the subcolumns order doesn't matter.
         if (!pos)
@@ -413,12 +424,10 @@ void MergeTreeReaderCompact::initSubcolumnsDeserializationOrder()
         /// that do not exist in this part (e.g. MapBucketIndexes in old bucketed Map parts).
         enumerate_settings.check_stream_exists_callback = [&, column_pos = *pos](const ISerialization::SubstreamPath & substream_path) -> bool
         {
-            auto substream = ISerialization::getFileNameForStream(
-                column, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
-            return columns_substreams.tryGetSubstreamPosition(column_pos, substream).has_value();
+            return columns_substreams.tryGetSubstreamPosition(column_pos, first_column, substream_path, storage_settings).has_value();
         };
 
-        auto order = getSubcolumnsDeserializationOrder(column, subcolumns_data, columns_substreams.getColumnSubstreams(*pos), enumerate_settings, ISerialization::StreamFileNameSettings(*storage_settings));
+        auto order = getSubcolumnsDeserializationOrder(first_column, subcolumns_data, columns_substreams.getColumnSubstreams(*pos), enumerate_settings, ISerialization::StreamFileNameSettings(*storage_settings));
         deserialization_order.reserve(subcolumns_indexes.size());
         for (size_t i : order)
             deserialization_order.push_back(subcolumn_data_index_to_subcolumn_index[i]);
@@ -461,14 +470,13 @@ void MergeTreeReaderCompact::readPrefix(size_t column_idx, size_t from_mark, Mer
     };
 
     /// Build check_stream_exists_callback for this column if we have a column position.
+    /// Resolve the same way as buffer_getter above: by column ID first, then by column name.
     ISerialization::DeserializeBinaryBulkSettings::CheckStreamExistsCallback check_stream_exists_callback;
     if (column_positions[column_idx])
     {
         check_stream_exists_callback = [&](const ISerialization::SubstreamPath & substream_path) -> bool
         {
-            auto substream = ISerialization::getFileNameForStream(
-                column, substream_path, ISerialization::StreamFileNameSettings(*storage_settings));
-            return columns_substreams.tryGetSubstreamPosition(*column_positions[column_idx], substream).has_value();
+            return columns_substreams.tryGetSubstreamPosition(*column_positions[column_idx], column, substream_path, storage_settings).has_value();
         };
     }
 

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -22,6 +22,11 @@ namespace DB
 namespace
 {
     constexpr auto DATA_FILE_EXTENSION = ".bin";
+
+    /// Keys of the reader's per-column maps: the substreams caches are shared by a column and its
+    /// subcolumns, so they key by the parent's id alone; the prefix-state map is per (sub)column.
+    String substreamsCacheKey(const NameAndTypePair & column) { return column.getColumnId().value(); }
+    String prefixStateKey(const NameAndTypePair & column) { return column.getStorageKey().value(); }
 }
 
 namespace ErrorCodes
@@ -69,6 +74,8 @@ MergeTreeReaderWide::MergeTreeReaderWide(
             if (!isColumnDroppedByPendingMutation(i) && !isSystemColumnInvalidated(i))
                 addStreams(columns_to_read[i], serializations[i]);
         }
+
+        collectNestedOffsetsSiblings();
     }
     catch (...)
     {
@@ -132,7 +139,7 @@ void MergeTreeReaderWide::prefetchForAllColumns(
 
         try
         {
-            auto & cache = caches[columns_to_read[pos].getNameInStorage()];
+            auto & cache = caches[substreamsCacheKey(columns_to_read[pos])];
             prefetchForColumn(
                 priority, columns_to_read[pos], serializations[pos], from_mark, continue_reading, cache);
         }
@@ -186,8 +193,8 @@ size_t MergeTreeReaderWide::readRows(
             try
             {
                 size_t column_size_before_reading = column->size();
-                auto & cache = caches[column_to_read.getNameInStorage()];
-                auto & deserialize_states_cache = deserialize_states_caches[column_to_read.getNameInStorage()];
+                auto & cache = caches[substreamsCacheKey(column_to_read)];
+                auto & deserialize_states_cache = deserialize_states_caches[substreamsCacheKey(column_to_read)];
 
                 readData(
                     column_to_read,
@@ -199,6 +206,8 @@ size_t MergeTreeReaderWide::readRows(
                     rows_offset,
                     cache,
                     deserialize_states_cache);
+
+                shareNestedOffsetsWithSiblings(pos, cache);
 
                 /// For elements of Nested, column_size_before_reading may be greater than column size
                 ///  if offsets are not empty and were already read, but elements are empty.
@@ -304,6 +313,61 @@ void MergeTreeReaderWide::addStreams(
         partially_read_columns.insert(name_and_type.name);
 }
 
+/// The offsets substream every Array column reads through; a flattened Nested group shares one on
+/// disk, named after the group rather than the column.
+static const ISerialization::SubstreamPath & offsetsSubstreamPath()
+{
+    static const ISerialization::SubstreamPath path{{ISerialization::Substream::ArraySizes}};
+    return path;
+}
+
+/// Which columns share an offsets stream with which. Flattened Nested siblings ("n.x", "n.y") do, and
+/// under column IDs they stay separate top-level columns -- `Nested::convertToSubcolumns` skips
+/// id-carrying ones -- so each gets its own substreams cache instead of the group's single one.
+void MergeTreeReaderWide::collectNestedOffsetsSiblings()
+{
+    std::unordered_map<String, std::vector<size_t>> by_offsets_stream;
+    for (size_t pos = 0; pos < columns_to_read.size(); ++pos)
+    {
+        if (isColumnDroppedByPendingMutation(pos) || columns_to_read[pos].column_id.empty())
+            continue;
+
+        auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+            columns_to_read[pos], offsetsSubstreamPath(), ".bin", data_part_info_for_read->getChecksums(), storage_settings);
+
+        if (stream_name)
+            by_offsets_stream[*stream_name].push_back(pos);
+    }
+
+    nested_offsets_siblings.resize(columns_to_read.size());
+    for (const auto & [_, group] : by_offsets_stream)
+    {
+        /// Only the siblings a column is read BEFORE: the read fills their caches, never its own.
+        for (size_t i = 0; i + 1 < group.size(); ++i)
+            nested_offsets_siblings[group[i]].assign(group.begin() + i + 1, group.end());
+    }
+}
+
+/// Hands the offsets just read for column @pos to the siblings still to come; without it the second
+/// sibling reads from wherever the first left the shared stream, surfacing far away as siblings
+/// disagreeing on the row count. Only the offsets -- sharing the whole cache would alias the values.
+void MergeTreeReaderWide::shareNestedOffsetsWithSiblings(size_t pos, ISerialization::SubstreamsCache & cache)
+{
+    if (nested_offsets_siblings[pos].empty())
+        return;
+
+    auto cached = ISerialization::getColumnWithNumReadRowsFromSubstreamsCache(&cache, offsetsSubstreamPath());
+    if (!cached)
+        return;
+
+    const auto & [offsets_column, num_read_rows] = *cached;
+    for (size_t sibling : nested_offsets_siblings[pos])
+    {
+        ISerialization::addColumnWithNumReadRowsToSubstreamsCache(
+            &caches[substreamsCacheKey(columns_to_read[sibling])], offsetsSubstreamPath(), offsets_column, num_read_rows);
+    }
+}
+
 MergeTreeReaderWide::FileStreams::iterator MergeTreeReaderWide::addStream(const ISerialization::SubstreamPath & substream_path, const String & stream_name)
 {
     auto context = data_part_info_for_read->getContext();
@@ -359,15 +423,19 @@ ReadBuffer * MergeTreeReaderWide::getStream(
     auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, ".bin", checksums, storage_settings);
     if (!stream_name)
     {
-        /// We allow missing streams only for columns/subcolumns that are not present in this part.
+        /// A miss is expected when the part holds no slot for the id at all -- the column is new to
+        /// the table, or a DROP + re-ADD gave it a fresh id (see ColumnIdMapping.h). Fill defaults.
+        if (!data_part_info_for_read->getColumnPosition(name_and_type.getColumnId()))
+            return nullptr;
+
         auto column = data_part_info_for_read->getColumnsDescription().tryGetColumn(GetColumnsOptions::AllPhysical, name_and_type.getNameInStorage());
         if (column && (!name_and_type.isSubcolumn() || column->type->hasSubcolumn(name_and_type.getSubcolumnName())))
         {
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Stream {} for column {} with type {} is not found",
-                ISerialization::getFileNameForStream(
-                    name_and_type.name, substream_path, ISerialization::StreamFileNameSettings(*storage_settings)),
+                ISerialization::getFileNameForStreamByColumnId(
+                    name_and_type, substream_path, ISerialization::StreamFileNameSettings(*storage_settings)),
                     name_and_type.name,
                     name_and_type.type->getName());
         }
@@ -405,7 +473,7 @@ void MergeTreeReaderWide::deserializePrefix(
     ISerialization::SubstreamsDeserializeStatesCache & deserialize_states_cache,
     ISerialization::StreamCallback prefixes_prefetch_callback)
 {
-    const auto & name = name_and_type.name;
+    const auto name = prefixStateKey(name_and_type);
     if (!deserialize_state_map.contains(name))
     {
         ISerialization::DeserializeBinaryBulkSettings deserialize_settings;
@@ -518,8 +586,8 @@ void MergeTreeReaderWide::deserializePrefixForAllColumnsImpl(size_t num_columns,
 
             try
             {
-                auto & cache = caches[columns_to_read[pos].getNameInStorage()];
-                auto & deserialize_states_cache = deserialize_states_caches[columns_to_read[pos].getNameInStorage()];
+                auto & cache = caches[substreamsCacheKey(columns_to_read[pos])];
+                auto & deserialize_states_cache = deserialize_states_caches[substreamsCacheKey(columns_to_read[pos])];
                 deserializePrefix(
                     serializations[pos],
                     columns_to_read[pos],
@@ -561,7 +629,7 @@ void MergeTreeReaderWide::deserializePrefixForAllColumnsWithPrefetch(size_t num_
             auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, ".bin", data_part_info_for_read->getChecksums(), storage_settings);
             if (stream_name && !prefetched_streams.contains(*stream_name))
             {
-                if (ReadBuffer * buf = getStream(/* seek_to_start = */true, substream_path, data_part_info_for_read->getChecksums(), name_and_type, 0, /* seek_to_mark = */false, caches[name_and_type.getNameInStorage()]))
+                if (ReadBuffer * buf = getStream(/* seek_to_start = */true, substream_path, data_part_info_for_read->getChecksums(), name_and_type, 0, /* seek_to_mark = */false, caches[substreamsCacheKey(name_and_type)]))
                 {
                     buf->prefetch(priority);
                     prefetched_streams.insert(*stream_name);
@@ -603,7 +671,7 @@ void MergeTreeReaderWide::prefetchForColumn(
     /// If we already deserialized prefixes, we can use deserialization state during streams enumeration to enumerate dynamic subcolumns.
     if (!deserialize_binary_bulk_state_map.empty())
     {
-        auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withDeserializeState(deserialize_binary_bulk_state_map[name_and_type.name]);
+        auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withDeserializeState(deserialize_binary_bulk_state_map[prefixStateKey(name_and_type)]);
         ISerialization::EnumerateStreamsSettings settings;
         serialization->enumerateStreams(settings, callback, data);
     }
@@ -691,7 +759,7 @@ void MergeTreeReaderWide::readData(
     };
 
     deserialize_settings.continuous_reading = continue_reading;
-    auto & deserialize_state = deserialize_binary_bulk_state_map[name_and_type.name];
+    auto & deserialize_state = deserialize_binary_bulk_state_map[prefixStateKey(name_and_type)];
 
     serialization->deserializeBinaryBulkWithMultipleStreams(
         column, rows_offset, max_rows_to_read, deserialize_settings, deserialize_state, &cache);
@@ -716,7 +784,7 @@ std::unordered_map<String, std::vector<String>> MergeTreeReaderWide::getAllColum
                 column_to_streams[name_and_type.name].push_back(*stream_name);
         };
 
-        auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withDeserializeState(deserialize_binary_bulk_state_map[name_and_type.name]);
+        auto data = ISerialization::SubstreamData(serialization).withType(name_and_type.type).withDeserializeState(deserialize_binary_bulk_state_map[prefixStateKey(name_and_type)]);
         ISerialization::EnumerateStreamsSettings settings;
         serialization->enumerateStreams(settings, callback, data);
     }

--- a/src/Storages/MergeTree/MergeTreeReaderWide.h
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.h
@@ -101,11 +101,18 @@ private:
         ISerialization::SubstreamsDeserializeStatesCache & deserialize_states_cache,
         ISerialization::StreamCallback prefixes_prefetch_callback);
 
+    void collectNestedOffsetsSiblings();
+    void shareNestedOffsetsWithSiblings(size_t pos, ISerialization::SubstreamsCache & cache);
+
     void deserializePrefixForAllColumns(size_t num_columns, size_t from_mark);
     void deserializePrefixForAllColumnsWithPrefetch(size_t num_columns, size_t from_mark, Priority priority);
 
     using StreamCallbackGetter = std::function<ISerialization::StreamCallback(const NameAndTypePair &)>;
     void deserializePrefixForAllColumnsImpl(size_t num_columns, size_t from_mark, StreamCallbackGetter prefixes_prefetch_callback_getter);
+
+    /// Per column, the later columns that read their offsets from the same stream. Fixed for the
+    /// reader's lifetime; see `collectNestedOffsetsSiblings`.
+    std::vector<std::vector<size_t>> nested_offsets_siblings;
 
     std::unordered_map<String, ISerialization::SubstreamsCache> caches;
     std::unordered_map<String, ISerialization::SubstreamsDeserializeStatesCache> deserialize_states_caches;

--- a/src/Storages/MergeTree/MergeTreeVirtualColumns.cpp
+++ b/src/Storages/MergeTree/MergeTreeVirtualColumns.cpp
@@ -1,7 +1,9 @@
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
+#include <Core/Names.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <Parsers/ASTAssignment.h>
@@ -56,6 +58,51 @@ DataTypePtr PartitionValueColumn::type(const KeyDescription * partition_key)
 {
     auto partition_types = partition_key->sample_block.getDataTypes();
     return std::make_shared<DataTypeTuple>(std::move(partition_types));
+}
+
+VirtualColumnsDescription getMergeTreeVirtuals(const KeyDescription * partition_key)
+{
+    VirtualColumnsDescription desc;
+
+    desc.addEphemeral("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of part", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_part_index", std::make_shared<DataTypeUInt64>(), "Sequential index of the part in the query result", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_part_starting_offset", std::make_shared<DataTypeUInt64>(), "Cumulative starting row of the part in the query result", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_part_uuid", std::make_shared<DataTypeUUID>(), "Unique part identifier (if enabled MergeTree setting assign_part_uuids)", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral(PartitionIdColumn::name, PartitionIdColumn::type, "Name of partition", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_sample_factor", std::make_shared<DataTypeFloat64>(), "Sample factor (from the query)", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_part_offset", std::make_shared<DataTypeUInt64>(), "Number of row in the part", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_part_granule_offset", std::make_shared<DataTypeUInt64>(), "Number of granule in the part", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral(PartDataVersionColumn::name, PartDataVersionColumn::type, "Data version of part (either min block number or mutation version)", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_disk_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Disk name", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_distance", std::make_shared<DataTypeFloat32>(), "Pre-computed distance for vector search queries", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_table", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "", VirtualsMaterializationPlace::Reader);
+    desc.addEphemeral("_database", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "", VirtualsMaterializationPlace::Reader);
+
+    if (partition_key && partition_key->sample_block.columns() > 0)
+        desc.addEphemeral(PartitionValueColumn::name, PartitionValueColumn::type(partition_key), "Value (a tuple) of a PARTITION BY expression", VirtualsMaterializationPlace::Reader);
+
+    desc.addPersistent(RowExistsColumn::name, RowExistsColumn::type, nullptr, "Persisted mask created by lightweight delete that show whether row exists or is deleted");
+    desc.addPersistent(BlockNumberColumn::name, BlockNumberColumn::type, BlockNumberColumn::codec, "Persisted original number of block that was assigned at insert");
+    desc.addPersistent(BlockOffsetColumn::name, BlockOffsetColumn::type, BlockOffsetColumn::codec, "Persisted original number of row in block that was assigned at insert");
+
+    return desc;
+}
+
+bool isVirtualColumn(const String & column_name)
+{
+    /// Derived from the one registry (`getMergeTreeVirtuals`) so it cannot drift from the set a
+    /// MergeTree table actually exposes. Built once (partition-key-independent membership).
+    /// `_partition_value` is registered only with a partition key, so add it explicitly here —
+    /// it is a virtual name regardless of whether the current table has a partition key.
+    static const NameSet virtual_columns = []
+    {
+        NameSet names;
+        for (const auto & column : getMergeTreeVirtuals(nullptr))
+            names.insert(column.name);
+        names.insert(PartitionValueColumn::name);
+        return names;
+    }();
+    return virtual_columns.contains(column_name);
 }
 
 Field getFieldForConstVirtualColumn(const String & column_name, const IMergeTreeDataPart & part_or_projection)

--- a/src/Storages/MergeTree/MergeTreeVirtualColumns.h
+++ b/src/Storages/MergeTree/MergeTreeVirtualColumns.h
@@ -5,6 +5,7 @@
 #include <Parsers/IAST_fwd.h>
 
 #include <Storages/KeyDescription.h>
+#include <Storages/VirtualColumnsDescription.h>
 #include <Storages/MergeTree/MergeTreePartition.h>
 
 #include <Core/Types.h>
@@ -58,6 +59,25 @@ struct PartitionValueColumn
     static const String name;
     static DataTypePtr type(const KeyDescription * partition_key);
 };
+
+/// Whether a column is a virtual column physically stored inside data parts, rather than computed
+/// on the fly. Not managed by the column ID mapping, so column remapping passes it through.
+/// Keep in sync with the `addPersistent` calls in `getMergeTreeVirtuals`.
+inline bool isPersistentVirtualColumn(const String & column_name)
+{
+    return column_name == RowExistsColumn::name
+        || column_name == BlockNumberColumn::name
+        || column_name == BlockOffsetColumn::name;
+}
+
+/// The one registry of the virtual columns a MergeTree table exposes, with their types and
+/// materialization places; `_partition_value` only when a partition key is present. Both
+/// `MergeTreeData::createVirtuals` and `isVirtualColumn` derive from it, so they cannot drift.
+VirtualColumnsDescription getMergeTreeVirtuals(const KeyDescription * partition_key);
+
+/// Whether a column is any MergeTree virtual column (ephemeral or persistent) — the full set
+/// registered in `getMergeTreeVirtuals`. Virtual columns are not managed by the column ID mapping.
+bool isVirtualColumn(const String & column_name);
 
 Field getFieldForConstVirtualColumn(const String & column_name, const IMergeTreeDataPart & part_or_projection);
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -238,9 +238,11 @@ MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
         auto part_columns = total_columns_list ? *total_columns_list : columns_list;
         auto serialization_infos = new_part->getSerializationInfos();
 
+        /// Into the part's key space, or `replaceData` misses the join and loses the chosen kinds.
+        new_serialization_infos.reKeyToColumnIds(part_columns);
         serialization_infos.replaceData(new_serialization_infos);
         files_to_remove_after_sync
-            = removeEmptyColumnsFromPart(new_part, part_columns, new_part->expired_columns, serialization_infos, checksums);
+            = removeEmptyColumnsFromPart(new_part, part_columns, new_part->expired_column_ids, serialization_infos, checksums);
 
         new_part->setColumns(part_columns, serialization_infos, metadata_snapshot->getMetadataVersion());
     }
@@ -367,7 +369,7 @@ MergedBlockOutputStream::WrittenFiles MergedBlockOutputStream::finalizePartOnDis
 
             if (new_part->getMinMaxIndex()->initialized)
             {
-                auto files = new_part->getMinMaxIndex()->store(metadata_snapshot, new_part->getDataPartStorage(), checksums, storage_settings);
+                auto files = new_part->getMinMaxIndex()->store(metadata_snapshot, new_part->getDataPartStorage(), checksums, storage_settings, new_part->getColumns());
                 for (auto & file : files)
                     written_files.emplace_back(std::move(file));
             }
@@ -404,6 +406,7 @@ MergedBlockOutputStream::WrittenFiles MergedBlockOutputStream::finalizePartOnDis
     const auto & serialization_infos = new_part->getSerializationInfos();
     if (serialization_infos.needsPersistence())
     {
+        /// Already keyed by the stamped column IDs (`setColumns`), which is the on-disk key.
         write_hashed_file(IMergeTreeDataPart::SERIALIZATION_FILE_NAME, [&](auto & buffer)
         {
             serialization_infos.writeJSON(buffer);
@@ -417,20 +420,20 @@ MergedBlockOutputStream::WrittenFiles MergedBlockOutputStream::finalizePartOnDis
     {
         if (isFullPartStorage(new_part->getDataPartStorage()))
         {
-            auto out = serializeStatisticsPacked(new_part->getDataPartStorage(), checksums, statistics, default_codec, writer_settings.query_write_settings);
+            auto out = serializeStatisticsPacked(new_part->getDataPartStorage(), checksums, statistics, new_part->getColumns(), default_codec, writer_settings.query_write_settings);
             written_files.emplace_back(std::move(out));
         }
         /// Write statistics as separate compressed files in packed parts to avoid double buffering.
         else
         {
-            auto files = serializeStatisticsWide(new_part->getDataPartStorage(), checksums, statistics, default_codec, writer_settings.query_write_settings);
+            auto files = serializeStatisticsWide(new_part->getDataPartStorage(), checksums, statistics, new_part->getColumns(), default_codec, writer_settings.query_write_settings);
             std::move(files.begin(), files.end(), std::back_inserter(written_files));
         }
     }
 
     write_plain_file("columns.txt", [&](auto & buffer)
     {
-        new_part->getColumns().writeText(buffer);
+        new_part->getColumns().writeText(buffer, /*use_column_ids=*/true);
     });
 
     /// Merge columns substreams from current writer and additional columns substreams

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -89,15 +89,20 @@ MergeTreeData::DataPart::Checksums MergedColumnOnlyOutputStream::fillChecksums(M
 
     auto columns = new_part->getColumns();
     auto serialization_infos = new_part->getSerializationInfos();
+
+    /// Into the part's key space, or `replaceData` misses the join and loses the chosen kinds.
+    new_serialization_infos.reKeyToColumnIds(columns);
     serialization_infos.replaceData(new_serialization_infos);
 
-    NameSet empty_columns;
-    for (const auto & column : writer->getColumnsSample())
+    /// Only the columns this stream wrote are its to remove, and its sample block names them logically.
+    const auto & columns_sample = writer->getColumnsSample();
+    ColumnIdSet empty_column_ids;
+    for (const auto & column : columns)
     {
-        if (new_part->expired_columns.contains(column.name))
-            empty_columns.emplace(column.name);
+        if (new_part->expired_column_ids.contains(column.getColumnId()) && columns_sample.has(column.name))
+            empty_column_ids.emplace(column.getColumnId());
     }
-    auto removed_files = removeEmptyColumnsFromPart(new_part, columns, empty_columns, serialization_infos, checksums);
+    auto removed_files = removeEmptyColumnsFromPart(new_part, columns, empty_column_ids, serialization_infos, checksums);
 
     for (const String & removed_file : removed_files)
     {

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -4,6 +4,8 @@
 #include <Parsers/ASTAssignment.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeTreeDataPartTTLInfo.h>
+#include <Storages/MergeTree/ColumnIdHelper.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Storages/MergeTree/MutateTask.h>
 
 #include <Columns/ColumnsNumber.h>
@@ -133,25 +135,39 @@ namespace MutationHelpers
 /// column whose name collides with this sentinel).
 static const String NOT_YET_WRITTEN_COLUMN_SUBSTREAM_PLACEHOLDER = "dummy";
 
-static bool haveMutationsOfDynamicColumns(const MergeTreeData::DataPartPtr & data_part, const MutationCommands & commands)
+/// The part's column for a name a mutation command carries. A command names its column as the current
+/// schema does, which resolves through the id the part's files are keyed by; a RENAME or DROP names it
+/// as it was BEFORE the mutation, a name the schema no longer has but the part still answers to.
+static std::optional<NameAndTypePair> tryGetPartColumnForCommand(
+    const MergeTreeData::DataPartPtr & data_part, const String & column_name, const StorageMetadataPtr & metadata_snapshot)
 {
+    if (auto column = data_part->tryGetColumnBySnapshotName(column_name, metadata_snapshot))
+        return column;
+    return data_part->tryGetColumnByNameUnsafe(column_name);
+}
+
+static bool haveMutationsOfDynamicColumns(
+    const MergeTreeData::DataPartPtr & data_part, const MutationCommands & commands, const StorageMetadataPtr & metadata_snapshot)
+{
+    /// A miss here picks the partial-mutation path, which cannot enumerate a dynamic column's
+    /// dependent substreams.
+    auto has_dynamic_subcolumns_in_part = [&](const String & column_name)
+    {
+        auto column = tryGetPartColumnForCommand(data_part, column_name, metadata_snapshot);
+        return column && column->type->hasDynamicSubcolumns();
+    };
+
     for (const auto & command : commands)
     {
-        if (!command.column_name.empty())
-        {
-            auto column = data_part->tryGetColumn(command.column_name);
-            if (column && column->type->hasDynamicSubcolumns())
-                return true;
-        }
+        if (!command.column_name.empty() && has_dynamic_subcolumns_in_part(command.column_name))
+            return true;
 
         auto alter = command.ast();
         if (!alter || !alter->update_assignments)
             continue;
         for (const auto & child : alter->update_assignments->children)
         {
-            const auto & column_name = child->as<ASTAssignment &>().column_name;
-            auto column = data_part->tryGetColumn(column_name);
-            if (column && column->type->hasDynamicSubcolumns())
+            if (has_dynamic_subcolumns_in_part(child->as<ASTAssignment &>().column_name))
                 return true;
         }
     }
@@ -198,9 +214,10 @@ static bool hasDynamicColumnsWithoutRecordedSubstreams(const MergeTreeData::Data
 static bool rewritesAllPartColumns(
     const MergeTreeData::DataPartPtr & source_part,
     const MutationCommands & commands_for_part,
-    const MutationsInterpreter * interpreter)
+    const MutationsInterpreter * interpreter,
+    const StorageMetadataPtr & metadata_snapshot)
 {
-    return haveMutationsOfDynamicColumns(source_part, commands_for_part)
+    return haveMutationsOfDynamicColumns(source_part, commands_for_part, metadata_snapshot)
         || hasDynamicColumnsWithoutRecordedSubstreams(source_part)
         || !isWidePart(source_part)
         || !isFullPartStorage(source_part->getDataPartStorage())
@@ -248,6 +265,36 @@ static NameSet getRemovedStatistics(const StorageMetadataPtr & metadata_snapshot
     return removed_stats;
 }
 
+/// Rewrites @part_columns into the current-schema name domain, keeping only names the schema still
+/// has plus the persistent virtuals (which no ALTER can rename or drop) -- a metadata-only RENAME
+/// neither reloads the part nor records itself in alter_conversions, so the names below would be stale.
+static void remapPartColumnsToCurrentNames(
+    ColumnsDescription & part_columns,
+    const NamesAndTypesList & part_id_columns,
+    const ColumnIdMapping & mapping)
+{
+    /// Rebuilt rather than renamed in place. Two live columns can hold each other's names -- `RENAME a
+    /// TO tmp, b TO a, tmp TO b` leaves the mapping crossed against any part older than it -- and
+    /// `ColumnsDescription::rename` onto an occupied name does not fail, it drops a column: `modify_key`
+    /// erases the element whose new key collides, and its result is discarded.
+    ColumnsDescription remapped;
+    for (const auto & description : part_columns)
+    {
+        auto column_in_part = part_id_columns.tryGetByName(description.name);
+        /// No current name means the mapping dropped the id. Leaving that orphan out is what keeps it
+        /// from answering the split decisions below under a name a live column may now hold.
+        auto current_name = column_in_part ? tryGetCurrentColumnName(*column_in_part, &mapping) : description.name;
+        if (!current_name)
+            continue;
+
+        auto remapped_description = description;
+        remapped_description.name = *current_name;
+        remapped.add(std::move(remapped_description));
+    }
+
+    part_columns = std::move(remapped);
+}
+
 /** Split mutation commands into two parts:
 *   First part should be executed by mutations interpreter.
 *   Other is just simple drop/renames, so they can be executed without interpreter.
@@ -265,7 +312,12 @@ static void splitAndModifyMutationCommands(
     auto part_columns = part->getColumnsDescription();
     const auto & table_columns = metadata_snapshot->getColumns();
 
-    if (haveMutationsOfDynamicColumns(part, commands) || hasDynamicColumnsWithoutRecordedSubstreams(part)
+    /// Under column ids the part keeps its load-time names after a metadata-only ALTER; bring
+    /// part_columns into the current-schema domain so both split branches reason over live names.
+    if (auto column_id_mapping = metadata_snapshot->getActiveColumnIdMapping())
+        remapPartColumnsToCurrentNames(part_columns, part->getColumns(), *column_id_mapping);
+
+    if (haveMutationsOfDynamicColumns(part, commands, metadata_snapshot) || hasDynamicColumnsWithoutRecordedSubstreams(part)
         || !isWidePart(part) || !isFullPartStorage(part->getDataPartStorage()))
     {
         NameSet mutated_columns;
@@ -281,7 +333,7 @@ static void splitAndModifyMutationCommands(
                 /// For ordinary column with default or materialized expression, MATERIALIZE COLUMN should not override past values
                 /// So we only mutate column if `command.column_name` is a default/materialized column or if the part does not have physical column file
                 auto column_ordinary = table_columns.getOrdinary().tryGetByName(command.column_name);
-                if (!column_ordinary || !part->tryGetColumn(command.column_name) || !part->hasColumnFiles(*column_ordinary))
+                if (!column_ordinary || !part_columns.has(command.column_name) || !part->hasColumnFiles(*column_ordinary))
                 {
                     for_interpreter.push_back(command);
                     mutated_columns.emplace(command.column_name);
@@ -578,7 +630,7 @@ static void splitAndModifyMutationCommands(
                 /// For ordinary column with default or materialized expression, MATERIALIZE COLUMN should not override past values
                 /// So we only mutate column if `command.column_name` is a default/materialized column or if the part does not have physical column file
                 auto column_ordinary = table_columns.getOrdinary().tryGetByName(command.column_name);
-                if (!column_ordinary || !part->tryGetColumn(command.column_name) || !part->hasColumnFiles(*column_ordinary))
+                if (!column_ordinary || !part_columns.has(command.column_name) || !part->hasColumnFiles(*column_ordinary))
                     for_interpreter.push_back(command);
 
                 /// Materialize column in case of complex data types like tuple can remove some nested columns
@@ -659,6 +711,9 @@ static void splitAndModifyMutationCommands(
     }
 }
 
+/// @old_name must equal the prefix the source part's substream file names were built from -- the
+/// column's storage key, which is its own name only while the part carries no id.
+/// `getFileNameForRenamedColumnStream` throws LOGICAL_ERROR on a mismatch, so this is checked.
 static void addRenamedColumnToColumnsSubstreams(
     ColumnsSubstreams & new_columns_substreams,
     const ColumnsSubstreams & old_columns_substreams,
@@ -704,8 +759,11 @@ getColumnsForNewDataPart(
     const SerializationInfoByName & serialization_infos,
     const MutationCommands & commands_for_interpreter,
     const MutationCommands & commands_for_removes,
-    bool rewrites_all_columns)
+    bool rewrites_all_columns,
+    const StorageMetadataPtr & metadata_snapshot)
 {
+    auto column_id_mapping = metadata_snapshot->getActiveColumnIdMapping();
+
     MutationCommands all_commands;
     all_commands.insert(all_commands.end(), commands_for_interpreter.begin(), commands_for_interpreter.end());
     all_commands.insert(all_commands.end(), commands_for_removes.begin(), commands_for_removes.end());
@@ -719,6 +777,37 @@ getColumnsForNewDataPart(
     bool deleted_mask_updated = false;
     bool affects_all_columns = false;
     bool supports_lightweight_deletes = source_part->supportLightweightDeleteMutate();
+    bool has_column_ids = column_id_mapping != nullptr;
+
+    /// The part's slots by stable id, built once -- the part's own lookups walk its column list. A
+    /// legacy column and a persistent virtual are unstamped and so key by their own name, which no
+    /// id can collide with (a real column is refused a virtual's reserved name).
+    std::unordered_map<String, NameAndTypePair> part_column_by_id;
+    for (const auto & column : source_part->getColumns())
+        part_column_by_id.emplace(column.getColumnId().value(), column);
+
+    /// `IMergeTreeDataPart::tryGetColumnBySnapshotName` with two differences this function needs: it
+    /// answers for a persistent virtual, which no schema lists, and it indexes the part once for the
+    /// per-column loops below. Like it, it never falls back to the name -- a stale slot may hold a name
+    /// the schema has since given to another column.
+    auto part_column_for = [&](const String & current_name) -> std::optional<NameAndTypePair>
+    {
+        /// A persistent virtual is outside the mapping and outside the schema: it is its own id.
+        String column_id = current_name;
+        if (has_column_ids && !isPersistentVirtualColumn(current_name))
+        {
+            auto schema_column = metadata_snapshot->getColumns().tryGetColumnOrSubcolumn(
+                GetColumnsOptions::AllPhysical, current_name);
+            if (!schema_column)
+                return {};
+            column_id = schema_column->getColumnId().value();
+        }
+
+        auto part_column = part_column_by_id.find(column_id);
+        if (part_column == part_column_by_id.end())
+            return {};
+        return part_column->second;
+    };
 
     NameSet storage_columns_set;
     for (const auto & [name, _] : storage_columns)
@@ -731,8 +820,10 @@ getColumnsForNewDataPart(
         if (supports_lightweight_deletes)
             deleted_mask_updated |= isDeletedMaskUpdated(command, storage_columns_set);
 
-        /// If we don't have this column in source part, than we don't need to materialize it
-        if (!part_columns.has(command.column_name))
+        /// If we don't have this column in source part, than we don't need to materialize it.
+        /// Either name: the command names the column as the current schema does, while the part may
+        /// still hold it -- or an orphan of it -- under the name it was loaded with.
+        if (!part_columns.has(command.column_name) && !part_column_for(command.column_name))
         {
             /// For RENAME commands, handle chained renames:
             /// e.g., if column A was already renamed to B, and now B is renamed to C,
@@ -817,8 +908,23 @@ getColumnsForNewDataPart(
         settings = storage_serialization_settings;
 
     SerializationInfoByName new_serialization_infos(settings);
-    for (const auto & [name, old_info] : serialization_infos)
+    for (const auto & [stored_key, old_info] : serialization_infos)
     {
+        /// A record is stored under its column's id; the rest of this loop works in the part's own
+        /// name domain, so translate through the part's list.
+        String name = stored_key;
+        if (has_column_ids)
+        {
+            /// A record whose id has left the mapping belongs to a dropped column and must not carry
+            /// into the new part: the same column name may now belong to a re-added column with a
+            /// fresh id. Persistent virtuals are never in the mapping -- keep them.
+            if (!column_id_mapping->hasColumnId(stored_key) && !isPersistentVirtualColumn(stored_key))
+                continue;
+
+            if (auto part_column = part_column_by_id.find(stored_key); part_column != part_column_by_id.end())
+                name = part_column->second.name;
+        }
+
         auto it = renamed_columns_from_to.find(name);
         auto new_name = it == renamed_columns_from_to.end() ? name : it->second;
 
@@ -901,11 +1007,9 @@ getColumnsForNewDataPart(
     if (!isWidePart(source_part) || !isFullPartStorage(source_part->getDataPartStorage()))
         return {updated_header.getNamesAndTypesList(), new_serialization_infos, {}};
 
-    const auto & source_columns = source_part->getColumns();
-    std::unordered_map<String, DataTypePtr> source_columns_name_to_type;
-    for (const auto & it : source_columns)
-        source_columns_name_to_type[it.name] = it.type;
-
+    /// Renames below are rename MUTATIONS, which a table with column IDs never has: RENAME COLUMN is
+    /// metadata-only there, and activation while one is queued is refused. So the stream files really
+    /// are named from the column's name here, and re-prefixing them by name is right.
     const ColumnsSubstreams & source_columns_substreams = source_part->getColumnsSubstreams();
     bool fill_columns_substreams = !source_columns_substreams.empty();
     ColumnsSubstreams new_columns_substreams;
@@ -938,16 +1042,16 @@ getColumnsForNewDataPart(
         }
         else
         {
-            auto source_col = source_columns_name_to_type.find(it->name);
-            if (source_col == source_columns_name_to_type.end())
+            auto source_col = part_column_for(it->name);
+            if (!source_col)
             {
                 /// Source part doesn't have column but some other column
                 /// was renamed to it's name.
                 auto renamed_it = renamed_columns_to_from.find(it->name);
                 if (renamed_it != renamed_columns_to_from.end())
                 {
-                    source_col = source_columns_name_to_type.find(renamed_it->second);
-                    if (source_col == source_columns_name_to_type.end())
+                    source_col = part_column_for(renamed_it->second);
+                    if (!source_col)
                         it = storage_columns.erase(it);
                     else
                     {
@@ -959,10 +1063,15 @@ getColumnsForNewDataPart(
                         /// so the new part must record the type in storage - see the same-named
                         /// case below.
                         if (!rewrites_all_columns)
-                            it->type = source_col->second;
+                            it->type = source_col->type;
 
                         if (fill_columns_substreams)
-                            addRenamedColumnToColumnsSubstreams(new_columns_substreams, source_columns_substreams, it->name, source_col->first, *source_part->getColumnPosition(source_col->first));
+                            addRenamedColumnToColumnsSubstreams(
+                                new_columns_substreams,
+                                source_columns_substreams,
+                                it->name,
+                                source_col->name,
+                                *source_part->getColumnPosition(source_col->getColumnId()));
 
                         ++it;
                     }
@@ -1001,20 +1110,25 @@ getColumnsForNewDataPart(
                         /// being renamed away (DROP xxx + RENAME yyy TO xxx, or the swap
                         /// RENAME xxx TO zzz + RENAME yyy TO xxx).
                         auto renamed_from = renamed_columns_to_from.at(it->name);
-                        auto maybe_name_and_type = source_columns.tryGetByName(renamed_from);
-                        if (!maybe_name_and_type)
+                        auto renamed_from_column = part_column_for(renamed_from);
+                        if (!renamed_from_column)
                             throw Exception(
                                 ErrorCodes::LOGICAL_ERROR,
-                                "Got incorrect mutation commands, column {} was renamed from {}, but it doesn't exist in source columns {}",
-                                it->name, renamed_from, source_columns.toString());
+                                "Got incorrect mutation commands, column {} was renamed from {}, but part {} does not have it",
+                                it->name, renamed_from, source_part->name);
 
                         /// A full rewrite produces this column at the type in storage, the same
                         /// way it does for the two cases around this one.
                         if (!rewrites_all_columns)
-                            it->type = maybe_name_and_type->type;
+                            it->type = renamed_from_column->type;
 
                         if (fill_columns_substreams)
-                            addRenamedColumnToColumnsSubstreams(new_columns_substreams, source_columns_substreams, it->name, renamed_from, *source_part->getColumnPosition(renamed_from));
+                            addRenamedColumnToColumnsSubstreams(
+                                new_columns_substreams,
+                                source_columns_substreams,
+                                it->name,
+                                renamed_from_column->name,
+                                *source_part->getColumnPosition(renamed_from_column->getColumnId()));
                     }
                     else
                     {
@@ -1031,12 +1145,13 @@ getColumnsForNewDataPart(
                         /// the pipeline, so it would hand, say, a `ColumnNullable` to
                         /// `SerializationString` and throw `Bad cast` before writing anything.
                         if (!rewrites_all_columns)
-                            it->type = source_col->second;
+                            it->type = source_col->type;
 
                         if (fill_columns_substreams)
                         {
                             new_columns_substreams.addColumn(it->name);
-                            new_columns_substreams.addSubstreamsToLastColumn(source_columns_substreams.getColumnSubstreams(*source_part->getColumnPosition(it->name)));
+                            new_columns_substreams.addSubstreamsToLastColumn(
+                                source_columns_substreams.getColumnSubstreams(*source_part->getColumnPosition(source_col->getColumnId())));
                         }
                     }
                     ++it;
@@ -1135,11 +1250,19 @@ static std::unordered_map<String, size_t> getStreamCounts(
             continue;
         }
 
-        if (auto serialization = data_part->tryGetSerialization(column_name))
+        /// The pair the part holds under this name. Its stamped id keys both the serialization and
+        /// the stream files -- naming the streams from the bare name instead would let a name that
+        /// equals a foreign column's id miscount the shared-stream refcount.
+        auto part_column = data_part->tryGetColumnByNameUnsafe(column_name);
+        if (!part_column)
+            continue;
+
+        if (auto serialization = data_part->tryGetSerialization(part_column->getStorageKey()))
         {
             auto callback = [&](const ISerialization::SubstreamPath & substream_path)
             {
-                auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(column_name, substream_path, ".bin", source_part_checksums, data_part->storage.getSettings());
+                auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+                    *part_column, substream_path, ".bin", source_part_checksums, data_part->storage.getSettings());
                 if (stream_name)
                     ++stream_counts[*stream_name];
             };
@@ -1357,9 +1480,21 @@ static NameToNameVector collectFilesForRenames(
         {
             if (command.type == MutationCommand::Type::DROP_COLUMN)
             {
-                ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
+                /// The part's own pair for the column keys both its serialization and its files. A
+                /// CLEAR COLUMN names a column a metadata-only ALTER renamed by its current name, which
+                /// the part answers to only through the id -- else no stream is found and it no-ops.
+                auto column_in_part = tryGetPartColumnForCommand(source_part, command.column_name, metadata_snapshot);
+                if (!column_in_part)
+                    continue;
+
+                auto serialization = source_part->tryGetSerialization(column_in_part->getStorageKey());
+                if (!serialization)
+                    continue;
+
+                serialization->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
                 {
-                    auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(command.column_name, substream_path, ".bin", source_part->checksums, source_part->storage.getSettings());
+                    auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(
+                        *column_in_part, substream_path, ".bin", source_part->checksums, source_part->storage.getSettings());
 
                     /// Delete files if they are no longer shared with another column.
                     if (stream_name && --stream_counts[*stream_name] == 0)
@@ -1367,10 +1502,7 @@ static NameToNameVector collectFilesForRenames(
                         add_rename(*stream_name + ".bin", "");
                         add_rename(*stream_name + mrk_extension, "");
                     }
-                };
-
-                if (auto serialization = source_part->tryGetSerialization(command.column_name))
-                    serialization->enumerateStreams(callback);
+                });
             }
             else if (command.type == MutationCommand::Type::RENAME_COLUMN)
             {
@@ -1381,6 +1513,8 @@ static NameToNameVector collectFilesForRenames(
                 String escaped_name_from = escapeForFileName(command.column_name);
                 String escaped_name_to = escapeForFileName(command.rename_to);
 
+                /// Named from the column's name, not its id: a table with column IDs has no rename
+                /// mutations at all (see getColumnsForNewDataPart).
                 ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
                 {
                     auto storage_settings = source_part->storage.getSettings();
@@ -1401,16 +1535,16 @@ static NameToNameVector collectFilesForRenames(
                     }
                 };
 
-                if (auto serialization = source_part->tryGetSerialization(command.column_name))
+                if (auto serialization = source_part->tryGetSerializationByNameUnsafe(command.column_name))
                     serialization->enumerateStreams(callback);
             }
             else if (command.type == MutationCommand::Type::UPDATE || command.type == MutationCommand::Type::READ_COLUMN || command.type == MutationCommand::Type::MATERIALIZE_COLUMN)
             {
-                /// Remove files for streams that exist in source_part,
-                /// but were removed in new_part by MODIFY COLUMN or MATERIALIZE COLUMN from
-                /// type with higher number of streams (e.g. LowCardinality -> String).
+                /// Remove files for streams that exist in source_part but were removed in new_part by
+                /// MODIFY/MATERIALIZE COLUMN. Each part is asked for its OWN column list: one shared
+                /// name set would falsely flag live files after a metadata-only RENAME.
                 auto old_streams = getStreamCounts(source_part, source_part->checksums, source_part->getColumns().getNames());
-                auto new_streams = getStreamCounts(new_part, source_part->checksums, source_part->getColumns().getNames());
+                auto new_streams = getStreamCounts(new_part, source_part->checksums, new_part->getColumns().getNames());
 
                 for (const auto & [old_stream, _] : old_streams)
                 {
@@ -1551,6 +1685,7 @@ static void finalizeMutatedPart(
     {
         auto out_serialization = new_data_part->getDataPartStorage().writeFile(IMergeTreeDataPart::SERIALIZATION_FILE_NAME, 4096, context->getWriteSettings());
         HashingWriteBuffer out_hashing(*out_serialization);
+        /// Already keyed by the stamped column IDs (`setColumns`), which is the on-disk key.
         serialization_infos.writeJSON(out_hashing);
         out_hashing.finalize();
         new_data_part->checksums.files[IMergeTreeDataPart::SERIALIZATION_FILE_NAME].file_size = out_hashing.count();
@@ -1565,13 +1700,13 @@ static void finalizeMutatedPart(
     {
         if (isFullPartStorage(new_data_part->getDataPartStorage()))
         {
-            auto out = serializeStatisticsPacked(new_data_part->getDataPartStorage(), new_data_part->checksums, statistics, codec, context->getWriteSettings());
+            auto out = serializeStatisticsPacked(new_data_part->getDataPartStorage(), new_data_part->checksums, statistics, new_data_part->getColumns(), codec, context->getWriteSettings());
             written_files.push_back(std::move(out));
         }
         /// Write statistics as separate compressed files in packed parts to avoid double buffering.
         else
         {
-            auto files = serializeStatisticsWide(new_data_part->getDataPartStorage(), new_data_part->checksums, statistics, codec, context->getWriteSettings());
+            auto files = serializeStatisticsWide(new_data_part->getDataPartStorage(), new_data_part->checksums, statistics, new_data_part->getColumns(), codec, context->getWriteSettings());
             std::move(files.begin(), files.end(), std::back_inserter(written_files));
         }
     }
@@ -1599,7 +1734,7 @@ static void finalizeMutatedPart(
     {
         /// Write a file with a description of columns.
         auto out_columns = new_data_part->getDataPartStorage().writeFile("columns.txt", 4096, context->getWriteSettings());
-        new_data_part->getColumns().writeText(*out_columns);
+        new_data_part->getColumns().writeText(*out_columns, /*use_column_ids=*/true);
         written_files.push_back(std::move(out_columns));
     }
 
@@ -1682,6 +1817,13 @@ struct MutationContext
     StorageMetadataPtr metadata_snapshot;
     StorageSnapshotPtr storage_snapshot;
     DiskPtr disk;
+
+    /// The mutation's single column-ID mapping, read off the pinned `metadata_snapshot`
+    /// (the mapping is folded into the metadata, captured atomically with the schema).
+    ColumnIdMappingPtr getActiveColumnIdMapping() const
+    {
+        return metadata_snapshot ? metadata_snapshot->getActiveColumnIdMapping() : nullptr;
+    }
 
     MutationCommandsConstPtr commands;
     time_t time_of_mutation{};
@@ -2113,7 +2255,8 @@ void PartMergerWriter::writeTempProjectionPart(size_t projection_idx, Chunk chun
         projection,
         ctx->new_data_part.get(),
         ++projection_block_num,
-        ctx->context);
+        ctx->context,
+        ctx->getActiveColumnIdMapping());
 
     tmp_part->finalize();
     tmp_part->part->getDataPartStorage().commitTransaction();
@@ -3025,6 +3168,8 @@ private:
                     if (new_part_columns_set.contains(col.name))
                         columns_for_writer.push_back(col);
             }
+            if (const auto column_id_mapping = ctx->getActiveColumnIdMapping())
+                column_id_mapping->stampColumnIds(columns_for_writer);
 
             ctx->out = std::make_shared<MergedColumnOnlyOutputStream>(
                 ctx->new_data_part,
@@ -3292,6 +3437,8 @@ MutateTask::MutateTask(
     ctx->metadata_snapshot = metadata_snapshot_;
     ctx->storage_snapshot = ctx->data->getStorageSnapshotWithoutData(ctx->metadata_snapshot, context_);
     ctx->space_reservation = space_reservation_;
+    /// getAllPhysical() already carries the stamped ids (folded into the schema at metadata publish
+    /// via setColumnIds), so no separate stampColumnIds pass is needed here.
     ctx->storage_columns = metadata_snapshot_->getColumns().getAllPhysical();
     ctx->txn = txn;
     ctx->source_part = ctx->future_part->parts[0];
@@ -3359,7 +3506,10 @@ static bool canSkipConversionToNullable(const MergeTreeDataPartPtr & part, const
     if (command.type != MutationCommand::READ_COLUMN)
         return false;
 
-    auto part_column = part->tryGetColumn(command.column_name);
+    auto snap_col = metadata_snapshot->getColumns().tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, command.column_name);
+    if (!snap_col)
+        return false;
+    auto part_column = part->tryGetColumn(snap_col->getColumnId());
     if (!part_column)
         return false;
 
@@ -3372,8 +3522,8 @@ static bool canSkipConversionToNullable(const MergeTreeDataPartPtr & part, const
     if (!part_column->type->equals(*to_nullable->getNestedType()))
         return false;
 
-    auto serialization = part->getSerialization(command.column_name);
-    if (serialization->getKindStack() != ISerialization::KindStack{ISerialization::Kind::DEFAULT})
+    auto serialization = part->tryGetSerialization(snap_col->getStorageKey());
+    if (!serialization || serialization->getKindStack() != ISerialization::KindStack{ISerialization::Kind::DEFAULT})
         return false;
 
     /// We need to rewrite statistics because they have different serialization with nullable type.
@@ -3388,12 +3538,12 @@ static bool canSkipConversionToNullable(const MergeTreeDataPartPtr & part, const
     return true;
 }
 
-static bool canSkipConversionToVariant(const MergeTreeDataPartPtr & part, const MutationCommand & command)
+static bool canSkipConversionToVariant(const MergeTreeDataPartPtr & part, const StorageMetadataPtr & metadata_snapshot, const MutationCommand & command)
 {
     if (command.type != MutationCommand::READ_COLUMN)
         return false;
 
-    auto part_column = part->tryGetColumn(command.column_name);
+    auto part_column = part->tryGetColumnBySnapshotName(command.column_name, metadata_snapshot);
     if (!part_column)
         return false;
 
@@ -3421,7 +3571,7 @@ static bool canSkipMutationCommandForPart(const MergeTreeDataPartPtr & part, con
     if (canSkipConversionToNullable(part, metadata_snapshot, command))
         return true;
 
-    if (canSkipConversionToVariant(part, command))
+    if (canSkipConversionToVariant(part, metadata_snapshot, command))
         return true;
 
     return false;
@@ -3937,12 +4087,17 @@ bool MutateTask::prepare()
     /// Decided once here and reused for the task selection below, so that the column list of the new
     /// part cannot disagree with the task that fills it.
     const bool rewrites_all_columns = MutationHelpers::rewritesAllPartColumns(
-        ctx->source_part, ctx->commands_for_part, ctx->interpreter.get());
+        ctx->source_part, ctx->commands_for_part, ctx->interpreter.get(), ctx->metadata_snapshot);
 
     auto [new_columns, new_infos, new_columns_substreams] = MutationHelpers::getColumnsForNewDataPart(
         ctx->source_part, ctx->updated_header, ctx->storage_columns, ctx->metadata_snapshot->virtuals.getSampleBlock(VirtualsKind::Persistent, VirtualsMaterializationPlace::Reader).getNamesAndTypesList(),
-        ctx->source_part->getSerializationInfos(), ctx->for_interpreter, ctx->for_file_renames, rewrites_all_columns);
+        ctx->source_part->getSerializationInfos(), ctx->for_interpreter, ctx->for_file_renames, rewrites_all_columns, ctx->metadata_snapshot);
 
+    if (const auto column_id_mapping = ctx->getActiveColumnIdMapping())
+        column_id_mapping->stampColumnIds(new_columns);
+
+    /// `getColumnsForNewDataPart` produced `new_infos` in the logical-name domain.
+    new_infos.reKeyToColumnIds(new_columns);
     ctx->new_data_part->setColumns(new_columns, new_infos, ctx->metadata_snapshot->getMetadataVersion());
     if (!new_columns_substreams.empty())
         ctx->new_data_part->setColumnsSubstreams(new_columns_substreams);

--- a/src/Storages/MergeTree/SharedPartColumns.cpp
+++ b/src/Storages/MergeTree/SharedPartColumns.cpp
@@ -34,14 +34,16 @@ namespace DB
 namespace
 {
 
-/// The keys view into the names of `columns`, which belongs to the same bundle and outlives the map.
+/// The keys view into `columns`, which belongs to the same bundle and outlives the map. Spelled out
+/// rather than taken from `getColumnId`, which returns a fresh `ColumnId` by value: a view of that
+/// would dangle. Whole columns only, so no subcolumn name has to be built.
 SharedPartColumns::NameToNumber buildColumnPositions(const NamesAndTypesList & columns)
 {
     SharedPartColumns::NameToNumber positions;
     positions.reserve(columns.size());
     size_t pos = 0;
     for (const auto & column : columns)
-        positions.emplace(std::string_view(column.name), pos++);
+        positions.emplace(column.column_id.empty() ? column.name : column.column_id.value(), pos++);
     return positions;
 }
 
@@ -104,7 +106,9 @@ SharedPartColumns::SharedPartColumns(
     bool collect_nested_,
     String interning_key_)
     : columns(std::move(columns_))
-    , column_name_to_position(buildColumnPositions(columns))
+    , column_storage_key_to_position(buildColumnPositions(columns))
+    , has_stamped_column_ids(std::any_of(
+          columns.begin(), columns.end(), [](const auto & column) { return !column.column_id.empty(); }))
     , columns_description(std::move(columns_description_))
     , columns_description_with_collected_nested(std::move(columns_description_with_collected_nested_))
     , collect_nested(collect_nested_)
@@ -123,6 +127,10 @@ String SharedPartColumns::describeColumns(const NamesAndTypesList & columns)
     WriteBufferFromOwnString out;
     for (const auto & column : columns)
     {
+        /// The id belongs in the key even though it is a function of the name within one schema: after
+        /// `DROP x` and `ADD x` the table holds parts whose `x` carries the old id and parts whose `x`
+        /// carries the new one, and on the name alone the two would share a bundle.
+        writeStringBinary(column.getColumnId().value(), out);
         writeStringBinary(column.name, out);
         writeStringBinary(column.type->getName(), out);
 
@@ -162,7 +170,9 @@ std::vector<SharedPartColumns::SerializationGroupKey> SharedPartColumns::buildSe
     UInt32 position = 0;
     for (const auto & column : columns)
     {
-        auto it = infos.find(column.name);
+        /// `serialization.json` is keyed the same way the part's columns are -- by ID once the part
+        /// has them, by name before that.
+        auto it = infos.find(column.getColumnId().value());
 
         SerializationGroupKey key;
         key.column_position = position;
@@ -189,20 +199,18 @@ std::vector<SharedPartColumns::SerializationGroupKey> SharedPartColumns::buildSe
 
 PartSerializations::ColumnGroupPtr SharedPartColumns::buildSerializationGroup(const NameAndTypePair & column, const SerializationInfoByName & infos) const
 {
-    auto it = infos.find(column.name);
-    auto serialization = it == infos.end()
-        ? IDataType::getSerialization(column, infos.getSettings())
-        : IDataType::getSerialization(column, *it->second);
+    const String storage_key = column.getColumnId().value();
+    auto serialization = infos.getSerialization(column);
 
     auto group = std::make_shared<PartSerializations::ColumnGroup>();
     group->serializations.push_back(serialization);
-    group->names.push_back(column.name);
+    group->names.push_back(storage_key);
 
     IDataType::forEachSubcolumn([&](const auto &, const auto & subname, const auto & subdata)
     {
-        auto full_name = Nested::concatenateName(column.name, subname);
+        auto full_name = Nested::concatenateName(storage_key, subname);
         /// Don't override the column serialization with subcolumn serialization if column with the same name exists.
-        if (!column_name_to_position.contains(full_name))
+        if (!column_storage_key_to_position.contains(full_name))
         {
             group->names.push_back(std::move(full_name));
             group->serializations.push_back(subdata.serialization);
@@ -233,7 +241,7 @@ SharedPartColumns::SerializationsCacheKey SharedPartColumns::buildSerializations
         for (const auto & column : columns)
         {
             size_t offset = out.count();
-            if (auto it = infos.find(column.name); it != infos.end())
+            if (auto it = infos.find(column.getColumnId().value()); it != infos.end())
             {
                 it->second->serialializeKindStackBinary(out);
                 auto entry_settings = normalizeSettingsForKey(it->second->getSettings());

--- a/src/Storages/MergeTree/SharedPartColumns.h
+++ b/src/Storages/MergeTree/SharedPartColumns.h
@@ -28,7 +28,7 @@ class ColumnsDescription;
 /// a `shared_ptr` to one immutable `SharedPartColumns` bundle interned in a per-`MergeTreeData` cache
 /// keyed by the stored column list (see `MergeTreeData::getSharedPartColumnsForColumns`).
 ///
-/// The members that are a pure function of the column list (`columns`, `column_name_to_position`,
+/// The members that are a pure function of the column list (`columns`, `column_storage_key_to_position`,
 /// `columns_description{,_with_collected_nested}`) live directly in the bundle. The members that also
 /// depend on the per-part serialization kinds (the `serializations` map and `columns_substreams`) are
 /// interned in secondary caches nested inside the bundle, so they deduplicate across all parts whose
@@ -62,14 +62,14 @@ public:
         /// The serialization of the column itself followed by the serializations of its
         /// subcolumns in enumeration order.
         std::vector<SerializationPtr> serializations;
-        /// The lookup name of every serialization above (the column name, then the subcolumn full
+        /// The lookup name of every serialization above (the storage key, then the subcolumn full
         /// names). Stored so that the name lookup map can be assembled from interned groups
         /// without re-enumerating the subcolumns.
         std::vector<String> names;
     };
     using ColumnGroupPtr = std::shared_ptr<const ColumnGroup>;
 
-    /// Column name or subcolumn full name -> (column position, index within the column's group).
+    /// Storage key of a column or subcolumn -> (column position, index within the column's group).
     using NameToSlot = std::unordered_map<String, std::pair<UInt32, UInt32>>;
     using NameToSlotPtr = std::shared_ptr<const NameToSlot>;
 
@@ -109,8 +109,8 @@ using PartSerializationsPtr = std::shared_ptr<const PartSerializations>;
 class SharedPartColumns
 {
 public:
-    /// The keys are views into the names of the `columns` member of the owning bundle, which is
-    /// immutable and outlives the map, so the names are not duplicated.
+    /// The keys are views into the `columns` member of the owning bundle, which is immutable and
+    /// outlives the map, so the keys are not duplicated.
     using NameToNumber = std::unordered_map<std::string_view, size_t>;
 
     SharedPartColumns(
@@ -121,7 +121,7 @@ public:
         String interning_key_);
 
     /// What makes two column lists interchangeable for a data part, and therefore the interning key of a
-    /// bundle: the names of the columns, their full type names and the identities of the custom
+    /// bundle: the ids and names of the columns, their full type names and the identities of the custom
     /// serializations attached to them from outside the type. `NamesAndTypesList` equality is not enough:
     /// it compares types with `IDataType::equals`, which ignores custom names at any depth
     /// (`Nullable(Bool)` against `Nullable(UInt8)`) although a part persists the name it was declared
@@ -129,7 +129,10 @@ public:
     static String describeColumns(const NamesAndTypesList & columns);
 
     const NamesAndTypesList columns;
-    const NameToNumber column_name_to_position;
+    /// Keyed by storage id (`NameAndTypePair::getColumnId`).
+    const NameToNumber column_storage_key_to_position;
+    /// Whether the list carries ids of its own. A pure function of it, hence interned with it.
+    const bool has_stamped_column_ids;
     const std::shared_ptr<const ColumnsDescription> columns_description;
     /// Aliases `columns_description` when `Nested::collect` produces no distinct list
     /// (or when the `share_nested_offsets` setting is disabled).

--- a/src/Storages/MergeTree/StatisticsSerialization.cpp
+++ b/src/Storages/MergeTree/StatisticsSerialization.cpp
@@ -10,16 +10,17 @@
 namespace DB
 {
 
-static String getStatisticsFilename(const String & column_name)
+static String getStatisticsFilename(const String & column_name, const NamesAndTypesList & part_columns)
 {
     /// Note, we cannot use replaceFileNameToHashIfNeeded(), since we do not handle hashes->column names for statistics in getColumnForStatisticsFile()
-    return String(STATS_FILE_PREFIX) + escapeForFileName(column_name) + String(STATS_FILE_SUFFIX);
+    return String(STATS_FILE_PREFIX) + escapeForFileName(part_columns.getColumnIdByName(column_name).value()) + String(STATS_FILE_SUFFIX);
 }
 
 std::unique_ptr<WriteBufferFromFileBase> serializeStatisticsPacked(
     IDataPartStorage & data_part_storage,
     MergeTreeDataPartChecksums & out_checksums,
     const ColumnsStatistics & statistics,
+    const NamesAndTypesList & part_columns,
     const CompressionCodecPtr & compression_codec,
     const WriteSettings & write_settings)
 {
@@ -27,7 +28,7 @@ std::unique_ptr<WriteBufferFromFileBase> serializeStatisticsPacked(
 
     for (const auto & [column_name, stat] : statistics)
     {
-        String filename = getStatisticsFilename(column_name);
+        String filename = getStatisticsFilename(column_name, part_columns);
         auto out = packed_writer.writeFile(filename, write_settings);
 
         CompressedWriteBuffer compressor(*out, compression_codec, 1024 * 1024);
@@ -54,6 +55,7 @@ WrittenFiles serializeStatisticsWide(
     IDataPartStorage & data_part_storage,
     MergeTreeDataPartChecksums & out_checksums,
     const ColumnsStatistics & statistics,
+    const NamesAndTypesList & part_columns,
     const CompressionCodecPtr & compression_codec,
     const WriteSettings & write_settings)
 {
@@ -61,7 +63,7 @@ WrittenFiles serializeStatisticsWide(
 
     for (const auto & [column_name, stat] : statistics)
     {
-        String filename = getStatisticsFilename(column_name);
+        String filename = getStatisticsFilename(column_name, part_columns);
 
         /// Buffer chain: plain_file <- plain_hashing <- compressor <- compressed_hashing
         auto plain_file = data_part_storage.writeFile(filename, 4096, write_settings);

--- a/src/Storages/MergeTree/StatisticsSerialization.h
+++ b/src/Storages/MergeTree/StatisticsSerialization.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/NamesAndTypes.h>
 #include <Storages/Statistics/Statistics.h>
 #include <IO/WriteBuffer.h>
 
@@ -16,19 +17,22 @@ using CompressionCodecPtr = std::shared_ptr<ICompressionCodec>;
 
 using WrittenFiles = std::vector<std::unique_ptr<WriteBufferFromFileBase>>;
 
-/// Serialize statistics into a single packed archive file (statistics.packed).
+/// Serialize statistics into a single packed archive file (statistics.packed), each entry named
+/// after the column's id in `part_columns` (see `NamesAndTypesList::getColumnIdByName`).
 std::unique_ptr<WriteBufferFromFileBase> serializeStatisticsPacked(
     IDataPartStorage & data_part_storage,
     MergeTreeDataPartChecksums & out_checksums,
     const ColumnsStatistics & statistics,
+    const NamesAndTypesList & part_columns,
     const CompressionCodecPtr & compression_codec,
     const WriteSettings & write_settings);
 
-/// Serialize statistics as separate compressed files (column_name.stats each).
+/// Serialize statistics as separate compressed files, one per column, named as above.
 WrittenFiles serializeStatisticsWide(
     IDataPartStorage & data_part_storage,
     MergeTreeDataPartChecksums & out_checksums,
     const ColumnsStatistics & statistics,
+    const NamesAndTypesList & part_columns,
     const CompressionCodecPtr & compression_codec,
     const WriteSettings & write_settings);
 

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -8,6 +8,7 @@
 #include <Storages/MergeTree/MergeTreeDataPartCompact.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Interpreters/FileCache/FileCache.h>
 #include <Interpreters/FileCache/FileCacheFactory.h>
 #include <Compression/CompressedReadBuffer.h>
@@ -146,6 +147,25 @@ bool isRetryableException(std::exception_ptr exception_ptr)
     }
 }
 
+/// `columns.txt` spells ids, and `columns_list` -- the list the part loaded from that same file --
+/// carries each token as its column's id, so names cannot be compared after a metadata-only RENAME.
+/// Positional: a compact part's reader seeks a column by its `columns.txt` ordinal.
+static bool columnsMatchInIdSpace(const NamesAndTypesList & columns_txt, const NamesAndTypesList & columns_list)
+{
+    if (columns_txt.size() != columns_list.size())
+        return false;
+
+    auto expected = columns_list.begin();
+    for (const auto & column : columns_txt)
+    {
+        if (column.getColumnId() != expected->getColumnId() || !column.type->equals(*expected->type))
+            return false;
+        ++expected;
+    }
+
+    return true;
+}
+
 static IMergeTreeDataPart::Checksums checkDataPart(
     MergeTreeData::DataPartPtr data_part,
     const IDataPartStorage & data_part_storage,
@@ -171,13 +191,18 @@ static IMergeTreeDataPart::Checksums checkDataPart(
 
     {
         auto buf = data_part_storage.readFile("columns.txt", read_settings, std::nullopt);
-        columns_txt.readText(*buf);
+        /// The comparison below is in ID space, so this reader has to accept an ID-keyed list --
+        /// refusing the version would fail the check on every part that carries IDs.
+        columns_txt.readText(*buf, /*check_eof=*/true, /*allow_column_ids=*/true);
         assertEOF(*buf);
     }
 
-    if (columns_txt != columns_list)
+    if (!columnsMatchInIdSpace(columns_txt, columns_list))
         throw Exception(ErrorCodes::CORRUPTED_DATA, "Columns doesn't match in part {}. Expected: {}. Found: {}",
             data_part_storage.getFullPath(), columns_list.toString(), columns_txt.toString());
+
+    /// Read `serialization.json` the way the part's own loader read it (`loadColumns`).
+    const bool column_ids_active = data_part->storage.getActiveColumnIdMapping() != nullptr;
 
     /// Real checksums based on contents of data. Must correspond to checksums.txt. If not - it means the data is broken.
     IMergeTreeDataPart::Checksums checksums_data;
@@ -204,7 +229,10 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         try
         {
             auto serialization_file = data_part_storage.readFile(IMergeTreeDataPart::SERIALIZATION_FILE_NAME, read_settings, std::nullopt);
-            serialization_infos = SerializationInfoByName::readJSON(columns_txt, *serialization_file);
+            if (column_ids_active)
+                serialization_infos = SerializationInfoByName::readJSONWithColumnIds(columns_list, *serialization_file);
+            else
+                serialization_infos = SerializationInfoByName::readJSON(columns_txt, *serialization_file);
         }
         catch (...)
         {
@@ -216,14 +244,6 @@ static IMergeTreeDataPart::Checksums checkDataPart(
                 getCurrentExceptionMessage(true));
         }
     }
-
-    auto get_serialization = [&serialization_infos](const auto & column)
-    {
-        auto it = serialization_infos.find(column.name);
-        return it == serialization_infos.end()
-            ? column.type->getSerialization(serialization_infos.getSettings())
-            : column.type->getSerialization(*it->second);
-    };
 
     /// This function calculates only checksum of file content (compressed or uncompressed).
     auto checksum_file = [&](const String & file_name)
@@ -281,7 +301,7 @@ static IMergeTreeDataPart::Checksums checkDataPart(
             settings.enumerate_dynamic_streams = false;
             for (const auto & column : columns_list)
             {
-                auto serialization = get_serialization(column);
+                auto serialization = serialization_infos.getSerialization(column);
                 auto data = ISerialization::SubstreamData(serialization)
                     .withType(column.type)
                     .withColumn(data_part->getColumnSample(column));
@@ -379,7 +399,9 @@ static IMergeTreeDataPart::Checksums checkDataPart(
             if (projection_columns.empty())
             {
                 auto buf = projection_storage->readFile("columns.txt", read_settings, std::nullopt);
-                projection_columns.readText(*buf);
+                /// A projection part is written with the parent's mapping, so its list can be
+                /// ID-keyed too.
+                projection_columns.readText(*buf, /*check_eof=*/true, /*allow_column_ids=*/true);
                 assertEOF(*buf);
             }
 

--- a/src/Storages/MergeTree/tests/gtest_column_id_mapping.cpp
+++ b/src/Storages/MergeTree/tests/gtest_column_id_mapping.cpp
@@ -1,0 +1,361 @@
+#include <gtest/gtest.h>
+
+#include <base/defines.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeVirtualColumns.h>
+#include <Storages/VirtualColumnsDescription.h>
+#include <Common/Exception.h>
+
+
+using namespace DB;
+
+namespace
+{
+
+DataTypePtr uint64Type()
+{
+    static const auto type = std::make_shared<DataTypeUInt64>();
+    return type;
+}
+
+NamesAndTypesList makeColumns(std::initializer_list<String> names)
+{
+    NamesAndTypesList columns;
+    for (const auto & name : names)
+        columns.emplace_back(name, uint64Type());
+    return columns;
+}
+
+}
+
+TEST(ColumnIdMapping, DropReAddSameName)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a"}));
+
+    EXPECT_EQ(mapping.getColumnId("a"), "a");
+
+    mapping.removeColumn("a");
+    auto new_column_id = mapping.allocateColumnId();
+    mapping.addColumn("a", new_column_id);
+
+    EXPECT_EQ(mapping.getColumnId("a"), "1");
+    EXPECT_EQ(new_column_id, "1");
+    EXPECT_NE(new_column_id, "a");
+}
+
+TEST(ColumnIdMapping, CounterWithNumericColumnNames)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"2", "a", "10"}));
+
+    EXPECT_EQ(mapping.allocateColumnId(), "11");
+}
+
+TEST(ColumnIdMapping, CounterCoversBothHalvesOfACompoundId)
+{
+    /// A flattened Nested child id spends a counter value on each half, so both halves have to
+    /// push the counter up -- whether they come from a column name at activation or from a
+    /// mapping an earlier ALTER wrote.
+    auto identity = ColumnIdMapping::createIdentity(makeColumns({"n.3", "a"}));
+    EXPECT_EQ(identity.allocateColumnId(), "4");
+
+    auto restored = ColumnIdMapping::fromString(R"({
+        "active": true,
+        "next_column_id": 2,
+        "mapping": {
+            "n.x": "1.7",
+            "n.y": "1.5"
+        }
+    })");
+
+    EXPECT_EQ(restored.allocateColumnId(), "8");
+}
+
+TEST(ColumnIdMapping, RenamePreservesColumnId)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a", "b"}));
+
+    mapping.beginRename("a", "c");
+    mapping.finishRename("a");
+
+    EXPECT_FALSE(mapping.hasColumnName("a"));
+    EXPECT_TRUE(mapping.hasColumnName("c"));
+    EXPECT_EQ(mapping.getColumnId("c"), "a");
+    EXPECT_EQ(mapping.getColumnName("a"), "c");
+}
+
+TEST(ColumnIdMapping, SerializeDeserializeRoundTrip)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"10", "a"}));
+    auto new_column_id = mapping.allocateColumnId();
+    mapping.addColumn("c", new_column_id);
+    mapping.beginRename("a", "b");
+    mapping.finishRename("a");
+
+    auto restored = ColumnIdMapping::fromString(mapping.toString());
+
+    EXPECT_TRUE(restored.isActive());
+    EXPECT_EQ(restored.getColumnId("10"), "10");
+    EXPECT_EQ(restored.getColumnId("b"), "a");
+    EXPECT_EQ(restored.getColumnId("c"), "11");
+    EXPECT_EQ(restored.getColumnName("a"), "b");
+    EXPECT_EQ(restored.allocateColumnId(), "12");
+}
+
+TEST(ColumnIdMapping, DeserializeClampsNextColumnIdToExistingIds)
+{
+    auto restored = ColumnIdMapping::fromString(R"({
+        "active": true,
+        "next_column_id": 2,
+        "mapping": {
+            "a": "10",
+            "b": "name"
+        }
+    })");
+
+    EXPECT_EQ(restored.allocateColumnId(), "11");
+}
+
+TEST(ColumnIdMapping, UnmappedColumnsPassthrough)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a"}));
+
+    EXPECT_EQ(mapping.getColumnIdOrDefault("_row_exists"), "_row_exists");
+
+    /// A virtual column is left UNSTAMPED; `getColumnId()` falls back to the name,
+    /// so empty is equivalent to the old write behavior of stamping it to its own name.
+    auto columns = makeColumns({"a", "_row_exists"});
+    mapping.stampColumnIds(columns);
+
+    auto a = columns.tryGetByName("a");
+    auto row_exists = columns.tryGetByName("_row_exists");
+
+    ASSERT_TRUE(a.has_value());
+    ASSERT_TRUE(row_exists.has_value());
+    EXPECT_EQ(a->getColumnId().value(), "a");
+    EXPECT_TRUE(row_exists->column_id.empty());
+    EXPECT_EQ(row_exists->getColumnId().value(), "_row_exists");
+}
+
+TEST(ColumnIdMapping, TwoPhaseRenameNormal)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a", "b"}));
+
+    mapping.beginRename("a", "c");
+
+    EXPECT_TRUE(mapping.hasColumnName("a"));
+    EXPECT_TRUE(mapping.hasColumnName("c"));
+    EXPECT_EQ(mapping.getColumnId("a"), "a");
+    EXPECT_EQ(mapping.getColumnId("c"), "a");
+
+    mapping.finishRename("a");
+
+    EXPECT_FALSE(mapping.hasColumnName("a"));
+    EXPECT_TRUE(mapping.hasColumnName("c"));
+    EXPECT_EQ(mapping.getColumnId("c"), "a");
+    EXPECT_EQ(mapping.getColumnName("a"), "c");
+}
+
+TEST(ColumnIdMapping, TwoPhaseRenameCrashRecovery)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a", "b"}));
+
+    mapping.beginRename("a", "c");
+
+    auto serialized = mapping.toString();
+    auto restored = ColumnIdMapping::fromString(serialized);
+
+    EXPECT_TRUE(restored.hasColumnName("a"));
+    EXPECT_TRUE(restored.hasColumnName("c"));
+    /// Both "a" and "c" map to column ID "a"; reverse map must be deterministic
+    /// (lexicographically smallest column name wins).
+    EXPECT_EQ(restored.getColumnName("a"), "a");
+
+    restored.removeColumn("c");
+
+    EXPECT_TRUE(restored.hasColumnName("a"));
+    EXPECT_FALSE(restored.hasColumnName("c"));
+    EXPECT_EQ(restored.getColumnId("a"), "a");
+    EXPECT_EQ(restored.getColumnName("a"), "a");
+}
+
+TEST(ColumnIdMapping, TwoPhaseRenameRemoveOldPreservesColumnId)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a", "b"}));
+
+    auto column_id = mapping.allocateColumnId();
+    mapping.addColumn("c", column_id);
+
+    mapping.beginRename("c", "d");
+
+    mapping.removeColumn("c");
+
+    EXPECT_TRUE(mapping.hasColumnName("d"));
+    EXPECT_EQ(mapping.getColumnId("d"), column_id);
+    EXPECT_TRUE(mapping.hasColumnId(column_id));
+}
+
+TEST(ColumnIdMapping, ConcurrentDropAddCycle)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a"}));
+
+    mapping.removeColumn("a");
+    auto b_column_id = mapping.allocateColumnId();
+    mapping.addColumn("b", b_column_id);
+
+    mapping.removeColumn("b");
+    auto a_column_id = mapping.allocateColumnId();
+    mapping.addColumn("a", a_column_id);
+
+    EXPECT_EQ(b_column_id, "1");
+    EXPECT_EQ(a_column_id, "2");
+    EXPECT_EQ(mapping.getColumnId("a"), "2");
+    EXPECT_NE(a_column_id, b_column_id);
+}
+
+TEST(ColumnIdMapping, RenameToExistingColumnIdIsRejected)
+{
+    /// Renaming a column to a name equal to another active column's id is rejected: on-disk
+    /// artifacts are keyed by the column id, so such a column name makes name-vs-id resolution
+    /// ambiguous (reachable via a mutation that then reads/writes the wrong streams). The
+    /// two-phase rotation a->x; b->a is a special case of this and is likewise rejected.
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a", "b"}));
+    auto id = mapping.allocateColumnId();
+    mapping.addColumn("c", id);
+    ASSERT_EQ(id, "1");
+
+    /// Renaming "a" to "1" collides with column c's id "1".
+    EXPECT_THROW(mapping.beginRename("a", id), Exception);
+
+    /// Two-phase rotation: after a->x, "x" holds id "a", so renaming "b" to "a" is rejected.
+    auto rot = ColumnIdMapping::createIdentity(makeColumns({"a", "b"}));
+    rot.beginRename("a", "x");
+    rot.finishRename("a");
+    EXPECT_THROW(rot.beginRename("b", "a"), Exception);
+
+    /// Self-case: renaming "c" to its own id "1" is allowed.
+    EXPECT_NO_THROW(mapping.beginRename("c", id));
+    EXPECT_NO_THROW(mapping.finishRename("c"));
+    EXPECT_EQ(mapping.getColumnId(id), id);
+}
+
+/// stampColumnIds must NOT clobber a column that already carries a part-local id.
+/// Callers such as MergeTreeDataPartWide::getListOfStreamsForColumn (subcolumn sizes) feed
+/// an already-stamped part column into the reader factory, which then re-stamps off the
+/// *live* metadata mapping. After a DROP + re-ADD reuses the column name at a fresh id,
+/// re-stamping would rewrite the old part's real id to the live one and mis-resolve its
+/// streams. Columns that arrive id-less (the main read path's query columns) must still
+/// get stamped.
+TEST(ColumnIdMapping, StampForReadPreservesExistingId)
+{
+    /// Live mapping after DROP COLUMN a; ADD COLUMN a ...: name "a" now resolves to "1",
+    /// while old parts still store it under the original id "a".
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a"}));
+    mapping.removeColumn("a");
+    auto fresh_id = mapping.allocateColumnId();
+    mapping.addColumn("a", fresh_id);
+    ASSERT_EQ(fresh_id, "1");
+    ASSERT_EQ(mapping.getColumnId("a"), "1");
+
+    /// A pre-stamped old-part column keeps its own id.
+    NamesAndTypesList prestamped = makeColumns({"a"});
+    prestamped.front().setColumnId(ColumnId{"a"});
+    mapping.stampColumnIds(prestamped);
+    EXPECT_EQ(prestamped.front().getColumnId().value(), "a");
+
+    /// An id-less query column (the main read path) still gets stamped to the live id.
+    NamesAndTypesList idless = makeColumns({"a"});
+    mapping.stampColumnIds(idless);
+    EXPECT_EQ(idless.front().getColumnId().value(), "1");
+}
+
+/// Change-detector tied to the `addPersistent(...)` set in MergeTreeData::createVirtuals.
+/// `isPersistentVirtualColumn` hardcodes that set; if a new persistent virtual column is
+/// added there, BOTH `isPersistentVirtualColumn` and this test must be updated. Persistent
+/// virtuals are stored in parts and must NOT be remapped by the column ID mapping;
+/// misclassifying one would corrupt its stream resolution.
+TEST(ColumnIdMapping, IsPersistentVirtualColumnMatchesAddPersistentSet)
+{
+    /// Exactly the three columns added via addPersistent(...).
+    EXPECT_TRUE(isPersistentVirtualColumn(RowExistsColumn::name));
+    EXPECT_TRUE(isPersistentVirtualColumn(BlockNumberColumn::name));
+    EXPECT_TRUE(isPersistentVirtualColumn(BlockOffsetColumn::name));
+
+    /// A sample of ephemeral (read-computed) virtuals must be excluded.
+    EXPECT_FALSE(isPersistentVirtualColumn(PartDataVersionColumn::name));
+    EXPECT_FALSE(isPersistentVirtualColumn("_part"));
+    EXPECT_FALSE(isPersistentVirtualColumn("_part_offset"));
+}
+
+/// Drift guard: `isVirtualColumn` and `MergeTreeData::createVirtuals` now share one registry
+/// (`getMergeTreeVirtuals`), so they cannot drift. This asserts the invariant end-to-end
+/// (were the single source ever re-forked, this catches it): the predicate must cover every
+/// virtual `createVirtuals` registers, plus `_partition_value` (added only when a partition key
+/// is present, so absent from `createVirtuals(nullptr)`). With strict stamping, a miss means the
+/// stamp treats a virtual as a real stored column and throws.
+TEST(ColumnIdMapping, IsVirtualColumnCoversCreateVirtuals)
+{
+    const auto virtuals = MergeTreeData::createVirtuals(nullptr);
+    for (const auto & column : virtuals)
+        EXPECT_TRUE(isVirtualColumn(column.name)) << "createVirtuals registers '" << column.name
+            << "' but isVirtualColumn does not cover it";
+
+    EXPECT_TRUE(isVirtualColumn(PartitionValueColumn::name));
+
+    /// A real user column is not virtual.
+    EXPECT_FALSE(isVirtualColumn("a"));
+}
+
+/// Unified stamp (write == read): a mapped column takes its id, a virtual is left UNSTAMPED
+/// (empty ≡ name-keyed on disk), and an already-stamped part-local id is preserved (not
+/// clobbered by the live mapping after a DROP + re-ADD name reuse).
+TEST(ColumnIdMapping, StampColumnIdsStampsMappedLeavesVirtualEmpty)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a"}));
+    mapping.removeColumn("a");
+    auto fresh_id = mapping.allocateColumnId();
+    mapping.addColumn("a", fresh_id);
+    ASSERT_EQ(fresh_id, "1");
+
+    auto columns = makeColumns({"a", BlockNumberColumn::name});
+    mapping.stampColumnIds(columns);
+    EXPECT_EQ(columns.tryGetByName("a")->getColumnId().value(), "1");
+    /// Virtual left unstamped; name fallback yields its own name (the old write behavior).
+    EXPECT_TRUE(columns.tryGetByName(BlockNumberColumn::name)->column_id.empty());
+    EXPECT_EQ(columns.tryGetByName(BlockNumberColumn::name)->getColumnId().value(), BlockNumberColumn::name);
+
+    NamesAndTypesList prestamped = makeColumns({"a"});
+    prestamped.front().setColumnId(ColumnId{"42"});
+    mapping.stampColumnIds(prestamped);
+    EXPECT_EQ(prestamped.front().getColumnId().value(), "42");
+}
+
+/// Lenient stamp: mapped columns get their id, columns outside the mapping (synthetic
+/// projection aggregates, not-yet-applied ALTER columns, a projection part's parent-mapped
+/// columns during loadColumns) are left UNSTAMPED, and it never throws.
+TEST(ColumnIdMapping, StampColumnIdsLenientLeavesUnmappedEmpty)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a", "c"}));
+
+    auto columns = makeColumns({"a", "sum(c)"});
+    EXPECT_NO_THROW(mapping.stampColumnIdsLenient(columns));
+    EXPECT_EQ(columns.tryGetByName("a")->getColumnId().value(), "a");
+    EXPECT_TRUE(columns.tryGetByName("sum(c)")->column_id.empty());
+}
+
+/// Discriminating: a real stored column absent from an active mapping is a schema/mapping
+/// desync. The unified stamp must fail loud (LOGICAL_ERROR -> abort under debug/sanitizer, a
+/// throw otherwise) instead of silently defaulting the id to the name / leaving it empty.
+/// With the old lenient code it would not fail, so this is RED without the fix.
+TEST(ColumnIdMappingDeathTest, StampColumnIdsRejectsUnmappedColumn)
+{
+    auto mapping = ColumnIdMapping::createIdentity(makeColumns({"a"}));
+    auto columns = makeColumns({"a", "ghost"});
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    EXPECT_DEATH({ mapping.stampColumnIds(columns); }, "desynced");
+#else
+    EXPECT_THROW(mapping.stampColumnIds(columns), DB::Exception);
+#endif
+}

--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -18,6 +18,7 @@
 #include <Parsers/ASTSQLSecurity.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Storages/IndicesDescription.h>
+#include <Storages/MergeTree/ColumnIdMapping.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
@@ -69,6 +70,7 @@ StorageInMemoryMetadata::StorageInMemoryMetadata(const StorageInMemoryMetadata &
     , comment(other.comment)
     , metadata_version(other.metadata_version)
     , datalake_table_state(other.datalake_table_state)
+    , column_id_mapping(other.column_id_mapping)
 {
 }
 
@@ -110,8 +112,25 @@ StorageInMemoryMetadata & StorageInMemoryMetadata::operator=(const StorageInMemo
     comment = other.comment;
     metadata_version = other.metadata_version;
     datalake_table_state = other.datalake_table_state;
+    column_id_mapping = other.column_id_mapping;
 
     return *this;
+}
+
+ColumnIdMappingPtr StorageInMemoryMetadata::getActiveColumnIdMapping() const
+{
+    if (column_id_mapping && column_id_mapping->isActive())
+        return column_id_mapping;
+    return nullptr;
+}
+
+void StorageInMemoryMetadata::syncColumnIdsFromMapping()
+{
+    /// The single chokepoint that keeps the schema's per-column IDs in step with the mapping, so
+    /// every derived `NamesAndTypesList` speaks IDs without a separate mapping consult. No-op for
+    /// tables without an active mapping (columns keep an empty ID -> fall back to name).
+    if (column_id_mapping && column_id_mapping->isActive())
+        columns.setColumnIds(*column_id_mapping);
 }
 
 void StorageInMemoryMetadata::setComment(const String & comment_)

--- a/src/Storages/StorageInMemoryMetadata.h
+++ b/src/Storages/StorageInMemoryMetadata.h
@@ -21,6 +21,8 @@ namespace DB
 
 class ClientInfo;
 class ASTSQLSecurity;
+class ColumnIdMapping;
+using ColumnIdMappingPtr = std::shared_ptr<const ColumnIdMapping>;
 
 /// Common metadata for all storages. Contains all possible parts of CREATE
 /// query from all storages, but only some subset used.
@@ -85,6 +87,20 @@ struct StorageInMemoryMetadata
 
     ///  Current state of a datalake table.
     std::optional<DataLakeTableStateSnapshot> datalake_table_state;
+
+    /// Column-ID mapping, folded in so it is captured atomically with the schema. Null unless
+    /// the table opted into column IDs. Shallow-copied below.
+    ColumnIdMappingPtr column_id_mapping;
+
+    /// The column-ID mapping, but only when it is active (parts are written with IDs);
+    /// nullptr otherwise. Every holder of this metadata (a StorageMetadataPtr or a
+    /// StorageSnapshot's `metadata`) resolves names->IDs against this, so the mapping
+    /// rides the schema it is consistent with instead of being threaded separately.
+    ColumnIdMappingPtr getActiveColumnIdMapping() const;
+
+    /// Stamp `columns` from the active `column_id_mapping`. Call after any (re)publish of the
+    /// mapping onto this metadata so the schema itself carries per-column IDs.
+    void syncColumnIdsFromMapping();
 
     /// If metadata was cloned we need to extend lifetime of previous metadata.
     std::shared_ptr<const StorageInMemoryMetadata> cloned_from = nullptr;

--- a/src/Storages/StorageMergeTreeIndex.cpp
+++ b/src/Storages/StorageMergeTreeIndex.cpp
@@ -13,7 +13,6 @@
 #include <Parsers/ASTSelectQuery.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
-#include <Storages/MergeTree/MergeTreeDataPartCompact.h>
 #include <Storages/MergeTree/MergeTreeMarksLoader.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Access/Common/AccessFlags.h>
@@ -41,7 +40,6 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int NO_SUCH_COLUMN_IN_TABLE;
-    extern const int NOT_IMPLEMENTED;
 }
 
 class MergeTreeIndexSource final : public ISource, WithContext
@@ -53,7 +51,8 @@ public:
         SharedHeader minmax_header_,
         MergeTreeData::DataPartsVector data_parts_,
         ContextPtr context_,
-        bool with_marks_)
+        bool with_marks_,
+        StorageMetadataHandle source_metadata_)
         : ISource(header_)
         , WithContext(context_)
         , header(std::move(header_))
@@ -61,6 +60,7 @@ public:
         , minmax_header(std::move(minmax_header_))
         , data_parts(std::move(data_parts_))
         , with_marks(with_marks_)
+        , source_metadata(std::move(source_metadata_))
     {
     }
 
@@ -77,15 +77,9 @@ protected:
         const auto & part = data_parts[part_index];
         const auto & index_granularity = part->index_granularity;
 
-        std::shared_ptr<MergeTreeMarksLoader> marks_loader;
-        if (with_marks && isCompactPart(part))
-        {
-            marks_loader = createMarksLoader(
-                part,
-                MergeTreeDataPartCompact::DATA_FILE_NAME,
-                part->index_granularity_info.mark_type.with_substreams ? part->getColumnsSubstreams().getTotalSubstreams()
-                                                                       : part->getColumns().size());
-        }
+        /// Both caches below describe one part, so drop what the previous part left.
+        part_streams_by_logical_name.reset();
+        marks_loaders.clear();
 
         size_t num_columns = header->columns();
         size_t num_rows = index_granularity->getMarksCount();
@@ -164,7 +158,7 @@ protected:
             }
             else if (auto [first, second] = Nested::splitName(column_name, true); with_marks && second == "mark")
             {
-                result_columns[pos] = fillMarks(part, marks_loader, *column_type, first);
+                result_columns[pos] = fillMarks(part, *column_type, first);
             }
             else
             {
@@ -195,55 +189,68 @@ private:
             local_context->getSettingsRef()[Setting::use_streaming_marks_compression]);
     }
 
-    ColumnPtr fillMarks(
-        MergeTreeDataPartPtr part,
-        std::shared_ptr<MergeTreeMarksLoader> marks_loader,
-        const IDataType & data_type,
-        const String & column_name)
+    /// A stream as the part addresses it -- by the column's stamped ID.
+    struct PartStream
     {
-        size_t col_idx = 0;
-        bool has_marks_in_part = false;
+        NameAndTypePair column_in_part;
+        ISerialization::SubstreamPath substream_path;
+    };
+
+    /// A stream name as `getFileNameForStream` derives it from a column's CURRENT logical name --
+    /// never `getFileNameForStreamByColumnId`. The header's `<stream>.mark` columns are named this way
+    /// (see TableFunctionMergeTreeIndex), and the name is all `fillMarks` is handed.
+    using LogicalStreamName = String;
+
+    using PartStreamByLogicalName = std::unordered_map<LogicalStreamName, PartStream>;
+
+    PartStreamByLogicalName buildPartStreamsByLogicalName(const MergeTreeDataPartPtr & part) const
+    {
+        PartStreamByLogicalName streams;
+        ISerialization::StreamFileNameSettings stream_file_name_settings(*part->storage.getSettings());
+
+        for (const auto & column : source_metadata->getColumns().getAllPhysical())
+        {
+            auto column_in_part = part->tryGetColumnBySnapshotName(column.name, source_metadata);
+            if (!column_in_part)
+                continue;
+
+            /// The header also asks for the stream carrying the column itself, which for some types
+            /// (e.g. Tuple) is not among the substreams. Insert it first so that it wins over an
+            /// equally named substream, matching how the header was built.
+            streams.emplace(escapeForFileName(column.name), PartStream{*column_in_part, {}});
+
+            auto serialization = part->tryGetSerialization(column_in_part->getStorageKey());
+            if (!serialization)
+                continue;
+
+            serialization->enumerateStreams([&](const auto & substream_path)
+            {
+                auto stream_name = ISerialization::getFileNameForStream(column.name, substream_path, stream_file_name_settings);
+                streams.emplace(std::move(stream_name), PartStream{*column_in_part, substream_path});
+            });
+        }
+
+        return streams;
+    }
+
+    ColumnPtr fillMarks(const MergeTreeDataPartPtr & part, const IDataType & data_type, const LogicalStreamName & logical_stream_name)
+    {
         size_t num_rows = part->index_granularity->getMarksCount();
 
-        if (isWidePart(part))
-        {
-            if (auto stream_name = IMergeTreeDataPart::getStreamNameOrHash(column_name, ".bin", part->checksums))
-            {
-                col_idx = 0;
-                has_marks_in_part = true;
-                marks_loader = createMarksLoader(part, *stream_name, /*num_columns=*/ 1);
-            }
-        }
-        else if (isCompactPart(part))
-        {
-            if (part->index_granularity_info.mark_type.with_substreams)
-            {
-                if (auto col_idx_opt = part->getColumnsSubstreams().tryGetSubstreamPosition(column_name))
-                {
-                    col_idx = *col_idx_opt;
-                    has_marks_in_part = true;
-                }
-            }
-            else
-            {
-                auto unescaped_name = unescapeForFileName(column_name);
-                if (auto col_idx_opt = part->getColumnPosition(unescaped_name))
-                {
-                    col_idx = *col_idx_opt;
-                    has_marks_in_part = true;
-                }
-            }
-        }
-        else
-        {
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Parts with type {} are not supported", part->getTypeName());
-        }
+        if (!part_streams_by_logical_name)
+            part_streams_by_logical_name = buildPartStreamsByLogicalName(part);
 
-        if (!has_marks_in_part)
-        {
-            auto column = data_type.createColumnConstWithDefaultValue(num_rows);
-            return column->convertToFullColumnIfConst();
-        }
+        std::optional<ColumnMarksLocation> marks_location;
+        if (auto it = part_streams_by_logical_name->find(logical_stream_name); it != part_streams_by_logical_name->end())
+            marks_location = part->getColumnMarksLocation(it->second.column_in_part, it->second.substream_path);
+
+        /// The part stores nothing for this stream, so the column has no marks here.
+        if (!marks_location)
+            return data_type.createColumnConstWithDefaultValue(num_rows)->convertToFullColumnIfConst();
+
+        auto & marks_loader = marks_loaders[marks_location->marks_stream_name];
+        if (!marks_loader)
+            marks_loader = createMarksLoader(part, marks_location->marks_stream_name, marks_location->columns_in_mark);
 
         auto compressed = ColumnUInt64::create(num_rows);
         auto uncompressed = ColumnUInt64::create(num_rows);
@@ -255,7 +262,7 @@ private:
 
         for (size_t i = 0; i < num_rows; ++i)
         {
-            auto mark = marks_getter->getMark(i, col_idx);
+            auto mark = marks_getter->getMark(i, marks_location->index_in_mark);
 
             compressed_data[i] = mark.offset_in_compressed_file;
             uncompressed_data[i] = mark.offset_in_decompressed_block;
@@ -272,8 +279,16 @@ private:
     SharedHeader minmax_header;
     MergeTreeData::DataPartsVector data_parts;
     bool with_marks;
+    /// Source table's live metadata, captured once at pipeline init (this source holds no
+    /// StorageSnapshot of the source table). It carries the current logical names the header is built
+    /// from, and resolves them to a part's columns by their stable IDs.
+    StorageMetadataHandle source_metadata;
 
     size_t part_index = 0;
+
+    std::optional<PartStreamByLogicalName> part_streams_by_logical_name;
+    /// Keyed by marks stream name, so a Wide part gets a loader per column and a Compact part one.
+    std::unordered_map<String, std::shared_ptr<MergeTreeMarksLoader>> marks_loaders;
 };
 
 const ColumnWithTypeAndName StorageMergeTreeIndex::part_name_column{std::make_shared<DataTypeString>(), "part_name"};
@@ -433,13 +448,16 @@ void ReadFromMergeTreeIndex::initializePipeline(QueryPipelineBuilder & pipeline,
         filtered_parts.size(),
         storage->source_table->getStorageID().getNameForLogs());
 
+    auto source_metadata = storage->source_table->getInMemoryMetadataPtr(context, false);
+
     pipeline.init(Pipe(std::make_shared<MergeTreeIndexSource>(
         getOutputHeader(),
         storage->key_sample_block,
         storage->minmax_sample_block,
         std::move(filtered_parts),
         context,
-        storage->with_marks)));
+        storage->with_marks,
+        std::move(source_metadata))));
 }
 
 }

--- a/src/Storages/System/StorageSystemPartsColumns.cpp
+++ b/src/Storages/System/StorageSystemPartsColumns.cpp
@@ -250,7 +250,7 @@ void StorageSystemPartsColumns::processNextStorage(
                     columns[res_index++]->insertDefault();
             }
 
-            ColumnSize column_size = part->getColumnSize(column.name);
+            ColumnSize column_size = part->getColumnSize(column.getColumnId());
             if (columns_mask[src_index++])
                 columns[res_index++]->insert(column_size.data_compressed + column_size.marks);
             if (columns_mask[src_index++])
@@ -261,7 +261,7 @@ void StorageSystemPartsColumns::processNextStorage(
                 columns[res_index++]->insert(column_size.marks);
             if (columns_mask[src_index++])
             {
-                if (auto column_modification_time = part->getColumnModificationTime(column.name))
+                if (auto column_modification_time = part->getColumnModificationTime(column.getColumnId()))
                     columns[res_index++]->insert(UInt64(column_modification_time.value()));
                 else
                     columns[res_index++]->insertDefault();
@@ -344,7 +344,7 @@ void StorageSystemPartsColumns::processNextStorage(
                     columns[res_index++]->insertDefault();
             }
 
-            auto serialization = part->getSerialization(column.name);
+            auto serialization = part->getSerialization(column.getStorageKey());
             if (columns_mask[src_index++])
                 columns[res_index++]->insert(ISerialization::kindStackToString(serialization->getKindStack()));
 

--- a/src/Storages/System/StorageSystemProjectionPartsColumns.cpp
+++ b/src/Storages/System/StorageSystemProjectionPartsColumns.cpp
@@ -239,7 +239,7 @@ void StorageSystemProjectionPartsColumns::processNextStorage(
                     columns[res_index++]->insertDefault();
             }
 
-            ColumnSize column_size = part->getColumnSize(column.name);
+            ColumnSize column_size = part->getColumnSize(column.getColumnId());
             if (columns_mask[src_index++])
                 columns[res_index++]->insert(column_size.data_compressed + column_size.marks);
             if (columns_mask[src_index++])
@@ -250,7 +250,7 @@ void StorageSystemProjectionPartsColumns::processNextStorage(
                 columns[res_index++]->insert(column_size.marks);
             if (columns_mask[src_index++])
             {
-                if (auto column_modification_time = part->getColumnModificationTime(column.name))
+                if (auto column_modification_time = part->getColumnModificationTime(column.getColumnId()))
                     columns[res_index++]->insert(UInt64(column_modification_time.value()));
                 else
                     columns[res_index++]->insertDefault();

--- a/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeIndex.cpp
@@ -137,7 +137,9 @@ static NameSet getAllPossibleStreamNames(
     /// add columns with marks of its substreams to the table.
     for (const auto & part : data_parts)
     {
-        serialization = part->tryGetSerialization(column.name);
+        /// `column` came from the pinned metadata snapshot's getAllPhysical(), so it already carries
+        /// the authoritative id; query the part by that id, not the part's own name index.
+        serialization = part->tryGetSerialization(column.getStorageKey());
         if (serialization && ISerialization::hasKind(serialization->getKindStack(), ISerialization::Kind::SPARSE))
         {
             serialization->enumerateStreams(callback);


### PR DESCRIPTION
Second step towards metadata-only `RENAME` / `DROP COLUMN` on MergeTree, stacked on #114507 (the data structure). That PR is not merged yet, so its three commits are included here — **only the last commit is this PR's**.

Activation, the DDL that makes a rename metadata-only, and the tests come in the next PR.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
