### PR TITLE
Fix possible crash due to ThreadGroup use-after-free (for async INSERTs/MVs/EXPLAIN ANALYZE)

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -72,6 +72,13 @@ using ThreadGroupPtr = std::shared_ptr<ThreadGroup>;
 
 class ThreadGroup
 {
+    /// Stores parent ThreadGroup for e.g. async INSERTs/MVs/EXPLAIN ANALYZE (those creates nested ThreadGroup's):
+    /// - createForMaterializedView()
+    /// - createForFlushAsyncInsertQueue()
+    /// - createForExplainAnalyze()
+    /// Required for raw pointers to memory_tracker/performance_counters
+    ThreadGroupPtr parent;
+
 public:
     using FatalErrorCallback = std::function<void()>;
     ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_, FatalErrorCallback fatal_error_callback_ = {});
@@ -130,8 +137,8 @@ public:
     static ThreadGroupPtr createForMergeMutate(ContextPtr storage_context);
 
     static ThreadGroupPtr createForMaterializedView(ContextPtr context);
-    static ThreadGroupPtr createForFlushAsyncInsertQueue(ContextPtr context, ThreadGroupPtr parent);
-    static ThreadGroupPtr createForExplainAnalyze(ThreadGroupPtr parent);
+    static ThreadGroupPtr createForFlushAsyncInsertQueue(ContextPtr context, ThreadGroupPtr parent_thread_group);
+    static ThreadGroupPtr createForExplainAnalyze(ThreadGroupPtr parent_thread_group);
 
     std::vector<UInt64> getInvolvedThreadIds() const;
     size_t getPeakThreadsUsage() const;
@@ -160,8 +167,8 @@ private:
 
     static ThreadGroupPtr create(ContextPtr context, Int32 os_threads_nice_value);
 
-    explicit ThreadGroup(ThreadGroupPtr parent);
-    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent);
+    explicit ThreadGroup(ThreadGroupPtr parent_thread_group);
+    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent_thread_group);
 };
 
 /** Encapsulates all per-thread info (ProfileEvents, MemoryTracker, query_id, query context, etc.).

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -75,8 +75,6 @@ class ThreadGroup
 public:
     using FatalErrorCallback = std::function<void()>;
     ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_, FatalErrorCallback fatal_error_callback_ = {});
-    explicit ThreadGroup(ThreadGroupPtr parent);
-    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent);
 
     /// The first thread created this thread group
     const UInt64 master_thread_id;
@@ -133,6 +131,7 @@ public:
 
     static ThreadGroupPtr createForMaterializedView(ContextPtr context);
     static ThreadGroupPtr createForFlushAsyncInsertQueue(ContextPtr context, ThreadGroupPtr parent);
+    static ThreadGroupPtr createForExplainAnalyze(ThreadGroupPtr parent);
 
     std::vector<UInt64> getInvolvedThreadIds() const;
     size_t getPeakThreadsUsage() const;
@@ -160,6 +159,9 @@ private:
     UInt64 elapsed_group_ms TSA_GUARDED_BY(mutex) = 0;
 
     static ThreadGroupPtr create(ContextPtr context, Int32 os_threads_nice_value);
+
+    explicit ThreadGroup(ThreadGroupPtr parent);
+    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent);
 };
 
 /** Encapsulates all per-thread info (ProfileEvents, MemoryTracker, query_id, query context, etc.).

--- a/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
+++ b/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
@@ -1,0 +1,84 @@
+#include <future>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <Common/CurrentMemoryTracker.h>
+#include <Common/CurrentThread.h>
+#include <Common/CurrentMetrics.h>
+#include <Common/ThreadPool.h>
+#include <Common/ThreadGroupSwitcher.h>
+#include <Common/ThreadStatus.h>
+#include <Common/threadPoolCallbackRunner.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Interpreters/Context.h>
+
+namespace CurrentMetrics
+{
+    extern const Metric LocalThread;
+    extern const Metric LocalThreadActive;
+    extern const Metric LocalThreadScheduled;
+}
+
+/// Assertions are written against observable behaviour (which group a pool thread runs under,
+/// where allocations are charged, what stays alive), so this file also compiles against the
+/// unfixed sources and reproduces the bugs there - that is what the `Bugfix validation
+/// (unit tests)` job needs.
+
+namespace DB
+{
+
+namespace
+{
+
+std::unique_ptr<ThreadPool> makeSingleThreadPool()
+{
+    return std::make_unique<ThreadPool>(
+        CurrentMetrics::LocalThread,
+        CurrentMetrics::LocalThreadActive,
+        CurrentMetrics::LocalThreadScheduled,
+        /*max_threads=*/ 1,
+        /*max_free_threads=*/ 1,
+        /*queue_size=*/ 10);
+}
+
+}
+
+/// The group is captured when a task is enqueued, on the scheduling thread - not when the runner
+/// object is created: a runner may be stored in a long-lived object (e.g. a `WriteBufferFromS3`
+/// scheduler kept by a per-table writer) and reused by later queries, which would account all
+/// their work to the query that happened to create it. Also pins that a runner object alone
+/// keeps no group alive between enqueues.
+TEST(ThreadPoolCallbackRunner, UnsafeRunnerCapturesGroupAtEnqueueTime)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto pool = makeSingleThreadPool();
+
+        auto creation_group = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> creation_group_weak = creation_group;
+        auto enqueue_group = std::make_shared<ThreadGroup>(context, 0);
+
+        CurrentThread::attachToGroupIfDetached(creation_group);
+        auto runner = threadPoolCallbackRunnerUnsafe<ThreadGroupPtr>(*pool, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        CurrentThread::attachToGroupIfDetached(enqueue_group);
+        auto future = runner([] { return getCurrentThreadGroup(); }, Priority{});
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        EXPECT_EQ(future.get(), enqueue_group)
+            << "the pool thread must run under the group current at enqueue time, not at runner creation";
+        pool->wait();
+
+        creation_group.reset();
+        EXPECT_TRUE(creation_group_weak.expired())
+            << "a runner object must not keep the group current at its creation alive";
+    });
+    t.join();
+}
+
+} // namespace DB

--- a/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
+++ b/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
@@ -81,4 +81,62 @@ TEST(ThreadPoolCallbackRunner, UnsafeRunnerCapturesGroupAtEnqueueTime)
     t.join();
 }
 
+/// The use-after-free regression: async work enqueued from a borrowed `ThreadGroup` scope
+/// (materialized views, async-insert flushes, `EXPLAIN ANALYZE`) may outlive the parent query.
+/// The capture must keep the accounting chain alive, allocations must still charge the owning
+/// query group, and once the work is done nothing must stay pinned.
+TEST(BorrowedThreadGroupLifetime, AsyncWorkFromBorrowedScopeChargesOwningQueryAccounting)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto pool = makeSingleThreadPool();
+
+        auto root = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> root_weak = root;
+        auto borrowed = ThreadGroup::createForFlushAsyncInsertQueue(context, root);
+
+        /// The async work is gated so that it allocates only after the test dropped its own
+        /// references to both groups - the exact window of the use-after-free.
+        std::promise<void> refs_dropped;
+        std::shared_future<void> refs_dropped_future = refs_dropped.get_future().share();
+
+        CurrentThread::attachToGroupIfDetached(borrowed);
+        auto runner = threadPoolCallbackRunnerUnsafe<Int64>(*pool, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+        auto future = runner([refs_dropped_future, root_weak]
+        {
+            refs_dropped_future.wait();
+
+            auto root_locked = root_weak.lock();
+            if (!root_locked)
+                return Int64(-1);
+
+            /// Large enough to exceed any per-thread untracked-memory batching.
+            constexpr Int64 allocation = 64 << 20;
+            const Int64 before = root_locked->memory_tracker.get();
+            std::ignore = CurrentMemoryTracker::alloc(allocation);
+            const Int64 charged = root_locked->memory_tracker.get() - before;
+            std::ignore = CurrentMemoryTracker::free(allocation);
+            return charged;
+        }, Priority{});
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        borrowed.reset();
+        root.reset();
+        refs_dropped.set_value();
+
+        const Int64 charged = future.get();
+        pool->wait();
+
+        ASSERT_NE(charged, -1)
+            << "the async capture must keep the owning query group it charges alive";
+        EXPECT_GE(charged, 32 << 20) << "async allocations must charge the owning query group";
+        EXPECT_TRUE(root_weak.expired())
+            << "once the async work is done nothing must keep the chain alive";
+    });
+    t.join();
+}
+
 } // namespace DB

--- a/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
+++ b/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
@@ -118,10 +118,9 @@ TEST(ThreadPoolCallbackRunner, DroppedOnShutdownDoesNotBreakPromise)
 /// when scheduleOrThrowOnError() throws (the pool is shutting down, or -- as injected here -- a
 /// thread-allocation fault), the just-created job lambda that solely owns the CallbackRunnerTask is
 /// destroyed during stack unwinding on the caller's thread. That thread is typically running a query
-/// and is already attached to its own thread group, which differs from the group the runner captured
-/// at creation time (e.g. a persistent WriteBufferFromS3 whose scheduler was created by an earlier
-/// query). The drop path (~CallbackRunnerTask) must release the callback under the task's group
-/// WITHOUT asserting the thread is detached; otherwise it constructs a LOGICAL_ERROR, which aborts
+/// and is already attached to its own thread group. To release the callback the drop path
+/// (~CallbackRunnerTask) attaches the task's group and must tolerate the thread already having one;
+/// otherwise ThreadGroupSwitcher raises the `already attached to a group` LOGICAL_ERROR, which aborts
 /// the server in builds that treat logical errors as assertions.
 TEST(ThreadPoolCallbackRunner, DroppedSynchronouslyWhileAttachedToAnotherGroup)
 {
@@ -131,7 +130,7 @@ TEST(ThreadPoolCallbackRunner, DroppedSynchronouslyWhileAttachedToAnotherGroup)
     {
         ThreadStatus ts;
         auto context = getContext().context;
-        auto task_group = std::make_shared<ThreadGroup>(context, 0);   /// group the runner captures
+        auto task_group = std::make_shared<ThreadGroup>(context, 0);   /// group current when the runner is created
         auto caller_group = std::make_shared<ThreadGroup>(context, 0); /// group the scheduling thread is on
 
         ThreadPool pool(
@@ -140,9 +139,7 @@ TEST(ThreadPoolCallbackRunner, DroppedSynchronouslyWhileAttachedToAnotherGroup)
             CurrentMetrics::LocalThreadScheduled,
             /*max_threads=*/ 1);
 
-        /// The runner captures getCurrentThreadGroup() at creation, so create it while attached to
-        /// task_group. The dropped task will then try to switch to a group that differs from the
-        /// scheduling thread's own group.
+        /// Create the runner while attached to task_group (capture happens at enqueue, below -- not here).
         CurrentThread::attachToGroupIfDetached(task_group);
         auto runner = threadPoolCallbackRunnerUnsafe<void>(pool, ThreadName::REMOTE_FS_WRITE_THREAD_POOL);
         CurrentThread::detachFromGroupIfNotDetached();
@@ -177,8 +174,10 @@ TEST(ThreadPoolCallbackRunner, DroppedSynchronouslyWhileAttachedToAnotherGroup)
         }
 
         EXPECT_TRUE(threw_cannot_schedule) << "scheduling onto a faulted pool must throw CANNOT_SCHEDULE_TASK";
-        /// The drop path must release the callback under the task's group, not the caller's.
-        EXPECT_EQ(*released_group, task_group) << "dropped callback must be released under the task's thread group";
+        /// The runner captures the current group at ENQUEUE time, not at creation: it was created under
+        /// task_group but enqueued under caller_group, so the dropped callback is released under
+        /// caller_group (with the old creation-time capture it would have been task_group).
+        EXPECT_EQ(*released_group, caller_group) << "dropped callback must be released under the enqueue-time group";
         /// ... and it must restore the scheduling thread's original group afterwards.
         EXPECT_EQ(getCurrentThreadGroup(), caller_group) << "the scheduling thread's group must be restored";
 

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -135,7 +135,7 @@ struct CallbackRunnerTask
 template <typename Result, typename Callback = std::function<Result()>>
 ThreadPoolCallbackRunnerUnsafe<Result, Callback> threadPoolCallbackRunnerUnsafe(ThreadPool & pool, ThreadName thread_name)
 {
-    return [my_pool = &pool, thread_group = getCurrentThreadGroup(), thread_name](Callback && callback, Priority priority) mutable -> std::future<Result>
+    return [my_pool = &pool, thread_name](Callback && callback, Priority priority) mutable -> std::future<Result>
     {
         auto task = std::make_shared<detail::CallbackRunnerTask<Result, Callback>>(thread_group, thread_name, std::move(callback));
 

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -137,6 +137,11 @@ ThreadPoolCallbackRunnerUnsafe<Result, Callback> threadPoolCallbackRunnerUnsafe(
 {
     return [my_pool = &pool, thread_name](Callback && callback, Priority priority) mutable -> std::future<Result>
     {
+        /// Since it is a wrapper for a task that will be reused for each task
+        /// we need to obtain ThreadGroup here not during creating the task wrapper,
+        /// otherwise the accounting will be incorrect
+        auto thread_group = getCurrentThreadGroup();
+
         auto task = std::make_shared<detail::CallbackRunnerTask<Result, Callback>>(thread_group, thread_name, std::move(callback));
 
         auto future = task->promise.get_future();

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -1262,7 +1262,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
             if (!outer_thread_group)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "EXPLAIN ANALYZE: current thread is not attached to a thread group");
 
-            auto analyze_thread_group = std::make_shared<ThreadGroup>(outer_thread_group);
+            auto analyze_thread_group = ThreadGroup::createForExplainAnalyze(outer_thread_group);
             analyze_thread_group->memory_tracker.setDescription("EXPLAIN ANALYZE");
 
             watch.restart();

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -130,7 +130,6 @@ ThreadGroup::ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_
     };
 }
 
-// c-tor for method createForMaterializedView
 ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
     : master_thread_id(parent->master_thread_id)
     , query_context(parent->query_context)
@@ -144,7 +143,6 @@ ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
 {
 }
 
-// c-tor for method createForFlushAsyncInsertQueue
 ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent)
     : master_thread_id(CurrentThread::get().thread_id)
     , query_context(query_context_)
@@ -250,7 +248,7 @@ ThreadGroupPtr ThreadGroup::createForMaterializedView(ContextPtr context)
     ThreadGroupPtr res_group;
     if (auto current_group = CurrentThread::getGroup())
     {
-        res_group = std::make_shared<ThreadGroup>(current_group);
+        res_group = ThreadGroupPtr(new ThreadGroup(current_group));
     }
     else
     {
@@ -261,9 +259,14 @@ ThreadGroupPtr ThreadGroup::createForMaterializedView(ContextPtr context)
     return res_group;
 }
 
+ThreadGroupPtr ThreadGroup::createForExplainAnalyze(ThreadGroupPtr parent)
+{
+    return ThreadGroupPtr(new ThreadGroup(parent));
+}
+
 ThreadGroupPtr ThreadGroup::createForFlushAsyncInsertQueue(ContextPtr context, ThreadGroupPtr parent)
 {
-    auto res_group = std::make_shared<ThreadGroup>(context, parent);
+    auto res_group = ThreadGroupPtr(new ThreadGroup(context, parent));
     res_group->memory_tracker.setDescription("FlushAsyncInsertQueue");
     return res_group;
 }

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -130,8 +130,9 @@ ThreadGroup::ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_
     };
 }
 
-ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
-    : master_thread_id(parent->master_thread_id)
+ThreadGroup::ThreadGroup(ThreadGroupPtr parent_thread_group)
+    : parent(std::move(parent_thread_group))
+    , master_thread_id(parent->master_thread_id)
     , query_context(parent->query_context)
     , global_context(parent->global_context)
     , fatal_error_callback(parent->fatal_error_callback)
@@ -143,8 +144,9 @@ ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
 {
 }
 
-ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent)
-    : master_thread_id(CurrentThread::get().thread_id)
+ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent_thread_group)
+    : parent(std::move(parent_thread_group))
+    , master_thread_id(CurrentThread::get().thread_id)
     , query_context(query_context_)
     , global_context(query_context_->getGlobalContext())
     , fatal_error_callback(parent->fatal_error_callback)
@@ -259,14 +261,14 @@ ThreadGroupPtr ThreadGroup::createForMaterializedView(ContextPtr context)
     return res_group;
 }
 
-ThreadGroupPtr ThreadGroup::createForExplainAnalyze(ThreadGroupPtr parent)
+ThreadGroupPtr ThreadGroup::createForExplainAnalyze(ThreadGroupPtr parent_thread_group)
 {
-    return ThreadGroupPtr(new ThreadGroup(parent));
+    return ThreadGroupPtr(new ThreadGroup(parent_thread_group));
 }
 
-ThreadGroupPtr ThreadGroup::createForFlushAsyncInsertQueue(ContextPtr context, ThreadGroupPtr parent)
+ThreadGroupPtr ThreadGroup::createForFlushAsyncInsertQueue(ContextPtr context, ThreadGroupPtr parent_thread_group)
 {
-    auto res_group = ThreadGroupPtr(new ThreadGroup(context, parent));
+    auto res_group = ThreadGroupPtr(new ThreadGroup(context, parent_thread_group));
     res_group->memory_tracker.setDescription("FlushAsyncInsertQueue");
     return res_group;
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible crash due to ThreadGroup use-after-free (for async INSERTs/MVs/EXPLAIN ANALYZE)

@filimonov "Borrowed ThreadGroup objects used by materialized view and async insert flush paths point their performance_counters and memory_tracker to the parent query group, so they are valid only while that parent group is alive. Async callbacks could capture such a borrowed group and later attach it on a pool thread after the parent query group had finished."

Eventually we have to store parent's `ThreadGroupPtr` to account things properly, initial fix #108988 tries to avoid this, but this breaks propagating counters to queries

Thanks to @filimonov for original fix https://github.com/ClickHouse/ClickHouse/pull/108988
This supersedes https://github.com/ClickHouse/ClickHouse/pull/109891 it became too complex


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1471` (included in `26.8` and later)
<!-- ch-version-info:end -->