### PR TITLE
Fix ANY INNER JOIN with OR conditions depending on which table is built

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -1713,6 +1713,13 @@ bool HashJoin::isUsed(UInt32 block_no, size_t row_idx) const
     return used_flags->getUsedSafe(block_no, row_idx);
 }
 
+bool HashJoin::needUsedFlagsPerClauseKey() const
+{
+    /// `ANY INNER JOIN` emits one row per key, so the flag is indexed by the cell of a disjunct's map.
+    /// A per-row flag cannot do it: one row is the stored row of a different key in every disjunct.
+    return !table_join->oneDisjunct() && isInner(kind) && strictness == JoinStrictness::Any;
+}
+
 bool HashJoin::needUsedFlagsForPerRightTableRow(std::shared_ptr<TableJoin> table_join_) const
 {
     if (!table_join_->oneDisjunct())
@@ -2009,10 +2016,29 @@ bool HashJoin::canConvertToFixedHashMap() const
 
 void HashJoin::reinitUsedFlags()
 {
+    const bool prefer_use_maps_all = preferUseMapsAll();
+
+    if (needUsedFlagsPerClauseKey())
+    {
+        std::vector<size_t> sizes;
+        sizes.reserve(data->maps.size());
+        for (auto & map : data->maps)
+        {
+            joinDispatch(
+                kind,
+                strictness,
+                map,
+                prefer_use_maps_all,
+                [&](auto, auto, auto & map_) { sizes.push_back(map_.getBufferSizeInCells(data->type) + 1); });
+        }
+        used_flags->reinitPerClauseOffsets(sizes);
+        return;
+    }
+
+    /// Per-row flags are sized by `addBlockToJoin` for each stored block instead.
     if (needUsedFlagsForPerRightTableRow(table_join))
         return;
 
-    const bool prefer_use_maps_all = preferUseMapsAll();
     for (auto & map : data->maps)
     {
         joinDispatch(

--- a/src/Interpreters/HashJoin/HashJoin.h
+++ b/src/Interpreters/HashJoin/HashJoin.h
@@ -616,6 +616,7 @@ private:
 
     void validateAdditionalFilterExpression(std::shared_ptr<ExpressionActions> additional_filter_expression);
     bool needUsedFlagsForPerRightTableRow(std::shared_ptr<TableJoin> table_join_) const;
+    bool needUsedFlagsPerClauseKey() const;
 
     bool rightTableCanBeReranged() const;
     void tryRerangeRightTableData();

--- a/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
+++ b/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
@@ -470,7 +470,8 @@ void processMatch(
     size_t ind,
     IColumn::Offset & current_offset,
     KnownRowsHolder<flag_per_row> & known_rows,
-    bool is_last_disjunct)
+    bool is_last_disjunct,
+    size_t clause_idx [[maybe_unused]])
 {
     constexpr JoinFeatures<KIND, STRICTNESS, MapsTemplate> join_features;
 
@@ -508,13 +509,26 @@ void processMatch(
     }
     else if constexpr (join_features.is_any_join && join_features.inner)
     {
-        bool used_once = used_flags.template setUsedOnce<join_features.need_flags, flag_per_row>(find_result);
-
+        /// One row per key of this disjunct, from both sides: the map stores the first right row of the
+        /// key, and the flag of its cell is won by the first left row that reaches it. So the result is
+        /// the union of the single-condition joins, and a pair of rows matching through several
+        /// conditions is joined once per condition. Deduplicating those would make the number of
+        /// result rows depend on which left row claims a key first, and so on the probe order.
+        /// The caller sets the filter, because a left row may claim a key in several disjuncts.
+        if constexpr (flag_per_row)
+        {
+            if (used_flags.template setUsedOncePerClause<join_features.need_flags>(clause_idx, find_result.getOffset()))
+            {
+                added_columns.appendFromBlock(firstRefWord(mapped), join_features.add_missing);
+                ++current_offset;
+            }
+        }
         /// Use first appeared left key only
-        if (used_once)
+        else if (used_flags.template setUsedOnce<join_features.need_flags, flag_per_row>(find_result))
         {
             setUsed<need_filter>(added_columns.filter, i, added_columns.matched_rows);
             added_columns.appendFromBlock(firstRefWord(mapped), join_features.add_missing);
+            ++current_offset;
         }
     }
     else if constexpr (join_features.is_any_join && join_features.full)
@@ -613,7 +627,8 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumns(
             {
                 right_row_found = true;
                 processMatch<KIND, STRICTNESS, need_filter, flag_per_row, MapsTemplate, Map, KeyGetter>(
-                    find_result, added_columns, used_flags, i, ind, current_offset, dummy_known_rows, /*is_last_disjunct=*/ true);
+                    find_result, added_columns, used_flags, i, ind, current_offset, dummy_known_rows,
+                    /*is_last_disjunct=*/ true, /*clause_idx=*/ 0);
             }
         }
 
@@ -717,6 +732,7 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumns(
 
         bool right_row_found = false;
         KnownRowsHolder<flag_per_row> known_rows;
+        const IColumn::Offset offset_before_row = current_offset;
         for (size_t onexpr_idx = 0; onexpr_idx < added_columns.join_on_keys.size(); ++onexpr_idx)
         {
             bool skip_row = false;
@@ -732,12 +748,20 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumns(
                     right_row_found = true;
                     const bool is_last_disjunct = onexpr_idx + 1 == added_columns.join_on_keys.size();
                     processMatch<KIND, STRICTNESS, need_filter, flag_per_row, MapsTemplate, Map, KeyGetter>(
-                        find_result, added_columns, used_flags, i, ind, current_offset, known_rows, is_last_disjunct);
+                        find_result, added_columns, used_flags, i, ind, current_offset, known_rows, is_last_disjunct, onexpr_idx);
 
-                    if constexpr (join_features.is_any_or_semi_join && !(join_features.is_any_join && (join_features.right || join_features.full)))
+                    /// ANY INNER JOIN claims a key of every disjunct, so it visits all of them; the other
+                    /// ANY/SEMI kinds that join a left row at most once stop at the first match.
+                    if constexpr (join_features.is_any_or_semi_join && !(join_features.is_any_join && !join_features.left))
                         break;
                 }
             }
+        }
+
+        if constexpr (join_features.is_any_join && join_features.inner)
+        {
+            if (current_offset != offset_before_row)
+                setUsed<need_filter>(added_columns.filter, i, added_columns.matched_rows);
         }
 
         if (!right_row_found)
@@ -915,6 +939,17 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumnsWithAddi
     find_results.reserve(left_block_rows);
     IColumn::Offset total_added_rows = 0;
 
+    /// `ANY INNER JOIN` with several disjuncts claims a key of one disjunct, so the candidates of every
+    /// found key are kept apart: `found_keys` names the key each range of `selected_rows` came from.
+    constexpr bool claims_key_per_disjunct = join_features.is_any_join && join_features.inner;
+    struct FoundKey
+    {
+        size_t clause_idx;
+        size_t offset;
+        size_t candidates_end;
+    };
+    std::vector<FoundKey> found_keys;
+
     IColumn::Offsets row_replicate_offset;
     row_replicate_offset.reserve(left_block_rows);
 
@@ -968,10 +1003,18 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumnsWithAddi
                     /// it's different from `joinRightColumns`.
                     PreSelectedRows selected_rows_view{selected_rows};
                     const bool is_last_disjunct = join_clause_idx + 1 == added_columns.join_on_keys.size();
-                    if (flag_per_row)
+                    /// A key claimed per disjunct needs the candidates of every disjunct, so they are
+                    /// not deduplicated across them.
+                    if (flag_per_row && !claims_key_per_disjunct)
                         addFoundRowAll<Map, false, true>(mapped, selected_rows_view, current_added_rows, all_flag_known_rows, nullptr, is_last_disjunct);
                     else
                         addFoundRowAll<Map, false, false>(mapped, selected_rows_view, current_added_rows, single_flag_know_rows, nullptr, is_last_disjunct);
+
+                    if constexpr (claims_key_per_disjunct)
+                    {
+                        if (flag_per_row)
+                            found_keys.push_back({join_clause_idx, find_result.getOffset(), current_added_rows});
+                    }
                 }
 
             }
@@ -1001,11 +1044,43 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumnsWithAddi
         size_t prev_replicated_row = 0;
         auto * selected_right_row_it = selected_rows.begin();
         size_t find_result_index = 0;
+        size_t next_found_key = 0;
         for (size_t i = 0, n = row_replicate_offset.size(); i < n; ++i)
         {
             bool any_matched = false;
+            bool joined_per_disjunct_key = false;
+            /// One row per key of every disjunct: the first candidate of the key that passes the filter,
+            /// claimed so that the key is joined for one left row only.
+            if constexpr (claims_key_per_disjunct)
+            {
+                if (flag_per_row)
+                {
+                    joined_per_disjunct_key = true;
+                    size_t candidates_begin = prev_replicated_row;
+                    while (next_found_key < found_keys.size() && found_keys[next_found_key].candidates_end <= row_replicate_offset[i])
+                    {
+                        const auto & found_key = found_keys[next_found_key];
+                        for (size_t candidate = candidates_begin; candidate < found_key.candidates_end; ++candidate)
+                        {
+                            if (!filter_flags[candidate])
+                                continue;
+
+                            if (used_flags.template setUsedOncePerClause<join_features.need_flags>(found_key.clause_idx, found_key.offset))
+                            {
+                                any_matched = true;
+                                total_added_rows += 1;
+                                added_columns.appendFromBlock(selected_rows[candidate], join_features.add_missing);
+                            }
+                            break;
+                        }
+                        candidates_begin = found_key.candidates_end;
+                        ++next_found_key;
+                    }
+                }
+            }
+
             /// right/full join or multiple disjuncts, we need to mark used flags for each row.
-            if (flag_per_row)
+            if (flag_per_row && !joined_per_disjunct_key)
             {
                 for (size_t replicated_row = prev_replicated_row; replicated_row < row_replicate_offset[i]; ++replicated_row)
                 {
@@ -1060,7 +1135,7 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumnsWithAddi
                     ++selected_right_row_it;
                 }
             }
-            else
+            else if (!joined_per_disjunct_key)
             {
                 for (size_t replicated_row = prev_replicated_row; replicated_row < row_replicate_offset[i]; ++replicated_row)
                 {
@@ -1068,7 +1143,7 @@ size_t HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinRightColumnsWithAddi
                     {
                         any_matched |= filter_flags[replicated_row];
                     }
-                    else if constexpr (join_features.need_replication)
+                    else if constexpr (join_features.join_every_match)
                     {
                         if (filter_flags[replicated_row])
                         {

--- a/src/Interpreters/HashJoin/JoinFeatures.h
+++ b/src/Interpreters/HashJoin/JoinFeatures.h
@@ -25,7 +25,14 @@ struct JoinFeatures
       * (key1, attr1, key1, attr2)
       * (key1, attr1, key1, attr3)
       */
-    static constexpr bool need_replication = is_all_join || (is_any_join && right) || (is_semi_join && right);
+    /// `ANY INNER JOIN` is in this list because with several disjuncts a left row is joined once per
+    /// disjunct whose key it claims, so it may need more than one output row.
+    static constexpr bool need_replication = is_all_join || (is_any_join && (right || inner)) || (is_semi_join && right);
+
+    /// Whether a left row is joined with every right row that matches it, as opposed to one of them.
+    /// Weaker than `need_replication`: `ANY INNER JOIN` may output several rows for one left row, but
+    /// only one per disjunct.
+    static constexpr bool join_every_match = is_all_join || (is_any_join && right) || (is_semi_join && right);
 
     /// Whether we need to filter rows from the left table that do not have matches in the right table.
     static constexpr bool need_filter = !need_replication && (inner || right || (is_semi_join && left) || (is_anti_join && left));

--- a/src/Interpreters/HashJoin/JoinUsedFlags.h
+++ b/src/Interpreters/HashJoin/JoinUsedFlags.h
@@ -35,6 +35,11 @@ public:
     /// Index is the offset in FindResult
     UsedFlagsForColumns per_offset_flags;
 
+    /// The same, but one container per disjunct: the offsets of different maps are unrelated, so they
+    /// cannot share `per_offset_flags`. Used by `ANY INNER JOIN`, which emits one row per key of every
+    /// disjunct, and therefore claims a key of one map rather than a row of the right table.
+    std::vector<UsedFlagsForColumns> per_clause_offset_flags;
+
     bool need_flags{};
 
     /// Update size for vector with flags.
@@ -53,6 +58,17 @@ public:
             if (per_offset_flags.size() < size) [[unlikely]]
                 per_offset_flags = std::vector<std::atomic_bool>(size);
         }
+    }
+
+    /// One flag per cell of every disjunct's map. Calling this invalidates existing flags, so it must
+    /// happen after the build phase filled the maps and before the probe phase reads them.
+    void reinitPerClauseOffsets(const std::vector<size_t> & sizes)
+    {
+        need_flags = true;
+        per_clause_offset_flags.clear();
+        per_clause_offset_flags.reserve(sizes.size());
+        for (size_t size : sizes)
+            per_clause_offset_flags.emplace_back(size);
     }
 
     /// Update size for vector with flags same as `reinit` but allows the updated size to be smaller.
@@ -227,6 +243,24 @@ public:
             return per_offset_flags[off].compare_exchange_strong(expected, true);
         }
 
+    }
+
+    /// Claim the key of one disjunct: only the first left row reaching this cell emits a row for it.
+    template <bool use_flags>
+    bool setUsedOncePerClause(size_t clause_idx, size_t offset)
+    {
+        if constexpr (!use_flags)
+            return true;
+
+        chassert(clause_idx < per_clause_offset_flags.size(), "per-clause flags were not sized for the build phase");
+        auto & flag = per_clause_offset_flags[clause_idx][offset];
+
+        /// fast check to prevent heavy CAS with seq_cst order
+        if (flag.load(std::memory_order_relaxed))
+            return false;
+
+        bool expected = false;
+        return flag.compare_exchange_strong(expected, true);
     }
 
     template <bool use_flags, bool flag_per_row>

--- a/tests/queries/0_stateless/01660_join_or_inner.reference
+++ b/tests/queries/0_stateless/01660_join_or_inner.reference
@@ -1,7 +1,9 @@
 any_join_distinct_right_table_keys = 0
 2	3	2	3
+2	3	2	3
 6	4	5	4
 ==
+2	3	2	3
 2	3	2	3
 6	4	5	4
 any_join_distinct_right_table_keys = 1

--- a/tests/queries/0_stateless/03006_join_on_inequal_expression_fast_2.reference
+++ b/tests/queries/0_stateless/03006_join_on_inequal_expression_fast_2.reference
@@ -349,6 +349,7 @@ key1	b	2	3	2	key1	C	3	4	5
 key1	c	3	2	1	key1	D	4	1	6
 SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 INNER ANY JOIN (SELECT 1 AS a, 1 AS b, 1 AS c) AS t2 ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0);
 1	1	1	1	1	1
+1	1	1	1	1	1
 SET join_algorithm='grace_hash';
 SELECT t1.*, t2.* FROM t1 INNER ANY JOIN t2 ON (t1.a < t2.a OR lower(t1.attr) == lower(t2.attr)) AND t1.key = t2.key ORDER BY (t1.key, t1.attr, t2.key, t2.attr);
 key1	a	1	1	2	key1	A	1	2	1
@@ -388,7 +389,7 @@ SELECT * FROM (SELECT 1 AS a, 1 AS b, 1 AS c) AS t1 INNER ANY JOIN (SELECT 1 AS 
 SET join_algorithm='hash';
 SELECT t1.* FROM t1 INNER ANY JOIN t2 ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a ORDER BY ALL;
 key1	a	1	1	2
+key1	a	1	1	2
 key1	b	2	3	2
 key1	c	3	2	1
 key1	d	4	7	2
-key2	a2	1	1	1

--- a/tests/queries/0_stateless/04870_any_inner_join_or_conditions.reference
+++ b/tests/queries/0_stateless/04870_any_inner_join_or_conditions.reference
@@ -1,0 +1,39 @@
+written left to right
+0	0	0	0
+0	0	0	0
+0	2	0	2
+1	1	1	1
+1	1	1	1
+2	2	2	2
+3	0	3	3
+4	1	4	4
+written right to left
+0	0	0	0
+0	0	0	0
+0	2	0	2
+1	1	1	1
+1	1	1	1
+2	2	2	2
+3	0	3	3
+4	1	4	4
+the same, with the tables swapped by the planner
+0	0	0	0
+0	0	0	0
+0	2	0	2
+1	1	1	1
+1	1	1	1
+2	2	2	2
+3	0	3	3
+4	1	4	4
+row count is the same for both swap settings and for several threads
+8	8	8
+with a residual condition: written left to right, written right to left, swapped, 8 threads
+8	8	8	8
+both keys of the shared right row are joined, whatever the probe order
+2
+2
+one row per condition that matches
+1	9
+9	5
+single condition: 2 left rows and 1 right row share the key
+1	9	1

--- a/tests/queries/0_stateless/04870_any_inner_join_or_conditions.sql
+++ b/tests/queries/0_stateless/04870_any_inner_join_or_conditions.sql
@@ -1,0 +1,81 @@
+-- Tags: no-old-analyzer
+
+-- ANY INNER JOIN returns one row per key of every OR-ed condition, taking the first row of that key
+-- from each side, so the result does not depend on which side the hash table is built from: neither on
+-- the order the tables are written in, nor on `query_plan_join_swap_table`, nor on the probe order.
+
+DROP TABLE IF EXISTS t_inner_l;
+DROP TABLE IF EXISTS t_inner_r;
+
+CREATE TABLE t_inner_l (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t_inner_r (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_inner_l SELECT number % 8, number % 3 FROM numbers(12);
+INSERT INTO t_inner_r SELECT number % 5, number % 8 FROM numbers(12);
+
+SELECT 'written left to right';
+SELECT t_inner_l.a, t_inner_l.b, t_inner_r.a, t_inner_r.b FROM t_inner_l ANY JOIN t_inner_r
+ON t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a
+ORDER BY ALL SETTINGS max_threads = 1, query_plan_join_swap_table = 'false';
+
+SELECT 'written right to left';
+SELECT t_inner_l.a, t_inner_l.b, t_inner_r.a, t_inner_r.b FROM t_inner_r ANY JOIN t_inner_l
+ON t_inner_r.b = t_inner_l.b OR t_inner_r.a = t_inner_l.a
+ORDER BY ALL SETTINGS max_threads = 1, query_plan_join_swap_table = 'false';
+
+SELECT 'the same, with the tables swapped by the planner';
+SELECT t_inner_l.a, t_inner_l.b, t_inner_r.a, t_inner_r.b FROM t_inner_l ANY JOIN t_inner_r
+ON t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a
+ORDER BY ALL SETTINGS max_threads = 1, query_plan_join_swap_table = 'true';
+
+SELECT 'row count is the same for both swap settings and for several threads';
+SELECT
+    (SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a) SETTINGS query_plan_join_swap_table = 'false'),
+    (SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a) SETTINGS query_plan_join_swap_table = 'true'),
+    (SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a) SETTINGS max_threads = 8);
+
+-- A condition over both tables that survives as a residual is executed by another code path, which
+-- filters the candidates of a key before claiming it.
+SELECT 'with a residual condition: written left to right, written right to left, swapped, 8 threads';
+SELECT
+    (SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON (t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a) AND t_inner_l.a + t_inner_r.a != -12345) SETTINGS max_threads = 1, query_plan_join_swap_table = 'false'),
+    (SELECT count() FROM (SELECT * FROM t_inner_r ANY JOIN t_inner_l ON (t_inner_r.b = t_inner_l.b OR t_inner_r.a = t_inner_l.a) AND t_inner_l.a + t_inner_r.a != -12345) SETTINGS max_threads = 1, query_plan_join_swap_table = 'false'),
+    (SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON (t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a) AND t_inner_l.a + t_inner_r.a != -12345) SETTINGS max_threads = 1, query_plan_join_swap_table = 'true'),
+    (SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON (t_inner_l.b = t_inner_r.b OR t_inner_l.a = t_inner_r.a) AND t_inner_l.a + t_inner_r.a != -12345) SETTINGS max_threads = 8);
+
+DROP TABLE t_inner_l;
+DROP TABLE t_inner_r;
+
+-- One right row is the stored row of a key in both conditions, and the left rows reaching those two
+-- keys are read from different parts: the number of result rows must not depend on which of them is
+-- probed first.
+CREATE TABLE t_inner_l (a Int32, b Int32) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_inner_r (a Int32, b Int32) ENGINE = MergeTree ORDER BY tuple();
+SYSTEM STOP MERGES t_inner_l;
+INSERT INTO t_inner_r VALUES (1, 5);
+INSERT INTO t_inner_l VALUES (1, 9);
+INSERT INTO t_inner_l VALUES (1, 5);
+
+SELECT 'both keys of the shared right row are joined, whatever the probe order';
+SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON t_inner_l.a = t_inner_r.a OR t_inner_l.b = t_inner_r.b) SETTINGS max_threads = 1;
+SELECT count() FROM (SELECT * FROM t_inner_l ANY JOIN t_inner_r ON t_inner_l.a = t_inner_r.a OR t_inner_l.b = t_inner_r.b) SETTINGS max_threads = 8;
+
+DROP TABLE t_inner_l;
+DROP TABLE t_inner_r;
+
+-- A right row reachable through a different condition from each of two left rows is joined to both.
+CREATE TABLE t_inner_l (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t_inner_r (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_inner_r VALUES (1, 5);
+INSERT INTO t_inner_l VALUES (1, 9), (9, 5);
+
+SELECT 'one row per condition that matches';
+SELECT t_inner_l.a, t_inner_l.b FROM t_inner_l ANY JOIN t_inner_r ON t_inner_l.a = t_inner_r.a OR t_inner_l.b = t_inner_r.b
+ORDER BY ALL SETTINGS max_threads = 1, query_plan_join_swap_table = 'false';
+
+-- A single condition keeps the one-row-per-key behaviour of both sides.
+SELECT 'single condition: 2 left rows and 1 right row share the key';
+SELECT t_inner_l.a, t_inner_l.b, t_inner_r.a FROM t_inner_l ANY JOIN t_inner_r ON t_inner_l.a = t_inner_r.a
+ORDER BY ALL SETTINGS max_threads = 1, query_plan_join_swap_table = 'false';
+
+DROP TABLE t_inner_l;
+DROP TABLE t_inner_r;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/114354
Related: https://github.com/ClickHouse/ClickHouse/pull/114676
Related: https://github.com/ClickHouse/ClickHouse/issues/111645

`ANY INNER JOIN` returns one row per key, from both the left and the right table. With several `OR`-ed conditions in `ON`, the key of a condition was claimed through the used flag of the right row that the key is stored for — and one right row can be the stored row of a different key in each condition, so claiming it for one key silently retired the others.

The result therefore depended on which side the hash table was built from. On the dataset from the issue, `t1 ANY JOIN t2` returned 3 rows and `t2 ANY JOIN t1` returned 6, and the same query returned 3 or 6 depending on `query_plan_join_swap_table`, which is a plan setting and must not change the result.

`JoinUsedFlags` now keeps one flag array per condition, indexed by the cell of that condition's map, exactly as `per_offset_flags` does for a single condition, so the claim names the key of a condition rather than a right row. A left row visits every condition instead of stopping at the first match, so it may be joined once per condition whose key it claims — hence `ANY INNER JOIN` results are replicated now. The residual-condition path (`joinRightColumnsWithAdditionalFilter`) claims the same way, after applying the filter to the candidates of a key.

The outcome is the union of the single-condition joins: a pair of rows matching through several conditions is joined once per condition, and the number of result rows no longer depends on the probe order, on the order the tables are written in, or on the plan. Deduplicating those pairs instead was measured to leave the row count dependent on which left row claims a key first, and so on the probe order — 39 runs out of 40 disagreed with the 40th at `max_threads = 8`.

That semantics change moves two existing references, both for pairs that match through more than one condition:
- `01660_join_or_inner`: `2 3 2 3` is returned twice, matching both `a2 = a3` and `b2 = b3`;
- `03006_join_on_inequal_expression_fast_2`: `(1, 1, 1) INNER ANY JOIN (1, 1, 1) ON t1.a = t2.a AND (t1.b > 0 OR t2.b > 0)` returns its row twice, and in `ON t1.key = t2.key AND t1.a < t2.a OR t1.a = t2.a` one left row is now dropped because another left row with the same key claimed it, as single-condition `ANY INNER JOIN` already does.

`SEMI`, `ANTI` and the `LEFT`/`RIGHT` forms of `ANY` are unaffected: their unit is the right row, which a per-row flag expresses exactly, and every branch added here is gated on `INNER` + `ANY`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `ANY INNER JOIN` with several `OR`-ed conditions in the `ON` section returning a different number of rows depending on which table the hash table is built from, that is on the order the tables are written in and on the `query_plan_join_swap_table` setting. Such a join now returns one row per key of every condition, from both tables.
