### PR TITLE
Docs: Add ADBC driver documentation

### DIFF
--- a/docs/concepts/features/interfaces/adbc.mdx
+++ b/docs/concepts/features/interfaces/adbc.mdx
@@ -1,0 +1,47 @@
+---
+description: 'Documentation for the ClickHouse ADBC driver'
+sidebarTitle: 'ADBC driver'
+slug: /interfaces/adbc
+title: 'ADBC driver'
+doc_type: 'reference'
+---
+
+The ClickHouse ADBC driver provides a standards-compliant [Arrow Database Connectivity (ADBC)](https://arrow.apache.org/adbc/)
+interface for connecting ADBC-compatible applications to ClickHouse.
+
+The driver communicates with the ClickHouse server using the [HTTP protocol](/concepts/features/interfaces/http), which is the primary
+protocol supported across all ClickHouse deployments. This allows the driver to operate consistently in diverse
+environments, including local installations, cloud-managed services, and environments where only HTTP-based access is
+available.
+
+The source code of the driver is available in the
+[adbc_clickhouse GitHub Repository](https://github.com/clickhouse/adbc_clickhouse).
+
+<Note>
+This driver is under active development. Some ADBC features may not yet be fully implemented. The current version
+focuses on providing essential connectivity and core ADBC functionality, with additional features planned for future
+releases.
+
+Your feedback is highly valuable and helps guide the prioritization of new features and improvements. If you encounter
+limitations, missing functionality, or unexpected behavior, please share your observations or feature requests through
+the issue tracker at
+[github.com/ClickHouse/adbc_clickhouse/issues](https://github.com/ClickHouse/adbc_clickhouse/issues)
+</Note>
+
+## Installation {#installation}
+
+You can install the latest version of the driver with [dbc](https://docs.columnar.tech/dbc/):
+
+```bash
+dbc install clickhouse
+```
+
+Alternatively, you can download it manually from [github.com/adbc-drivers/clickhouse/releases](https://github.com/adbc-drivers/clickhouse/releases).
+
+## Database options {#database-options}
+
+The database options below are used to establish a connection with the ClickHouse ADBC driver.
+
+- `uri`: Specifies the full HTTP(S) endpoint of the ClickHouse server. This includes the protocol, host, and port.
+- `username`: The username used for authentication with the ClickHouse server.
+- `password`: The password associated with the specified username.

--- a/docs/concepts/features/interfaces/overview.mdx
+++ b/docs/concepts/features/interfaces/overview.mdx
@@ -17,6 +17,7 @@ ClickHouse provides two network interfaces (they can be optionally wrapped in TL
 In most cases it is recommended to use an appropriate tool or library instead of interacting with those directly. The following are officially supported by ClickHouse:
 
 - [Command-line client](/concepts/features/interfaces/cli)
+- [ADBC driver](/concepts/features/interfaces/adbc)
 - [JDBC driver](/concepts/features/interfaces/jdbc)
 - [ODBC driver](/concepts/features/interfaces/odbc)
 - [C++ client library](/es/concepts/features/interfaces/cpp)

--- a/docs/concepts/navigation.json
+++ b/docs/concepts/navigation.json
@@ -216,6 +216,7 @@
                 "concepts/features/interfaces/overview",
                 "concepts/features/interfaces/http",
                 "concepts/features/interfaces/tcp",
+                "concepts/features/interfaces/adbc",
                 "concepts/features/interfaces/jdbc",
                 "concepts/features/interfaces/mysql",
                 "concepts/features/interfaces/odbc",


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1980` (included in `26.8` and later)
<!-- ch-version-info:end -->