### PR TITLE
LowCardinality merge optimization

### DIFF
--- a/src/Columns/ColumnIndex.cpp
+++ b/src/Columns/ColumnIndex.cpp
@@ -291,19 +291,34 @@ void ColumnIndex::insertIndexesRangeWithShift(const IColumn & column, size_t off
         if (!column_ptr)
             return false;
 
-        auto copy = [&]<typename CurIndexType>(CurIndexType /*type_value*/)
+        if (shift == 0 && size_of_type == sizeof(ColumnType))
+            indexes->insertRangeFrom(column, offset, limit);
+        else
         {
-            auto & indexes_data = getIndexesData<CurIndexType>();
-            const auto & column_data = column_ptr->getData();
+            const size_t column_size = column_ptr->size();
+            if (offset > column_size || limit > column_size - offset)
+                throw Exception(
+                    ErrorCodes::PARAMETER_OUT_OF_BOUND,
+                    "Parameters offset = {}, limit = {} are out of bound in ColumnIndex::insertIndexesRangeWithShift method "
+                    "(column.size() = {})",
+                    offset,
+                    limit,
+                    column_size);
 
-            size_t size = indexes_data.size();
-            indexes_data.resize(size + limit);
+            auto copy = [&]<typename CurIndexType>(CurIndexType /*type_value*/)
+            {
+                auto & indexes_data = getIndexesData<CurIndexType>();
+                const auto & column_data = column_ptr->getData();
 
-            for (size_t i = 0; i < limit; ++i)
-                indexes_data[size + i] = static_cast<CurIndexType>(static_cast<CurIndexType>(column_data[offset + i]) + shift);
-        };
+                size_t size = indexes_data.size();
+                indexes_data.resize(size + limit);
 
-        callForType(std::move(copy), size_of_type);
+                for (size_t i = 0; i < limit; ++i)
+                    indexes_data[size + i] = static_cast<CurIndexType>(static_cast<CurIndexType>(column_data[offset + i]) + shift);
+            };
+
+            callForType(std::move(copy), size_of_type);
+        }
 
         return true;
     };

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -12,6 +12,8 @@
 #include <base/sort.h>
 #include <base/scope_guard.h>
 
+#include <new>
+
 
 namespace DB
 {
@@ -49,25 +51,33 @@ namespace
     template <typename T>
     MutableColumnPtr mapUniqueIndexImplRef(PaddedPODArray<T> & index)
     {
+#if defined(DEBUG_OR_SANITIZER_BUILD)
         PaddedPODArray<T> copy(index.cbegin(), index.cend());
+#endif
 
         HashMap<T, T> hash_map;
-        for (auto val : index)
-            hash_map.insert({val, static_cast<T>(hash_map.size())});
-
         auto res_col = ColumnVector<T>::create();
         auto & data = res_col->getData();
 
-        data.resize(hash_map.size());
-        for (const auto & val : hash_map)
-            data[val.getMapped()] = val.getKey();
-
         for (auto & ind : index)
-            ind = hash_map[ind];
+        {
+            typename HashMap<T, T>::LookupResult it;
+            bool inserted = false;
+            hash_map.emplace(ind, it, inserted);
+            if (inserted)
+            {
+                const auto compact_index = static_cast<T>(data.size());
+                new (&it->getMapped()) T(compact_index);
+                data.push_back(ind);
+            }
+            ind = it->getMapped();
+        }
 
+#if defined(DEBUG_OR_SANITIZER_BUILD)
         for (size_t i = 0; i < index.size(); ++i)
             if (data[index[i]] != copy[i])
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected {}, but got {}", toString(data[index[i]]), toString(copy[i]));
+#endif
 
         return res_col;
     }

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -155,6 +155,53 @@ namespace
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Indexes column for getUniqueIndex must be ColumnUInt, got {}", column.getName());
     }
 
+    template <typename DestinationIndexType, typename SourceIndexType>
+    MutableColumnPtr convertIndexColumn(const PaddedPODArray<SourceIndexType> & source_indexes)
+    {
+        auto result = ColumnVector<DestinationIndexType>::create();
+        auto & result_indexes = result->getData();
+        result_indexes.reserve(source_indexes.size());
+        for (const auto index : source_indexes)
+            result_indexes.push_back(static_cast<DestinationIndexType>(index));
+        return result;
+    }
+
+    template <typename IndexType>
+    MutableColumnPtr narrowIndexColumnForType(
+        MutableColumnPtr indexes, const PaddedPODArray<IndexType> & indexes_data, size_t max_index)
+    {
+        if constexpr (sizeof(IndexType) == sizeof(UInt8))
+            return indexes;
+
+        if (max_index <= std::numeric_limits<UInt8>::max())
+            return convertIndexColumn<UInt8>(indexes_data);
+        if constexpr (sizeof(IndexType) > sizeof(UInt16))
+            if (max_index <= std::numeric_limits<UInt16>::max())
+                return convertIndexColumn<UInt16>(indexes_data);
+        if constexpr (sizeof(IndexType) > sizeof(UInt32))
+            if (max_index <= std::numeric_limits<UInt32>::max())
+                return convertIndexColumn<UInt32>(indexes_data);
+        return indexes;
+    }
+
+    MutableColumnPtr narrowIndexColumn(MutableColumnPtr indexes, size_t max_index)
+    {
+        if (indexes->empty())
+            return indexes;
+        if (const auto * indexes_data = getIndexesData<UInt8>(*indexes))
+            return narrowIndexColumnForType(std::move(indexes), *indexes_data, max_index);
+        if (const auto * indexes_data = getIndexesData<UInt16>(*indexes))
+            return narrowIndexColumnForType(std::move(indexes), *indexes_data, max_index);
+        if (const auto * indexes_data = getIndexesData<UInt32>(*indexes))
+            return narrowIndexColumnForType(std::move(indexes), *indexes_data, max_index);
+        if (const auto * indexes_data = getIndexesData<UInt64>(*indexes))
+            return narrowIndexColumnForType(std::move(indexes), *indexes_data, max_index);
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Indexes column for LowCardinality translation must be ColumnUInt, got {}",
+            indexes->getName());
+    }
+
     template <typename SourceIndexType>
     MutableColumnPtr translateSparseIndexesForSourceType(
         const IColumn & source_indexes_column,
@@ -191,10 +238,12 @@ namespace
             0,
             distinct_source_index_count,
             destination_size_upper_bound);
+        translated_distinct_indexes.indexes = narrowIndexColumn(
+            std::move(translated_distinct_indexes.indexes), translated_distinct_indexes.max_index);
 
         if (distinct_source_index_count == length)
-            return translated_distinct_indexes;
-        return IColumn::mutate(translated_distinct_indexes->index(*compact_indexes, 0));
+            return std::move(translated_distinct_indexes.indexes);
+        return IColumn::mutate(translated_distinct_indexes.indexes->index(*compact_indexes, 0));
     }
 
     MutableColumnPtr translateSparseIndexes(

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -20,6 +20,45 @@
 namespace DB
 {
 
+thread_local LowCardinalityHashMapSizeCache * LowCardinalityHashMapSizeCache::current_cache = nullptr;
+
+LowCardinalityHashMapSizeCache::Scope::Scope(LowCardinalityHashMapSizeCache & cache_)
+    : previous_cache(current_cache)
+{
+    current_cache = &cache_;
+}
+
+LowCardinalityHashMapSizeCache::Scope::~Scope()
+{
+    current_cache = previous_cache;
+}
+
+size_t LowCardinalityHashMapSizeCache::get(const IColumn * source_indexes) const
+{
+    for (const auto & entry : entries)
+        if (entry.source_indexes == source_indexes)
+            return entry.hash_map_size;
+    return 0;
+}
+
+void LowCardinalityHashMapSizeCache::set(const IColumn * source_indexes, size_t hash_map_size)
+{
+    for (auto & entry : entries)
+    {
+        if (entry.source_indexes == source_indexes)
+        {
+            entry.hash_map_size = hash_map_size;
+            return;
+        }
+    }
+    entries.push_back({source_indexes, hash_map_size});
+}
+
+LowCardinalityHashMapSizeCache * LowCardinalityHashMapSizeCache::getCurrent()
+{
+    return current_cache;
+}
+
 namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
@@ -62,13 +101,17 @@ namespace
     }
 
     template <typename T>
-    MutableColumnPtr mapUniqueIndexImplRef(PaddedPODArray<T> & index)
+    MutableColumnPtr mapUniqueIndexImplRef(PaddedPODArray<T> & index, const IColumn * reserve_cache_key)
     {
 #if defined(DEBUG_OR_SANITIZER_BUILD)
         PaddedPODArray<T> copy(index.cbegin(), index.cend());
 #endif
 
-        HashMap<T, T> hash_map;
+        auto * reserve_cache = LowCardinalityHashMapSizeCache::getCurrent();
+        const size_t reserve_size = reserve_cache && reserve_cache_key
+            ? std::min(index.size(), reserve_cache->get(reserve_cache_key))
+            : 0;
+        HashMap<T, T> hash_map(reserve_size);
         auto res_col = ColumnVector<T>::create();
         auto & data = res_col->getData();
 
@@ -86,6 +129,9 @@ namespace
             ind = it->getMapped();
         }
 
+        if (reserve_cache && reserve_cache_key)
+            reserve_cache->set(reserve_cache_key, hash_map.size());
+
 #if defined(DEBUG_OR_SANITIZER_BUILD)
         for (size_t i = 0; i < index.size(); ++i)
             if (data[index[i]] != copy[i])
@@ -96,7 +142,7 @@ namespace
     }
 
     template <typename T>
-    MutableColumnPtr mapUniqueIndexImpl(PaddedPODArray<T> & index)
+    MutableColumnPtr mapUniqueIndexImpl(PaddedPODArray<T> & index, const IColumn * reserve_cache_key)
     {
         if (index.empty())
             return ColumnVector<T>::create();
@@ -109,7 +155,7 @@ namespace
 
         /// May happen when dictionary is shared.
         if (max_val > size)
-            return mapUniqueIndexImplRef(index);
+            return mapUniqueIndexImplRef(index, reserve_cache_key);
 
         auto map_size = static_cast<UInt64>(max_val) + 1;
         PaddedPODArray<T> map(map_size, 0);
@@ -142,16 +188,16 @@ namespace
     }
 
     /// Returns unique values of column. Write new index to column.
-    MutableColumnPtr mapUniqueIndex(IColumn & column)
+    MutableColumnPtr mapUniqueIndex(IColumn & column, const IColumn * reserve_cache_key = nullptr)
     {
         if (auto * data_uint8 = getIndexesData<UInt8>(column))
-            return mapUniqueIndexImpl(*data_uint8);
+            return mapUniqueIndexImpl(*data_uint8, reserve_cache_key);
         if (auto * data_uint16 = getIndexesData<UInt16>(column))
-            return mapUniqueIndexImpl(*data_uint16);
+            return mapUniqueIndexImpl(*data_uint16, reserve_cache_key);
         if (auto * data_uint32 = getIndexesData<UInt32>(column))
-            return mapUniqueIndexImpl(*data_uint32);
+            return mapUniqueIndexImpl(*data_uint32, reserve_cache_key);
         if (auto * data_uint64 = getIndexesData<UInt64>(column))
-            return mapUniqueIndexImpl(*data_uint64);
+            return mapUniqueIndexImpl(*data_uint64, reserve_cache_key);
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Indexes column for getUniqueIndex must be ColumnUInt, got {}", column.getName());
     }
 
@@ -225,7 +271,7 @@ namespace
             return nullptr;
 
         auto compact_indexes = IColumn::mutate(source_indexes_column.cut(start, length));
-        auto distinct_source_indexes = mapUniqueIndex(*compact_indexes);
+        auto distinct_source_indexes = mapUniqueIndex(*compact_indexes, &source_indexes_column);
         const size_t distinct_source_index_count = distinct_source_indexes->size();
         const size_t max_new_keys = std::min(distinct_source_index_count, source_dictionary_size);
         const size_t destination_dictionary_size = destination_dictionary.size();
@@ -828,7 +874,7 @@ ColumnLowCardinality::DictionaryEncodedColumn
 ColumnLowCardinality::getMinimalDictionaryEncodedColumn(UInt64 offset, UInt64 limit) const
 {
     MutableColumnPtr sub_indexes = IColumn::mutate(idx.getIndexes()->cut(offset, limit));
-    auto indexes_map = mapUniqueIndex(*sub_indexes);
+    auto indexes_map = mapUniqueIndex(*sub_indexes, &getIndexes());
     auto sub_keys = getDictionary().getNestedColumn()->index(*indexes_map, 0);
 
     return {std::move(sub_keys), std::move(sub_indexes)};

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -12,6 +12,8 @@
 #include <base/sort.h>
 #include <base/scope_guard.h>
 
+#include <algorithm>
+#include <limits>
 #include <new>
 
 
@@ -23,6 +25,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_COLUMN;
     extern const int LOGICAL_ERROR;
     extern const int INCORRECT_DATA;
+    extern const int PARAMETER_OUT_OF_BOUND;
 }
 
 void throwUnexpectedLowCardinalityIndexType(size_t size)
@@ -42,6 +45,16 @@ namespace
     PaddedPODArray<T> * getIndexesData(IColumn & indexes)
     {
         auto * column = typeid_cast<ColumnVector<T> *>(&indexes);
+        if (column)
+            return &column->getData();
+
+        return nullptr;
+    }
+
+    template <typename T>
+    const PaddedPODArray<T> * getIndexesData(const IColumn & indexes)
+    {
+        const auto * column = typeid_cast<const ColumnVector<T> *>(&indexes);
         if (column)
             return &column->getData();
 
@@ -141,6 +154,75 @@ namespace
             return mapUniqueIndexImpl(*data_uint64);
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Indexes column for getUniqueIndex must be ColumnUInt, got {}", column.getName());
     }
+
+    template <typename SourceIndexType>
+    MutableColumnPtr translateSparseIndexesForSourceType(
+        const IColumn & source_indexes_column,
+        const PaddedPODArray<SourceIndexType> & source_indexes,
+        size_t start,
+        size_t length,
+        size_t source_dictionary_size,
+        const IColumn & source_keys,
+        IColumnUnique & destination_dictionary)
+    {
+        /// Every valid source index is dense-path eligible without scanning in this case.
+        if (source_dictionary_size == 0 || source_dictionary_size - 1 <= length)
+            return nullptr;
+
+        SourceIndexType max_source_index = source_indexes[start];
+        for (size_t i = 1; i < length; ++i)
+            max_source_index = std::max(max_source_index, source_indexes[start + i]);
+
+        /// Preserve the existing dense mapping path and its crossover exactly.
+        if (max_source_index <= length)
+            return nullptr;
+
+        auto compact_indexes = IColumn::mutate(source_indexes_column.cut(start, length));
+        auto distinct_source_indexes = mapUniqueIndex(*compact_indexes);
+        const size_t distinct_source_index_count = distinct_source_indexes->size();
+        const size_t max_new_keys = std::min(distinct_source_index_count, source_dictionary_size);
+        const size_t destination_dictionary_size = destination_dictionary.size();
+        if (max_new_keys > std::numeric_limits<size_t>::max() - destination_dictionary_size)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "LowCardinality dictionary size overflow");
+        const size_t destination_size_upper_bound = destination_dictionary_size + max_new_keys;
+        auto translated_distinct_indexes = destination_dictionary.uniqueInsertRangeFromDictionary(
+            source_keys,
+            *distinct_source_indexes,
+            0,
+            distinct_source_index_count,
+            destination_size_upper_bound);
+
+        if (distinct_source_index_count == length)
+            return translated_distinct_indexes;
+        return IColumn::mutate(translated_distinct_indexes->index(*compact_indexes, 0));
+    }
+
+    MutableColumnPtr translateSparseIndexes(
+        const IColumn & source_indexes,
+        size_t start,
+        size_t length,
+        size_t source_dictionary_size,
+        const IColumn & source_keys,
+        IColumnUnique & destination_dictionary)
+    {
+        if (const auto * indexes = getIndexesData<UInt8>(source_indexes))
+            return translateSparseIndexesForSourceType(
+                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+        if (const auto * indexes = getIndexesData<UInt16>(source_indexes))
+            return translateSparseIndexesForSourceType(
+                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+        if (const auto * indexes = getIndexesData<UInt32>(source_indexes))
+            return translateSparseIndexesForSourceType(
+                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+        if (const auto * indexes = getIndexesData<UInt64>(source_indexes))
+            return translateSparseIndexesForSourceType(
+                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Indexes column for LowCardinality translation must be ColumnUInt, got {}",
+            source_indexes.getName());
+    }
+
 }
 
 
@@ -215,6 +297,16 @@ void ColumnLowCardinality::doInsertRangeFrom(const IColumn & src, size_t start, 
     if (!low_cardinality_src)
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Expected ColumnLowCardinality, got {}", src.getName());
 
+    const size_t source_size = low_cardinality_src->size();
+    if (start > source_size || length > source_size - start)
+        throw Exception(
+            ErrorCodes::PARAMETER_OUT_OF_BOUND,
+            "Parameters start = {}, length = {} are out of bound in ColumnLowCardinality::insertRangeFrom method "
+            "(source.size() = {})",
+            start,
+            length,
+            source_size);
+
     if (length == 0)
         return;
 
@@ -238,13 +330,24 @@ void ColumnLowCardinality::doInsertRangeFrom(const IColumn & src, size_t start, 
     {
         compactIfSharedDictionary();
 
-        /// TODO: Support native insertion from other unique column. It will help to avoid null map creation.
+        const auto & source_keys = *low_cardinality_src->getDictionary().getNestedColumn();
+        auto translated_indexes = translateSparseIndexes(
+            low_cardinality_src->getIndexes(),
+            start,
+            length,
+            low_cardinality_src->getDictionary().size(),
+            source_keys,
+            getDictionary());
+        if (translated_indexes)
+        {
+            idx.insertIndexesRange(*translated_indexes, 0, length);
+            return;
+        }
 
+        /// Keep the existing batched path for dense source indexes.
         auto sub_idx = IColumn::mutate(low_cardinality_src->getIndexes().cut(start, length));
         auto idx_map = mapUniqueIndex(*sub_idx);
-
-        auto src_nested = low_cardinality_src->getDictionary().getNestedColumn();
-        auto used_keys = src_nested->index(*idx_map, 0);
+        auto used_keys = source_keys.index(*idx_map, 0);
 
         auto inserted_indexes = getDictionary().uniqueInsertRangeFrom(*used_keys, 0, used_keys->size());
         idx.insertIndexesRange(*inserted_indexes->index(*sub_idx, 0), 0, length);

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -373,7 +373,12 @@ void ColumnLowCardinality::doInsertRangeFrom(const IColumn & src, size_t start, 
     if (&low_cardinality_src->getDictionary() == &getDictionary())
     {
         /// Dictionary is shared with src column. Insert only indexes.
-        idx.insertIndexesRange(low_cardinality_src->getIndexes(), start, length);
+        idx.insertIndexesRangeWithShift(
+            low_cardinality_src->getIndexes(),
+            start,
+            length,
+            /*shift=*/0,
+            low_cardinality_src->getDictionary().size() - 1);
     }
     else
     {

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -208,10 +208,10 @@ namespace
         const PaddedPODArray<SourceIndexType> & source_indexes,
         size_t start,
         size_t length,
-        size_t source_dictionary_size,
-        const IColumn & source_keys,
+        const IColumnUnique & source_dictionary,
         IColumnUnique & destination_dictionary)
     {
+        const size_t source_dictionary_size = source_dictionary.size();
         /// Every valid source index is dense-path eligible without scanning in this case.
         if (source_dictionary_size == 0 || source_dictionary_size - 1 <= length)
             return nullptr;
@@ -233,7 +233,7 @@ namespace
             throw Exception(ErrorCodes::LOGICAL_ERROR, "LowCardinality dictionary size overflow");
         const size_t destination_size_upper_bound = destination_dictionary_size + max_new_keys;
         auto translated_distinct_indexes = destination_dictionary.uniqueInsertRangeFromDictionary(
-            source_keys,
+            source_dictionary,
             *distinct_source_indexes,
             0,
             distinct_source_index_count,
@@ -250,22 +250,21 @@ namespace
         const IColumn & source_indexes,
         size_t start,
         size_t length,
-        size_t source_dictionary_size,
-        const IColumn & source_keys,
+        const IColumnUnique & source_dictionary,
         IColumnUnique & destination_dictionary)
     {
         if (const auto * indexes = getIndexesData<UInt8>(source_indexes))
             return translateSparseIndexesForSourceType(
-                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+                source_indexes, *indexes, start, length, source_dictionary, destination_dictionary);
         if (const auto * indexes = getIndexesData<UInt16>(source_indexes))
             return translateSparseIndexesForSourceType(
-                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+                source_indexes, *indexes, start, length, source_dictionary, destination_dictionary);
         if (const auto * indexes = getIndexesData<UInt32>(source_indexes))
             return translateSparseIndexesForSourceType(
-                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+                source_indexes, *indexes, start, length, source_dictionary, destination_dictionary);
         if (const auto * indexes = getIndexesData<UInt64>(source_indexes))
             return translateSparseIndexesForSourceType(
-                source_indexes, *indexes, start, length, source_dictionary_size, source_keys, destination_dictionary);
+                source_indexes, *indexes, start, length, source_dictionary, destination_dictionary);
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "Indexes column for LowCardinality translation must be ColumnUInt, got {}",
@@ -389,8 +388,7 @@ void ColumnLowCardinality::doInsertRangeFrom(const IColumn & src, size_t start, 
             low_cardinality_src->getIndexes(),
             start,
             length,
-            low_cardinality_src->getDictionary().size(),
-            source_keys,
+            low_cardinality_src->getDictionary(),
             getDictionary());
         if (translated_indexes)
         {

--- a/src/Columns/ColumnLowCardinality.h
+++ b/src/Columns/ColumnLowCardinality.h
@@ -5,6 +5,7 @@
 #include <Columns/IColumn.h>
 #include <Columns/IColumnUnique.h>
 #include <Columns/ColumnIndex.h>
+#include <Common/VectorWithMemoryTracking.h>
 #include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
 
@@ -13,6 +14,38 @@ namespace DB
 {
 
 [[noreturn]] void throwUnexpectedLowCardinalityIndexType(size_t size);
+
+class LowCardinalityHashMapSizeCache
+{
+public:
+    class Scope
+    {
+    public:
+        explicit Scope(LowCardinalityHashMapSizeCache & cache_);
+        ~Scope();
+
+        Scope(const Scope &) = delete;
+        Scope & operator=(const Scope &) = delete;
+
+    private:
+        LowCardinalityHashMapSizeCache * previous_cache;
+    };
+
+    size_t get(const IColumn * source_indexes) const;
+    void set(const IColumn * source_indexes, size_t hash_map_size);
+
+    static LowCardinalityHashMapSizeCache * getCurrent();
+
+private:
+    struct Entry
+    {
+        const IColumn * source_indexes;
+        size_t hash_map_size;
+    };
+
+    VectorWithMemoryTracking<Entry> entries;
+    static thread_local LowCardinalityHashMapSizeCache * current_cache;
+};
 
 /**
  * How data is stored (in a nutshell):

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -67,7 +67,7 @@ public:
     size_t uniqueInsertFrom(const IColumn & src, size_t n) override;
     MutableColumnPtr uniqueInsertRangeFrom(const IColumn & src, size_t start, size_t length) override;
     IColumnUnique::IndexesWithMaxIndex uniqueInsertRangeFromDictionary(
-        const IColumn & src_dictionary,
+        const IColumnUnique & src_dictionary,
         const IColumn & src_indexes,
         size_t start,
         size_t length,
@@ -249,14 +249,14 @@ private:
 
     template <typename SourceIndexType, typename DestinationIndexType>
     IColumnUnique::IndexesWithMaxIndex uniqueInsertRangeFromDictionaryImpl(
-        const IColumn & src_dictionary,
+        const IColumnUnique & src_dictionary,
         const PaddedPODArray<SourceIndexType> & src_indexes,
         size_t start,
         size_t length);
 
     template <typename DestinationIndexType>
     IColumnUnique::IndexesWithMaxIndex uniqueInsertRangeFromDictionaryForDestinationType(
-        const IColumn & src_dictionary,
+        const IColumnUnique & src_dictionary,
         const IColumn & src_indexes,
         size_t start,
         size_t length);
@@ -469,7 +469,7 @@ size_t ColumnUnique<ColumnType>::uniqueInsertFrom(const IColumn & src, size_t n)
 template <typename ColumnType>
 template <typename SourceIndexType, typename DestinationIndexType>
 IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryImpl(
-    const IColumn & src_dictionary,
+    const IColumnUnique & src_dictionary,
     const PaddedPODArray<SourceIndexType> & src_indexes,
     size_t start,
     size_t length)
@@ -478,15 +478,7 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
     auto & translated_indexes = translated_column->getData();
     translated_indexes.reserve(length);
 
-    const ColumnType * source_column = nullptr;
-    const NullMap * source_null_map = nullptr;
-    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&src_dictionary))
-    {
-        source_column = typeid_cast<const ColumnType *>(&nullable_column->getNestedColumn());
-        source_null_map = &nullable_column->getNullMapData();
-    }
-    else
-        source_column = typeid_cast<const ColumnType *>(&src_dictionary);
+    const auto * source_column = typeid_cast<const ColumnType *>(src_dictionary.getNestedNotNullableColumn().get());
 
     if (!source_column)
         throw Exception(
@@ -495,15 +487,24 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
             column_holder->getName(),
             src_dictionary.getName());
 
-    auto * destination_column = getRawColumnPtr();
+    const bool source_is_nullable = src_dictionary.nestedColumnIsNullable();
+    const size_t source_null_value_index = source_is_nullable ? src_dictionary.getNullValueIndex() : 0;
+    [[maybe_unused]] const size_t source_nested_default_value_index = src_dictionary.getNestedTypeDefaultValueIndex();
     SCOPE_EXIT(updateNullMask());
 
     auto insert_source_index = [&](size_t source_index) -> size_t
     {
-        if (source_null_map && (*source_null_map)[source_index])
+        if (source_is_nullable && source_index == source_null_value_index)
             return getNullValueIndex();
-        if (destination_column->compareAt(
-                getNestedTypeDefaultValueIndex(), source_index, *source_column, 1) == 0)
+
+        if constexpr (is_float_vector_v<ColumnType>)
+        {
+            /// Floating-point dictionaries can contain a non-canonical signed zero outside the structural default position.
+            if (getRawColumnPtr()->compareAt(
+                    getNestedTypeDefaultValueIndex(), source_index, *source_column, 1) == 0)
+                return getNestedTypeDefaultValueIndex();
+        }
+        else if (source_index == source_nested_default_value_index)
             return getNestedTypeDefaultValueIndex();
 
         auto ref = source_column->getDataAt(source_index);
@@ -541,7 +542,7 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
 template <typename ColumnType>
 template <typename DestinationIndexType>
 IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryForDestinationType(
-    const IColumn & src_dictionary,
+    const IColumnUnique & src_dictionary,
     const IColumn & src_indexes,
     size_t start,
     size_t length)
@@ -566,7 +567,7 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
 
 template <typename ColumnType>
 IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionary(
-    const IColumn & src_dictionary,
+    const IColumnUnique & src_dictionary,
     const IColumn & src_indexes,
     size_t start,
     size_t length,

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -19,6 +19,7 @@
 #include <Columns/ColumnsNumber.h>
 
 #include <base/range.h>
+#include <base/scope_guard.h>
 #include <base/unaligned.h>
 
 
@@ -64,6 +65,12 @@ public:
     bool tryUniqueInsert(const Field & x, size_t & index) override;
     size_t uniqueInsertFrom(const IColumn & src, size_t n) override;
     MutableColumnPtr uniqueInsertRangeFrom(const IColumn & src, size_t start, size_t length) override;
+    MutableColumnPtr uniqueInsertRangeFromDictionary(
+        const IColumn & src_dictionary,
+        const IColumn & src_indexes,
+        size_t start,
+        size_t length,
+        size_t destination_size_upper_bound) override;
     IColumnUnique::IndexesWithOverflow uniqueInsertRangeWithOverflow(const IColumn & src, size_t start, size_t length,
                                                                      size_t max_dictionary_size) override;
     size_t uniqueInsertData(const char * pos, size_t length) override;
@@ -238,6 +245,20 @@ private:
         typename ColumnVector<IndexType>::MutablePtr && positions_column,
         ReverseIndex<UInt64, ColumnType> * secondary_index,
         size_t max_dictionary_size);
+
+    template <typename SourceIndexType, typename DestinationIndexType>
+    MutableColumnPtr uniqueInsertRangeFromDictionaryImpl(
+        const IColumn & src_dictionary,
+        const PaddedPODArray<SourceIndexType> & src_indexes,
+        size_t start,
+        size_t length);
+
+    template <typename DestinationIndexType>
+    MutableColumnPtr uniqueInsertRangeFromDictionaryForDestinationType(
+        const IColumn & src_dictionary,
+        const IColumn & src_indexes,
+        size_t start,
+        size_t length);
 };
 
 template <typename ColumnType>
@@ -442,6 +463,119 @@ size_t ColumnUnique<ColumnType>::uniqueInsertFrom(const IColumn & src, size_t n)
 
     auto ref = src.getDataAt(n);
     return uniqueInsertData(ref.data(), ref.size());
+}
+
+template <typename ColumnType>
+template <typename SourceIndexType, typename DestinationIndexType>
+MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryImpl(
+    const IColumn & src_dictionary,
+    const PaddedPODArray<SourceIndexType> & src_indexes,
+    size_t start,
+    size_t length)
+{
+    auto translated_column = ColumnVector<DestinationIndexType>::create();
+    auto & translated_indexes = translated_column->getData();
+    translated_indexes.reserve(length);
+
+    const ColumnType * source_column = nullptr;
+    const NullMap * source_null_map = nullptr;
+    if (const auto * nullable_column = checkAndGetColumn<ColumnNullable>(&src_dictionary))
+    {
+        source_column = typeid_cast<const ColumnType *>(&nullable_column->getNestedColumn());
+        source_null_map = &nullable_column->getNullMapData();
+    }
+    else
+        source_column = typeid_cast<const ColumnType *>(&src_dictionary);
+
+    if (!source_column)
+        throw Exception(
+            ErrorCodes::ILLEGAL_COLUMN,
+            "Invalid source dictionary type for ColumnUnique. Expected {}, got {}",
+            column_holder->getName(),
+            src_dictionary.getName());
+
+    auto * destination_column = getRawColumnPtr();
+    SCOPE_EXIT(updateNullMask());
+
+    auto insert_source_index = [&](size_t source_index) -> size_t
+    {
+        if (source_null_map && (*source_null_map)[source_index])
+            return getNullValueIndex();
+        if (destination_column->compareAt(
+                getNestedTypeDefaultValueIndex(), source_index, *source_column, 1) == 0)
+            return getNestedTypeDefaultValueIndex();
+
+        auto ref = source_column->getDataAt(source_index);
+        if constexpr (is_float_vector_v<ColumnType>)
+        {
+            const auto value = unalignedLoad<typename ColumnType::ValueType>(ref.data());
+            if (isNaN(value))
+            {
+                const auto nan = NaNOrZero<typename ColumnType::ValueType>();
+                return reverse_index.insert(
+                    std::string_view(reinterpret_cast<const char *>(&nan), sizeof(nan)));
+            }
+        }
+        return reverse_index.insert(ref);
+    };
+
+    for (size_t i = 0; i < length; ++i)
+    {
+        const auto source_index = src_indexes[start + i];
+        const size_t destination_index = insert_source_index(static_cast<size_t>(source_index));
+        if (destination_index > std::numeric_limits<DestinationIndexType>::max())
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "LowCardinality dictionary index {} does not fit in {} bytes",
+                destination_index,
+                sizeof(DestinationIndexType));
+        translated_indexes.push_back(static_cast<DestinationIndexType>(destination_index));
+    }
+
+    return translated_column;
+}
+
+template <typename ColumnType>
+template <typename DestinationIndexType>
+MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryForDestinationType(
+    const IColumn & src_dictionary,
+    const IColumn & src_indexes,
+    size_t start,
+    size_t length)
+{
+    if (const auto * indexes = typeid_cast<const ColumnUInt8 *>(&src_indexes))
+        return uniqueInsertRangeFromDictionaryImpl<UInt8, DestinationIndexType>(
+            src_dictionary, indexes->getData(), start, length);
+    if (const auto * indexes = typeid_cast<const ColumnUInt16 *>(&src_indexes))
+        return uniqueInsertRangeFromDictionaryImpl<UInt16, DestinationIndexType>(
+            src_dictionary, indexes->getData(), start, length);
+    if (const auto * indexes = typeid_cast<const ColumnUInt32 *>(&src_indexes))
+        return uniqueInsertRangeFromDictionaryImpl<UInt32, DestinationIndexType>(
+            src_dictionary, indexes->getData(), start, length);
+    if (const auto * indexes = typeid_cast<const ColumnUInt64 *>(&src_indexes))
+        return uniqueInsertRangeFromDictionaryImpl<UInt64, DestinationIndexType>(
+            src_dictionary, indexes->getData(), start, length);
+    throw Exception(
+        ErrorCodes::ILLEGAL_COLUMN,
+        "Indexes column for LowCardinality translation must be ColumnUInt, got {}",
+        src_indexes.getName());
+}
+
+template <typename ColumnType>
+MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionary(
+    const IColumn & src_dictionary,
+    const IColumn & src_indexes,
+    size_t start,
+    size_t length,
+    size_t destination_size_upper_bound)
+{
+    if (destination_size_upper_bound <= std::numeric_limits<UInt8>::max())
+        return uniqueInsertRangeFromDictionaryForDestinationType<UInt8>(src_dictionary, src_indexes, start, length);
+    if (destination_size_upper_bound <= std::numeric_limits<UInt16>::max())
+        return uniqueInsertRangeFromDictionaryForDestinationType<UInt16>(src_dictionary, src_indexes, start, length);
+    if (destination_size_upper_bound <= std::numeric_limits<UInt32>::max())
+        return uniqueInsertRangeFromDictionaryForDestinationType<UInt32>(src_dictionary, src_indexes, start, length);
+    return uniqueInsertRangeFromDictionaryForDestinationType<UInt64>(src_dictionary, src_indexes, start, length);
 }
 
 template <typename ColumnType>

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -490,14 +490,51 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
             column_holder->getName(),
             src_dictionary.getName());
 
-    if constexpr (!is_float_vector_v<ColumnType>)
-        if (getRawColumnPtr()->size() == numSpecialValues())
-            reverse_index.reserve(destination_size_upper_bound);
-
     const bool source_is_nullable = src_dictionary.nestedColumnIsNullable();
     const size_t source_null_value_index = source_is_nullable ? src_dictionary.getNullValueIndex() : 0;
     [[maybe_unused]] const size_t source_nested_default_value_index = src_dictionary.getNestedTypeDefaultValueIndex();
     SCOPE_EXIT(updateNullMask());
+
+    if constexpr (ReverseIndex<UInt64, ColumnType>::is_numeric_column && !is_float_vector_v<ColumnType>)
+    {
+        if (getRawColumnPtr()->size() == numSpecialValues() && !reverse_index.isBuilt())
+        {
+            auto & destination_data = getRawColumnPtr()->getData();
+            const auto & source_data = source_column->getData();
+            destination_data.reserve(destination_size_upper_bound);
+
+            size_t max_destination_index = 0;
+            for (size_t i = 0; i < length; ++i)
+            {
+                const size_t source_index = src_indexes[start + i];
+                size_t destination_index = 0;
+                if (source_is_nullable && source_index == source_null_value_index)
+                    destination_index = getNullValueIndex();
+                else if (source_index == source_nested_default_value_index)
+                    destination_index = getNestedTypeDefaultValueIndex();
+                else
+                {
+                    destination_index = destination_data.size();
+                    destination_data.push_back(source_data[source_index]);
+                }
+
+                max_destination_index = std::max(max_destination_index, destination_index);
+                if (destination_index > std::numeric_limits<DestinationIndexType>::max())
+                    throw Exception(
+                        ErrorCodes::LOGICAL_ERROR,
+                        "LowCardinality dictionary index {} does not fit in {} bytes",
+                        destination_index,
+                        sizeof(DestinationIndexType));
+                translated_indexes.push_back(static_cast<DestinationIndexType>(destination_index));
+            }
+
+            return {std::move(translated_column), max_destination_index};
+        }
+    }
+
+    if constexpr (!is_float_vector_v<ColumnType>)
+        if (getRawColumnPtr()->size() == numSpecialValues())
+            reverse_index.reserve(destination_size_upper_bound);
 
     auto insert_source_index = [&](size_t source_index) -> size_t
     {

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -22,6 +22,7 @@
 #include <base/scope_guard.h>
 #include <base/unaligned.h>
 
+#include <algorithm>
 
 namespace DB
 {
@@ -65,7 +66,7 @@ public:
     bool tryUniqueInsert(const Field & x, size_t & index) override;
     size_t uniqueInsertFrom(const IColumn & src, size_t n) override;
     MutableColumnPtr uniqueInsertRangeFrom(const IColumn & src, size_t start, size_t length) override;
-    MutableColumnPtr uniqueInsertRangeFromDictionary(
+    IColumnUnique::IndexesWithMaxIndex uniqueInsertRangeFromDictionary(
         const IColumn & src_dictionary,
         const IColumn & src_indexes,
         size_t start,
@@ -247,14 +248,14 @@ private:
         size_t max_dictionary_size);
 
     template <typename SourceIndexType, typename DestinationIndexType>
-    MutableColumnPtr uniqueInsertRangeFromDictionaryImpl(
+    IColumnUnique::IndexesWithMaxIndex uniqueInsertRangeFromDictionaryImpl(
         const IColumn & src_dictionary,
         const PaddedPODArray<SourceIndexType> & src_indexes,
         size_t start,
         size_t length);
 
     template <typename DestinationIndexType>
-    MutableColumnPtr uniqueInsertRangeFromDictionaryForDestinationType(
+    IColumnUnique::IndexesWithMaxIndex uniqueInsertRangeFromDictionaryForDestinationType(
         const IColumn & src_dictionary,
         const IColumn & src_indexes,
         size_t start,
@@ -467,7 +468,7 @@ size_t ColumnUnique<ColumnType>::uniqueInsertFrom(const IColumn & src, size_t n)
 
 template <typename ColumnType>
 template <typename SourceIndexType, typename DestinationIndexType>
-MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryImpl(
+IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryImpl(
     const IColumn & src_dictionary,
     const PaddedPODArray<SourceIndexType> & src_indexes,
     size_t start,
@@ -519,10 +520,12 @@ MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryImpl(
         return reverse_index.insert(ref);
     };
 
+    size_t max_destination_index = 0;
     for (size_t i = 0; i < length; ++i)
     {
         const auto source_index = src_indexes[start + i];
         const size_t destination_index = insert_source_index(static_cast<size_t>(source_index));
+        max_destination_index = std::max(max_destination_index, destination_index);
         if (destination_index > std::numeric_limits<DestinationIndexType>::max())
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
@@ -532,12 +535,12 @@ MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryImpl(
         translated_indexes.push_back(static_cast<DestinationIndexType>(destination_index));
     }
 
-    return translated_column;
+    return {std::move(translated_column), max_destination_index};
 }
 
 template <typename ColumnType>
 template <typename DestinationIndexType>
-MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryForDestinationType(
+IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryForDestinationType(
     const IColumn & src_dictionary,
     const IColumn & src_indexes,
     size_t start,
@@ -562,7 +565,7 @@ MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionaryForDes
 }
 
 template <typename ColumnType>
-MutableColumnPtr ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionary(
+IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFromDictionary(
     const IColumn & src_dictionary,
     const IColumn & src_indexes,
     size_t start,

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -252,14 +252,16 @@ private:
         const IColumnUnique & src_dictionary,
         const PaddedPODArray<SourceIndexType> & src_indexes,
         size_t start,
-        size_t length);
+        size_t length,
+        size_t destination_size_upper_bound);
 
     template <typename DestinationIndexType>
     IColumnUnique::IndexesWithMaxIndex uniqueInsertRangeFromDictionaryForDestinationType(
         const IColumnUnique & src_dictionary,
         const IColumn & src_indexes,
         size_t start,
-        size_t length);
+        size_t length,
+        size_t destination_size_upper_bound);
 };
 
 template <typename ColumnType>
@@ -472,7 +474,8 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
     const IColumnUnique & src_dictionary,
     const PaddedPODArray<SourceIndexType> & src_indexes,
     size_t start,
-    size_t length)
+    size_t length,
+    size_t destination_size_upper_bound)
 {
     auto translated_column = ColumnVector<DestinationIndexType>::create();
     auto & translated_indexes = translated_column->getData();
@@ -486,6 +489,10 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
             "Invalid source dictionary type for ColumnUnique. Expected {}, got {}",
             column_holder->getName(),
             src_dictionary.getName());
+
+    if constexpr (!is_float_vector_v<ColumnType>)
+        if (getRawColumnPtr()->size() == numSpecialValues())
+            reverse_index.reserve(destination_size_upper_bound);
 
     const bool source_is_nullable = src_dictionary.nestedColumnIsNullable();
     const size_t source_null_value_index = source_is_nullable ? src_dictionary.getNullValueIndex() : 0;
@@ -545,20 +552,21 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
     const IColumnUnique & src_dictionary,
     const IColumn & src_indexes,
     size_t start,
-    size_t length)
+    size_t length,
+    size_t destination_size_upper_bound)
 {
     if (const auto * indexes = typeid_cast<const ColumnUInt8 *>(&src_indexes))
         return uniqueInsertRangeFromDictionaryImpl<UInt8, DestinationIndexType>(
-            src_dictionary, indexes->getData(), start, length);
+            src_dictionary, indexes->getData(), start, length, destination_size_upper_bound);
     if (const auto * indexes = typeid_cast<const ColumnUInt16 *>(&src_indexes))
         return uniqueInsertRangeFromDictionaryImpl<UInt16, DestinationIndexType>(
-            src_dictionary, indexes->getData(), start, length);
+            src_dictionary, indexes->getData(), start, length, destination_size_upper_bound);
     if (const auto * indexes = typeid_cast<const ColumnUInt32 *>(&src_indexes))
         return uniqueInsertRangeFromDictionaryImpl<UInt32, DestinationIndexType>(
-            src_dictionary, indexes->getData(), start, length);
+            src_dictionary, indexes->getData(), start, length, destination_size_upper_bound);
     if (const auto * indexes = typeid_cast<const ColumnUInt64 *>(&src_indexes))
         return uniqueInsertRangeFromDictionaryImpl<UInt64, DestinationIndexType>(
-            src_dictionary, indexes->getData(), start, length);
+            src_dictionary, indexes->getData(), start, length, destination_size_upper_bound);
     throw Exception(
         ErrorCodes::ILLEGAL_COLUMN,
         "Indexes column for LowCardinality translation must be ColumnUInt, got {}",
@@ -574,12 +582,16 @@ IColumnUnique::IndexesWithMaxIndex ColumnUnique<ColumnType>::uniqueInsertRangeFr
     size_t destination_size_upper_bound)
 {
     if (destination_size_upper_bound <= std::numeric_limits<UInt8>::max())
-        return uniqueInsertRangeFromDictionaryForDestinationType<UInt8>(src_dictionary, src_indexes, start, length);
+        return uniqueInsertRangeFromDictionaryForDestinationType<UInt8>(
+            src_dictionary, src_indexes, start, length, destination_size_upper_bound);
     if (destination_size_upper_bound <= std::numeric_limits<UInt16>::max())
-        return uniqueInsertRangeFromDictionaryForDestinationType<UInt16>(src_dictionary, src_indexes, start, length);
+        return uniqueInsertRangeFromDictionaryForDestinationType<UInt16>(
+            src_dictionary, src_indexes, start, length, destination_size_upper_bound);
     if (destination_size_upper_bound <= std::numeric_limits<UInt32>::max())
-        return uniqueInsertRangeFromDictionaryForDestinationType<UInt32>(src_dictionary, src_indexes, start, length);
-    return uniqueInsertRangeFromDictionaryForDestinationType<UInt64>(src_dictionary, src_indexes, start, length);
+        return uniqueInsertRangeFromDictionaryForDestinationType<UInt32>(
+            src_dictionary, src_indexes, start, length, destination_size_upper_bound);
+    return uniqueInsertRangeFromDictionaryForDestinationType<UInt64>(
+        src_dictionary, src_indexes, start, length, destination_size_upper_bound);
 }
 
 template <typename ColumnType>

--- a/src/Columns/IColumnUnique.h
+++ b/src/Columns/IColumnUnique.h
@@ -57,7 +57,7 @@ public:
     /// Translates a range of dictionary indexes. Callers can pass distinct positions to insert each referenced key once.
     /// The returned indexes correspond one-to-one with src_indexes[start, start + length), and max_index is their maximum.
     virtual IndexesWithMaxIndex uniqueInsertRangeFromDictionary(
-        const IColumn & src_dictionary,
+        const IColumnUnique & src_dictionary,
         const IColumn & src_indexes,
         size_t start,
         size_t length,

--- a/src/Columns/IColumnUnique.h
+++ b/src/Columns/IColumnUnique.h
@@ -47,6 +47,14 @@ public:
     /// Appends range of elements from other column.
     /// Could be used to concatenate columns.
     virtual MutableColumnPtr uniqueInsertRangeFrom(const IColumn & src, size_t start, size_t length) = 0;
+    /// Translates a range of dictionary indexes. Callers can pass distinct positions to insert each referenced key once.
+    /// The returned indexes correspond one-to-one with src_indexes[start, start + length).
+    virtual MutableColumnPtr uniqueInsertRangeFromDictionary(
+        const IColumn & src_dictionary,
+        const IColumn & src_indexes,
+        size_t start,
+        size_t length,
+        size_t destination_size_upper_bound) = 0;
 
     struct IndexesWithOverflow
     {

--- a/src/Columns/IColumnUnique.h
+++ b/src/Columns/IColumnUnique.h
@@ -47,9 +47,16 @@ public:
     /// Appends range of elements from other column.
     /// Could be used to concatenate columns.
     virtual MutableColumnPtr uniqueInsertRangeFrom(const IColumn & src, size_t start, size_t length) = 0;
+
+    struct IndexesWithMaxIndex
+    {
+        MutableColumnPtr indexes;
+        size_t max_index;
+    };
+
     /// Translates a range of dictionary indexes. Callers can pass distinct positions to insert each referenced key once.
-    /// The returned indexes correspond one-to-one with src_indexes[start, start + length).
-    virtual MutableColumnPtr uniqueInsertRangeFromDictionary(
+    /// The returned indexes correspond one-to-one with src_indexes[start, start + length), and max_index is their maximum.
+    virtual IndexesWithMaxIndex uniqueInsertRangeFromDictionary(
         const IColumn & src_dictionary,
         const IColumn & src_indexes,
         size_t start,

--- a/src/Columns/ReverseIndex.h
+++ b/src/Columns/ReverseIndex.h
@@ -10,6 +10,8 @@
 #include <base/range.h>
 #include <base/unaligned.h>
 
+#include <algorithm>
+
 
 namespace DB
 {
@@ -324,6 +326,7 @@ public:
     static constexpr bool use_saved_hash = !is_numeric_column;
 
     UInt64 insert(std::string_view data);
+    void reserve(size_t num_rows);
 
     /// Returns the found data's index in the dictionary. If index is not built, builds it.
     UInt64 getInsertionPoint(std::string_view data)
@@ -391,7 +394,7 @@ private:
     mutable ColumnUInt64::MutablePtr external_saved_hash;
     mutable std::atomic<const ColumnUInt64 *> external_saved_hash_snapshot;
 
-    void buildIndex();
+    void buildIndex(size_t reserve_for_num_elements = 0);
 
     UInt64 getHash(std::string_view ref) const
     {
@@ -433,7 +436,7 @@ size_t ReverseIndex<IndexType, ColumnType>::size() const
 }
 
 template <typename IndexType, typename ColumnType>
-void ReverseIndex<IndexType, ColumnType>::buildIndex()
+void ReverseIndex<IndexType, ColumnType>::buildIndex(size_t reserve_for_num_elements)
 {
     if (index)
         return;
@@ -442,7 +445,7 @@ void ReverseIndex<IndexType, ColumnType>::buildIndex()
         throw Exception(ErrorCodes::LOGICAL_ERROR, "ReverseIndex can't build index because index column wasn't set.");
 
     auto size = column->size();
-    index = std::make_unique<IndexMapType>(size);
+    index = std::make_unique<IndexMapType>(std::max(size, reserve_for_num_elements));
 
     if constexpr (use_saved_hash)
         saved_hash = calcHashes();
@@ -470,6 +473,25 @@ void ReverseIndex<IndexType, ColumnType>::buildIndex()
         if (!inserted)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Duplicating keys found in ReverseIndex.");
     }
+}
+
+template <typename IndexType, typename ColumnType>
+void ReverseIndex<IndexType, ColumnType>::reserve(size_t num_rows)
+{
+    if (!column)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "ReverseIndex can't reserve because index column wasn't set.");
+
+    column->reserve(num_rows);
+
+    const size_t num_index_elements = num_rows > num_prefix_rows_to_skip ? num_rows - num_prefix_rows_to_skip : 0;
+
+    if (!index)
+        buildIndex(num_index_elements);
+    else
+        index->reserve(num_index_elements);
+
+    if constexpr (use_saved_hash)
+        saved_hash->reserve(num_rows);
 }
 
 template <typename IndexType, typename ColumnType>

--- a/src/Columns/ReverseIndex.h
+++ b/src/Columns/ReverseIndex.h
@@ -327,6 +327,7 @@ public:
 
     UInt64 insert(std::string_view data);
     void reserve(size_t num_rows);
+    bool isBuilt() const { return index != nullptr; }
 
     /// Returns the found data's index in the dictionary. If index is not built, builds it.
     UInt64 getInsertionPoint(std::string_view data)

--- a/src/Columns/benchmarks/CMakeLists.txt
+++ b/src/Columns/benchmarks/CMakeLists.txt
@@ -7,3 +7,8 @@ clickhouse_add_executable(benchmark_compute_hash_into benchmark_compute_hash_int
 target_link_libraries (benchmark_compute_hash_into PRIVATE
     ch_contrib::gbenchmark_all
     dbms)
+
+clickhouse_add_executable(column_low_cardinality_insert_range benchmark_low_cardinality_insert_range.cpp)
+target_link_libraries(column_low_cardinality_insert_range PRIVATE
+    ch_contrib::gbenchmark_all
+    dbms)

--- a/src/Columns/benchmarks/benchmark_low_cardinality_insert_range.cpp
+++ b/src/Columns/benchmarks/benchmark_low_cardinality_insert_range.cpp
@@ -115,6 +115,8 @@ void MapSparseOnly(benchmark::State & state)
     const size_t distinct_indexes = elements_per_operation / repetitions;
     auto source = makeSource(source_dictionary_size, elements_per_operation, distinct_indexes, source_index_begin);
     const auto & low_cardinality_source = assert_cast<const ColumnLowCardinality &>(*source);
+    LowCardinalityHashMapSizeCache hash_map_size_cache;
+    LowCardinalityHashMapSizeCache::Scope hash_map_size_cache_scope(hash_map_size_cache);
 
     for (auto _ : state)
     {
@@ -130,6 +132,8 @@ void EmptyDestinationDifferentDictionary(benchmark::State & state)
     const size_t repetitions = static_cast<size_t>(state.range(0));
     auto columns = makeBenchmarkColumns(repetitions, DestinationKeys::Disjoint);
     auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(columns.nested_type);
+    LowCardinalityHashMapSizeCache hash_map_size_cache;
+    LowCardinalityHashMapSizeCache::Scope hash_map_size_cache_scope(hash_map_size_cache);
 
     for (auto _ : state)
     {
@@ -202,6 +206,8 @@ void benchmarkNonEmptyDestination(benchmark::State & state, DestinationKeys dest
 {
     const size_t repetitions = static_cast<size_t>(state.range(0));
     auto columns = makeBenchmarkColumns(repetitions, destination_kind);
+    LowCardinalityHashMapSizeCache hash_map_size_cache;
+    LowCardinalityHashMapSizeCache::Scope hash_map_size_cache_scope(hash_map_size_cache);
 
     for (auto _ : state)
     {

--- a/src/Columns/benchmarks/benchmark_low_cardinality_insert_range.cpp
+++ b/src/Columns/benchmarks/benchmark_low_cardinality_insert_range.cpp
@@ -35,7 +35,12 @@ struct BenchmarkColumns
     ColumnPtr destination_keys;
 };
 
-MutableColumnPtr makeSource(size_t dictionary_size, size_t elements, size_t distinct_indexes, size_t first_index)
+MutableColumnPtr makeSource(
+    size_t dictionary_size,
+    size_t elements,
+    size_t distinct_indexes,
+    size_t first_index,
+    bool is_shared = false)
 {
     auto nested_type = std::make_shared<DataTypeUInt128>();
     auto keys = ColumnUInt128::create(dictionary_size);
@@ -49,7 +54,7 @@ MutableColumnPtr makeSource(size_t dictionary_size, size_t elements, size_t dist
     for (size_t i = 0; i < elements; ++i)
         index_data[i] = static_cast<UInt32>(first_index + i % distinct_indexes);
 
-    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), is_shared);
 }
 
 ColumnPtr makeDestinationKeys(DestinationKeys kind, size_t distinct_indexes, size_t first_source_index)
@@ -147,7 +152,8 @@ void EmptyDestinationMinimalDictionary(benchmark::State & state)
         /*dictionary_size=*/distinct_indexes + 1,
         elements_per_operation,
         distinct_indexes,
-        /*first_index=*/1);
+        /*first_index=*/1,
+        /*is_shared=*/true);
     auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(nested_type);
 
     for (auto _ : state)

--- a/src/Columns/benchmarks/benchmark_low_cardinality_insert_range.cpp
+++ b/src/Columns/benchmarks/benchmark_low_cardinality_insert_range.cpp
@@ -1,0 +1,291 @@
+#include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Common/assert_cast.h>
+#include <base/types.h>
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <cstdint>
+
+using namespace DB;
+
+namespace
+{
+
+constexpr size_t source_dictionary_size = 1ULL << 22;
+constexpr size_t elements_per_operation = 1ULL << 18;
+constexpr size_t source_index_begin = source_dictionary_size / 2;
+constexpr size_t oversized_dictionary_size = 1ULL << 20;
+constexpr UInt128 disjoint_key_prefix = UInt128{1} << 100;
+
+enum class DestinationKeys
+{
+    Disjoint,
+    FullyOverlapping,
+    PartiallyOverlapping,
+};
+
+struct BenchmarkColumns
+{
+    DataTypePtr nested_type;
+    MutableColumnPtr source;
+    ColumnPtr destination_keys;
+};
+
+MutableColumnPtr makeSource(size_t dictionary_size, size_t elements, size_t distinct_indexes, size_t first_index)
+{
+    auto nested_type = std::make_shared<DataTypeUInt128>();
+    auto keys = ColumnUInt128::create(dictionary_size);
+    auto & key_data = keys->getData();
+    for (size_t i = 0; i < dictionary_size; ++i)
+        key_data[i] = i;
+
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*nested_type, std::move(keys));
+    MutableColumnPtr indexes = ColumnUInt32::create(elements);
+    auto & index_data = assert_cast<ColumnUInt32 &>(*indexes).getData();
+    for (size_t i = 0; i < elements; ++i)
+        index_data[i] = static_cast<UInt32>(first_index + i % distinct_indexes);
+
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+}
+
+ColumnPtr makeDestinationKeys(DestinationKeys kind, size_t distinct_indexes, size_t first_source_index)
+{
+    size_t overlapping_keys = 0;
+    size_t disjoint_keys = 1ULL << 16;
+    if (kind == DestinationKeys::FullyOverlapping)
+    {
+        overlapping_keys = distinct_indexes;
+        disjoint_keys = 0;
+    }
+    else if (kind == DestinationKeys::PartiallyOverlapping)
+    {
+        overlapping_keys = distinct_indexes / 2;
+        disjoint_keys = distinct_indexes - overlapping_keys;
+    }
+
+    auto keys = ColumnUInt128::create(1 + overlapping_keys + disjoint_keys);
+    auto & data = keys->getData();
+    data[0] = 0;
+    for (size_t i = 0; i < overlapping_keys; ++i)
+        data[1 + i] = first_source_index + i;
+    for (size_t i = 0; i < disjoint_keys; ++i)
+        data[1 + overlapping_keys + i] = disjoint_key_prefix + i;
+    return keys;
+}
+
+BenchmarkColumns makeBenchmarkColumns(size_t repetitions, DestinationKeys destination_kind)
+{
+    const size_t distinct_indexes = elements_per_operation / repetitions;
+    BenchmarkColumns columns;
+    columns.nested_type = std::make_shared<DataTypeUInt128>();
+    columns.source = makeSource(source_dictionary_size, elements_per_operation, distinct_indexes, source_index_begin);
+    columns.destination_keys = makeDestinationKeys(destination_kind, distinct_indexes, source_index_begin);
+    return columns;
+}
+
+MutableColumnPtr makeNonEmptyDestination(const DataTypePtr & nested_type, const IColumn & keys)
+{
+    auto dictionary_keys = keys.cloneResized(keys.size());
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*nested_type, std::move(dictionary_keys));
+    MutableColumnPtr indexes = ColumnUInt8::create();
+    assert_cast<ColumnUInt8 &>(*indexes).getData().push_back(UInt8{0});
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+}
+
+void setThroughput(benchmark::State & state)
+{
+    const auto iterations = static_cast<int64_t>(state.iterations());
+    const auto elements = static_cast<int64_t>(elements_per_operation);
+    state.SetItemsProcessed(iterations * elements);
+    state.SetBytesProcessed(iterations * elements * static_cast<int64_t>(sizeof(UInt32)));
+}
+
+void MapSparseOnly(benchmark::State & state)
+{
+    const size_t repetitions = static_cast<size_t>(state.range(0));
+    const size_t distinct_indexes = elements_per_operation / repetitions;
+    auto source = makeSource(source_dictionary_size, elements_per_operation, distinct_indexes, source_index_begin);
+    const auto & low_cardinality_source = assert_cast<const ColumnLowCardinality &>(*source);
+
+    for (auto _ : state)
+    {
+        auto encoded = low_cardinality_source.getMinimalDictionaryEncodedColumn(0, elements_per_operation);
+        benchmark::DoNotOptimize(encoded.dictionary.get());
+        benchmark::DoNotOptimize(encoded.indexes.get());
+    }
+    setThroughput(state);
+}
+
+void EmptyDestinationDifferentDictionary(benchmark::State & state)
+{
+    const size_t repetitions = static_cast<size_t>(state.range(0));
+    auto columns = makeBenchmarkColumns(repetitions, DestinationKeys::Disjoint);
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(columns.nested_type);
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        auto destination = low_cardinality_type->createColumn();
+        state.ResumeTiming();
+
+        destination->insertRangeFrom(*columns.source, 0, elements_per_operation);
+        benchmark::DoNotOptimize(destination->size());
+    }
+    setThroughput(state);
+}
+
+void EmptyDestinationMinimalDictionary(benchmark::State & state)
+{
+    const size_t repetitions = static_cast<size_t>(state.range(0));
+    const size_t distinct_indexes = elements_per_operation / repetitions;
+    auto nested_type = std::make_shared<DataTypeUInt128>();
+    auto source = makeSource(
+        /*dictionary_size=*/distinct_indexes + 1,
+        elements_per_operation,
+        distinct_indexes,
+        /*first_index=*/1);
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(nested_type);
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        auto destination = low_cardinality_type->createColumn();
+        state.ResumeTiming();
+
+        destination->insertRangeFrom(*source, 0, elements_per_operation);
+        benchmark::DoNotOptimize(destination->size());
+    }
+    setThroughput(state);
+}
+
+void EmptyDestinationTinyRangeThenComputeHash(benchmark::State & state)
+{
+    constexpr size_t range_size = 1;
+    auto nested_type = std::make_shared<DataTypeUInt128>();
+    auto source = makeSource(
+        oversized_dictionary_size,
+        range_size,
+        /*distinct_indexes=*/range_size,
+        /*first_index=*/oversized_dictionary_size - 1);
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(nested_type);
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        auto destination = low_cardinality_type->createColumn();
+        state.ResumeTiming();
+
+        destination->insertRangeFrom(*source, 0, range_size);
+
+        UInt32 hash = 0;
+        destination->computeHashInto(0, range_size, &hash, /*initial=*/true);
+        benchmark::DoNotOptimize(hash);
+    }
+
+    const auto iterations = static_cast<int64_t>(state.iterations());
+    const auto elements = static_cast<int64_t>(range_size);
+    state.SetItemsProcessed(iterations * elements);
+    state.SetBytesProcessed(iterations * elements * static_cast<int64_t>(sizeof(UInt32)));
+}
+
+void benchmarkNonEmptyDestination(benchmark::State & state, DestinationKeys destination_kind)
+{
+    const size_t repetitions = static_cast<size_t>(state.range(0));
+    auto columns = makeBenchmarkColumns(repetitions, destination_kind);
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        auto destination = makeNonEmptyDestination(columns.nested_type, *columns.destination_keys);
+        state.ResumeTiming();
+
+        destination->insertRangeFrom(*columns.source, 0, elements_per_operation);
+        benchmark::DoNotOptimize(destination->size());
+    }
+    setThroughput(state);
+}
+
+void NonEmptyDisjointDictionaries(benchmark::State & state)
+{
+    benchmarkNonEmptyDestination(state, DestinationKeys::Disjoint);
+}
+
+void NonEmptyFullyOverlappingDictionaries(benchmark::State & state)
+{
+    benchmarkNonEmptyDestination(state, DestinationKeys::FullyOverlapping);
+}
+
+void NonEmptyPartiallyOverlapping(benchmark::State & state)
+{
+    benchmarkNonEmptyDestination(state, DestinationKeys::PartiallyOverlapping);
+}
+
+void SameDictionary(benchmark::State & state)
+{
+    const size_t repetitions = static_cast<size_t>(state.range(0));
+    const size_t distinct_indexes = elements_per_operation / repetitions;
+    auto source = makeSource(source_dictionary_size, elements_per_operation, distinct_indexes, source_index_begin);
+    const auto & low_cardinality_source = assert_cast<const ColumnLowCardinality &>(*source);
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        MutableColumnPtr shared_dictionary = low_cardinality_source.getDictionaryPtr()->assumeMutable();
+        MutableColumnPtr empty_indexes = ColumnUInt32::create();
+        MutableColumnPtr destination = ColumnLowCardinality::create(
+            std::move(shared_dictionary), std::move(empty_indexes), /*is_shared=*/false);
+        const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+        if (&low_cardinality_source.getDictionary() != &low_cardinality_destination.getDictionary())
+        {
+            state.ResumeTiming();
+            state.SkipWithError("SameDictionary fixture did not preserve dictionary identity");
+            break;
+        }
+        state.ResumeTiming();
+
+        destination->insertRangeFrom(*source, 0, elements_per_operation);
+        benchmark::DoNotOptimize(destination->size());
+    }
+    setThroughput(state);
+}
+
+void SmallDenseDictionary(benchmark::State & state)
+{
+    constexpr size_t small_dictionary_size = 1ULL << 12;
+    auto nested_type = std::make_shared<DataTypeUInt128>();
+    auto source = makeSource(
+        small_dictionary_size, elements_per_operation, small_dictionary_size - 1, /*first_index=*/1);
+    auto destination_keys = makeDestinationKeys(DestinationKeys::Disjoint, 0, 0);
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        auto destination = makeNonEmptyDestination(nested_type, *destination_keys);
+        state.ResumeTiming();
+
+        destination->insertRangeFrom(*source, 0, elements_per_operation);
+        benchmark::DoNotOptimize(destination->size());
+    }
+    setThroughput(state);
+}
+
+void applyRepetitionArguments(benchmark::internal::Benchmark * benchmark)
+{
+    benchmark->Arg(1)->Arg(2)->Arg(4);
+}
+
+BENCHMARK(MapSparseOnly)->Apply(applyRepetitionArguments);
+BENCHMARK(EmptyDestinationDifferentDictionary)->Apply(applyRepetitionArguments);
+BENCHMARK(EmptyDestinationMinimalDictionary)->Apply(applyRepetitionArguments);
+BENCHMARK(EmptyDestinationTinyRangeThenComputeHash);
+BENCHMARK(NonEmptyDisjointDictionaries)->Apply(applyRepetitionArguments);
+BENCHMARK(NonEmptyFullyOverlappingDictionaries)->Apply(applyRepetitionArguments);
+BENCHMARK(NonEmptyPartiallyOverlapping)->Apply(applyRepetitionArguments);
+BENCHMARK(SameDictionary)->Apply(applyRepetitionArguments);
+BENCHMARK(SmallDenseDictionary);
+
+}

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -146,7 +146,7 @@ namespace
 
 template <typename IndexType>
 ColumnLowCardinality::MutablePtr makeLowCardinalityUInt64Column(
-    size_t dictionary_size, const std::vector<IndexType> & index_values)
+    size_t dictionary_size, const std::vector<IndexType> & index_values, bool is_shared = false)
 {
     auto keys = ColumnUInt64::create(dictionary_size);
     auto & key_data = keys->getData();
@@ -158,7 +158,27 @@ ColumnLowCardinality::MutablePtr makeLowCardinalityUInt64Column(
     MutableColumnPtr indexes = ColumnVector<IndexType>::create();
     assert_cast<ColumnVector<IndexType> &>(*indexes).getData().assign(index_values.begin(), index_values.end());
 
-    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), is_shared);
+}
+
+template <typename IndexType>
+ColumnLowCardinality::MutablePtr makeNullableLowCardinalityUInt64Column(
+    size_t dictionary_size, const std::vector<IndexType> & index_values, bool is_shared = false)
+{
+    auto keys = ColumnUInt64::create(dictionary_size);
+    auto & key_data = keys->getData();
+    for (size_t i = 0; i < dictionary_size; ++i)
+        key_data[i] = i;
+    /// Nullable dictionaries reserve index 0 for NULL and index 1 for the nested default.
+    key_data[0] = 0;
+    key_data[1] = 0;
+
+    auto dictionary_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>());
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(keys));
+    MutableColumnPtr indexes = ColumnVector<IndexType>::create();
+    assert_cast<ColumnVector<IndexType> &>(*indexes).getData().assign(index_values.begin(), index_values.end());
+
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), is_shared);
 }
 
 template <typename IndexType>
@@ -229,20 +249,7 @@ TEST(ColumnLowCardinality, SparseMinimalDictionaryAllIndexTypes)
 
 TEST(ColumnLowCardinality, SparseMinimalDictionaryNullable)
 {
-    auto raw_keys = ColumnUInt64::create(201);
-    auto & key_data = raw_keys->getData();
-    for (size_t i = 0; i < key_data.size(); ++i)
-        key_data[i] = i;
-    /// Nullable dictionaries reserve index 0 for NULL and index 1 for the nested default.
-    key_data[0] = 0;
-    key_data[1] = 0;
-
-    auto dictionary_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>());
-    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(raw_keys));
-    MutableColumnPtr indexes = ColumnUInt16::create();
-    const ColumnUInt16::Container source_indexes{200, 0, 2, 200, 1};
-    assert_cast<ColumnUInt16 &>(*indexes).getData().assign(source_indexes.begin(), source_indexes.end());
-    auto column = ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+    auto column = makeNullableLowCardinalityUInt64Column<UInt16>(201, {200, 0, 2, 200, 1});
 
     const auto minimal = column->getMinimalDictionaryEncodedColumn(0, column->size());
     const auto * rewritten_indexes = typeid_cast<const ColumnUInt16 *>(minimal.indexes.get());
@@ -266,4 +273,226 @@ TEST(ColumnLowCardinality, InsertSparseRangeFromDifferentDictionary)
     ASSERT_EQ(destination->size(), 6);
     for (size_t i = 0; i < destination->size(); ++i)
         EXPECT_EQ((*destination)[i], (*source)[i + 1]);
+}
+
+TEST(ColumnLowCardinality, EmptyDestinationSharesMinimalSourceDictionary)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(5, {4, 1, 3, 2, 4, 2, 1}, /*is_shared=*/true);
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+
+    auto full_destination = low_cardinality_type->createColumn();
+    full_destination->insertRangeFrom(*source, 0, source->size());
+    const auto & full_low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*full_destination);
+    EXPECT_EQ(&full_low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_TRUE(full_low_cardinality_destination.isSharedDictionary());
+
+    auto sliced_destination = low_cardinality_type->createColumn();
+    sliced_destination->insertRangeFrom(*source, 1, 4);
+    const auto & sliced_low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*sliced_destination);
+    EXPECT_EQ(&sliced_low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_TRUE(sliced_low_cardinality_destination.isSharedDictionary());
+    EXPECT_EQ(sliced_low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt32));
+    for (size_t i = 0; i < 4; ++i)
+        EXPECT_EQ((*sliced_destination)[i], (*source)[i + 1]);
+
+    sliced_destination->insertRangeFrom(*source, 5, 2);
+    EXPECT_EQ(&sliced_low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_TRUE(sliced_low_cardinality_destination.isSharedDictionary());
+    for (size_t i = 0; i < 2; ++i)
+        EXPECT_EQ((*sliced_destination)[4 + i], (*source)[5 + i]);
+}
+
+TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareUnsharedMinimalSourceDictionary)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(4, {3, 1, 3, 0, 2});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+    const size_t source_size = source->size();
+
+    destination->insertRangeFrom(*source, 0, source_size);
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    const size_t destination_dictionary_size = low_cardinality_destination.getDictionary().size();
+
+    source->insert(UInt64{999});
+
+    EXPECT_EQ(low_cardinality_destination.getDictionary().size(), destination_dictionary_size);
+    EXPECT_EQ(destination->size(), source_size);
+    for (size_t i = 0; i < source_size; ++i)
+        EXPECT_EQ((*destination)[i], (*source)[i]);
+    EXPECT_EQ(source->getUInt(source_size), 999);
+}
+
+TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareNonMinimalSourceDictionary)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {200});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_EQ(low_cardinality_destination.getDictionary().size(), 2);
+    EXPECT_EQ(destination->getUInt(0), source->getUInt(0));
+}
+
+TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareRangeThatOmitsDictionaryKey)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(5, {1, 2, 3, 3});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_EQ(low_cardinality_destination.getDictionary().size(), 4);
+    expectRangeEquals(*destination, 0, *source, 0, source->size());
+}
+
+TEST(ColumnLowCardinality, EmptyNonNullableDestinationDoesNotShareNullableSourceDictionary)
+{
+    auto source = makeNullableLowCardinalityUInt64Column<UInt32>(256, {200, 1, 5});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.nestedIsNullable());
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    ASSERT_EQ(destination->size(), source->size());
+    for (size_t i = 0; i < source->size(); ++i)
+        EXPECT_EQ((*destination)[i], (*source)[i]);
+}
+
+TEST(ColumnLowCardinality, EmptyNullableDestinationDoesNotShareNonNullableSourceDictionary)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {0, 200, 5});
+    auto nested_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>());
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(nested_type);
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_TRUE(low_cardinality_destination.nestedIsNullable());
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    ASSERT_EQ(destination->size(), source->size());
+    for (size_t i = 0; i < source->size(); ++i)
+    {
+        EXPECT_FALSE(destination->isNullAt(i));
+        EXPECT_EQ((*destination)[i], (*source)[i]);
+    }
+}
+
+TEST(ColumnLowCardinality, EmptyRangeDoesNotShareSourceDictionary)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {17, 200, 5});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    const auto * original_dictionary = &low_cardinality_destination.getDictionary();
+
+    destination->insertRangeFrom(*source, source->size(), 0);
+
+    EXPECT_TRUE(destination->empty());
+    EXPECT_EQ(&low_cardinality_destination.getDictionary(), original_dictionary);
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+}
+
+TEST(ColumnLowCardinality, SharedDestinationCompactsForDifferentDictionary)
+{
+    auto first_source = makeLowCardinalityUInt64Column<UInt32>(3, {0, 2, 1, 2, 0}, /*is_shared=*/true);
+    auto second_source = makeLowCardinalityUInt64Column<UInt16>(256, {17, 5, 250, 17});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*first_source, 1, 3);
+    destination->insertRangeFrom(*second_source, 0, second_source->size());
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &first_source->getDictionary());
+    ASSERT_EQ(destination->size(), 3 + second_source->size());
+    for (size_t i = 0; i < 3; ++i)
+        EXPECT_EQ((*destination)[i], (*first_source)[i + 1]);
+    for (size_t i = 0; i < second_source->size(); ++i)
+        EXPECT_EQ((*destination)[3 + i], (*second_source)[i]);
+}
+
+TEST(ColumnLowCardinality, MutationAfterSharingDoesNotChangeSource)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(4, {3, 1, 3, 0, 2}, /*is_shared=*/true);
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+    const size_t source_dictionary_size = source->getDictionary().size();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+    destination->insert(UInt64{999});
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_EQ(source->getDictionary().size(), source_dictionary_size);
+    EXPECT_EQ(destination->getUInt(destination->size() - 1), 999);
+    for (size_t i = 0; i < source->size(); ++i)
+        EXPECT_EQ((*destination)[i], (*source)[i]);
+}
+
+TEST(ColumnLowCardinality, SourceMutationAfterSharingDoesNotChangeDestination)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(4, {3, 1, 3, 0, 2}, /*is_shared=*/true);
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+    const size_t source_size = source->size();
+
+    destination->insertRangeFrom(*source, 0, source_size);
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    ASSERT_EQ(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    ASSERT_TRUE(low_cardinality_destination.isSharedDictionary());
+    ASSERT_TRUE(source->isSharedDictionary());
+    const size_t destination_dictionary_size = low_cardinality_destination.getDictionary().size();
+
+    source->insert(UInt64{999});
+
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    EXPECT_EQ(low_cardinality_destination.getDictionary().size(), destination_dictionary_size);
+    EXPECT_EQ(destination->size(), source_size);
+    for (size_t i = 0; i < source_size; ++i)
+        EXPECT_EQ((*destination)[i], (*source)[i]);
+    EXPECT_EQ(source->getUInt(source_size), 999);
+}
+
+TEST(ColumnLowCardinality, NullableDefaultsSurviveSharingAndCompaction)
+{
+    auto first_source = makeNullableLowCardinalityUInt64Column<UInt32>(
+        4, {0, 1, 3, 0, 2}, /*is_shared=*/true);
+    auto second_source = makeNullableLowCardinalityUInt64Column<UInt16>(256, {1, 0, 150});
+    auto nested_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>());
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(nested_type);
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*first_source, 0, first_source->size());
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_EQ(&low_cardinality_destination.getDictionary(), &first_source->getDictionary());
+    destination->insertRangeFrom(*second_source, 0, second_source->size());
+
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_TRUE(destination->isNullAt(0));
+    EXPECT_FALSE(destination->isNullAt(1));
+    EXPECT_EQ(destination->getUInt(1), 0);
+    EXPECT_TRUE(destination->isNullAt(first_source->size() + 1));
+    for (size_t i = 0; i < first_source->size(); ++i)
+        EXPECT_EQ((*destination)[i], (*first_source)[i]);
+    for (size_t i = 0; i < second_source->size(); ++i)
+        EXPECT_EQ((*destination)[first_source->size() + i], (*second_source)[i]);
 }

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -1,11 +1,16 @@
 #include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
 
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 
 #include <gtest/gtest.h>
 #include <Common/Exception.h>
+
+#include <algorithm>
+#include <vector>
 
 using namespace DB;
 
@@ -134,4 +139,131 @@ TEST(ColumnLowCardinality, EmptyDictionaryEmptyIndexes)
     ASSERT_NO_THROW(lc_column.insertRangeFromDictionaryEncodedColumn(*empty_keys, *empty_indexes));
     
     ASSERT_EQ(column->size(), 0);
+}
+
+namespace
+{
+
+template <typename IndexType>
+ColumnLowCardinality::MutablePtr makeLowCardinalityUInt64Column(
+    size_t dictionary_size, const std::vector<IndexType> & index_values)
+{
+    auto keys = ColumnUInt64::create(dictionary_size);
+    auto & key_data = keys->getData();
+    for (size_t i = 0; i < dictionary_size; ++i)
+        key_data[i] = i;
+
+    auto dictionary_type = std::make_shared<DataTypeUInt64>();
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(keys));
+    MutableColumnPtr indexes = ColumnVector<IndexType>::create();
+    assert_cast<ColumnVector<IndexType> &>(*indexes).getData().assign(index_values.begin(), index_values.end());
+
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+}
+
+template <typename IndexType>
+void checkMinimalDictionary(
+    const std::vector<IndexType> & original_indexes, size_t offset, size_t length)
+{
+    const auto max_index = original_indexes.empty()
+        ? IndexType{0}
+        : *std::max_element(original_indexes.begin(), original_indexes.end());
+    auto column = makeLowCardinalityUInt64Column<IndexType>(static_cast<size_t>(max_index) + 1, original_indexes);
+
+    const auto minimal = column->getMinimalDictionaryEncodedColumn(offset, length);
+    const auto * rewritten_indexes = typeid_cast<const ColumnVector<IndexType> *>(minimal.indexes.get());
+    ASSERT_NE(rewritten_indexes, nullptr);
+
+    std::vector<IndexType> first_seen;
+    std::vector<IndexType> expected_indexes;
+    for (size_t i = offset; i < offset + length; ++i)
+    {
+        const auto source_index = original_indexes[i];
+        const auto it = std::find(first_seen.begin(), first_seen.end(), source_index);
+        if (it == first_seen.end())
+        {
+            expected_indexes.push_back(static_cast<IndexType>(first_seen.size()));
+            first_seen.push_back(source_index);
+        }
+        else
+            expected_indexes.push_back(static_cast<IndexType>(it - first_seen.begin()));
+    }
+
+    ASSERT_EQ(minimal.dictionary->size(), first_seen.size());
+    ASSERT_EQ(rewritten_indexes->size(), expected_indexes.size());
+    for (size_t i = 0; i < first_seen.size(); ++i)
+        EXPECT_EQ(minimal.dictionary->getUInt(i), first_seen[i]);
+    for (size_t i = 0; i < expected_indexes.size(); ++i)
+    {
+        EXPECT_EQ(rewritten_indexes->getData()[i], expected_indexes[i]);
+        EXPECT_EQ(
+            minimal.dictionary->getUInt(rewritten_indexes->getData()[i]),
+            original_indexes[offset + i]);
+    }
+}
+
+template <typename IndexType>
+void checkSparseMinimalDictionaryForIndexType()
+{
+    /// Nonzero offset, repeated indexes, a later zero, and first occurrences in nonsorted order.
+    checkMinimalDictionary<IndexType>({17, 200, 5, 200, 0, 130, 5, 17}, 1, 6);
+    /// Zero first, zero absent, one distinct key, and all distinct keys.
+    checkMinimalDictionary<IndexType>({0, 200, 0}, 0, 3);
+    checkMinimalDictionary<IndexType>({200, 5, 130}, 0, 3);
+    checkMinimalDictionary<IndexType>({200, 200, 200}, 0, 3);
+    checkMinimalDictionary<IndexType>({200, 130, 5}, 0, 3);
+    /// Empty range and a range ending exactly at the source boundary.
+    checkMinimalDictionary<IndexType>({17, 200, 5}, 2, 0);
+    checkMinimalDictionary<IndexType>({17, 200, 5}, 1, 2);
+}
+
+}
+
+TEST(ColumnLowCardinality, SparseMinimalDictionaryAllIndexTypes)
+{
+    checkSparseMinimalDictionaryForIndexType<UInt8>();
+    checkSparseMinimalDictionaryForIndexType<UInt16>();
+    checkSparseMinimalDictionaryForIndexType<UInt32>();
+    checkSparseMinimalDictionaryForIndexType<UInt64>();
+}
+
+TEST(ColumnLowCardinality, SparseMinimalDictionaryNullable)
+{
+    auto raw_keys = ColumnUInt64::create(201);
+    auto & key_data = raw_keys->getData();
+    for (size_t i = 0; i < key_data.size(); ++i)
+        key_data[i] = i;
+    /// Nullable dictionaries reserve index 0 for NULL and index 1 for the nested default.
+    key_data[0] = 0;
+    key_data[1] = 0;
+
+    auto dictionary_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>());
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(raw_keys));
+    MutableColumnPtr indexes = ColumnUInt16::create();
+    const ColumnUInt16::Container source_indexes{200, 0, 2, 200, 1};
+    assert_cast<ColumnUInt16 &>(*indexes).getData().assign(source_indexes.begin(), source_indexes.end());
+    auto column = ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+
+    const auto minimal = column->getMinimalDictionaryEncodedColumn(0, column->size());
+    const auto * rewritten_indexes = typeid_cast<const ColumnUInt16 *>(minimal.indexes.get());
+    ASSERT_NE(rewritten_indexes, nullptr);
+    ASSERT_EQ(rewritten_indexes->getData(), ColumnUInt16::Container({0, 1, 2, 0, 3}));
+    ASSERT_EQ(minimal.dictionary->size(), 4);
+    EXPECT_EQ(minimal.dictionary->getUInt(0), 200);
+    EXPECT_TRUE(minimal.dictionary->isNullAt(1));
+    EXPECT_EQ(minimal.dictionary->getUInt(2), 2);
+    EXPECT_EQ(minimal.dictionary->getUInt(3), 0);
+}
+
+TEST(ColumnLowCardinality, InsertSparseRangeFromDifferentDictionary)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {17, 200, 5, 200, 0, 130, 5, 17});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*source, 1, 6);
+
+    ASSERT_EQ(destination->size(), 6);
+    for (size_t i = 0; i < destination->size(); ++i)
+        EXPECT_EQ((*destination)[i], (*source)[i + 1]);
 }

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -676,6 +676,25 @@ TEST(ColumnLowCardinality, TranslateSparseIndexesPromotesDestinationType)
     expectRangeEquals(*destination_uint32, 1, *source, 0, source->size());
 }
 
+TEST(ColumnLowCardinality, TranslateSparseOverlappingIndexesDoesNotPromoteDestinationType)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {200, 201});
+
+    auto destination_uint8 = makeLowCardinalityUInt64Column<UInt8>(255, {1});
+    const size_t dictionary_size_uint8 = destination_uint8->getDictionary().size();
+    destination_uint8->insertRangeFrom(*source, 0, source->size());
+    EXPECT_EQ(destination_uint8->getDictionary().size(), dictionary_size_uint8);
+    EXPECT_EQ(destination_uint8->getSizeOfIndexType(), sizeof(UInt8));
+    expectRangeEquals(*destination_uint8, 1, *source, 0, source->size());
+
+    auto destination_uint16 = makeLowCardinalityUInt64Column<UInt16>(65535, {1});
+    const size_t dictionary_size_uint16 = destination_uint16->getDictionary().size();
+    destination_uint16->insertRangeFrom(*source, 0, source->size());
+    EXPECT_EQ(destination_uint16->getDictionary().size(), dictionary_size_uint16);
+    EXPECT_EQ(destination_uint16->getSizeOfIndexType(), sizeof(UInt16));
+    expectRangeEquals(*destination_uint16, 1, *source, 0, source->size());
+}
+
 TEST(ColumnLowCardinality, TranslateSparseIndexesFromAlternatingDictionaries)
 {
     auto first_source = makeLowCardinalityUInt64Column<UInt32>(256, {200, 5, 200, 130}, 1000);

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -403,21 +403,57 @@ TEST(ColumnLowCardinality, EmptyDestinationSharesMinimalSourceDictionary)
     const auto & full_low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*full_destination);
     EXPECT_EQ(&full_low_cardinality_destination.getDictionary(), &source->getDictionary());
     EXPECT_TRUE(full_low_cardinality_destination.isSharedDictionary());
+    EXPECT_EQ(full_low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt8));
 
     auto sliced_destination = low_cardinality_type->createColumn();
     sliced_destination->insertRangeFrom(*source, 1, 4);
     const auto & sliced_low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*sliced_destination);
     EXPECT_EQ(&sliced_low_cardinality_destination.getDictionary(), &source->getDictionary());
     EXPECT_TRUE(sliced_low_cardinality_destination.isSharedDictionary());
-    EXPECT_EQ(sliced_low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt32));
+    EXPECT_EQ(sliced_low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt8));
     for (size_t i = 0; i < 4; ++i)
         EXPECT_EQ((*sliced_destination)[i], (*source)[i + 1]);
 
     sliced_destination->insertRangeFrom(*source, 5, 2);
     EXPECT_EQ(&sliced_low_cardinality_destination.getDictionary(), &source->getDictionary());
     EXPECT_TRUE(sliced_low_cardinality_destination.isSharedDictionary());
+    EXPECT_EQ(sliced_low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt8));
     for (size_t i = 0; i < 2; ++i)
         EXPECT_EQ((*sliced_destination)[4 + i], (*source)[5 + i]);
+}
+
+TEST(ColumnLowCardinality, SharedDictionaryCopyUsesMinimalIndexWidth)
+{
+    auto check_width = [](size_t dictionary_size, size_t expected_index_width)
+    {
+        std::vector<UInt32> source_indexes;
+        source_indexes.reserve(dictionary_size - 1);
+        for (size_t index = 1; index < dictionary_size; ++index)
+            source_indexes.push_back(static_cast<UInt32>(index));
+
+        auto source = makeLowCardinalityUInt64Column<UInt32>(
+            dictionary_size, source_indexes, /*key_offset=*/0, /*is_shared=*/true);
+        ASSERT_EQ(source->getSizeOfIndexType(), sizeof(UInt32));
+
+        auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+        auto destination = low_cardinality_type->createColumn();
+
+        destination->insertRangeFrom(*source, 0, source->size());
+
+        const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+        EXPECT_EQ(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+        EXPECT_TRUE(low_cardinality_destination.isSharedDictionary());
+        EXPECT_EQ(low_cardinality_destination.getSizeOfIndexType(), expected_index_width);
+        expectRangeEquals(*destination, 0, *source, 0, source->size());
+
+        destination->insertRangeFrom(*source, 0, source->size());
+        EXPECT_EQ(low_cardinality_destination.getSizeOfIndexType(), expected_index_width);
+        expectRangeEquals(*destination, source->size(), *source, 0, source->size());
+    };
+
+    check_width(10, sizeof(UInt8));
+    check_width(256, sizeof(UInt8));
+    check_width(257, sizeof(UInt16));
 }
 
 TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareUnsharedMinimalSourceDictionary)

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -1,8 +1,11 @@
+#include <Columns/ColumnArray.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
 
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 
@@ -11,6 +14,11 @@
 
 #include <algorithm>
 #include <vector>
+
+namespace DB::ErrorCodes
+{
+    extern const int PARAMETER_OUT_OF_BOUND;
+}
 
 using namespace DB;
 
@@ -96,7 +104,7 @@ TEST(ColumnLowCardinality, CloneNullableKeepsZeroValue)
     ASSERT_EQ(value.safeGet<UInt64>(), 2);
 }
 
-TEST(ColumnLowCardinality, InsertRangeFromChecksBoundsAfterSharingDictionary)
+TEST(ColumnLowCardinality, InsertRangeFromChecksBoundsBeforeSharingDictionary)
 {
     auto dictionary_keys = ColumnUInt64::create();
     for (UInt64 value : {0, 10})
@@ -113,10 +121,23 @@ TEST(ColumnLowCardinality, InsertRangeFromChecksBoundsAfterSharingDictionary)
     auto wide_column = ColumnLowCardinality::create(dictionary, std::move(wide_indexes), /* is_shared = */ false);
     auto destination = wide_column->cloneEmpty();
     const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    const auto * original_dictionary = &low_cardinality_destination.getDictionary();
 
     ASSERT_EQ(low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt16));
-    EXPECT_THROW(destination->insertRangeFrom(*source, source->size(), 1), Exception);
+    ASSERT_NE(original_dictionary, &source->getDictionary());
+    try
+    {
+        destination->insertRangeFrom(*source, source->size(), 1);
+        FAIL() << "Expected PARAMETER_OUT_OF_BOUND for an invalid source range";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::PARAMETER_OUT_OF_BOUND);
+    }
     EXPECT_TRUE(destination->empty());
+    EXPECT_EQ(&low_cardinality_destination.getDictionary(), original_dictionary);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_EQ(low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt16));
 }
 
 TEST(ColumnLowCardinality, EmptyDictionaryEmptyIndexes)
@@ -146,12 +167,16 @@ namespace
 
 template <typename IndexType>
 ColumnLowCardinality::MutablePtr makeLowCardinalityUInt64Column(
-    size_t dictionary_size, const std::vector<IndexType> & index_values, bool is_shared = false)
+    size_t dictionary_size,
+    const std::vector<IndexType> & index_values,
+    UInt64 key_offset = 0,
+    bool is_shared = false)
 {
     auto keys = ColumnUInt64::create(dictionary_size);
     auto & key_data = keys->getData();
-    for (size_t i = 0; i < dictionary_size; ++i)
-        key_data[i] = i;
+    key_data[0] = 0;
+    for (size_t i = 1; i < dictionary_size; ++i)
+        key_data[i] = key_offset + i;
 
     auto dictionary_type = std::make_shared<DataTypeUInt64>();
     MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(keys));
@@ -159,6 +184,63 @@ ColumnLowCardinality::MutablePtr makeLowCardinalityUInt64Column(
     assert_cast<ColumnVector<IndexType> &>(*indexes).getData().assign(index_values.begin(), index_values.end());
 
     return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), is_shared);
+}
+
+template <typename IndexType>
+ColumnLowCardinality::MutablePtr makeLowCardinalityUInt128Column(
+    size_t dictionary_size, const std::vector<IndexType> & index_values, UInt128 key_offset = 0)
+{
+    auto keys = ColumnUInt128::create(dictionary_size);
+    auto & key_data = keys->getData();
+    key_data[0] = 0;
+    for (size_t i = 1; i < dictionary_size; ++i)
+        key_data[i] = key_offset + i;
+
+    auto dictionary_type = std::make_shared<DataTypeUInt128>();
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(keys));
+    MutableColumnPtr indexes = ColumnVector<IndexType>::create();
+    assert_cast<ColumnVector<IndexType> &>(*indexes).getData().assign(index_values.begin(), index_values.end());
+
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+}
+
+template <typename IndexType>
+ColumnLowCardinality::MutablePtr makeNullableLowCardinalityUInt128Column(
+    size_t dictionary_size, const std::vector<IndexType> & index_values, UInt128 key_offset = 0)
+{
+    auto keys = ColumnUInt128::create(dictionary_size);
+    auto & key_data = keys->getData();
+    key_data[0] = 0;
+    key_data[1] = 0;
+    for (size_t i = 2; i < dictionary_size; ++i)
+        key_data[i] = key_offset + i;
+
+    auto dictionary_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt128>());
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(keys));
+    MutableColumnPtr indexes = ColumnVector<IndexType>::create();
+    assert_cast<ColumnVector<IndexType> &>(*indexes).getData().assign(index_values.begin(), index_values.end());
+
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+}
+
+template <typename IndexType>
+ColumnLowCardinality::MutablePtr makeLowCardinalityStringColumn(
+    size_t dictionary_size, const std::vector<IndexType> & index_values, const String & key_prefix)
+{
+    auto keys = ColumnString::create();
+    keys->insertDefault();
+    for (size_t i = 1; i < dictionary_size; ++i)
+    {
+        const String key = key_prefix + std::to_string(i);
+        keys->insertData(key.data(), key.size());
+    }
+
+    auto dictionary_type = std::make_shared<DataTypeString>();
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*dictionary_type, std::move(keys));
+    MutableColumnPtr indexes = ColumnVector<IndexType>::create();
+    assert_cast<ColumnVector<IndexType> &>(*indexes).getData().assign(index_values.begin(), index_values.end());
+
+    return ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
 }
 
 template <typename IndexType>
@@ -237,6 +319,19 @@ void checkSparseMinimalDictionaryForIndexType()
     checkMinimalDictionary<IndexType>({17, 200, 5}, 1, 2);
 }
 
+void expectRangeEquals(
+    const IColumn & destination,
+    size_t destination_offset,
+    const IColumn & source,
+    size_t source_offset,
+    size_t length)
+{
+    ASSERT_LE(destination_offset + length, destination.size());
+    ASSERT_LE(source_offset + length, source.size());
+    for (size_t i = 0; i < length; ++i)
+        EXPECT_EQ(destination[destination_offset + i], source[source_offset + i]);
+}
+
 }
 
 TEST(ColumnLowCardinality, SparseMinimalDictionaryAllIndexTypes)
@@ -267,17 +362,40 @@ TEST(ColumnLowCardinality, InsertSparseRangeFromDifferentDictionary)
     auto source = makeLowCardinalityUInt64Column<UInt32>(256, {17, 200, 5, 200, 0, 130, 5, 17});
     auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
     auto destination = low_cardinality_type->createColumn();
+    destination->insert(UInt64{999});
 
     destination->insertRangeFrom(*source, 1, 6);
 
-    ASSERT_EQ(destination->size(), 6);
-    for (size_t i = 0; i < destination->size(); ++i)
-        EXPECT_EQ((*destination)[i], (*source)[i + 1]);
+    ASSERT_EQ(destination->size(), 7);
+    EXPECT_EQ(destination->getUInt(0), 999);
+    for (size_t i = 0; i < 6; ++i)
+        EXPECT_EQ((*destination)[i + 1], (*source)[i + 1]);
+}
+
+TEST(ColumnLowCardinality, InsertSparseRangeFromChecksBoundsBeforeReadingSourceIndexes)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {17, 200, 5});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+    destination->insert(UInt64{999});
+
+    try
+    {
+        destination->insertRangeFrom(*source, source->size(), 1);
+        FAIL() << "Expected PARAMETER_OUT_OF_BOUND for an invalid source range";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::PARAMETER_OUT_OF_BOUND);
+    }
+    ASSERT_EQ(destination->size(), 1);
+    EXPECT_EQ(destination->getUInt(0), 999);
 }
 
 TEST(ColumnLowCardinality, EmptyDestinationSharesMinimalSourceDictionary)
 {
-    auto source = makeLowCardinalityUInt64Column<UInt32>(5, {4, 1, 3, 2, 4, 2, 1}, /*is_shared=*/true);
+    auto source = makeLowCardinalityUInt64Column<UInt32>(
+        5, {4, 1, 3, 2, 4, 2, 1}, /*key_offset=*/0, /*is_shared=*/true);
     auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
 
     auto full_destination = low_cardinality_type->createColumn();
@@ -411,7 +529,8 @@ TEST(ColumnLowCardinality, EmptyRangeDoesNotShareSourceDictionary)
 
 TEST(ColumnLowCardinality, SharedDestinationCompactsForDifferentDictionary)
 {
-    auto first_source = makeLowCardinalityUInt64Column<UInt32>(3, {0, 2, 1, 2, 0}, /*is_shared=*/true);
+    auto first_source = makeLowCardinalityUInt64Column<UInt32>(
+        3, {0, 2, 1, 2, 0}, /*key_offset=*/0, /*is_shared=*/true);
     auto second_source = makeLowCardinalityUInt64Column<UInt16>(256, {17, 5, 250, 17});
     auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
     auto destination = low_cardinality_type->createColumn();
@@ -431,7 +550,8 @@ TEST(ColumnLowCardinality, SharedDestinationCompactsForDifferentDictionary)
 
 TEST(ColumnLowCardinality, MutationAfterSharingDoesNotChangeSource)
 {
-    auto source = makeLowCardinalityUInt64Column<UInt32>(4, {3, 1, 3, 0, 2}, /*is_shared=*/true);
+    auto source = makeLowCardinalityUInt64Column<UInt32>(
+        4, {3, 1, 3, 0, 2}, /*key_offset=*/0, /*is_shared=*/true);
     auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
     auto destination = low_cardinality_type->createColumn();
     const size_t source_dictionary_size = source->getDictionary().size();
@@ -450,7 +570,8 @@ TEST(ColumnLowCardinality, MutationAfterSharingDoesNotChangeSource)
 
 TEST(ColumnLowCardinality, SourceMutationAfterSharingDoesNotChangeDestination)
 {
-    auto source = makeLowCardinalityUInt64Column<UInt32>(4, {3, 1, 3, 0, 2}, /*is_shared=*/true);
+    auto source = makeLowCardinalityUInt64Column<UInt32>(
+        4, {3, 1, 3, 0, 2}, /*key_offset=*/0, /*is_shared=*/true);
     auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
     auto destination = low_cardinality_type->createColumn();
     const size_t source_size = source->size();
@@ -495,4 +616,139 @@ TEST(ColumnLowCardinality, NullableDefaultsSurviveSharingAndCompaction)
         EXPECT_EQ((*destination)[i], (*first_source)[i]);
     for (size_t i = 0; i < second_source->size(); ++i)
         EXPECT_EQ((*destination)[first_source->size() + i], (*second_source)[i]);
+}
+
+TEST(ColumnLowCardinality, TranslateSparseDifferentDictionaries)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {200, 5, 200, 0, 130});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+
+    auto disjoint_destination = low_cardinality_type->createColumn();
+    disjoint_destination->insert(UInt64{999});
+    disjoint_destination->insertRangeFrom(*source, 0, source->size());
+    expectRangeEquals(*disjoint_destination, 1, *source, 0, source->size());
+
+    auto overlapping_destination = low_cardinality_type->createColumn();
+    overlapping_destination->insert(UInt64{200});
+    overlapping_destination->insert(UInt64{5});
+    overlapping_destination->insert(UInt64{0});
+    overlapping_destination->insert(UInt64{130});
+    overlapping_destination->insertRangeFrom(*source, 0, source->size());
+    expectRangeEquals(*overlapping_destination, 4, *source, 0, source->size());
+
+    auto partially_overlapping_destination = low_cardinality_type->createColumn();
+    partially_overlapping_destination->insert(UInt64{999});
+    partially_overlapping_destination->insert(UInt64{200});
+    partially_overlapping_destination->insertRangeFrom(*source, 0, source->size());
+    expectRangeEquals(*partially_overlapping_destination, 2, *source, 0, source->size());
+}
+
+TEST(ColumnLowCardinality, TranslateSparseHighUInt32IndexesWithOffset)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(100000, {1, 99999, 70000, 99999, 50000});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+    destination->insert(UInt64{200000});
+
+    destination->insertRangeFrom(*source, 1, 4);
+
+    ASSERT_EQ(destination->size(), 5);
+    expectRangeEquals(*destination, 1, *source, 1, 4);
+}
+
+TEST(ColumnLowCardinality, TranslateSparseIndexesPromotesDestinationType)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {200, 201}, 1000000);
+
+    auto destination_uint8 = makeLowCardinalityUInt64Column<UInt8>(255, {1});
+    destination_uint8->insertRangeFrom(*source, 0, source->size());
+    EXPECT_EQ(destination_uint8->getSizeOfIndexType(), sizeof(UInt16));
+    expectRangeEquals(*destination_uint8, 1, *source, 0, source->size());
+
+    auto destination_uint16 = makeLowCardinalityUInt64Column<UInt16>(65535, {1});
+    destination_uint16->insertRangeFrom(*source, 0, source->size());
+    EXPECT_EQ(destination_uint16->getSizeOfIndexType(), sizeof(UInt32));
+    expectRangeEquals(*destination_uint16, 1, *source, 0, source->size());
+
+    auto destination_uint32 = makeLowCardinalityUInt64Column<UInt32>(70000, {1});
+    destination_uint32->insertRangeFrom(*source, 0, source->size());
+    EXPECT_EQ(destination_uint32->getSizeOfIndexType(), sizeof(UInt32));
+    expectRangeEquals(*destination_uint32, 1, *source, 0, source->size());
+}
+
+TEST(ColumnLowCardinality, TranslateSparseIndexesFromAlternatingDictionaries)
+{
+    auto first_source = makeLowCardinalityUInt64Column<UInt32>(256, {200, 5, 200, 130}, 1000);
+    auto second_source = makeLowCardinalityUInt64Column<UInt16>(256, {250, 17, 250}, 2000);
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+    destination->insert(UInt64{999999});
+
+    destination->insertRangeFrom(*first_source, 0, first_source->size());
+    destination->insertRangeFrom(*second_source, 0, second_source->size());
+    destination->insertRangeFrom(*first_source, 1, 2);
+
+    size_t offset = 1;
+    expectRangeEquals(*destination, offset, *first_source, 0, first_source->size());
+    offset += first_source->size();
+    expectRangeEquals(*destination, offset, *second_source, 0, second_source->size());
+    offset += second_source->size();
+    expectRangeEquals(*destination, offset, *first_source, 1, 2);
+}
+
+TEST(ColumnLowCardinality, TranslateSparseIndexesForNestedTypes)
+{
+    {
+        auto source = makeLowCardinalityUInt128Column<UInt32>(256, {200, 5, 200, 130}, UInt128{1} << 100);
+        auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt128>());
+        auto destination = low_cardinality_type->createColumn();
+        destination->insert(UInt128{999});
+        destination->insertRangeFrom(*source, 0, source->size());
+        expectRangeEquals(*destination, 1, *source, 0, source->size());
+    }
+
+    {
+        auto source = makeLowCardinalityStringColumn<UInt16>(256, {200, 5, 200, 130}, "source_");
+        auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
+        auto destination = low_cardinality_type->createColumn();
+        destination->insert(String{"seed"});
+        destination->insertRangeFrom(*source, 0, source->size());
+        expectRangeEquals(*destination, 1, *source, 0, source->size());
+    }
+
+    {
+        auto source = makeNullableLowCardinalityUInt128Column<UInt32>(256, {200, 0, 1, 200}, UInt128{1} << 100);
+        auto nested_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt128>());
+        auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(nested_type);
+        auto destination = low_cardinality_type->createColumn();
+        destination->insert(Field(Null()));
+        destination->insertRangeFrom(*source, 0, source->size());
+        expectRangeEquals(*destination, 1, *source, 0, source->size());
+        EXPECT_TRUE(destination->isNullAt(2));
+        EXPECT_FALSE(destination->isNullAt(3));
+    }
+}
+
+TEST(ColumnLowCardinality, TranslateSparseIndexesInsideArray)
+{
+    MutableColumnPtr source_nested = makeLowCardinalityUInt128Column<UInt32>(
+        256, {200, 5, 200, 130}, UInt128{1} << 100);
+    MutableColumnPtr source_offsets = ColumnArray::ColumnOffsets::create();
+    auto & source_offset_data = assert_cast<ColumnArray::ColumnOffsets &>(*source_offsets).getData();
+    source_offset_data.push_back(UInt64{2});
+    source_offset_data.push_back(UInt64{4});
+    MutableColumnPtr source = ColumnArray::create(std::move(source_nested), std::move(source_offsets));
+
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt128>());
+    MutableColumnPtr destination_nested = low_cardinality_type->createColumn();
+    destination_nested->insert(UInt128{999});
+    MutableColumnPtr destination_offsets = ColumnArray::ColumnOffsets::create();
+    assert_cast<ColumnArray::ColumnOffsets &>(*destination_offsets).getData().push_back(UInt64{1});
+    MutableColumnPtr destination = ColumnArray::create(std::move(destination_nested), std::move(destination_offsets));
+
+    destination->insertRangeFrom(*source, 0, source->size());
+
+    ASSERT_EQ(destination->size(), 3);
+    EXPECT_EQ((*destination)[1], (*source)[0]);
+    EXPECT_EQ((*destination)[2], (*source)[1]);
 }

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -525,6 +525,25 @@ TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareNonMinimalSourceDictionar
     EXPECT_EQ(destination->getUInt(0), source->getUInt(0));
 }
 
+TEST(ColumnLowCardinality, InsertAfterAppendingSparseRangeToEmptyDestination)
+{
+    auto source = makeLowCardinalityUInt64Column<UInt32>(256, {200, 5, 200, 130});
+    auto low_cardinality_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeUInt64>());
+    auto destination = low_cardinality_type->createColumn();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    const size_t dictionary_size = low_cardinality_destination.getDictionary().size();
+
+    destination->insert(UInt64{200});
+    EXPECT_EQ(low_cardinality_destination.getDictionary().size(), dictionary_size);
+
+    destination->insert(UInt64{999});
+    EXPECT_EQ(low_cardinality_destination.getDictionary().size(), dictionary_size + 1);
+    EXPECT_EQ(destination->getUInt(destination->size() - 2), 200);
+    EXPECT_EQ(destination->getUInt(destination->size() - 1), 999);
+}
+
 TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareRangeThatOmitsDictionaryKey)
 {
     auto source = makeLowCardinalityUInt64Column<UInt32>(5, {1, 2, 3, 3});

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -13,6 +13,8 @@
 #include <Common/Exception.h>
 
 #include <algorithm>
+#include <bit>
+#include <cmath>
 #include <vector>
 
 namespace DB::ErrorCodes
@@ -477,6 +479,35 @@ TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareUnsharedMinimalSourceDict
     for (size_t i = 0; i < source_size; ++i)
         EXPECT_EQ((*destination)[i], (*source)[i]);
     EXPECT_EQ(source->getUInt(source_size), 999);
+}
+
+TEST(ColumnLowCardinality, TranslateSparseFloatingPointIndexesCanonicalizesSpecialValues)
+{
+    auto keys = ColumnFloat64::create(256);
+    auto & key_data = keys->getData();
+    key_data[0] = 0.0;
+    key_data[1] = -0.0;
+    key_data[2] = std::bit_cast<Float64>(UInt64{0x7ff8000000000001ULL});
+    key_data[3] = std::bit_cast<Float64>(UInt64{0x7ff8000000000002ULL});
+    for (size_t i = 4; i < key_data.size(); ++i)
+        key_data[i] = static_cast<Float64>(i);
+
+    auto nested_type = std::make_shared<DataTypeFloat64>();
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*nested_type, std::move(keys));
+    auto indexes = ColumnUInt32::create();
+    indexes->getData().assign({200, 1, 2, 3});
+    auto source = ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/false);
+    auto destination = std::make_shared<DataTypeLowCardinality>(nested_type)->createColumn();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_EQ(low_cardinality_destination.getDictionary().size(), 3);
+    EXPECT_EQ(destination->getFloat64(0), 200.0);
+    EXPECT_EQ(destination->getFloat64(1), 0.0);
+    EXPECT_TRUE(std::isnan(destination->getFloat64(2)));
+    EXPECT_TRUE(std::isnan(destination->getFloat64(3)));
 }
 
 TEST(ColumnLowCardinality, EmptyDestinationDoesNotShareNonMinimalSourceDictionary)

--- a/src/Interpreters/ArrayJoinAction.cpp
+++ b/src/Interpreters/ArrayJoinAction.cpp
@@ -2,6 +2,7 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeMap.h>
 #include <Columns/ColumnArray.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnReplicated.h>
 #include <Columns/ColumnsCommon.h>
@@ -146,7 +147,12 @@ static void updateMaxLength(ColumnUInt64 & max_length, const IColumn & length)
 }
 
 ArrayJoinResultIterator::ArrayJoinResultIterator(const ArrayJoinAction * array_join_, Block block_, bool enable_lazy_columns_replication_)
-    : array_join(array_join_), block(std::move(block_)), enable_lazy_columns_replication(enable_lazy_columns_replication_), total_rows(block.rows()), current_row(0)
+    : array_join(array_join_)
+    , block(std::move(block_))
+    , enable_lazy_columns_replication(enable_lazy_columns_replication_)
+    , low_cardinality_hash_map_size_cache(std::make_unique<LowCardinalityHashMapSizeCache>())
+    , total_rows(block.rows())
+    , current_row(0)
 {
     const auto & columns = array_join->columns;
     bool is_unaligned = array_join->is_unaligned;
@@ -212,6 +218,8 @@ ArrayJoinResultIterator::ArrayJoinResultIterator(const ArrayJoinAction * array_j
     }
 }
 
+ArrayJoinResultIterator::~ArrayJoinResultIterator() = default;
+
 bool ArrayJoinResultIterator::hasNext() const
 {
     return total_rows != 0 && current_row < total_rows;
@@ -222,6 +230,8 @@ Block ArrayJoinResultIterator::next()
 {
     if (!hasNext())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No more elements in ArrayJoinResultIterator.");
+
+    LowCardinalityHashMapSizeCache::Scope hash_map_size_cache_scope(*low_cardinality_hash_map_size_cache);
 
     if (array_join->element_filter)
         return nextWithElementFilter();

--- a/src/Interpreters/ArrayJoinAction.h
+++ b/src/Interpreters/ArrayJoinAction.h
@@ -16,6 +16,7 @@ using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
 
 class DataTypeArray;
 class ColumnArray;
+class LowCardinalityHashMapSizeCache;
 std::shared_ptr<const DataTypeArray> getArrayJoinDataType(DataTypePtr type);
 const ColumnArray * getArrayJoinColumnRawPtr(const ColumnPtr & column);
 
@@ -59,7 +60,7 @@ class ArrayJoinResultIterator
 {
 public:
     explicit ArrayJoinResultIterator(const ArrayJoinAction * array_join_, Block block_, bool enable_lazy_columns_replication_);
-    ~ArrayJoinResultIterator() = default;
+    ~ArrayJoinResultIterator();
 
     Block next();
     bool hasNext() const;
@@ -77,6 +78,8 @@ private:
     const ColumnArray * any_array;
     /// If LEFT ARRAY JOIN, then we create columns in which empty arrays are replaced by arrays with one element - the default value.
     std::map<String, ColumnPtr> non_empty_array_columns;
+
+    std::unique_ptr<LowCardinalityHashMapSizeCache> low_cardinality_hash_map_size_cache;
 
     size_t total_rows;
     size_t current_row;

--- a/tests/performance/low_cardinality_ordered_merge_insert_range.xml
+++ b/tests/performance/low_cardinality_ordered_merge_insert_range.xml
@@ -1,0 +1,119 @@
+<test>
+    <!--
+        Exercise ColumnLowCardinality::insertRangeFrom while an in-order read
+        merges independently encoded parts. Each measured output block contains
+        one 4,096-row run from each of eight parts. With 16 array elements per
+        row, an inserted run contains 65,536 indexes from a 1,048,576-entry
+        source dictionary.
+
+        The two payloads isolate destination dictionary behavior:
+          * disjoint_ids has part-private UInt128 values;
+          * overlapping_ids has identical values in separate dictionary objects.
+    -->
+
+    <settings>
+        <max_memory_usage>20G</max_memory_usage>
+        <allow_suspicious_low_cardinality_types>1</allow_suspicious_low_cardinality_types>
+        <low_cardinality_max_dictionary_size>1000000000</low_cardinality_max_dictionary_size>
+        <low_cardinality_use_single_dictionary_for_part>1</low_cardinality_use_single_dictionary_for_part>
+    </settings>
+
+    <substitutions>
+        <substitution>
+            <name>part</name>
+            <values>
+                <value>0</value>
+                <value>1</value>
+                <value>2</value>
+                <value>3</value>
+                <value>4</value>
+                <value>5</value>
+                <value>6</value>
+                <value>7</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>DROP TABLE IF EXISTS low_cardinality_ordered_merge_insert_range</create_query>
+    <create_query>
+        CREATE TABLE low_cardinality_ordered_merge_insert_range
+        (
+            part UInt8,
+            sort_key UInt64,
+            disjoint_ids Array(LowCardinality(UInt128)),
+            overlapping_ids Array(LowCardinality(UInt128))
+        )
+        ENGINE = MergeTree
+        PARTITION BY part
+        ORDER BY sort_key
+        SETTINGS index_granularity = 4096
+    </create_query>
+    <create_query>SYSTEM STOP MERGES low_cardinality_ordered_merge_insert_range</create_query>
+
+    <!-- One INSERT per partition guarantees one independently encoded part. -->
+    <fill_query>
+        INSERT INTO low_cardinality_ordered_merge_insert_range
+        SELECT
+            toUInt8({part}) AS part,
+            ((intDiv(number, 4096) * 8 + part) * 4096) + (number % 4096) AS sort_key,
+            arrayMap(
+                element -&gt;
+                    bitOr(
+                        bitShiftLeft(toUInt128(part + 1), 120),
+                        toUInt128((number * 16 + element) % 1048576)),
+                range(16)) AS disjoint_ids,
+            arrayMap(
+                element -&gt; toUInt128((number * 16 + element) % 1048576),
+                range(16)) AS overlapping_ids
+        FROM numbers(262144)
+        SETTINGS max_threads = 1, max_insert_threads = 1, max_block_size = 262144
+    </fill_query>
+
+    <fill_query>
+        SELECT throwIf(
+            count() != 8
+                OR min(active_parts) != 1
+                OR max(active_parts) != 1
+                OR min(part_rows) != 262144
+                OR max(part_rows) != 262144,
+            'Expected one 262144-row active part in each of eight partitions')
+        FROM
+        (
+            SELECT partition, count() AS active_parts, sum(rows) AS part_rows
+            FROM system.parts
+            WHERE database = currentDatabase()
+                AND table = 'low_cardinality_ordered_merge_insert_range'
+                AND active
+            GROUP BY partition
+        )
+    </fill_query>
+
+    <query>
+        SELECT sort_key, disjoint_ids
+        FROM low_cardinality_ordered_merge_insert_range
+        ORDER BY sort_key
+        FORMAT Null
+        SETTINGS
+            max_threads = 8,
+            max_streams_for_merge_tree_reading = 8,
+            max_block_size = 32768,
+            preferred_block_size_bytes = 0,
+            read_in_order_use_buffering = 1
+    </query>
+
+    <query>
+        SELECT sort_key, overlapping_ids
+        FROM low_cardinality_ordered_merge_insert_range
+        ORDER BY sort_key
+        FORMAT Null
+        SETTINGS
+            max_threads = 8,
+            max_streams_for_merge_tree_reading = 8,
+            max_block_size = 32768,
+            preferred_block_size_bytes = 0,
+            read_in_order_use_buffering = 1
+    </query>
+
+    <drop_query>SYSTEM START MERGES low_cardinality_ordered_merge_insert_range</drop_query>
+    <drop_query>DROP TABLE IF EXISTS low_cardinality_ordered_merge_insert_range</drop_query>
+</test>


### PR DESCRIPTION
I'm using ClickHouse to store continuous profiling data. ClickHouse itself is subject to said continuous profiling.

There are some bits that I found to be slower than I would've expected, for example this part:

<img width="1512" height="605" alt="image" src="https://github.com/user-attachments/assets/2c370286-aa11-4682-af21-7435cc16b901" />

The optimizations here are very much AI assisted, based on continuous profiling data. The added benchmarks were used as a guiding star. Each optimization step is a separate commit that can be measured with benchmarks from the first one.

Here are the benchmarks measuring CPU time in ms (**WARNING: STALE, see** https://github.com/ClickHouse/ClickHouse/pull/114870#issuecomment-5363522671):

| Benchmark | Baseline | Sparse mapper | Dictionary sharing | Final translation | Total change |
| --- | ---: | ---: | ---: | ---: | ---: |
| `MapSparseOnly/1` | 9.390 | 5.807 | 5.774 | 5.789 | 38.4% faster |
| `MapSparseOnly/2` | 6.621 | 3.473 | 3.462 | 3.463 | 47.7% faster |
| `MapSparseOnly/4` | 4.334 | 2.350 | 2.341 | 2.345 | 45.9% faster |
| `EmptyDestinationDifferentDictionary/1` | 33.517 | 29.829 | 0.031 | 0.031 | 99.9% faster |
| `EmptyDestinationDifferentDictionary/2` | 10.902 | 7.682 | 0.031 | 0.032 | 99.7% faster |
| `EmptyDestinationDifferentDictionary/4` | 6.727 | 4.739 | 0.031 | 0.031 | 99.5% faster |
| `NonEmptyDisjointDictionaries/1` | 35.233 | 31.186 | 30.859 | 28.318 | 19.6% faster |
| `NonEmptyDisjointDictionaries/2` | 24.382 | 21.184 | 21.260 | 20.849 | 14.5% faster |
| `NonEmptyDisjointDictionaries/4` | 7.027 | 4.952 | 4.936 | 4.793 | 31.8% faster |
| `NonEmptyFullyOverlappingDictionaries/1` | 35.518 | 29.366 | 29.150 | 26.934 | 24.2% faster |
| `NonEmptyFullyOverlappingDictionaries/2` | 17.478 | 14.356 | 14.301 | 13.907 | 20.4% faster |
| `NonEmptyFullyOverlappingDictionaries/4` | 6.548 | 4.463 | 4.462 | 4.498 | 31.3% faster |
| `NonEmptyPartiallyOverlapping/1` | 38.009 | 32.130 | 31.700 | 29.155 | 23.3% faster |
| `NonEmptyPartiallyOverlapping/2` | 18.220 | 15.154 | 15.033 | 14.470 | 20.6% faster |
| `NonEmptyPartiallyOverlapping/4` | 6.600 | 4.533 | 4.515 | 4.453 | 32.5% faster |
| `SameDictionary/1` | 0.034 | 0.034 | 0.034 | 0.035 | 3.1% slower |
| `SameDictionary/2` | 0.034 | 0.034 | 0.034 | 0.034 | 0.6% slower |
| `SameDictionary/4` | 0.034 | 0.034 | 0.034 | 0.034 | 1.3% slower |
| `SmallDenseDictionary` | 1.055 | 1.034 | 1.037 | 1.058 | 0.3% slower |

For the last step we went through a few iterations to land on something that does not regress partial overlaps:

| Benchmark | Before translation | Direct | Batched | Typed | Compact/final |
| --- | ---: | ---: | ---: | ---: | ---: |
| `Disjoint/1` | 30.859 | 41.588 | 41.034 | 40.121 | 28.318 |
| `Disjoint/2` | 21.260 | 21.929 | 22.000 | 21.464 | 20.849 |
| `Disjoint/4` | 4.936 | 5.271 | 5.208 | 4.967 | 4.793 |
| `Fully overlapping/1` | 29.150 | 35.935 | 35.592 | 35.128 | 26.934 |
| `Fully overlapping/2` | 14.301 | 8.392 | 8.353 | 7.896 | 13.907 |
| `Fully overlapping/4` | 4.462 | 4.853 | 4.818 | 4.628 | 4.498 |
| `Partially overlapping/1` | 31.700 | 38.288 | 37.867 | 37.095 | 29.155 |
| `Partially overlapping/2` | 15.033 | 8.610 | 8.440 | 8.034 | 14.470 |
| `Partially overlapping/4` | 4.515 | 4.856 | 4.848 | 4.608 | 4.453 |

You can see that the wins here are not amazing compared to the rest (_just_ 8%), and there's a fair bit of code. I would understand if you would like to drop it or split in a separate PR.

For the query benchmark added in the first commit, comparing the first commit against the las tone:

* Disjoint dictionaries: 3.431s -> 2.704s, 21.2% faster (1.27x).
* Fully overlapping dictionaries: 2.121s -> 1.643s, 22.5% faster (1.29x).

This change removes the long standing TODO from @KochetovNicolai:

```
/// TODO: Support native insertion from other unique column. It will help to avoid null map creation.
```

cc @nickitat, @Avogar, @nihalzp, @alexey-milovidov

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

LowCardinality merge optimizations.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114870&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114870](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114870+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
