### PR TITLE
Docs: Document number-tile color picker on ClickStack dashboards

### DIFF
--- a/docs/clickstack/features/dashboards/overview.mdx
+++ b/docs/clickstack/features/dashboards/overview.mdx
@@ -193,6 +193,43 @@ To remove, edit, or duplicate a visualization, hover over it and use the corresp
 
 Each tile has a **Display Settings** drawer for options that control how its value is rendered. Open it from the tile editor by clicking **Display Settings**. The available options depend on the visualization type.
 
+#### Number tile color {#number-tile-color}
+
+Number tiles support a static **Color** choice from the curated chart palette. With a number tile selected, open **Display Settings** and use the **Color** control (labeled **Number tile color** for accessibility) to pick a swatch, or clear the selection to use the default text color.
+
+Colors are stored as palette tokens, not raw hex values, so the same tile reflows correctly across light, dark, and IDE themes.
+
+**Categorical tokens** (multi-series hues):
+
+| Token | Label |
+|---|---|
+| `chart-blue` | Blue |
+| `chart-orange` | Orange |
+| `chart-red` | Red |
+| `chart-cyan` | Cyan |
+| `chart-green` | Green |
+| `chart-pink` | Pink |
+| `chart-purple` | Purple |
+| `chart-light-blue` | Light Blue |
+| `chart-brown` | Brown |
+| `chart-gray` | Gray |
+
+**Semantic tokens** (status-oriented):
+
+| Token | Label |
+|---|---|
+| `chart-success` | Success |
+| `chart-warning` | Warning |
+| `chart-error` | Error |
+
+Use semantic tokens when the number represents a status (for example error count in `chart-error`, or a healthy rate in `chart-success`). Use categorical tokens when you want visual distinction between related KPI tiles without implying status.
+
+Older configs may still store legacy numeric tokens (`chart-1` through `chart-10`). ClickStack maps those to the hue-named tokens above when loading a dashboard.
+
+The same palette powers optional **color rules** in the same drawer: ordered conditions evaluated against the displayed value (last match wins). When no rule matches, the static color applies, then the default text color.
+
+#### Number tile background chart {#number-tile-background-chart}
+
 Number tiles can show a **background chart**: a trend sparkline drawn behind the value, so its movement over the selected time range is visible at a glance. This is useful for SLO and error-budget tiles, where how a value is trending matters as much as its current reading.
 
 With a number tile selected, open **Display Settings** and set **Background chart** to **Line** or **Area** (or **None** to turn it off). The sparkline is derived from a time-bucketed version of the tile's query, so no extra configuration is needed. It inherits the tile color by default; set a **Background color** to override it with a specific palette color.
@@ -208,6 +245,44 @@ With a table tile selected, open **Display Settings** and turn on **Alternate Ro
 <Image img="/images/clickstack/dashboards/table-tile-display-settings.webp" alt="Display Settings drawer for a table tile, with Alternate Row Background turned on" size="lg"/>
 
 Table tiles also keep a separator between the header row and the data as you scroll, so the column headers stay distinct.
+
+#### Dashboards API: number tile color {#api-number-tile-color}
+
+When creating or updating dashboards through the external API (`POST` / `PUT` `/api/v2/dashboards`), set `color` on a builder number-tile config to a palette token. Raw hex values are rejected.
+
+```json
+{
+  "name": "Error rate KPIs",
+  "tiles": [
+    {
+      "id": "65f5e4a3b9e77c001a222222",
+      "name": "Errors",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 4,
+      "config": {
+        "displayType": "number",
+        "sourceId": "<SOURCE_ID>",
+        "select": [
+          {
+            "aggFn": "count",
+            "where": "SeverityText:error",
+            "whereLanguage": "lucene",
+            "alias": "Errors"
+          }
+        ],
+        "color": "chart-error",
+        "backgroundChart": {
+          "type": "area"
+        }
+      }
+    }
+  ]
+}
+```
+
+`color` accepts any token from the categorical and semantic lists above (for example `chart-blue` or `chart-success`). Optional `backgroundChart.color` overrides the sparkline color with the same token enum. See the [ClickStack API reference](/use-cases/observability/clickstack/api-reference) for authentication and base URLs.
 
 ## Dashboard - Listing and search {#dashboard-listing-search}
 


### PR DESCRIPTION
Ports the original ClickStack number-tile color documentation from the retired `ClickHouse/clickhouse-docs` repository into the core repository after the docs consolidation. It documents the `Display Settings` color control, palette tokens, theme behavior, legacy token mapping, color-rule precedence, and the dashboard API fields.

Authorship of the migrated commit remains with the original contributor, @sankalpsthakur.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6564
Related: https://github.com/ClickHouse/ClickHouse/issues/113307

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.