### PR TITLE
Spill the adaptive aggregator's learning-phase tables under memory pressure

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -978,6 +978,7 @@ The server successfully detected this situation and will download merged part fr
     M(AggregationPreallocatedElementsInHashTables, "How many elements were preallocated in hash tables for aggregation.", ValueType::Number) \
     M(AdaptiveAggregationLocalFreezes, "How many local hash tables the adaptive aggregation froze at the freeze threshold.", ValueType::Number) \
     M(AdaptiveAggregationGiveUps, "How many threads gave up on freezing in the adaptive aggregation because their stream held few distinct keys.", ValueType::Number) \
+    M(AdaptiveAggregationPressureStandDowns, "How many threads in the adaptive aggregation left the learning phase for good because memory pressure crossed the external aggregation threshold, so their local tables spill through the ordinary external aggregation.", ValueType::Number) \
     M(AdaptiveAggregationThaws, "How many times the adaptive aggregation thawed the local tables because the staged stream proved repeat-dominated.", ValueType::Number) \
     M(AdaptiveAggregationProbeBypasses, "How many threads stopped probing their frozen local table in the adaptive aggregation because almost no row hit it.", ValueType::Number) \
     M(AdaptiveAggregationStagedRecords, "How many delayed records the adaptive aggregation staged before deduplication.", ValueType::Number) \

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -61,6 +61,7 @@ namespace ProfileEvents
     extern const Event AggregationBucketTopKConversions;
     extern const Event AdaptiveAggregationLocalFreezes;
     extern const Event AdaptiveAggregationGiveUps;
+    extern const Event AdaptiveAggregationPressureStandDowns;
 }
 
 namespace CurrentMetrics
@@ -1950,7 +1951,11 @@ bool Aggregator::executeOnBlock(Columns columns,
             /// frozen one it can join the baseline path for good and spill through the branch below.
             if (params.max_bytes_before_external_group_by
                 && current_memory_usage > static_cast<Int64>(params.max_bytes_before_external_group_by))
+            {
+                if (adaptive->isLearning())
+                    ProfileEvents::increment(ProfileEvents::AdaptiveAggregationPressureStandDowns);
                 adaptive->standDown(AdaptiveAggregationProducer::BaselineState::Reason::TooFewDistinctKeys);
+            }
 
             if (!adaptive->isBaseline())
             {

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1946,6 +1946,12 @@ bool Aggregator::executeOnBlock(Columns columns,
                 LOG_TRACE(log, "Adaptive aggregation: giving up on freezing after {} rows at {} keys", rows_seen, result_size);
             }
 
+            /// A learning table has no frozen twin to pair with and nothing staged, so unlike the
+            /// frozen one it can join the baseline path for good and spill through the branch below.
+            if (params.max_bytes_before_external_group_by
+                && current_memory_usage > static_cast<Int64>(params.max_bytes_before_external_group_by))
+                adaptive->standDown(AdaptiveAggregationProducer::BaselineState::Reason::TooFewDistinctKeys);
+
             if (!adaptive->isBaseline())
             {
                 /// Checking the constraints.

--- a/tests/queries/0_stateless/04649_adaptive_aggregator_external.reference
+++ b/tests/queries/0_stateless/04649_adaptive_aggregator_external.reference
@@ -10,5 +10,7 @@ Partial pressure mixes early and merge-time drains
 1
 Give-up threads spill through the baseline branch
 1
+Learning-phase spill preserves results
+1
 Analytic guard under pressure
 30000	449985000	7199940000	120000

--- a/tests/queries/0_stateless/04649_adaptive_aggregator_external.sql
+++ b/tests/queries/0_stateless/04649_adaptive_aggregator_external.sql
@@ -54,6 +54,15 @@ SELECT
     =
     (SELECT count(), sum(u) FROM (SELECT number % 50 AS g, uniqExact(number) AS u FROM numbers_mt(400000) GROUP BY g SETTINGS enable_adaptive_aggregator = 1, max_bytes_before_external_group_by = 1));
 
+-- A freeze threshold above both the key count and the give-up bound keeps every producer
+-- learning for the whole query, so the results mix tables that stood down under pressure and
+-- spilled with tables that never crossed the threshold at all.
+SELECT 'Learning-phase spill preserves results';
+SELECT
+    (SELECT count(), sum(c) FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k SETTINGS enable_adaptive_aggregator = 0))
+    =
+    (SELECT count(), sum(c) FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k SETTINGS enable_adaptive_aggregator = 1, adaptive_aggregator_freeze_threshold = 4000000, group_by_two_level_threshold = 1000, max_bytes_before_external_group_by = 20000000, max_bytes_ratio_before_external_group_by = 0));
+
 SELECT 'Analytic guard under pressure';
 SELECT count(), sum(g), sum(s), sum(c) FROM (SELECT number % 30000 AS g, sum(number) AS s, count() AS c FROM numbers_mt(120000) GROUP BY g)
 SETTINGS enable_adaptive_aggregator = 1, max_bytes_before_external_group_by = 1;

--- a/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.reference
+++ b/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.reference
@@ -6,5 +6,9 @@ The spill was exercised
 1
 Learning-phase tables spill under the external threshold
 1
+The learning phase stood down under pressure
+1
 A learning-phase query fits in a limit only spilling can meet
 3000000
+No pressure, no stand-down
+0

--- a/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.reference
+++ b/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.reference
@@ -4,3 +4,7 @@ The drain processed multiple spill floors of records
 1
 The spill was exercised
 1
+Learning-phase tables spill under the external threshold
+1
+A learning-phase query fits in a limit only spilling can meet
+3000000

--- a/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.sh
+++ b/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.sh
@@ -36,3 +36,29 @@ SELECT coalesce(sum(value), 0) >= 2000000 FROM system.events WHERE event = 'Adap
 SELECT 'The spill was exercised';
 SELECT coalesce(sum(value), 0) > 0 FROM system.events WHERE event = 'ExternalAggregationWritePart';
 "
+
+# A freeze threshold above both the key count and the give-up bound keeps every producer in the
+# learning phase for the whole query, which is the one regime where no frozen table is ever built.
+# A learning table must still spill: the counter has to advance across the query, and the query
+# has to fit in a limit that only the spilling arm can meet. Both external thresholds are pinned
+# per query because the runner randomizes them, and `max_memory_usage` is the cell that encodes
+# the user-visible consequence rather than a counter. A separate `clickhouse-local` process keeps
+# these counters clear of the cells above.
+$CLICKHOUSE_LOCAL --query "
+SET max_threads = 4;
+SET group_by_two_level_threshold = 1000;
+SET collect_hash_table_stats_during_aggregation = 0;
+SET enable_sharding_aggregator = 0;
+SET enable_adaptive_aggregator = 1;
+SET adaptive_aggregator_freeze_threshold = 4000000;
+SET max_bytes_before_external_group_by = 20000000;
+SET max_bytes_ratio_before_external_group_by = 0;
+
+SELECT 'Learning-phase tables spill under the external threshold';
+SELECT count() FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k) FORMAT Null;
+SELECT coalesce(sum(value), 0) > 0 FROM system.events WHERE event = 'ExternalAggregationWritePart';
+
+SELECT 'A learning-phase query fits in a limit only spilling can meet';
+SELECT count() FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k)
+SETTINGS max_memory_usage = 700000000;
+"

--- a/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.sh
+++ b/tests/queries/0_stateless/04650_adaptive_aggregator_pressure_spill.sh
@@ -58,7 +58,27 @@ SELECT 'Learning-phase tables spill under the external threshold';
 SELECT count() FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k) FORMAT Null;
 SELECT coalesce(sum(value), 0) > 0 FROM system.events WHERE event = 'ExternalAggregationWritePart';
 
+SELECT 'The learning phase stood down under pressure';
+SELECT coalesce(sum(value), 0) > 0 FROM system.events WHERE event = 'AdaptiveAggregationPressureStandDowns';
+
 SELECT 'A learning-phase query fits in a limit only spilling can meet';
 SELECT count() FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k)
 SETTINGS max_memory_usage = 700000000;
+"
+
+# The same shape with no external threshold: the pressure trigger cannot fire, so the producers
+# stay in the learning phase and the counter must not move.
+$CLICKHOUSE_LOCAL --query "
+SET max_threads = 4;
+SET group_by_two_level_threshold = 1000;
+SET collect_hash_table_stats_during_aggregation = 0;
+SET enable_sharding_aggregator = 0;
+SET enable_adaptive_aggregator = 1;
+SET adaptive_aggregator_freeze_threshold = 4000000;
+SET max_bytes_before_external_group_by = 0;
+SET max_bytes_ratio_before_external_group_by = 0;
+
+SELECT 'No pressure, no stand-down';
+SELECT count() FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k) FORMAT Null;
+SELECT coalesce(sum(value), 0) FROM system.events WHERE event = 'AdaptiveAggregationPressureStandDowns';
 "


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/114987
-->

Closes: #114987

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Requested by @ nihalzp in https://github.com/ClickHouse/ClickHouse/issues/114987#issuecomment-5307798148.

**The problem.** `Aggregator::executeOnBlock` ends in a baseline tail that converts the table to
two-level, checks limits and spills past `max_bytes_before_external_group_by`. The adaptive block
returns before that tail. Its thaw arm stands down first and its frozen arm runs a drain valve, but
the learning arm returned with no memory response at all. A producer leaves learning only by
freezing at `adaptive_aggregator_freeze_threshold` keys or by giving up after 16x that many rows, so
with the threshold raised neither bound fires inside one query and the table grows in RAM with no
byte bound.

**The change.** A learning table has no frozen twin to pair with and nothing staged, so under
pressure it can stand down for good and spill through the branch that already exists below. Gating
it on the pressure trigger matters: the tail can convert the table to two-level, after which
`isConvertibleToTwoLevel()` is false and the producer could never freeze again, so an unconditional
fall-through would disable the feature rather than fix it.

**Reachability is narrower than the report implies.** At the default
`adaptive_aggregator_freeze_threshold = 16384` the spill still works, so this needs a raised
threshold, not stock settings. The reporter agreed on the issue.

**Validation.** On the report's query with the threshold raised, `ExternalAggregationWritePart` goes
from 0 to 46, matching the feature-off arm, and under `max_memory_usage = 700000000` the query
changes from `MEMORY_LIMIT_EXCEEDED` to completing. Each new defect cell fails on the unfixed
binary, the freeze counters are byte-identical on the fast path, and the two files passed 100
randomized runs.

Left alone deliberately: the stand-down reuses `Reason::TooFewDistinctKeys` rather than adding a
`MemoryPressure` enumerator, since that field has no readers today; and a frozen local table stays
unbounded in bytes for growing states such as `groupArray`, which the issue raises separately.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1521` (included in `26.8` and later)
<!-- ch-version-info:end -->