### PR TITLE
Fix a lambda argument taking the type of a table column with the same name

### DIFF
--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -734,6 +734,8 @@ private:
 
     NodeNameAndNodeMinLevel visitLambda(const QueryTreeNodePtr & node);
 
+    NameSet collectLambdaArgumentNamesUsedByColumns(const LambdaNode & lambda_node);
+
     NodeNameAndNodeMinLevel makeSetForInFunction(const QueryTreeNodePtr & node);
 
     NodeNameAndNodeMinLevel visitIndexHintFunction(const QueryTreeNodePtr & node);
@@ -1006,6 +1008,40 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
     return {constant_node_name, Levels(0)};
 }
 
+NameSet PlannerActionsVisitorImpl::collectLambdaArgumentNamesUsedByColumns(const LambdaNode & lambda_node)
+{
+    const auto & argument_names = lambda_node.getArguments().getNames();
+    NameSet result;
+
+    QueryTreeNodes to_visit{lambda_node.getExpression()};
+    while (!to_visit.empty())
+    {
+        auto current = to_visit.back();
+        to_visit.pop_back();
+
+        if (const auto * column_node = current->as<ColumnNode>())
+        {
+            /// Mirrors visitColumn: a column with a non-constant expression is replaced by that
+            /// expression and never looked up under its own name.
+            bool looked_up_by_name = !column_node->hasExpression() || use_column_identifier_as_action_node_name
+                || column_node->getExpression()->getNodeType() == QueryTreeNodeType::CONSTANT;
+
+            if (looked_up_by_name)
+            {
+                const auto & column_name = column_node->getColumnName();
+                if (std::find(argument_names.begin(), argument_names.end(), column_name) != argument_names.end())
+                    result.insert(column_name);
+            }
+        }
+
+        for (const auto & child : current->getChildren())
+            if (child)
+                to_visit.push_back(child);
+    }
+
+    return result;
+}
+
 PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::visitLambda(const QueryTreeNodePtr & node)
 {
     auto & lambda_node = node->as<LambdaNode &>();
@@ -1027,10 +1063,12 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
     ActionsDAG lambda_actions_dag;
     actions_stack.emplace_back(lambda_actions_dag, node);
 
-    /// Declared before the body so an argument's INPUT carries the argument's own type: a table
-    /// column of the same name then only finds that INPUT, never defines it. Unread ones are pruned.
+    /// A body column named after an argument resolves to the argument's type, so the argument is
+    /// declared first. Other names stay undeclared: a body node may legitimately carry them.
+    const auto argument_names_read_as_columns = collectLambdaArgumentNamesUsedByColumns(lambda_node);
     for (const auto & lambda_argument : lambda_arguments_names_and_types)
-        actions_stack.back().addInputColumnIfNecessary(lambda_argument.name, lambda_argument.type);
+        if (argument_names_read_as_columns.contains(lambda_argument.name))
+            actions_stack.back().addInputColumnIfNecessary(lambda_argument.name, lambda_argument.type);
 
     auto [lambda_expression_node_name, levels] = visitImpl(lambda_node.getExpression());
     lambda_actions_dag.getOutputs().push_back(actions_stack.back().getNodeOrThrow(lambda_expression_node_name));

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -734,7 +734,7 @@ private:
 
     NodeNameAndNodeMinLevel visitLambda(const QueryTreeNodePtr & node);
 
-    NameSet collectLambdaArgumentNamesUsedByColumns(const LambdaNode & lambda_node);
+    NameSet collectLambdaArgumentNamesToDeclare(const LambdaNode & lambda_node);
 
     NodeNameAndNodeMinLevel makeSetForInFunction(const QueryTreeNodePtr & node);
 
@@ -1008,11 +1008,16 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
     return {constant_node_name, Levels(0)};
 }
 
-NameSet PlannerActionsVisitorImpl::collectLambdaArgumentNamesUsedByColumns(const LambdaNode & lambda_node)
+NameSet PlannerActionsVisitorImpl::collectLambdaArgumentNamesToDeclare(const LambdaNode & lambda_node)
 {
     const auto & argument_names = lambda_node.getArguments().getNames();
     const auto * own_arguments = &lambda_node.getArguments();
-    NameSet result;
+
+    auto is_argument_name = [&](const String & name)
+    { return std::find(argument_names.begin(), argument_names.end(), name) != argument_names.end(); };
+
+    NameSet declared;
+    NameSet contested;
 
     QueryTreeNodes to_visit{lambda_node.getExpression()};
     while (!to_visit.empty())
@@ -1020,26 +1025,40 @@ NameSet PlannerActionsVisitorImpl::collectLambdaArgumentNamesUsedByColumns(const
         auto current = to_visit.back();
         to_visit.pop_back();
 
-        if (const auto * column_node = current->as<ColumnNode>())
-        {
-            /// Both tests mirror visitColumn. A column carrying a non-constant expression is
-            /// replaced by that expression and never looked up under its own name, and a column
-            /// sourced from another lambda's arguments is bound there, so an equal name is a
-            /// different binding.
-            bool looked_up_by_name = !column_node->hasExpression() || use_column_identifier_as_action_node_name
-                || column_node->getExpression()->getNodeType() == QueryTreeNodeType::CONSTANT;
+        auto node_type = current->getNodeType();
 
-            auto column_source = column_node->getColumnSourceOrNull();
+        /// A subquery is planned in its own scope, so no name inside it is looked up here.
+        if (node_type == QueryTreeNodeType::QUERY || node_type == QueryTreeNodeType::UNION)
+            continue;
+
+        if (node_type == QueryTreeNodeType::COLUMN)
+        {
+            const auto & column_node = current->as<ColumnNode &>();
+
+            /// Mirrors visitColumn: a column carrying a non-constant expression is replaced by
+            /// that expression, and one sourced from another lambda's arguments is bound there.
+            bool looked_up_by_name = !column_node.hasExpression() || use_column_identifier_as_action_node_name
+                || column_node.getExpression()->getNodeType() == QueryTreeNodeType::CONSTANT;
+
+            auto column_source = column_node.getColumnSourceOrNull();
             bool bound_by_this_scope = !column_source
                 || column_source->getNodeType() != QueryTreeNodeType::LAMBDA_ARGS
                 || column_source.get() == own_arguments;
 
             if (looked_up_by_name && bound_by_this_scope)
             {
-                const auto & column_name = column_node->getColumnName();
-                if (std::find(argument_names.begin(), argument_names.end(), column_name) != argument_names.end())
-                    result.insert(column_name);
+                auto column_node_name = action_node_name_helper.calculateActionNodeName(current);
+                if (is_argument_name(column_node_name))
+                    declared.insert(column_node_name);
             }
+        }
+        else if (node_type == QueryTreeNodeType::FUNCTION || node_type == QueryTreeNodeType::CONSTANT)
+        {
+            /// One name holds one node, so a name the body computes for itself cannot also
+            /// carry an argument.
+            auto contested_name = action_node_name_helper.calculateActionNodeName(current);
+            if (is_argument_name(contested_name))
+                contested.insert(contested_name);
         }
 
         for (const auto & child : current->getChildren())
@@ -1047,7 +1066,10 @@ NameSet PlannerActionsVisitorImpl::collectLambdaArgumentNamesUsedByColumns(const
                 to_visit.push_back(child);
     }
 
-    return result;
+    for (const auto & contested_name : contested)
+        declared.erase(contested_name);
+
+    return declared;
 }
 
 PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::visitLambda(const QueryTreeNodePtr & node)
@@ -1073,9 +1095,9 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
 
     /// A body column named after an argument resolves to the argument's type, so the argument is
     /// declared first. Other names stay undeclared: a body node may legitimately carry them.
-    const auto argument_names_read_as_columns = collectLambdaArgumentNamesUsedByColumns(lambda_node);
+    const auto argument_names_to_declare = collectLambdaArgumentNamesToDeclare(lambda_node);
     for (const auto & lambda_argument : lambda_arguments_names_and_types)
-        if (argument_names_read_as_columns.contains(lambda_argument.name))
+        if (argument_names_to_declare.contains(lambda_argument.name))
             actions_stack.back().addInputColumnIfNecessary(lambda_argument.name, lambda_argument.type);
 
     auto [lambda_expression_node_name, levels] = visitImpl(lambda_node.getExpression());

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -1011,6 +1011,7 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
 NameSet PlannerActionsVisitorImpl::collectLambdaArgumentNamesUsedByColumns(const LambdaNode & lambda_node)
 {
     const auto & argument_names = lambda_node.getArguments().getNames();
+    const auto * own_arguments = &lambda_node.getArguments();
     NameSet result;
 
     QueryTreeNodes to_visit{lambda_node.getExpression()};
@@ -1021,12 +1022,19 @@ NameSet PlannerActionsVisitorImpl::collectLambdaArgumentNamesUsedByColumns(const
 
         if (const auto * column_node = current->as<ColumnNode>())
         {
-            /// Mirrors visitColumn: a column with a non-constant expression is replaced by that
-            /// expression and never looked up under its own name.
+            /// Both tests mirror visitColumn. A column carrying a non-constant expression is
+            /// replaced by that expression and never looked up under its own name, and a column
+            /// sourced from another lambda's arguments is bound there, so an equal name is a
+            /// different binding.
             bool looked_up_by_name = !column_node->hasExpression() || use_column_identifier_as_action_node_name
                 || column_node->getExpression()->getNodeType() == QueryTreeNodeType::CONSTANT;
 
-            if (looked_up_by_name)
+            auto column_source = column_node->getColumnSourceOrNull();
+            bool bound_by_this_scope = !column_source
+                || column_source->getNodeType() != QueryTreeNodeType::LAMBDA_ARGS
+                || column_source.get() == own_arguments;
+
+            if (looked_up_by_name && bound_by_this_scope)
             {
                 const auto & column_name = column_node->getColumnName();
                 if (std::find(argument_names.begin(), argument_names.end(), column_name) != argument_names.end())

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -1027,6 +1027,11 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
     ActionsDAG lambda_actions_dag;
     actions_stack.emplace_back(lambda_actions_dag, node);
 
+    /// Declared before the body so an argument's INPUT carries the argument's own type: a table
+    /// column of the same name then only finds that INPUT, never defines it. Unread ones are pruned.
+    for (const auto & lambda_argument : lambda_arguments_names_and_types)
+        actions_stack.back().addInputColumnIfNecessary(lambda_argument.name, lambda_argument.type);
+
     auto [lambda_expression_node_name, levels] = visitImpl(lambda_node.getExpression());
     lambda_actions_dag.getOutputs().push_back(actions_stack.back().getNodeOrThrow(lambda_expression_node_name));
     lambda_actions_dag.removeUnusedActions(Names(1, lambda_expression_node_name));

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
@@ -76,3 +76,9 @@ b
 LowCardinality(String) column: PREWHERE
 a
 b
+argument named after a generated action name
+[3]
+argument named after a generated action name, nested use
+[13]
+argument named after a generated action name, analyzer disabled
+[3]

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
@@ -49,19 +49,10 @@ nullable argument, argument read first: PREWHERE
 nullable argument, tuple body: PREWHERE
 10
 20
-nullable argument, arrayMap: PREWHERE
-10
-20
-nullable argument, arrayFilter: PREWHERE
-10
-20
 nullable argument, nested lambda: PREWHERE
 10
 20
 unread first argument: PREWHERE
-10
-20
-unread second argument: PREWHERE
 10
 20
 colliding name resolves per site
@@ -70,9 +61,6 @@ colliding name resolves per site
 nullable column, plain argument: PREWHERE
 10
 20
-String column: PREWHERE
-a
-b
 LowCardinality(String) column: PREWHERE
 a
 b
@@ -85,4 +73,12 @@ argument named after a generated action name, analyzer disabled
 nested lambda argument named after a generated action name
 [3]
 nested lambda argument named after a generated action name, analyzer disabled
+[3]
+generated action name argument, read in the body
+[6]
+generated action name argument, read in the body, analyzer disabled
+[45]
+column named after a generated action name
+[3]
+column named after a generated action name, analyzer disabled
 [3]

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
@@ -52,6 +52,9 @@ nullable argument, tuple body: PREWHERE
 nullable argument, nested lambda: PREWHERE
 10
 20
+nullable argument, outer binder with a nested lambda: PREWHERE
+10
+20
 unread first argument: PREWHERE
 10
 20

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
@@ -37,3 +37,42 @@ multi-column: PREWHERE
 multi-column: WHERE
 100	1
 200	2
+nullable argument, column read first: PREWHERE
+10
+20
+nullable argument, column read first: WHERE
+10
+20
+nullable argument, argument read first: PREWHERE
+10
+20
+nullable argument, tuple body: PREWHERE
+10
+20
+nullable argument, arrayMap: PREWHERE
+10
+20
+nullable argument, arrayFilter: PREWHERE
+10
+20
+nullable argument, nested lambda: PREWHERE
+10
+20
+unread first argument: PREWHERE
+10
+20
+unread second argument: PREWHERE
+10
+20
+colliding name resolves per site
+[310]
+[320]
+nullable column, plain argument: PREWHERE
+10
+20
+String column: PREWHERE
+a
+b
+LowCardinality(String) column: PREWHERE
+a
+b

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.reference
@@ -82,3 +82,7 @@ argument named after a generated action name, nested use
 [13]
 argument named after a generated action name, analyzer disabled
 [3]
+nested lambda argument named after a generated action name
+[3]
+nested lambda argument named after a generated action name, analyzer disabled
+[3]

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
@@ -70,3 +70,75 @@ SELECT 'multi-column: WHERE';
 SELECT * FROM t2 WHERE arrayMap(x -> t2.x + t2.y, [1])[1] > 50;
 
 DROP TABLE t2;
+
+-- The colliding name must resolve to the lambda argument's own type, not the column's.
+-- Above, column and argument are both UInt32, so a mistyped argument node is invisible;
+-- below the types differ and the mismatch surfaces at execution.
+DROP TABLE IF EXISTS t3;
+CREATE TABLE t3 (v UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t3 VALUES (10)(20);
+
+SELECT 'nullable argument, column read first: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))]) ORDER BY v;
+
+SELECT 'nullable argument, column read first: WHERE';
+SELECT v FROM t3 WHERE arrayExists(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))]) ORDER BY v;
+
+-- Both operand orders must agree: the argument's type cannot depend on which is visited first.
+SELECT 'nullable argument, argument read first: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists(v -> (v = 7) AND (t3.v != 0), [toNullable(toUInt64(7))]) ORDER BY v;
+
+-- tuple() has no short-circuit evaluation, so this pins the order dependence to analysis.
+SELECT 'nullable argument, tuple body: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists(v -> tuple(t3.v != 0, v = 7).2, [toNullable(toUInt64(7))]) ORDER BY v;
+
+SELECT 'nullable argument, arrayMap: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists(x -> x, arrayMap(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))])) ORDER BY v;
+
+SELECT 'nullable argument, arrayFilter: PREWHERE';
+SELECT v FROM t3 PREWHERE length(arrayFilter(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))])) > 0 ORDER BY v;
+
+SELECT 'nullable argument, nested lambda: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists(y -> arrayExists(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))]), [1]) ORDER BY v;
+
+-- An unread argument must not be captured: a retained INPUT would change the capture arity.
+SELECT 'unread first argument: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists((a, b) -> b = 7, [1], [toNullable(toUInt64(7))]) ORDER BY v;
+
+SELECT 'unread second argument: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists((a, b) -> a = 7, [toNullable(toUInt64(7))], [1]) ORDER BY v;
+
+-- The body must still read the table column, not the argument that shadows it.
+SELECT 'colliding name resolves per site';
+SELECT arrayMap(v -> assumeNotNull(v) * 100 + t3.v, [toNullable(toUInt64(3))]) FROM t3 ORDER BY v;
+
+DROP TABLE t3;
+
+-- Nullable column with a non-nullable argument: the mismatch direction follows the types,
+-- so the argument takes the wrong type rather than merely losing nullability.
+DROP TABLE IF EXISTS t4;
+CREATE TABLE t4 (v Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t4 VALUES (10)(20);
+
+SELECT 'nullable column, plain argument: PREWHERE';
+SELECT v FROM t4 PREWHERE arrayExists(v -> (t4.v != 0) AND (v = 7), [toUInt64(7)]) ORDER BY v;
+
+DROP TABLE t4;
+
+DROP TABLE IF EXISTS t5;
+CREATE TABLE t5 (s String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t5 VALUES ('a')('b');
+
+SELECT 'String column: PREWHERE';
+SELECT s FROM t5 PREWHERE arrayExists(s -> (t5.s != '') AND (s = 'q'), [toNullable('q')]) ORDER BY s;
+
+DROP TABLE t5;
+
+DROP TABLE IF EXISTS t6;
+CREATE TABLE t6 (s LowCardinality(String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t6 VALUES ('a')('b');
+
+SELECT 'LowCardinality(String) column: PREWHERE';
+SELECT s FROM t6 PREWHERE arrayExists(s -> (t6.s != '') AND (s = 'q'), [toNullable('q')]) ORDER BY s;
+
+DROP TABLE t6;

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
@@ -95,6 +95,10 @@ SELECT v FROM t3 PREWHERE arrayExists(v -> tuple(t3.v != 0, v = 7).2, [toNullabl
 SELECT 'nullable argument, nested lambda: PREWHERE';
 SELECT v FROM t3 PREWHERE arrayExists(y -> arrayExists(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))]), [1]) ORDER BY v;
 
+-- A nested lambda planned beside the collision must not change how the outer binding resolves.
+SELECT 'nullable argument, outer binder with a nested lambda: PREWHERE';
+SELECT v FROM t3 PREWHERE arrayExists(v -> (t3.v != 0) AND (v = 7) AND arrayExists(x -> plus(x, 2) > 0, [toUInt8(0)]), [toNullable(toUInt64(7))]) ORDER BY v;
+
 -- An unread argument must not be captured: a retained INPUT would change the capture arity.
 SELECT 'unread first argument: PREWHERE';
 SELECT v FROM t3 PREWHERE arrayExists((a, b) -> b = 7, [1], [toNullable(toUInt64(7))]) ORDER BY v;

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
@@ -142,3 +142,13 @@ SELECT 'LowCardinality(String) column: PREWHERE';
 SELECT s FROM t6 PREWHERE arrayExists(s -> (t6.s != '') AND (s = 'q'), [toNullable('q')]) ORDER BY s;
 
 DROP TABLE t6;
+
+-- An argument name spelled like a generated action name must not displace the body's own node.
+SELECT 'argument named after a generated action name';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1), [toUInt8(2)], [toUInt16(42)]);
+
+SELECT 'argument named after a generated action name, nested use';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> materialize(plus(x, 1)) + 10, [toUInt8(2)], [toUInt16(42)]);
+
+SELECT 'argument named after a generated action name, analyzer disabled';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1), [toUInt8(2)], [toUInt16(42)]) SETTINGS enable_analyzer = 0;

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
@@ -152,3 +152,11 @@ SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> materialize(plus(x, 1)) + 10, [toUInt
 
 SELECT 'argument named after a generated action name, analyzer disabled';
 SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1), [toUInt8(2)], [toUInt16(42)]) SETTINGS enable_analyzer = 0;
+
+-- A nested lambda binds its own argument, so an equal name in the outer lambda is a different
+-- binding and must not displace the outer body's own node.
+SELECT 'nested lambda argument named after a generated action name';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + arrayMap(`plus(x, 1_UInt8)` -> `plus(x, 1_UInt8)`, [toUInt8(0)])[1], [toUInt8(2)], [toUInt16(42)]);
+
+SELECT 'nested lambda argument named after a generated action name, analyzer disabled';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + arrayMap(`plus(x, 1_UInt8)` -> `plus(x, 1_UInt8)`, [toUInt8(0)])[1], [toUInt8(2)], [toUInt16(42)]) SETTINGS enable_analyzer = 0;

--- a/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
+++ b/tests/queries/0_stateless/04108_lambda_column_name_collision_bug.sql
@@ -92,21 +92,12 @@ SELECT v FROM t3 PREWHERE arrayExists(v -> (v = 7) AND (t3.v != 0), [toNullable(
 SELECT 'nullable argument, tuple body: PREWHERE';
 SELECT v FROM t3 PREWHERE arrayExists(v -> tuple(t3.v != 0, v = 7).2, [toNullable(toUInt64(7))]) ORDER BY v;
 
-SELECT 'nullable argument, arrayMap: PREWHERE';
-SELECT v FROM t3 PREWHERE arrayExists(x -> x, arrayMap(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))])) ORDER BY v;
-
-SELECT 'nullable argument, arrayFilter: PREWHERE';
-SELECT v FROM t3 PREWHERE length(arrayFilter(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))])) > 0 ORDER BY v;
-
 SELECT 'nullable argument, nested lambda: PREWHERE';
 SELECT v FROM t3 PREWHERE arrayExists(y -> arrayExists(v -> (t3.v != 0) AND (v = 7), [toNullable(toUInt64(7))]), [1]) ORDER BY v;
 
 -- An unread argument must not be captured: a retained INPUT would change the capture arity.
 SELECT 'unread first argument: PREWHERE';
 SELECT v FROM t3 PREWHERE arrayExists((a, b) -> b = 7, [1], [toNullable(toUInt64(7))]) ORDER BY v;
-
-SELECT 'unread second argument: PREWHERE';
-SELECT v FROM t3 PREWHERE arrayExists((a, b) -> a = 7, [toNullable(toUInt64(7))], [1]) ORDER BY v;
 
 -- The body must still read the table column, not the argument that shadows it.
 SELECT 'colliding name resolves per site';
@@ -124,15 +115,6 @@ SELECT 'nullable column, plain argument: PREWHERE';
 SELECT v FROM t4 PREWHERE arrayExists(v -> (t4.v != 0) AND (v = 7), [toUInt64(7)]) ORDER BY v;
 
 DROP TABLE t4;
-
-DROP TABLE IF EXISTS t5;
-CREATE TABLE t5 (s String) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t5 VALUES ('a')('b');
-
-SELECT 'String column: PREWHERE';
-SELECT s FROM t5 PREWHERE arrayExists(s -> (t5.s != '') AND (s = 'q'), [toNullable('q')]) ORDER BY s;
-
-DROP TABLE t5;
 
 DROP TABLE IF EXISTS t6;
 CREATE TABLE t6 (s LowCardinality(String)) ENGINE = MergeTree ORDER BY tuple();
@@ -160,3 +142,25 @@ SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + arrayMap(`plus(x, 1_UInt
 
 SELECT 'nested lambda argument named after a generated action name, analyzer disabled';
 SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + arrayMap(`plus(x, 1_UInt8)` -> `plus(x, 1_UInt8)`, [toUInt8(0)])[1], [toUInt8(2)], [toUInt16(42)]) SETTINGS enable_analyzer = 0;
+
+-- Reading such an argument leaves it and the body's own node claiming one name, so one of the two
+-- is lost. Which one is pre-existing analyzer behaviour; the legacy interpreter returns 45.
+SELECT 'generated action name argument, read in the body';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + `plus(x, 1_UInt8)`, [toUInt8(2)], [toUInt16(42)]);
+
+SELECT 'generated action name argument, read in the body, analyzer disabled';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + `plus(x, 1_UInt8)`, [toUInt8(2)], [toUInt16(42)]) SETTINGS enable_analyzer = 0;
+
+-- A table column is named by its qualified identifier here, so it never contends with an
+-- argument of the same unqualified name.
+DROP TABLE IF EXISTS t7;
+CREATE TABLE t7 (`plus(x, 1_UInt8)` UInt16) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t7 VALUES (42);
+
+SELECT 'column named after a generated action name';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + t7.`plus(x, 1_UInt8)` * 0, [toUInt8(2)], [toUInt8(9)]) FROM t7;
+
+SELECT 'column named after a generated action name, analyzer disabled';
+SELECT arrayMap((x, `plus(x, 1_UInt8)`) -> plus(x, 1) + t7.`plus(x, 1_UInt8)` * 0, [toUInt8(2)], [toUInt8(9)]) FROM t7 SETTINGS enable_analyzer = 0;
+
+DROP TABLE t7;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/103584
Related: https://github.com/ClickHouse/ClickHouse/pull/103627


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `LOGICAL_ERROR: Unexpected return type from FunctionExpression` when a higher-order function in `PREWHERE` has a lambda parameter named after a table column of a different type and the body reads that column before the parameter. The parameter took the column's type. A parameter whose name is also a generated expression name in the body is not covered.

### Description

A lambda parameter named after a table column takes the column's type when the body reads the column first:

```sql
CREATE TABLE t (v UInt64) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t SELECT 10 UNION ALL SELECT 20;
SELECT v FROM t PREWHERE arrayExists(v -> (t.v != 0) AND (v = 7), [toNullable(toUInt64(7))]) ORDER BY v;
-- Code: 49. Unexpected return type from FunctionExpression. Expected Nullable(UInt8). Got UInt8.
```

Renaming the parameter, or swapping the `AND` operands, returns `10, 20`. Reproduced on master 26.8.1.1454; debug builds abort. Found by the AST fuzzer, STID 2458-5396: [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114721&sha=39164d61335228645d86f6613ff2bb2bfff00280&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29).

Root cause: `ActionsScopeNode::addInputColumnIfNecessary` is a name-keyed get-or-create, called by `visitColumn` with the unqualified name (`use_column_identifier_as_action_node_name` is false in `PREWHERE`, mutations and `Merge`). The first visitor to reach the lambda scope decides its type. With the column first, the argument's INPUT takes the column's type, so the body yields `UInt8` while the declared return type stays `Nullable(UInt8)`. #103627 fixes the capture name, but runs later.

Fix: before visiting the body, declare the arguments the body reads as a column as INPUTs of the lambda scope, so the name-keyed lookup finds them. The old interpreter does this in `ScopeStack::pushLevel`, so `enable_analyzer = 0` is unaffected. One scope map is shared by all node kinds, so the declaration is narrow: a candidate is matched through the same `calculateActionNodeName` the visitor uses, and a name bound by another lambda, or computed by the body, is left alone. A parameter whose name is also a generated expression name in the body is not covered, and still fails as on master.

Validation: `arrayExists`, `arrayMap`, a `tuple()` body, nested lambdas, `LowCardinality(String)` and the inverted case failed before and pass now; `EXPLAIN actions = 1` is unchanged elsewhere.