### PR TITLE
Add a userspace page cache tier to the experimental ReaderExecutor

### DIFF
--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -1,8 +1,14 @@
 #include <IO/PageCacheProvider.h>
 
-#include <Common/logger_useful.h>
+#include <Common/ProfileEvents.h>
+#include <base/defines.h>
 #include <algorithm>
 #include <cstring>
+
+namespace ProfileEvents
+{
+    extern const Event PageCacheReadBytes;
+}
 
 namespace DB
 {
@@ -35,6 +41,7 @@ ChainedBuffers PageCacheReader::read(ByteRange sub)
 
     auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
     result.append(ChainedBufferNode{std::move(buf), lo - range_member.offset, hi - lo, lo});
+    ProfileEvents::increment(ProfileEvents::PageCacheReadBytes, hi - lo);
     return result;
 }
 
@@ -97,8 +104,6 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
         std::lock_guard lock(committed_mutex);
         cell = std::move(got);
     }
-    if (loaded)
-        LOG_TRACE(log, "PageCacheWriter::write: populated block [{}, {})", range_member.offset, range_member.end());
     return loaded ? range_member.size : 0;
 }
 
@@ -135,6 +140,7 @@ ChainedBuffers PageCacheWriter::read(ByteRange sub)
 
     auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
     result.append(ChainedBufferNode{std::move(buf), lo - range_member.offset, hi - lo, lo});
+    ProfileEvents::increment(ProfileEvents::PageCacheReadBytes, hi - lo);
     return result;
 }
 
@@ -164,6 +170,7 @@ VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::res
     const StoredObject & /*object*/, size_t /*object_file_offset*/, ByteRange range)
 {
     VectorWithMemoryTracking<ICacheProvider::CacheResolution> out;
+    chassert(block_size > 0);
     const size_t blk = block_size;
     const size_t file_size = file_size_in_bytes;
     if (range.offset >= file_size)
@@ -171,7 +178,9 @@ VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::res
 
     SipHash base_hash = file.baseHash();
     const size_t end_in_file = std::min(range.end(), file_size);
-    for (size_t pos = range.offset / blk * blk; pos < end_in_file; pos += std::min(blk, file_size - pos))
+    const size_t first_pos = range.offset / blk * blk;
+    out.reserve((end_in_file - first_pos + blk - 1) / blk);
+    for (size_t pos = first_pos; pos < end_in_file; pos += std::min(blk, file_size - pos))
     {
         const ByteRange block{pos, std::min(blk, file_size - pos)};
         CacheResolution r;

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -178,28 +178,22 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
 
 CacheWriter::Lead PageCacheWriter::claimLeadRole(ByteRange range)
 {
-    /// The page cache has no downloader role, so the base default trivially holds one. But a concurrent
-    /// query may have populated this block between `resolve` (a read-only `get` probe) and now. Re-probe
-    /// read-only: adopt any resident contiguous prefix and report it as `available` (already committed),
-    /// so the executor serves it from cache instead of re-reading it from the source. Hold the role only
-    /// if an uncommitted tail remains for us to fill.
+    /// Re-probe read-only: adopt any prefix a concurrent query cached since `resolve` and report it as
+    /// `available`; hold the role only for an uncommitted tail.
     Lead lead;
     lead.available = ByteRange{range.offset, 0};
 
-    if (!bypass_if_missing)
+    SipHash base_hash = file.baseHash();
+    std::lock_guard lock(state_mutex);
+    for (size_t off = range.offset; off < range.end(); off += block_size)
     {
-        SipHash base_hash = file.baseHash();
-        std::lock_guard lock(state_mutex);
-        for (size_t off = range.offset; off < range.end(); off += block_size)
-        {
-            const size_t sz = std::min(block_size, file_size_in_bytes - off);
-            auto cell = cache->get(PageCacheByteRange{off, sz}.hash(base_hash), inject_eviction);
-            if (!cell)
-                break;  /// `available` is a contiguous committed prefix; stop at the first gap.
-            blocks.push_back(std::move(cell));
-            committed_ranges.add(ByteRange{off, sz});
-            lead.available = ByteRange{range.offset, std::min(off + sz, range.end()) - range.offset};
-        }
+        const size_t sz = std::min(block_size, file_size_in_bytes - off);
+        auto cell = cache->get(PageCacheByteRange{off, sz}.hash(base_hash), inject_eviction);
+        if (!cell)
+            break;
+        blocks.push_back(std::move(cell));
+        committed_ranges.add(ByteRange{off, sz});
+        lead.available = ByteRange{range.offset, std::min(off + sz, range.end()) - range.offset};
     }
 
     lead.claim = makeClaim(/*held=*/lead.available.end() < range.end(), /*release=*/nullptr);

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -20,7 +20,7 @@ PageCacheChainedBuffer::PageCacheChainedBuffer(PageCache::MappedPtr cell_)
 }
 
 
-PageCacheReader::PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<HeldCell> cells_)
+PageCacheReader::PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<PageCache::MappedPtr> cells_)
     : range_member(range_in_file)
     , cells(std::move(cells_))
 {
@@ -40,13 +40,13 @@ ChainedBuffers PageCacheReader::read(ByteRange sub)
         sub = ByteRange{lo, hi - lo};
     }
 
-    /// Zero-copy nodes from the held cells overlapping `sub`.
-    for (const auto & held : cells)
+    /// Zero-copy nodes from the held cells overlapping `sub`. Each cell knows its own file range.
+    for (const auto & cell : cells)
     {
-        if (!held.cell)
+        if (!cell)
             continue;
 
-        ByteRange block_range{held.byte_range.offset, held.byte_range.size};
+        ByteRange block_range{cell->range.offset, cell->range.size};
         if (block_range.end() <= sub.offset || block_range.offset >= sub.end())
             continue;
 
@@ -55,7 +55,7 @@ ChainedBuffers PageCacheReader::read(ByteRange sub)
         size_t offset_in_cell = overlap_start - block_range.offset;
         size_t overlap_size = overlap_end - overlap_start;
 
-        auto buf = std::make_shared<PageCacheChainedBuffer>(held.cell);
+        auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
         result.append(ChainedBufferNode{std::move(buf), offset_in_cell, overlap_size, overlap_start});
     }
     return result;
@@ -158,13 +158,9 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
         /// bytes WE wrote.
         if (cell)
         {
-            AdoptedBlock adopted;
-            adopted.byte_range = byte_range;
-            adopted.key_hash = key_hash;
-            adopted.cell = cell;
             {
                 std::lock_guard lock(state_mutex);
-                blocks.push_back(std::move(adopted));
+                blocks.push_back(cell);
                 committed_ranges.add(block_range);
             }
 
@@ -196,12 +192,12 @@ ChainedBuffers PageCacheWriter::read(ByteRange sub)
     /// Serve the self-populated blocks overlapping `sub`, zero-copy. Under the lock:
     /// a concurrent `write` on the same writer appends to `blocks`.
     std::lock_guard lock(state_mutex);
-    for (const auto & block : blocks)
+    for (const auto & cell : blocks)
     {
-        if (!block.cell)
+        if (!cell)
             continue;
 
-        ByteRange block_range{block.byte_range.offset, block.byte_range.size};
+        ByteRange block_range{cell->range.offset, cell->range.size};
         if (block_range.end() <= sub.offset || block_range.offset >= sub.end())
             continue;
 
@@ -210,7 +206,7 @@ ChainedBuffers PageCacheWriter::read(ByteRange sub)
         size_t offset_in_cell = overlap_start - block_range.offset;
         size_t overlap_size = overlap_end - overlap_start;
 
-        auto buf = std::make_shared<PageCacheChainedBuffer>(block.cell);
+        auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
         result.append(ChainedBufferNode{std::move(buf), offset_in_cell, overlap_size, overlap_start});
     }
     return result;
@@ -279,15 +275,15 @@ VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::res
         }
 
         /// Coalesce contiguous cached blocks into one bounded hit run; one
-        /// reader holds the run's cells.
-        VectorWithMemoryTracking<PageCacheReader::HeldCell> cells;
+        /// reader holds the run's cells (each cell knows its own file range).
+        VectorWithMemoryTracking<PageCache::MappedPtr> cells;
         const size_t run_start = pos;
         size_t run_end = pos;
         PageCache::MappedPtr held = std::move(cell);
         while (true)
         {
             const size_t sz = std::min(blk, file_size - run_end);
-            cells.push_back(PageCacheReader::HeldCell{PageCacheByteRange{run_end, sz}, std::move(held)});
+            cells.push_back(std::move(held));
             run_end += sz;
             if (run_end >= file_size || run_end - run_start >= HIT_RUN_CAP)
                 break;

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -159,6 +159,7 @@ PageCacheProvider::PageCacheProvider(
     , bypass_if_missing(bypass_if_missing_)
     , file_size_in_bytes(file_size_in_bytes_)
 {
+    chassert(block_size > 0);  /// `resolve` divides by it
 }
 
 /// The page tier's residency walk over `range`: one resolution per whole block. It holds no per-call
@@ -170,19 +171,17 @@ VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::res
     const StoredObject & /*object*/, size_t /*object_file_offset*/, ByteRange range)
 {
     VectorWithMemoryTracking<ICacheProvider::CacheResolution> out;
-    chassert(block_size > 0);
-    const size_t blk = block_size;
     const size_t file_size = file_size_in_bytes;
     if (range.offset >= file_size)
         return out;
 
     SipHash base_hash = file.baseHash();
     const size_t end_in_file = std::min(range.end(), file_size);
-    const size_t first_pos = range.offset / blk * blk;
-    out.reserve((end_in_file - first_pos + blk - 1) / blk);
-    for (size_t pos = first_pos; pos < end_in_file; pos += std::min(blk, file_size - pos))
+    const size_t first_pos = range.offset / block_size * block_size;
+    out.reserve((end_in_file - first_pos + block_size - 1) / block_size);
+    for (size_t pos = first_pos; pos < end_in_file; pos += std::min(block_size, file_size - pos))
     {
-        const ByteRange block{pos, std::min(blk, file_size - pos)};
+        const ByteRange block{pos, std::min(block_size, file_size - pos)};
         CacheResolution r;
         r.range = block;
         if (auto cell = cache->get(PageCacheByteRange{block.offset, block.size}.hash(base_hash), inject_eviction))

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -1,0 +1,308 @@
+#include <IO/PageCacheProvider.h>
+
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+#include <algorithm>
+#include <cstring>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+
+PageCacheChainedBuffer::PageCacheChainedBuffer(PageCache::MappedPtr cell_)
+    : cell(std::move(cell_))
+{
+}
+
+
+PageCacheReader::PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<HeldCell> cells_)
+    : range_member(range_in_file)
+    , cells(std::move(cells_))
+{
+}
+
+ChainedBuffers PageCacheReader::read(ByteRange sub)
+{
+    ChainedBuffers result;
+
+    /// Clamp `sub` to this buffer's own range: a `read` outside `range_member`
+    /// would otherwise reach into a neighbouring hit's cells.
+    {
+        const size_t lo = std::max(sub.offset, range_member.offset);
+        const size_t hi = std::min(sub.end(), range_member.end());
+        if (lo >= hi)
+            return result;
+        sub = ByteRange{lo, hi - lo};
+    }
+
+    /// Zero-copy nodes from the held cells overlapping `sub`.
+    for (const auto & held : cells)
+    {
+        if (!held.cell)
+            continue;
+
+        ByteRange block_range{held.byte_range.offset, held.byte_range.size};
+        if (block_range.end() <= sub.offset || block_range.offset >= sub.end())
+            continue;
+
+        size_t overlap_start = std::max(block_range.offset, sub.offset);
+        size_t overlap_end = std::min(block_range.end(), sub.end());
+        size_t offset_in_cell = overlap_start - block_range.offset;
+        size_t overlap_size = overlap_end - overlap_start;
+
+        auto buf = std::make_shared<PageCacheChainedBuffer>(held.cell);
+        result.append(ChainedBufferNode{std::move(buf), offset_in_cell, overlap_size, overlap_start});
+    }
+    return result;
+}
+
+
+PageCacheWriter::PageCacheWriter(
+    PageCachePtr cache_,
+    PageCacheFile file_,
+    size_t block_size_,
+    size_t file_size_in_bytes_,
+    bool inject_eviction_,
+    bool bypass_if_missing_,
+    ByteRange aligned_range_in_file)
+    : cache(std::move(cache_))
+    , file(std::move(file_))
+    , block_size(block_size_)
+    , file_size_in_bytes(file_size_in_bytes_)
+    , inject_eviction(inject_eviction_)
+    , bypass_if_missing(bypass_if_missing_)
+    , range_member(aligned_range_in_file)
+{
+}
+
+size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim & claim)
+{
+    /// A bypass tier populates nothing - skip before any `getOrSet`.
+    if (bypass_if_missing)
+        return 0;
+
+    SipHash base_hash = file.baseHash();
+
+    size_t bytes_written = 0;
+    /// Walk whole blocks of the aligned range; only act on uncommitted blocks
+    /// that `data` FULLY covers (a partially-covered block is left for a later
+    /// `write`).
+    for (size_t offset = range_member.offset; offset < range_member.end(); offset += block_size)
+    {
+        /// Tail block clamped to the file's real byte length.
+        size_t this_block_size = std::min(block_size, file_size_in_bytes - offset);
+        ByteRange block_range{offset, this_block_size};
+
+        {
+            std::lock_guard lock(state_mutex);
+            if (committed_ranges.subtract(block_range).empty())
+                continue;
+        }
+
+        if (!data.covers(block_range))
+            continue;
+
+        PageCacheByteRange byte_range{block_range.offset, block_range.size};
+        UInt128 key_hash = byte_range.hash(base_hash);
+
+        /// First-writer-wins: if another thread cached this block concurrently,
+        /// `getOrSet` returns the existing cell and skips the load lambda.
+        bool loaded = false;
+        size_t loaded_bytes = 0;
+        auto cell = cache->getOrSet(
+            file,
+            byte_range,
+            /*detached_if_missing=*/false,
+            inject_eviction,
+            [&](const PageCache::MappedPtr & new_cell)
+            {
+                /// The cell expects block-relative layout: data must start at
+                /// the block boundary and have no internal gaps. Partial-at-end
+                /// (EOF) is fine.
+                ChainedBuffers slice = data.slice(block_range);
+                ByteRange covered = slice.range();
+                size_t pos = covered.size;
+                if (pos > 0)
+                {
+                    if (covered.offset != block_range.offset)
+                        throw Exception(ErrorCodes::LOGICAL_ERROR,
+                            "PageCacheWriter::write: data does not start at block boundary: "
+                            "block=[{}, {}), covered=[{}, {})",
+                            block_range.offset, block_range.end(), covered.offset, covered.end());
+
+                    ByteRange to_copy{block_range.offset, pos};
+                    if (!slice.covers(to_copy))
+                        throw Exception(ErrorCodes::LOGICAL_ERROR,
+                            "PageCacheWriter::write: data has internal gaps within block [{}, {})",
+                            block_range.offset, block_range.end());
+
+                    slice.copyTo(new_cell->data(), to_copy);
+                }
+
+                if (pos < new_cell->size())
+                    std::memset(new_cell->data() + pos, 0, new_cell->size() - pos);
+
+                loaded = true;
+                loaded_bytes = pos;
+            },
+            key_hash);
+
+        /// ALWAYS adopt the returned cell (loaded by us OR an existing
+        /// first-writer cell) and mark the block committed - otherwise
+        /// `complete` never becomes true under contention. Return only the
+        /// bytes WE wrote.
+        if (cell)
+        {
+            AdoptedBlock adopted;
+            adopted.byte_range = byte_range;
+            adopted.key_hash = key_hash;
+            adopted.cell = cell;
+            {
+                std::lock_guard lock(state_mutex);
+                blocks.push_back(std::move(adopted));
+                committed_ranges.add(block_range);
+            }
+
+            if (loaded)
+            {
+                LOG_TRACE(log, "PageCacheWriter::write: populated block [{}, {})",
+                    block_range.offset, block_range.end());
+                bytes_written += loaded_bytes;
+            }
+        }
+    }
+
+    return bytes_written;
+}
+
+ChainedBuffers PageCacheWriter::read(ByteRange sub)
+{
+    ChainedBuffers result;
+
+    /// Clamp to this buffer's range (its adopted cells only back `range_member`).
+    {
+        const size_t lo = std::max(sub.offset, range_member.offset);
+        const size_t hi = std::min(sub.end(), range_member.end());
+        if (lo >= hi)
+            return result;
+        sub = ByteRange{lo, hi - lo};
+    }
+
+    /// Serve the self-populated blocks overlapping `sub`, zero-copy. Under the lock:
+    /// a concurrent `write` on the same writer appends to `blocks`.
+    std::lock_guard lock(state_mutex);
+    for (const auto & block : blocks)
+    {
+        if (!block.cell)
+            continue;
+
+        ByteRange block_range{block.byte_range.offset, block.byte_range.size};
+        if (block_range.end() <= sub.offset || block_range.offset >= sub.end())
+            continue;
+
+        size_t overlap_start = std::max(block_range.offset, sub.offset);
+        size_t overlap_end = std::min(block_range.end(), sub.end());
+        size_t offset_in_cell = overlap_start - block_range.offset;
+        size_t overlap_size = overlap_end - overlap_start;
+
+        auto buf = std::make_shared<PageCacheChainedBuffer>(block.cell);
+        result.append(ChainedBufferNode{std::move(buf), offset_in_cell, overlap_size, overlap_start});
+    }
+    return result;
+}
+
+
+PageCacheProvider::PageCacheProvider(
+    PageCachePtr cache_,
+    PageCacheFile file_,
+    size_t block_size_,
+    bool inject_eviction_,
+    bool bypass_if_missing_,
+    size_t file_size_in_bytes_)
+    : cache(std::move(cache_))
+    , file(std::move(file_))
+    , block_size(block_size_)
+    , inject_eviction(inject_eviction_)
+    , bypass_if_missing(bypass_if_missing_)
+    , file_size_in_bytes(file_size_in_bytes_)
+{
+}
+
+/// The page tier's residency walk. One `resolve` is a ranged block walk holding
+/// no per-call state, so a shared provider is safe to resolve from many threads
+/// (the `readBigAt` fan-out). Blocks are probed read-only (`cache->get` never
+/// creates a cell), contiguous cached blocks coalesce into one hit run - capped
+/// so a warm file does not pin unboundedly through a single reader - and an
+/// uncached block is one miss cell carrying its whole-block writer when the
+/// provider populates (bypass leaves it writer-less). The plan fills the misses
+/// through those writers.
+VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::resolve(
+    const StoredObject & /*object*/, size_t /*object_file_offset*/, ByteRange range)
+{
+    VectorWithMemoryTracking<ICacheProvider::CacheResolution> out;
+    const size_t blk = block_size;
+    const size_t file_size = file_size_in_bytes;
+    if (range.offset >= file_size)
+        return out;
+
+    static constexpr size_t HIT_RUN_CAP = 8 * 1024 * 1024;
+    SipHash base_hash = file.baseHash();
+    auto probe = [&](size_t off) -> PageCache::MappedPtr
+    {
+        const size_t sz = std::min(blk, file_size - off);
+        PageCacheByteRange byte_range{off, sz};
+        return cache->get(byte_range.hash(base_hash), inject_eviction);
+    };
+
+    const size_t end_in_file = std::min(range.end(), file_size);
+    size_t pos = range.offset / blk * blk;
+    while (pos < end_in_file)
+    {
+        auto cell = probe(pos);
+        if (!cell)
+        {
+            CacheResolution miss;
+            miss.kind = CacheResolution::Kind::Miss;
+            miss.range = ByteRange{pos, std::min(blk, file_size - pos)};
+            if (populatesOnMiss())
+                miss.writer = std::make_unique<PageCacheWriter>(
+                    cache, file, blk, file_size,
+                    inject_eviction, bypass_if_missing, miss.range);
+            pos = miss.range.end();
+            out.push_back(std::move(miss));
+            continue;
+        }
+
+        /// Coalesce contiguous cached blocks into one bounded hit run; one
+        /// reader holds the run's cells.
+        VectorWithMemoryTracking<PageCacheReader::HeldCell> cells;
+        const size_t run_start = pos;
+        size_t run_end = pos;
+        PageCache::MappedPtr held = std::move(cell);
+        while (true)
+        {
+            const size_t sz = std::min(blk, file_size - run_end);
+            cells.push_back(PageCacheReader::HeldCell{PageCacheByteRange{run_end, sz}, std::move(held)});
+            run_end += sz;
+            if (run_end >= file_size || run_end - run_start >= HIT_RUN_CAP)
+                break;
+            held = probe(run_end);
+            if (!held)
+                break;
+        }
+        CacheResolution hit;
+        hit.kind = CacheResolution::Kind::Hit;
+        hit.range = ByteRange{run_start, run_end - run_start};
+        hit.reader = std::make_unique<PageCacheReader>(hit.range, std::move(cells));
+        pos = run_end;
+        out.push_back(std::move(hit));
+    }
+    return out;
+}
+
+}

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -259,8 +259,8 @@ PageCacheProvider::PageCacheProvider(
 /// creates a cell), contiguous cached blocks coalesce into one hit run - capped
 /// so a warm file does not pin unboundedly through a single reader - and an
 /// uncached block is one miss cell carrying its whole-block writer when the
-/// provider populates (bypass leaves it writer-less). The plan fills the misses
-/// through those writers.
+/// provider populates (bypass leaves it writer-less). The executor fetches
+/// consecutive misses together.
 VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::resolve(
     const StoredObject & /*object*/, size_t /*object_file_offset*/, ByteRange range)
 {

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -178,8 +178,8 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
 
 CacheWriter::Lead PageCacheWriter::claimLeadRole(ByteRange range)
 {
-    /// Re-probe read-only: adopt any prefix a concurrent query cached since `resolve` and report it as
-    /// `available`; hold the role only for an uncommitted tail.
+    /// Re-probe read-only: adopt any prefix a concurrent query cached since `resolve`, report it as
+    /// `available`, and return a held claim only when an uncommitted tail is left to fill.
     Lead lead;
     lead.available = ByteRange{range.offset, 0};
 
@@ -213,8 +213,7 @@ ChainedBuffers PageCacheWriter::read(ByteRange sub)
         sub = ByteRange{lo, hi - lo};
     }
 
-    /// Serve the self-populated blocks overlapping `sub`, zero-copy. Under the lock:
-    /// a concurrent `write` on the same writer appends to `blocks`.
+    /// Serve the self-populated blocks overlapping `sub`, zero-copy, under the lock that guards `blocks`.
     std::lock_guard lock(state_mutex);
     for (const auto & cell : blocks)
     {
@@ -253,14 +252,12 @@ PageCacheProvider::PageCacheProvider(
 {
 }
 
-/// The page tier's residency walk. One `resolve` is a ranged block walk holding
-/// no per-call state, so a shared provider is safe to resolve from many threads
-/// (the `readBigAt` fan-out). Blocks are probed read-only (`cache->get` never
-/// creates a cell), contiguous cached blocks coalesce into one hit run - capped
-/// so a warm file does not pin unboundedly through a single reader - and an
-/// uncached block is one miss cell carrying its whole-block writer when the
-/// provider populates (bypass leaves it writer-less). The executor fetches
-/// consecutive misses together.
+/// The page tier's residency walk over `range`. It holds no per-call state, so a shared provider is
+/// safe to resolve concurrently. Each block is probed read-only (`cache->get` never creates a cell):
+/// contiguous cached blocks coalesce into one bounded hit run (capped so a warm file does not pin
+/// unboundedly through one reader), and each uncached block is a one-block miss carrying a whole-block
+/// writer when the tier populates (writer-less on a bypass tier). The executor fetches consecutive
+/// misses together.
 VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::resolve(
     const StoredObject & /*object*/, size_t /*object_file_offset*/, ByteRange range)
 {

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -81,11 +81,8 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
         size_t this_block_size = std::min(block_size, file_size_in_bytes - offset);
         ByteRange block_range{offset, this_block_size};
 
-        {
-            std::lock_guard lock(state_mutex);
-            if (committed_ranges.subtract(block_range).empty())
-                continue;
-        }
+        if (committed_ranges.subtract(block_range).empty())
+            continue;
 
         if (!data.covers(block_range))
             continue;
@@ -141,11 +138,8 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
         /// bytes WE wrote.
         if (cell)
         {
-            {
-                std::lock_guard lock(state_mutex);
-                blocks.push_back(cell);
-                committed_ranges.add(block_range);
-            }
+            blocks.push_back(cell);
+            committed_ranges.add(block_range);
 
             if (loaded)
             {
@@ -167,7 +161,6 @@ CacheWriter::Lead PageCacheWriter::claimLeadRole(ByteRange range)
     lead.available = ByteRange{range.offset, 0};
 
     SipHash base_hash = file.baseHash();
-    std::lock_guard lock(state_mutex);
     for (size_t off = range.offset; off < range.end(); off += block_size)
     {
         const size_t sz = std::min(block_size, file_size_in_bytes - off);
@@ -196,8 +189,7 @@ ChainedBuffers PageCacheWriter::read(ByteRange sub)
         sub = ByteRange{lo, hi - lo};
     }
 
-    /// Serve the self-populated blocks overlapping `sub`, zero-copy, under the lock that guards `blocks`.
-    std::lock_guard lock(state_mutex);
+    /// Serve the self-populated blocks overlapping `sub`, zero-copy.
     for (const auto & cell : blocks)
     {
         if (!cell)

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -176,6 +176,36 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
     return bytes_written;
 }
 
+CacheWriter::Lead PageCacheWriter::claimLeadRole(ByteRange range)
+{
+    /// The page cache has no downloader role, so the base default trivially holds one. But a concurrent
+    /// query may have populated this block between `resolve` (a read-only `get` probe) and now. Re-probe
+    /// read-only: adopt any resident contiguous prefix and report it as `available` (already committed),
+    /// so the executor serves it from cache instead of re-reading it from the source. Hold the role only
+    /// if an uncommitted tail remains for us to fill.
+    Lead lead;
+    lead.available = ByteRange{range.offset, 0};
+
+    if (!bypass_if_missing)
+    {
+        SipHash base_hash = file.baseHash();
+        std::lock_guard lock(state_mutex);
+        for (size_t off = range.offset; off < range.end(); off += block_size)
+        {
+            const size_t sz = std::min(block_size, file_size_in_bytes - off);
+            auto cell = cache->get(PageCacheByteRange{off, sz}.hash(base_hash), inject_eviction);
+            if (!cell)
+                break;  /// `available` is a contiguous committed prefix; stop at the first gap.
+            blocks.push_back(std::move(cell));
+            committed_ranges.add(ByteRange{off, sz});
+            lead.available = ByteRange{range.offset, std::min(off + sz, range.end()) - range.offset};
+        }
+    }
+
+    lead.claim = makeClaim(/*held=*/lead.available.end() < range.end(), /*release=*/nullptr);
+    return lead;
+}
+
 ChainedBuffers PageCacheWriter::read(ByteRange sub)
 {
     ChainedBuffers result;

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -20,44 +20,27 @@ PageCacheChainedBuffer::PageCacheChainedBuffer(PageCache::MappedPtr cell_)
 }
 
 
-PageCacheReader::PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<PageCache::MappedPtr> cells_)
+PageCacheReader::PageCacheReader(ByteRange range_in_file, PageCache::MappedPtr cell_)
     : range_member(range_in_file)
-    , cells(std::move(cells_))
+    , cell(std::move(cell_))
 {
 }
 
 ChainedBuffers PageCacheReader::read(ByteRange sub)
 {
     ChainedBuffers result;
+    if (!cell)
+        return result;
 
-    /// Clamp `sub` to this buffer's own range: a `read` outside `range_member`
-    /// would otherwise reach into a neighbouring hit's cells.
-    {
-        const size_t lo = std::max(sub.offset, range_member.offset);
-        const size_t hi = std::min(sub.end(), range_member.end());
-        if (lo >= hi)
-            return result;
-        sub = ByteRange{lo, hi - lo};
-    }
+    /// Clamp `sub` to this block's range (`range_member == cell->range`), then emit one zero-copy node
+    /// into the cell at the matching offset.
+    const size_t lo = std::max(sub.offset, range_member.offset);
+    const size_t hi = std::min(sub.end(), range_member.end());
+    if (lo >= hi)
+        return result;
 
-    /// Zero-copy nodes from the held cells overlapping `sub`. Each cell knows its own file range.
-    for (const auto & cell : cells)
-    {
-        if (!cell)
-            continue;
-
-        ByteRange block_range{cell->range.offset, cell->range.size};
-        if (block_range.end() <= sub.offset || block_range.offset >= sub.end())
-            continue;
-
-        size_t overlap_start = std::max(block_range.offset, sub.offset);
-        size_t overlap_end = std::min(block_range.end(), sub.end());
-        size_t offset_in_cell = overlap_start - block_range.offset;
-        size_t overlap_size = overlap_end - overlap_start;
-
-        auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
-        result.append(ChainedBufferNode{std::move(buf), offset_in_cell, overlap_size, overlap_start});
-    }
+    auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
+    result.append(ChainedBufferNode{std::move(buf), lo - range_member.offset, hi - lo, lo});
     return result;
 }
 
@@ -252,12 +235,11 @@ PageCacheProvider::PageCacheProvider(
 {
 }
 
-/// The page tier's residency walk over `range`. It holds no per-call state, so a shared provider is
-/// safe to resolve concurrently. Each block is probed read-only (`cache->get` never creates a cell):
-/// contiguous cached blocks coalesce into one bounded hit run (capped so a warm file does not pin
-/// unboundedly through one reader), and each uncached block is a one-block miss carrying a whole-block
-/// writer when the tier populates (writer-less on a bypass tier). The executor fetches consecutive
-/// misses together.
+/// The page tier's residency walk over `range`: one resolution per whole block. It holds no per-call
+/// state, so a shared provider is safe to resolve concurrently. Each block is probed read-only
+/// (`cache->get` never creates a cell): a cached block is a hit whose reader holds that cell, an
+/// uncached block is a miss carrying its whole-block writer when the tier populates (writer-less on a
+/// bypass tier). The executor gathers consecutive misses for the fetch and serves one block per window.
 VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::resolve(
     const StoredObject & /*object*/, size_t /*object_file_offset*/, ByteRange range)
 {
@@ -267,57 +249,26 @@ VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::res
     if (range.offset >= file_size)
         return out;
 
-    static constexpr size_t HIT_RUN_CAP = 8 * 1024 * 1024;
     SipHash base_hash = file.baseHash();
-    auto probe = [&](size_t off) -> PageCache::MappedPtr
-    {
-        const size_t sz = std::min(blk, file_size - off);
-        PageCacheByteRange byte_range{off, sz};
-        return cache->get(byte_range.hash(base_hash), inject_eviction);
-    };
-
     const size_t end_in_file = std::min(range.end(), file_size);
-    size_t pos = range.offset / blk * blk;
-    while (pos < end_in_file)
+    for (size_t pos = range.offset / blk * blk; pos < end_in_file; pos += std::min(blk, file_size - pos))
     {
-        auto cell = probe(pos);
-        if (!cell)
+        const ByteRange block{pos, std::min(blk, file_size - pos)};
+        CacheResolution r;
+        r.range = block;
+        if (auto cell = cache->get(PageCacheByteRange{block.offset, block.size}.hash(base_hash), inject_eviction))
         {
-            CacheResolution miss;
-            miss.kind = CacheResolution::Kind::Miss;
-            miss.range = ByteRange{pos, std::min(blk, file_size - pos)};
+            r.kind = CacheResolution::Kind::Hit;
+            r.reader = std::make_unique<PageCacheReader>(block, std::move(cell));
+        }
+        else
+        {
+            r.kind = CacheResolution::Kind::Miss;
             if (populatesOnMiss())
-                miss.writer = std::make_unique<PageCacheWriter>(
-                    cache, file, blk, file_size,
-                    inject_eviction, bypass_if_missing, miss.range);
-            pos = miss.range.end();
-            out.push_back(std::move(miss));
-            continue;
+                r.writer = std::make_unique<PageCacheWriter>(
+                    cache, file, blk, file_size, inject_eviction, bypass_if_missing, block);
         }
-
-        /// Coalesce contiguous cached blocks into one bounded hit run; one
-        /// reader holds the run's cells (each cell knows its own file range).
-        VectorWithMemoryTracking<PageCache::MappedPtr> cells;
-        const size_t run_start = pos;
-        size_t run_end = pos;
-        PageCache::MappedPtr held = std::move(cell);
-        while (true)
-        {
-            const size_t sz = std::min(blk, file_size - run_end);
-            cells.push_back(std::move(held));
-            run_end += sz;
-            if (run_end >= file_size || run_end - run_start >= HIT_RUN_CAP)
-                break;
-            held = probe(run_end);
-            if (!held)
-                break;
-        }
-        CacheResolution hit;
-        hit.kind = CacheResolution::Kind::Hit;
-        hit.range = ByteRange{run_start, run_end - run_start};
-        hit.reader = std::make_unique<PageCacheReader>(hit.range, std::move(cells));
-        pos = run_end;
-        out.push_back(std::move(hit));
+        out.push_back(std::move(r));
     }
     return out;
 }

--- a/src/IO/PageCacheProvider.cpp
+++ b/src/IO/PageCacheProvider.cpp
@@ -1,17 +1,11 @@
 #include <IO/PageCacheProvider.h>
 
-#include <Common/Exception.h>
 #include <Common/logger_useful.h>
 #include <algorithm>
 #include <cstring>
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
 
 
 PageCacheChainedBuffer::PageCacheChainedBuffer(PageCache::MappedPtr cell_)
@@ -48,18 +42,14 @@ ChainedBuffers PageCacheReader::read(ByteRange sub)
 PageCacheWriter::PageCacheWriter(
     PageCachePtr cache_,
     PageCacheFile file_,
-    size_t block_size_,
-    size_t file_size_in_bytes_,
     bool inject_eviction_,
     bool bypass_if_missing_,
-    ByteRange aligned_range_in_file)
+    ByteRange block_range)
     : cache(std::move(cache_))
     , file(std::move(file_))
-    , block_size(block_size_)
-    , file_size_in_bytes(file_size_in_bytes_)
     , inject_eviction(inject_eviction_)
     , bypass_if_missing(bypass_if_missing_)
-    , range_member(aligned_range_in_file)
+    , range_member(block_range)
 {
 }
 
@@ -69,144 +59,82 @@ size_t PageCacheWriter::write(ChainedBuffers data, [[maybe_unused]] const Claim 
     if (bypass_if_missing)
         return 0;
 
-    SipHash base_hash = file.baseHash();
-
-    size_t bytes_written = 0;
-    /// Walk whole blocks of the aligned range; only act on uncommitted blocks
-    /// that `data` FULLY covers (a partially-covered block is left for a later
-    /// `write`).
-    for (size_t offset = range_member.offset; offset < range_member.end(); offset += block_size)
     {
-        /// Tail block clamped to the file's real byte length.
-        size_t this_block_size = std::min(block_size, file_size_in_bytes - offset);
-        ByteRange block_range{offset, this_block_size};
-
-        if (committed_ranges.subtract(block_range).empty())
-            continue;
-
-        if (!data.covers(block_range))
-            continue;
-
-        PageCacheByteRange byte_range{block_range.offset, block_range.size};
-        UInt128 key_hash = byte_range.hash(base_hash);
-
-        /// First-writer-wins: if another thread cached this block concurrently,
-        /// `getOrSet` returns the existing cell and skips the load lambda.
-        bool loaded = false;
-        size_t loaded_bytes = 0;
-        auto cell = cache->getOrSet(
-            file,
-            byte_range,
-            /*detached_if_missing=*/false,
-            inject_eviction,
-            [&](const PageCache::MappedPtr & new_cell)
-            {
-                /// The cell expects block-relative layout: data must start at
-                /// the block boundary and have no internal gaps. Partial-at-end
-                /// (EOF) is fine.
-                ChainedBuffers slice = data.slice(block_range);
-                ByteRange covered = slice.range();
-                size_t pos = covered.size;
-                if (pos > 0)
-                {
-                    if (covered.offset != block_range.offset)
-                        throw Exception(ErrorCodes::LOGICAL_ERROR,
-                            "PageCacheWriter::write: data does not start at block boundary: "
-                            "block=[{}, {}), covered=[{}, {})",
-                            block_range.offset, block_range.end(), covered.offset, covered.end());
-
-                    ByteRange to_copy{block_range.offset, pos};
-                    if (!slice.covers(to_copy))
-                        throw Exception(ErrorCodes::LOGICAL_ERROR,
-                            "PageCacheWriter::write: data has internal gaps within block [{}, {})",
-                            block_range.offset, block_range.end());
-
-                    slice.copyTo(new_cell->data(), to_copy);
-                }
-
-                if (pos < new_cell->size())
-                    std::memset(new_cell->data() + pos, 0, new_cell->size() - pos);
-
-                loaded = true;
-                loaded_bytes = pos;
-            },
-            key_hash);
-
-        /// ALWAYS adopt the returned cell (loaded by us OR an existing
-        /// first-writer cell) and mark the block committed - otherwise
-        /// `complete` never becomes true under contention. Return only the
-        /// bytes WE wrote.
-        if (cell)
-        {
-            blocks.push_back(cell);
-            committed_ranges.add(block_range);
-
-            if (loaded)
-            {
-                LOG_TRACE(log, "PageCacheWriter::write: populated block [{}, {})",
-                    block_range.offset, block_range.end());
-                bytes_written += loaded_bytes;
-            }
-        }
+        std::lock_guard lock(committed_mutex);
+        if (cell)  /// already committed (by us or an adopted first-writer cell)
+            return 0;
     }
 
-    return bytes_written;
+    /// Whole-block, all-or-nothing: a partially-covered block is left for a later `write`.
+    if (!data.covers(range_member))
+        return 0;
+
+    PageCacheByteRange byte_range{range_member.offset, range_member.size};
+    UInt128 key_hash = byte_range.hash(file.baseHash());
+
+    /// First-writer-wins: if another thread cached this block concurrently, `getOrSet` returns the
+    /// existing cell and skips the load lambda.
+    bool loaded = false;
+    auto got = cache->getOrSet(
+        file,
+        byte_range,
+        /*detached_if_missing=*/false,
+        inject_eviction,
+        [&](const PageCache::MappedPtr & new_cell)
+        {
+            /// `data` covers the whole block (checked above); copy it in, zero any cell padding past it.
+            data.slice(range_member).copyTo(new_cell->data(), range_member);
+            if (range_member.size < new_cell->size())
+                std::memset(new_cell->data() + range_member.size, 0, new_cell->size() - range_member.size);
+            loaded = true;
+        },
+        key_hash);
+
+    /// Adopt the returned cell (ours or the first-writer's) so `read`/`committed` see it. Return the
+    /// bytes we wrote - 0 if we lost the first-writer race.
+    if (got)
+    {
+        std::lock_guard lock(committed_mutex);
+        cell = std::move(got);
+    }
+    if (loaded)
+        LOG_TRACE(log, "PageCacheWriter::write: populated block [{}, {})", range_member.offset, range_member.end());
+    return loaded ? range_member.size : 0;
 }
 
 CacheWriter::Lead PageCacheWriter::claimLeadRole(ByteRange range)
 {
-    /// Re-probe read-only: adopt any prefix a concurrent query cached since `resolve`, report it as
-    /// `available`, and return a held claim only when an uncommitted tail is left to fill.
+    /// Re-probe read-only: if the block was cached by a concurrent query since `resolve`, adopt its cell
+    /// and report the whole block as `available`; otherwise hold the claim to fill it.
     Lead lead;
     lead.available = ByteRange{range.offset, 0};
 
-    SipHash base_hash = file.baseHash();
-    for (size_t off = range.offset; off < range.end(); off += block_size)
+    if (auto got = cache->get(PageCacheByteRange{range_member.offset, range_member.size}.hash(file.baseHash()), inject_eviction))
     {
-        const size_t sz = std::min(block_size, file_size_in_bytes - off);
-        auto cell = cache->get(PageCacheByteRange{off, sz}.hash(base_hash), inject_eviction);
-        if (!cell)
-            break;
-        blocks.push_back(std::move(cell));
-        committed_ranges.add(ByteRange{off, sz});
-        lead.available = ByteRange{range.offset, std::min(off + sz, range.end()) - range.offset};
+        std::lock_guard lock(committed_mutex);
+        cell = std::move(got);
+        lead.available = range_member;
     }
 
-    lead.claim = makeClaim(/*held=*/lead.available.end() < range.end(), /*release=*/nullptr);
+    lead.claim = makeClaim(/*held=*/lead.available.size == 0, /*release=*/nullptr);
     return lead;
 }
 
 ChainedBuffers PageCacheWriter::read(ByteRange sub)
 {
+    std::lock_guard lock(committed_mutex);
     ChainedBuffers result;
+    if (!cell)
+        return result;
 
-    /// Clamp to this buffer's range (its adopted cells only back `range_member`).
-    {
-        const size_t lo = std::max(sub.offset, range_member.offset);
-        const size_t hi = std::min(sub.end(), range_member.end());
-        if (lo >= hi)
-            return result;
-        sub = ByteRange{lo, hi - lo};
-    }
+    /// Clamp to this block's range, then emit one zero-copy node into the cell.
+    const size_t lo = std::max(sub.offset, range_member.offset);
+    const size_t hi = std::min(sub.end(), range_member.end());
+    if (lo >= hi)
+        return result;
 
-    /// Serve the self-populated blocks overlapping `sub`, zero-copy.
-    for (const auto & cell : blocks)
-    {
-        if (!cell)
-            continue;
-
-        ByteRange block_range{cell->range.offset, cell->range.size};
-        if (block_range.end() <= sub.offset || block_range.offset >= sub.end())
-            continue;
-
-        size_t overlap_start = std::max(block_range.offset, sub.offset);
-        size_t overlap_end = std::min(block_range.end(), sub.end());
-        size_t offset_in_cell = overlap_start - block_range.offset;
-        size_t overlap_size = overlap_end - overlap_start;
-
-        auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
-        result.append(ChainedBufferNode{std::move(buf), offset_in_cell, overlap_size, overlap_start});
-    }
+    auto buf = std::make_shared<PageCacheChainedBuffer>(cell);
+    result.append(ChainedBufferNode{std::move(buf), lo - range_member.offset, hi - lo, lo});
     return result;
 }
 
@@ -258,7 +186,7 @@ VectorWithMemoryTracking<ICacheProvider::CacheResolution> PageCacheProvider::res
             r.kind = CacheResolution::Kind::Miss;
             if (populatesOnMiss())
                 r.writer = std::make_unique<PageCacheWriter>(
-                    cache, file, blk, file_size, inject_eviction, bypass_if_missing, block);
+                    cache, file, inject_eviction, bypass_if_missing, block);
         }
         out.push_back(std::move(r));
     }

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -6,8 +6,6 @@
 #include <Common/logger_useful.h>
 #include <Common/VectorWithMemoryTracking.h>
 
-#include <mutex>
-
 namespace DB
 {
 
@@ -59,11 +57,7 @@ public:
         ByteRange aligned_range_in_file);
 
     ByteRange range() const override { return range_member; }
-    IntervalSet committed() const override
-    {
-        std::lock_guard lock(state_mutex);
-        return committed_ranges;
-    }
+    IntervalSet committed() const override { return committed_ranges; }
     size_t write(ChainedBuffers data, const Claim & claim) override;
     ChainedBuffers read(ByteRange sub) override;
     /// Re-probe the cache: a block may have been populated by a concurrent query since `resolve`. Any
@@ -83,11 +77,9 @@ private:
     ByteRange range_member;
     IntervalSet committed_ranges;
     /// The whole-block cells this writer populated or adopted, in file order (same layout as the
-    /// reader's `cells`: each cell carries its own `cell->range` and size).
+    /// reader's `cell`: each carries its own `cell->range` and size). One writer is driven by a single
+    /// thread, so no lock is needed.
     VectorWithMemoryTracking<PageCache::MappedPtr> blocks;
-    /// Guards `committed_ranges` and `blocks`. Uncontended today (the executor drives one writer from a
-    /// single thread); it makes the writer ready for the concurrent fill a later prefetch worker adds.
-    mutable std::mutex state_mutex;
     LoggerPtr log = getLogger("PageCacheWriter");
 };
 

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -29,9 +29,8 @@ private:
 
 /// ── Per-range buffer API (see `ICacheProvider.h`) ──
 
-/// `CacheReader` over the pinned whole-block cell(s) backing one hit range.
-/// Page cells are whole blocks, so a hit is always fully resident and there is
-/// no deferred-LRU bump.
+/// `CacheReader` for one hit range: it holds the whole-block cells covering the range and serves
+/// `read` as zero-copy views into them.
 class PageCacheReader : public CacheReader
 {
 public:
@@ -42,16 +41,14 @@ public:
 
 private:
     ByteRange range_member;
-    /// Pinned whole-block cells backing this run, in file order. Each cell knows its own file range
-    /// (`cell->range`) and size, so the reader needs no separate per-cell bookkeeping.
+    /// The whole-block cells covering this range, in file order (kept alive by the shared_ptr). Each
+    /// cell carries its own file range (`cell->range`) and size, so no separate bookkeeping is needed.
     VectorWithMemoryTracking<PageCache::MappedPtr> cells;
 };
 
-/// `CacheWriter` over one whole-block-aligned miss range. Cells are created
-/// lazily on `write` (`PageCache::getOrSet`, first-writer-wins) and adopted
-/// into `blocks`; the write buffer doubles as a read buffer for the
-/// self-populated blocks. No evictable in-flight segment, so `pin` keeps the
-/// default no-op.
+/// `CacheWriter` for one miss range. `write` creates each block's cell on demand
+/// (`PageCache::getOrSet`, first-writer-wins) and adopts it into `blocks`, which also lets the writer
+/// serve `read` for the blocks it populated.
 class PageCacheWriter : public CacheWriter
 {
 public:
@@ -88,11 +85,11 @@ private:
     bool bypass_if_missing;
     ByteRange range_member;
     IntervalSet committed_ranges;
-    /// Whole-block cells this writer populated or adopted, in file order. Each cell knows its own
-    /// file range (`cell->range`) and size, so the writer needs no separate per-block bookkeeping.
+    /// The whole-block cells this writer populated or adopted, in file order (same layout as the
+    /// reader's `cells`: each cell carries its own `cell->range` and size).
     VectorWithMemoryTracking<PageCache::MappedPtr> blocks;
-    /// Guards `committed_ranges` and `blocks`: the prefetch worker may write this writer
-    /// while the foreground reads the self-populated blocks of the same writer.
+    /// Guards `committed_ranges` and `blocks`. Uncontended today (the executor drives one writer from a
+    /// single thread); it makes the writer ready for the concurrent fill a later prefetch worker adds.
     mutable std::mutex state_mutex;
     LoggerPtr log = getLogger("PageCacheWriter");
 };

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <IO/ICacheProvider.h>
+#include <IO/IntervalSet.h>
+#include <Common/PageCache.h>
+#include <Common/logger_useful.h>
+#include <Common/VectorWithMemoryTracking.h>
+
+#include <mutex>
+
+namespace DB
+{
+
+/// ChainedBuffer backed by a PageCache cell. Zero-copy: the shared_ptr pins the
+/// cell, and data() points directly into the cache's mmap arena.
+class PageCacheChainedBuffer : public ChainedBuffer
+{
+public:
+    explicit PageCacheChainedBuffer(PageCache::MappedPtr cell_);
+
+    char * data() override { return cell->data(); }
+    const char * data() const override { return cell->data(); }
+    size_t size() const override { return cell->size(); }
+
+private:
+    PageCache::MappedPtr cell;
+};
+
+
+/// ── Per-range buffer API (see `ICacheProvider.h`) ──
+
+/// `CacheReader` over the pinned whole-block cell(s) backing one hit range.
+/// Page cells are whole blocks, so a hit is always fully resident and there is
+/// no deferred-LRU bump.
+class PageCacheReader : public CacheReader
+{
+public:
+    struct HeldCell
+    {
+        PageCacheByteRange byte_range;
+        PageCache::MappedPtr cell;
+    };
+
+    PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<HeldCell> cells_);
+
+    ByteRange range() const override { return range_member; }
+    ChainedBuffers read(ByteRange sub) override;
+
+private:
+    ByteRange range_member;
+    VectorWithMemoryTracking<HeldCell> cells;
+};
+
+/// `CacheWriter` over one whole-block-aligned miss range. Cells are created
+/// lazily on `write` (`PageCache::getOrSet`, first-writer-wins) and adopted
+/// into `blocks`; the write buffer doubles as a read buffer for the
+/// self-populated blocks. No evictable in-flight segment, so `pin` keeps the
+/// default no-op.
+class PageCacheWriter : public CacheWriter
+{
+public:
+    PageCacheWriter(
+        PageCachePtr cache_,
+        PageCacheFile file_,
+        size_t block_size_,
+        size_t file_size_in_bytes_,
+        bool inject_eviction_,
+        bool bypass_if_missing_,
+        ByteRange aligned_range_in_file);
+
+    ByteRange range() const override { return range_member; }
+    IntervalSet committed() const override
+    {
+        std::lock_guard lock(state_mutex);
+        return committed_ranges;
+    }
+    size_t write(ChainedBuffers data, const Claim & claim) override;
+    ChainedBuffers read(ByteRange sub) override;
+
+private:
+    struct AdoptedBlock
+    {
+        PageCacheByteRange byte_range;
+        UInt128 key_hash{};
+        PageCache::MappedPtr cell;
+    };
+
+    PageCachePtr cache;
+    PageCacheFile file;
+    size_t block_size;
+    size_t file_size_in_bytes;
+    bool inject_eviction;
+    /// Mirrors `read_from_page_cache_if_exists_otherwise_bypass_cache`: a
+    /// bypass tier populates nothing, so `write` returns 0 before any `getOrSet`.
+    bool bypass_if_missing;
+    ByteRange range_member;
+    IntervalSet committed_ranges;
+    VectorWithMemoryTracking<AdoptedBlock> blocks;
+    /// Guards `committed_ranges` and `blocks`: the prefetch worker may write this writer
+    /// while the foreground reads the self-populated blocks of the same writer.
+    mutable std::mutex state_mutex;
+    LoggerPtr log = getLogger("PageCacheWriter");
+};
+
+/// `ICacheProvider` wrapping PageCache. PageCache is FILE-level (one logical
+/// file per `PageCacheFile` regardless of how many `StoredObject`s back it),
+/// so the file is configured once at construction and lookups ignore the
+/// `StoredObject` argument.
+class PageCacheProvider : public ICacheProvider
+{
+public:
+    /// `file_size_in_bytes` must be the authoritative byte length: tail cells
+    /// are clamped to it so no past-EOF region can be served later. PageCache
+    /// requires known size - unknown-size sources must not be wrapped.
+    PageCacheProvider(
+        PageCachePtr cache_,
+        PageCacheFile file_,
+        size_t block_size_,
+        bool inject_eviction_,
+        bool bypass_if_missing_,
+        size_t file_size_in_bytes_);
+
+    String name() const override { return "PageCache"; }
+    CacheTier tier() const override { return CacheTier::PageCache; }
+    bool populatesOnMiss() const override { return !bypass_if_missing; }
+
+    /// A page-cache block is written whole (first-writer-wins, no later
+    /// completion); the probe reports one miss range per block.
+    bool fillsWholeSegment() const override { return true; }
+
+    /// Resolve `range` into per-block hits (readers) and misses (whole-block
+    /// writers when populating); see the definition.
+    VectorWithMemoryTracking<CacheResolution> resolve(
+        const StoredObject & object, size_t object_file_offset, ByteRange range) override;
+
+private:
+    PageCachePtr cache;
+    PageCacheFile file;
+    size_t block_size;
+    bool inject_eviction;
+    bool bypass_if_missing;
+    size_t file_size_in_bytes;
+    LoggerPtr log = getLogger("PageCacheProvider");
+};
+
+}

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -35,20 +35,16 @@ private:
 class PageCacheReader : public CacheReader
 {
 public:
-    struct HeldCell
-    {
-        PageCacheByteRange byte_range;
-        PageCache::MappedPtr cell;
-    };
-
-    PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<HeldCell> cells_);
+    PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<PageCache::MappedPtr> cells_);
 
     ByteRange range() const override { return range_member; }
     ChainedBuffers read(ByteRange sub) override;
 
 private:
     ByteRange range_member;
-    VectorWithMemoryTracking<HeldCell> cells;
+    /// Pinned whole-block cells backing this run, in file order. Each cell knows its own file range
+    /// (`cell->range`) and size, so the reader needs no separate per-cell bookkeeping.
+    VectorWithMemoryTracking<PageCache::MappedPtr> cells;
 };
 
 /// `CacheWriter` over one whole-block-aligned miss range. Cells are created
@@ -78,13 +74,6 @@ public:
     ChainedBuffers read(ByteRange sub) override;
 
 private:
-    struct AdoptedBlock
-    {
-        PageCacheByteRange byte_range;
-        UInt128 key_hash{};
-        PageCache::MappedPtr cell;
-    };
-
     PageCachePtr cache;
     PageCacheFile file;
     size_t block_size;
@@ -95,7 +84,9 @@ private:
     bool bypass_if_missing;
     ByteRange range_member;
     IntervalSet committed_ranges;
-    VectorWithMemoryTracking<AdoptedBlock> blocks;
+    /// Whole-block cells this writer populated or adopted, in file order. Each cell knows its own
+    /// file range (`cell->range`) and size, so the writer needs no separate per-block bookkeeping.
+    VectorWithMemoryTracking<PageCache::MappedPtr> blocks;
     /// Guards `committed_ranges` and `blocks`: the prefetch worker may write this writer
     /// while the foreground reads the self-populated blocks of the same writer.
     mutable std::mutex state_mutex;

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -6,6 +6,8 @@
 #include <Common/logger_useful.h>
 #include <Common/VectorWithMemoryTracking.h>
 
+#include <mutex>
+
 namespace DB
 {
 
@@ -41,45 +43,50 @@ private:
     PageCache::MappedPtr cell;  /// the block's cell, kept alive by the shared_ptr
 };
 
-/// `CacheWriter` for one miss range. `write` creates each block's cell on demand
-/// (`PageCache::getOrSet`, first-writer-wins) and adopts it into `blocks`, which also lets the writer
-/// serve `read` for the blocks it populated.
+/// `CacheWriter` for one whole miss block, all-or-nothing. `write` creates the block's cell on demand
+/// (`PageCache::getOrSet`, first-writer-wins) and adopts it; the writer then serves `read` for it. The
+/// block is either committed (`cell` set) or not, so there is no committed-range set.
 class PageCacheWriter : public CacheWriter
 {
 public:
     PageCacheWriter(
         PageCachePtr cache_,
         PageCacheFile file_,
-        size_t block_size_,
-        size_t file_size_in_bytes_,
         bool inject_eviction_,
         bool bypass_if_missing_,
-        ByteRange aligned_range_in_file);
+        ByteRange block_range);
 
     ByteRange range() const override { return range_member; }
-    IntervalSet committed() const override { return committed_ranges; }
+    IntervalSet committed() const override
+    {
+        std::lock_guard lock(committed_mutex);
+        IntervalSet c;
+        if (cell)
+            c.add(range_member);
+        return c;
+    }
     size_t write(ChainedBuffers data, const Claim & claim) override;
     ChainedBuffers read(ByteRange sub) override;
-    /// Re-probe the cache: a block may have been populated by a concurrent query since `resolve`. Any
-    /// resident prefix is adopted and reported as `available` (already committed, served from cache),
-    /// so the executor does not re-read it from the source.
+    /// Re-probe the cache: the block may have been populated by a concurrent query since `resolve`. If
+    /// so, adopt its cell and report the whole block as `available` (already committed, served from
+    /// cache) with no claim; otherwise hold the claim to fill it.
     Lead claimLeadRole(ByteRange range) override;
 
 private:
     PageCachePtr cache;
     PageCacheFile file;
-    size_t block_size;
-    size_t file_size_in_bytes;
     bool inject_eviction;
     /// Mirrors `read_from_page_cache_if_exists_otherwise_bypass_cache`: a
     /// bypass tier populates nothing, so `write` returns 0 before any `getOrSet`.
     bool bypass_if_missing;
-    ByteRange range_member;
-    IntervalSet committed_ranges;
-    /// The whole-block cells this writer populated or adopted, in file order (same layout as the
-    /// reader's `cell`: each carries its own `cell->range` and size). One writer is driven by a single
-    /// thread, so no lock is needed.
-    VectorWithMemoryTracking<PageCache::MappedPtr> blocks;
+    ByteRange range_member;  /// the one block this writer covers
+    /// The block's cell once populated (by us) or adopted (a concurrent first-writer); null = not
+    /// committed.
+    PageCache::MappedPtr cell;
+    /// Guards `cell`. Per the `CacheWriter::committed` contract - and like the disk cache's
+    /// `committed_mutex` - a background prefetch and the foreground read may fill and read this writer
+    /// at the same time.
+    mutable std::mutex committed_mutex;
     LoggerPtr log = getLogger("PageCacheWriter");
 };
 

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -122,7 +122,7 @@ public:
 private:
     PageCachePtr cache;
     PageCacheFile file;
-    size_t block_size;
+    const size_t block_size;
     bool inject_eviction;
     bool bypass_if_missing;
     size_t file_size_in_bytes;

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -29,21 +29,18 @@ private:
 
 /// ── Per-range buffer API (see `ICacheProvider.h`) ──
 
-/// `CacheReader` for one hit range: it holds the whole-block cells covering the range and serves
-/// `read` as zero-copy views into them.
+/// `CacheReader` for one cached block: it holds the block's cell and serves `read` as a zero-copy view.
 class PageCacheReader : public CacheReader
 {
 public:
-    PageCacheReader(ByteRange range_in_file, VectorWithMemoryTracking<PageCache::MappedPtr> cells_);
+    PageCacheReader(ByteRange range_in_file, PageCache::MappedPtr cell_);
 
     ByteRange range() const override { return range_member; }
     ChainedBuffers read(ByteRange sub) override;
 
 private:
     ByteRange range_member;
-    /// The whole-block cells covering this range, in file order (kept alive by the shared_ptr). Each
-    /// cell carries its own file range (`cell->range`) and size, so no separate bookkeeping is needed.
-    VectorWithMemoryTracking<PageCache::MappedPtr> cells;
+    PageCache::MappedPtr cell;  /// the block's cell, kept alive by the shared_ptr
 };
 
 /// `CacheWriter` for one miss range. `write` creates each block's cell on demand

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -72,6 +72,10 @@ public:
     }
     size_t write(ChainedBuffers data, const Claim & claim) override;
     ChainedBuffers read(ByteRange sub) override;
+    /// Re-probe the cache: a block may have been populated by a concurrent query since `resolve`. Any
+    /// resident prefix is adopted and reported as `available` (already committed, served from cache),
+    /// so the executor does not re-read it from the source.
+    Lead claimLeadRole(ByteRange range) override;
 
 private:
     PageCachePtr cache;

--- a/src/IO/PageCacheProvider.h
+++ b/src/IO/PageCacheProvider.h
@@ -3,7 +3,6 @@
 #include <IO/ICacheProvider.h>
 #include <IO/IntervalSet.h>
 #include <Common/PageCache.h>
-#include <Common/logger_useful.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 #include <mutex>
@@ -87,7 +86,6 @@ private:
     /// `committed_mutex` - a background prefetch and the foreground read may fill and read this writer
     /// at the same time.
     mutable std::mutex committed_mutex;
-    LoggerPtr log = getLogger("PageCacheWriter");
 };
 
 /// `ICacheProvider` wrapping PageCache. PageCache is FILE-level (one logical
@@ -128,7 +126,6 @@ private:
     bool inject_eviction;
     bool bypass_if_missing;
     size_t file_size_in_bytes;
-    LoggerPtr log = getLogger("PageCacheProvider");
 };
 
 }

--- a/src/IO/ReadPipeline.cpp
+++ b/src/IO/ReadPipeline.cpp
@@ -14,6 +14,7 @@
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReaderExecutor.h>
 #include <IO/DiskCacheProvider.h>
+#include <IO/PageCacheProvider.h>
 #include <IO/PipelineReadBuffer.h>
 #include <IO/LocalSourceReader.h>
 #include <IO/ObjectStorageSourceReader.h>
@@ -204,14 +205,14 @@ std::unique_ptr<ReadBufferFromFileBase> ReadPipeline::tryBuildReaderExecutor() c
     if (!settings.reader_executor.enabled)
         return nullptr;
 
-    /// The executor implements neither async prefetch, the distributed cache, nor the page cache,
-    /// so fall back rather than silently drop those stages. Decryption and the filesystem cache ARE
-    /// supported (fed below).
-    if (distributed_cache || memory_cache || async_prefetch)
+    /// The executor implements neither async prefetch nor the distributed cache, so fall back rather
+    /// than silently drop those stages. Decryption, the filesystem cache, and the page (memory) cache
+    /// ARE supported (fed below).
+    if (distributed_cache || async_prefetch)
     {
         LOG_DEBUG(log,
             "use_reader_executor: falling back to the legacy read path "
-            "(distributed cache, page cache, or async prefetch not supported by the executor)");
+            "(distributed cache or async prefetch not supported by the executor)");
         return nullptr;
     }
 
@@ -253,6 +254,39 @@ std::unique_ptr<ReadBufferFromFileBase> ReadPipeline::tryBuildReaderExecutor() c
         LOG_DEBUG(log,
             "use_reader_executor: falling back to the legacy read path (source kind not supported by the executor)");
         return nullptr;
+    }
+
+    /// PageCache (memory) goes first in the chain (fastest). It's file-level: one `PageCacheFile`
+    /// derived from the front object serves every lookup. Skipped when any object has unknown size —
+    /// cells are sized to the file's real byte length (so the tail block has no past-EOF region),
+    /// which needs the total size up front. Object storage with an unknown-size object already fell
+    /// back above; this guard also covers any future unknown-size source.
+    bool any_unknown_size = false;
+    size_t total_file_size = 0;
+    for (const auto & object : source->objects)
+    {
+        if (object.bytes_size == StoredObject::UnknownSize)
+        {
+            any_unknown_size = true;
+            break;
+        }
+        total_file_size += object.bytes_size;
+    }
+
+    if (memory_cache && memory_cache->page_cache_settings.cache && !any_unknown_size)
+    {
+        const auto & pcs = memory_cache->page_cache_settings;
+        PageCacheFile cache_file;
+        cache_file.path = memory_cache->custom_cache_path.value_or(
+            memory_cache->cache_path_prefix + source->objects.front().remote_path);
+        cache_file.file_version = memory_cache->custom_file_version.value_or("");
+        cache_chain.push_back(std::make_shared<PageCacheProvider>(
+            pcs.cache,
+            std::move(cache_file),
+            pcs.block_size,
+            pcs.random_eviction_for_tests,
+            pcs.read_if_exists_otherwise_bypass,
+            total_file_size));
     }
 
     /// Cache chain of the filesystem cache(s). `filesystem_caches` is inner-to-outer; the executor

--- a/src/IO/ReadPipeline.cpp
+++ b/src/IO/ReadPipeline.cpp
@@ -275,17 +275,17 @@ std::unique_ptr<ReadBufferFromFileBase> ReadPipeline::tryBuildReaderExecutor() c
 
     if (memory_cache && memory_cache->page_cache_settings.cache && !any_unknown_size)
     {
-        const auto & pcs = memory_cache->page_cache_settings;
+        const auto & page_cache_settings = memory_cache->page_cache_settings;
         PageCacheFile cache_file;
         cache_file.path = memory_cache->custom_cache_path.value_or(
             memory_cache->cache_path_prefix + source->objects.front().remote_path);
         cache_file.file_version = memory_cache->custom_file_version.value_or("");
         cache_chain.push_back(std::make_shared<PageCacheProvider>(
-            pcs.cache,
+            page_cache_settings.cache,
             std::move(cache_file),
-            pcs.block_size,
-            pcs.random_eviction_for_tests,
-            pcs.read_if_exists_otherwise_bypass,
+            page_cache_settings.block_size,
+            page_cache_settings.random_eviction_for_tests,
+            page_cache_settings.read_if_exists_otherwise_bypass,
             total_file_size));
     }
 

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -405,8 +405,7 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
 
     /// Every tier missed. Claim the lead role of each writing tier BEFORE the fetch. A held claim keeps
     /// the downloader role open across the fetch+write, so concurrent executors dedup to one download.
-    /// `claimLeadRole` also reports any prefix that became committed since `resolve` (a concurrent query
-    /// populated it) as `available`; we serve that from cache below instead of re-reading it.
+    /// `claimLeadRole` also reports any prefix cached since `resolve` as `available` (served below).
     bool any_writer = false;
     for (auto & miss_tier : miss_tiers)
     {
@@ -418,11 +417,9 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
         any_writer = true;
     }
 
-    /// A tier's block(s) may have become resident between `resolve` and the claim above (a concurrent
-    /// query populated them). `claimLeadRole` reports that committed prefix as `available`; serve it
-    /// straight from that writer's cells - no source read - from the fastest tier that covers
-    /// `window_offset`. Tiers using the trivial default report an empty `available`, so this is a no-op
-    /// for them. Held claims on the other tiers release when `miss_tiers` is destroyed on return.
+    /// A prefix cached since `resolve` is reported as `available`; serve it from that writer's cells,
+    /// no source read, taking the fastest tier that covers `window_offset`. Empty `available` (the
+    /// default) is a no-op. Held claims on other tiers release when `miss_tiers` is destroyed on return.
     for (const auto & miss_tier : miss_tiers)
     {
         const ByteRange avail = miss_tier.available;

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -383,7 +383,7 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
 
     /// A populating miss carries its own open writer; a bypass tier's miss is writer-less. `claim` is
     /// filled by the claim loop below (empty for a bypass tier or a tail a concurrent downloader leads).
-    struct MissTier { CacheWriterPtr writer; ByteRange range; CacheWriter::Claim claim; ByteRange available{}; };
+    struct MissTier { CacheWriterPtr writer; ByteRange range; CacheWriter::Claim claim; };
     VectorWithMemoryTracking<MissTier> miss_tiers;
     for (auto & cache : cache_chain)
     {
@@ -407,28 +407,20 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
         }
     }
 
-    /// Every tier missed. Claim the lead role of each writing tier BEFORE the fetch. A held claim keeps
-    /// the downloader role open across the fetch+write, so concurrent executors dedup to one download.
-    /// `claimLeadRole` also reports any prefix cached since `resolve` as `available` (served below).
+    /// Every tier missed: claim each writing tier's lead role before the fetch (a held claim dedups the
+    /// download). If `claimLeadRole` reports a prefix cached since `resolve` covering the head, serve it
+    /// from that tier - no source read; otherwise keep the claim for the fetch.
     bool any_writer = false;
     for (auto & miss_tier : miss_tiers)
     {
         if (!miss_tier.writer)
             continue;  /// a bypass tier populates nothing
-        auto lead = miss_tier.writer->claimLeadRole(miss_tier.range);
-        miss_tier.available = lead.available;
-        miss_tier.claim = std::move(lead.claim);
         any_writer = true;
-    }
-
-    /// A prefix cached since `resolve` is reported as `available`; serve it from that writer's cells,
-    /// no source read, taking the fastest tier that covers `window_offset`. Empty `available` (the
-    /// default) is a no-op. Held claims on other tiers release when `miss_tiers` is destroyed on return.
-    for (const auto & miss_tier : miss_tiers)
-    {
-        const ByteRange avail = miss_tier.available;
-        if (miss_tier.writer && avail.size && avail.offset <= window_offset && window_offset < avail.end())
+        auto lead = miss_tier.writer->claimLeadRole(miss_tier.range);
+        const ByteRange avail = lead.available;
+        if (avail.size && avail.offset <= window_offset && window_offset < avail.end())
             return miss_tier.writer->read(ByteRange{window_offset, serve_len(std::min(avail.end(), miss_tier.range.end()))});
+        miss_tier.claim = std::move(lead.claim);
     }
 
     /// A range another thread is already downloading is fetched through below (its `write` lands 0).

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -385,6 +385,7 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
     /// filled by the claim loop below (empty for a bypass tier or a tail a concurrent downloader leads).
     struct MissTier { CacheWriterPtr writer; ByteRange range; CacheWriter::Claim claim; };
     VectorWithMemoryTracking<MissTier> miss_tiers;
+    size_t next_resident = window_offset + max_serve;  /// nearest block any tier already has, ahead of the head
     for (auto & cache : cache_chain)
     {
         stats.add(Stats::CacheGetRequests);
@@ -401,6 +402,7 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
             {
                 if (resolution.range.offset <= window_offset && resolution.reader)
                     return resolution.reader->read(ByteRange{window_offset, serve_len(resolution.range.end())});
+                next_resident = std::min(next_resident, resolution.range.offset);  /// a resident block ahead
                 break;
             }
             miss_tiers.push_back(MissTier{std::move(resolution.writer), resolution.range, {}});
@@ -437,10 +439,10 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
         return readSource(window_offset, miss_end - window_offset);
     }
 
-    /// Fetch the whole writer ranges (across the objects they span), populate each, serve one block.
-    /// Coarse by design: with stacked filesystem caches a slower tier may already hold part of this
-    /// range, which is re-fetched from source here rather than promoted up. The thin executor does not
-    /// subtract slower-tier hits. The following development can improve this.
+    /// Fetch the writer ranges in one source read (across the objects they span) and populate each.
+    /// Capped at `next_resident` - the nearest block a slower tier already holds - so a gathered miss run
+    /// never re-reads a suffix the filesystem cache already has; that suffix is served from the slower
+    /// tier on the next window.
     size_t fetch_lo = window_offset;
     size_t fetch_hi = window_offset;
     for (const auto & miss_tier : miss_tiers)
@@ -451,6 +453,7 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
         fetch_hi = std::max(fetch_hi, miss_tier.range.end());
     }
     fetch_hi = std::min<size_t>(fetch_hi, offset_map.totalSize());
+    fetch_hi = std::min(fetch_hi, next_resident);  /// do not re-read a block a slower tier already has
 
     ChainedBuffers fetched = readSource(fetch_lo, fetch_hi - fetch_lo);
     const size_t fetched_end = fetched.empty() ? fetch_lo : fetched.range().end();

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -388,18 +388,22 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
     for (auto & cache : cache_chain)
     {
         stats.add(Stats::CacheGetRequests);
-        /// `resolve` returns the window's residency in offset order; the first run reaching past
-        /// `window_offset` is the one covering it (coverage is contiguous from the ask start).
+        /// `resolve` returns the window's residency in offset order, coverage contiguous from the ask
+        /// start. The run covering `window_offset` decides the tier: a hit there serves the block from
+        /// cache. A miss is recorded, and we keep gathering the contiguous miss run behind it so the
+        /// fetch below reads the whole uncached extent in one source request; a later hit ends the run.
         auto resolutions = cache->resolve(object, object_offset, ByteRange{window_offset, max_serve});
         for (auto & resolution : resolutions)
         {
             if (resolution.range.end() <= window_offset)
                 continue;
-            if (resolution.kind == ICacheProvider::CacheResolution::Kind::Hit && resolution.reader)
-                return resolution.reader->read(ByteRange{window_offset, serve_len(resolution.range.end())});
-            if (resolution.kind == ICacheProvider::CacheResolution::Kind::Miss)
-                miss_tiers.push_back(MissTier{std::move(resolution.writer), resolution.range, {}});
-            break;
+            if (resolution.kind == ICacheProvider::CacheResolution::Kind::Hit)
+            {
+                if (resolution.range.offset <= window_offset && resolution.reader)
+                    return resolution.reader->read(ByteRange{window_offset, serve_len(resolution.range.end())});
+                break;
+            }
+            miss_tiers.push_back(MissTier{std::move(resolution.writer), resolution.range, {}});
         }
     }
 

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -383,7 +383,7 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
 
     /// A populating miss carries its own open writer; a bypass tier's miss is writer-less. `claim` is
     /// filled by the claim loop below (empty for a bypass tier or a tail a concurrent downloader leads).
-    struct MissTier { CacheWriterPtr writer; ByteRange range; CacheWriter::Claim claim; };
+    struct MissTier { CacheWriterPtr writer; ByteRange range; CacheWriter::Claim claim; ByteRange available{}; };
     VectorWithMemoryTracking<MissTier> miss_tiers;
     for (auto & cache : cache_chain)
     {
@@ -405,15 +405,29 @@ ChainedBuffers ReaderExecutor::readThroughCaches(size_t window_offset, size_t ma
 
     /// Every tier missed. Claim the lead role of each writing tier BEFORE the fetch. A held claim keeps
     /// the downloader role open across the fetch+write, so concurrent executors dedup to one download.
-    /// The `available` prefix is unused here (the thin executor fetches the whole range coarsely).
+    /// `claimLeadRole` also reports any prefix that became committed since `resolve` (a concurrent query
+    /// populated it) as `available`; we serve that from cache below instead of re-reading it.
     bool any_writer = false;
     for (auto & miss_tier : miss_tiers)
     {
         if (!miss_tier.writer)
             continue;  /// a bypass tier populates nothing
         auto lead = miss_tier.writer->claimLeadRole(miss_tier.range);
+        miss_tier.available = lead.available;
         miss_tier.claim = std::move(lead.claim);
         any_writer = true;
+    }
+
+    /// A tier's block(s) may have become resident between `resolve` and the claim above (a concurrent
+    /// query populated them). `claimLeadRole` reports that committed prefix as `available`; serve it
+    /// straight from that writer's cells - no source read - from the fastest tier that covers
+    /// `window_offset`. Tiers using the trivial default report an empty `available`, so this is a no-op
+    /// for them. Held claims on the other tiers release when `miss_tiers` is destroyed on return.
+    for (const auto & miss_tier : miss_tiers)
+    {
+        const ByteRange avail = miss_tier.available;
+        if (miss_tier.writer && avail.size && avail.offset <= window_offset && window_offset < avail.end())
+            return miss_tier.writer->read(ByteRange{window_offset, serve_len(std::min(avail.end(), miss_tier.range.end()))});
     }
 
     /// A range another thread is already downloading is fetched through below (its `write` lands 0).

--- a/src/IO/tests/gtest_page_cache_buffers.cpp
+++ b/src/IO/tests/gtest_page_cache_buffers.cpp
@@ -1,0 +1,470 @@
+#include <IO/PageCacheProvider.h>
+#include <IO/ChainedBuffers.h>
+#include <Common/PageCache.h>
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace DB;
+
+namespace
+{
+
+/// Test-local twins of the executor's residency-walk collectors. The real
+/// `ResidencyIterator` / `probeView` land with the executor cache-chain in a
+/// later PR; here `probeView` just buckets a provider's `resolve` output into
+/// hits and misses (the provider itself coalesces contiguous cached blocks).
+struct HitEntry { ByteRange range; CacheReaderPtr reader; };
+struct MissEntry { ByteRange range; CacheWriterPtr writer; };
+
+class CacheView
+{
+public:
+    const std::vector<HitEntry> & hits() const { return hit_entries; }
+    const std::vector<MissEntry> & misses() const { return miss_entries; }
+    std::vector<HitEntry> hit_entries;
+    std::vector<MissEntry> miss_entries;
+};
+using CacheViewPtr = std::unique_ptr<CacheView>;
+
+/// Read-only one-shot: bucket the provider's ranged `resolve` output (hits with
+/// readers, misses with writers when it populates) into a view for assertions.
+CacheViewPtr probeView(
+    ICacheProvider & provider, const StoredObject & object, size_t object_file_offset, ByteRange span)
+{
+    auto view = std::make_unique<CacheView>();
+    for (auto & r : provider.resolve(object, object_file_offset, span))
+    {
+        if (r.kind == ICacheProvider::CacheResolution::Kind::Hit)
+            view->hit_entries.push_back(HitEntry{r.range, std::move(r.reader)});
+        else if (r.kind == ICacheProvider::CacheResolution::Kind::Miss)
+            view->miss_entries.push_back(MissEntry{r.range, std::move(r.writer)});
+    }
+    return view;
+}
+
+/// Test twin of the plan's open step: resolve each cell and collect its miss
+/// resolutions - the provider attaches a writer to each (one per cache block
+/// the cell spans). Any resident prefix comes back as a hit, not a miss.
+CacheViewPtr openWriters(ICacheProvider & provider, const StoredObject & object,
+                         size_t object_file_offset, std::vector<ByteRange> cells)
+{
+    auto view = std::make_unique<CacheView>();
+    for (auto c : cells)
+        for (auto & r : provider.resolve(object, object_file_offset, c))
+            if (r.kind == ICacheProvider::CacheResolution::Kind::Miss)
+                view->miss_entries.push_back(MissEntry{r.range, std::move(r.writer)});
+    return view;
+}
+
+/// `min_size_in_bytes` is the initial per-shard capacity. Tests don't call
+/// `autoResize`, so set it equal to `max_size_in_bytes` so the shard can store
+/// entries from the get-go.
+PageCachePtr makeCache(size_t capacity = (1ull << 20))
+{
+    return std::make_shared<PageCache>(
+        std::chrono::milliseconds(2000), "LRU", 0.5,
+        /*min_size_in_bytes=*/capacity,
+        /*max_size_in_bytes=*/capacity,
+        /*free_memory_ratio=*/0.0,
+        /*num_shards=*/1);
+}
+
+PageCacheFile makeFile(const std::string & path)
+{
+    PageCacheFile file;
+    file.path = path;
+    file.file_version = "v1";
+    return file;
+}
+
+/// Build a single-node ChainedBuffers of `size` bytes filled with `fill`, logically at
+/// `[offset, offset + size)`.
+ChainedBuffers makeChain(size_t offset, size_t size, char fill)
+{
+    ChainedBuffers chain;
+    auto buf = std::make_shared<OwnedChainedBuffer>(size);
+    std::memset(buf->data(), fill, size);
+    chain.append(ChainedBufferNode{buf, 0, size, offset});
+    return chain;
+}
+
+/// Claim the writer's range then write - the page cache has no downloader role, so its default
+/// claim always authorizes; mirrors how the executor drives a write under a held claim.
+size_t claimedWrite(CacheWriter & writer, ChainedBuffers chain)
+{
+    auto lead = writer.claimLeadRole(writer.range());
+    if (!lead.claim)
+        return 0;
+    return writer.write(std::move(chain), lead.claim);
+}
+
+/// Flatten `chain`'s coverage of `[offset, offset + size)` into a std::string,
+/// asserting full coverage first.
+std::string flatten(const ChainedBuffers & chain, size_t offset, size_t size)
+{
+    EXPECT_TRUE(chain.covers(ByteRange{offset, size}));
+    std::string out(size, '\0');
+    chain.copyTo(out.data(), ByteRange{offset, size});
+    return out;
+}
+
+}
+
+/// (a) openWriter over a miss range, write a whole block => complete() true,
+/// committed() spans the range, probeView afterward reports a hit, and
+/// read() round-trips the bytes.
+TEST(PageCacheBuffers, WriteWholeBlockThenHit)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-write-whole-block");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    /// One openWriter over the aligned miss block.
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    ASSERT_EQ(misses.size(), 1u);
+    ASSERT_NE(misses[0].writer, nullptr);
+    auto & writer = *misses[0].writer;
+
+    EXPECT_FALSE(writer.complete());
+
+    size_t wrote = claimedWrite(writer, makeChain(0, block_size, 'A'));
+    EXPECT_EQ(wrote, block_size) << "the whole block newly landed";
+    EXPECT_TRUE(writer.complete());
+
+    /// committed() spans the whole range.
+    EXPECT_TRUE(writer.committed().subtract(ByteRange{0, block_size}).empty());
+
+    /// probeView now reports the block as a hit (cell registered).
+    auto view = probeView(provider, StoredObject{}, 0, ByteRange{0, block_size});
+    ASSERT_EQ(view->hits().size(), 1u);
+    ASSERT_EQ(view->misses().size(), 0u);
+    EXPECT_EQ(view->hits()[0].range.offset, 0u);
+    EXPECT_EQ(view->hits()[0].range.size, block_size);
+
+    /// The hit read buffer round-trips the written bytes.
+    auto chain = view->hits()[0].reader->read(ByteRange{0, block_size});
+    EXPECT_EQ(flatten(chain, 0, block_size), std::string(block_size, 'A'));
+}
+
+/// (b) The write buffer doubles as a read buffer: after write(), writer.read(sub)
+/// returns the written bytes.
+TEST(PageCacheBuffers, WriteBufferDoublesAsReadBuffer)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-write-doubles-read");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    ASSERT_EQ(misses.size(), 1u);
+    auto & writer = *misses[0].writer;
+
+    claimedWrite(writer, makeChain(0, block_size, 'Z'));
+
+    /// Whole-block read back.
+    auto whole = writer.read(ByteRange{0, block_size});
+    EXPECT_EQ(flatten(whole, 0, block_size), std::string(block_size, 'Z'));
+
+    /// Sub-range read back (zero-copy slice of the same cell).
+    auto sub = writer.read(ByteRange{1000, 100});
+    EXPECT_EQ(flatten(sub, 1000, 100), std::string(100, 'Z'));
+}
+
+/// (c) EOF tail block: a file whose size is not a block multiple => the tail block
+/// is short; write the tail, probeView reports it as a hit of the short
+/// size, read returns exactly the valid bytes (no past-EOF bytes).
+TEST(PageCacheBuffers, EofTailBlockShort)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-eof-tail");
+    constexpr size_t block_size = 1024;
+    constexpr size_t file_size = 1500;  /// tail block = 476 bytes
+    constexpr size_t tail_off = 1024;
+    constexpr size_t tail_size = file_size - tail_off;  /// 476
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, file_size);
+
+    /// The aligned miss range for the tail is clamped to the file's real length.
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{tail_off, tail_size}}); const auto & misses = view_misses->misses();
+    ASSERT_EQ(misses.size(), 1u);
+    auto & writer = *misses[0].writer;
+    EXPECT_EQ(writer.range().size, tail_size);
+
+    size_t wrote = claimedWrite(writer, makeChain(tail_off, tail_size, 'T'));
+    EXPECT_EQ(wrote, tail_size);
+    EXPECT_TRUE(writer.complete());
+
+    /// probeView reports the tail as a hit of the SHORT size.
+    auto view = probeView(provider, StoredObject{}, 0, ByteRange{tail_off, block_size});
+    ASSERT_EQ(view->hits().size(), 1u);
+    EXPECT_EQ(view->hits()[0].range.offset, tail_off);
+    EXPECT_EQ(view->hits()[0].range.size, tail_size) << "tail hit sized to valid bytes, not full block";
+
+    /// A read asking for a full block returns only the 476 valid bytes — the cell
+    /// physically has no more (no past-EOF region).
+    auto chain = view->hits()[0].reader->read(ByteRange{tail_off, block_size});
+    EXPECT_EQ(chain.totalBytes(), tail_size);
+    EXPECT_EQ(flatten(chain, tail_off, tail_size), std::string(tail_size, 'T'));
+}
+
+/// (d) bypass: a provider with bypass_if_missing=true => openWriter returns
+/// nullptr; `lookAt` misses carry writer == nullptr; a direct write on a
+/// bypass write buffer returns 0 and creates no registered cell.
+TEST(PageCacheBuffers, BypassOpensNoWritersAndPopulatesNothing)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-bypass");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider bypass_provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/true, /*file_size_in_bytes=*/block_size);
+
+    /// The bypass upgrade is a no-op: the miss cell remains, the writer stays null.
+    auto view_misses = openWriters(bypass_provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    ASSERT_EQ(misses.size(), 1u);
+    EXPECT_EQ(misses[0].writer, nullptr);
+
+    /// `lookAt` misses carry writer == nullptr (it never opens writers).
+    auto view = probeView(bypass_provider, StoredObject{}, 0, ByteRange{0, block_size});
+    ASSERT_EQ(view->misses().size(), 1u);
+    EXPECT_EQ(view->misses()[0].writer, nullptr);
+
+    /// A direct write on a bypass write buffer returns 0 and registers no cell.
+    {
+        PageCacheWriter writer(
+            cache, file, block_size, /*file_size_in_bytes=*/block_size,
+            /*inject_eviction=*/false, /*bypass_if_missing=*/true, ByteRange{0, block_size});
+        size_t wrote = claimedWrite(writer, makeChain(0, block_size, 'X'));
+        EXPECT_EQ(wrote, 0u);
+        EXPECT_FALSE(writer.complete()) << "bypass write commits nothing";
+    }
+
+    /// A non-bypass provider on the same file still misses — nothing was registered.
+    PageCacheProvider observer(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+    auto observed = probeView(observer, StoredObject{}, 0, ByteRange{0, block_size});
+    ASSERT_EQ(observed->hits().size(), 0u);
+    ASSERT_EQ(observed->misses().size(), 1u);
+}
+
+/// (e) the residency probe (`lookAt`) is READ-ONLY: over an uncached range it creates no cells
+/// (a subsequent probe still reports misses).
+TEST(PageCacheBuffers, ProbeIsReadOnly)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-plan-readonly");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    auto view1 = probeView(provider, StoredObject{}, 0, ByteRange{0, block_size});
+    ASSERT_EQ(view1->hits().size(), 0u);
+    ASSERT_EQ(view1->misses().size(), 1u);
+    view1.reset();
+
+    /// A second probe still misses — the first probe created no cell.
+    auto view2 = probeView(provider, StoredObject{}, 0, ByteRange{0, block_size});
+    EXPECT_EQ(view2->hits().size(), 0u);
+    ASSERT_EQ(view2->misses().size(), 1u);
+}
+
+/// (f) first-writer-wins: pre-populate a block via one write buffer, then a second
+/// write buffer write() over the same block returns 0 newly-loaded but marks
+/// committed() (and read returns the first writer's bytes).
+TEST(PageCacheBuffers, FirstWriterWins)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-first-writer-wins");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    /// Open TWO writers over the still-uncached block: page `resolve` uses
+    /// `cache->get`, so it creates no cell - both see a miss until a write lands.
+    auto view_first = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & first = view_first->misses();
+    ASSERT_EQ(first.size(), 1u);
+    auto view_second = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & second = view_second->misses();
+    ASSERT_EQ(second.size(), 1u);
+
+    /// First writer populates the block with 'F'.
+    EXPECT_EQ(claimedWrite(*first[0].writer, makeChain(0, block_size, 'F')), block_size);
+
+    /// Second writer tries 'S' over the same block: it loses the race.
+    auto & writer = *second[0].writer;
+    size_t wrote = claimedWrite(writer, makeChain(0, block_size, 'S'));
+    EXPECT_EQ(wrote, 0u) << "lost the first-writer-wins race: nothing newly landed";
+    EXPECT_TRUE(writer.complete()) << "the byte IS cached (by the first writer), so committed must advance";
+    EXPECT_TRUE(writer.committed().subtract(ByteRange{0, block_size}).empty());
+
+    /// read returns the FIRST writer's bytes (the adopted existing cell).
+    auto chain = writer.read(ByteRange{0, block_size});
+    EXPECT_EQ(flatten(chain, 0, block_size), std::string(block_size, 'F'));
+}
+
+/// (g) multi-block write + read-back per block: a range spanning >= 2 blocks, one
+/// openWriter, write all, complete() true, each block round-trips (mirrors
+/// DiskCache's WriteAcrossTwoSegments).
+TEST(PageCacheBuffers, WriteAcrossTwoBlocks)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-two-blocks");
+    constexpr size_t block_size = 4096;
+    constexpr size_t file_size = 3 * block_size;
+    /// Span the first two blocks: [0, 8192).
+    constexpr size_t span = 2 * block_size;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, file_size);
+
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, span}}); const auto & misses = view_misses->misses();
+    ASSERT_EQ(misses.size(), 2u);
+    auto & w0 = *misses[0].writer;
+    auto & w1 = *misses[1].writer;
+    /// One writer per block (the page grid is one block per cell).
+    EXPECT_EQ(w0.range().offset, 0u);
+    EXPECT_EQ(w0.range().size, block_size);
+    EXPECT_EQ(w1.range().offset, block_size);
+    EXPECT_EQ(w1.range().size, block_size);
+
+    /// Fill block 0 with '0', block 1 with '1'; each whole block lands.
+    EXPECT_EQ(claimedWrite(w0, makeChain(0, block_size, '0')), block_size);
+    EXPECT_TRUE(w0.complete());
+    EXPECT_EQ(claimedWrite(w1, makeChain(block_size, block_size, '1')), block_size);
+    EXPECT_TRUE(w1.complete());
+
+    /// probeView coalesces the two adjacent hit blocks into one HitEntry.
+    auto view = probeView(provider, StoredObject{}, 0, ByteRange{0, span});
+    ASSERT_EQ(view->hits().size(), 1u) << "adjacent hit blocks coalesce into one HitEntry";
+    EXPECT_EQ(view->hits()[0].range.offset, 0u);
+    EXPECT_EQ(view->hits()[0].range.size, span);
+    ASSERT_EQ(view->misses().size(), 0u);
+
+    /// Each block round-trips through the coalesced hit reader.
+    auto & reader = *view->hits()[0].reader;
+    auto rope0 = reader.read(ByteRange{0, block_size});
+    EXPECT_EQ(flatten(rope0, 0, block_size), std::string(block_size, '0'));
+    auto rope1 = reader.read(ByteRange{block_size, block_size});
+    EXPECT_EQ(flatten(rope1, block_size, block_size), std::string(block_size, '1'));
+}
+
+/// (h) partial-block write is skipped: write() over a block the data does not fully
+/// cover takes the `if (!data.covers(block_range)) continue;` skip — nothing newly
+/// lands, complete() stays false, committed() is empty, and no cell is registered.
+TEST(PageCacheBuffers, PartialBlockWriteIsSkipped)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-partial-block-skipped");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    ASSERT_EQ(misses.size(), 1u);
+    auto & writer = *misses[0].writer;
+
+    /// Data covers only the first half of the block — the whole block is not covered.
+    size_t wrote = claimedWrite(writer, makeChain(0, block_size / 2, 'P'));
+    EXPECT_EQ(wrote, 0u) << "a partially-covered block is left for a later write";
+    EXPECT_FALSE(writer.complete());
+    auto uncommitted = writer.committed().subtract(ByteRange{0, block_size});
+    ASSERT_EQ(uncommitted.size(), 1u);
+    EXPECT_EQ(uncommitted[0].size, block_size) << "the whole range is still uncommitted";
+
+    /// No partial cell was registered: a subsequent probe still misses.
+    auto view = probeView(provider, StoredObject{}, 0, ByteRange{0, block_size});
+    EXPECT_TRUE(view->hits().empty());
+    ASSERT_EQ(view->misses().size(), 1u);
+}
+
+/// (i) hit/miss interleaving: a 3-block file with ONLY the middle block resident
+/// drives the probe's kind-flip coalescing (miss → hit → miss), which the all-hit
+/// and all-miss tests never exercise.
+TEST(PageCacheBuffers, HitMissInterleavedTiling)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-hit-miss-interleaved");
+    constexpr size_t block_size = 4096;
+    constexpr size_t file_size = 3 * block_size;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, file_size);
+
+    /// Populate ONLY the middle block (block 1), leaving blocks 0 and 2 cold.
+    {
+        auto view_middle = openWriters(provider, StoredObject{}, 0, {ByteRange{block_size, block_size}}); const auto & middle = view_middle->misses();
+        ASSERT_EQ(middle.size(), 1u);
+        size_t wrote = claimedWrite(*middle[0].writer, makeChain(block_size, block_size, 'M'));
+        EXPECT_EQ(wrote, block_size);
+    }
+
+    /// Probe the whole file: miss[0] → hit[1] → miss[2].
+    auto view = probeView(provider, StoredObject{}, 0, ByteRange{0, file_size});
+    ASSERT_EQ(view->hits().size(), 1u);
+    ASSERT_EQ(view->misses().size(), 2u);
+
+    EXPECT_EQ(view->hits()[0].range.offset, block_size);
+    EXPECT_EQ(view->hits()[0].range.size, block_size);
+
+    EXPECT_EQ(view->misses()[0].range.offset, 0u);
+    EXPECT_EQ(view->misses()[0].range.size, block_size);
+    EXPECT_EQ(view->misses()[1].range.offset, 2 * block_size);
+    EXPECT_EQ(view->misses()[1].range.size, block_size);
+
+    /// The middle hit reader round-trips the written bytes.
+    auto chain = view->hits()[0].reader->read(ByteRange{block_size, block_size});
+    EXPECT_EQ(flatten(chain, block_size, block_size), std::string(block_size, 'M'));
+}
+
+/// (j) first-writer-wins is keyed by the cache + file identity, not the provider
+/// instance: a SECOND provider over the SAME cache and file loses the race against
+/// an already-resident block and adopts the first writer's bytes.
+TEST(PageCacheBuffers, FirstWriterWinsAcrossProviders)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-first-writer-wins-cross-provider");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider provider1(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    /// A SECOND provider over the SAME cache and file produces the SAME cache key.
+    PageCacheProvider provider2(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    /// Open a writer through EACH provider over the still-uncached block (page
+    /// `resolve` creates no cell, so both see a miss until a write lands).
+    auto view_first = openWriters(provider1, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & first = view_first->misses();
+    ASSERT_EQ(first.size(), 1u);
+    auto view_second = openWriters(provider2, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & second = view_second->misses();
+    ASSERT_EQ(second.size(), 1u);
+
+    /// provider1 populates the block with 'F'.
+    EXPECT_EQ(claimedWrite(*first[0].writer, makeChain(0, block_size, 'F')), block_size);
+
+    /// provider2's writer tries 'S' over the same cache key: it loses the race.
+    auto & writer = *second[0].writer;
+    size_t wrote = claimedWrite(writer, makeChain(0, block_size, 'S'));
+    EXPECT_EQ(wrote, 0u) << "lost the cross-provider first-writer-wins race: nothing newly landed";
+    EXPECT_TRUE(writer.complete()) << "the byte IS cached (by provider1), so committed must advance";
+    EXPECT_TRUE(writer.committed().subtract(ByteRange{0, block_size}).empty());
+
+    /// read returns the FIRST provider's bytes (the adopted existing cell).
+    auto chain = writer.read(ByteRange{0, block_size});
+    EXPECT_EQ(flatten(chain, 0, block_size), std::string(block_size, 'F'));
+}

--- a/src/IO/tests/gtest_page_cache_buffers.cpp
+++ b/src/IO/tests/gtest_page_cache_buffers.cpp
@@ -352,18 +352,18 @@ TEST(PageCacheBuffers, WriteAcrossTwoBlocks)
     EXPECT_EQ(claimedWrite(w1, makeChain(block_size, block_size, '1')), block_size);
     EXPECT_TRUE(w1.complete());
 
-    /// probeView coalesces the two adjacent hit blocks into one HitEntry.
+    /// One resolution per block: each cached block is its own hit, read from its own reader.
     auto view = probeView(provider, StoredObject{}, 0, ByteRange{0, span});
-    ASSERT_EQ(view->hits().size(), 1u) << "adjacent hit blocks coalesce into one HitEntry";
-    EXPECT_EQ(view->hits()[0].range.offset, 0u);
-    EXPECT_EQ(view->hits()[0].range.size, span);
+    ASSERT_EQ(view->hits().size(), 2u) << "one hit per cached block";
     ASSERT_EQ(view->misses().size(), 0u);
+    EXPECT_EQ(view->hits()[0].range.offset, 0u);
+    EXPECT_EQ(view->hits()[0].range.size, block_size);
+    EXPECT_EQ(view->hits()[1].range.offset, block_size);
+    EXPECT_EQ(view->hits()[1].range.size, block_size);
 
-    /// Each block round-trips through the coalesced hit reader.
-    auto & reader = *view->hits()[0].reader;
-    auto rope0 = reader.read(ByteRange{0, block_size});
+    auto rope0 = view->hits()[0].reader->read(ByteRange{0, block_size});
     EXPECT_EQ(flatten(rope0, 0, block_size), std::string(block_size, '0'));
-    auto rope1 = reader.read(ByteRange{block_size, block_size});
+    auto rope1 = view->hits()[1].reader->read(ByteRange{block_size, block_size});
     EXPECT_EQ(flatten(rope1, block_size, block_size), std::string(block_size, '1'));
 }
 

--- a/src/IO/tests/gtest_page_cache_buffers.cpp
+++ b/src/IO/tests/gtest_page_cache_buffers.cpp
@@ -479,3 +479,40 @@ TEST(PageCacheBuffers, FirstWriterWinsAcrossProviders)
     auto chain = writer.read(ByteRange{0, block_size});
     EXPECT_EQ(flatten(chain, 0, block_size), std::string(block_size, 'F'));
 }
+
+/// (k) claimLeadRole re-probes the cache: a block populated by another writer between the openWriter
+/// (a read-only `resolve`) and the claim is adopted and reported as `available` with NO claim, so the
+/// caller serves it from cache instead of re-reading it from the source.
+TEST(PageCacheBuffers, ClaimLeadRoleAdoptsBlockCachedSinceResolve)
+{
+    auto cache = makeCache();
+    auto file = makeFile("buffers-claim-recheck");
+    constexpr size_t block_size = 4096;
+    PageCacheProvider provider(
+        cache, file, block_size, /*inject_eviction=*/false,
+        /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
+
+    /// Two writers over the still-uncached block (both saw a miss at resolve).
+    auto view_late = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & late = view_late->misses();
+    ASSERT_EQ(late.size(), 1u);
+    auto view_early = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & early = view_early->misses();
+    ASSERT_EQ(early.size(), 1u);
+
+    /// A concurrent writer populates the block with 'C'.
+    EXPECT_EQ(claimedWrite(*early[0].writer, makeChain(0, block_size, 'C')), block_size);
+
+    /// The late writer's claimLeadRole re-probes: the block is now resident, so it is reported as
+    /// available (the whole block) with no claim to fill.
+    auto & late_writer = *late[0].writer;
+    auto lead = late_writer.claimLeadRole(late_writer.range());
+    EXPECT_EQ(lead.available.offset, 0u);
+    EXPECT_EQ(lead.available.size, block_size);
+    EXPECT_FALSE(static_cast<bool>(lead.claim)) << "nothing left to fill: the block is already committed";
+    EXPECT_TRUE(late_writer.committed().subtract(ByteRange{0, block_size}).empty());
+
+    /// The late writer serves the concurrently-written bytes from cache (adopted its cell).
+    auto chain = late_writer.read(ByteRange{0, block_size});
+    EXPECT_EQ(flatten(chain, 0, block_size), std::string(block_size, 'C'));
+}

--- a/src/IO/tests/gtest_page_cache_buffers.cpp
+++ b/src/IO/tests/gtest_page_cache_buffers.cpp
@@ -247,8 +247,7 @@ TEST(PageCacheBuffers, BypassOpensNoWritersAndPopulatesNothing)
     /// A direct write on a bypass write buffer returns 0 and registers no cell.
     {
         PageCacheWriter writer(
-            cache, file, block_size, /*file_size_in_bytes=*/block_size,
-            /*inject_eviction=*/false, /*bypass_if_missing=*/true, ByteRange{0, block_size});
+            cache, file, /*inject_eviction=*/false, /*bypass_if_missing=*/true, ByteRange{0, block_size});
         size_t wrote = claimedWrite(writer, makeChain(0, block_size, 'X'));
         EXPECT_EQ(wrote, 0u);
         EXPECT_FALSE(writer.complete()) << "bypass write commits nothing";

--- a/src/IO/tests/gtest_page_cache_buffers.cpp
+++ b/src/IO/tests/gtest_page_cache_buffers.cpp
@@ -321,9 +321,8 @@ TEST(PageCacheBuffers, FirstWriterWins)
     EXPECT_EQ(flatten(chain, 0, block_size), std::string(block_size, 'F'));
 }
 
-/// (g) multi-block write + read-back per block: a range spanning >= 2 blocks, one
-/// openWriter, write all, complete() true, each block round-trips (mirrors
-/// DiskCache's WriteAcrossTwoSegments).
+/// (g) multi-block write + read-back per block: a range spanning >= 2 blocks resolves to one miss per
+/// block, write each, complete() true, each block round-trips (mirrors DiskCache's WriteAcrossTwoSegments).
 TEST(PageCacheBuffers, WriteAcrossTwoBlocks)
 {
     auto cache = makeCache();

--- a/src/IO/tests/gtest_page_cache_buffers.cpp
+++ b/src/IO/tests/gtest_page_cache_buffers.cpp
@@ -128,7 +128,8 @@ TEST(PageCacheBuffers, WriteWholeBlockThenHit)
         /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
 
     /// One openWriter over the aligned miss block.
-    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & misses = view_misses->misses();
     ASSERT_EQ(misses.size(), 1u);
     ASSERT_NE(misses[0].writer, nullptr);
     auto & writer = *misses[0].writer;
@@ -165,7 +166,8 @@ TEST(PageCacheBuffers, WriteBufferDoublesAsReadBuffer)
         cache, file, block_size, /*inject_eviction=*/false,
         /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
 
-    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & misses = view_misses->misses();
     ASSERT_EQ(misses.size(), 1u);
     auto & writer = *misses[0].writer;
 
@@ -196,7 +198,8 @@ TEST(PageCacheBuffers, EofTailBlockShort)
         /*bypass_if_missing=*/false, file_size);
 
     /// The aligned miss range for the tail is clamped to the file's real length.
-    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{tail_off, tail_size}}); const auto & misses = view_misses->misses();
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{tail_off, tail_size}});
+    const auto & misses = view_misses->misses();
     ASSERT_EQ(misses.size(), 1u);
     auto & writer = *misses[0].writer;
     EXPECT_EQ(writer.range().size, tail_size);
@@ -231,7 +234,8 @@ TEST(PageCacheBuffers, BypassOpensNoWritersAndPopulatesNothing)
         /*bypass_if_missing=*/true, /*file_size_in_bytes=*/block_size);
 
     /// The bypass upgrade is a no-op: the miss cell remains, the writer stays null.
-    auto view_misses = openWriters(bypass_provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    auto view_misses = openWriters(bypass_provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & misses = view_misses->misses();
     ASSERT_EQ(misses.size(), 1u);
     EXPECT_EQ(misses[0].writer, nullptr);
 
@@ -295,9 +299,11 @@ TEST(PageCacheBuffers, FirstWriterWins)
 
     /// Open TWO writers over the still-uncached block: page `resolve` uses
     /// `cache->get`, so it creates no cell - both see a miss until a write lands.
-    auto view_first = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & first = view_first->misses();
+    auto view_first = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & first = view_first->misses();
     ASSERT_EQ(first.size(), 1u);
-    auto view_second = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & second = view_second->misses();
+    auto view_second = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & second = view_second->misses();
     ASSERT_EQ(second.size(), 1u);
 
     /// First writer populates the block with 'F'.
@@ -330,7 +336,8 @@ TEST(PageCacheBuffers, WriteAcrossTwoBlocks)
         cache, file, block_size, /*inject_eviction=*/false,
         /*bypass_if_missing=*/false, file_size);
 
-    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, span}}); const auto & misses = view_misses->misses();
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, span}});
+    const auto & misses = view_misses->misses();
     ASSERT_EQ(misses.size(), 2u);
     auto & w0 = *misses[0].writer;
     auto & w1 = *misses[1].writer;
@@ -373,7 +380,8 @@ TEST(PageCacheBuffers, PartialBlockWriteIsSkipped)
         cache, file, block_size, /*inject_eviction=*/false,
         /*bypass_if_missing=*/false, /*file_size_in_bytes=*/block_size);
 
-    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & misses = view_misses->misses();
+    auto view_misses = openWriters(provider, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & misses = view_misses->misses();
     ASSERT_EQ(misses.size(), 1u);
     auto & writer = *misses[0].writer;
 
@@ -406,7 +414,8 @@ TEST(PageCacheBuffers, HitMissInterleavedTiling)
 
     /// Populate ONLY the middle block (block 1), leaving blocks 0 and 2 cold.
     {
-        auto view_middle = openWriters(provider, StoredObject{}, 0, {ByteRange{block_size, block_size}}); const auto & middle = view_middle->misses();
+        auto view_middle = openWriters(provider, StoredObject{}, 0, {ByteRange{block_size, block_size}});
+        const auto & middle = view_middle->misses();
         ASSERT_EQ(middle.size(), 1u);
         size_t wrote = claimedWrite(*middle[0].writer, makeChain(block_size, block_size, 'M'));
         EXPECT_EQ(wrote, block_size);
@@ -449,9 +458,11 @@ TEST(PageCacheBuffers, FirstWriterWinsAcrossProviders)
 
     /// Open a writer through EACH provider over the still-uncached block (page
     /// `resolve` creates no cell, so both see a miss until a write lands).
-    auto view_first = openWriters(provider1, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & first = view_first->misses();
+    auto view_first = openWriters(provider1, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & first = view_first->misses();
     ASSERT_EQ(first.size(), 1u);
-    auto view_second = openWriters(provider2, StoredObject{}, 0, {ByteRange{0, block_size}}); const auto & second = view_second->misses();
+    auto view_second = openWriters(provider2, StoredObject{}, 0, {ByteRange{0, block_size}});
+    const auto & second = view_second->misses();
     ASSERT_EQ(second.size(), 1u);
 
     /// provider1 populates the block with 'F'.

--- a/src/IO/tests/gtest_reader_executor.cpp
+++ b/src/IO/tests/gtest_reader_executor.cpp
@@ -95,6 +95,10 @@ struct MockCacheState
     size_t declared_size;
     IntervalSet resident;
     IntervalSet concurrent_download;
+    /// Ranges that became committed AFTER `resolve` but are still reported as a miss by `resolve`
+    /// (they are not in `resident`). `claimLeadRole` reports them as `available` - models a block a
+    /// concurrent query populated in the window between our read-only probe and the claim.
+    IntervalSet late_committed;
     VectorWithMemoryTracking<ByteRange> writes;
     explicit MockCacheState(size_t file_size) : store(file_size, 0), declared_size(file_size) {}
 
@@ -189,9 +193,16 @@ private:
             lead.available = ByteRange{lo, 0};
             if (lo >= hi)
                 return lead;
+            const ByteRange overlap{lo, hi - lo};
+            /// A block populated since `resolve` is reported as an available committed prefix; the
+            /// caller serves it from cache and there is nothing left to fill (no claim).
+            if (state->late_committed.subtract(overlap).empty())
+            {
+                lead.available = overlap;
+                return lead;
+            }
             /// We hold the role over the free part (not led by a concurrent downloader); if the whole
             /// overlap is being downloaded elsewhere we hold nothing, matching the real provider.
-            const ByteRange overlap{lo, hi - lo};
             const bool held = !state->concurrent_download.subtract(overlap).empty();
             lead.claim = makeClaim(held, /*release=*/nullptr);
             return lead;
@@ -584,6 +595,42 @@ TEST_F(ReaderExecutorTest, ConcurrentDownloadCellIsFetchedThrough)
     for (const auto & wr : state->writes)
         EXPECT_GE(wr.offset, 256u) << "wrote into the concurrently-downloaded block";
     EXPECT_FALSE(state->resident.subtract(ByteRange{0, block}).empty());
+}
+
+TEST_F(ReaderExecutorTest, ServesBlockCommittedBetweenResolveAndClaimFromCache)
+{
+    /// A block that a concurrent query populated AFTER our `resolve` (a read-only probe) but BEFORE we
+    /// claim it: `claimLeadRole` re-probes and reports it as `available`, so the executor serves it
+    /// from cache and does not re-read it from the source. Here block 0 is committed-since-resolve;
+    /// blocks 1..3 are plain misses fetched from source. Zero source bytes for block 0 is the signal.
+    const size_t block = 256;
+    StoredObjects objects{makeFile("a.bin", 4 * block)};
+
+    auto state = std::make_shared<MockCacheState>(/*file_size=*/4 * block);
+    /// Block [0, block) is NOT resident (so `resolve` misses it), but it became committed since - the
+    /// bytes are in the store and the claim reports it available.
+    state->late_committed.add(ByteRange{0, block});
+    for (size_t i = 0; i < block; ++i)
+        state->store[i] = static_cast<char>(patternByte(i));
+
+    CacheChain chain;
+    chain.push_back(std::make_shared<MockFileCacheProvider>(block, state));
+
+    TestThreadGroup tg;
+    ReaderExecutor ex(std::make_shared<LocalSourceReader>(), objects,
+        ReaderExecutor::Options{.window_size = 4 * block, .block_size = block, .cache_chain = std::move(chain)});
+
+    auto data = drain(ex);
+    ASSERT_EQ(data.size(), 4 * block);
+    for (size_t i = 0; i < data.size(); ++i)
+        ASSERT_EQ(static_cast<unsigned char>(data[i]), patternByte(i)) << "at " << i;
+
+    /// Only blocks 1..3 hit the source; block 0 came from cache via the claim-time recheck.
+    EXPECT_EQ(tg.get(ProfileEvents::ReaderExecutorBytesFromSource), 3 * block)
+        << "block committed since resolve should be served from cache, not the source";
+    /// Nothing filled block 0 - it was already committed (available, no claim).
+    for (const auto & wr : state->writes)
+        EXPECT_GE(wr.offset, block) << "wrote the already-committed block 0";
 }
 
 TEST_F(ReaderExecutorTest, BypassTierServesCachedCellAfterHeadMiss)

--- a/src/IO/tests/gtest_reader_executor.cpp
+++ b/src/IO/tests/gtest_reader_executor.cpp
@@ -659,6 +659,38 @@ TEST_F(ReaderExecutorTest, CoalescesConsecutiveMissesIntoOneSourceRead)
     EXPECT_EQ(tg.get(ProfileEvents::ReaderExecutorBytesFromSource), 4 * block);
 }
 
+TEST_F(ReaderExecutorTest, GatheredMissRunDoesNotReReadSlowerTierHit)
+{
+    /// Stacked tiers: a fast tier misses blocks 0..1, a slower tier already holds block 1. Gathering the
+    /// fast tier's miss run must not stretch the source fetch across block 1 - it is served from the
+    /// slower tier next window, so only block 0 hits the source.
+    const size_t block = 256;
+    StoredObjects objects{makeFile("a.bin", 2 * block)};
+
+    auto fast = std::make_shared<MockCacheState>(2 * block);   // tier0: all miss
+    auto slow = std::make_shared<MockCacheState>(2 * block);   // tier1: block1 resident
+    slow->resident.add(ByteRange{block, block});
+    for (size_t i = block; i < 2 * block; ++i)
+        slow->store[i] = static_cast<char>(patternByte(i));
+
+    CacheChain chain;
+    chain.push_back(std::make_shared<MockFileCacheProvider>(block, fast));
+    chain.push_back(std::make_shared<MockFileCacheProvider>(block, slow));
+
+    TestThreadGroup tg;
+    ReaderExecutor ex(std::make_shared<LocalSourceReader>(), objects,
+        ReaderExecutor::Options{.window_size = 2 * block, .block_size = block, .cache_chain = std::move(chain)});
+
+    auto data = drain(ex);
+    ASSERT_EQ(data.size(), 2 * block);
+    for (size_t i = 0; i < data.size(); ++i)
+        ASSERT_EQ(static_cast<unsigned char>(data[i]), patternByte(i)) << "at " << i;
+
+    /// block1 was warm in the slower tier, so only block0 hits the source.
+    EXPECT_EQ(tg.get(ProfileEvents::ReaderExecutorBytesFromSource), block)
+        << "block1 (resident in the slower tier) must not be re-read from source";
+}
+
 TEST_F(ReaderExecutorTest, BypassTierServesCachedCellAfterHeadMiss)
 {
     /// A read-only (bypass) tier - `resolve` returns writer-less misses, like `*_if_exists_otherwise_bypass = 1`

--- a/src/IO/tests/gtest_reader_executor.cpp
+++ b/src/IO/tests/gtest_reader_executor.cpp
@@ -633,6 +633,32 @@ TEST_F(ReaderExecutorTest, ServesBlockCommittedBetweenResolveAndClaimFromCache)
         EXPECT_GE(wr.offset, block) << "wrote the already-committed block 0";
 }
 
+TEST_F(ReaderExecutorTest, CoalescesConsecutiveMissesIntoOneSourceRead)
+{
+    /// Several consecutive cold blocks in one window are fetched in a SINGLE source request, not one
+    /// per block: `resolve` returns per-block misses and `readThroughCaches` gathers the contiguous run,
+    /// fetches it whole, and populates every block (later windows then hit the just-written cells).
+    const size_t block = 256;
+    StoredObjects objects{makeFile("a.bin", 4 * block)};
+
+    auto state = std::make_shared<MockCacheState>(/*file_size=*/4 * block);
+    CacheChain chain;
+    chain.push_back(std::make_shared<MockFileCacheProvider>(block, state));
+
+    TestThreadGroup tg;
+    ReaderExecutor ex(std::make_shared<LocalSourceReader>(), objects,
+        ReaderExecutor::Options{.window_size = 4 * block, .block_size = block, .cache_chain = std::move(chain)});
+
+    auto data = drain(ex);
+    ASSERT_EQ(data.size(), 4 * block);
+    for (size_t i = 0; i < data.size(); ++i)
+        ASSERT_EQ(static_cast<unsigned char>(data[i]), patternByte(i)) << "at " << i;
+
+    EXPECT_EQ(tg.get(ProfileEvents::ReaderExecutorSourceRequests), 1u)
+        << "four cold blocks should be one source request, not one per block";
+    EXPECT_EQ(tg.get(ProfileEvents::ReaderExecutorBytesFromSource), 4 * block);
+}
+
 TEST_F(ReaderExecutorTest, BypassTierServesCachedCellAfterHeadMiss)
 {
     /// A read-only (bypass) tier - `resolve` returns writer-less misses, like `*_if_exists_otherwise_bypass = 1`

--- a/tests/integration/test_reader_executor_page_cache/configs/conf.xml
+++ b/tests/integration/test_reader_executor_page_cache/configs/conf.xml
@@ -1,0 +1,26 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <!-- Raw object storage with NO filesystem cache: the userspace page cache is the only
+                 cache tier, and the ReaderExecutor engages (a filesystem cache would be a separate
+                 tier; here we isolate the page-cache path). -->
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </s3>
+        </disks>
+        <policies>
+            <s3>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3>
+        </policies>
+    </storage_configuration>
+
+    <page_cache_max_size>10000000000</page_cache_max_size>
+</clickhouse>

--- a/tests/integration/test_reader_executor_page_cache/test.py
+++ b/tests/integration/test_reader_executor_page_cache/test.py
@@ -1,0 +1,94 @@
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.add_instance(
+            "node",
+            main_configs=["configs/conf.xml"],
+            with_minio=True,
+        )
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+# Settings that engage the experimental ReaderExecutor with the userspace page (memory) cache as the
+# only tier on a raw-s3 disk (no filesystem cache):
+#  - use_reader_executor: turn on the executor path.
+#  - remote_filesystem_read_method='read': avoid the async-prefetch stage (not implemented by the
+#    executor, would force a fallback to the legacy path).
+#  - use_page_cache_for_disks_without_file_cache: enable the page cache on the cache-less s3 disk, so
+#    DiskObjectStorage::prepareRead requests the memory-cache stage and the executor builds the
+#    PageCacheProvider tier.
+#  - page_cache_inject_eviction=0: keep the cold read's populate alive for the warm read.
+#  - read_from_page_cache_if_exists_otherwise_bypass_cache=0: populate on miss (not read-only bypass).
+READER_EXECUTOR_PAGE_CACHE_SETTINGS = (
+    "use_reader_executor=1, "
+    "remote_filesystem_read_method='read', "
+    "use_page_cache_for_disks_without_file_cache=1, "
+    "page_cache_inject_eviction=0, "
+    "read_from_page_cache_if_exists_otherwise_bypass_cache=0"
+)
+
+
+def _profile_events(node, query_id):
+    node.query("system flush logs")
+    row = node.query(
+        "SELECT "
+        "ProfileEvents['ReaderExecutorBytesFromSource'], "
+        "ProfileEvents['ReaderExecutorCachePopulateRequests'], "
+        "ProfileEvents['PageCacheMisses'], "
+        "ProfileEvents['PageCacheHits'] "
+        f"FROM system.query_log WHERE query_id='{query_id}' AND type='QueryFinish'"
+    ).strip()
+    src, populate, misses, hits = (int(x) for x in row.split("\t"))
+    return src, populate, misses, hits
+
+
+def test_reader_executor_populates_and_serves_page_cache(started_cluster):
+    node = cluster.instances["node"]
+
+    node.query(
+        "CREATE TABLE t_re_page_cache (k UInt64 CODEC(NONE)) "
+        "ENGINE = MergeTree ORDER BY k "
+        "SETTINGS storage_policy = 's3', min_bytes_for_wide_part = 0"
+    )
+    # One stable wide part, not populated on write.
+    node.query("SYSTEM STOP MERGES t_re_page_cache")
+    node.query("INSERT INTO t_re_page_cache SELECT number FROM numbers(1000000)")
+    node.query("SYSTEM DROP PAGE CACHE")
+
+    # Cold read: nothing cached, so the executor reads from the source and populates the page cache.
+    cold_id = uuid.uuid4().hex
+    node.query(
+        f"SELECT sum(k) FROM t_re_page_cache SETTINGS {READER_EXECUTOR_PAGE_CACHE_SETTINGS}",
+        query_id=cold_id,
+    )
+    cold_src, cold_populate, cold_misses, _ = _profile_events(node, cold_id)
+    # The executor engaged (read physical bytes from the source) and populated the page cache itself.
+    # These ReaderExecutor* counters are emitted only by the executor, so they also prove engagement.
+    assert cold_src > 0, "executor did not read from the source (did it fall back?)"
+    assert cold_populate > 0, "executor did not populate the page cache"
+    assert cold_misses > 0, "cold read did not miss the page cache"
+
+    # Warm read: the same bytes are now served from the userspace page cache.
+    warm_id = uuid.uuid4().hex
+    node.query(
+        f"SELECT sum(k) FROM t_re_page_cache SETTINGS {READER_EXECUTOR_PAGE_CACHE_SETTINGS}",
+        query_id=warm_id,
+    )
+    warm_src, _, _, warm_hits = _profile_events(node, warm_id)
+    assert warm_hits > 0, "warm read did not hit the page cache"
+    assert warm_src < cold_src, "warm read did not read fewer source bytes than the cold read"
+
+    node.query("DROP TABLE t_re_page_cache")
+    node.query("SYSTEM DROP PAGE CACHE")

--- a/tests/integration/test_reader_executor_page_cache/test.py
+++ b/tests/integration/test_reader_executor_page_cache/test.py
@@ -88,7 +88,9 @@ def test_reader_executor_populates_and_serves_page_cache(started_cluster):
     )
     warm_src, _, _, warm_hits = _profile_events(node, warm_id)
     assert warm_hits > 0, "warm read did not hit the page cache"
-    assert warm_src < cold_src, "warm read did not read fewer source bytes than the cold read"
+    assert (
+        warm_src < cold_src
+    ), "warm read did not read fewer source bytes than the cold read"
 
     node.query("DROP TABLE t_re_page_cache")
     node.query("SYSTEM DROP PAGE CACHE")


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/103706
Related: https://github.com/ClickHouse/ClickHouse/issues/102282

Next incremental slice of the experimental `ReaderExecutor` (split of #103706),
following the merged disk-cache provider #110029. Adds the userspace page (memory)
cache tier: `PageCacheProvider` implements `ICacheProvider` over `PageCache` with
zero-copy hits (the arena is pinned by a shared_ptr) and whole-block
first-writer-wins fills via `PageCache::getOrSet`. `ReadPipeline` wires it as the
first (fastest) tier of the executor cache chain when the page cache applies, and
skips it on unknown-size sources. `ReadPipeline.cpp` is the only non-verbatim file;
the provider and its gtest are ports from #103706.

Gated by `use_reader_executor` (default off); the legacy read path is unchanged.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a userspace page cache tier to the experimental `ReaderExecutor` read path (`use_reader_executor`, off by default). On a miss the executor now populates the userspace page cache and serves subsequent reads from it, zero-copy.

### Documentation entry for user-facing changes
Not required — experimental feature, off by default.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114890&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114890](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114890+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1715` (included in `26.8` and later)
<!-- ch-version-info:end -->