### PR TITLE
Fix lost wakeup of restarting thread on startup from the attach thread

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5930,7 +5930,8 @@ void StorageReplicatedMergeTree::startupImpl(bool from_attach_thread, const ZooK
             LOG_TRACE(log, "Trying to startup table from right now");
             /// Try activating replica in the current thread.
             restarting_thread.run();
-            restarting_thread.start(false);
+            /// The restarting thread task can be deactivated (i.e. due to shutdown()), and then run() will not schedule task, so force scheduling as well
+            restarting_thread.start(/*schedule=*/ true);
         }
         else
         {


### PR DESCRIPTION
A schedule request on a deactivated task is a silent no-op. On startup from the attach thread the restarting thread runs inline with its task activated only afterwards, so when a failed previous startup attempt had deactivated the task, the retry scheduled from inside the inline attempt was lost and nothing ever scheduled the task again: the table stayed readonly until an unrelated session expiry. Schedule the task after activating it; this also restores the periodic session-expiration check, lost the same way when the inline attempt succeeds.

Fixes: test_replicated_table_attach/test.py::test_startup_with_small_bg_pool_partitioned

Found on CI [1]

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114285&sha=2012a0d75a6da14f3979a80ceef1ffa97fc304e0&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29

<details>

    2026.08.13 17:06:16.210619 [ 832 ] {} <Information> default.replicated_table_partitioned (817045c5-1a64-490c-83ed-59eb04185a92): Table will be in readonly mode until initialization is finished
    2026.08.13 17:06:16.210818 [ 841 ] {} <Trace> default.replicated_table_partitioned (817045c5-1a64-490c-83ed-59eb04185a92): Starting up table
    2026.08.13 17:06:19.276552 [ 675 ] {BgSchPool::2e51bc00-dcb8-4c85-a834-11d24cb60e43} <Trace> default.replicated_table_partitioned (ReplicatedMergeTreeRestartingThread): Restarting thread finished
    2026.08.13 17:06:19.305027 [ 675 ] {BgSchPool::2e51bc00-dcb8-4c85-a834-11d24cb60e43} <Error> default.replicated_table_partitioned (ReplicatedMergeTreeAttachThread): Initialization failed. Error: Code: 999. Coordination::Exception: Session expired (fault injected on send). (KEEPER_EXCEPTION)

    0. base/poco/Foundation/src/Exception.cpp:32:1: Poco::Exception::Exception(String&&, int) @ 0x000000001f1f0538
    1. src/Common/Exception.cpp:164:7: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000fe742d0
    2. src/Common/Exception.h:201:100: DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000ac6b9d8
    3. src/Common/ZooKeeper/KeeperException.h:25:44: Coordination::Exception::Exception<char const (&) [41]>(T&&, Coordination::Error) @ 0x0000000018bd419c
    4. src/Common/ZooKeeper/ZooKeeperImpl.cpp:2367:15: Coordination::ZooKeeper::maybeInjectSendFault() @ 0x0000000019bed6a4
    5. src/Common/ZooKeeper/ZooKeeperImpl.cpp:1672:9: Coordination::ZooKeeper::pushRequest(Coordination::ZooKeeper::RequestInfo&&) @ 0x0000000019becfb8
    6. src/Common/ZooKeeper/ZooKeeperImpl.cpp:2012:5: Coordination::ZooKeeper::list(String const&, Coordination::ListRequestType, std::function<void (Coordination::ListResponse const&)>, Coordination::WatchCallbackPtrOrEventPtr, bool, bool) @ 0x0000000019bf3178
    7. src/Common/ZooKeeper/ZooKeeper.cpp:1766:11: zkutil::ZooKeeper::asyncTryGetChildrenNoThrow(String const&, Coordination::WatchCallbackPtrOrEventPtr, Coordination::ListRequestType, bool, bool) @ 0x0000000019c1ad6c
    8. src/Common/ZooKeeper/ZooKeeper.cpp:427:26: zkutil::ZooKeeper::getChildrenImpl(String const&, std::vector<String, std::allocator<String>>&, Coordination::Stat*, Coordination::WatchCallbackPtrOrEventPtr, Coordination::ListRequestType, bool, bool) @ 0x0000000019c1a7dc
    9. src/Common/ZooKeeper/ZooKeeper.cpp:486:32: zkutil::ZooKeeper::tryGetChildrenWatch(String const&, std::vector<String, std::allocator<String>>&, Coordination::Stat*, Coordination::WatchCallbackPtrOrEventPtr, Coordination::ListRequestType, bool, bool) @ 0x0000000019c1b4b0
    10. src/Common/ZooKeeper/ZooKeeper.cpp:474:12: zkutil::ZooKeeper::tryGetChildren(String const&, std::vector<String, std::allocator<String>>&, Coordination::Stat*, std::shared_ptr<Poco::Event> const&, Coordination::ListRequestType, bool, bool) @ 0x0000000019c1b24c
    11. src/Storages/MergeTree/LeaderElection.h:33:46: zkutil::checkNoOldLeaders(std::shared_ptr<Poco::Logger>, zkutil::ZooKeeper&, String) @ 0x0000000018517914
    12. src/Storages/StorageReplicatedMergeTree.cpp:4998:9: DB::StorageReplicatedMergeTree::startBeingLeader(DB::ZooKeeperRetriesInfo const&)::$_0::operator()() const @ 0x000000001848ba38
    13. src/Storages/StorageReplicatedMergeTree.cpp:5014:9: DB::StorageReplicatedMergeTree::startBeingLeader(DB::ZooKeeperRetriesInfo const&) @ 0x000000001848b290
    14. src/Storages/StorageReplicatedMergeTree.cpp:5926:9: DB::StorageReplicatedMergeTree::startupImpl(bool, DB::ZooKeeperRetriesInfo const&) @ 0x00000000184989ac
    15. src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:210:13: DB::ReplicatedMergeTreeAttachThread::finalizeInitialization() @ 0x0000000018b63dd8
    16. src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:72:13: DB::ReplicatedMergeTreeAttachThread::run() @ 0x0000000018b60c3c
    17. contrib/llvm-project/libcxx/include/__functional/function.h:502:12: ? @ 0x0000000013fd9860
    18. src/Core/BackgroundSchedulePool.cpp:643:36: DB::BackgroundSchedulePool::threadFunction() @ 0x0000000013fde2ec
    19. contrib/llvm-project/libcxx/include/__functional/function.h:502:12: ? @ 0x000000001009927c
    20. contrib/llvm-project/libcxx/include/__functional/function.h:502:12: ? @ 0x000000001008f784
    21. contrib/llvm-project/libcxx/include/__type_traits/invoke.h:0: void* std::__thread_proxy[abi:fqe220101]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(v>
    22. start_thread @ 0x00000000000803c8
    23. thread_start @ 0x00000000000e9edc (version 26.8.1.1) 2026.08.13 17:06:19.305058 [ 675 ] {BgSchPool::2e51bc00-dcb8-4c85-a834-11d24cb60e43} <Information> default.replicated_table_partitioned (ReplicatedMergeTreeAttachThread): Will retry initialization in 3s 2026.08.13 17:06:22.343787 [ 675 ] {BgSchPool::e9986f43-2ef2-4cc2-8f41-3899bd19e525} <Debug> default.replicated_table_partitioned (ReplicatedMergeTreeRestartingThread): Activating replica. 2026.08.13 17:06:22.378579 [ 675 ] {BgSchPool::e9986f43-2ef2-4cc2-8f41-3899bd19e525} <Error> default.replicated_table_partitioned (ReplicatedMergeTreeRestartingThread): Couldn't start replication (table will be in readonly mode): Coordination error: Connection loss, path /clickhouse/replicated_table_partitioned/replicas/r1/log_pointer. Code: 999. Coordination::Exception: Coordination error: Connection loss, path /clickhouse/replicated_table_partitioned/replicas/r1/log_pointer. (KEEPER_EXCEPTION)

    0. base/poco/Foundation/src/Exception.cpp:32:1: Poco::Exception::Exception(String&&, int) @ 0x000000001f1f0538
    1. src/Common/Exception.cpp:164:7: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000fe742d0
    2. src/Common/Exception.h:201:100: DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000ac6b9d8
    3. src/Common/Exception.h:57:54: DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000ac6b40c
    4. src/Common/Exception.h:219:77: DB::Exception::Exception<char const*, String const&>(int, FormatStringHelperImpl<std::type_identity<char const*>::type, std::type_identity<String const&>::type>, char const*&&, String const&) @ 0x000000000c96c3dc
    5. src/Common/ZooKeeper/KeeperException.h:38:11: Coordination::Exception::fromPath(Coordination::Error, String const&) @ 0x000000000c96c31c
    6. src/Common/ZooKeeper/ZooKeeper.cpp:854:15: zkutil::ZooKeeper::tryGetWatch(String const&, String&, Coordination::Stat*, Coordination::WatchCallbackPtrOrEventPtr, Coordination::Error*) @ 0x0000000019c2021c
    7. src/Common/ZooKeeper/ZooKeeper.cpp:841:12: zkutil::ZooKeeper::get(String const&, Coordination::Stat*, std::shared_ptr<Poco::Event> const&) @ 0x0000000019c1fdf4
    8. src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:838:35: DB::ReplicatedMergeTreeQueue::pullLogsToQueue(std::shared_ptr<zkutil::ZooKeeper>, std::shared_ptr<std::function<void (Coordination::WatchResponse const&)>>, DB::ReplicatedMergeTreeQueue::PullLogsReason) @ 0x0000000018b92f40
    9. src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp:211:27: DB::ReplicatedMergeTreeRestartingThread::tryStartup() @ 0x0000000018bbeaa8
    10. src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp:165:10: DB::ReplicatedMergeTreeRestartingThread::runImpl() @ 0x0000000018bbda30
    11. src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp:91:34: DB::ReplicatedMergeTreeRestartingThread::run() @ 0x0000000018bbd044
    12. src/Storages/StorageReplicatedMergeTree.cpp:5932:31: DB::StorageReplicatedMergeTree::startupImpl(bool, DB::ZooKeeperRetriesInfo const&) @ 0x000000001849903c
    13. src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:210:13: DB::ReplicatedMergeTreeAttachThread::finalizeInitialization() @ 0x0000000018b63dd8
    14. src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:72:13: DB::ReplicatedMergeTreeAttachThread::run() @ 0x0000000018b60c3c
    15. contrib/llvm-project/libcxx/include/__functional/function.h:502:12: ? @ 0x0000000013fd9860
    16. src/Core/BackgroundSchedulePool.cpp:643:36: DB::BackgroundSchedulePool::threadFunction() @ 0x0000000013fde2ec
    17. contrib/llvm-project/libcxx/include/__functional/function.h:502:12: ? @ 0x000000001009927c
    18. contrib/llvm-project/libcxx/include/__functional/function.h:502:12: ? @ 0x000000001008f784
    19. contrib/llvm-project/libcxx/include/__type_traits/invoke.h:0: void* std::__thread_proxy[abi:fqe220101]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(v>
    20. start_thread @ 0x00000000000803c8
    21. thread_start @ 0x00000000000e9edc (version 26.8.1.1) 2026.08.13 17:06:22.378609 [ 675 ] {BgSchPool::e9986f43-2ef2-4cc2-8f41-3899bd19e525} <Trace> default.replicated_table_partitioned (ReplicatedMergeTreeRestartingThread): Starting the restarting thread, schedule: false 2026.08.13 17:06:22.378624 [ 675 ] {BgSchPool::e9986f43-2ef2-4cc2-8f41-3899bd19e525} <Information> default.replicated_table_partitioned (ReplicatedMergeTreeAttachThread): Table is initialized 2026.08.13 17:12:25.404633 [ 652 ] {} <Trace> default.replicated_table_partitioned (ReplicatedMergeTreeRestartingThread): Restarting thread finished

</details>

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix lost wakeup of restarting thread on startup from the attach thread


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1446` (included in `26.8` and later)
<!-- ch-version-info:end -->