### PR TITLE
Bucket `timeSeries*ToGrid` samples in runs

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionLast2Samples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionLast2Samples.h
@@ -124,6 +124,13 @@ public:
             }
         }
 
+        /// Bulk `add`, for the batch bucketing kernel of `AggregateFunctionTimeseriesBase`.
+        ALWAYS_INLINE void addMany(const TimestampType * __restrict timestamps_ptr, const ValueType * __restrict values_ptr, size_t count)
+        {
+            for (size_t i = 0; i < count; ++i)
+                add(timestamps_ptr[i], values_ptr[i]);
+        }
+
         void merge(const Data & rhs)
         {
             for (size_t i = 0; i < rhs.filled; ++i)

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -980,51 +980,9 @@ private:
     })
     )
 
-    /// The flagged counterpart, reached with the NULL map of a `Nullable` value column
-    /// (`addBatchSinglePlaceNotNull`) and with the condition column of the `-If` combinator
-    /// (`if_argument_pos`, e.g. `timeSeriesRateToGridIf`): flags break runs unpredictably, so samples are
-    /// added one by one, but the bucket resolved for the previous sample is reused while timestamps stay in
-    /// its range - including a skip range (`bucket == nullptr`). Requires `fast_bucket_math`.
-    template <bool flag_value_to_include>
-    void addSamplesToBucketsFlagged(State * __restrict state,
-        const TimestampType * __restrict timestamps,
-        const ValueType * __restrict values,
-        const UInt8 * __restrict flags,
-        size_t row_begin,
-        size_t row_end) const
-    {
-        Bucket * bucket = nullptr;
-        Int64 lo = 0;
-        Int64 hi = 0;   /// Empty range: the first included sample always takes `classifySampleFast`
-        for (size_t i = row_begin; i < row_end; ++i)
-        {
-            if ((flags[i] != 0) != flag_value_to_include)
-                continue;
-
-            const Int64 timestamp = toInt64(timestamps[i]);
-            if (timestamp > lo && timestamp <= hi)
-            {
-                if (bucket)
-                    bucket->add(timestamps[i], values[i]);
-                continue;
-            }
-
-            const SampleClass sample_class = classifySampleFast(timestamp);
-            lo = sample_class.lo;
-            hi = sample_class.hi;
-            if (sample_class.bucket_index == NO_BUCKET)
-            {
-                bucket = nullptr;
-                continue;
-            }
-            /// The reference stays valid until the next lookup: only another insertion can rehash the map.
-            bucket = &state->buckets[sample_class.bucket_index];
-            bucket->add(timestamps[i], values[i]);
-        }
-    }
-
     /// Entry point of the batch add path; `flags == nullptr` means every sample is included.
-    /// Falls back to the per-sample `add` when the Int64 bucket math is disabled.
+    /// Flagged samples (a NULL map of a `Nullable` value column or a `-If` condition) and grids without the
+    /// Int64 bucket math stay on the plain per-sample path.
     template <bool flag_value_to_include>
     void addSamples(AggregateDataPtr __restrict place,
         const TimestampType * __restrict timestamps,
@@ -1033,7 +991,7 @@ private:
         size_t row_begin,
         size_t row_end) const
     {
-        if (!fast_bucket_math)
+        if (!fast_bucket_math || flags)
         {
             for (size_t i = row_begin; i < row_end; ++i)
                 if (!flags || (flags[i] != 0) == flag_value_to_include)
@@ -1042,12 +1000,6 @@ private:
         }
 
         State * state = data(place);
-
-        if (flags)
-        {
-            addSamplesToBucketsFlagged<flag_value_to_include>(state, timestamps, values, flags, row_begin, row_end);
-            return;
-        }
 
 #if USE_MULTITARGET_CODE
         if (isArchSupported(TargetArch::x86_64_v4))

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -957,17 +957,6 @@ private:
         return scanned;
     }
 
-    /// Batch counterpart of `add` for samples of one aggregation state. Requires `fast_bucket_math`.
-    ///
-    /// Instead of per-sample bucket math and a per-sample hash-map lookup, the batch is processed in runs of
-    /// consecutive samples that fall into one bucket's time range (or one skip range): real samples mostly
-    /// arrive in timestamp order and a bucket typically covers many scrape intervals, so runs are long. Each
-    /// run costs one `classifySampleFast` (with its integer division), one bucket lookup and one bulk append;
-    /// within the run each sample costs two comparisons (`scanSamplesInRange`) and a store. On randomly
-    /// ordered timestamps runs degenerate to one sample and this matches the cost of the plain loop.
-    /// Compiled for x86-64-v4 in addition to the default target ('CPU dispatch'): the run scan and the bulk
-    /// append of `Samples::addMany` are data-parallel loops that profit from the wider vectors, and
-    /// `addSamples` picks the v4 variant at runtime on CPUs with AVX-512.
     MULTITARGET_FUNCTION_X86_V4(
     MULTITARGET_FUNCTION_HEADER(void NO_INLINE),
     addSamplesToBucketsImpl,
@@ -991,7 +980,9 @@ private:
     })
     )
 
-    /// The flagged (`-If` condition or NULL map) counterpart: flags break runs unpredictably, so samples are
+    /// The flagged counterpart, reached with the NULL map of a `Nullable` value column
+    /// (`addBatchSinglePlaceNotNull`) and with the condition column of the `-If` combinator
+    /// (`if_argument_pos`, e.g. `timeSeriesRateToGridIf`): flags break runs unpredictably, so samples are
     /// added one by one, but the bucket resolved for the previous sample is reused while timestamps stay in
     /// its range - including a skip range (`bucket == nullptr`). Requires `fast_bucket_math`.
     template <bool flag_value_to_include>

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -168,7 +168,7 @@ public:
         size_t place_offset,
         const IColumn ** columns,
         Arena * arena,
-        ssize_t if_argument_pos = -1) const override
+        ssize_t if_argument_pos) const override
     {
         if (array_arguments)
         {

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -24,6 +24,7 @@
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h>
 #include <Common/HashTable/HashMap.h>
+#include <Common/TargetSpecific.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 
@@ -964,11 +965,17 @@ private:
     /// run costs one `classifySampleFast` (with its integer division), one bucket lookup and one bulk append;
     /// within the run each sample costs two comparisons (`scanSamplesInRange`) and a store. On randomly
     /// ordered timestamps runs degenerate to one sample and this matches the cost of the plain loop.
-    void NO_INLINE addSamplesToBucketsImpl(State * __restrict state,
+    /// Compiled for x86-64-v4 in addition to the default target ('CPU dispatch'): the run scan and the bulk
+    /// append of `Samples::addMany` are data-parallel loops that profit from the wider vectors, and
+    /// `addSamples` picks the v4 variant at runtime on CPUs with AVX-512.
+    MULTITARGET_FUNCTION_X86_V4(
+    MULTITARGET_FUNCTION_HEADER(void NO_INLINE),
+    addSamplesToBucketsImpl,
+    MULTITARGET_FUNCTION_BODY((State * __restrict state,
         const TimestampType * __restrict timestamps,
         const ValueType * __restrict values,
         size_t row_begin,
-        size_t row_end) const
+        size_t row_end) const /// NOLINT
     {
         size_t i = row_begin;
         while (i < row_end)
@@ -981,7 +988,8 @@ private:
             /// so the scan may return 0 - still consume one sample.
             i += std::max<size_t>(run, static_cast<size_t>(1));
         }
-    }
+    })
+    )
 
     /// The flagged (`-If` condition or NULL map) counterpart: flags break runs unpredictably, so samples are
     /// added one by one, but the bucket resolved for the previous sample is reused while timestamps stay in
@@ -1050,6 +1058,13 @@ private:
             return;
         }
 
+#if USE_MULTITARGET_CODE
+        if (isArchSupported(TargetArch::x86_64_v4))
+        {
+            addSamplesToBucketsImpl_x86_64_v4(state, timestamps, values, row_begin, row_end);
+            return;
+        }
+#endif
         addSamplesToBucketsImpl(state, timestamps, values, row_begin, row_end);
     }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -155,6 +155,51 @@ public:
         }
     }
 
+    /// Batch add with a per-row aggregation state. Rows reach the aggregator in storage order, and tables with
+    /// time series data are typically sorted by (series, timestamp) - so rows come in long runs of the same
+    /// state. The batch is split into runs of equal `places[i]` and each run goes through the batch add path,
+    /// with the column casts hoisted out of the per-row loop; the generic implementation instead pays a virtual
+    /// `add` with two `typeid_cast`s per row.
+    void addBatch(
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const override
+    {
+        if (array_arguments)
+        {
+            /// A row of arrays holds a whole series, so the generic path's per-row overhead is amortized.
+            Base::addBatch(row_begin, row_end, places, place_offset, columns, arena, if_argument_pos);
+            return;
+        }
+
+        const UInt8 * flags = nullptr;
+        if (if_argument_pos >= 0)
+            flags = typeid_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData().data();
+
+        const auto & timestamp_column = typeid_cast<const ColVecType &>(*columns[0]);
+        const auto & value_column = typeid_cast<const ColVecResultType &>(*columns[1]);
+        const TimestampType * timestamp_data = timestamp_column.getData().data();
+        const ValueType * value_data = value_column.getData().data();
+
+        size_t i = row_begin;
+        while (i < row_end)
+        {
+            AggregateDataPtr place = places[i];
+            size_t run_end = i + 1;
+            while (run_end < row_end && places[run_end] == place)
+                ++run_end;
+
+            if (place)
+                addSamples<true>(place + place_offset, timestamp_data, value_data, flags, i, run_end);
+
+            i = run_end;
+        }
+    }
+
     void addBatchSinglePlace(
         size_t row_begin,
         size_t row_end,
@@ -731,13 +776,31 @@ private:
             && (0 < step_128 && step_128 < bound) && (0 <= window_128 && window_128 < bound);
     }
 
-    /// Same as `bucketIndexForTimestamp` with all arithmetic in Int64. Requires `fast_bucket_math`.
-    size_t ALWAYS_INLINE bucketIndexForTimestampFast(const TimestampType timestamp) const
+    /// What the batch bucketing kernel (`addSamplesToBucketsImpl`) does with a sample: add it to bucket
+    /// `bucket_index`, or skip it (`bucket_index == NO_BUCKET`). Either way `(lo, hi]` is a timestamp range
+    /// whose samples all share this fate - the bucket's time range for an accepted sample, a range of
+    /// rejected timestamps for a skipped one - so the kernel handles the run of consecutive samples within
+    /// the range in one go.
+    struct SampleClass
     {
-        const Int64 ts = static_cast<Int64>(timestamp);
-        /// Samples at or below `start - window` are out of window for every grid point.
-        if (ts > static_cast<Int64>(end_timestamp) || ts <= static_cast<Int64>(start_timestamp) - static_cast<Int64>(window))
-            return NO_BUCKET;
+        size_t bucket_index;
+        Int64 lo;
+        Int64 hi;
+    };
+
+    /// Same as `bucketIndexForTimestamp` with all arithmetic in Int64, plus the `(lo, hi]` range for run
+    /// detection. Requires `fast_bucket_math`, which bounds every expression here away from Int64 overflow.
+    ALWAYS_INLINE SampleClass classifySampleFast(const Int64 ts) const
+    {
+        if (ts > static_cast<Int64>(end_timestamp))
+            return {NO_BUCKET, static_cast<Int64>(end_timestamp), std::numeric_limits<Int64>::max()};
+
+        /// Samples at or below `start - window` are out of window for every grid point. (A sample at
+        /// `INT64_MIN` never falls into the returned skip range - the run scan then returns 0 and the
+        /// kernel consumes the sample by itself.)
+        const Int64 lowest = static_cast<Int64>(start_timestamp) - static_cast<Int64>(window);
+        if (ts <= lowest)
+            return {NO_BUCKET, std::numeric_limits<Int64>::min(), lowest};
 
         const Int64 offset = ts - static_cast<Int64>(start_timestamp);
         const Int64 step_64 = static_cast<Int64>(step);
@@ -747,8 +810,12 @@ private:
             ++unclamped_grid_index;
 
         const Int64 grid_index = std::max<Int64>(unclamped_grid_index, 0);
-        if (ts + static_cast<Int64>(window) <= static_cast<Int64>(start_timestamp) + grid_index * step_64)
-            return NO_BUCKET;
+        const Int64 grid_timestamp = static_cast<Int64>(start_timestamp) + grid_index * step_64;
+
+        /// A sample out of its grid point's window is out of every window (windows of later grid points
+        /// start even higher), and so is everything down to the previous bucket's end - hence the skip range.
+        if (ts + static_cast<Int64>(window) <= grid_timestamp)
+            return {NO_BUCKET, std::max(lowest, grid_timestamp - step_64), grid_timestamp - static_cast<Int64>(window)};
 
         const Int64 leading_buckets = static_cast<Int64>(buckets_per_first_window);
         Int64 bucket_index = 0;
@@ -764,12 +831,28 @@ private:
         }
 
         chassert(bucket_index >= 0 && bucket_index < static_cast<Int64>(bucket_count));
-        return static_cast<size_t>(bucket_index);
+        const auto [lo, hi] = bucketRangeFast(static_cast<size_t>(bucket_index));
+        chassert(ts > lo && ts <= hi);
+        return {static_cast<size_t>(bucket_index), lo, hi};
+    }
+
+    /// `Int64` counterpart of `bucketTimeRange` (as a `(lo, hi]` pair). Requires `fast_bucket_math`.
+    /// For a clamped bucket #0 (possible only for unsigned `DateTime` timestamps) `lo` may fall below zero,
+    /// which over the unsigned domain means the same as "no lower bound".
+    ALWAYS_INLINE std::pair<Int64, Int64> bucketRangeFast(size_t bucket_index) const
+    {
+        const Int64 num_even_buckets = static_cast<Int64>(bucket_index / 2);
+        const Int64 num_odd_buckets = static_cast<Int64>(bucket_index) - num_even_buckets;
+        const Int64 hi = static_cast<Int64>(first_bucket_end_time)
+            + num_odd_buckets * static_cast<Int64>(odd_bucket_step) + num_even_buckets * static_cast<Int64>(even_bucket_step);
+        const Int64 lo = hi - static_cast<Int64>((bucket_index % 2 != 0) ? odd_bucket_width : even_bucket_width);
+        return {lo, hi};
     }
 
     size_t ALWAYS_INLINE bucketIndex(const TimestampType timestamp) const
     {
-        return fast_bucket_math ? bucketIndexForTimestampFast(timestamp) : bucketIndexForTimestamp(timestamp);
+        /// The unused range computation of `classifySampleFast` is eliminated after inlining.
+        return fast_bucket_math ? classifySampleFast(static_cast<Int64>(timestamp)).bucket_index : bucketIndexForTimestamp(timestamp);
     }
 
     /// Returns a half-open range [first, last) of bucket indices that fall in a grid point's window. The range has
@@ -840,69 +923,149 @@ private:
         bucket.add(timestamp, value);
     }
 
-    /// The batch loops cache the last bucket: samples arrive sorted by timestamp within a series,
-    /// so consecutive samples usually land in the same bucket and skip the hash-map lookup.
-    /// Inserting into the map can invalidate the cached pointer, but an insert happens only on
-    /// a bucket change, which re-acquires the pointer anyway.
+    static ALWAYS_INLINE Int64 toInt64(TimestampType timestamp)
+    {
+        return static_cast<Int64>(timestamp);
+    }
+
+    /// Returns the number of leading samples of `timestamps[0, count)` with timestamps in `(lo, hi]`.
+    /// Checked in blocks so that the loop vectorizes; the samples of a partial block are re-checked one by one.
+    static ALWAYS_INLINE size_t scanSamplesInRange(const TimestampType * __restrict timestamps, size_t count, Int64 lo, Int64 hi)
+    {
+        constexpr size_t block_size = 16;
+        size_t scanned = 0;
+        while (scanned + block_size <= count)
+        {
+            UInt8 all_in_range = 1;
+            for (size_t j = 0; j < block_size; ++j)
+            {
+                const Int64 timestamp = toInt64(timestamps[scanned + j]);
+                all_in_range &= static_cast<UInt8>(timestamp > lo) & static_cast<UInt8>(timestamp <= hi);
+            }
+            if (!all_in_range)
+                break;
+            scanned += block_size;
+        }
+        while (scanned < count)
+        {
+            const Int64 timestamp = toInt64(timestamps[scanned]);
+            if (!(timestamp > lo && timestamp <= hi))
+                break;
+            ++scanned;
+        }
+        return scanned;
+    }
+
+    /// Batch counterpart of `add` for samples of one aggregation state. Requires `fast_bucket_math`.
+    ///
+    /// Instead of per-sample bucket math and a per-sample hash-map lookup, the batch is processed in runs of
+    /// consecutive samples that fall into one bucket's time range (or one skip range): real samples mostly
+    /// arrive in timestamp order and a bucket typically covers many scrape intervals, so runs are long. Each
+    /// run costs one `classifySampleFast` (with its integer division), one bucket lookup and one bulk append;
+    /// within the run each sample costs two comparisons (`scanSamplesInRange`) and a store. On randomly
+    /// ordered timestamps runs degenerate to one sample and this matches the cost of the plain loop.
+    void NO_INLINE addSamplesToBucketsImpl(State * __restrict state,
+        const TimestampType * __restrict timestamps,
+        const ValueType * __restrict values,
+        size_t row_begin,
+        size_t row_end) const
+    {
+        size_t i = row_begin;
+        while (i < row_end)
+        {
+            const SampleClass sample_class = classifySampleFast(toInt64(timestamps[i]));
+            const size_t run = scanSamplesInRange(timestamps + i, row_end - i, sample_class.lo, sample_class.hi);
+            if (sample_class.bucket_index != NO_BUCKET)
+                state->buckets[sample_class.bucket_index].addMany(timestamps + i, values + i, run);
+            /// A rejected sample is not always inside its own skip range (see `classifySampleFast`),
+            /// so the scan may return 0 - still consume one sample.
+            i += std::max<size_t>(run, static_cast<size_t>(1));
+        }
+    }
+
+    /// The flagged (`-If` condition or NULL map) counterpart: flags break runs unpredictably, so samples are
+    /// added one by one, but the bucket resolved for the previous sample is reused while timestamps stay in
+    /// its range - including a skip range (`bucket == nullptr`). Requires `fast_bucket_math`.
+    template <bool flag_value_to_include>
+    void addSamplesToBucketsFlagged(State * __restrict state,
+        const TimestampType * __restrict timestamps,
+        const ValueType * __restrict values,
+        const UInt8 * __restrict flags,
+        size_t row_begin,
+        size_t row_end) const
+    {
+        Bucket * bucket = nullptr;
+        Int64 lo = 0;
+        Int64 hi = 0;   /// Empty range: the first included sample always takes `classifySampleFast`
+        for (size_t i = row_begin; i < row_end; ++i)
+        {
+            if ((flags[i] != 0) != flag_value_to_include)
+                continue;
+
+            const Int64 timestamp = toInt64(timestamps[i]);
+            if (timestamp > lo && timestamp <= hi)
+            {
+                if (bucket)
+                    bucket->add(timestamps[i], values[i]);
+                continue;
+            }
+
+            const SampleClass sample_class = classifySampleFast(timestamp);
+            lo = sample_class.lo;
+            hi = sample_class.hi;
+            if (sample_class.bucket_index == NO_BUCKET)
+            {
+                bucket = nullptr;
+                continue;
+            }
+            /// The reference stays valid until the next lookup: only another insertion can rehash the map.
+            bucket = &state->buckets[sample_class.bucket_index];
+            bucket->add(timestamps[i], values[i]);
+        }
+    }
+
+    /// Entry point of the batch add path; `flags == nullptr` means every sample is included.
+    /// Falls back to the per-sample `add` when the Int64 bucket math is disabled.
+    template <bool flag_value_to_include>
+    void addSamples(AggregateDataPtr __restrict place,
+        const TimestampType * __restrict timestamps,
+        const ValueType * __restrict values,
+        const UInt8 * __restrict flags,
+        size_t row_begin,
+        size_t row_end) const
+    {
+        if (!fast_bucket_math)
+        {
+            for (size_t i = row_begin; i < row_end; ++i)
+                if (!flags || (flags[i] != 0) == flag_value_to_include)
+                    add(place, timestamps[i], values[i]);
+            return;
+        }
+
+        State * state = data(place);
+
+        if (flags)
+        {
+            addSamplesToBucketsFlagged<flag_value_to_include>(state, timestamps, values, flags, row_begin, row_end);
+            return;
+        }
+
+        addSamplesToBucketsImpl(state, timestamps, values, row_begin, row_end);
+    }
+
     void addMany(AggregateDataPtr __restrict place, const TimestampType * __restrict timestamp_ptr, const ValueType * __restrict value_ptr, size_t start, size_t end) const
     {
-        auto & buckets = data(place)->buckets;
-        size_t cached_bucket_index = NO_BUCKET;
-        Bucket * cached_bucket = nullptr;
-        for (size_t i = start; i < end; ++i)
-        {
-            const size_t bucket_index = bucketIndex(timestamp_ptr[i]);
-            if (bucket_index == NO_BUCKET)
-                continue;
-            if (bucket_index != cached_bucket_index)
-            {
-                cached_bucket = &buckets[bucket_index];
-                cached_bucket_index = bucket_index;
-            }
-            cached_bucket->add(timestamp_ptr[i], value_ptr[i]);
-        }
+        addSamples<true>(place, timestamp_ptr, value_ptr, nullptr, start, end);
     }
 
     void addManyNotNull(AggregateDataPtr __restrict place, const TimestampType * __restrict timestamp_ptr, const ValueType * __restrict value_ptr, const UInt8 * __restrict null_map, size_t start, size_t end) const
     {
-        auto & buckets = data(place)->buckets;
-        size_t cached_bucket_index = NO_BUCKET;
-        Bucket * cached_bucket = nullptr;
-        for (size_t i = start; i < end; ++i)
-        {
-            if (null_map[i])
-                continue;
-            const size_t bucket_index = bucketIndex(timestamp_ptr[i]);
-            if (bucket_index == NO_BUCKET)
-                continue;
-            if (bucket_index != cached_bucket_index)
-            {
-                cached_bucket = &buckets[bucket_index];
-                cached_bucket_index = bucket_index;
-            }
-            cached_bucket->add(timestamp_ptr[i], value_ptr[i]);
-        }
+        addSamples<false>(place, timestamp_ptr, value_ptr, null_map, start, end);
     }
 
     void addManyConditional(AggregateDataPtr __restrict place, const TimestampType * __restrict timestamp_ptr, const ValueType * __restrict value_ptr, const UInt8 * __restrict condition_map, size_t start, size_t end) const
     {
-        auto & buckets = data(place)->buckets;
-        size_t cached_bucket_index = NO_BUCKET;
-        Bucket * cached_bucket = nullptr;
-        for (size_t i = start; i < end; ++i)
-        {
-            if (!condition_map[i])
-                continue;
-            const size_t bucket_index = bucketIndex(timestamp_ptr[i]);
-            if (bucket_index == NO_BUCKET)
-                continue;
-            if (bucket_index != cached_bucket_index)
-            {
-                cached_bucket = &buckets[bucket_index];
-                cached_bucket_index = bucket_index;
-            }
-            cached_bucket->add(timestamp_ptr[i], value_ptr[i]);
-        }
+        addSamples<true>(place, timestamp_ptr, value_ptr, condition_map, start, end);
     }
 
     /// `flag_value_to_include` parameter determines which rows are included into result.

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -49,6 +49,28 @@ public:
         buffer.emplace_back(timestamp, value);
     }
 
+    /// Bulk `add` of `count` samples in one append. Produces the same samples as adding them one by one: they
+    /// are appended as is, and if they violate the sorted invariant (out-of-order or duplicate timestamps -
+    /// rare) the next `sort` restores it, with the same result because the `getMax` deduplication is
+    /// order-independent. `ALWAYS_INLINE` so that the loops are compiled - and vectorized - with the target
+    /// options of the caller, the batch bucketing kernel of `AggregateFunctionTimeseriesBase`.
+    ALWAYS_INLINE void addMany(const TimestampType * __restrict timestamps, const ValueType * __restrict values, size_t count)
+    {
+        if (count == 0)
+            return;
+
+        const size_t old_size = buffer.size();
+        buffer.resize(old_size + count);
+        auto * __restrict appended = buffer.data() + old_size;
+        for (size_t i = 0; i < count; ++i)
+            appended[i] = {timestamps[i], values[i]};
+
+        UInt8 in_order = old_size == 0 || appended[-1].first < timestamps[0];
+        for (size_t i = 1; i < count; ++i)
+            in_order &= static_cast<UInt8>(timestamps[i - 1] < timestamps[i]);
+        sorted = sorted && in_order;
+    }
+
     void merge(const AggregateFunctionTimeseriesSamples & other)
     {
         if (other.buffer.empty())

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -49,11 +49,6 @@ public:
         buffer.emplace_back(timestamp, value);
     }
 
-    /// Bulk `add` of `count` samples in one append. Produces the same samples as adding them one by one: they
-    /// are appended as is, and if they violate the sorted invariant (out-of-order or duplicate timestamps -
-    /// rare) the next `sort` restores it, with the same result because the `getMax` deduplication is
-    /// order-independent. `ALWAYS_INLINE` so that the loops are compiled - and vectorized - with the target
-    /// options of the caller, the batch bucketing kernel of `AggregateFunctionTimeseriesBase`.
     ALWAYS_INLINE void addMany(const TimestampType * __restrict timestamps, const ValueType * __restrict values, size_t count)
     {
         if (count == 0)

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesToGridSparse.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesToGridSparse.h
@@ -48,6 +48,13 @@ struct AggregateFunctionTimeseriesToGridSparseTraits
             }
         }
 
+        /// Bulk `add`, for the batch bucketing kernel of `AggregateFunctionTimeseriesBase`.
+        ALWAYS_INLINE void addMany(const TimestampType * __restrict timestamps, const ValueType * __restrict values, size_t count)
+        {
+            for (size_t i = 0; i < count; ++i)
+                add(timestamps[i], values[i]);
+        }
+
         void merge(const Summary & other)
         {
             if (other.has_value)

--- a/tests/performance/timeseries_to_grid_bucketing.xml
+++ b/tests/performance/timeseries_to_grid_bucketing.xml
@@ -1,0 +1,71 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_aggregate_functions>1</allow_experimental_time_series_aggregate_functions>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <!--
+        Benchmarks the sample-bucketing stage of the `timeSeries*ToGrid` aggregate functions (the batch add
+        path of `AggregateFunctionTimeseriesBase`): mapping each sample to its bucket and appending it there.
+        The grids are short (a few hundred points), so the grid-filling stage (`doInsertResultInto`) is cheap
+        and the bucketing dominates; `timeseries_to_grid_aggregation_functions.xml` covers the opposite,
+        grid-filling-heavy case.
+
+        Scenarios:
+          - sorted: timestamps ascend within each series (the storage order of time series tables), so
+            consecutive samples fall into the same bucket - long runs for the run-detecting kernel.
+          - rejected samples: `window < step` leaves gaps between buckets; with window 60 and step 900 about
+            93% of the samples fall into a gap and are skipped.
+          - unsorted: the storage order shuffles timestamps within each series, so bucket runs degenerate to
+            single samples - the worst case for run detection, guarding the fallback cost.
+    -->
+
+    <create_query>
+        CREATE TABLE ts_bucketing (id UInt64, timestamp DateTime64(3), value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
+    </create_query>
+    <create_query>
+        CREATE TABLE ts_bucketing_unsorted (id UInt64, h UInt64, timestamp DateTime64(3), value Float64) ENGINE = MergeTree ORDER BY (id, h)
+    </create_query>
+
+    <!-- 2500 series, one sample every 15s over [0, 300000) -> 20000 samples/series, 50M rows total.
+         The value is a sawtooth counter so rate sees transitions and resets. -->
+    <fill_query>
+        INSERT INTO ts_bucketing
+        SELECT
+            number % 2500 AS id,
+            toDateTime64(intDiv(number, 2500) * 15, 3) AS timestamp,
+            (intDiv(number, 2500) % 1000)::Float64 AS value
+        FROM numbers_mt(2500 * 20000)
+    </fill_query>
+
+    <!-- Same data with timestamps shuffled within each series by the storage order. 20M rows. -->
+    <fill_query>
+        INSERT INTO ts_bucketing_unsorted
+        SELECT
+            number % 2500 AS id,
+            intHash64(number) AS h,
+            toDateTime64(intDiv(number, 2500) * 15, 3) AS timestamp,
+            (intDiv(number, 2500) % 1000)::Float64 AS value
+        FROM numbers_mt(2500 * 8000)
+    </fill_query>
+
+    <!-- Sorted, all samples accepted: step = window = 300s -> 1001 grid points, 20 samples per bucket. -->
+    <query>SELECT id, timeSeriesRateToGrid(0, 300000, 300, 300)(timestamp, value) FROM ts_bucketing GROUP BY id FORMAT Null</query>
+    <query>SELECT id, timeSeriesInstantRateToGrid(0, 300000, 300, 300)(timestamp, value) FROM ts_bucketing GROUP BY id FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 300000, 300, 300)(timestamp, value) FROM ts_bucketing GROUP BY id FORMAT Null</query>
+
+    <!-- Sorted, most samples rejected: window 60 < step 900 -> only samples in (grid - 60, grid] contribute. -->
+    <query>SELECT id, timeSeriesRateToGrid(0, 300000, 900, 60)(timestamp, value) FROM ts_bucketing GROUP BY id FORMAT Null</query>
+
+    <!-- Split buckets: window 240 is not a multiple of step 180 -> two buckets per step. -->
+    <query>SELECT id, timeSeriesRateToGrid(0, 300000, 180, 240)(timestamp, value) FROM ts_bucketing GROUP BY id FORMAT Null</query>
+
+    <!-- Single aggregation state: the addBatchSinglePlace path over all series at once. -->
+    <query>SELECT timeSeriesRateToGrid(0, 300000, 300, 300)(timestamp, value) FROM ts_bucketing FORMAT Null</query>
+
+    <!-- Unsorted: bucket runs degenerate to single samples. -->
+    <query>SELECT id, timeSeriesRateToGrid(0, 300000, 300, 300)(timestamp, value) FROM ts_bucketing_unsorted GROUP BY id FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS ts_bucketing</drop_query>
+    <drop_query>DROP TABLE IF EXISTS ts_bucketing_unsorted</drop_query>
+</test>


### PR DESCRIPTION
Based on #114889 — the new changes are the last four commits.

The add path of `timeSeries*ToGrid` paid the bucket-index math and a hash-map lookup per sample. Samples arrive sorted by timestamp within a series and a bucket covers many scrape intervals, so the batch add path now works in runs: `classifySampleFast` returns the `(lo, hi]` timestamp range sharing the sample's fate (the bucket's time range, or a range of rejected timestamps — e.g. the whole gap between buckets when `window < step`), a vectorizable scan finds the run of consecutive in-range samples, and the run is appended to the bucket in bulk. One classification, one lookup, one append per run; two comparisons and a store per sample; unsorted input degenerates to the old per-sample cost. `addBatch` is also overridden to split batches into runs of the same aggregation state, hoisting the per-row `typeid_cast`s. The kernel is additionally compiled for x86-64-v4 with runtime dispatch; end-to-end neutral on the AVX2 baseline (the loops are bandwidth-bound), kept as future-proofing.

Bit-identical to master on a differential test over all 12 functions: all window/step shapes, `DateTime`/`DateTime64`, `Float32/64`, NaN, duplicate/unsorted timestamps, `Nullable`, `-If`, arrays, two-level/external aggregation, `-State`/`-Merge`, extreme parameters (which keep the `Int128` path).

On top of #114889 (100M rows, 1000 series, 16 threads, min of 7): rate 1.18x, rate with `window < step` 1.29x, instant rate 1.24x, deriv 1.24x, changes 1.15x; unsorted and finalize-heavy unchanged. Single-threaded (add path isolated): 1.26-2.09x.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Process samples of the `timeSeries*ToGrid` aggregate functions in runs of consecutive samples falling into one grid bucket, speeding up the sample-ingestion stage of `timeSeriesRateToGrid` and related functions by 1.2-2x on sorted time series data.
