### PR TITLE
Read fresh in-memory metadata at the OPTIMIZE merge-selection read

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1663,7 +1663,7 @@ bool StorageMergeTree::merge(
         /// which publishes new metadata and registers the rename mutation atomically under
         /// the same mutex, so this `OPTIMIZE`-driven merge selection cannot observe new
         /// metadata without also seeing the pending rename mutation. See #80648.
-        metadata_snapshot = getInMemoryMetadataPtr();
+        metadata_snapshot = getInMemoryMetadataPtr(/*bypass_metadata_cache=*/true);
 
         return selectPartsToMerge(
             metadata_snapshot,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104822
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed data loss when a `RENAME COLUMN` runs concurrently with `OPTIMIZE TABLE ... FINAL` on a `MergeTree` table: the merged part could be written with the pre-rename column list, permanently filling the renamed column with its `DEFAULT`.


### Description

`26.3`-only fix for issue 80648, authorized in https://github.com/ClickHouse/ClickHouse/pull/113929#issuecomment-5229587902.

`StorageMergeTree::optimize` calls `merge` synchronously on the query thread, so the merge-selection
metadata read runs with a live query context. `MergeTreeData` overrides `getInMemoryMetadataPtr` with
a per-query cache that `InterpreterOptimizeQuery` has already populated with the pre-`ALTER` snapshot,
so the read returns metadata predating the rename while selection pairs it with parts that already
carry the mutation. `MergeTask` takes `storage_columns` from that snapshot and never re-reads, so the
merged part keeps the old column list and the renamed column stays `DEFAULT`.

Passing `bypass_metadata_cache=true` makes the read honour the invariant the comment above it already
states. `scheduleDataProcessingJob` keeps its bare read: its only caller is the background pool, which
has no query context, so it already bypasses.

`26.4` and later declare the accessor as `(ContextPtr, bool)` with no default, forcing every caller to
state a context, so the read is already fresh there. `25.8` has the same bare read but ships
`enable_shared_storage_snapshot_in_query` defaulting to `false`. `26.3` is the only supported branch
with both the defaulted parameter and that setting `true`, which is why the backport of 104822
compiled unchanged as `getInMemoryMetadataPtr()` and took the cache-consulting path.

Validation on two interleaved, load-matched servers built from this tree, setting at its default:
base reddens 16 of 7000 iterations against 0 for the fix (Fisher exact p = 3.0e-05); swapping the
binaries onto each other's port and data directory keeps the effect with the binary (30/7000 against
0/7000); 80 runner runs of the unmodified `04238_alter_rename_column_merge_race` per arm give 3 base
failures with the exact CI signature and 80/80 on the fix. None of the 211 merge and mutation tests
with a verdict in both arms regressed.
