### PR TITLE
Fix the lost wakeup that hangs the BackgroundSchedulePool schedule tests

### DIFF
--- a/src/Core/tests/gtest_BackgroundSchedulePool.cpp
+++ b/src/Core/tests/gtest_BackgroundSchedulePool.cpp
@@ -20,7 +20,7 @@ TEST(BackgroundSchedulePool, Schedule)
 {
     auto pool = BackgroundSchedulePool::create(4, 4, 0, CurrentMetrics::end(), CurrentMetrics::end(), ThreadName::TEST_SCHEDULER);
 
-    std::atomic<size_t> counter;
+    std::atomic<size_t> counter{0};
     std::mutex mutex;
     std::condition_variable condvar;
 
@@ -28,6 +28,9 @@ TEST(BackgroundSchedulePool, Schedule)
     BackgroundSchedulePoolTaskHolder task;
     task = pool->createTask(StorageID::createEmpty(), "test", [&]
     {
+        /// The notify must be issued under the waiter's mutex: otherwise the last iteration can
+        /// notify between the waiter's predicate check and its block, and nothing re-notifies.
+        std::lock_guard lock(mutex);
         ++counter;
         if (counter < ITERATIONS)
             ASSERT_EQ(task->schedule(), true);
@@ -36,19 +39,26 @@ TEST(BackgroundSchedulePool, Schedule)
     });
     ASSERT_EQ(task->activateAndSchedule(), true);
 
-    std::unique_lock lock(mutex);
-    condvar.wait(lock, [&] { return counter == ITERATIONS; });
+    bool finished = false;
+    {
+        std::unique_lock lock(mutex);
+        /// Bounded wait so a regression fails the test instead of hanging it.
+        finished = condvar.wait_for(lock, std::chrono::seconds(60), [&] { return counter == ITERATIONS; });
+    }
 
-    ASSERT_EQ(counter, ITERATIONS);
-
+    /// Join before asserting: the pool's destructor requires join(), so a fatal assertion here
+    /// would abort the binary instead of failing the test.
     pool->join();
+
+    EXPECT_TRUE(finished) << "only " << counter << " of " << ITERATIONS << " iterations ran";
+    ASSERT_EQ(counter, ITERATIONS);
 }
 
 TEST(BackgroundSchedulePool, ScheduleAfter)
 {
     auto pool = BackgroundSchedulePool::create(4, 4, 0, CurrentMetrics::end(), CurrentMetrics::end(), ThreadName::TEST_SCHEDULER);
 
-    std::atomic<size_t> counter;
+    std::atomic<size_t> counter{0};
     std::mutex mutex;
     std::condition_variable condvar;
 
@@ -56,6 +66,9 @@ TEST(BackgroundSchedulePool, ScheduleAfter)
     BackgroundSchedulePoolTaskHolder task;
     task = pool->createTask(StorageID::createEmpty(), "test", [&]
     {
+        /// The notify must be issued under the waiter's mutex: otherwise the last iteration can
+        /// notify between the waiter's predicate check and its block, and nothing re-notifies.
+        std::lock_guard lock(mutex);
         ++counter;
         if (counter < ITERATIONS)
             ASSERT_EQ(task->scheduleAfter(1), true);
@@ -64,14 +77,19 @@ TEST(BackgroundSchedulePool, ScheduleAfter)
     });
     ASSERT_EQ(task->activateAndSchedule(), true);
 
+    bool finished = false;
     {
         std::unique_lock lock(mutex);
-        condvar.wait(lock, [&] { return counter == ITERATIONS; });
+        /// Bounded wait so a regression fails the test instead of hanging it.
+        finished = condvar.wait_for(lock, std::chrono::seconds(60), [&] { return counter == ITERATIONS; });
     }
 
-    ASSERT_EQ(counter, ITERATIONS);
-
+    /// Join before asserting: the pool's destructor requires join(), so a fatal assertion here
+    /// would abort the binary instead of failing the test.
     pool->join();
+
+    EXPECT_TRUE(finished) << "only " << counter << " of " << ITERATIONS << " iterations ran";
+    ASSERT_EQ(counter, ITERATIONS);
 }
 
 /// Previously leads to UB

--- a/src/Core/tests/gtest_BackgroundSchedulePool.cpp
+++ b/src/Core/tests/gtest_BackgroundSchedulePool.cpp
@@ -28,8 +28,8 @@ TEST(BackgroundSchedulePool, Schedule)
     BackgroundSchedulePoolTaskHolder task;
     task = pool->createTask(StorageID::createEmpty(), "test", [&]
     {
-        /// The notify must be issued under the waiter's mutex: otherwise the last iteration can
-        /// notify between the waiter's predicate check and its block, and nothing re-notifies.
+        /// counter is published under the waiter's mutex, so the increment that completes it is
+        /// visible to a waiter that has already evaluated its predicate.
         std::lock_guard lock(mutex);
         ++counter;
         if (counter < ITERATIONS)
@@ -39,18 +39,20 @@ TEST(BackgroundSchedulePool, Schedule)
     });
     ASSERT_EQ(task->activateAndSchedule(), true);
 
-    bool finished = false;
+    bool timed_out = false;
     {
         std::unique_lock lock(mutex);
-        /// Bounded wait so a regression fails the test instead of hanging it.
-        finished = condvar.wait_for(lock, std::chrono::seconds(60), [&] { return counter == ITERATIONS; });
+        /// The wait status decides, not the predicate: a dropped notification leaves the predicate
+        /// true, so the predicate overload of wait_for would report success after the deadline.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+        while (counter != ITERATIONS && !timed_out)
+            timed_out = condvar.wait_until(lock, deadline) == std::cv_status::timeout;
     }
 
-    /// Join before asserting: the pool's destructor requires join(), so a fatal assertion here
-    /// would abort the binary instead of failing the test.
+    /// The pool's destructor requires join(), so a fatal assertion must not precede it.
     pool->join();
 
-    EXPECT_TRUE(finished) << "only " << counter << " of " << ITERATIONS << " iterations ran";
+    EXPECT_FALSE(timed_out) << "timed out with " << counter << " of " << ITERATIONS << " iterations run";
     ASSERT_EQ(counter, ITERATIONS);
 }
 
@@ -66,8 +68,8 @@ TEST(BackgroundSchedulePool, ScheduleAfter)
     BackgroundSchedulePoolTaskHolder task;
     task = pool->createTask(StorageID::createEmpty(), "test", [&]
     {
-        /// The notify must be issued under the waiter's mutex: otherwise the last iteration can
-        /// notify between the waiter's predicate check and its block, and nothing re-notifies.
+        /// counter is published under the waiter's mutex, so the increment that completes it is
+        /// visible to a waiter that has already evaluated its predicate.
         std::lock_guard lock(mutex);
         ++counter;
         if (counter < ITERATIONS)
@@ -77,18 +79,20 @@ TEST(BackgroundSchedulePool, ScheduleAfter)
     });
     ASSERT_EQ(task->activateAndSchedule(), true);
 
-    bool finished = false;
+    bool timed_out = false;
     {
         std::unique_lock lock(mutex);
-        /// Bounded wait so a regression fails the test instead of hanging it.
-        finished = condvar.wait_for(lock, std::chrono::seconds(60), [&] { return counter == ITERATIONS; });
+        /// The wait status decides, not the predicate: a dropped notification leaves the predicate
+        /// true, so the predicate overload of wait_for would report success after the deadline.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+        while (counter != ITERATIONS && !timed_out)
+            timed_out = condvar.wait_until(lock, deadline) == std::cv_status::timeout;
     }
 
-    /// Join before asserting: the pool's destructor requires join(), so a fatal assertion here
-    /// would abort the binary instead of failing the test.
+    /// The pool's destructor requires join(), so a fatal assertion must not precede it.
     pool->join();
 
-    EXPECT_TRUE(finished) << "only " << counter << " of " << ITERATIONS << " iterations ran";
+    EXPECT_FALSE(timed_out) << "timed out with " << counter << " of " << ITERATIONS << " iterations run";
     ASSERT_EQ(counter, ITERATIONS);
 }
 


### PR DESCRIPTION
Fix the lost wakeup that hangs the BackgroundSchedulePool schedule tests

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`TEST(BackgroundSchedulePool, Schedule)` can block forever. The unit tests run sequentially in a
single binary, so one hang consumes the job's whole 90 minute budget and the binary is killed
before it writes `gtest.json`: the job reported 2 rows instead of the usual ~20,285, losing every
other gtest's result. `ScheduleAfter` has the same defect.

Root cause: the task callback called `condvar.notify_one()` without holding the mutex the
waiter uses, and the waiter's `condvar.wait` was unbounded. If the last iteration increments
the counter and notifies after the waiter evaluated its predicate but before it blocked, the
notification is dropped. That iteration is also the one that stops re-scheduling, so the pool
goes idle and nothing can notify again; the wait is permanent rather than slow.

The fix takes the mutex around the increment and the notify, closing that window, and bounds the
wait at 60 seconds. `pool->join()` now runs before the assertions, because the pool's destructor
requires `join()` and a fatal assertion before it would abort the binary on the timeout path.

The bound waits on the wait's status, not on the predicate: the predicate overload of `wait_for`
re-evaluates the predicate after the deadline and returns its value, so a dropped notification,
which leaves the counter complete, would report success and keep the test green on the very
regression the bound exists to catch.

Validated by injecting a delay inside the waiter's predicate to force the losing interleaving:
before the change the test hangs with a backtrace matching the reported one, after it the probe
passes, and against that state the predicate overload passes in 301 ms while the status loop
fails at the deadline. 50 repetitions of both arms pass in Debug and under TSan.

Found on a private-repo `Unit tests (tsan)` run, so there is no public CI report to link.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1526` (included in `26.8` and later)
<!-- ch-version-info:end -->