### PR TITLE
Do not abort the server when a loader worker cannot be spawned

### DIFF
--- a/src/Common/AsyncLoader.cpp
+++ b/src/Common/AsyncLoader.cpp
@@ -23,6 +23,7 @@
 namespace ProfileEvents
 {
     extern const Event AsyncLoaderWaitMicroseconds;
+    extern const Event AsyncLoaderSpawnFailures;
 }
 
 namespace DB
@@ -69,6 +70,9 @@ AsyncLoader::Pool::Pool(Pool&& o) noexcept
     , max_threads(o.max_threads)
     , workers(o.workers)
     , suspended_workers(o.suspended_workers.load()) // All these constructors are needed because std::atomic is neither copy-constructible, nor move-constructible. We never move pools after init, so it is safe.
+    , waiting_workers(o.waiting_workers.load())
+    , started_workers(o.started_workers)
+    , spawn_failed(o.spawn_failed)
     , thread_pool(std::move(o.thread_pool))
 {}
 
@@ -529,7 +533,10 @@ void AsyncLoader::setMaxThreads(size_t pool, size_t value)
     if (!is_running)
         return;
     for (size_t i = 0; canSpawnWorker(p, lock) && i < p.ready_queue.size(); i++)
-        spawn(p, lock);
+    {
+        if (!spawn(p, lock))
+            break; // The pool is saturated, do not retry for every queued job
+    }
 }
 
 size_t AsyncLoader::getMaxThreads(size_t pool) const
@@ -778,6 +785,7 @@ void AsyncLoader::wait(std::unique_lock<std::mutex> & job_lock, const LoadJobPtr
     if (job->job_id == 0)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Load job '{}' waits for not scheduled load job '{}'", current_load_job->name, job->name);
 
+    scope_guard waiting_lock; // Released last, so that `waiting_workers` remains a superset of `suspended_workers`
     scope_guard suspended_lock;
 
     // Deadlock detection and resolution
@@ -798,8 +806,6 @@ void AsyncLoader::wait(std::unique_lock<std::mutex> & job_lock, const LoadJobPtr
             job_lock.lock();
         }
 
-        // Spawn more workers to avoid exhaustion of worker pool ("blocked pool" deadlock)
-        if (worker_pool == job->pool_id)
         {
             job_lock.unlock(); // Avoid reverse locking order
             std::unique_lock lock{mutex};
@@ -809,17 +815,29 @@ void AsyncLoader::wait(std::unique_lock<std::mutex> & job_lock, const LoadJobPtr
             if (job->load_status != LoadStatus::PENDING)
                 return; // Job is already done, no wait required
 
+            // A worker inside `wait()` cannot take a job from its own pool's ready queue, whichever pool the
+            // awaited job belongs to. Only this increment is under `mutex`; the decrement runs on return
+            // from `wait()`, so `spawn()` can read a value that is too high, which only makes it spawn.
+            Pool & pool = pools[worker_pool];
+            pool.waiting_workers.fetch_add(1);
+            waiting_lock = [&pool] { chassert(pool.waiting_workers.load()); pool.waiting_workers.fetch_sub(1); };
+
             if (worker_pool == job->pool_id)
             {
-                // To resolve "blocked pool" deadlocks we spawn a new worker for every suspended worker, if required
+                // To resolve "blocked pool" deadlocks we allow a new worker for every suspended worker.
                 // This can lead to a visible excess of `max_threads` specified for a pool,
                 // but actual number of NOT suspended workers may exceed `max_threads` ONLY in intermittent state.
-                Pool & pool = pools[worker_pool];
                 pool.suspended_workers.fetch_add(1);
                 suspended_lock = [&pool] { chassert(pool.suspended_workers.load()); pool.suspended_workers.fetch_sub(1); };
-                if (canSpawnWorker(pool, lock))
-                    spawn(pool, lock);
             }
+
+            // Spawn more workers to avoid exhaustion of worker pool ("blocked pool" deadlock). This worker
+            // stops draining its own pool's ready queue for the whole wait, whichever pool it waits on.
+            // A spawn dropped while this worker was still draining says nothing about the pool now that it
+            // is not, so the pool gets one more attempt before the memo starts skipping them again.
+            pool.spawn_failed = false;
+            if (canSpawnWorker(pool, lock))
+                spawn(pool, lock);
         }
     }
 
@@ -897,21 +915,63 @@ void AsyncLoader::updateCurrentPriorityAndSpawn(std::unique_lock<std::mutex> & l
     for (Pool & pool : pools)
     {
         for (size_t i = 0; canSpawnWorker(pool, lock) && i < pool.ready_queue.size(); i++)
-            spawn(pool, lock);
+        {
+            if (!spawn(pool, lock))
+                break; // The pool is saturated, do not retry for every queued job
+        }
     }
 }
 
-void AsyncLoader::spawn(Pool & pool, std::unique_lock<std::mutex> & lock)
+bool AsyncLoader::spawn(Pool & pool, std::unique_lock<std::mutex> & lock)
 {
     setCurrentPriority(lock, pool.priority); // canSpawnWorker() ensures this would not decrease current_priority
+
+    // The ready queue is drained without this spawn while the pool keeps a worker that has started and is
+    // not waiting, or one waiting for a job of another pool, which resumes once that pool runs it. It is
+    // not drained by a worker still queued in the global pool, nor by one waiting for a job of this pool.
+    const size_t waiting = pool.waiting_workers.load();
+    const size_t suspended = pool.suspended_workers.load();
+    const bool has_running_worker = pool.started_workers > waiting;
+    const bool has_resuming_worker = !has_running_worker && waiting > suspended;
+    const bool spawn_is_required = !has_running_worker && !has_resuming_worker;
+
+    if (!spawn_is_required && pool.spawn_failed)
+        return false;
+
     pool.workers++;
+    bool spawned = true;
     NOEXCEPT_SCOPE({
         ALLOW_ALLOCATIONS_IN_SCOPE;
         if (log_events)
             LOG_DEBUG(log, "Spawn loader worker #{} in {}", pool.workers, pool.name);
-        auto blocker = CannotAllocateThreadFaultInjector::blockFaultInjections();
-        pool.thread_pool->scheduleOrThrowOnError([this, &pool] { worker(pool); });
+        if (has_running_worker)
+        {
+            // Losing this spawn costs concurrency only, so a fault injected here is a state to tolerate.
+            spawned = pool.thread_pool->trySchedule([this, &pool] { worker(pool); });
+        }
+        else
+        {
+            auto blocker = CannotAllocateThreadFaultInjector::blockFaultInjections();
+            if (spawn_is_required)
+                pool.thread_pool->scheduleOrThrowOnError([this, &pool] { worker(pool); });
+            else
+                spawned = pool.thread_pool->trySchedule([this, &pool] { worker(pool); });
+        }
+        if (!spawned)
+        {
+            ProfileEvents::increment(ProfileEvents::AsyncLoaderSpawnFailures);
+            if (has_running_worker)
+                LOG_WARNING(log, "Failed to spawn a loader worker in {}: the global thread pool could not provide a thread. "
+                    "The {} running worker(s) will run the queued jobs", pool.name, pool.started_workers - waiting);
+            else
+                LOG_WARNING(log, "Failed to spawn a loader worker in {}: the global thread pool could not provide a thread. "
+                    "The queued jobs will be run by the worker that is waiting for another pool", pool.name);
+        }
     });
+    pool.spawn_failed = !spawned;
+    if (!spawned)
+        pool.workers--;
+    return spawned;
 }
 
 void AsyncLoader::worker(Pool & pool)
@@ -921,6 +981,12 @@ void AsyncLoader::worker(Pool & pool)
     size_t pool_id = &pool - &*pools.begin();
     LoadJobPtr job;
     std::exception_ptr exception_from_job;
+
+    {
+        std::unique_lock lock{mutex};
+        pool.started_workers++;
+    }
+
     while (true)
     {
         // This is inside the loop to also reset previous thread names set inside the jobs
@@ -944,6 +1010,8 @@ void AsyncLoader::worker(Pool & pool)
                         LOG_DEBUG(log, "Stop worker in {}", pool.name);
                     });
                 }
+                pool.started_workers--;
+                pool.spawn_failed = false; // A thread was just released, so a spawn may succeed again
                 if (--pool.workers == 0)
                     updateCurrentPriorityAndSpawn(lock); // It will spawn lower priority workers if needed
                 return;

--- a/src/Common/AsyncLoader.h
+++ b/src/Common/AsyncLoader.h
@@ -369,8 +369,11 @@ private:
         const Priority priority;
         std::map<UInt64, LoadJobPtr> ready_queue; // FIFO queue of jobs to be executed in this pool. Map is used for faster erasing. Key is `ready_seqno`
         size_t max_threads; // Max number of workers to be spawn
-        size_t workers = 0; // Number of currently executing workers
+        size_t workers = 0; // Number of submitted workers, including the ones still queued in the global thread pool
         std::atomic<size_t> suspended_workers{0}; // Number of workers that are blocked by `wait()` call on a job executing in the same pool (for deadlock resolution)
+        std::atomic<size_t> waiting_workers{0}; // Number of workers of this pool that are inside a `wait()` call, on a job of any pool. Superset of `suspended_workers`
+        size_t started_workers = 0; // Number of workers that entered `worker()`. Unlike `workers`, this excludes the ones still queued in the global thread pool
+        bool spawn_failed = false; // Set while the global thread pool is known to have no thread available for this pool
         std::unique_ptr<ThreadPool> thread_pool; // NOTE: we avoid using a `ThreadPool` queue to be able to move jobs between pools.
 
         explicit Pool(const PoolInitializer & init);
@@ -434,7 +437,8 @@ public:
     // Waiting for a not scheduled job is considered to be LOGICAL_ERROR, use waitLoad() helper instead to make sure the job is scheduled.
     // There are more rules if `wait()` is called from another job:
     //  1) waiting on a dependent job is considered to be LOGICAL_ERROR;
-    //  2) waiting on a job in the same pool might lead to more workers spawned in that pool to resolve "blocked pool" deadlock;
+    //  2) waiting stops this worker from draining its own pool's queue, so it might lead to more workers
+    //     spawned in that pool; in the same-pool case that also resolves the "blocked pool" deadlock;
     //  3) waiting on a job with lower priority lead to priority inheritance to avoid priority inversion.
     void wait(const LoadJobPtr & job, bool no_throw = false);
 
@@ -477,7 +481,9 @@ private:
     bool canWorkerLive(Pool & pool, std::unique_lock<std::mutex> & lock);
     void setCurrentPriority(std::unique_lock<std::mutex> & lock, std::optional<Priority> priority);
     void updateCurrentPriorityAndSpawn(std::unique_lock<std::mutex> & lock);
-    void spawn(Pool & pool, std::unique_lock<std::mutex> & lock);
+    // Returns false if no worker was spawned, which is only allowed while the pool keeps a worker that
+    // drains its ready queue: one that is running, or one resuming from a wait on another pool.
+    bool spawn(Pool & pool, std::unique_lock<std::mutex> & lock);
     void worker(Pool & pool);
     bool hasWorker(std::unique_lock<std::mutex> & lock) const;
 

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1191,6 +1191,7 @@ The server successfully detected this situation and will download merged part fr
     \
     M(ConnectionPoolIsFullMicroseconds, "Total time spent waiting for a slot in connection pool.", ValueType::Microseconds) \
     M(AsyncLoaderWaitMicroseconds, "Total time a query was waiting for async loader jobs.", ValueType::Microseconds) \
+    M(AsyncLoaderSpawnFailures, "Number of times the async loader could not spawn a worker because the global thread pool could not provide a thread. Queued jobs are then run by a worker the pool already has: one that is running, or one resuming from a wait on a job of another pool.", ValueType::Number) \
     \
     M(DistrCacheServerSwitches, "Distributed Cache read buffer event. Number of server switches between distributed cache servers in read/write-through cache", ValueType::Number) \
     M(DistrCacheReadMicroseconds, "Distributed Cache read buffer event. Time spent reading from distributed cache", ValueType::Microseconds) \

--- a/src/Common/tests/gtest_async_loader.cpp
+++ b/src/Common/tests/gtest_async_loader.cpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstdlib>
 #include <exception>
 #include <list>
 #include <barrier>
@@ -19,9 +20,30 @@
 #include <base/sleep.h>
 #include <Common/Exception.h>
 #include <Common/AsyncLoader.h>
+#include <Common/ProfileEvents.h>
 #include <Common/randomSeed.h>
+#include <Common/ThreadPool.h>
 
 using namespace DB;
+
+namespace
+{
+
+// Looked up by name, so this file links whether or not the event is registered. 0 when it is not.
+UInt64 spawnFailures()
+{
+    static const ProfileEvents::Event event = []
+    {
+        for (auto e = ProfileEvents::Event(0); e < ProfileEvents::end(); ++e)
+            if (ProfileEvents::getName(e) == "AsyncLoaderSpawnFailures")
+                return e;
+        return ProfileEvents::end();
+    }();
+
+    return event == ProfileEvents::end() ? 0 : ProfileEvents::global_counters[event];
+}
+
+}
 
 namespace CurrentMetrics
 {
@@ -1260,4 +1282,484 @@ TEST(AsyncLoader, RecursiveJob)
                 ASSERT_TRUE(component.isLoaded());
         }
     }
+}
+
+// Restores the global thread pool limits whatever the test does, because exhausting them is
+// observable by every other test in this binary.
+struct GlobalThreadPoolLimits
+{
+    GlobalThreadPool & pool = GlobalThreadPool::instance();
+
+    void saturate(size_t capacity)
+    {
+        pool.setMaxThreads(capacity);
+        pool.setMaxFreeThreads(0);
+        pool.setQueueSize(capacity);
+    }
+
+    // Accepts jobs into the queue but runs none of them, so a spawned worker stays submitted
+    // without ever entering `worker()`.
+    void submitWithoutStarting(size_t queue_capacity)
+    {
+        pool.setMaxThreads(0);
+        pool.setMaxFreeThreads(0);
+        pool.setQueueSize(queue_capacity);
+    }
+
+    void restore()
+    {
+        pool.setMaxThreads(10000);
+        pool.setMaxFreeThreads(1000);
+        pool.setQueueSize(10000);
+    }
+
+    ~GlobalThreadPoolLimits() { restore(); }
+};
+
+// `spawn()` blocks fault injections unless the pool has a running worker, so at probability 1 only the
+// spawn made alongside a running worker fails. Which tier was taken is therefore observable in
+// `AsyncLoaderSpawnFailures` without exhausting anything and without aborting.
+struct AlwaysFailToAllocateThread
+{
+    AlwaysFailToAllocateThread() { CannotAllocateThreadFaultInjector::setFaultProbability(1.0); }
+    ~AlwaysFailToAllocateThread() { CannotAllocateThreadFaultInjector::setFaultProbability(0.0); }
+};
+
+// A spawn dropped while a worker is still running costs concurrency only, so every job must still
+// complete, and the pool must be probed once per saturation episode, not once per queued job.
+TEST(AsyncLoader, SpawnFailureWithRunningWorkerDoesNotTerminate)
+{
+    GlobalThreadPoolLimits limits;
+    const auto failures_before = spawnFailures();
+
+    AsyncLoaderTest t(16); // > 1 so that every enqueue attempts a spawn
+    std::barrier<std::__empty_completion> sync(2);
+    std::atomic<size_t> jobs_done{0};
+
+    auto blocking_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
+    {
+        sync.arrive_and_wait(); // (A) hold this worker running while the global pool is saturated
+        jobs_done++;
+    };
+    auto job_func = [&] (AsyncLoader &, const LoadJobPtr &) { jobs_done++; };
+
+    auto blocking_job = makeLoadJob({}, "blocking_job", blocking_job_func);
+    auto blocking_task = t.schedule({blocking_job});
+    t.loader.unpause();
+
+    // The first worker must be running, and not suspended, before the pool is saturated.
+    while (blocking_job->startTime() == LoadJob::TimePoint{})
+        std::this_thread::yield();
+    limits.saturate(1);
+
+    LoadTaskPtrs tasks;
+    tasks.reserve(64);
+    for (size_t i = 0; i < 64; i++)
+        tasks.push_back(t.schedule({makeLoadJob({}, "job", job_func)}));
+
+    sync.arrive_and_wait(); // (A) release the worker so it drains the queue itself
+    waitLoad(blocking_task);
+    waitLoad(tasks);
+
+    ASSERT_EQ(jobs_done, 65);
+    // One failed attempt per saturation episode, whatever the number of queued jobs.
+    ASSERT_EQ(spawnFailures() - failures_before, 1);
+    t.loader.wait();
+}
+
+// A dropped spawn must not leave `Pool::workers` overcounted: a leaked increment makes `hasWorker()`
+// report a worker forever, so `wait()` never returns. Once the limits are restored the pool must
+// spawn again, which is asserted by requiring two jobs to run at the same time.
+TEST(AsyncLoader, SpawnFailureThenRecovers)
+{
+    GlobalThreadPoolLimits limits;
+
+    AsyncLoaderTest t(16);
+    std::barrier<std::__empty_completion> sync(2);
+    std::atomic<size_t> jobs_done{0};
+
+    auto blocking_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
+    {
+        sync.arrive_and_wait(); // (A)
+        jobs_done++;
+    };
+    auto job_func = [&] (AsyncLoader &, const LoadJobPtr &) { jobs_done++; };
+
+    auto blocking_job = makeLoadJob({}, "blocking_job", blocking_job_func);
+    auto blocking_task = t.schedule({blocking_job});
+    t.loader.unpause();
+    while (blocking_job->startTime() == LoadJob::TimePoint{})
+        std::this_thread::yield();
+    limits.saturate(1);
+
+    LoadTaskPtrs tasks;
+    tasks.reserve(32);
+    for (size_t i = 0; i < 32; i++)
+        tasks.push_back(t.schedule({makeLoadJob({}, "job", job_func)}));
+
+    sync.arrive_and_wait(); // (A)
+    waitLoad(blocking_task);
+    waitLoad(tasks);
+    ASSERT_EQ(jobs_done, 33);
+
+    limits.restore();
+
+    // The second job is enqueued while the first one is already running, which is the case in which
+    // a spawn is droppable. It can therefore only run if the pool spawns a worker again. Both jobs
+    // wait for the other to arrive, so a pool that stopped spawning leaves them both waiting; the
+    // wait is bounded so that this fails the assertion instead of hanging the test binary.
+    std::mutex overlap_mutex;
+    std::condition_variable overlap_cv;
+    size_t arrived = 0;
+    size_t observed_overlap = 0;
+    auto overlapping_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
+    {
+        std::unique_lock lock{overlap_mutex};
+        arrived++;
+        overlap_cv.notify_all();
+        if (overlap_cv.wait_for(lock, std::chrono::seconds(30), [&] { return arrived == 2; }))
+            observed_overlap++;
+    };
+
+    auto first_job = makeLoadJob({}, "overlapping_job0", overlapping_job_func);
+    auto first_overlapping_task = t.schedule({first_job});
+    while (first_job->startTime() == LoadJob::TimePoint{})
+        std::this_thread::yield();
+    auto second_overlapping_task = t.schedule({makeLoadJob({}, "overlapping_job1", overlapping_job_func)});
+    waitLoad(first_overlapping_task);
+    waitLoad(second_overlapping_task);
+
+    ASSERT_EQ(observed_overlap, 2);
+    t.loader.wait();
+}
+
+// The reported abort happens on the job-completion path: a worker calls `finish()`, which enqueues
+// the now-ready dependent job and spawns a worker for it. The calling worker is still running, so
+// dropping that spawn is safe and it picks the dependent job up itself.
+TEST(AsyncLoader, SpawnFailureFromFinishDoesNotTerminate)
+{
+    GlobalThreadPoolLimits limits;
+
+    AsyncLoaderTest t(16);
+    std::barrier<std::__empty_completion> sync(2);
+    std::atomic<size_t> jobs_done{0};
+
+    auto blocking_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
+    {
+        sync.arrive_and_wait(); // (A) saturate the global pool while this worker runs
+        jobs_done++;
+    };
+    auto job_func = [&] (AsyncLoader &, const LoadJobPtr &) { jobs_done++; };
+
+    // Dependents are enqueued from `finish()`, i.e. from inside the worker, which is the reported path.
+    auto blocking_job = makeLoadJob({}, "blocking_job", blocking_job_func);
+    std::vector<LoadJobPtr> jobs{blocking_job};
+    for (size_t i = 0; i < 8; i++)
+        jobs.push_back(makeLoadJob({blocking_job}, fmt::format("dependent_job{}", i), job_func));
+    auto task = t.schedule({jobs.begin(), jobs.end()});
+
+    t.loader.unpause();
+    while (blocking_job->startTime() == LoadJob::TimePoint{}) // The worker must be running before saturating
+        std::this_thread::yield();
+    limits.saturate(1);
+
+    const auto failures_before = spawnFailures();
+    sync.arrive_and_wait(); // (A) `finish(blocking_job)` now enqueues the dependents and fails to spawn
+    waitLoad(task);
+
+    ASSERT_EQ(jobs_done, 9);
+    // Completion alone would also hold if the spawn were skipped, so require that it was attempted.
+    ASSERT_EQ(spawnFailures() - failures_before, 1);
+    t.loader.wait();
+}
+
+// A submitted but not yet started worker cannot take a job from the ready queue, so a pool holding
+// only such workers still needs a spawn. Measurements are taken into locals and asserted only after
+// the limits are restored: an early return while the pool cannot run jobs hangs in `~LoadTask`.
+TEST(AsyncLoader, SpawnIsRequiredWhileNoWorkerHasStarted)
+{
+    GlobalThreadPoolLimits limits;
+
+    AsyncLoaderTest t(16);
+    std::atomic<size_t> jobs_done{0};
+    auto job_func = [&] (AsyncLoader &, const LoadJobPtr &) { jobs_done++; };
+
+    t.loader.unpause();
+    limits.submitWithoutStarting(1000); // Loader workers get queued in the global pool but never start
+
+    LoadTaskPtrs tasks;
+    tasks.reserve(8);
+    for (size_t i = 0; i < 4; i++)
+        tasks.push_back(t.schedule({makeLoadJob({}, "job", job_func)}));
+
+    // No worker has started, so every spawn here runs with injections blocked and succeeds. One that
+    // counted a queued worker as a drainer would call `trySchedule`, which the injector fails.
+    const auto failures_before = spawnFailures();
+    const auto submitted_before = limits.pool.active();
+    {
+        AlwaysFailToAllocateThread always_fail;
+        for (size_t i = 0; i < 4; i++)
+            tasks.push_back(t.schedule({makeLoadJob({}, "job", job_func)}));
+    }
+    const auto failures = spawnFailures() - failures_before;
+    // Zero failures alone would also hold if no spawn had been attempted, so require that each of the
+    // four enqueues submitted a worker of its own.
+    const auto submitted = limits.pool.active() - submitted_before;
+
+    limits.restore(); // Let the submitted workers start and drain everything
+    waitLoad(tasks);
+
+    ASSERT_EQ(failures, 0);
+    ASSERT_EQ(submitted, 4);
+    ASSERT_EQ(jobs_done, 8);
+    t.loader.wait();
+}
+
+// A worker blocked in `wait()` cannot take a job from its own pool's ready queue even when it waits
+// for a job of another pool, a case that priority inheritance does not convert into a same-pool wait.
+// Treating it as a drainer leaves that pool's queue with nobody to run it.
+TEST(AsyncLoader, SpawnIsAttemptedWhileTheOnlyWorkerWaitsForAnotherPool)
+{
+    // Sibling pools of equal priority: `prioritize()` refuses to move a job between them and `wait()`
+    // does not inherit priority, so the wait stays cross-pool and is never counted as suspended.
+    // Equal priority is also what lets both pools spawn at the same time.
+    AsyncLoaderTest t({
+        {.max_threads = 2, .priority = Priority{0}},
+        {.max_threads = 2, .priority = Priority{0}},
+    });
+
+    std::barrier<std::__empty_completion> sync(2);
+    std::atomic<size_t> jobs_done{0};
+    auto job_func = [&] (AsyncLoader &, const LoadJobPtr &) { jobs_done++; };
+
+    // Held pending until the measurement is taken, so the waiting worker really is inside `wait()`.
+    auto awaited_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
+    {
+        sync.arrive_and_wait(); // (A)
+        jobs_done++;
+    };
+    auto awaited_job = makeLoadJob({}, 0, "awaited_job", awaited_job_func);
+    auto awaited_task = t.schedule({awaited_job});
+
+    auto waiting_job_func = [&] (AsyncLoader & loader, const LoadJobPtr &)
+    {
+        loader.wait(awaited_job); // Blocks this pool-1 worker on a pool-0 job
+        jobs_done++;
+    };
+    auto waiting_job = makeLoadJob({}, 1, "waiting_job", waiting_job_func);
+    auto waiting_task = t.schedule({waiting_job});
+    t.loader.unpause();
+
+    while (awaited_job->waitersCount() == 0) // Pool 1's only worker is inside `wait()`
+        std::this_thread::yield();
+    const auto suspended_in_pool1 = t.loader.suspendedWorkersCount(1);
+
+    // Queue a job in pool 1 while its only worker is inside `wait()`. That spawn runs with injections
+    // blocked, so it succeeds; treating the waiter as a drainer would leave the job with nobody to run it.
+    const auto failures_before = spawnFailures();
+    auto queued_job = makeLoadJob({}, 1, "queued_job", job_func);
+    LoadTaskPtr queued_task;
+    {
+        AlwaysFailToAllocateThread always_fail;
+        queued_task = t.schedule({queued_job});
+    }
+    const auto failures = spawnFailures() - failures_before;
+
+    // The spawned worker must run the queued job while the wait is still outstanding. Zero failures
+    // alone would also hold if no spawn had been attempted, since the waiter drains once released.
+    // Polled rather than awaited, so a queue left with no worker fails here instead of hanging.
+    bool ran_during_wait = false;
+    for (size_t i = 0; i < 3000 && !ran_during_wait; i++)
+    {
+        ran_during_wait = queued_job->status() == LoadStatus::OK;
+        if (!ran_during_wait)
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    sync.arrive_and_wait(); // (A) release the awaited job before asserting, so a failure cannot hang
+    waitLoad(awaited_task);
+    waitLoad(waiting_task);
+    waitLoad(queued_task);
+
+    ASSERT_EQ(suspended_in_pool1, 0); // The cross-pool wait is not counted as suspended
+    ASSERT_EQ(failures, 0);
+    ASSERT_TRUE(ran_during_wait);
+    ASSERT_EQ(jobs_done, 3);
+    t.loader.wait();
+}
+
+// A job left in a pool's ready queue is drained by that pool's running worker, so no spawn is needed
+// while such a worker exists. When that worker enters `wait()` it stops draining, and the job needs a
+// worker of its own from that moment, whichever pool the awaited job belongs to. A wait that does not
+// reconsider spawning leaves the job queued for the whole duration of the wait.
+TEST(AsyncLoader, SpawnIsAttemptedWhenTheOnlyWorkerStartsWaitingForAnotherPool)
+{
+    // Sibling pools of equal priority, so `prioritize()` refuses to move a job between them and
+    // `wait()` does not inherit priority: the wait stays cross-pool.
+    AsyncLoaderTest t({
+        {.max_threads = 2, .priority = Priority{0}},
+        {.max_threads = 2, .priority = Priority{0}},
+    });
+
+    std::barrier<std::__empty_completion> sync(2);
+    std::atomic<bool> start_waiting{false};
+    std::atomic<bool> queued_job_done{false};
+    std::atomic<size_t> jobs_done{0};
+
+    // Held pending until the measurement is taken, so the cross-pool wait is still outstanding then.
+    auto awaited_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
+    {
+        sync.arrive_and_wait(); // (A)
+        jobs_done++;
+    };
+    auto awaited_job = makeLoadJob({}, 0, "awaited_job", awaited_job_func);
+    auto awaited_task = t.schedule({awaited_job});
+
+    auto waiting_job_func = [&] (AsyncLoader & loader, const LoadJobPtr &)
+    {
+        while (!start_waiting.load()) // Stay running, and not waiting, while the next job is queued
+            std::this_thread::yield();
+        loader.wait(awaited_job); // Blocks this pool-1 worker on a pool-0 job
+        jobs_done++;
+    };
+    auto waiting_job = makeLoadJob({}, 1, "waiting_job", waiting_job_func);
+    auto waiting_task = t.schedule({waiting_job});
+    t.loader.unpause();
+
+    while (waiting_job->startTime() == LoadJob::TimePoint{})
+        std::this_thread::yield();
+
+    // Queue a job in pool 1 while that pool has a running worker to drain it. The spawn is optional
+    // here, and the injector makes it fail, which is the state the pool is meant to tolerate.
+    LoadTaskPtr queued_task;
+    {
+        AlwaysFailToAllocateThread always_fail;
+        queued_task = t.schedule({makeLoadJob({}, 1, "queued_job", [&] (AsyncLoader &, const LoadJobPtr &)
+        {
+            queued_job_done = true;
+            jobs_done++;
+        })});
+    }
+
+    // The only worker able to run it now enters a cross-pool wait.
+    start_waiting = true;
+    while (awaited_job->waitersCount() == 0)
+        std::this_thread::yield();
+
+    // The queued job must run while that wait is still outstanding. Bounded, so a pool that never
+    // spawns fails by assertion instead of hanging here.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+    while (!queued_job_done.load() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::yield();
+    const bool ran_during_wait = queued_job_done.load();
+
+    sync.arrive_and_wait(); // (A) release the awaited job, so everything drains either way
+    waitLoad(awaited_task);
+    waitLoad(waiting_task);
+    waitLoad(queued_task);
+
+    ASSERT_TRUE(ran_during_wait);
+    ASSERT_EQ(jobs_done, 3);
+    t.loader.wait();
+}
+
+// A worker waiting on another pool's job resumes draining its own queue once that job runs, so a
+// failed spawn costs latency, not liveness, and must not be fatal. Measurements are taken into
+// locals and asserted only after the limits are restored: an early return hangs in `~LoadTask`.
+TEST(AsyncLoader, SpawnFailureWithOnlyAWorkerWaitingForAnotherPoolDoesNotTerminate)
+{
+    GlobalThreadPoolLimits limits;
+
+    // Sibling pools of equal priority, so `prioritize()` refuses to move a job between them and
+    // `wait()` does not inherit priority: the wait stays cross-pool and is never counted as suspended.
+    AsyncLoaderTest t({
+        {.max_threads = 2, .priority = Priority{0}},
+        {.max_threads = 2, .priority = Priority{0}},
+    });
+
+    std::barrier<std::__empty_completion> sync(2);
+    std::atomic<bool> start_waiting{false};
+    std::atomic<size_t> jobs_done{0};
+
+    // Held pending until the measurement is taken, so the cross-pool wait is still outstanding then.
+    auto awaited_job_func = [&] (AsyncLoader &, const LoadJobPtr &)
+    {
+        sync.arrive_and_wait(); // (A)
+        jobs_done++;
+    };
+    auto awaited_job = makeLoadJob({}, 0, "awaited_job", awaited_job_func);
+    auto awaited_task = t.schedule({awaited_job});
+
+    auto waiting_job_func = [&] (AsyncLoader & loader, const LoadJobPtr &)
+    {
+        while (!start_waiting.load()) // Stay running while the global pool is exhausted and a job is queued
+            std::this_thread::yield();
+        loader.wait(awaited_job); // Blocks this pool-1 worker on a pool-0 job, and spawns from there
+        jobs_done++;
+    };
+    auto waiting_job = makeLoadJob({}, 1, "waiting_job", waiting_job_func);
+    auto waiting_task = t.schedule({waiting_job});
+    t.loader.unpause();
+
+    // Both workers must be running before the global pool is exhausted, so that the spawn attempted
+    // from inside `wait()` is the one that fails.
+    while (awaited_job->startTime() == LoadJob::TimePoint{} || waiting_job->startTime() == LoadJob::TimePoint{})
+        std::this_thread::yield();
+    limits.saturate(2);
+
+    const auto failures_before = spawnFailures();
+
+    // Queued while pool 1 still has a running worker to drain it, so this spawn is droppable and its
+    // failure is expected. It also arms the memo, which must not suppress the attempt made below.
+    auto queued_task = t.schedule({makeLoadJob({}, 1, "queued_job", [&] (AsyncLoader &, const LoadJobPtr &) { jobs_done++; })});
+    const auto failures_after_queueing = spawnFailures() - failures_before;
+
+    // Pool 1's only worker now enters a cross-pool wait, which reaches the spawn while the global pool
+    // still cannot provide a thread. Reaching a fatal branch here would abort the whole test binary.
+    start_waiting = true;
+    while (awaited_job->waitersCount() == 0)
+        std::this_thread::yield();
+    const auto failures_after_wait = spawnFailures() - failures_before;
+
+    sync.arrive_and_wait(); // (A) release the awaited job, so the wait ends whatever happened
+    limits.restore();
+    waitLoad(awaited_task);
+    waitLoad(waiting_task);
+    waitLoad(queued_task);
+
+    // Surviving is necessary but not sufficient: the spawn attempted from inside `wait()` must have
+    // been made and must have failed, otherwise this test would pass without exercising the branch.
+    ASSERT_EQ(failures_after_queueing, 1); // The droppable spawn, before the wait
+    ASSERT_EQ(failures_after_wait, 2); // Plus the one attempted from inside `wait()`
+    ASSERT_EQ(jobs_done, 3); // The queued job still runs once the wait ends
+    t.loader.wait();
+}
+
+// The abort is kept for the one state that cannot be recovered from: a pool with no worker able to
+// drain its queue, and no thread to be had. Dropping the spawn there would leave the jobs queued
+// forever, so a failure to spawn must remain fatal.
+TEST(AsyncLoaderDeathTest, MandatorySpawnFailureTerminates)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+    auto mandatory_spawn_with_no_thread_available = []
+    {
+        // Fill the global thread pool's queue while it can run nothing, so the next request for a
+        // thread fails immediately rather than waiting. Only this child process is affected.
+        GlobalThreadPoolLimits limits;
+        limits.submitWithoutStarting(1);
+        GlobalThreadPool::instance().scheduleOrThrow([] {}, {}, /* wait_microseconds = */ 0);
+
+        // A pool whose workers have all yet to start needs this spawn to succeed, so the fault
+        // injector is bypassed and the failure cannot be dropped.
+        AsyncLoaderTest t(16);
+        auto task = t.schedule({makeLoadJob({}, "job", [] (AsyncLoader &, const LoadJobPtr &) {})});
+        t.loader.unpause(); // Spawns, and must not return
+
+        // Reached only if the failure was swallowed. Exiting successfully reports that to the parent,
+        // whereas draining would be impossible here and would hang instead.
+        std::_Exit(0);
+    };
+
+    EXPECT_DEATH(mandatory_spawn_with_no_thread_available(), "Cannot schedule a task");
 }


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110174
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a server abort that happens when the global thread pool is momentarily saturated while tables are still loading. `AsyncLoader` now keeps running if it cannot spawn an extra loader worker and some worker will still drain the queued jobs, instead of calling `std::terminate`.


### Description

`AsyncLoader::spawn` wrapped `scheduleOrThrowOnError` in `NOEXCEPT_SCOPE`, whose handler is unconditionally `std::terminate()`. A transient `CANNOT_SCHEDULE_TASK` from a saturated global thread pool therefore killed the server (`Received signal 6`) during table loading. Seen 4 times over 4 unrelated PRs and 4 build flavours in 30 days, e.g. [`Stress test (arm_tsan)`](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108468&sha=27a154474608ee82636207020a9bd13beb8c9449&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29), whose stack is `terminate_handler()` -> `std::terminate()` -> `AsyncLoader.cpp:908` `spawn()` -> `:744` `enqueue()`.

A spawn must succeed only when nothing else will drain the pool's ready queue, so it now tells three states apart:

- a worker that entered `worker()` and is not inside `wait()` drains the queue now;
- a worker inside `wait()` on *another* pool's job resumes draining once that job runs;
- neither of those means nobody ever will.

In the first two cases `spawn` uses the non-throwing `trySchedule`, rolls back its `Pool::workers` increment on failure, warns and returns false. Only the last case keeps the fatal path, byte for byte: the queued jobs would be stranded, and throwing is not an option because `schedule` marks that region non-exception-safe. Covering it needs rollback-and-retry across the loading DAG, out of scope here. All 4 observed rows are recoverable. `BackgroundSchedulePool` narrows the same way (`929227464f9736b`).

Two counters are added because `Pool::workers` also counts a worker still queued in the global pool, which drains nothing, and one blocked in `wait()`, which cannot take its own pool's jobs. A saturated pool is remembered so the failing thread creation happens once per episode, not once per queued job, counted by the new `AsyncLoaderSpawnFailures` event; entering `wait()` clears the memo.

Tests are gtests asserting which branch was taken, not just that the process survived. A SQL test cannot reach the line: on master the whole call sits under `blockFaultInjections()`.

Related: #110174, which removed the mask that hid this exception.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.53`, `26.6.6.11`
<!-- ch-version-info:end -->