### PR TITLE
Fix `codex` worker authentication and accounting

### DIFF
--- a/utils/continue-all-prs.sh
+++ b/utils/continue-all-prs.sh
@@ -593,13 +593,20 @@ declare -a WORKER_PIDS=()
 stop_workers()
 {
     local roots own_pgid entry pid pgid
-    local -a targets active_workers
-    local -A target_groups=()
+    local -a targets
+    local -a active_workers=() live_jobs=()
+    local -A target_groups=() worker_pid_set=()
 
     # `WORKER_PIDS` retains exited child PIDs until `wait` completes. Resolve
     # roots through the shell's live job table so a recycled PID can never be
     # mistaken for a worker and signalled during interrupt handling.
-    mapfile -t active_workers < <(jobs -pr)
+    for pid in "${WORKER_PIDS[@]}"; do
+        worker_pid_set["$pid"]=1
+    done
+    mapfile -t live_jobs < <(jobs -pr)
+    for pid in "${live_jobs[@]}"; do
+        [[ -n "${worker_pid_set[$pid]:-}" ]] && active_workers+=("$pid")
+    done
     (( ${#active_workers[@]} )) || return 0
     roots="${active_workers[*]}"
     own_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ' || true)

--- a/utils/continue-all-prs.sh
+++ b/utils/continue-all-prs.sh
@@ -64,9 +64,9 @@ set -euo pipefail
 #   --effort LEVEL        Reasoning effort for each worker; default: medium.
 #                         Passed as `--effort` to `claude` and as the
 #                         `model_reasoning_effort` setting to `codex`.
-#   --api-key KEY         Use a custom API key for the workers (exported as
-#                         ANTHROPIC_API_KEY or OPENAI_API_KEY according to
-#                         --agent). NOTE: visible in `ps`
+#   --api-key KEY         Use a custom API key for the workers. `claude` reads
+#                         `ANTHROPIC_API_KEY`; `codex` logs into a worker-local
+#                         `CODEX_HOME`. NOTE: visible in `ps`
 #                         while running; prefer --api-key-file.
 #   --api-key-file FILE   Read the custom API key from FILE (not shown
 #                         in `ps`). Default: whatever API key or login the
@@ -199,8 +199,9 @@ if (( ! MODE_ANY )); then
     MODE_MINE=1; MODE_ASSIGNED=1; MODE_RELATED=1
 fi
 
-# Custom API key for worker processes. `codex` uses `OPENAI_API_KEY` in preference
-# to its configured login, allowing a worker pool to use the requested account.
+# Custom API key for worker processes. `claude` reads its key from the environment.
+# `codex` is logged in with the key in a worker-local `CODEX_HOME` before it starts,
+# so it cannot inherit or overwrite an ambient Codex login.
 # Prefer --api-key-file: an inline --api-key is visible in `ps`.
 if [[ -n "$API_KEY_FILE" ]]; then
     [[ -r "$API_KEY_FILE" ]] || { echo "${S}Error: --api-key-file not readable: $API_KEY_FILE${R}" >&2; exit 1; }
@@ -210,8 +211,6 @@ if (( API_KEY_PROVIDED )); then
     [[ -n "$API_KEY" ]] || { echo "${S}Error: --api-key must not be empty${R}" >&2; exit 1; }
     if [[ "$AGENT" == "claude" ]]; then
         export ANTHROPIC_API_KEY="$API_KEY"
-    else
-        export OPENAI_API_KEY="$API_KEY"
     fi
     CUSTOM_KEY=1
 else
@@ -700,7 +699,8 @@ run_continue_pr()
 {
     local wt="$1" number="$2" log="$3"
     local url="https://github.com/$REPO/pull/$number"
-    local sid deadline iter ec now remaining build_steer prompt usage
+    local sid deadline iter ec now remaining build_steer prompt usage codex_home
+    local -a codex_env
     local u_i u_o u_ci u_co u_cost
     local -a model_args
     sid=""
@@ -718,6 +718,23 @@ run_continue_pr()
     : > "$log"
     iter=0
     ec=0
+
+    # Codex API-key authentication is configured state, not an environment
+    # variable consumed by `codex exec`. Keep that state private to this worker
+    # and remove it after the run, so a requested key cannot fall back to or
+    # modify the caller's ambient Codex login.
+    codex_home=""
+    codex_env=()
+    if [[ "$AGENT" == "codex" && "$CUSTOM_KEY" == 1 ]]; then
+        codex_home="$wt/tmp/continue-all-prs/codex-home"
+        codex_env=("CODEX_HOME=$codex_home")
+        mkdir -p "$codex_home"
+        rm -f "$codex_home/auth.json"
+        if ! printf '%s\n' "$API_KEY" | CODEX_HOME="$codex_home" codex login --with-api-key >> "$log" 2>&1; then
+            rm -f "$codex_home/auth.json"
+            return 1
+        fi
+    fi
 
     while :; do
         iter=$(( iter + 1 ))
@@ -756,7 +773,7 @@ run_continue_pr()
                 prompt="/continue-pr-auto $url
 
 ${STEER_PROMPT} ${build_steer}"
-                ( cd "$wt" && timeout "$remaining" codex exec \
+                ( cd "$wt" && timeout "$remaining" env "${codex_env[@]}" codex exec \
                     --dangerously-bypass-approvals-and-sandbox --json \
                     --config "model_reasoning_effort=$EFFORT" "${model_args[@]}" \
                     --output-last-message "$log.last" - <<< "$prompt" \
@@ -767,7 +784,7 @@ ${STEER_PROMPT} ${build_steer}"
                     ec=1
                 fi
             else
-                ( cd "$wt" && timeout "$remaining" codex exec resume \
+                ( cd "$wt" && timeout "$remaining" env "${codex_env[@]}" codex exec resume \
                     --dangerously-bypass-approvals-and-sandbox --json \
                     --config "model_reasoning_effort=$EFFORT" "${model_args[@]}" \
                     --output-last-message "$log.last" "$sid" - <<< "$NUDGE_PROMPT" \
@@ -810,6 +827,7 @@ ${STEER_PROMPT} ${build_steer}"
         (( ec != 0 )) && break
     done
 
+    [[ -z "$codex_home" ]] || rm -f "$codex_home/auth.json"
     return "$ec"
 }
 

--- a/utils/continue-all-prs.sh
+++ b/utils/continue-all-prs.sh
@@ -64,9 +64,9 @@ set -euo pipefail
 #   --effort LEVEL        Reasoning effort for each worker; default: medium.
 #                         Passed as `--effort` to `claude` and as the
 #                         `model_reasoning_effort` setting to `codex`.
-#   --api-key KEY         Use a custom API key for the workers (exported as
-#                         ANTHROPIC_API_KEY or OPENAI_API_KEY according to
-#                         --agent). NOTE: visible in `ps`
+#   --api-key KEY         Use a custom API key for `claude` workers (exported as
+#                         ANTHROPIC_API_KEY). `codex` workers use their configured
+#                         login and reject this option. NOTE: visible in `ps`
 #                         while running; prefer --api-key-file.
 #   --api-key-file FILE   Read the custom API key from FILE (not shown
 #                         in `ps`). Default: whatever API key or login the
@@ -198,8 +198,9 @@ if (( ! MODE_ANY )); then
     MODE_MINE=1; MODE_ASSIGNED=1; MODE_RELATED=1
 fi
 
-# Custom API key for the worker processes. Export the variable used by the
-# selected agent so every worker inherits it.
+# Custom API key for `claude` worker processes. The Codex CLI reads credentials
+# from `CODEX_HOME/auth.json`, so exporting `OPENAI_API_KEY` would not select the
+# requested account and must not silently fall back to an ambient Codex login.
 # Prefer --api-key-file: an inline --api-key is visible in `ps`.
 if [[ -n "$API_KEY_FILE" ]]; then
     [[ -r "$API_KEY_FILE" ]] || { echo "${S}Error: --api-key-file not readable: $API_KEY_FILE${R}" >&2; exit 1; }
@@ -209,7 +210,8 @@ if [[ -n "$API_KEY" ]]; then
     if [[ "$AGENT" == "claude" ]]; then
         export ANTHROPIC_API_KEY="$API_KEY"
     else
-        export OPENAI_API_KEY="$API_KEY"
+        echo "${S}Error: --api-key and --api-key-file are not supported with --agent codex; configure Codex login first${R}" >&2
+        exit 1
     fi
     CUSTOM_KEY=1
 else
@@ -222,6 +224,7 @@ fi
 # ChatGPT subscription usage is not billed per token.
 CODEX_INPUT_PRICE=""
 CODEX_CACHED_INPUT_PRICE=""
+CODEX_CACHE_WRITE_INPUT_PRICE=""
 CODEX_OUTPUT_PRICE=""
 CODEX_LONG_CONTEXT_PRICING=0
 
@@ -229,11 +232,13 @@ configure_codex_pricing()
 {
     case "$MODEL" in
         gpt-5.6|gpt-5.6-sol|gpt-5.6-sol-*)
-            CODEX_INPUT_PRICE=5; CODEX_CACHED_INPUT_PRICE=0.5; CODEX_OUTPUT_PRICE=30; CODEX_LONG_CONTEXT_PRICING=1 ;;
-        gpt-5.6-terra|gpt-5.6-terra-*|gpt-5.4|gpt-5.4-20*)
-            CODEX_INPUT_PRICE=2.5; CODEX_CACHED_INPUT_PRICE=0.25; CODEX_OUTPUT_PRICE=15; CODEX_LONG_CONTEXT_PRICING=1 ;;
+            CODEX_INPUT_PRICE=5; CODEX_CACHED_INPUT_PRICE=0.5; CODEX_CACHE_WRITE_INPUT_PRICE=6.25; CODEX_OUTPUT_PRICE=30; CODEX_LONG_CONTEXT_PRICING=1 ;;
+        gpt-5.6-terra|gpt-5.6-terra-*)
+            CODEX_INPUT_PRICE=2; CODEX_CACHED_INPUT_PRICE=0.2; CODEX_CACHE_WRITE_INPUT_PRICE=2.5; CODEX_OUTPUT_PRICE=12; CODEX_LONG_CONTEXT_PRICING=1 ;;
         gpt-5.6-luna|gpt-5.6-luna-*)
-            CODEX_INPUT_PRICE=1; CODEX_CACHED_INPUT_PRICE=0.1; CODEX_OUTPUT_PRICE=6; CODEX_LONG_CONTEXT_PRICING=1 ;;
+            CODEX_INPUT_PRICE=0.2; CODEX_CACHED_INPUT_PRICE=0.02; CODEX_CACHE_WRITE_INPUT_PRICE=0.25; CODEX_OUTPUT_PRICE=1.2; CODEX_LONG_CONTEXT_PRICING=1 ;;
+        gpt-5.4|gpt-5.4-20*)
+            CODEX_INPUT_PRICE=2.5; CODEX_CACHED_INPUT_PRICE=0.25; CODEX_OUTPUT_PRICE=15; CODEX_LONG_CONTEXT_PRICING=1 ;;
         gpt-5.5-pro|gpt-5.5-pro-*|gpt-5.4-pro|gpt-5.4-pro-*)
             CODEX_INPUT_PRICE=30; CODEX_CACHED_INPUT_PRICE=30; CODEX_OUTPUT_PRICE=180; CODEX_LONG_CONTEXT_PRICING=1 ;;
         gpt-5.5|gpt-5.5-20*)
@@ -255,17 +260,17 @@ configure_codex_pricing()
 
 estimate_codex_cost()
 {
-    local input_tokens="$1" cached_input_tokens="$2" output_tokens="$3"
+    local input_tokens="$1" cached_input_tokens="$2" output_tokens="$3" cache_write_input_tokens="$4"
     [[ -n "$CODEX_INPUT_PRICE" ]] || { printf '0'; return; }
-    awk -v i="$input_tokens" -v ci="$cached_input_tokens" -v o="$output_tokens" \
-        -v ip="$CODEX_INPUT_PRICE" -v cip="$CODEX_CACHED_INPUT_PRICE" -v op="$CODEX_OUTPUT_PRICE" \
+    awk -v i="$input_tokens" -v ci="$cached_input_tokens" -v o="$output_tokens" -v cwi="$cache_write_input_tokens" \
+        -v ip="$CODEX_INPUT_PRICE" -v cip="$CODEX_CACHED_INPUT_PRICE" -v cwip="${CODEX_CACHE_WRITE_INPUT_PRICE:-$CODEX_INPUT_PRICE}" -v op="$CODEX_OUTPUT_PRICE" \
         -v long="$CODEX_LONG_CONTEXT_PRICING" '
         BEGIN {
-            uncached = i - ci;
+            uncached = i - ci - cwi;
             if (uncached < 0) uncached = 0;
             input_multiplier = (long && i > 272000) ? 2 : 1;
             output_multiplier = (long && i > 272000) ? 1.5 : 1;
-            printf "%.9f", ((uncached * ip + ci * cip) * input_multiplier + o * op * output_multiplier) / 1000000;
+            printf "%.9f", ((uncached * ip + ci * cip + cwi * cwip) * input_multiplier + o * op * output_multiplier) / 1000000;
         }'
 }
 
@@ -588,11 +593,15 @@ declare -a WORKER_PIDS=()
 stop_workers()
 {
     local roots own_pgid entry pid pgid
-    local -a targets
+    local -a targets active_workers
     local -A target_groups=()
 
-    (( ${#WORKER_PIDS[@]} )) || return 0
-    roots="${WORKER_PIDS[*]}"
+    # `WORKER_PIDS` retains exited child PIDs until `wait` completes. Resolve
+    # roots through the shell's live job table so a recycled PID can never be
+    # mistaken for a worker and signalled during interrupt handling.
+    mapfile -t active_workers < <(jobs -pr)
+    (( ${#active_workers[@]} )) || return 0
+    roots="${active_workers[*]}"
     own_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ' || true)
 
     # Snapshot the complete descendant tree before sending any signal. Commands
@@ -646,12 +655,8 @@ stop_workers()
         read -r pid pgid <<< "$entry"
         kill -KILL "$pid" 2>/dev/null || true
     done
-    for pid in "${WORKER_PIDS[@]}"; do
-        kill -KILL "$pid" 2>/dev/null || true
-    done
-
-    if (( ${#WORKER_PIDS[@]} )); then
-        wait "${WORKER_PIDS[@]}" 2>/dev/null || true
+    if (( ${#active_workers[@]} )); then
+        wait "${active_workers[@]}" 2>/dev/null || true
     fi
     WORKER_PIDS=()
 }
@@ -769,11 +774,11 @@ ${STEER_PROMPT} ${build_steer}"
                     [splits("\n") | fromjson?] as $events
                     | [([$events[] | select(.type == "turn.completed") | (.usage.input_tokens // 0)] | add // 0),
                      ([$events[] | select(.type == "turn.completed") | (.usage.output_tokens // 0)] | add // 0),
-                     0,
+                     ([$events[] | select(.type == "turn.completed") | (.usage.cache_write_input_tokens // 0)] | add // 0),
                      ([$events[] | select(.type == "turn.completed") | (.usage.cached_input_tokens // 0)] | add // 0),
                      0] | @tsv' "$log.json" 2>/dev/null)
                 IFS=$'\t' read -r u_i u_o u_ci u_co u_cost <<< "$usage"
-                u_cost=$(estimate_codex_cost "${u_i:-0}" "${u_co:-0}" "${u_o:-0}")
+                u_cost=$(estimate_codex_cost "${u_i:-0}" "${u_co:-0}" "${u_o:-0}" "${u_ci:-0}")
                 stats_add 0 0 0 "${u_i:-0}" "${u_o:-0}" "${u_ci:-0}" "${u_co:-0}" "${u_cost:-0}"
             fi
             if [[ ! -s "$log.last" ]]; then

--- a/utils/continue-all-prs.sh
+++ b/utils/continue-all-prs.sh
@@ -64,9 +64,9 @@ set -euo pipefail
 #   --effort LEVEL        Reasoning effort for each worker; default: medium.
 #                         Passed as `--effort` to `claude` and as the
 #                         `model_reasoning_effort` setting to `codex`.
-#   --api-key KEY         Use a custom API key for `claude` workers (exported as
-#                         ANTHROPIC_API_KEY). `codex` workers use their configured
-#                         login and reject this option. NOTE: visible in `ps`
+#   --api-key KEY         Use a custom API key for the workers (exported as
+#                         ANTHROPIC_API_KEY or OPENAI_API_KEY according to
+#                         --agent). NOTE: visible in `ps`
 #                         while running; prefer --api-key-file.
 #   --api-key-file FILE   Read the custom API key from FILE (not shown
 #                         in `ps`). Default: whatever API key or login the
@@ -140,6 +140,7 @@ MODEL=""               # model passed to the selected agent (empty -> its config
 SHOW_STATUS=1          # show the persistent bottom status bar (TTY only; --no-status disables)
 API_KEY=""             # custom provider API key for worker processes (--api-key)
 API_KEY_FILE=""        # ...or read it from this file (safer: not visible in `ps`)
+API_KEY_PROVIDED=0      # whether either custom-key option was supplied
 
 # PR selection modes (combinable). If none are given, all are enabled.
 MODE_MINE=0       # PRs I authored
@@ -166,8 +167,8 @@ while [[ $# -gt 0 ]]; do
         --model)          MODEL="$2"; shift 2 ;;
         --effort)         EFFORT="$2"; shift 2 ;;
         --no-status)      SHOW_STATUS=0; shift ;;
-        --api-key)        API_KEY="$2"; shift 2 ;;
-        --api-key-file)   API_KEY_FILE="$2"; shift 2 ;;
+        --api-key)        API_KEY="$2"; API_KEY_PROVIDED=1; shift 2 ;;
+        --api-key-file)   API_KEY_FILE="$2"; API_KEY_PROVIDED=1; shift 2 ;;
         --once)           ONCE=1; shift ;;
         --skip-submodules) SKIP_SUBMODULES=1; shift ;;
         --color)          COLOR_WHEN="$2"; shift 2 ;;
@@ -198,20 +199,19 @@ if (( ! MODE_ANY )); then
     MODE_MINE=1; MODE_ASSIGNED=1; MODE_RELATED=1
 fi
 
-# Custom API key for `claude` worker processes. The Codex CLI reads credentials
-# from `CODEX_HOME/auth.json`, so exporting `OPENAI_API_KEY` would not select the
-# requested account and must not silently fall back to an ambient Codex login.
+# Custom API key for worker processes. `codex` uses `OPENAI_API_KEY` in preference
+# to its configured login, allowing a worker pool to use the requested account.
 # Prefer --api-key-file: an inline --api-key is visible in `ps`.
 if [[ -n "$API_KEY_FILE" ]]; then
     [[ -r "$API_KEY_FILE" ]] || { echo "${S}Error: --api-key-file not readable: $API_KEY_FILE${R}" >&2; exit 1; }
     API_KEY="$(tr -d ' \t\r\n' < "$API_KEY_FILE")"
 fi
-if [[ -n "$API_KEY" ]]; then
+if (( API_KEY_PROVIDED )); then
+    [[ -n "$API_KEY" ]] || { echo "${S}Error: --api-key must not be empty${R}" >&2; exit 1; }
     if [[ "$AGENT" == "claude" ]]; then
         export ANTHROPIC_API_KEY="$API_KEY"
     else
-        echo "${S}Error: --api-key and --api-key-file are not supported with --agent codex; configure Codex login first${R}" >&2
-        exit 1
+        export OPENAI_API_KEY="$API_KEY"
     fi
     CUSTOM_KEY=1
 else

--- a/utils/continue-all-prs.sh
+++ b/utils/continue-all-prs.sh
@@ -589,6 +589,16 @@ STATSLOCK="$LOGDIR/stats.lock"
 NAFILE="$LOGDIR/needs-attention"
 declare -a WORKER_PIDS=()
 
+cleanup_worker_codex_auth()
+{
+    [[ "$AGENT" == "codex" && "$CUSTOM_KEY" == 1 ]] || return 0
+
+    local wt
+    for wt in "${WT[@]-}"; do
+        rm -f "$wt/tmp/continue-all-prs/codex-home/auth.json" 2>/dev/null || true
+    done
+}
+
 stop_workers()
 {
     local roots own_pgid entry pid pgid
@@ -606,7 +616,7 @@ stop_workers()
     for pid in "${live_jobs[@]}"; do
         [[ -n "${worker_pid_set[$pid]:-}" ]] && active_workers+=("$pid")
     done
-    (( ${#active_workers[@]} )) || return 0
+    (( ${#active_workers[@]} )) || { cleanup_worker_codex_auth; return 0; }
     roots="${active_workers[*]}"
     own_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ' || true)
 
@@ -664,6 +674,7 @@ stop_workers()
     if (( ${#active_workers[@]} )); then
         wait "${active_workers[@]}" 2>/dev/null || true
     fi
+    cleanup_worker_codex_auth
     WORKER_PIDS=()
 }
 
@@ -730,10 +741,14 @@ run_continue_pr()
         codex_env=("CODEX_HOME=$codex_home")
         mkdir -p "$codex_home"
         rm -f "$codex_home/auth.json"
-        if ! printf '%s\n' "$API_KEY" | CODEX_HOME="$codex_home" codex login --with-api-key >> "$log" 2>&1; then
+        now=$(date +%s)
+        remaining=$(( deadline - now ))
+        (( remaining > 0 )) || return 124
+        printf '%s\n' "$API_KEY" | timeout "$remaining" env CODEX_HOME="$codex_home" codex login --with-api-key >> "$log" 2>&1 || {
+            ec=$?
             rm -f "$codex_home/auth.json"
-            return 1
-        fi
+            return "$ec"
+        }
     fi
 
     while :; do

--- a/utils/tests/test_continue_all_prs.sh
+++ b/utils/tests/test_continue_all_prs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+mkdir -p "$repo/tmp"
+scratch=$(mktemp -d "$repo/tmp/test-continue-all-prs.XXXXXX")
+bin="$scratch/bin"
+worktree_base="$scratch/worktree"
+pr_file="$scratch/prs"
+runner_pid=""
+
+cleanup()
+{
+    [[ -z "$runner_pid" ]] || kill "$runner_pid" 2>/dev/null || true
+    git -C "$repo" worktree remove --force "${worktree_base}-0" 2>/dev/null || true
+    rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+mkdir -p "$bin"
+printf '1\tMocked PR\n' > "$pr_file"
+
+printf '%s\n' '#!/usr/bin/env bash' 'printf "{\\"headRefOid\\":\\"mock-sha\\"}\\n"' > "$bin/gh"
+chmod +x "$bin/gh"
+
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'if [[ "$1" == login ]]; then' \
+    '    mkdir -p "$CODEX_HOME"' \
+    '    printf key > "$CODEX_HOME/auth.json"' \
+    '    [[ -z "${CODEX_TEST_READY:-}" ]] || : > "$CODEX_TEST_READY"' \
+    '    sleep "${CODEX_TEST_LOGIN_SLEEP:-0}"' \
+    '    exit 0' \
+    'fi' \
+    'exit 0' > "$bin/codex"
+chmod +x "$bin/codex"
+
+PATH="$bin:$PATH" CONTINUE_ALL_PRS_PRS_FILE="$pr_file" CODEX_TEST_LOGIN_SLEEP=10 \
+    "$repo/utils/continue-all-prs.sh" --agent codex --api-key test-key --timeout 1 --once \
+        --skip-submodules --no-status --worktree-base "$worktree_base" --color never > "$scratch/timeout.log" 2>&1
+
+grep -q 'TIMEOUT' "$scratch/timeout.log"
+[[ ! -e "${worktree_base}-0/tmp/continue-all-prs/codex-home/auth.json" ]]
+
+PATH="$bin:$PATH" CONTINUE_ALL_PRS_PRS_FILE="$pr_file" CODEX_TEST_LOGIN_SLEEP=30 \
+    CODEX_TEST_READY="$scratch/login-ready" "$repo/utils/continue-all-prs.sh" --agent codex --api-key test-key \
+        --timeout 60 --once --skip-submodules --no-status --worktree-base "$worktree_base" --color never \
+        > "$scratch/interrupt.log" 2>&1 &
+runner_pid=$!
+
+for _ in {1..100}; do
+    [[ -e "$scratch/login-ready" ]] && break
+    sleep 0.05
+done
+[[ -e "$scratch/login-ready" ]]
+kill -TERM "$runner_pid"
+wait "$runner_pid" || true
+runner_pid=""
+
+[[ ! -e "${worktree_base}-0/tmp/continue-all-prs/codex-home/auth.json" ]]


### PR DESCRIPTION
Correct `codex` worker authentication handling, GPT-5.6 cost estimation, and interrupt cleanup.

Custom `codex` workers now log into a worker-local `CODEX_HOME` when `--api-key` or `--api-key-file` is provided. Cache writes are charged separately, current Terra/Luna prices are used, and shutdown only signals live worker jobs.

Related: https://github.com/ClickHouse/ClickHouse/pull/114750

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1468` (included in `26.8` and later)
<!-- ch-version-info:end -->