### PR TITLE
Fix columns reading as defaults after a merge during a pending RENAME COLUMN

### DIFF
--- a/src/Storages/MergeTree/AlterConversions.h
+++ b/src/Storages/MergeTree/AlterConversions.h
@@ -4,6 +4,8 @@
 #include <Storages/MergeTree/MergeTreeRangeReader.h>
 #include <Storages/MergeTree/PatchParts/PatchPartInfo.h>
 
+#include <ranges>
+
 namespace DB
 {
 
@@ -44,6 +46,25 @@ public:
 
     /// Column was dropped by a pending mutation (data in part is stale)
     bool isColumnDropped(const std::string & name, bool share_nested_offsets = true) const;
+
+    /// Whether the pending rename of `new_name` still has to be applied when reading a part whose
+    /// columns are given by `part_has_column`. It does not when the part already stores the new name
+    /// and no other pending rename takes that name as its source: such a part was written after the
+    /// rename was carried out (a merge does that while keeping the sources' data version, which is
+    /// what decides pendingness), so mapping back would look for a file that is not there. The
+    /// second condition matters because a freed name can be handed to another column, as in
+    /// `RENAME A TO C, RENAME B TO A`, where a part's `A` holds what is now `C`.
+    template <typename HasColumn>
+    bool needApplyRename(const std::string & new_name, HasColumn && part_has_column) const
+    {
+        if (part_has_column(getColumnOldName(new_name)))
+            return true;
+
+        if (!part_has_column(new_name))
+            return true;
+
+        return std::ranges::any_of(rename_map, [&](const RenamePair & entry) { return entry.rename_from == new_name; });
+    }
 
     static bool isSupportedDataMutation(MutationCommand::Type type);
     static bool isSupportedAlterMutation(MutationCommand::Type type);

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -357,8 +357,11 @@ std::pair<String, String> IMergeTreeReader::getStorageAndSubcolumnNameInPart(con
     auto name_in_storage = required_column.getNameInStorage();
     auto subcolumn_name = required_column.getSubcolumnName();
 
-    if (alter_conversions->isColumnRenamed(name_in_storage))
+    if (alter_conversions->isColumnRenamed(name_in_storage)
+        && alter_conversions->needApplyRename(name_in_storage, [&](const auto & name) { return part_columns.has(name); }))
+    {
         name_in_storage = alter_conversions->getColumnOldName(name_in_storage);
+    }
 
     /// A special case when we read subcolumn of shared offsets of Nested.
     /// E.g. instead of requested column "n.arr1.size0" we must read column "n.size0" from disk.

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -103,8 +103,14 @@ bool injectRequiredColumnsRecursively(
     if (column_in_storage)
     {
         auto column_name_in_part = column_in_storage->getNameInStorage();
-        if (alter_conversions && alter_conversions->isColumnRenamed(column_name_in_part))
+        /// The condition has to match IMergeTreeReader::getStorageAndSubcolumnNameInPart, which decides
+        /// the name the column is actually read under.
+        if (alter_conversions && alter_conversions->isColumnRenamed(column_name_in_part)
+            && alter_conversions->needApplyRename(column_name_in_part,
+                [&](const auto & name) { return data_part_info_for_reader.getColumns().contains(name); }))
+        {
             column_name_in_part = alter_conversions->getColumnOldName(column_name_in_part);
+        }
 
         auto column_in_part = data_part_info_for_reader.getColumns().tryGetByName(column_name_in_part);
 

--- a/tests/queries/0_stateless/04873_read_merged_part_with_pending_rename.reference
+++ b/tests/queries/0_stateless/04873_read_merged_part_with_pending_rename.reference
@@ -1,0 +1,12 @@
+one column renamed
+2000	100	1199
+2000	100	1199
+every column renamed
+2000	0	1999	1	1
+one column renamed, compact part
+2000	100	1199
+Compact
+a freed name handed to another column
+7	100
+7	101
+7	102

--- a/tests/queries/0_stateless/04873_read_merged_part_with_pending_rename.sh
+++ b/tests/queries/0_stateless/04873_read_merged_part_with_pending_rename.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: uses the server-global failpoint mt_select_parts_to_mutate_no_free_threads
+
+# A part produced by a merge while an `ALTER TABLE ... RENAME COLUMN` is still pending already stores
+# the new column name, because the merge writes the current structure. The rename nevertheless still
+# looks pending for that part: what decides that on plain MergeTree is the part's data version, and a
+# merge keeps the data version of its sources. Applying the rename a second time on read looks for a
+# file under the old name, does not find it, and returns the column's default -- silently wrong values
+# for data that is intact on disk. The mapping must therefore only be applied to a part that actually
+# holds the old name, which is how `MutateTask` already guards its own renames.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# The failpoint is server-global: release it even if a query below fails, or every later test on this
+# server would run with mutations disabled.
+cleanup() {
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_merge_pending_rename" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_merge_pending_rename_all" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_pending_rename_name_reuse" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_merge_pending_rename_compact" 2>/dev/null
+}
+trap cleanup EXIT
+
+echo 'one column renamed'
+
+$CLICKHOUSE_CLIENT -mq "
+DROP TABLE IF EXISTS t_merge_pending_rename;
+
+CREATE TABLE t_merge_pending_rename (k UInt64, a UInt64)
+ENGINE = MergeTree() ORDER BY k
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_merge_pending_rename SELECT number, number + 100 FROM numbers(1000);
+INSERT INTO t_merge_pending_rename SELECT number + 1000, number + 200 FROM numbers(1000);
+
+SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+
+SET alter_sync = 0;
+ALTER TABLE t_merge_pending_rename RENAME COLUMN a TO c;
+
+-- Reading the source parts, which still hold the old name.
+SELECT count(), min(c), max(c) FROM t_merge_pending_rename;
+
+OPTIMIZE TABLE t_merge_pending_rename FINAL;
+
+-- Reading the merged part, which already holds the new name while the rename is still pending.
+SELECT count(), min(c), max(c) FROM t_merge_pending_rename;
+
+SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+"
+
+echo 'every column renamed'
+
+# With no column left under its old name the merged part shares no name with the source parts, which is
+# also the shape that makes a merge need an injected row-count column.
+$CLICKHOUSE_CLIENT -mq "
+DROP TABLE IF EXISTS t_merge_pending_rename_all;
+
+CREATE TABLE t_merge_pending_rename_all (a UInt64, h UInt8 DEFAULT 0)
+ENGINE = MergeTree() ORDER BY tuple()
+SETTINGS
+    min_bytes_for_wide_part = 0,
+    min_rows_for_wide_part = 0,
+    vertical_merge_algorithm_min_rows_to_activate = 0,
+    vertical_merge_algorithm_min_columns_to_activate = 0;
+
+INSERT INTO t_merge_pending_rename_all SELECT number, 1 FROM numbers(1000);
+INSERT INTO t_merge_pending_rename_all SELECT number + 1000, 1 FROM numbers(1000);
+
+SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+
+SET alter_sync = 0;
+ALTER TABLE t_merge_pending_rename_all RENAME COLUMN a TO c, RENAME COLUMN h TO d;
+
+OPTIMIZE TABLE t_merge_pending_rename_all FINAL;
+
+SELECT count(), min(c), max(c), min(d), max(d) FROM t_merge_pending_rename_all;
+
+SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+"
+
+echo 'one column renamed, compact part'
+
+# The same defect on compact parts: the column list lives in one file rather than per-column files, but
+# the merged part is written under the current structure just the same.
+$CLICKHOUSE_CLIENT -mq "
+DROP TABLE IF EXISTS t_merge_pending_rename_compact;
+
+CREATE TABLE t_merge_pending_rename_compact (k UInt64, a UInt64)
+ENGINE = MergeTree() ORDER BY k
+SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
+
+INSERT INTO t_merge_pending_rename_compact SELECT number, number + 100 FROM numbers(1000);
+INSERT INTO t_merge_pending_rename_compact SELECT number + 1000, number + 200 FROM numbers(1000);
+
+SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+
+SET alter_sync = 0;
+ALTER TABLE t_merge_pending_rename_compact RENAME COLUMN a TO c;
+
+OPTIMIZE TABLE t_merge_pending_rename_compact FINAL;
+
+SELECT count(), min(c), max(c) FROM t_merge_pending_rename_compact;
+SELECT part_type FROM system.parts WHERE table = 't_merge_pending_rename_compact' AND database = currentDatabase() AND active;
+
+SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+"
+
+echo 'a freed name handed to another column'
+
+# The name a rename frees can be given to a different column in the same statement. A source part then
+# holds `A` containing what is now `C`, so a request for the new `A` must NOT settle for that file just
+# because the part happens to have a column of that name -- it has to map to `B`, find it absent, and
+# read the default. This is the case that a plain "does the part hold the old name" test gets wrong.
+#
+# Only the source part is read here on purpose. Running a merge in this state is a separate, still
+# unfixed defect: the merged part then holds `C` and `A`, both current names, and nothing distinguishes
+# them from a pre-rename part, so `C` reads what is now `A`. That is pre-existing -- master produces the
+# identical wrong output -- and cannot be decided in the read path, so it is tracked separately rather
+# than pinned here.
+$CLICKHOUSE_CLIENT -mq "
+DROP TABLE IF EXISTS t_pending_rename_name_reuse;
+
+CREATE TABLE t_pending_rename_name_reuse (k UInt64, A UInt64)
+ENGINE = MergeTree() ORDER BY k
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_pending_rename_name_reuse SELECT number, number + 100 FROM numbers(3);
+
+ALTER TABLE t_pending_rename_name_reuse ADD COLUMN B UInt64 DEFAULT 7;
+
+SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+
+SET alter_sync = 0;
+ALTER TABLE t_pending_rename_name_reuse RENAME COLUMN A TO C, RENAME COLUMN B TO A;
+
+SELECT A, C FROM t_pending_rename_name_reuse ORDER BY k;
+
+SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_no_free_threads;
+"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114562
Related: https://github.com/ClickHouse/ClickHouse/pull/114601

## Problem

A merge that runs while an `ALTER ... RENAME COLUMN` is still being applied leaves the renamed column
reading as its **default value**, on a plain `MergeTree` table:

```sql
CREATE TABLE t (k UInt64, a UInt64) ENGINE = MergeTree ORDER BY k
SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
INSERT INTO t SELECT number, number + 100 FROM numbers(1000);
INSERT INTO t SELECT number + 1000, number + 200 FROM numbers(1000);

SET alter_sync = 0;                       -- mutation still pending
ALTER TABLE t RENAME COLUMN a TO c;

SELECT min(c), max(c) FROM t;             -- 100  1199   correct, source parts
OPTIMIZE TABLE t FINAL;
SELECT min(c), max(c) FROM t;             -- 0    0      <- wrong, merged part
```

No error, nothing in the log, and the data is intact on disk the whole time. It reproduces on wide and
compact parts and on vertical and horizontal merges, needs only one pending rename, and lasts until the
mutation happens to run on the merged part.

## Root cause

`ALTER ... RENAME COLUMN` on plain `MergeTree` splits into two halves with different timing: the table
metadata is updated synchronously, before the statement returns, while the per-part file rename is
deferred to a mutation. Measured with `alter_sync = 0`: `system.columns` already reports `k, c` while
every part still stores `k, a`.

A merge scheduled in that window takes the **current** metadata (`getInMemoryMetadataPtr()`), reads its
sources through `AlterConversions` — resolving `c` to the file `a` — and writes its output under the
current structure:

```cpp
// MergeTask.cpp:940
global_ctx->new_data_part->setColumns(global_ctx->storage_columns, infos,
                                     global_ctx->metadata_snapshot->getMetadataVersion());
```

So the merged part physically **has the rename applied**. But `FutureMergedMutatedPart` gives it the
maximum data version of its sources, and `StorageMergeTree::MutationsSnapshot::getOnFlyMutationCommandsForPart`
decides pendingness from the data version alone:

```cpp
if (mutation_version <= part_data_version) break;   // 3 <= 1 ? no
addSupportedCommands(...);                          // → "RENAME a TO c still pending"
```

Measured for the example above: mutation version 3, merged part `all_1_2_1` with `data_version = 1` and
files `k, c`. The reader therefore maps `c` back to `a`, the file is absent, and the column is filled
from its default.

The merge did apply the rename but had no way to record it: it cannot advance `data_version` past 3,
because that would also claim any `UPDATE`/`DELETE` at version ≤ 3 was applied, which a merge never
does.

### Why plain `MergeTree` only

| engine | table `metadata_version` after the rename | merged part's `metadata_version` | affected |
|---|---|---|---|
| `MergeTree` | **0** | **0** | **yes** |
| `ReplicatedMergeTree` | 1 | 1 | no |
| `SharedMergeTree` | 1 | 1 | no |

Replicated and Shared gate metadata mutations on `part_metadata_version >= params.metadata_version`
(`ReplicatedMergeTreeQueue.cpp:2333`, and `SharedMergeTree/Mutations.cpp:175` in the private repo), so
the merged part is exempt and the rename is never applied twice, while data mutations stay on the
separate `data_version` track. On plain `MergeTree` the rename never bumps that field — `grep
metadata_version src/Storages/StorageMergeTree.cpp` returns **zero** hits in the public and private
repos alike — which is exactly why it has only one counter to reason with. Porting the Replicated rule
here does not work: the comparison would be `0 >= 0` for every part and would suppress every rename,
which was measured to break plain `SELECT`s on the source parts.

## Solution

Apply the mapping unless the part is demonstrably already past the rename — it holds the new name and no
other pending rename takes that name as its source. The decision lives in one place,
`AlterConversions::needApplyRename`, called from both read-path sites so they cannot disagree about which
name a column is read under:

| part holds | another rename takes the new name as its source? | result |
|---|---|---|
| the old name | — | mapped, as before |
| only the new name | no | not mapped → reads the real data |
| only the new name | yes | mapped → column absent → default |
| neither | — | mapped → column absent → default, as before |

`MutateTask` already consults the part's own column list the same way when deciding which files to
rename (`if (part_columns.has(rename_from))`), and its comment states the principle: required renames
depend on more than the part's data version.

The second condition is not hypothetical. A rename frees a name that the same statement can hand to
another column, and a first version of this fix without it regressed exactly that:

```sql
ALTER TABLE t ADD COLUMN B UInt64 DEFAULT 7;
ALTER TABLE t RENAME COLUMN A TO C, RENAME COLUMN B TO A;   -- pending
SELECT A, C FROM t;    -- gave A=100 C=100; A must read its default, 7
```

A source part's physical `A` is now logical `C`, so settling for that file serves one column's values
under another's name.

### Tests

`tests/queries/0_stateless/04873_read_merged_part_with_pending_rename.sh` — five cases:

| case | asserts |
|---|---|
| one column renamed, wide | source parts *and* merged part both read `100 1199` |
| every column renamed | `0 1999 / 1 1` — merged part shares no name with its sources |
| one column renamed, compact | `100 1199` |
| a freed name handed to another column | `7 100` — must-not-over-fire |

Every clause was checked by reverting it alone. With both files at `master` the three merged-part cases
return `0 0` / `0 0 0 0` / `0 0` while the freed-name control stays green, so the test isolates the
defect; dropping the second condition of the predicate flips the freed-name case to `100 100`.
`01281_alter_rename_and_other_renames`, `03990_alter_rename_column_swap_different_types`,
`03905_chained_rename_column_mutation`, `04011_detach_rename_attach_column` and
`03830_vertical_merge_inject_column_after_drop` all pass, and a sweep over the rename / drop /
vertical-merge / detach / attach / optimize-final selectors gives 131 passed with no failures in those
families.

### Notes for reviewers

- One remaining case is **not** fixed here and is pre-existing: `RENAME A TO C, RENAME B TO A` followed
  by a merge. The merged part then holds `C` and `A`, both current names, and a source part holds `A`
  and `B` — both contain a column called `A`, with identical `AlterConversions` state, so only the
  rename ordering distinguishes them and the read path does not have it. `master` produces
  byte-identical wrong output (`C=500 A=0`), so this change neither causes nor widens it. Two read-path
  approaches to it were measured to fail, one of them breaking
  `01281_alter_rename_and_other_renames` and `03990_alter_rename_column_swap_different_types`. Fixing it
  needs a per-part record of which metadata mutations a part has applied — i.e. maintaining
  `metadata_version` on `RENAME` the way Replicated does — or
  https://github.com/ClickHouse/ClickHouse/pull/99754 (column IDs), which removes the name/filename
  coupling and with it this whole family.
- The guard costs one lookup in the part's column list per renamed column per read task, and only when a
  rename is actually pending.
- It changes what a merged part *reads*, not what any merge *writes*, so there is no part-format change
  and nothing has to be re-mutated.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed columns reading as their default values on a `MergeTree` table after a merge that ran while an `ALTER TABLE ... RENAME COLUMN` was still being applied.
