### PR TITLE
Remove the stale TODO about unloading tables in reverse topological order

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -1945,9 +1945,10 @@ void DatabaseCatalog::checkTableCanBeRemovedOrRenamedUnlocked(
         return;
     }
 
-    /// For DROP DATABASE we should ignore dependent tables from the same database:
-    /// `InterpreterDropQuery::executeToDatabaseImpl` unloads them in reverse topological order
-    /// of loading dependencies, so a dependent is always dropped before the table it depends on.
+    /// For DROP DATABASE we should ignore dependent tables from the same database.
+    /// `InterpreterDropQuery::executeToDatabaseImpl` unloads loading dependencies in reverse topological order,
+    /// so a dependent is always dropped before the table it depends on.
+    /// TODO: Do the same for referential dependencies.
     std::vector<StorageID> from_other_databases;
     for (const auto & dependent : dependents)
         if (dependent.database_name != removing_table.database_name)

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -1945,8 +1945,9 @@ void DatabaseCatalog::checkTableCanBeRemovedOrRenamedUnlocked(
         return;
     }
 
-    /// For DROP DATABASE we should ignore dependent tables from the same database.
-    /// TODO unload tables in reverse topological order and remove this code
+    /// For DROP DATABASE we should ignore dependent tables from the same database:
+    /// `InterpreterDropQuery::executeToDatabaseImpl` unloads them in reverse topological order
+    /// of loading dependencies, so a dependent is always dropped before the table it depends on.
     std::vector<StorageID> from_other_databases;
     for (const auto & dependent : dependents)
         if (dependent.database_name != removing_table.database_name)


### PR DESCRIPTION
`DatabaseCatalog::checkTableCanBeRemovedOrRenamedUnlocked` skips dependent tables from the same database when the removal comes from `DROP DATABASE`, and carried a TODO asking for the tables to be unloaded in reverse topological order instead.

That ordering exists since https://github.com/ClickHouse/ClickHouse/pull/97057: `InterpreterDropQuery::executeToDatabaseImpl` sorts the tables of a `DROP DATABASE` in reverse loading dependency order, so a dependent is always dropped before the table it depends on. The skip itself is still required, since the dependency graph is consulted per table while the database is being emptied, so only the obsolete TODO is replaced by a pointer to the code that maintains the invariant.

Comment-only change.

Related: https://github.com/ClickHouse/ClickHouse/issues/87369
Related: https://github.com/ClickHouse/ClickHouse/pull/102506

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1460` (included in `26.8` and later)
<!-- ch-version-info:end -->