### PR TITLE
Fix host path leak in Keeper CLI path resolution

### DIFF
--- a/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.cpp
+++ b/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.cpp
@@ -72,6 +72,45 @@ String formatKeeperNodeName(const String & name)
     return result;
 }
 
+String normalizeKeeperPath(String path)
+{
+    std::vector<String> stack;
+    size_t i = 0;
+    while (i <= path.size())
+    {
+        size_t j = path.find('/', i);
+        if (j == String::npos)
+            j = path.size();
+
+        String part = path.substr(i, j - i);
+        i = j + 1;
+
+        if (part.empty() || part == ".")
+            continue;
+        if (part == "..")
+        {
+            if (!stack.empty())
+                stack.pop_back();
+            continue;
+        }
+        stack.push_back(std::move(part));
+    }
+
+    if (stack.empty())
+        return "/";
+
+    String result;
+    result.reserve(path.size());
+    result = "/";
+    for (size_t k = 0; k < stack.size(); ++k)
+    {
+        if (k > 0)
+            result += '/';
+        result += stack[k];
+    }
+    return result;
+}
+
 String KeeperClientBase::executeFourLetterCommand(const String & /* command */)
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "4lwc is not implemented");
@@ -92,11 +131,15 @@ void KeeperClientBase::askConfirmation(const String & prompt, std::function<void
 
 fs::path KeeperClientBase::getAbsolutePath(const String & relative) const
 {
-    String result;
+    String combined;
     if (relative.starts_with('/'))
-        result = fs::weakly_canonical(relative);
+        combined = relative;
+    else if (cwd == fs::path("/"))
+        combined = "/" + relative;
     else
-        result = fs::weakly_canonical(cwd / relative);
+        combined = cwd.string() + "/" + relative;
+
+    String result = normalizeKeeperPath(combined);
 
     if (result.ends_with('/') && result.size() > 1)
         result.pop_back();

--- a/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.h
+++ b/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.h
@@ -30,6 +30,9 @@ static const NameSet four_letter_word_commands
 /// Used by both `ls` output and tab completion.
 String formatKeeperNodeName(const String & name);
 
+/// Lexically normalize a Keeper (znode) absolute path without filesystem resolution.
+String normalizeKeeperPath(String path);
+
 class KeeperClientBase
 {
 public:

--- a/src/Common/ZooKeeper/tests/gtest_keeper_path_normalize.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_keeper_path_normalize.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include <Common/ZooKeeper/KeeperClientCLI/KeeperClient.h>
+
+#include <sstream>
+
+using namespace DB;
+
+TEST(KeeperPathNormalize, NormalizeKeeperPath)
+{
+    EXPECT_EQ(normalizeKeeperPath("/"), "/");
+    EXPECT_EQ(normalizeKeeperPath("/foo/../bar"), "/bar");
+    EXPECT_EQ(normalizeKeeperPath("/foo/./bar"), "/foo/bar");
+    EXPECT_EQ(normalizeKeeperPath("//foo///bar"), "/foo/bar");
+    EXPECT_EQ(normalizeKeeperPath("/.."), "/");
+    EXPECT_EQ(normalizeKeeperPath("/../foo"), "/foo");
+    EXPECT_EQ(normalizeKeeperPath("/proc/self/cwd/foo"), "/proc/self/cwd/foo");
+}
+
+TEST(KeeperPathNormalize, GetAbsolutePath)
+{
+    std::ostringstream cout;
+    std::ostringstream cerr;
+    KeeperClientBase client(cout, cerr);
+
+    client.cwd = "/a/b";
+    EXPECT_EQ(client.getAbsolutePath("foo").string(), "/a/b/foo");
+    EXPECT_EQ(client.getAbsolutePath("../c").string(), "/a/c");
+    EXPECT_EQ(client.getAbsolutePath("/x").string(), "/x");
+
+    client.cwd = "/";
+    EXPECT_EQ(client.getAbsolutePath("foo").string(), "/foo");
+
+    client.cwd = "/proc/self/cwd";
+    EXPECT_EQ(client.getAbsolutePath("foo").string(), "/proc/self/cwd/foo");
+}

--- a/src/Common/ZooKeeper/tests/gtest_keeper_path_normalize.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_keeper_path_normalize.cpp
@@ -6,17 +6,6 @@
 
 using namespace DB;
 
-TEST(KeeperPathNormalize, NormalizeKeeperPath)
-{
-    EXPECT_EQ(normalizeKeeperPath("/"), "/");
-    EXPECT_EQ(normalizeKeeperPath("/foo/../bar"), "/bar");
-    EXPECT_EQ(normalizeKeeperPath("/foo/./bar"), "/foo/bar");
-    EXPECT_EQ(normalizeKeeperPath("//foo///bar"), "/foo/bar");
-    EXPECT_EQ(normalizeKeeperPath("/.."), "/");
-    EXPECT_EQ(normalizeKeeperPath("/../foo"), "/foo");
-    EXPECT_EQ(normalizeKeeperPath("/proc/self/cwd/foo"), "/proc/self/cwd/foo");
-}
-
 TEST(KeeperPathNormalize, GetAbsolutePath)
 {
     std::ostringstream cout;
@@ -30,7 +19,15 @@ TEST(KeeperPathNormalize, GetAbsolutePath)
 
     client.cwd = "/";
     EXPECT_EQ(client.getAbsolutePath("foo").string(), "/foo");
+    EXPECT_EQ(client.getAbsolutePath("/foo/../bar").string(), "/bar");
+    EXPECT_EQ(client.getAbsolutePath("/foo/./bar").string(), "/foo/bar");
+    EXPECT_EQ(client.getAbsolutePath("//foo///bar").string(), "/foo/bar");
+    EXPECT_EQ(client.getAbsolutePath("/..").string(), "/");
+    EXPECT_EQ(client.getAbsolutePath("/../foo").string(), "/foo");
 
+    /// Keeper znode paths must not be resolved through the filesystem. A path segment
+    /// like /proc/self/cwd is a literal znode name, not a symlink to be canonicalized.
     client.cwd = "/proc/self/cwd";
     EXPECT_EQ(client.getAbsolutePath("foo").string(), "/proc/self/cwd/foo");
+    EXPECT_EQ(client.getAbsolutePath("/proc/self/cwd/foo").string(), "/proc/self/cwd/foo");
 }

--- a/src/Server/KeeperHTTPHandlerFactory.cpp
+++ b/src/Server/KeeperHTTPHandlerFactory.cpp
@@ -335,6 +335,19 @@ KeeperHTTPCommandsHandler::KeeperHTTPCommandsHandler(
 {
 }
 
+static bool validateAndAssignCwd(KeeperClientBase & client, const String & cwd_param, HTTPServerResponse & response)
+{
+    if (!cwd_param.empty() && !cwd_param.starts_with('/'))
+    {
+        response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "Invalid cwd");
+        *response.send() << "Invalid cwd: must be an absolute path starting with '/'.\n";
+        return false;
+    }
+
+    client.cwd = fs::path(normalizeKeeperPath(cwd_param.empty() ? "/" : cwd_param));
+    return true;
+}
+
 void KeeperHTTPCommandsHandler::handleRequest(
     HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & /*write_event*/)
 try
@@ -400,8 +413,10 @@ try
         std::ostringstream stream; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
         KeeperClientBase client(stream, stream);
         client.zookeeper = keeper_client->get();
-        client.cwd = cwd;
         client.ask_confirmation = false;  // Confirmations are not supported in UI
+
+        if (!validateAndAssignCwd(client, cwd, response))
+            return;
 
         client.processQueryText(command);
         response_json.set("result", stream.str());

--- a/tests/integration/test_keeper_http_control_cli/test.py
+++ b/tests/integration/test_keeper_http_control_cli/test.py
@@ -82,3 +82,32 @@ def test_http_commands_cli_response(started_cluster):
     ) as client:
         assert client.get("foo") == "bar"
         client.rm("foo")
+
+
+def test_http_commands_no_host_path_leak_via_proc_cwd(started_cluster):
+    leader: ClickHouseInstance = keeper_utils.get_leader(cluster, [node1, node2, node3])
+    response = requests.get(
+        "http://{host}:{port}/api/v1/commands".format(host=leader.ip_address, port=9182),
+        params={"command": "cd foo", "cwd": "/proc/self/cwd"},
+    )
+    assert response.status_code == 200
+    assert "/proc/self/cwd/foo" in response.json()["result"]
+    assert "does not exist" in response.json()["result"]
+
+
+def test_http_commands_rejects_invalid_cwd(started_cluster):
+    leader: ClickHouseInstance = keeper_utils.get_leader(cluster, [node1, node2, node3])
+
+    empty_cwd_response = requests.get(
+        "http://{host}:{port}/api/v1/commands".format(host=leader.ip_address, port=9182),
+        params={"command": "ls", "cwd": ""},
+    )
+    assert empty_cwd_response.status_code == 200
+
+    for invalid_cwd in ("..", "relative/path"):
+        response = requests.get(
+            "http://{host}:{port}/api/v1/commands".format(host=leader.ip_address, port=9182),
+            params={"command": "ls", "cwd": invalid_cwd},
+        )
+        assert response.status_code == 400
+        assert "Invalid cwd" in response.text


### PR DESCRIPTION
Keeper CLI paths are znode names in the coordination service, not host filesystem paths. `KeeperClientBase::getAbsolutePath` used `std::filesystem::weakly_canonical`, which resolves symlinks against the server filesystem. When a path segment is a symlink (for example `/proc/self/cwd`, or a custom symlink such as `/tmp/keeper_leak_symlink_demo -> /root/ClickHouse/build_release/programs`), CLI and HTTP error messages could expose the Keeper process working directory and other host paths that the client never sent.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix host filesystem path leakage in `clickhouse-keeper-client` and the Keeper HTTP CLI when resolving paths through symlinks such as `/proc/self/cwd`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115016&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115016](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115016+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
