### PR TITLE
Fix `S3Queue` regression test processing path

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -318,8 +318,11 @@ def test_batch_set_processing_failure_does_not_crash(started_cluster):
     conflict_file = f"{files_path}/test_1.csv"
     conflict_node = node.query(f"SELECT sipHash64('{conflict_file}')").strip()
     zk = started_cluster.get_kazoo_client("zoo1")
-    zk.ensure_path(f"{keeper_path}/processing")
-    zk.create(f"{keeper_path}/processing/{conflict_node}", b"conflict")
+    # `create_table` enables persistent processing nodes, so the conflicting node must
+    # be created in the same Keeper directory used by the queue.
+    processing_path = f"{keeper_path}/persistent_processing"
+    zk.ensure_path(processing_path)
+    zk.create(f"{processing_path}/{conflict_node}", b"conflict")
 
     def batch_set_processing_failures():
         node.query("SELECT 1")  # fails loudly if the server aborted
@@ -356,7 +359,7 @@ def test_batch_set_processing_failure_does_not_crash(started_cluster):
 
         # Remove the artificial conflict and confirm the queue keeps making progress after the
         # failed batch (the iterator recovered rather than getting stuck or having crashed).
-        zk.delete(f"{keeper_path}/processing/{conflict_node}")
+        zk.delete(f"{processing_path}/{conflict_node}")
 
         def get_count():
             return int(node.query(f"SELECT count() FROM {dst_table_name}"))

--- a/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
+++ b/tests/integration/test_storage_s3_queue/test_parallel_inserts.py
@@ -318,9 +318,9 @@ def test_batch_set_processing_failure_does_not_crash(started_cluster):
     conflict_file = f"{files_path}/test_1.csv"
     conflict_node = node.query(f"SELECT sipHash64('{conflict_file}')").strip()
     zk = started_cluster.get_kazoo_client("zoo1")
-    # `create_table` enables persistent processing nodes, so the conflicting node must
-    # be created in the same Keeper directory used by the queue.
-    processing_path = f"{keeper_path}/persistent_processing"
+    # Persistent processing controls the node mode; the queue still creates live nodes
+    # under `processing`, so seed the exact path used by its Keeper multi.
+    processing_path = f"{keeper_path}/processing"
     zk.ensure_path(processing_path)
     zk.create(f"{processing_path}/{conflict_node}", b"conflict")
 


### PR DESCRIPTION
Correct the regression setup so its pre-created Keeper node uses the live `processing` path that `S3Queue` still writes to, even when persistent processing nodes are enabled. This makes the test exercise its intended failed `multi` path rather than time out.

Related: https://github.com/ClickHouse/ClickHouse/pull/114761

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1461` (included in `26.8` and later)
<!-- ch-version-info:end -->