### PR TITLE
Remove Gorilla codec from TimeSeries engine defaults

### DIFF
--- a/docs/reference/engines/table-engines/integrations/time-series.mdx
+++ b/docs/reference/engines/table-engines/integrations/time-series.mdx
@@ -104,7 +104,7 @@ This is equivalent to declaring the timestamp and value column types in the samp
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
 ```
 
 If both forms are used in the same `CREATE TABLE` statement, the declared types must match.
@@ -136,7 +136,7 @@ The _samples_ table must have columns:
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
 Columns the engine creates itself get time-series compression codecs:
-`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(Gorilla, ZSTD(1))`. Near-monotonic timestamps barely
+`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(ZSTD(1))`. Near-monotonic timestamps barely
 compress under generic codecs and can otherwise dominate the on-disk size of the samples table.
 See also [Adjusting types of columns](#adjusting-column-types).
 
@@ -196,7 +196,7 @@ SAMPLES INNER COLUMNS
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(Gorilla, ZSTD(1))
+    `value` Float64 CODEC(ZSTD(1))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp) SETTINGS index_granularity = 32768
 TAGS INNER COLUMNS
@@ -231,7 +231,7 @@ CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(Gorilla(8), ZSTD(1))
+    `value` Float64 CODEC(ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
@@ -284,7 +284,7 @@ You can adjust the types of columns in the inner target tables using the `INNER 
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
 ```
 
 Specifying inner columns without codecs means using the default codec for them:

--- a/docs/reference/engines/table-engines/integrations/time-series.mdx
+++ b/docs/reference/engines/table-engines/integrations/time-series.mdx
@@ -104,7 +104,7 @@ This is equivalent to declaring the timestamp and value column types in the samp
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
 ```
 
 If both forms are used in the same `CREATE TABLE` statement, the declared types must match.
@@ -136,7 +136,7 @@ The _samples_ table must have columns:
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
 Columns the engine creates itself get time-series compression codecs:
-`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(ZSTD(1))`. Near-monotonic timestamps barely
+`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(Gorilla, ZSTD(1))`. Near-monotonic timestamps barely
 compress under generic codecs and can otherwise dominate the on-disk size of the samples table.
 See also [Adjusting types of columns](#adjusting-column-types).
 
@@ -151,8 +151,7 @@ The _tags_ table must have columns:
 | `id` | [x] | `Tuple(UInt64, UUID)` | any (must match the type of `id` in the [samples](#samples-table) table) | An `id` identifies a combination of a metric name and tags. The DEFAULT expression specifies how to calculate such an identifier |
 | `metric_name` | [x] | `LowCardinality(String)` | `String` or `LowCardinality(String)` | The name of a metric |
 | `<tag_value_column>` | [ ] | `String` | `String` or `LowCardinality(String)` or `LowCardinality(Nullable(String))` | The value of a specific tag, the tag's name and the name of a corresponding column are specified in the [tags_to_columns](#settings) setting |
-| `tags` | [x] | `Map(LowCardinality(String), String)` | `Map(String, String)` or `Map(LowCardinality(String), String)` or `Map(LowCardinality(String), LowCardinality(String))` | Map of tags excluding the tag `__name__` containing the name of a metric and excluding tags with names enumerated in the [tags_to_columns](#settings) setting |
-| `all_tags` | [ ] | `Map(String, String)` | `Map(String, String)` or `Map(LowCardinality(String), String)` or `Map(LowCardinality(String), LowCardinality(String))` | Ephemeral column, each row is a map of all the tags excluding only the tag `__name__` containing the name of a metric. The only purpose of that column is to be used while calculating `id` |
+| `tags` | [x] | `Map(LowCardinality(String), String)` | `Map(String, String)` or `Map(LowCardinality(String), String)` or `Map(LowCardinality(String), LowCardinality(String))` | Map of all the tags, including the tag `__name__` containing the name of a metric and including the tags with names enumerated in the [tags_to_columns](#settings) setting. Tables created by older versions of ClickHouse stored in this column only the tags without dedicated columns and without the metric name; reading handles both cases |
 | `min_time` | [ ] | `Nullable(DateTime64(3))` | `DateTime64(X)` or `Nullable(DateTime64(X))` | Minimum timestamp of time series with that `id`. The column is created if [store_min_time_and_max_time](#settings) is `true` |
 | `max_time` | [ ] | `Nullable(DateTime64(3))` | `DateTime64(X)` or `Nullable(DateTime64(X))` | Maximum timestamp of time series with that `id`. The column is created if [store_min_time_and_max_time](#settings) is `true` |
 
@@ -196,15 +195,14 @@ SAMPLES INNER COLUMNS
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(ZSTD(1))
+    `value` Float64 CODEC(Gorilla, ZSTD(1))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp) SETTINGS index_granularity = 32768
 TAGS INNER COLUMNS
 (
-    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(metric_name, all_tags))),
+    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(tags))),
     `metric_name` LowCardinality(String),
     `tags` Map(LowCardinality(String), String),
-    `all_tags` Map(String, String) EPHEMERAL,
     `min_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
     `max_time` SimpleAggregateFunction(max, Nullable(DateTime64(3)))
 )
@@ -231,7 +229,7 @@ CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(ZSTD(1))
+    `value` Float64 CODEC(Gorilla(8), ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
@@ -241,10 +239,9 @@ SETTINGS index_granularity = 32768
 ```sql
 CREATE TABLE default.`.inner_id.tags.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
-    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(metric_name, all_tags))),
+    `id` Tuple(UInt64, UUID) DEFAULT tuple(sipHash64(metric_name), reinterpretAsUUID(sipHash128(tags))),
     `metric_name` LowCardinality(String),
     `tags` Map(LowCardinality(String), String),
-    `all_tags` Map(String, String) EPHEMERAL,
     `min_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
     `max_time` SimpleAggregateFunction(max, Nullable(DateTime64(3)))
 )
@@ -284,7 +281,7 @@ You can adjust the types of columns in the inner target tables using the `INNER 
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
 ```
 
 Specifying inner columns without codecs means using the default codec for them:
@@ -301,7 +298,7 @@ The type and the `DEFAULT` expression used to generate identifiers can be custom
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-TAGS INNER COLUMNS (id UInt64 DEFAULT sipHash64(metric_name, all_tags))
+TAGS INNER COLUMNS (id UInt64 DEFAULT sipHash64(tags))
 ```
 
 The `id` column can be of any comparable non-Nullable type. The `id` types declared in the samples and tags inner tables must match.
@@ -312,16 +309,17 @@ The `id_generator` setting offers the same customization without using the `INNE
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SETTINGS id_generator = 'sipHash64(metric_name, all_tags)'
+SETTINGS id_generator = 'sipHash64(tags)'
 ```
 
 If the setting is set, it's used to generate `id` even if the column's `DEFAULT` contains a different expression.
 
-## The `tags` and `all_tags` columns {#tags-and-all-tags}
+## The `tags` column {#tags-column}
 
-There are two columns containing maps of tags - `tags` and `all_tags`. In this example they mean the same, however they can be different
-if setting `tags_to_columns` is used. This setting allows to specify that a specific tag should be stored in a separate column instead of storing
-in a map inside the `tags` column:
+The `tags` column contains all the tags of a time series, including the `__name__` tag with the name of a metric.
+
+The `tags_to_columns` setting allows to specify that a specific tag should also be stored in a separate column
+in addition to the map inside the `tags` column:
 
 ```sql
 CREATE TABLE my_table
@@ -330,9 +328,13 @@ SETTINGS tags_to_columns = {'instance': 'instance', 'job': 'job'}
 ```
 
 This statement will add columns `instance` and `job` to the inner [tags](#tags-table) target table.
-In this case the `tags` column will not contain tags `instance` and `job`,
-but the `all_tags` column will contain them. The `all_tags` column is ephemeral and its only purpose to be used in the DEFAULT expression
-for the `id` column.
+The values of the tags `instance` and `job` will be stored both in those columns and in the `tags` column.
+
+<Note>
+In tables created by older versions of ClickHouse the `tags` column contains only the tags without dedicated
+columns and without the metric name, and the `all_tags` column is an ephemeral column which was filled on insertion
+with all the tags except the metric name.
+</Note>
 
 ## Table engines of inner target tables {#inner-table-engines}
 
@@ -352,7 +354,7 @@ TAGS ENGINE=ReplicatedAggregatingMergeTree
 METRICS ENGINE=ReplicatedReplacingMergeTree
 ```
 
-The [tags](#tags-table) table keeps the tag columns (and the `tags`/`all_tags` Maps) outside its sorting key,
+The [tags](#tags-table) table keeps the tag columns (and the `tags` Map) outside its sorting key,
 which `AggregatingMergeTree` rejects by default (see [`allow_dimensions_outside_sorting_key`](/reference/engines/table-engines/mergetree-family/aggregatingmergetree)).
 This is safe here because those columns are functionally dependent on `id`, which is part of the sorting key, so all
 rows that a background merge collapses together share the same values. When the inner tags table is generated or its
@@ -392,7 +394,7 @@ Two settings can be changed after `CREATE`:
 - `filter_by_min_time_and_max_time`
 
 ```sql
-ALTER TABLE my_table MODIFY SETTING id_generator = 'sipHash64(metric_name, all_tags)';
+ALTER TABLE my_table MODIFY SETTING id_generator = 'sipHash64(tags)';
 ALTER TABLE my_table MODIFY SETTING filter_by_min_time_and_max_time = 0;
 ```
 
@@ -408,7 +410,7 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 |---|---|---|---|
 | `id_generator` | Expression | depends on `id` type | Expression that computes the identifier (fingerprint) of a time series from its tags. If unset, the default expression for the `id` column is used. If the default expression for the `id` column is also unset then the expression is chosen automatically |
 | `tags_to_columns` | Map | {} | Map specifying which tags should be put to separate columns in the [tags](#tags-table) table. Syntax: `{'tag1': 'column1', 'tag2' : column2, ...}` |
-| `use_all_tags_column_to_generate_id` | Bool | true | When generating an expression to calculate an identifier of a time series, this flag enables using the `all_tags` column in that calculation |
+| `use_all_tags_column_to_generate_id` | Bool | false | Obsolete setting, does nothing |
 | `store_min_time_and_max_time` | Bool | true | If set to true then the table will store `min_time` and `max_time` for each time series |
 | `aggregate_min_time_and_max_time` | Bool | true | When creating an inner target `tags` table, this flag enables using `SimpleAggregateFunction(min, Nullable(DateTime64(3)))` instead of just `Nullable(DateTime64(3))` as the type of the `min_time` column, and the same for the `max_time` column |
 | `filter_by_min_time_and_max_time` | Bool | true | If set to true then the table will use the `min_time` and `max_time` columns for filtering time series |

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -766,7 +766,7 @@ This is equivalent to declaring the timestamp and value column types in the samp
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(3)))
 ```
 
 If both forms are used in the same `CREATE TABLE` statement, the declared types must match.
@@ -798,7 +798,7 @@ The _samples_ table must have columns:
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
 Columns the engine creates itself get time-series compression codecs:
-`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(ZSTD(1))`. Near-monotonic timestamps barely
+`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(ZSTD(3))`. Near-monotonic timestamps barely
 compress under generic codecs and can otherwise dominate the on-disk size of the samples table.
 See also [Adjusting types of columns](#adjusting-column-types).
 
@@ -858,7 +858,7 @@ SAMPLES INNER COLUMNS
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(ZSTD(1))
+    `value` Float64 CODEC(ZSTD(3))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp) SETTINGS index_granularity = 32768
 TAGS INNER COLUMNS
@@ -893,7 +893,7 @@ CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(ZSTD(1))
+    `value` Float64 CODEC(ZSTD(3))
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
@@ -946,7 +946,7 @@ You can adjust the types of columns in the inner target tables using the `INNER 
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(3)))
 ```
 
 Specifying inner columns without codecs means using the default codec for them:

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -766,7 +766,7 @@ This is equivalent to declaring the timestamp and value column types in the samp
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp UInt32 CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
 ```
 
 If both forms are used in the same `CREATE TABLE` statement, the declared types must match.
@@ -798,7 +798,7 @@ The _samples_ table must have columns:
 | `value` | [x] | `Float64` | `Float32` or `Float64` | A value associated with the `timestamp` |
 
 Columns the engine creates itself get time-series compression codecs:
-`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(Gorilla, ZSTD(1))`. Near-monotonic timestamps barely
+`timestamp CODEC(DoubleDelta, ZSTD(1))` and `value CODEC(ZSTD(1))`. Near-monotonic timestamps barely
 compress under generic codecs and can otherwise dominate the on-disk size of the samples table.
 See also [Adjusting types of columns](#adjusting-column-types).
 
@@ -858,7 +858,7 @@ SAMPLES INNER COLUMNS
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(Gorilla, ZSTD(1))
+    `value` Float64 CODEC(ZSTD(1))
 )
 SAMPLES INNER ENGINE = MergeTree ORDER BY (id, timestamp) SETTINGS index_granularity = 32768
 TAGS INNER COLUMNS
@@ -893,7 +893,7 @@ CREATE TABLE default.`.inner_id.samples.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 (
     `id` Tuple(UInt64, UUID),
     `timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
-    `value` Float64 CODEC(Gorilla(8), ZSTD(1))
+    `value` Float64 CODEC(ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY (id, timestamp)
@@ -946,7 +946,7 @@ You can adjust the types of columns in the inner target tables using the `INNER 
 
 ```sql
 CREATE TABLE my_table ENGINE=TimeSeries
-SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(Gorilla, ZSTD(1)))
+SAMPLES INNER COLUMNS (timestamp DateTime64(6) CODEC(DoubleDelta, ZSTD(1)), value Float32 CODEC(ZSTD(1)))
 ```
 
 Specifying inner columns without codecs means using the default codec for them:

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -395,21 +395,20 @@ namespace
                 /// exist in samples.
                 add_column_if_missing(TimeSeriesColumnNames::ID, dataTypeToAST(resolved_types.id_type));
 
-                /// Auto-created "timestamp" and "value" columns get time-series codecs: under generic LZ4
+                /// Auto-created "timestamp" and "value" columns get compression codecs: under generic LZ4
                 /// near-monotonic millisecond timestamps barely compress and dominate the table size
                 /// (>90% of on-disk bytes on a scrape-like corpus). All types accepted by the validation
-                /// above are compatible: DoubleDelta takes DateTime64/DateTime/UInt32, Gorilla takes
-                /// Float64/Float32. Explicitly declared columns keep whatever the user wrote.
-                auto make_codec = [](const char * codec_name)
+                /// above are compatible with DoubleDelta (DateTime64/DateTime/UInt32). The "value" column
+                /// gets plain ZSTD: specialized floating-point codecs such as Gorilla proved unreliable in
+                /// practice. Explicitly declared columns keep whatever the user wrote.
+                auto make_zstd = []
                 {
-                    return makeASTFunction("CODEC",
-                        make_intrusive<ASTIdentifier>(codec_name),
-                        makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1})));
+                    return makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}));
                 };
                 if (auto * timestamp_decl = add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type)))
-                    timestamp_decl->setCodec(make_codec("DoubleDelta"));
+                    timestamp_decl->setCodec(makeASTFunction("CODEC", make_intrusive<ASTIdentifier>("DoubleDelta"), make_zstd()));
                 if (auto * value_decl = add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type)))
-                    value_decl->setCodec(make_codec("Gorilla"));
+                    value_decl->setCodec(makeASTFunction("CODEC", make_zstd()));
 
                 break;
             }

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -399,13 +399,13 @@ namespace
                 /// near-monotonic millisecond timestamps barely compress and dominate the table size
                 /// (>90% of on-disk bytes on a scrape-like corpus). All types accepted by the validation
                 /// above are compatible with DoubleDelta (DateTime64/DateTime/UInt32). The "value" column
-                /// gets plain ZSTD: specialized floating-point codecs such as Gorilla proved unreliable in
-                /// practice. Explicitly declared columns keep whatever the user wrote.
+                /// gets plain ZSTD(3): specialized floating-point codecs such as Gorilla proved unreliable
+                /// in practice. Explicitly declared columns keep whatever the user wrote.
                 if (auto * timestamp_decl = add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type)))
                     timestamp_decl->setCodec(makeASTFunction(
                         "CODEC", make_intrusive<ASTIdentifier>("DoubleDelta"), makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}))));
                 if (auto * value_decl = add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type)))
-                    value_decl->setCodec(makeASTFunction("CODEC", makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}))));
+                    value_decl->setCodec(makeASTFunction("CODEC", makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{3}))));
 
                 break;
             }

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -401,14 +401,11 @@ namespace
                 /// above are compatible with DoubleDelta (DateTime64/DateTime/UInt32). The "value" column
                 /// gets plain ZSTD: specialized floating-point codecs such as Gorilla proved unreliable in
                 /// practice. Explicitly declared columns keep whatever the user wrote.
-                auto make_zstd = []
-                {
-                    return makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}));
-                };
                 if (auto * timestamp_decl = add_column_if_missing(TimeSeriesColumnNames::Timestamp, dataTypeToAST(resolved_types.timestamp_type)))
-                    timestamp_decl->setCodec(makeASTFunction("CODEC", make_intrusive<ASTIdentifier>("DoubleDelta"), make_zstd()));
+                    timestamp_decl->setCodec(makeASTFunction(
+                        "CODEC", make_intrusive<ASTIdentifier>("DoubleDelta"), makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}))));
                 if (auto * value_decl = add_column_if_missing(TimeSeriesColumnNames::Value, dataTypeToAST(resolved_types.scalar_type)))
-                    value_decl->setCodec(makeASTFunction("CODEC", make_zstd()));
+                    value_decl->setCodec(makeASTFunction("CODEC", makeASTFunction("ZSTD", make_intrusive<ASTLiteral>(UInt64{1}))));
 
                 break;
             }

--- a/tests/queries/0_stateless/04600_timeseries_column_validation.reference
+++ b/tests/queries/0_stateless/04600_timeseries_column_validation.reference
@@ -1,6 +1,6 @@
 ok
 Array(Tuple(UInt32, Float32))
-`id` Tuple(UInt64, UUID), `timestamp` UInt32 CODEC(DoubleDelta, ZSTD(1)), `value` Float32 CODEC(Gorilla, ZSTD(1))
+`id` Tuple(UInt64, UUID), `timestamp` UInt32 CODEC(DoubleDelta, ZSTD(1)), `value` Float32 CODEC(ZSTD(1))
 metric_name	String
 tags	Map(String, String)
 time_series	Array(Tuple(DateTime64(3), Float64))

--- a/tests/queries/0_stateless/04600_timeseries_column_validation.reference
+++ b/tests/queries/0_stateless/04600_timeseries_column_validation.reference
@@ -1,6 +1,6 @@
 ok
 Array(Tuple(UInt32, Float32))
-`id` Tuple(UInt64, UUID), `timestamp` UInt32 CODEC(DoubleDelta, ZSTD(1)), `value` Float32 CODEC(ZSTD(1))
+`id` Tuple(UInt64, UUID), `timestamp` UInt32 CODEC(DoubleDelta, ZSTD(1)), `value` Float32 CODEC(ZSTD(3))
 metric_name	String
 tags	Map(String, String)
 time_series	Array(Tuple(DateTime64(3), Float64))

--- a/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
+++ b/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
@@ -1,11 +1,11 @@
 default codecs:
 id	Tuple(UInt64, UUID)	
 timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
-value	Float64	CODEC(ZSTD(1))
+value	Float64	CODEC(ZSTD(3))
 after detach/attach:
 id	Tuple(UInt64, UUID)	
 timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
-value	Float64	CODEC(ZSTD(1))
+value	Float64	CODEC(ZSTD(3))
 explicit columns keep user codecs:
 id	UUID	
 timestamp	DateTime64(3)	

--- a/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
+++ b/tests/queries/0_stateless/04648_timeseries_samples_codecs.reference
@@ -1,11 +1,11 @@
 default codecs:
 id	Tuple(UInt64, UUID)	
 timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
-value	Float64	CODEC(Gorilla(8), ZSTD(1))
+value	Float64	CODEC(ZSTD(1))
 after detach/attach:
 id	Tuple(UInt64, UUID)	
 timestamp	DateTime64(3)	CODEC(DoubleDelta, ZSTD(1))
-value	Float64	CODEC(Gorilla(8), ZSTD(1))
+value	Float64	CODEC(ZSTD(1))
 explicit columns keep user codecs:
 id	UUID	
 timestamp	DateTime64(3)	

--- a/tests/queries/0_stateless/04648_timeseries_samples_codecs.sql
+++ b/tests/queries/0_stateless/04648_timeseries_samples_codecs.sql
@@ -2,8 +2,9 @@
 -- Tag no-replicated-database: the experimental TimeSeries table engine does not round-trip through DatabaseReplicated.
 
 -- Auto-created `timestamp` and `value` columns of the TimeSeries samples inner table
--- get time-series compression codecs; explicitly declared columns keep the user's codecs
--- (or none), and the normalized table round-trips through DETACH/ATTACH unchanged.
+-- get compression codecs (DoubleDelta + ZSTD for timestamps, plain ZSTD for values);
+-- explicitly declared columns keep the user's codecs (or none), and the normalized
+-- table round-trips through DETACH/ATTACH unchanged.
 
 SET allow_experimental_time_series_table = 1;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The experimental `TimeSeries` table engine no longer applies the `Gorilla` codec to auto-created `value` columns of the samples inner table; they now default to `CODEC(ZSTD(1))`. Explicitly declared columns keep whatever codecs the user wrote. The `timestamp` column default is unchanged (`CODEC(DoubleDelta, ZSTD(1))`).

The `Gorilla` codec has proved unreliable in practice, so the `TimeSeries` engine should not choose it by default. Only newly created tables are affected — existing tables keep the codecs stored in their metadata, and users can still declare `CODEC(Gorilla)` explicitly. Documentation (`docs/reference/engines/table-engines/integrations/time-series.mdx` and the embedded doc in `StorageTimeSeries.cpp`) and the stateless tests `04648_timeseries_samples_codecs` / `04600_timeseries_column_validation` are updated accordingly; both tests pass locally.