### PR TITLE
Fix `rows_before_limit_at_least` under parallel replicas local plan (#113279)

### DIFF
--- a/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
+++ b/src/Processors/QueryPlan/ParallelReplicasLocalPlan.cpp
@@ -203,7 +203,8 @@ std::pair<QueryPlanPtr, bool> createLocalPlanForParallelReplicas(
     /// leading to column name mismatches with the expected header.
     auto select_query_options = SelectQueryOptions(processed_stage);
     select_query_options.is_local_shard_plan
-        = processed_stage == QueryProcessingStage::WithMergeableStateAfterAggregationAndLimit;
+        = processed_stage == QueryProcessingStage::WithMergeableState
+        || processed_stage == QueryProcessingStage::WithMergeableStateAfterAggregationAndLimit;
     /// The local replica's plan is united into the parent pipeline in this process.
     select_query_options.is_local_plan_for_distributed_query = true;
 

--- a/tests/queries/0_stateless/04510_preferred_local_prelimit_runtime.sql
+++ b/tests/queries/0_stateless/04510_preferred_local_prelimit_runtime.sql
@@ -54,16 +54,12 @@ SET prefer_localhost_replica = 1;
 SELECT '' FROM cluster(test_cluster_two_shards, currentDatabase(), preferred_local_prelimit_rt)
 WHERE id < 30 ORDER BY id LIMIT 1 OFFSET 3 FORMAT Template;
 
--- (2) Parallel replicas. A single shard read cooperatively by three replicas
--- => exact count 30. Assert the statistic at runtime, not just the plan shape
--- (which is all 04509 checks for this path).
+-- (2) Parallel replicas with local plan (`parallel_replicas_local_plan = 1`, `parallel_replicas_plan_based = 0`).
+-- A single shard read cooperatively by three replicas => exact count 30.
 --
--- `parallel_replicas_local_plan = 0` is deliberate, and this assertion does NOT
--- cover the local-plan path: with the local plan the statistic comes back as 0,
--- because the local branch's preliminary LIMIT is never marked as a shard limit
--- (the marking added in #110136 is gated on a processing stage that parallel
--- replicas never use), so `initRowsBeforeLimit` stops at it and only the remote
--- replicas are counted. Restore this to 1 once #113279 is fixed.
+-- With `parallel_replicas_local_plan = 1`, the local replica's preliminary LIMIT
+-- is marked as a shard limit (#113279), allowing `initRowsBeforeLimit` to count
+-- through it and report the correct total 30.
 SELECT '' FROM preferred_local_prelimit_rt
 WHERE id < 30 ORDER BY id LIMIT 1 OFFSET 3
 FORMAT Template
@@ -76,6 +72,7 @@ SETTINGS
     max_parallel_replicas = 3,
     cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
     parallel_replicas_for_non_replicated_merge_tree = 1,
-    parallel_replicas_local_plan = 0;
+    parallel_replicas_local_plan = 1,
+    parallel_replicas_plan_based = 0;
 
 DROP TABLE preferred_local_prelimit_rt;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/113279

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `rows_before_limit_at_least` returning 0 for the legacy parallel-replicas local-plan path when `parallel_replicas_local_plan = 1` and `parallel_replicas_plan_based = 0`.

### Detailed description / Documentation draft:
When parallel replicas is enabled with `parallel_replicas_local_plan = 1` and `parallel_replicas_plan_based = 0`, the local replica plan built by `createLocalPlanForParallelReplicas` previously did not set `select_query_options.is_local_shard_plan = true` for `QueryProcessingStage::WithMergeableState`. This caused `addPreliminaryLimitStep` to omit the shard limit mark on the preliminary limit, preventing `QueryPipeline::initRowsBeforeLimit` from traversing the processor graph and counting source rows on the local replica branch.

This fix sets `is_local_shard_plan = true` in `createLocalPlanForParallelReplicas` and updates `04510_preferred_local_prelimit_runtime.sql` to verify runtime `rows_before_limit_at_least` reports the correct qualifying count (30) under `parallel_replicas_local_plan = 1` and `parallel_replicas_plan_based = 0`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114954&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114954](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114954+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
