### PR TITLE
Fix readability-container-contains in gtest_aggregating_step_settings_roundtrip

### DIFF
--- a/src/Processors/QueryPlan/tests/gtest_aggregating_step_settings_roundtrip.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_aggregating_step_settings_roundtrip.cpp
@@ -51,7 +51,7 @@ bool wireCarriesSerializeStringWithZeroByte(const IQueryPlanStep & step, UInt64 
     WriteBufferFromOwnString out;
     written.writeChangedBinary(out);
 
-    return out.str().find("serialize_string_in_memory_with_zero_byte") != std::string::npos;
+    return out.str().contains("serialize_string_in_memory_with_zero_byte");
 }
 
 SharedHeader makeHeader()


### PR DESCRIPTION
Closes: (none — master tidy breakage)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

`3c9cdbb1831` left a `find(...) != std::string::npos` membership check in `gtest_aggregating_step_settings_roundtrip.cpp:54`; clang-tidy's `readability-container-contains` (warnings-as-errors) fails the `arm_tidy` build of any PR that CI merges with current master (observed on #114665). One-line `contains()` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvXEBdaJTCCnUdunCf8icr


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1447` (included in `26.8` and later)
<!-- ch-version-info:end -->