### PR TITLE
Run 04869_postgresql_tls_trailing_arguments sequentially

### DIFF
--- a/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
+++ b/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
@@ -1,5 +1,11 @@
--- Tags: no-fasttest, need-query-parameters
--- no-fasttest: the PostgreSQL integration is not available in the fast test build.
+-- Tags: no-fasttest, no-parallel, need-query-parameters
+-- Tag justification:
+--   no-fasttest: the PostgreSQL integration is not available in the fast test build.
+--   no-parallel: creates a PostgreSQL database pointing at an unreachable host.
+--     Because `show_remote_databases_in_system_tables` defaults to `true`, that database is
+--     visible in `system.tables`, `system.columns` and `system.completions`, so any concurrent
+--     query that scans those tables without a database filter would try to connect to the
+--     unreachable host and log a `POSTGRESQL_CONNECTION_FAILURE` to its own stderr.
 
 -- A TLS parameter of a PostgreSQL source given twice in the trailing key-value arguments must be
 -- rejected, and the trailing arguments must not count towards the positional ones.

--- a/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
+++ b/tests/queries/0_stateless/04869_postgresql_tls_trailing_arguments.sql
@@ -9,8 +9,8 @@
 
 -- A TLS parameter of a PostgreSQL source given twice in the trailing key-value arguments must be
 -- rejected, and the trailing arguments must not count towards the positional ones.
--- The database name comes from the CLICKHOUSE_DATABASE_1 macro: the flaky check runs this test
--- many times in parallel, and a fixed name collides across runs.
+-- The database name comes from the CLICKHOUSE_DATABASE_1 macro rather than a fixed name, so
+-- concurrent independent runs of this test against the same server do not collide on it.
 
 DROP TABLE IF EXISTS t_04869;
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114580
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/114580

`04869_postgresql_tls_trailing_arguments` registers a PostgreSQL database pointing at the
unreachable `127.0.0.1:1` and ran in the parallel group. Since
`show_remote_databases_in_system_tables` defaults to `true`, that database is visible in
`system.tables`, `system.columns` and `system.completions`, so a concurrent query scanning
those tables without a database filter connects to the unreachable host. The connection
failure is logged on the scanning query's own thread, so it reaches that client's stderr, and
`clickhouse-test` fails any test whose stderr is non-empty. The polluter stays green and an
unrelated test goes red, which makes the failure unattributable from the victim's side.

One master hit since the test landed on 2026-08-13: `00938_fix_rwlock_segfault_long` in
`Stateless tests (arm_binary, parallel)`, whose whole body is an unfiltered `system.tables` and
`system.columns` scan.
[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5c5dd13e2760e7087bd9a7f5e6e6fa572a2b003f&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29)

I add `no-parallel` with a written justification, matching the sibling
`04210_show_remote_databases_in_system_tables`, which documents this exact hazard and carries
the tag for it. I checked the two alternatives first, and both are impossible rather than
merely unattractive: the visibility setting is read from the scanning query's context, so the
polluter cannot hide itself (verified: setting it to 0 on the scanner silences the log, setting
anything on the creator cannot), and a blackholed address only turns an instant refusal into a
connect timeout while still logging, which is why `04210` uses `192.0.2.1` and the tag. Test
statements and the reference file are unchanged; the test runs in 0.23 s, so serializing it
costs nothing.