### PR TITLE
Fix PromQL offset inside range selectors

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOffset.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOffset.cpp
@@ -63,8 +63,11 @@ namespace
                     /// timestamp + INTERVAL x MILLISECONDS
                     chassert(context.timestamp_scale <= 9); /// Maximum scale for DateTime64 is 9 (nanoseconds).
                     /// Round up the scale to next number divisible by 3.
-                    UInt32 scale = std::max<UInt32>((context.timestamp_scale + 2) / 3 * 3, 9);
-                    Decimal64 scaled_offset_value = DecimalUtils::convertTo<Decimal64>(scale, offset_value, context.timestamp_scale);
+                    UInt32 scale = std::min<UInt32>((context.timestamp_scale + 2) / 3 * 3, 9);
+                    /// The interval functions do not accept Decimal arguments, so the literal must be
+                    /// the integer number of units of 10^-scale seconds. The conversion is exact because
+                    /// scale >= timestamp_scale.
+                    Int64 scaled_offset_value = DecimalUtils::convertTo<Decimal64>(scale, offset_value, context.timestamp_scale).value;
 
                     static const std::string_view to_interval_functions[] = {"toIntervalSecond", "toIntervalMillisecond", "toIntervalMicrosecond", "toIntervalNanosecond"};
                     std::string_view to_interval_function = to_interval_functions[scale / 3];

--- a/tests/queries/0_stateless/04897_promql_offset_in_range_selector.reference
+++ b/tests/queries/0_stateless/04897_promql_offset_in_range_selector.reference
@@ -1,0 +1,10 @@
+rate with offset, instant:
+[('l','a')]	1970-01-12 13:53:40.000	0.016666666666666666
+offset is equivalent to shifting the evaluation time:
+1
+increase with offset, range:
+[('l','a')]	[('1970-01-12 13:49:40.000',2)]
+plain vector offset, range:
+[('__name__','m'),('l','a')]	[('1970-01-12 13:51:40.000',1),('1970-01-12 13:53:20.000',2)]
+nanosecond timestamps, sub-second offset:
+[('__name__','n')]	1970-01-12 13:49:20.500000000	20

--- a/tests/queries/0_stateless/04897_promql_offset_in_range_selector.sql
+++ b/tests/queries/0_stateless/04897_promql_offset_in_range_selector.sql
@@ -1,0 +1,77 @@
+-- Tags: no-fasttest, no-replicated-database
+-- ^^ ANTLR4 support is disabled in the fast-test build, and the PromQL
+-- grammar requires it. The experimental TimeSeries table engine does not
+-- round-trip through DatabaseReplicated.
+
+-- Regression test: `offset` inside a range selector (e.g. `rate(m[2m] offset 5m)`)
+-- used to fail with "Illegal type Decimal(18, 0) of argument of function
+-- toIntervalNanosecond": the transpiled `timestamp + INTERVAL x` expression always
+-- picked the nanosecond interval regardless of the timestamp scale, and passed the
+-- offset as a Decimal literal, which the interval functions do not accept.
+
+SET allow_experimental_time_series_table = 1;
+SET allow_experimental_time_series_aggregate_functions = 1;
+SET session_timezone = 'UTC'; -- the reference contains rendered DateTime64 values
+
+DROP TABLE IF EXISTS ts;
+CREATE TABLE ts ENGINE = TimeSeries;
+
+INSERT INTO ts (metric_name, tags, time_series) VALUES
+    ('m', map('l', 'a'), [(toDateTime64(1000000, 3), 1.0), (toDateTime64(1000060, 3), 2.0), (toDateTime64(1000120, 3), 3.0)]);
+
+-- The failing case: offset in a range selector, instant query (default timestamps are DateTime64(3)).
+SELECT 'rate with offset, instant:';
+SELECT tags, timestamp, value FROM prometheusQuery(ts, 'rate(m[2m] offset 5m)', 1000420) ORDER BY ALL;
+
+-- `rate(m[2m] offset 5m)` evaluated at T must equal `rate(m[2m])` evaluated at T - 300.
+SELECT 'offset is equivalent to shifting the evaluation time:';
+SELECT (SELECT groupArray(value) FROM prometheusQuery(ts, 'rate(m[2m] offset 5m)', 1000420))
+     = (SELECT groupArray(value) FROM prometheusQuery(ts, 'rate(m[2m])', 1000120));
+
+SELECT 'increase with offset, range:';
+SELECT tags, time_series FROM prometheusQueryRange(ts, 'increase(m[2m] offset 1m)', 1000180, 1000300, 60) ORDER BY ALL;
+
+-- Instant-vector offset took a different code path and worked before; keep it covered.
+SELECT 'plain vector offset, range:';
+SELECT tags, time_series FROM prometheusQueryRange(ts, 'm offset 5m', 1000300, 1000400, 100) ORDER BY ALL;
+
+DROP TABLE ts;
+
+-- Nanosecond timestamps exercise the toIntervalNanosecond branch, including a sub-second offset.
+DROP TABLE IF EXISTS ts_data;
+DROP TABLE IF EXISTS ts_tags;
+DROP TABLE IF EXISTS ts_metrics;
+DROP TABLE IF EXISTS ts_ns;
+
+CREATE TABLE ts_data (id UUID, timestamp DateTime64(9, 'UTC'), value Float64)
+ENGINE = MergeTree ORDER BY (id, timestamp);
+
+CREATE TABLE ts_tags (
+    id UUID,
+    metric_name LowCardinality(String),
+    tags Map(LowCardinality(String), String),
+    min_time SimpleAggregateFunction(min, Nullable(DateTime64(9, 'UTC'))),
+    max_time SimpleAggregateFunction(max, Nullable(DateTime64(9, 'UTC'))))
+-- `tags` is functionally dependent on `id`, so it is kept outside the sorting key on purpose.
+ENGINE = AggregatingMergeTree ORDER BY (metric_name, id) SETTINGS allow_dimensions_outside_sorting_key = 1;
+
+CREATE TABLE ts_metrics (
+    metric_family_name String,
+    type String,
+    unit String,
+    help String)
+ENGINE = ReplacingMergeTree ORDER BY metric_family_name;
+
+CREATE TABLE ts_ns ENGINE = TimeSeries
+DATA ts_data TAGS ts_tags METRICS ts_metrics;
+
+INSERT INTO ts_ns (metric_name, tags, time_series) VALUES
+    ('n', map(), [(toDateTime64('1970-01-12 13:46:40.000000001', 9, 'UTC'), 10.0), (toDateTime64('1970-01-12 13:47:40.000000001', 9, 'UTC'), 20.0)]);
+
+SELECT 'nanosecond timestamps, sub-second offset:';
+SELECT tags, timestamp, value FROM prometheusQuery(ts_ns, 'last_over_time(n[2m] offset 500ms)', 1000160.5) ORDER BY ALL;
+
+DROP TABLE ts_ns;
+DROP TABLE ts_metrics;
+DROP TABLE ts_tags;
+DROP TABLE ts_data;


### PR DESCRIPTION
Any PromQL query using `offset` inside a range selector, e.g. `rate(m[2m] offset 5m)`, failed with:

```
Code: 43. DB::Exception: Illegal type Decimal(18, 0) of argument of function toIntervalNanosecond: In scope prometheus_query_step_2. (ILLEGAL_TYPE_OF_ARGUMENT)
```

Instant-vector `offset` (e.g. `m offset 5m`) worked, because it takes the grid branch of `applyOffset` which only shifts the evaluation range. The `StoreMethod::RAW_DATA` branch, which rewrites `timestamp + INTERVAL x` in the generated SQL, had two defects:

1. The scale clamp used `std::max` instead of `std::min`, so the rounded-up scale was always 9 and the generated function was always `toIntervalNanosecond`, regardless of the timestamp scale.
2. The offset was emitted as a `Decimal64` literal, which the `toInterval*` functions do not accept (and which loses its scale, hence `Decimal(18, 0)` in the message) — so the path failed unconditionally for any `DateTime64` timestamp column, including the default `DateTime64(3)`.

The fix emits the exact integer number of interval units (exact because the interval unit scale is rounded up from the timestamp scale). The new test covers `rate`/`increase`/`last_over_time` with `offset` in instant and range evaluation, asserts that `offset` is equivalent to shifting the evaluation time, and exercises the `toIntervalNanosecond` branch with `DateTime64(9)` timestamps and a sub-second offset. Found via a PromQL equivalence harness while benchmarking the TimeSeries engine.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the error `Illegal type Decimal(18, 0) of argument of function toIntervalNanosecond` when a PromQL query uses `offset` inside a range selector, e.g. `rate(m[2m] offset 5m)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1516` (included in `26.8` and later)
<!-- ch-version-info:end -->