### PR TITLE
Perf(Column): Bulk insert repeated values into nullable columns

### DIFF
--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -328,8 +328,11 @@ void ColumnNullable::insertRangeFromNotNullable(const IColumn & src, size_t star
 
 void ColumnNullable::insertManyFromNotNullable(const IColumn & src, size_t position, size_t length)
 {
-    for (size_t i = 0; i < length; ++i)
-        insertFromNotNullable(src, position);
+    if (length == 0)
+        return;
+
+    getNestedColumn().insertManyFrom(src, position, length);
+    getNullMapData().resize_fill(getNullMapData().size() + length);
 }
 
 void ColumnNullable::popBack(size_t n)

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -337,14 +337,14 @@ void ColumnNullable::insertManyFromNotNullable(const IColumn & src, size_t posit
         return;
     }
 
-    auto & null_map = getNullMapData();
-    const size_t new_size = null_map.size() + length;
+    auto & null_map_data = getNullMapData();
+    const size_t new_size = null_map_data.size() + length;
 
     /// Reserve before modifying the nested column so extending the null map cannot fail after a
     /// successful nested insertion.
-    null_map.reserve(new_size);
+    null_map_data.reserve(new_size);
     getNestedColumn().insertManyFrom(src, position, length);
-    null_map.resize_fill(new_size);
+    null_map_data.resize_fill(new_size);
 }
 
 void ColumnNullable::popBack(size_t n)

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -337,8 +337,14 @@ void ColumnNullable::insertManyFromNotNullable(const IColumn & src, size_t posit
         return;
     }
 
+    auto & null_map = getNullMapData();
+    const size_t new_size = null_map.size() + length;
+
+    /// Reserve before modifying the nested column so extending the null map cannot fail after a
+    /// successful nested insertion.
+    null_map.reserve(new_size);
     getNestedColumn().insertManyFrom(src, position, length);
-    getNullMapData().resize_fill(getNullMapData().size() + length);
+    null_map.resize_fill(new_size);
 }
 
 void ColumnNullable::popBack(size_t n)

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -331,6 +331,12 @@ void ColumnNullable::insertManyFromNotNullable(const IColumn & src, size_t posit
     if (length == 0)
         return;
 
+    if (length == 1)
+    {
+        insertFromNotNullable(src, position);
+        return;
+    }
+
     getNestedColumn().insertManyFrom(src, position, length);
     getNullMapData().resize_fill(getNullMapData().size() + length);
 }

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -338,13 +338,27 @@ void ColumnNullable::insertManyFromNotNullable(const IColumn & src, size_t posit
     }
 
     auto & null_map_data = getNullMapData();
-    const size_t new_size = null_map_data.size() + length;
+    const size_t old_size = null_map_data.size();
+    const size_t new_size = old_size + length;
 
     /// Reserve before modifying the nested column so extending the null map cannot fail after a
     /// successful nested insertion.
     null_map_data.reserve(new_size);
-    getNestedColumn().insertManyFrom(src, position, length);
-    null_map_data.resize_fill(new_size);
+
+    /// Some nested columns may partially insert rows before throwing. Keep both columns in sync
+    /// if that happens.
+    auto checkpoint = getNestedColumn().getCheckpoint();
+    try
+    {
+        getNestedColumn().insertManyFrom(src, position, length);
+        null_map_data.resize_fill(new_size);
+    }
+    catch (...)
+    {
+        null_map_data.resize_assume_reserved(old_size);
+        getNestedColumn().rollback(*checkpoint);
+        throw;
+    }
 }
 
 void ColumnNullable::popBack(size_t n)

--- a/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
+++ b/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
@@ -60,6 +60,17 @@ static ColumnPtr mockColumn(const DataTypePtr & type, size_t rows)
     return std::move(column);
 }
 
+static ColumnPtr mockNonEmptyStringColumn(size_t rows)
+{
+    auto column = DataTypeFactory::instance().get("String")->createColumn();
+    const String value = "helloworld123456";
+
+    for (size_t i = 0; i < rows; ++i)
+        column->insert(value);
+
+    return column;
+}
+
 
 static NO_INLINE void insertManyFrom(IColumn & dst, const IColumn & src)
 {
@@ -95,7 +106,10 @@ template <const std::string & str_type>
 static void BM_insertManyFromNotNullable(benchmark::State & state)
 {
     auto nullable_type = DataTypeFactory::instance().get(str_type);
-    auto src = mockColumn(removeNullable(nullable_type), ROWS);
+    auto type_not_nullable = removeNullable(nullable_type);
+    auto src = isString(type_not_nullable)
+        ? mockNonEmptyStringColumn(ROWS)
+        : mockColumn(type_not_nullable, ROWS);
     const size_t length = state.range(0);
 
     for ([[maybe_unused]] auto _ : state)

--- a/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
+++ b/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
@@ -1,6 +1,8 @@
 #include <cstddef>
 #include <random>
+#include <Columns/ColumnNullable.h>
 #include <Columns/IColumn.h>
+#include <Common/assert_cast.h>
 #include <Core/Block.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeFactory.h>
@@ -65,6 +67,11 @@ static NO_INLINE void insertManyFrom(IColumn & dst, const IColumn & src)
     dst.insertManyFrom(src, size / 2, size);
 }
 
+static NO_INLINE void insertManyFromNotNullable(ColumnNullable & dst, const IColumn & src, size_t position, size_t length)
+{
+    dst.insertManyFromNotNullable(src, position, length);
+}
+
 
 template <const std::string & str_type>
 static void BM_insertManyFrom(benchmark::State & state)
@@ -80,6 +87,26 @@ static void BM_insertManyFrom(benchmark::State & state)
         state.ResumeTiming();
 
         insertManyFrom(*dst, *src);
+        benchmark::DoNotOptimize(dst);
+    }
+}
+
+template <const std::string & str_type>
+static void BM_insertManyFromNotNullable(benchmark::State & state)
+{
+    auto nullable_type = DataTypeFactory::instance().get(str_type);
+    auto src = mockColumn(removeNullable(nullable_type), ROWS);
+    const size_t length = state.range(0);
+
+    for ([[maybe_unused]] auto _ : state)
+    {
+        state.PauseTiming();
+        auto dst = nullable_type->createColumn();
+        dst->reserve(length);
+        state.ResumeTiming();
+
+        auto & dst_nullable = assert_cast<ColumnNullable &>(*dst);
+        insertManyFromNotNullable(dst_nullable, *src, src->size() / 2, length);
         benchmark::DoNotOptimize(dst);
     }
 }
@@ -107,3 +134,10 @@ BENCHMARK_TEMPLATE(BM_insertManyFrom, type_array_int64);
 BENCHMARK_TEMPLATE(BM_insertManyFrom, type_array_nullable_int64);
 BENCHMARK_TEMPLATE(BM_insertManyFrom, type_array_string);
 BENCHMARK_TEMPLATE(BM_insertManyFrom, type_array_nullable_string);
+
+BENCHMARK_TEMPLATE(BM_insertManyFromNotNullable, type_nullable_int64)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);
+BENCHMARK_TEMPLATE(BM_insertManyFromNotNullable, type_nullable_string)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);
+BENCHMARK_TEMPLATE(BM_insertManyFromNotNullable, type_nullable_decimal)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);

--- a/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
+++ b/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
@@ -83,6 +83,12 @@ static NO_INLINE void insertManyFromNotNullable(ColumnNullable & dst, const ICol
     dst.insertManyFromNotNullable(src, position, length);
 }
 
+static NO_INLINE void insertManyFromNotNullableScalar(ColumnNullable & dst, const IColumn & src, size_t position, size_t length)
+{
+    for (size_t i = 0; i < length; ++i)
+        dst.insertFromNotNullable(src, position);
+}
+
 
 template <const std::string & str_type>
 static void BM_insertManyFrom(benchmark::State & state)
@@ -102,8 +108,8 @@ static void BM_insertManyFrom(benchmark::State & state)
     }
 }
 
-template <const std::string & str_type>
-static void BM_insertManyFromNotNullable(benchmark::State & state)
+template <const std::string & str_type, bool use_bulk_insert>
+static void BM_insertManyFromNotNullableImpl(benchmark::State & state)
 {
     auto nullable_type = DataTypeFactory::instance().get(str_type);
     auto type_not_nullable = removeNullable(nullable_type);
@@ -120,9 +126,24 @@ static void BM_insertManyFromNotNullable(benchmark::State & state)
         state.ResumeTiming();
 
         auto & dst_nullable = assert_cast<ColumnNullable &>(*dst);
-        insertManyFromNotNullable(dst_nullable, *src, src->size() / 2, length);
+        if constexpr (use_bulk_insert)
+            insertManyFromNotNullable(dst_nullable, *src, src->size() / 2, length);
+        else
+            insertManyFromNotNullableScalar(dst_nullable, *src, src->size() / 2, length);
         benchmark::DoNotOptimize(dst);
     }
+}
+
+template <const std::string & str_type>
+static void BM_insertManyFromNotNullable(benchmark::State & state)
+{
+    BM_insertManyFromNotNullableImpl<str_type, true>(state);
+}
+
+template <const std::string & str_type>
+static void BM_insertManyFromNotNullableScalar(benchmark::State & state)
+{
+    BM_insertManyFromNotNullableImpl<str_type, false>(state);
 }
 
 static const String type_int64 = "Int64";
@@ -154,4 +175,11 @@ BENCHMARK_TEMPLATE(BM_insertManyFromNotNullable, type_nullable_int64)
 BENCHMARK_TEMPLATE(BM_insertManyFromNotNullable, type_nullable_string)
     ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);
 BENCHMARK_TEMPLATE(BM_insertManyFromNotNullable, type_nullable_decimal)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);
+
+BENCHMARK_TEMPLATE(BM_insertManyFromNotNullableScalar, type_nullable_int64)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);
+BENCHMARK_TEMPLATE(BM_insertManyFromNotNullableScalar, type_nullable_string)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);
+BENCHMARK_TEMPLATE(BM_insertManyFromNotNullableScalar, type_nullable_decimal)
     ->Arg(1)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(64)->Arg(256)->Arg(ROWS);

--- a/src/Columns/tests/gtest_column_nullable.cpp
+++ b/src/Columns/tests/gtest_column_nullable.cpp
@@ -25,16 +25,19 @@ TEST(ColumnNullable, InsertManyFromNotNullableRepeatsValue)
     auto dst = ColumnNullable::create(std::move(nested), std::move(null_map));
 
     dst->insertManyFromNotNullable(*src, 1, 3);
+    dst->insertManyFromNotNullable(*src, 2, 1);
 
-    ASSERT_EQ(dst->size(), 4);
+    ASSERT_EQ(dst->size(), 5);
     EXPECT_EQ(dst->getNestedColumn().getUInt(0), 7);
     EXPECT_EQ(dst->getNestedColumn().getUInt(1), 20);
     EXPECT_EQ(dst->getNestedColumn().getUInt(2), 20);
     EXPECT_EQ(dst->getNestedColumn().getUInt(3), 20);
+    EXPECT_EQ(dst->getNestedColumn().getUInt(4), 30);
     EXPECT_EQ(dst->getNullMapData()[0], 1);
     EXPECT_EQ(dst->getNullMapData()[1], 0);
     EXPECT_EQ(dst->getNullMapData()[2], 0);
     EXPECT_EQ(dst->getNullMapData()[3], 0);
+    EXPECT_EQ(dst->getNullMapData()[4], 0);
     dst->checkConsistency();
 }
 

--- a/src/Columns/tests/gtest_column_nullable.cpp
+++ b/src/Columns/tests/gtest_column_nullable.cpp
@@ -68,12 +68,17 @@ TEST(ColumnNullable, InsertManyFromNotNullableSupportsStringColumns)
 TEST(ColumnNullable, InsertManyFromNotNullableWithZeroLengthIsNoOp)
 {
     auto src = ColumnUInt64::create();
+    src->insert(10);
     auto nested = ColumnUInt64::create();
+    nested->insert(7);
     auto null_map = ColumnUInt8::create();
+    null_map->insert(1);
     auto dst = ColumnNullable::create(std::move(nested), std::move(null_map));
 
     dst->insertManyFromNotNullable(*src, std::numeric_limits<size_t>::max(), 0);
 
-    EXPECT_EQ(dst->size(), 0);
+    ASSERT_EQ(dst->size(), 1);
+    EXPECT_EQ(dst->getNestedColumn().getUInt(0), 7);
+    EXPECT_EQ(dst->getNullMapData()[0], 1);
     dst->checkConsistency();
 }

--- a/src/Columns/tests/gtest_column_nullable.cpp
+++ b/src/Columns/tests/gtest_column_nullable.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+#include <Common/assert_cast.h>
+
+#include <limits>
+#include <string>
+#include <utility>
+
+using namespace DB;
+
+TEST(ColumnNullable, InsertManyFromNotNullableRepeatsValue)
+{
+    auto src = ColumnUInt64::create();
+    src->insert(10);
+    src->insert(20);
+    src->insert(30);
+
+    auto nested = ColumnUInt64::create();
+    nested->insert(7);
+    auto null_map = ColumnUInt8::create();
+    null_map->insert(1);
+    auto dst = ColumnNullable::create(std::move(nested), std::move(null_map));
+
+    dst->insertManyFromNotNullable(*src, 1, 3);
+
+    ASSERT_EQ(dst->size(), 4);
+    EXPECT_EQ(dst->getNestedColumn().getUInt(0), 7);
+    EXPECT_EQ(dst->getNestedColumn().getUInt(1), 20);
+    EXPECT_EQ(dst->getNestedColumn().getUInt(2), 20);
+    EXPECT_EQ(dst->getNestedColumn().getUInt(3), 20);
+    EXPECT_EQ(dst->getNullMapData()[0], 1);
+    EXPECT_EQ(dst->getNullMapData()[1], 0);
+    EXPECT_EQ(dst->getNullMapData()[2], 0);
+    EXPECT_EQ(dst->getNullMapData()[3], 0);
+    dst->checkConsistency();
+}
+
+TEST(ColumnNullable, InsertManyFromNotNullableSupportsStringColumns)
+{
+    auto src = ColumnString::create();
+    src->insertData("one", 3);
+    src->insertData("two", 3);
+
+    auto nested = ColumnString::create();
+    nested->insertData("prefix", 6);
+    auto null_map = ColumnUInt8::create();
+    null_map->insert(0);
+    auto dst = ColumnNullable::create(std::move(nested), std::move(null_map));
+
+    dst->insertManyFromNotNullable(*src, 1, 2);
+
+    const auto & result = assert_cast<const ColumnString &>(dst->getNestedColumn());
+    ASSERT_EQ(dst->size(), 3);
+    EXPECT_EQ(std::string(result.getDataAt(0)), "prefix");
+    EXPECT_EQ(std::string(result.getDataAt(1)), "two");
+    EXPECT_EQ(std::string(result.getDataAt(2)), "two");
+    EXPECT_EQ(dst->getNullMapData()[1], 0);
+    EXPECT_EQ(dst->getNullMapData()[2], 0);
+    dst->checkConsistency();
+}
+
+TEST(ColumnNullable, InsertManyFromNotNullableWithZeroLengthIsNoOp)
+{
+    auto src = ColumnUInt64::create();
+    auto nested = ColumnUInt64::create();
+    auto null_map = ColumnUInt8::create();
+    auto dst = ColumnNullable::create(std::move(nested), std::move(null_map));
+
+    dst->insertManyFromNotNullable(*src, std::numeric_limits<size_t>::max(), 0);
+
+    EXPECT_EQ(dst->size(), 0);
+    dst->checkConsistency();
+}

--- a/tests/performance/nullable_merge_join_bulk_insert.xml
+++ b/tests/performance/nullable_merge_join_bulk_insert.xml
@@ -1,0 +1,41 @@
+<test>
+    <!--
+        Keep the join output column nullable while the source column is not
+        nullable. One right row matches a large duplicate-key range on the
+        left, so MergeJoin copies the right value in bulk into the Nullable
+        column.
+    -->
+    <settings>
+        <max_threads>1</max_threads>
+        <max_block_size>65536</max_block_size>
+        <join_algorithm>partial_merge</join_algorithm>
+        <join_use_nulls>1</join_use_nulls>
+    </settings>
+
+    <create_query>
+        CREATE TABLE nullable_bulk_left
+        (
+            k UInt64
+        ) ENGINE = MergeTree ORDER BY k
+    </create_query>
+    <create_query>
+        CREATE TABLE nullable_bulk_right
+        (
+            k UInt64,
+            value String
+        ) ENGINE = MergeTree ORDER BY k
+    </create_query>
+
+    <fill_query>INSERT INTO nullable_bulk_left SELECT toUInt64(0) FROM numbers(1048576)</fill_query>
+    <fill_query>INSERT INTO nullable_bulk_right SELECT toUInt64(0), repeat('x', 64) FROM numbers(1)</fill_query>
+
+    <query>
+        SELECT sum(length(r.value))
+        FROM nullable_bulk_left AS l
+        ALL LEFT JOIN nullable_bulk_right AS r ON l.k = r.k
+        FORMAT Null
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS nullable_bulk_left</drop_query>
+    <drop_query>DROP TABLE IF EXISTS nullable_bulk_right</drop_query>
+</test>

--- a/tests/performance/nullable_merge_join_bulk_insert.xml
+++ b/tests/performance/nullable_merge_join_bulk_insert.xml
@@ -26,7 +26,7 @@
         ) ENGINE = MergeTree ORDER BY k
     </create_query>
 
-    <fill_query>INSERT INTO nullable_bulk_left SELECT toUInt64(0) FROM numbers(1048576)</fill_query>
+    <fill_query>INSERT INTO nullable_bulk_left SELECT toUInt64(0) FROM numbers(2097152)</fill_query>
     <fill_query>INSERT INTO nullable_bulk_right SELECT toUInt64(0), repeat('x', 64) FROM numbers(1)</fill_query>
 
     <query>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improves repeated value insertion into nullable columns by using the nested column's bulk insertion path.


### What does this PR do?

- Uses `insertManyFrom` when the same non-nullable source value is inserted more than once.
- Keeps the existing scalar `insertFromNotNullable` path for `length == 1`.
- Extends the null map with one zero-filled range instead of pushing `false` one row at a time.
- Keeps `length == 0` as a no-op, including when `position` is invalid.
- Adds coverage for numeric columns, string columns, repeated single-row insertion, and the zero-length case.
- Extends the existing `column_insert_many_from` benchmark with this exact non-nullable-to-nullable path.

### Why?

`ColumnNullable::insertManyFromNotNullable` currently does this for every output row:

- insert one value into the nested column
- append one `false` value to the null map

The caller in `MergeJoin::copyRightRange` can insert the same source row many times. The `IColumn::insertManyFrom` contract already represents this operation, and numeric and string columns have bulk implementations for it.

For the common `length == 1` case, the existing scalar operation is kept so unique-key joins do not pay bulk setup costs.

### Benchmark

The repository benchmark now measures non-nullable source columns inserted into nullable destinations for `Int64`, `String`, and `Decimal128(3)`, with fanouts of **1, 2, 4, 8, 16, 64, 256, and 65536**.

Focused local measurements with pre-reserved output columns, `clang++ -O3 -march=native`:

- Numeric nested columns, batches of 16-256 rows: **1.7x-2.4x faster**.
- 16-byte strings, batches of 16-256 rows: **1.6x-1.8x faster**.
- Null-map filling alone was up to **8x-20x faster** for 64-256 row batches.
- Very small strings and batches can be neutral or slower because the bulk-call setup is not free. The scalar path is retained for `length == 1`.

These are method-level numbers. The end-to-end improvement depends on join fanout and the output column types.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115014&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115014](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115014+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
