### PR TITLE
Docs: dbt `INDEX` projections

### DIFF
--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
@@ -179,6 +179,7 @@ You can add [data skipping indexes](/concepts/features/performance/skip-indexes/
 You can add [projections](/concepts/features/projections/projections) to `table` and `distributed_table` materializations using the `projections` configuration. Each projection entry requires either a `query` or an `index` key (not both).
 
 **Note**: For distributed tables, the projection is applied to the `_local` tables, not to the distributed proxy table.
+**Note**: Specifying both `query` and `index` on the same projection entry raises a compile-time error.
 
 #### Query projections {#query-projections}
 
@@ -234,9 +235,6 @@ dbt-clickhouse generates version-appropriate DDL automatically:
 |--------------------|---------------|
 | 26.1+ | `ADD PROJECTION proj_by_age INDEX age TYPE basic` |
 | 25.6 – 26.0 | `ADD PROJECTION proj_by_age (SELECT _part_offset ORDER BY age)` |
-| < 25.6 | Compile-time error |
-
-Specifying both `query` and `index` on the same projection entry raises a compile-time error.
 
 ## Materialization: incremental {#materialization-incremental}
 

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
@@ -199,10 +199,6 @@ Use `query` to define a full projection query:
 
 #### Index projections {#index-projections}
 
-<Note>
-Requires ClickHouse 25.6 or later.
-</Note>
-
 Use `index` as syntax sugar for lightweight [index projections](https://clickhouse.com/blog/clickhouse-release-25-06#index-projections) that use the `_part_offset` virtual column. Pass a single column name or a list of columns to order by:
 
 ```sql

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
@@ -230,7 +230,7 @@ dbt-clickhouse generates version-appropriate DDL automatically:
 | ClickHouse version | Generated SQL |
 |--------------------|---------------|
 | 26.1+ | `ADD PROJECTION proj_by_age INDEX age TYPE basic` |
-| 25.6 – 26.0 | `ADD PROJECTION proj_by_age (SELECT _part_offset ORDER BY age)` |
+| 25.8 – 26.0 | `ADD PROJECTION proj_by_age (SELECT _part_offset ORDER BY age)` |
 
 ## Materialization: incremental {#materialization-incremental}
 

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
@@ -176,7 +176,13 @@ You can add [data skipping indexes](/concepts/features/performance/skip-indexes/
 
 ### Projections {#projections}
 
-You can add [projections](/concepts/features/projections/projections) to `table` and `distributed_table` materializations using the `projections` configuration:
+You can add [projections](/concepts/features/projections/projections) to `table` and `distributed_table` materializations using the `projections` configuration. Each projection entry requires either a `query` or an `index` key (not both).
+
+**Note**: For distributed tables, the projection is applied to the `_local` tables, not to the distributed proxy table.
+
+#### Query projections {#query-projections}
+
+Use `query` to define a full projection query:
 
 ```sql
 {{ config(
@@ -189,7 +195,48 @@ You can add [projections](/concepts/features/projections/projections) to `table`
        ]
 ) }}
 ```
-**Note**: For distributed tables, the projection is applied to the `_local` tables, not to the distributed proxy table.
+
+#### Index projections {#index-projections}
+
+<Note>
+Requires ClickHouse 25.6 or later.
+</Note>
+
+Use `index` as syntax sugar for lightweight [index projections](https://clickhouse.com/blog/clickhouse-release-25-06#index-projections) that use the `_part_offset` virtual column. Pass a single column name or a list of columns to order by:
+
+```sql
+{{ config(
+       materialized='table',
+       projections=[
+           {
+               'name': 'proj_by_age',
+               'index': 'age'
+           }
+       ]
+) }}
+```
+
+```sql
+{{ config(
+       materialized='table',
+       projections=[
+           {
+               'name': 'proj_by_dept_age',
+               'index': ['department', 'age']
+           }
+       ]
+) }}
+```
+
+dbt-clickhouse generates version-appropriate DDL automatically:
+
+| ClickHouse version | Generated SQL |
+|--------------------|---------------|
+| 26.1+ | `ADD PROJECTION proj_by_age INDEX age TYPE basic` |
+| 25.6 – 26.0 | `ADD PROJECTION proj_by_age (SELECT _part_offset ORDER BY age)` |
+| < 25.6 | Compile-time error |
+
+Specifying both `query` and `index` on the same projection entry raises a compile-time error.
 
 ## Materialization: incremental {#materialization-incremental}
 


### PR DESCRIPTION
Ports the original dbt `index`-projection documentation from the retired `ClickHouse/clickhouse-docs` repository into the core repository. This intentionally preserves the contributor's content 1:1; the only mechanical adaptations are the current file path, the current internal projections link, and the Mintlify `<Note>` wrapper.

Authorship of the migrated commit remains with the original contributor, @29antonioac.

Reviewer context: @Blargian approved the original documentation PR. @koletzilla took over and approved the corresponding adapter implementation, and @ClickHouse/integrations-ecosystem was the requested domain-review team.

Review note: the original documentation says ClickHouse versions before 25.6 produce a compile-time error. Discussion on the final adapter implementation says those versions are unsupported and the explicit guard was removed, so this wording should receive maintainer review before the PR is marked ready.

Related: https://github.com/ClickHouse/clickhouse-docs/pull/6546
Related: https://github.com/ClickHouse/dbt-clickhouse/pull/651

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1561` (included in `26.8` and later)
<!-- ch-version-info:end -->