### PR TITLE
Fix clang-tidy complaint about .contains() not being used

### DIFF
--- a/src/Processors/QueryPlan/tests/gtest_aggregating_step_settings_roundtrip.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_aggregating_step_settings_roundtrip.cpp
@@ -51,7 +51,7 @@ bool wireCarriesSerializeStringWithZeroByte(const IQueryPlanStep & step, UInt64 
     WriteBufferFromOwnString out;
     written.writeChangedBinary(out);
 
-    return out.str().find("serialize_string_in_memory_with_zero_byte") != std::string::npos;
+    return out.str().contains("serialize_string_in_memory_with_zero_byte");
 }
 
 SharedHeader makeHeader()


### PR DESCRIPTION
```
/ClickHouse/src/Processors/QueryPlan/tests/gtest_aggregating_step_settings_roundtrip.cpp:54:22: error: use 'contains' to check for membership [readability-container-contains,-warnings-as-errors]
   54 |     return out.str().find("serialize_string_in_memory_with_zero_byte") != std::string::npos;
      |                      ^~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                      contains "serialize_string_in_memory_with_zero_byte")
```

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
