### PR TITLE
Prometheus HTTP API: implement /api/v1/label/<name>/values

### DIFF
--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil-antlr.cpp
@@ -1082,4 +1082,68 @@ bool PrometheusQueryParsingUtil::tryParseQuery([[maybe_unused]] std::string_view
 
 }
 
+bool PrometheusQueryParsingUtil::tryParseMetricSelector(
+    [[maybe_unused]] std::string_view input,
+    [[maybe_unused]] UInt32 timestamp_scale,
+    [[maybe_unused]] PrometheusQueryTree & res_selector,
+    [[maybe_unused]] String * error_message,
+    [[maybe_unused]] size_t * error_pos)
+{
+#if USE_ANTLR4_GRAMMARS
+    ErrorListener error_listener{input};
+    antlr4::ANTLRInputStream input_stream{input};
+
+    PromQLLexerBailingOutOnError promql_lexer{&input_stream, input, error_listener};
+    promql_lexer.removeErrorListeners();
+    promql_lexer.addErrorListener(&error_listener);
+
+    antlr4::CommonTokenStream token_stream{&promql_lexer};
+
+    antlr4_grammars::PromQLParser promql_parser{&token_stream};
+    promql_parser.removeErrorListeners();
+    promql_parser.addErrorListener(&error_listener);
+
+    antlr4_grammars::PromQLParser::InstantSelectorContext * selector = nullptr;
+    if (!error_listener.hasError())
+        selector = promql_parser.instantSelector();
+
+    if (!selector)
+        error_listener.setError("Couldn't get a metric selector after parsing promql query", 0);
+    else if (!error_listener.hasError() && token_stream.LA(1) != antlr4::Token::EOF)
+    {
+        auto * next_token = token_stream.LT(1);
+        const size_t token_pos = next_token
+            ? convertCodePointPositionToByteOffset(input, next_token->getStartIndex())
+            : input.size();
+        error_listener.setError("Unexpected input after metric selector", token_pos);
+    }
+
+    PrometheusQueryTreeBuilder builder{input, timestamp_scale, error_listener};
+    std::vector<std::unique_ptr<Node>> parsed_nodes;
+    Node * parsed_root = nullptr;
+    if (selector && !error_listener.hasError())
+    {
+        parsed_root = builder.makeNode(selector);
+        parsed_nodes = builder.extractNodes();
+    }
+
+    if (error_listener.hasError())
+    {
+        if (error_message)
+            *error_message = error_listener.getErrorMessage();
+        if (error_pos)
+            *error_pos = error_listener.getErrorPos();
+        return false;
+    }
+
+    if (!parsed_root)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Parsing promql metric selector '{}' failed without setting any error message", input);
+
+    res_selector = PrometheusQueryTree{std::move(parsed_nodes), parsed_root, timestamp_scale};
+    return true;
+#else
+    throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "ANTLR4 support is disabled");
+#endif
+}
+
 }

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
@@ -1,12 +1,22 @@
 #include <Common/StringUtils.h>
 #include <Parsers/Prometheus/PrometheusQueryParsingUtil.h>
 
+#include <Common/DateLUT.h>
+#include <Common/DateLUTImpl.h>
 #include <Common/UTF8Helpers.h>
 #include <Common/quoteString.h>
+#include <Core/DecimalFunctions.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/readDecimalText.h>
 #include <IO/readIntText.h>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
 
 
 namespace DB
@@ -347,12 +357,291 @@ namespace
 
     using ScalarType = PrometheusQueryParsingUtil::ScalarType;
     using TimestampType = PrometheusQueryParsingUtil::TimestampType;
+    using RequestTimestampType = PrometheusQueryParsingUtil::RequestTimestampType;
     using DurationType = PrometheusQueryParsingUtil::DurationType;
+
+    bool tryParsePrometheusRequestTimestampFloat(std::string_view input, Float64 & result)
+    {
+        if (input.empty() || input.find_first_of(" \t\n\r\f\v") != std::string_view::npos)
+            return false;
+
+        size_t number_start = 0;
+        if (input[number_start] == '+' || input[number_start] == '-')
+            ++number_start;
+        if (number_start >= input.size())
+            return false;
+
+        const bool is_hex = number_start + 2 <= input.size()
+            && input[number_start] == '0'
+            && (input[number_start + 1] == 'x' || input[number_start + 1] == 'X');
+        if (is_hex && input.find_first_of("pP", number_start + 2) == std::string_view::npos)
+            return false;
+
+        const String normalized = is_hex
+            ? removeUnderscoresBetweenDigits<true>(input)
+            : removeUnderscoresBetweenDigits<false>(input);
+
+        if (is_hex)
+        {
+            char * end = nullptr;
+            result = std::strtod(normalized.c_str(), &end);
+            if (end != normalized.data() + normalized.size())
+                return false;
+        }
+        else if (!tryParse(result, normalized))
+        {
+            return false;
+        }
+
+        return std::isfinite(result);
+    }
+
+    bool isPrometheusRequestTimestampNumber(std::string_view input)
+    {
+        Float64 result = 0;
+        return tryParsePrometheusRequestTimestampFloat(input, result);
+    }
+
+    bool isValidRFC3339Date(UInt32 year, UInt32 month, UInt32 day)
+    {
+        if (month == 0 || month > 12 || day == 0)
+            return false;
+
+        UInt32 days_in_month = 31;
+        switch (month)
+        {
+            case 4:
+            case 6:
+            case 9:
+            case 11:
+                days_in_month = 30;
+                break;
+            case 2:
+                days_in_month = 28;
+                if ((year % 400 == 0) || (year % 100 != 0 && year % 4 == 0))
+                    ++days_in_month;
+                break;
+            default:
+                break;
+        }
+
+        return day <= days_in_month;
+    }
+
+    bool tryParseFloatInteger(Float64 input, Int128 & result)
+    {
+        std::array<char, 512> buffer{};
+        const auto [end, error] = std::to_chars(
+            buffer.data(), buffer.data() + buffer.size(), input, std::chars_format::fixed, /* precision */ 0);
+        if (error != std::errc())
+            return false;
+
+        return tryParseInt(result, std::string_view(buffer.data(), end - buffer.data()));
+    }
+
+    /// Parse a numeric HTTP timestamp through the same Float64 -> fractional milliseconds path as
+    /// Prometheus' parseTime. Keep the result in Decimal128 after rounding so range validation can
+    /// still distinguish values outside the storage domain before converting them to its timestamp type.
+    bool tryParsePrometheusRequestTimestampNumber(
+        std::string_view input, UInt32 timestamp_scale, RequestTimestampType & result)
+    {
+        Float64 timestamp = 0;
+        if (!tryParsePrometheusRequestTimestampFloat(input, timestamp))
+            return false;
+
+        Float64 whole_seconds_float = 0;
+        const Float64 fractional_seconds = std::modf(timestamp, &whole_seconds_float);
+        const auto rounded_milliseconds = static_cast<Int64>(std::round(fractional_seconds * 1000));
+
+        Int128 whole_seconds = 0;
+        if (!tryParseFloatInteger(whole_seconds_float, whole_seconds))
+            return false;
+
+        Int64 milliseconds = rounded_milliseconds;
+        if (milliseconds == 1000)
+        {
+            if (whole_seconds == std::numeric_limits<Int128>::max())
+                return false;
+            ++whole_seconds;
+            milliseconds = 0;
+        }
+        else if (milliseconds == -1000)
+        {
+            if (whole_seconds == std::numeric_limits<Int128>::min())
+                return false;
+            --whole_seconds;
+            milliseconds = 0;
+        }
+
+        const auto scale_multiplier = DecimalUtils::scaleMultiplier<Int128>(timestamp_scale);
+        Int128 scaled_milliseconds = milliseconds;
+        if (timestamp_scale > 3)
+            scaled_milliseconds *= DecimalUtils::scaleMultiplier<Int128>(timestamp_scale - 3);
+        else if (timestamp_scale < 3)
+            scaled_milliseconds /= DecimalUtils::scaleMultiplier<Int128>(3 - timestamp_scale);
+
+        return DecimalUtils::tryMultiplyAdd(
+            whole_seconds, scale_multiplier, scaled_milliseconds, result.value);
+    }
+
+    /// Prometheus accepts these two values as special cases because Go's RFC3339 parser only accepts
+    /// four-digit years. Keep the same wire forms and represent them in the request timestamp scale;
+    /// appendTimeRangeConditions() will clip them to the actual TimeSeries storage domain later.
+    constexpr std::string_view prometheus_min_time_string = "-292273086-05-16T16:47:06Z";
+    constexpr std::string_view prometheus_max_time_string = "292277025-08-18T07:12:54.999999999Z";
+    constexpr Int128 prometheus_min_time_seconds
+        = static_cast<Int128>(std::numeric_limits<Int64>::min()) / 1000 + 62135596801;
+    constexpr Int128 prometheus_max_time_seconds
+        = static_cast<Int128>(std::numeric_limits<Int64>::max()) / 1000 - 62135596801;
+
+    bool tryParsePrometheusRequestTimestampBoundary(
+        std::string_view input, UInt32 timestamp_scale, RequestTimestampType & result)
+    {
+        Int128 seconds = 0;
+        UInt32 nanoseconds = 0;
+        if (input == prometheus_min_time_string)
+        {
+            seconds = prometheus_min_time_seconds;
+        }
+        else if (input == prometheus_max_time_string)
+        {
+            seconds = prometheus_max_time_seconds;
+            nanoseconds = 999'999'999;
+        }
+        else
+        {
+            return false;
+        }
+
+        const auto scale_multiplier = DecimalUtils::scaleMultiplier<Int128>(timestamp_scale);
+        Int128 fractional = nanoseconds;
+        if (timestamp_scale > 9)
+            fractional *= DecimalUtils::scaleMultiplier<Int128>(timestamp_scale - 9);
+        else if (timestamp_scale < 9)
+            fractional /= DecimalUtils::scaleMultiplier<Int128>(9 - timestamp_scale);
+
+        result.value = seconds * scale_multiplier + fractional;
+        return true;
+    }
+
+    /// Parse the RFC3339 form accepted by time.Parse(time.RFC3339Nano, ...). The
+    /// DateTime parser has useful calendar validation and UTC conversion, but accepts many
+    /// ClickHouse-specific forms such as date-only and space-separated timestamps. Validate the
+    /// wire grammar here before using DateLUT for the calendar conversion.
+    bool tryParsePrometheusRFC3339Timestamp(
+        std::string_view input, UInt32 timestamp_scale, RequestTimestampType & result)
+    {
+        if (tryParsePrometheusRequestTimestampBoundary(input, timestamp_scale, result))
+            return true;
+
+        constexpr size_t date_time_prefix_size = 19; /// YYYY-MM-DDTHH:MM:SS
+        if (input.size() <= date_time_prefix_size)
+            return false;
+
+        const auto is_digit = [](char c) { return c >= '0' && c <= '9'; };
+        for (size_t i : {0uz, 1uz, 2uz, 3uz, 5uz, 6uz, 8uz, 9uz, 11uz, 12uz, 14uz, 15uz, 17uz, 18uz})
+        {
+            if (!is_digit(input[i]))
+                return false;
+        }
+
+        if (input[4] != '-' || input[7] != '-' || input[10] != 'T' || input[13] != ':' || input[16] != ':')
+            return false;
+
+        const auto read_two_digits = [&](size_t pos)
+        {
+            return static_cast<UInt32>((input[pos] - '0') * 10 + input[pos + 1] - '0');
+        };
+
+        const UInt32 year = static_cast<UInt32>((input[0] - '0') * 1000 + (input[1] - '0') * 100 + (input[2] - '0') * 10 + input[3] - '0');
+        const UInt32 month = read_two_digits(5);
+        const UInt32 day = read_two_digits(8);
+        const UInt32 hour = read_two_digits(11);
+        const UInt32 minute = read_two_digits(14);
+        const UInt32 second = read_two_digits(17);
+
+        /// Match time.Parse's range checks for the local clock and calendar fields. Go accepts
+        /// offsets up to 24:60, so retain that behavior here too.
+        if (!isValidRFC3339Date(year, month, day) || hour >= 24 || minute >= 60 || second >= 60)
+            return false;
+
+        size_t pos = date_time_prefix_size;
+        size_t fraction_start = pos;
+        size_t fraction_end = pos;
+        if (input[pos] == '.' || input[pos] == ',')
+        {
+            fraction_start = ++pos;
+            while (pos < input.size() && is_digit(input[pos]))
+                ++pos;
+            if (pos == fraction_start)
+                return false;
+            fraction_end = pos;
+        }
+
+        UInt32 offset_hours = 0;
+        UInt32 offset_minutes = 0;
+        bool negative_offset = false;
+        if (pos < input.size() && input[pos] == 'Z')
+        {
+            ++pos;
+        }
+        else if (pos < input.size() && (input[pos] == '+' || input[pos] == '-'))
+        {
+            negative_offset = input[pos] == '-';
+            if (input.size() != pos + 6 || !is_digit(input[pos + 1]) || !is_digit(input[pos + 2]) || input[pos + 3] != ':'
+                || !is_digit(input[pos + 4]) || !is_digit(input[pos + 5]))
+                return false;
+
+            offset_hours = read_two_digits(pos + 1);
+            offset_minutes = read_two_digits(pos + 4);
+            if (offset_hours > 24 || offset_minutes > 60)
+                return false;
+            pos += 6;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (pos != input.size())
+            return false;
+
+        const auto seconds_since_epoch = DateLUT::instance("UTC").tryToMakeDateTime(
+            static_cast<Int16>(year),
+            static_cast<UInt8>(month),
+            static_cast<UInt8>(day),
+            static_cast<UInt8>(hour),
+            static_cast<UInt8>(minute),
+            static_cast<UInt8>(second));
+        if (!seconds_since_epoch)
+            return false;
+
+        Int128 utc_seconds = static_cast<Int128>(*seconds_since_epoch);
+        const Int128 offset_seconds = static_cast<Int128>(offset_hours) * 3600 + static_cast<Int128>(offset_minutes) * 60;
+        if (negative_offset)
+            utc_seconds += offset_seconds;
+        else
+            utc_seconds -= offset_seconds;
+
+        const auto scale_multiplier = DecimalUtils::scaleMultiplier<Int128>(timestamp_scale);
+        Int128 fractional = 0;
+        const size_t fraction_digits = fraction_end - fraction_start;
+        const size_t retained_fraction_digits = std::min({fraction_digits, size_t(9), static_cast<size_t>(timestamp_scale)});
+        for (size_t i = 0; i < retained_fraction_digits; ++i)
+            fractional = fractional * 10 + (input[fraction_start + i] - '0');
+        if (retained_fraction_digits < timestamp_scale)
+            fractional *= DecimalUtils::scaleMultiplier<Int128>(timestamp_scale - static_cast<UInt32>(retained_fraction_digits));
+
+        result.value = utc_seconds * scale_multiplier + fractional;
+        return true;
+    }
 
     template <typename T>
     std::string_view getTypeName()
     {
         if constexpr (std::is_same_v<T, TimestampType>)
+            return "timestamp";
+        else if constexpr (std::is_same_v<T, RequestTimestampType>)
             return "timestamp";
         else if constexpr (std::is_same_v<T, DurationType>)
             return "duration";
@@ -711,6 +1000,25 @@ bool PrometheusQueryParsingUtil::tryParseTimestamp(
     std::string_view input, UInt32 timestamp_scale, TimestampType & res_timestamp, String * error_message, size_t * error_pos)
 {
     return tryParseNumber(input, timestamp_scale, res_timestamp, error_message, error_pos);
+}
+
+bool PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(
+    std::string_view input,
+    UInt32 timestamp_scale,
+    RequestTimestampType & res_timestamp,
+    String * error_message,
+    size_t * error_pos)
+{
+    if (isPrometheusRequestTimestampNumber(input)
+        && tryParsePrometheusRequestTimestampNumber(input, timestamp_scale, res_timestamp))
+        return true;
+
+    if (tryParsePrometheusRFC3339Timestamp(input, timestamp_scale, res_timestamp))
+        return true;
+
+    setErrorMessage(error_message, "Cannot parse Prometheus HTTP API timestamp {}", quoteString(input));
+    setErrorPos(error_pos, 0);
+    return false;
 }
 
 bool PrometheusQueryParsingUtil::tryParseDuration(

--- a/src/Parsers/Prometheus/PrometheusQueryParsingUtil.h
+++ b/src/Parsers/Prometheus/PrometheusQueryParsingUtil.h
@@ -13,7 +13,16 @@ struct PrometheusQueryParsingUtil
 {
     using ScalarType = Float64;
     using TimestampType = DateTime64;
+    using RequestTimestampType = Decimal128;
     using DurationType = Decimal64;
+
+    /// Parses a Prometheus metric selector, without accepting general PromQL expressions.
+    /// Scale `timestamp_scale` is used to parse decimals representing timestamps and durations.
+    static bool tryParseMetricSelector(std::string_view input,
+                                       UInt32 timestamp_scale,
+                                       PrometheusQueryTree & res_selector,
+                                       String * error_message = nullptr,
+                                       size_t * error_pos = nullptr);
 
     /// Parses a prometheus query.
     /// Scale `timestamp_scale` is used to parse decimals representing timestamps and durations.
@@ -47,6 +56,17 @@ struct PrometheusQueryParsingUtil
                                   TimestampType & res_timestamp,
                                   String * error_message = nullptr,
                                   size_t * error_pos = nullptr);
+
+    /// Parses an HTTP API timestamp in a wider representation. The finite numeric form follows
+    /// Prometheus' strconv.ParseFloat grammar, including decimal underscores and hexadecimal
+    /// floating-point values, and is rounded to milliseconds; the other accepted form is strict
+    /// RFC3339Nano. The wider representation is useful when the request value must be compared with
+    /// a storage timestamp domain before converting it to DateTime64.
+    static bool tryParsePrometheusRequestTimestamp(std::string_view input,
+                                                   UInt32 timestamp_scale,
+                                                   RequestTimestampType & res_timestamp,
+                                                   String * error_message = nullptr,
+                                                   size_t * error_pos = nullptr);
 
     /// Parses a timestamp which can be either an integer or floating-point number of seconds,
     /// or a hexadecimal number of seconds, or a duration with time units.

--- a/src/Parsers/Prometheus/PrometheusQueryTree.cpp
+++ b/src/Parsers/Prometheus/PrometheusQueryTree.cpp
@@ -421,6 +421,11 @@ bool PrometheusQueryTree::tryParse(std::string_view promql_query_, UInt32 timest
     return PrometheusQueryParsingUtil::tryParseQuery(promql_query_, timestamp_scale_, *this, error_message_, error_pos_);
 }
 
+bool PrometheusQueryTree::tryParseMetricSelector(std::string_view selector_, UInt32 timestamp_scale_, String * error_message_, size_t * error_pos_)
+{
+    return PrometheusQueryParsingUtil::tryParseMetricSelector(selector_, timestamp_scale_, *this, error_message_, error_pos_);
+}
+
 
 String PrometheusQueryTree::Scalar::toString(const PrometheusQueryTree &) const
 {

--- a/src/Parsers/Prometheus/PrometheusQueryTree.h
+++ b/src/Parsers/Prometheus/PrometheusQueryTree.h
@@ -249,6 +249,11 @@ public:
     /// If it isn't successful the function sets `error_pos` and `error_message` and returns false.
     bool tryParse(std::string_view promql_query_, UInt32 timestamp_scale_ = 3, String * error_message_ = nullptr, size_t * error_pos_ = nullptr);
 
+    /// Tries to parse a Prometheus metric selector without accepting general PromQL expressions.
+    /// If it isn't successful the function sets `error_pos` and `error_message` and returns false.
+    bool tryParseMetricSelector(
+        std::string_view selector_, UInt32 timestamp_scale_ = 3, String * error_message_ = nullptr, size_t * error_pos_ = nullptr);
+
     bool empty() const { return node_list.empty(); }
     size_t size() const { return node_list.size(); }
 

--- a/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PromQLParser.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <Parsers/Prometheus/PrometheusQueryParsingUtil.h>
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
 
 #include <fmt/format.h>
@@ -98,6 +99,60 @@ TEST(PromQLParser, InvalidQuotedSelectorIdentifiers)
         size_t error_pos = 0;
         EXPECT_FALSE(query_tree.tryParse(query, 3, &error_message, &error_pos)) << query;
         EXPECT_FALSE(error_message.empty()) << query;
+    }
+}
+
+
+TEST(PromQLParser, PrometheusRequestTimestampDecimalSyntax)
+{
+    for (const auto * const timestamp : {"1.2.3", "1..0", "..1"})
+    {
+        PrometheusQueryParsingUtil::RequestTimestampType parsed_timestamp;
+        String error_message;
+        size_t error_pos = 0;
+        EXPECT_FALSE(PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(
+            timestamp, 3, parsed_timestamp, &error_message, &error_pos))
+            << timestamp;
+    }
+
+    for (const auto * const timestamp : {"1e3", "1.5e3", "1e+3", "1e-3"})
+    {
+        PrometheusQueryParsingUtil::RequestTimestampType parsed_timestamp;
+        String error_message;
+        size_t error_pos = 0;
+        EXPECT_TRUE(PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(
+            timestamp, 3, parsed_timestamp, &error_message, &error_pos))
+            << timestamp << ": " << error_message;
+    }
+}
+
+
+TEST(PromQLParser, MetricSelectorParsing)
+{
+    for (const auto * const selector : {"cpu_usage", R"({host="server1"})", R"(cpu_usage{host="server1"})"})
+    {
+        PrometheusQueryTree query_tree;
+        String error_message;
+        size_t error_pos = 0;
+        EXPECT_TRUE(query_tree.tryParseMetricSelector(selector, 3, &error_message, &error_pos))
+            << selector << ": " << error_message;
+        ASSERT_NE(query_tree.getRoot(), nullptr);
+        EXPECT_EQ(query_tree.getRoot()->node_type, PrometheusQueryTree::NodeType::InstantSelector);
+    }
+
+    for (const auto * const selector : {
+             "(cpu_usage)",
+             R"(((cpu_usage{host="server1"})))",
+             "cpu_usage[5m]",
+             "cpu_usage offset 5m",
+             "cpu_usage @ 1700000000",
+             "sum(cpu_usage)"})
+    {
+        PrometheusQueryTree query_tree;
+        String error_message;
+        size_t error_pos = 0;
+        EXPECT_FALSE(query_tree.tryParseMetricSelector(selector, 3, &error_message, &error_pos)) << selector;
+        EXPECT_FALSE(error_message.empty()) << selector;
     }
 }
 

--- a/src/Parsers/Prometheus/tests/gtest_PrometheusQueryParsingUtil.cpp
+++ b/src/Parsers/Prometheus/tests/gtest_PrometheusQueryParsingUtil.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include <Parsers/Prometheus/PrometheusQueryParsingUtil.h>
+
+#include <limits>
+
+using namespace DB;
+
+namespace
+{
+PrometheusQueryParsingUtil::RequestTimestampType parseRequestTimestamp(std::string_view input)
+{
+    PrometheusQueryParsingUtil::RequestTimestampType result{0};
+    String error_message;
+    size_t error_pos = 0;
+    EXPECT_TRUE(PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(
+        input, 9, result, &error_message, &error_pos))
+        << input << ": " << error_message << " at position " << error_pos;
+    return result;
+}
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampAcceptsStrictHttpForms)
+{
+    EXPECT_EQ(parseRequestTimestamp("1000").value, static_cast<Int128>(1000'000'000'000LL));
+    EXPECT_EQ(parseRequestTimestamp("1970-01-01T00:16:40Z").value, static_cast<Int128>(1000'000'000'000LL));
+    EXPECT_EQ(parseRequestTimestamp("1970-01-01T01:16:40.123456789+01:00").value, static_cast<Int128>(1000'123'456'789LL));
+    EXPECT_EQ(parseRequestTimestamp("1970-01-01T00:16:40,123Z").value, static_cast<Int128>(1000'123'000'000LL));
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampAcceptsGoFloatSyntax)
+{
+    EXPECT_EQ(parseRequestTimestamp("1_000").value, static_cast<Int128>(1000'000'000'000LL));
+    EXPECT_EQ(parseRequestTimestamp("0x1p4").value, static_cast<Int128>(16'000'000'000LL));
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampRoundsNumericValuesToMilliseconds)
+{
+    EXPECT_EQ(parseRequestTimestamp("1000.9994").value, static_cast<Int128>(1000'999'000'000LL));
+    EXPECT_EQ(parseRequestTimestamp("1000.9996").value, static_cast<Int128>(1001'000'000'000LL));
+    EXPECT_EQ(parseRequestTimestamp("-0.9996").value, static_cast<Int128>(-1'000'000'000LL));
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampMatchesFloat64RoundingAtHalfMillisecondBoundaries)
+{
+    constexpr Int128 base = static_cast<Int128>(1'700'000'000'000'000'000LL);
+    EXPECT_EQ(parseRequestTimestamp("1700000000.0004999").value, base);
+    EXPECT_EQ(parseRequestTimestamp("1700000000.0005000").value, base);
+    EXPECT_EQ(parseRequestTimestamp("1700000000.0005001").value, base + 1'000'000);
+
+    EXPECT_EQ(parseRequestTimestamp("-1700000000.0004999").value, -base);
+    EXPECT_EQ(parseRequestTimestamp("-1700000000.0005000").value, -base);
+    EXPECT_EQ(parseRequestTimestamp("-1700000000.0005001").value, -base - 1'000'000);
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampAcceptsPrometheusTimeBounds)
+{
+    const Int128 min_time_seconds = static_cast<Int128>(std::numeric_limits<Int64>::min()) / 1000 + 62135596801;
+    const Int128 max_time_seconds = static_cast<Int128>(std::numeric_limits<Int64>::max()) / 1000 - 62135596801;
+    constexpr Int128 scale = 1'000'000'000;
+
+    EXPECT_EQ(
+        parseRequestTimestamp("-292273086-05-16T16:47:06Z").value,
+        min_time_seconds * scale);
+    EXPECT_EQ(
+        parseRequestTimestamp("292277025-08-18T07:12:54.999999999Z").value,
+        max_time_seconds * scale + 999'999'999);
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampValidatesRFC3339CalendarDates)
+{
+    for (const auto *const input : {
+             "2023-02-29T00:00:00Z",
+             "2024-02-30T00:00:00Z",
+             "2024-04-31T00:00:00Z",
+             "2024-06-31T00:00:00Z",
+             "2024-09-31T00:00:00Z",
+             "2024-11-31T00:00:00Z",
+             "2024-00-01T00:00:00Z",
+             "2024-13-01T00:00:00Z",
+             "2024-01-00T00:00:00Z",
+             "0000-02-30T00:00:00Z",
+         })
+    {
+        PrometheusQueryParsingUtil::RequestTimestampType result;
+        EXPECT_FALSE(PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(input, 9, result)) << input;
+    }
+
+    for (const auto *const input : {
+             "2023-02-28T00:00:00Z",
+             "2024-02-29T00:00:00Z",
+             "2024-04-30T00:00:00Z",
+             "0000-02-29T00:00:00Z",
+             "9999-12-31T23:59:59Z",
+         })
+    {
+        PrometheusQueryParsingUtil::RequestTimestampType result;
+        String error_message;
+        size_t error_pos = 0;
+        EXPECT_TRUE(PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(
+            input, 9, result, &error_message, &error_pos))
+            << input << ": " << error_message << " at position " << error_pos;
+    }
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampAcceptsFloatUnderflowAsZero)
+{
+    EXPECT_EQ(parseRequestTimestamp("1e-4000").value, 0);
+    EXPECT_EQ(parseRequestTimestamp("-1e-4000").value, 0);
+}
+
+TEST(PromQLParser, PrometheusRequestTimestampRejectsNonHttpForms)
+{
+    for (const auto *const input : {
+             "5m",
+             "0x10",
+             "1970-01-01",
+             "1970-01-01 00:16:40",
+             "1970-01-01T00:16:40",
+             "1970-01-01T00:16:40+0100",
+         })
+    {
+        PrometheusQueryParsingUtil::RequestTimestampType result;
+        EXPECT_FALSE(PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(input, 9, result));
+    }
+}

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -786,13 +786,13 @@ void prepareBuildQueryPlanForTableExpression(const QueryTreeNodePtr & table_expr
       * We do not check access rights for table functions because they have been already checked in ITableFunction::execute().
       */
     NameSet columns_names_allowed_to_select;
-    if (table_node)
+    if (!select_query_options.ignore_access_check && table_node)
     {
         const auto & column_names_with_aliases = table_expression_data.getSelectedColumnsNames();
         columns_names_allowed_to_select = checkAccessRights(
             table_node->getStorage(), table_node->getStorageID(), table_node->getStorageSnapshot(), column_names_with_aliases, query_context);
     }
-    else if (table_function_node)
+    else if (!select_query_options.ignore_access_check && table_function_node)
     {
         /// A parameterized view is resolved as a `TableFunctionNode` that wraps a real `StorageView`, but no
         /// `ITableFunction::execute` runs for it, so the access check skipped above for regular table functions
@@ -806,7 +806,9 @@ void prepareBuildQueryPlanForTableExpression(const QueryTreeNodePtr & table_expr
                 storage, table_function_node->getStorageID(), table_function_node->getStorageSnapshot(), column_names_with_aliases, query_context);
         }
     }
-    else if ((query_node || union_node) && select_query_options.check_subquery_table_access)
+    else if (!select_query_options.ignore_access_check
+        && (query_node || union_node)
+        && select_query_options.check_subquery_table_access)
     {
         /// Check permissions for all tables referenced in the subquery.
         /// This is needed because in only_analyze mode, subqueries are not recursively planned,

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -592,11 +592,12 @@ public:
             }
             else if (auto label_name = extractLabelValuesName(uri_path))
             {
-                String match = params->get("match[]", "");
+                Strings match = params->getAll("match[]");
                 String start = params->get("start", "");
                 String end = params->get("end", "");
+                UInt64 limit = getLimitParam();
 
-                protocol.getLabelValues(getOutputStream(response), *label_name, match, start, end);
+                protocol.getLabelValues(getOutputStream(response), *label_name, match, start, end, limit, query_finish_callback);
             }
             else
             {

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -32,12 +32,14 @@
 #include <Server/HTTP/authenticateUserByHTTP.h>
 #include <Server/HTTP/checkHTTPHeader.h>
 #include <Server/HTTP/setReadOnlyIfHTTPMethodIdempotent.h>
+#include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Core/Settings.h>
 #include <Storages/TimeSeries/PrometheusRemoteReadProtocol.h>
 #include <Storages/TimeSeries/PrometheusRemoteWriteProtocol.h>
 #include <Storages/TimeSeries/PrometheusHTTPProtocolAPI.h>
+#include <Storages/StorageTimeSeries.h>
 
 
 namespace DB
@@ -439,32 +441,36 @@ public:
 
     bool isSettingLikeParameter(const String & name) override
     {
-        /// Empty parameter appears when URL like ?&a=b or a=b&&c=d. Just skip them for user's convenience.
-        if (name.empty())
+        /// Start from the generic exclusions applied by `ImplWithContext` (`user`, `password`, `quota_key`,
+        /// `stacktrace`, `role`, `query_id`, `database`, `table`): `makeContext` gives them the shared HTTP
+        /// semantics (roles, query id, ...), so they must not fail as unknown settings here.
+        if (!ImplWithContext::isSettingLikeParameter(name))
             return false;
 
-        /// Some parameters (default_format, everything used in the code above) do not belong to the
-        /// Settings class. `limit` is defined by Prometheus on these endpoints, so it must not fall through to the ClickHouse setting.
-        static const NameSet reserved_param_names{"user", "password", "query", "time", "start", "end", "step", "match[]", "limit", "limit_per_metric", "metric", "lookback_delta", "database", "table"};
+        /// Additionally reserve the Prometheus HTTP API parameters consumed by these endpoints.
+        /// Prometheus defines `limit` on these endpoints, so it must not fall through to ClickHouse's
+        /// generic `limit` setting.
+        static const NameSet reserved_param_names{"query", "time", "start", "end", "step", "match[]", "limit", "limit_per_metric", "metric", "lookback_delta"};
         return !reserved_param_names.contains(name);
     }
 
-    /// Parses the optional `limit` parameter of the metadata endpoints: the maximum number of returned items,
-    /// with 0 (the default) meaning no limit.
+    /// Parses the optional `limit` parameter of the Prometheus endpoints (the maximum number of returned
+    /// items; 0 means no limit, which is also the default). An absent or empty parameter means no limit.
     UInt64 getLimitParam() const
     {
-        String limit_param = params->get("limit", "");
-        if (limit_param.empty())
+        String limit_str = params->get("limit", "");
+        if (limit_str.empty())
             return 0;
 
         Int64 parsed_limit = 0;
-        if (!tryParse(parsed_limit, limit_param.data(), limit_param.size()) || (parsed_limit < 0))
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                            "Invalid value of the 'limit' parameter: '{}', expected a non-negative integer",
-                            limit_param);
+        if (!tryParse(parsed_limit, limit_str.data(), limit_str.size()) || parsed_limit < 0)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid value of the 'limit' parameter: '{}', expected a non-negative integer",
+                limit_str);
+
         return static_cast<UInt64>(parsed_limit);
     }
-
     void handlingRequestWithContext(HTTPServerRequest & request, HTTPServerResponse & response) override
     {
         const String & uri = request.getURI();
@@ -476,7 +482,36 @@ public:
 
         try
         {
-            auto table = DatabaseCatalog::instance().getTable(getTimeSeriesTableID(), context);
+            /// Resolve the route before touching the configured table. Unknown paths are a routing
+            /// error, not a table read, so they must keep their 404 response even for users who do not
+            /// have SELECT on the configured TimeSeries table.
+            const String uri_path = Poco::URI(uri).getPath();
+            const bool known_endpoint
+                = uri_path.ends_with("/query_range")
+                || uri_path.ends_with("/query")
+                || uri_path.ends_with("/format_query")
+                || uri_path.ends_with("/parse_query")
+                || uri_path.ends_with("/series")
+                || uri_path.ends_with("/labels")
+                || uri_path.ends_with("/metadata")
+                || extractLabelValuesName(uri_path).has_value();
+
+            if (!known_endpoint)
+            {
+                LOG_ERROR(log(), "No matching endpoint found for URI: {}, method: {}", maskSensitiveQueryParametersInURI(uri), request.getMethod());
+                response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
+                writeString(R"({"status":"error","errorType":"not_found","error":"API endpoint not found"})", getOutputStream(response));
+                return;
+            }
+
+            if (uri_path.ends_with("/format_query"))
+                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The format_query endpoint is not implemented");
+            if (uri_path.ends_with("/parse_query"))
+                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The parse_query endpoint is not implemented");
+
+            const auto time_series_table_id = getTimeSeriesTableID();
+            checkTimeSeriesTableSelectAccess(context, time_series_table_id);
+            auto table = DatabaseCatalog::instance().getTable(time_series_table_id, context);
             PrometheusHTTPProtocolAPI protocol{table, context};
 
             auto query_finish_callback = [&]()
@@ -484,23 +519,14 @@ public:
                 getOutputStream(response).finalize();
             };
 
-            /// Dispatch by the trailing path segment only (e.g. "/query_range", "/query"), so the same
-            /// endpoint works both bare ("/api/v1/query") and behind a configured prefix ("/prefix/api/v1/query").
-            /// Use the decoded path without the query string (matching APIv1Impl::getImpl) so a
-            /// percent-encoded label name in ".../label/<name>/values" is read correctly.
-            const String uri_path = Poco::URI(uri).getPath();
-
             if (uri_path.ends_with("/query_range"))
             {
                 String query = params->get("query", "");
                 String start = params->get("start", "");
                 String end = params->get("end", "");
                 String step = params->get("step", "");
+                UInt64 limit = getLimitParam();
                 String lookback_delta = params->get("lookback_delta", "");
-
-                /// TODO: Support the following **optional** query parameters:
-                /// - timeout=<duration>: Evaluation timeout
-                /// - limit=<number>: Maximum number of returned series
 
                 PrometheusHTTPProtocolAPI::Params params
                 {
@@ -511,6 +537,7 @@ public:
                     .end_param = end,
                     .step_param = step,
                     .lookback_delta_param = lookback_delta,
+                    .limit = limit,
                 };
 
                 protocol.executePromQLQuery(getOutputStream(response), params, query_finish_callback);
@@ -519,9 +546,8 @@ public:
             {
                 String query = params->get("query", "");
                 String time = params->get("time", "");
+                UInt64 limit = getLimitParam();
                 String lookback_delta = params->get("lookback_delta", "");
-
-                /// TODO: Support optional parameters same as for the range query.
 
                 PrometheusHTTPProtocolAPI::Params params
                 {
@@ -532,17 +558,10 @@ public:
                     .end_param = "",
                     .step_param = "",
                     .lookback_delta_param = lookback_delta,
+                    .limit = limit,
                 };
 
                 protocol.executePromQLQuery(getOutputStream(response), params, query_finish_callback);
-            }
-            else if (uri_path.ends_with("/format_query"))
-            {
-                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The format_query endpoint is not implemented");
-            }
-            else if (uri_path.ends_with("/parse_query"))
-            {
-                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The parse_query endpoint is not implemented");
             }
             else if (uri_path.ends_with("/series"))
             {

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -1,5 +1,7 @@
 #include <Storages/StorageTimeSeries.h>
 
+#include <Access/Common/AccessFlags.h>
+#include <Access/EnabledRowPolicies.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
 #include <Core/Settings.h>
@@ -41,6 +43,7 @@ namespace Setting
 
 namespace ErrorCodes
 {
+    extern const int ACCESS_DENIED;
     extern const int INCORRECT_QUERY;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
@@ -713,6 +716,32 @@ std::shared_ptr<const StorageTimeSeries> storagePtrToTimeSeries(ConstStoragePtr 
 }
 
 
+void checkTimeSeriesTableSelectAccess(const ContextPtr & context, const StorageID & time_series_table_id)
+{
+    context->checkAccess(AccessType::SELECT, time_series_table_id);
+
+    auto check_row_policy = [&](const StorageID & table_id)
+    {
+        const auto row_policy_filter = context->getRowPolicyFilter(
+            table_id.getDatabaseName(),
+            table_id.getTableName(),
+            RowPolicyFilterType::SELECT_FILTER);
+        if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
+            throw Exception(
+                ErrorCodes::ACCESS_DENIED,
+                "Cannot read TimeSeries targets because SELECT row policies are applied on table {}",
+                table_id.getNameForLogs());
+    };
+
+    check_row_policy(time_series_table_id);
+
+    const auto time_series_storage = storagePtrToTimeSeries(
+        DatabaseCatalog::instance().getTable(time_series_table_id, context));
+    for (const auto target_kind : time_series_storage->getTargetKinds())
+        check_row_policy(time_series_storage->getTargetTable(target_kind, context)->getStorageID());
+}
+
+
 void registerStorageTimeSeries(StorageFactory & factory);
 void registerStorageTimeSeries(StorageFactory & factory)
 {
@@ -1144,6 +1173,52 @@ Here is a list of settings which can be specified while defining a `TimeSeries` 
 | `recent_samples_ttl_seconds` | UInt64 | 345600 | Retention of the additional `recent samples` target table, which every inserted sample is written to as well. An inner recent samples table always gets `TTL toDateTime(timestamp) + toIntervalSecond(recent_samples_ttl_seconds)` derived from this setting (overriding any TTL from the engine declaration); an external recent samples table must retain at least this many seconds of data. Queries whose time range fits in the TTL window prefer the recent samples table to the main samples table (see the query-level setting `time_series_prefer_recent_samples_table`). The default is 4 days; the effective value is pinned into the table definition at CREATE time. Set to 0 to disable the recent samples table |
 | `recent_samples_partition_by` | Expression | `toStartOfInterval(toDateTime(timestamp), toIntervalHour(5))` | Partition key of the inner `recent samples` table, for example `toStartOfHour(timestamp)`. Requires `recent_samples_ttl_seconds` to be non-zero |
 | `recent_samples_index_granularity` | UInt64 | 8192 | Sets `index_granularity` of the inner `recent samples` table. Requires `recent_samples_ttl_seconds` to be non-zero |
+
+## Prometheus-compatible HTTP API {#prometheus-http-api}
+
+A `TimeSeries` table can be exposed through a Prometheus-compatible HTTP API configured under the `prometheus` section of the server configuration. The `/api/v1/series` endpoint returns the matching series together with their full label set (the metric name as `__name__` plus all tags).
+
+The configured outer `TimeSeries` table is the access-control boundary for these HTTP endpoints and all `TimeSeries` table functions. Callers need `SELECT` on the outer table; `SELECT` on an inner target table alone is not sufficient. Existing configurations that grant access only to inner target tables must grant access to the outer `TimeSeries` table.
+
+`SELECT` row policies are not supported on the outer `TimeSeries` table or any of its target tables for these target-backed reads. Queries with an effective policy are rejected because the implementation reads target tables directly instead of applying the policy to the outer representation. Use table-level grants for access control.
+
+The `match[]` parameter is a Prometheus series selector: a bare metric name, for example `/api/v1/series?match[]=cpu_usage`, or a full instant selector with label matchers, for example `/api/v1/series?match[]=cpu_usage{host="server1"}` or `/api/v1/series?match[]={host=~"server.*"}`. The `=`, `!=`, `=~`, and `!~` matchers are supported, and regular expressions are anchored on both sides, as in Prometheus. A non-legacy label name can be written as a quoted string literal in a selector, for example `/api/v1/series?match[]={"http.status_code"="200"}`. The parameter can be repeated; the result is the union of the series matched by each selector.
+
+The `/api/v1/series` endpoint requires at least one non-empty `match[]` selector, so a request without a selector never runs an unbounded scan over the whole `tags` table. The optional `limit` parameter caps the number of returned series (`0` means no limit, which is also the default); a truncated response carries the Prometheus warning `results truncated due to limit`. The `/api/v1/query` and `/api/v1/query_range` endpoints accept the same parameter to cap vector and matrix results.
+
+The optional `start` and `end` parameters restrict the result to series whose time range (`min_time`/`max_time`) overlaps the requested interval when both `store_min_time_and_max_time` and `filter_by_min_time_and_max_time` are enabled. Prometheus allows `/api/v1/series` filtering to be approximate, so if either setting is disabled, or the `tags` target has no maintained bounds, the endpoint returns the matching series without applying the time filter instead of rejecting the request.
+
+The `/api/v1/label/<name>/values` endpoint returns the distinct values of a label. Use `__name__` to get metric names. Its optional `match[]`, `start`, `end`, and `limit` parameters use the same semantics as `/api/v1/series`. Non-legacy label names use Prometheus' escaped path form, for example `U__http_2e_status__code` for `http.status_code`.
+
+Tags configured via `tags_to_columns` are included whether their values are present in the dedicated columns, the `tags` Map, or both. The endpoint reads the [tags](#tags-table) target table and deduplicates by series identity.
+
+Configure a handler of type `query` for the endpoint:
+
+```xml
+<prometheus>
+    <port>9363</port>
+    <handlers>
+        <my_rule>
+            <url>/api/v1/series</url>
+            <handler>
+                <type>query</type>
+                <table>default.prometheus</table>
+            </handler>
+        </my_rule>
+        <my_label_values>
+            <url>regex:/api/v1/label/[^/]+/values</url>
+            <handler>
+                <type>query</type>
+                <table>default.prometheus</table>
+            </handler>
+        </my_label_values>
+    </handlers>
+</prometheus>
+```
+
+:::note
+Each `match[]` value must be an instant series selector. A range selector (for example `cpu_usage[5m]`) or any other PromQL expression is rejected, as are the empty selector `{}`, an explicitly empty `match[]` value (for example `?match[]=`), and a selector whose matchers all match the empty label value (for example `{host=~".*"}`). At least one matcher must narrow the set of series.
+:::
 
 # Functions {#functions}
 

--- a/src/Storages/StorageTimeSeries.h
+++ b/src/Storages/StorageTimeSeries.h
@@ -150,4 +150,8 @@ private:
 std::shared_ptr<StorageTimeSeries> storagePtrToTimeSeries(StoragePtr storage);
 std::shared_ptr<const StorageTimeSeries> storagePtrToTimeSeries(ConstStoragePtr storage);
 
+/// Checks SELECT access to a TimeSeries table and rejects effective row policies on the outer table or its targets.
+/// Target-based reads cannot preserve policies defined on either representation.
+void checkTimeSeriesTableSelectAccess(const ContextPtr & context, const StorageID & time_series_table_id);
+
 }

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -1,5 +1,6 @@
 #include <Storages/StorageTimeSeriesSelector.h>
 
+#include <Access/Common/AccessFlags.h>
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
@@ -35,6 +36,7 @@
 #include <Storages/TimeSeries/TimeSeriesSettings.h>
 #include <Storages/TimeSeries/TimeSeriesTagNames.h>
 #include <Storages/TimeSeries/splitTimeSeriesType.h>
+#include <Storages/TimeSeries/timeSeriesMatchersToAST.h>
 #include <Storages/TimeSeries/timeSeriesTypesToAST.h>
 
 
@@ -130,6 +132,9 @@ StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfigura
     }
 
     time_series_storage_id = context->resolveStorageID(time_series_storage_id);
+    /// The outer TimeSeries table is the access-control boundary. The physical samples and tags tables
+    /// are implementation details and may be inner tables without separate SELECT grants.
+    context->checkAccess(AccessType::SELECT, time_series_storage_id);
 
     auto time_series_storage = storagePtrToTimeSeries(DatabaseCatalog::instance().getTable(time_series_storage_id, context));
     auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(context, false);
@@ -193,49 +198,6 @@ VirtualColumnsDescription StorageTimeSeriesSelector::createVirtuals()
 
 namespace
 {
-    /// Makes an AST for the expression referencing a tag value.
-    ASTPtr tagNameToAST(const String & tag_name, const std::unordered_map<String, String> & column_name_by_tag_name)
-    {
-        if (tag_name == TimeSeriesTagNames::MetricName)
-            return make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::MetricName);
-
-        auto it = column_name_by_tag_name.find(tag_name);
-        if (it != column_name_by_tag_name.end())
-            return make_intrusive<ASTIdentifier>(it->second);
-
-        /// arrayElement() can be used to extract a value from a Map too.
-        return makeASTFunction("arrayElement", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Tags), make_intrusive<ASTLiteral>(tag_name));
-    }
-
-    ASTPtr matcherToAST(const PrometheusQueryTree::Matcher & matcher, const std::unordered_map<String, String> & column_name_by_tag_name)
-    {
-        std::string_view function_name;
-        bool add_anchors = false;
-        bool add_not = false;
-
-        auto matcher_type = matcher.matcher_type;
-        switch (matcher_type)
-        {
-            case PrometheusQueryTree::MatcherType::EQ:  function_name = "equals"; break;
-            case PrometheusQueryTree::MatcherType::NE:  function_name = "notEquals"; break;
-            case PrometheusQueryTree::MatcherType::RE:  function_name = "match"; add_anchors = true; break;
-            case PrometheusQueryTree::MatcherType::NRE: function_name = "match"; add_anchors = true; add_not = true; break;
-        }
-
-        String value = matcher.label_value;
-        if (add_anchors)
-        {
-            if (!value.starts_with('^'))
-                value = '^' + value;
-            if (!value.ends_with('$'))
-                value += '$';
-        }
-        ASTPtr res = makeASTFunction(function_name, tagNameToAST(matcher.label_name, column_name_by_tag_name), make_intrusive<ASTLiteral>(value));
-        if (add_not)
-            res = makeASTFunction("not", res);
-        return res;
-    }
-
     ASTPtr makeWhereFilterForTagsTable(
         const PrometheusQueryTree::MatcherList & matchers,
         const std::unordered_map<String, String> & column_name_by_tag_name,
@@ -245,7 +207,7 @@ namespace
     {
         ASTs asts;
         for (const auto & matcher : matchers)
-            asts.push_back(matcherToAST(matcher, column_name_by_tag_name));
+            asts.push_back(timeSeriesMatcherToAST(matcher, column_name_by_tag_name));
 
         if (asts.empty())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Instant selector without matchers is not allowed");
@@ -292,10 +254,10 @@ namespace
             args.push_back(make_intrusive<ASTLiteral>(TimeSeriesTagNames::MetricName));
             args.push_back(make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::MetricName));
 
-            for (const auto & [tag_name, column_name] : column_name_by_tag_name)
+            for (const auto & tag : column_name_by_tag_name)
             {
-                args.push_back(make_intrusive<ASTLiteral>(tag_name));
-                args.push_back(make_intrusive<ASTIdentifier>(column_name));
+                args.push_back(make_intrusive<ASTLiteral>(tag.first));
+                args.push_back(timeSeriesTagNameToAST(tag.first, column_name_by_tag_name));
             }
 
             select_list.push_back(makeASTFunction("timeSeriesStoreTags", std::move(args)));
@@ -697,7 +659,7 @@ namespace
             {
                 ASTs other_matcher_asts;
                 for (const auto * matcher : other_matchers)
-                    other_matcher_asts.push_back(matcherToAST(*matcher, column_name_by_tag_name));
+                    other_matcher_asts.push_back(timeSeriesMatcherToAST(*matcher, column_name_by_tag_name));
                 counterexample = makeASTFunction(
                     "or", makeASTFunction("not", makeASTForLogicalAnd(std::move(other_matcher_asts))), std::move(counterexample));
             }
@@ -737,7 +699,7 @@ namespace
 
             try
             {
-                InterpreterSelectQueryAnalyzer interpreter(probe_query, context, SelectQueryOptions{});
+                InterpreterSelectQueryAnalyzer interpreter(probe_query, context, SelectQueryOptions().ignoreAccessCheck());
                 auto io = interpreter.execute();
                 PullingPipelineExecutor executor(io.pipeline);
                 Block block;
@@ -906,7 +868,10 @@ void StorageTimeSeriesSelector::readImpl(
     LOG_DEBUG(log, "Building SQL for selector: {}", config.selector.toString());
     LOG_DEBUG(log, "Will execute query:\n{}", select_query->formatForLogging());
 
+    /// The table-function execution path rejects effective SELECT row policies before this generated
+    /// query is built. The generated query reads physical samples and tags targets, so skip duplicate grants.
     auto options = SelectQueryOptions(QueryProcessingStage::Complete, 0, false, query_info.settings_limit_offset_done);
+    options.ignoreAccessCheck();
 
     InterpreterSelectQueryAnalyzer interpreter(select_query, interpreter_context, options, column_names);
     interpreter.addStorageLimits(*query_info.storage_limits);

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -213,6 +213,72 @@ String makeMatchCondition(const Strings & match_params, const std::unordered_map
     return fmt::format("({})", makeASTForLogicalOr(std::move(selector_conditions))->formatWithSecretsOneLine());
 }
 
+/// Prometheus escapes label names that are not legacy names ([a-zA-Z_][a-zA-Z0-9_]*) using the "values"
+/// escaping scheme before putting them into the /api/v1/label/<name>/values path: e.g. the tag
+/// http.status_code is requested as U__http_2e_status__code. Decode it back so the endpoint looks up
+/// the real stored tag key; otherwise dotted/slashed tag names are unqueryable. This mirrors Prometheus'
+/// model.UnescapeName for ValueEncoding: a name is decoded only when it starts with U__; then __ is an
+/// escaped underscore and _<hex>_ is an escaped code point. A malformed escape leaves the name unchanged.
+String unescapePrometheusLabelName(const String & name)
+{
+    static constexpr std::string_view prefix = "U__";
+    if (!name.starts_with(prefix))
+        return name;
+
+    String result;
+    result.reserve(name.size());
+    size_t i = prefix.size();
+    while (i < name.size())
+    {
+        char c = name[i];
+        if (c != '_')
+        {
+            result += c;
+            ++i;
+            continue;
+        }
+
+        /// __ means a literal underscore.
+        if (i + 1 < name.size() && name[i + 1] == '_')
+        {
+            result += '_';
+            i += 2;
+            continue;
+        }
+
+        /// _<hex>_ means the code point with that value. Prometheus accepts at most six hex
+        /// digits here, which is enough to represent the largest Unicode code point.
+        size_t closing = name.find('_', i + 1);
+        if (closing == String::npos || closing == i + 1)
+            return name;
+        if (closing - (i + 1) > 6)
+            return name;
+
+        UInt32 code_point = 0;
+        for (size_t j = i + 1; j < closing; ++j)
+        {
+            if (!isHexDigit(name[j]))
+                return name;
+            char h = name[j];
+            UInt32 digit = (h >= '0' && h <= '9') ? (h - '0') : ((h | 0x20) - 'a' + 10);
+            code_point = code_point * 16 + digit;
+        }
+
+        /// convertCodePointToUTF8() does not reject values outside the Unicode scalar range,
+        /// including UTF-16 surrogate code points, so validate them before converting.
+        if (code_point > 0x10FFFF || UTF8::isSurrogateCodePoint(code_point))
+            return name;
+
+        char utf8_bytes[4];
+        size_t utf8_length = UTF8::convertCodePointToUTF8(static_cast<int>(code_point), utf8_bytes, sizeof(utf8_bytes));
+        if (utf8_length == 0)
+            return name;
+        result.append(utf8_bytes, utf8_length);
+        i = closing + 1;
+    }
+    return result;
+}
+
 /// Closes the "data" array of a metadata endpoint response. When the optional `limit` parameter cut
 /// the result short, the response carries the same warning Prometheus produces for a truncated
 /// /api/v1/series, /api/v1/labels or /api/v1/label/<name>/values result.
@@ -364,6 +430,33 @@ ASTPtr makeSelectFromSubquery(ASTs select_list, ASTPtr subquery, bool distinct, 
     select_with_union_query->list_of_selects = select_with_union_query->children.back();
     return select_with_union_query;
 }
+
+String makeMapTagValuesExpression(const String & tag_name)
+{
+    const String labels_expr = fmt::format(
+        "arrayZip(mapKeys({0}), mapValues({0}))",
+        TimeSeriesColumnNames::Tags);
+    return fmt::format(
+        "arrayMap(x -> x.2, arrayFilter(x -> (x.1 = {0} AND x.2 != ''), {1}))",
+        quoteString(tag_name),
+        labels_expr);
+}
+
+String makeTagCarrierConflictCondition(const String & tag_name, const String & column_name)
+{
+    String column_expr = fmt::format("coalesce(toString({}), '')", backQuoteIfNeed(column_name));
+    String map_values_expr = makeMapTagValuesExpression(tag_name);
+    return fmt::format(
+        "(arrayUniq({0}) > 1) OR (({1} != '') AND (arrayUniq(arrayConcat([{1}], {0})) > 1))",
+        map_values_expr,
+        column_expr);
+}
+
+String makeMapTagConflictCondition(const String & tag_name)
+{
+    return fmt::format("arrayUniq({}) > 1", makeMapTagValuesExpression(tag_name));
+}
+
 }
 
 PrometheusHTTPProtocolAPI::PrometheusHTTPProtocolAPI(ConstStoragePtr time_series_storage_, const ContextMutablePtr & context_)
@@ -784,6 +877,7 @@ ASTPtr PrometheusHTTPProtocolAPI::makeSeriesIDsQuery(
     }
 
     auto tags_table_id = time_series_storage->getTargetTableID(ViewTarget::Tags, getContext());
+    const auto & time_series_table_id = time_series_storage->getStorageID();
 
     /// Each `match[]` value must be an instant selector; the result is the union of the series matched by each selector.
     auto union_query = make_intrusive<ASTSelectWithUnionQuery>();
@@ -811,6 +905,24 @@ ASTPtr PrometheusHTTPProtocolAPI::makeSeriesIDsQuery(
         auto select_ids_query = StorageTimeSeriesSelector::makeSelectIDsQuery(
             tags_table_id, matchers, *time_series_settings, min_time, max_time, timestamp_data_type);
         const auto & select_ids = typeid_cast<const ASTSelectWithUnionQuery &>(*select_ids_query);
+
+        /// Authorize the tags read through the configured TimeSeries table, as for the other metadata endpoints.
+        auto table_expression = make_intrusive<ASTTableExpression>();
+        table_expression->table_function = makeASTFunction(
+            "timeSeriesTags",
+            make_intrusive<ASTLiteral>(time_series_table_id.database_name),
+            make_intrusive<ASTLiteral>(time_series_table_id.table_name));
+        table_expression->children.push_back(table_expression->table_function);
+
+        auto table = make_intrusive<ASTTablesInSelectQueryElement>();
+        table->table_expression = table_expression;
+        table->children.push_back(std::move(table_expression));
+
+        auto tables = make_intrusive<ASTTablesInSelectQuery>();
+        tables->children.push_back(std::move(table));
+        auto & select_query = typeid_cast<ASTSelectQuery &>(*select_ids.list_of_selects->children.at(0));
+        select_query.setExpression(ASTSelectQuery::Expression::TABLES, std::move(tables));
+
         list_of_selects->children.push_back(select_ids.list_of_selects->children.at(0));
     }
 
@@ -1513,13 +1625,213 @@ void PrometheusHTTPProtocolAPI::getLabels(
 
 void PrometheusHTTPProtocolAPI::getLabelValues(
     WriteBuffer & response,
-    const String & /* label_name */,
-    const String & /* match_param */,
-    const String & /* start_param */,
-    const String & /* end_param */)
+    const String & label_name_param,
+    const Strings & match_params,
+    const String & start_param,
+    const String & end_param,
+    UInt64 limit,
+    QueryFinishCallback query_finish_callback)
 {
-    UNUSED(response);
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The label values endpoint is not implemented");
+    auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
+    auto tags_metadata = tags_table->getInMemoryMetadataPtr(getContext(), false);
+    auto make_unique_alias = [&tags_metadata](String alias)
+    {
+        while (tags_metadata->columns.has(alias))
+            alias += "_";
+        return alias;
+    };
+
+    const String label_value_alias = make_unique_alias("__prometheus_label_value");
+    const String metric_name_empty_alias = make_unique_alias("__prometheus_metric_name_empty");
+    const String metric_name_invalid_utf8_alias = make_unique_alias("__prometheus_metric_name_invalid_utf8");
+    const String metric_name_carrier_conflict_alias = make_unique_alias("__prometheus_metric_name_carrier_conflict");
+    const String label_carrier_conflict_alias = make_unique_alias("__prometheus_label_carrier_conflict");
+
+    const auto & time_series_table_id = time_series_storage->getStorageID();
+    const String tags_table_expression = fmt::format(
+        "timeSeriesTags({}, {})",
+        quoteString(time_series_table_id.database_name),
+        quoteString(time_series_table_id.table_name));
+
+    /// Prometheus escapes non-legacy label names in the path. Decode them before comparing against
+    /// tags_to_columns or indexing the tags Map.
+    const String label_name = unescapePrometheusLabelName(label_name_param);
+    if (label_name.empty()
+        || !UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(label_name.data()), label_name.size()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid label name: {}", quoteString(label_name_param));
+
+    auto tag_columns = getConfiguredTagColumns();
+    const String metric_name_carrier_conflict_condition
+        = makeTagCarrierConflictCondition(TimeSeriesTagNames::MetricName, TimeSeriesColumnNames::MetricName);
+
+    String query;
+    String label_value_expr;
+    String label_carrier_conflict_condition = "0";
+    /// Collect WHERE conditions and join them, so the query stays valid regardless of which branch is taken.
+    std::vector<String> conditions;
+
+    if (label_name == "__name__")
+    {
+        /// Keep empty metric names in the result so a matched malformed row is rejected below instead of
+        /// being silently treated as an absent __name__ label.
+        label_value_expr = TimeSeriesColumnNames::MetricName;
+    }
+    else
+    {
+        /// If the label is configured in tags_to_columns, prefer its dedicated column and fall back
+        /// to the tags Map for older or external rows that carry the label only there.
+        String column_name;
+        for (const auto & [tag_name, col_name] : tag_columns)
+        {
+            if (tag_name == label_name)
+            {
+                column_name = col_name;
+                break;
+            }
+        }
+
+        if (!column_name.empty())
+        {
+            /// A supported external tags table can still contain the configured tag only in the
+            /// residual Map with the dedicated column empty or NULL, so fall back to the Map. A row
+            /// with conflicting non-empty carriers is rejected instead of silently choosing one value.
+            String column_expr = fmt::format("coalesce(toString({}), '')", backQuoteIfNeed(column_name));
+            String map_value_expr = fmt::format("arrayElement({}, 1)", makeMapTagValuesExpression(label_name));
+            label_value_expr = fmt::format(
+                "if({0} != '', {0}, {1})",
+                column_expr,
+                map_value_expr);
+            label_carrier_conflict_condition = makeTagCarrierConflictCondition(label_name, column_name);
+            conditions.push_back(fmt::format("{} != ''", label_value_expr));
+        }
+        else
+        {
+            /// A key stored with an empty value is treated as an absent label.
+            label_value_expr = fmt::format("arrayElement({}, 1)", makeMapTagValuesExpression(label_name));
+            label_carrier_conflict_condition = makeMapTagConflictCondition(label_name);
+            conditions.push_back(fmt::format("{} != ''", label_value_expr));
+        }
+    }
+
+    /// Group by the value returned by this endpoint instead of carrying a metric name through the
+    /// DISTINCT/sort pipeline. The validation flags are aggregated across every selected row, so
+    /// fail-closed validation still sees malformed data even when multiple series share one value.
+    query = fmt::format(
+        "SELECT {0} AS `{1}`, max({2} = '') AS `{3}`, "
+        "max(isValidUTF8({2}) = 0) AS `{4}`, max({5}) AS `{6}`, max({7}) AS `{8}` FROM {9}",
+        label_value_expr,
+        label_value_alias,
+        TimeSeriesColumnNames::MetricName,
+        metric_name_empty_alias,
+        metric_name_invalid_utf8_alias,
+        metric_name_carrier_conflict_condition,
+        metric_name_carrier_conflict_alias,
+        label_carrier_conflict_condition,
+        label_carrier_conflict_alias,
+        tags_table_expression);
+
+    std::unordered_map<String, String> column_name_by_tag_name(tag_columns.begin(), tag_columns.end());
+    if (String match_condition = makeMatchCondition(match_params, column_name_by_tag_name); !match_condition.empty())
+        conditions.push_back(match_condition);
+    appendTimeRangeConditions(conditions, tags_table, start_param, end_param);
+
+    for (size_t i = 0; i < conditions.size(); ++i)
+        query += (i == 0 ? " WHERE " : " AND ") + conditions[i];
+
+    query += fmt::format(" GROUP BY `{}` ORDER BY `{}`", label_value_alias, label_value_alias);
+
+    /// The limit is enforced while collecting values for the response. The query still reads all matching
+    /// rows so the conflicting-carrier check cannot be skipped just because the response limit was reached.
+    LOG_TRACE(log, "Prometheus label values query: {}", query);
+
+    auto [ast, io] = executeQuery(query, getContext(), {}, QueryProcessingStage::Complete);
+
+    try
+    {
+        PullingAsyncPipelineExecutor executor(io.pipeline);
+        Block result_block;
+
+        /// Materialize the values before writing the success envelope. External String columns can
+        /// contain invalid UTF-8, while both Prometheus and the JSON serializer require valid UTF-8.
+        std::vector<String> values_to_write;
+        UInt64 emitted = 0;
+        bool truncated = false;
+        while (executor.pull(result_block))
+        {
+            if (result_block.rows() == 0)
+                continue;
+
+            const auto & value_col = result_block.getByName(label_value_alias).column;
+            const auto & metric_name_empty_col = result_block.getByName(metric_name_empty_alias).column;
+            const auto & metric_name_invalid_utf8_col = result_block.getByName(metric_name_invalid_utf8_alias).column;
+            const auto & metric_name_carrier_conflict_col = result_block.getByName(metric_name_carrier_conflict_alias).column;
+            const auto & label_carrier_conflict_col = result_block.getByName(label_carrier_conflict_alias).column;
+
+            for (size_t i = 0; i < result_block.rows(); ++i)
+            {
+                if (metric_name_empty_col->getUInt(i))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found empty metric name in a row of the 'tags' table");
+
+                if (metric_name_invalid_utf8_col->getUInt(i))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found invalid UTF-8 in a metric name in a row of the 'tags' table");
+
+                if (metric_name_carrier_conflict_col->getUInt(i))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found two tags with the same name {} but different values in a row of the 'tags' table",
+                        quoteString(TimeSeriesTagNames::MetricName));
+
+                if (label_carrier_conflict_col->getUInt(i))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found two tags with the same name {} but different values in a row of the 'tags' table",
+                        quoteString(label_name));
+
+                auto value = value_col->getDataAt(i);
+                if (value.empty())
+                    continue;
+
+                if (!UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(value.data()), value.size()))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found invalid UTF-8 in a label value in a row of the 'tags' table");
+
+                if (limit && emitted == limit)
+                {
+                    truncated = true;
+                    continue;
+                }
+
+                values_to_write.emplace_back(value.data(), value.size());
+                ++emitted;
+            }
+        }
+
+        writeString(R"({"status":"success","data":[)", response);
+        for (size_t i = 0; i < values_to_write.size(); ++i)
+        {
+            if (i > 0)
+                writeString(",", response);
+            writeJSONString(std::string_view(values_to_write[i]), response, format_settings);
+        }
+        writeMetadataResponseFooter(response, truncated);
+
+        /// Store the buffered result in the query result cache now. The executor destructor cancels
+        /// pipeline processors, so leaving this until destruction would discard the pending write.
+        io.pipeline.finalizeWriteInQueryResultCache();
+    }
+    catch (...)
+    {
+        io.onException();
+        throw;
+    }
+
+    /// Release the query slot and record QueryFinish after the pipeline has been exhausted.
+    finishExecutedQuery(io, query_finish_callback);
 }
 
 

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -2,6 +2,9 @@
 
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
+#include <Common/StringUtils.h>
+#include <Common/UTF8Helpers.h>
+#include <Common/isValidUTF8.h>
 #include <Core/DecimalFunctions.h>
 #include <Core/Field.h>
 #include <IO/WriteBufferFromString.h>
@@ -16,18 +19,25 @@
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
+#include <Storages/StorageInMemoryMetadata.h>
+#include <Storages/TimeSeries/TimeSeriesSettings.h>
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
 #include <Parsers/Prometheus/PrometheusQueryResultType.h>
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
+#include <Parsers/makeASTForLogicalFunction.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/Converter.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
-#include <Storages/TimeSeries/TimeSeriesSettings.h>
+#include <Storages/TimeSeries/TimeSeriesTagNames.h>
 #include <Storages/TimeSeries/splitTimeSeriesType.h>
+#include <Storages/TimeSeries/timeSeriesMatchersToAST.h>
+#include <Storages/TimeSeries/timeSeriesTypesToAST.h>
 #include <Interpreters/executeQuery.h>
 #include <Interpreters/Context.h>
 #include <Core/Settings.h>
+#include <Parsers/Prometheus/PrometheusQueryParsingUtil.h>
 #include <Processors/Executors/PullingAsyncPipelineExecutor.h>
+#include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -38,9 +48,14 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnString.h>
-
+#include <Interpreters/DatabaseCatalog.h>
 #include <fmt/format.h>
+#include <Common/re2.h>
 
+#include <algorithm>
+#include <limits>
+#include <utility>
+#include <vector>
 
 namespace DB
 {
@@ -52,20 +67,253 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
+namespace TimeSeriesSetting
+{
+    extern const TimeSeriesSettingsBool filter_by_min_time_and_max_time;
+    extern const TimeSeriesSettingsBool store_min_time_and_max_time;
+    extern const TimeSeriesSettingsMap tags_to_columns;
+}
+
+namespace
+{
+
+bool containsUnsupportedPrometheusRegexpEscape(std::string_view regexp)
+{
+    bool escaped = false;
+    for (const char character : regexp)
+    {
+        if (character == '\\')
+        {
+            escaped = !escaped;
+            continue;
+        }
+
+        if (escaped && character == 'C')
+            return true;
+        escaped = false;
+    }
+    return false;
+}
+
+/// Whether a matcher matches a series that does not have the label at all, under the Prometheus
+/// semantics "a missing label is equal to the empty label value". A regexp matcher is evaluated
+/// against the empty string with the same fully-anchored RE2 semantics as the generated `match`
+/// condition; an invalid regexp is rejected here (fail closed), like in the Prometheus parser.
+bool matcherCanMatchEmptyLabelValue(const PrometheusQueryTree::Matcher & matcher, const String & match_param)
+{
+    switch (matcher.matcher_type)
+    {
+        case PrometheusQueryTree::MatcherType::EQ:
+            return matcher.label_value.empty();
+        case PrometheusQueryTree::MatcherType::NE:
+            return !matcher.label_value.empty();
+        case PrometheusQueryTree::MatcherType::RE:
+        case PrometheusQueryTree::MatcherType::NRE:
+        {
+            if (containsUnsupportedPrometheusRegexpEscape(matcher.label_value))
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Invalid value {} of the 'match[]' parameter: regexp escape sequence \\C is not supported",
+                    quoteString(match_param));
+
+            re2::RE2 regexp(matcher.label_value, re2::RE2::Quiet);
+            if (!regexp.ok())
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Invalid value {} of the 'match[]' parameter: cannot parse the regexp of the {}{}~{} matcher: {}",
+                    quoteString(match_param),
+                    matcher.label_name,
+                    (matcher.matcher_type == PrometheusQueryTree::MatcherType::NRE) ? "!" : "=",
+                    quoteString(matcher.label_value),
+                    regexp.error());
+            bool empty_matches_regexp = re2::RE2::FullMatch("", regexp);
+            return (matcher.matcher_type == PrometheusQueryTree::MatcherType::RE) ? empty_matches_regexp : !empty_matches_regexp;
+        }
+    }
+
+    UNREACHABLE();
+}
+
+/// The `match[]` parameter of the metadata endpoints is a Prometheus series selector: a bare metric name
+/// (`go_info`) or a full instant selector with label matchers (`go_info{group="PROD"}`, `{job=~"prom.*"}`).
+/// Grafana emits the selector forms when it narrows label names / label values by filters. Each value is
+/// parsed with the same PromQL parser as `/api/v1/query`, and each label matcher is translated into the
+/// same condition over the `tags` table that the real query path builds in `StorageTimeSeriesSelector`
+/// (see `timeSeriesMatcherToAST`), so the metadata endpoints filter series exactly like the query
+/// endpoints do. Prometheus defines the result of a repeated `match[]` as the union of the series matched
+/// by each selector, hence the disjunction over the parameters. Each value is parsed with the PromQL
+/// metric-selector grammar used by the query parser. Returns an empty string when there is no filter
+/// to apply (no `match[]` values at all).
+///
+/// An explicitly empty `match[]` value (e.g. `?match[]=`), a value that is not an instant selector (e.g.
+/// a range selector `up[5m]` or a PromQL expression), the empty selector `{}`, and a selector whose
+/// matchers all match the empty label value (e.g. `{job=~".*"}` - see `matcherCanMatchEmptyLabelValue`)
+/// are rejected (fail closed), as in Prometheus, instead of being silently dropped or treated as an
+/// unfiltered result. The last rule is what keeps the "`match[]` is required" guard on `/api/v1/series`
+/// meaningful: without it `match[]={job=~".*"}` would degenerate into a full scan of the `tags` table.
+String makeMatchCondition(const Strings & match_params, const std::unordered_map<String, String> & column_name_by_tag_name)
+{
+    ASTs selector_conditions;
+    for (const auto & match_param : match_params)
+    {
+        if (match_param.empty())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid empty value of the 'match[]' parameter: expected a series selector");
+
+        PrometheusQueryTree selector;
+        String error_message;
+        if (!selector.tryParseMetricSelector(match_param, /* timestamp_scale_ = */ 3, &error_message))
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid value {} of the 'match[]' parameter: cannot parse a series selector: {}",
+                quoteString(match_param), error_message);
+
+        const auto * root = selector.getRoot();
+        if (!root || root->node_type != PrometheusQueryTree::NodeType::InstantSelector)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid value {} of the 'match[]' parameter: expected a series selector, not a PromQL expression",
+                quoteString(match_param));
+
+        const auto & matchers = typeid_cast<const PrometheusQueryTree::InstantSelector &>(*root).matchers;
+        if (matchers.empty())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid value {} of the 'match[]' parameter: the selector must contain at least one matcher",
+                quoteString(match_param));
+
+        /// Prometheus rejects a selector whose matchers all match the empty label value (i.e. all match
+        /// a series that has none of the mentioned labels), because such a selector does not narrow the
+        /// series set at all: `{job=~".*"}` would degenerate into a full scan of the `tags` table.
+        /// Every matcher is checked (no short-circuit), so an invalid regexp anywhere in the selector
+        /// is rejected here with `bad_data` instead of failing later inside the generated SQL.
+        bool has_non_empty_matcher = false;
+        for (const auto & matcher : matchers)
+            has_non_empty_matcher |= !matcherCanMatchEmptyLabelValue(matcher, match_param);
+        if (!has_non_empty_matcher)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Invalid value {} of the 'match[]' parameter: the selector must contain at least one matcher "
+                "that does not match the empty label value",
+                quoteString(match_param));
+
+        ASTs matcher_asts;
+        matcher_asts.reserve(matchers.size());
+        for (const auto & matcher : matchers)
+            matcher_asts.push_back(timeSeriesMatcherToAST(matcher, column_name_by_tag_name));
+        selector_conditions.push_back(makeASTForLogicalAnd(std::move(matcher_asts)));
+    }
+
+    if (selector_conditions.empty())
+        return {};
+
+    /// The parenthesized form keeps the condition intact when the caller appends it to other
+    /// conditions with a plain textual " AND ".
+    return fmt::format("({})", makeASTForLogicalOr(std::move(selector_conditions))->formatWithSecretsOneLine());
+}
+
+/// Closes the "data" array of a metadata endpoint response. When the optional `limit` parameter cut
+/// the result short, the response carries the same warning Prometheus produces for a truncated
+/// /api/v1/series, /api/v1/labels or /api/v1/label/<name>/values result.
+void writeMetadataResponseFooter(WriteBuffer & response, bool truncated)
+{
+    if (truncated)
+        writeString(R"(],"warnings":["results truncated due to limit"]})", response);
+    else
+        writeString("]}", response);
+}
+
+}
+
 namespace Setting
 {
     extern const SettingsBool enable_materialized_cte;
 }
 
-namespace TimeSeriesSetting
-{
-    extern const TimeSeriesSettingsBool filter_by_min_time_and_max_time;
-    extern const TimeSeriesSettingsBool store_min_time_and_max_time;
-}
-
 namespace
 {
 constexpr UInt32 LOOKBACK_DELTA_SCALE = 9;
+
+/// Clip a request range to the domain represented by the storage timestamp column. Values outside that
+/// domain cannot be converted to the native type safely: for DateTime/UInt32 the conversion can wrap,
+/// while DateTime64 has a signed Int64 tick domain that can overflow at high precision.
+bool clipTimestampRangeToStorageType(
+    std::optional<Decimal128> & start_time,
+    std::optional<Decimal128> & end_time,
+    const DataTypePtr & timestamp_data_type,
+    UInt32 timestamp_scale,
+    UInt32 request_timestamp_scale)
+{
+    WhichDataType which_data_type{timestamp_data_type};
+    if (!(which_data_type.isDateTime64() || which_data_type.isDateTime() || which_data_type.isUInt32()))
+        return true;
+
+    Decimal128 min_storage_timestamp;
+    Decimal128 max_storage_timestamp;
+    if (which_data_type.isDateTime64())
+    {
+        min_storage_timestamp = Decimal128{static_cast<Int128>(std::numeric_limits<Int64>::min())};
+        max_storage_timestamp = Decimal128{static_cast<Int128>(std::numeric_limits<Int64>::max())};
+    }
+    else
+    {
+        min_storage_timestamp = Decimal128{0};
+        max_storage_timestamp = Decimal128{
+            static_cast<Int128>(std::numeric_limits<UInt32>::max())
+            * DecimalUtils::scaleMultiplier<Decimal128>(timestamp_scale)};
+    }
+
+    /// Compare in the same scale as the parsed request values. `request_timestamp_scale` is never
+    /// lower than `timestamp_scale`, so this conversion cannot lose fractional request precision.
+    const auto min_timestamp
+        = DecimalUtils::convertTo<Decimal128>(request_timestamp_scale, min_storage_timestamp, timestamp_scale);
+    const auto max_timestamp
+        = DecimalUtils::convertTo<Decimal128>(request_timestamp_scale, max_storage_timestamp, timestamp_scale);
+
+    /// A range entirely before or after the representable storage domain cannot overlap any series.
+    if ((end_time && *end_time < min_timestamp) || (start_time && *start_time > max_timestamp))
+        return false;
+
+    /// Clamp only bounds that extend beyond the domain. The resulting native-type predicates are then
+    /// equivalent for every representable timestamp and cannot wrap during AST conversion.
+    if (start_time && *start_time < min_timestamp)
+        *start_time = min_timestamp;
+    if (end_time && *end_time > max_timestamp)
+        *end_time = max_timestamp;
+
+    return true;
+}
+
+/// Reduce a request timestamp to the storage precision while preserving an inclusive overlap predicate.
+/// A lower bound on max_time needs a ceiling; an upper bound on min_time needs a floor. DecimalUtils' generic
+/// scale conversion truncates towards zero, which is not a directional rounding operation for negative values.
+DateTime64 rescaleTimestampBound(const Decimal128 & value, UInt32 storage_scale, UInt32 request_scale, bool round_up)
+{
+    if (storage_scale >= request_scale)
+        return DecimalUtils::convertTo<DateTime64>(storage_scale, value, request_scale);
+
+    const auto divisor = DecimalUtils::scaleMultiplier<Decimal128>(request_scale - storage_scale);
+    auto quotient = value.value / divisor;
+    const auto remainder = value.value % divisor;
+
+    if (remainder != 0 && ((round_up && value.value > 0) || (!round_up && value.value < 0)))
+        quotient += round_up ? Int128{1} : Int128{-1};
+
+    return DateTime64{static_cast<Int64>(quotient)};
+}
+
+Decimal128 parsePrometheusRequestTimestamp(const String & value, UInt32 request_timestamp_scale)
+{
+    PrometheusQueryParsingUtil::RequestTimestampType timestamp;
+    String error_message;
+    size_t error_pos = 0;
+    if (PrometheusQueryParsingUtil::tryParsePrometheusRequestTimestamp(
+            value, request_timestamp_scale, timestamp, &error_message, &error_pos))
+        return timestamp;
+
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "{} at position {}", error_message, error_pos);
+}
 
 Decimal64 parsePrometheusLookbackDelta(const String & value, UInt32 timestamp_scale)
 {
@@ -138,6 +386,7 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
     std::tie(evaluation_settings.timestamp_data_type, evaluation_settings.scalar_data_type)
         = splitTimeSeriesType(time_series_metadata->columns.get(TimeSeriesColumnNames::TimeSeries).type);
     UInt32 timestamp_scale = tryGetDecimalScale(*evaluation_settings.timestamp_data_type).value_or(0);
+    const UInt32 request_timestamp_scale = std::max(timestamp_scale, LOOKBACK_DELTA_SCALE);
 
     if (!params.lookback_delta_param.empty())
     {
@@ -150,6 +399,9 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
     query_tree->parse(params.promql_query, timestamp_scale);
     LOG_TRACE(log, "Parsed PromQL query: {}. Result type: {}", params.promql_query, query_tree->getResultType());
 
+    std::optional<Decimal128> request_start_time;
+    std::optional<Decimal128> request_end_time;
+
     if (params.type == Type::Instant)
     {
         evaluation_settings.mode = PrometheusQueryEvaluationMode::QUERY;
@@ -159,17 +411,38 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
         }
         else
         {
-            evaluation_settings.start_time = parseTimeSeriesTimestamp(params.time_param, timestamp_scale);
-            evaluation_settings.end_time = evaluation_settings.start_time;
+            request_start_time = parsePrometheusRequestTimestamp(params.time_param, request_timestamp_scale);
+            request_end_time = request_start_time;
             evaluation_settings.step = 0;
         }
     }
     else if (params.type == Type::Range)
     {
         evaluation_settings.mode = PrometheusQueryEvaluationMode::QUERY_RANGE;
-        evaluation_settings.start_time = parseTimeSeriesTimestamp(params.start_param, timestamp_scale);
-        evaluation_settings.end_time = parseTimeSeriesTimestamp(params.end_param, timestamp_scale);
+        request_start_time = parsePrometheusRequestTimestamp(params.start_param, request_timestamp_scale);
+        request_end_time = parsePrometheusRequestTimestamp(params.end_param, request_timestamp_scale);
         evaluation_settings.step = parseTimeSeriesDuration(params.step_param, timestamp_scale);
+    }
+
+    if (request_start_time && request_end_time && *request_start_time > *request_end_time)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "start must not be greater than end");
+
+    if (request_start_time || request_end_time)
+    {
+        if (!clipTimestampRangeToStorageType(
+                request_start_time,
+                request_end_time,
+                evaluation_settings.timestamp_data_type,
+                timestamp_scale,
+                request_timestamp_scale))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Prometheus HTTP API timestamp is outside the storage timestamp range");
+
+        if (request_start_time)
+            evaluation_settings.start_time
+                = rescaleTimestampBound(*request_start_time, timestamp_scale, request_timestamp_scale, /* round_up */ false);
+        if (request_end_time)
+            evaluation_settings.end_time
+                = rescaleTimestampBound(*request_end_time, timestamp_scale, request_timestamp_scale, /* round_up */ false);
     }
 
     PrometheusQueryToSQL::Converter converter{query_tree, evaluation_settings};
@@ -194,7 +467,7 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
         PullingAsyncPipelineExecutor executor(io.pipeline);
 
         /// Mind using the getResultType() method from PrometheusQueryToSQL::Converter, not from the PrometheusQueryTree.
-        writeQueryResponse(response, executor, converter.getResultType());
+        writeQueryResponse(response, executor, converter.getResultType(), params.limit);
 
         /// Store the buffered result in the query result cache now (no-op if no cache writers exist in the pipeline):
         /// the executor's destructor cancels the pipeline processors, after which the pending write would be discarded.
@@ -212,7 +485,10 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
 }
 
 void PrometheusHTTPProtocolAPI::writeQueryResponse(
-    WriteBuffer & response, PullingAsyncPipelineExecutor & pulling_executor, PrometheusQueryResultType result_type)
+    WriteBuffer & response,
+    PullingAsyncPipelineExecutor & pulling_executor,
+    PrometheusQueryResultType result_type,
+    UInt64 limit)
 {
     /// Pull until the first non-empty block is ready before writing the header
     /// because pulling_executor.pull() can throw an exception and it's better to catch it early and write
@@ -229,19 +505,21 @@ void PrometheusHTTPProtocolAPI::writeQueryResponse(
     }
 
     writeQueryResponseHeader(response, result_type);
+    UInt64 emitted = 0;
+    bool truncated = false;
 
     if (has_output)
     {
-        writeQueryResponseBlock(response, result_type, block, /*first=*/ true);
+        writeQueryResponseBlock(response, result_type, block, /*first=*/ true, limit, emitted, truncated);
 
         while (pulling_executor.pull(block))
         {
             if (block.rows() > 0)
-                writeQueryResponseBlock(response, result_type, block, /*first=*/ false);
+                writeQueryResponseBlock(response, result_type, block, /*first=*/ false, limit, emitted, truncated);
         }
     }
 
-    writeQueryResponseFooter(response);
+    writeQueryResponseFooter(response, truncated);
 }
 
 void PrometheusHTTPProtocolAPI::writeQueryResponseHeader(WriteBuffer & response, PrometheusQueryResultType result_type)
@@ -268,12 +546,22 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseHeader(WriteBuffer & response,
     writeString(R"(","result":[)", response);
 }
 
-void PrometheusHTTPProtocolAPI::writeQueryResponseFooter(WriteBuffer & response)
+void PrometheusHTTPProtocolAPI::writeQueryResponseFooter(WriteBuffer & response, bool truncated)
 {
-    writeString("]}}", response);
+    if (truncated)
+        writeString(R"(]},"warnings":["results truncated due to limit"]})", response);
+    else
+        writeString("]}}", response);
 }
 
-void PrometheusHTTPProtocolAPI::writeQueryResponseBlock(WriteBuffer & response, PrometheusQueryResultType result_type, const Block & result_block, bool first)
+void PrometheusHTTPProtocolAPI::writeQueryResponseBlock(
+    WriteBuffer & response,
+    PrometheusQueryResultType result_type,
+    const Block & result_block,
+    bool first,
+    UInt64 limit,
+    UInt64 & emitted,
+    bool & truncated)
 {
     LOG_TRACE(log, "Prometheus: Writing {} result ({} rows)", result_type, result_block.rows());
 
@@ -291,12 +579,12 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseBlock(WriteBuffer & response, 
         }
         case PrometheusQueryTree::ResultType::INSTANT_VECTOR:
         {
-            writeQueryResponseInstantVectorBlock(response, result_block, first);
+            writeQueryResponseInstantVectorBlock(response, result_block, limit, emitted, truncated);
             return;
         }
         case PrometheusQueryTree::ResultType::RANGE_VECTOR:
         {
-            writeQueryResponseRangeVectorBlock(response, result_block, first);
+            writeQueryResponseRangeVectorBlock(response, result_block, limit, emitted, truncated);
             return;
         }
     }
@@ -345,17 +633,28 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseStringBlock(WriteBuffer & resp
     writeJSONString(value, response, format_settings);
 }
 
-void PrometheusHTTPProtocolAPI::writeQueryResponseInstantVectorBlock(WriteBuffer & response, const Block & result_block, bool first)
+void PrometheusHTTPProtocolAPI::writeQueryResponseInstantVectorBlock(
+    WriteBuffer & response,
+    const Block & result_block,
+    UInt64 limit,
+    UInt64 & emitted,
+    bool & truncated)
 {
     const auto & timestamp_column = result_block.getByName(TimeSeriesColumnNames::Timestamp).column;
     auto timestamp_data_type = result_block.getByName(TimeSeriesColumnNames::Timestamp).type;
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
     const auto & value_column = result_block.getByName(TimeSeriesColumnNames::Value).column;
 
-    bool need_comma = !first;
+    bool need_comma = emitted > 0;
 
     for (size_t i = 0; i < result_block.rows(); ++i)
     {
+        if (limit && emitted == limit)
+        {
+            truncated = true;
+            return;
+        }
+
         if (need_comma)
             writeString(",", response);
 
@@ -383,11 +682,17 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseInstantVectorBlock(WriteBuffer
         writeString("\"", response);
 
         writeString("]}", response);
+        ++emitted;
         need_comma = true;
     }
 }
 
-void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer & response, const Block & result_block, bool first)
+void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(
+    WriteBuffer & response,
+    const Block & result_block,
+    UInt64 limit,
+    UInt64 & emitted,
+    bool & truncated)
 {
     const auto & time_series_column = result_block.getByName(TimeSeriesColumnNames::TimeSeries).column;
     const auto & array_column = typeid_cast<const ColumnArray &>(*time_series_column);
@@ -403,10 +708,16 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
 
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
 
-    bool need_comma = !first;
+    bool need_comma = emitted > 0;
 
     for (size_t i = 0; i < result_block.rows(); ++i)
     {
+        if (limit && emitted == limit)
+        {
+            truncated = true;
+            return;
+        }
+
         if (need_comma)
             writeString(",", response);
 
@@ -438,6 +749,7 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
         }
 
         writeString("]}", response);
+        ++emitted;
         need_comma = true;
     }
 }
@@ -508,6 +820,142 @@ ASTPtr PrometheusHTTPProtocolAPI::makeSeriesIDsQuery(
 }
 
 
+std::vector<std::pair<String, String>> PrometheusHTTPProtocolAPI::getConfiguredTagColumns() const
+{
+    std::vector<std::pair<String, String>> result;
+    auto settings = time_series_storage->getStorageSettings();
+    const Map & tags_to_columns = (*settings)[TimeSeriesSetting::tags_to_columns];
+    for (const auto & tag_name_and_column_name : tags_to_columns)
+    {
+        const auto & tuple = tag_name_and_column_name.safeGet<Tuple>();
+        const auto & tag_name = tuple.at(0).safeGet<String>();
+        const auto & column_name = tuple.at(1).safeGet<String>();
+        result.emplace_back(tag_name, column_name);
+    }
+    return result;
+}
+
+void PrometheusHTTPProtocolAPI::appendTimeRangeConditions(
+    std::vector<String> & conditions, const StoragePtr & tags_table, const String & start_param, const String & end_param)
+{
+    if (start_param.empty() && end_param.empty())
+        return;
+
+    /// `min_time`/`max_time` store the timestamp type of the `TimeSeries` table (`DateTime64(X)`, `DateTime`,
+    /// `UInt32`, ...), which is not necessarily `DateTime64(3)`. Derive that type/scale from the `time_series`
+    /// column the same way the PromQL query path does, and build the comparison literals with the same
+    /// conversion path (`timeSeriesTimestampToAST`), so no precision is lost for higher-scale tables and the
+    /// comparison type matches the column for non-`DateTime64` timestamps.
+    auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(getContext(), false);
+    auto timestamp_data_type
+        = splitTimeSeriesType(time_series_metadata->columns.get(TimeSeriesColumnNames::TimeSeries).type).first;
+    UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
+
+    /// Parse both bounds in a wider request representation so validation does not depend on the native
+    /// precision or range of this particular storage table. Parsing at DateTime64(0), for example, would
+    /// collapse `start=1000.9&end=1000.1` to two equal values and accept an inverted range. Retry at a
+    /// lower common scale when a valid large Unix timestamp cannot fit at the initially requested scale,
+    /// but never reduce below the storage scale.
+    UInt32 request_timestamp_scale = std::max(timestamp_scale, LOOKBACK_DELTA_SCALE);
+    std::optional<Decimal128> start_time;
+    std::optional<Decimal128> end_time;
+
+    for (UInt32 candidate_timestamp_scale = request_timestamp_scale;; --candidate_timestamp_scale)
+    {
+        try
+        {
+            std::optional<Decimal128> candidate_start_time;
+            std::optional<Decimal128> candidate_end_time;
+            if (!start_param.empty())
+                candidate_start_time = parsePrometheusRequestTimestamp(start_param, candidate_timestamp_scale);
+            if (!end_param.empty())
+                candidate_end_time = parsePrometheusRequestTimestamp(end_param, candidate_timestamp_scale);
+
+            start_time = candidate_start_time;
+            end_time = candidate_end_time;
+            request_timestamp_scale = candidate_timestamp_scale;
+            break;
+        }
+        catch (const Exception & e)
+        {
+            if (e.code() != ErrorCodes::BAD_ARGUMENTS || candidate_timestamp_scale == timestamp_scale)
+                throw;
+        }
+    }
+
+    /// Keep the stricter ClickHouse behavior here: reject an inverted interval before bound rescaling.
+    /// Otherwise, the overlap predicate below could return a series spanning both bounds, which is
+    /// surprising for an interval.
+    if (start_time && end_time && *start_time > *end_time)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "start must not be greater than end");
+
+    /// `StorageTimeSeriesSelector::readImpl` uses the tags-table bounds only when both settings are enabled;
+    /// otherwise the query path falls back to exact samples-table filtering. The metadata endpoint has no
+    /// samples-table fallback, so follow Prometheus's approximate /series contract and return a superset when
+    /// trusted bounds are unavailable instead of rejecting an otherwise valid request with `bad_data`.
+    auto time_series_settings = time_series_storage->getStorageSettings();
+    if (!(*time_series_settings)[TimeSeriesSetting::filter_by_min_time_and_max_time]
+        || !(*time_series_settings)[TimeSeriesSetting::store_min_time_and_max_time])
+    {
+        LOG_DEBUG(
+            log,
+            "Ignoring the Prometheus metadata time range because min_time/max_time filtering is unavailable; returning an approximate superset");
+        return;
+    }
+
+    auto tags_metadata = tags_table->getInMemoryMetadataPtr(getContext(), false);
+    if (!tags_metadata->columns.has(TimeSeriesColumnNames::MinTime) || !tags_metadata->columns.has(TimeSeriesColumnNames::MaxTime))
+    {
+        LOG_DEBUG(
+            log,
+            "Ignoring the Prometheus metadata time range because the tags table has no min_time/max_time columns; returning an approximate superset");
+        return;
+    }
+
+    /// Clip the validated request bounds before reducing them to storage precision. This also handles
+    /// values just outside the UInt32 domain, such as `end=-0.1` or `start=4294967295.9`, which would
+    /// otherwise truncate into the representable domain before the check.
+    if (!clipTimestampRangeToStorageType(
+            start_time, end_time, timestamp_data_type, timestamp_scale, request_timestamp_scale))
+    {
+        /// Keep the query path uniform while making an out-of-domain range return no metadata rows.
+        conditions.emplace_back("0");
+        return;
+    }
+
+    /// Convert the already validated and clipped request bounds separately at storage precision. For
+    /// unsigned timestamp types this conversion is safe only after the domain check above.
+    std::optional<DateTime64> native_start_time;
+    std::optional<DateTime64> native_end_time;
+    if (start_time)
+        native_start_time = rescaleTimestampBound(*start_time, timestamp_scale, request_timestamp_scale, /* round_up */ true);
+    if (end_time)
+        native_end_time = rescaleTimestampBound(*end_time, timestamp_scale, request_timestamp_scale, /* round_up */ false);
+
+    /// A series overlaps the requested range [start, end] when its `max_time >= start` and `min_time <= end`.
+    /// This mirrors `StorageTimeSeriesSelector::makeWhereFilterForTagsTable`, which the real query path
+    /// (`/api/v1/query`, `/api/v1/query_range`) uses on the `tags` table. There the comparisons are plain, so a
+    /// `NULL` `min_time`/`max_time` makes the predicate evaluate to `NULL` and the row is dropped. An empty
+    /// `time_series` row (a series with no samples) is stored with `NULL` bounds by
+    /// `TimeSeriesSink::fillMinMaxTimeColumns`, and such a series never contributes to a ranged query. The
+    /// metadata endpoints must fail closed the same way: keeping those rows with an `IS NULL OR ...` branch
+    /// would let `/api/v1/series`, `/api/v1/labels`, and `/api/v1/label/<name>/values` report series and labels
+    /// for an interval where `/api/v1/query` returns no data.
+    if (native_start_time)
+        conditions.push_back(fmt::format(
+            "{0} >= {1}",
+            TimeSeriesColumnNames::MaxTime,
+            timeSeriesTimestampToAST(*native_start_time, timestamp_data_type)->formatWithSecretsOneLine()));
+
+    if (native_end_time)
+        conditions.push_back(fmt::format(
+            "{0} <= {1}",
+            TimeSeriesColumnNames::MinTime,
+            timeSeriesTimestampToAST(*native_end_time, timestamp_data_type)->formatWithSecretsOneLine()));
+}
+
+/// Implements /api/v1/series: returns time series matching the supplied series selectors.
+/// Queries the tags table and serializes each series as a JSON object with __name__ and all tag key-value pairs.
 void PrometheusHTTPProtocolAPI::getSeries(
     WriteBuffer & response,
     const Strings & match_params,
@@ -516,87 +964,271 @@ void PrometheusHTTPProtocolAPI::getSeries(
     UInt64 limit,
     QueryFinishCallback query_finish_callback)
 {
-    /// Prometheus requires at least one `match[]` selector here; without it the endpoint would scan the whole tags table.
+    /// Prometheus requires at least one `match[]` series selector on `/api/v1/series` (unlike
+    /// `/labels` and `/label/<name>/values`, where it is optional). Without it the endpoint would run
+    /// an unbounded `SELECT DISTINCT ... FROM <tags>` over the whole table and return a potentially
+    /// huge response for a malformed or incomplete client call, so reject it (fail closed). An
+    /// explicitly empty `match[]` value is rejected by `makeMatchCondition` below.
     if (match_params.empty())
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
             "The Prometheus /api/v1/series endpoint requires at least one 'match[]' series selector");
 
-    auto series_ids_query = makeSeriesIDsQuery(match_params, start_param, end_param);
+    auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
+    const auto & time_series_table_id = time_series_storage->getStorageID();
 
-    /// SELECT DISTINCT timeSeriesIdToTags(series_id) AS tags FROM (<series_ids_query>) [LIMIT <limit> + 1]
-    /// timeSeriesIdToTags returns the tags registered by the inner query (including `__name__`); `DISTINCT` dedups, and one extra row detects truncation.
-    auto tags_expression = makeASTFunction("timeSeriesIdToTags", make_intrusive<ASTIdentifier>("series_id"));
-    tags_expression->setAlias(TimeSeriesColumnNames::Tags);
+    /// Tags configured via `tags_to_columns` are stored in dedicated columns instead of the `tags` Map,
+    /// but a supported external `tags` table can also carry such a tag in the residual Map (e.g. legacy
+    /// rows written before the tag was moved to a dedicated column). Deduplicating by the raw table layout
+    /// (`metric_name`, `tags`, the dedicated columns) would then return the same logical series twice, or
+    /// emit the same label key twice from a single mixed row. So normalize each row to its logical
+    /// Prometheus label set right in the query, with the same rules `timeSeriesStoreTags` applies on the
+    /// write path: merge both carriers, collapse exact duplicates (`arrayDistinct`), drop empty values
+    /// (an empty label value means the label is absent), retain empty-name entries until validation,
+    /// and sort by label name. Conflicting carriers
+    /// (same name, different values) survive as adjacent entries of the sorted array and are rejected
+    /// during emission below, again as in `timeSeriesStoreTags`.
+    auto tag_columns = getConfiguredTagColumns();
 
-    std::optional<UInt64> sql_limit;
+    auto tags_metadata = tags_table->getInMemoryMetadataPtr(getContext(), false);
+    String series_labels_alias = "__series_labels";
+    while (tags_metadata->columns.has(series_labels_alias))
+        series_labels_alias += "_";
+
+    String labels_expr = fmt::format("arrayZip(mapKeys({0}), mapValues({0}))", TimeSeriesColumnNames::Tags);
+    if (!tag_columns.empty())
+    {
+        String dedicated_entries;
+        for (const auto & [tag_name, column_name] : tag_columns)
+        {
+            if (!dedicated_entries.empty())
+                dedicated_entries += ", ";
+            dedicated_entries += fmt::format("({}, coalesce(toString({}), ''))", quoteString(tag_name), backQuoteIfNeed(column_name));
+        }
+        labels_expr = fmt::format("arrayConcat({}, [{}])", labels_expr, dedicated_entries);
+    }
+
+    /// Keep the canonical metric name in the normalized label array as well. The serializer omits it from
+    /// the per-series labels because it writes `__name__` separately, while `validate_labels` can detect a
+    /// conflicting `tags['__name__']` carrier after the row has passed the selector and any SQL LIMIT.
+    labels_expr = fmt::format(
+        "arrayConcat({}, [({}, {})])",
+        labels_expr,
+        quoteString(TimeSeriesTagNames::MetricName),
+        TimeSeriesColumnNames::MetricName);
+
+    String select_columns = fmt::format(
+        "{}, arraySort(arrayDistinct(arrayFilter(x -> (x.2 != '' OR x.1 = ''), {}))) AS `{}`",
+        TimeSeriesColumnNames::MetricName,
+        labels_expr,
+        series_labels_alias);
+
+    /// Read through the TimeSeries-owned table function so the configured TimeSeries table remains the
+    /// authorization boundary. The physical tags target can be an inner implementation table without a
+    /// separate SELECT grant.
+    const String tags_table_expression = fmt::format(
+        "timeSeriesTags({}, {})",
+        quoteString(time_series_table_id.database_name),
+        quoteString(time_series_table_id.table_name));
+
+    /// Build query: SELECT DISTINCT metric_name, <normalized labels> FROM timeSeriesTags(...) [WHERE ...]
+    /// The tags target is usually `AggregatingMergeTree`/`ReplacingMergeTree` and stores a row per write,
+    /// so the same series can be present multiple times until parts are merged. `DISTINCT` deduplicates
+    /// by series identity (metric name + normalized label set).
+    String query = fmt::format("SELECT DISTINCT {} FROM {}", select_columns, tags_table_expression);
+
+    std::vector<String> conditions;
+    std::unordered_map<String, String> column_name_by_tag_name(tag_columns.begin(), tag_columns.end());
+    if (String match_condition = makeMatchCondition(match_params, column_name_by_tag_name); !match_condition.empty())
+        conditions.push_back(match_condition);
+    appendTimeRangeConditions(conditions, tags_table, start_param, end_param);
+
+    for (size_t i = 0; i < conditions.size(); ++i)
+        query += (i == 0 ? " WHERE " : " AND ") + conditions[i];
+
+    /// Fetch one extra row for a finite limit so the response can report truncation without scanning the
+    /// complete matching series set.
     if (limit)
-        sql_limit = limit + 1;
+        query += fmt::format(" LIMIT {}", limit + 1);
 
-    auto sql_query = makeSelectFromSubquery({std::move(tags_expression)}, std::move(series_ids_query), /* distinct = */ true, sql_limit);
+    LOG_TRACE(log, "Prometheus series query: {}", query);
 
-    LOG_TRACE(log, "SQL query to execute:\n{}", sql_query->formatForLogging());
+    /// The SQL query itself is limited to `limit + 1` rows only to detect truncation. Do not cache
+    /// that partial query result, otherwise a later unlimited request can receive the truncated rows.
+    auto query_context = getContext();
+    if (limit)
+    {
+        query_context = Context::createCopy(getContext());
+        query_context->setSetting("use_query_cache", false);
+    }
 
-    /// Functions timeSeriesStoreTags() and timeSeriesIdToTags() are supported by the analyzer only.
-    getContext()->setSetting("allow_experimental_analyzer", true);
-
-    auto [ast, io] = executeQuery(sql_query->formatWithSecretsOneLine(), getContext(), {}, QueryProcessingStage::Complete);
+    auto [ast, io] = executeQuery(query, query_context, {}, QueryProcessingStage::Complete);
 
     try
     {
         PullingAsyncPipelineExecutor executor(io.pipeline);
+        Block result_block;
 
-        /// Pull the first non-empty block before writing the header so an early exception still produces the correct error response.
-        bool has_output = false;
-        Block block;
-        while (executor.pull(block))
+        /// Exact duplicates were collapsed by `arrayDistinct`, so two adjacent entries with the same
+        /// name in a sorted `__series_labels` array mean the row stores conflicting values for one
+        /// label (e.g. in the residual `tags` map and in a dedicated `tags_to_columns` column). Reject
+        /// it like `timeSeriesStoreTags` does on the write path instead of emitting an invalid series
+        /// with a repeated label key. Validate the strings at this API boundary because external String
+        /// columns can contain invalid UTF-8, while both Prometheus and the JSON serializer require it.
+        auto is_valid_utf8 = [](const auto & value)
         {
-            if (block.rows() > 0)
-            {
-                has_output = true;
-                break;
-            }
-        }
+            return UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(value.data()), value.size());
+        };
 
-        writeString(R"({"status":"success","data":[)", response);
-
-        UInt64 written = 0;
-        bool truncated = false;
-
-        auto write_block = [&](const Block & result_block)
+        auto validate_row = [&](const auto & metric_name_column,
+                                const auto & offsets,
+                                const auto & key_column,
+                                const auto & value_column,
+                                size_t i)
         {
-            for (size_t i = 0; i < result_block.rows(); ++i)
+            if (metric_name_column->getDataAt(i).empty())
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Found empty metric name in a row of the 'tags' table");
+
+            if (!is_valid_utf8(metric_name_column->getDataAt(i)))
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Found invalid UTF-8 in a metric name in a row of the 'tags' table");
+
+            size_t start = (i == 0) ? 0 : offsets[i - 1];
+            for (size_t j = start; j < offsets[i]; ++j)
             {
-                if (limit && (written == limit))
-                {
-                    truncated = true;
-                    return;
-                }
-                if (written)
-                    writeString(",", response);
-                writeTags(response, result_block, i);
-                ++written;
+                if (key_column.getDataAt(j).empty())
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found a tag with an empty name in a row of the 'tags' table");
+
+                if (!is_valid_utf8(key_column.getDataAt(j)) || !is_valid_utf8(value_column.getDataAt(j)))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found invalid UTF-8 in a label name or value in a row of the 'tags' table");
+
+                if (j > start && key_column.getDataAt(j) == key_column.getDataAt(j - 1))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Found two tags with the same name {} but different values {} and {} in a row of the 'tags' table",
+                        quoteString(key_column.getDataAt(j)),
+                        quoteString(value_column.getDataAt(j - 1)),
+                        quoteString(value_column.getDataAt(j)));
             }
         };
 
-        if (has_output)
+        auto validate_emittable_rows = [&](const Block & block, UInt64 already_emitted)
         {
-            write_block(block);
-            while (!truncated && executor.pull(block))
+            const auto & metric_name_column = block.getByName(TimeSeriesColumnNames::MetricName).column;
+            const auto & array_column = typeid_cast<const ColumnArray &>(*block.getByName(series_labels_alias).column);
+            const auto & offsets = array_column.getOffsets();
+            const auto & tuple_column = typeid_cast<const ColumnTuple &>(array_column.getData());
+            const auto & key_column = tuple_column.getColumn(0);
+            const auto & value_column = tuple_column.getColumn(1);
+
+            for (size_t i = 0; i < block.rows(); ++i)
             {
-                if (block.rows() > 0)
-                    write_block(block);
+                /// Do not validate the extra row used only to detect truncation.
+                if (limit && (already_emitted == limit || i >= limit - already_emitted))
+                    break;
+                validate_row(metric_name_column, offsets, key_column, value_column, i);
             }
+        };
+
+        /// Materialize all rows that will be emitted before writing the success envelope. Otherwise a
+        /// malformed row in a later block could be discovered after the response buffer has flushed,
+        /// making the result depend on block boundaries and `http_response_buffer_size`.
+        std::vector<Block> blocks_to_write;
+        UInt64 emitted = 0;
+        bool truncated = false;
+
+        while (executor.pull(result_block))
+        {
+            if (result_block.rows() == 0)
+                continue;
+
+            size_t rows_to_write = result_block.rows();
+            if (limit)
+            {
+                /// A row beyond `limit` only signals truncation and must not be validated or retained.
+                if (emitted == limit)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                const UInt64 remaining = limit - emitted;
+                if (remaining < rows_to_write)
+                {
+                    rows_to_write = static_cast<size_t>(remaining);
+                    truncated = true;
+                }
+            }
+
+            validate_emittable_rows(result_block, emitted);
+            if (rows_to_write < result_block.rows())
+                blocks_to_write.emplace_back(result_block.cloneWithCutColumns(0, rows_to_write));
+            else
+                blocks_to_write.emplace_back(std::move(result_block));
+            emitted += rows_to_write;
+
+            if (truncated)
+                break;
         }
 
-        if (truncated)
-            writeString(R"(],"warnings":["results truncated due to limit"]})", response);
-        else
-            writeString("]}", response);
+        bool first_row = true;
+        auto write_block = [&](const Block & block)
+        {
+            const auto & metric_name_col = block.getByName(TimeSeriesColumnNames::MetricName).column;
+            const auto & labels_col = block.getByName(series_labels_alias).column;
 
-        /// Finalize the query result cache write before the executor's destructor cancels the pipeline; a truncated (incomplete) result must not be cached.
-        if (!truncated)
-            io.pipeline.finalizeWriteInQueryResultCache();
+            /// `__series_labels` is an `Array(Tuple(String, String))` of (label name, label value)
+            /// pairs, already normalized in the query: sorted by name, exact duplicates collapsed,
+            /// empty values dropped. `ColumnArray(ColumnTuple(names, values))` — read the nested
+            /// tuple once per block before serializing its rows.
+            const auto & array_column = typeid_cast<const ColumnArray &>(*labels_col);
+            const auto & offsets = array_column.getOffsets();
+            const auto & tuple_column = typeid_cast<const ColumnTuple &>(array_column.getData());
+            const auto & key_column = tuple_column.getColumn(0);
+            const auto & value_column = tuple_column.getColumn(1);
+
+            for (size_t i = 0; i < block.rows(); ++i)
+            {
+                if (!first_row)
+                    writeString(",", response);
+                first_row = false;
+
+                writeString(R"({"__name__":)", response);
+                writeJSONString(metric_name_col->getDataAt(i), response, format_settings);
+
+                size_t start = (i == 0) ? 0 : offsets[i - 1];
+                size_t end = offsets[i];
+
+                for (size_t j = start; j < end; ++j)
+                {
+                    if (key_column.getDataAt(j) == TimeSeriesTagNames::MetricName)
+                        continue;
+                    writeString(",", response);
+                    writeJSONString(key_column.getDataAt(j), response, format_settings);
+                    writeString(":", response);
+                    writeJSONString(value_column.getDataAt(j), response, format_settings);
+                }
+
+                writeString("}", response);
+            }
+        };
+
+        writeString(R"({"status":"success","data":[)", response);
+        for (const auto & block : blocks_to_write)
+        write_block(block);
+
+        writeMetadataResponseFooter(response, truncated);
+
+        /// Store the streamed result in the query result cache now (no-op if no cache writers exist in the pipeline):
+        /// the executor's destructor cancels the pipeline processors, after which the pending write would be discarded.
+        io.pipeline.finalizeWriteInQueryResultCache();
     }
     catch (...)
     {
@@ -604,7 +1236,10 @@ void PrometheusHTTPProtocolAPI::getSeries(
         throw;
     }
 
-    /// Release the query slot early, flush the response and record QueryFinish.
+    /// Release the query slot early and record QueryFinish in system.query_log, mirroring executePromQLQuery.
+    /// BlockIO::~BlockIO only resets the pipeline and never runs the finish/exception callbacks, so without
+    /// this a successful metadata request would never emit a QueryFinish entry and would keep the query slot
+    /// occupied until the whole HTTP response is written instead of releasing it when the pipeline is exhausted.
     finishExecutedQuery(io, query_finish_callback);
 }
 
@@ -941,5 +1576,6 @@ void PrometheusHTTPProtocolAPI::writeScalar(WriteBuffer & response, Float64 valu
         writeString("NaN", response);
     }
 }
+
 
 }

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include <Common/Logger_fwd.h>
 #include <Core/Names.h>
 #include <Formats/FormatSettings.h>
@@ -41,6 +44,7 @@ public:
         String end_param;
         String step_param;
         String lookback_delta_param;
+        UInt64 limit = 0;
     };
 
     /// Execute an instant query (/api/v1/query) or range query (/api/v1/query_range)
@@ -49,7 +53,11 @@ public:
         const Params & params,
         QueryFinishCallback query_finish_callback = {});
 
-    /// Get series metadata (/api/v1/series): the union of the series matched by the `match[]` selectors, capped by `limit` (0 means no limit).
+    /// Get series metadata (/api/v1/series).
+    /// `match_params` are the values of the repeated `match[]` parameter. The result is the union
+    /// over all selectors; an empty list is rejected by the HTTP endpoint.
+    /// `limit` is the maximum number of returned items (0 means no limit); when the result is
+    /// truncated, the response carries the Prometheus "results truncated due to limit" warning.
     void getSeries(
         WriteBuffer & response,
         const Strings & match_params,
@@ -94,19 +102,51 @@ private:
     ASTPtr makeSeriesIDsQuery(const Strings & match_params, const String & start_param, const String & end_param);
 
     /// Writes the result of a prometheus query as a JSON.
-    void writeQueryResponse(WriteBuffer & response, PullingAsyncPipelineExecutor & pulling_executor, PrometheusQueryResultType result_type);
+    void writeQueryResponse(
+        WriteBuffer & response,
+        PullingAsyncPipelineExecutor & pulling_executor,
+        PrometheusQueryResultType result_type,
+        UInt64 limit);
 
     /// Helper methods.
     void writeQueryResponseHeader(WriteBuffer & response, PrometheusQueryResultType result_type);
-    void writeQueryResponseFooter(WriteBuffer & response);
-    void writeQueryResponseBlock(WriteBuffer & response, PrometheusQueryResultType result_type, const Block & result_block, bool first);
+    void writeQueryResponseFooter(WriteBuffer & response, bool truncated);
+    void writeQueryResponseBlock(
+        WriteBuffer & response,
+        PrometheusQueryResultType result_type,
+        const Block & result_block,
+        bool first,
+        UInt64 limit,
+        UInt64 & emitted,
+        bool & truncated);
     void writeQueryResponseScalarBlock(WriteBuffer & response, const Block & result_block, bool first);
     void writeQueryResponseStringBlock(WriteBuffer & response, const Block & result_block, bool first);
-    void writeQueryResponseInstantVectorBlock(WriteBuffer & response, const Block & result_block, bool first);
-    void writeQueryResponseRangeVectorBlock(WriteBuffer & response, const Block & result_block, bool first);
+    void writeQueryResponseInstantVectorBlock(
+        WriteBuffer & response,
+        const Block & result_block,
+        UInt64 limit,
+        UInt64 & emitted,
+        bool & truncated);
+    void writeQueryResponseRangeVectorBlock(
+        WriteBuffer & response,
+        const Block & result_block,
+        UInt64 limit,
+        UInt64 & emitted,
+        bool & truncated);
     void writeTags(WriteBuffer & response, const Block & result_block, size_t row_index);
     void writeTimestamp(WriteBuffer & response, DateTime64 value, UInt32 scale);
     void writeScalar(WriteBuffer & response, Float64 value);
+
+    /// Returns the (tag name -> column name) pairs configured via the `tags_to_columns` setting.
+    /// These tags can be present in the dedicated columns of the `tags` table, the `tags` Map, or both.
+    std::vector<std::pair<String, String>> getConfiguredTagColumns() const;
+
+    /// Appends `min_time`/`max_time` overlap conditions to `conditions` for the optional `start`/`end`
+    /// parameters of the metadata endpoints when trusted time bounds are available. Otherwise validates
+    /// the request and leaves the conditions unchanged, returning the approximate superset allowed by
+    /// Prometheus's `/api/v1/series` contract.
+    void appendTimeRangeConditions(
+        std::vector<String> & conditions, const StoragePtr & tags_table, const String & start_param, const String & end_param);
 
     std::shared_ptr<const StorageTimeSeries> time_series_storage;
     FormatSettings format_settings;

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -91,9 +91,11 @@ public:
     void getLabelValues(
         WriteBuffer & response,
         const String & label_name,
-        const String & match_param,
+        const Strings & match_params,
         const String & start_param,
-        const String & end_param);
+        const String & end_param,
+        UInt64 limit,
+        QueryFinishCallback query_finish_callback = {});
 
 private:
     /// Parses the `match[]` instant selectors and the optional `start` and `end` bounds of the metadata endpoints

--- a/src/Storages/TimeSeries/timeSeriesMatchersToAST.cpp
+++ b/src/Storages/TimeSeries/timeSeriesMatchersToAST.cpp
@@ -1,0 +1,148 @@
+#include <Storages/TimeSeries/timeSeriesMatchersToAST.h>
+
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Storages/TimeSeries/TimeSeriesColumnNames.h>
+#include <Storages/TimeSeries/TimeSeriesTagNames.h>
+
+#include <utility>
+
+
+namespace DB
+{
+
+ASTPtr timeSeriesTagNameToAST(const String & tag_name, const std::unordered_map<String, String> & column_name_by_tag_name)
+{
+    if (tag_name == TimeSeriesTagNames::MetricName)
+        return make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::MetricName);
+
+    /// arrayElement() extracts a value from the `tags` Map and returns '' for a missing key, which matches
+    /// Prometheus semantics: a missing label is equal to the empty label value.
+    auto make_map_value = [&]
+    {
+        return makeASTFunction("arrayElement", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Tags), make_intrusive<ASTLiteral>(tag_name));
+    };
+
+    auto it = column_name_by_tag_name.find(tag_name);
+    if (it == column_name_by_tag_name.end())
+        return make_map_value();
+
+    /// A dedicated tag column is allowed to be Nullable (e.g. `LowCardinality(Nullable(String))` in an external
+    /// tags table), and a series without this tag stores NULL there. Prometheus treats a missing label as equal
+    /// to the empty label value, so normalize NULL to '' - otherwise matchers like {host=""}, {host!="prod"} or
+    /// {host=~".*"} would evaluate to NULL and filter such series out, unlike the `tags` Map path, where
+    /// arrayElement() returns '' for a missing key.
+    auto make_column_value = [&]
+    {
+        return makeASTFunction("ifNull", make_intrusive<ASTIdentifier>(it->second), make_intrusive<ASTLiteral>(""));
+    };
+
+    /// A tag configured via `tags_to_columns` normally lives in the dedicated column, but a supported external
+    /// tags table can also carry it in the residual `tags` Map (e.g. legacy rows written before the dedicated
+    /// column was adopted). Resolve the tag with the same precedence as `timeSeriesStoreTags` on the write path:
+    /// use the dedicated column when it is non-empty and fall back to the Map otherwise. Conflict validation is
+    /// deliberately kept out of this expression because it is also used in matcher predicates, where an
+    /// exception could be evaluated for a row that another matcher would have excluded.
+    return makeASTFunction(
+        "if",
+        makeASTFunction("notEquals", make_column_value(), make_intrusive<ASTLiteral>("")),
+        make_column_value(),
+        make_map_value());
+}
+
+ASTPtr timeSeriesMatcherToAST(
+    const PrometheusQueryTree::Matcher & matcher,
+    const std::unordered_map<String, String> & column_name_by_tag_name)
+{
+    std::string_view function_name;
+    bool add_anchors = false;
+    bool add_not = false;
+
+    auto matcher_type = matcher.matcher_type;
+    switch (matcher_type)
+    {
+        case PrometheusQueryTree::MatcherType::EQ:  function_name = "equals"; break;
+        case PrometheusQueryTree::MatcherType::NE:  function_name = "notEquals"; break;
+        case PrometheusQueryTree::MatcherType::RE:  function_name = "match"; add_anchors = true; break;
+        case PrometheusQueryTree::MatcherType::NRE: function_name = "match"; add_anchors = true; add_not = true; break;
+    }
+
+    String value = matcher.label_value;
+    if (add_anchors)
+    {
+        /// Prometheus regexp matchers are fully anchored: the pattern must match the whole label value.
+        /// The pattern is wrapped in a non-capturing group before anchoring - the same way Prometheus does it -
+        /// because otherwise a top-level alternation would bind the anchors to its first and last branches only
+        /// (e.g. "a|b" would become "^a|b$", which also matches "ax" and "xb").
+        value = "^(?:" + value + ")$";
+    }
+    auto make_matcher = [&](ASTPtr value_ast)
+    {
+        return makeASTFunction(function_name, std::move(value_ast), make_intrusive<ASTLiteral>(value));
+    };
+
+    /// A dedicated column normally contains the tag value, but external tables can still contain
+    /// legacy rows where the value exists only in the residual Map. Keep the two cases as separate
+    /// branches so MergeTree can use the dedicated-column comparison for index pruning:
+    ///
+    ///   (column is non-empty AND matcher(column))
+    ///   OR (column is NULL/empty AND matcher(tags[tag_name]))
+    ///
+    /// The unguarded `direct_match OR canonical_match` form is equivalent for row evaluation, but
+    /// its Map branch can match any granule and therefore prevents the primary key analyzer from
+    /// pruning on the dedicated column. Regex matchers stay on the canonical path because `match`
+    /// is not a key-condition atom and the extra branch would only add work.
+    const auto dedicated_column_it = column_name_by_tag_name.find(matcher.label_name);
+    const bool use_dedicated_column_fast_path =
+        (matcher_type == PrometheusQueryTree::MatcherType::EQ || matcher_type == PrometheusQueryTree::MatcherType::NE)
+        && matcher.label_name != TimeSeriesTagNames::MetricName
+        && dedicated_column_it != column_name_by_tag_name.end();
+
+    ASTPtr res;
+    if (use_dedicated_column_fast_path)
+    {
+        auto make_dedicated_value = [&]
+        {
+            return make_intrusive<ASTIdentifier>(dedicated_column_it->second);
+        };
+        auto make_map_value = [&]
+        {
+            return makeASTFunction(
+                "arrayElement",
+                make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Tags),
+                make_intrusive<ASTLiteral>(matcher.label_name));
+        };
+
+        auto direct_match = makeASTFunction(
+            "and",
+            makeASTFunction("notEquals", make_dedicated_value(), make_intrusive<ASTLiteral>("")),
+            make_matcher(make_dedicated_value()));
+
+        auto dedicated_value_is_empty = makeASTFunction(
+            "or",
+            makeASTFunction("isNull", make_dedicated_value()),
+            makeASTFunction("equals", make_dedicated_value(), make_intrusive<ASTLiteral>("")));
+        auto map_match = makeASTFunction(
+            "and",
+            std::move(dedicated_value_is_empty),
+            make_matcher(make_map_value()));
+
+        /// `and()` over a Nullable dedicated column can be Nullable. Normalize it to false so a
+        /// missing dedicated value reaches the Map branch instead of propagating NULL through `or()`.
+        res = makeASTFunction(
+            "or",
+            makeASTFunction("ifNull", std::move(direct_match), make_intrusive<ASTLiteral>(false)),
+            std::move(map_match));
+    }
+    else
+    {
+        res = make_matcher(timeSeriesTagNameToAST(matcher.label_name, column_name_by_tag_name));
+    }
+
+    if (add_not)
+        res = makeASTFunction("not", res);
+    return res;
+}
+
+}

--- a/src/Storages/TimeSeries/timeSeriesMatchersToAST.h
+++ b/src/Storages/TimeSeries/timeSeriesMatchersToAST.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Parsers/IAST_fwd.h>
+#include <Parsers/Prometheus/PrometheusQueryTree.h>
+
+#include <unordered_map>
+
+
+namespace DB
+{
+
+/// Makes an AST for the expression referencing the value of a tag in the 'tags' target table of a
+/// TimeSeries storage: the 'metric_name' column for '__name__', a dedicated column for a tag configured
+/// via 'tags_to_columns' with a fallback to the 'tags' map, and an element of the 'tags' map otherwise.
+/// A dedicated column may be Nullable, in which case NULL (a missing tag) is normalized to '',
+/// because Prometheus treats a missing label as equal to the empty label value. A supported external
+/// tags table can also carry a 'tags_to_columns' tag in only the residual 'tags' map (e.g. an older
+/// or external layout), so when the dedicated column is empty the expression falls back to the map,
+/// using the same precedence as `timeSeriesStoreTags` on the write path. This helper does not validate
+/// conflicting non-empty carriers; callers that emit complete series metadata validate selected rows
+/// separately.
+ASTPtr timeSeriesTagNameToAST(const String & tag_name, const std::unordered_map<String, String> & column_name_by_tag_name);
+
+/// Makes an AST for the condition filtering rows of the 'tags' target table of a TimeSeries storage
+/// by a single label matcher of a Prometheus instant selector, e.g. {job="prometheus"}.
+/// A regexp matcher is anchored on both sides (as in Prometheus) before being passed to `match`.
+/// Equality and inequality matchers on a tag configured via `tags_to_columns` expose a guarded
+/// predicate over the dedicated column so MergeTree can use it for index pruning while retaining
+/// the residual Map fallback for legacy rows.
+ASTPtr timeSeriesMatcherToAST(
+    const PrometheusQueryTree::Matcher & matcher,
+    const std::unordered_map<String, String> & column_name_by_tag_name);
+
+}

--- a/src/TableFunctions/TableFunctionPrometheusQuery.cpp
+++ b/src/TableFunctions/TableFunctionPrometheusQuery.cpp
@@ -1,6 +1,9 @@
 #include <TableFunctions/TableFunctionPrometheusQuery.h>
 
+#include <Access/Common/AccessFlags.h>
+#include <Interpreters/Context.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/StorageTimeSeries.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/Converter.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -30,8 +33,9 @@ void TableFunctionPrometheusQuery<over_range>::parseArguments(const ASTPtr & ast
 
 template <bool over_range>
 ColumnsDescription
-TableFunctionPrometheusQuery<over_range>::getActualTableStructure(ContextPtr /* context */, bool /* is_insert_query */) const
+TableFunctionPrometheusQuery<over_range>::getActualTableStructure(ContextPtr context, bool /* is_insert_query */) const
 {
+    context->checkAccess(AccessType::SELECT, config.evaluation_settings.time_series_storage_id);
     PrometheusQueryToSQL::Converter converter{config.promql_query, config.evaluation_settings};
     return converter.getResultColumns();
 }
@@ -45,6 +49,7 @@ StoragePtr TableFunctionPrometheusQuery<over_range>::executeImpl(
     ColumnsDescription /* cached_columns */,
     bool is_insert_query) const
 {
+    checkTimeSeriesTableSelectAccess(context, config.evaluation_settings.time_series_storage_id);
     auto columns = getActualTableStructure(context, is_insert_query);
     auto res = std::make_shared<StoragePrometheusQuery>(StorageID(getDatabaseName(), table_name), columns, config);
     res->startup();

--- a/src/TableFunctions/TableFunctionTimeSeries.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeries.cpp
@@ -1,5 +1,6 @@
 #include <TableFunctions/TableFunctionTimeSeries.h>
 
+#include <Access/Common/AccessFlags.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/evaluateConstantExpression.h>
@@ -87,14 +88,19 @@ StoragePtr TableFunctionTimeSeriesTarget<target_kind>::executeImpl(
         ContextPtr context,
         const String & /* table_name */,
         ColumnsDescription /* cached_columns */,
-        bool /* is_insert_query */) const
+        bool is_insert_query) const
 {
+    if (is_insert_query)
+        context->checkAccess(AccessType::INSERT, time_series_storage_id);
+    else
+        checkTimeSeriesTableSelectAccess(context, time_series_storage_id);
     return getTargetTable(context);
 }
 
 template <ViewTarget::Kind target_kind>
 ColumnsDescription TableFunctionTimeSeriesTarget<target_kind>::getActualTableStructure(ContextPtr context, bool /* is_insert_query */) const
 {
+    context->checkAccess(AccessType::SELECT, time_series_storage_id);
     auto metadata_snapshot = getTargetTable(context)->getInMemoryMetadataPtr(context, false);
     return metadata_snapshot->columns;
 }
@@ -135,7 +141,9 @@ SELECT * FROM timeSeriesSamples('db_name', 'time_series_table');
 <Note>
 The function `timeSeriesSamples` has an alias `timeSeriesData` which is kept for backwards compatibility.
 </Note>
-)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction});
+
+The outer `TimeSeries` table is the access-control boundary. `SELECT` on the inner target table alone is not sufficient; callers need `SELECT` on the outer `TimeSeries` table. `SELECT` row policies on the outer table or any target table are not supported for this target-backed read and cause the query to be rejected.
+)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction}, {.allow_readonly = true});
 
     factory.registerAlias("timeSeriesData", "timeSeriesSamples");
 
@@ -161,7 +169,9 @@ SELECT * FROM timeSeriesTags(db_name.time_series_table);
 SELECT * FROM timeSeriesTags('db_name.time_series_table');
 SELECT * FROM timeSeriesTags('db_name', 'time_series_table');
 ```
-)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction});
+
+The outer `TimeSeries` table is the access-control boundary. `SELECT` on the inner target table alone is not sufficient; callers need `SELECT` on the outer `TimeSeries` table. `SELECT` row policies on the outer table or any target table are not supported for this target-backed read and cause the query to be rejected.
+)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction}, {.allow_readonly = true});
 
     factory.registerFunction<TableFunctionTimeSeriesTarget<ViewTarget::Metrics>>(
         {.description = R"DOCS_MD(
@@ -185,12 +195,16 @@ SELECT * FROM timeSeriesMetrics(db_name.time_series_table);
 SELECT * FROM timeSeriesMetrics('db_name.time_series_table');
 SELECT * FROM timeSeriesMetrics('db_name', 'time_series_table');
 ```
-)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction});
+
+The outer `TimeSeries` table is the access-control boundary. `SELECT` on the inner target table alone is not sufficient; callers need `SELECT` on the outer `TimeSeries` table. `SELECT` row policies on the outer table or any target table are not supported for this target-backed read and cause the query to be rejected.
+)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction}, {.allow_readonly = true});
 
     factory.registerFunction<TableFunctionTimeSeriesSelector>(
         {.description = R"DOCS_MD(
 Reads time series from a TimeSeries table filtered by a selector and with timestamps in a specified interval.
 This function is similar to [range selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#range-vector-selectors) but it's used to implement [instant selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) too.
+
+`SELECT` row policies on the outer `TimeSeries` table or any target table are not supported for this target-backed read and cause the query to be rejected.
 
 ## Syntax {#syntax}
 
@@ -222,11 +236,13 @@ There is no specific order for returned data.
 ```sql
 SELECT * FROM timeSeriesSelector(mytable, 'http_requests{job="prometheus"}', now() - INTERVAL 10 MINUTES, now())
 ```
-)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction});
+)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction}, {.allow_readonly = true});
 
     factory.registerFunction<TableFunctionPrometheusQuery</* range = */ false>>(
         {.description = R"DOCS_MD(
 Evaluates a prometheus query using data from a TimeSeries table.
+
+`SELECT` row policies on the outer `TimeSeries` table or any target table are not supported for this target-backed read and cause the query to be rejected.
 
 ## Syntax {#syntax}
 
@@ -298,10 +314,12 @@ Unary operators `+` and `-`.
 ```sql
 SELECT * FROM prometheusQuery(mytable, 'rate(http_requests{job="prometheus"}[10m])[1h:10m]', now())
 ```
-)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction});
+)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction}, {.allow_readonly = true});
     factory.registerFunction<TableFunctionPrometheusQuery</* range = */ true>>(
         {.description = R"DOCS_MD(
 Evaluates a prometheus query using data from a TimeSeries table over a range of evaluation times.
+
+`SELECT` row policies on the outer `TimeSeries` table or any target table are not supported for this target-backed read and cause the query to be rejected.
 
 ## Syntax {#syntax}
 
@@ -375,7 +393,7 @@ Unary operators `+` and `-`.
 ```sql
 SELECT * FROM prometheusQueryRange(mytable, 'rate(http_requests{job="prometheus"}[10m])[1h:10m]', now() - INTERVAL 10 MINUTES, now(), INTERVAL 1 MINUTE)
 ```
-)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction});
+)DOCS_MD", .category = FunctionDocumentation::Category::TableFunction}, {.allow_readonly = true});
 }
 
 }

--- a/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeriesSelector.cpp
@@ -1,6 +1,9 @@
 #include <TableFunctions/TableFunctionTimeSeriesSelector.h>
 
+#include <Access/Common/AccessFlags.h>
+#include <Interpreters/Context.h>
 #include <Parsers/ASTFunction.h>
+#include <Storages/StorageTimeSeries.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
 #include <TableFunctions/TableFunctionFactory.h>
 
@@ -25,8 +28,9 @@ void TableFunctionTimeSeriesSelector::parseArguments(const ASTPtr & ast_function
     config = StorageTimeSeriesSelector::getConfiguration(args, context);
 }
 
-ColumnsDescription TableFunctionTimeSeriesSelector::getActualTableStructure(ContextPtr /* context */, bool /* is_insert_query */) const
+ColumnsDescription TableFunctionTimeSeriesSelector::getActualTableStructure(ContextPtr context, bool /* is_insert_query */) const
 {
+    context->checkAccess(AccessType::SELECT, config.time_series_storage_id);
     return ColumnsDescription({
         {TimeSeriesColumnNames::ID, config.id_data_type},
         {TimeSeriesColumnNames::Timestamp, config.timestamp_data_type},
@@ -41,6 +45,7 @@ StoragePtr TableFunctionTimeSeriesSelector::executeImpl(
         ColumnsDescription /* cached_columns */,
         bool is_insert_query) const
 {
+    checkTimeSeriesTableSelectAccess(context, config.time_series_storage_id);
     auto columns = getActualTableStructure(context, is_insert_query);
     auto res = std::make_shared<StorageTimeSeriesSelector>(StorageID(getDatabaseName(), table_name), columns, config);
     res->startup();

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -65,7 +65,7 @@
                 </handler>
             </my_rule_8>
             <my_rule_9>
-                <url>/api/v1/label/*/values</url>
+                <url>regex:/api/v1/label/[^/]+/values</url>
                 <handler>
                     <type>query</type>
                     <table>default.prometheus</table>

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -113,7 +113,23 @@
                 </handler>
             </my_rule_11>
 
-            <!-- Table without min_time/max_time columns: /api/v1/series must ignore the time range for it. -->
+            <!-- Prefix used by access-control and unknown-route regression tests. -->
+            <my_rule_16>
+                <url_prefix>/combined</url_prefix>
+                <handler>
+                    <type>api_v1</type>
+                    <table>default.prometheus</table>
+                </handler>
+            </my_rule_16>
+
+            <!-- Tables used to verify the Prometheus-compatible ranged-series fallback. -->
+            <my_rule_17>
+                <url_prefix>/no_filter</url_prefix>
+                <handler>
+                    <type>query</type>
+                    <table>default.prometheus_no_filter</table>
+                </handler>
+            </my_rule_17>
             <my_rule_12>
                 <url_prefix>/no_bounds</url_prefix>
                 <handler>
@@ -121,6 +137,31 @@
                     <table>default.prometheus_no_bounds</table>
                 </handler>
             </my_rule_12>
+
+            <!-- Table used to verify that metadata time bounds do not wrap for UInt32 timestamps. -->
+            <my_rule_18>
+                <url_prefix>/uint32</url_prefix>
+                <handler>
+                    <type>query</type>
+                    <table>default.prometheus_uint32</table>
+                </handler>
+            </my_rule_18>
+
+            <!-- Table used to verify that metadata time bounds are clipped for DateTime64(9). -->
+            <my_rule_19>
+                <url_prefix>/datetime64_9</url_prefix>
+                <handler>
+                    <type>query</type>
+                    <table>default.prometheus_datetime64_9</table>
+                </handler>
+            </my_rule_19>
+            <my_rule_20>
+                <url_prefix>/datetime64_3_future</url_prefix>
+                <handler>
+                    <type>query</type>
+                    <table>default.prometheus_datetime64_3_future</table>
+                </handler>
+            </my_rule_20>
         </handlers>
     </prometheus>
 </clickhouse>

--- a/tests/integration/test_prometheus_protocols/configs/prometheus_metadata_users.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus_metadata_users.xml
@@ -1,0 +1,60 @@
+<clickhouse>
+    <users>
+        <metadata_temp_table_only>
+            <password></password>
+            <profile>metadata_temp_table_only</profile>
+            <grants>
+                <query>GRANT CREATE TEMPORARY TABLE ON *.*</query>
+            </grants>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+        </metadata_temp_table_only>
+        <metadata_select_time_series>
+            <password></password>
+            <profile>metadata_select_time_series</profile>
+            <grants>
+                <query>GRANT SELECT ON default.prometheus</query>
+            </grants>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+        </metadata_select_time_series>
+        <metadata_select_temp_table_only>
+            <password></password>
+            <profile>metadata_select_temp_table_only</profile>
+            <grants>
+                <query>GRANT SELECT ON default.prometheus</query>
+                <query2>GRANT CREATE TEMPORARY TABLE ON *.*</query2>
+            </grants>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+        </metadata_select_temp_table_only>
+        <metadata_insert_temp_table_only>
+            <password></password>
+            <profile>metadata_insert_temp_table_only</profile>
+            <grants>
+                <query>GRANT INSERT ON default.prometheus</query>
+                <query2>GRANT CREATE TEMPORARY TABLE ON *.*</query2>
+            </grants>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+        </metadata_insert_temp_table_only>
+    </users>
+    <profiles>
+        <metadata_temp_table_only>
+            <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        </metadata_temp_table_only>
+        <metadata_select_time_series>
+            <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        </metadata_select_time_series>
+        <metadata_select_temp_table_only>
+            <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        </metadata_select_temp_table_only>
+        <metadata_insert_temp_table_only>
+            <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        </metadata_insert_temp_table_only>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_prometheus_protocols/test_http_port.py
+++ b/tests/integration/test_prometheus_protocols/test_http_port.py
@@ -7,7 +7,7 @@ from .prometheus_test_utils import (
     convert_time_series_to_protobuf,
     execute_query_via_http_api,
     execute_range_query_via_http_api,
-    extract_error_from_http_api_response,
+    extract_data_from_http_api_response,
     get_response_to_http_api,
     receive_protobuf_from_remote_read,
     send_protobuf_to_remote_write,
@@ -170,8 +170,8 @@ def test_main_http_prefixed_label_values_api():
         f"&end={int(timestamp + 1)}"
     )
     response = get_response_to_http_api(url)
-    error = extract_error_from_http_api_response(response)
-    assert "label values endpoint is not implemented" in error
+    data = extract_data_from_http_api_response(response)
+    assert label_value in data
 
 
 def test_main_http_prefixed_and_bare_share_table():

--- a/tests/integration/test_prometheus_protocols/test_label_values_api.py
+++ b/tests/integration/test_prometheus_protocols/test_label_values_api.py
@@ -1,0 +1,296 @@
+"""Tests for the Prometheus /api/v1/label/<name>/values endpoint."""
+
+import uuid
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+from .prometheus_test_utils import convert_time_series_to_protobuf, send_protobuf_to_remote_write
+
+
+cluster = ClickHouseCluster(__file__)
+MAIN_HTTP_PORT = 8123
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=[
+        "configs/allow_experimental_time_series_table.xml",
+        "configs/prometheus_metadata_users.xml",
+    ],
+    handle_prometheus_remote_write=(9093, "/write"),
+)
+
+
+def send_test_data():
+    time_series = [
+        (
+            {
+                "__name__": "cpu_usage",
+                "host": "server1",
+                "datacenter": "us-east",
+                "http.status_code": "200",
+                "U__bad__utf_D900_": "surrogate_literal",
+                "U__my_00000061_": "overlong_literal",
+            },
+            {1000: 0.5, 1015: 0.6, 1030: 0.7},
+        ),
+        (
+            {
+                "__name__": "cpu_usage",
+                "host": "server2",
+                "datacenter": "us-west",
+                "http.status_code": "500",
+            },
+            {1000: 0.3, 1015: 0.4, 1030: 0.5},
+        ),
+        (
+            {"__name__": "memory_usage", "host": "server1", "datacenter": "us-east"},
+            {1000: 0.8, 1015: 0.85, 1030: 0.9},
+        ),
+    ]
+    send_protobuf_to_remote_write(node.ip_address, 9093, "/write", convert_time_series_to_protobuf(time_series))
+
+
+def get_json_from_api(path, **kwargs):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", **kwargs)
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Expected success, got: {data}"
+    return data
+
+
+def execute_sql(query, auth):
+    return requests.post(
+        f"http://{node.ip_address}:{MAIN_HTTP_PORT}",
+        data=query,
+        auth=auth,
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    try:
+        cluster.start()
+        node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+        node.query(
+            "CREATE TABLE prometheus_no_filter ENGINE=TimeSeries "
+            "SETTINGS tags_to_columns = {'region': 'label_value'}"
+        )
+        node.query(
+            "INSERT INTO prometheus_no_filter (metric_name, tags, time_series) "
+            "SELECT concat('cardinality_metric_', toString(number)), "
+            "map('region', if(number % 2 = 0, 'eu', 'us'), 'zone', if(number % 2 = 0, 'a', 'b')), "
+            "[(toDateTime64(1000, 3), toFloat64(number))] "
+            "FROM numbers(1000)"
+        )
+        send_test_data()
+        assert_eq_with_retry(node, "SELECT count() > 0 FROM timeSeriesData(prometheus)", "1")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_label_values_returns_metric_names():
+    data = get_json_from_api("/api/v1/label/__name__/values")["data"]
+    assert data == ["cpu_usage", "memory_usage"]
+
+
+def test_label_values_returns_distinct_tag_values():
+    data = get_json_from_api("/api/v1/label/host/values")["data"]
+    assert data == ["server1", "server2"]
+
+
+def test_label_values_decodes_prometheus_value_encoding():
+    data = get_json_from_api("/api/v1/label/U__http_2e_status__code/values")["data"]
+    assert data == ["200", "500"]
+
+
+def test_label_values_keeps_malformed_escaped_names_literal():
+    assert get_json_from_api("/api/v1/label/U__bad__utf_D900_/values")["data"] == ["surrogate_literal"]
+    assert get_json_from_api("/api/v1/label/U__my_00000061_/values")["data"] == ["overlong_literal"]
+
+
+def test_label_values_rejects_empty_decoded_name():
+    response = requests.get(f"http://{node.ip_address}:9093/api/v1/label/U__/values")
+    assert response.status_code == 400, response.text
+    result = response.json()
+    assert result["status"] == "error"
+    assert result["errorType"] == "bad_data"
+
+
+def test_label_values_match_filter():
+    data = get_json_from_api("/api/v1/label/host/values?match[]=memory_usage")["data"]
+    assert data == ["server1"]
+
+
+def test_label_values_for_unknown_label_is_empty():
+    assert get_json_from_api("/api/v1/label/missing/values")["data"] == []
+
+
+def test_label_values_avoids_source_column_alias_collision():
+    data = get_json_from_api(
+        "/no_filter/api/v1/label/zone/values",
+        params={"prefer_column_name_to_alias": 1},
+    )["data"]
+    assert data == ["a", "b"]
+
+
+def test_label_values_time_range_filters_series():
+    assert get_json_from_api("/api/v1/label/host/values?start=2000&end=3000")["data"] == []
+
+
+def test_label_values_ignores_empty_optional_parameters():
+    data = get_json_from_api("/api/v1/label/host/values?start=&end=&limit=")["data"]
+    assert data == ["server1", "server2"]
+
+
+def test_label_values_limit_reports_truncation():
+    data = get_json_from_api("/api/v1/label/host/values?limit=1")
+    assert data["data"] == ["server1"]
+    assert data["warnings"] == ["results truncated due to limit"]
+
+
+def test_label_values_accepts_signed_int64_max_limit():
+    data = get_json_from_api("/api/v1/label/host/values?limit=9223372036854775807")
+    assert data["data"] == ["server1", "server2"]
+    assert "warnings" not in data
+
+
+@pytest.mark.parametrize("limit", ["9223372036854775808", "18446744073709551615"])
+def test_label_values_rejects_limit_above_signed_int64_max(limit):
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/label/host/values",
+        params={"limit": limit},
+    )
+    assert response.status_code == 400, response.text
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["errorType"] == "bad_data"
+
+
+@pytest.mark.parametrize(
+    "path, expected_values",
+    [
+        ("/api/v1/label/host/values", ["server1", "server2"]),
+        ("/api/v1/label/__name__/values", ["cpu_usage", "memory_usage"]),
+    ],
+)
+def test_label_values_authorizes_through_time_series_table(path, expected_values):
+    data = get_json_from_api(path, auth=("metadata_select_time_series", ""))
+    assert data["data"] == expected_values
+
+
+def test_label_values_rejects_outer_time_series_row_policy():
+    policy_name = f"prometheus_read_policy_{uuid.uuid4().hex}"
+    node.query(
+        f"CREATE ROW POLICY {policy_name} ON default.prometheus "
+        "FOR SELECT USING metric_name = 'cpu_usage' TO metadata_select_time_series"
+    )
+    try:
+        response = requests.get(
+            f"http://{node.ip_address}:9093/api/v1/label/host/values",
+            auth=("metadata_select_time_series", ""),
+        )
+        assert response.status_code == 400, response.text
+        result = response.json()
+        assert result["status"] == "error", result
+        assert result["errorType"] == "bad_data", result
+        assert "row policies" in result["error"], result
+    finally:
+        node.query(f"DROP ROW POLICY {policy_name} ON default.prometheus")
+
+
+def test_label_values_rejects_inner_time_series_row_policy():
+    tags_table = node.query("SELECT _table FROM timeSeriesTags(prometheus) LIMIT 1").strip()
+    quoted_tags_table = tags_table.replace("`", "``")
+    policy_name = f"prometheus_inner_read_policy_{uuid.uuid4().hex}"
+    node.query(
+        f"CREATE ROW POLICY {policy_name} ON default.`{quoted_tags_table}` "
+        "FOR SELECT USING metric_name = 'cpu_usage' TO metadata_select_time_series"
+    )
+    try:
+        response = execute_sql(
+            "SELECT count() FROM timeSeriesTags('default', 'prometheus')",
+            auth=("metadata_select_time_series", ""),
+        )
+        assert response.status_code != 200, response.text
+        assert "row policies" in response.text, response.text
+
+        response = requests.get(
+            f"http://{node.ip_address}:9093/api/v1/label/host/values",
+            auth=("metadata_select_time_series", ""),
+        )
+        assert response.status_code == 400, response.text
+        result = response.json()
+        assert result["status"] == "error", result
+        assert result["errorType"] == "bad_data", result
+        assert "row policies" in result["error"], result
+    finally:
+        node.query(f"DROP ROW POLICY {policy_name} ON default.`{quoted_tags_table}`")
+
+
+def test_time_series_table_function_insert_requires_insert_access():
+    response = execute_sql(
+        "INSERT INTO TABLE FUNCTION timeSeriesSamples('default', 'prometheus') "
+        "SELECT id, timestamp, value "
+        "FROM timeSeriesSamples('default', 'prometheus') LIMIT 0",
+        auth=("metadata_select_temp_table_only", ""),
+    )
+    assert response.status_code != 200, response.text
+    assert "INSERT" in response.text, response.text
+    assert "default.prometheus" in response.text, response.text
+
+
+def test_time_series_table_function_insert_allows_insert_only_user():
+    sample_id = uuid.uuid4()
+    response = execute_sql(
+        "INSERT INTO TABLE FUNCTION timeSeriesSamples('default', 'prometheus') "
+        f"SELECT tuple(toUInt64(0), toUUID('{sample_id}')), toDateTime64(2000, 3), 1.0",
+        auth=("metadata_insert_temp_table_only", ""),
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_label_values_records_query_finish():
+    query_id = "prometheus_label_values_query_log_test"
+    get_json_from_api("/api/v1/label/host/values", headers={"X-ClickHouse-Query-Id": query_id})
+    node.query("SYSTEM FLUSH LOGS query_log")
+    assert_eq_with_retry(
+        node,
+        f"SELECT count() FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'",
+        "1",
+    )
+
+
+def test_label_values_requires_select_on_configured_time_series_table():
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/label/__name__/values",
+        auth=("metadata_temp_table_only", ""),
+    )
+    assert response.status_code == 400, response.text
+    result = response.json()
+    assert result["status"] == "error", result
+    assert result["errorType"] == "bad_data", result
+    assert "SELECT" in result["error"], result
+    assert "default.prometheus" in result["error"], result
+
+
+def test_label_values_aggregates_before_returning_rows():
+    query_id = "prometheus_label_values_cardinality_query_log_test"
+    data = get_json_from_api(
+        "/no_filter/api/v1/label/region/values",
+        headers={"X-ClickHouse-Query-Id": query_id},
+    )
+    assert data["data"] == ["eu", "us"]
+
+    node.query("SYSTEM FLUSH LOGS query_log")
+    assert_eq_with_retry(
+        node,
+        f"SELECT result_rows FROM system.query_log "
+        f"WHERE query_id = '{query_id}' AND type = 'QueryFinish' "
+        "ORDER BY event_time_microseconds DESC LIMIT 1",
+        "2",
+    )

--- a/tests/integration/test_prometheus_protocols/test_query_api.py
+++ b/tests/integration/test_prometheus_protocols/test_query_api.py
@@ -57,6 +57,12 @@ def send_test_data():
             ({"__name__": "foo", "shape": "circle", "size": "l"}, {110: 16, 130: 16, 150: 16}),
         ]
     )
+    send_to_clickhouse(
+        [
+            ({"__name__": "regex_metric", "host": "server1x"}, {110: 1}),
+            ({"__name__": "regex_metric", "host": "server2"}, {110: 2}),
+        ]
+    )
     # `stream_error` is used by the tests that expect the error only after results have
     # already been written.
     send_to_clickhouse(
@@ -103,6 +109,17 @@ def test_query_post_urlencoded():
     )
     post_data = extract_data_from_http_api_response(post_resp)
     assert get_data == post_data
+
+
+def test_query_regex_matchers_are_anchored():
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/query",
+        params={"query": 'regex_metric{host=~"server1|server2"}', "time": 110},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    assert [result["metric"]["host"] for result in data["data"]["result"]] == ["server2"]
 
 
 # `/api/v1/query_range` must accept params via a POST `application/x-www-form-urlencoded`
@@ -156,6 +173,229 @@ def test_range_query_accepts_positive_step_for_equal_start_and_end():
         1,
     )
     assert result == '{"resultType": "matrix", "result": [{"metric": {"__name__": "post_body_metric", "job": "test"}, "values": [[1000, "1"]]}]}'
+
+
+@pytest.mark.parametrize(
+    "path, params",
+    [
+        ("/api/v1/query", {"query": "post_body_metric", "time": "5m"}),
+        ("/api/v1/query", {"query": "post_body_metric", "time": "0x10"}),
+        ("/api/v1/query", {"query": "post_body_metric", "time": "1970-01-01"}),
+        (
+            "/api/v1/query_range",
+            {"query": "post_body_metric", "start": "5m", "end": "1002", "step": "1"},
+        ),
+        (
+            "/api/v1/query_range",
+            {"query": "post_body_metric", "start": "1000", "end": "1970-01-01 00:16:42", "step": "1"},
+        ),
+    ],
+)
+def test_query_endpoints_reject_non_prometheus_http_timestamps(path, params):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", params=params)
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["errorType"] == "bad_data"
+
+
+@pytest.mark.parametrize(
+    "path, params",
+    [
+        ("/api/v1/query", {"query": "post_body_metric", "time": "1000.0009"}),
+        (
+            "/api/v1/query_range",
+            {"query": "post_body_metric", "start": "1000.0009", "end": "1000.0009", "step": "1"},
+        ),
+    ],
+)
+def test_query_endpoints_round_numeric_timestamps_to_milliseconds(path, params):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", params=params)
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    result = data["data"]["result"][0]
+    if data["data"]["resultType"] == "vector":
+        assert result["value"][0] == 1000.001
+    else:
+        assert result["values"][0][0] == 1000.001
+
+
+@pytest.mark.parametrize(
+    "path, form_data",
+    [
+        ("/api/v1/query", {"query": "foo", "time": "110", "limit": "1"}),
+        ("/api/v1/query_range", {"query": "foo", "start": "110", "end": "130", "step": "10", "limit": "1"}),
+    ],
+)
+def test_query_limit_is_read_from_post_body(path, form_data):
+    response = requests.post(
+        f"http://{node.ip_address}:9093{path}",
+        data=form_data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert len(data["data"]["result"]) == 1
+    assert data["warnings"] == ["results truncated due to limit"]
+
+
+def test_query_limit_reports_truncation():
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/query",
+        params={"query": "foo", "time": 110, "limit": 1},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"]["resultType"] == "vector"
+    assert len(data["data"]["result"]) == 1
+    assert data["warnings"] == ["results truncated due to limit"]
+
+
+def test_range_query_limit_reports_truncation():
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/query_range",
+        params={"query": "foo", "start": 110, "end": 130, "step": 10, "limit": 1},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"]["resultType"] == "matrix"
+    assert len(data["data"]["result"]) == 1
+    assert data["warnings"] == ["results truncated due to limit"]
+
+
+@pytest.mark.parametrize("path, params", [
+    ("/api/v1/query", {"query": "foo", "time": 110}),
+    ("/api/v1/query_range", {"query": "foo", "start": 110, "end": 130, "step": 10}),
+])
+def test_query_zero_limit_is_unlimited(path, params):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", params={**params, "limit": 0})
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert len(data["data"]["result"]) == 3
+    assert "warnings" not in data
+
+
+@pytest.mark.parametrize("path, params", [
+    ("/api/v1/query", {"query": "foo", "time": 110, "limit": 3}),
+    ("/api/v1/query_range", {"query": "foo", "start": 110, "end": 130, "step": 10, "limit": 3}),
+])
+def test_query_exact_limit_is_not_reported_as_truncated(path, params):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", params=params)
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert len(data["data"]["result"]) == 3
+    assert "warnings" not in data
+
+
+@pytest.mark.parametrize(
+    "path, params",
+    [
+        ("/api/v1/query", {"query": "foo", "time": 110}),
+        ("/api/v1/query_range", {"query": "foo", "start": 110, "end": 130, "step": 10}),
+    ],
+)
+def test_query_limit_is_enforced_across_multiple_blocks(path, params):
+    limited_response = requests.get(
+        f"http://{node.ip_address}:9093{path}",
+        params={**params, "limit": 2, "max_block_size": 1},
+    )
+    assert limited_response.status_code == 200, f"Expected 200, got {limited_response.status_code}: {limited_response.text}"
+    limited_data = limited_response.json()
+    assert limited_data["status"] == "success"
+    assert len(limited_data["data"]["result"]) == 2
+    assert limited_data["warnings"] == ["results truncated due to limit"]
+
+    exact_response = requests.get(
+        f"http://{node.ip_address}:9093{path}",
+        params={**params, "limit": 3, "max_block_size": 1},
+    )
+    assert exact_response.status_code == 200, f"Expected 200, got {exact_response.status_code}: {exact_response.text}"
+    exact_data = exact_response.json()
+    assert exact_data["status"] == "success"
+    assert len(exact_data["data"]["result"]) == 3
+    assert "warnings" not in exact_data
+
+
+@pytest.mark.parametrize(
+    "path, params",
+    [
+        ("/api/v1/query", {"query": "foo", "time": 110}),
+        ("/api/v1/query_range", {"query": "foo", "start": 110, "end": 130, "step": 10}),
+    ],
+)
+def test_query_endpoints_accept_signed_int64_max_limit(path, params):
+    response = requests.get(
+        f"http://{node.ip_address}:9093{path}",
+        params={**params, "limit": "9223372036854775807"},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert len(data["data"]["result"]) == 3
+    assert "warnings" not in data
+
+
+@pytest.mark.parametrize(
+    "query, result_type",
+    [("1", "scalar"), ('"hello"', "string")],
+)
+def test_query_limit_does_not_truncate_scalar_or_string_results(query, result_type):
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/query",
+        params={"query": query, "time": 110, "limit": 1},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"]["resultType"] == result_type
+    assert "warnings" not in data
+
+
+@pytest.mark.parametrize(
+    "limit",
+    [
+        "-1",
+        "not-a-number",
+        "9223372036854775808",
+        "18446744073709551615",
+        "18446744073709551616",
+    ],
+)
+@pytest.mark.parametrize(
+    "path, base_params",
+    [
+        ("/api/v1/query", {"query": "foo", "time": 110}),
+        ("/api/v1/query_range", {"query": "foo", "start": 110, "end": 130, "step": 10}),
+    ],
+)
+def test_query_endpoints_reject_invalid_limit(path, base_params, limit):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", params={**base_params, "limit": limit})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["errorType"] == "bad_data"
+
+
+@pytest.mark.parametrize(
+    "path, params",
+    [
+        ("/api/v1/query", {"query": "foo", "time": 110, "limit": ""}),
+        (
+            "/api/v1/query_range",
+            {"query": "foo", "start": 110, "end": 130, "step": 10, "limit": ""},
+        ),
+    ],
+)
+def test_empty_query_limit_is_ignored(path, params):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", params=params)
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    assert response.json()["status"] == "success"
 
 
 def test_query_lookback_delta():

--- a/tests/integration/test_prometheus_protocols/test_series_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_api.py
@@ -5,17 +5,18 @@ import requests
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
-from .prometheus_test_utils import (
-    convert_time_series_to_protobuf,
-    send_protobuf_to_remote_write,
-)
+from .prometheus_test_utils import convert_time_series_to_protobuf, send_protobuf_to_remote_write
+
 
 cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance(
     "node",
     main_configs=["configs/prometheus.xml"],
-    user_configs=["configs/allow_experimental_time_series_table.xml"],
+    user_configs=[
+        "configs/allow_experimental_time_series_table.xml",
+        "configs/prometheus_metadata_users.xml",
+    ],
     handle_prometheus_remote_write=(9093, "/write"),
 )
 
@@ -35,6 +36,10 @@ def send_test_data():
             {1000: 0.8, 1015: 0.85, 1030: 0.9},
         ),
         (
+            {"__name__": "http_requests_total", "host": "server1", "method": "GET", "status": "200"},
+            {1000: 100, 1015: 150, 1030: 200},
+        ),
+        (
             {"__name__": "quoted_label_metric", "http.status_code": "200", "service": "web"},
             {1000: 1.0},
         ),
@@ -47,16 +52,12 @@ def send_test_data():
             {1000: 2.0},
         ),
     ]
-    send_protobuf_to_remote_write(
-        node.ip_address, 9093, "/write", convert_time_series_to_protobuf(time_series)
-    )
+    send_protobuf_to_remote_write(node.ip_address, 9093, "/write", convert_time_series_to_protobuf(time_series))
 
 
 def get_json_from_api(path, **kwargs):
     response = requests.get(f"http://{node.ip_address}:9093{path}", **kwargs)
-    assert (
-        response.status_code == 200
-    ), f"Expected 200, got {response.status_code}: {response.text}"
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
     data = response.json()
     assert data["status"] == "success", f"Expected success, got: {data}"
     return data
@@ -64,17 +65,11 @@ def get_json_from_api(path, **kwargs):
 
 def get_bad_data_from_api(path, **kwargs):
     response = requests.get(f"http://{node.ip_address}:9093{path}", **kwargs)
-    assert (
-        response.status_code == 400
-    ), f"Expected 400, got {response.status_code}: {response.text}"
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
     data = response.json()
     assert data["status"] == "error", f"Expected error, got: {data}"
     assert data["errorType"] == "bad_data", f"Expected bad_data, got: {data}"
     return data
-
-
-def sorted_series(series_list):
-    return sorted(series_list, key=lambda labels: sorted(labels.items()))
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -83,12 +78,42 @@ def setup():
         cluster.start()
         node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
         node.query(
+            "CREATE TABLE prometheus_no_filter ENGINE=TimeSeries "
+            "SETTINGS filter_by_min_time_and_max_time = 0"
+        )
+        node.query(
             "CREATE TABLE prometheus_no_bounds ENGINE=TimeSeries "
             "SETTINGS store_min_time_and_max_time = 0"
         )
+        for table in ("prometheus_no_filter", "prometheus_no_bounds"):
+            node.query(
+                f"INSERT INTO {table} (metric_name, tags, time_series) VALUES "
+                "('cpu_usage', {'host': 'server1'}, [(toDateTime64(1000, 3), 0.5)])"
+            )
         node.query(
-            "INSERT INTO prometheus_no_bounds (metric_name, tags, time_series) VALUES "
-            "('cpu_usage', {'host': 'server1'}, [(toDateTime64(1000, 3), 0.5)])"
+            "CREATE TABLE prometheus_uint32 (time_series Array(Tuple(UInt32, Float64))) ENGINE=TimeSeries"
+        )
+        node.query(
+            "INSERT INTO prometheus_uint32 (metric_name, tags, time_series) VALUES "
+            "('uint32_metric', {'host': 'server1'}, [(toUInt32(100), 1)])"
+        )
+        node.query(
+            "CREATE TABLE prometheus_datetime64_9 (time_series Array(Tuple(DateTime64(9), Float64))) ENGINE=TimeSeries"
+        )
+        node.query(
+            "INSERT INTO prometheus_datetime64_9 (metric_name, tags, time_series) VALUES "
+            "('datetime64_9_metric', {'host': 'server1'}, [(toDateTime64(1000, 9), 1)])"
+        )
+        node.query(
+            "CREATE TABLE prometheus_datetime64_3_future "
+            "(time_series Array(Tuple(DateTime64(3), Float64))) ENGINE=TimeSeries"
+        )
+        node.query(
+            "INSERT INTO prometheus_datetime64_3_future (metric_name, tags, time_series) VALUES "
+            "('datetime64_3_future_metric', {'host': 'server1'}, "
+            "[(toDateTime64('2286-11-20 17:46:40.250', 3), 1)]),"
+            "('datetime64_3_negative_metric', {'host': 'server1'}, "
+            "[(toDateTime64(-100, 3), 1)])"
         )
         send_test_data()
         assert_eq_with_retry(node, "SELECT count() > 0 FROM timeSeriesData(prometheus)", "1")
@@ -99,149 +124,515 @@ def setup():
 
 def test_series_returns_metric_labels():
     data = get_json_from_api("/api/v1/series?match[]=cpu_usage")["data"]
-    assert sorted_series(data) == sorted_series(
-        [
-            {"__name__": "cpu_usage", "host": "server1", "datacenter": "us-east"},
-            {"__name__": "cpu_usage", "host": "server2", "datacenter": "us-west"},
-        ]
+    assert {entry["__name__"] for entry in data} == {"cpu_usage"}
+    assert {entry["host"] for entry in data} == {"server1", "server2"}
+    assert all("datacenter" in entry for entry in data)
+
+
+def test_series_match_filter():
+    data = get_json_from_api("/api/v1/series?match[]=memory_usage")["data"]
+    assert len(data) == 1
+    assert data[0]["__name__"] == "memory_usage"
+
+
+def test_series_does_not_duplicate_metric_name():
+    response = requests.get(f"http://{node.ip_address}:9093/api/v1/series?match[]=memory_usage")
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    assert response.text.count('"__name__"') == 1, f"Unexpected body: {response.text}"
+
+
+def test_series_repeated_match_is_union():
+    data = get_json_from_api("/api/v1/series?match[]=cpu_usage&match[]=memory_usage")["data"]
+    assert {entry["__name__"] for entry in data} == {"cpu_usage", "memory_usage"}
+
+
+def test_series_repeated_match_deduplicates_overlapping_results():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", "cpu_usage"), ("match[]", 'cpu_usage{host="server1"}')],
+    )["data"]
+    assert len(data) == 2
+    assert {entry["host"] for entry in data} == {"server1", "server2"}
+
+
+def test_series_post_urlencoded_repeated_match_is_union():
+    response = requests.post(
+        f"http://{node.ip_address}:9093/api/v1/series",
+        data=[("match[]", "cpu_usage"), ("match[]", "memory_usage")],
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert {entry["__name__"] for entry in data["data"]} == {"cpu_usage", "memory_usage"}
+
+
+def test_series_post_urlencoded_empty_optional_parameters_are_ignored():
+    response = requests.post(
+        f"http://{node.ip_address}:9093/api/v1/series",
+        data=[("match[]", "cpu_usage"), ("start", ""), ("end", ""), ("limit", "")],
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success"
+    assert len(data["data"]) == 2
+    assert "warnings" not in data
 
 
 def test_series_selector_filters_labels():
     data = get_json_from_api('/api/v1/series?match[]=cpu_usage{host="server1"}')["data"]
-    assert data == [
-        {"__name__": "cpu_usage", "host": "server1", "datacenter": "us-east"}
-    ]
+    assert data == [{"__name__": "cpu_usage", "datacenter": "us-east", "host": "server1"}]
 
 
 @pytest.mark.parametrize(
-    "selector,expected_hosts",
+    "selector, expected_hosts",
     [
-        ('regex_metric{host="server2"}', ["server2"]),
-        ('regex_metric{host!="server2"}', ["server1x"]),
-        ('regex_metric{host=~"server[0-9]"}', ["server2"]),
-        ('regex_metric{host!~"server[0-9]"}', ["server1x"]),
+        ('cpu_usage{host="server1"}', {"server1"}),
+        ('cpu_usage{host!="server1"}', {"server2"}),
+        ('cpu_usage{host=~"server1|server2"}', {"server1", "server2"}),
+        ('cpu_usage{host!~"server1"}', {"server2"}),
     ],
 )
 def test_series_selector_matcher_operators(selector, expected_hosts):
     data = get_json_from_api("/api/v1/series", params={"match[]": selector})["data"]
-    assert sorted(labels["host"] for labels in data) == expected_hosts
+    assert {entry["host"] for entry in data} == expected_hosts
+
+
+def test_series_selector_matches_metric_name_and_multiple_labels():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": '{__name__="cpu_usage",host="server1",datacenter="us-east"}'},
+    )["data"]
+    assert data == [{"__name__": "cpu_usage", "datacenter": "us-east", "host": "server1"}]
 
 
 def test_series_regex_matchers_are_anchored():
-    # "server1" must not match host="server1x" (Prometheus anchors regexps on both sides).
-    data = get_json_from_api('/api/v1/series?match[]=regex_metric{host=~"server1"}')["data"]
+    data = get_json_from_api("/api/v1/series", params={"match[]": 'cpu_usage{host=~"server"}'})["data"]
     assert data == []
 
 
 def test_series_matches_without_metric_name():
-    data = get_json_from_api('/api/v1/series?match[]={datacenter="us-east"}')["data"]
-    assert sorted_series(data) == sorted_series(
-        [
-            {"__name__": "cpu_usage", "host": "server1", "datacenter": "us-east"},
-            {"__name__": "memory_usage", "host": "server1", "datacenter": "us-east"},
-        ]
-    )
+    data = get_json_from_api('/api/v1/series?match[]={datacenter="us-east"}')['data']
+    assert {tuple(sorted(entry.items())) for entry in data} == {
+        (("__name__", "cpu_usage"), ("datacenter", "us-east"), ("host", "server1")),
+        (("__name__", "memory_usage"), ("datacenter", "us-east"), ("host", "server1")),
+    }
+
+
+def test_series_regex_matcher_alternation_is_anchored_as_a_whole():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": 'regex_metric{host=~"server1|server2"}'},
+    )["data"]
+    assert [entry["host"] for entry in data] == ["server2"]
+
+
+def test_series_rejects_prometheus_unsupported_regexp_escape():
+    get_bad_data_from_api("/api/v1/series", params={"match[]": r"{host=~`\C`}"})
+
+
+def test_series_missing_label_matches_empty_value():
+    equal_data = get_json_from_api("/api/v1/series", params={"match[]": 'cpu_usage{zone=""}'})["data"]
+    not_equal_data = get_json_from_api("/api/v1/series", params={"match[]": 'cpu_usage{zone!="prod"}'})["data"]
+    assert {entry["host"] for entry in equal_data} == {"server1", "server2"}
+    assert {entry["host"] for entry in not_equal_data} == {"server1", "server2"}
 
 
 def test_series_supports_quoted_label_names():
     data = get_json_from_api(
         "/api/v1/series", params={"match[]": '{"http.status_code"="200"}'}
     )["data"]
-    assert data == [
-        {"__name__": "quoted_label_metric", "http.status_code": "200", "service": "web"}
-    ]
-
-
-def test_series_repeated_match_is_union():
-    data = get_json_from_api(
-        "/api/v1/series?match[]=memory_usage&match[]=quoted_label_metric"
-    )["data"]
-    assert sorted_series(data) == sorted_series(
-        [
-            {"__name__": "memory_usage", "host": "server1", "datacenter": "us-east"},
-            {"__name__": "quoted_label_metric", "http.status_code": "200", "service": "web"},
-        ]
-    )
-
-
-def test_series_repeated_match_deduplicates_overlapping_results():
-    data = get_json_from_api(
-        '/api/v1/series?match[]=memory_usage&match[]={datacenter="us-east"}'
-    )["data"]
-    assert sorted_series(data) == sorted_series(
-        [
-            {"__name__": "cpu_usage", "host": "server1", "datacenter": "us-east"},
-            {"__name__": "memory_usage", "host": "server1", "datacenter": "us-east"},
-        ]
-    )
-
-
-def test_series_post_urlencoded_match():
-    response = requests.post(
-        f"http://{node.ip_address}:9093/api/v1/series",
-        data=[("match[]", "memory_usage"), ("match[]", "quoted_label_metric")],
-    )
-    assert response.status_code == 200, response.text
-    data = response.json()
-    assert data["status"] == "success"
-    assert len(data["data"]) == 2
+    assert data == [{"__name__": "quoted_label_metric", "http.status_code": "200", "service": "web"}]
 
 
 def test_series_requires_match_selector():
-    get_bad_data_from_api("/api/v1/series")
+    response = requests.get(f"http://{node.ip_address}:9093/api/v1/series")
+    assert response.status_code == 400
+    assert response.json()["errorType"] == "bad_data"
+
+
+def test_series_requires_select_on_configured_time_series_table():
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/series",
+        params={"match[]": "cpu_usage"},
+        auth=("metadata_temp_table_only", ""),
+    )
+    assert response.status_code == 400, response.text
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["errorType"] == "bad_data"
+    assert "SELECT" in data["error"]
+    assert "default.prometheus" in data["error"]
+
+
+def test_series_allows_select_on_configured_time_series_table():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage"},
+        auth=("metadata_select_time_series", ""),
+    )["data"]
+    assert {entry["host"] for entry in data} == {"server1", "server2"}
+
+
+@pytest.mark.parametrize("path", ["/combined/api/v1/format_query", "/combined/api/v1/parse_query"])
+def test_parser_endpoints_do_not_require_time_series_select(path):
+    response = requests.get(
+        f"http://{node.ip_address}:9093{path}",
+        auth=("metadata_temp_table_only", ""),
+    )
+    assert response.status_code == 400, response.text
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["errorType"] == "bad_data"
+    assert "not implemented" in data["error"]
+    assert "SELECT" not in data["error"]
+    assert "default.prometheus" not in data["error"]
+
+
+@pytest.mark.parametrize(
+    "path, params",
+    [
+        ("/combined/api/v1/query", {"query": "cpu_usage", "time": 1015}),
+        (
+            "/combined/api/v1/query_range",
+            {"query": "cpu_usage", "start": 1000, "end": 1030, "step": 15},
+        ),
+        ("/combined/api/v1/series", {"match[]": "cpu_usage"}),
+        ("/combined/api/v1/labels", {}),
+        ("/combined/api/v1/label/host/values", {}),
+    ],
+)
+def test_all_query_endpoints_require_select_on_configured_time_series_table(path, params):
+    response = requests.get(
+        f"http://{node.ip_address}:9093{path}",
+        params=params,
+        auth=("metadata_temp_table_only", ""),
+    )
+    assert response.status_code == 400, response.text
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["errorType"] == "bad_data"
+    assert "SELECT" in data["error"]
+    assert "default.prometheus" in data["error"]
+
+
+@pytest.mark.parametrize(
+    "path, params",
+    [
+        ("/api/v1/query", {"query": "cpu_usage", "time": 1015}),
+        (
+            "/api/v1/query_range",
+            {"query": "cpu_usage", "start": 1000, "end": 1030, "step": 15},
+        ),
+    ],
+)
+def test_query_endpoints_allow_select_on_configured_time_series_table(path, params):
+    data = get_json_from_api(
+        path,
+        params=params,
+        auth=("metadata_select_time_series", ""),
+    )
+    assert data["status"] == "success"
+
+
+def test_scalar_query_requires_select_on_configured_time_series_table():
+    response = requests.get(
+        f"http://{node.ip_address}:9093/api/v1/query",
+        params={"query": "1", "time": 1015},
+        auth=("metadata_temp_table_only", ""),
+    )
+    assert response.status_code == 400, response.text
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["errorType"] == "bad_data"
+    assert "SELECT" in data["error"]
+    assert "default.prometheus" in data["error"]
+
+
+def test_unknown_endpoint_is_not_authorized_as_a_table_read():
+    response = requests.get(
+        f"http://{node.ip_address}:9093/combined/api/v1/does-not-exist",
+        auth=("metadata_temp_table_only", ""),
+    )
+    assert response.status_code == 404, response.text
+    assert "default.prometheus" not in response.text
+    assert response.json() == {
+        "status": "error",
+        "errorType": "not_found",
+        "error": "API endpoint not found",
+    }
 
 
 @pytest.mark.parametrize(
     "selector",
     [
-        "",  # explicitly empty value
-        "{}",  # selector without matchers
-        "cpu_usage[5m]",  # range selector, not an instant selector
-        "rate(cpu_usage[5m])",  # PromQL expression, not a selector
-        'cpu_usage{host="server1"',  # unparsable
+        "",
+        "{}",
+        "cpu_usage[5m]",
+        "rate(cpu_usage[5m])",
+        "sum(cpu_usage)",
+        "(cpu_usage)",
+        '((cpu_usage{host="server1"}))',
+        "cpu_usage offset 5m",
+        "cpu_usage @ 1700000000",
+        '{host=""}',
+        '{host!="prod"}',
+        '{host!~"prod"}',
+        '{host=~".*"}',
+        'cpu_usage{host=~"["}',
     ],
 )
-def test_series_rejects_invalid_selectors(selector):
+def test_series_rejects_invalid_or_unbounded_selectors(selector):
     get_bad_data_from_api("/api/v1/series", params={"match[]": selector})
 
 
 def test_series_rejects_an_invalid_selector_in_a_repeated_request():
     get_bad_data_from_api(
-        "/api/v1/series", params=[("match[]", "cpu_usage"), ("match[]", "{}")]
+        "/api/v1/series",
+        params=[("match[]", "cpu_usage"), ("match[]", "")],
     )
 
 
+def test_series_accepts_negative_regex_that_cannot_match_empty():
+    data = get_json_from_api(
+        "/api/v1/series", params={"match[]": '{host!~".*"}'}
+    )["data"]
+    assert data == []
+
+
+@pytest.mark.parametrize("selector", ['{host!=""}', '{host=~".+"}'])
+def test_series_accepts_matchers_that_cannot_match_empty(selector):
+    data = get_json_from_api("/api/v1/series", params={"match[]": selector})["data"]
+    assert data
+
+
+def test_series_deduplicates_rows_before_limit():
+    send_test_data()
+    data = get_json_from_api(
+        "/api/v1/series", params={"match[]": "cpu_usage", "limit": 2}
+    )
+    assert len(data["data"]) == 2
+    assert "warnings" not in data
+
+
 def test_series_time_range():
-    # All test samples are within [1000, 1030].
-    path = "/api/v1/series?match[]=cpu_usage"
-    assert len(get_json_from_api(f"{path}&start=990&end=1040")["data"]) == 2
-    assert get_json_from_api(f"{path}&start=2000&end=3000")["data"] == []
-    assert get_json_from_api(f"{path}&start=0&end=500")["data"] == []
+    in_range = get_json_from_api("/api/v1/series?match[]=cpu_usage&start=1010&end=1020")["data"]
+    out_of_range = get_json_from_api("/api/v1/series?match[]=cpu_usage&start=2000&end=3000")["data"]
+    assert len(in_range) == 2
+    assert out_of_range == []
 
 
 def test_series_time_range_is_inclusive_and_supports_one_sided_bounds():
-    path = "/api/v1/series?match[]=cpu_usage"
-    # The range [end of the series, ...) and (..., start of the series] both overlap the series.
-    assert len(get_json_from_api(f"{path}&start=1030")["data"]) == 2
-    assert len(get_json_from_api(f"{path}&end=1000")["data"]) == 2
-    assert get_json_from_api(f"{path}&start=1031")["data"] == []
-    assert get_json_from_api(f"{path}&end=999")["data"] == []
+    at_start = get_json_from_api(
+        "/api/v1/series", params={"match[]": "cpu_usage", "start": 1000, "end": 1000}
+    )["data"]
+    at_end = get_json_from_api(
+        "/api/v1/series", params={"match[]": "cpu_usage", "start": 1030, "end": 1030}
+    )["data"]
+    from_start = get_json_from_api("/api/v1/series", params={"match[]": "cpu_usage", "start": 1030})["data"]
+    through_end = get_json_from_api("/api/v1/series", params={"match[]": "cpu_usage", "end": 1000})["data"]
+    assert len(at_start) == 2
+    assert len(at_end) == 2
+    assert len(from_start) == 2
+    assert len(through_end) == 2
 
 
-def test_series_rejects_inverted_time_range():
-    get_bad_data_from_api("/api/v1/series?match[]=cpu_usage&start=1030&end=1000")
-
-
-def test_series_empty_time_range_parameters_are_ignored():
-    data = get_json_from_api("/api/v1/series?match[]=cpu_usage&start=&end=")["data"]
+def test_series_time_range_accepts_rfc3339_bounds():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={
+            "match[]": "cpu_usage",
+            "start": "1970-01-01T00:16:40Z",
+            "end": "1970-01-01T00:16:40Z",
+        },
+    )["data"]
     assert len(data) == 2
 
 
-def test_series_time_range_is_ignored_without_stored_time_bounds():
-    # Without stored min_time/max_time the time range is ignored (a superset is allowed by Prometheus).
-    data = get_json_from_api("/no_bounds/api/v1/series?match[]=cpu_usage&start=2000&end=3000")["data"]
+def test_series_time_range_accepts_rfc3339_comma_fraction():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={
+            "match[]": "cpu_usage",
+            "start": "1970-01-01T00:16:40,000Z",
+            "end": "1970-01-01T00:16:40,000Z",
+        },
+    )["data"]
+    assert len(data) == 2
+
+
+def test_series_time_range_applies_rfc3339_timezone_offsets():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={
+            "match[]": "cpu_usage",
+            "start": "1970-01-01T02:16:40+02:00",
+            "end": "1970-01-01T02:16:40+02:00",
+        },
+    )["data"]
+    assert len(data) == 2
+
+
+@pytest.mark.parametrize(
+    "bound_value",
+    [
+        "1970-01-01T00:16:40",
+        "1970-01-01T00:16:40Ztrailing",
+        "5m",
+        "0x10",
+        "1.2.3",
+        "1..0",
+        "..1",
+        "2023-02-29T00:00:00Z",
+        "2024-02-30T00:00:00Z",
+        "2024-04-31T00:00:00Z",
+    ],
+)
+def test_series_rejects_non_prometheus_http_timestamps(bound_value):
+    get_bad_data_from_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage", "start": bound_value},
+    )
+
+
+@pytest.mark.parametrize("bound_value", ["1e3", "1.5e3", "1e+3", "1e-3"])
+def test_series_accepts_decimal_exponents_in_http_timestamps(bound_value):
+    get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage", "start": bound_value},
+    )
+
+
+@pytest.mark.parametrize("bound_value", ["1_000", "0x1p4"])
+def test_series_accepts_go_float_syntax_in_http_timestamps(bound_value):
+    get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage", "start": bound_value},
+    )
+
+
+def test_series_datetime64_3_preserves_far_future_rfc3339_fractions():
+    data = get_json_from_api(
+        "/datetime64_3_future/api/v1/series",
+        params={
+            "match[]": "datetime64_3_future_metric",
+            "start": "2286-11-20T17:46:40.250Z",
+            "end": "2286-11-20T17:46:40.500Z",
+        },
+    )["data"]
+    assert len(data) == 1
+
+
+@pytest.mark.parametrize(
+    "path, selector, start, end",
+    [
+        ("/api/v1/series", "cpu_usage", "1000.0009", "1000.0001"),
+        ("/uint32/api/v1/series", "uint32_metric", "100.9", "100.1"),
+    ],
+)
+def test_series_rejects_inverted_range_before_storage_quantization(path, selector, start, end):
+    get_bad_data_from_api(path, params={"match[]": selector, "start": start, "end": end})
+
+
+@pytest.mark.parametrize(
+    "params, expected_count",
+    [
+        ({"match[]": "uint32_metric", "start": "-1", "end": "200"}, 1),
+        ({"match[]": "uint32_metric", "start": "0", "end": "4294967296"}, 1),
+        ({"match[]": "uint32_metric", "start": "4294967296"}, 0),
+        ({"match[]": "uint32_metric", "end": "-1"}, 0),
+    ],
+)
+def test_series_uint32_time_bounds_do_not_wrap(params, expected_count):
+    data = get_json_from_api("/uint32/api/v1/series", params=params)["data"]
+    assert len(data) == expected_count
+
+
+@pytest.mark.parametrize(
+    "bound_name, bound_value, expected_count",
+    [
+        ("end", "10000000000", 1),
+        ("end", "2286-11-20T17:46:40Z", 1),
+        ("start", "10000000000", 0),
+        ("start", "2286-11-20T17:46:40Z", 0),
+    ],
+)
+def test_series_datetime64_9_time_bounds_are_clipped_before_native_conversion(
+    bound_name, bound_value, expected_count
+):
+    params = {"match[]": "datetime64_9_metric", bound_name: bound_value}
+    data = get_json_from_api("/datetime64_9/api/v1/series", params=params)["data"]
+    assert len(data) == expected_count
+
+
+@pytest.mark.parametrize(
+    "path, selector, bound_name, bound_value, expected_count",
+    [
+        ("/uint32/api/v1/series", "uint32_metric", "start", "100.9", 0),
+        ("/api/v1/series", "cpu_usage", "start", "1000.001", 2),
+        (
+            "/datetime64_3_future/api/v1/series",
+            "datetime64_3_negative_metric",
+            "end",
+            "-100.0009",
+            0,
+        ),
+        (
+            "/datetime64_3_future/api/v1/series",
+            "datetime64_3_negative_metric",
+            "end",
+            "-100",
+            1,
+        ),
+        ("/api/v1/series", "cpu_usage", "start", "1000.0000", 2),
+    ],
+)
+def test_series_fractional_bounds_are_quantized_towards_overlap(
+    path, selector, bound_name, bound_value, expected_count
+):
+    data = get_json_from_api(
+        path,
+        params={"match[]": selector, bound_name: bound_value},
+    )["data"]
+    assert len(data) == expected_count
+
+
+@pytest.mark.parametrize("path", ["/no_filter/api/v1/series", "/no_bounds/api/v1/series"])
+def test_series_time_range_returns_approximate_superset_without_trusted_bounds(path):
+    data = get_json_from_api(
+        path,
+        params={"match[]": "cpu_usage", "start": 2000, "end": 3000},
+    )["data"]
     assert data == [{"__name__": "cpu_usage", "host": "server1"}]
+
+
+@pytest.mark.parametrize("path", ["/no_filter/api/v1/series", "/no_bounds/api/v1/series"])
+def test_series_time_range_still_validates_timestamps_without_trusted_bounds(path):
+    get_bad_data_from_api(
+        path,
+        params={"match[]": "cpu_usage", "start": "not-a-timestamp"},
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"match[]": "cpu_usage", "start": 2000, "end": 1000},
+        {"match[]": "cpu_usage", "start": "not-a-timestamp"},
+        {"match[]": "cpu_usage", "end": "not-a-timestamp"},
+    ],
+)
+def test_series_rejects_invalid_time_ranges(params):
+    get_bad_data_from_api("/api/v1/series", params=params)
+
+
+def test_series_empty_time_range_is_ignored():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage", "start": "", "end": "", "limit": ""},
+    )["data"]
+    assert len(data) == 2
 
 
 def test_series_limit_reports_truncation():
@@ -250,32 +641,106 @@ def test_series_limit_reports_truncation():
     assert data["warnings"] == ["results truncated due to limit"]
 
 
-def test_series_exact_limit_is_not_reported_as_truncated():
-    data = get_json_from_api("/api/v1/series?match[]=cpu_usage&limit=2")
+def test_series_limit_across_multiple_blocks():
+    params = {
+        "match[]": ["cpu_usage", "memory_usage"],
+        "limit": 2,
+        "max_block_size": 1,
+        "max_threads": 1,
+    }
+    data = get_json_from_api("/api/v1/series", params=params)
     assert len(data["data"]) == 2
-    assert "warnings" not in data
+    assert data["warnings"] == ["results truncated due to limit"]
+
+    exact_data = get_json_from_api(
+        "/api/v1/series",
+        params={**params, "limit": 3},
+    )
+    assert len(exact_data["data"]) == 3
+    assert "warnings" not in exact_data
+
+
+def test_series_limit_does_not_cache_a_partial_result():
+    node.query("SYSTEM DROP QUERY CACHE")
+    cache_params = {
+        "match[]": ["cpu_usage", "memory_usage"],
+        "use_query_cache": 1,
+        "query_cache_nondeterministic_function_handling": "save",
+        "query_cache_min_query_duration": 0,
+        "max_block_size": 1,
+        "max_threads": 1,
+    }
+
+    limited_data = get_json_from_api(
+        "/api/v1/series",
+        params={**cache_params, "limit": 1},
+    )
+    assert len(limited_data["data"]) == 1
+    assert limited_data["warnings"] == ["results truncated due to limit"]
+    assert int(node.query("SELECT count() FROM system.query_cache")) == 0
+
+    unlimited_data = get_json_from_api("/api/v1/series", params=cache_params)
+    assert len(unlimited_data["data"]) == 3
+    assert "warnings" not in unlimited_data
+    assert int(node.query("SELECT count() FROM system.query_cache")) == 1
 
 
 def test_series_zero_limit_is_unlimited():
-    data = get_json_from_api("/api/v1/series?match[]=cpu_usage&limit=0")
+    data = get_json_from_api("/api/v1/series", params={"match[]": "cpu_usage", "limit": 0})
     assert len(data["data"]) == 2
     assert "warnings" not in data
 
 
-@pytest.mark.parametrize("limit", ["-1", "abc", "1.5"])
+def test_series_exact_limit_is_not_reported_as_truncated():
+    data = get_json_from_api("/api/v1/series", params={"match[]": "cpu_usage", "limit": 2})
+    assert len(data["data"]) == 2
+    assert "warnings" not in data
+
+
+def test_series_accepts_signed_int64_max_limit():
+    data = get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage", "limit": "9223372036854775807"},
+    )
+    assert len(data["data"]) == 2
+    assert "warnings" not in data
+
+
+@pytest.mark.parametrize(
+    "limit",
+    [
+        "-1",
+        "not-a-number",
+        "9223372036854775808",
+        "18446744073709551615",
+        "18446744073709551616",
+    ],
+)
 def test_series_rejects_invalid_limit(limit):
-    get_bad_data_from_api(f"/api/v1/series?match[]=cpu_usage&limit={limit}")
+    get_bad_data_from_api("/api/v1/series", params={"match[]": "cpu_usage", "limit": limit})
 
 
 def test_series_records_query_finish():
-    get_json_from_api("/api/v1/series?match[]=memory_usage")
+    query_id = "prometheus_series_query_log_test"
+    get_json_from_api("/api/v1/series?match[]=cpu_usage", headers={"X-ClickHouse-Query-Id": query_id})
     node.query("SYSTEM FLUSH LOGS query_log")
-    assert (
-        int(
-            node.query(
-                "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' "
-                "AND query LIKE '%timeSeriesIdToTags%' AND query NOT LIKE '%query_log%'"
-            )
-        )
-        > 0
+    assert_eq_with_retry(
+        node,
+        f"SELECT count() FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'",
+        "1",
+    )
+
+
+def test_series_limited_response_records_query_finish():
+    query_id = "prometheus_series_limited_query_log_test"
+    get_json_from_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage", "limit": 1},
+        headers={"X-ClickHouse-Query-Id": query_id},
+    )
+    node.query("SYSTEM FLUSH LOGS query_log")
+    assert_eq_with_retry(
+        node,
+        f"SELECT count() FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'",
+        "1",
     )

--- a/tests/integration/test_prometheus_protocols/test_series_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_api.py
@@ -275,6 +275,26 @@ def test_series_allows_select_on_configured_time_series_table():
     assert {entry["host"] for entry in data} == {"server1", "server2"}
 
 
+@pytest.mark.parametrize(
+    "params, expected_labels",
+    [
+        ({}, ["__name__", "datacenter", "host", "http.status_code", "method", "service", "status"]),
+        ({"match[]": "cpu_usage"}, ["__name__", "datacenter", "host"]),
+        (
+            [("match[]", "cpu_usage"), ("match[]", "http_requests_total")],
+            ["__name__", "datacenter", "host", "method", "status"],
+        ),
+    ],
+)
+def test_labels_allows_select_on_configured_time_series_table(params, expected_labels):
+    data = get_json_from_api(
+        "/combined/api/v1/labels",
+        params=params,
+        auth=("metadata_select_time_series", ""),
+    )
+    assert data["data"] == expected_labels
+
+
 @pytest.mark.parametrize("path", ["/combined/api/v1/format_query", "/combined/api/v1/parse_query"])
 def test_parser_endpoints_do_not_require_time_series_select(path):
     response = requests.get(

--- a/tests/integration/test_prometheus_protocols/test_series_api_mixed_carrier_dedup.py
+++ b/tests/integration/test_prometheus_protocols/test_series_api_mixed_carrier_dedup.py
@@ -1,0 +1,518 @@
+"""Tests that `/api/v1/series` deduplicates by the logical Prometheus label set, not by the raw
+`tags`-table layout. A supported external tags table can store a `tags_to_columns` tag in two
+carriers: the dedicated column and the residual `tags` Map (e.g. legacy rows written before the
+dedicated column was adopted). The same logical series stored once per carrier must be returned
+once, a single row carrying the same value in both carriers must emit the label key once, and a
+row with conflicting values in the two carriers must be rejected with `bad_data`, following the
+same normalization rules as `timeSeriesStoreTags` on the write path."""
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node_mixed_carrier_dedup",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=["configs/allow_experimental_time_series_table.xml"],
+)
+
+
+def request_api(path, params=None, **kwargs):
+    url = f"http://{node.ip_address}:9093{path}"
+    response = requests.get(url, params=params, **kwargs)
+    return response
+
+
+def get_series(match):
+    response = request_api("/api/v1/series", params={"match[]": match})
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Expected success, got: {data}"
+    return data["data"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(request):
+    try:
+        cluster.start()
+        node.query("CREATE TABLE prometheus_data (id UUID, timestamp DateTime64(3, 'UTC'), value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)")
+        node.query(
+            "CREATE TABLE prometheus_tags (id UUID, metric_name LowCardinality(String),"
+            " host LowCardinality(Nullable(String)),"
+            " tags Map(LowCardinality(String), String),"
+            " min_time SimpleAggregateFunction(min, Nullable(DateTime64(3, 'UTC'))),"
+            " max_time SimpleAggregateFunction(max, Nullable(DateTime64(3, 'UTC'))))"
+            " ENGINE = AggregatingMergeTree ORDER BY (metric_name, id)"
+            " SETTINGS allow_dimensions_outside_sorting_key = 1"
+        )
+        node.query("CREATE TABLE prometheus_metrics (metric_family_name String, type String, unit String, help String) ENGINE = ReplacingMergeTree ORDER BY metric_family_name")
+        node.query("CREATE TABLE prometheus ENGINE = TimeSeries SETTINGS tags_to_columns = {'host': 'host'} DATA prometheus_data TAGS prometheus_tags METRICS prometheus_metrics")
+        # `cpu_usage{host="server1",instance="i1"}` is stored twice, once per carrier layout:
+        # a legacy row with `host` only in the residual Map and a migrated row with `host` only in
+        # the dedicated column. `mem_usage` is a single mixed row carrying the same `host` value in
+        # both carriers at once. `conflicting_metric` carries two different `host` values. The
+        # first row of `late_conflicting_metric` is valid and the second row is malformed, so a
+        # finite series limit can use the second row only as a truncation probe.
+        node.query(
+            "INSERT INTO prometheus_tags VALUES"
+            " ('00000000-0000-0000-0000-000000000001', 'cpu_usage', NULL, map('instance', 'i1', 'host', 'server1'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')) ,"
+            " ('00000000-0000-0000-0000-000000000002', 'cpu_usage', 'server1', map('instance', 'i1'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')) ,"
+            " ('00000000-0000-0000-0000-000000000003', 'mem_usage', 'server2', map('instance', 'i2', 'host', 'server2'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')) ,"
+            " ('00000000-0000-0000-0000-000000000004', 'conflicting_metric', 'column_host', map('host', 'map_host'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000005', 'legacy_metric', NULL, map('instance', 'i3', 'host', 'server3'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-00000000000e', 'empty_dedicated_metric', '', map('host', 'server4'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000014', 'missing_label_metric', NULL, map('instance', 'i4'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000007', 'empty_label_name_metric', NULL, map('', 'invalid'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000008', 'empty_label_name_empty_value_metric', NULL, map('', ''),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000009', 'invalid_utf8_metric', NULL, map('bad', unhex('FF')),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000013', unhex('FF'), NULL, map('host', 'invalid_metric_name_host'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-00000000000c', '', NULL, map('host', 'empty_canonical_host'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-00000000000d', '', NULL, map('__name__', 'map_metric', 'host', 'map_only_empty_name'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-00000000000a', 'late_conflicting_metric', 'good_host', map('host', 'good_host'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-00000000000b', 'late_conflicting_metric', 'column_host', map('host', 'map_host'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000006', 'conflicting_metric_name', 'canonical_name', map('__name__', 'map_name'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000015', 'duplicate_map_metric', NULL,"
+            "  map('host', 'server5', 'host', 'server6', 'zone', 'a', 'zone', 'b'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000016', 'duplicate_map_metric_name', NULL,"
+            "  map('__name__', 'duplicate_map_metric_name', '__name__', 'other_name'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC')),"
+            " ('00000000-0000-0000-0000-000000000017', 'duplicate_map_same_value', NULL,"
+            "  map('host', 'server7', 'host', 'server7'),"
+            "  toDateTime64(1700000000, 3, 'UTC'), toDateTime64(1700000000, 3, 'UTC'))"
+        )
+        node.query(
+            "INSERT INTO prometheus_data VALUES"
+            " ('00000000-0000-0000-0000-000000000001', toDateTime64(1700000000, 3, 'UTC'), 1),"
+            " ('00000000-0000-0000-0000-000000000002', toDateTime64(1700000000, 3, 'UTC'), 2),"
+            " ('00000000-0000-0000-0000-000000000003', toDateTime64(1700000000, 3, 'UTC'), 3),"
+            " ('00000000-0000-0000-0000-000000000004', toDateTime64(1700000000, 3, 'UTC'), 4),"
+            " ('00000000-0000-0000-0000-000000000005', toDateTime64(1700000000, 3, 'UTC'), 5),"
+            " ('00000000-0000-0000-0000-00000000000e', toDateTime64(1700000000, 3, 'UTC'), 6),"
+            " ('00000000-0000-0000-0000-000000000014', toDateTime64(1700000000, 3, 'UTC'), 9),"
+            " ('00000000-0000-0000-0000-000000000006', toDateTime64(1700000000, 3, 'UTC'), 6),"
+            " ('00000000-0000-0000-0000-000000000007', toDateTime64(1700000000, 3, 'UTC'), 7),"
+            " ('00000000-0000-0000-0000-000000000008', toDateTime64(1700000000, 3, 'UTC'), 8),"
+            " ('00000000-0000-0000-0000-000000000009', toDateTime64(1700000000, 3, 'UTC'), 9),"
+            " ('00000000-0000-0000-0000-000000000013', toDateTime64(1700000000, 3, 'UTC'), 13),"
+            " ('00000000-0000-0000-0000-000000000010', toDateTime64(1700000000, 3, 'UTC'), 10),"
+            " ('00000000-0000-0000-0000-000000000011', toDateTime64(1700000000, 3, 'UTC'), 11),"
+            " ('00000000-0000-0000-0000-000000000012', toDateTime64(1700000000, 3, 'UTC'), 12),"
+            " ('00000000-0000-0000-0000-000000000015', toDateTime64(1700000000, 3, 'UTC'), 15),"
+            " ('00000000-0000-0000-0000-000000000016', toDateTime64(1700000000, 3, 'UTC'), 16),"
+            " ('00000000-0000-0000-0000-000000000017', toDateTime64(1700000000, 3, 'UTC'), 17)"
+        )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_mixed_carrier_rows_collapse_to_one_series():
+    """The same logical series stored once per carrier layout is returned exactly once."""
+    data = get_series("cpu_usage")
+    assert data == [{"__name__": "cpu_usage", "host": "server1", "instance": "i1"}], f"Unexpected series: {data}"
+
+
+def test_single_row_with_both_carriers_emits_label_once():
+    """A row carrying the same value in the Map and in the dedicated column emits `host` once."""
+    response = request_api("/api/v1/series", params={"match[]": 'mem_usage{host="server2"}'})
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    assert response.text.count('"host"') == 1, f"Unexpected body: {response.text}"
+    data = response.json()
+    assert data["data"] == [{"__name__": "mem_usage", "host": "server2", "instance": "i2"}], f"Unexpected series: {data}"
+
+
+def test_conflicting_carriers_are_rejected():
+    """A row with different `host` values in the Map and in the dedicated column fails with
+    `bad_data`, like `timeSeriesStoreTags` on the write path, instead of emitting an invalid
+    series with a repeated label key."""
+    response = request_api("/api/v1/series", params={"match[]": "conflicting_metric"})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "host" in data["error"], f"Unexpected error message: {data}"
+
+
+@pytest.mark.parametrize("metric_name", ["empty_label_name_metric", "empty_label_name_empty_value_metric"])
+def test_empty_label_names_are_rejected(metric_name):
+    response = request_api("/api/v1/series", params={"match[]": metric_name})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "empty name" in data["error"], f"Unexpected error message: {data}"
+
+
+@pytest.mark.parametrize("selector", ['{host="empty_canonical_host"}', '{host="map_only_empty_name"}'])
+def test_empty_canonical_metric_names_are_rejected(selector):
+    response = request_api("/api/v1/series", params={"match[]": selector})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "empty metric name" in data["error"], f"Unexpected error message: {data}"
+
+
+def test_series_limit_still_validates_returned_conflicting_row():
+    """A conflicting row inside the response limit must still fail closed."""
+    response = request_api(
+        "/api/v1/series",
+        params={"match[]": "late_conflicting_metric", "limit": 2, "max_threads": 1},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "host" in data["error"], f"Unexpected error message: {data}"
+
+
+def test_invalid_utf8_label_values_are_rejected():
+    response = request_api("/api/v1/series", params={"match[]": "invalid_utf8_metric"})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "UTF-8" in data["error"], f"Unexpected body: {data}"
+
+
+def test_label_values_reject_invalid_utf8_values():
+    response = request_api(
+        "/api/v1/label/bad/values",
+        params={"match[]": "invalid_utf8_metric"},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "UTF-8" in data["error"], f"Unexpected body: {data}"
+
+
+def test_label_values_ignores_conflicting_carrier_outside_match():
+    response = request_api(
+        "/api/v1/label/host/values",
+        params={"match[]": '{instance="i1"}'},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    assert response.json() == {"status": "success", "data": ["server1"]}, response.text
+
+
+def test_label_values_rejects_conflicting_carrier_in_selected_series():
+    response = request_api(
+        "/api/v1/label/host/values",
+        params={"match[]": "conflicting_metric"},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "host" in data["error"], f"Unexpected body: {data}"
+
+
+@pytest.mark.parametrize(
+    "path, selector, expected_error_fragment",
+    [
+        ("/api/v1/label/host/values", '{host="empty_canonical_host"}', "empty metric name"),
+        ("/api/v1/label/host/values", '{host="map_only_empty_name"}', "empty metric name"),
+        ("/api/v1/label/__name__/values", '{host="empty_canonical_host"}', "empty metric name"),
+        ("/api/v1/label/host/values", '{host="invalid_metric_name_host"}', "invalid UTF-8"),
+    ],
+)
+def test_label_values_rejects_invalid_canonical_metric_names(path, selector, expected_error_fragment):
+    response = request_api(path, params={"match[]": selector})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert expected_error_fragment in data["error"], f"Unexpected body: {data}"
+
+
+@pytest.mark.parametrize("max_block_size", [1, 100])
+def test_late_conflicting_sentinel_is_not_validated(max_block_size):
+    """A malformed row fetched only as the limit sentinel must not poison the returned response."""
+    response = request_api(
+        "/api/v1/series",
+        params={
+            "match[]": "late_conflicting_metric",
+            "limit": 1,
+            "max_threads": 1,
+            "max_block_size": max_block_size,
+        },
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    assert response.json() == {
+        "status": "success",
+        "data": [{"__name__": "late_conflicting_metric", "host": "good_host"}],
+        "warnings": ["results truncated due to limit"],
+    }
+
+
+def test_late_emittable_conflict_returns_bad_data_before_response_starts():
+    """A malformed returned row must be rejected before a success response is sent."""
+    response = request_api(
+        "/api/v1/series",
+        params={
+            "match[]": "late_conflicting_metric",
+            "max_threads": 1,
+            "max_block_size": 1,
+            "http_response_buffer_size": 1,
+        },
+        stream=True,
+    )
+    try:
+        assert response.status_code == 400, f"Expected 400, got {response.status_code}"
+        data = response.json()
+        assert data["status"] == "error", f"Unexpected body: {data}"
+        assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+        assert "host" in data["error"], f"Unexpected body: {data}"
+    finally:
+        response.close()
+
+
+def test_conflicting_metric_name_carriers_are_rejected():
+    """The metric name in the Map must agree with the dedicated metric_name column."""
+    response = request_api("/api/v1/series", params={"match[]": "conflicting_metric_name"})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "__name__" in data["error"], f"Unexpected error message: {data}"
+
+
+@pytest.mark.parametrize(
+    "selector, expected_error_fragment",
+    [
+        ('{host="empty_canonical_host"}', "empty metric name"),
+        ('{host="map_only_empty_name"}', "empty metric name"),
+    ],
+)
+def test_empty_canonical_metric_name_is_rejected(selector, expected_error_fragment):
+    """The canonical metric_name column cannot be replaced by a Map __name__ value."""
+    response = request_api("/api/v1/series", params={"match[]": selector})
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert expected_error_fragment in data["error"], f"Unexpected body: {data}"
+
+
+def test_label_values_reject_conflicting_metric_name_carriers():
+    """The label-values endpoint must validate the virtual __name__ carrier too."""
+    response = request_api(
+        "/api/v1/label/__name__/values",
+        params={"match[]": "conflicting_metric_name"},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "__name__" in data["error"], f"Unexpected error message: {data}"
+
+
+def test_label_values_rejects_conflicting_duplicate_map_keys():
+    response = request_api(
+        "/api/v1/label/host/values",
+        params={"match[]": "duplicate_map_metric"},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "host" in data["error"], f"Unexpected error message: {data}"
+
+
+def test_label_values_rejects_conflicting_duplicate_residual_map_keys():
+    response = request_api(
+        "/api/v1/label/zone/values",
+        params={"match[]": "duplicate_map_metric"},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "zone" in data["error"], f"Unexpected error message: {data}"
+
+
+def test_label_values_rejects_conflicting_duplicate_map_metric_names():
+    response = request_api(
+        "/api/v1/label/__name__/values",
+        params={"match[]": "duplicate_map_metric_name"},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "__name__" in data["error"], f"Unexpected error message: {data}"
+
+
+def test_label_values_accepts_duplicate_map_keys_with_the_same_value():
+    response = request_api(
+        "/api/v1/label/host/values",
+        params={"match[]": "duplicate_map_same_value"},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    assert response.json() == {"status": "success", "data": ["server7"]}, response.text
+
+
+def test_query_reads_legacy_map_carrier_with_short_circuit_disabled():
+    response = request_api(
+        "/api/v1/query",
+        params={
+            "query": 'legacy_metric{host="server3"}',
+            "time": 1700000000,
+            "short_circuit_function_evaluation": "disable",
+        },
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    assert data["data"]["resultType"] == "vector", f"Unexpected body: {data}"
+    assert data["data"]["result"][0]["metric"] == {
+        "__name__": "legacy_metric",
+        "host": "server3",
+        "instance": "i3",
+    }, f"Unexpected body: {data}"
+
+
+@pytest.mark.parametrize(
+    "matcher, expected_result_count",
+    [('host="server4"', 1), ('host!="server4"', 0), ('host=""', 0)],
+)
+def test_query_preserves_map_fallback_for_empty_dedicated_column(matcher, expected_result_count):
+    response = request_api(
+        "/api/v1/query",
+        params={
+            "query": f"empty_dedicated_metric{{{matcher}}}",
+            "time": 1700000000,
+            "short_circuit_function_evaluation": "disable",
+        },
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    assert len(data["data"]["result"]) == expected_result_count, f"Unexpected body: {data}"
+
+
+def test_query_preserves_negative_regex_missing_label_semantics():
+    response = request_api(
+        "/api/v1/query",
+        params={
+            "query": 'legacy_metric{host!~"other"}',
+            "time": 1700000000,
+            "short_circuit_function_evaluation": "disable",
+        },
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    assert len(data["data"]["result"]) == 1, f"Unexpected body: {data}"
+
+
+@pytest.mark.parametrize(
+    "matcher, expected_result_count",
+    [
+        ('host=""', 1),
+        ('host!="prod"', 1),
+        ('host!=""', 0),
+        ('host=~".*"', 1),
+        ('host!~"prod"', 1),
+    ],
+)
+def test_query_uses_empty_label_semantics_for_a_missing_label(matcher, expected_result_count):
+    response = request_api(
+        "/api/v1/query",
+        params={
+            "query": f"missing_label_metric{{{matcher}}}",
+            "time": 1700000000,
+            "short_circuit_function_evaluation": "disable",
+        },
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    result = data["data"]["result"]
+    assert len(result) == expected_result_count, f"Unexpected body: {data}"
+    if expected_result_count:
+        assert result[0]["metric"] == {
+            "__name__": "missing_label_metric",
+            "instance": "i4",
+        }, f"Unexpected body: {data}"
+
+
+def test_series_ignores_unrelated_conflicting_carrier_with_short_circuit_disabled():
+    response = request_api(
+        "/api/v1/series",
+        params={
+            "match[]": 'legacy_metric{host="server3"}',
+            "short_circuit_function_evaluation": "disable",
+        },
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    assert data["data"] == [{"__name__": "legacy_metric", "host": "server3", "instance": "i3"}], data
+
+
+@pytest.mark.parametrize(
+    "selector, expected_data",
+    [
+        ('empty_dedicated_metric{host="server4"}', [{"__name__": "empty_dedicated_metric", "host": "server4"}]),
+        ('empty_dedicated_metric{host!="server4"}', []),
+        ('empty_dedicated_metric{host=""}', []),
+    ],
+)
+def test_series_preserves_map_fallback_for_empty_dedicated_column(selector, expected_data):
+    response = request_api(
+        "/api/v1/series",
+        params={"match[]": selector, "short_circuit_function_evaluation": "disable"},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    assert data["data"] == expected_data, data
+
+
+def test_series_limit_does_not_hide_conflicting_carrier():
+    """A SQL-side limit must not stop validation before a later malformed row."""
+    response = request_api(
+        "/api/v1/series",
+        params={"match[]": '{__name__=~"(aa|bb|cc|conflicting)_metric"}', "limit": "1"},
+    )
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Unexpected body: {data}"
+    assert data["errorType"] == "bad_data", f"Unexpected body: {data}"
+    assert "host" in data["error"], f"Unexpected error message: {data}"
+
+
+def test_series_deduplicates_before_limit():
+    """Duplicate physical rows must not consume the logical series limit."""
+    response = request_api(
+        "/api/v1/series",
+        params={"match[]": "cpu_usage", "limit": 1},
+    )
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Unexpected body: {data}"
+    assert data["data"] == [{"__name__": "cpu_usage", "host": "server1", "instance": "i1"}]
+    assert "warnings" not in data, f"Unexpected body: {data}"


### PR DESCRIPTION
### Changelog category (leave one):

- **Experimental Feature**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

****Prometheus HTTP API:** implement **`/api/v1/label/<name>/values`** for **`TimeSeries`** tables.**

### Why this matters

**Prometheus-compatible clients** use **`/api/v1/label/<name>/values`** to discover the values available for a label. This is used by **Grafana dashboards**, variable pickers, and integrations that need to populate label-value selectors.

Prometheus also supports **escaped UTF-8 label names**. The endpoint must decode those names correctly while preserving malformed or intentionally literal values in a predictable way.

### Description

This PR adds **Prometheus `/api/v1/label/<name>/values` support** for **`TimeSeries` tables**.

The endpoint returns a **sorted, distinct list of values** for one label. It supports metric names through **`__name__`**, labels from the **`tags` Map**, dedicated columns configured with **`tags_to_columns`**, series selectors, time ranges, and result limits.

Supported parameters:

- **`<name>`** identifies the label whose values should be returned, including Prometheus **`U__...` escaped names**.
- **`match[]`** filters the series contributing values.
- **`start` and `end`** restrict the matching series by their **time range**.
- **`limit`** limits the returned values and reports when the response was **truncated**.

### Changes

- **Value discovery:** return distinct values for ordinary labels and the special **`__name__`** metric-name label.
- **Storage compatibility:** read values from the **`tags` Map** and dedicated **`tags_to_columns`** columns using the same logical label semantics as the other metadata endpoints.
- **Name decoding:** decode valid Prometheus escaped label names, preserve malformed or overlong escape sequences as literal names, and reject an empty decoded label name.
- **Selector support:** filter values by metric and series selectors, including unknown-label and no-match cases.
- **Time ranges:** apply trusted min/max bounds when available and keep ranged requests valid with the **approximate superset** behavior allowed by Prometheus when bounds are unavailable.
- **Result limits:** support empty, zero, positive, maximum, and invalid **`limit`** values, including the Prometheus truncation warning.
- **HTTP handling:** add the label-values route to the **combined `/api/v1` handler** and keep endpoint parameters separate from ClickHouse settings.
- **Access control:** enforce the configured **`TimeSeries` table authorization boundary** before reading the underlying target tables.
- **Query lifecycle:** execute through the **normal query pipeline**, preserve query completion handling, and record the request in **`query_log`**.

### Tests

Added integration coverage for:

- **Metric names:** values returned through **`__name__`**.
- **Label values:** distinct Map values and values from configured dedicated columns.
- **Escaped names:** valid UTF-8 decoding, malformed escape sequences, overlong escapes, and empty decoded names.
- **Filtering:** selectors, unknown labels, and requests with no matching series.
- **Time ranges:** matching and non-matching intervals, including empty optional parameters.
- **Limits:** truncation warnings and the maximum valid **UInt64** limit.
- **Authorization:** wrapper-only **`SELECT` grants** on the configured `TimeSeries` table.
- **HTTP integration:** the main HTTP port, routing, and query completion records.

Also ran **Python syntax checks**, **XML parsing**, and **`git diff --check`**.

### Documentation

**Documentation is written.**

The **TimeSeries engine documentation** now describes the label-values handler, escaped label names, and its supported parameters.

### Stack

This PR is **stacked on #114867** and includes the **`/api/v1/series`** changes. After **#114867** merges, this branch can be rebased onto `master`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114869&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114869](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114869+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
