### PR TITLE
Report candidates instead of failing on a projection-served read for WHATIF

### DIFF
--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -376,11 +376,6 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "EXPLAIN WHATIF: query analysis result is not available");
     const auto & analysis = *analysis_ptr;
 
-    /// Can't model a projection-served read, the hypothetical index isn't on projection parts
-    if (analysis.readFromProjection())
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-            "EXPLAIN WHATIF is not supported when the query is served from a projection");
-
     const RangesInDataParts & baseline_parts = analysis.parts_with_ranges;
 
     Result result;
@@ -434,8 +429,18 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
         return result;
     }
 
+    /// Conditions that rule out every candidate at once. Reporting them per candidate keeps the
+    /// baseline visible and tells the user why nothing can help, instead of failing the statement
+    String blanket_not_applicable_reason;
+    if (query_with_final)
+        blanket_not_applicable_reason = "EXPLAIN WHATIF cannot accurately model skip-index pruning under FINAL "
+                                        "(PrimaryKeyExpand may re-include granules selected by skip indexes)";
+    else if (analysis.readFromProjection())
+        blanket_not_applicable_reason = "The query is served from projection '"
+            + baseline_parts.front().data_part->name + "', so an index on the base table's parts would not be read";
+
     /// Only track per-candidate surviving marks when a combined row could actually be produced
-    const bool want_combined = settings.empirical && !query_with_final
+    const bool want_combined = settings.empirical && blanket_not_applicable_reason.empty()
         && hypo_indexes.size() >= 2 && result.baseline_marks > 0;
 
     std::vector<UInt8> combined_surviving_marks;
@@ -446,14 +451,13 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
 
     for (const auto & index_desc : hypo_indexes)
     {
-        if (query_with_final)
+        if (!blanket_not_applicable_reason.empty())
         {
             IndexResult r;
             r.index_name = index_desc.name;
             r.index_type = index_desc.type;
             r.status = IndexResult::NotApplicable;
-            r.not_applicable_reason = "EXPLAIN WHATIF cannot accurately model skip-index pruning under FINAL "
-                                      "(PrimaryKeyExpand may re-include granules selected by skip indexes)";
+            r.not_applicable_reason = blanket_not_applicable_reason;
             result.index_results.push_back(std::move(r));
             continue;
         }

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -71,8 +71,9 @@ StoragePtr tryResolveSingleTable(const ASTPtr & query, const ContextPtr & contex
     return JoinedTables(context, *select).getLeftTableStorage();
 }
 
-/// Empty table, nothing to scan, just mark every candidate not-applicable
-WhatIfIndexEstimator::Result buildEmptyTableResult(const MergeTreeData & data, const HypotheticalIndexStore & store)
+/// Nothing was scanned, so mark every candidate not-applicable with the same reason
+WhatIfIndexEstimator::Result buildResultWithoutScan(
+    const MergeTreeData & data, const HypotheticalIndexStore & store, const String & reason)
 {
     WhatIfIndexEstimator::Result result;
     result.database = data.getStorageID().getDatabaseName();
@@ -83,7 +84,7 @@ WhatIfIndexEstimator::Result buildEmptyTableResult(const MergeTreeData & data, c
         r.index_name = index_desc.name;
         r.index_type = index_desc.type;
         r.status = WhatIfIndexEstimator::IndexResult::NotApplicable;
-        r.not_applicable_reason = "Table is empty, so there is no data to estimate a benefit";
+        r.not_applicable_reason = reason;
         result.index_results.push_back(std::move(r));
     }
     if (result.index_results.empty())
@@ -332,11 +333,20 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
 
     if (read_steps.empty())
     {
-        /// Empty table -> ReadNothing, no read step, report a zero baseline
         auto storage = tryResolveSingleTable(select_query, local_context);
-        if (const auto * mt = dynamic_cast<const MergeTreeData *>(storage.get());
-            mt && mt->getActivePartsCount() == 0)
-            return buildEmptyTableResult(*mt, local_context->getHypotheticalIndexStore());
+        const auto & store = local_context->getHypotheticalIndexStore();
+        if (const auto * mt = dynamic_cast<const MergeTreeData *>(storage.get()))
+        {
+            /// Empty table -> ReadNothing, report a zero baseline
+            if (mt->getActivePartsCount() == 0)
+                return buildResultWithoutScan(*mt, store, "Table is empty, so there is no data to estimate a benefit");
+
+            /// The plan answers the query without reading the table's parts at all: a trivial
+            /// count, a minmax_count or exact-count projection, or a projection that selected no
+            /// ranges. No index on those parts would be read
+            return buildResultWithoutScan(
+                *mt, store, "The query is answered without reading the table's parts, so an index on them would not be read");
+        }
 
         throw Exception(ErrorCodes::NOT_IMPLEMENTED,
             "EXPLAIN WHATIF requires a query reading from a MergeTree family table");

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -347,15 +347,20 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
             /// The plan answers the query without reading the table's parts at all: a trivial
             /// count, a minmax_count or exact-count projection, or a projection that selected no
             /// ranges. No index on those parts would be read
-            /// Nothing can satisfy a forced name here, so throw like a real read would
-            for (const auto & forced_string : forced_strings)
+            /// a forced name can never be satisfied here, so throw like a real read would, but
+            /// only when skip indexes are on, matching the scanning path below
+            const auto & effective_settings = plan_context->getSettingsRef();
+            if (effective_settings[Setting::use_skip_indexes])
             {
-                auto forced = parseIdentifiersOrStringLiteralsToSet(forced_string, local_context->getSettingsRef());
-                if (!forced.empty())
-                    throw Exception(
-                        ErrorCodes::INDEX_NOT_USED,
-                        "Index {} is not used and setting 'force_data_skipping_indices' contains it",
-                        backQuoteIfNeed(*forced.begin()));
+                for (const auto & forced_string : forced_strings)
+                {
+                    auto forced = parseIdentifiersOrStringLiteralsToSet(forced_string, effective_settings);
+                    if (!forced.empty())
+                        throw Exception(
+                            ErrorCodes::INDEX_NOT_USED,
+                            "Index {} is not used and setting 'force_data_skipping_indices' contains it",
+                            backQuoteIfNeed(*forced.begin()));
+                }
             }
 
             return buildResultWithoutScan(

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -384,7 +384,9 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
     result.baseline_parts = analysis.selected_parts;
     result.baseline_marks = analysis.selected_marks;
 
-    if (analysis.selected_rows > 0)
+    /// The average row size is the parent table's, so it says nothing about rows selected from a
+    /// projection. Leave it at 0 and the formatter omits the line rather than printing a wrong one
+    if (analysis.selected_rows > 0 && !analysis.readFromProjection())
     {
         auto total_bytes = data.getTotalActiveSizeInBytes();
         auto total_rows = data.getTotalActiveSizeInRows();

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -349,11 +349,14 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
             /// ranges. No index on those parts would be read
             /// Nothing can satisfy a forced name here, so throw like a real read would
             for (const auto & forced_string : forced_strings)
-                for (const auto & name : parseIdentifiersOrStringLiteralsToSet(forced_string, local_context->getSettingsRef()))
+            {
+                auto forced = parseIdentifiersOrStringLiteralsToSet(forced_string, local_context->getSettingsRef());
+                if (!forced.empty())
                     throw Exception(
                         ErrorCodes::INDEX_NOT_USED,
                         "Index {} is not used and setting 'force_data_skipping_indices' contains it",
-                        backQuoteIfNeed(name));
+                        backQuoteIfNeed(*forced.begin()));
+            }
 
             return buildResultWithoutScan(
                 *mt, store, "The query is answered without reading the table's parts, so an index on them would not be read");

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -348,7 +348,8 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
             /// count, a minmax_count or exact-count projection, or a projection that selected no
             /// ranges. No index on those parts would be read
             /// a forced name can never be satisfied here, so throw like a real read would, but
-            /// only when skip indexes are on, matching the scanning path below
+            /// only when skip indexes are on, matching the scanning path below. FINAL always keeps
+            /// its read step, so use_skip_indexes_if_final cannot apply on this path
             const auto & effective_settings = plan_context->getSettingsRef();
             if (effective_settings[Setting::use_skip_indexes])
             {

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -429,8 +429,6 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
         return result;
     }
 
-    /// Conditions that rule out every candidate at once. Reporting them per candidate keeps the
-    /// baseline visible and tells the user why nothing can help, instead of failing the statement
     String blanket_not_applicable_reason;
     if (query_with_final)
         blanket_not_applicable_reason = "EXPLAIN WHATIF cannot accurately model skip-index pruning under FINAL "

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -68,7 +68,10 @@ StoragePtr tryResolveSingleTable(const ASTPtr & query, const ContextPtr & contex
     const auto * select = union_query->list_of_selects->children.front()->as<ASTSelectQuery>();
     if (!select)
         return nullptr;
-    return JoinedTables(context, *select).getLeftTableStorage();
+    JoinedTables joined_tables(context, *select);
+    if (joined_tables.tablesCount() != 1)
+        return nullptr;
+    return joined_tables.getLeftTableStorage();
 }
 
 /// Nothing was scanned, so mark every candidate not-applicable with the same reason
@@ -344,6 +347,14 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
             /// The plan answers the query without reading the table's parts at all: a trivial
             /// count, a minmax_count or exact-count projection, or a projection that selected no
             /// ranges. No index on those parts would be read
+            /// Nothing can satisfy a forced name here, so throw like a real read would
+            for (const auto & forced_string : forced_strings)
+                for (const auto & name : parseIdentifiersOrStringLiteralsToSet(forced_string, local_context->getSettingsRef()))
+                    throw Exception(
+                        ErrorCodes::INDEX_NOT_USED,
+                        "Index {} is not used and setting 'force_data_skipping_indices' contains it",
+                        backQuoteIfNeed(name));
+
             return buildResultWithoutScan(
                 *mt, store, "The query is answered without reading the table's parts, so an index on them would not be read");
         }

--- a/tests/queries/0_stateless/04224_hypothetical_index_whatif_edge_cases.reference
+++ b/tests/queries/0_stateless/04224_hypothetical_index_whatif_edge_cases.reference
@@ -1,5 +1,5 @@
---- projection-served query is rejected ---
-served from a projection
+--- projection-served query reports a not_applicable candidate ---
+served from projection
 --- empty table reports a clean baseline ---
   parts:       0
 With idx_b (minmax, hypothetical):

--- a/tests/queries/0_stateless/04224_hypothetical_index_whatif_edge_cases.sh
+++ b/tests/queries/0_stateless/04224_hypothetical_index_whatif_edge_cases.sh
@@ -6,7 +6,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-echo "--- projection-served query is rejected ---"
+echo "--- projection-served query reports a not_applicable candidate ---"
 $CLICKHOUSE_CLIENT -n -q "
     DROP TABLE IF EXISTS t_hypo_proj;
     CREATE TABLE t_hypo_proj (a UInt64, b UInt64, PROJECTION p (SELECT a, b ORDER BY b))
@@ -14,7 +14,7 @@ $CLICKHOUSE_CLIENT -n -q "
     INSERT INTO t_hypo_proj SELECT number, number FROM numbers(1000);
     CREATE HYPOTHETICAL INDEX idx_b ON t_hypo_proj (b) TYPE minmax GRANULARITY 1;
     EXPLAIN WHATIF SELECT a FROM t_hypo_proj WHERE b = 5 SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
-" 2>&1 | grep -m1 -o 'served from a projection'
+" 2>&1 | grep -m1 -o 'served from projection'
 
 
 echo "--- empty table reports a clean baseline ---"

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -10,3 +10,7 @@ source: empirical
 --- a plan with no MergeTree read step still reports candidates ---
 status: not_applicable
 reason: The query is answered without reading the table\'s parts, so an index on them would not be read
+--- a join is not silently reported as single-table ---
+NOT_IMPLEMENTED
+--- a forced index still fails when nothing is read ---
+INDEX_NOT_USED

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -1,0 +1,9 @@
+--- projection-served read: baseline is reported, candidate is not_applicable ---
+Baseline (after PK + partition + existing indexes):
+status: not_applicable
+served from projection 'p_b'
+--- and the statement succeeds ---
+no exception
+--- with projections off the same candidate is estimated as usual ---
+status: applicable
+source: empirical

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -7,7 +7,17 @@ no exception
 --- with projections off the same candidate is estimated as usual ---
 status: applicable
 source: empirical
---- a plan with no MergeTree read step still reports candidates ---
+--- plans with no MergeTree read step still report candidates ---
+trivial count
+status: not_applicable
+reason: The query is answered without reading the table\'s parts, so an index on them would not be read
+minmax_count projection
+status: not_applicable
+reason: The query is answered without reading the table\'s parts, so an index on them would not be read
+exact_count projection
+status: not_applicable
+reason: The query is answered without reading the table\'s parts, so an index on them would not be read
+normal projection with no ranges
 status: not_applicable
 reason: The query is answered without reading the table\'s parts, so an index on them would not be read
 --- a join is not silently reported as single-table ---

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -14,3 +14,5 @@ reason: The query is answered without reading the table\'s parts, so an index on
 NOT_IMPLEMENTED
 --- a forced index still fails when nothing is read ---
 INDEX_NOT_USED
+--- but not when skip indexes are off, since a real read ignores the setting ---
+no exception

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -1,7 +1,7 @@
 --- projection-served read: baseline is reported, candidate is not_applicable ---
 Baseline (after PK + partition + existing indexes):
 status: not_applicable
-reason: The query is served from projection 'p_b', so an index on the base table's parts would not be read
+reason: The query is served from projection \'p_b\', so an index on the base table\'s parts would not be read
 --- and the statement succeeds ---
 no exception
 --- with projections off the same candidate is estimated as usual ---

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -1,7 +1,7 @@
 --- projection-served read: baseline is reported, candidate is not_applicable ---
 Baseline (after PK + partition + existing indexes):
 status: not_applicable
-served from projection 'p_b'
+reason: The query is served from projection 'p_b', so an index on the base table's parts would not be read
 --- and the statement succeeds ---
 no exception
 --- with projections off the same candidate is estimated as usual ---

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -17,9 +17,8 @@ reason: The query is answered without reading the table\'s parts, so an index on
 exact_count projection
 status: not_applicable
 reason: The query is answered without reading the table\'s parts, so an index on them would not be read
-normal projection with no ranges
-status: not_applicable
-reason: The query is answered without reading the table\'s parts, so an index on them would not be read
+--- a normal projection with no ranges does not fail ---
+no exception
 --- a join is not silently reported as single-table ---
 NOT_IMPLEMENTED
 --- a forced index still fails when nothing is read ---

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.reference
@@ -7,3 +7,6 @@ no exception
 --- with projections off the same candidate is estimated as usual ---
 status: applicable
 source: empirical
+--- a plan with no MergeTree read step still reports candidates ---
+status: not_applicable
+reason: The query is answered without reading the table\'s parts, so an index on them would not be read

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS t_hypo_proj_baseline;
+    CREATE TABLE t_hypo_proj_baseline (a UInt64, b UInt64, PROJECTION p_b (SELECT a, b ORDER BY b))
+    ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 100;
+    INSERT INTO t_hypo_proj_baseline SELECT number, number % 100 FROM numbers(10000);
+"
+
+# The query is served from projection p_b, so a hypothetical index on the base table's parts
+# cannot affect it. That used to fail the whole statement with NOT_IMPLEMENTED
+echo "--- projection-served read: baseline is reported, candidate is not_applicable ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42;
+" 2>&1 | grep -oE "Baseline \(after PK \+ partition \+ existing indexes\):|status: +not_applicable|served from projection 'p_b'" | tr -s ' '
+
+echo "--- and the statement succeeds ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42;
+" > /dev/null 2>&1 && echo "no exception" || echo "FAILED"
+
+echo "--- with projections off the same candidate is estimated as usual ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42 SETTINGS optimize_use_projections = 0;
+" 2>&1 | grep -oE 'status: +applicable|source: +empirical' | tr -s ' '
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_proj_baseline;"

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -31,13 +31,22 @@ $CLICKHOUSE_CLIENT -q "
     EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42 SETTINGS optimize_use_projections = 0;
 " 2>&1 | grep -oE 'status: +applicable|source: +empirical' | tr -s ' '
 
-# A plan with no ReadFromMergeTree at all (trivial count here; a minmax_count or exact-count
-# projection reaches the same path) must also report candidates instead of throwing
-echo "--- a plan with no MergeTree read step still reports candidates ---"
-$CLICKHOUSE_CLIENT -q "
-    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
-    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 1;
-" 2>&1 | grep -oE "status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
+# Every plan shape that leaves no ReadFromMergeTree must report candidates instead of throwing.
+# The projection rewrites and trivial count reach that state by different routes
+echo "--- plans with no MergeTree read step still report candidates ---"
+while IFS='|' read -r label query
+do
+    echo "$label"
+    $CLICKHOUSE_CLIENT -q "
+        CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+        EXPLAIN WHATIF $query;
+    " 2>&1 | grep -oE "status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
+done <<'EOF'
+trivial count|SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 1
+minmax_count projection|SELECT max(a) FROM t_hypo_proj_baseline SETTINGS optimize_use_implicit_projections = 1
+exact_count projection|SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 0, optimize_use_implicit_projections = 1
+normal projection with no ranges|SELECT a FROM t_hypo_proj_baseline WHERE b = 999999 SETTINGS optimize_use_projections = 1
+EOF
 
 # the no-scan path is still single-table only, and still honours force_data_skipping_indices
 echo "--- a join is not silently reported as single-table ---"

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -17,7 +17,7 @@ echo "--- projection-served read: baseline is reported, candidate is not_applica
 $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
     EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42;
-" 2>&1 | grep -oE "Baseline \(after PK \+ partition \+ existing indexes\):|status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
+" 2>&1 | grep -oE "Baseline \(after PK \+ partition \+ existing indexes\):|est_bytes:.*|status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
 
 echo "--- and the statement succeeds ---"
 $CLICKHOUSE_CLIENT -q "

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -43,8 +43,8 @@ do
     " 2>&1 | grep -oE "status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
 done <<'EOF'
 trivial count|SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 1
-minmax_count projection|SELECT max(a) FROM t_hypo_proj_baseline SETTINGS optimize_use_implicit_projections = 1
-exact_count projection|SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 0, optimize_use_implicit_projections = 1
+minmax_count projection|SELECT max(a) FROM t_hypo_proj_baseline SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1
+exact_count projection|SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 0, optimize_use_projections = 1, optimize_use_implicit_projections = 1
 EOF
 
 # A normal projection that selects no ranges may drop the read step or keep an empty one, which

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -45,8 +45,15 @@ done <<'EOF'
 trivial count|SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 1
 minmax_count projection|SELECT max(a) FROM t_hypo_proj_baseline SETTINGS optimize_use_implicit_projections = 1
 exact_count projection|SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 0, optimize_use_implicit_projections = 1
-normal projection with no ranges|SELECT a FROM t_hypo_proj_baseline WHERE b = 999999 SETTINGS optimize_use_projections = 1
 EOF
+
+# A normal projection that selects no ranges may drop the read step or keep an empty one, which
+# differs by plan; either way the statement must not fail
+echo "--- a normal projection with no ranges does not fail ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 999999 SETTINGS optimize_use_projections = 1;
+" > /dev/null 2>&1 && echo "no exception" || echo "FAILED"
 
 # the no-scan path is still single-table only, and still honours force_data_skipping_indices
 echo "--- a join is not silently reported as single-table ---"

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -31,4 +31,12 @@ $CLICKHOUSE_CLIENT -q "
     EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42 SETTINGS optimize_use_projections = 0;
 " 2>&1 | grep -oE 'status: +applicable|source: +empirical' | tr -s ' '
 
+# A plan with no ReadFromMergeTree at all (trivial count here; a minmax_count or exact-count
+# projection reaches the same path) must also report candidates instead of throwing
+echo "--- a plan with no MergeTree read step still reports candidates ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline;
+" 2>&1 | grep -oE "status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
+
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_proj_baseline;"

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -16,13 +16,13 @@ $CLICKHOUSE_CLIENT -q "
 echo "--- projection-served read: baseline is reported, candidate is not_applicable ---"
 $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
-    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42;
+    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42 SETTINGS optimize_use_projections = 1;
 " 2>&1 | grep -oE "Baseline \(after PK \+ partition \+ existing indexes\):|est_bytes:.*|status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
 
 echo "--- and the statement succeeds ---"
 $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
-    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42;
+    EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42 SETTINGS optimize_use_projections = 1;
 " > /dev/null 2>&1 && echo "no exception" || echo "FAILED"
 
 echo "--- with projections off the same candidate is estimated as usual ---"
@@ -36,7 +36,7 @@ $CLICKHOUSE_CLIENT -q "
 echo "--- a plan with no MergeTree read step still reports candidates ---"
 $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
-    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline;
+    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 1;
 " 2>&1 | grep -oE "status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
 
 # the no-scan path is still single-table only, and still honours force_data_skipping_indices
@@ -46,13 +46,13 @@ $CLICKHOUSE_CLIENT -q "EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline A
 echo "--- a forced index still fails when nothing is read ---"
 $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
-    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS force_data_skipping_indices = 'hi_b';
+    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 1, force_data_skipping_indices = 'hi_b';
 " 2>&1 | grep -m1 -oE 'INDEX_NOT_USED'
 
 echo "--- but not when skip indexes are off, since a real read ignores the setting ---"
 $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
-    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS use_skip_indexes = 0, force_data_skipping_indices = 'hi_b';
+    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS optimize_trivial_count_query = 1, use_skip_indexes = 0, force_data_skipping_indices = 'hi_b';
 " > /dev/null 2>&1 && echo "no exception" || echo "FAILED"
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_proj_baseline;"

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -49,4 +49,10 @@ $CLICKHOUSE_CLIENT -q "
     EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS force_data_skipping_indices = 'hi_b';
 " 2>&1 | grep -m1 -oE 'INDEX_NOT_USED'
 
+echo "--- but not when skip indexes are off, since a real read ignores the setting ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS use_skip_indexes = 0, force_data_skipping_indices = 'hi_b';
+" > /dev/null 2>&1 && echo "no exception" || echo "FAILED"
+
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_proj_baseline;"

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -17,7 +17,7 @@ echo "--- projection-served read: baseline is reported, candidate is not_applica
 $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
     EXPLAIN WHATIF SELECT a FROM t_hypo_proj_baseline WHERE b = 42;
-" 2>&1 | grep -oE "Baseline \(after PK \+ partition \+ existing indexes\):|status: +not_applicable|served from projection 'p_b'" | tr -s ' '
+" 2>&1 | grep -oE "Baseline \(after PK \+ partition \+ existing indexes\):|status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
 
 echo "--- and the statement succeeds ---"
 $CLICKHOUSE_CLIENT -q "

--- a/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
+++ b/tests/queries/0_stateless/04757_hypothetical_index_projection_baseline.sh
@@ -39,4 +39,14 @@ $CLICKHOUSE_CLIENT -q "
     EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline;
 " 2>&1 | grep -oE "status: +not_applicable|reason: +.*" | awk '{$1=$1; print}'
 
+# the no-scan path is still single-table only, and still honours force_data_skipping_indices
+echo "--- a join is not silently reported as single-table ---"
+$CLICKHOUSE_CLIENT -q "EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline AS x INNER JOIN t_hypo_proj_baseline AS y ON 0;" 2>&1 | grep -m1 -oE 'NOT_IMPLEMENTED'
+
+echo "--- a forced index still fails when nothing is read ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi_b ON t_hypo_proj_baseline (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF SELECT count() FROM t_hypo_proj_baseline SETTINGS force_data_skipping_indices = 'hi_b';
+" 2>&1 | grep -m1 -oE 'INDEX_NOT_USED'
+
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_proj_baseline;"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
With this change, while using the WHATIF indices, the projection-served baseline reports per-candidate `not_applicable` instead of failing the statement.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114846&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114846](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114846+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
