### PR TITLE
Do not alias pre-aggregation states of a zero-size aggregate in arrayReduceInRanges

### DIFF
--- a/src/Functions/array/arrayReduceInRanges.cpp
+++ b/src/Functions/array/arrayReduceInRanges.cpp
@@ -75,6 +75,10 @@ ColumnPtr FunctionArrayReduceInRanges::executeImpl(
     const IAggregateFunction & agg_func = *aggregate_function;
     std::unique_ptr<Arena> arena = std::make_unique<Arena>();
 
+    /// A zero-byte arena allocation does not advance the arena, so states of a zero-size aggregate
+    /// function would all share one address.
+    const size_t state_size = std::max<size_t>(agg_func.sizeOfData(), 1);
+
     /// Aggregate functions do not support constant columns. Therefore, we materialize them.
     VectorWithMemoryTracking<ColumnPtr> materialized_columns;
 
@@ -179,7 +183,7 @@ ColumnPtr FunctionArrayReduceInRanges::executeImpl(
         PODArray<AggregateDataPtr> places(place_total);
         for (size_t j = 0; j < place_total; ++j)
         {
-            places[j] = arena->alignedAlloc(agg_func.sizeOfData(), agg_func.alignOfData());
+            places[j] = arena->alignedAlloc(state_size, agg_func.alignOfData());
             try
             {
                 agg_func.create(places[j]);

--- a/tests/queries/0_stateless/04925_array_reduce_in_ranges_zero_size_state.reference
+++ b/tests/queries/0_stateless/04925_array_reduce_in_ranges_zero_size_state.reference
@@ -1,0 +1,15 @@
+[NULL]
+[NULL]
+[NULL]
+[0]
+[0]
+[NULL]
+Array(AggregateFunction(nothing, UInt16))
+00
+00
+[(NULL,NULL)]
+[NULL,NULL,NULL]
+[NULL]
+[200]
+[[0,1,2,3,4],[9,10,11,12,13]]
+[7]

--- a/tests/queries/0_stateless/04925_array_reduce_in_ranges_zero_size_state.sql
+++ b/tests/queries/0_stateless/04925_array_reduce_in_ranges_zero_size_state.sql
@@ -1,0 +1,39 @@
+-- Aggregates over only-NULL arguments have a zero-byte state. arrayReduceInRanges must behave the
+-- same for them as for any other aggregate.
+
+-- per-range merge: a range spanning a whole 64-row block
+SELECT arrayReduceInRanges('groupArray', [(1, 64)],  arrayMap(x -> (x + NULL), range(64)));
+SELECT arrayReduceInRanges('groupArray', [(1, 100)], arrayMap(x -> (x + NULL), range(100)));
+-- pairwise level merge
+SELECT arrayReduceInRanges('groupArray', [(1, 200)], arrayMap(x -> (x + NULL), range(257)));
+SELECT arrayReduceInRanges('uniq',       [(1, 200)], arrayMap(x -> (x + NULL), range(257)));
+SELECT arrayReduceInRanges('count',      [(1, 200)], arrayMap(x -> (x + NULL), range(257)));
+-- an only-NULL argument collapses to the bare placeholder before the State combinator applies
+SELECT arrayReduceInRanges('groupArrayState', [(1, 200)], arrayMap(x -> (x + NULL), range(257)));
+-- -State delegates sizeOfData, so over a zero-size nested function its state is zero-size too.
+-- The argument must be non-null, otherwise the Null combinator replaces the wrapper.
+SELECT toTypeName(arrayReduceInRanges('nothingState', [(1, 200)], range(257)));
+SELECT hex(arrayReduceInRanges('nothingState', [(1, 200)], range(257))[1]);
+SELECT hex(arrayReduceInRanges('nothingState', [(1, 64)],  range(64))[1]);
+-- -Tuple whose every element is zero-size
+SELECT arrayReduceInRanges('sumTuple', [(1, 200)], arrayMap(x -> (x + NULL, x + NULL), range(257)));
+-- several ranges
+SELECT arrayReduceInRanges('groupArray', [(1, 200), (50, 150), (100, 100)],
+                           arrayMap(x -> (x + NULL), range(257)));
+-- zero-size state reaching neither merge
+SELECT arrayReduceInRanges('groupArray', [(1, 60)], arrayMap(x -> (x + NULL), range(63)));
+
+-- A window function is zero-size too, and stays rejected as an aggregate at every range length.
+-- For these three the per-range finalize reports it, so they do not observe whether a merge ran.
+SELECT arrayReduceInRanges('rankIf', [(1, 64)],  arrayMap(x -> (x + NULL), range(64)));  -- { serverError BAD_ARGUMENTS }
+SELECT arrayReduceInRanges('rankIf', [(1, 200)], arrayMap(x -> (x + NULL), range(257))); -- { serverError BAD_ARGUMENTS }
+SELECT arrayReduceInRanges('rankIf', [(1, 10)],  arrayMap(x -> (x + NULL), range(10)));  -- { serverError BAD_ARGUMENTS }
+-- With no ranges the per-range loop never runs, so the merge over pre-aggregation places is the
+-- only remaining path to the aggregate's merge. The CAST is required: a bare [] is Array(Nothing).
+SELECT arrayReduceInRanges('rankIf', CAST([], 'Array(Tuple(Int64, UInt64))'),
+                           arrayMap(x -> (x + NULL), range(257)));                       -- { serverError BAD_ARGUMENTS }
+
+-- Non-zero-size states through the same paths are unchanged
+SELECT arrayReduceInRanges('sum',        [(1, 200)], arrayMap(x -> 1, range(257)));
+SELECT arrayReduceInRanges('groupArray', [(1, 5), (10, 5)], range(257));
+SELECT arrayReduceInRanges('uniq',       [(1, 200)], arrayMap(x -> x % 7, range(257)));


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108781
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108781

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`arrayReduceInRanges` over an array whose elements are all NULL aborts a debug or sanitizer build
with `Logical error: 'IAggregateFunction::merge called with the same source and destination state'`:

```sql
SELECT arrayReduceInRanges('groupArray', [(1, 64)], arrayMap(x -> (x + NULL), range(64)));
```

Found by the AST fuzzer:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114747&sha=95a67283e1b33c000dba21cddefcd4418c4a2c94&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29

An all-NULL argument collapses the aggregate to `AggregateFunctionNothing`, whose `sizeOfData()` is
0. `Arena::alignedAlloc` advances the arena by `size`, so every zero-byte allocation returns the same
address. The function allocates one pre-aggregation state per 64 rows plus one state per range from a
single arena, so all of those states alias and both the pairwise level merge and the per-range merge
become `merge(p, p)`.

The fix allocates `max(sizeOfData(), 1)` bytes for the pre-aggregation states, so they are distinct
and every merge still runs. The per-range state needs no padding: that merge only runs when the range
spans a whole 64-row block, which is also the condition for a pre-aggregation state to exist, and its
one-byte allocation has already advanced the arena. For an aggregate with a non-empty state the
allocation is byte-identical to before.

I deliberately did not suppress the merge for zero-size states. `sizeOfData() == 0` does not imply
that merging is a no-op: `StatelessWindowFunction` is also zero-size and its `mergeImpl` throws.
Since the aggregate is caller-supplied, a genuinely empty state cannot be told apart from one whose
merge enforces a contract, so skipping the call could drop that enforcement.

Two further places with the same allocation pattern are left alone. `ColumnAggregateFunction` can
hold zero-size states (the test builds one via `nothingState`) but its `insertMergeFrom` merges
across two different arenas. The `Aggregator` merge paths have one reported sighting of the sibling
assertion (`mergeAndDestroyBatch`, on #111459) that 15 probes did not reproduce.

Release behaviour is unchanged - the assertion compiles out and `Nothing::mergeImpl` is empty.