### PR TITLE
Perf: Skip ASCII scan for byte-mode substringIndex

### DIFF
--- a/src/Functions/substringIndex.cpp
+++ b/src/Functions/substringIndex.cpp
@@ -124,8 +124,9 @@ namespace
             res_data.reserve(str_column->getChars().size() / 2);
             res_offsets.reserve(input_rows_count);
 
-            bool all_ascii = isAllASCII(str_column->getChars().data(), str_column->getChars().size())
-                && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size());
+            bool all_ascii = !is_utf8
+                || (isAllASCII(str_column->getChars().data(), str_column->getChars().size())
+                    && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
                 = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
 
@@ -157,8 +158,9 @@ namespace
             res_data.reserve(str_column->getChars().size() / 2);
             res_offsets.reserve(input_rows_count);
 
-            bool all_ascii = isAllASCII(str_column->getChars().data(), str_column->getChars().size())
-                && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size());
+            bool all_ascii = !is_utf8
+                || (isAllASCII(str_column->getChars().data(), str_column->getChars().size())
+                    && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
                 = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
 
@@ -189,8 +191,9 @@ namespace
             res_data.reserve(str.size() * rows / 2);
             res_offsets.reserve(rows);
 
-            bool all_ascii = isAllASCII(reinterpret_cast<const UInt8 *>(str.data()), str.size())
-                && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size());
+            bool all_ascii = !is_utf8
+                || (isAllASCII(reinterpret_cast<const UInt8 *>(str.data()), str.size())
+                    && isAllASCII(reinterpret_cast<const UInt8 *>(delim.data()), delim.size()));
             std::unique_ptr<PositionCaseSensitiveUTF8::SearcherInBigHaystack> searcher
                 = !is_utf8 || all_ascii ? nullptr : std::make_unique<PositionCaseSensitiveUTF8::SearcherInBigHaystack>(delim.data(), delim.size());
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/commit/d03ae0655abaef54117f6455063009aa7aed790b
Related: https://github.com/ClickHouse/ClickHouse/pull/115003

### Description

- **Problem:** byte-mode `substringIndex` still scans the input with `isAllASCII` before taking the byte search path.
- **Why the scan exists:** UTF-8 variants use it to take the byte path when the input and delimiter are ASCII; non-ASCII input needs UTF-8 character handling.
- **Why byte mode does not need it:** `is_utf8` is already `false`, so the ASCII result cannot change the selected implementation.
- **Change:** skip the input and delimiter scans when `is_utf8` is `false`.
- **Paths covered:** `vectorVector`, `vectorConstant`, and `constantVector`.
- **Behavior:** unchanged. The existing byte and UTF-8 search paths are still used.

### Benchmark

- **Machine:** macOS arm64
- **Compiler:** `clang++ -O3`
- **Implementation:** real ClickHouse `isAllASCII` implementation
- **Input:** 1,048,576 ASCII rows with 64-byte strings, `.` delimiter, and count `1`
- **Method:** median samples from three process runs
- **`vectorVector`, byte mode:** `47.63 to 47.70 ms` before, `45.18 to 45.26 ms` after, **about 5.1% faster**.
- **`vectorConstant`, byte mode:** `53.72 ms` before, `53.62 to 53.70 ms` after, **within 0.2%**. The constant-string scan is tiny.
- **UTF-8 scan control:** `5.76 to 5.82 ms` before, `5.79 to 5.80 ms` after, **within +/- 0.6%**.

### History

- **`d03ae0655ab`:** added the ASCII check so UTF-8 functions can use the byte path for ASCII input.
- **#115003:** applies the same byte-mode short-circuit to `leftPad` and `rightPad`.

### Tests

- **Test changes:** none. This only skips dead ASCII detection in byte mode; the result and search implementations are unchanged.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve byte-mode `substringIndex` performance by avoiding an unnecessary ASCII scan.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115006&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115006](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115006+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
