### PR TITLE
Reduce merge write amplification in test_rabbitmq_mv_combo

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -728,7 +728,7 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster, db, unique):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = '{unique}_combo',
                      rabbitmq_queue_base = '{unique}_combo',
-                     rabbitmq_max_block_size = 100,
+                     rabbitmq_max_block_size = 10000,
                      rabbitmq_flush_interval_ms=1000,
                      rabbitmq_num_consumers = 2,
                      rabbitmq_num_queues = 5,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/109909
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/109909

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_rabbitmq_mv_combo` intermittently fails `Time limit of 180 seconds reached` on
master, most recently on `amd_msan, 6/8`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=236b530a8018049fb73c0417cceebbf346888949&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%206%2F8%29)).

The run is not stalled: consumption strictly increases at every poll, zero no-progress polls.
It is too slow because `rabbitmq_max_block_size = 100` makes every consumer flush a 100-row
part, so each of the 5 materialized-view targets accumulates ~2,000 level-0 parts and every
merge round re-reads the growing `all_1_*` base part - ~300 times over (final merge level
295-316). In the failing job merges read 124M rows to consume the 693k reached before the
deadline (~179x); locally, same signature, 122M rows for the full 1M (~122x), ~96% base-part
re-reads.

This raises `rabbitmq_max_block_size` to 10000 for this test's table only, matching
`test_nats_overloaded_insert` (the same high-volume MV fan-out shape). It reduces the work
rather than relaxing the budget: the 180s deadline is unchanged and the
`parallel_view_processing` setting from #110224 is retained. `rabbitmq_flush_interval_ms`
stays at 1000, so partial blocks still flush every second - measured block sizes stay
between 538 and 6168 rows and never reach the new cap, so the test cannot wait on a full
block. The final exact-count assertion is untouched. 10000 is still 52x below the engine
default for this table (`max_insert_block_size / rabbitmq_num_consumers`).

Validated with 12 interleaved A/B pairs on an MSAN build (the failing configuration, same
binary both arms, order alternated). Amplification drops 122.11x -> 12.43x with
non-overlapping ranges, and the consumption loop the deadline measures is faster in 12/12
pairs (median 77.2s -> 66.6s). A Debug build cannot show this: there merges use 0.23 of 384
cores, so the amplification is free. 9 tests in the module pass, including
`test_rabbitmq_flush_by_block_size`; the other 31 occurrences are unchanged.

One residual, not addressed here: the test's `SELECT count() FROM merge(...)` poll still
scans rows (~590k per poll) rather than using the trivial-count path.

<details>
<summary>Per-arm measurements (12 interleaved MSAN pairs)</summary>

| metric | base (n=12) | fix (n=12) | delta |
|---|---|---|---|
| consumption loop (s), median (range) | 77.2 (69.1-81.0) | 66.6 (52.0-71.2) | -13.8% |
| merge read amplification (x) | 122.11 (120.51-124.50) | 12.43 (10.90-13.25) | -89.8% |
| merge rows read | 122,101,440 | 12,430,342 | -89.8% |
| max merge level | 295 (291-301) | 25 (20-27) | -91.5% |
| level-0 parts per table | 2000 | 142 (117-152) | -92.9% |

Level-0 part size is exactly 100 rows for 9,989 of 9,989 parts before the change; after it,
sizes range 538-6168 and reach the 10000 cap in 0 of 2,090 parts.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1551` (included in `26.8` and later)
<!-- ch-version-info:end -->