### PR TITLE
Set the current Keeper component in TextIndexCountSource::generate

### DIFF
--- a/src/Processors/QueryPlan/ReadFromTextIndexCount.cpp
+++ b/src/Processors/QueryPlan/ReadFromTextIndexCount.cpp
@@ -1,6 +1,7 @@
 #include <Processors/QueryPlan/ReadFromTextIndexCount.h>
 
 #include <AggregateFunctions/AggregateFunctionCount.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <Interpreters/ProcessList.h>
 #include <Processors/ISource.h>
@@ -250,6 +251,9 @@ public:
 protected:
     Chunk generate() override
     {
+        /// Reading part files may issue Keeper requests, which require a component to be set for the scope.
+        auto component_guard = Coordination::setCurrentComponent("TextIndexCountSource::generate");
+
         size_t part_idx = state->next_part.fetch_add(1);
         if (part_idx >= state->parts.size())
             return {};


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113295
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #113295

`SELECT count() FROM t WHERE hasAllTokens(str, [...])` is rewritten by the trivial-count-from-text-index optimization into a `ReadFromTextIndexCount` step (added in #111494). Its source runs on a pipeline execution thread:

`TextIndexCountSource::generate` -> `computeCountForPart` -> `makeTextIndexInputStream` -> `IMergeTreeDataPart::getStreamNameOrHash(..., IDataPartStorage &)`, whose body probes the part storage with `existsFile`.

On a disk that keeps part metadata in Keeper that probe is a real Keeper request, and `Coordination::ZooKeeper::pushRequest` throws `LOGICAL_ERROR` when no component is set for the scope. `generate()` is the outermost scope this step owns on that thread, and it set none: the step builds its own `Pipe`, so unlike the ordinary read path it never inherits the guard from `MergeTreeSource::tryGenerate`.

This adds the one-line RAII guard at the top of `generate()`. The guard is a nesting-safe thread-local stack and every Keeper-reaching call above is a descendant of that scope, so no deeper placement is needed. Same shape as #113295 for `MergeTreeCodecBlockCountsSource::generate` and the sibling `MergeTreeTextIndexSource::generate`.

Of the four callers of `makeTextIndexInputStream`, the other three already have an ancestor guard (`MergeTreeSource::tryGenerate` for both `MergeTreeReaderTextIndex` sites, the mutate/merge task guards for `MergeTextIndexesTask`); this step was the only gap.

Category is `CI Fix or Improvement`, as in #113295 and #113386: the metadata-in-Keeper storage type is registered only under `#if CLICKHOUSE_CLOUD`, and `LOGICAL_ERROR` aborts only in debug and sanitizer builds, so this cannot happen in an official stable build. For the same reason no test is added: no public build reaches Keeper through `existsFile`. Validated with the existing `02346_text_index*` suite (plus 50/50 randomized runs of `02346_text_index_optimize_trivial_count`), an `EXPLAIN` assertion that the modified scope is the one the query executes, and a run with `enforce_keeper_component_tracking = 1`.

Left alone: the plan-time `getDeserializedFormat` path can also reach `existsFile` for packed skip-index parts and is likewise unguarded, but it predates this step by three weeks and is not this failure's carrier.