### PR TITLE
Do not regenerate part names from part infos for tables with the deprecated syntax

### DIFF
--- a/src/Storages/MergeTree/OverlappingPartCovering.h
+++ b/src/Storages/MergeTree/OverlappingPartCovering.h
@@ -47,13 +47,15 @@ public:
       * existing covering entry already implies coverage of the new one).
       *
       * `out_skipped_reason`, if non-null, receives the human-readable description from
-      * `ActiveDataPartSet::tryAddPart` when a part lands in the overlapping list. Empty when the
+      * `ActiveDataPartSet::tryAdd` when a part lands in the overlapping list. Empty when the
       * part is added to the primary set or when the part is already covered.
       */
     void add(const MergeTreePartInfo & part_info, const String & part_name, String * out_skipped_reason = nullptr)
     {
         String reason;
-        const auto outcome = set.tryAddPart(part_info, &reason);
+        /// A part name cannot be derived from a part info in the V0 (date-based) name format, so only
+        /// the name-taking overload is usable here.
+        const auto outcome = set.tryAdd(part_name, &reason);
         if (outcome == ActiveDataPartSet::AddPartOutcome::HasIntersectingPart)
         {
             overlapping.emplace_back(part_info, part_name);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -995,7 +995,14 @@ namespace
 /// We use this representation to understand which parts mutation actually have to mutate.
 struct QueueEntryRepresentation
 {
-    std::vector<MergeTreePartInfo> produced_parts;
+    /// The name is stored rather than derived on demand: that is impossible in the V0 name format.
+    struct NamedPartInfo
+    {
+        MergeTreePartInfo info;
+        String name;
+    };
+
+    std::vector<NamedPartInfo> produced_parts;
     std::vector<MergeTreePartInfo> dropped_parts;
 };
 
@@ -1019,7 +1026,8 @@ PartitionQueueRepresentation getQueueRepresentation(const std::list<ReplicatedMe
             case LogEntryType::MERGE_PARTS:
             case LogEntryType::MUTATE_PART:
             {
-                representations_by_znode[znode_name].produced_parts.push_back(MergeTreePartInfo::fromPartName(entry->new_part_name, format_version));
+                representations_by_znode[znode_name].produced_parts.push_back(
+                    {MergeTreePartInfo::fromPartName(entry->new_part_name, format_version), entry->new_part_name});
                 break;
             }
             case LogEntryType::REPLACE_RANGE:
@@ -1031,7 +1039,7 @@ PartitionQueueRepresentation getQueueRepresentation(const std::list<ReplicatedMe
                 produced_parts.reserve(produced_parts.size() + new_parts.size());
                 for (const auto & new_part : new_parts)
                 {
-                    produced_parts.push_back(MergeTreePartInfo::fromPartName(new_part, format_version));
+                    produced_parts.push_back({MergeTreePartInfo::fromPartName(new_part, format_version), new_part});
                 }
 
                 if (auto drop_range = entry->getDropRange(format_version))
@@ -1069,10 +1077,10 @@ PartitionQueueRepresentation getQueueRepresentation(const std::list<ReplicatedMe
             representations_by_partition[partiton_id].dropped_parts.push_back(std::move(part_to_drop_info));
         }
 
-        for (auto & part_to_add_info : entry_representation.produced_parts)
+        for (auto & part_to_add : entry_representation.produced_parts)
         {
-            const auto partiton_id = part_to_add_info.getPartitionId();
-            representations_by_partition[partiton_id].produced_parts.push_back(std::move(part_to_add_info));
+            const auto partiton_id = part_to_add.info.getPartitionId();
+            representations_by_partition[partiton_id].produced_parts.push_back(std::move(part_to_add));
         }
     }
     return representations_by_partition;
@@ -1125,11 +1133,11 @@ ActiveDataPartSet getPartNamesToMutate(
         }
 
         /// After we have to add parts if entry adds them
-        for (const auto & part_to_add_info : queue_representation.at(partition_id).produced_parts)
+        for (const auto & part_to_add : queue_representation.at(partition_id).produced_parts)
         {
-            if (part_to_add_info.getDataVersion() < block_num)
+            if (part_to_add.info.getDataVersion() < block_num)
             {
-                result.add(part_to_add_info);
+                result.add(part_to_add.info, part_to_add.name);
             }
         }
     }

--- a/src/Storages/MergeTree/tests/gtest_active_data_part_set.cpp
+++ b/src/Storages/MergeTree/tests/gtest_active_data_part_set.cpp
@@ -9,6 +9,10 @@ using namespace DB;
 namespace
 {
 constexpr auto FORMAT_VERSION = MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING;
+
+/// Tables created with the deprecated positional `MergeTree(date, key, granularity)` syntax use
+/// date-based part names, for which a name cannot be derived from a `MergeTreePartInfo`.
+constexpr auto FORMAT_VERSION_V0 = MergeTreeDataFormatVersion(0);
 }
 
 /// Two parts can both be marked "uncovered" (no other part contains either of them) and
@@ -210,4 +214,57 @@ TEST(OverlappingPartCovering, EmptySet)
     EXPECT_TRUE(markers.empty());
     EXPECT_EQ(0u, markers.size());
     EXPECT_TRUE(markers.getContainingPart("all_0_5_1").empty());
+}
+
+/// V0 format version ------------------------------------------------------------------------------
+///
+/// `StorageReplicatedMergeTree::checkPartsImpl` builds this index from the empty unexpected parts on
+/// disk and passes both the info and the name of every part. Deriving the name from the info instead
+/// throws `BAD_DATA_PART_NAME` for a V0 table and leaves it readonly.
+
+TEST(OverlappingPartCovering, V0DisjointMarkers)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION_V0);
+    const String first = "20150101_20150101_0_5_2";
+    const String second = "20150101_20150101_6_11_3";
+
+    markers.add(MergeTreePartInfo::fromPartName(first, FORMAT_VERSION_V0), first);
+    markers.add(MergeTreePartInfo::fromPartName(second, FORMAT_VERSION_V0), second);
+
+    EXPECT_EQ(2u, markers.size());
+    EXPECT_TRUE(markers.getOverlappingParts().empty());
+    EXPECT_EQ(first, markers.getContainingPart(MergeTreePartInfo::fromPartName("20150101_20150101_0_3_1", FORMAT_VERSION_V0)));
+    EXPECT_EQ(second, markers.getContainingPart(MergeTreePartInfo::fromPartName("20150101_20150101_8_10_1", FORMAT_VERSION_V0)));
+}
+
+TEST(OverlappingPartCovering, V0IntersectingMarkersStillCoverDownstreamParts)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION_V0);
+    const String first = "20150101_20150101_0_5_2";
+    const String second = "20150101_20150101_2_11_3";
+
+    markers.add(MergeTreePartInfo::fromPartName(first, FORMAT_VERSION_V0), first);
+
+    String reason;
+    markers.add(MergeTreePartInfo::fromPartName(second, FORMAT_VERSION_V0), second, &reason);
+    EXPECT_FALSE(reason.empty());
+
+    EXPECT_EQ(2u, markers.size());
+    EXPECT_EQ(1u, markers.getOverlappingParts().size());
+    EXPECT_EQ(second, markers.getContainingPart(MergeTreePartInfo::fromPartName("20150101_20150101_9_10_1", FORMAT_VERSION_V0)));
+    EXPECT_EQ(first, markers.getContainingPart(MergeTreePartInfo::fromPartName("20150101_20150101_0_5_1", FORMAT_VERSION_V0)));
+}
+
+TEST(OverlappingPartCovering, V0ContainedPartIsNotStored)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION_V0);
+    const String outer = "20150101_20150101_0_11_3";
+    const String inner = "20150101_20150101_2_5_1";
+
+    markers.add(MergeTreePartInfo::fromPartName(outer, FORMAT_VERSION_V0), outer);
+    markers.add(MergeTreePartInfo::fromPartName(inner, FORMAT_VERSION_V0), inner);
+
+    EXPECT_EQ(1u, markers.size());
+    EXPECT_TRUE(markers.getOverlappingParts().empty());
+    EXPECT_EQ(outer, markers.getContainingPart(MergeTreePartInfo::fromPartName(inner, FORMAT_VERSION_V0)));
 }

--- a/tests/queries/0_stateless/04907_mutation_parts_to_do_deprecated_syntax.reference
+++ b/tests/queries/0_stateless/04907_mutation_parts_to_do_deprecated_syntax.reference
@@ -1,0 +1,5 @@
+queue entries pending on r2	1
+r2 mutation done	0	parts to do	2
+r2 rows before mutation applies	[1]
+r1 rows	[100,100]
+r2 rows	[100,100]

--- a/tests/queries/0_stateless/04907_mutation_parts_to_do_deprecated_syntax.sql
+++ b/tests/queries/0_stateless/04907_mutation_parts_to_do_deprecated_syntax.sql
@@ -23,8 +23,12 @@ SYSTEM STOP MERGES v0_r2;
 INSERT INTO v0_r1 VALUES ('2015-01-01', 2, 2);
 SYSTEM SYNC REPLICA v0_r2 PULL;
 
+-- An entry for a part r2 already holds can still be queued here; it gets skipped, not fetched.
 SELECT 'queue entries pending on r2', count() FROM system.replication_queue
-    WHERE database = currentDatabase() AND replica_name = 'r2';
+    WHERE database = currentDatabase() AND replica_name = 'r2' AND type = 'GET_PART'
+        AND new_part_name NOT IN (
+            SELECT name FROM system.parts
+                WHERE database = currentDatabase() AND table = 'v0_r2' AND active);
 
 ALTER TABLE v0_r1 UPDATE v = 100 WHERE 1 SETTINGS mutations_sync = 0;
 SYSTEM SYNC REPLICA v0_r2 PULL;

--- a/tests/queries/0_stateless/04907_mutation_parts_to_do_deprecated_syntax.sql
+++ b/tests/queries/0_stateless/04907_mutation_parts_to_do_deprecated_syntax.sql
@@ -1,0 +1,49 @@
+-- Tags: replica, no-replicated-database, no-shared-merge-tree
+-- Tag no-replicated-database: Old syntax is not allowed
+-- Tag no-shared-merge-tree: Old syntax is not allowed
+
+SET allow_deprecated_syntax_for_merge_tree = 1;
+
+DROP TABLE IF EXISTS v0_r1 SYNC;
+DROP TABLE IF EXISTS v0_r2 SYNC;
+
+CREATE TABLE v0_r1 (d Date, k UInt64, v UInt64)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04907', 'r1', d, k, 8192);
+CREATE TABLE v0_r2 (d Date, k UInt64, v UInt64)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04907', 'r2', d, k, 8192);
+
+INSERT INTO v0_r2 VALUES ('2015-01-01', 1, 1);
+SYSTEM SYNC REPLICA v0_r1;
+
+-- Freeze r2 so that the queue entry produced by the next INSERT stays pending and nothing
+-- can make progress while the mutation bookkeeping is inspected.
+SYSTEM STOP FETCHES v0_r2;
+SYSTEM STOP MERGES v0_r2;
+
+INSERT INTO v0_r1 VALUES ('2015-01-01', 2, 2);
+SYSTEM SYNC REPLICA v0_r2 PULL;
+
+SELECT 'queue entries pending on r2', count() FROM system.replication_queue
+    WHERE database = currentDatabase() AND replica_name = 'r2';
+
+ALTER TABLE v0_r1 UPDATE v = 100 WHERE 1 SETTINGS mutations_sync = 0;
+SYSTEM SYNC REPLICA v0_r2 PULL;
+
+-- Both the part r2 already has and the part its pending queue entry will produce are older than
+-- the mutation, so the mutation cannot be done on r2 while r2 is frozen.
+SELECT 'r2 mutation done', max(is_done), 'parts to do', max(parts_to_do) FROM system.mutations
+    WHERE database = currentDatabase() AND table = 'v0_r2';
+
+SELECT 'r2 rows before mutation applies', groupArray(v) FROM (SELECT v FROM v0_r2 ORDER BY k);
+
+SYSTEM START FETCHES v0_r2;
+SYSTEM START MERGES v0_r2;
+SYSTEM SYNC REPLICA v0_r2;
+
+ALTER TABLE v0_r1 UPDATE v = 100 WHERE 1 SETTINGS mutations_sync = 2;
+
+SELECT 'r1 rows', groupArray(v) FROM (SELECT v FROM v0_r1 ORDER BY k);
+SELECT 'r2 rows', groupArray(v) FROM (SELECT v FROM v0_r2 ORDER BY k);
+
+DROP TABLE v0_r1 SYNC;
+DROP TABLE v0_r2 SYNC;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/87206
Related: https://github.com/ClickHouse/ClickHouse/pull/103537
Related: https://github.com/ClickHouse/ClickHouse/pull/112457
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `BAD_DATA_PART_NAME` ("Trying to get part name in new format for old format version") on a `ReplicatedMergeTree` created with the deprecated positional syntax under `allow_deprecated_syntax_for_merge_tree`. A mutation could be reported as done on a replica that had not applied it, and the table could stay readonly after a restart.

### Description

Reported by @ alexey-milovidov on #112457 ([`Upgrade check (amd_release)` report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112457&sha=f888781eb610bfabdc8c8675d835b99482bec8a2&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29)). No related open issue found.

A table created with `ENGINE = ReplicatedMergeTree(date, key, granularity)` uses date-based (V0) part names. `MergeTreePartInfo::getPartNameAndCheckFormat` cannot produce one, because the min/max dates it needs are not part of a `MergeTreePartInfo`, so it throws. Two `ActiveDataPartSet` entry points take only an info and regenerate the name that way; each had exactly one caller, and both callers already held the name and threw it away. This change passes the name at both call sites, as in `536b611c96a757e`, which fixed the `ATTACH PARTITION` instance of this bug. V0 name formatting is untouched, and current-format tables are unaffected because the name-taking overload re-parses to the same info and runs the same insertion code.

The linked report contains both failures:

- `ReplicatedMergeTreeQueue::getPartNamesToMutate` builds `mutation.parts_to_do`. The throw left it empty, so a mutation reported `is_done` on a replica that never mutated its part, and `mutations_sync = 2` returned success while that replica still served pre-mutation values. Regressed by #87206, which changed `produced_parts` to hold infos instead of names.
- `StorageReplicatedMergeTree::checkPartsImpl` builds the set of empty unexpected parts. The throw aborted `ReplicatedMergeTreeAttachThread`, leaving the table readonly. Regressed by my own #103537, which replaced a name-based call with an info-based one.

The V0 gap in `MergeTreeData::restorePartFromBackup` that the throw-site comment describes is a different code path, absent from both stacks, and is not addressed.

A new stateless test asserts `parts_to_do` on the frozen replica: it fails on master (`parts to do 0`) and passes here (`parts to do 2`), and 50/50 randomized runs pass. `checkPartsImpl`'s state needs parts fabricated on disk, so that half is covered by three V0 cases added to `gtest_active_data_part_set.cpp`, all of which fail with this change reverted. `00062_replicated_merge_tree_alter_zookeeper_long` and `00652_replicated_mutations_zookeeper` still pass.