### PR TITLE
Resolve the 25.8 cherry-pick conflict of #112327

### DIFF
--- a/src/Dictionaries/DictionaryHelpers.h
+++ b/src/Dictionaries/DictionaryHelpers.h
@@ -655,7 +655,8 @@ Block mergeBlockWithPipe(
 /**
  * Returns ColumnVector data as PaddedPodArray.
 
- * If column is constant parameter backup_storage is used to store values.
+ * If the column has to be converted to a full one, parameter backup_storage is used to store values,
+ * because the converted column may not be owned by anything that outlives this call.
  */
 /// TODO: Remove
 template <typename T>
@@ -664,7 +665,6 @@ static const PaddedPODArray<T> & getColumnVectorData(
     const ColumnPtr column,
     PaddedPODArray<T> & backup_storage)
 {
-    bool is_const_column = isColumnConst(*column);
     auto full_column = recursiveRemoveSparse(column->convertToFullColumnIfConst());
     auto vector_col = checkAndGetColumn<ColumnVector<T>>(full_column.get());
 
@@ -676,12 +676,13 @@ static const PaddedPODArray<T> & getColumnVectorData(
             TypeName<T>);
     }
 
-    if (is_const_column)
+    /// A different pointer means a conversion happened (Const or Sparse; a Tuple never reaches here
+    /// because the check above requires a ColumnVector), so the data may live only in a column owned
+    /// by `full_column` and die at return: copy it. An unconverted column is kept alive by `column`
+    /// itself.
+    if (full_column.get() != column.get())
     {
-        // With type conversion and const columns we need to use backup storage here
-        auto & data = vector_col->getData();
-        backup_storage.assign(data);
-
+        backup_storage.assign(vector_col->getData());
         return backup_storage;
     }
 

--- a/tests/queries/0_stateless/04652_direct_join_dictionary_sparse_key.reference
+++ b/tests/queries/0_stateless/04652_direct_join_dictionary_sparse_key.reference
@@ -1,0 +1,19 @@
+The join keys are really serialized Sparse
+probe_sparse	1
+probe_sparse_arr	1
+Sparse key, key presence only
+4000	3200	800	160	3200	800
+Sparse key, dictionary attribute read
+336000	4000	3200	800
+Sparse default key 0 is really found
+800	3200	160
+Sparse key, aggregation in order
+1	1	50
+Sparse key replicated by ARRAY JOIN, attribute read
+378000	4500	900	3600
+Sparse mapping equals dense mapping
+1
+Sparse mapping equals hash join mapping
+1
+Direct join is still chosen for the sparse key
+1

--- a/tests/queries/0_stateless/04652_direct_join_dictionary_sparse_key.sql
+++ b/tests/queries/0_stateless/04652_direct_join_dictionary_sparse_key.sql
@@ -1,0 +1,105 @@
+-- Tags: no-parallel-replicas
+-- The direct join algorithm is not available with parallel replicas.
+
+DROP DICTIONARY IF EXISTS dict_sparse_key;
+DROP TABLE IF EXISTS probe_sparse;
+DROP TABLE IF EXISTS probe_dense;
+DROP TABLE IF EXISTS probe_sparse_arr;
+DROP TABLE IF EXISTS dict_source;
+
+-- The attribute is never 0, so with join_use_nulls = 0 the value `r.v = 0` means "key not found".
+CREATE TABLE dict_source (j UInt64, v UInt64) ENGINE = MergeTree ORDER BY j;
+INSERT INTO dict_source SELECT number, (number + 1) * 10 FROM numbers(20);
+
+CREATE DICTIONARY dict_sparse_key (j UInt64, v UInt64) PRIMARY KEY j
+SOURCE(CLICKHOUSE(TABLE 'dict_source' DB currentDatabase())) LAYOUT(FLAT()) LIFETIME(MIN 0 MAX 0);
+
+-- `j` is default-heavy, so it is serialized Sparse. Keys 0..19 are in the dictionary, 20..24 are not.
+CREATE TABLE probe_sparse (k UInt32, j UInt64) ENGINE = MergeTree ORDER BY k
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.0;
+INSERT INTO probe_sparse SELECT number % 50, number % 25 FROM numbers(4000);
+
+-- The same data written densely, used as the expected result below.
+CREATE TABLE probe_dense (k UInt32, j UInt64) ENGINE = MergeTree ORDER BY k
+SETTINGS ratio_of_defaults_for_sparse_serialization = 1.0;
+INSERT INTO probe_dense SELECT number % 50, number % 25 FROM numbers(4000);
+
+-- A sparse `j` carried through ARRAY JOIN, so the join key arrives replicated rather than plain.
+CREATE TABLE probe_sparse_arr (j UInt64, arr Array(UInt8)) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.0;
+INSERT INTO probe_sparse_arr SELECT number % 25, [1, 2, 3] FROM numbers(1500);
+
+SELECT 'The join keys are really serialized Sparse';
+SELECT table, countIf(serialization_kind = 'Sparse') > 0 FROM system.parts_columns
+WHERE database = currentDatabase() AND table IN ('probe_sparse', 'probe_sparse_arr')
+  AND column = 'j' AND active
+GROUP BY table ORDER BY table;
+
+SET join_algorithm = 'direct';
+-- Pinned, not left to randomization: a miss must read as 0 rather than NULL below.
+SET join_use_nulls = 0;
+
+-- `r.j` observes which keys were found; the two `l.j` counts catch a key classified the wrong way.
+SELECT 'Sparse key, key presence only';
+SELECT count(), countIf(r.v != 0), countIf(r.v = 0), countIf(l.j = 0 AND r.v = 10),
+       countIf(l.j < 20 AND r.j = l.j), countIf(l.j >= 20 AND r.j = 0)
+FROM probe_sparse AS l LEFT JOIN dict_sparse_key AS r ON l.j = r.j;
+
+-- `r.v = (l.j + 1) * 10` restates the dictionary contents, so values swapped between keys are
+-- caught even though the sum stays the same.
+SELECT 'Sparse key, dictionary attribute read';
+SELECT sum(r.v), count(), countIf(r.v = (l.j + 1) * 10), countIf(r.v = 0 AND l.j >= 20)
+FROM probe_sparse AS l LEFT JOIN dict_sparse_key AS r ON l.j = r.j;
+
+-- Key 0 is the sparse default and an unmatched right key is 0 too, so join_use_nulls = 1 is what
+-- separates a found key 0 from a lost one here.
+SELECT 'Sparse default key 0 is really found';
+SELECT countIf(r.j IS NULL), countIf(l.j < 20 AND r.j IS NOT NULL), countIf(l.j = 0 AND r.j = 0)
+FROM probe_sparse AS l LEFT JOIN dict_sparse_key AS r ON l.j = r.j
+SETTINGS join_use_nulls = 1;
+
+SELECT 'Sparse key, aggregation in order';
+SELECT max(u), min(u), count() FROM
+(
+    SELECT l.k, uniqExact(l.k) AS u FROM probe_sparse AS l LEFT JOIN dict_sparse_key AS r ON l.j = r.j GROUP BY l.k
+)
+SETTINGS optimize_aggregation_in_order = 1, max_threads = 1;
+
+SELECT 'Sparse key replicated by ARRAY JOIN, attribute read';
+SELECT sum(r.v), count(), countIf(r.v = 0), countIf(r.v = (l.j + 1) * 10)
+FROM (SELECT j FROM probe_sparse_arr ARRAY JOIN arr) AS l
+LEFT JOIN dict_sparse_key AS r ON l.j = r.j;
+
+-- Comparing the whole per-key mapping, not a total: a total survives values swapped between keys.
+SELECT 'Sparse mapping equals dense mapping';
+SELECT
+    (SELECT arraySort(groupArray((j, v, c))) FROM
+        (SELECT l.j AS j, r.v AS v, count() AS c FROM probe_sparse AS l
+         LEFT JOIN dict_sparse_key AS r ON l.j = r.j GROUP BY l.j, r.v))
+        = (SELECT arraySort(groupArray((j, v, c))) FROM
+            (SELECT l.j AS j, r.v AS v, count() AS c FROM probe_dense AS l
+             LEFT JOIN dict_sparse_key AS r ON l.j = r.j GROUP BY l.j, r.v));
+
+SELECT 'Sparse mapping equals hash join mapping';
+SELECT
+    (SELECT arraySort(groupArray((j, v, c))) FROM
+        (SELECT l.j AS j, r.v AS v, count() AS c FROM probe_sparse AS l
+         LEFT JOIN dict_sparse_key AS r ON l.j = r.j GROUP BY l.j, r.v))
+        = (SELECT arraySort(groupArray((j, v, c))) FROM
+            (SELECT l.j AS j, r.v AS v, count() AS c FROM probe_sparse AS l
+             LEFT JOIN dict_sparse_key AS r ON l.j = r.j GROUP BY l.j, r.v
+             SETTINGS join_algorithm = 'hash'));
+
+SELECT 'Direct join is still chosen for the sparse key';
+SELECT count() > 0 FROM
+(
+    EXPLAIN actions = 1
+    SELECT count() FROM probe_sparse AS l LEFT JOIN dict_sparse_key AS r ON l.j = r.j
+)
+WHERE explain ILIKE '%Algorithm: DirectKeyValueJoin%';
+
+DROP DICTIONARY dict_sparse_key;
+DROP TABLE probe_sparse;
+DROP TABLE probe_dense;
+DROP TABLE probe_sparse_arr;
+DROP TABLE dict_source;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112327
Related: https://github.com/ClickHouse/ClickHouse/pull/114796
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a use-after-free when a `LEFT JOIN` to a dictionary with `join_algorithm = 'direct'` had a join key that is serialized `Sparse`. `getColumnVectorData` returned a `PaddedPODArray` reference into a column owned only by a function-local `ColumnPtr`, so the dictionary lookup read freed memory.

### Description

Backport of #112327 to `25.8`. The robot cherry-pick #114796 is `CONFLICTING`, so the automation cannot carry it.

The conflict is in one file. `getColumnVectorData` materializes its key column with `removeSpecialRepresentations` on master and with `recursiveRemoveSparse` here; `removeSpecialRepresentations` does not exist on this branch. The resolution keeps 25.8's call and takes the fix's predicate, so the resolved change is the same 8 insertions and 7 deletions as the merged commit. On this branch the copy therefore guards `Const` and `Sparse`; `ColumnReplicated` does not exist here and is dropped from the comment's carrier list.

`25.8` is affected. On the official `25.8.30.17` binary the repro (a 2M-row sparse probe joined to a `FLAT()` dictionary) segfaults in 2 of 7 runs, and with jemalloc junk filling it fails 4 of 4 with `Invalid number of rows in Chunk ... expected 65409, got 0`. The same data written densely passes. Comparing returned values alone cannot see this, because freed but intact memory still yields the correct numbers.

Verified in both directions with a clang-19 Debug build, this branch's pinned compiler, asserting build ids against the running server. Pristine `25.8` aborts on the first assertion of the ported test, at `PODArray::operator[]` inside `FlatDictionary::hasKeys` reached through `IDictionary::getByKeys` and `DirectKeyValueJoin::joinBlock` - the mechanism reported on master. With the fix the test passes and the repro returns the correct result in 3 of 3 runs.

One branch adaptation in the test: `enable_lazy_columns_replication` does not exist on `25.8` and is rejected as an unknown setting, so it is dropped from the `ARRAY JOIN` statement. The statement and every assertion are kept.
