### PR TITLE
Perf: Reserve nested element count in generic arrayReverse

### DIFF
--- a/src/Functions/array/arrayReverse.cpp
+++ b/src/Functions/array/arrayReverse.cpp
@@ -106,7 +106,7 @@ ColumnPtr FunctionArrayReverse::executeImpl(const ColumnsWithTypeAndName & argum
 bool FunctionArrayReverse::executeGeneric(const IColumn & src_data, const ColumnArray::Offsets & src_array_offsets, IColumn & res_data)
 {
     size_t size = src_array_offsets.size();
-    res_data.reserve(size);
+    res_data.reserve(src_data.size());
 
     ColumnArray::Offset src_prev_offset = 0;
     for (size_t i = 0; i < size; ++i)

--- a/tests/performance/array_reverse_generic.xml
+++ b/tests/performance/array_reverse_generic.xml
@@ -20,6 +20,8 @@
         </substitution>
     </substitutions>
 
-    <query>SELECT arrayReverse(materialize(range(8)::Array({type}))) FROM numbers(3000000) FORMAT Null</query>
-    <query>SELECT arrayReverse(materialize(range(32)::Array({type}))) FROM numbers(1000000) FORMAT Null</query>
+    <query>SELECT arrayReverse(materialize(range(8)::Array({type}))) FROM numbers(10000000) FORMAT Null</query>
+    <query>SELECT arrayReverse(materialize(range(32)::Array({type}))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT arrayReverse(materialize(arrayMap(x -> (x, x), range(32)))) FROM numbers(2000000) FORMAT Null</query>
+    <query>SELECT arrayReverse(materialize(arrayMap(x -> [x, x], range(32)))) FROM numbers(2000000) FORMAT Null</query>
 </test>

--- a/tests/performance/array_reverse_generic.xml
+++ b/tests/performance/array_reverse_generic.xml
@@ -1,0 +1,25 @@
+<test>
+    <!--
+        arrayReverse falls back to a generic per-element insertFrom loop for element types that
+        executeNumber/executeString do not cover (Decimal*, Int128/256, Tuple, nested Array).
+        That loop used to reserve the row count rather than the nested element count, so an
+        array of several elements paid repeated capacity growth.
+    -->
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <substitutions>
+        <substitution>
+            <name>type</name>
+            <values>
+                <value>Decimal64(3)</value>
+                <value>Int128</value>
+                <value>Decimal256(3)</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <query>SELECT arrayReverse(materialize(range(8)::Array({type}))) FROM numbers(3000000) FORMAT Null</query>
+    <query>SELECT arrayReverse(materialize(range(32)::Array({type}))) FROM numbers(1000000) FORMAT Null</query>
+</test>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/commit/73e3a7b662161d6005e7727d8a711b930386b871

### Description

- **Problem:** the generic path reserves `res_data` using `src_array_offsets.size()`, which is the number of outer arrays.
- **Actual output:** the loop inserts one value for every nested source element.
- **Change:** reserve `src_data.size()`, the exact number of nested elements that will be inserted.
- **Scope:** generic fallback only. The typed numeric and string paths already size their output from the nested source data.
- **Behavior:** unchanged. `arrayReverse` still inserts the same values in the same order; only capacity planning changes.

### Benchmark

- **Added:** `tests/performance/array_reverse_generic.xml`
- **Coverage:** generic fallback for `Decimal64(3)`, `Int128`, `Decimal256(3)`, `Tuple`, and nested `Array` values.
- **Workload:** arrays with 8 and 32 elements, using 10,000,000 and 2,000,000 rows with one thread and `FORMAT Null`.
- **Method:** CI compares the before/after ClickHouse binaries with the performance-test harness.
- **Results:** pending the CI performance report for this head.

#### CI performance results

Added by a reviewer from the CI run [`pr-115011-ee919f5b499f`](https://performance.ci.clickhouse.com/runs/pr-115011-ee919f5b499f41295d5cd09d0c3c2ba2d74ea0ab) (`client_time`, `amd_release`, baseline `95f0e9ff9d1f`):

| query | old, s | new, s | change |
|---|---:|---:|---:|
| `range(8)::Array(Int128)`, 10M rows | 0.327 | 0.255 | −22.1% |
| `range(8)::Array(Decimal256(3))`, 10M rows | 0.564 | 0.406 | −28.1% |
| `range(32)::Array(Decimal64(3))`, 2M rows | 0.204 | 0.163 | −20.0% |
| `range(32)::Array(Int128)`, 2M rows | 0.400 | 0.264 | −34.1% |
| `range(32)::Array(Decimal256(3))`, 2M rows | 0.890 | 0.568 | −36.2% |

The gain grows with the number of nested elements per row, as expected from reserving them up front. The remaining three queries (`range(8)::Array(Decimal64(3))`, `Tuple`, nested `Array`) reported no `client_time` change beyond their noise thresholds. The slowdowns flagged elsewhere in that run are on unrelated tests with a history of flapping (`and_compare_chain_derived`, `join_convert_outer_to_inner`, `timeseries_to_grid_aggregation_functions`).

### History

- **`73e3a7b6621`:** introduced the generic `arrayReverse` implementation and the original reservation in 2018.
- **Current typed paths:** already use the nested source size for exact output sizing.
- **`arrayTranspose`:** uses the same `src_data.size()` reservation pattern.

### Tests

- **Existing coverage:** the original `00758_array_reverse` test covers the output behavior.
- **Added:** `tests/performance/array_reverse_generic.xml` covers the generic fallback with Decimal, wide integer, Tuple, and nested Array element types.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve generic `arrayReverse` performance by reserving space for all nested elements.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115011&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115011](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115011+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.756` (included in `26.9` and later)
<!-- ch-version-info:end -->