### PR TITLE
Add test: `parallel_hash` `unique keys` summation over one-level slot maps untested

### DIFF
--- a/tests/queries/0_stateless/04904_explain_analyze_join_parallel_hash_unique_keys.reference
+++ b/tests/queries/0_stateless/04904_explain_analyze_join_parallel_hash_unique_keys.reference
@@ -1,0 +1,6 @@
+ground truth: unique right keys
+200
+max_threads = 2
+200.00
+max_threads = 16
+200.00

--- a/tests/queries/0_stateless/04904_explain_analyze_join_parallel_hash_unique_keys.sql
+++ b/tests/queries/0_stateless/04904_explain_analyze_join_parallel_hash_unique_keys.sql
@@ -1,0 +1,35 @@
+-- `unique keys` of a `parallel_hash` join is the sum over the per-slot hash tables when they are
+-- one-level, which a key narrower than 32 bits gives. The value counts the whole right table and so
+-- must not depend on the number of slots.
+
+DROP TABLE IF EXISTS left_side;
+DROP TABLE IF EXISTS right_side;
+SET enable_analyzer = 1;
+-- EXPLAIN ANALYZE rejects distributed plans.
+SET enable_parallel_replicas = 0;
+SET query_plan_join_swap_table = 0;
+SET enable_join_runtime_filters = 0;
+SET join_use_nulls = 0;
+
+DROP TABLE IF EXISTS left_side;
+DROP TABLE IF EXISTS right_side;
+
+CREATE TABLE left_side (k UInt8, v UInt64) ENGINE = MergeTree ORDER BY k;
+CREATE TABLE right_side (k UInt8, v UInt64) ENGINE = MergeTree ORDER BY k;
+
+INSERT INTO left_side SELECT number % 200, number FROM numbers(1000);
+INSERT INTO right_side SELECT number % 200, number FROM numbers(1000);
+
+SELECT 'ground truth: unique right keys';
+SELECT uniqExact(k) FROM right_side;
+
+SELECT 'max_threads = 2';
+SELECT maxIf(extract(explain, 'unique keys ([0-9.]+)'), explain LIKE '%Hash table:%') AS unique_keys
+FROM (EXPLAIN ANALYZE SELECT count() FROM left_side AS l ALL INNER JOIN right_side AS r ON l.k = r.k SETTINGS join_algorithm = 'parallel_hash', parallel_hash_join_threshold = 1, max_threads = 2);
+
+SELECT 'max_threads = 16';
+SELECT maxIf(extract(explain, 'unique keys ([0-9.]+)'), explain LIKE '%Hash table:%') AS unique_keys
+FROM (EXPLAIN ANALYZE SELECT count() FROM left_side AS l ALL INNER JOIN right_side AS r ON l.k = r.k SETTINGS join_algorithm = 'parallel_hash', parallel_hash_join_threshold = 1, max_threads = 16);
+
+DROP TABLE left_side;
+DROP TABLE right_side;


### PR DESCRIPTION
_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #110892](https://github.com/ClickHouse/ClickHouse/pull/110892).
That PR: (1) Adds join internals to `EXPLAIN ANALYZE`: every `IJoin` implementation gets `getAnalysisReport`, a new metric model (`StepAnalyzeInfo`, `AnalyzePlanStats`, `JoinStatsAnalyzer`), a new `EXPLAIN ANALYZE matches = 1` option carried through `Context::join_analyze_mode`, and per-algorithm groups …

**1. `parallel_hash` `unique keys` summation over one-level slot maps untested**
  `src/Interpreters/ConcurrentHashJoin.cpp:499`
  **Risk:** `ConcurrentHashJoin::getUniqueKeys` short-circuits on `twoLevelMapIsUsed` and otherwise sums the per-slot maps (`ConcurrentHashJoin.cpp`:499-502, LLVM-confirmed uncovered). `chooseMethod` maps only 4/8/16/32-byte and string keys to two-level variants, so a `UInt8`/`UInt16` key lands on the one- …
  **Unique vs PR tests:** 04510 and 04603 exercise `parallel_hash` only over `UInt64` keys (two-level maps, the early return) and only check that the `unique keys` line exists; this test pins the value on the one-level branch and makes it slot-count invariant.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/9513fd08-2463-4d08-95bb-79824631c1f4)

cc @Fgrtue (author of #110892), @vdimir (merged/approved #110892) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1552` (included in `26.8` and later)
<!-- ch-version-info:end -->