### PR TITLE
Perf: Skip ASCII scans in byte-mode string functions

### DIFF
--- a/src/Functions/padString.cpp
+++ b/src/Functions/padString.cpp
@@ -227,9 +227,9 @@ namespace
         void executeForSource(SourceStrings && strings, const ColumnPtr & column_length, const String & pad_string, StringSink & res_sink) const
         {
             const auto & chars = strings.getElements();
-            bool all_ascii = isAllASCII(reinterpret_cast<const UInt8 *>(pad_string.data()), pad_string.size())
-                                && isAllASCII(chars.data(), chars.size());
-            bool is_actually_utf8 = is_utf8 && !all_ascii;
+            bool is_actually_utf8 = is_utf8
+                && !(isAllASCII(reinterpret_cast<const UInt8 *>(pad_string.data()), pad_string.size())
+                    && isAllASCII(chars.data(), chars.size()));
 
             if (!is_actually_utf8)
             {

--- a/src/Functions/substringIndex.cpp
+++ b/src/Functions/substringIndex.cpp
@@ -124,8 +124,9 @@ namespace
             res_data.reserve(str_column->getChars().size() / 2);
             res_offsets.reserve(input_rows_count);
 
-            bool all_ascii = isAllASCII(str_column->getChars().data(), str_column->getChars().size())
-                && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size());
+            bool all_ascii = !is_utf8
+                || (isAllASCII(str_column->getChars().data(), str_column->getChars().size())
+                    && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
                 = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
 
@@ -157,8 +158,9 @@ namespace
             res_data.reserve(str_column->getChars().size() / 2);
             res_offsets.reserve(input_rows_count);
 
-            bool all_ascii = isAllASCII(str_column->getChars().data(), str_column->getChars().size())
-                && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size());
+            bool all_ascii = !is_utf8
+                || (isAllASCII(str_column->getChars().data(), str_column->getChars().size())
+                    && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
                 = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
 
@@ -189,8 +191,9 @@ namespace
             res_data.reserve(str.size() * rows / 2);
             res_offsets.reserve(rows);
 
-            bool all_ascii = isAllASCII(reinterpret_cast<const UInt8 *>(str.data()), str.size())
-                && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size());
+            bool all_ascii = !is_utf8
+                || (isAllASCII(reinterpret_cast<const UInt8 *>(str.data()), str.size())
+                    && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
                 = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
 

--- a/src/Functions/substringIndex.cpp
+++ b/src/Functions/substringIndex.cpp
@@ -124,11 +124,11 @@ namespace
             res_data.reserve(str_column->getChars().size() / 2);
             res_offsets.reserve(input_rows_count);
 
-            bool all_ascii = !is_utf8
-                || (isAllASCII(str_column->getChars().data(), str_column->getChars().size())
+            bool is_actually_utf8 = is_utf8
+                && !(isAllASCII(str_column->getChars().data(), str_column->getChars().size())
                     && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
-                = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
+                = is_actually_utf8 ? std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size()) : nullptr;
 
             for (size_t i = 0; i < input_rows_count; ++i)
             {
@@ -136,12 +136,10 @@ namespace
                 Int64 count = count_column->getInt(i);
 
                 std::string_view res_ref;
-                if (!is_utf8)
-                    res_ref = substringIndex(str_ref, delim[0], count);
-                else if (all_ascii)
-                    res_ref = substringIndex(str_ref, delim[0], count);
-                else
+                if (is_actually_utf8)
                     res_ref = substringIndexUTF8(searcher.get(), str_ref, delim, count);
+                else
+                    res_ref = substringIndex(str_ref, delim[0], count);
 
                 appendToResultColumn<true>(res_ref, res_data, res_offsets);
             }
@@ -158,23 +156,21 @@ namespace
             res_data.reserve(str_column->getChars().size() / 2);
             res_offsets.reserve(input_rows_count);
 
-            bool all_ascii = !is_utf8
-                || (isAllASCII(str_column->getChars().data(), str_column->getChars().size())
+            bool is_actually_utf8 = is_utf8
+                && !(isAllASCII(str_column->getChars().data(), str_column->getChars().size())
                     && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
-                = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
+                = is_actually_utf8 ? std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size()) : nullptr;
 
             for (size_t i = 0; i < input_rows_count; ++i)
             {
                 std::string_view str_ref = str_column->getDataAt(i);
 
                 std::string_view res_ref;
-                if (!is_utf8)
-                    res_ref = substringIndex(str_ref, delim[0], count);
-                else if (all_ascii)
-                    res_ref = substringIndex(str_ref, delim[0], count);
-                else
+                if (is_actually_utf8)
                     res_ref = substringIndexUTF8(searcher.get(), str_ref, delim, count);
+                else
+                    res_ref = substringIndex(str_ref, delim[0], count);
 
                 appendToResultColumn<true>(res_ref, res_data, res_offsets);
             }
@@ -191,11 +187,11 @@ namespace
             res_data.reserve(str.size() * rows / 2);
             res_offsets.reserve(rows);
 
-            bool all_ascii = !is_utf8
-                || (isAllASCII(reinterpret_cast<const UInt8 *>(str.data()), str.size())
+            bool is_actually_utf8 = is_utf8
+                && !(isAllASCII(reinterpret_cast<const UInt8 *>(str.data()), str.size())
                     && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
-                = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
+                = is_actually_utf8 ? std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size()) : nullptr;
 
             std::string_view str_ref{str};
             for (size_t i = 0; i < rows; ++i)
@@ -203,12 +199,10 @@ namespace
                 Int64 count = count_column->getInt(i);
 
                 std::string_view res_ref;
-                if (!is_utf8)
-                    res_ref = substringIndex(str_ref, delim[0], count);
-                else if (all_ascii)
-                    res_ref = substringIndex(str_ref, delim[0], count);
-                else
+                if (is_actually_utf8)
                     res_ref = substringIndexUTF8(searcher.get(), str_ref, delim, count);
+                else
+                    res_ref = substringIndex(str_ref, delim[0], count);
 
                 appendToResultColumn<false>(res_ref, res_data, res_offsets);
             }

--- a/tests/performance/pad_substring_skip_ascii_scan.xml
+++ b/tests/performance/pad_substring_skip_ascii_scan.xml
@@ -1,0 +1,18 @@
+<test>
+    <!--
+        Byte-mode leftPad, rightPad, and substringIndex do not need to inspect whether the input is ASCII.
+        The input depends on `number`, so it is a ColumnString and the old paths scan the full input buffer.
+        The UTF-8 queries are controls: their ASCII scan is still needed for byte-path selection.
+    -->
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <query>SELECT leftPad(concat(repeat('a', 63), toString(number % 10)), 64, 'x') FROM numbers(10000000) FORMAT Null</query>
+    <query>SELECT rightPad(concat(repeat('a', 63), toString(number % 10)), 64, 'x') FROM numbers(10000000) FORMAT Null</query>
+    <query>SELECT leftPadUTF8(concat(repeat('a', 63), toString(number % 10)), 64, 'x') FROM numbers(10000000) FORMAT Null</query>
+
+    <query>SELECT substringIndex(concat(repeat('a', 63), toString(number % 10), '.tail'), '.', number % 2 + 1) FROM numbers(10000000) FORMAT Null</query>
+    <query>SELECT substringIndex(concat(repeat('a', 63), toString(number % 10), '.tail'), '.', 1) FROM numbers(10000000) FORMAT Null</query>
+    <query>SELECT substringIndexUTF8(concat(repeat('a', 63), toString(number % 10), '.tail'), '.', number % 2 + 1) FROM numbers(10000000) FORMAT Null</query>
+</test>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/commit/a4466496488
Related: https://github.com/ClickHouse/ClickHouse/commit/d03ae0655abaef54117f6455063009aa7aed790b
Combined with: https://github.com/ClickHouse/ClickHouse/pull/115006

### Description

- **Problem:** byte-mode `leftPad`, `rightPad`, and `substringIndex` scan their input with `isAllASCII` even though byte mode does not need that check.
- **Why the scan exists:** the UTF-8 variants use it to take the byte path for ASCII input; non-ASCII input needs UTF-8 character handling.
- **Change:** skip the ASCII scan when the function is already in byte mode.
- **Scope:** byte-mode paths only. `leftPadUTF8`, `rightPadUTF8`, and `substringIndexUTF8` keep their ASCII check for byte-path selection.
- **Behavior:** unchanged. The same byte and UTF-8 implementations return the same values in the same order.

### Benchmark

- **Added:** `tests/performance/pad_substring_skip_ascii_scan.xml`
- **Coverage:** byte-mode `leftPad`, `rightPad`, and `substringIndex`, with UTF-8 controls.
- **Workload:** dynamic ASCII strings of about 64 bytes, 10,000,000 rows, one thread, and `FORMAT Null`.
- **Method:** CI compares the actual before/after ClickHouse binaries with the performance-test harness.
- **Results:** pending the CI performance report for this combined head.
- **Measured results:** CI performance comparison, head `188b38b4fe5` and the previous run `3bd888a8bbe`, [dashboard](https://performance.ci.clickhouse.com/runs?q=115003):

| # | Query | amd `188b38b4` | arm `188b38b4` | amd `3bd888a8` | arm `3bd888a8` |
|---|---|---|---|---|---|
| 0 | `leftPad`, byte mode | -11.9% | -8.7% | -12.7% | -8.0% |
| 1 | `rightPad`, byte mode | -11.6% | -8.8% | -11.3% | -11.5% |
| 2 | `leftPadUTF8`, control | 0.0% | +0.2% | 0.0% | -0.2% |
| 3 | `substringIndex`, `vectorVector` | -4.9% | +2.0% | -6.1% | -0.1% |
| 4 | `substringIndex`, `vectorConstant` | -5.1% | -6.3% | -5.2% | -4.0% |
| 5 | `substringIndexUTF8`, control | -1.4% | +2.8% | -5.4% | -5.1% |

- **Pad functions:** the improvement reproduces over both runs and both architectures, eight measurements between -8.0% and -11.9%, while the `leftPadUTF8` control stays flat. The absolute delta of 15 to 21 ms matches the cost of `isAllASCII` over the input buffer.
- **`substringIndex`:** not resolved by these queries. The `substringIndexUTF8` control itself moves by up to 5.4% between runs, and query 3 changes sign, so the noise floor is the size of the expected effect. About 80% of the runtime of these queries is the delimiter search and the prefix copy, which this change does not touch; a variant with the delimiter near the start of the string would isolate the scan.
- **Harness verdict:** all 12 queries are reported as unchanged in both runs, since none crossed both the 5% threshold and the 95th percentile of the randomization distribution.

### History

- **`a4466496488`:** added the ASCII scan for the UTF-8 padding optimization.
- **`d03ae0655ab`:** added the ASCII scan so UTF-8 substring functions can use the byte path for ASCII input.
- **#115006:** contained the matching byte-mode `substringIndex` change and is now combined here.

### Tests

- **Existing coverage:** `01940_pad_string.sql`, `02986_leftpad_fixedstring.sql`, `04070_pad_string_asan_overflow.sql`, and `02798_substring_index.sql` cover the existing byte and UTF-8 behavior.
- **Added:** `tests/performance/pad_substring_skip_ascii_scan.xml` exercises the changed byte-mode paths and UTF-8 controls.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve byte-mode string function performance by avoiding unnecessary ASCII scans.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115003&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115003](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115003+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.986` (included in `26.9` and later)
<!-- ch-version-info:end -->