### PR TITLE
Improve Dashboard Webpage

### DIFF
--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -510,7 +510,7 @@ const dashboardSearchQuery = (dashboard_name) => `SELECT title, query FROM syste
 let dashboard_queries = {
     "Overview": dashboardSearchQuery("Overview"),
 };
-const default_dashboard = 'Cloud overview';
+const default_dashboard = 'Overview';
 
 /// Query to fill `queries` list for the dashboard
 let search_query = dashboardSearchQuery(default_dashboard);

--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -928,7 +928,7 @@ function insertChart(i) {
     chart.addEventListener('mouseenter', e => { edit_buttons.style.display = 'block'; });
     chart.addEventListener('mouseleave', e => { edit_buttons.style.display = 'none'; });
 
-    charts.appendChild(chart);
+    charts.insertBefore(chart, charts.children[i] || null);
     return {chart: chart, textarea: query_editor_textarea};
 }
 
@@ -1196,14 +1196,28 @@ function metricsEditorApplyChanges() {
     }
     queries.unshift(...new_charts);
     hideMetricsEditor();
-    regenerate();
+
+    /// Insert and draw only the new charts; the existing ones are not reloaded.
+    new_charts.forEach(q => findParamsInQuery(q.query, params));
+    buildParams();
+    plots.unshift(...new_charts.map(() => null));
+    for (let i = 0; i < new_charts.length; i++) {
+        insertChart(i);
+    }
+    resize();
     refreshCustomized(true);
     saveState();
-    drawAll();
-    const chart_divs = charts.querySelectorAll('.chart');
-    if (chart_divs[0]) {
-        chart_divs[0].scrollIntoView();
+
+    const url_params = getParamsForURL();
+    const chartsArray = charts.getElementsByClassName('chart');
+    for (let i = 0; i < new_charts.length; i++) {
+        draw(i, chartsArray[i], url_params, queries[i].query).catch((e) => {
+            if (e.name != 'AbortError') {
+                showError(e.message);
+            }
+        });
     }
+    chartsArray[0].scrollIntoView();
 }
 
 document.getElementById('add-metrics').addEventListener('click', e => {

--- a/programs/server/dashboard.html
+++ b/programs/server/dashboard.html
@@ -135,46 +135,12 @@
             background: var(--background-color-1);
         }
 
-        .inputs.unconnected {
-            height: 100vh;
-        }
-        .unconnected #params {
-            display: flex;
-            flex-flow: column nowrap;
-            justify-content: center;
-            align-items: center;
-        }
-        .unconnected #connection-params {
-            width: 50%;
-
-            display: flex;
-            flex-flow: column nowrap;
-        }
-        .unconnected #url {
-            width: 100%;
-        }
-        .unconnected #button-options {
-            display: grid;
-            grid-auto-flow: column;
-            grid-auto-columns: 1fr;
-            gap: 0.3rem;
-        }
-        .unconnected #user {
-            margin-right: 0;
-            width: auto;
-        }
-        .unconnected #password {
-            width: auto;
-        }
         #user {
             margin-right: 0.25rem;
             width: 50%;
         }
         #password {
             width: 49.5%;
-        }
-        .unconnected input {
-            margin-bottom: 5px;
         }
 
         #username-password {
@@ -183,21 +149,9 @@
             display: flex;
             flex-flow: row nowrap;
         }
-        .unconnected #username-password {
-            width: 100%;
-
-            gap: 0.3rem;
-
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-        }
 
         .inputs #chart-params {
             display: block;
-        }
-
-        .inputs.unconnected #chart-params {
-            display: none;
         }
 
         #connection-params {
@@ -249,19 +203,6 @@
             display: inline-block;
             transform: translate(1px, 1px);
             filter: brightness(125%);
-        }
-
-        #run {
-            background: var(--button-background-color);
-            color: var(--button-text-color);
-            font-weight: bold;
-            user-select: none;
-            cursor: pointer;
-            margin-bottom: 1rem;
-        }
-
-        #run:hover {
-            filter: contrast(125%);
         }
 
         #add, #add-metrics, #reload, #edit, #search {
@@ -344,10 +285,6 @@
         }
         .chart-buttons a:hover {
             color: var(--chart-button-hover-color);
-        }
-
-        .disabled {
-            opacity: 0.5;
         }
 
         .query-editor {
@@ -490,7 +427,7 @@
     </style>
 </head>
 <body>
-<div class="inputs unconnected">
+<div class="inputs">
     <form id="params">
         <div id="connection-params">
             <input spellcheck="false" id="url" type="text" value="" placeholder="URL" />
@@ -502,11 +439,11 @@
         </div>
         <div id="button-options">
             <span class="nowrap themes"><span id="toggle-dark">🌚</span><span id="toggle-light">🌞</span></span>
-            <input id="edit" type="button" value="✎" style="display: none;">
-            <input id="add-metrics" type="button" value="Add charts from metrics" style="display: none;">
-            <input id="add" type="button" value="Add chart" style="display: none;">
+            <input id="edit" type="button" value="✎">
+            <input id="add-metrics" type="button" value="Add charts from metrics">
+            <input id="add" type="button" value="Add chart">
             <input id="reload" type="button" value="Reload">
-            <span id="search-span" class="nowrap" style="display: none;"><input id="search" type="button" value="🔎" title="Run query to obtain list of charts from ClickHouse. Either select dashboard name or write your own query"><input id="search-query" name="search" list="search-options" type="text" spellcheck="false"><datalist id="search-options"></datalist></span>
+            <span id="search-span" class="nowrap"><input id="search" type="button" value="🔎" title="Run query to obtain list of charts from ClickHouse. Either select dashboard name or write your own query"><input id="search-query" name="search" list="search-options" type="text" spellcheck="false"><datalist id="search-options"></datalist></span>
             <div id="chart-params"></div>
         </div>
     </form>
@@ -573,7 +510,7 @@ const dashboardSearchQuery = (dashboard_name) => `SELECT title, query FROM syste
 let dashboard_queries = {
     "Overview": dashboardSearchQuery("Overview"),
 };
-const default_dashboard = 'Overview';
+const default_dashboard = 'Cloud overview';
 
 /// Query to fill `queries` list for the dashboard
 let search_query = dashboardSearchQuery(default_dashboard);
@@ -754,13 +691,6 @@ function buildParams() {
     for (let [name, value] of Object.entries(params)) {
         insertParam(name, value);
     }
-
-    let run = document.createElement('input');
-    run.id = 'run';
-    run.type = 'submit';
-    run.value = 'Ok';
-
-    document.getElementById('chart-params').appendChild(run);
 }
 
 function updateParams() {
@@ -829,7 +759,11 @@ function insertChart(i) {
         refreshCustomized(true);
         saveState();
         const idx = getCurrentIndex();
-        draw(idx, chart, getParamsForURL(), q.query);
+        draw(idx, chart, getParamsForURL(), q.query).catch((e) => {
+            if (e.name != 'AbortError') {
+                showError(e.message);
+            }
+        });
     }
 
     query_editor_confirm.addEventListener('click', editConfirm);
@@ -1394,6 +1328,14 @@ function legendAsTooltipPlugin({ className, style = { background: "var(--legend-
 }
 
 
+/// Aborted and recreated on every reload, so stale in-flight queries never paint over a newer run.
+let query_controller = new AbortController();
+
+function cancelQueries() {
+    query_controller.abort();
+    query_controller = new AbortController();
+}
+
 async function doFetch(query, url_params = '') {
     host = document.getElementById('url').value || host;
     user = document.getElementById('user').value;
@@ -1415,7 +1357,7 @@ async function doFetch(query, url_params = '') {
 
     let response, reply, error;
     try {
-        response = await fetch(url + url_params, { method: "POST", body: query, headers: { 'Authorization': 'never' } });
+        response = await fetch(url + url_params, { method: "POST", body: query, headers: { 'Authorization': 'never' }, signal: query_controller.signal });
         reply = await response.text();
         if (response.ok) {
             reply = JSON.parse(reply);
@@ -1426,6 +1368,9 @@ async function doFetch(query, url_params = '') {
             error = reply;
         }
     } catch (e) {
+        if (e.name == 'AbortError') {
+            throw e;
+        }
         console.log(e);
         error = e.toString();
     }
@@ -1460,7 +1405,11 @@ async function draw(idx, chart, url_params, query) {
         plots[idx] = null;
     }
 
+    const signal = query_controller.signal;
     let {reply, error} = await doFetch(query, url_params);
+    if (signal.aborted) {
+        return false;
+    }
     if (!error) {
         if (reply.rows == 0) {
             error = "Query returned empty result.";
@@ -1641,70 +1590,37 @@ async function draw(idx, chart, url_params, query) {
     return true;
 }
 
+/// The error is shown as a banner above the charts; the charts always stay visible.
 function showError(message) {
-    const charts = document.getElementById('charts');
-    charts.style.height = '0px';
-    charts.style.opacity = '0';
-    document.getElementById('add').style.display = 'none';
-    document.getElementById('add-metrics').style.display = 'none';
-    document.getElementById('edit').style.display = 'none';
-
     const error = document.getElementById('global-error');
     error.textContent = message;
     error.style.display = 'flex';
 }
 
 function hideError() {
-    const charts = document.getElementById('charts');
-    charts.style.height = 'auto';
-    charts.style.opacity = '1';
-
     const error = document.getElementById('global-error');
     error.textContent = '';
     error.style.display = 'none';
 }
 
-let firstLoad = true;
-let is_drawing = false; // Prevent race condition leading to duplicate/dangling charts.
 async function drawAll() {
-    if (is_drawing) return;
-    is_drawing = true;
+    /// Supersede any in-flight run: its queries are aborted, so it cannot paint stale charts.
+    cancelQueries();
+    const signal = query_controller.signal;
 
-    try {
-        hideError();
+    hideError();
 
-        let params = getParamsForURL();
-        const chartsArray = document.getElementsByClassName('chart');
+    let params = getParamsForURL();
+    const chartsArray = document.getElementsByClassName('chart');
 
-        let had_global_error = false;
-        const results = await Promise.all([...Array(queries.length)].map(async (_, i) => {
-            return draw(i, chartsArray[i], params, queries[i].query).catch((e) => {
+    await Promise.all([...Array(queries.length)].map(async (_, i) => {
+        return draw(i, chartsArray[i], params, queries[i].query).catch((e) => {
+            if (e.name != 'AbortError' && !signal.aborted) {
                 showError(e.message);
-                had_global_error = true;
-                return false;
-            });
-        }));
-
-        if (firstLoad) {
-            firstLoad = false;
-        } else {
-            enableButtons();
-        }
-
-        if (!had_global_error && results.length > 0) {
-            /// At least one chart was processed without a global error
-            /// (auth/connection).  Show the connected UI.  Individual charts
-            /// may still have per-chart query errors displayed in their divs.
-            const element = document.querySelector('.inputs');
-            element.classList.remove('unconnected');
-            document.getElementById('add').style.display = 'inline-block';
-            document.getElementById('add-metrics').style.display = 'inline-block';
-            document.getElementById('edit').style.display = 'inline-block';
-            document.getElementById('search-span').style.display = '';
-        }
-    } finally {
-        is_drawing = false;
-    }
+            }
+            return false;
+        });
+    }));
 }
 
 function resize() {
@@ -1718,46 +1634,17 @@ function resize() {
 
 new ResizeObserver(resize).observe(document.body);
 
-function disableButtons() {
-    const reloadButton = document.getElementById('reload');
-    reloadButton.value = 'Reloading…';
-    reloadButton.disabled = true;
-    reloadButton.classList.add('disabled');
-
-    const runButton = document.getElementById('run');
-    if (runButton) {
-        runButton.value = 'Reloading…';
-        runButton.disabled = true;
-        runButton.classList.add('disabled');
-    }
-
-    const searchButton = document.getElementById('search');
-    searchButton.value = '…';
-    searchButton.disabled = true;
-    searchButton.classList.add('disabled');
+/// The buttons stay clickable while loading: pressing Reload again cancels the in-flight queries and restarts.
+function setButtonsLoading(loading) {
+    document.getElementById('reload').value = loading ? 'Reloading…' : 'Reload';
+    document.getElementById('search').value = loading ? '…' : '🔎';
 }
 
-function enableButtons() {
-    const reloadButton = document.getElementById('reload');
-    reloadButton.value = 'Reload';
-    reloadButton.disabled = false;
-    reloadButton.classList.remove('disabled');
-
-    const runButton = document.getElementById('run');
-    if (runButton) {
-        runButton.value = 'Ok';
-        runButton.disabled = false;
-        runButton.classList.remove('disabled');
-    }
-
-    const searchButton = document.getElementById('search');
-    searchButton.value = '🔎';
-    searchButton.disabled = false;
-    searchButton.classList.remove('disabled');
-}
-
+let reload_epoch = 0;
 async function reloadAll(do_search) {
-    disableButtons();
+    const epoch = ++reload_epoch;
+    cancelQueries();
+    setButtonsLoading(true);
     try {
         updateParams();
         if (do_search) {
@@ -1771,9 +1658,13 @@ async function reloadAll(do_search) {
         }
         await drawAll();
     } catch (e) {
-        showError(e.message);
+        if (e.name != 'AbortError') {
+            showError(e.message);
+        }
     }
-    enableButtons();
+    if (epoch == reload_epoch) {
+        setButtonsLoading(false);
+    }
 }
 
 document.getElementById('params').onsubmit = function(event) {
@@ -1920,7 +1811,9 @@ async function start() {
         }
         await populateSearchOptions();
     } catch (e) {
-        showError(e.message);
+        if (e.name != 'AbortError') {
+            showError(e.message);
+        }
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch:
1. Removes the global error screen (blue screen) and replaces it with a note above the dashboards. In this approach, on any error, already fetched graphs will not be hidden. 
2. Dashboard now opens the graphs view immediately. 
3. Reload button and any other button can be pressed during runtime refresh - this will cancel all in-flight queries and start a new refresh with the new configuration immediately.
4. Newly added graphs do not trigger a full page refresh; only new graphs will be fetched.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1553` (included in `26.8` and later)
- Backported to: `26.7.5.12`, `26.6.3.59`, `26.5.8.10`, `26.3.21.8`
<!-- ch-version-info:end -->