### PR TITLE
Report the real error when an in-place `IN`-set build destroys its source

### DIFF
--- a/src/Interpreters/PreparedSets.cpp
+++ b/src/Interpreters/PreparedSets.cpp
@@ -401,6 +401,13 @@ std::unique_ptr<QueryPlan> FutureSetFromSubquery::build(const SizeLimits & netwo
     if (set_and_key->set->isCreated())
         return nullptr;
 
+    /// A destructive in-place build consumed `source` and then threw, so this set can never be built.
+    /// Every caller treats a null plan as "nothing to build" and moves on, which leaves the set unready
+    /// and makes `FunctionIn` report "Not-ready Set is passed as the second argument" once the main
+    /// pipeline evaluates the condition. Report the real reason instead. See `buildOrderedSetInplace`.
+    if (in_place_build_failure)
+        std::rethrow_exception(in_place_build_failure);
+
     auto plan = std::move(source);
 
     if (!plan)
@@ -568,94 +575,112 @@ SetPtr FutureSetFromSubquery::buildOrderedSetInplace(const ContextPtr & context)
     /// destructive fallback, which builds directly into the canonical `set_and_key->set`.
     SetPtr speculative_set;
 
-    if (source_preserved)
+    /// The destructive fallback below leaves the set unbuildable if anything throws after `build` has
+    /// consumed `source`: every `build` caller treats a null plan as "nothing to do", so the set stays
+    /// not-ready and `FunctionIn` reports "Not-ready Set is passed as the second argument" once the main
+    /// pipeline evaluates the condition. That is exactly what a caller which deliberately ignores an
+    /// in-place build failure produces — primary key, skip index, and statistics analysis all run this
+    /// build speculatively and continue without the set when it throws. Remember the failure so that
+    /// `build` can report the real reason instead. Nothing is remembered on the non-destructive path:
+    /// `source` is intact there and the deferred build simply runs the subquery again.
+    try
     {
-        /// Non-destructive path. Build into a *temporary* `Set` so the canonical `set_and_key->set` is
-        /// never mutated unless the build fully succeeds. With `overflow_mode = 'break'` the pipeline can
-        /// stop after `CreatingSetsTransform::consume` has inserted a prefix of rows but before
-        /// `generate` calls `Set::finishInsert`; building into a temporary set keeps those partial rows
-        /// out of the canonical set, which the deferred build reuses. Publishing only a created set means
-        /// a non-deterministic subquery (e.g. one using `rand`) is evaluated against a single result.
-        ///
-        /// Do not share this speculative build through `PreparedSetsCache`: if the in-place pipeline stops
-        /// silently, the `CreatingSetsTransform` destructor stores an exception into the cache for this
-        /// key, and the later deferred build would rethrow it via `shared_future::get` instead of
-        /// rebuilding from the preserved `source`. The deferred build still uses the cache.
-        const auto & canonical_set = *set_and_key->set;
-        speculative_set = std::make_shared<Set>(canonical_set.limits, canonical_set.max_elements_to_fill, canonical_set.transform_null_in);
-        speculative_set->setHeader(plan->getCurrentHeader()->getColumnsWithTypeAndName());
-        speculative_set->fillSetElements();
-
-        /// The temporary `SetAndKey` has no external table (the non-destructive path is only taken when
-        /// `set_and_key->external_table` is null, see above), so the speculative `CreatingSetsTransform`
-        /// only builds the set and never touches a `GLOBAL IN` temporary table.
-        auto tmp_set_and_key = std::make_shared<SetAndKey>();
-        tmp_set_and_key->key = set_and_key->key;
-        tmp_set_and_key->set = speculative_set;
-
-        auto creating_set = std::make_unique<CreatingSetStep>(
-            plan->getCurrentHeader(),
-            tmp_set_and_key,
-            network_transfer_limits,
-            /*prepared_sets_cache=*/ nullptr);
-        creating_set->setStepDescription("Create set for subquery");
-        plan->addStep(std::move(creating_set));
-    }
-    else
-    {
-        /// Destructive fallback for non-clonable sources: `build` consumes `source` and binds the
-        /// `CreatingSetStep` to the canonical `set_and_key` (as this code always did). On a silent failure
-        /// `source` is gone, so the deferred build cannot rebuild — exactly the previous behavior; the set
-        /// is never reused with partial rows, because the deferred build throws "Not-ready Set" instead.
-        auto prepared_sets_cache = context->getPreparedSetsCache();
-        /// A distributed plan ships the set's values to worker tasks, and a cached set has none.
-        if (settings[Setting::make_distributed_plan])
-            prepared_sets_cache = nullptr;
-        plan = build(network_transfer_limits, prepared_sets_cache);
-        if (!plan)
-            return nullptr;
-
-        /// `Set::fillSetElements` appends to `set_elements` without clearing, and this function may run
-        /// more than once for the same set; fill only once, mirroring `FutureSetFromTuple`.
-        if (!set_and_key->set->hasExplicitSetElements())
-            set_and_key->set->fillSetElements();
-    }
-
-    /// Run the speculative pipeline in its own scope so that `executor`, `pipeline`, and the pipeline
-    /// builder are destroyed before `source` is reset below. On the non-destructive path the cloned `plan`
-    /// carries an *empty* `QueryPlanResourceHolder` (`QueryPlan::clone` copies the plan nodes only, not the
-    /// resources), so the speculative pipeline relies on the original `source` plan to keep the interpreter
-    /// contexts, storage holders, and table locks alive: processors may use them implicitly, including in
-    /// their destructors — this is exactly what the resource holder normally guarantees for the lifetime of
-    /// the pipeline. Resetting `source` while the pipeline is still alive would release them too early. On
-    /// the destructive fallback `build` moved the resources into `plan`, which outlives this scope, so the
-    /// ordering is safe there too.
-    {
-        auto builder = plan->buildQueryPipeline(makeInplaceBuildOptimizationSettings(context), BuildQueryPipelineSettings(context));
-        auto pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
-        pipeline.complete(std::make_shared<EmptySink>(std::make_shared<const Block>(Block())));
-
-        CompletedPipelineExecutor executor(pipeline);
-        if (context->hasQueryContext())
+        if (source_preserved)
         {
-            if (auto cancel_callback = context->getQueryContext()->getInteractiveCancelCallback())
-                executor.setCancelCallback(std::move(cancel_callback), std::max(UInt64(100), context->getSettingsRef()[Setting::interactive_delay] / 1000));
+            /// Non-destructive path. Build into a *temporary* `Set` so the canonical `set_and_key->set` is
+            /// never mutated unless the build fully succeeds. With `overflow_mode = 'break'` the pipeline can
+            /// stop after `CreatingSetsTransform::consume` has inserted a prefix of rows but before
+            /// `generate` calls `Set::finishInsert`; building into a temporary set keeps those partial rows
+            /// out of the canonical set, which the deferred build reuses. Publishing only a created set means
+            /// a non-deterministic subquery (e.g. one using `rand`) is evaluated against a single result.
+            ///
+            /// Do not share this speculative build through `PreparedSetsCache`: if the in-place pipeline stops
+            /// silently, the `CreatingSetsTransform` destructor stores an exception into the cache for this
+            /// key, and the later deferred build would rethrow it via `shared_future::get` instead of
+            /// rebuilding from the preserved `source`. The deferred build still uses the cache.
+            const auto & canonical_set = *set_and_key->set;
+            speculative_set = std::make_shared<Set>(canonical_set.limits, canonical_set.max_elements_to_fill, canonical_set.transform_null_in);
+            speculative_set->setHeader(plan->getCurrentHeader()->getColumnsWithTypeAndName());
+            speculative_set->fillSetElements();
+
+            /// The temporary `SetAndKey` has no external table (the non-destructive path is only taken when
+            /// `set_and_key->external_table` is null, see above), so the speculative `CreatingSetsTransform`
+            /// only builds the set and never touches a `GLOBAL IN` temporary table.
+            auto tmp_set_and_key = std::make_shared<SetAndKey>();
+            tmp_set_and_key->key = set_and_key->key;
+            tmp_set_and_key->set = speculative_set;
+
+            auto creating_set = std::make_unique<CreatingSetStep>(
+                plan->getCurrentHeader(),
+                tmp_set_and_key,
+                network_transfer_limits,
+                /*prepared_sets_cache=*/ nullptr);
+            creating_set->setStepDescription("Create set for subquery");
+            plan->addStep(std::move(creating_set));
         }
-        executor.execute();
+        else
+        {
+            /// Destructive fallback for non-clonable sources: `build` consumes `source` and binds the
+            /// `CreatingSetStep` to the canonical `set_and_key` (as this code always did). On a silent failure
+            /// `source` is gone, so the deferred build cannot rebuild — exactly the previous behavior; the set
+            /// is never reused with partial rows, because the deferred build throws "Not-ready Set" instead.
+            /// A failure that *throws* is remembered by the `catch` below and reported as itself instead.
+            auto prepared_sets_cache = context->getPreparedSetsCache();
+            /// A distributed plan ships the set's values to worker tasks, and a cached set has none.
+            if (settings[Setting::make_distributed_plan])
+                prepared_sets_cache = nullptr;
+            plan = build(network_transfer_limits, prepared_sets_cache);
+            if (!plan)
+                return nullptr;
 
-        /// SET may not be created successfully at this step because of the sub-query timeout, but if we have
-        /// `timeout_overflow_mode` set to `break`, no exception is thrown, and the executor just stops executing
-        /// the pipeline without setting `is_created` to true. On the non-destructive path the cloned source
-        /// above keeps `source` intact, so `DelayedCreatingSetsStep::makePlansForSets` can still build the set
-        /// later (on the destructive fallback `source` is already gone, as it always was).
-        Set & built_set = speculative_set ? *speculative_set : *set_and_key->set;
-        if (!built_set.isCreated())
-            return nullptr;
+            /// `Set::fillSetElements` appends to `set_elements` without clearing, and this function may run
+            /// more than once for the same set; fill only once, mirroring `FutureSetFromTuple`.
+            if (!set_and_key->set->hasExplicitSetElements())
+                set_and_key->set->fillSetElements();
+        }
 
-        logProcessorProfile(context, pipeline.getProcessors());
+        /// Run the speculative pipeline in its own scope so that `executor`, `pipeline`, and the pipeline
+        /// builder are destroyed before `source` is reset below. On the non-destructive path the cloned `plan`
+        /// carries an *empty* `QueryPlanResourceHolder` (`QueryPlan::clone` copies the plan nodes only, not the
+        /// resources), so the speculative pipeline relies on the original `source` plan to keep the interpreter
+        /// contexts, storage holders, and table locks alive: processors may use them implicitly, including in
+        /// their destructors — this is exactly what the resource holder normally guarantees for the lifetime of
+        /// the pipeline. Resetting `source` while the pipeline is still alive would release them too early. On
+        /// the destructive fallback `build` moved the resources into `plan`, which outlives this scope, so the
+        /// ordering is safe there too.
+        {
+            auto builder = plan->buildQueryPipeline(makeInplaceBuildOptimizationSettings(context), BuildQueryPipelineSettings(context));
+            auto pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
+            pipeline.complete(std::make_shared<EmptySink>(std::make_shared<const Block>(Block())));
 
-        /// Finalize write in query cache to save subquery result (no-op if no cache writers exist in the pipeline)
-        pipeline.finalizeWriteInQueryResultCache();
+            CompletedPipelineExecutor executor(pipeline);
+            if (context->hasQueryContext())
+            {
+                if (auto cancel_callback = context->getQueryContext()->getInteractiveCancelCallback())
+                    executor.setCancelCallback(std::move(cancel_callback), std::max(UInt64(100), context->getSettingsRef()[Setting::interactive_delay] / 1000));
+            }
+            executor.execute();
+
+            /// SET may not be created successfully at this step because of the sub-query timeout, but if we have
+            /// `timeout_overflow_mode` set to `break`, no exception is thrown, and the executor just stops executing
+            /// the pipeline without setting `is_created` to true. On the non-destructive path the cloned source
+            /// above keeps `source` intact, so `DelayedCreatingSetsStep::makePlansForSets` can still build the set
+            /// later (on the destructive fallback `source` is already gone, as it always was).
+            Set & built_set = speculative_set ? *speculative_set : *set_and_key->set;
+            if (!built_set.isCreated())
+                return nullptr;
+
+            logProcessorProfile(context, pipeline.getProcessors());
+
+            /// Finalize write in query cache to save subquery result (no-op if no cache writers exist in the pipeline)
+            pipeline.finalizeWriteInQueryResultCache();
+        }
+    }
+    catch (...)
+    {
+        if (!source_preserved)
+            in_place_build_failure = std::current_exception();
+        throw;
     }
 
     /// In-place build succeeded. On the non-destructive path, publish the fully-created temporary set into

--- a/src/Interpreters/PreparedSets.h
+++ b/src/Interpreters/PreparedSets.h
@@ -3,6 +3,7 @@
 #include <city.h>
 #include <Parsers/IAST_fwd.h>
 #include <DataTypes/IDataType.h>
+#include <exception>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -213,6 +214,11 @@ private:
 
     std::unique_ptr<QueryPlan> source;
     QueryTreeNodePtr query_tree;
+
+    /// Why the destructive in-place build in `buildOrderedSetInplace` failed after it consumed `source`.
+    /// The set can never be built once that happened, so `build` rethrows this instead of returning a null
+    /// plan, which its callers would silently take for "nothing left to build".
+    std::exception_ptr in_place_build_failure;
 };
 
 using FutureSetFromSubqueryPtr = std::shared_ptr<FutureSetFromSubquery>;

--- a/tests/queries/0_stateless/04907_not_ready_set_unavailable_replica.sql
+++ b/tests/queries/0_stateless/04907_not_ready_set_unavailable_replica.sql
@@ -1,0 +1,29 @@
+-- Regression test for the logical error "Not-ready Set is passed as the second argument for
+-- function 'in'".
+--
+-- `FutureSetFromSubquery::buildOrderedSetInplace` speculatively builds the set of an `IN` subquery
+-- during index analysis. A subquery whose source plan cannot be cloned - a read from a remote
+-- cluster is one - takes the destructive path there, which consumes the source plan. When that
+-- build throws and the caller swallows the error, nothing can build the set afterwards: statistics
+-- based part pruning is such a caller, it keeps reading the part whose condition it failed to
+-- evaluate. `FunctionIn` then reported a logical error once the main pipeline reached the
+-- condition. The build failure is remembered now and reported as itself instead.
+
+DROP TABLE IF EXISTS t_not_ready_set_unavailable;
+
+CREATE TABLE t_not_ready_set_unavailable (key UInt32, a UInt32)
+ENGINE = MergeTree ORDER BY key
+SETTINGS auto_statistics_types = 'basic';
+
+SET materialize_statistics_on_insert = 1;
+INSERT INTO t_not_ready_set_unavailable VALUES (1, 10), (2, 15), (3, 20);
+
+SET use_statistics = 1, use_statistics_for_part_pruning = 1, use_index_for_in_with_subqueries = 1;
+
+-- `a` is not part of the primary key, but it carries automatic statistics, so statistics based part
+-- pruning evaluates the `IN` condition and builds the set in place. One replica of the cluster is
+-- unreachable, so that build fails.
+SELECT count() FROM t_not_ready_set_unavailable
+WHERE a IN (SELECT a FROM clusterAllReplicas('test_cluster_1_shard_3_replicas_1_unavailable', currentDatabase(), t_not_ready_set_unavailable)); -- { serverError ALL_CONNECTION_TRIES_FAILED }
+
+DROP TABLE t_not_ready_set_unavailable;


### PR DESCRIPTION
`FutureSetFromSubquery::buildOrderedSetInplace` speculatively builds the set of an `IN` subquery during index analysis. A subquery whose source plan cannot be cloned - a read from a remote cluster, for example - takes the destructive path there, which consumes the source plan. When that build then throws, the set can never be built again: `build` returns a null plan, every caller takes that for "nothing left to build", and the query keeps running with an unready set until `FunctionIn` reports the logical error `Not-ready Set is passed as the second argument for function 'in'`.

That is exactly what happens whenever a caller deliberately ignores an in-place build failure. Statistics-based part pruning is such a caller: it logs the failure and keeps reading the part whose condition it could not evaluate. So

```sql
SELECT count() FROM t
WHERE a IN (SELECT a FROM clusterAllReplicas('cluster_with_an_unavailable_replica', currentDatabase(), t))
```

reported `Not-ready Set` instead of the connection error, which aborts the server in a build with `abort_on_logical_error`.

The failure of a destructive in-place build is remembered now and rethrown from `build` instead of returning a null plan, so the query fails with the real reason - the same error it fails with when no in-place build is attempted at all.

This is the cause of the recurring master `Stress test` failure `Logical error: Not-ready Set is passed as the second argument for function 'A (STID: 0250-3e49)`, seen on `arm_release` and `arm_msan` a few times a day since 2026-07-23:

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2926be24e6102daae60b8f44c88969495a76ec3c&name_0=MasterCI&name_1=Stress%20test%20%28arm_release%29

Related: https://github.com/ClickHouse/ClickHouse/pull/107924
Related: https://github.com/ClickHouse/ClickHouse/issues/107619

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the logical error `Not-ready Set is passed as the second argument for function 'in'` for a query with an `IN` subquery reading from a remote cluster: the query now fails with the actual error from the subquery, such as a connection failure.
