### PR TITLE
Schedule text-index virtual columns first in the PREWHERE cost model

### DIFF
--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -14,6 +14,7 @@
 #include <Parsers/ASTSubquery.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Storages/MergeTree/MergeTreeWhereOptimizer.h>
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Common/typeid_cast.h>
@@ -44,6 +45,21 @@ static NameToIndexMap fillNamesPositions(const Names & names)
     }
 
     return names_positions;
+}
+
+/// Whether the condition reads only `__text_index_*` virtual columns, which the text-index reader
+/// fills from posting lists. A mixed condition (a virtual column plus a physical column) does not
+/// qualify: it still pays the I/O of its physical columns.
+static bool isTextIndexVirtualColumnsCondition(const NameSet & condition_table_columns)
+{
+    if (condition_table_columns.empty())
+        return false;
+
+    for (const auto & column : condition_table_columns)
+        if (!isTextIndexVirtualColumn(column))
+            return false;
+
+    return true;
 }
 
 /// Find minimal position of any of the column in primary key.
@@ -521,9 +537,20 @@ void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTree
             else if (rejected_rows <= 0)
                 /// Rejects no rows, so it is useless in PREWHERE regardless of its cost: schedule it last.
                 cond.cost_with_selectivity = std::numeric_limits<double>::infinity();
+            else if (isTextIndexVirtualColumnsCondition(cond.table_columns))
+                /// Text-index virtual columns (`__text_index_*`) are filled by the index reader from posting
+                /// lists that are read for granule pruning anyway; evaluating them is a bitmap lookup per row,
+                /// with no column I/O. Their columns_size is 0 (they are not physical columns), so without this
+                /// branch they would take the selectivity fallback below and its row-count score would lose to
+                /// any byte-per-rejected-row score of a physical predicate. Their real marginal cost is ~0:
+                /// schedule them first.
+                cond.cost_with_selectivity = 0;
             else if (cond.columns_size == 0)
                 /// Compact parts don't track per-column compressed sizes: fall back to pure selectivity,
                 /// otherwise every condition collapses to cost 0 and keeps its original position.
+                /// This is also the deliberately pessimistic path for the other zero-size cases (table virtual
+                /// columns, columns not yet materialized after ALTER, subcolumns without size info): their
+                /// evaluation cost is unknown, so they must not be scheduled first.
                 cond.cost_with_selectivity = static_cast<double>(cond.estimated_row_count);
             else
                 cond.cost_with_selectivity = static_cast<double>(cond.columns_size) / rejected_rows;

--- a/tests/queries/0_stateless/04907_prewhere_text_index_virtual_columns_first.reference
+++ b/tests/queries/0_stateless/04907_prewhere_text_index_virtual_columns_first.reference
@@ -1,0 +1,5 @@
+-- correctness: no row has both tokens
+0
+0
+-- reordering must not schedule the raw predicate before the index virtual columns
+1

--- a/tests/queries/0_stateless/04907_prewhere_text_index_virtual_columns_first.sql
+++ b/tests/queries/0_stateless/04907_prewhere_text_index_virtual_columns_first.sql
@@ -1,0 +1,73 @@
+-- Regression test: `__text_index_*` virtual columns must be scheduled before physical-column
+-- predicates in PREWHERE. They are filled by the index reader from posting lists (no column I/O),
+-- but they have columns_size = 0, so the cost-per-rejected-row score used to fall back to
+-- estimated_row_count (a row count) and lose against any byte-based score of a physical predicate.
+-- The raw predicate then ran first, on all rows, reading the whole `text` column.
+-- See https://github.com/ClickHouse/ClickHouse/pull/110695
+
+SET allow_experimental_full_text_index = 1;
+SET enable_analyzer = 1;
+SET use_statistics = 1;
+SET materialize_statistics_on_insert = 1;
+SET optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1;
+SET allow_reorder_prewhere_conditions = 1; -- CI may inject False, preventing statistics-based reordering
+SET enable_multiple_prewhere_read_steps = 1; -- CI may inject False, collapsing PREWHERE into one step
+SET use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+SET query_plan_direct_read_from_text_index = 1;
+SET use_query_condition_cache = 0; -- the second run must not skip reads via the cache
+SET log_queries = 1;
+
+DROP TABLE IF EXISTS t_prewhere_text_index_cost;
+
+-- Wide parts so physical columns get real sizes and feed the byte-based cost score.
+-- tdigest statistics on `v` make the estimator active (total_rows > 0), which routes
+-- zero-size conditions into the score fallback where the defect lived.
+CREATE TABLE t_prewhere_text_index_cost
+(
+    id UInt64,
+    v UInt64 STATISTICS(tdigest),
+    text String,
+    INDEX idx_text text TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, auto_statistics_types = '';
+
+-- Token `aaa` is in even rows, `bbb` in odd rows: every granule contains both tokens, so the
+-- index prunes no granules and the filtering happens at row level, where the order matters.
+-- No row contains both tokens, so the virtual columns reject everything and a correctly
+-- ordered plan never reads `text` for the equality predicate. The per-row tail keeps the
+-- `text` column's size nonzero so the equality predicate gets a byte-based cost score; the
+-- hex alphabet (0-9A-F) cannot accidentally produce the lowercase query tokens. One hash per
+-- row and no OPTIMIZE: the flaky check runs this test dozens of times on sanitizer builds
+-- with S3 storage, under a 180 s cap.
+SET max_insert_threads = 1; -- one part; a single INSERT is enough, no merge needed
+INSERT INTO t_prewhere_text_index_cost
+SELECT
+    number,
+    number % 1000,
+    concat(if(number % 2 = 0, 'aaa', 'bbb'), ' row ', toString(number), ' ', repeat(hex(sipHash64(number)), 12))
+FROM numbers(20000);
+
+SELECT '-- correctness: no row has both tokens';
+
+SELECT count() FROM t_prewhere_text_index_cost
+WHERE hasToken(text, 'aaa') AND hasToken(text, 'bbb') AND text = concat('x', toString(v))
+SETTINGS allow_reorder_prewhere_conditions = 0, log_comment = '04907_baseline_natural_order';
+
+SELECT count() FROM t_prewhere_text_index_cost
+WHERE hasToken(text, 'aaa') AND hasToken(text, 'bbb') AND text = concat('x', toString(v))
+SETTINGS allow_reorder_prewhere_conditions = 1, log_comment = '04907_reordered';
+
+SYSTEM FLUSH LOGS query_log;
+
+-- With allow_reorder_prewhere_conditions = 0 the conditions keep their written order: the two
+-- index virtual columns run first and reject all rows, so `text` is never read for the equality.
+-- The reordered plan must not read more than that natural order (margin 2x for accounting noise).
+SELECT '-- reordering must not schedule the raw predicate before the index virtual columns';
+SELECT maxIf(read_bytes, log_comment = '04907_reordered') <= 2 * maxIf(read_bytes, log_comment = '04907_baseline_natural_order')
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND type = 'QueryFinish'
+  AND log_comment IN ('04907_baseline_natural_order', '04907_reordered');
+
+DROP TABLE t_prewhere_text_index_cost;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110695

The `cost_with_selectivity` score from #110695 orders PREWHERE conditions by bytes-per-rejected-row, but conditions with `columns_size == 0` fall back to a score of `estimated_row_count` — a plain row count. The two units are not comparable. `__text_index_*` virtual columns are not physical columns, so they always score through the fallback (millions) and lose to any byte-based score of a physical predicate (hundreds). The expensive raw predicate then runs first, on all rows, reading the whole `text` column; the near-free index check runs last, where it filters nothing.

Our internal full-text-search benchmark (59M rows of StackOverflow data, multi-KB `text` column with a `text` index) caught this the day after #110695 merged, on 14 query shapes: an equality residual (`hasToken(...) AND text = concat(...)`) went from 89 ms to 3.45 s on every execution (~39x), `match` residuals slowed 2–2.4x, `multiMatchAny`/`multiSearchAny` by 30–40%.

The fix is deliberately narrow. Conditions that read only text-index virtual columns get cost 0: their posting lists are read for granule pruning anyway, so their marginal evaluation cost is a bitmap lookup per row, with no column I/O. Every other zero-size case (compact parts, table virtual columns like `_part`, columns not yet materialized after `ALTER`, subcolumns without size info) keeps the existing pessimistic selectivity fallback, because their evaluation cost is unknown and they must not be scheduled first.

Standalone reproduction (wide part required — on compact parts all sizes are 0, every condition ties, and the bug hides):

```sql
CREATE TABLE t (id UInt64, v UInt64, text String,
    INDEX idx_text text TYPE text(tokenizer = 'splitByNonAlpha'))
ENGINE = MergeTree ORDER BY id
SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
-- insert rows where the token filter is index-answerable and the residual is per-row
-- then run with send_logs_level='test':
SELECT count() FROM t WHERE hasToken(text, 'alpha') AND text = concat('x', toString(id));
```

The `Condition ... moved to PREWHERE` log lines print in scheduling order. Before this fix: `equals(text, ...)` (columns_size 293748504, score ≈ 877) is scheduled before `__text_index_*` (columns_size 0, score = 165000). After: the virtual column comes first. Note `EXPLAIN` cannot show this — the printed argument order of the `AND` is the reverse of the evaluation order — hence the new test asserts on `read_bytes` instead: with the correct order the equality never reads `text`, because the token conditions reject every row first.

After the fix, the internal benchmark returned to its pre-#110695 numbers (0 regressions), and one query improved 11.6x beyond its old baseline (a per-row `LIKE concat(...)` residual that had been misordered by an earlier heuristic as well).

cc @avogar

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)