### PR TITLE
Keep parent `ThreadGroup` alive for child counters

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -72,11 +72,15 @@ using ThreadGroupPtr = std::shared_ptr<ThreadGroup>;
 
 class ThreadGroup
 {
+    /// Child counters keep raw pointers to the parent counters. Keep the parent `ThreadGroup`
+    /// alive until after the child counters are destroyed.
+    const ThreadGroupPtr parent_thread_group;
+
 public:
     using FatalErrorCallback = std::function<void()>;
     ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_, FatalErrorCallback fatal_error_callback_ = {});
-    explicit ThreadGroup(ThreadGroupPtr parent);
-    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent);
+    explicit ThreadGroup(ThreadGroupPtr parent_);
+    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent_);
 
     /// The first thread created this thread group
     const UInt64 master_thread_id;

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -19,6 +19,25 @@ namespace FailPoints
     extern const char thread_group_switcher_post_attach_failure[];
 }
 
+TEST(ThreadGroup, ChildKeepsParentAlive)
+{
+    std::thread t([]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> weak_parent = parent;
+        auto child = std::make_shared<ThreadGroup>(parent);
+
+        parent.reset();
+        EXPECT_FALSE(weak_parent.expired());
+
+        child.reset();
+        EXPECT_TRUE(weak_parent.expired());
+    });
+    t.join();
+}
+
 /// After a failed ThreadGroupSwitcher construction the thread must be left in the
 /// state it was in before construction started (detached or attached to the original
 /// group), so the next switcher on the same thread can attach cleanly.

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -131,29 +131,31 @@ ThreadGroup::ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_
 }
 
 // c-tor for method createForMaterializedView
-ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
-    : master_thread_id(parent->master_thread_id)
-    , query_context(parent->query_context)
-    , global_context(parent->global_context)
-    , fatal_error_callback(parent->fatal_error_callback)
-    , os_threads_nice_value(parent->os_threads_nice_value)
-    , memory_spill_scheduler(parent->memory_spill_scheduler)
-    , performance_counters(VariableContext::Process, &parent->performance_counters)
-    , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
-    , shared_data(parent->getSharedData())
+ThreadGroup::ThreadGroup(ThreadGroupPtr parent_)
+    : parent_thread_group(std::move(parent_))
+    , master_thread_id(parent_thread_group->master_thread_id)
+    , query_context(parent_thread_group->query_context)
+    , global_context(parent_thread_group->global_context)
+    , fatal_error_callback(parent_thread_group->fatal_error_callback)
+    , os_threads_nice_value(parent_thread_group->os_threads_nice_value)
+    , memory_spill_scheduler(parent_thread_group->memory_spill_scheduler)
+    , performance_counters(VariableContext::Process, &parent_thread_group->performance_counters)
+    , memory_tracker(&parent_thread_group->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
+    , shared_data(parent_thread_group->getSharedData())
 {
 }
 
 // c-tor for method createForFlushAsyncInsertQueue
-ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent)
-    : master_thread_id(CurrentThread::get().thread_id)
+ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent_)
+    : parent_thread_group(std::move(parent_))
+    , master_thread_id(CurrentThread::get().thread_id)
     , query_context(query_context_)
     , global_context(query_context_->getGlobalContext())
-    , fatal_error_callback(parent->fatal_error_callback)
-    , os_threads_nice_value(parent->os_threads_nice_value)
-    , memory_spill_scheduler(parent->memory_spill_scheduler)
-    , performance_counters(VariableContext::Process, &parent->performance_counters)
-    , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
+    , fatal_error_callback(parent_thread_group->fatal_error_callback)
+    , os_threads_nice_value(parent_thread_group->os_threads_nice_value)
+    , memory_spill_scheduler(parent_thread_group->memory_spill_scheduler)
+    , performance_counters(VariableContext::Process, &parent_thread_group->performance_counters)
+    , memory_tracker(&parent_thread_group->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
 {
     shared_data.query_is_canceled_predicate = [this] () -> bool {
         if (auto context_locked = query_context.lock())

--- a/tests/queries/0_stateless/04726_kill_undrop_table_busy_wait.sh
+++ b/tests/queries/0_stateless/04726_kill_undrop_table_busy_wait.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database
+# Tag no-replicated-database: `UNDROP TABLE` is not supported by a `Replicated` database.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Child `ThreadGroup` objects connect their memory and profile counters to parent
counters through raw pointers, but did not retain ownership of the parent group.
Asynchronous child work could therefore outlive its parent and access destroyed
counters. Retain the parent until all child counters have been destroyed.

The same CI report exposed that `04726_kill_undrop_table_busy_wait` runs with a
`Replicated` database even though `UNDROP TABLE` is unsupported there. Mark the
test accordingly so this configuration skips it.

The full release `clickhouse` target builds successfully.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=432b1ae96183f5b085835f4b0aece8d95ce9ce73&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a segmentation fault in asynchronous work when a child `ThreadGroup` outlives its parent and accesses destroyed memory or profile counters.
