### PR TITLE
Do not treat an unaccounted skip-index file as a materialized index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -273,9 +273,11 @@ MergeTreeIndexSubstreams MergeTreeIndexMinMax::getAllSubstreamsInPart(
     /// minmax format changed `.idx` (v1) -> `.idx2` (v2); a part may carry both. Return every
     /// extension present, not just the preferred one, so cleanup does not miss the stale file.
     MergeTreeIndexSubstreams substreams;
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx2", storage))
+    if (indexFileExistsInChecksums(
+            checksums, relative_path_prefix, ".idx2", storage, IndexFilePresence::OrDanglingOnDisk))
         substreams.push_back({MergeTreeIndexSubstream::Type::Regular, "", ".idx2"});
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
+    if (indexFileExistsInChecksums(
+            checksums, relative_path_prefix, ".idx", storage, IndexFilePresence::OrDanglingOnDisk))
         substreams.push_back({MergeTreeIndexSubstream::Type::Regular, "", ".idx"});
     return substreams;
 }

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -12,6 +12,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/NestedUtils.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Storages/MergeTree/DataPartStorageOnDiskBase.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Common/escapeForFileName.h>
@@ -33,7 +34,8 @@ bool indexFileExistsInChecksums(
     const MergeTreeDataPartChecksums & checksums,
     const std::string & path_prefix,
     const std::string & extension,
-    const IDataPartStorage * storage)
+    const IDataPartStorage * storage,
+    IndexFilePresence presence)
 {
     if (checksums.files.contains(path_prefix + extension))
         return true;
@@ -43,15 +45,18 @@ bool indexFileExistsInChecksums(
     if (checksums.files.contains(hash + extension))
         return true;
 
-    /// Packed substreams: not listed in checksums.txt as individual entries, but the
-    /// storage overlay reports their existence via the skp_idx.packed index.
+    /// A substream inside skp_idx.packed has no checksums entry of its own, so the archive index is
+    /// the only record of it. Members are stored under the logical name.
     if (storage && checksums.files.contains(String(SKIP_INDICES_PACKED_FILENAME)))
     {
-        if (storage->existsFile(path_prefix + extension))
-            return true;
-        if (storage->existsFile(hash + extension))
-            return true;
+        if (const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(storage))
+            if (disk_storage->isFileInPackedSkipIndicesArchive(path_prefix + extension))
+                return true;
     }
+
+    /// Nothing accounts for the name, so a file still present under it is an orphan.
+    if (presence == IndexFilePresence::OrDanglingOnDisk && storage)
+        return storage->existsFile(path_prefix + extension) || storage->existsFile(hash + extension);
 
     return false;
 }
@@ -386,7 +391,9 @@ MergeTreeIndexSubstreams IMergeTreeIndex::getAllSubstreamsInPart(
     /// still has to be skipped/stripped here. (minmax overrides to add its legacy `.idx`.)
     MergeTreeIndexSubstreams substreams;
     for (const auto & substream : getSubstreams())
-        if (indexFileExistsInChecksums(checksums, relative_path_prefix + substream.suffix, substream.extension, storage))
+        if (indexFileExistsInChecksums(
+                checksums, relative_path_prefix + substream.suffix, substream.extension, storage,
+                IndexFilePresence::OrDanglingOnDisk))
             substreams.push_back(substream);
 
     return substreams;

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -52,11 +52,12 @@ bool indexFileExistsInChecksums(
         if (const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(storage))
             if (disk_storage->isFileInPackedSkipIndicesArchive(path_prefix + extension))
                 return true;
-    }
 
-    /// Nothing accounts for the name, so a file still present under it is an orphan.
-    if (presence == IndexFilePresence::OrDanglingOnDisk && storage)
-        return storage->existsFile(path_prefix + extension) || storage->existsFile(hash + extension);
+        /// Neither checksums.txt nor the archive accounts for the name, so a file still present
+        /// under it is an orphan.
+        if (presence == IndexFilePresence::OrDanglingOnDisk)
+            return storage->existsFile(path_prefix + extension) || storage->existsFile(hash + extension);
+    }
 
     return false;
 }

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -431,8 +431,9 @@ enum class IndexFilePresence
     /// Accounted for: a checksums.txt entry or a member of skp_idx.packed. A file that is on disk
     /// but in neither is an orphan whose index is already dead, so it is not a readable substream.
     Accounted,
-    /// Also any file present on disk under that name. Cleanup must see an orphan in order to strip
-    /// it from inherited checksums and keep it out of the hardlink loop.
+    /// On a part carrying skp_idx.packed, also a file present on disk that the archive does not
+    /// hold. Cleanup must see such an orphan in order to strip it from inherited checksums and
+    /// keep it out of the hardlink loop.
     OrDanglingOnDisk,
 };
 

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -300,7 +300,7 @@ struct IMergeTreeIndex
     /// because such a part can still carry the index's granules.
     bool isPartTypeCompatible(const IMergeTreeDataPart & part) const;
 
-    /// Union of every checksummed or packed on-disk version present (unlike
+    /// Union of every on-disk version present, including one accounted for by nothing (unlike
     /// `getDeserializedFormat`, which returns only the preferred readable layout and reports
     /// nothing once a required system column is invalidated). Mutation cleanup uses this so a
     /// stale legacy substream on a mixed-format part is skipped/stripped, not hardlinked forward.
@@ -425,13 +425,23 @@ void textIndexValidator(const IndexDescription & index, bool attach, const Merge
 
 String getIndexFileName(const String & index_name, bool escape_filename);
 
-/// Check if an index substream file exists for the part. Returns true if the file is listed
-/// directly in checksums.txt (original or hashed name) OR if it's a virtual file inside
-/// skp_idx.packed (resolved through the storage overlay). Passing a null @storage skips
-/// the archive check, which is fine for callers that only see standalone per-file layouts.
+/// Which files count as belonging to an index substream.
+enum class IndexFilePresence
+{
+    /// Accounted for: a checksums.txt entry or a member of skp_idx.packed. A file that is on disk
+    /// but in neither is an orphan whose index is already dead, so it is not a readable substream.
+    Accounted,
+    /// Also any file present on disk under that name. Cleanup must see an orphan in order to strip
+    /// it from inherited checksums and keep it out of the hardlink loop.
+    OrDanglingOnDisk,
+};
+
+/// Check if an index substream file exists for the part. Passing a null @storage answers from
+/// checksums.txt alone, which is what callers that only see standalone per-file layouts need.
 bool indexFileExistsInChecksums(
     const MergeTreeDataPartChecksums & checksums,
     const std::string & path_prefix,
     const std::string & extension,
-    const IDataPartStorage * storage = nullptr);
+    const IDataPartStorage * storage = nullptr,
+    IndexFilePresence presence = IndexFilePresence::Accounted);
 }

--- a/tests/integration/test_packed_skip_index_orphan/test.py
+++ b/tests/integration/test_packed_skip_index_orphan/test.py
@@ -69,12 +69,34 @@ def make_packed_part(table, index_ddl, extra_columns=""):
     return path
 
 
-def inject_orphan(path, name, size=64):
+def make_unpacked_part(table, index_ddl):
+    """The same shape with packing off, so the part carries no archive at all. Returns its path."""
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table} (k UInt64, a UInt64, b UInt64, {index_ddl})
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+                 packed_skip_index_max_bytes = 0, index_granularity = 100,
+                 replace_long_file_name_to_hash = 0,
+                 columns_and_secondary_indices_sizes_lazy_calculation = 0
+        """
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number, number, number FROM numbers(2000)"
+    )
+    path = part_path(table)
+    # Guard the fixture: with an archive present this would exercise the packed path instead.
+    assert not file_exists(f"{path}/skp_idx.packed"), "fixture built a packed archive"
+    return path
+
+
+def inject_orphan(path, name, size=64, source="skp_idx.packed"):
     """A standalone skip-index file with no checksums entry and no archive member."""
-    sh(f'head -c {size} "{path}/skp_idx.packed" > "{path}/{name}"')
+    sh(f'head -c {size} "{path}/{source}" > "{path}/{name}"')
     # Owned by the server user, so a leak fails the assertion below on its own merits rather
     # than on a permission error from the injection.
-    sh(f'chown --reference="{path}/skp_idx.packed" "{path}/{name}"')
+    sh(f'chown --reference="{path}/{source}" "{path}/{name}"')
     assert file_exists(f"{path}/{name}")
 
 
@@ -132,4 +154,27 @@ def test_orphan_is_not_hardlinked_by_mutation(start_cluster):
     assert (
         node.query("CHECK TABLE t_mutate SETTINGS check_query_single_value_result = 1")
         == "1\n"
+    )
+
+
+def test_orphan_on_unpacked_part_is_not_counted(start_cluster):
+    """Without an archive the part is outside this probe's scope, so the orphan stays invisible."""
+    path = make_unpacked_part(
+        "t_unpacked",
+        "INDEX mm_a a TYPE minmax GRANULARITY 1",
+    )
+    # mm_b is declared but never materialized, so nothing accounts for skp_idx_mm_b.idx2.
+    node.query("ALTER TABLE t_unpacked ADD INDEX mm_b b TYPE minmax GRANULARITY 1")
+    inject_orphan(path, "skp_idx_mm_b.idx2", source="skp_idx_mm_a.idx2")
+    node.query("DETACH TABLE t_unpacked")
+    node.query("ATTACH TABLE t_unpacked")
+
+    # mm_a is checksummed and sized; mm_b exists only as an unaccounted file and reads as absent,
+    # so its bytes never enter the totals that only a checksummed index can later subtract.
+    assert (
+        node.query(
+            "SELECT name, data_compressed_bytes > 0 FROM system.data_skipping_indices"
+            " WHERE database = currentDatabase() AND table = 't_unpacked' ORDER BY name"
+        )
+        == "mm_a\t1\nmm_b\t0\n"
     )

--- a/tests/integration/test_packed_skip_index_orphan/test.py
+++ b/tests/integration/test_packed_skip_index_orphan/test.py
@@ -1,0 +1,135 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance("node1")
+
+# A part whose skip indices live in `skp_idx.packed` can also carry a standalone `skp_idx_*` file
+# that no `checksums.txt` entry and no archive member accounts for. Building that shape needs a
+# write into the part directory, which functional tests must not do, so it lives here.
+#
+# `packed_skip_index_max_bytes` is a MergeTree default, so both halves coexist under stock
+# settings: an archive plus an unaccounted standalone file.
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def part_path(table, part="all_1_1_0"):
+    return node.query(
+        f"SELECT path FROM system.parts WHERE database = currentDatabase()"
+        f" AND table = '{table}' AND name = '{part}'"
+    ).strip()
+
+
+def active_part_path(table):
+    return node.query(
+        f"SELECT path FROM system.parts WHERE database = currentDatabase()"
+        f" AND table = '{table}' AND active ORDER BY name LIMIT 1"
+    ).strip()
+
+
+def sh(command):
+    return node.exec_in_container(
+        ["bash", "-c", command], privileged=True, user="root"
+    ).strip()
+
+
+def file_exists(path):
+    return sh(f'test -e "{path}" && echo 1 || echo 0') == "1"
+
+
+def make_packed_part(table, index_ddl, extra_columns=""):
+    """A wide part with skip indices bundled into skp_idx.packed. Returns its path."""
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table} (k UInt64, a UInt64, b UInt64{extra_columns}, {index_ddl})
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+                 packed_skip_index_max_bytes = 1048576, index_granularity = 100,
+                 replace_long_file_name_to_hash = 0,
+                 columns_and_secondary_indices_sizes_lazy_calculation = 0
+        """
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number, number, number FROM numbers(2000)"
+    )
+    path = part_path(table)
+    # Guard the fixture itself: without an archive both assertions below are vacuous.
+    assert file_exists(f"{path}/skp_idx.packed"), "fixture built no packed archive"
+    return path
+
+
+def inject_orphan(path, name, size=64):
+    """A standalone skip-index file with no checksums entry and no archive member."""
+    sh(f'head -c {size} "{path}/skp_idx.packed" > "{path}/{name}"')
+    # Owned by the server user, so a leak fails the assertion below on its own merits rather
+    # than on a permission error from the injection.
+    sh(f'chown --reference="{path}/skp_idx.packed" "{path}/{name}"')
+    assert file_exists(f"{path}/{name}")
+
+
+def test_orphan_is_not_a_materialized_index(start_cluster):
+    """A query over a part carrying an orphan must still answer, and must not count it."""
+    path = make_packed_part(
+        "t_read",
+        "INDEX mm_a a TYPE minmax GRANULARITY 1",
+    )
+    # mm_b is declared but never materialized, so nothing accounts for skp_idx_mm_b.idx2.
+    node.query("ALTER TABLE t_read ADD INDEX mm_b b TYPE minmax GRANULARITY 1")
+    inject_orphan(path, "skp_idx_mm_b.idx2")
+    node.query("DETACH TABLE t_read")
+    node.query("ATTACH TABLE t_read")
+
+    assert node.query("SELECT count() FROM t_read WHERE b = 1500") == "1\n"
+
+    # mm_a is a real archive member and must keep pruning; mm_b is an orphan and reads as absent.
+    assert (
+        node.query(
+            "SELECT name, data_compressed_bytes > 0 FROM system.data_skipping_indices"
+            " WHERE database = currentDatabase() AND table = 't_read' AND name = 'mm_a'"
+        )
+        == "mm_a\t1\n"
+    )
+    assert (
+        node.query(
+            "SELECT count() > 0 FROM (EXPLAIN indexes = 1"
+            " SELECT count() FROM t_read WHERE a = 1500)"
+            " WHERE explain ILIKE '%Granules: 1/20%'"
+        )
+        == "1\n"
+    )
+
+
+def test_orphan_is_not_hardlinked_by_mutation(start_cluster):
+    """A mutation must strip the orphan rather than carry it into the new part."""
+    path = make_packed_part(
+        "t_mutate",
+        "INDEX mm_b b TYPE minmax GRANULARITY 1",
+    )
+    # minmax moved .idx (v1) -> .idx2 (v2); a stale v1 file may sit beside the packed v2 one.
+    inject_orphan(path, "skp_idx_mm_b.idx")
+
+    # Mutating the indexed column puts mm_b in indices_to_recalc, which is what consults the
+    # substream list that decides whether the stale file is hardlinked forward.
+    node.query(
+        "ALTER TABLE t_mutate UPDATE b = b + 0 WHERE 1 SETTINGS mutations_sync = 2"
+    )
+
+    new_path = active_part_path("t_mutate")
+    assert new_path != path
+    assert not file_exists(f"{new_path}/skp_idx_mm_b.idx")
+    assert node.query("SELECT count() FROM t_mutate WHERE b = 1500") == "1\n"
+    assert (
+        node.query("CHECK TABLE t_mutate SETTINGS check_query_single_value_result = 1")
+        == "1\n"
+    )


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/109595
Related: https://github.com/ClickHouse/ClickHouse/pull/104431
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a query failure on a part that carries both a `skp_idx.packed` archive and a leftover standalone skip-index file with no `checksums.txt` entry. The leftover file was counted as a materialized index, so a valid query was rejected with a `file_size` filesystem error.


### Description

Reported on https://github.com/ClickHouse/ClickHouse/pull/104431#issuecomment-5306256247, on the corrupted-part shape of https://github.com/ClickHouse/ClickHouse/issues/109595

`indexFileExistsInChecksums` says whether a skip-index substream is materialized in a part. When the part carried `skp_idx.packed` it fell through to `storage->existsFile`, which tries the archive and then does a raw disk stat, and that one answer served two callers needing different ones. A read-time probe must not accept a file that neither `checksums.txt` nor the archive accounts for: it is an orphan, its index already dead, and counting it as materialized fails a valid query with `Code: 1001 ... in file_size: No such file or directory`. Mutation cleanup does need the wider answer, to strip the orphan from inherited checksums and keep it out of the hardlink loop; narrowing it there leaks the stale file forward and `CHECK TABLE` fails with `UNEXPECTED_FILE_IN_DATA_PART`. Each caller now asks by mode.

One behaviour delta: read-time no longer calls generic part storage. The union answer is unchanged on every part, so nothing new reaches cleanup or `system.data_skipping_indices`.

On a Keeper-backed metadata disk that stat reached Keeper with no component set, so the server threw `Current component is empty, please set it for your scope using Coordination::setCurrentComponent`. That is the private-sync failure in `Stress test (amd_tsan, SharedCatalog, meta in keeper)`, whose frames end in `DataPartStorageOnDiskFull::existsFileImpl`: the generic fallback, not the archive probe. I worked from those frames and cannot read the private logs. Asking the archive directly needs no new guard, since its loader already sets a component. This covers every unguarded probe of the class, not just the frame above: the rest of `getDeserializedFormat` is in-memory type comparison.

Reachable on defaults: `packed_skip_index_max_bytes` is on and text indices are never packed. Building the shape needs a write into a part directory, so the test is `tests/integration/test_packed_skip_index_orphan`; each case fails on exactly the binary it targets.