### PR TITLE
Arrow Flight SQL: add bearer_token_timeout_seconds setting

### DIFF
--- a/docs/concepts/features/interfaces/arrowflight.mdx
+++ b/docs/concepts/features/interfaces/arrowflight.mdx
@@ -66,7 +66,7 @@ Clients authenticate with a username and password via the standard HTTP `Authori
 
 ### Bearer Token Authentication {#bearer-auth}
 
-Subsequent requests can use the Bearer token returned from Basic authentication via the `Authorization: Bearer <token>` header. The token is automatically refreshed on each use. Its sliding expiration is controlled by `arrowflight.bearer_token_timeout_seconds` (default: 60 seconds).
+Subsequent requests can use the Bearer token returned from Basic authentication via the `Authorization: Bearer <token>` header. The token is automatically refreshed on each use. Its sliding expiration follows `default_session_timeout`, or `arrowflight.bearer_token_timeout_seconds` when that setting is explicitly configured.
 
 ### Python Example {#auth-python-example}
 
@@ -128,7 +128,7 @@ Sessions allow setting persistent ClickHouse settings via the `SetSessionOptions
 | `arrowflight.cancel_flight_descriptor_after_poll_flight_info` | `false` | If `true`, poll descriptors are cancelled after being consumed by `PollFlightInfo`. |
 | `arrowflight.max_prepared_statements_per_user` | `100` | Maximum number of open prepared statements per user. Set to `0` to disable the limit. |
 | `arrowflight.prepared_statements_lifetime_seconds` | `-1` | Prepared statement lifetime mode. `> 0`: use this value as lifetime and refresh expiration on each request for both session-bound and session-less statements. `0`: disable automatic expiration. `-1`: for session-bound statements, use session timeout as lifetime and refresh it on each request; session-less statements do not expire automatically. |
-| `arrowflight.bearer_token_timeout_seconds` | `60` | Bearer token sliding expiration in seconds. |
+| `arrowflight.bearer_token_timeout_seconds` | _(uses `default_session_timeout`)_ | Bearer token sliding expiration in seconds. When omitted, Bearer tokens follow `default_session_timeout`. |
 | `enable_arrow_close_session` | `true` | Allow clients to close sessions via the `x-clickhouse-session-close` header. |
 | `default_session_timeout` | `60` | Default session timeout in seconds. |
 | `max_session_timeout` | `3600` | Maximum allowed session timeout in seconds. |

--- a/docs/concepts/features/interfaces/arrowflight.mdx
+++ b/docs/concepts/features/interfaces/arrowflight.mdx
@@ -66,7 +66,7 @@ Clients authenticate with a username and password via the standard HTTP `Authori
 
 ### Bearer Token Authentication {#bearer-auth}
 
-Subsequent requests can use the Bearer token returned from Basic authentication via the `Authorization: Bearer <token>` header. The token is automatically refreshed on each use and expires based on the `default_session_timeout` server setting (default: 60 seconds).
+Subsequent requests can use the Bearer token returned from Basic authentication via the `Authorization: Bearer <token>` header. The token is automatically refreshed on each use. Its sliding expiration is controlled by `arrowflight.bearer_token_timeout_seconds` (default: 60 seconds).
 
 ### Python Example {#auth-python-example}
 
@@ -128,8 +128,9 @@ Sessions allow setting persistent ClickHouse settings via the `SetSessionOptions
 | `arrowflight.cancel_flight_descriptor_after_poll_flight_info` | `false` | If `true`, poll descriptors are cancelled after being consumed by `PollFlightInfo`. |
 | `arrowflight.max_prepared_statements_per_user` | `100` | Maximum number of open prepared statements per user. Set to `0` to disable the limit. |
 | `arrowflight.prepared_statements_lifetime_seconds` | `-1` | Prepared statement lifetime mode. `> 0`: use this value as lifetime and refresh expiration on each request for both session-bound and session-less statements. `0`: disable automatic expiration. `-1`: for session-bound statements, use session timeout as lifetime and refresh it on each request; session-less statements do not expire automatically. |
+| `arrowflight.bearer_token_timeout_seconds` | `60` | Bearer token sliding expiration in seconds. |
 | `enable_arrow_close_session` | `true` | Allow clients to close sessions via the `x-clickhouse-session-close` header. |
-| `default_session_timeout` | `60` | Default session timeout in seconds. Also controls Bearer token expiration. |
+| `default_session_timeout` | `60` | Default session timeout in seconds. |
 | `max_session_timeout` | `3600` | Maximum allowed session timeout in seconds. |
 
 ## Supported RPC Methods {#rpc-methods}

--- a/src/Server/ArrowFlight/AuthMiddleware.cpp
+++ b/src/Server/ArrowFlight/AuthMiddleware.cpp
@@ -142,14 +142,15 @@ namespace
 }
 
 
-String AuthMiddlewareFactory::TokenStorage::getToken(std::string username, std::string password)
+String AuthMiddlewareFactory::TokenStorage::getToken(
+    std::string username, std::string password, std::chrono::seconds token_timeout)
 {
     std::lock_guard<std::mutex> lock(token_mutex);
 
     cleanupExpiredTokens();
 
     auto token = toString(UUIDHelpers::generateV4());
-    auto expiration_time = std::chrono::steady_clock::now() + std::chrono::seconds(config.getInt("default_session_timeout", 60));
+    auto expiration_time = std::chrono::steady_clock::now() + token_timeout;
     auto exp_iter = token_expiration_list.insert({expiration_time, token});
     token_expiration_list_index[token] = exp_iter;
     token_to_credentials[token] = {username, password};
@@ -157,7 +158,8 @@ String AuthMiddlewareFactory::TokenStorage::getToken(std::string username, std::
     return token;
 }
 
-std::optional<std::pair<std::string, std::string>> AuthMiddlewareFactory::TokenStorage::getCredentials(std::string token)
+std::optional<std::pair<std::string, std::string>> AuthMiddlewareFactory::TokenStorage::getCredentials(
+    std::string token, std::chrono::seconds token_timeout)
 {
     std::lock_guard<std::mutex> lock(token_mutex);
 
@@ -166,7 +168,7 @@ std::optional<std::pair<std::string, std::string>> AuthMiddlewareFactory::TokenS
     auto it = token_to_credentials.find(token);
     if (it != token_to_credentials.end())
     {
-        auto expiration_time = std::chrono::steady_clock::now() + std::chrono::seconds(config.getInt("default_session_timeout", 60));
+        auto expiration_time = std::chrono::steady_clock::now() + token_timeout;
         auto new_iter = token_expiration_list.insert({expiration_time, token});
         token_expiration_list.erase(token_expiration_list_index[token]);
         token_expiration_list_index[token] = new_iter;
@@ -192,6 +194,37 @@ arrow::Status AuthMiddlewareFactory::StartCall(
         std::shared_ptr<arrow::flight::ServerMiddleware> * middleware)
 {
     const auto & headers = context.incoming_headers();
+    const auto & config = server.context()->getConfigRef();
+
+    std::string session_id;
+    auto session_it = headers.find("x-clickhouse-session-id");
+    if (session_it != headers.end())
+        session_id = std::string(session_it->second);
+
+    std::string session_check;
+    session_it = headers.find("x-clickhouse-session-check");
+    if (session_it != headers.end())
+        session_check = std::string(session_it->second);
+
+    std::string session_timeout_str;
+    session_it = headers.find("x-clickhouse-session-timeout");
+    if (session_it != headers.end())
+        session_timeout_str = std::string(session_it->second);
+
+    unsigned session_timeout = 0;
+    if (!session_timeout_str.empty())
+    {
+        ReadBufferFromString buf(session_timeout_str);
+        if (!tryReadIntText(session_timeout, buf) || !buf.eof())
+            return arrow::Status::Invalid("Invalid session timeout: " + session_timeout_str);
+    }
+
+    std::string session_close;
+    session_it = headers.find("x-clickhouse-session-close");
+    if (session_it != headers.end())
+        session_close = std::string(session_it->second);
+
+    const auto bearer_token_timeout = std::chrono::seconds(config.getUInt("arrowflight.bearer_token_timeout_seconds", 60));
 
     std::string username("default");
     std::string password;
@@ -210,7 +243,7 @@ arrow::Status AuthMiddlewareFactory::StartCall(
         else if (auto token_opt = getTokenFromBearerHeader(headers); token_opt && *token_opt != "None")
         {
             token = *token_opt;
-            credentials = token_storage.getCredentials(token);
+            credentials = token_storage.getCredentials(token, bearer_token_timeout);
             if (!credentials)
                 return arrow::flight::MakeFlightError(arrow::flight::FlightStatusCode::Unauthenticated, "Session expired or not authenticated.");
 
@@ -225,45 +258,17 @@ arrow::Status AuthMiddlewareFactory::StartCall(
 
     try
     {
-        std::string session_id;
-        auto session_it = headers.find("x-clickhouse-session-id");
-        if (session_it != headers.end())
-            session_id = std::string(session_it->second);
-
-        std::string session_check;
-        session_it = headers.find("x-clickhouse-session-check");
-        if (session_it != headers.end())
-            session_check = std::string(session_it->second);
-
-        std::string session_timeout_str;
-        session_it = headers.find("x-clickhouse-session-timeout");
-        if (session_it != headers.end())
-            session_timeout_str = std::string(session_it->second);
-
-        unsigned session_timeout = 0;
-        if (!session_timeout_str.empty())
-        {
-            ReadBufferFromString buf(session_timeout_str);
-            if (!tryReadIntText(session_timeout, buf) || !buf.eof())
-                return arrow::Status::Invalid("Invalid session timeout: " + session_timeout_str);
-        }
-
-        std::string session_close;
-        session_it = headers.find("x-clickhouse-session-close");
-        if (session_it != headers.end())
-            session_close = std::string(session_it->second);
-
         if (session_id.empty())
             session->makeSessionContext();
         else
-            session->makeSessionContext(session_id, parseSessionTimeout(server.context()->getConfigRef(), session_timeout), session_check == "1");
+            session->makeSessionContext(session_id, parseSessionTimeout(config, session_timeout), session_check == "1");
 
         if (auth)
-            token = token_storage.getToken(username, password);
+            token = token_storage.getToken(username, password, bearer_token_timeout);
 
         auto parsed_session_timeout = session_id.empty()
             ? std::chrono::steady_clock::duration{0}
-            : parseSessionTimeout(server.context()->getConfigRef(), session_timeout);
+            : parseSessionTimeout(config, session_timeout);
 
         *middleware = std::make_unique<AuthMiddleware>(session, token, username, calls_data, session_id, session_close == "1" && server.config().getBool("enable_arrow_close_session", true), parsed_session_timeout);
     }

--- a/src/Server/ArrowFlight/AuthMiddleware.cpp
+++ b/src/Server/ArrowFlight/AuthMiddleware.cpp
@@ -224,7 +224,9 @@ arrow::Status AuthMiddlewareFactory::StartCall(
     if (session_it != headers.end())
         session_close = std::string(session_it->second);
 
-    const auto bearer_token_timeout = std::chrono::seconds(config.getUInt("arrowflight.bearer_token_timeout_seconds", 60));
+    const auto bearer_token_timeout = config.has("arrowflight.bearer_token_timeout_seconds")
+        ? std::chrono::seconds(config.getUInt("arrowflight.bearer_token_timeout_seconds"))
+        : std::chrono::seconds(config.getInt("default_session_timeout", 60));
 
     std::string username("default");
     std::string password;
@@ -245,7 +247,7 @@ arrow::Status AuthMiddlewareFactory::StartCall(
             token = *token_opt;
             credentials = token_storage.getCredentials(token, bearer_token_timeout);
             if (!credentials)
-                return arrow::flight::MakeFlightError(arrow::flight::FlightStatusCode::Unauthenticated, "Session expired or not authenticated.");
+                return arrow::flight::MakeFlightError(arrow::flight::FlightStatusCode::Unauthenticated, "Bearer token expired or not authenticated.");
 
             std::tie(username, password) = *credentials;
         }

--- a/src/Server/ArrowFlight/AuthMiddleware.h
+++ b/src/Server/ArrowFlight/AuthMiddleware.h
@@ -72,14 +72,14 @@ class AuthMiddlewareFactory : public arrow::flight::ServerMiddlewareFactory
     class TokenStorage
     {
     public:
-        explicit TokenStorage(const Poco::Util::AbstractConfiguration & config_) : config(config_) {}
+        TokenStorage() = default;
 
         /// Generates unique token for given credentials and saves it in storage.
-        String getToken(std::string username, std::string password);
+        String getToken(std::string username, std::string password, std::chrono::seconds token_timeout);
 
         /// Returns credential associated with specific token and updates expiration time for this token.
         /// If the token isn't found (never existed or expired) - returns empty optional.
-        std::optional<std::pair<std::string, std::string>> getCredentials(std::string token);
+        std::optional<std::pair<std::string, std::string>> getCredentials(std::string token, std::chrono::seconds token_timeout);
 
     private:
         void cleanupExpiredTokens() TSA_REQUIRES(token_mutex);
@@ -90,14 +90,11 @@ class AuthMiddlewareFactory : public arrow::flight::ServerMiddlewareFactory
         TokenExpirationList token_expiration_list TSA_GUARDED_BY(token_mutex);
         std::unordered_map<std::string, TokenExpirationList::iterator> token_expiration_list_index TSA_GUARDED_BY(token_mutex);
         std::unordered_map<std::string, std::pair<std::string, std::string>> token_to_credentials TSA_GUARDED_BY(token_mutex);
-
-        const Poco::Util::AbstractConfiguration & config;
     };
 
 public:
     explicit AuthMiddlewareFactory(IServer & server_, ArrowFlight::CallsData & calls_data_)
         : server(server_)
-        , token_storage(server_.config())
         , calls_data(calls_data_)
     {}
 

--- a/tests/integration/test_arrowflight_interface/configs/bearer_token_timeout.xml
+++ b/tests/integration/test_arrowflight_interface/configs/bearer_token_timeout.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <arrowflight>
+        <bearer_token_timeout_seconds>3</bearer_token_timeout_seconds>
+    </arrowflight>
+</clickhouse>

--- a/tests/integration/test_arrowflight_interface/test_bearer_token_timeout.py
+++ b/tests/integration/test_arrowflight_interface/test_bearer_token_timeout.py
@@ -8,6 +8,9 @@ import pyarrow.flight as flight
 from helpers.cluster import ClickHouseCluster
 
 
+# Must match configs/bearer_token_timeout.xml
+BEARER_TOKEN_TTL_SECONDS = 3
+
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
@@ -36,15 +39,21 @@ def _do_select_one(client, options):
 
 
 def test_bearer_token_timeout_from_server_config():
-    """Bearer token TTL follows arrowflight.bearer_token_timeout_seconds."""
+    """Bearer token TTL follows arrowflight.bearer_token_timeout_seconds with sliding expiration."""
     client = flight.FlightClient(f"grpc://{node.ip_address}:8888")
     token_pair = client.authenticate_basic_token(b"default", b"")
     options = flight.FlightCallOptions(headers=[token_pair])
 
     _do_select_one(client, options)
-    time.sleep(2)
+
+    # Each Bearer-authenticated request refreshes expiry; stay within the sliding window.
+    time.sleep(BEARER_TOKEN_TTL_SECONDS - 1)
     _do_select_one(client, options)
 
-    time.sleep(2)
-    with pytest.raises(flight.FlightUnauthenticatedError, match="Session expired or not authenticated"):
+    time.sleep(BEARER_TOKEN_TTL_SECONDS - 1)
+    _do_select_one(client, options)
+
+    # No Bearer use since the last refresh; wait past the configured TTL.
+    time.sleep(BEARER_TOKEN_TTL_SECONDS + 1)
+    with pytest.raises(flight.FlightUnauthenticatedError, match="Bearer token expired or not authenticated"):
         _do_select_one(client, options)

--- a/tests/integration/test_arrowflight_interface/test_bearer_token_timeout.py
+++ b/tests/integration/test_arrowflight_interface/test_bearer_token_timeout.py
@@ -1,0 +1,50 @@
+# coding: utf-8
+
+import time
+
+import pytest
+import pyarrow.flight as flight
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=[
+        "configs/flight_port.xml",
+        "configs/bearer_token_timeout.xml",
+    ],
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        node.wait_until_port_is_ready(8888, timeout=10)
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def _do_select_one(client, options):
+    ticket = flight.Ticket(b"SELECT 1")
+    reader = client.do_get(ticket, options)
+    table = reader.read_all()
+    assert table.column(0)[0].as_py() == 1
+
+
+def test_bearer_token_timeout_from_server_config():
+    """Bearer token TTL follows arrowflight.bearer_token_timeout_seconds."""
+    client = flight.FlightClient(f"grpc://{node.ip_address}:8888")
+    token_pair = client.authenticate_basic_token(b"default", b"")
+    options = flight.FlightCallOptions(headers=[token_pair])
+
+    _do_select_one(client, options)
+    time.sleep(2)
+    _do_select_one(client, options)
+
+    time.sleep(2)
+    with pytest.raises(flight.FlightUnauthenticatedError, match="Session expired or not authenticated"):
+        _do_select_one(client, options)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/115018


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `arrowflight.bearer_token_timeout_seconds` to control Arrow Flight Bearer token sliding expiration independently from `default_session_timeout`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115025&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115025](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115025+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
