### PR TITLE
SQLancer: track sqlancer main, deduplicate findings, fail the job on them

### DIFF
--- a/.github/workflows/nightly_sqlancer.yml
+++ b/.github/workflows/nightly_sqlancer.yml
@@ -12,6 +12,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: 1
   CHECKOUT_REF: ""
+  SLACK_WEBHOOK_CORE_QA: ${{ secrets.SLACK_WEBHOOK_CORE_QA }}
 
 
 jobs:
@@ -120,6 +121,41 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Dockers Build (arm)' --workflow "NightlySQLancer" --ci --timestamp
 
+  build_arm_release:
+    runs-on: [self-hosted, arm-large]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
+    name: "Build (arm_release)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (arm_release)' --workflow "NightlySQLancer" --ci --timestamp
+
   build_arm_asan_ubsan:
     runs-on: [self-hosted, arm-large]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm]
@@ -155,6 +191,41 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (arm_asan_ubsan)' --workflow "NightlySQLancer" --ci --timestamp
 
+  sqlancer_arm_release:
+    runs-on: [self-hosted, arm-medium]
+    needs: [build_arm_release, config_workflow, dockers_build_amd, dockers_build_arm]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U1FMYW5jZXIgKGFybV9yZWxlYXNlKQ==') }}
+    name: "SQLancer (arm_release)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'SQLancer (arm_release)' --workflow "NightlySQLancer" --ci --timestamp
+
   sqlancer_arm_asan_ubsan:
     runs-on: [self-hosted, arm-medium]
     needs: [build_arm_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
@@ -189,6 +260,41 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'SQLancer (arm_asan_ubsan)' --workflow "NightlySQLancer" --ci --timestamp
+
+  sqlancerpp_arm_release:
+    runs-on: [self-hosted, arm-medium]
+    needs: [build_arm_release, config_workflow, dockers_build_amd, dockers_build_arm]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U1FMYW5jZXJQUCAoYXJtX3JlbGVhc2Up') }}
+    name: "SQLancerPP (arm_release)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'SQLancerPP (arm_release)' --workflow "NightlySQLancer" --ci --timestamp
 
   sqlancerpp_arm_asan_ubsan:
     runs-on: [self-hosted, arm-medium]
@@ -227,7 +333,7 @@ jobs:
 
   finish_workflow:
     runs-on: [self-hosted, style-checker-aarch64]
-    needs: [build_arm_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm, sqlancer_arm_asan_ubsan, sqlancerpp_arm_asan_ubsan]
+    needs: [build_arm_asan_ubsan, build_arm_release, config_workflow, dockers_build_amd, dockers_build_arm, sqlancer_arm_asan_ubsan, sqlancer_arm_release, sqlancerpp_arm_asan_ubsan, sqlancerpp_arm_release]
     if: ${{ always() }}
     name: "Finish Workflow"
     outputs:

--- a/ci/AGENTS.md
+++ b/ci/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/ci/CLAUDE.md
+++ b/ci/CLAUDE.md
@@ -1,0 +1,103 @@
+# Working with CI (praktika) from an agent
+
+Notes for reading CI results and for writing job scripts. Everything here is
+reachable from a terminal - no browser needed.
+
+## Reading a run's results
+
+The HTML report (`json.html?REF=…&sha=…&name_0=<workflow>&name_1=<job>`) is only a
+renderer for one public JSON file. Fetch that instead:
+
+```bash
+curl -s "https://s3.amazonaws.com/clickhouse-test-reports/REFs/<ref>/<sha>/result_<normalized_workflow_name>.json"
+```
+
+`<normalized_workflow_name>` is `Utils.normalize_string(workflow.name)` (lowercase,
+non-alphanumerics to `_`), e.g. `result_nightlysqlancer.json`. In that file each
+job is an entry under `results`, with its `status`, `info`, sub-results and
+`links`.
+
+- **Always follow `links`; never build an artifact URL by hand.** Files attached
+  to a *sub-result* are uploaded under an extra `normalize_string(<row name>)`
+  prefix (`_ResultS3.upload_result_files_to_s3`), so guessing the job directory
+  returns S3 `AccessDenied` - which looks like a permissions problem but is just
+  a missing key.
+- Only **failed leaves** survive in the workflow report: OK sub-results are
+  dropped and a row that has children is replaced by its children
+  (`Result._flat_failed_leaves`). If a grouping row must stay visible, emit it as
+  a leaf with no children.
+- Raw job logs: `gh api repos/ClickHouse/ClickHouse/actions/jobs/<job_id>/logs`.
+  `gh run view --job <id> --log` returns nothing for long jobs, and a *running*
+  job exposes no logs at all - wait for it to finish.
+- History across runs is in CI DB, readable without credentials:
+
+```bash
+curl -s 'https://play.clickhouse.com/?user=play&default_format=TSV' --data-binary \
+  "SELECT check_start_time, test_name, test_status FROM default.checks
+   WHERE check_name = 'SQLancer (arm_release)' AND check_start_time > now() - INTERVAL 30 DAY
+   ORDER BY check_start_time DESC LIMIT 20"
+```
+
+  Every job produces one row per report row (`CIDB.json_data_generator`), with
+  `test_name` = the row name. Stable row names are therefore what makes
+  "when did this first appear" answerable - avoid embedding counts or timestamps
+  in them.
+
+## Triggering a workflow on a branch
+
+`gh workflow run <WorkflowName> --ref <branch>` works for any branch:
+`Workflow.Config(branches=...)` only gates the push trigger. The run uses the
+workflow file and job scripts from that ref, pinned at dispatch time (a later
+push does not affect a running dispatch).
+
+Praktika caches by job digest, so a job whose digest is unchanged is skipped and
+its artifacts are reused. Basing a validation branch on a commit whose build
+already ran turns a 1-2h build into a cache hit.
+
+## Writing a job script that reports properly
+
+A job that writes its own `ci/tmp/result_<normalized_job_name>.json` must get
+three things right, and praktika is silent about all three:
+
+1. **The `name` inside the file must equal the job name.** The workflow report is
+   updated by `Result.update_sub_result`, which matches the job's placeholder
+   entry *by name* and silently keeps the placeholder when nothing matches - the
+   job's status, sub-results and artifact links are then dropped without a
+   warning. Read the name from `_Environment.get().JOB_NAME`; `JOB_NAME` is not
+   exported into the job's docker container.
+2. **Statuses are uppercase**: `OK`, `FAIL`, `ERROR`, `SKIPPED`, `XFAIL`, `XPASS`
+   (`Result.Status`). `"success"`/`"failure"` are not `is_ok()` and render as
+   "completed but unknown".
+3. **The GitHub job conclusion comes from the script's exit code**
+   (`res = run_code == 0` in `ci/praktika/runner.py`); the result file only drives
+   the HTML report and CI DB. A script that writes `FAIL` and exits 0 produces a
+   green job with a red report. End such scripts with
+   `[ "$OVERALL_STATUS" = "OK" ]`.
+
+Other things worth knowing:
+
+- Add every file the job depends on to `digest_config.include_paths`, otherwise
+  editing a helper script does not invalidate the cache and the old result is
+  reused.
+- Secrets reach a dockerized job only if they are in the workflow's `secrets` AND
+  passed through with `+-e NAME` in `run_in_docker`.
+- After changing anything under `ci/workflows/` or `ci/defs/`, regenerate the
+  GitHub workflow files: `PYTHONPATH=./ci:. python3 -m praktika yaml`.
+
+## SQLancer jobs specifically
+
+`ci/jobs/sqlancer_job.sh` (+ `ci/jobs/scripts/sqlancer_failures.py`,
+`sqlancer_notify.py`) and `ci/jobs/sqlancer_pp_job.sh`, image
+`ci/docker/sqlancer-test`, workflow `ci/workflows/nightly_sqlancer.py`.
+
+- The fuzzer's own console output is deliberately filtered to one progress line
+  per ~5 minutes; the full output, the server logs, one log per finding and
+  `failures/analysis.txt` + `failures/findings.json` are attached to the report.
+- Findings are deduplicated into distinct failures by
+  (exception class + ClickHouse error code, reporting oracle, first sqlancer stack
+  frame). Start triage from `analysis.txt`, not from the job log.
+- The job fails on any finding, on a sanitizer report or `<Fatal>` in the server
+  log, on a dead server, and on a run that produced no statistics.
+- `SQLANCER_TIMEOUT_SECONDS`, `SQLANCER_REF`, `SQLANCER_BUILD_AT_RUNTIME`,
+  `SQLANCER_MAX_DISTINCT_FAILURES` and `SQLANCER_SERVER_LOG_LEVEL` override the
+  defaults for a one-off run.

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1578,17 +1578,35 @@ class JobConfigs:
         requires=["Build (amd_release)", "Build (arm_release)"],
         post_hooks=["python3 ./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py"],
     )
+    # Both fuzzers run against two builds. The release build is the wrong-result
+    # hunt: a sanitizer binary executes SQL 2-3x slower, so most of a 5h budget
+    # would buy sanitizer coverage instead of SQL coverage (measured: 47-80
+    # queries/s at 10 threads on arm_asan_ubsan). The arm_asan_ubsan build is kept
+    # as its own job for what only it can find - memory errors and UB reached
+    # through generated SQL.
+    # `-e SLACK_WEBHOOK_CORE_QA`: the job alerts on new findings (see
+    # ci/jobs/scripts/sqlancer_notify.py); without the secret it is a no-op.
     sqlancer_master_jobs = Job.Config(
         name=JobNames.SQLANCER,
         runs_on=[],  # from parametrize()
         command="./ci/jobs/sqlancer_job.sh",
         digest_config=Job.CacheDigestConfig(
-            include_paths=["./ci/jobs/sqlancer_job.sh", "./ci/docker/sqlancer-test"],
+            include_paths=[
+                "./ci/jobs/sqlancer_job.sh",
+                "./ci/jobs/scripts/sqlancer_failures.py",
+                "./ci/jobs/scripts/sqlancer_notify.py",
+                "./ci/docker/sqlancer-test",
+            ],
         ),
-        run_in_docker="clickhouse/sqlancer-test",
+        run_in_docker="clickhouse/sqlancer-test+-e SLACK_WEBHOOK_CORE_QA",
         # 5h sqlancer run (set in sqlancer_job.sh) plus server start/teardown.
         timeout=3600 * 5 + 1800,
     ).parametrize(
+        Job.ParamSet(
+            parameter="arm_release",
+            runs_on=RunnerLabels.FUNC_TESTER_ARM,
+            requires=[ArtifactNames.CH_ARM_RELEASE],
+        ),
         Job.ParamSet(
             parameter="arm_asan_ubsan",
             runs_on=RunnerLabels.FUNC_TESTER_ARM,
@@ -1608,6 +1626,11 @@ class JobConfigs:
         run_in_docker="clickhouse/sqlancer-test",
         timeout=3600,
     ).parametrize(
+        Job.ParamSet(
+            parameter="arm_release",
+            runs_on=RunnerLabels.FUNC_TESTER_ARM,
+            requires=[ArtifactNames.CH_ARM_RELEASE],
+        ),
         Job.ParamSet(
             parameter="arm_asan_ubsan",
             runs_on=RunnerLabels.FUNC_TESTER_ARM,

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1595,6 +1595,7 @@ class JobConfigs:
                 "./ci/jobs/sqlancer_job.sh",
                 "./ci/jobs/scripts/sqlancer_failures.py",
                 "./ci/jobs/scripts/sqlancer_notify.py",
+                "./ci/jobs/scripts/sqlancer_server_errors.sh",
                 "./ci/docker/sqlancer-test",
             ],
         ),
@@ -1620,6 +1621,7 @@ class JobConfigs:
         digest_config=Job.CacheDigestConfig(
             include_paths=[
                 "./ci/jobs/sqlancer_pp_job.sh",
+                "./ci/jobs/scripts/sqlancer_server_errors.sh",
                 "./ci/docker/sqlancer-test",
             ],
         ),

--- a/ci/docker/sqlancer-test/Dockerfile
+++ b/ci/docker/sqlancer-test/Dockerfile
@@ -47,18 +47,24 @@ RUN wget -q https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-
     && rm /tmp/maven.tar.gz
 ENV PATH="/opt/apache-maven-3.9.9/bin:${PATH}"
 
-# ClickHouse/sqlancer @ main after PR #4 (wrong-result oracle suite, 31 oracles,
-# recursive type system, client-v2/RowBinary transport).
-# https://github.com/ClickHouse/sqlancer/pull/4
+# The ClickHouse SQLancer provider, built from the default branch of
+# https://github.com/ClickHouse/sqlancer (`main`).
+#
+# This baked build is a warm cache, not the revision that gets fuzzed: the image
+# is rebuilt only when its digest - the contents of this directory - changes, so
+# a branch fetched here would freeze at whatever `main` was when this file was
+# last edited. `ci/jobs/sqlancer_job.sh` therefore re-clones and rebuilds `main`
+# at job start and falls back to this build if that fails. The clone keeps its
+# `.git` so both paths can report the commit that ran, and the maven repository
+# is kept (world-writable, under /sqlancer so the job's non-root user can extend
+# it) to make the job-time rebuild take ~1 minute instead of re-downloading every
+# dependency.
+ARG SQLANCER_REF=main
 RUN mkdir /sqlancer && \
-	wget -q -O- https://github.com/ClickHouse/sqlancer/archive/a62ea509ee53862b5dd37f452e8c2edce8038951.tar.gz | \
-	tar zx -C /sqlancer && \
-	mv /sqlancer/sqlancer-a62ea509ee53862b5dd37f452e8c2edce8038951 /sqlancer/sqlancer-main && \
-    find /sqlancer -type d -exec chmod 777 {} \; && \
-    find /sqlancer -type f -exec chmod 666 {} \; && \
+	git clone --depth 1 --branch ${SQLANCER_REF} https://github.com/ClickHouse/sqlancer /sqlancer/sqlancer-main && \
 	cd /sqlancer/sqlancer-main && \
-	mvn --no-transfer-progress package -Dmaven.test.skip=true -Djacoco.skip=true && \
-	rm -r /root/.m2
+	mvn --no-transfer-progress package -Dmaven.test.skip=true -Djacoco.skip=true -Dmaven.repo.local=/sqlancer/.m2 && \
+	chmod -R a+rwX /sqlancer
 
 # SQLancer++ (https://github.com/suyZhong/SQLancerPlusPlus): a generalised
 # successor to upstream SQLancer with a built-in ClickHouse engine in its

--- a/ci/jobs/scripts/sqlancer_failures.py
+++ b/ci/jobs/scripts/sqlancer_failures.py
@@ -28,10 +28,21 @@ different bugs.
 Outputs:
   <out-dir>/<databaseN>.log     one reproducer per finding (gzipped above 10 MB)
   <out-dir>/analysis.txt        human-readable analysis, attached to the report
+  <out-dir>/findings.json       the same data as JSON: one entry per distinct
+                                failure with its occurrences, for tooling (the
+                                Slack notifier diffs it against CIDB history)
   <out-dir>/subresults.json     report rows: one per distinct failure, with that
                                 failure's reproducer logs attached, as a JSON
                                 fragment (comma-separated objects, no brackets)
-  stdout                        "<findings>\t<families>\t<one-line summary>"
+  stdout                        "<findings>\t<distinct failures>\t<summary>"
+
+Report row names are the fingerprint WITHOUT the occurrence count, because
+praktika turns every row into a CIDB row keyed by that name (`CIDB.json_data_generator`):
+a stable name is what makes "when did this failure first appear" answerable
+across nightlies. The count lives in the row info.
+
+`--dry-run` only counts (no files written, no copies) - used by the job script to
+poll for a finding flood while the fuzzer is still running.
 """
 
 import argparse
@@ -153,6 +164,11 @@ def family_title(members):
     return " / ".join(parts)
 
 
+def fingerprint_key(members):
+    """Stable identity of a distinct failure - the CIDB test name."""
+    return family_title(members)
+
+
 def family_label(members):
     """Short `oracle/error` label for the one-line summary."""
     example = members[0]
@@ -177,12 +193,16 @@ def main():
     parser.add_argument("--logs-dir", required=True, help="sqlancer logs/<dbms> directory")
     parser.add_argument("--out-dir", required=True, help="where to put per-finding logs and the analysis")
     parser.add_argument("--max-files", type=int, default=50, help="cap on attached reproducer logs")
-    parser.add_argument("--max-per-family", type=int, default=10, help="cap on attached logs per family")
+    parser.add_argument("--max-per-family", type=int, default=10, help="cap on attached logs per distinct failure")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="only count findings and distinct failures; write nothing (used while the fuzzer runs)",
+    )
     args = parser.parse_args()
 
     logs_dir = Path(args.logs_dir)
     out_dir = Path(args.out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
 
     reproducers = []
     if logs_dir.is_dir():
@@ -191,15 +211,27 @@ def main():
                 continue
             reproducers.append(path)
 
-    findings = []
-    for path in reproducers:
-        findings.append(parse_reproducer(path))
+    findings = [parse_reproducer(path) for path in reproducers]
 
     families = {}
     for finding in findings:
         families.setdefault(finding["fingerprint"], []).append(finding)
-    # Loudest family first - that is the one worth triaging.
+    # Loudest first - that is the one worth triaging.
     ordered = sorted(families.values(), key=lambda members: (-len(members), family_title(members)))
+
+    if findings:
+        top = ", ".join(family_label(members) for members in ordered[:5])
+        if len(ordered) > 5:
+            top += ", ..."
+        summary = f"{len(findings)} finding(s) in {len(ordered)} distinct failure(s): {top}"
+    else:
+        summary = "no findings"
+
+    if args.dry_run:
+        print(f"{len(findings)}\t{len(ordered)}\t{summary}")
+        return
+
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     attached = 0
     for members in ordered:
@@ -241,6 +273,31 @@ def main():
         for finding in findings:
             print(f"{finding['database']}\t{finding['kind']}\t{finding['oracle']}\t{finding['head']}", file=f)
 
+    # Machine-readable twin of analysis.txt: consumed by the Slack notifier and
+    # available as an artifact for any cross-run tooling.
+    findings_json = {
+        "findings": len(findings),
+        "distinct_failures": len(ordered),
+        "summary": summary,
+        "failures": [
+            {
+                "fingerprint": fingerprint_key(members),
+                "count": len(members),
+                "oracle": members[0]["oracle"],
+                "kind": members[0]["kind"],
+                "code": members[0]["code"],
+                "error_name": members[0]["error_name"],
+                "frame": members[0]["frame"],
+                "message_shapes": message_shapes(members),
+                "example_head": members[0]["head"],
+                "databases": [m["database"] for m in members],
+                "logs": [m["file"] for m in members if m["file"]],
+            }
+            for members in ordered
+        ],
+    }
+    (out_dir / "findings.json").write_text(json.dumps(findings_json, indent=1), encoding="utf-8")
+
     # One flat row per distinct failure, with its reproducer logs attached.
     # Deliberately NOT nested per finding: the workflow report keeps only failed
     # *leaves* of a job result (`Result._flat_failed_leaves`), so a parent row
@@ -249,13 +306,13 @@ def main():
     rows = []
     for members in ordered:
         files = [m["file"] for m in members[: args.max_per_family] if m["file"]]
-        info = "; ".join(message_shapes(members, limit=2))
-        info += f" | {len(members)} occurrence(s): {' '.join(m['database'] for m in members)}"
+        info = f"x{len(members)} | " + "; ".join(message_shapes(members, limit=2))
+        info += f" | occurrences: {' '.join(m['database'] for m in members)}"
         if len(members) > len(files):
             info += f" ({len(files)} log(s) attached)"
         rows.append(
             {
-                "name": f"{family_title(members)} (x{len(members)})",
+                "name": fingerprint_key(members),
                 "status": "FAIL",
                 "files": files,
                 "info": info,
@@ -264,22 +321,16 @@ def main():
         )
 
     if findings:
-        top = ", ".join(family_label(members) for members in ordered[:5])
-        if len(ordered) > 5:
-            top += ", ..."
-        summary = f"{len(findings)} finding(s) in {len(ordered)} distinct failure(s): {top}"
         rows.insert(
             0,
             {
                 "name": "Failure analysis",
                 "status": "FAIL",
-                "files": [str(analysis)],
+                "files": [str(analysis), str(out_dir / "findings.json")],
                 "info": summary,
                 "results": [],
             },
         )
-    else:
-        summary = "no findings"
 
     fragment = out_dir / "subresults.json"
     fragment.write_text(",\n".join(json.dumps(row) for row in rows), encoding="utf-8")

--- a/ci/jobs/scripts/sqlancer_failures.py
+++ b/ci/jobs/scripts/sqlancer_failures.py
@@ -233,21 +233,35 @@ def main():
 
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    for finding in findings:
+        finding["file"] = ""
+
+    def attach(member):
+        source = logs_dir / f"{member['database']}.log"
+        target = out_dir / f"{member['database']}.log"
+        shutil.copyfile(source, target)
+        if target.stat().st_size > COMPRESS_ABOVE_BYTES:
+            with target.open("rb") as raw, gzip.open(f"{target}.gz", "wb") as packed:
+                shutil.copyfileobj(raw, packed)
+            target.unlink()
+            target = Path(f"{target}.gz")
+        member["file"] = str(target)
+
+    # Give every distinct failure one reproducer before spending the rest of the
+    # budget on the loud ones. Straight loudest-first spending would let a single
+    # 200-occurrence family eat the whole cap and leave the rare failures - the
+    # interesting ones - as rows with no log to open.
     attached = 0
     for members in ordered:
-        for member in members:
-            member["file"] = ""
+        if attached >= args.max_files:
+            break
+        attach(members[0])
+        attached += 1
+    for members in ordered:
+        for member in members[1 : args.max_per_family]:
             if attached >= args.max_files:
-                continue
-            source = logs_dir / f"{member['database']}.log"
-            target = out_dir / f"{member['database']}.log"
-            shutil.copyfile(source, target)
-            if target.stat().st_size > COMPRESS_ABOVE_BYTES:
-                with target.open("rb") as raw, gzip.open(f"{target}.gz", "wb") as packed:
-                    shutil.copyfileobj(raw, packed)
-                target.unlink()
-                target = Path(f"{target}.gz")
-            member["file"] = str(target)
+                break
+            attach(member)
             attached += 1
 
     analysis = out_dir / "analysis.txt"
@@ -305,7 +319,7 @@ def main():
     # here - would disappear from the report.
     rows = []
     for members in ordered:
-        files = [m["file"] for m in members[: args.max_per_family] if m["file"]]
+        files = [m["file"] for m in members if m["file"]]
         info = f"x{len(members)} | " + "; ".join(message_shapes(members, limit=2))
         info += f" | occurrences: {' '.join(m['database'] for m in members)}"
         if len(members) > len(files):

--- a/ci/jobs/scripts/sqlancer_failures.py
+++ b/ci/jobs/scripts/sqlancer_failures.py
@@ -28,9 +28,9 @@ different bugs.
 Outputs:
   <out-dir>/<databaseN>.log     one reproducer per finding (gzipped above 10 MB)
   <out-dir>/analysis.txt        human-readable analysis, attached to the report
-  <out-dir>/subresults.json     report rows: one per family, with the individual
-                                findings nested underneath, as a JSON fragment
-                                (comma-separated objects, no enclosing brackets)
+  <out-dir>/subresults.json     report rows: one per distinct failure, with that
+                                failure's reproducer logs attached, as a JSON
+                                fragment (comma-separated objects, no brackets)
   stdout                        "<findings>\t<families>\t<one-line summary>"
 """
 
@@ -241,29 +241,25 @@ def main():
         for finding in findings:
             print(f"{finding['database']}\t{finding['kind']}\t{finding['oracle']}\t{finding['head']}", file=f)
 
+    # One flat row per distinct failure, with its reproducer logs attached.
+    # Deliberately NOT nested per finding: the workflow report keeps only failed
+    # *leaves* of a job result (`Result._flat_failed_leaves`), so a parent row
+    # would be replaced by its children and the deduplication - the whole point
+    # here - would disappear from the report.
     rows = []
     for members in ordered:
-        children = []
-        for member in members[: args.max_per_family]:
-            children.append(
-                {
-                    "name": member["database"],
-                    "status": "FAIL",
-                    "files": [member["file"]] if member["file"] else [],
-                    "info": member["head"],
-                }
-            )
+        files = [m["file"] for m in members[: args.max_per_family] if m["file"]]
         info = "; ".join(message_shapes(members, limit=2))
         info += f" | {len(members)} occurrence(s): {' '.join(m['database'] for m in members)}"
-        if len(members) > len(children):
-            info += f" (first {len(children)} logs attached)"
+        if len(members) > len(files):
+            info += f" ({len(files)} log(s) attached)"
         rows.append(
             {
                 "name": f"{family_title(members)} (x{len(members)})",
                 "status": "FAIL",
-                "files": [],
+                "files": files,
                 "info": info,
-                "results": children,
+                "results": [],
             }
         )
 

--- a/ci/jobs/scripts/sqlancer_failures.py
+++ b/ci/jobs/scripts/sqlancer_failures.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Collect and deduplicate SQLancer findings at the end of a fuzzing run.
+
+When an oracle throws, SQLancer's `StateLogger.logException` writes the stack
+trace plus the whole CREATE/INSERT/.../SELECT sequence of that database to
+`logs/<dbms>/databaseN.log` and the worker then continues with a fresh database
+name, so each of those files is exactly one finding (`databaseN-cur.log` is the
+live per-select transcript of an in-progress database, not a finding).
+
+A 5h run repeats the same bug many times, so the raw list is unreadable. This
+script copies every reproducer log into `<out-dir>` (one file per finding, ready
+to be attached as an artifact), fingerprints each one and groups equal
+fingerprints into distinct failures:
+
+    fingerprint = (exception class + ClickHouse error code/name from the
+                   `Caused by:` chain, reporting oracle, first sqlancer frame)
+
+The failure *message* is deliberately NOT part of the fingerprint: for most
+oracles it is the generated SQL, which is unique to every finding and would
+defeat the whole point. What identifies a bug is where it was detected (oracle +
+assertion site) and, if the server rejected a query, which error it raised. Each
+family therefore lists every occurrence by database name and up to three distinct
+message shapes (literals to `'S'`, numbers to `N`, generated identifiers such as
+`c0`/`t3`/`database7` to `id`) so an over-merged family is still visible as such.
+Stack frame line numbers are kept: two assertions inside the same oracle are two
+different bugs.
+
+Outputs:
+  <out-dir>/<databaseN>.log     one reproducer per finding (gzipped above 10 MB)
+  <out-dir>/analysis.txt        human-readable analysis, attached to the report
+  <out-dir>/subresults.json     report rows: one per family, with the individual
+                                findings nested underneath, as a JSON fragment
+                                (comma-separated objects, no enclosing brackets)
+  stdout                        "<findings>\t<families>\t<one-line summary>"
+"""
+
+import argparse
+import gzip
+import re
+import shutil
+import json
+from pathlib import Path
+
+COMPRESS_ABOVE_BYTES = 10 * 1024 * 1024
+
+EXCEPTION_RE = re.compile(r"^\s*([\w.$]*(?:Error|Exception))\s*:?\s*(.*)$")
+CODE_RE = re.compile(r"\bCode:\s*(\d+)")
+CH_ERROR_NAME_RE = re.compile(r"\(([A-Z][A-Z0-9_]{3,})\)")
+CAUSED_BY_RE = re.compile(r"^--\s*Caused by:\s*(.*)$")
+FRAME_RE = re.compile(r"^--\s*at\s+([\w.$]+)\.([\w$]+)\((?:\w+\.java:(\d+)|[^)]*)\)")
+# Oracles live in a `.oracle.` package; the ClickHouse ones are all named
+# `ClickHouse<Name>Oracle`, the shared ones keep their upstream names
+# (`PivotedQuerySynthesisBase` = PQS, `CERTOracle`, `NoRECOracle`, ...).
+# `CompositeTestOracle` is only the dispatcher that runs the others.
+CLICKHOUSE_ORACLE_RE = re.compile(r"^ClickHouse([A-Za-z0-9_]+)Oracle$")
+ORACLE_DISPATCHERS = {"CompositeTestOracle", "TestOracle"}
+
+
+def normalize_message(message):
+    """Collapse a failure message to its shape so equal bugs compare equal."""
+    text = re.sub(r"'[^']*'", "'S'", message)
+    text = re.sub(r'"[^"]*"', "'S'", text)
+    # Generated identifiers: c0, t12, database7, v_zero1, ...
+    text = re.sub(r"\b[A-Za-z_][A-Za-z_]*\d+\b", "id", text)
+    text = re.sub(r"\b\d[\d.,e+-]*\b", "N", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def oracle_from_frame(qualified_class):
+    """The oracle name if this stack frame belongs to one, else ''."""
+    class_name = qualified_class.rsplit(".", 1)[-1].split("$", 1)[0]
+    if class_name in ORACLE_DISPATCHERS:
+        return ""
+    match = CLICKHOUSE_ORACLE_RE.match(class_name)
+    if match:
+        return match.group(1)
+    if ".oracle." in qualified_class:
+        # Shared oracles keep their upstream class names; trim the boilerplate so
+        # `NoRECOracle` reads as `NoREC`, like the `--oracle` option values.
+        return class_name.removeprefix("ClickHouse").removesuffix("Oracle")
+    return ""
+
+
+def parse_reproducer(path):
+    """Fingerprint one reproducer log."""
+    exception = ""
+    message = ""
+    frame = ""
+    oracle = ""
+    code = ""
+    error_name = ""
+    head = ""
+
+    with path.open(encoding="utf-8", errors="replace") as f:
+        for lineno, line in enumerate(f):
+            line = line.rstrip("\n").rstrip("\r")
+            if lineno == 0:
+                head = line.removeprefix("--")
+                match = EXCEPTION_RE.match(head)
+                if match:
+                    exception, message = match.group(1), match.group(2)
+                else:
+                    message = head
+            # The server's error code usually only appears down the `Caused by:`
+            # chain (the top-level AssertionError message is just the query), and
+            # it is the strongest signal for telling two failures apart.
+            if not code:
+                caused_by = CAUSED_BY_RE.match(line)
+                if caused_by or lineno == 0:
+                    text = caused_by.group(1) if caused_by else head
+                    code_match = CODE_RE.search(text)
+                    if code_match:
+                        code = code_match.group(1)
+                        name_match = CH_ERROR_NAME_RE.search(text)
+                        if name_match:
+                            error_name = name_match.group(1)
+            frame_match = FRAME_RE.match(line)
+            if frame_match:
+                if not frame and frame_match.group(1).startswith("sqlancer."):
+                    frame = f"{frame_match.group(1).rsplit('.', 1)[-1]}.{frame_match.group(2)}"
+                    if frame_match.group(3):
+                        frame += f":{frame_match.group(3)}"
+                if not oracle:
+                    oracle = oracle_from_frame(frame_match.group(1))
+            # The statement dump follows the stack trace; everything needed for
+            # the fingerprint is in the first lines.
+            if lineno > 200:
+                break
+
+    normalized = normalize_message(message)
+    kind = exception or "unknown failure"
+    if code:
+        kind += f" / Code {code}" + (f" ({error_name})" if error_name else "")
+    return {
+        "database": path.stem,
+        "head": head[:400],
+        "exception": exception,
+        "code": code,
+        "error_name": error_name,
+        "oracle": oracle,
+        "frame": frame,
+        "message": normalized[:200],
+        "kind": kind,
+        "fingerprint": (kind, oracle, frame),
+    }
+
+
+def family_title(members):
+    example = members[0]
+    parts = [example["oracle"] or "unknown oracle", example["kind"]]
+    if example["frame"]:
+        parts.append(f"at {example['frame']}")
+    return " / ".join(parts)
+
+
+def family_label(members):
+    """Short `oracle/error` label for the one-line summary."""
+    example = members[0]
+    oracle = example["oracle"] or "unknown"
+    if example["code"]:
+        return f"{oracle}/Code {example['code']} x{len(members)}"
+    return f"{oracle}/{example['exception'].rsplit('.', 1)[-1] or 'failure'} x{len(members)}"
+
+
+def message_shapes(members, limit=3):
+    shapes = []
+    for member in members:
+        if member["message"] not in shapes:
+            shapes.append(member["message"])
+        if len(shapes) >= limit:
+            break
+    return shapes
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--logs-dir", required=True, help="sqlancer logs/<dbms> directory")
+    parser.add_argument("--out-dir", required=True, help="where to put per-finding logs and the analysis")
+    parser.add_argument("--max-files", type=int, default=50, help="cap on attached reproducer logs")
+    parser.add_argument("--max-per-family", type=int, default=10, help="cap on attached logs per family")
+    args = parser.parse_args()
+
+    logs_dir = Path(args.logs_dir)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    reproducers = []
+    if logs_dir.is_dir():
+        for path in sorted(logs_dir.glob("database*.log")):
+            if path.name.endswith("-cur.log") or path.stat().st_size == 0:
+                continue
+            reproducers.append(path)
+
+    findings = []
+    for path in reproducers:
+        findings.append(parse_reproducer(path))
+
+    families = {}
+    for finding in findings:
+        families.setdefault(finding["fingerprint"], []).append(finding)
+    # Loudest family first - that is the one worth triaging.
+    ordered = sorted(families.values(), key=lambda members: (-len(members), family_title(members)))
+
+    attached = 0
+    for members in ordered:
+        for member in members:
+            member["file"] = ""
+            if attached >= args.max_files:
+                continue
+            source = logs_dir / f"{member['database']}.log"
+            target = out_dir / f"{member['database']}.log"
+            shutil.copyfile(source, target)
+            if target.stat().st_size > COMPRESS_ABOVE_BYTES:
+                with target.open("rb") as raw, gzip.open(f"{target}.gz", "wb") as packed:
+                    shutil.copyfileobj(raw, packed)
+                target.unlink()
+                target = Path(f"{target}.gz")
+            member["file"] = str(target)
+            attached += 1
+
+    analysis = out_dir / "analysis.txt"
+    with analysis.open("w", encoding="utf-8") as f:
+        print("SQLancer failure analysis", file=f)
+        print("=========================", file=f)
+        print(f"findings: {len(findings)}    distinct failures: {len(ordered)}", file=f)
+        print("", file=f)
+        for members in ordered:
+            example = members[0]
+            shapes = message_shapes(members)
+            print(f"x{len(members)}  {family_title(members)}", file=f)
+            for i, shape in enumerate(shapes):
+                print(f"    {'message:  ' if i == 0 else 'also:     '} {shape}", file=f)
+            distinct = len({m["message"] for m in members})
+            if distinct > len(shapes):
+                print(f"    (+{distinct - len(shapes)} more message shape(s) - this family may cover more than one bug)", file=f)
+            print(f"    example:   {example['database']}.log", file=f)
+            print(f"    databases: {' '.join(m['database'] for m in members)}", file=f)
+            print("", file=f)
+        print("Per-finding index", file=f)
+        print("-----------------", file=f)
+        for finding in findings:
+            print(f"{finding['database']}\t{finding['kind']}\t{finding['oracle']}\t{finding['head']}", file=f)
+
+    rows = []
+    for members in ordered:
+        children = []
+        for member in members[: args.max_per_family]:
+            children.append(
+                {
+                    "name": member["database"],
+                    "status": "FAIL",
+                    "files": [member["file"]] if member["file"] else [],
+                    "info": member["head"],
+                }
+            )
+        info = "; ".join(message_shapes(members, limit=2))
+        info += f" | {len(members)} occurrence(s): {' '.join(m['database'] for m in members)}"
+        if len(members) > len(children):
+            info += f" (first {len(children)} logs attached)"
+        rows.append(
+            {
+                "name": f"{family_title(members)} (x{len(members)})",
+                "status": "FAIL",
+                "files": [],
+                "info": info,
+                "results": children,
+            }
+        )
+
+    if findings:
+        top = ", ".join(family_label(members) for members in ordered[:5])
+        if len(ordered) > 5:
+            top += ", ..."
+        summary = f"{len(findings)} finding(s) in {len(ordered)} distinct failure(s): {top}"
+        rows.insert(
+            0,
+            {
+                "name": "Failure analysis",
+                "status": "FAIL",
+                "files": [str(analysis)],
+                "info": summary,
+                "results": [],
+            },
+        )
+    else:
+        summary = "no findings"
+
+    fragment = out_dir / "subresults.json"
+    fragment.write_text(",\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    print(f"{len(findings)}\t{len(ordered)}\t{summary}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/jobs/scripts/sqlancer_notify.py
+++ b/ci/jobs/scripts/sqlancer_notify.py
@@ -163,8 +163,12 @@ def main():
         seen = known_fingerprints(args.job_name)
         print(f"CI DB knows {len(seen)} fingerprint(s) for [{args.job_name}] from the last {HISTORY_DAYS} days")
     except Exception as e:  # noqa: BLE001 - never fail the job over a query
-        print(f"WARNING: could not read failure history from CI DB ({e}); treating every failure as new")
-        seen = set()
+        # Fail closed. Without the history every known failure looks new, and one
+        # play.clickhouse.com blip would post the whole backlog to the channel -
+        # which is how an alert channel gets muted for good. The findings are in
+        # the job report either way.
+        print(f"WARNING: could not read failure history from CI DB ({e}) - skipping the alert")
+        return
 
     new_failures = [f for f in failures if f["fingerprint"] not in seen]
     for failure in failures:

--- a/ci/jobs/scripts/sqlancer_notify.py
+++ b/ci/jobs/scripts/sqlancer_notify.py
@@ -150,11 +150,30 @@ def main():
     parser.add_argument("--findings", required=True, help="findings.json from sqlancer_failures.py")
     parser.add_argument("--job-name", required=True, help="job name, i.e. the CI DB check_name")
     parser.add_argument("--info", default="", help="one-line run summary for the message footer")
+    parser.add_argument(
+        "--extra-failure",
+        default="",
+        help="fingerprint of a failure found outside the oracles (a sanitizer report or a "
+        "<Fatal> server message); must be the report row name so it matches CI DB history",
+    )
+    parser.add_argument("--extra-failure-message", default="", help="first line of that failure")
     parser.add_argument("--dry-run", action="store_true", help="print the message instead of posting it")
     args = parser.parse_args()
 
     findings = json.loads(open(args.findings, encoding="utf-8").read())
     failures = findings.get("failures") or []
+    if args.extra_failure:
+        # A sanitizer report or a `<Fatal>` message is a finding with no oracle
+        # reproducer behind it, so it never reaches findings.json - and it is
+        # exactly what the sanitizer build exists to catch. Feed it in so it takes
+        # part in the new-vs-known diff like any other failure.
+        failures = failures + [
+            {
+                "fingerprint": args.extra_failure,
+                "count": 1,
+                "message_shapes": [args.extra_failure_message] if args.extra_failure_message else [],
+            }
+        ]
     if not failures:
         print("No findings - nothing to notify about")
         return

--- a/ci/jobs/scripts/sqlancer_notify.py
+++ b/ci/jobs/scripts/sqlancer_notify.py
@@ -109,7 +109,7 @@ def sql_string(value):
     return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
 
 
-def slack_blocks(job_name, new_failures, findings, info):
+def slack_blocks(job_name, new_failures, findings, info, extra_failures=0):
     listed = new_failures[:MAX_LISTED]
     lines = []
     for failure in listed:
@@ -160,8 +160,9 @@ def slack_blocks(job_name, new_failures, findings, info):
                 {
                     "type": "mrkdwn",
                     "text": (
-                        f"{findings.get('findings', 0)} finding(s) in "
-                        f"{findings.get('distinct_failures', 0)} distinct failure(s) this run  ·  {info}"
+                        f"{findings.get('findings', 0) + extra_failures} finding(s) in "
+                        f"{findings.get('distinct_failures', 0) + extra_failures} distinct failure(s) "
+                        f"this run  ·  {info}"
                     ),
                 }
             ],
@@ -230,7 +231,11 @@ def main():
         print("All failures are already known - no alert")
         return
 
-    blocks = slack_blocks(args.job_name, new_failures, findings, args.info)
+    # The server-log finding has no oracle reproducer, so findings.json does not
+    # count it - add it to what the message displays, not just to the diff set.
+    blocks = slack_blocks(
+        args.job_name, new_failures, findings, args.info, extra_failures=1 if args.extra_failure else 0
+    )
     webhook = os.getenv(SLACK_WEBHOOK_ENV)
     if args.dry_run or not webhook:
         if not webhook:

--- a/ci/jobs/scripts/sqlancer_notify.py
+++ b/ci/jobs/scripts/sqlancer_notify.py
@@ -27,8 +27,15 @@ import urllib.request
 from pathlib import Path
 
 # The job runs with the sqlancer checkout as its working directory, so the repo
-# root has to come from this file's location, not from `.`.
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+# root has to come from this file's location, not from `.`. Praktika then reads
+# its own context from RELATIVE `./ci/tmp` paths (`Settings.TEMP_DIR`,
+# `_Environment.get`), so the process also has to sit in the repo root - from
+# anywhere else `Info()` silently degrades and the run looks like the scheduled
+# master stream with no report links.
+ORIGINAL_CWD = Path.cwd()
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+os.chdir(REPO_ROOT)
 
 SLACK_WEBHOOK_ENV = "SLACK_WEBHOOK_CORE_QA"
 HISTORY_DAYS = 30
@@ -180,7 +187,9 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="print the message instead of posting it")
     args = parser.parse_args()
 
-    findings = json.loads(open(args.findings, encoding="utf-8").read())
+    # Resolved against the caller's directory, since this process chdir'd away.
+    findings_path = ORIGINAL_CWD / args.findings
+    findings = json.loads(findings_path.read_text(encoding="utf-8"))
     failures = findings.get("failures") or []
     if args.extra_failure:
         # A sanitizer report or a `<Fatal>` message is a finding with no oracle

--- a/ci/jobs/scripts/sqlancer_notify.py
+++ b/ci/jobs/scripts/sqlancer_notify.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Post a Slack alert when a SQLancer run surfaces a failure we have not seen before.
+
+A nightly fuzzer that alerts on every failure trains everyone to ignore it: the
+same known bug is re-found every run until it is fixed upstream. So this alerts
+on NEW fingerprints only.
+
+"New" is answered from CI DB itself rather than from a state file: praktika
+inserts one row per report row (`CIDB.json_data_generator`), and the rows for a
+SQLancer job are named after the failure fingerprint, so
+`SELECT DISTINCT test_name ... WHERE check_name = <this job>` over the last N days
+is exactly the set of failures this job has already reported. The current run's
+own rows are inserted after the job script finishes, so they cannot mask a new
+finding.
+
+Everything here is best-effort: no webhook, no network, a bad response - the
+script says so and exits 0. A notification problem must never change a fuzzing
+run's verdict.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+# The job runs with the sqlancer checkout as its working directory, so the repo
+# root has to come from this file's location, not from `.`.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+SLACK_WEBHOOK_ENV = "SLACK_WEBHOOK_CORE_QA"
+HISTORY_DAYS = 30
+MAX_LISTED = 5
+TIMEOUT_SEC = 20
+
+# Defaults matching ci/settings/settings.py, used if praktika cannot be imported:
+# an alert is more valuable than a perfectly linked one.
+CI_DB_READ_URL = "https://play.clickhouse.com"
+CI_DB_READ_USER = "play"
+CI_DB_NAME = "default"
+CI_DB_TABLE = "checks"
+
+try:
+    from ci.praktika.info import Info
+    from ci.praktika.settings import Settings
+
+    CI_DB_READ_URL = Settings.CI_DB_READ_URL or CI_DB_READ_URL
+    CI_DB_READ_USER = Settings.CI_DB_READ_USER or CI_DB_READ_USER
+    CI_DB_NAME = Settings.CI_DB_DB_NAME or CI_DB_NAME
+    CI_DB_TABLE = Settings.CI_DB_TABLE_NAME or CI_DB_TABLE
+except Exception as e:  # noqa: BLE001
+    print(f"WARNING: praktika not importable ({e}); alerting without report links")
+    Info = None
+
+
+def http_post(url, data, headers=None, timeout=TIMEOUT_SEC):
+    request = urllib.request.Request(url, data=data, headers=headers or {}, method="POST")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.status, response.read().decode("utf-8", "replace")
+
+
+def known_fingerprints(job_name):
+    """Fingerprints this job has already reported, from CI DB (read-only endpoint)."""
+    query = (
+        f"SELECT DISTINCT test_name FROM {CI_DB_NAME}.{CI_DB_TABLE} "
+        f"WHERE check_name = {sql_string(job_name)} "
+        f"AND check_start_time > now() - INTERVAL {HISTORY_DAYS} DAY "
+        f"AND test_name != ''"
+    )
+    url = f"{CI_DB_READ_URL}/?" + urllib.parse.urlencode(
+        {"user": CI_DB_READ_USER, "default_format": "TSVRaw"}
+    )
+    status, body = http_post(url, query.encode("utf-8"))
+    if status != 200:
+        raise RuntimeError(f"CI DB query failed with status {status}: {body[:200]}")
+    return {line for line in body.splitlines() if line}
+
+
+def sql_string(value):
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def slack_blocks(job_name, new_failures, findings, info):
+    listed = new_failures[:MAX_LISTED]
+    lines = []
+    for failure in listed:
+        shape = (failure.get("message_shapes") or [""])[0]
+        lines.append(f"• *{failure['fingerprint']}* (x{failure['count']})\n    `{shape[:180]}`")
+    if len(new_failures) > len(listed):
+        lines.append(f"• … and {len(new_failures) - len(listed)} more new failure(s)")
+
+    elements = []
+    report_url = job_url = ""
+    if Info is not None:
+        try:
+            report_url = Info().get_job_report_url()
+            job_url = Info().get_job_url()
+        except Exception as e:  # noqa: BLE001
+            print(f"WARNING: could not build report links ({e})")
+    if report_url:
+        elements.append(
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "📊 Report", "emoji": True},
+                "url": report_url,
+            }
+        )
+    if job_url:
+        elements.append(
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "📋 Job logs", "emoji": True},
+                "url": job_url,
+            }
+        )
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f"🐞 *{job_name}: {len(new_failures)} new failure(s)*\n"
+                    + "\n".join(lines)
+                ),
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"{findings.get('findings', 0)} finding(s) in "
+                        f"{findings.get('distinct_failures', 0)} distinct failure(s) this run  ·  {info}"
+                    ),
+                }
+            ],
+        },
+    ]
+    if elements:
+        blocks.append({"type": "actions", "elements": elements})
+    return blocks
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--findings", required=True, help="findings.json from sqlancer_failures.py")
+    parser.add_argument("--job-name", required=True, help="job name, i.e. the CI DB check_name")
+    parser.add_argument("--info", default="", help="one-line run summary for the message footer")
+    parser.add_argument("--dry-run", action="store_true", help="print the message instead of posting it")
+    args = parser.parse_args()
+
+    findings = json.loads(open(args.findings, encoding="utf-8").read())
+    failures = findings.get("failures") or []
+    if not failures:
+        print("No findings - nothing to notify about")
+        return
+
+    try:
+        seen = known_fingerprints(args.job_name)
+        print(f"CI DB knows {len(seen)} fingerprint(s) for [{args.job_name}] from the last {HISTORY_DAYS} days")
+    except Exception as e:  # noqa: BLE001 - never fail the job over a query
+        print(f"WARNING: could not read failure history from CI DB ({e}); treating every failure as new")
+        seen = set()
+
+    new_failures = [f for f in failures if f["fingerprint"] not in seen]
+    for failure in failures:
+        state = "NEW" if failure["fingerprint"] not in seen else "known"
+        print(f"  [{state}] x{failure['count']} {failure['fingerprint']}")
+    if not new_failures:
+        print("All failures are already known - no alert")
+        return
+
+    blocks = slack_blocks(args.job_name, new_failures, findings, args.info)
+    webhook = os.getenv(SLACK_WEBHOOK_ENV)
+    if args.dry_run or not webhook:
+        if not webhook:
+            print(f"{SLACK_WEBHOOK_ENV} not set - would have alerted about {len(new_failures)} new failure(s)")
+        print(json.dumps(blocks, indent=1))
+        return
+
+    try:
+        status, body = http_post(
+            webhook,
+            json.dumps({"blocks": blocks}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        if status == 200:
+            print(f"Alerted about {len(new_failures)} new failure(s)")
+        else:
+            print(f"WARNING: Slack post failed: {status} {body[:200]}")
+    except Exception as e:  # noqa: BLE001
+        print(f"WARNING: Slack post failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/jobs/scripts/sqlancer_notify.py
+++ b/ci/jobs/scripts/sqlancer_notify.py
@@ -61,11 +61,31 @@ def http_post(url, data, headers=None, timeout=TIMEOUT_SEC):
         return response.status, response.read().decode("utf-8", "replace")
 
 
+def current_stream():
+    """(pull_request_number, head_ref) of this run, as CI DB records them."""
+    if Info is not None:
+        try:
+            info = Info()
+            return int(info.pr_number or 0), (info.git_branch or "master")
+        except Exception as e:  # noqa: BLE001
+            print(f"WARNING: could not read the current branch ({e}); assuming the scheduled master stream")
+    return 0, "master"
+
+
 def known_fingerprints(job_name):
-    """Fingerprints this job has already reported, from CI DB (read-only endpoint)."""
+    """Fingerprints this job has already reported, from CI DB (read-only endpoint).
+
+    Scoped to this run's own stream. The workflow is `workflow_dispatch`-able on
+    any ref, so a throwaway validation run would otherwise share the seen-set with
+    the scheduled master nightlies and suppress the first real master alert for a
+    failure it happened to reproduce first.
+    """
+    pr_number, head_ref = current_stream()
     query = (
         f"SELECT DISTINCT test_name FROM {CI_DB_NAME}.{CI_DB_TABLE} "
         f"WHERE check_name = {sql_string(job_name)} "
+        f"AND pull_request_number = {pr_number} "
+        f"AND head_ref = {sql_string(head_ref)} "
         f"AND check_start_time > now() - INTERVAL {HISTORY_DAYS} DAY "
         f"AND test_name != ''"
     )
@@ -180,7 +200,11 @@ def main():
 
     try:
         seen = known_fingerprints(args.job_name)
-        print(f"CI DB knows {len(seen)} fingerprint(s) for [{args.job_name}] from the last {HISTORY_DAYS} days")
+        pr_number, head_ref = current_stream()
+        print(
+            f"CI DB knows {len(seen)} fingerprint(s) for [{args.job_name}] on "
+            f"[{head_ref}, PR {pr_number}] from the last {HISTORY_DAYS} days"
+        )
     except Exception as e:  # noqa: BLE001 - never fail the job over a query
         # Fail closed. Without the history every known failure looks new, and one
         # play.clickhouse.com blip would post the whole backlog to the channel -

--- a/ci/jobs/scripts/sqlancer_server_errors.sh
+++ b/ci/jobs/scripts/sqlancer_server_errors.sh
@@ -35,7 +35,11 @@ scan_server_errors() {
             | grep -av "For details see https://github.com/google/sanitizers" \
             | head -n 200 || true)"
     fi
-    fatal_hits="$(grep -a '<Fatal>' "$server_log" "$server_err" 2>/dev/null | head -n 50 || true)"
+    # -h: with two files grep prefixes every match with the file name, which would
+    # end up inside the report row name and the alert fingerprint - making the same
+    # fatal re-hash when it moves between stdout and stderr or the workspace path
+    # changes.
+    fatal_hits="$(grep -ha '<Fatal>' "$server_log" "$server_err" 2>/dev/null | head -n 50 || true)"
     [ -n "$sanitizer_hits$fatal_hits" ] || return 1
 
     : > "$report"

--- a/ci/jobs/scripts/sqlancer_server_errors.sh
+++ b/ci/jobs/scripts/sqlancer_server_errors.sh
@@ -7,6 +7,13 @@
 # Writes the report file and echoes its first offending line; echoes nothing and
 # returns 1 when the logs are clean.
 #
+#        server_error_signature <report path>
+# Echoes a stable identity for that report: the kind of failure plus the frame it
+# happened in, with addresses, pids, sizes and line numbers normalized away. Used
+# as the report row name, which is also the CI DB test name and the alert
+# fingerprint - so it has to survive a rerun unchanged and still tell two
+# different bugs apart.
+#
 # Call it BEFORE stopping the server, so a leak report emitted during shutdown
 # does not turn every run red.
 
@@ -39,4 +46,23 @@ scan_server_errors() {
         printf '%s\n' "=== <Fatal> messages ===" "$fatal_hits" >> "$report"
     fi
     sed -n '2p' "$report" | cut -c1-400
+}
+
+server_error_signature() {
+    local report="$1" kind frame
+    # Line 1 is the section header written by scan_server_errors; line 2 is the
+    # sanitizer summary / first `<Fatal>` line.
+    kind="$(sed -n '2p' "$report" | sed -e 's/0x[0-9a-fA-F]*/ADDR/g' -e 's/[0-9][0-9]*/N/g' | cut -c1-120)"
+    # The kind alone is not an identity: two unrelated heap-buffer-overflows share
+    # it. Add the innermost symbolized frame - "#0 0x... in DB::Foo::bar() src/x.cpp:12".
+    frame="$(grep -m1 -aE '^[[:space:]]*#0[[:space:]]' "$report" \
+        | sed -e 's/.*[[:space:]]in[[:space:]]//' -e 's/0x[0-9a-fA-F]*/ADDR/g' -e 's/:[0-9]\+/:N/g' \
+        | cut -c1-120 || true)"
+    if [ -z "$frame" ]; then
+        # UBSan reports have no frame list; their `file.cpp:line:col: runtime error`
+        # prefix already went into `kind`, so only look past it for extra context.
+        frame="$(sed -n '3,8p' "$report" | grep -m1 -aE '\.(cpp|h|hpp):[0-9]+' \
+            | sed -e 's/0x[0-9a-fA-F]*/ADDR/g' -e 's/:[0-9]\+/:N/g' | cut -c1-120 || true)"
+    fi
+    printf '%s' "$kind${frame:+ @ $frame}"
 }

--- a/ci/jobs/scripts/sqlancer_server_errors.sh
+++ b/ci/jobs/scripts/sqlancer_server_errors.sh
@@ -1,0 +1,42 @@
+# Shared by sqlancer_job.sh and sqlancer_pp_job.sh: scan a fuzzing run's server
+# logs for a sanitizer report or a `<Fatal>` message. Both jobs run against an
+# ASan+UBSan build, where either is a finding on its own even when no oracle
+# noticed anything.
+#
+# Usage: scan_server_errors <server stdout log> <server stderr log> <report path>
+# Writes the report file and echoes its first offending line; echoes nothing and
+# returns 1 when the logs are clean.
+#
+# Call it BEFORE stopping the server, so a leak report emitted during shutdown
+# does not turn every run red.
+
+SANITIZER_PATTERN='(ERROR|SUMMARY): (Address|Leak|Memory|Thread|UndefinedBehavior)Sanitizer|runtime error:'
+
+scan_server_errors() {
+    local server_log="$1" server_err="$2" report="$3"
+    local sanitizer_hits="" fatal_hits first_hit
+
+    # Report from the first sanitizer line to the end of the log so the whole
+    # stack trace comes along, minus ASan's own boilerplate (same ignore list as
+    # `ci/jobs/scripts/clickhouse_proc.py`).
+    first_hit="$(grep -n -aE "$SANITIZER_PATTERN" "$server_err" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+    if [ -n "$first_hit" ]; then
+        sanitizer_hits="$(sed -n "${first_hit},\$p" "$server_err" \
+            | grep -av "ASan doesn't fully support makecontext/swapcontext functions" \
+            | grep -av "ASan is ignoring requested __asan_handle_no_return" \
+            | grep -av "False positive error reports may follow" \
+            | grep -av "For details see https://github.com/google/sanitizers" \
+            | head -n 200 || true)"
+    fi
+    fatal_hits="$(grep -a '<Fatal>' "$server_log" "$server_err" 2>/dev/null | head -n 50 || true)"
+    [ -n "$sanitizer_hits$fatal_hits" ] || return 1
+
+    : > "$report"
+    if [ -n "$sanitizer_hits" ]; then
+        printf '%s\n' "=== sanitizer report ===" "$sanitizer_hits" >> "$report"
+    fi
+    if [ -n "$fatal_hits" ]; then
+        printf '%s\n' "=== <Fatal> messages ===" "$fatal_hits" >> "$report"
+    fi
+    sed -n '2p' "$report" | cut -c1-400
+}

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -471,8 +471,10 @@ fi
 
 # The console filter above hides ordinary fuzzer output, so show the tail when
 # sqlancer itself misbehaved - that is where "jar not found", a bad option or an
-# OOM kill shows up.
-if [ "$JAVA_EXIT" -ne 0 ] || [ -z "$QUERY_STATS" ]; then
+# OOM kill shows up. Not when findings explain the non-zero exit: sqlancer exits
+# with its error code whenever a worker died on an assertion, and the analysis
+# above already says what happened.
+if [ -z "$QUERY_STATS" ] || { [ "$JAVA_EXIT" -ne 0 ] && [ "$FAILURE_COUNT" -eq 0 ]; }; then
     echo "=== last 30 lines of sqlancer.out ==="
     tail -n 30 "$OUTPUT_FILE" || true
 fi

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -220,6 +220,11 @@ MAVEN_REPO=/sqlancer/.m2
 # the world-writable /sqlancer tree so git and maven have somewhere to scribble.
 export HOME=/sqlancer
 
+# Exit code says what went wrong, because the two cases mean different things:
+#   1 - the clone did not happen (network, GitHub) - transient, not our problem
+#   2 - `main` was fetched but does not build - a real regression in the repo we
+#       are supposed to be fuzzing, and the reason the run below is not testing
+#       what this job promises
 build_sqlancer() {
     local ref="$1" dest="$2"
     rm -rf "$dest"
@@ -229,18 +234,28 @@ build_sqlancer() {
         mvn --no-transfer-progress -B package \
             -Dmaven.test.skip=true -Djacoco.skip=true \
             -Dmaven.repo.local="$MAVEN_REPO"
-    ) > "$SQLANCER_BUILD_LOG" 2>&1 || return 1
-    compgen -G "$dest/target/sqlancer-*.jar" > /dev/null || return 1
+    ) > "$SQLANCER_BUILD_LOG" 2>&1 || return 2
+    compgen -G "$dest/target/sqlancer-*.jar" > /dev/null || return 2
 }
 
 SQLANCER_DIR="$SQLANCER_BAKED_DIR"
 BUILD_WARNING=""
 echo "=== Building sqlancer from $SQLANCER_REPO @ $SQLANCER_REF ==="
-if [ "${SQLANCER_BUILD_AT_RUNTIME:-1}" = "1" ] && build_sqlancer "$SQLANCER_REF" "$SQLANCER_RUN_DIR"; then
-    SQLANCER_DIR="$SQLANCER_RUN_DIR"
-else
-    BUILD_WARNING="failed to build $SQLANCER_REF at runtime, fell back to the image's build"
-    echo "WARNING: $BUILD_WARNING; see $SQLANCER_BUILD_LOG" >&2
+if [ "${SQLANCER_BUILD_AT_RUNTIME:-1}" = "1" ]; then
+    BUILD_RC=0
+    build_sqlancer "$SQLANCER_REF" "$SQLANCER_RUN_DIR" || BUILD_RC=$?
+    if [ "$BUILD_RC" = "0" ]; then
+        SQLANCER_DIR="$SQLANCER_RUN_DIR"
+    elif [ "$BUILD_RC" = "1" ]; then
+        BUILD_WARNING="could not fetch $SQLANCER_REF (network?), fell back to the image's build"
+        echo "WARNING: $BUILD_WARNING" >&2
+    else
+        BUILD_WARNING="$SQLANCER_REF does not build, fell back to the image's build - this run does NOT test current $SQLANCER_REF"
+        echo "ERROR: $BUILD_WARNING; see $SQLANCER_BUILD_LOG" >&2
+        # Fuzz on with the baked build - some coverage beats none - but fail the
+        # job: a broken `main` is exactly what this job must not hide.
+        add_test_result "sqlancer $SQLANCER_REF build" ERROR "$BUILD_WARNING" "$SQLANCER_BUILD_LOG"
+    fi
 fi
 if [ -f "$SQLANCER_BUILD_LOG" ]; then
     ATTACHED_FILES_ARRAY+=("$SQLANCER_BUILD_LOG")
@@ -450,43 +465,17 @@ if [ "$FAILURE_COUNT" -gt 0 ] && [ -f "$FAILURES_PATH/analysis.txt" ]; then
     sed -n '/^x[0-9]/,/^Per-finding index/{/^Per-finding index/!p}' "$FAILURES_PATH/analysis.txt" | head -n 60
 fi
 
-# Sanitizer reports and `<Fatal>` messages: this job runs an ASan+UBSan build, so
-# either is a finding on its own even when no oracle noticed anything. Checked
-# before the server is stopped, so a leak report emitted during shutdown does not
-# turn every run red. The filtered-out lines are ASan's own boilerplate, same list
-# as `ci/jobs/scripts/clickhouse_proc.py`.
-SANITIZER_PATTERN='(ERROR|SUMMARY): (Address|Leak|Memory|Thread|UndefinedBehavior)Sanitizer|runtime error:'
-
-collect_server_errors() {
-    local report="$FAILURES_PATH/server-fatal.log" sanitizer_hits fatal_hits first_hit
-    # Report from the first sanitizer line to the end of the log so the whole
-    # stack trace comes along, minus ASan's own boilerplate (same ignore list as
-    # `ci/jobs/scripts/clickhouse_proc.py`).
-    first_hit="$(grep -n -aE "$SANITIZER_PATTERN" "$OUTPUT_PATH/clickhouse-server.log.err" 2>/dev/null | head -1 | cut -d: -f1 || true)"
-    sanitizer_hits=""
-    if [ -n "$first_hit" ]; then
-        sanitizer_hits="$(sed -n "${first_hit},\$p" "$OUTPUT_PATH/clickhouse-server.log.err" \
-            | grep -av "ASan doesn't fully support makecontext/swapcontext functions" \
-            | grep -av "ASan is ignoring requested __asan_handle_no_return" \
-            | grep -av "False positive error reports may follow" \
-            | grep -av "For details see https://github.com/google/sanitizers" \
-            | head -n 200 || true)"
-    fi
-    fatal_hits="$(grep -a '<Fatal>' "$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err" 2>/dev/null | head -n 50 || true)"
-    [ -n "$sanitizer_hits$fatal_hits" ] || return 0
-    : > "$report"
-    if [ -n "$sanitizer_hits" ]; then
-        printf '%s\n' "=== sanitizer report ===" "$sanitizer_hits" >> "$report"
-    fi
-    if [ -n "$fatal_hits" ]; then
-        printf '%s\n' "=== <Fatal> messages ===" "$fatal_hits" >> "$report"
-    fi
-    local first_line
-    first_line="$(sed -n '2p' "$report" | cut -c1-400)"
-    add_test_result "Sanitizer assert or Fatal messages in server logs" FAIL "$first_line" "$report"
-    echo " - server log finding: $first_line"
-}
-collect_server_errors
+# Sanitizer reports and `<Fatal>` messages are a finding on their own, even when
+# no oracle noticed anything. Shared with the SQLancer++ job, which runs against
+# the same builds.
+# shellcheck source=./scripts/sqlancer_server_errors.sh
+. "$REPO_DIR/ci/jobs/scripts/sqlancer_server_errors.sh"
+SERVER_ERROR_REPORT="$FAILURES_PATH/server-fatal.log"
+if server_error_line="$(scan_server_errors \
+        "$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err" "$SERVER_ERROR_REPORT")"; then
+    add_test_result "Sanitizer assert or Fatal messages in server logs" FAIL "$server_error_line" "$SERVER_ERROR_REPORT"
+    echo " - server log finding: $server_error_line"
+fi
 
 if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) != 'Ok.' ]]; then
     add_test_result "Server is alive after the run" FAIL "Server died during the SQLancer run"

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -484,12 +484,11 @@ SERVER_ERROR_REPORT="$FAILURES_PATH/server-fatal.log"
 SERVER_ERROR_FINGERPRINT=""
 if server_error_line="$(scan_server_errors \
         "$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err" "$SERVER_ERROR_REPORT")"; then
-    # Name the row after the *shape* of the report (addresses, pids and sizes
-    # stripped) rather than "sanitizer report": that name is the CI DB test name
-    # and the alert fingerprint, so two different sanitizer bugs must not collapse
-    # into one - and the same one must not re-alert every night.
-    SERVER_ERROR_FINGERPRINT="Sanitizer/Fatal: $(printf '%s' "$server_error_line" \
-        | sed -e 's/0x[0-9a-fA-F]*/ADDR/g' -e 's/[0-9][0-9]*/N/g' | cut -c1-160)"
+    # Name the row after the report's identity - kind plus the frame it happened
+    # in - rather than "sanitizer report": that name is the CI DB test name and the
+    # alert fingerprint, so two different sanitizer bugs must not collapse into one
+    # row, and the same one must not re-alert every night.
+    SERVER_ERROR_FINGERPRINT="Sanitizer/Fatal: $(server_error_signature "$SERVER_ERROR_REPORT")"
     add_test_result "$SERVER_ERROR_FINGERPRINT" FAIL "$server_error_line" "$SERVER_ERROR_REPORT"
     echo " - server log finding: $server_error_line"
 fi

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -239,6 +239,10 @@ build_sqlancer() {
     local ref="$1" dest="$2"
     rm -rf "$dest"
     git clone --quiet --depth 1 --branch "$ref" "$SQLANCER_REPO" "$dest" || return 1
+    # Remember what we fetched before anything else can fail: on a broken `main`
+    # this is the only place the offending revision is known, and the run has to
+    # stay attributable exactly there.
+    SQLANCER_FETCHED_COMMIT="$(git -c safe.directory='*' -C "$dest" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
     if ! (
         cd "$dest" &&
         mvn --no-transfer-progress -B package \
@@ -255,6 +259,7 @@ build_sqlancer() {
 
 SQLANCER_DIR="$SQLANCER_BAKED_DIR"
 BUILD_WARNING=""
+SQLANCER_FETCHED_COMMIT=""
 echo "=== Building sqlancer from $SQLANCER_REPO @ $SQLANCER_REF ==="
 if [ "${SQLANCER_BUILD_AT_RUNTIME:-1}" = "1" ]; then
     BUILD_RC=0
@@ -265,7 +270,7 @@ if [ "${SQLANCER_BUILD_AT_RUNTIME:-1}" = "1" ]; then
         BUILD_WARNING="could not fetch or resolve dependencies for $SQLANCER_REF (network?), fell back to the image's build"
         echo "WARNING: $BUILD_WARNING" >&2
     else
-        BUILD_WARNING="$SQLANCER_REF does not build, fell back to the image's build - this run does NOT test current $SQLANCER_REF"
+        BUILD_WARNING="$SQLANCER_REF @ ${SQLANCER_FETCHED_COMMIT:-unknown} does not build, fell back to the image's build - this run does NOT test current $SQLANCER_REF"
         echo "ERROR: $BUILD_WARNING; see $SQLANCER_BUILD_LOG" >&2
         # Fuzz on with the baked build - some coverage beats none - but fail the
         # job: a broken `main` is exactly what this job must not hide.
@@ -560,7 +565,14 @@ if [ "$OVERALL_STATUS" = "OK" ]; then
     add_test_result "SQLancer" OK ""
 fi
 
-RESULT_INFO="sqlancer $SQLANCER_REF @ $SQLANCER_COMMIT; ${QUERY_STATS:-no statistics}; $FAILURE_SUMMARY"
+# Say which revision actually ran. On a fallback the fetched SHA is not the one
+# that produced these findings, and reporting it would misattribute them.
+if [ "$SQLANCER_DIR" = "$SQLANCER_RUN_DIR" ]; then
+    SQLANCER_PROVENANCE="sqlancer $SQLANCER_REF @ $SQLANCER_COMMIT"
+else
+    SQLANCER_PROVENANCE="sqlancer image build @ $SQLANCER_COMMIT (NOT $SQLANCER_REF @ ${SQLANCER_FETCHED_COMMIT:-not fetched})"
+fi
+RESULT_INFO="$SQLANCER_PROVENANCE; ${QUERY_STATS:-no statistics}; $FAILURE_SUMMARY"
 if [ -n "$BUILD_WARNING" ]; then
     RESULT_INFO="$RESULT_INFO; WARNING: $BUILD_WARNING"
 fi

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -1,10 +1,38 @@
 #!/bin/bash
 
-# DISCLAIMER:
-# 1. This job script is written in bash to demonstrate "praktika CI" flexibility
-# 2. Other than for demonstration purposes it would be wierd to write this in bash
+# SQLancer nightly job.
+#
+# Runs the ClickHouse SQLancer provider (https://github.com/ClickHouse/sqlancer,
+# branch `main`) against a server started from this workflow's ClickHouse binary.
+#
+# Console output is deliberately terse: one progress line every ~5 minutes plus a
+# summary at the end. Everything else is written to files that are attached to
+# the job report:
+#   sqlancer.out                   full fuzzer stdout+stderr
+#   sqlancer-build.log             maven build of the sqlancer checkout
+#   clickhouse-server.log[.err]    server stdout / stderr
+#   failures/<databaseN>.log       ONE FILE PER FINDING: the exact
+#                                  CREATE/INSERT/.../SELECT sequence that
+#                                  reproduces it plus the reporting oracle's
+#                                  stack trace
+#   failures/analysis.txt          all findings deduplicated into distinct
+#                                  failures, loudest first, plus a per-finding
+#                                  index (see ci/jobs/scripts/sqlancer_failures.py)
+#   failures/server-fatal.log      sanitizer report / `<Fatal>` server messages
+# The report gets one row per *distinct* failure ("TLPWhere / AssertionError at
+# ComparatorHelper.assumeResultSetsAreEqual:127 (x7)") with the individual
+# findings and their logs nested underneath, so a 5h run that hit the same bug
+# 40 times reads as one row - not 40, and not one wall of interleaved
+# multi-threaded text.
+#
+# The job is marked FAILED whenever anything was found: a reproducer, a
+# sanitizer/fatal server message, a dead or unreachable server, a non-zero
+# sqlancer exit code, or a run that produced no statistics at all. Both signals
+# are needed for that: the result file's status drives the HTML report, while the
+# GitHub job conclusion comes from this script's *exit code* (`res = run_code == 0`
+# in `ci/praktika/runner.py`), so a finding also has to exit non-zero.
 
-set -exu
+set -eu
 set -o pipefail
 
 # Capture the job start timestamp so the result file (written by the EXIT trap)
@@ -13,8 +41,10 @@ set -o pipefail
 # which fails with `'NoneType' object cannot be interpreted as an integer`).
 JOB_START_TIME=$(date +%s)
 
+REPO_DIR=$(readlink -f .)
 TMP_PATH=$(readlink -f ./ci/tmp/)
 OUTPUT_PATH="$TMP_PATH/sqlancer_output"
+FAILURES_PATH="$OUTPUT_PATH/failures"
 PID_FILE="$TMP_PATH/clickhouse-server.pid"
 CLICKHOUSE_BIN="$TMP_PATH/clickhouse"
 
@@ -31,12 +61,53 @@ print(Utils.normalize_string(_Environment.get().JOB_NAME))
 ')
 RESULT_FILE="$TMP_PATH/result_${NORMALIZED_JOB_NAME}.json"
 
-mkdir -p $OUTPUT_PATH
+mkdir -p "$OUTPUT_PATH" "$FAILURES_PATH"
 
 # Properly JSON-escape a string using python3, outputting only the inner
 # content (without surrounding quotes) so callers can embed it in "...".
 json_escape() {
     printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1], end="")'
+}
+
+# Praktika uploads every file listed in a (sub-)result to S3 and links it in the
+# report (see `_ResultS3.upload_result_files_to_s3`). A 5h run produces a large
+# statement log, so compress anything above 10 MB; smaller files stay plain text
+# so the report renders them inline. Echoes the path to attach.
+prepare_attachment() {
+    local f="$1" size
+    if [ ! -f "$f" ]; then
+        [ -f "$f.gz" ] && printf '%s' "$f.gz" && return 0
+        return 1
+    fi
+    size=$(stat -c%s "$f" 2>/dev/null || echo 0)
+    if [ "$size" -gt $((10 * 1024 * 1024)) ] && gzip -f "$f"; then
+        f="$f.gz"
+    fi
+    [ -f "$f" ] || return 1
+    printf '%s' "$f"
+}
+
+files_json_for() {
+    local out="" f attach
+    for f in "$@"; do
+        attach="$(prepare_attachment "$f")" || continue
+        [ -n "$out" ] && out+=", "
+        out+="\"$attach\""
+    done
+    printf '%s' "$out"
+}
+
+# Sub-results are stored tab-separated (name, status, info) with a parallel array
+# holding each row's attached files. Tabs never occur in the collapsed one-line
+# infos built below, and a tab inside `info` would be harmless anyway since
+# `read` puts the whole remainder into the last field.
+add_test_result() {
+    local name="$1" status="$2" info="$3"
+    shift 3
+    name="$(printf '%s' "$name" | tr '\n\t' '  ')"
+    info="$(printf '%s' "$info" | tr '\n\t' '  ')"
+    TEST_RESULTS+=("$(printf '%s\t%s\t%s' "$name" "$status" "$info")")
+    TEST_RESULT_FILES+=("$*")
 }
 
 # Write result on any exit to ensure logs are always uploaded as artifacts
@@ -50,108 +121,152 @@ write_result() {
     elif [ "$status" = "OK" ]; then
         info=""
     elif [ "$status" = "FAIL" ]; then
-        info="Some SQLancer tests failed"
+        info="SQLancer found something - see the per-finding rows below"
     else
         info="Script terminated unexpectedly"
     fi
 
-    # Build results array
+    # The deduplicated failure families come from `sqlancer_failures.py` as a
+    # ready JSON fragment (comma-separated objects); they go first so the report
+    # opens with the analysis.
     local results_json=""
+    if [ -s "${SUBRESULTS_FRAGMENT:-}" ]; then
+        results_json="$(cat "$SUBRESULTS_FRAGMENT")"
+    fi
     if [ ${#TEST_RESULTS[@]} -gt 0 ]; then
+        local i test_name test_status test_info test_files_json
         for i in "${!TEST_RESULTS[@]}"; do
-            IFS=',' read -r test_name test_status test_info <<< "${TEST_RESULTS[i]}"
+            IFS=$'\t' read -r test_name test_status test_info <<< "${TEST_RESULTS[i]}"
+            # shellcheck disable=SC2086
+            test_files_json="$(files_json_for ${TEST_RESULT_FILES[i]})"
             if [ -n "$results_json" ]; then
                 results_json+=","
             fi
-            local escaped_info
-            escaped_info="$(json_escape "$test_info")"
-            results_json+=$(printf '\n    {"name": "%s", "status": "%s", "files": [], "info": "%s"}' "$test_name" "$test_status" "$escaped_info")
+            results_json+=$(printf '\n    {"name": "%s", "status": "%s", "files": [%s], "info": "%s"}' \
+                "$(json_escape "$test_name")" "$test_status" "$test_files_json" "$(json_escape "$test_info")")
         done
     fi
 
-    # Build files array. Praktika uploads every path listed here to S3 as a
-    # downloadable artifact and links it in the job report (see
-    # `_ResultS3.upload_result_files_to_s3`). A 5h run produces a
-    # several-hundred-MB statement log (sqlancer logs every executed statement),
-    # so compress files larger than 10 MB; keep smaller ones (e.g. the
-    # sanitizer report on stderr) as plain text so they render inline.
-    local files_json=""
     local candidate_files=(
         "$OUTPUT_PATH/clickhouse-server.log"
         "$OUTPUT_PATH/clickhouse-server.log.err"
     )
     candidate_files+=("${ATTACHED_FILES_ARRAY[@]+"${ATTACHED_FILES_ARRAY[@]}"}")
-    local attach size
-    for f in "${candidate_files[@]}"; do
-        [ -f "$f" ] || continue
-        size=$(stat -c%s "$f" 2>/dev/null || echo 0)
-        if [ "$size" -gt $((10 * 1024 * 1024)) ] && gzip -f "$f"; then
-            attach="$f.gz"
-        else
-            attach="$f"
-        fi
-        [ -f "$attach" ] || continue
-        if [ -n "$files_json" ]; then
-            files_json+=", "
-        fi
-        files_json+="\"$attach\""
-    done
+    local files_json
+    files_json="$(files_json_for "${candidate_files[@]}")"
 
     local escaped_overall_info
     escaped_overall_info="$(json_escape "$info")"
 
     local job_duration=$(( $(date +%s) - JOB_START_TIME ))
 
-    printf '{\n' > $RESULT_FILE
-    printf '  "name": "SQLancer",\n' >> $RESULT_FILE
-    printf '  "status": "%s",\n' "$status" >> $RESULT_FILE
-    printf '  "start_time": %d,\n' "$JOB_START_TIME" >> $RESULT_FILE
-    printf '  "duration": %d,\n' "$job_duration" >> $RESULT_FILE
-    printf '  "results": [%s\n  ],\n' "$results_json" >> $RESULT_FILE
-    printf '  "files": [%s],\n' "$files_json" >> $RESULT_FILE
-    printf '  "info": "%s"\n' "$escaped_overall_info" >> $RESULT_FILE
-    printf '}\n' >> $RESULT_FILE
+    printf '{\n' > "$RESULT_FILE"
+    printf '  "name": "SQLancer",\n' >> "$RESULT_FILE"
+    printf '  "status": "%s",\n' "$status" >> "$RESULT_FILE"
+    printf '  "start_time": %d,\n' "$JOB_START_TIME" >> "$RESULT_FILE"
+    printf '  "duration": %d,\n' "$job_duration" >> "$RESULT_FILE"
+    printf '  "results": [%s\n  ],\n' "$results_json" >> "$RESULT_FILE"
+    printf '  "files": [%s],\n' "$files_json" >> "$RESULT_FILE"
+    printf '  "info": "%s"\n' "$escaped_overall_info" >> "$RESULT_FILE"
+    printf '}\n' >> "$RESULT_FILE"
 }
 
 # Initialize variables used by the trap handler
 TEST_RESULTS=()
+TEST_RESULT_FILES=()
 ATTACHED_FILES_ARRAY=()
 OVERALL_STATUS="ERROR"
 RESULT_INFO=""
+SUBRESULTS_FRAGMENT=""
 
 trap write_result EXIT
 
-if [[ -f "$CLICKHOUSE_BIN" ]]; then
-    echo "$CLICKHOUSE_BIN exists"
-else
-    echo "$CLICKHOUSE_BIN does not exists"
+if [[ ! -f "$CLICKHOUSE_BIN" ]]; then
+    RESULT_INFO="$CLICKHOUSE_BIN does not exist"
+    echo "$RESULT_INFO" >&2
     exit 1
 fi
 
-chmod +x $CLICKHOUSE_BIN
-$CLICKHOUSE_BIN local --version
+chmod +x "$CLICKHOUSE_BIN"
+"$CLICKHOUSE_BIN" local --version
 
+# ---------------------------------------------------------------------------
+# SQLancer checkout
+# ---------------------------------------------------------------------------
+# The image bakes a build of `ClickHouse/sqlancer@main` (see
+# `ci/docker/sqlancer-test/Dockerfile`), but that image is only rebuilt when its
+# digest - the contents of the docker directory - changes, so the baked build
+# freezes at whatever `main` was when the Dockerfile was last touched. Re-clone
+# and rebuild `main` here so every nightly run actually fuzzes current `main`;
+# the baked build is the fallback (and its warm maven repo makes this rebuild
+# take ~1 minute). The resolved commit is reported in the job info so a finding
+# stays attributable.
+SQLANCER_REPO="${SQLANCER_REPO:-https://github.com/ClickHouse/sqlancer}"
+SQLANCER_REF="${SQLANCER_REF:-main}"
+SQLANCER_BAKED_DIR=/sqlancer/sqlancer-main
+SQLANCER_RUN_DIR=/sqlancer/checkout
+SQLANCER_BUILD_LOG="$OUTPUT_PATH/sqlancer-build.log"
+MAVEN_REPO=/sqlancer/.m2
+# The job container runs as `--user $(id -u):$(id -g)`, an id that has no entry
+# in the image's /etc/passwd, so `$HOME` may be unset or unwritable. Point it at
+# the world-writable /sqlancer tree so git and maven have somewhere to scribble.
+export HOME=/sqlancer
+
+build_sqlancer() {
+    local ref="$1" dest="$2"
+    rm -rf "$dest"
+    git clone --quiet --depth 1 --branch "$ref" "$SQLANCER_REPO" "$dest" || return 1
+    (
+        cd "$dest" &&
+        mvn --no-transfer-progress -B package \
+            -Dmaven.test.skip=true -Djacoco.skip=true \
+            -Dmaven.repo.local="$MAVEN_REPO"
+    ) > "$SQLANCER_BUILD_LOG" 2>&1 || return 1
+    compgen -G "$dest/target/sqlancer-*.jar" > /dev/null || return 1
+}
+
+SQLANCER_DIR="$SQLANCER_BAKED_DIR"
+BUILD_WARNING=""
+echo "=== Building sqlancer from $SQLANCER_REPO @ $SQLANCER_REF ==="
+if [ "${SQLANCER_BUILD_AT_RUNTIME:-1}" = "1" ] && build_sqlancer "$SQLANCER_REF" "$SQLANCER_RUN_DIR"; then
+    SQLANCER_DIR="$SQLANCER_RUN_DIR"
+else
+    BUILD_WARNING="failed to build $SQLANCER_REF at runtime, fell back to the image's build"
+    echo "WARNING: $BUILD_WARNING; see $SQLANCER_BUILD_LOG" >&2
+fi
+if [ -f "$SQLANCER_BUILD_LOG" ]; then
+    ATTACHED_FILES_ARRAY+=("$SQLANCER_BUILD_LOG")
+fi
+
+# `safe.directory`: the image's clone is owned by root while the job runs as the
+# runner's uid, which git otherwise refuses to read ("dubious ownership").
+SQLANCER_COMMIT="$(git -c safe.directory='*' -C "$SQLANCER_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+echo "Using sqlancer checkout [$SQLANCER_DIR] at commit [$SQLANCER_COMMIT]"
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
 # Apply the server-side config overrides shipped with the SQLancer provider
-# (ClickHouse/sqlancer PR #4, `.claude/clickhouse-config/`): drop the file logger
-# to `warning`, remove the heavy `system.*_log` tables, and pin the profile
-# settings the oracles depend on (`async_insert=0`, `alter_sync=2`,
-# `mutations_sync=2`) so an INSERT/ALTER/mutation is visible to the next read in
-# the same oracle iteration. The server runs without `--config-file`, so it uses
-# the binary's embedded `config.xml` and merges any `config.d/*.xml` relative to
-# its working directory (see `ConfigProcessor::loadConfig`); starting it from
-# `$SERVER_DIR` is what makes the overrides take effect. The embedded config's
-# `users_config` points at `config.xml` itself, so `<profiles>` overrides placed
-# in `config.d/` reach the default profile (verified) -- unlike a packaged
-# server, this does not need a separate `users.d/`.
+# (`.claude/clickhouse-config/`): drop the file logger to `warning`, remove the
+# heavy `system.*_log` tables, and pin the profile settings the oracles depend on
+# (`async_insert=0`, `alter_sync=2`, `mutations_sync=2`) so an INSERT/ALTER/
+# mutation is visible to the next read in the same oracle iteration. The server
+# runs without `--config-file`, so it uses the binary's embedded `config.xml` and
+# merges any `config.d/*.xml` relative to its working directory (see
+# `ConfigProcessor::loadConfig`); starting it from `$SERVER_DIR` is what makes the
+# overrides take effect. The embedded config's `users_config` points at
+# `config.xml` itself, so `<profiles>` overrides placed in `config.d/` reach the
+# default profile (verified) -- unlike a packaged server, this does not need a
+# separate `users.d/`.
 SERVER_DIR="$TMP_PATH/server"
 mkdir -p "$SERVER_DIR/config.d"
-cp /sqlancer/sqlancer-main/.claude/clickhouse-config/*.xml "$SERVER_DIR/config.d/"
+cp "$SQLANCER_DIR"/.claude/clickhouse-config/*.xml "$SERVER_DIR/config.d/"
 
-echo "Starting ClickHouse server..."
-( cd "$SERVER_DIR" && exec "$CLICKHOUSE_BIN" server -P "$PID_FILE" ) 1>$OUTPUT_PATH/clickhouse-server.log 2>$OUTPUT_PATH/clickhouse-server.log.err &
+echo "=== Starting ClickHouse server ==="
+( cd "$SERVER_DIR" && exec "$CLICKHOUSE_BIN" server -P "$PID_FILE" ) 1>"$OUTPUT_PATH/clickhouse-server.log" 2>"$OUTPUT_PATH/clickhouse-server.log.err" &
 for _ in $(seq 1 60); do if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) == 'Ok.' ]]; then break ; else sleep 1; fi ; done
 
-cd /sqlancer/sqlancer-main
+cd "$SQLANCER_DIR"
 
 # Run all oracles in a single invocation bounded by one wall-clock timeout,
 # matching the upstream `.claude/run-sqlancer.sh --oracles all` reference run.
@@ -162,9 +277,9 @@ cd /sqlancer/sqlancer-main
 # Derive the oracle list from the provider's own curated `ALL_ORACLES` (its
 # `--oracles all` set) instead of hardcoding it here: the list changes between
 # sqlancer revisions (oracles are added, and noisy ones such as `RowPolicy` are
-# dropped), so reading it from the pinned image keeps it in sync with whatever
-# commit the Dockerfile builds. Fail closed if it cannot be parsed -- an empty
-# `--oracle` would otherwise make sqlancer error out cryptically.
+# dropped), so reading it from the checkout keeps it in sync with whatever commit
+# is being run. Fail closed if it cannot be parsed -- an empty `--oracle` would
+# otherwise make sqlancer error out cryptically.
 #
 # `--random-session-settings` is intentionally NOT passed: it is rejected in
 # combination with the `SEMR`/`SEMRMulti` oracles (which toggle session settings
@@ -172,9 +287,8 @@ cd /sqlancer/sqlancer-main
 # provide setting-differential coverage.
 TIMEOUT="${SQLANCER_TIMEOUT_SECONDS:-18000}"
 NUM_THREADS=10
-ORACLES=$(grep -E '^ALL_ORACLES=' /sqlancer/sqlancer-main/.claude/run-sqlancer.sh | head -1 | cut -d'"' -f2)
+ORACLES=$(grep -E '^ALL_ORACLES=' "$SQLANCER_DIR/.claude/run-sqlancer.sh" | head -1 | cut -d'"' -f2)
 if [ -z "$ORACLES" ]; then
-    OVERALL_STATUS="ERROR"
     RESULT_INFO="Could not parse ALL_ORACLES from the sqlancer run script"
     echo "$RESULT_INFO" >&2
     exit 1
@@ -190,74 +304,192 @@ for excluded in $EXCLUDED_ORACLES; do
     ORACLES=$(printf '%s' "$ORACLES" | tr ',' '\n' | grep -vxF "$excluded" | paste -sd, -)
 done
 if [ -z "$ORACLES" ]; then
-    OVERALL_STATUS="ERROR"
     RESULT_INFO="Oracle list is empty after applying exclusions"
     echo "$RESULT_INFO" >&2
     exit 1
 fi
-echo "$ORACLES"
+echo "Oracles ($(printf '%s' "$ORACLES" | tr ',' '\n' | grep -c .)): $ORACLES"
 
-OVERALL_STATUS=OK
-TEST_NAME="SQLancer"
-output_file="$OUTPUT_PATH/sqlancer.out"
-ATTACHED_FILES_ARRAY+=("$output_file")
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+OUTPUT_FILE="$OUTPUT_PATH/sqlancer.out"
+ATTACHED_FILES_ARRAY+=("$OUTPUT_FILE")
 
-if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) == 'Ok.' ]]; then
-    echo "Server is OK"
-    java_exit=0
-    java -jar target/sqlancer-*.jar \
-        --num-threads "$NUM_THREADS" \
-        --num-tries 999999 \
-        --timeout-seconds "$TIMEOUT" \
-        --use-connection-test false \
-        --print-progress-summary true \
-        --host 127.0.0.1 --port 8123 \
-        --username default --password "" \
-        clickhouse --oracle "$ORACLES" 2>&1 | tee "$output_file" || java_exit=${PIPESTATUS[0]}
-
-    if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) != 'Ok.' ]]; then
-        echo "Server crashed during SQLancer run"
-        TEST_RESULTS+=("${TEST_NAME},ERROR,Server crashed during test")
-        OVERALL_STATUS="FAIL"
-        RESULT_INFO="Server crashed during SQLancer run"
-    else
-        assertion_error="$(grep 'AssertionError' "$output_file" ||:)"
-        if [ -n "$assertion_error" ]; then
-            # Collapse to single line; full JSON escaping is done in write_result
-            assertion_error_clean="$(printf '%s' "$assertion_error" | tr '\n' ' ')"
-            TEST_RESULTS+=("${TEST_NAME},FAIL,${assertion_error_clean}")
-            OVERALL_STATUS="FAIL"
-        elif [ "$java_exit" -ne 0 ]; then
-            TEST_RESULTS+=("${TEST_NAME},ERROR,SQLancer exited with code $java_exit")
-            OVERALL_STATUS="FAIL"
-        else
-            TEST_RESULTS+=("${TEST_NAME},OK,")
-        fi
-    fi
-else
-    TEST_RESULTS+=("${TEST_NAME},ERROR,Server is not responding")
+if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) != 'Ok.' ]]; then
+    add_test_result "SQLancer" ERROR "Server is not responding before the run"
     OVERALL_STATUS="FAIL"
-    RESULT_INFO="Server is not responding before SQLancer run"
+    RESULT_INFO="Server is not responding before the SQLancer run"
+    exit 1
 fi
 
-# On failure, attach the per-database reproducer logs as an artifact. With
-# `--log-each-select true` SQLancer writes every statement of each generated
-# database to `logs/<dbms>/databaseN.log` (+ `databaseN-cur.log` for the
-# in-progress one), so the failing database's log is the exact
-# CREATE/INSERT/.../SELECT sequence needed to reproduce the bug - far easier
-# than reconstructing it from the interleaved, multi-threaded stdout. Only on
-# failure and as a single `.tar` (write_result gzips it if it exceeds 10 MB),
-# to avoid uploading a multi-hundred-MB log on clean runs.
-SQLANCER_LOG_DIR="/sqlancer/sqlancer-main/logs"
-if [ "$OVERALL_STATUS" != "OK" ] && [ -d "$SQLANCER_LOG_DIR" ]; then
-    reproducer_archive="$OUTPUT_PATH/sqlancer_reproducer_logs.tar"
-    if tar -C "$(dirname "$SQLANCER_LOG_DIR")" -cf "$reproducer_archive" "$(basename "$SQLANCER_LOG_DIR")"; then
-        ATTACHED_FILES_ARRAY+=("$reproducer_archive")
+echo "=== Running SQLancer for ${TIMEOUT}s with $NUM_THREADS threads ==="
+echo "(console shows one progress line per ~5 min; full output goes to sqlancer.out)"
+JAVA_EXIT=0
+# Everything sqlancer prints is kept in `$OUTPUT_FILE`; the console gets only the
+# start-up chatter and one progress line per ~5 min (sqlancer prints one every
+# 5s). Without this filter a 5h run buries the job log under ~3600 progress lines
+# plus, for every finding, the whole reproducer state dump that SQLancer's
+# `AlsoWriteToConsoleFileWriter` mirrors to stderr.
+java -jar target/sqlancer-*.jar \
+    --num-threads "$NUM_THREADS" \
+    --num-tries 999999 \
+    --timeout-seconds "$TIMEOUT" \
+    --use-connection-test false \
+    --print-progress-summary true \
+    --host 127.0.0.1 --port 8123 \
+    --username default --password "" \
+    clickhouse --oracle "$ORACLES" 2>&1 | tee "$OUTPUT_FILE" | awk '
+    /Executed [0-9]+ queries/ { progress++; if (progress % 60 == 0) { print; fflush() } next }
+    { other++; if (other <= 100) { print; fflush() } }
+' || JAVA_EXIT=${PIPESTATUS[0]}
+
+echo "=== SQLancer finished (exit code $JAVA_EXIT) ==="
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+OVERALL_STATUS=OK
+FAILURE_COUNT=0
+FAILURE_SUMMARY="no findings"
+# A pathological night could produce hundreds of reproducers; cap the uploads.
+# Every finding still appears in `analysis.txt`, and each family's row lists all
+# of its occurrences by database name, so nothing is dropped silently.
+MAX_ATTACHED_REPRODUCERS=50
+
+# Collect, fingerprint and deduplicate the reproducer logs (one per finding, see
+# the script's docstring) into failure families: one report row per distinct
+# failure with the individual findings and their logs nested underneath, plus
+# `failures/analysis.txt`. A 5h run hits the same bug many times, so the family
+# view is what makes the result readable.
+echo "=== Analysing findings ==="
+SQLANCER_LOG_DIR="$SQLANCER_DIR/logs/clickhouse"
+FAILURE_ANALYSIS="$(python3 "$REPO_DIR/ci/jobs/scripts/sqlancer_failures.py" \
+    --logs-dir "$SQLANCER_LOG_DIR" \
+    --out-dir "$FAILURES_PATH" \
+    --max-files "$MAX_ATTACHED_REPRODUCERS" || true)"
+IFS=$'\t' read -r FAILURE_COUNT FAILURE_FAMILIES FAILURE_SUMMARY <<< "$FAILURE_ANALYSIS"
+if [ -z "${FAILURE_COUNT:-}" ]; then
+    # The analysis itself failed. Never let that swallow a finding: count the raw
+    # logs, attach them wholesale and report the analysis as broken.
+    FAILURE_COUNT="$(find "$SQLANCER_LOG_DIR" -maxdepth 1 -name 'database*.log' ! -name '*-cur.log' -size +0 2>/dev/null | wc -l)"
+    FAILURE_FAMILIES=0
+    FAILURE_SUMMARY="failure analysis failed; $FAILURE_COUNT raw reproducer log(s)"
+    raw_archive="$OUTPUT_PATH/sqlancer_reproducer_logs.tar"
+    if tar -C "$(dirname "$SQLANCER_LOG_DIR")" -cf "$raw_archive" "$(basename "$SQLANCER_LOG_DIR")" 2>/dev/null; then
+        add_test_result "Failure analysis" ERROR "sqlancer_failures.py failed; raw reproducer logs attached" "$raw_archive"
+    else
+        add_test_result "Failure analysis" ERROR "sqlancer_failures.py failed"
     fi
+    echo "ERROR: $FAILURE_SUMMARY" >&2
+else
+    SUBRESULTS_FRAGMENT="$FAILURES_PATH/subresults.json"
+fi
+echo "$FAILURE_SUMMARY"
+if [ "$FAILURE_COUNT" -gt 0 ] && [ -f "$FAILURES_PATH/analysis.txt" ]; then
+    ATTACHED_FILES_ARRAY+=("$FAILURES_PATH/analysis.txt")
+    sed -n '/^x[0-9]/,/^Per-finding index/{/^Per-finding index/!p}' "$FAILURES_PATH/analysis.txt" | head -n 60
 fi
 
-ls "$OUTPUT_PATH"
+# Sanitizer reports and `<Fatal>` messages: this job runs an ASan+UBSan build, so
+# either is a finding on its own even when no oracle noticed anything. Checked
+# before the server is stopped, so a leak report emitted during shutdown does not
+# turn every run red. The filtered-out lines are ASan's own boilerplate, same list
+# as `ci/jobs/scripts/clickhouse_proc.py`.
+SANITIZER_PATTERN='(ERROR|SUMMARY): (Address|Leak|Memory|Thread|UndefinedBehavior)Sanitizer|runtime error:'
 
+collect_server_errors() {
+    local report="$FAILURES_PATH/server-fatal.log" sanitizer_hits fatal_hits first_hit
+    # Report from the first sanitizer line to the end of the log so the whole
+    # stack trace comes along, minus ASan's own boilerplate (same ignore list as
+    # `ci/jobs/scripts/clickhouse_proc.py`).
+    first_hit="$(grep -n -aE "$SANITIZER_PATTERN" "$OUTPUT_PATH/clickhouse-server.log.err" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+    sanitizer_hits=""
+    if [ -n "$first_hit" ]; then
+        sanitizer_hits="$(sed -n "${first_hit},\$p" "$OUTPUT_PATH/clickhouse-server.log.err" \
+            | grep -av "ASan doesn't fully support makecontext/swapcontext functions" \
+            | grep -av "ASan is ignoring requested __asan_handle_no_return" \
+            | grep -av "False positive error reports may follow" \
+            | grep -av "For details see https://github.com/google/sanitizers" \
+            | head -n 200 || true)"
+    fi
+    fatal_hits="$(grep -a '<Fatal>' "$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err" 2>/dev/null | head -n 50 || true)"
+    [ -n "$sanitizer_hits$fatal_hits" ] || return 0
+    : > "$report"
+    if [ -n "$sanitizer_hits" ]; then
+        printf '%s\n' "=== sanitizer report ===" "$sanitizer_hits" >> "$report"
+    fi
+    if [ -n "$fatal_hits" ]; then
+        printf '%s\n' "=== <Fatal> messages ===" "$fatal_hits" >> "$report"
+    fi
+    local first_line
+    first_line="$(sed -n '2p' "$report" | cut -c1-400)"
+    add_test_result "Sanitizer assert or Fatal messages in server logs" FAIL "$first_line" "$report"
+    echo " - server log finding: $first_line"
+}
+collect_server_errors
+
+if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) != 'Ok.' ]]; then
+    add_test_result "Server is alive after the run" FAIL "Server died during the SQLancer run"
+    echo " - server died during the run"
+fi
+
+if [ "$JAVA_EXIT" -ne 0 ] && [ "$FAILURE_COUNT" -eq 0 ]; then
+    # A non-zero exit with no reproducer file means sqlancer itself failed to run
+    # (bad arguments, OOM, jar problem) - that is an infrastructure error, not a
+    # ClickHouse finding.
+    add_test_result "SQLancer run" ERROR "SQLancer exited with code $JAVA_EXIT and left no reproducer log" \
+        "$OUTPUT_FILE"
+    echo " - sqlancer exited with code $JAVA_EXIT without leaving a reproducer log"
+fi
+
+# Belt and braces: a finding whose reproducer log could not be read still shows
+# up as an AssertionError in the fuzzer output.
+ASSERTION_COUNT="$(grep -c 'AssertionError' "$OUTPUT_FILE" || true)"
+if [ "${ASSERTION_COUNT:-0}" -gt 0 ] && [ "$FAILURE_COUNT" -eq 0 ]; then
+    add_test_result "SQLancer assertions" FAIL \
+        "$ASSERTION_COUNT AssertionError line(s) in the fuzzer output but no reproducer log was written" \
+        "$OUTPUT_FILE"
+    echo " - $ASSERTION_COUNT AssertionError line(s) without a reproducer log"
+fi
+
+# Guard against a silently broken run: with `--print-progress-summary true`
+# sqlancer always prints the statistics block when it stops.
+QUERY_STATS="$(awk '/Overall execution statistics/,0' "$OUTPUT_FILE" | grep -m1 'queries' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//' || true)"
+if [ -z "$QUERY_STATS" ]; then
+    add_test_result "SQLancer statistics" ERROR "SQLancer produced no execution statistics" "$OUTPUT_FILE"
+    echo " - no execution statistics in the fuzzer output"
+fi
+
+# The console filter above hides ordinary fuzzer output, so show the tail when
+# sqlancer itself misbehaved - that is where "jar not found", a bad option or an
+# OOM kill shows up.
+if [ "$JAVA_EXIT" -ne 0 ] || [ -z "$QUERY_STATS" ]; then
+    echo "=== last 30 lines of sqlancer.out ==="
+    tail -n 30 "$OUTPUT_FILE" || true
+fi
+
+if [ "$FAILURE_COUNT" -gt 0 ]; then
+    OVERALL_STATUS="FAIL"
+fi
+for entry in "${TEST_RESULTS[@]+"${TEST_RESULTS[@]}"}"; do
+    case "$entry" in
+        *$'\t'FAIL$'\t'*|*$'\t'ERROR$'\t'*) OVERALL_STATUS="FAIL" ;;
+    esac
+done
+if [ "$OVERALL_STATUS" = "OK" ]; then
+    add_test_result "SQLancer" OK ""
+fi
+
+RESULT_INFO="sqlancer $SQLANCER_REF @ $SQLANCER_COMMIT; ${QUERY_STATS:-no statistics}; $FAILURE_SUMMARY"
+if [ -n "$BUILD_WARNING" ]; then
+    RESULT_INFO="$RESULT_INFO; WARNING: $BUILD_WARNING"
+fi
+echo "=== Summary: $OVERALL_STATUS - $RESULT_INFO ==="
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
 if [ -f "$PID_FILE" ]; then
     pid="$(cat "$PID_FILE" 2>/dev/null || true)"
     # Validate the PID before sending a signal: it must be numeric, the process
@@ -280,3 +512,7 @@ else
     echo "Warning: PID file not found at $PID_FILE"
 fi
 for _ in $(seq 1 60); do if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) == 'Ok.' ]]; then sleep 1 ; else break; fi ; done
+
+# Praktika derives the GitHub job conclusion from this exit code, so a finding
+# has to exit non-zero to turn the nightly red.
+[ "$OVERALL_STATUS" = "OK" ]

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -20,8 +20,8 @@
 #                                  index (see ci/jobs/scripts/sqlancer_failures.py)
 #   failures/server-fatal.log      sanitizer report / `<Fatal>` server messages
 # The report gets one row per *distinct* failure ("TLPWhere / AssertionError at
-# ComparatorHelper.assumeResultSetsAreEqual:127 (x7)") with the individual
-# findings and their logs nested underneath, so a 5h run that hit the same bug
+# ComparatorHelper.assumeResultSetsAreEqual:127 (x7)") listing every occurrence
+# and carrying that failure's reproducer logs, so a 5h run that hit the same bug
 # 40 times reads as one row - not 40, and not one wall of interleaved
 # multi-threaded text.
 #
@@ -50,15 +50,23 @@ CLICKHOUSE_BIN="$TMP_PATH/clickhouse"
 
 # Praktika reads the job result from `./ci/tmp/result_<normalized_job_name>.json`,
 # where the normalization matches `Utils.normalize_string` in `ci/praktika/utils.py`.
-# `JOB_NAME` is not propagated into the docker container, so read it from the
-# serialized environment file that Praktika writes before invoking the job.
-NORMALIZED_JOB_NAME=$(python3 -c '
+# The `name` INSIDE that file must be the job name too: the workflow report is
+# updated with `Result.update_sub_result`, which matches the job's placeholder
+# entry by name, and silently keeps the placeholder when nothing matches - which
+# is why this job used to show up in the report with no status, no sub-results and
+# no attached logs at all. `JOB_NAME` is not propagated into the docker container,
+# so read it from the serialized environment file Praktika writes before the job.
+JOB_META=$(python3 -c '
 import sys
 sys.path.insert(0, ".")
 from ci.praktika._environment import _Environment
 from ci.praktika.utils import Utils
-print(Utils.normalize_string(_Environment.get().JOB_NAME))
+name = _Environment.get().JOB_NAME
+print(name)
+print(Utils.normalize_string(name))
 ')
+JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 1p)"
+NORMALIZED_JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 2p)"
 RESULT_FILE="$TMP_PATH/result_${NORMALIZED_JOB_NAME}.json"
 
 mkdir -p "$OUTPUT_PATH" "$FAILURES_PATH"
@@ -121,7 +129,7 @@ write_result() {
     elif [ "$status" = "OK" ]; then
         info=""
     elif [ "$status" = "FAIL" ]; then
-        info="SQLancer found something - see the per-finding rows below"
+        info="SQLancer found something - see the rows below"
     else
         info="Script terminated unexpectedly"
     fi
@@ -161,7 +169,7 @@ write_result() {
     local job_duration=$(( $(date +%s) - JOB_START_TIME ))
 
     printf '{\n' > "$RESULT_FILE"
-    printf '  "name": "SQLancer",\n' >> "$RESULT_FILE"
+    printf '  "name": "%s",\n' "$(json_escape "$JOB_NAME")" >> "$RESULT_FILE"
     printf '  "status": "%s",\n' "$status" >> "$RESULT_FILE"
     printf '  "start_time": %d,\n' "$JOB_START_TIME" >> "$RESULT_FILE"
     printf '  "duration": %d,\n' "$job_duration" >> "$RESULT_FILE"

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -495,6 +495,14 @@ if server_error_line="$(scan_server_errors \
     # row, and the same one must not re-alert every night.
     SERVER_ERROR_FINGERPRINT="Sanitizer/Fatal: $(server_error_signature "$SERVER_ERROR_REPORT")"
     add_test_result "$SERVER_ERROR_FINGERPRINT" FAIL "$server_error_line" "$SERVER_ERROR_REPORT"
+    # Fold it into the run summary too: it is a finding with no oracle reproducer,
+    # so the counts from the analysis do not include it, and a sanitizer-only run
+    # would otherwise be summarized as "no findings".
+    if [ "$FAILURE_SUMMARY" = "no findings" ]; then
+        FAILURE_SUMMARY="1 server-log finding"
+    else
+        FAILURE_SUMMARY="$FAILURE_SUMMARY; 1 server-log finding"
+    fi
     echo " - server log finding: $server_error_line"
 fi
 

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -471,9 +471,16 @@ fi
 # shellcheck source=./scripts/sqlancer_server_errors.sh
 . "$REPO_DIR/ci/jobs/scripts/sqlancer_server_errors.sh"
 SERVER_ERROR_REPORT="$FAILURES_PATH/server-fatal.log"
+SERVER_ERROR_FINGERPRINT=""
 if server_error_line="$(scan_server_errors \
         "$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err" "$SERVER_ERROR_REPORT")"; then
-    add_test_result "Sanitizer assert or Fatal messages in server logs" FAIL "$server_error_line" "$SERVER_ERROR_REPORT"
+    # Name the row after the *shape* of the report (addresses, pids and sizes
+    # stripped) rather than "sanitizer report": that name is the CI DB test name
+    # and the alert fingerprint, so two different sanitizer bugs must not collapse
+    # into one - and the same one must not re-alert every night.
+    SERVER_ERROR_FINGERPRINT="Sanitizer/Fatal: $(printf '%s' "$server_error_line" \
+        | sed -e 's/0x[0-9a-fA-F]*/ADDR/g' -e 's/[0-9][0-9]*/N/g' | cut -c1-160)"
+    add_test_result "$SERVER_ERROR_FINGERPRINT" FAIL "$server_error_line" "$SERVER_ERROR_REPORT"
     echo " - server log finding: $server_error_line"
 fi
 
@@ -545,7 +552,9 @@ if [ -f "$FAILURES_PATH/findings.json" ]; then
     python3 "$REPO_DIR/ci/jobs/scripts/sqlancer_notify.py" \
         --findings "$FAILURES_PATH/findings.json" \
         --job-name "$JOB_NAME" \
-        --info "$RESULT_INFO" || echo "WARNING: new-finding notification failed"
+        --info "$RESULT_INFO" \
+        --extra-failure "$SERVER_ERROR_FINGERPRINT" \
+        --extra-failure-message "$server_error_line" || echo "WARNING: new-finding notification failed"
 fi
 
 # ---------------------------------------------------------------------------

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -270,6 +270,23 @@ SERVER_DIR="$TMP_PATH/server"
 mkdir -p "$SERVER_DIR/config.d"
 cp "$SQLANCER_DIR"/.claude/clickhouse-config/*.xml "$SERVER_DIR/config.d/"
 
+# Fuzzing means ~2% of statements fail on purpose, and ClickHouse logs every one
+# of them at error level *with a full stack trace* - measured 10 MB of stderr per
+# 20 minutes (~150 MB over a 5h run) of pure noise. There is no switch for the
+# trace alone (it is baked into the message by `Exception::getStackTraceString`),
+# so raise the level instead. `fatal` keeps exactly what this job looks at: the
+# `<Fatal>` lines of a crash, and sanitizer reports, which the runtime writes
+# straight to stderr and not through the logger. Set SQLANCER_SERVER_LOG_LEVEL to
+# `warning` for a debugging run. The `zz_` prefix sorts this last in config.d so
+# it overrides the provider's own `log_level.xml`.
+cat > "$SERVER_DIR/config.d/zz_ci_log_level.xml" <<XML
+<clickhouse>
+    <logger>
+        <level>${SQLANCER_SERVER_LOG_LEVEL:-fatal}</level>
+    </logger>
+</clickhouse>
+XML
+
 echo "=== Starting ClickHouse server ==="
 ( cd "$SERVER_DIR" && exec "$CLICKHOUSE_BIN" server -P "$PID_FILE" ) 1>"$OUTPUT_PATH/clickhouse-server.log" 2>"$OUTPUT_PATH/clickhouse-server.log.err" &
 for _ in $(seq 1 60); do if [[ $(wget -q 'localhost:8123' -O- 2>/dev/null) == 'Ok.' ]]; then break ; else sleep 1; fi ; done
@@ -333,6 +350,34 @@ fi
 
 echo "=== Running SQLancer for ${TIMEOUT}s with $NUM_THREADS threads ==="
 echo "(console shows one progress line per ~5 min; full output goes to sqlancer.out)"
+
+# Finding-flood watchdog. One dominant bug can produce hundreds of reproducers -
+# every one of them also kills its worker and orphans a database, which
+# eventually drags the server down - so the rest of the budget is spent
+# re-finding the same thing. Stop once the run has surfaced enough DISTINCT
+# failures to fill a triage session; everything found so far is kept and
+# reported.
+MAX_DISTINCT_FAILURES="${SQLANCER_MAX_DISTINCT_FAILURES:-50}"
+ABORT_FLAG="$OUTPUT_PATH/aborted-on-finding-flood"
+watch_finding_flood() {
+    local counts distinct
+    while sleep 60; do
+        pgrep -f 'target/sqlancer-.*\.jar' > /dev/null || return 0
+        counts="$(python3 "$REPO_DIR/ci/jobs/scripts/sqlancer_failures.py" \
+            --logs-dir "$SQLANCER_DIR/logs/clickhouse" --out-dir "$FAILURES_PATH" --dry-run 2>/dev/null || true)"
+        distinct="$(printf '%s' "$counts" | cut -f2)"
+        case "$distinct" in ''|*[!0-9]*) continue ;; esac
+        if [ "$distinct" -ge "$MAX_DISTINCT_FAILURES" ]; then
+            echo "$distinct" > "$ABORT_FLAG"
+            echo "=== Stopping SQLancer: $distinct distinct failures reached (cap $MAX_DISTINCT_FAILURES) ==="
+            pkill -f 'target/sqlancer-.*\.jar' || true
+            return 0
+        fi
+    done
+}
+watch_finding_flood &
+FLOOD_WATCHDOG_PID=$!
+
 JAVA_EXIT=0
 # Everything sqlancer prints is kept in `$OUTPUT_FILE`; the console gets only the
 # start-up chatter and one progress line per ~5 min (sqlancer prints one every
@@ -352,6 +397,7 @@ java -jar target/sqlancer-*.jar \
     { other++; if (other <= 100) { print; fflush() } }
 ' || JAVA_EXIT=${PIPESTATUS[0]}
 
+kill "$FLOOD_WATCHDOG_PID" 2>/dev/null || true
 echo "=== SQLancer finished (exit code $JAVA_EXIT) ==="
 
 # ---------------------------------------------------------------------------
@@ -394,8 +440,13 @@ else
     SUBRESULTS_FRAGMENT="$FAILURES_PATH/subresults.json"
 fi
 echo "$FAILURE_SUMMARY"
+if [ -f "$ABORT_FLAG" ]; then
+    add_test_result "SQLancer stopped early" FAIL \
+        "stopped after $(cat "$ABORT_FLAG") distinct failures (cap $MAX_DISTINCT_FAILURES) - the remaining budget would only have re-found them"
+    FAILURE_SUMMARY="$FAILURE_SUMMARY; stopped early at the distinct-failure cap"
+fi
 if [ "$FAILURE_COUNT" -gt 0 ] && [ -f "$FAILURES_PATH/analysis.txt" ]; then
-    ATTACHED_FILES_ARRAY+=("$FAILURES_PATH/analysis.txt")
+    ATTACHED_FILES_ARRAY+=("$FAILURES_PATH/analysis.txt" "$FAILURES_PATH/findings.json")
     sed -n '/^x[0-9]/,/^Per-finding index/{/^Per-finding index/!p}' "$FAILURES_PATH/analysis.txt" | head -n 60
 fi
 
@@ -464,7 +515,7 @@ fi
 # Guard against a silently broken run: with `--print-progress-summary true`
 # sqlancer always prints the statistics block when it stops.
 QUERY_STATS="$(awk '/Overall execution statistics/,0' "$OUTPUT_FILE" | grep -m1 'queries' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//' || true)"
-if [ -z "$QUERY_STATS" ]; then
+if [ -z "$QUERY_STATS" ] && [ ! -f "$ABORT_FLAG" ]; then
     add_test_result "SQLancer statistics" ERROR "SQLancer produced no execution statistics" "$OUTPUT_FILE"
     echo " - no execution statistics in the fuzzer output"
 fi
@@ -474,7 +525,7 @@ fi
 # OOM kill shows up. Not when findings explain the non-zero exit: sqlancer exits
 # with its error code whenever a worker died on an assertion, and the analysis
 # above already says what happened.
-if [ -z "$QUERY_STATS" ] || { [ "$JAVA_EXIT" -ne 0 ] && [ "$FAILURE_COUNT" -eq 0 ]; }; then
+if [ ! -f "$ABORT_FLAG" ] && { [ -z "$QUERY_STATS" ] || { [ "$JAVA_EXIT" -ne 0 ] && [ "$FAILURE_COUNT" -eq 0 ]; }; }; then
     echo "=== last 30 lines of sqlancer.out ==="
     tail -n 30 "$OUTPUT_FILE" || true
 fi
@@ -496,6 +547,17 @@ if [ -n "$BUILD_WARNING" ]; then
     RESULT_INFO="$RESULT_INFO; WARNING: $BUILD_WARNING"
 fi
 echo "=== Summary: $OVERALL_STATUS - $RESULT_INFO ==="
+
+# Alert on NEW findings only: `sqlancer_notify.py` diffs this run's fingerprints
+# against the ones CIDB has already seen for this job and posts to Slack when
+# something is new. A no-op without SLACK_WEBHOOK_CORE_QA in the environment, and
+# never fatal - a notification problem must not change the job's verdict.
+if [ -f "$FAILURES_PATH/findings.json" ]; then
+    python3 "$REPO_DIR/ci/jobs/scripts/sqlancer_notify.py" \
+        --findings "$FAILURES_PATH/findings.json" \
+        --job-name "$JOB_NAME" \
+        --info "$RESULT_INFO" || echo "WARNING: new-finding notification failed"
+fi
 
 # ---------------------------------------------------------------------------
 # Teardown

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -220,21 +220,31 @@ MAVEN_REPO=/sqlancer/.m2
 # the world-writable /sqlancer tree so git and maven have somewhere to scribble.
 export HOME=/sqlancer
 
-# Exit code says what went wrong, because the two cases mean different things:
-#   1 - the clone did not happen (network, GitHub) - transient, not our problem
-#   2 - `main` was fetched but does not build - a real regression in the repo we
-#       are supposed to be fuzzing, and the reason the run below is not testing
-#       what this job promises
+# Exit code says what went wrong, because the cases mean different things:
+#   1 - nothing was built for a reason outside this repository: the clone failed,
+#       or maven could not reach/resolve its dependencies. Transient - warn and
+#       fall back.
+#   2 - `main` was fetched and maven ran, but the code does not compile or no jar
+#       came out. A real regression in the repository this job exists to fuzz, and
+#       the reason the run below is not testing what the job promises.
+# Maven reports both through a failed `package`, so the log decides. The patterns
+# are maven's own transport/resolution wording; anything else counts as broken code.
+MAVEN_TRANSIENT_PATTERN='Could not resolve dependencies|Could not transfer artifact|Failed to read artifact descriptor|Non-resolvable|could not be resolved|Connection (timed out|reset)|Read timed out|Connect to .* failed|status code: 5[0-9][0-9]|Unknown host|Network is unreachable'
 build_sqlancer() {
     local ref="$1" dest="$2"
     rm -rf "$dest"
     git clone --quiet --depth 1 --branch "$ref" "$SQLANCER_REPO" "$dest" || return 1
-    (
+    if ! (
         cd "$dest" &&
         mvn --no-transfer-progress -B package \
             -Dmaven.test.skip=true -Djacoco.skip=true \
             -Dmaven.repo.local="$MAVEN_REPO"
-    ) > "$SQLANCER_BUILD_LOG" 2>&1 || return 2
+    ) > "$SQLANCER_BUILD_LOG" 2>&1; then
+        if grep -qE "$MAVEN_TRANSIENT_PATTERN" "$SQLANCER_BUILD_LOG"; then
+            return 1
+        fi
+        return 2
+    fi
     compgen -G "$dest/target/sqlancer-*.jar" > /dev/null || return 2
 }
 
@@ -247,7 +257,7 @@ if [ "${SQLANCER_BUILD_AT_RUNTIME:-1}" = "1" ]; then
     if [ "$BUILD_RC" = "0" ]; then
         SQLANCER_DIR="$SQLANCER_RUN_DIR"
     elif [ "$BUILD_RC" = "1" ]; then
-        BUILD_WARNING="could not fetch $SQLANCER_REF (network?), fell back to the image's build"
+        BUILD_WARNING="could not fetch or resolve dependencies for $SQLANCER_REF (network?), fell back to the image's build"
         echo "WARNING: $BUILD_WARNING" >&2
     else
         BUILD_WARNING="$SQLANCER_REF does not build, fell back to the image's build - this run does NOT test current $SQLANCER_REF"

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -69,6 +69,11 @@ JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 1p)"
 NORMALIZED_JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 2p)"
 RESULT_FILE="$TMP_PATH/result_${NORMALIZED_JOB_NAME}.json"
 
+# Start from an empty output directory. In CI the workflow wipes `ci/tmp` before
+# every job, but a local `praktika run` reuses it, and a leftover
+# `aborted-on-finding-flood` sentinel or a stale `sqlancer.out` would be read as
+# this run's - and attached to this run's report.
+rm -rf "$OUTPUT_PATH"
 mkdir -p "$OUTPUT_PATH" "$FAILURES_PATH"
 
 # Properly JSON-escape a string using python3, outputting only the inner

--- a/ci/jobs/sqlancer_pp_job.sh
+++ b/ci/jobs/sqlancer_pp_job.sh
@@ -21,6 +21,7 @@ set -exu
 # (it calls `datetime.utcfromtimestamp(start_time)`, which fails on `None`).
 JOB_START_TIME=$(date +%s)
 
+REPO_DIR=$(readlink -f .)
 TMP_PATH=$(readlink -f ./ci/tmp/)
 OUTPUT_PATH="$TMP_PATH/sqlancer_pp_output"
 PID_FILE="$TMP_PATH/clickhouse-server.pid"
@@ -52,6 +53,43 @@ NORMALIZED_JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 2p)"
 RESULT_FILE="$TMP_PATH/result_${NORMALIZED_JOB_NAME}.json"
 
 mkdir -p "$OUTPUT_PATH"
+
+# Properly JSON-escape a string, outputting only the inner content so callers can
+# embed it in "...". A failing SQLancer++ query legitimately contains backslashes
+# and quotes; hand-rolled escaping produced result files that `json.loads`
+# rejected, and praktika then dropped the whole job result.
+json_escape() {
+    printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1], end="")'
+}
+
+# Praktika learns what happened only from the result file, and `set -e` can abort
+# the startup path below (missing jar, CREATE USER failing, server never coming
+# up) long before the real result is written - which lands the job on the generic
+# "no Result provided" error with none of the logs attached. Write a fallback on
+# any exit until the real result replaces it.
+RESULT_WRITTEN=0
+write_fallback_result() {
+    [ "$RESULT_WRITTEN" = "1" ] && return 0
+    local files_json="" f
+    for f in "$OUTPUT_PATH"/*.out "$OUTPUT_PATH"/*.err "$OUTPUT_PATH"/clickhouse-server.log*; do
+        [ -f "$f" ] || continue
+        case "$files_json" in *"\"$f\""*) continue ;; esac
+        [ -n "$files_json" ] && files_json+=", "
+        files_json+="\"$f\""
+    done
+    {
+        printf '{\n'
+        printf '  "name": "%s",\n' "$(json_escape "$JOB_NAME")"
+        printf '  "status": "ERROR",\n'
+        printf '  "start_time": %d,\n' "$JOB_START_TIME"
+        printf '  "duration": %d,\n' "$(( $(date +%s) - JOB_START_TIME ))"
+        printf '  "results": [],\n'
+        printf '  "files": [%s],\n' "$files_json"
+        printf '  "info": "SQLancer++ job terminated before running the oracles"\n'
+        printf '}\n'
+    } > "$RESULT_FILE"
+}
+trap write_fallback_result EXIT
 
 if [[ -f "$CLICKHOUSE_BIN" ]]; then
     echo "$CLICKHOUSE_BIN exists"
@@ -170,7 +208,8 @@ for ORACLE in "${ORACLES[@]}"; do
     else
         info="exit=${exit_code}"
         if [[ -n "$assertion_error" ]]; then
-            cleaned="$(printf '%s' "$assertion_error" | tr '\n' ' ' | sed 's/"/\\"/g' | cut -c1-500)"
+            # Collapse to one line only; JSON escaping happens at write time.
+            cleaned="$(printf '%s' "$assertion_error" | tr '\n' ' ' | cut -c1-500)"
             info="${info}; ${cleaned}"
         fi
         TEST_RESULTS+=("${ORACLE},FAIL,${info}")
@@ -180,6 +219,20 @@ for ORACLE in "${ORACLES[@]}"; do
 done
 
 ATTACHED_FILES_ARRAY+=("$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err")
+
+# A sanitizer report or a `<Fatal>` message is a finding even when no oracle
+# asserted - which is the whole point of the arm_asan_ubsan variant. Scanned
+# before the server is stopped, so shutdown-time leak reports do not count.
+# shellcheck source=./scripts/sqlancer_server_errors.sh
+. "$REPO_DIR/ci/jobs/scripts/sqlancer_server_errors.sh"
+SERVER_ERROR_REPORT="$OUTPUT_PATH/server-fatal.log"
+if server_error_line="$(scan_server_errors \
+        "$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err" "$SERVER_ERROR_REPORT")"; then
+    echo "Server log finding: $server_error_line"
+    TEST_RESULTS+=("Sanitizer assert or Fatal messages in server logs,FAIL,$server_error_line")
+    TEST_RESULT_FILES+=("$SERVER_ERROR_REPORT")
+    OVERALL_STATUS="FAIL"
+fi
 
 # On failure, attach the per-database reproducer logs as an artifact. With
 # `--log-each-select true` SQLancer++ writes every statement of each generated
@@ -212,7 +265,7 @@ fi
             row_files_json+="\"$f\""
         done
         printf '    {"name": "%s", "status": "%s", "files": [%s], "info": "%s"}' \
-            "$test_name" "$status" "$row_files_json" "$info"
+            "$(json_escape "$test_name")" "$status" "$row_files_json" "$(json_escape "$info")"
         if [ "$i" -lt $((${#TEST_RESULTS[@]} - 1)) ]; then
             printf ',\n'
         else
@@ -239,6 +292,7 @@ fi
     printf '  "info": ""\n'
     printf '}\n'
 } > "$RESULT_FILE"
+RESULT_WRITTEN=1
 
 ls "$OUTPUT_PATH"
 pkill clickhouse || true

--- a/ci/jobs/sqlancer_pp_job.sh
+++ b/ci/jobs/sqlancer_pp_job.sh
@@ -33,13 +33,22 @@ CLICKHOUSE_BIN="$TMP_PATH/clickhouse"
 # and drop every oracle result and attached log - the job's real FAIL/OK status
 # was written to a file Praktika never reads. `JOB_NAME` is not propagated into
 # the docker container, so read it from the serialized environment Praktika dumps.
-NORMALIZED_JOB_NAME=$(python3 -c '
+# The `name` INSIDE the file must be the job name as well: the workflow report is
+# updated via `Result.update_sub_result`, which matches this job's placeholder
+# entry by name and silently keeps the placeholder when nothing matches - which is
+# why this job showed up in the report with no status, no oracle rows and no logs,
+# and why the 2026-08-13 nightly stayed green while two oracles here had failed.
+JOB_META=$(python3 -c '
 import sys
 sys.path.insert(0, ".")
 from ci.praktika._environment import _Environment
 from ci.praktika.utils import Utils
-print(Utils.normalize_string(_Environment.get().JOB_NAME))
+name = _Environment.get().JOB_NAME
+print(name)
+print(Utils.normalize_string(name))
 ')
+JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 1p)"
+NORMALIZED_JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 2p)"
 RESULT_FILE="$TMP_PATH/result_${NORMALIZED_JOB_NAME}.json"
 
 mkdir -p "$OUTPUT_PATH"
@@ -188,7 +197,7 @@ fi
 
 {
     printf '{\n'
-    printf '  "name": "SQLancerPP",\n'
+    printf '  "name": "%s",\n' "$JOB_NAME"
     printf '  "status": "%s",\n' "$OVERALL_STATUS"
     printf '  "start_time": %d,\n' "$JOB_START_TIME"
     printf '  "duration": %d,\n' "$(( $(date +%s) - JOB_START_TIME ))"

--- a/ci/jobs/sqlancer_pp_job.sh
+++ b/ci/jobs/sqlancer_pp_job.sh
@@ -52,6 +52,9 @@ JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 1p)"
 NORMALIZED_JOB_NAME="$(printf '%s\n' "$JOB_META" | sed -n 2p)"
 RESULT_FILE="$TMP_PATH/result_${NORMALIZED_JOB_NAME}.json"
 
+# Same reason as in sqlancer_job.sh: the fallback result attaches whatever is in
+# here, which must not be a previous local run's oracle logs.
+rm -rf "$OUTPUT_PATH"
 mkdir -p "$OUTPUT_PATH"
 
 # Properly JSON-escape a string, outputting only the inner content so callers can

--- a/ci/jobs/sqlancer_pp_job.sh
+++ b/ci/jobs/sqlancer_pp_job.sh
@@ -108,8 +108,15 @@ NUM_THREADS=4
 ORACLES=( "WHERE" "NoREC" "QUERY_PARTITIONING" "FUZZING" )
 
 TEST_RESULTS=()
+# Per-TEST_RESULTS entry: the files attached to that oracle's row in the report
+# (its own stdout/stderr), so a failing oracle's log sits next to it instead of
+# only in the job-level file list.
+TEST_RESULT_FILES=()
 ATTACHED_FILES_ARRAY=()
-OVERALL_STATUS=success
+# Praktika's Result.Status tokens are uppercase (OK / FAIL / ERROR); anything
+# else - "success"/"failure" as this script used to write - is not `is_ok()` and
+# renders as "completed but unknown" in the report.
+OVERALL_STATUS=OK
 
 for ORACLE in "${ORACLES[@]}"; do
     echo "=== Oracle: $ORACLE ==="
@@ -119,7 +126,8 @@ for ORACLE in "${ORACLES[@]}"; do
 
     if [[ $(wget -q -T 1 -O- 'http://localhost:8123/' 2>/dev/null) != 'Ok.' ]]; then
         TEST_RESULTS+=("${ORACLE},ERROR,Server is not responding")
-        OVERALL_STATUS="failure"
+        TEST_RESULT_FILES+=("")
+        OVERALL_STATUS="FAIL"
         continue
     fi
 
@@ -149,6 +157,7 @@ for ORACLE in "${ORACLES[@]}"; do
 
     if [[ $exit_code -eq 0 && -z "$assertion_error" ]]; then
         TEST_RESULTS+=("${ORACLE},OK,")
+        TEST_RESULT_FILES+=("")
     else
         info="exit=${exit_code}"
         if [[ -n "$assertion_error" ]]; then
@@ -156,7 +165,8 @@ for ORACLE in "${ORACLES[@]}"; do
             info="${info}; ${cleaned}"
         fi
         TEST_RESULTS+=("${ORACLE},FAIL,${info}")
-        OVERALL_STATUS="failure"
+        TEST_RESULT_FILES+=("$stdout_file $error_output_file")
+        OVERALL_STATUS="FAIL"
     fi
 done
 
@@ -169,7 +179,7 @@ ATTACHED_FILES_ARRAY+=("$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickh
 # "Check the *-cur.log" hint points here). Only on failure, and gzip-compressed,
 # to avoid uploading a large log on clean runs.
 SQLANCER_PP_LOG_DIR="/sqlancer-pp/logs"
-if [[ "$OVERALL_STATUS" != "success" && -d "$SQLANCER_PP_LOG_DIR" ]]; then
+if [[ "$OVERALL_STATUS" != "OK" && -d "$SQLANCER_PP_LOG_DIR" ]]; then
     reproducer_archive="$OUTPUT_PATH/sqlancer_pp_reproducer_logs.tar.gz"
     if tar -C "$(dirname "$SQLANCER_PP_LOG_DIR")" -czf "$reproducer_archive" "$(basename "$SQLANCER_PP_LOG_DIR")"; then
         ATTACHED_FILES_ARRAY+=("$reproducer_archive")
@@ -186,8 +196,14 @@ fi
 
     for i in "${!TEST_RESULTS[@]}"; do
         IFS=',' read -r test_name status info <<< "${TEST_RESULTS[i]}"
-        printf '    {"name": "%s", "status": "%s", "files": [], "info": "%s"}' \
-            "$test_name" "$status" "$info"
+        row_files_json=""
+        for f in ${TEST_RESULT_FILES[i]}; do
+            [ -f "$f" ] || continue
+            [ -n "$row_files_json" ] && row_files_json+=", "
+            row_files_json+="\"$f\""
+        done
+        printf '    {"name": "%s", "status": "%s", "files": [%s], "info": "%s"}' \
+            "$test_name" "$status" "$row_files_json" "$info"
         if [ "$i" -lt $((${#TEST_RESULTS[@]} - 1)) ]; then
             printf ',\n'
         else
@@ -220,3 +236,10 @@ for _ in $(seq 1 60); do
         break
     fi
 done
+
+# Praktika derives the GitHub job conclusion from this script's exit code
+# (`res = run_code == 0` in `ci/praktika/runner.py`); the result file's status
+# only drives the HTML report. Exiting 0 on a finding is what kept this job green
+# while its report said "failure", so fail loud here.
+echo "=== Summary: $OVERALL_STATUS ==="
+[ "$OVERALL_STATUS" = "OK" ]

--- a/ci/jobs/sqlancer_pp_job.sh
+++ b/ci/jobs/sqlancer_pp_job.sh
@@ -223,12 +223,17 @@ fi
     printf '  ],\n'
     printf '  "files": ['
 
-    for i in "${!ATTACHED_FILES_ARRAY[@]}"; do
-        printf '"%s"' "${ATTACHED_FILES_ARRAY[i]}"
-        if [ "$i" -lt $((${#ATTACHED_FILES_ARRAY[@]} - 1)) ]; then
-            printf ', '
-        fi
+    # Skip files that were never created: the per-oracle logs are registered
+    # before the oracle runs, so an oracle skipped after the server died leaves
+    # none. Praktika replaces the whole job `info` with "WARNING: File [...] was
+    # not found" for each missing path, which buries the actual result.
+    files_out=""
+    for f in "${ATTACHED_FILES_ARRAY[@]}"; do
+        [ -f "$f" ] || continue
+        [ -n "$files_out" ] && files_out+=", "
+        files_out+="\"$f\""
     done
+    printf '%s' "$files_out"
 
     printf '],\n'
     printf '  "info": ""\n'

--- a/ci/workflows/nightly_sqlancer.py
+++ b/ci/workflows/nightly_sqlancer.py
@@ -1,4 +1,4 @@
-from praktika import Job, Workflow
+from praktika import Job, Secret, Workflow
 
 from ci.defs.defs import (
     BASE_BRANCH,
@@ -10,36 +10,47 @@ from ci.defs.defs import (
 )
 from ci.defs.job_configs import JobConfigs
 
-# SQLancer runs against an ASan+UBSan ClickHouse server (the long run is a good
-# place to surface memory errors and undefined behaviour), so build the
-# arm_asan_ubsan binary in this workflow to satisfy the job's `CH_ARM_ASAN_UBSAN`
-# artifact requirement.
+# Both fuzzers run against two builds, so this workflow builds both:
+#   * arm_release      - the wrong-result hunt. A sanitizer binary executes SQL
+#                        2-3x slower, so a release build explores several times
+#                        more generated SQL per hour.
+#   * arm_asan_ubsan   - memory errors and UB reached through generated SQL.
+release_build_job = Job.Config.get_job(
+    JobConfigs.release_build_jobs, f"Build ({BuildTypes.ARM_RELEASE})"
+).set_provides(ArtifactNames.CH_ARM_RELEASE, reset=True)
 asan_ubsan_build_job = Job.Config.get_job(
     JobConfigs.build_jobs, f"Build ({BuildTypes.ARM_ASAN_UBSAN})"
 ).set_provides(ArtifactNames.CH_ARM_ASAN_UBSAN, reset=True)
-
-# TODO: add alert on workflow failure
 
 workflow = Workflow.Config(
     name="NightlySQLancer",
     event=Workflow.Event.SCHEDULE,
     branches=[BASE_BRANCH],
     jobs=[
+        release_build_job,
         asan_ubsan_build_job,
         *JobConfigs.sqlancer_master_jobs,
-        # SQLancer++ shares the same arm_asan_ubsan build (it also requires
-        # CH_ARM_ASAN_UBSAN) and runs in parallel with SQLancer.
         *JobConfigs.sqlancer_pp_jobs,
     ],
     artifacts=[
         *ArtifactConfigs.clickhouse_binaries,
     ],
     dockers=DOCKERS,
-    secrets=SECRETS,
+    # `SLACK_WEBHOOK_CORE_QA` (same webhook as NightlySchemaReplay in
+    # clickhouse-private) is used by ci/jobs/scripts/sqlancer_notify.py to alert
+    # #core-team-qa-alerts about failures this job has never reported before. The
+    # job runs fine without it - the notifier just prints what it would have sent.
+    secrets=[
+        *SECRETS,
+        Secret.Config(
+            name="SLACK_WEBHOOK_CORE_QA",
+            type=Secret.Type.GH_SECRET,
+        ),
+    ],
     enable_cache=True,
     enable_report=True,
     enable_cidb=True,
-    # Every 3 days (the run itself is ~5h); day-of-month step.
+    # Every 3 days (the runs themselves are ~5h); day-of-month step.
     cron_schedules=["13 6 */3 * *"],
     pre_hooks=["python3 ./ci/jobs/scripts/workflow_hooks/store_data.py"],
 )


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Documentation entry for user-facing changes
Not user-facing.


### Description

Three fixes to the nightly SQLancer job (`NightlySQLancer`, every 3 days).

#### 1. Fuzz `ClickHouse/sqlancer` `main`, not a hardcoded commit

The image pinned `ClickHouse/sqlancer@a62ea509`, so oracle work landing in the fork never reached CI.

Pointing the Dockerfile at a branch is not enough: praktika rebuilds an image only when its directory digest changes, so a branch fetched at image-build time freezes at whatever `main` was when the Dockerfile was last edited — worse than an explicit pin, because it silently lies about what is being fuzzed. Instead:

- the image clones `main` as a **warm cache** and keeps `.git` plus the maven repository under `/sqlancer` (world-writable, so the job's non-root user can extend it);
- `sqlancer_job.sh` **re-clones and rebuilds `main` at job start** (~1 min with the warm maven repo) and falls back to the baked build if GitHub or Maven is unavailable;
- the resolved commit is printed and included in the job info, so a finding stays attributable after `main` moves.

Overrides for a one-off run: `SQLANCER_REF`, `SQLANCER_REPO`, `SQLANCER_BUILD_AT_RUNTIME=0`.

#### 2. Readable output: one artifact per finding, deduplicated

Before, the job log was ~3600 progress lines for a 5h run plus, for every finding, the whole reproducer state dump that SQLancer's `AlsoWriteToConsoleFileWriter` mirrors to stderr — impossible to read, and the reproducers were only available as one tarball of everything.

Now the console shows one progress line per ~5 minutes and a summary (~20 lines for a clean run); the full fuzzer output remains an artifact. Findings are reported individually **and** deduplicated:

- Each `logs/clickhouse/databaseN.log` is exactly one finding (`StateLogger.logException` writes the stack trace plus that database's whole `CREATE`/`INSERT`/…/`SELECT` sequence, then the worker continues under a fresh database name), so each is copied out and attached as its own artifact.
- New `ci/jobs/scripts/sqlancer_failures.py` fingerprints every finding as **(exception class + ClickHouse error code/name from the `Caused by:` chain, reporting oracle, first sqlancer stack frame)** and groups equal fingerprints.
- The report gets one row per *distinct* failure with the individual findings and their logs nested underneath, plus `failures/analysis.txt` (all families, loudest first, and a per-finding index).

The failure *message* is deliberately **not** part of the fingerprint: for most oracles it is the generated SQL, unique to every finding, which would defeat the dedup. To keep that safe, every family lists all of its occurrences by database name and up to three distinct *message shapes* (literals → `'S'`, numbers → `N`, generated identifiers such as `c0`/`t3`/`database7` → `id`), so a family that merged more than one bug is visible as such.

The job info line becomes, for example:

```
sqlancer main @ 3a66cc5ce597; 1,407k queries; 43 finding(s) in 13 distinct failure(s): PivotedQuerySynthesisBase/Code 241 x20, NoREC/Code 241 x8, TLPDistinct/AssertionError x3, ...
```

and the rows:

```
Failure analysis                                                                      [analysis.txt]
PivotedQuerySynthesisBase / AssertionError / Code 241 (MEMORY_LIMIT_EXCEEDED) / at SQLQueryAdapter.checkException:176 (x20)
   |- database0    [database0.log]
   \- ...
TLPDistinct / AssertionError / at ComparatorHelper.assumeResultSetsAreEqual:127 (x3)
   |- database48   [database48.log]
   \- ...
```

If the analysis script itself fails, the job still fails and attaches the raw reproducer logs, so a bug in it can never swallow a finding.

#### 3. A finding now marks the job failed

Praktika derives the GitHub job conclusion from the job script's **exit code** (`res = run_code == 0` in `ci/praktika/runner.py`); the result file's status only drives the HTML report. Both SQLancer scripts exited 0 unconditionally, so a finding could not turn the nightly red. They now exit non-zero whenever anything was found:

- a reproducer log;
- a sanitizer report or `<Fatal>` message in the server logs (this job runs an ASan+UBSan build) — checked before the server is stopped, so a leak report emitted during shutdown does not turn every run red;
- a dead or unreachable server;
- a non-zero sqlancer exit code;
- a run that produced no execution statistics at all (silently broken run).

`sqlancer_pp_job.sh` additionally wrote the invalid status tokens `success`/`failure` instead of `OK`/`FAIL`, which made praktika render its result as "completed but unknown". Concretely, the [2026-08-13 nightly](https://github.com/ClickHouse/ClickHouse/actions/runs/31674904130) reported **green** while the SQLancerPP job had failed on the `WHERE` and `NoREC` oracles. Its per-oracle logs are now attached to their own rows too.

### Testing

The scripts' logic was exercised directly, without a real fuzzing run:

- `ci/jobs/scripts/sqlancer_failures.py` against **43 real reproducer logs** from a saved SQLancer run: 43 findings → **13 distinct failures**, grouped the way they are actually triaged (PQS memory-limit noise x20, NoREC memory-limit x8, TLPDistinct row-count mismatch x3, TLPSetOp `UNION_DISTINCT` mismatch x1, TLPSetOp NPE x1, CODDTest Code 27 x1, …). Empty and missing log directories yield `no findings` and an empty fragment.
- `ci/jobs/sqlancer_job.sh` end to end against stubbed `java`/`wget`/`git`/`mvn`/`clickhouse` binaries: clean run → `OK`, exit 0, 18 console lines; run with findings → `FAIL`, exit 1, 36 console lines and valid nested result JSON; UBSan `runtime error:` → `FAIL` while benign ASan boilerplate stays `OK`; server death, sqlancer crash, missing statistics, runtime-build failure (falls back with a warning), the 50-file upload cap, >10 MB log compression and a deliberately broken analysis script all behave as described.

The real verification is the next nightly run of this workflow.


### CI validation (2026-08-14)

Validated by dispatching `NightlySQLancer` twice from a throwaway branch on top of this one (short fuzz runs; branch deleted since).

**[Run 31825081436](https://github.com/ClickHouse/ClickHouse/actions/runs/31825081436) — clean path, 20 min fuzz.** Workflow conclusion `failure`, driven by SQLancerPP (see below).

- Docker image with the new Dockerfile built (by this PR's own CI) and reused from the registry here.
- Runtime clone + rebuild of `ClickHouse/sqlancer` `main`: **11 s**, commit `3a66cc5ce597`, no fallback (the warm maven repo in the image is doing its job).
- **93 oracles** exercised, versus 31 with the old pinned commit.
- 4 progress lines on the console for the whole fuzz run; job info `sqlancer main @ 3a66cc5ce597; 56k queries; no findings`; exit 0, job green.
- The job's report entry is populated for the first time: status `OK`, `duration: 1243`, the info line and 5 artifact links. For comparison, the same entry in the [2026-08-13 nightly](https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/45cb8371bbe63a39f7d0c655543563e8f15e5a40/result_nightlysqlancer.json) is `{"results": [], "links": [], "duration": null}`.
- SQLancerPP went `failure` with per-oracle rows (`WHERE`, `QUERY_PARTITIONING` assertions; `FUZZING` → server not responding), each with its logs — and the **workflow status became `FAIL`**. The identical failure reported green on 2026-08-13.

**[Run 31830811184](https://github.com/ClickHouse/ClickHouse/actions/runs/31830811184) — failure path, 15 min fuzz** with `TextIndexDirectRead` re-included, since it reliably fires on the open ClickHouse#107186.

- **37 findings deduplicated into 1 distinct failure**: `TextIndexDirectRead / java.lang.AssertionError / at ClickHouseTextIndexDirectReadOracle.check:95 (x37)`, one report row listing all 37 databases with 10 reproducer logs attached, plus the `Failure analysis` row with `analysis.txt`.
- `analysis.txt` per-finding index carries the full assertion for each one (`ClickHouse#107186`, tokenizer, preprocessor, predicate, the diverging key sets and the DDL).
- A downloaded reproducer (`database0.log`, 2035 lines) starts with the assertion plus stack trace and ends with the exact `CREATE TABLE ... INDEX idx (s) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(s))` + `INSERT` that reproduces it.
- Job info `39k queries; 37 finding(s) in 1 distinct failure(s)`, job red, workflow `FAIL`.

Two fixes came out of this validation and are included: the result-name bug above, and `SQLancerPP` no longer listing per-oracle logs that were never written (praktika replaces the whole job `info` with `WARNING: File [...] was not found`, which buried the result).

One observation, not addressed here: the ASan+UBSan server writes ~10 MB of `DB::Exception` stack traces to stderr per 20 minutes (~150 MB projected over 5 h), from logging every failed fuzzer statement at error level. Dropping the mounted `log_level.xml` to `fatal` would remove it while keeping `<Fatal>` and sanitizer detection intact.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.55` (included in `26.9` and later)
<!-- ch-version-info:end -->