### PR TITLE
Disable trivial count optimization in perf test `text_index_analysis`

### DIFF
--- a/tests/performance/text_index_analysis.xml
+++ b/tests/performance/text_index_analysis.xml
@@ -3,6 +3,7 @@
       <use_skip_indexes_on_data_read>1</use_skip_indexes_on_data_read>
       <query_plan_direct_read_from_text_index>1</query_plan_direct_read_from_text_index>
       <force_data_skipping_indices>idx_s</force_data_skipping_indices>
+      <query_plan_optimize_count_from_text_index>0</query_plan_optimize_count_from_text_index>
   </settings>
 
   <create_query>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This test was supposed to test the index analysis, which is skipped when trivial count optimization is enabled.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1448` (included in `26.8` and later)
<!-- ch-version-info:end -->