### PR TITLE
Enable CORS in clickhouse-local by default

### DIFF
--- a/docs/concepts/features/tools-and-utilities/clickhouse-local.mdx
+++ b/docs/concepts/features/tools-and-utilities/clickhouse-local.mdx
@@ -381,10 +381,14 @@ clickhouse-local \
 
 The `--listen_host`, `--tcp_port`, and `--http_port` options configure the bind address and ports. Default ports are `9000` for TCP and `8123` for HTTP.
 
+The HTTP listener answers CORS preflight requests with the same permissive headers as the default `clickhouse-server` configuration, so a web application can query it from the browser out of the box - including the web UI opened from a `file://` URL, whose origin is `null`. To restrict this, define your own `http_options_response` section in a configuration file passed with `--config-file`; it replaces the defaults entirely.
+
 <Warning>
 **Security**
 
 By default, `clickhouse-local` runs with the temporary users setup, so any listener it opens is unauthenticated. Bind to a loopback address (`127.0.0.1` or `::1`) unless you have explicitly configured users and access control by pointing the `users_config` setting at a custom `users.xml` (for example via `--config-file`). Listening on a non-loopback address without authentication exposes the data of the local instance to anyone who can reach the chosen port.
+
+Note that a loopback address is still reachable from the browser: while an HTTP listener is open, any web page you visit can query the local instance and, thanks to the default CORS headers, read the results.
 </Warning>
 
 ## Related Content {#related-content-1}

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -1781,6 +1781,36 @@ void LocalServer::processConfig()
     if (!getClientConfiguration().has("http_port"))
         getClientConfiguration().setInt("http_port", DBMS_DEFAULT_HTTP_PORT);
 
+    /// Answer CORS preflight requests the same way the default `clickhouse-server` configuration does,
+    /// so the HTTP interface started by `SYSTEM START LISTEN HTTP` is usable from a browser out of the
+    /// box. `clickhouse-local` normally runs without a config file, and without these headers every
+    /// cross-origin request is rejected by the browser - including the web UI opened from a `file://`
+    /// URL, whose origin is `null`. A configuration file with its own `http_options_response` section
+    /// replaces these defaults entirely.
+    if (!getClientConfiguration().has("http_options_response"))
+    {
+        static constexpr std::pair<const char *, const char *> default_http_options_response[]
+        {
+            {"Access-Control-Allow-Origin", "*"},
+            {"Access-Control-Allow-Headers", "origin, x-requested-with, x-clickhouse-format, x-clickhouse-user, x-clickhouse-key, Authorization"},
+            {"Access-Control-Allow-Methods", "POST, GET, OPTIONS"},
+            {"Access-Control-Max-Age", "86400"},
+        };
+
+        /// The configuration layer that receives these keys is a flat key-value map with no notion of a
+        /// parent node, so the section itself has to be set explicitly - otherwise `config.has` does not
+        /// see it and the headers are never applied.
+        getClientConfiguration().setString("http_options_response", "");
+
+        for (size_t index = 0; index < std::size(default_http_options_response); ++index)
+        {
+            const auto & [name, value] = default_http_options_response[index];
+            const String key = fmt::format("http_options_response.header[{}]", index);
+            getClientConfiguration().setString(key + ".name", name);
+            getClientConfiguration().setString(key + ".value", value);
+        }
+    }
+
     /// Register callbacks for SYSTEM START/STOP LISTEN queries.
     global_context->setStartServersCallback([this](const ServerType & server_type)
     {

--- a/tests/queries/0_stateless/04908_clickhouse_local_http_cors.reference
+++ b/tests/queries/0_stateless/04908_clickhouse_local_http_cors.reference
@@ -1,0 +1,3 @@
+preflight: 1
+query: 1
+no origin: 0

--- a/tests/queries/0_stateless/04908_clickhouse_local_http_cors.sh
+++ b/tests/queries/0_stateless/04908_clickhouse_local_http_cors.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The HTTP interface of clickhouse-local must answer CORS preflight requests with the same
+# permissive headers as the default clickhouse-server configuration, so that a browser can talk
+# to it out of the box - including the web UI opened from a `file://` URL, whose origin is `null`.
+# clickhouse-local usually runs without a config file, so these defaults cannot come from one.
+
+PORT_FILE="${CLICKHOUSE_TMP}/$(basename "${BASH_SOURCE[0]}" .sh).port"
+rm -f "$PORT_FILE"
+
+# Bind an HTTP listener on an OS-assigned port (`--http_port 0`) to stay parallel-safe, publish
+# the bound port via INTO OUTFILE, then keep the process alive long enough to probe it.
+$CLICKHOUSE_LOCAL \
+    --listen_host 127.0.0.1 \
+    --http_port 0 \
+    --tcp_port 0 \
+    --query "
+    SYSTEM START LISTEN HTTP;
+    SELECT getServerPort('http_port') INTO OUTFILE '${PORT_FILE}' FORMAT TSVRaw;
+    SELECT sleep(3) FROM numbers(20) SETTINGS max_block_size = 1 FORMAT Null;
+    " >/dev/null 2>&1 &
+LOCAL_PID=$!
+
+PORT=""
+for _ in $(seq 1 100); do
+    if [ -s "$PORT_FILE" ]; then PORT=$(cat "$PORT_FILE"); break; fi
+    sleep 0.1
+done
+
+if [ -z "$PORT" ]; then
+    echo "FAIL: HTTP listener did not start"
+else
+    # The preflight of a request carrying an `Authorization` header, as sent by the web UI.
+    echo -n 'preflight: '
+    curl -s -D - -o /dev/null --max-time 30 -X OPTIONS \
+        -H 'Origin: null' \
+        -H 'Access-Control-Request-Method: POST' \
+        -H 'Access-Control-Request-Headers: authorization' \
+        "http://127.0.0.1:${PORT}/?query" | grep -ci '^access-control-allow-origin: \*'
+
+    # The response to the request itself must be readable by the page as well.
+    echo -n 'query: '
+    curl -s -D - -o /dev/null --max-time 30 -H 'Origin: null' --data-binary 'SELECT 1' \
+        "http://127.0.0.1:${PORT}/" | grep -ci '^access-control-allow-origin: \*'
+
+    # Without an `Origin` there is no cross-origin request and no CORS headers.
+    echo -n 'no origin: '
+    curl -s -D - -o /dev/null --max-time 30 --data-binary 'SELECT 1' \
+        "http://127.0.0.1:${PORT}/" | grep -ci '^access-control-allow-origin:'
+fi
+
+kill "$LOCAL_PID" 2>/dev/null
+wait "$LOCAL_PID" 2>/dev/null
+rm -f "$PORT_FILE"


### PR DESCRIPTION
`clickhouse-local` can serve HTTP after `SYSTEM START LISTEN HTTP`, but it normally runs without a config file, so it had no `http_options_response` section and answered the CORS preflight with a bare `204` carrying no `Access-Control-*` headers. A browser therefore refuses every cross-origin request to it - including the Web UI opened from a `file://` URL, whose origin is `null`.

Now `clickhouse-local` sets the same default `http_options_response` headers that the `clickhouse-server` configuration ships (`Access-Control-Allow-Origin: *` and friends). A configuration file with its own `http_options_response` section still replaces them entirely, and the headers are sent only for requests that carry an `Origin`, exactly as in `clickhouse-server`.

Note the implication, which is now documented next to the existing security warning for the listeners: while an HTTP listener is open, any web page you visit can query the local instance over the loopback address and read the results.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`clickhouse-local` now answers CORS preflight requests with the same permissive headers as `clickhouse-server`, so the HTTP interface opened by `SYSTEM START LISTEN HTTP` can be used from a browser out of the box, including the Web UI opened from a `file://` URL.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1522` (included in `26.8` and later)
<!-- ch-version-info:end -->