### PR TITLE
Avoid repeated EXPLAIN ANALYZE clock lookups for staged processors

### DIFF
--- a/src/Processors/Executors/Runtime/ExecutionThreadContext.cpp
+++ b/src/Processors/Executors/Runtime/ExecutionThreadContext.cpp
@@ -104,12 +104,15 @@ bool ExecutionThreadContext::executeTask()
         /// and are not attributed to any query plan step, so there is no clock for them.
         if (const auto * step = node->processor()->getQueryPlanStep())
         {
-            auto & cached_clock = node->processor()->query_plan_step_wall_clock_ptr;
+            auto & cached_clock = node->processor()->query_plan_step_wall_clock_cache;
             /// We will search in the registry only initially or when the group of the processor changed
-            if (!cached_clock)
-                cached_clock = step_to_wall_clock_registry->find(step, group);
+            if (!cached_clock.wall_clock_ptr || cached_clock.group != group)
+            {
+                cached_clock.wall_clock_ptr = step_to_wall_clock_registry->find(step, group);
+                cached_clock.group = group;
+            }
 
-            clock = cached_clock;
+            clock = cached_clock.wall_clock_ptr;
             chassert(clock);
             if (clock)
                 clock->onEnter();

--- a/src/Processors/IProcessor.cpp
+++ b/src/Processors/IProcessor.cpp
@@ -42,7 +42,7 @@ void IProcessor::setQueryPlanStep(const IQueryPlanStep * step, size_t group)
 {
     query_plan_step = step;
     query_plan_step_group = group;
-    query_plan_step_wall_clock_ptr = nullptr;
+    query_plan_step_wall_clock_cache = {};
     if (step)
     {
         plan_step_name = step->getName();
@@ -54,14 +54,14 @@ void IProcessor::setQueryPlanStep(const IQueryPlanStep * step, size_t group)
 void IProcessor::setQueryPlanStepGroup(size_t group)
 {
     query_plan_step_group = group;
-    query_plan_step_wall_clock_ptr = nullptr;
+    query_plan_step_wall_clock_cache = {};
 }
 
 void IProcessor::inheritQueryPlanStepFromParent(const IProcessor & parent, size_t group)
 {
     query_plan_step = parent.query_plan_step;
     query_plan_step_group = group;
-    query_plan_step_wall_clock_ptr = nullptr;
+    query_plan_step_wall_clock_cache = {};
     plan_step_name = parent.plan_step_name;
     plan_step_description = parent.plan_step_description;
     step_uniq_id = parent.step_uniq_id;

--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -400,7 +400,7 @@ private:
     /// For:
     /// - elapsed_ns
     /// - num_executed_jobs
-    /// - query_plan_step_wall_clock_ptr
+    /// - query_plan_step_wall_clock_cache
     friend class ExecutionThreadContext;
     /// For
     /// - input_wait_elapsed_ns
@@ -422,7 +422,12 @@ private:
     const IQueryPlanStep * query_plan_step = nullptr;
     String step_uniq_id;
     size_t query_plan_step_group = 0;
-    StepWallClock * query_plan_step_wall_clock_ptr = nullptr;
+
+    struct StepWallClockCache
+    {
+        size_t group = 0;
+        StepWallClock * wall_clock_ptr = nullptr;
+    } query_plan_step_wall_clock_cache;
 
     size_t processor_index = 0;
     String plan_step_name;


### PR DESCRIPTION
### Changelog category (leave one):
- **Performance Improvement**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
- **Avoid repeated wall-clock registry lookups in **EXPLAIN ANALYZE** for multi-stage processors.**

### Why this matters

- `StepWallClockRegistry::find()` is keyed by the query-plan step and processor group.
- The cache pointer was stored, but the group stayed at its default value of `0`.
- For non-default groups, such as aggregation finalization and join build/probe, the old code repeated the lookup for every task.
- Normal query execution is unchanged because this registry is only used by **EXPLAIN ANALYZE**.

### Changes

- **Store:** the group together with the clock pointer after lookup.
- **Keep:** the existing retry behavior when no clock is found.
- **Use:** the cached-clock alias consistently in the condition.

### Benchmark

This is a focused microbenchmark of the cache lookup section, not end-to-end **EXPLAIN ANALYZE** latency.

Setup: Apple arm64, Apple Clang `-O3`, stable group `1`, matching registry entry, 10,000,000 tasks, 9 rounds, median result.

| Version | Registry lookups | Median time | Relative |
| --- | ---: | ---: | ---: |
| Before | 10,000,000 | 25.89 ms | 1.00x |
| After | 1 | 3.21 ms | 8.07x faster |

The lookup count is exact. Wall-clock time is machine-dependent.

### Validation

- `git diff --check`
- **Validation:** Focused cache lookup microbenchmark
- **Validation:** Existing **EXPLAIN ANALYZE** coverage for aggregation and join stages

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114857&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114857](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114857+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
