### PR TITLE
Apply HAVING without aggregation in the old analyzer

### DIFF
--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -1509,10 +1509,9 @@ TreeRewriterResultPtr TreeRewriter::analyzeSelect(
     result.window_function_asts = getWindowFunctions(query, *select_query);
     result.expressions_with_window_function = getExpressionsWithWindowFunctions(query);
 
-    /// Without aggregation HAVING is equivalent to WHERE, and only WHERE is applied: a HAVING
-    /// filter is built and executed solely in the aggregation branch. The condition spells out
-    /// `has_aggregation` exactly as ExpressionAnalyzer does. Keep this after getAggregates and
-    /// getWindowFunctions, which reject aggregates in WHERE and window functions in HAVING.
+    /// Without aggregation a HAVING filter is never built: it is built and executed solely in the
+    /// aggregation branch. Keep this after getAggregates and getWindowFunctions, which reject
+    /// aggregates in WHERE and window functions in HAVING.
     if (select_query->having() && result.aggregates.empty() && !select_query->groupBy())
     {
         ASTPtr condition = select_query->where()

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -1509,6 +1509,20 @@ TreeRewriterResultPtr TreeRewriter::analyzeSelect(
     result.window_function_asts = getWindowFunctions(query, *select_query);
     result.expressions_with_window_function = getExpressionsWithWindowFunctions(query);
 
+    /// Without aggregation HAVING is equivalent to WHERE, and only WHERE is applied: a HAVING
+    /// filter is built and executed solely in the aggregation branch. The condition spells out
+    /// `has_aggregation` exactly as ExpressionAnalyzer does. Keep this after getAggregates and
+    /// getWindowFunctions, which reject aggregates in WHERE and window functions in HAVING.
+    if (select_query->having() && result.aggregates.empty() && !select_query->groupBy())
+    {
+        ASTPtr condition = select_query->where()
+            ? makeASTOperator("and", select_query->where(), select_query->having())
+            : select_query->having();
+
+        select_query->setExpression(ASTSelectQuery::Expression::HAVING, {});
+        select_query->setExpression(ASTSelectQuery::Expression::WHERE, std::move(condition));
+    }
+
     result.collectUsedColumns(query, true);
 
     if (!result.missed_subcolumns.empty())

--- a/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.reference
+++ b/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.reference
@@ -4,10 +4,15 @@
 2
 -- an alias in HAVING resolves to the projection
 6
--- rowNumberInBlock is numbered over the filtered rows
+-- rowNumberInBlock is numbered over the unfiltered block, since both conditions merge into one filter
+-- the same predicate matches the row at the unfiltered index
+2
 -- the predicate reaches the storage and prunes
 1
 -- aggregation keeps HAVING in the aggregation branch
 -- a bare column with an aggregate HAVING is still rejected
 -- a window function in HAVING is still rejected
 -- WITH TOTALS without aggregation is still rejected
+-- the predicate is applied on shards too
+3
+3

--- a/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.reference
+++ b/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.reference
@@ -1,0 +1,13 @@
+-- no aggregation, predicate rewrite off
+-- no aggregation, stateful conjunct blocks the rewrite at default settings
+-- WHERE and HAVING are combined, not replaced
+2
+-- an alias in HAVING resolves to the projection
+6
+-- rowNumberInBlock is numbered over the filtered rows
+-- the predicate reaches the storage and prunes
+1
+-- aggregation keeps HAVING in the aggregation branch
+-- a bare column with an aggregate HAVING is still rejected
+-- a window function in HAVING is still rejected
+-- WITH TOTALS without aggregation is still rejected

--- a/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.sql
+++ b/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.sql
@@ -1,0 +1,42 @@
+CREATE TABLE t (a UInt64) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t SELECT number + 1 FROM numbers(3);
+
+SELECT '-- no aggregation, predicate rewrite off';
+SELECT a FROM t HAVING a > 999 ORDER BY a
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- no aggregation, stateful conjunct blocks the rewrite at default settings';
+SELECT a FROM t HAVING a > 999 AND blockNumber() >= 0 ORDER BY a
+SETTINGS enable_analyzer = 0;
+
+SELECT '-- WHERE and HAVING are combined, not replaced';
+SELECT a FROM t WHERE a > 1 HAVING a < 3 ORDER BY a
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- an alias in HAVING resolves to the projection';
+SELECT a * 2 AS d FROM t HAVING d > 4 ORDER BY d
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- rowNumberInBlock is numbered over the filtered rows';
+SELECT number FROM numbers(10) WHERE number % 2 = 0 HAVING rowNumberInBlock() = 1 ORDER BY number
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- the predicate reaches the storage and prunes';
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT a FROM t HAVING a > 999) WHERE explain ILIKE '%Parts: 0/1%'
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- aggregation keeps HAVING in the aggregation branch';
+SELECT a FROM t GROUP BY a HAVING a > 999 ORDER BY a
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- a bare column with an aggregate HAVING is still rejected';
+SELECT a FROM t HAVING count() > 999
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0; -- { serverError NOT_AN_AGGREGATE }
+
+SELECT '-- a window function in HAVING is still rejected';
+SELECT a FROM t HAVING count() OVER () > 999
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0; -- { serverError ILLEGAL_AGGREGATION }
+
+SELECT '-- WITH TOTALS without aggregation is still rejected';
+SELECT a FROM t WITH TOTALS HAVING a > 999
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0; -- { serverError NOT_IMPLEMENTED }

--- a/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.sql
+++ b/tests/queries/0_stateless/04911_having_without_aggregation_old_analyzer.sql
@@ -17,8 +17,12 @@ SELECT '-- an alias in HAVING resolves to the projection';
 SELECT a * 2 AS d FROM t HAVING d > 4 ORDER BY d
 SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
 
-SELECT '-- rowNumberInBlock is numbered over the filtered rows';
+SELECT '-- rowNumberInBlock is numbered over the unfiltered block, since both conditions merge into one filter';
 SELECT number FROM numbers(10) WHERE number % 2 = 0 HAVING rowNumberInBlock() = 1 ORDER BY number
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+SELECT '-- the same predicate matches the row at the unfiltered index';
+SELECT number FROM numbers(10) WHERE number % 2 = 0 HAVING rowNumberInBlock() = 2 ORDER BY number
 SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
 
 SELECT '-- the predicate reaches the storage and prunes';
@@ -40,3 +44,9 @@ SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0; -- { ser
 SELECT '-- WITH TOTALS without aggregation is still rejected';
 SELECT a FROM t WITH TOTALS HAVING a > 999
 SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0; -- { serverError NOT_IMPLEMENTED }
+
+SELECT '-- the predicate is applied on shards too';
+SELECT a FROM remote('127.0.0.{1,2}', currentDatabase(), t) HAVING a > 2 ORDER BY a
+SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
+
+DROP TABLE t;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113760


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results with `enable_analyzer = 0` when a query has a `HAVING` clause but no aggregation: the condition was silently ignored and excluded rows were returned. `HAVING` is now merged into `WHERE` for such queries, matching the new analyzer.

### Description

With `enable_analyzer = 0`, a `SELECT` that has a `HAVING` clause but no aggregation silently
discarded the condition and returned rows it excludes. Over a MergeTree table holding 1, 2, 3:

```sql
SELECT a FROM t HAVING a > 999 SETTINGS enable_analyzer = 0, enable_optimize_predicate_expression = 0;
-- returned 1, 2, 3; the new analyzer returns nothing
```

Root cause: the old analyzer builds and executes a `HAVING` filter only in its aggregation
branch (`appendHaving` is called under `if (need_aggregate)`, and `executeHaving` is reachable
only from inside `else if (expressions.need_aggregate)`), so without aggregation the clause is
never applied. What normally hides this is `PredicateExpressionsOptimizer` moving non-aggregate
conjuncts to `WHERE`, i.e. a performance optimizer was load-bearing for correctness with no
interpreter fallback. It also fails at default settings when a stateful conjunct makes
`tryMovePredicatesFromHavingToWhere` bail out, so `HAVING a > 999 AND blockNumber() >= 0`
reproduces with `enable_analyzer = 0` alone.

This merges `HAVING` into `WHERE` in `TreeRewriter::analyzeSelect` when the query does not
aggregate, the canonicalization the new analyzer already performs in `Planner.cpp:2231-2238`.
The interpreter, `ExpressionAnalyzer` and `PredicateExpressionsOptimizer` are unchanged. The
site sits after `getAggregates` and `getWindowFunctions` so `NOT_AN_AGGREGATE` and
`ILLEGAL_AGGREGATION` keep being raised, after `PredicateExpressionsOptimizer` so the default
path is a no-op, and outside the `ast_optimizations_allowed` gate so it also applies on shards.

Validation: `EXPLAIN` shows no `Filter` step before; after the fix the predicate reaches the
storage and prunes (`Parts: 0/1`). 33 query shapes now agree across the old analyzer, the old
analyzer with the rewrite enabled and the new analyzer; 20 disagreed before. `NOT_AN_AGGREGATE`,
`ILLEGAL_AGGREGATION` and the `NOT_IMPLEMENTED` for `WITH TOTALS` without aggregation are
unchanged and pinned by the new test. Distributed and `remote()` queries were checked on a
two-shard cluster. The 44 stateless tests setting `enable_optimize_predicate_expression` pass,
589 further `HAVING` and `*analyzer*` tests show no regression.