### PR TITLE
Raise p99 gate for netem fault scenarios in Keeper stress tests

### DIFF
--- a/tests/stress/keeper/scenarios/core_faults.yaml
+++ b/tests/stress/keeper/scenarios/core_faults.yaml
@@ -34,6 +34,9 @@ scenarios:
   - type: single_leader
   - type: error_rate_le
   - type: p99_le
+    # Since #104351 the ZooKeeper client keeps netem-stalled requests alive instead of
+    # fast-failing them, so they complete in the latency tail (observed p99 up to ~12.6s).
+    max_ms: 15000
   - type: log_sanity_ok
   - type: print_summary
   - type: mntr_print
@@ -239,6 +242,9 @@ scenarios:
   - type: single_leader
   - type: error_rate_le
   - type: p99_le
+    # Since #104351 the ZooKeeper client keeps netem-stalled requests alive instead of
+    # fast-failing them, so they complete in the latency tail (observed p99 up to ~11.6s).
+    max_ms: 15000
   - type: log_sanity_ok
   - type: print_summary
 - id: single-hot-get-fault


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

`NightlyKeeperFaults` has failed on every scheduled run since 2026-05-20, always on the same gate: `p99_le` on `prod-mix-fault` and `large-payload-fault` (both `default` and `rocks` backends), with p99 of 10.3–12.6s against the default 10s threshold.

The cause is https://github.com/ClickHouse/ClickHouse/pull/104351 (progress-based timeout in the ZooKeeper client, merged a few hours after the last passing nightly on 2026-05-18). Requests stalled by netem fault injection are no longer fast-failed by the operation timeout — they stay alive and complete in the latency tail. The `keeper_stress_tests` warehouse shows a clean step at exactly that nightly on `prod-mix-fault[default]`: read p99 8.3–8.9s → 11.0–12.6s, errors ~130–300 per run → exactly 0, on every one of the 37 nightlies since. Paired no-fault scenarios are flat across the boundary and all server-side hard-failure counters (`KeeperCommitsFailed`, snapshot failures, soft-memory rejections) are zero, so this is a measurement-semantics change (arguably an improvement — zero failed requests during faults), not a Keeper regression.

These are the only two scenarios still gating p99 with the 10s default (the `latency-*` fault scenarios gate on error rate only). This PR sets an explicit `max_ms: 15000` on both, giving ~20% headroom over the worst observed nightly (12.58s) while still tripping on a real ≥2x regression.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0eb658995715c01dd3bc1d6fdd13d61598b8096e&name_0=NightlyKeeperFaults&name_1=Keeper%20Stress%20%28Faults%29
Caused by: https://github.com/ClickHouse/ClickHouse/pull/104351

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1510` (included in `26.8` and later)
<!-- ch-version-info:end -->