### PR TITLE
Fix server abort on a corrupt ORC stripe footer

### DIFF
--- a/tests/queries/0_stateless/04856_orc_corrupt_stripe_footer.reference
+++ b/tests/queries/0_stateless/04856_orc_corrupt_stripe_footer.reference
@@ -1,0 +1,5 @@
+INCORRECT_DATA
+Read past EOF in DecompressionStream::readBuffer
+0	0
+1	1
+2	2

--- a/tests/queries/0_stateless/04856_orc_corrupt_stripe_footer.sh
+++ b/tests/queries/0_stateless/04856_orc_corrupt_stripe_footer.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The stripe footer of this blob is truncated, so ORC's decompression stream reports the
+# failure by throwing from inside the protobuf parser. The parse must surface as a regular
+# INCORRECT_DATA exception; a protobuf has-bits assertion instead means the message was left
+# inconsistent while the exception unwound. Only debug and sanitizer builds check that
+# assertion, so the discriminating arm of this test is those builds.
+BLOB='4f52431100000a061204080150005500000a280a06000000000000121e08014a1818b8fef997d7d63820b8fef997d7d63828c1fc1530c1fc1550000f0000780039604d293e0b00006e0007dda36300\000a0608061000180b0a0608061001182d0a0608011001180a0a060805100118081204080010001204080210001a03474d545100000a260a04080150000a1e08014a1818b8fef997d7d63820b8fef997d7d63828c1fc1530c1fc155000b500000803107e1a0a08031038181220342801220f080c1201011a0263302000280030002208080920002800300030013a04080150003a1e08014a1818b8fef997d7d63820b8fef997d7d63828c1fc1530c1fc15500040904e48016200085d1005188080102202000c282b300682f403034f524317'
+
+$CLICKHOUSE_LOCAL -q "SELECT c0 FROM format(ORC, 'c0 DateTime64(3)', unhex('$BLOB'));" 2>&1 \
+    | grep -oE "Code: [0-9]+.*Read past EOF in DecompressionStream::readBuffer|INCORRECT_DATA|Has bits mismatch|Check failure stack trace" \
+    | sed -E 's/^Code: [0-9]+.*Read past EOF in DecompressionStream::readBuffer$/Read past EOF in DecompressionStream::readBuffer/' \
+    | sort -u
+
+# Well-formed ORC must still read back unchanged.
+DATA_FILE="$CLICKHOUSE_TMP/04856_orc_control_${CLICKHOUSE_DATABASE}.orc"
+$CLICKHOUSE_LOCAL -q "SELECT number AS a, toString(number) AS b FROM numbers(3) FORMAT ORC" > "$DATA_FILE"
+$CLICKHOUSE_LOCAL -q "SELECT a, b FROM file('$DATA_FILE', ORC) ORDER BY a"
+
+rm "$DATA_FILE"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/114674
Related: https://github.com/ClickHouse/orc/pull/25

Reading a corrupt ORC blob aborts a debug or sanitizer server instead of raising
`INCORRECT_DATA`:

```
generated_message_tctable_lite.cc:228] Check failed: VerifyHasBitConsistency(msg, table) is OK
(INTERNAL: Has bits mismatch for Type=orc.proto.StripeFooter Field=1
```

Found by the AST fuzzer (`AST fuzzer (amd_debug, targeted)`,
[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114267&sha=08273e65417c8b6a4fe95d2c2cdad899ea17d041&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29)),
and reproduced on pristine master with default settings by
`SELECT c0 FROM format(ORC, 'c0 DateTime64(3)', unhex('4f524311...524317'))`, so any
user-supplied ORC bytes reach it.

**Root cause.** ORC's `DecompressionStream` throws where protobuf's
`ZeroCopyInputStream::Next` contract requires a `false` return, so the exception originates
inside protobuf's parse loop. `TcParser` keeps has-bits in a register-cached local and writes
them back only on its own exit paths, so the unwind skips that write-back and leaves
`StripeFooter` with the repeated field `streams` appended to and its has-bit clear. Since
the v35.1 protobuf bump the generated destructor checks that invariant, so destroying it
aborts. `DebugHardenCheckHasBitConsistency()` gates it on `!NDEBUG` or a sanitizer, so
release builds are unaffected, hence a CI fix.

**Change.** A submodule bump only. ORC's parse boundary now wraps the caller's stream in an
adapter that captures anything escaping `Next`/`BackUp`/`Skip`/`ByteCount`, returns the
contract's failure value, and rethrows the original exception once the parser has returned
consistent. One header covers all nine `parseProtobufFromStream` call sites, including
embedder streams such as ClickHouse's `ORCInputStream`.

**Validation.** The blob aborts (RC 134) before the change and afterwards reports
`Code: 117 ... Read past EOF in DecompressionStream::readBuffer ... (INCORRECT_DATA)`,
byte-identical to master release today, so no user-visible message or code changes. New test
`04856_orc_corrupt_stripe_footer` passes 50/50 randomized and fails on the unfixed binary
with the has-bits tokens. A 183-case corruption sweep and the full `orc` suite show no
behaviour change.

`ProtobufZeroCopyInputStreamFromReadBuffer` (Prometheus remote-write) has the same shape,
but is unreported and I could not reproduce a failure there, so it is untouched.