### PR TITLE
Honour do_not_block_pipeline_on_failure for every non-ok job status

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -584,6 +584,20 @@ class Runner:
         return result
 
     @staticmethod
+    def _pipeline_status(result) -> str:
+        """The GH Actions `pipeline_status` output for a finished job.
+
+        These are GH Actions output values matched by workflow YAML conditions,
+        not Result.Status values - they must stay lowercase "success"/"failure".
+        A "failure" skips the job's whole transitive downstream closure.
+        `hook_html` decides whether to mark dependees `DROPPED` from the same
+        flag and must reach the same verdict as this function.
+        """
+        if not result.is_ok() and not result.do_not_block_pipeline_on_failure():
+            return "failure"
+        return "success"
+
+    @staticmethod
     def _skip_missing_optional_artifact(artifact, artifact_path) -> bool:
         """Whether a providing artifact that matched no file may be skipped.
 
@@ -903,15 +917,7 @@ class Runner:
                 traceback.print_exc()
 
         # finally, set the status flag for GH Actions
-        # These are GH Actions output values matched by workflow YAML conditions,
-        # not Result.Status values — must stay lowercase "success"/"failure".
-        pipeline_status = "success"
-        if not result.is_ok():
-            if result.is_failure() and result.do_not_block_pipeline_on_failure():
-                # job explicitly says to not block ci even though result is failure
-                pass
-            else:
-                pipeline_status = "failure"
+        pipeline_status = self._pipeline_status(result)
         with open(env.JOB_OUTPUT_STREAM, "a", encoding="utf8") as f:
             print(
                 f"pipeline_status={pipeline_status}",

--- a/ci/tests/test_pipeline_status_non_blocking.py
+++ b/ci/tests/test_pipeline_status_non_blocking.py
@@ -132,6 +132,38 @@ def test_both_consumers_read_the_flag_with_the_same_predicate():
     ), "hook_html dependee-drop predicate changed - re-check Runner._pipeline_status"
 
 
+def test_the_output_site_delegates_to_the_helper():
+    """The `pipeline_status` writer must not re-implement the predicate.
+
+    Every other test here calls `Runner._pipeline_status` directly, so a call
+    site that computed its own status would leave them all green while GitHub
+    went back to seeing `failure` for a non-blocking `ERROR`.
+    """
+    import inspect
+
+    source = inspect.getsource(Runner._post_run)
+    assert "pipeline_status = self._pipeline_status(result)" in source
+    assert "is_failure()" not in source, (
+        "the output site must not re-derive the status - call _pipeline_status"
+    )
+
+
+def test_the_merge_gate_never_reads_the_non_blocking_flag():
+    """Merge readiness must stay independent of the flag.
+
+    A non-blocking job is exempted from downstream dispatch only. Were the
+    merge computation to honour the same flag, a job could go green for merging
+    on a status it merely asked not to propagate.
+    """
+    import inspect
+
+    from ci.praktika import native_jobs
+
+    source = inspect.getsource(native_jobs._finish_workflow)
+    assert "do_not_block_pipeline_on_failure" not in source
+    assert "allow_failure" in source
+
+
 def test_the_reported_shard_shape_does_not_block_the_pipeline():
     """End to end on the measured production result.
 

--- a/ci/tests/test_pipeline_status_non_blocking.py
+++ b/ci/tests/test_pipeline_status_non_blocking.py
@@ -1,0 +1,193 @@
+"""Tests for the `pipeline_status` GH Actions output and the non-blocking flag.
+
+`pipeline_status` is the only signal GitHub has for whether a finished job
+blocks the rest of the pipeline: every dependent job's generated `if:` is
+`!contains(needs.*.outputs.pipeline_status, 'failure')`
+(`yaml_generator.py`), and `needs` is made transitive, so one `failure` token
+skips a job's whole downstream closure.
+
+Two consumers read `do_not_block_pipeline_on_failure` and must reach the same
+verdict for the same result: `Runner._pipeline_status` decides what GitHub
+sees, and `HtmlRunnerHooks.post_run` decides whether dependees are marked
+`DROPPED` in the report. When they disagree, a job is non-blocking in the
+report and blocking in GitHub - a job whose only non-ok child is a synthetic
+harness row then skips ~110 downstream jobs, including every
+`Bugfix validation (*)`, which `new_tests_check.py` reports back to the author
+as "the test either passes on master HEAD on every arch (so it's not actually
+a regression test for the fix) or every arch errored out".
+
+Both integration and functional test jobs pass `force_ok_exit` into
+`complete_job(do_not_block_pipeline_on_failure=...)` after a path that can
+leave the job-level result `ERROR` rather than `FAIL`, so the exemption has to
+hold for every non-ok status.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.result import Result
+from ci.praktika.runner import Runner
+
+
+def _result(status, non_blocking):
+    """A finished job result, as `complete_job` leaves it.
+
+    `Result.complete_job` records the flag only when the result is not ok
+    (`result.py`), which is mirrored here so a test can never assert on a
+    combination the production setter cannot produce.
+    """
+    r = Result(name="Integration tests (amd_asan_ubsan, db disk, old analyzer, 1/6)", status=status)
+    if non_blocking and not r.is_ok():
+        r.ext["do_not_block_pipeline_on_failure"] = True
+    return r
+
+
+# Every non-ok status a job-level result can carry. DROPPED is included even
+# though it is only set on a job that never ran: if such a result ever reached
+# the output, "did not run" must not be laundered into a green pipeline unless
+# the job asked for it.
+NON_OK_STATUSES = [
+    Result.Status.FAIL,
+    Result.Status.ERROR,
+    Result.Status.XPASS,
+    Result.Status.DROPPED,
+    Result.Status.UNKNOWN,
+    Result.Status.PENDING,
+    Result.Status.RUNNING,
+]
+
+OK_STATUSES = [Result.Status.OK, Result.Status.SKIPPED, Result.Status.XFAIL]
+
+
+@pytest.mark.parametrize("status", NON_OK_STATUSES)
+def test_non_blocking_job_does_not_block_the_pipeline_for_any_non_ok_status(status):
+    """The flag exempts every non-ok status, not only `FAIL`.
+
+    A session-timeout leaves the integration job `ERROR` (a child `Timeout`
+    row rolls up to `FAIL`, then the job sets `ERROR` for the error flag) while
+    `force_ok_exit` is True, so an exemption restricted to `FAIL` never applies
+    to the case that actually occurs.
+    """
+    assert Runner._pipeline_status(_result(status, non_blocking=True)) == "success"
+
+
+@pytest.mark.parametrize("status", NON_OK_STATUSES)
+def test_a_job_that_did_not_ask_to_be_non_blocking_still_blocks(status):
+    """Without the flag every non-ok status blocks the downstream closure.
+
+    This is the half that must not move: a real failure has to keep skipping
+    dependent jobs, so an exemption that ignores the flag is not a fix.
+    """
+    assert Runner._pipeline_status(_result(status, non_blocking=False)) == "failure"
+
+
+@pytest.mark.parametrize("status", OK_STATUSES)
+@pytest.mark.parametrize("non_blocking", [True, False])
+def test_ok_statuses_never_block(status, non_blocking):
+    assert Runner._pipeline_status(_result(status, non_blocking)) == "success"
+
+
+def _html_hook_drops_dependees(result):
+    """The dependee-drop predicate from `HtmlRunnerHooks.post_run`.
+
+    Kept in sync by `test_both_consumers_read_the_flag_with_the_same_predicate`,
+    which asserts the source of the production site rather than trusting this
+    copy.
+    """
+    return not result.is_ok() and not result.do_not_block_pipeline_on_failure()
+
+
+@pytest.mark.parametrize("status", NON_OK_STATUSES + OK_STATUSES)
+@pytest.mark.parametrize("non_blocking", [True, False])
+def test_the_two_consumers_of_the_flag_agree(status, non_blocking):
+    """GitHub and the report must not disagree about whether a job blocks.
+
+    Anything else is visible to an author as a red `Finish Workflow` with no
+    failing test and a report that shows nothing dropped.
+    """
+    result = _result(status, non_blocking)
+    blocks_in_github = Runner._pipeline_status(result) == "failure"
+    assert blocks_in_github == _html_hook_drops_dependees(result)
+
+
+def test_both_consumers_read_the_flag_with_the_same_predicate():
+    """Pin the `hook_html` predicate to the copy asserted above.
+
+    `test_the_two_consumers_of_the_flag_agree` compares against a local copy of
+    the report-side predicate, which would keep passing if the production one
+    were changed. Assert the production source too, so the pair cannot drift
+    apart silently.
+    """
+    import inspect
+
+    from ci.praktika.hook_html import HtmlRunnerHooks
+
+    source = inspect.getsource(HtmlRunnerHooks.post_run)
+    assert (
+        "not result.is_ok() and not result.do_not_block_pipeline_on_failure()" in source
+    ), "hook_html dependee-drop predicate changed - re-check Runner._pipeline_status"
+
+
+def test_the_reported_shard_shape_does_not_block_the_pipeline():
+    """End to end on the measured production result.
+
+    903 `OK` + 17 `SKIPPED` + 1 `FAIL` named `Timeout` is the published row set
+    of `Integration tests (amd_asan_ubsan, db disk, old analyzer, 1/6)` on
+    PR #107115 at `937dffffc320`: every real test passed and the only non-ok
+    child is the synthetic session-timeout row.
+    """
+    children = [Result(name=f"test_ok_{i}", status=Result.Status.OK) for i in range(903)]
+    children += [
+        Result(name=f"test_skipped_{i}", status=Result.Status.SKIPPED) for i in range(17)
+    ]
+    children.append(
+        Result(
+            name="Timeout",
+            status=Result.Status.FAIL,
+            info="ERROR: session-timeout occurred during test execution",
+        )
+    )
+
+    # integration_test_job.py: a single non-ok test means "do not block pipeline"
+    failures_cnt = len([r for r in children if not r.is_ok()])
+    assert failures_cnt == 1
+    force_ok_exit = 0 < failures_cnt < 2
+    assert force_ok_exit
+
+    result = Result.create_from(name="Integration tests", results=children)
+    assert result.status == Result.Status.FAIL
+    # integration_test_job.py: the error flag set for a session-timeout in a
+    # non-targeted, non-flaky check makes the job-level status ERROR
+    result.set_error()
+    assert result.status == Result.Status.ERROR
+    assert not result.is_failure(), "an ERROR is outside the is_failure() domain"
+
+    if force_ok_exit and not result.is_ok():
+        result.ext["do_not_block_pipeline_on_failure"] = True
+
+    assert Runner._pipeline_status(result) == "success"
+    assert not _html_hook_drops_dependees(result)
+
+
+def test_the_old_analyzer_shards_still_block_the_merge():
+    """The merge gate must stay independent of this flag.
+
+    `ready_for_merge` is computed from `job.allow_failure` alone
+    (`native_jobs.py`) and never reads `do_not_block_pipeline_on_failure`, so a
+    genuinely failing shard still blocks the merge. Assert the shards are
+    `allow_failure=False`: were they flipped, a non-blocking status would be
+    the only thing left holding the gate.
+    """
+    from ci.defs.job_configs import JobConfigs
+
+    shards = [
+        job
+        for job in JobConfigs.integration_test_jobs_required
+        if "_asan_ubsan, db disk, old analyzer" in job.name
+    ]
+    assert shards, "old-analyzer integration shards not found"
+    assert all(job.allow_failure is False for job in shards)

--- a/ci/tests/test_pipeline_status_non_blocking.py
+++ b/ci/tests/test_pipeline_status_non_blocking.py
@@ -133,11 +133,14 @@ def test_both_consumers_read_the_flag_with_the_same_predicate():
 
 
 def test_the_output_site_delegates_to_the_helper():
-    """The `pipeline_status` writer must not re-implement the predicate.
+    """The emitted `pipeline_status` must be the helper's return value.
 
     Every other test here calls `Runner._pipeline_status` directly, so a call
     site that computed its own status would leave them all green while GitHub
-    went back to seeing `failure` for a non-blocking `ERROR`.
+    went back to seeing `failure` for a non-blocking `ERROR`. The predicate is
+    only observable through the line that writes this output, so pin the whole
+    hop: the helper is called, its result is what gets written, and no verdict
+    is hardcoded anywhere in between.
     """
     import inspect
 
@@ -146,6 +149,16 @@ def test_the_output_site_delegates_to_the_helper():
     assert "is_failure()" not in source, (
         "the output site must not re-derive the status - call _pipeline_status"
     )
+    assert 'f"pipeline_status={pipeline_status}"' in source, (
+        "the emitted value must be the helper's result, not a literal"
+    )
+    for literal in (
+        '"pipeline_status=failure"',
+        '"pipeline_status=success"',
+        'pipeline_status = "failure"',
+        'pipeline_status = "success"',
+    ):
+        assert literal not in source, f"hardcoded pipeline verdict: {literal}"
 
 
 def test_the_merge_gate_never_reads_the_non_blocking_flag():


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/107115
Related: https://github.com/ClickHouse/ClickHouse/pull/109071


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

A job that sets `do_not_block_pipeline_on_failure` still blocked its whole downstream closure
whenever it ended `ERROR` rather than `FAIL`.

The two consumers disagreed. `hook_html.py:224` gates on `not result.is_ok()`, so
dependees were correctly not marked `DROPPED`. `runner.py:910` gated on `result.is_failure()`,
which is `FAIL`/`XPASS` only, so an `ERROR` was never exempted and the job emitted
`pipeline_status=failure`. Every dependent job's guard is
`!contains(needs.*.outputs.pipeline_status, 'failure')` over a transitive `needs`, so that one
token skips the entire closure.

The case that hits it: an integration shard exhausts its 7200 s parallel-phase budget and appends
a synthetic `Timeout` child while every real test passes. One non-ok child means
`force_ok_exit = True`, so the job declares itself non-blocking, but the same timeout sets the
error flag and `set_error()` makes the status `ERROR`. That skipped 107 of 175 results on #107115
and 112 of 177 on #109071, including all five `Bugfix validation (*)` jobs. Because those never
ran, `new_tests_check.py` read them as `PENDING` and failed `Finish Workflow` with "it's not
actually a regression test for the fix", reporting a timeout in an unrelated shard as a verdict on
the author's regression test. 8 occurrences across 8 PRs and 5 of the 6 shards in 30 days.

`runner.py` now uses the same predicate as `hook_html`, extracted so it is reachable from a test.
They have been asymmetric since the `runner.py` consumer was added in `b35b5fd41f28412`.
`functional_tests.py:1527` passes the same flag after a path that can also end `ERROR`, so it is
fixed by the same line.

**Merge-blocking is unchanged.** `ready_for_merge` is computed from `job.allow_failure` alone
(`native_jobs.py:1102-1117`) and never reads this flag; all six shards are `allow_failure=False`,
so a failing shard still blocks the merge and still reports red. Only downstream dispatch changes.
`new_tests_check.py` is left as it is: its strict check is correct once the jobs actually run.

<details>
<summary>Validation</summary>

Every mutation below was applied to production code and the suite re-run.

| arm | mutation | result |
|---|---|---|
| 0 | the fix | 45 passed |
| A | predicate reverted to `is_failure()` (pre-fix behaviour) | 11 failed, incl. the end-to-end shard shape |
| B | exemption made unconditional, flag ignored (negative control) | 14 failed (every `flag=False` row) |
| C | `hook_html` predicate drifted to `is_failure()` | 1 failed (the agreement pin) |
| D | output site re-derives the status inline, helper left unused | 1 failed (the delegation pin) |
| E | merge gate made to read the flag | 1 failed (the merge-gate pin) |
| F | emitted token hardcoded, or overridden after the call | 1 failed each (the emit pin) |

Arm B is what rules out a vacuous oracle: a test that ignored the flag would stay green. Arms D,
E and F each redden exactly one test, pinning the seams nothing else covers: the call site the
extraction created, the token actually emitted, and the merge computation the paragraph above
rests on.

The new test parametrizes every non-ok member of `Result.Status` (`FAIL`, `ERROR`, `XPASS`,
`DROPPED`, `UNKNOWN`, `PENDING`, `RUNNING`) and all three ok members against flag on/off, asserts
the two consumers reach the same verdict, reproduces the measured production shape (903 `OK` +
17 `SKIPPED` + 1 `Timeout`), and pins `allow_failure=False` on the six shards.

Full `ci/tests`: 972 passed / 31 skipped / 8 failed with the fix, versus 927 / 31 / 8 on pristine
`runner.py`. The same 8 pre-existing environment failures on both arms (`clickhouse was not found
in PATH`); the delta is the new tests.

Exactly two production `complete_job(` call sites pass this flag, and both are covered by this
one line. The only other writer of `pipeline_status` is the config job's unconditional
`success`. The remaining `is_failure()` uses are test-level row filtering or rendering, not
job-level gating.

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1812` (included in `26.8` and later)
<!-- ch-version-info:end -->