### PR TITLE
Give Poco::Net::SocketAddress a noexcept move constructor

### DIFF
--- a/base/poco/Net/include/Poco/Net/SocketAddress.h
+++ b/base/poco/Net/include/Poco/Net/SocketAddress.h
@@ -140,6 +140,11 @@ namespace Net
         SocketAddress(const SocketAddress & addr);
         /// Creates a SocketAddress by copying another one.
 
+        SocketAddress(SocketAddress && addr) noexcept;
+        /// Creates a SocketAddress by moving another one.
+        /// The moved-from address holds no implementation, so its
+        /// accessors throw Poco::NullPointerException.
+
         SocketAddress(const struct sockaddr * addr, poco_socklen_t length);
         /// Creates a SocketAddress from a native socket address.
 
@@ -148,6 +153,11 @@ namespace Net
 
         SocketAddress & operator=(const SocketAddress & socketAddress);
         /// Assigns another SocketAddress.
+
+        SocketAddress & operator=(SocketAddress && socketAddress) noexcept;
+        /// Moves another SocketAddress.
+        /// The moved-from address holds no implementation, so its
+        /// accessors throw Poco::NullPointerException.
 
         IPAddress host() const;
         /// Returns the host IP address.

--- a/base/poco/Net/src/SocketAddress.cpp
+++ b/base/poco/Net/src/SocketAddress.cpp
@@ -148,6 +148,13 @@ SocketAddress::SocketAddress(const SocketAddress& socketAddress)
 }
 
 
+SocketAddress::SocketAddress(SocketAddress&& socketAddress) noexcept
+{
+	// AutoPtr has no move operations: assigning it duplicates the refcount, swapping transfers it.
+	_pImpl.swap(socketAddress._pImpl);
+}
+
+
 SocketAddress::SocketAddress(const struct sockaddr* sockAddr, poco_socklen_t length)
 {
 	if (length == sizeof(struct sockaddr_in) && sockAddr->sa_family == AF_INET)
@@ -196,6 +203,17 @@ SocketAddress& SocketAddress::operator = (const SocketAddress& socketAddress)
 		else if (socketAddress.family() == UNIX_LOCAL)
 			newLocal(reinterpret_cast<const sockaddr_un*>(socketAddress.addr()));
 #endif
+	}
+	return *this;
+}
+
+
+SocketAddress& SocketAddress::operator = (SocketAddress&& socketAddress) noexcept
+{
+	if (&socketAddress != this)
+	{
+		_pImpl.swap(socketAddress._pImpl);
+		socketAddress._pImpl.reset();
 	}
 	return *this;
 }

--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -129,6 +129,10 @@ struct SystemLogQueueSettings
 template <typename LogElement>
 class SystemLogQueue
 {
+    /// `queue` reallocates while `mutex` is held. libc++ relocates with std::move_if_noexcept, so an element
+    /// that can throw on move is deep-copied instead, and the critical section becomes O(queue size).
+    static_assert(std::is_nothrow_move_constructible_v<LogElement>);
+
 public:
     using Index = ISystemLog::Index;
 

--- a/src/Interpreters/QueryLogElement.h
+++ b/src/Interpreters/QueryLogElement.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <type_traits>
 #include <unordered_set>
 
 namespace ProfileEvents
@@ -126,4 +127,7 @@ struct QueryLogElement
 
     static void appendClientInfo(const ClientInfo & client_info, MutableColumns & columns, size_t & i);
 };
+
+/// Keep the moves implicit: the trait must reflect the members, not a declaration.
+static_assert(std::is_nothrow_move_constructible_v<QueryLogElement>);
 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110479
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Appending to a system log queue no longer deep-copies the whole queue when it grows. `Poco::Net::SocketAddress` had no move constructor, which made `QueryLogElement` and three other element types not nothrow-move-constructible, so a `std::vector` reallocation copied every element (allocating per address) while the queue mutex was held, blocking every query that writes to `system.query_log`.


### Description

Found while investigating a server that accepted and planned queries but executed none for 3.5 minutes on `Stateless tests (amd_tsan, flaky check)`: [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110479&sha=038667a9c024695126415fe5f37b76f7a06662fa&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20flaky%20check%29). The sampling profiler shows one thread inside `SystemLogQueue<QueryLogElement>::push` for 177 of 181 seconds, in `vector::__emplace_back_slow_path`, with 31 threads blocked on `std::mutex::lock()` in the same call.

`push()` appends under `mutex`, so a `std::vector` reallocation happens in the critical section. libc++ relocates with `std::move_if_noexcept`, which falls back to **copying** every element when the type is not nothrow-move-constructible. `QueryLogElement` was not, for one reason: `Poco::Net::SocketAddress` declared copy operations only, and its copy heap-allocates a new `SocketAddressImpl`. `ClientInfo` holds three of those.

The fix belongs in Poco because that is where the cause is: a refcounted-pointer wrapper whose move is nothing but a pointer transfer. The moves of `ClientInfo` and the log elements stay implicit, so their trait is derived. `AutoPtr::swap` is used because `AutoPtr` also declares no move, so assignment would bump the refcount and leave the source non-null.

Measured over one reallocation of 8192 elements: 32769 allocations before, 1 after. Four element types were affected (`QueryLog`, `QueryThreadLog`, `SessionLog`, `ZooKeeperLog`); a `static_assert` in `SystemLogQueue` now enumerates every element type at build time (30 here, 32 in a cloud build) and fails on the unpatched tree.

A moved-from `SocketAddress` has a null `_pImpl`; all seven accessors already route through `pImpl()`, which throws `NullPointerException`, so that state stays defined.

Left out deliberately: the slow `query_log` flush that triggered the reallocation is a separate question, and a move on `Poco::AutoPtr` would be the broader fix. This is one mechanism proven on one artifact, not a claim about every `Server died` report. No SQL test, because a C++ relocation trait is not observable from SQL.