### PR TITLE
Reuse LowCardinality aggregation mappings across blocks

### DIFF
--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -19,6 +19,8 @@
 #include <Core/Defines.h>
 #include <algorithm>
 #include <memory>
+#include <optional>
+#include <vector>
 #include <Common/HashTable/Hash.h>
 
 namespace DB
@@ -78,18 +80,100 @@ private:
     Cache cache;
 };
 
+enum class LowCardinalityCacheVisitValue : uint8_t
+{
+    Empty = 0,
+    Found = 1,
+    NotFound = 2,
+};
+
+template <typename Mapped>
+struct LowCardinalityHashMethodBlockCache
+{
+    /// Keep block-local storage free of persistent-cache metadata so cheap fixed hash tables
+    /// can access these arrays directly in the aggregation hot path.
+    columns_hashing_impl::MappedCache<Mapped> mapped_cache;
+    PaddedPODArray<LowCardinalityCacheVisitValue> visit_cache;
+
+    void resetForBlock(size_t size)
+    {
+        if constexpr (!std::is_same_v<Mapped, void>)
+            mapped_cache.resize(size);
+        visit_cache.assign(size, LowCardinalityCacheVisitValue::Empty);
+    }
+};
+
+/// Cache dictionary positions resolved to mapped values in one hash table.
+/// Mapped values are valid only while the hash table owning this cache is alive.
+/// This cache can be used for aggregation mappings pointing into arenas, because hash-table
+/// growth does not invalidate them. It cannot be used when the mapped value itself is mutable.
+template <typename Mapped>
+struct LowCardinalityHashMethodCache
+{
+    using DictionaryKey = LowCardinalityDictionaryCache::DictionaryKey;
+
+    std::optional<DictionaryKey> dictionary_key;
+    columns_hashing_impl::MappedCache<Mapped> mapped_cache;
+    PaddedPODArray<LowCardinalityCacheVisitValue> visit_cache;
+
+    bool hasDictionary(const DictionaryKey & key) const
+    {
+        return dictionary_key && *dictionary_key == key;
+    }
+
+    void resetForSharedDictionary(const DictionaryKey & key, size_t size)
+    {
+        /// Mappings from the previous dictionary are unusable, and keeping their capacity can
+        /// retain buffers sized for a much larger dictionary until aggregation finishes.
+        clear();
+        if constexpr (!std::is_same_v<Mapped, void>)
+            mapped_cache.resize(size);
+        visit_cache.assign(size, LowCardinalityCacheVisitValue::Empty);
+        dictionary_key = key;
+    }
+
+    void resetForBlock(size_t size)
+    {
+        dictionary_key.reset();
+        if constexpr (!std::is_same_v<Mapped, void>)
+            mapped_cache.resize(size);
+        visit_cache.assign(size, LowCardinalityCacheVisitValue::Empty);
+    }
+
+    void clear()
+    {
+        dictionary_key.reset();
+        if constexpr (!std::is_same_v<Mapped, void>)
+        {
+            decltype(mapped_cache) empty_mapped_cache;
+            mapped_cache.swap(empty_mapped_cache);
+        }
+        decltype(visit_cache) empty_visit_cache;
+        visit_cache.swap(empty_visit_cache);
+    }
+
+    size_t allocatedBytes() const
+    {
+        size_t bytes = visit_cache.allocated_bytes();
+        if constexpr (!std::is_same_v<Mapped, void>)
+            bytes += mapped_cache.allocated_bytes();
+        return bytes;
+    }
+};
+
 /// Single low cardinality column.
-template <typename SingleColumnMethod, typename Mapped, bool use_cache>
+template <
+    typename SingleColumnMethod,
+    typename Mapped,
+    bool use_cache,
+    bool cache_mapped_values = true,
+    bool use_persistent_cache = true>
 struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
 {
     using Base = SingleColumnMethod;
-
-    enum class VisitValue : uint8_t
-    {
-        Empty = 0,
-        Found = 1,
-        NotFound = 2,
-    };
+    using VisitValue = LowCardinalityCacheVisitValue;
+    using PositionCache = LowCardinalityHashMethodCache<Mapped>;
+    using BlockCache = std::conditional_t<use_persistent_cache, PositionCache, LowCardinalityHashMethodBlockCache<Mapped>>;
 
     static constexpr bool has_mapped = !std::is_same_v<Mapped, void>;
     using EmplaceResult = typename Base::EmplaceResult;
@@ -115,17 +199,12 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
     ColumnPtr dictionary_holder;
 
     /// Cache AggregateDataPtr for current column in order to decrease the number of hash table usages.
-    columns_hashing_impl::MappedCache<Mapped> mapped_cache;
-    PaddedPODArray<VisitValue> visit_cache;
-
-    PaddedPODArray<UInt64> filled_visit_cache_indexes;
-
-    ALWAYS_INLINE void setVisited(size_t index, VisitValue value)
-    {
-        if (visit_cache[index] == VisitValue::Empty)
-            filled_visit_cache_indexes.push_back(index);
-        visit_cache[index] = value;
-    }
+    BlockCache block_cache;
+    PositionCache * position_cache = nullptr;
+    /// Negative lookups are valid only for the current block, even when successful mappings persist.
+    std::vector<size_t> not_found_positions;
+    bool retain_found_entries = false;
+    bool clear_position_cache_after_block = false;
 
     /// If initialized column is nullable.
     bool is_nullable = false;
@@ -140,7 +219,10 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
     }
 
     HashMethodSingleLowCardinalityColumn(
-        const ColumnRawPtrs & key_columns_low_cardinality, const Sizes & key_sizes, const HashMethodContextPtr & context)
+        const ColumnRawPtrs & key_columns_low_cardinality,
+        const Sizes & key_sizes,
+        const HashMethodContextPtr & context,
+        PositionCache * persistent_cache = nullptr)
         : Base({getLowCardinalityColumn(key_columns_low_cardinality[0]).getDictionary().getNestedNotNullableColumn().get()}, key_sizes, context)
     {
         const auto * column = &getLowCardinalityColumn(key_columns_low_cardinality[0]);
@@ -198,26 +280,80 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
             }
         }
 
-        if constexpr (has_mapped)
-            mapped_cache.resize(key_columns[0]->size());
-
-        visit_cache.assign(key_columns[0]->size(), VisitValue::Empty);
+        if constexpr (cache_mapped_values)
+        {
+            if constexpr (use_persistent_cache)
+            {
+                if (persistent_cache)
+                {
+                    position_cache = persistent_cache;
+                    if (is_shared_dict)
+                    {
+                        retain_found_entries = true;
+                        if (!position_cache->hasDictionary(dictionary_key))
+                            position_cache->resetForSharedDictionary(dictionary_key, dict->size());
+                    }
+                    else
+                    {
+                        /// A non-shared dictionary ends a run of reusable dictionary positions.
+                        /// Reuse the buffers for this block, but do not retain any mappings from it.
+                        position_cache->resetForBlock(dict->size());
+                        clear_position_cache_after_block = true;
+                    }
+                }
+                else
+                {
+                    position_cache = &block_cache;
+                    position_cache->resetForBlock(dict->size());
+                }
+            }
+            else
+                block_cache.resetForBlock(dict->size());
+        }
 
         size_of_index_type = column->getSizeOfIndexType();
         positions = column->getIndexesPtr().get();
     }
 
+    ~HashMethodSingleLowCardinalityColumn()
+    {
+        if constexpr (cache_mapped_values && use_persistent_cache)
+        {
+            for (size_t position : not_found_positions)
+            {
+                if (position_cache->visit_cache[position] == VisitValue::NotFound)
+                    position_cache->visit_cache[position] = VisitValue::Empty;
+            }
+
+            if (clear_position_cache_after_block)
+                position_cache->clear();
+        }
+    }
+
+    ALWAYS_INLINE auto & getPositionCache()
+    {
+        if constexpr (use_persistent_cache)
+            return *position_cache;
+        else
+            return block_cache;
+    }
+
     ALWAYS_INLINE void resetCache()
     {
         Base::resetCache();
+    }
 
-        if (filled_visit_cache_indexes.size() > visit_cache.size() / 4)
-            std::fill(visit_cache.begin(), visit_cache.end(), VisitValue::Empty);
-        else
-            for (UInt64 index : filled_visit_cache_indexes)
-                visit_cache[index] = VisitValue::Empty;
+    ALWAYS_INLINE void resetCacheAfterHashTableChange()
+    {
+        Base::resetCacheAfterHashTableChange();
 
-        filled_visit_cache_indexes.clear();
+        if constexpr (cache_mapped_values)
+        {
+            auto & cache = getPositionCache();
+            std::fill(cache.visit_cache.begin(), cache.visit_cache.end(), VisitValue::Empty);
+            if constexpr (use_persistent_cache)
+                not_found_positions.clear();
+        }
     }
 
     ALWAYS_INLINE size_t getIndexAt(size_t row) const
@@ -245,22 +381,33 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
 
         if (is_nullable && row == 0)
         {
-            setVisited(row, VisitValue::Found);
+            if constexpr (cache_mapped_values)
+                getPositionCache().visit_cache[row] = VisitValue::Found;
             bool has_null_key = data.hasNullKeyData();
             data.hasNullKeyData() = true;
 
             if constexpr (has_mapped)
-                return EmplaceResult(data.getNullKeyData(), mapped_cache[0], !has_null_key);
+            {
+                auto & mapped = data.getNullKeyData();
+                if constexpr (cache_mapped_values)
+                    return EmplaceResult(mapped, getPositionCache().mapped_cache[0], !has_null_key);
+                else
+                    return EmplaceResult(mapped, mapped, !has_null_key);
+            }
             else
                 return EmplaceResult(!has_null_key);
         }
 
-        if (visit_cache[row] == VisitValue::Found)
+        if constexpr (cache_mapped_values)
         {
-            if constexpr (has_mapped)
-                return EmplaceResult(mapped_cache[row], mapped_cache[row], false);
-            else
-                return EmplaceResult(false);
+            auto & cache = getPositionCache();
+            if (cache.visit_cache[row] == VisitValue::Found)
+            {
+                if constexpr (has_mapped)
+                    return EmplaceResult(cache.mapped_cache[row], cache.mapped_cache[row], false);
+                else
+                    return EmplaceResult(false);
+            }
         }
 
         auto key_holder = getKeyHolder(row_, pool);
@@ -273,8 +420,6 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
         else
             data.emplace(key_holder, it, inserted);
 
-        setVisited(row, VisitValue::Found);
-
         if constexpr (has_mapped)
         {
             auto & mapped = it->getMapped();
@@ -282,11 +427,21 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
             {
                 new (&mapped) Mapped();
             }
-            mapped_cache[row] = mapped;
-            return EmplaceResult(mapped, mapped_cache[row], inserted, std::move(key));
+            if constexpr (cache_mapped_values)
+            {
+                auto & cache = getPositionCache();
+                cache.visit_cache[row] = VisitValue::Found;
+                cache.mapped_cache[row] = mapped;
+                return EmplaceResult(mapped, cache.mapped_cache[row], inserted, std::move(key));
+            }
+            return EmplaceResult(mapped, mapped, inserted, std::move(key));
         }
         else
+        {
+            if constexpr (cache_mapped_values)
+                getPositionCache().visit_cache[row] = VisitValue::Found;
             return EmplaceResult(inserted);
+        }
     }
 
     ALWAYS_INLINE bool isNullAt(size_t i)
@@ -310,12 +465,16 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
                 return FindResult(data.hasNullKeyData(), 0);
         }
 
-        if (visit_cache[row] != VisitValue::Empty)
+        if constexpr (cache_mapped_values)
         {
-            if constexpr (has_mapped)
-                return FindResult(&mapped_cache[row], visit_cache[row] == VisitValue::Found, 0);
-            else
-                return FindResult(visit_cache[row] == VisitValue::Found, 0);
+            auto & cache = getPositionCache();
+            if (cache.visit_cache[row] != VisitValue::Empty)
+            {
+                if constexpr (has_mapped)
+                    return FindResult(&cache.mapped_cache[row], cache.visit_cache[row] == VisitValue::Found, 0);
+                else
+                    return FindResult(cache.visit_cache[row] == VisitValue::Found, 0);
+            }
         }
 
         auto key_holder = getKeyHolder(row_, pool);
@@ -327,12 +486,23 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
             it = data.find(keyHolderGetKey(key_holder));
 
         bool found = it;
-        setVisited(row, found ? VisitValue::Found : VisitValue::NotFound);
-
-        if constexpr (has_mapped)
+        if constexpr (cache_mapped_values)
         {
+            auto & cache = getPositionCache();
             if (found)
-                mapped_cache[row] = it->getMapped();
+                cache.visit_cache[row] = VisitValue::Found;
+            else
+            {
+                if (retain_found_entries)
+                    not_found_positions.push_back(row);
+                cache.visit_cache[row] = VisitValue::NotFound;
+            }
+
+            if constexpr (has_mapped)
+            {
+                if (found)
+                    cache.mapped_cache[row] = it->getMapped();
+            }
         }
 
         size_t offset = 0;
@@ -341,7 +511,12 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
             offset = found ? data.offsetInternal(it) : 0;
 
         if constexpr (has_mapped)
-            return FindResult(&mapped_cache[row], found, offset);
+        {
+            if constexpr (cache_mapped_values)
+                return FindResult(&getPositionCache().mapped_cache[row], found, offset);
+            else
+                return FindResult(found ? &it->getMapped() : nullptr, found, offset);
+        }
         else
             return FindResult(found, offset);
     }

--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -352,6 +352,11 @@ public:
         }
     }
 
+    ALWAYS_INLINE void resetCacheAfterHashTableChange()
+    {
+        resetCache();
+    }
+
     ALWAYS_INLINE bool hasOnlyOneValueSinceLastReset() const
     {
         if constexpr (consecutive_keys_optimization)

--- a/src/Interpreters/AggregatedDataVariants.cpp
+++ b/src/Interpreters/AggregatedDataVariants.cpp
@@ -154,6 +154,7 @@ size_t AggregatedDataVariants::allocatedBytes() const
     #define M(NAME, IS_TWO_LEVEL) \
         case Type::NAME: \
             res += (NAME)->data.getBufferSizeInBytes(); \
+            res += getAggregationMethodAdditionalAllocatedBytes(*(NAME)); \
             break;
         APPLY_FOR_AGGREGATED_VARIANTS(M)
     #undef M
@@ -240,6 +241,10 @@ void AggregatedDataVariants::convertToTwoLevel()
     if (aggregator)
         LOG_TRACE(aggregator->log, "Converting aggregation data to two-level.");
 
+    /// Conversion copies the hash table directly and does not use dictionary-position mappings.
+    /// Release them before allocating the two-level table so their buffers do not increase the peak.
+    clearLowCardinalityCache();
+
     switch (type)
     {
 #define M(NAME) \
@@ -256,6 +261,23 @@ void AggregatedDataVariants::convertToTwoLevel()
 
         default:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong data variant passed.");
+    }
+}
+
+void AggregatedDataVariants::clearLowCardinalityCache() const
+{
+    switch (type)
+    {
+        case Type::EMPTY:
+        case Type::without_key:
+            break;
+
+    #define M(NAME, IS_TWO_LEVEL) \
+        case Type::NAME: \
+            clearAggregationMethodCache(*(NAME)); \
+            break;
+        APPLY_FOR_AGGREGATED_VARIANTS(M)
+    #undef M
     }
 }
 

--- a/src/Interpreters/AggregatedDataVariants.h
+++ b/src/Interpreters/AggregatedDataVariants.h
@@ -489,6 +489,7 @@ struct AggregatedDataVariants : private boost::noncopyable
     bool isConvertibleToTwoLevel() const;
     static bool isConvertibleToTwoLevel(Type type);
     void convertToTwoLevel();
+    void clearLowCardinalityCache() const;
     bool isLowCardinality() const;
     static ColumnsHashing::HashMethodContextPtr createCache(Type type, const ColumnsHashing::HashMethodContextSettings & settings);
     bool topKHeapEverRejected() const;

--- a/src/Interpreters/AggregationMethod.h
+++ b/src/Interpreters/AggregationMethod.h
@@ -265,8 +265,13 @@ struct AggregationMethodSingleLowCardinalityColumn : public SingleColumnMethod
     using Data = typename Base::Data;
     using Key = typename Base::Key;
     using Mapped = typename Base::Mapped;
+    using LowCardinalityCache = ColumnsHashing::LowCardinalityHashMethodCache<Mapped>;
     using Base::data;
     using Base::top_k_heap;
+
+    LowCardinalityCache low_cardinality_cache;
+    /// A `UInt8` fixed hash table lookup is cheaper than persistent-cache indirection.
+    static constexpr bool use_persistent_low_cardinality_cache = !std::is_same_v<Key, UInt8>;
 
     template <bool use_cache>
     using BaseStateImpl = typename Base::template StateImpl<use_cache>;
@@ -276,13 +281,18 @@ struct AggregationMethodSingleLowCardinalityColumn : public SingleColumnMethod
     template <typename Other>
     explicit AggregationMethodSingleLowCardinalityColumn(const Other & other) : Base(other) {}
 
-    template <bool use_cache>
-    using StateImpl = ColumnsHashing::HashMethodSingleLowCardinalityColumn<BaseStateImpl<use_cache>, Mapped, use_cache>;
+    template <bool use_cache, bool cache_mapped_values = true>
+    using StateImpl = ColumnsHashing::HashMethodSingleLowCardinalityColumn<
+        BaseStateImpl<use_cache>, Mapped, use_cache, cache_mapped_values, use_persistent_low_cardinality_cache>;
 
     using State = StateImpl<true>;
     using StateNoCache = StateImpl<false>;
+    using StateNoCacheWithoutMappedCache = StateImpl<false, false>;
 
     static const bool low_cardinality_optimization = true;
+
+    size_t additionalAllocatedBytes() const { return low_cardinality_cache.allocatedBytes(); }
+    void clearCache() { low_cardinality_cache.clear(); }
 
     std::optional<Sizes> shuffleKeyColumns(std::vector<IColumn *> &, const Sizes &) { return {}; }
 
@@ -292,6 +302,63 @@ struct AggregationMethodSingleLowCardinalityColumn : public SingleColumnMethod
         const Sizes & /*key_sizes*/,
         const IColumn::SerializationSettings * settings);
 };
+
+template <typename Method>
+using AggregationMethodLowCardinalityCache = ColumnsHashing::LowCardinalityHashMethodCache<typename Method::Mapped>;
+
+template <typename Method, bool low_cardinality_optimization = Method::low_cardinality_optimization>
+struct AggregationMethodInlineCountState
+{
+    using Type = typename Method::StateNoCache;
+};
+
+template <typename Method>
+struct AggregationMethodInlineCountState<Method, true>
+{
+    using Type = typename Method::StateNoCacheWithoutMappedCache;
+};
+
+template <typename Method>
+using AggregationMethodInlineCountStateT = typename AggregationMethodInlineCountState<Method>::Type;
+
+template <typename State, typename Method>
+State createAggregationMethodState(
+    Method & method,
+    const ColumnRawPtrs & key_columns,
+    const Sizes & key_sizes,
+    const ColumnsHashing::HashMethodContextPtr & context,
+    AggregationMethodLowCardinalityCache<Method> * low_cardinality_cache_override = nullptr)
+{
+    if constexpr (Method::low_cardinality_optimization)
+    {
+        AggregationMethodLowCardinalityCache<Method> * low_cardinality_cache = nullptr;
+        if constexpr (Method::use_persistent_low_cardinality_cache)
+        {
+            low_cardinality_cache = low_cardinality_cache_override
+                ? low_cardinality_cache_override
+                : &method.low_cardinality_cache;
+        }
+        return State(key_columns, key_sizes, context, low_cardinality_cache);
+    }
+    else
+        return State(key_columns, key_sizes, context);
+}
+
+template <typename Method>
+size_t getAggregationMethodAdditionalAllocatedBytes(const Method & method)
+{
+    if constexpr (Method::low_cardinality_optimization)
+        return method.additionalAllocatedBytes();
+    else
+        return 0;
+}
+
+template <typename Method>
+void clearAggregationMethodCache(Method & method)
+{
+    if constexpr (Method::low_cardinality_optimization)
+        method.clearCache();
+}
 
 /// For the case where all keys are of fixed length, and they fit in N (for example, 128) bits.
 template <typename TData, bool has_nullable_keys_ = false, bool has_low_cardinality_ = false, bool consecutive_keys_optimization = false>

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -824,24 +824,6 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
             method_chosen_for_in_order = AggregatedDataVariants::Type::nullable_serialized_void;
     }
 
-    /// TODO(ab): HashMethodSingleLowCardinalityColumn uses a hardcoded internal cache,
-    /// which interferes with inline aggregation (e.g. for COUNT). This needs to be
-    /// refactored to respect the `use_cache` setting.
-    ///
-    /// For now, disable the simple COUNT optimization to avoid incorrect behavior.
-    switch (method_chosen)
-    {
-    #define M(NAME) \
-        case AggregatedDataVariants::Type::NAME: \
-            is_simple_count = false; \
-            break;
-
-        APPLY_FOR_LOW_CARDINALITY_VARIANTS(M)
-    #undef M
-        default:
-            ;
-    }
-
     HashMethodContext::Settings cache_settings;
     cache_settings.max_threads = params.max_threads;
     cache_settings.serialize_string_with_zero_byte = params.serialize_string_with_zero_byte;
@@ -1098,19 +1080,29 @@ void NO_INLINE Aggregator::executeImpl(
     bool all_keys_are_const,
     AggregateDataPtr overflow_row) const
 {
+    if (is_simple_count)
+    {
+        auto state = createAggregationMethodState<AggregationMethodInlineCountStateT<Method>>(
+            method, key_columns, key_sizes, aggregation_state_cache);
+        executeImpl(method, state, key_columns, aggregates_pool, row_begin, row_end, aggregate_instructions, no_more_keys, all_keys_are_const, overflow_row);
+        return;
+    }
+
     UInt64 total_records = consecutive_keys_cache_stats.hits + consecutive_keys_cache_stats.misses;
     double cache_hit_rate = total_records ? static_cast<double>(consecutive_keys_cache_stats.hits) / static_cast<double>(total_records) : 1.0;
-    bool use_cache = !is_simple_count && cache_hit_rate >= static_cast<double>(params.min_hit_rate_to_use_consecutive_keys_optimization);
+    bool use_cache = cache_hit_rate >= static_cast<double>(params.min_hit_rate_to_use_consecutive_keys_optimization);
 
     if (use_cache)
     {
-        typename Method::State state(key_columns, key_sizes, aggregation_state_cache);
+        auto state = createAggregationMethodState<typename Method::State>(
+            method, key_columns, key_sizes, aggregation_state_cache);
         executeImpl(method, state, key_columns, aggregates_pool, row_begin, row_end, aggregate_instructions, no_more_keys, all_keys_are_const, overflow_row);
         consecutive_keys_cache_stats.update(row_end - row_begin, state.getCacheMissesSinceLastReset());
     }
     else
     {
-        typename Method::StateNoCache state(key_columns, key_sizes, aggregation_state_cache);
+        auto state = createAggregationMethodState<typename Method::StateNoCache>(
+            method, key_columns, key_sizes, aggregation_state_cache);
         executeImpl(method, state, key_columns, aggregates_pool, row_begin, row_end, aggregate_instructions, no_more_keys, all_keys_are_const, overflow_row);
     }
 }
@@ -1308,19 +1300,28 @@ size_t Aggregator::executeImplUntilAdaptiveFreeze(
             return row_end;
         };
 
-        UInt64 total_records = cache_stats.hits + cache_stats.misses;
-        double cache_hit_rate = total_records ? static_cast<double>(cache_stats.hits) / static_cast<double>(total_records) : 1.0;
-        bool use_cache = !is_simple_count && cache_hit_rate >= static_cast<double>(params.min_hit_rate_to_use_consecutive_keys_optimization);
-
         /// The hashing state is constructed once and shared by all slices: for the serialized
         /// and fixed-key methods its constructor does whole-block work (batch key serialization
         /// or packing), which must not be repeated per slice.
+        if (is_simple_count)
+        {
+            auto state = createAggregationMethodState<AggregationMethodInlineCountStateT<Method>>(
+                method, key_columns, key_sizes, aggregation_state_cache);
+            return run_slices(state, [](size_t) {});
+        }
+
+        UInt64 total_records = cache_stats.hits + cache_stats.misses;
+        double cache_hit_rate = total_records ? static_cast<double>(cache_stats.hits) / static_cast<double>(total_records) : 1.0;
+        bool use_cache = cache_hit_rate >= static_cast<double>(params.min_hit_rate_to_use_consecutive_keys_optimization);
+
         if (use_cache)
         {
-            typename Method::State state(key_columns, key_sizes, aggregation_state_cache);
+            auto state = createAggregationMethodState<typename Method::State>(
+                method, key_columns, key_sizes, aggregation_state_cache);
             return run_slices(state, [&](size_t rows) { cache_stats.update(rows, state.getCacheMissesSinceLastReset()); });
         }
-        typename Method::StateNoCache state(key_columns, key_sizes, aggregation_state_cache);
+        auto state = createAggregationMethodState<typename Method::StateNoCache>(
+            method, key_columns, key_sizes, aggregation_state_cache);
         return run_slices(state, [](size_t) {});
     };
 
@@ -1339,6 +1340,8 @@ void Aggregator::freezeAdaptive(AggregatedDataVariants & result, AdaptiveAggrega
 {
     std::call_once(adaptive.session->init_flag, [&] { initAdaptiveSession(result, *adaptive.session); });
     adaptive.freeze();
+    /// The frozen path probes the local table directly and does not use dictionary-position mappings.
+    result.clearLowCardinalityCache();
     ProfileEvents::increment(ProfileEvents::AdaptiveAggregationLocalFreezes);
     LOG_TRACE(log, "Adaptive aggregation: local table frozen at {} keys", result.sizeWithoutOverflowRow());
 }
@@ -1463,7 +1466,7 @@ void NO_INLINE Aggregator::executeImplBatchNoAggregates(
             {
                 trimHeapAndPruneHashTable(method, nullptr, i);
                 skip_bitmap = nullptr;
-                state.resetCache();
+                state.resetCacheAfterHashTableChange();
             }
         }
     }
@@ -1688,7 +1691,7 @@ void NO_INLINE Aggregator::executeImplBatch(
                     {
                         trimHeapAndPruneHashTable(method, nullptr, i);
                         skip_bitmap = nullptr;
-                        state.resetCache();
+                        state.resetCacheAfterHashTableChange();
                     }
                 }
             }
@@ -1829,7 +1832,7 @@ void NO_INLINE Aggregator::executeImplBatch(
                 {
                     trimHeapAndPruneHashTable(method, &destroyed_states, i);
                     skip_bitmap = nullptr;
-                    state.resetCache();
+                    state.resetCacheAfterHashTableChange();
                 }
             }
 
@@ -2521,6 +2524,9 @@ void Aggregator::flushToTemporaryFile(AggregatedDataVariants & data_variants, si
     }();
 
     LOG_DEBUG(log, "Writing part of aggregation data into temporary file {}", out_stream.getHolder()->describeFilePath());
+
+    /// The table is consumed below and reinitialized or destroyed afterwards.
+    data_variants.clearLowCardinalityCache();
 
     /// Flush only two-level data and possibly overflow data.
 
@@ -3936,6 +3942,9 @@ template <bool return_single_block>
 std::conditional_t<return_single_block, Aggregator::AggregatedChunk, Aggregator::AggregatedChunks>
 Aggregator::prepareChunkAndFillSingleLevel(AggregatedDataVariants & data_variants, bool final) const
 {
+    /// This consumes the table directly; dictionary-position mappings are dead before output allocation starts.
+    data_variants.clearLowCardinalityCache();
+
     Chunks res_variant;
     const size_t rows = data_variants.sizeWithoutOverflowRow();
 #define M(NAME) \
@@ -4048,6 +4057,9 @@ Aggregator::AggregatedChunks Aggregator::convertToChunks(AggregatedDataVariants 
     /// In what data structure is the data aggregated?
     if (data_variants.empty())
         return {};
+
+    /// Output conversion does not use dictionary-position mappings and can allocate sizable columns.
+    data_variants.clearLowCardinalityCache();
 
     if (data_variants.without_key)
         chunks.emplace_back(prepareChunkAndFillWithoutKey(
@@ -4579,6 +4591,10 @@ ManyAggregatedDataVariants Aggregator::prepareVariantsToMerge(
 
     updateStatistics(data_variants, adaptive_session, params.stats_collecting_params);
 
+    /// Input is complete. Merging consumes the tables directly rather than probing them by input dictionary positions.
+    for (auto & data : data_variants)
+        data->clearLowCardinalityCache();
+
     ManyAggregatedDataVariants non_empty_data;
     non_empty_data.reserve(data_variants.size());
     for (auto & data : data_variants)
@@ -4793,7 +4809,8 @@ void NO_INLINE Aggregator::mergeStreamsImpl(
     LastElementCacheStats & consecutive_keys_cache_stats,
     bool no_more_keys,
     std::atomic<bool> & is_cancelled,
-    Arena * arena_for_keys) const
+    Arena * arena_for_keys,
+    AggregationMethodLowCardinalityCache<Method> * low_cardinality_cache_override) const
 {
     const AggregateColumnsConstData & aggregate_columns_data = makeAggregateColumnsData(columns, params.keys_size, params.aggregates_size);
     ColumnRawPtrs key_columns = makeRawKeyColumns(columns, params.keys_size);
@@ -4810,7 +4827,8 @@ void NO_INLINE Aggregator::mergeStreamsImpl(
         aggregate_columns_data,
         key_columns,
         is_cancelled,
-        arena_for_keys);
+        arena_for_keys,
+        low_cardinality_cache_override);
 }
 
 template <typename Method, typename Table>
@@ -4826,12 +4844,9 @@ void NO_INLINE Aggregator::mergeStreamsImpl(
     const AggregateColumnsConstData & aggregate_columns_data,
     const ColumnRawPtrs & key_columns,
     std::atomic<bool> & is_cancelled,
-    Arena * arena_for_keys) const
+    Arena * arena_for_keys,
+    AggregationMethodLowCardinalityCache<Method> * low_cardinality_cache_override) const
 {
-    UInt64 total_records = consecutive_keys_cache_stats.hits + consecutive_keys_cache_stats.misses;
-    double cache_hit_rate = total_records ? static_cast<double>(consecutive_keys_cache_stats.hits) / static_cast<double>(total_records) : 1.0;
-    bool use_cache = !is_simple_count && cache_hit_rate >= static_cast<double>(params.min_hit_rate_to_use_consecutive_keys_optimization);
-
     auto merge_count_variant = [&]<typename State>(State & state)
     {
         chassert(aggregate_columns_data.size() == 1);
@@ -4867,59 +4882,54 @@ void NO_INLINE Aggregator::mergeStreamsImpl(
         }
     };
 
-    if (use_cache)
+    if constexpr (MapAggregationMethod<Method>)
     {
-        typename Method::State state(key_columns, key_sizes, aggregation_state_cache);
         if (is_simple_count)
         {
-            /// A set method has no aggregates, so it never sets `is_simple_count` and never reaches this.
-            /// Guarding the call rather than the lambda keeps the lambda from being instantiated for one -
-            /// its body reads the count out of a mapped slot that a set cell does not have.
-            if constexpr (MapAggregationMethod<Method>)
-                merge_count_variant(state);
+            auto state = createAggregationMethodState<AggregationMethodInlineCountStateT<Method>>(
+                method, key_columns, key_sizes, aggregation_state_cache, low_cardinality_cache_override);
+            merge_count_variant(state);
+            return;
         }
-        else
-        {
-            mergeStreamsImplCase(
-                aggregates_pool,
-                state,
-                data,
-                no_more_keys,
-                overflow_row,
-                row_begin,
-                row_end,
-                aggregate_columns_data,
-                is_cancelled,
-                arena_for_keys);
-        }
+    }
+
+    UInt64 total_records = consecutive_keys_cache_stats.hits + consecutive_keys_cache_stats.misses;
+    double cache_hit_rate = total_records ? static_cast<double>(consecutive_keys_cache_stats.hits) / static_cast<double>(total_records) : 1.0;
+    bool use_cache = cache_hit_rate >= static_cast<double>(params.min_hit_rate_to_use_consecutive_keys_optimization);
+
+    if (use_cache)
+    {
+        auto state = createAggregationMethodState<typename Method::State>(
+            method, key_columns, key_sizes, aggregation_state_cache, low_cardinality_cache_override);
+        mergeStreamsImplCase(
+            aggregates_pool,
+            state,
+            data,
+            no_more_keys,
+            overflow_row,
+            row_begin,
+            row_end,
+            aggregate_columns_data,
+            is_cancelled,
+            arena_for_keys);
 
         consecutive_keys_cache_stats.update(row_end - row_begin, state.getCacheMissesSinceLastReset());
     }
     else
     {
-        typename Method::StateNoCache state(key_columns, key_sizes, aggregation_state_cache);
-        if (is_simple_count)
-        {
-            /// A set method has no aggregates, so it never sets `is_simple_count` and never reaches this.
-            /// Guarding the call rather than the lambda keeps the lambda from being instantiated for one -
-            /// its body reads the count out of a mapped slot that a set cell does not have.
-            if constexpr (MapAggregationMethod<Method>)
-                merge_count_variant(state);
-        }
-        else
-        {
-            mergeStreamsImplCase(
-                aggregates_pool,
-                state,
-                data,
-                no_more_keys,
-                overflow_row,
-                row_begin,
-                row_end,
-                aggregate_columns_data,
-                is_cancelled,
-                arena_for_keys);
-        }
+        auto state = createAggregationMethodState<typename Method::StateNoCache>(
+            method, key_columns, key_sizes, aggregation_state_cache, low_cardinality_cache_override);
+        mergeStreamsImplCase(
+            aggregates_pool,
+            state,
+            data,
+            no_more_keys,
+            overflow_row,
+            row_begin,
+            row_end,
+            aggregate_columns_data,
+            is_cancelled,
+            arena_for_keys);
     }
 }
 
@@ -5122,15 +5132,38 @@ void Aggregator::mergeBlocks(BucketToChunks bucket_to_chunks, AggregatedDataVari
                 if (is_cancelled.load())
                     return;
 
+                /// `LowCardinality` dictionary-position mappings point into one bucket's hash table.
+                ColumnsHashing::LowCardinalityHashMethodCache<AggregateDataPtr> bucket_low_cardinality_cache;
                 for (auto & agg_chunk : bucket_to_chunks[bucket])
                 {
                     /// Copy to avoid race.
                     auto consecutive_keys_cache_stats_copy = result.consecutive_keys_cache_stats;
                     size_t chunk_rows = agg_chunk.chunk.getNumRows();
                     auto chunk_columns = agg_chunk.chunk.detachColumns();
+
+                    auto merge_chunk = [&]<typename Method, typename Table>(Method & method, Table & table)
+                    {
+                        AggregationMethodLowCardinalityCache<Method> * low_cardinality_cache = nullptr;
+                        if constexpr (MapAggregationMethod<Method>)
+                            low_cardinality_cache = &bucket_low_cardinality_cache;
+
+                        mergeStreamsImpl(
+                            chunk_columns,
+                            chunk_rows,
+                            aggregates_pool,
+                            method,
+                            table,
+                            nullptr,
+                            consecutive_keys_cache_stats_copy,
+                            false,
+                            is_cancelled,
+                            nullptr,
+                            low_cardinality_cache);
+                    };
+
                 #define M(NAME) \
                     else if (result.type == AggregatedDataVariants::Type::NAME) \
-                        mergeStreamsImpl(chunk_columns, chunk_rows, aggregates_pool, *result.NAME, result.NAME->data.impls[bucket], nullptr, consecutive_keys_cache_stats_copy, false, is_cancelled);
+                        merge_chunk(*result.NAME, result.NAME->data.impls[bucket]);
 
                     if (false) {} // NOLINT
                         APPLY_FOR_VARIANTS_TWO_LEVEL(M)
@@ -5309,6 +5342,9 @@ Aggregator::AggregatedChunk Aggregator::mergeBlocks(
 
     if (dataflow_cache_updater)
         dataflow_cache_updater->recordAggregationStateSizes(result, bucket_num);
+
+    /// Output conversion does not use dictionary-position mappings and can allocate sizable columns.
+    result.clearLowCardinalityCache();
 
     AggregatedChunk agg_chunk;
     if (result.type == AggregatedDataVariants::Type::without_key || is_overflows)

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1107,7 +1107,8 @@ private:
         LastElementCacheStats & consecutive_keys_cache_stats,
         bool no_more_keys,
         std::atomic<bool> & is_cancelled,
-        Arena * arena_for_keys = nullptr) const;
+        Arena * arena_for_keys = nullptr,
+        AggregationMethodLowCardinalityCache<Method> * low_cardinality_cache_override = nullptr) const;
 
     template <typename Method, typename Table>
     void mergeStreamsImpl(
@@ -1122,7 +1123,8 @@ private:
         const AggregateColumnsConstData & aggregate_columns_data,
         const ColumnRawPtrs & key_columns,
         std::atomic<bool> & is_cancelled,
-        Arena * arena_for_keys) const;
+        Arena * arena_for_keys,
+        AggregationMethodLowCardinalityCache<Method> * low_cardinality_cache_override = nullptr) const;
 
     void mergeBlockWithoutKeyStreamsImpl(
         const Columns & columns,

--- a/src/Interpreters/tests/gtest_aggregator_parallel_partition_merge.cpp
+++ b/src/Interpreters/tests/gtest_aggregator_parallel_partition_merge.cpp
@@ -410,6 +410,70 @@ TEST_F(AggregatorParallelPartitionMerge, LowCardinalityStringKey)
     EXPECT_EQ(scenario.mergePartitions({scenario.aggregate(block_a), scenario.aggregate(block_b)}, 4), expected);
 }
 
+/// The parallel two-level `mergeBlocks` path shares one result method between bucket workers. Each worker
+/// must use a bucket-local dictionary-position cache because the partial `LowCardinality` columns have
+/// different dictionaries and their mapped values belong to different bucket hash tables.
+TEST_F(AggregatorParallelPartitionMerge, LowCardinalityBucketCachesAreIsolated)
+{
+    const DataTypePtr lc_type = std::make_shared<DataTypeLowCardinality>(uint64_type);
+    auto params = makeParams({"k"}, {makeAggregate("sum", {"v"}, {uint64_type})});
+    params.group_by_two_level_threshold = 1;
+    params.max_threads = 4;
+    Scenario scenario(makeHeader(lc_type), std::move(params));
+
+    auto make_block = [&](UInt64 offset)
+    {
+        std::vector<Field> keys;
+        keys.reserve(60000);
+        for (UInt64 key = 0; key < 60000; ++key)
+            keys.emplace_back(offset + key);
+        return Columns{makeColumn(lc_type, keys), makeColumn(uint64_type, keys)};
+    };
+
+    auto first = scenario.aggregate({make_block(0)});
+    auto second = scenario.aggregate({make_block(60000)});
+    ASSERT_TRUE(first->isTwoLevel());
+    ASSERT_TRUE(second->isTwoLevel());
+
+    Aggregator::BucketToChunks bucket_to_chunks;
+    size_t input_rows = 0;
+    auto append_chunks = [&](AggregatedDataVariants & variants)
+    {
+        for (auto & chunk : scenario.aggregator.convertToChunks(variants, /*final=*/false))
+        {
+            EXPECT_GE(chunk.bucket_num, 0);
+            input_rows += chunk.chunk.getNumRows();
+            bucket_to_chunks[chunk.bucket_num].push_back(std::move(chunk));
+        }
+    };
+    append_chunks(*first);
+    append_chunks(*second);
+    ASSERT_EQ(input_rows, 120000u);
+    ASSERT_GT(bucket_to_chunks.size(), 1u);
+
+    AggregatedDataVariants merged;
+    std::atomic<bool> cancelled{false};
+    scenario.aggregator.mergeBlocks(std::move(bucket_to_chunks), merged, cancelled);
+
+    UInt64 groups = 0;
+    UInt64 total_sum = 0;
+    UInt64 key_sum = 0;
+    for (auto & chunk : scenario.aggregator.convertToChunks(merged, /*final=*/true))
+    {
+        const auto & columns = chunk.chunk.getColumns();
+        for (size_t row = 0; row < chunk.chunk.getNumRows(); ++row)
+        {
+            ++groups;
+            key_sum += columns[0]->getUInt(row);
+            total_sum += columns[1]->getUInt(row);
+        }
+    }
+
+    EXPECT_EQ(groups, 120000u);
+    EXPECT_EQ(total_sum, 7199940000u);
+    EXPECT_EQ(key_sum, 7199940000u);
+}
+
 /// Heavy per-key states (`uniqExact`): first-seen keys adopt the state pointer, split keys go
 /// through the batched merge of the state sets.
 TEST_F(AggregatorParallelPartitionMerge, UniqExactHeavyStates)

--- a/src/Interpreters/tests/gtest_low_cardinality_aggregation_cache.cpp
+++ b/src/Interpreters/tests/gtest_low_cardinality_aggregation_cache.cpp
@@ -1,0 +1,344 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnsNumber.h>
+#include <Common/Arena.h>
+#include <Common/HashTable/HashMap.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/AggregatedData.h>
+#include <Interpreters/AggregationMethod.h>
+#include <Interpreters/Aggregator.h>
+
+#include <initializer_list>
+#include <utility>
+
+using namespace DB;
+
+namespace
+{
+
+class CountingData : public HashMap<UInt64, UInt64>
+{
+public:
+    using Base = HashMap<UInt64, UInt64>;
+    using LookupResult = typename Base::LookupResult;
+
+    template <typename KeyHolder>
+    void emplace(KeyHolder && key_holder, LookupResult & result, bool & inserted)
+    {
+        ++emplace_calls;
+        Base::emplace(std::forward<KeyHolder>(key_holder), result, inserted);
+    }
+
+    template <typename KeyHolder>
+    void emplace(KeyHolder && key_holder, LookupResult & result, bool & inserted, size_t hash)
+    {
+        ++emplace_calls;
+        Base::emplace(std::forward<KeyHolder>(key_holder), result, inserted, hash);
+    }
+
+    LookupResult find(const UInt64 & key)
+    {
+        ++find_calls;
+        return Base::find(key);
+    }
+
+    LookupResult find(const UInt64 & key, size_t hash)
+    {
+        ++find_calls;
+        return Base::find(key, hash);
+    }
+
+    bool & hasNullKeyData() { return has_null_key_data; }
+    UInt64 & getNullKeyData() { return null_key_data; }
+
+    size_t emplace_calls = 0;
+    size_t find_calls = 0;
+
+private:
+    bool has_null_key_data = false;
+    UInt64 null_key_data = 0;
+};
+
+using BaseMethod = AggregationMethodOneNumber<UInt64, CountingData>;
+using Method = AggregationMethodSingleLowCardinalityColumn<BaseMethod>;
+using InlineCountBaseMethod = AggregationMethodOneNumber<UInt64, AggregatedDataWithNullableUInt64Key>;
+using InlineCountMethod = AggregationMethodSingleLowCardinalityColumn<InlineCountBaseMethod>;
+using UInt8BaseMethod = AggregationMethodOneNumber<UInt8, AggregatedDataWithNullableUInt8Key, false>;
+using UInt8Method = AggregationMethodSingleLowCardinalityColumn<UInt8BaseMethod>;
+
+ColumnPtr makeDictionary(std::initializer_list<UInt64> values)
+{
+    auto keys = ColumnUInt64::create();
+    for (UInt64 value : values)
+        keys->insertValue(value);
+
+    return DataTypeLowCardinality::createColumnUnique(DataTypeUInt64(), std::move(keys));
+}
+
+ColumnPtr makeDictionary(size_t size)
+{
+    auto keys = ColumnUInt64::create();
+    for (size_t value = 0; value < size; ++value)
+        keys->insertValue(value);
+
+    return DataTypeLowCardinality::createColumnUnique(DataTypeUInt64(), std::move(keys));
+}
+
+ColumnPtr makeUInt8Dictionary(std::initializer_list<UInt8> values)
+{
+    auto keys = ColumnUInt8::create();
+    for (UInt8 value : values)
+        keys->insertValue(value);
+
+    return DataTypeLowCardinality::createColumnUnique(DataTypeUInt8(), std::move(keys));
+}
+
+ColumnPtr makeLowCardinalityColumn(const ColumnPtr & dictionary, std::initializer_list<UInt8> indexes, bool is_shared)
+{
+    auto index_column = ColumnUInt8::create();
+    for (UInt8 index : indexes)
+        index_column->insertValue(index);
+
+    return ColumnLowCardinality::create(dictionary, std::move(index_column), is_shared);
+}
+
+template <typename AggregationMethod = Method>
+ColumnsHashing::HashMethodContextPtr makeContext()
+{
+    ColumnsHashing::HashMethodContextSettings settings;
+    settings.max_threads = 1;
+    return AggregationMethod::StateNoCache::createContext(settings);
+}
+
+void aggregateBlock(
+    Method & method,
+    CountingData & data,
+    const ColumnPtr & column,
+    const ColumnsHashing::HashMethodContextPtr & context,
+    Method::LowCardinalityCache * low_cardinality_cache_override = nullptr)
+{
+    ColumnRawPtrs key_columns{column.get()};
+    Sizes key_sizes{sizeof(UInt64)};
+    auto state = createAggregationMethodState<typename Method::StateNoCache>(
+        method, key_columns, key_sizes, context, low_cardinality_cache_override);
+    Arena pool;
+    state.resetCache();
+
+    for (size_t row = 0; row < column->size(); ++row)
+    {
+        auto result = state.emplaceKey(data, row, pool);
+        const UInt64 expected_mapped = column->getUInt(row) + 1000;
+        if (result.isInserted())
+            result.setMapped(expected_mapped);
+        EXPECT_EQ(result.getMapped(), expected_mapped);
+    }
+}
+
+void aggregateBlock(Method & method, const ColumnPtr & column, const ColumnsHashing::HashMethodContextPtr & context)
+{
+    aggregateBlock(method, method.data, column, context);
+}
+
+TEST(LowCardinalityAggregationCache, ReusesMappingsForSharedDictionaryAcrossBlocks)
+{
+    Method method;
+    auto context = makeContext();
+    auto dictionary = makeDictionary({0, 11, 22});
+
+    aggregateBlock(method, makeLowCardinalityColumn(dictionary, {1, 2, 1}, true), context);
+    ASSERT_EQ(method.data.emplace_calls, 2);
+
+    aggregateBlock(method, makeLowCardinalityColumn(dictionary, {2, 1, 2}, true), context);
+    EXPECT_EQ(method.data.emplace_calls, 2);
+}
+
+TEST(LowCardinalityAggregationCache, InvalidatesMappingsAfterHashTableChange)
+{
+    Method method;
+    auto context = makeContext();
+    auto dictionary = makeDictionary({0, 11});
+    auto column = makeLowCardinalityColumn(dictionary, {1, 1, 1}, true);
+    ColumnRawPtrs key_columns{column.get()};
+    Sizes key_sizes{sizeof(UInt64)};
+    auto state = createAggregationMethodState<typename Method::StateNoCache>(
+        method, key_columns, key_sizes, context);
+    Arena pool;
+
+    auto first = state.emplaceKey(method.data, 0, pool);
+    ASSERT_TRUE(first.isInserted());
+    first.setMapped(1011);
+    ASSERT_EQ(method.data.emplace_calls, 1);
+
+    state.resetCache();
+    auto second = state.emplaceKey(method.data, 1, pool);
+    EXPECT_FALSE(second.isInserted());
+    EXPECT_EQ(second.getMapped(), 1011);
+    EXPECT_EQ(method.data.emplace_calls, 1);
+
+    state.resetCacheAfterHashTableChange();
+    auto third = state.emplaceKey(method.data, 2, pool);
+    EXPECT_FALSE(third.isInserted());
+    EXPECT_EQ(third.getMapped(), 1011);
+    EXPECT_EQ(method.data.emplace_calls, 2);
+}
+
+TEST(LowCardinalityAggregationCache, ReplacesMappingsForDifferentSharedDictionary)
+{
+    Method method;
+    auto context = makeContext();
+
+    aggregateBlock(method, makeLowCardinalityColumn(makeDictionary({0, 11}), {1}, true), context);
+    ASSERT_EQ(method.data.emplace_calls, 1);
+
+    aggregateBlock(method, makeLowCardinalityColumn(makeDictionary({0, 22}), {1}, true), context);
+    EXPECT_EQ(method.data.emplace_calls, 2);
+}
+
+TEST(LowCardinalityAggregationCache, ReleasesBuffersForDifferentSharedDictionary)
+{
+    Method method;
+    auto context = makeContext();
+
+    aggregateBlock(method, makeLowCardinalityColumn(makeDictionary(200), {199}, true), context);
+    const size_t large_dictionary_bytes = method.low_cardinality_cache.allocatedBytes();
+
+    aggregateBlock(method, makeLowCardinalityColumn(makeDictionary(2), {1}, true), context);
+    EXPECT_LT(method.low_cardinality_cache.allocatedBytes(), large_dictionary_bytes);
+}
+
+TEST(LowCardinalityAggregationCache, DoesNotRetainMappingsForNonSharedDictionary)
+{
+    Method method;
+    auto context = makeContext();
+    auto dictionary = makeDictionary({0, 11});
+
+    aggregateBlock(method, makeLowCardinalityColumn(dictionary, {1, 1}, false), context);
+    ASSERT_EQ(method.data.emplace_calls, 1);
+    EXPECT_FALSE(method.low_cardinality_cache.dictionary_key.has_value());
+    EXPECT_TRUE(method.low_cardinality_cache.visit_cache.empty());
+
+    aggregateBlock(method, makeLowCardinalityColumn(dictionary, {1}, false), context);
+    EXPECT_EQ(method.data.emplace_calls, 2);
+}
+
+TEST(LowCardinalityAggregationCache, KeepsMappingsIsolatedBetweenCaches)
+{
+    Method method;
+    CountingData first_data;
+    CountingData second_data;
+    Method::LowCardinalityCache first_cache;
+    Method::LowCardinalityCache second_cache;
+    auto context = makeContext();
+    auto dictionary = makeDictionary({0, 11});
+    auto column = makeLowCardinalityColumn(dictionary, {1}, true);
+
+    aggregateBlock(method, first_data, column, context, &first_cache);
+    aggregateBlock(method, second_data, column, context, &second_cache);
+    ASSERT_EQ(first_data.emplace_calls, 1);
+    ASSERT_EQ(second_data.emplace_calls, 1);
+
+    aggregateBlock(method, first_data, column, context, &first_cache);
+    aggregateBlock(method, second_data, column, context, &second_cache);
+    EXPECT_EQ(first_data.emplace_calls, 1);
+    EXPECT_EQ(second_data.emplace_calls, 1);
+}
+
+TEST(LowCardinalityAggregationCache, CachesMissingMappingsOnlyWithinBlock)
+{
+    Method method;
+    auto context = makeContext();
+    auto dictionary = makeDictionary({0, 11});
+    auto column = makeLowCardinalityColumn(dictionary, {1, 1, 1}, true);
+    ColumnRawPtrs key_columns{column.get()};
+    Sizes key_sizes{sizeof(UInt64)};
+    Arena pool;
+
+    {
+        auto state = createAggregationMethodState<typename Method::StateNoCache>(
+            method, key_columns, key_sizes, context);
+        for (size_t row = 0; row < column->size(); ++row)
+            EXPECT_FALSE(state.findKey(method.data, row, pool).isFound());
+    }
+    ASSERT_EQ(method.data.find_calls, 1);
+
+    method.data[11] = 1011;
+
+    {
+        auto state = createAggregationMethodState<typename Method::StateNoCache>(
+            method, key_columns, key_sizes, context);
+        auto result = state.findKey(method.data, 0, pool);
+        ASSERT_TRUE(result.isFound());
+        EXPECT_EQ(result.getMapped(), 1011);
+    }
+    EXPECT_EQ(method.data.find_calls, 2);
+}
+
+TEST(LowCardinalityAggregationCache, DoesNotCacheInlineCountMappedValuesAcrossBlocks)
+{
+    InlineCountMethod method;
+    auto context = makeContext();
+    auto dictionary = makeDictionary({0, 11, 22});
+
+    const auto aggregate_block = [&](const ColumnPtr & column)
+    {
+        ColumnRawPtrs key_columns{column.get()};
+        Sizes key_sizes{sizeof(UInt64)};
+        auto state = createAggregationMethodState<typename InlineCountMethod::StateNoCacheWithoutMappedCache>(
+            method, key_columns, key_sizes, context);
+        Arena pool;
+
+        for (size_t row = 0; row < column->size(); ++row)
+        {
+            auto result = state.emplaceKey(method.data, row, pool);
+            if (result.isInserted())
+                getInlineCountState(result.getMapped()) = 1;
+            else
+                ++getInlineCountState(result.getMapped());
+        }
+    };
+
+    aggregate_block(makeLowCardinalityColumn(dictionary, {1, 2}, true));
+    aggregate_block(makeLowCardinalityColumn(dictionary, {1, 2}, true));
+
+    ASSERT_TRUE(method.data.find(11));
+    EXPECT_EQ(getInlineCountState(method.data.find(11)->getMapped()), 2);
+    ASSERT_TRUE(method.data.find(22));
+    EXPECT_EQ(getInlineCountState(method.data.find(22)->getMapped()), 2);
+}
+
+TEST(LowCardinalityAggregationCache, UsesBlockLocalMappingsForUInt8Keys)
+{
+    UInt8Method method;
+    UInt8Method::LowCardinalityCache cache_override;
+    auto context = makeContext<UInt8Method>();
+    auto dictionary = makeUInt8Dictionary({0, 11});
+    auto column = makeLowCardinalityColumn(dictionary, {1, 1}, true);
+    ColumnRawPtrs key_columns{column.get()};
+    Sizes key_sizes{sizeof(UInt8)};
+    Arena pool;
+    char aggregate_state = 0;
+
+    {
+        auto state = createAggregationMethodState<typename UInt8Method::StateNoCache>(
+            method, key_columns, key_sizes, context, &cache_override);
+        {
+            auto result = state.emplaceKey(method.data, 0, pool);
+            ASSERT_TRUE(result.isInserted());
+            result.setMapped(&aggregate_state);
+        }
+        {
+            auto result = state.emplaceKey(method.data, 1, pool);
+            EXPECT_FALSE(result.isInserted());
+            EXPECT_EQ(result.getMapped(), &aggregate_state);
+        }
+    }
+
+    EXPECT_FALSE(method.low_cardinality_cache.dictionary_key.has_value());
+    EXPECT_TRUE(method.low_cardinality_cache.visit_cache.empty());
+    EXPECT_FALSE(cache_override.dictionary_key.has_value());
+    EXPECT_TRUE(cache_override.visit_cache.empty());
+}
+
+}

--- a/tests/performance/group_by_low_cardinality_shared_dictionary.xml
+++ b/tests/performance/group_by_low_cardinality_shared_dictionary.xml
@@ -1,0 +1,140 @@
+<test>
+    <!--
+        Measure single-key aggregation when every read block uses the same
+        shared LowCardinality dictionary. The source has 8,190 distinct values,
+        so every dictionary fits within the default per-part limit without
+        relying on server-wide writer settings.
+
+        Each key is inserted once before randomized repetitions. This ensures
+        that the first read block touches the complete dictionary and later
+        blocks can reuse all dictionary-position-to-aggregate-state mappings.
+        Plain integer and String columns provide controls for the same values
+        and row order. String cases cover 6-, 26-, and 56-byte values.
+    -->
+
+    <settings>
+        <allow_suspicious_low_cardinality_types>1</allow_suspicious_low_cardinality_types>
+        <merge_tree_use_deserialization_prefixes_cache>1</merge_tree_use_deserialization_prefixes_cache>
+        <max_memory_usage>20G</max_memory_usage>
+    </settings>
+
+    <substitutions>
+        <substitution>
+            <name>key</name>
+            <values>
+                <value>stack_lc_uint8</value>
+                <value>stack_uint8</value>
+                <value>stack_lc_uint16</value>
+                <value>stack_uint16</value>
+                <value>stack_lc_uint32</value>
+                <value>stack_uint32</value>
+                <value>stack_lc_uint64</value>
+                <value>stack_uint64</value>
+                <value>stack_lc_uint128</value>
+                <value>stack_uint128</value>
+                <value>stack_lc_uint256</value>
+                <value>stack_uint256</value>
+                <value>stack_lc_string_6</value>
+                <value>stack_string_6</value>
+                <value>stack_lc_string_26</value>
+                <value>stack_string_26</value>
+                <value>stack_lc_string_56</value>
+                <value>stack_string_56</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>DROP TABLE IF EXISTS group_by_low_cardinality_shared_dictionary</create_query>
+    <create_query>
+        CREATE TABLE group_by_low_cardinality_shared_dictionary
+        (
+            stack_lc_uint8 LowCardinality(UInt8),
+            stack_uint8 UInt8,
+            stack_lc_uint16 LowCardinality(UInt16),
+            stack_uint16 UInt16,
+            stack_lc_uint32 LowCardinality(UInt32),
+            stack_uint32 UInt32,
+            stack_lc_uint64 LowCardinality(UInt64),
+            stack_uint64 UInt64,
+            stack_lc_uint128 LowCardinality(UInt128),
+            stack_uint128 UInt128,
+            stack_lc_uint256 LowCardinality(UInt256),
+            stack_uint256 UInt256,
+            stack_lc_string_6 LowCardinality(String),
+            stack_string_6 String,
+            stack_lc_string_26 LowCardinality(String),
+            stack_string_26 String,
+            stack_lc_string_56 LowCardinality(String),
+            stack_string_56 String,
+            value UInt64
+        )
+        ENGINE = MergeTree
+        ORDER BY tuple()
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0
+    </create_query>
+
+    <fill_query>
+        INSERT INTO group_by_low_cardinality_shared_dictionary
+        SELECT
+            toUInt8(stack_number) AS stack_lc_uint8,
+            stack_lc_uint8 AS stack_uint8,
+            toUInt16(stack_number) AS stack_lc_uint16,
+            stack_lc_uint16 AS stack_uint16,
+            toUInt32(stack_number) AS stack_lc_uint32,
+            stack_lc_uint32 AS stack_uint32,
+            stack_number AS stack_lc_uint64,
+            stack_number AS stack_uint64,
+            bitOr(
+                bitShiftLeft(toUInt128(cityHash64(stack_number)), 64),
+                toUInt128(stack_number)) AS stack_lc_uint128,
+            stack_lc_uint128 AS stack_uint128,
+            bitOr(
+                bitShiftLeft(toUInt256(cityHash64(stack_number + 1)), 192),
+                bitOr(
+                    bitShiftLeft(toUInt256(cityHash64(stack_number + 2)), 128),
+                    toUInt256(stack_lc_uint128))) AS stack_lc_uint256,
+            stack_lc_uint256 AS stack_uint256,
+            leftPad(toString(stack_number), 6, '0') AS stack_lc_string_6,
+            stack_lc_string_6 AS stack_string_6,
+            leftPad(toString(stack_number), 26, '0') AS stack_lc_string_26,
+            stack_lc_string_26 AS stack_string_26,
+            leftPad(toString(stack_number), 56, '0') AS stack_lc_string_56,
+            stack_lc_string_56 AS stack_string_56,
+            toUInt64(1) AS value
+        FROM
+        (
+            SELECT
+                if(number &lt; 8190, number, intHash64(number) % 8190) AS stack_number
+            FROM numbers(25000000)
+        )
+        SETTINGS
+            max_threads = 1,
+            max_insert_threads = 1,
+            max_block_size = 25000000,
+            max_insert_block_size = 25000000,
+            min_insert_block_size_rows = 25000000,
+            min_insert_block_size_bytes = 0
+    </fill_query>
+
+    <fill_query>
+        SELECT throwIf(
+            count() != 1 OR countIf(part_type = 'Wide') != 1,
+            'Expected one active Wide part')
+        FROM system.parts
+        WHERE database = currentDatabase()
+          AND table = 'group_by_low_cardinality_shared_dictionary'
+          AND active
+    </fill_query>
+
+    <query>
+        SELECT {key}, sum(value)
+        FROM group_by_low_cardinality_shared_dictionary
+        GROUP BY {key}
+        FORMAT Null
+        SETTINGS
+            max_threads = 1,
+            max_block_size = 65536
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS group_by_low_cardinality_shared_dictionary</drop_query>
+</test>


### PR DESCRIPTION
Previously dictionary position to aggregate state mappings were only valid within a block. For parts where there's only a single dictionary, this is too restrictive and resulted in repeated work.

This moves the mapping cache to the aggregation method, matching its lifetime to the aggregation hash table. We keep the successful mappings while the dict remains unchanged. Non-shared dictionaries remain block local.

This gives a very nice speedup to the benchmark in the previous commit:

| Width           | LC before |  LC after | Change |
|-----------------|----------:|----------:|-------:|
| `UInt8`         |  0.1220 s |  0.1158 s |  -5.1% |
| `UInt16`        |  0.1703 s |  0.1395 s | -18.1% |
| `UInt32`        |  0.1884 s |  0.1489 s | -20.9% |
| `UInt64`        |  0.1952 s |  0.1513 s | -22.5% |
| `UInt128`       |  0.5676 s |  0.5649 s |  -0.5% |
| `UInt256`       |  0.9354 s |  0.9206 s |  -1.6% |
| `String` (6 B)  |  0.2535 s |  0.1598 s | -37.0% |
| `String` (26 B) |  0.2521 s |  0.1630 s | -35.4% |
| `String` (56 B) |  0.2689 s |  0.1655 s | -38.5% |

The improvements for UInt128 and UInt256 will be there after #114982 is merged.

The benefit is largest when many blocks share the same dictionary, because dictionary-position mappings are reused across those blocks.

_AI assisted, scratching an itch I've had for a while._

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improve aggregation performance by reusing LowCardinality aggregation mappings across blocks.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114993&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/114993](https://github.com/search?q=head%3Async-upstream%2Fpr%2F114993+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
