### PR TITLE
Retry transient GitHub errors in the `good-prs` skill

### DIFF
--- a/.claude/skills/good-prs/SKILL.md
+++ b/.claude/skills/good-prs/SKILL.md
@@ -58,7 +58,8 @@ regardless of the directory the skill is run from.
 
 `test.sh` runs `report.sh` against a stubbed `gh` (no network) and checks the
 `bucket`→label classification, the "only `CH Inc sync` is non-green" criterion, empty
-input, `--repo` pinning, and the fail-loud-on-real-error behaviour:
+input, `--repo` pinning, the fail-loud-on-real-error behaviour, and the retry policy
+(a transient failure is retried until it succeeds, a permanent one is not retried):
 
 ```bash
 bash .claude/skills/good-prs/test.sh
@@ -84,7 +85,17 @@ bash .claude/skills/good-prs/test.sh
   `pending` / `skipping` / `cancel`), not by raw state strings, so unusual states such as
   `QUEUED`, `TIMED_OUT`, `CANCELLED`, or `STARTUP_FAILURE` are handled without a PR being
   silently dropped.
-- The script fails loudly: if a `gh` call cannot read a PR's data (an API, rate-limit, or
-  permission error, as opposed to a legitimately check-less PR), it aborts with the
-  original `gh` diagnostic rather than silently omitting that PR from the report.
+- A full report makes roughly two GraphQL calls per PR — several hundred per run — so
+  hitting at least one transient GitHub failure is close to certain. Those (`HTTP 408`,
+  `429`, any `5xx`, gateway timeouts, connection resets, secondary rate limits) are
+  retried with exponential backoff, and a primary rate-limit rejection waits for the
+  hourly window to reset. `GH_RETRIES` (default 5) and `GH_RETRY_DELAY` (default 2
+  seconds) tune this.
+- The script still fails loudly: an error that will never fix itself (auth, unknown PR,
+  bad flag) aborts on the first attempt, and a transient error that outlives every retry
+  aborts too — in both cases with the original `gh` diagnostic, rather than silently
+  omitting that PR from the report.
+- A run costs a large share of the hourly GraphQL quota (5000 points), so a few
+  back-to-back runs can exhaust it. Check with
+  `gh api rate_limit --jq .resources.graphql`.
 - The script needs `gh` authenticated and `jq` available.

--- a/.claude/skills/good-prs/report.sh
+++ b/.claude/skills/good-prs/report.sh
@@ -31,6 +31,58 @@ if [ "$#" -gt 0 ]; then TRACK_AUTHORS=("$@"); fi
 ME=$(gh api user --jq .login)
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
+# The per-PR helpers below are separate scripts run by xargs, so they locate the
+# shared retry wrapper through the environment rather than a relative path.
+export GOOD_PRS_WORK="$WORK"
+
+# ---- retry wrapper shared by both per-PR helpers ----------------------------
+# A full report makes roughly two GraphQL calls per PR - several hundred per run -
+# so hitting at least one transient GitHub failure is close to certain: the API
+# regularly answers 502/503/504, and a wide fan-out can trip the secondary rate
+# limit. Aborting on the first one throws away all the quota already spent, so
+# those are retried with exponential backoff, and a primary rate-limit rejection
+# waits for the hourly window to roll over instead.
+#
+# This does not weaken the fail-loud design: errors that will never fix
+# themselves (auth, unknown PR, bad flag) still fail on the first attempt, and a
+# transient error that outlives every attempt is still fatal. A row is never
+# silently dropped either way.
+cat > "$WORK/ghretry.sh" <<'SH'
+GH_RETRIES=${GH_RETRIES:-5}
+GH_RETRY_DELAY=${GH_RETRY_DELAY:-2}
+
+# gh_retry <errfile> <cmd...>
+# On success sets GH_OUT to the command's stdout and returns 0. On failure returns
+# non-zero, leaving the last attempt's stderr in <errfile> for the caller to report.
+gh_retry() {
+  local errfile="$1"; shift
+  local attempt=1 delay="$GH_RETRY_DELAY" reset now wait_s
+  while :; do
+    if GH_OUT=$("$@" 2>"$errfile"); then return 0; fi
+    if [ "$attempt" -ge "$GH_RETRIES" ]; then return 1; fi
+    if grep -qiE 'secondary rate limit|submitted too quickly' "$errfile"; then
+      sleep "$delay"; delay=$(( delay * 2 + 1 ))
+    elif grep -qiE 'rate limit' "$errfile"; then
+      # Primary hourly limit: retrying before the window resets can only fail
+      # again, so wait it out. The rate_limit endpoint is itself unmetered, and
+      # the wait is capped so a run always terminates.
+      reset=$(gh api rate_limit --jq .resources.graphql.reset 2>/dev/null) || reset=""
+      case "$reset" in (*[!0-9]*|"") reset=0 ;; esac
+      now=$(date +%s)
+      wait_s=$(( reset - now + 5 ))
+      if [ "$wait_s" -lt "$GH_RETRY_DELAY" ]; then wait_s="$GH_RETRY_DELAY"; fi
+      if [ "$wait_s" -gt 900 ]; then wait_s=900; fi
+      echo "good-prs: GraphQL rate limit reached, waiting ${wait_s}s for the window to reset (attempt $attempt/$GH_RETRIES)" >&2
+      sleep "$wait_s"
+    elif grep -qiE 'HTTP (408|429|5[0-9][0-9])|Service Unavailable|Bad Gateway|Gateway Time-?out|couldn.t respond|timed out|connection reset|unexpected EOF|TLS handshake' "$errfile"; then
+      sleep "$delay"; delay=$(( delay * 2 ))
+    else
+      return 1   # permanent error: no point burning attempts on it
+    fi
+    attempt=$(( attempt + 1 ))
+  done
+}
+SH
 
 # ---- helper invoked per-PR by xargs: classify the checks --------------------
 # Output: "<num>\t<sync-label>\t<#other-non-green>" where <sync-label> is one of
@@ -46,14 +98,17 @@ trap 'rm -rf "$WORK"' EXIT
 # whenever it could read the checks (even if some are failing or pending). A
 # non-zero exit therefore means either "no checks reported" (a legitimate empty
 # result) or a real API / auth / rate-limit error. We treat the former as NO_CHECKS
-# and abort the whole run on the latter, rather than silently dropping the row.
+# and abort the whole run on the latter (once gh_retry has exhausted its attempts),
+# rather than silently dropping the row.
 cat > "$WORK/classify.sh" <<'SH'
 #!/usr/bin/env bash
 set -uo pipefail
+. "$GOOD_PRS_WORK/ghretry.sh"
 n="$1"
 err=$(mktemp)
 trap 'rm -f "$err"' EXIT
-if json=$(gh pr checks "$n" --repo "$REPO" --json name,state,bucket 2>"$err"); then
+if gh_retry "$err" gh pr checks "$n" --repo "$REPO" --json name,state,bucket; then
+  json="$GH_OUT"
   if [ -z "$json" ] || [ "$json" = "[]" ]; then
     printf '%s\tNO_CHECKS\t99\n' "$n"; exit 0
   fi
@@ -86,12 +141,13 @@ chmod +x "$WORK/classify.sh"
 cat > "$WORK/approval.sh" <<'SH'
 #!/usr/bin/env bash
 set -uo pipefail
+. "$GOOD_PRS_WORK/ghretry.sh"
 n="$1"
 err=$(mktemp)
 trap 'rm -f "$err"' EXIT
-if res=$(gh pr view "$n" --repo "$REPO" --json state,reviews \
-  --jq '[.state, ([.reviews[].state] | any(. == "APPROVED"))] | @tsv' 2>"$err"); then
-  printf '%s\t%s\n' "$n" "$res"
+if gh_retry "$err" gh pr view "$n" --repo "$REPO" --json state,reviews \
+  --jq '[.state, ([.reviews[].state] | any(. == "APPROVED"))] | @tsv'; then
+  printf '%s\t%s\n' "$n" "$GH_OUT"
 else
   echo "good-prs: 'gh pr view $n' failed: $(tr '\n' ' ' <"$err")" >&2
   exit 255

--- a/.claude/skills/good-prs/test.sh
+++ b/.claude/skills/good-prs/test.sh
@@ -12,6 +12,9 @@ set -uo pipefail
 HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPORT="$HERE/report.sh"
 
+# Keep the retry wrapper's timing out of the tests: same code path, no sleeping.
+export GH_RETRIES=3 GH_RETRY_DELAY=0
+
 RC=0
 ok()  { printf '  ok   - %s\n' "$*"; }
 bad() { printf '  FAIL - %s\n' "$*"; RC=1; }
@@ -44,6 +47,15 @@ case "$sub" in
     ;;
   "pr checks")
     n="$3"
+    # <n>.flaky holds a count of leading attempts that fail transiently, so a test
+    # can assert that gh_retry keeps going and eventually returns the real answer.
+    if [ -f "$GH_STUB_DIR/checks/$n.flaky" ]; then
+      cnt=$(cat "$GH_STUB_DIR/checks/$n.count" 2>/dev/null || echo 0)
+      cnt=$(( cnt + 1 )); printf '%s\n' "$cnt" > "$GH_STUB_DIR/checks/$n.count"
+      if [ "$cnt" -le "$(cat "$GH_STUB_DIR/checks/$n.flaky")" ]; then
+        echo "HTTP 503: 503 Service Unavailable (https://api.github.com/graphql)" >&2; exit 1
+      fi
+    fi
     if [ -f "$GH_STUB_DIR/checks/$n.err" ]; then cat "$GH_STUB_DIR/checks/$n.err" >&2; exit 1; fi
     if [ -f "$GH_STUB_DIR/checks/$n.nochecks" ]; then echo "no checks reported on the 'br-$n' branch" >&2; exit 1; fi
     cat "$GH_STUB_DIR/checks/$n.json"
@@ -189,6 +201,39 @@ run_report "$E"
 not_present 501 "$OUT" "#501 with no checks -> excluded"
 row_has "$OUT" 502 GREEN "#502 green PR still rendered alongside excluded one"
 rm -rf "$E"
+
+################## Test F: a transient error is retried, not fatal ##############
+echo "Test F: transient 503s are retried and the run still succeeds"
+F=$(mktemp -d); write_stub "$F"; mkdir -p "$F/fix/list" "$F/fix/checks" "$F/fix/view"
+printf 'testuser\n' > "$F/fix/me"
+printf '601\ttestuser\tFlaky then green\n' > "$F/fix/list/author_testuser.tsv"
+printf '2\n' > "$F/fix/checks/601.flaky"   # fail twice, succeed on the third call
+printf '%s\n' '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"}]' > "$F/fix/checks/601.json"
+printf 'OPEN\ttrue\n' > "$F/fix/view/601.tsv"
+run_report "$F"
+[ "$EXIT" = 0 ] && ok "exit code 0 after retried 503s" || { bad "exit code 0 after retried 503s (got $EXIT)"; cat "$ERRF"; }
+row_has "$OUT" 601 GREEN "#601 rendered after the transient failures"
+if [ "$(grep -c '^pr checks 601 ' "$F/calls.log")" = 3 ]; then
+  ok "gh pr checks retried exactly until it succeeded"
+else
+  bad "gh pr checks retried exactly until it succeeded (got $(grep -c '^pr checks 601 ' "$F/calls.log") calls)"
+fi
+rm -rf "$F"
+
+############## Test G: a permanent error is not retried, still fatal ############
+echo "Test G: a permanent error fails on the first attempt"
+G=$(mktemp -d); write_stub "$G"; mkdir -p "$G/fix/list" "$G/fix/checks" "$G/fix/view"
+printf 'testuser\n' > "$G/fix/me"
+printf '701\ttestuser\tPermanently broken\n' > "$G/fix/list/author_testuser.tsv"
+printf 'GraphQL: Could not resolve to a PullRequest with the number of 701.\n' > "$G/fix/checks/701.err"
+run_report "$G"
+[ "$EXIT" != 0 ] && ok "non-zero exit on permanent failure" || bad "non-zero exit on permanent failure (got $EXIT)"
+if [ "$(grep -c '^pr checks 701 ' "$G/calls.log")" = 1 ]; then
+  ok "permanent error not retried"
+else
+  bad "permanent error not retried (got $(grep -c '^pr checks 701 ' "$G/calls.log") calls)"
+fi
+rm -rf "$G"
 
 echo
 if [ "$RC" = 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi


### PR DESCRIPTION
Make the `good-prs` skill survive transient GitHub API errors.

A full report makes roughly two GraphQL calls per pull request — several hundred per run — so hitting at least one transient GitHub failure is close to certain. The script aborted the whole run on the first one, which threw away all the API quota already spent. Three consecutive runs died this way: on `HTTP 503`, on `API rate limit already exceeded`, and on `HTTP 504`.

This adds a shared `gh_retry` wrapper used by both per-pull-request helpers:

- Transient failures (`HTTP 408`, `429`, any `5xx`, gateway timeouts, connection resets, TLS handshake errors) are retried with exponential backoff.
- Secondary rate limits back off more aggressively.
- A primary rate-limit rejection waits for the hourly window to reset, using the unmetered `rate_limit` endpoint, capped so a run always terminates.

The fail-loud design is preserved. An error that will never fix itself (auth, unknown pull request, bad flag) still aborts on the first attempt, and a transient error that outlives every retry still aborts — in both cases with the original `gh` diagnostic. A row is never silently dropped from the report.

Two tests were added to `test.sh`: a pull request whose checks fail twice with `HTTP 503` is retried and still rendered (exactly three calls), and a permanent error is attempted exactly once. `GH_RETRIES` and `GH_RETRY_DELAY` make the suite exercise the retry path without sleeping. All tests pass.

This only touches `.claude/skills/good-prs/`, a developer-facing helper script; there is no change to ClickHouse itself.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1472` (included in `26.8` and later)
<!-- ch-version-info:end -->