### PR TITLE
Keep the materialized-CTE gate above the sets in a collapsed distributed plan

### DIFF
--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -24,6 +24,7 @@
 #include <Processors/QueryPlan/IQueryPlanStep.h>
 #include <Processors/QueryPlan/CreatingSetsStep.h>
 #include <Processors/QueryPlan/DistributedPlanSets.h>
+#include <Processors/QueryPlan/MaterializingCTEStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/QueryPlan/QueryPlan.h>
@@ -83,6 +84,26 @@ void assertFragmentSerializable(const QueryPlan & fragment, const String & stage
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
             "make_distributed_plan cannot distribute this query: step '{}' in stage '{}' is not "
             "serializable for remote execution", node->step->getName(), stage_name);
+}
+
+/// A `DelayedMaterializingCTEsStep`'s gate holds back only the pipeline below it, so a
+/// `DelayedCreatingSetsStep` whose sources may read a materialized CTE belongs below the whole
+/// root-level chain (`addBuildSubqueriesForMaterializedCTEsIfNeeded` stacks one step per level).
+/// Returns nullptr when the root is not such a step.
+QueryPlan::Node ** findSlotBelowDelayedMaterializingCTEs(QueryPlan::Node *& root)
+{
+    QueryPlan::Node ** slot = nullptr;
+    QueryPlan::Node ** current = &root;
+    while (*current && typeid_cast<DelayedMaterializingCTEsStep *>((*current)->step.get()))
+    {
+        if ((*current)->children.size() != 1)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Expected DelayedMaterializingCTEsStep to have exactly one child, got {}",
+                (*current)->children.size());
+        current = &(*current)->children.front();
+        slot = current;
+    }
+    return slot;
 }
 
 }
@@ -879,11 +900,24 @@ void QueryPlan::convertToDistributed(const QueryPlanOptimizationSettings & optim
         /// locally, so add the detached sets back and expand them the ordinary way (sets already
         /// built during planning are reused).
         if (!delayed_sets.empty() && optimization_settings.build_sets)
-            addStep(std::make_unique<DelayedCreatingSetsStep>(
-                getCurrentHeader(),
+        {
+            /// The planner nests the sets below the materialized-CTE steps, so the CTE gate
+            /// encloses the set-build pipeline; adding them at the root would invert that.
+            QueryPlan::Node ** slot = findSlotBelowDelayedMaterializingCTEs(root);
+            auto step = std::make_unique<DelayedCreatingSetsStep>(
+                slot ? (*slot)->step->getOutputHeader() : getCurrentHeader(),
                 std::move(delayed_sets),
                 optimization_settings.network_transfer_limits,
-                optimization_settings.prepared_sets_cache));
+                optimization_settings.prepared_sets_cache);
+
+            if (slot)
+            {
+                auto & node = nodes.emplace_back(Node{.step = std::move(step), .children = {*slot}});
+                *slot = &node;
+            }
+            else
+                addStep(std::move(step));
+        }
 
         QueryPlanOptimizationSettings local_settings = optimization_settings;
         local_settings.make_distributed_plan = false;

--- a/tests/queries/0_stateless/04739_materialized_cte_in_set_distributed_plan.reference
+++ b/tests/queries/0_stateless/04739_materialized_cte_in_set_distributed_plan.reference
@@ -1,0 +1,20 @@
+-- CTE read by both the outer query and the set
+4
+4
+-- nested set
+4
+-- chained CTEs, one gate step per dependency level
+4
+4
+-- UNION ALL
+4
+4
+-- CTE over a MergeTree table, primary-key and non-primary-key sets
+4
+4
+-- only one side reads the CTE
+4
+4
+-- unchanged without a distributed plan
+4
+-- a plan that stays multi-stage is still refused

--- a/tests/queries/0_stateless/04739_materialized_cte_in_set_distributed_plan.sql
+++ b/tests/queries/0_stateless/04739_materialized_cte_in_set_distributed_plan.sql
@@ -1,0 +1,81 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- A collapsed distributed plan keeps the whole query in one stage only without ORDER BY,
+-- so each result below is made deterministic by a single-row predicate instead.
+
+SET enable_analyzer = 1;
+SET enable_materialized_cte = 1;
+SET make_distributed_plan = 1;
+
+DROP TABLE IF EXISTS mt_04739;
+CREATE TABLE mt_04739 (n UInt64, v UInt64) ENGINE = MergeTree ORDER BY n;
+INSERT INTO mt_04739 SELECT number, number * 2 FROM numbers(9);
+
+SELECT '-- CTE read by both the outer query and the set';
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT * FROM cte WHERE number IN (SELECT number FROM cte) AND number = 4;
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT * FROM cte WHERE number GLOBAL IN (SELECT number FROM cte) AND number = 4;
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT * FROM cte WHERE number NOT IN (SELECT number FROM cte);
+
+SELECT '-- nested set';
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT * FROM cte
+WHERE number IN (SELECT number FROM cte WHERE number IN (SELECT number FROM cte)) AND number = 4;
+
+SELECT '-- chained CTEs, one gate step per dependency level';
+
+WITH a AS MATERIALIZED (SELECT number FROM numbers(9)),
+     b AS MATERIALIZED (SELECT number FROM a)
+SELECT * FROM b WHERE number IN (SELECT number FROM a) AND number = 4;
+
+WITH a AS MATERIALIZED (SELECT number FROM numbers(9)),
+     b AS MATERIALIZED (SELECT number FROM a),
+     c AS MATERIALIZED (SELECT number FROM b)
+SELECT * FROM c WHERE number IN (SELECT number FROM a) AND number = 4;
+
+SELECT '-- UNION ALL';
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT * FROM (
+    SELECT number FROM cte WHERE number IN (SELECT number FROM cte) AND number = 4
+    UNION ALL
+    SELECT number FROM cte WHERE number = 4);
+
+SELECT '-- CTE over a MergeTree table, primary-key and non-primary-key sets';
+
+WITH cte AS MATERIALIZED (SELECT n FROM mt_04739)
+SELECT * FROM cte WHERE n IN (SELECT n FROM cte) AND n = 4;
+
+WITH cte AS MATERIALIZED (SELECT n, v FROM mt_04739)
+SELECT n FROM cte WHERE v IN (SELECT v FROM cte) AND v = 8;
+
+SELECT '-- only one side reads the CTE';
+
+WITH cte AS MATERIALIZED (SELECT n FROM mt_04739)
+SELECT * FROM cte WHERE n IN (SELECT n FROM mt_04739) AND n = 4;
+
+WITH cte AS MATERIALIZED (SELECT n FROM mt_04739)
+SELECT n FROM mt_04739 WHERE n IN (SELECT n FROM cte) AND n = 4;
+
+SELECT '-- unchanged without a distributed plan';
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT * FROM cte WHERE number IN (SELECT number FROM cte) AND number = 4
+SETTINGS make_distributed_plan = 0;
+
+SELECT '-- a plan that stays multi-stage is still refused';
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT count() FROM (SELECT number FROM cte UNION ALL SELECT number FROM cte); -- { serverError SUPPORT_IS_DISABLED }
+
+WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
+SELECT * FROM cte WHERE number IN (SELECT number FROM cte) ORDER BY number; -- { serverError SUPPORT_IS_DISABLED }
+
+DROP TABLE mt_04739;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/110176
Related: https://github.com/ClickHouse/ClickHouse/pull/110102
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/110176
Related: https://github.com/ClickHouse/ClickHouse/pull/110102

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `Reading from materialized CTE before its materialization completed` when a materialized CTE is read both by the outer query and inside an `IN` subquery with `make_distributed_plan = 1`.


### Description

Found by `AST fuzzer (amd_debug, targeted)` on #110102, which is unrelated to it. Reproducer, on a server:

```sql
WITH cte AS MATERIALIZED (SELECT number FROM numbers(9))
SELECT * FROM cte WHERE number IN (SELECT number FROM cte) AND number = 4
SETTINGS enable_analyzer = 1, enable_materialized_cte = 1, make_distributed_plan = 1;
```

The planner nests `DelayedMaterializingCTEs` above `DelayedCreatingSets`, so the `DelayedPortsProcessor` that the CTE step installs holds back every reader below it, including the set build. With `make_distributed_plan = 1`, `QueryPlan::optimize` defers the expansion of both steps, `extractSetsForDistributedPlan` splices the sets out, and the collapsed single-stage branch re-attached them with `addStep` - which makes them the new root, above the CTE step. The gate then no longer covers the set build, so the set's read of the CTE's `StorageMemory` runs before materialization and trips the fail-fast check in `MemorySource::generate`. Without that check the read would return partial data.

`EXPLAIN PIPELINE` for the query above shows the inversion directly: `CreatingSets` over `MaterializingCTEs` with the setting on, the reverse with it off.

The fix inserts the re-attached `DelayedCreatingSetsStep` below the root-level `DelayedMaterializingCTEsStep` chain instead of on top of it, restoring the nesting the non-distributed path produces. The whole chain is walked, since one such step is stacked per CTE dependency level. When there is no materialized-CTE step at the root the original `addStep` runs unchanged, so nothing changes with `make_distributed_plan = 0`.

Validation: the new test covers `IN`/`NOT IN`/`GLOBAL IN`, nested sets, two- and three-level chained CTEs, `UNION ALL`, and primary-key and non-primary-key sets over a MergeTree-backed CTE. Every one of those aborts on master and returns correct rows with this change; reverting the change re-breaks them. Shapes that stay multi-stage keep their existing `SUPPORT_IS_DISABLED` refusal, unchanged. Every `materialized_cte` and `make_distributed_plan` test was run on both binaries with identical per-test results.