### PR TITLE
Type `IN (subquery)` over `LowCardinality` consistently in the old analyzer

### DIFF
--- a/src/Functions/in.cpp
+++ b/src/Functions/in.cpp
@@ -17,6 +17,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_COLUMN;
     extern const int LOGICAL_ERROR;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
 
 namespace
@@ -45,13 +46,24 @@ public:
         return function_name;
     }
 
+    /// The `IgnoreSet` variants are called with the left operand alone during type analysis, but
+    /// `inIgnoreSet(x, set)` written explicitly stays valid, hence the variadic arity.
+    bool isVariadic() const override { return ignore_set; }
+
     size_t getNumberOfArguments() const override
     {
-        return 2;
+        return ignore_set ? 0 : 2;
     }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
+        if (ignore_set && (arguments.empty() || arguments.size() > 2))
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Number of arguments for function {} doesn't match: passed {}, should be 1 or 2",
+                getName(),
+                arguments.size());
+
         if (arguments[0]->hasDynamicStructure())
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {}", arguments[0]->getName(), getName());
 

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -24,6 +24,7 @@
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/FieldToDataType.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -32,6 +33,7 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnSet.h>
+#include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnTuple.h>
 
 #include <Storages/StorageSet.h>
@@ -1309,9 +1311,24 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
                 /// Do not evaluate subquery and create sets. We replace "in*" function to "in*IgnoreSet".
 
                 auto argument_name = node.arguments->children.at(0)->getColumnName();
+
+                /// The second argument stands in for the set that is not built yet; the `IgnoreSet`
+                /// variants never look at it. It must still be a constant of a type that is neither
+                /// `LowCardinality` nor `Nullable`, like the `Set` column the real `in` is given during
+                /// execution: the general typing rule wraps the result in `LowCardinality` only when
+                /// every other argument is a constant (`IFunctionOverloadResolver::getReturnType`).
+                /// Passing the left operand twice would type `in` over a full `LowCardinality` operand
+                /// as plain `UInt8` here while execution yields `LowCardinality(UInt8)`, and a query
+                /// reading such a column across a subquery boundary would then hit the type check in
+                /// `ActionsDAG::updateHeader`.
+                ColumnConstPtr ignored_set_column = ColumnConst::create(ColumnUInt8::create(1, static_cast<UInt8>(0)), 1);
+                auto ignored_set_type = std::make_shared<DataTypeUInt8>();
+                auto ignored_set_name = data.getUniqueName("__ignored_set");
+                data.addColumn(std::move(ignored_set_column), ignored_set_type, ignored_set_name);
+
                 data.addFunction(
                     FunctionFactory::instance().get(node.name + "IgnoreSet", data.getContext()),
-                    {argument_name, argument_name},
+                    {argument_name, ignored_set_name},
                     column_name);
             }
             return;

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -24,7 +24,6 @@
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/FieldToDataType.h>
 #include <DataTypes/DataTypesDecimal.h>
-#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -33,7 +32,6 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnSet.h>
-#include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnTuple.h>
 
 #include <Storages/StorageSet.h>
@@ -1310,25 +1308,20 @@ void ActionsMatcher::visit(const ASTFunction & node, const ASTPtr & ast, Data & 
                 /// We are in the part of the tree that we are not going to compute. You just need to define types.
                 /// Do not evaluate subquery and create sets. We replace "in*" function to "in*IgnoreSet".
 
+                /// Pass the left operand alone: the `IgnoreSet` variants never read the set, and the
+                /// real `in` always gets its set as a constant column, so a constant is what the
+                /// `LowCardinality` bookkeeping in `IFunctionOverloadResolver::getReturnType` expects
+                /// to see there. Passing the left operand twice instead would count two full
+                /// `LowCardinality` columns and type the expression as plain `UInt8` while execution
+                /// yields `LowCardinality(UInt8)`, so a query reading such a column across a subquery
+                /// boundary would fail the type check in `ActionsDAG::updateHeader`. A stand-in
+                /// constant column is not an option either: it would become part of the captured
+                /// arguments of an enclosing lambda and be looked up in later analysis passes that
+                /// never created it.
                 auto argument_name = node.arguments->children.at(0)->getColumnName();
-
-                /// The second argument stands in for the set that is not built yet; the `IgnoreSet`
-                /// variants never look at it. It must still be a constant of a type that is neither
-                /// `LowCardinality` nor `Nullable`, like the `Set` column the real `in` is given during
-                /// execution: the general typing rule wraps the result in `LowCardinality` only when
-                /// every other argument is a constant (`IFunctionOverloadResolver::getReturnType`).
-                /// Passing the left operand twice would type `in` over a full `LowCardinality` operand
-                /// as plain `UInt8` here while execution yields `LowCardinality(UInt8)`, and a query
-                /// reading such a column across a subquery boundary would then hit the type check in
-                /// `ActionsDAG::updateHeader`.
-                ColumnConstPtr ignored_set_column = ColumnConst::create(ColumnUInt8::create(1, static_cast<UInt8>(0)), 1);
-                auto ignored_set_type = std::make_shared<DataTypeUInt8>();
-                auto ignored_set_name = data.getUniqueName("__ignored_set");
-                data.addColumn(std::move(ignored_set_column), ignored_set_type, ignored_set_name);
-
                 data.addFunction(
                     FunctionFactory::instance().get(node.name + "IgnoreSet", data.getContext()),
-                    {argument_name, ignored_set_name},
+                    {argument_name},
                     column_name);
             }
             return;

--- a/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.reference
+++ b/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.reference
@@ -5,7 +5,7 @@ LowCardinality(UInt8)
 ('b',0)
 1
 1
--- new analyzer
+-- the analyzer
 LowCardinality(UInt8)	LowCardinality(UInt8)
 LowCardinality(UInt8)
 ('a',1)

--- a/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.reference
+++ b/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.reference
@@ -1,0 +1,14 @@
+-- old analyzer
+LowCardinality(UInt8)	LowCardinality(UInt8)
+LowCardinality(UInt8)
+('a',1)
+('b',0)
+1
+1
+-- new analyzer
+LowCardinality(UInt8)	LowCardinality(UInt8)
+LowCardinality(UInt8)
+('a',1)
+('b',0)
+1
+1

--- a/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.reference
+++ b/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.reference
@@ -3,6 +3,8 @@ LowCardinality(UInt8)	LowCardinality(UInt8)
 LowCardinality(UInt8)
 ('a',1)
 ('b',0)
+['a']
+[]
 1
 1
 -- the analyzer
@@ -10,5 +12,7 @@ LowCardinality(UInt8)	LowCardinality(UInt8)
 LowCardinality(UInt8)
 ('a',1)
 ('b',0)
+['a']
+[]
 1
 1

--- a/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.sql
+++ b/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.sql
@@ -1,0 +1,31 @@
+-- The result type of `IN` over a full `LowCardinality` column must not depend on the form of the
+-- right-hand side, and must be the same during analysis and during execution. The old analyzer
+-- replaces `in` with `inIgnoreSet` while it only needs the types, and used to pass the left operand
+-- as the stand-in for the set that is not built yet: two full `LowCardinality` arguments type as
+-- plain `UInt8`, while executing the real `in` against a constant set yields `LowCardinality(UInt8)`.
+-- Reading such a column across a subquery boundary then failed the type check in
+-- `ActionsDAG::updateHeader` with `Unexpected return type from tuple` (`LOGICAL_ERROR`).
+
+DROP TABLE IF EXISTS t_in_lc_type;
+CREATE TABLE t_in_lc_type (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t_in_lc_type VALUES ('a'), ('b');
+
+SELECT '-- old analyzer';
+SET enable_analyzer = 0;
+
+SELECT DISTINCT toTypeName(s IN ('a')) AS literal_set, toTypeName(s IN (SELECT 'a')) AS subquery_set FROM t_in_lc_type;
+SELECT DISTINCT toTypeName(f) FROM (SELECT s IN (SELECT 'a') AS f FROM t_in_lc_type);
+SELECT tuple(*) AS t FROM (SELECT s, s IN (SELECT 'a') AS f FROM t_in_lc_type) ORDER BY t;
+SELECT count() FROM t_in_lc_type WHERE s IN (SELECT 'a');
+SELECT count() FROM t_in_lc_type WHERE s NOT IN (SELECT 'a');
+
+SELECT '-- new analyzer';
+SET enable_analyzer = 1;
+
+SELECT DISTINCT toTypeName(s IN ('a')) AS literal_set, toTypeName(s IN (SELECT 'a')) AS subquery_set FROM t_in_lc_type;
+SELECT DISTINCT toTypeName(f) FROM (SELECT s IN (SELECT 'a') AS f FROM t_in_lc_type);
+SELECT tuple(*) AS t FROM (SELECT s, s IN (SELECT 'a') AS f FROM t_in_lc_type) ORDER BY t;
+SELECT count() FROM t_in_lc_type WHERE s IN (SELECT 'a');
+SELECT count() FROM t_in_lc_type WHERE s NOT IN (SELECT 'a');
+
+DROP TABLE t_in_lc_type;

--- a/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.sql
+++ b/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.sql
@@ -19,7 +19,7 @@ SELECT tuple(*) AS t FROM (SELECT s, s IN (SELECT 'a') AS f FROM t_in_lc_type) O
 SELECT count() FROM t_in_lc_type WHERE s IN (SELECT 'a');
 SELECT count() FROM t_in_lc_type WHERE s NOT IN (SELECT 'a');
 
-SELECT '-- new analyzer';
+SELECT '-- the analyzer';
 SET enable_analyzer = 1;
 
 SELECT DISTINCT toTypeName(s IN ('a')) AS literal_set, toTypeName(s IN (SELECT 'a')) AS subquery_set FROM t_in_lc_type;

--- a/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.sql
+++ b/tests/queries/0_stateless/04894_in_subquery_lowcardinality_type_old_analyzer.sql
@@ -5,6 +5,8 @@
 -- plain `UInt8`, while executing the real `in` against a constant set yields `LowCardinality(UInt8)`.
 -- Reading such a column across a subquery boundary then failed the type check in
 -- `ActionsDAG::updateHeader` with `Unexpected return type from tuple` (`LOGICAL_ERROR`).
+-- The `arrayFilter` queries cover the same rewrite inside a lambda, whose captured arguments
+-- must not gain columns that later analysis passes never create.
 
 DROP TABLE IF EXISTS t_in_lc_type;
 CREATE TABLE t_in_lc_type (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
@@ -16,6 +18,7 @@ SET enable_analyzer = 0;
 SELECT DISTINCT toTypeName(s IN ('a')) AS literal_set, toTypeName(s IN (SELECT 'a')) AS subquery_set FROM t_in_lc_type;
 SELECT DISTINCT toTypeName(f) FROM (SELECT s IN (SELECT 'a') AS f FROM t_in_lc_type);
 SELECT tuple(*) AS t FROM (SELECT s, s IN (SELECT 'a') AS f FROM t_in_lc_type) ORDER BY t;
+SELECT arrayFilter(x -> (x IN (SELECT 'a')), [s, 'b']) FROM t_in_lc_type ORDER BY s;
 SELECT count() FROM t_in_lc_type WHERE s IN (SELECT 'a');
 SELECT count() FROM t_in_lc_type WHERE s NOT IN (SELECT 'a');
 
@@ -25,6 +28,7 @@ SET enable_analyzer = 1;
 SELECT DISTINCT toTypeName(s IN ('a')) AS literal_set, toTypeName(s IN (SELECT 'a')) AS subquery_set FROM t_in_lc_type;
 SELECT DISTINCT toTypeName(f) FROM (SELECT s IN (SELECT 'a') AS f FROM t_in_lc_type);
 SELECT tuple(*) AS t FROM (SELECT s, s IN (SELECT 'a') AS f FROM t_in_lc_type) ORDER BY t;
+SELECT arrayFilter(x -> (x IN (SELECT 'a')), [s, 'b']) FROM t_in_lc_type ORDER BY s;
 SELECT count() FROM t_in_lc_type WHERE s IN (SELECT 'a');
 SELECT count() FROM t_in_lc_type WHERE s NOT IN (SELECT 'a');
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114229
Related: https://github.com/ClickHouse/ClickHouse/pull/100226


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `LOGICAL_ERROR: Unexpected return type from tuple. Expected Tuple(..., UInt8). Got Tuple(..., LowCardinality(UInt8))` when a `LowCardinality` column compared with `IN (subquery)` is read through `tuple(...)` across a subquery boundary and `enable_analyzer = 0`. With the old analyzer, `x IN (subquery)` over a `LowCardinality` column now returns `LowCardinality(UInt8)`, the same type as `x IN (literal list)` and the same as with `enable_analyzer = 1`.


### Description

The old-analyzer half of https://github.com/ClickHouse/ClickHouse/pull/114229, whose test is tagged `no-old-analyzer`.

Reproducer, broken since 26.6 and still broken on master:

```sql
CREATE TABLE t (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
INSERT INTO t VALUES ('a');
SET enable_analyzer = 0;
SELECT tuple(*) FROM (SELECT s, s IN (SELECT 'a') AS f FROM t);
-- Code: 49. Unexpected return type from tuple. Expected Tuple(LowCardinality(String), UInt8).
--           Got Tuple(LowCardinality(String), LowCardinality(UInt8)). (LOGICAL_ERROR)
```

**Root cause.** The general typing rule wraps a result in `LowCardinality` only when at most one argument is a full `LowCardinality` column and no argument is a full ordinary column (`IFunctionOverloadResolver::getReturnType`, `src/Functions/IFunction.cpp:797`). The two passes over the same expression disagree:

- during execution the set is a constant column (`ColumnSet` is always wrapped in `ColumnConst` since https://github.com/ClickHouse/ClickHouse/pull/100226) and a `Set`-typed argument counts as constant since https://github.com/ClickHouse/ClickHouse/pull/114229, so `in` returns `LowCardinality(UInt8)`;
- during analysis the set from a subquery is not built yet, so `in` is replaced with `inIgnoreSet` and the left operand is passed twice as the stand-in for the missing set (`src/Interpreters/ActionsVisitor.cpp`). Two full `LowCardinality` arguments fail the `num_full_low_cardinality_columns <= 1` condition, so the result types as plain `UInt8`.

The outer query records `UInt8` for that column and the pipeline delivers `LowCardinality(UInt8)`, so `columnMatchesType` rejects the `tuple` result in `executeActionForPartialResult` during `ActionsDAG::updateHeader`. `DESCRIBE (subquery)` and `EXPLAIN header = 1` disagreeing on the type is the quick diagnostic. In a release build this is a query error; in debug and sanitizer builds it aborts the server.

**Change.** The stand-in for the missing set is a constant `UInt8` instead of the left operand. It is indistinguishable from the real `Set` argument in every dimension the typing rule inspects — it is constant, so it is skipped by both `LowCardinality` counters; it is not `Nullable`, so it does not affect the null wrapper; and `FunctionIn::getReturnTypeImpl` only reads `arguments[0]`. Analysis and execution therefore agree by construction, for all eight `in` / `notIn` / `nullIn` / `notNullIn` × `global` variants and for every operand shape, not only the one in the reproducer. The `IgnoreSet` variants never look at their second argument.

A `Set`-typed stand-in would mirror execution more literally, but `getRootActionsNoMakeSet` feeds window-definition expressions into an executed plan (`src/Interpreters/ExpressionAnalyzer.cpp:1562`), which can be serialized for distributed execution, and a `ColumnSet` with no set behind it would be dereferenced there. A `UInt8` constant cannot be.

**Visible type change**, mirroring what https://github.com/ClickHouse/ClickHouse/pull/114229 did for the analyzer: with `enable_analyzer = 0`, `toTypeName(x IN (subquery))`, `DESCRIBE` of such a subquery, `EXPLAIN` headers, and column types of `CREATE ... AS SELECT` over such an expression now show `LowCardinality(UInt8)` instead of `UInt8`. Values do not change.

**Validation.** New stateless test `04894_in_subquery_lowcardinality_type_old_analyzer` asserts, for both analyzers, that the literal-set and subquery-set forms have the same type, that the type recorded for the subquery column is `LowCardinality(UInt8)`, and that `tuple(*)` over that column across a subquery boundary works, with `IN` / `NOT IN` `count()` controls. Its first two arms fail and the `tuple(*)` arm aborts a debug server without the change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114856&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114856](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114856+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1958` (included in `26.8` and later)
- Backported to: `26.6.6.10`
<!-- ch-version-info:end -->