### PR TITLE
Fix an unkillable hang when dropping a low-sorting-name TimeSeries table

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -265,7 +265,8 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
             else if (query.kind == ASTDropQuery::Kind::Drop)
                 context_->checkAccess(drop_storage, table_id);
 
-            ddl_guard->releaseTableLock();
+            if (ddl_guard)
+                ddl_guard->releaseTableLock();
             table.reset();
 
             query_to_send.if_empty = false;
@@ -882,6 +883,8 @@ void InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind kind, ContextPtr 
         drop_query->kind = kind;
         drop_query->sync = sync;
         drop_query->if_exists = true;
+        /// The DDLGuard for this exact name is already held above, and it is not recursive.
+        drop_query->no_ddl_lock = need_ddl_guard;
         ASTPtr ast_drop_query = drop_query;
         /// FIXME We have to use global context to execute DROP query for inner table
         /// to avoid "Not enough privileges" error if current user has only DROP VIEW ON mat_view_name privilege

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -277,8 +277,8 @@ void StorageTimeSeries::dropInnerTableIfAny(bool sync, ContextPtr local_context)
         {
             if (auto inner_table_id = tryGetTargetTableID(target_kind, local_context))
             {
-                /// DDLGuards must be locked in order of increasing table name, and the guard for this table
-                /// is already held here, so the inner one may be taken only if this name sorts first.
+                /// DDLGuards must be locked in order of increasing table name, so the inner guard
+                /// may be requested only when this table's name sorts first.
                 bool may_lock_ddl_guard = getStorageID().getQualifiedName() < inner_table_id.getQualifiedName();
                 InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id,
                                                     sync, /* ignore_sync_setting= */ true, may_lock_ddl_guard);

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -277,8 +277,8 @@ void StorageTimeSeries::dropInnerTableIfAny(bool sync, ContextPtr local_context)
         {
             if (auto inner_table_id = tryGetTargetTableID(target_kind, local_context))
             {
-                /// Best-effort to make them work: the inner table name is almost always less than the TimeSeries name (so it's safe to lock DDLGuard).
-                /// (See the comment in StorageMaterializedView::dropInnerTableIfAny.)
+                /// DDLGuards must be locked in order of increasing table name, and the guard for this table
+                /// is already held here, so the inner one may be taken only if this name sorts first.
                 bool may_lock_ddl_guard = getStorageID().getQualifiedName() < inner_table_id.getQualifiedName();
                 InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind::Drop, getContext(), local_context, inner_table_id,
                                                     sync, /* ignore_sync_setting= */ true, may_lock_ddl_guard);

--- a/tests/queries/0_stateless/04920_timeseries_drop_low_sorting_name.reference
+++ b/tests/queries/0_stateless/04920_timeseries_drop_low_sorting_name.reference
@@ -1,0 +1,4 @@
+low_sorting_name_dropped
+mv_inner_timeseries_dropped
+control_high_sorting_name_dropped
+0

--- a/tests/queries/0_stateless/04920_timeseries_drop_low_sorting_name.sql
+++ b/tests/queries/0_stateless/04920_timeseries_drop_low_sorting_name.sql
@@ -1,0 +1,28 @@
+-- Tags: no-fasttest
+-- no-fasttest: the TimeSeries engine is not built in the fast-test image.
+
+SET allow_experimental_time_series_table = 1;
+
+-- A TimeSeries whose own name sorts below its inner tables' names used to self-deadlock on the
+-- DDL guard, so this hung instead of returning.
+DROP TABLE IF EXISTS `-ts`;
+CREATE TABLE `-ts` ENGINE = TimeSeries;
+DROP TABLE `-ts`;
+SELECT 'low_sorting_name_dropped';
+
+-- Same state reached without choosing a name: the view's own inner name is `.inner_id.<uuid>`,
+-- which always sorts below `.inner_id.metrics.<uuid>`.
+DROP TABLE IF EXISTS mv;
+CREATE MATERIALIZED VIEW mv ENGINE = TimeSeries AS SELECT 1 AS a;
+DROP TABLE mv;
+SELECT 'mv_inner_timeseries_dropped';
+
+-- Control: a name that sorts above the inner tables' names takes the other branch of the
+-- ordering predicate and always worked.
+DROP TABLE IF EXISTS prom;
+CREATE TABLE prom ENGINE = TimeSeries;
+DROP TABLE prom;
+SELECT 'control_high_sorting_name_dropped';
+
+-- No inner tables may be left behind by any of the drops above.
+SELECT count() FROM system.tables WHERE database = currentDatabase();

--- a/tests/queries/0_stateless/04920_timeseries_drop_low_sorting_name.sql
+++ b/tests/queries/0_stateless/04920_timeseries_drop_low_sorting_name.sql
@@ -1,7 +1,7 @@
--- Tags: no-fasttest
--- no-fasttest: the TimeSeries engine is not built in the fast-test image.
-
 SET allow_experimental_time_series_table = 1;
+-- The stress runner sets ignore_drop_queries_probability=0.2, which rewrites a DROP of a table
+-- that keeps no data on disk into a TRUNCATE; TRUNCATE does not drop inner tables.
+SET ignore_drop_queries_probability = 0;
 
 -- A TimeSeries whose own name sorts below its inner tables' names used to self-deadlock on the
 -- DDL guard, so this hung instead of returning.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/114259

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a hang when dropping a `TimeSeries` table whose name sorts lexicographically below its inner tables' names, for example `` DROP TABLE `-ts` `` or dropping a materialized view declared with `ENGINE = TimeSeries`. The drop self-deadlocked on the DDL guard and could not be cancelled with `KILL QUERY`.


### Description

`DROP TABLE` of a `TimeSeries` table never returned and could not be killed when the table's own
qualified name sorted below its inner tables' names:

```sql
SET allow_experimental_time_series_table = 1;
CREATE TABLE `-ts` ENGINE = TimeSeries;
DROP TABLE `-ts`;                                       -- hung forever
```

A materialized view's inner name is `.inner_id.<uuid>`, which always sorts below
`.inner_id.metrics.<uuid>`, so dropping an `MV ... ENGINE = TimeSeries` hung too.

**Root cause.** `executeDropQuery` takes the DDL guard for the inner table, then synthesizes an
`ASTDropQuery` for that same table without setting `no_ddl_lock`, so the nested interpreter takes
the guard for the identical name again. `DDLGuard::table_lock` wraps a non-recursive `std::mutex`,
so the thread deadlocks against itself. A mutex wait is not a cancellation point, so `KILL QUERY`
could not land and the guard stayed held for the server's lifetime.

`need_ddl_guard = true` comes from one call site, `StorageTimeSeries::dropInnerTableIfAny`, which
requests the inner guard only when the parent name sorts first. That predicate is correct and is
kept: guards must be taken in increasing name order. Only its comment was wrong, claiming the
inner name is "almost always less", which holds for `MaterializedView` but not `TimeSeries`.

**The change.** `executeDropQuery` now sets `no_ddl_lock = need_ddl_guard`, so the inner name is
guarded exactly once, by the caller, across the nested execute. `InterpreterCreateQuery` sets the
same field for the same reason. The fix is inert for the other ten call sites, which all take the
`need_ddl_guard = false` default. The `ddl_guard` null check is pre-existing hardening.

**Validation.** Both shapes time out before the fix and succeed after, while a high-sorting-name
control passes on both builds. Eight concurrent drops serialize and complete and the name is
reusable afterwards, so the guard is still taken and released. New test `04920` covers both shapes
and asserts no inner table is left behind.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1839` (included in `26.8` and later)
- Backported to: `26.7.6.7`, `26.6.4.12`, `26.5.8.20`, `26.3.22.8`
<!-- ch-version-info:end -->