### PR TITLE
Show why a job failed when it never uploaded its own report

### DIFF
--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -2545,9 +2545,9 @@
         const results = await Promise.all(fetchTasks);
 
         if (nameParams.length > 1) {
-            const { data, updated, status } = results[0]; // First request result
-            // A null json1 is supported: getTargetResults then resolves the node from task0.
-            if (status !== 403 && updated) {
+            const { data, updated } = results[0]; // First request result
+            // A missing per-job report is not a missing report.
+            if (updated) {
                 runtimeCache.json1 = data;
                 hasNewData = true;
             }

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -2675,13 +2675,12 @@
                     // For single-level results, check json0 status
                     shouldContinue = ["running", "pending"].includes((runtimeCache?.json0?.status || '').toLowerCase());
                 } else if (nameParams?.length === 2) {
-                    // For two-level results, check json1 status (or json0 if json1 is null)
-                    if (runtimeCache?.json1) {
-                        shouldContinue = ["running", "pending"].includes((runtimeCache?.json1?.status || '').toLowerCase());
-                    } else {
-                        // If json1 is null, we might still be loading, so continue
-                        shouldContinue = true;
-                    }
+                    // For two-level results, check the status of the node actually rendered
+                    const target = runtimeCache?.json1 || getTargetResults(nameParams);
+                    // An unresolved target means nothing is loaded yet, so keep polling.
+                    shouldContinue = target
+                        ? ["running", "pending"].includes((target.status || '').toLowerCase())
+                        : true;
                 }
 
                 if (!shouldContinue) {

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -2546,10 +2546,8 @@
 
         if (nameParams.length > 1) {
             const { data, updated, status } = results[0]; // First request result
-            if (status === 403) {
-                return { error: 403, message: 'Report does not exist or expired' };
-            }
-            if (updated) {
+            // A null json1 is supported: getTargetResults then resolves the node from task0.
+            if (status !== 403 && updated) {
                 runtimeCache.json1 = data;
                 hasNewData = true;
             }

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -1091,7 +1091,6 @@ def _finish_workflow(workflow, job_name):
                     f"ERROR: not finished job [{result.name}] in the workflow - set status to error"
                 )
                 result.status = Result.Status.ERROR
-                # The only copy of the reason for a job that uploaded no report.
                 result.add_error(ResultInfo.NOT_FINALIZED)
                 # dump workflow result after update - to have an updated result in post
                 workflow_result.dump()

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -1091,6 +1091,8 @@ def _finish_workflow(workflow, job_name):
                     f"ERROR: not finished job [{result.name}] in the workflow - set status to error"
                 )
                 result.status = Result.Status.ERROR
+                # The only copy of the reason for a job that uploaded no report.
+                result.add_error(ResultInfo.NOT_FINALIZED)
                 # dump workflow result after update - to have an updated result in post
                 workflow_result.dump()
                 # Attribute the error to the failed job (not Finish Workflow)

--- a/ci/tests/test_result.py
+++ b/ci/tests/test_result.py
@@ -7,12 +7,14 @@ and the event feed. Think twice before adding one — and update all mapping
 tables (GH._STATUS_TO_GH, CIDB._STATUS_TO_CIDB) and these tests.
 """
 
+import dataclasses
+import json
 import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
-from ci.praktika.result import Result
+from ci.praktika.result import Result, ResultInfo
 
 
 # The canonical set of all statuses.  If you add a new status, you MUST
@@ -221,3 +223,26 @@ def test_create_from_omits_child_info_by_default():
     subs = [Result("hook_bad", Result.Status.FAIL, info="ERROR: something is wrong")]
     r = Result.create_from(name="Pre Hooks", results=subs)
     assert r.info == ""
+
+
+# --- add_error on a sub-result must survive the workflow report round trip ---
+# A job that loses its runner never uploads its own result_<job>.json, so the only
+# copy of the reason is the one _finish_workflow writes onto the sub-result inside
+# the workflow report. json.html resolves that node out of the workflow report and
+# renders ext["errors"], so the entry has to survive serialization.
+
+def test_add_error_on_sub_result_survives_workflow_serialization():
+    name = "AST fuzzer (amd_debug, targeted)"
+    child = Result(name, Result.Status.ERROR)
+    healthy = Result("AST fuzzer (amd_debug)", Result.Status.OK)
+    workflow = Result("PR", Result.Status.ERROR, results=[healthy, child])
+
+    child.add_error(ResultInfo.NOT_FINALIZED)
+
+    restored = Result.from_dict(json.loads(json.dumps(dataclasses.asdict(workflow))))
+    by_name = {r.name: r for r in restored.results}
+    assert by_name[name].ext["errors"] == [
+        {"message": ResultInfo.NOT_FINALIZED, "from": name}
+    ]
+    # Only the failed job is annotated.
+    assert "errors" not in by_name["AST fuzzer (amd_debug)"].ext

--- a/ci/tests/test_result.py
+++ b/ci/tests/test_result.py
@@ -7,10 +7,10 @@ and the event feed. Think twice before adding one — and update all mapping
 tables (GH._STATUS_TO_GH, CIDB._STATUS_TO_CIDB) and these tests.
 """
 
-import dataclasses
 import json
 import os
 import sys
+import types
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -225,24 +225,84 @@ def test_create_from_omits_child_info_by_default():
     assert r.info == ""
 
 
-# --- add_error on a sub-result must survive the workflow report round trip ---
-# A job that loses its runner never uploads its own result_<job>.json, so the only
-# copy of the reason is the one _finish_workflow writes onto the sub-result inside
-# the workflow report. json.html resolves that node out of the workflow report and
-# renders ext["errors"], so the entry has to survive serialization.
+def test_unfinished_job_carries_its_own_error_in_the_workflow_report(
+    tmp_path, monkeypatch
+):
+    """A job that never uploaded a report gets the reason on its own node.
 
-def test_add_error_on_sub_result_survives_workflow_serialization():
-    name = "AST fuzzer (amd_debug, targeted)"
-    child = Result(name, Result.Status.ERROR)
-    healthy = Result("AST fuzzer (amd_debug)", Result.Status.OK)
-    workflow = Result("PR", Result.Status.ERROR, results=[healthy, child])
+    The workflow report is the only place such a job appears, and json.html
+    renders each node's ext["errors"], so the entry must reach the uploaded
+    file - not merely the in-memory object.
+    """
+    import ci.praktika.native_jobs as native_jobs
+    from ci.praktika.settings import Settings
 
-    child.add_error(ResultInfo.NOT_FINALIZED)
+    dead = "AST fuzzer (amd_debug, targeted)"
+    healthy = "AST fuzzer (amd_debug)"
+    workflow_result = Result(
+        "PR",
+        Result.Status.RUNNING,
+        results=[
+            Result(dead, Result.Status.RUNNING, start_time=1.0),
+            Result(healthy, Result.Status.OK, start_time=1.0, duration=5.0),
+        ],
+    )
 
-    restored = Result.from_dict(json.loads(json.dumps(dataclasses.asdict(workflow))))
-    by_name = {r.name: r for r in restored.results}
-    assert by_name[name].ext["errors"] == [
-        {"message": ResultInfo.NOT_FINALIZED, "from": name}
+    # Result.dump() writes into Settings.TEMP_DIR.
+    monkeypatch.setattr(Settings, "TEMP_DIR", str(tmp_path))
+    # Absent status file -> no GitHub verdict for the job -> the error branch.
+    monkeypatch.setattr(Settings, "WORKFLOW_STATUS_FILE", str(tmp_path / "absent.json"))
+
+    workflow_errors = []
+
+    class Env:
+        PR_BODY = ""
+
+        def get_needs_statuses(self):
+            return {}
+
+        def add_workflow_error(self, message, source=""):
+            workflow_errors.append((message, source))
+
+    uploads = []
+
+    class ResultS3:
+        @classmethod
+        def copy_result_from_s3_with_version(cls, _path):
+            return 7
+
+        @classmethod
+        def copy_result_to_s3_with_version(cls, result, version, no_strict=False):
+            result.dump()
+            with open(result.file_name(), "r", encoding="utf8") as f:
+                uploads.append(json.load(f))
+            return True
+
+    class Workflow:
+        name = "PR"
+        post_hooks = []
+        enable_merge_ready_status = False
+        enable_open_issues_check = False
+
+        def get_job(self, _name):
+            return types.SimpleNamespace(allow_failure=False)
+
+    monkeypatch.setattr(
+        native_jobs, "_Environment", types.SimpleNamespace(get=lambda: Env())
+    )
+    monkeypatch.setattr(native_jobs, "_ResultS3", ResultS3)
+    monkeypatch.setattr(
+        Result, "from_fs", classmethod(lambda cls, name: workflow_result)
+    )
+
+    native_jobs._finish_workflow(Workflow(), "Finish Workflow")
+
+    assert len(uploads) == 1, "the workflow report must be re-uploaded"
+    nodes = {node["name"]: node for node in uploads[0]["results"]}
+    assert nodes[dead]["status"] == Result.Status.ERROR
+    assert nodes[dead]["ext"]["errors"] == [
+        {"message": ResultInfo.NOT_FINALIZED, "from": dead}
     ]
-    # Only the failed job is annotated.
-    assert "errors" not in by_name["AST fuzzer (amd_debug)"].ext
+    assert "errors" not in nodes[healthy]["ext"]
+    # The workflow node keeps the summary attribution.
+    assert workflow_errors == [(ResultInfo.NOT_FINALIZED, dead)]


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113382
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not user-facing: CI report only.


### Description

Two jobs on #113382 lost their runner mid-`Run`, and both report pages render nothing, so
the failure looks like a 0-second job with no output:

- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113382&sha=f7f79281458bd4558f12725868c0035cbc7b8f5d&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113382&sha=f7f79281458bd4558f12725868c0035cbc7b8f5d&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29

praktika did detect the failure and record the reason, but three defects hide it.

`_finish_workflow` reported such a job only through
`env.add_workflow_error(..., source=result.name)`. `source=` sets the `from` label, not the
destination, so the message landed on the workflow node while the job's own node kept an
empty `info`, and the page renders notifications from the node it resolved, which is the
job. The `Status.ERROR` sites in `runner.py` already call `add_error` on the job's own
result; this site did not.

A job uploads its own `result_<job>.json` from inside the job, so a job that dies never
uploads one and S3 answers 403. The page turned that 403 into "Report does not exist or
expired" and returned, discarding the workflow report it had already fetched, which does
contain the job's node. That early return is gone, and the cached per-job report is now
overwritten on every fetch that came back, so a page polling `sha=latest` cannot keep
showing an older commit's node.

Rendering that node exposed a third defect, already on master: the auto-reload predicate
asked whether the per-job report was running, so a null one read as still loading and the
page refetched S3 every 30 seconds forever. It now asks the node the page actually renders.

The runner loss is not fixable here and this does not try to.

A test drives `_finish_workflow` against a stubbed environment and asserts the reason reaches
the uploaded workflow report. For the page, a script extracts the relevant functions from
`json.html` and replays the measured S3 responses. Reverting any one fix alone reintroduces
its symptom; the healthy and expired paths stay byte-identical.