### PR TITLE
convertColumnToType: column-native wide-int / Decimal / Date-DateTime conversions (close B3, part 1)

### DIFF
--- a/src/Interpreters/convertColumnToType.cpp
+++ b/src/Interpreters/convertColumnToType.cpp
@@ -4,15 +4,21 @@
 #include <Interpreters/castColumn.h>
 #include <Columns/IColumn.h>
 #include <Columns/ColumnNullable.h>
+#include <Columns/ColumnDecimal.h>
+#include <Columns/ColumnsNumber.h>
 #include <Core/ColumnWithTypeAndName.h>
 #include <Core/Field.h>
+#include <Core/DecimalFunctions.h>
 #include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypesDecimal.h>
 #include <Common/Exception.h>
+#include <Common/FieldAccurateComparison.h>
 #include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
 
@@ -73,6 +79,112 @@ std::optional<ColumnPtr> tryConvertNumericColumnNative(
     if (nullable.isNullAt(0))
         return ColumnPtr{};
     return nullable.getNestedColumnPtr();
+}
+
+/// Faithful column-native `X -> Decimal` conversion. Reuses the exact public primitives that
+/// `convertFieldToType`'s Decimal helpers call (`DataTypeDecimal::canStoreWhole`/`getScaleMultiplier`,
+/// `convertToDecimal`, `convertDecimals`, and `accurateEquals` for the strict exactness check), reading
+/// the value straight from the size-1 column instead of materializing a `Field`. Mirrors
+/// `convertDecimalType` (and its `convertIntToDecimalType`/`convertFloatToDecimalType`/
+/// `convertDecimalToDecimalType` cases): an integer or float too big for the target throws
+/// `ARGUMENT_OUT_OF_BOUND` exactly as there. Returns the converted size-1 column, a null `ColumnPtr{}`
+/// for a strict-rejected lossy value, or `std::nullopt` when the source is not handled here (caller
+/// uses the `Field` fallback). Pinned by `gtest_convert_column_to_type`.
+template <typename ToDataType>
+std::optional<ColumnPtr> convertToDecimalColumnNative(
+    const IColumn & value, const DataTypePtr & from, const ToDataType & to_type, bool strict)
+{
+    using ToField = typename ToDataType::FieldType;
+    const UInt32 to_scale = to_type.getScale();
+
+    auto build = [&](const ToField & converted) -> ColumnPtr
+    {
+        auto column = to_type.createColumn();
+        assert_cast<ColumnDecimal<ToField> &>(*column).getData().push_back(converted);
+        return column;
+    };
+
+    /// integers (native + wide): `int -> Decimal` is exact, so `strict` adds no check here.
+    auto from_integer = [&]<typename From>(const From & v) -> ColumnPtr
+    {
+        if (!to_type.canStoreWhole(v))
+            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Number is too big to place in {}", to_type.getName());
+        return build(to_type.getScaleMultiplier() * ToField(static_cast<typename ToField::NativeType>(v)));
+    };
+
+    /// Decimals: mirror `convertDecimalToDecimalType` + the strict `accurateEquals` lossy-reject.
+    auto from_decimal = [&]<typename FromField>(const FromField & src, UInt32 from_scale) -> ColumnPtr
+    {
+        using FromDataType = DataTypeDecimal<FromField>;
+        const ToField converted = convertDecimals<FromDataType, ToDataType>(src, from_scale, to_scale);
+        if (strict
+            && !accurateEquals(Field(DecimalField<FromField>(src, from_scale)), Field(DecimalField<ToField>(converted, to_scale))))
+            return ColumnPtr{};
+        return build(converted);
+    };
+
+    const WhichDataType which_from(from);
+
+    if (which_from.isNativeUInt())
+        return from_integer(value.getUInt(0));
+    if (which_from.isNativeInt())
+        return from_integer(value.getInt(0));
+    if (which_from.isUInt128())
+        return from_integer(assert_cast<const ColumnVector<UInt128> &>(value).getData()[0]);
+    if (which_from.isUInt256())
+        return from_integer(assert_cast<const ColumnVector<UInt256> &>(value).getData()[0]);
+    if (which_from.isInt128())
+        return from_integer(assert_cast<const ColumnVector<Int128> &>(value).getData()[0]);
+    if (which_from.isInt256())
+        return from_integer(assert_cast<const ColumnVector<Int256> &>(value).getData()[0]);
+
+    /// floats (`Float32` widens to `Float64`, matching `NearestFieldType`): mirror `convertFloatToDecimalType`.
+    if (which_from.isFloat32() || which_from.isFloat64())
+    {
+        const Float64 v = value.getFloat64(0);
+        if (!to_type.canStoreWhole(v))
+            throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Number is too big to place in {}", to_type.getName());
+        const ToField converted = convertToDecimal<DataTypeNumber<Float64>, ToDataType>(v, to_scale);
+        if (strict && DecimalUtils::convertTo<Float64>(converted, to_scale) != v)
+            return ColumnPtr{};
+        return build(converted);
+    }
+
+    if (which_from.isDecimal32())
+        return from_decimal(assert_cast<const ColumnDecimal<Decimal32> &>(value).getData()[0],
+                            assert_cast<const DataTypeDecimal<Decimal32> &>(*from).getScale());
+    if (which_from.isDecimal64())
+        return from_decimal(assert_cast<const ColumnDecimal<Decimal64> &>(value).getData()[0],
+                            assert_cast<const DataTypeDecimal<Decimal64> &>(*from).getScale());
+    if (which_from.isDecimal128())
+        return from_decimal(assert_cast<const ColumnDecimal<Decimal128> &>(value).getData()[0],
+                            assert_cast<const DataTypeDecimal<Decimal128> &>(*from).getScale());
+    if (which_from.isDecimal256())
+        return from_decimal(assert_cast<const ColumnDecimal<Decimal256> &>(value).getData()[0],
+                            assert_cast<const DataTypeDecimal<Decimal256> &>(*from).getScale());
+
+    return std::nullopt;  // unsupported source (String/Date/Enum/wrappers/...) -> caller uses the Field fallback
+}
+
+/// Dispatch on the Decimal target width. Returns std::nullopt when `to` is not a Decimal, the source is
+/// `Bool` (which `convertFieldToType` does not accept for a Decimal target - it throws), or the source is
+/// otherwise not handled here, so the caller falls back to the `Field` path.
+std::optional<ColumnPtr> tryConvertToDecimalColumnNative(
+    const IColumn & value, const DataTypePtr & from, const DataTypePtr & to, bool strict)
+{
+    if (isBool(from))
+        return std::nullopt;
+
+    const WhichDataType which_to(to);
+    if (which_to.isDecimal32())
+        return convertToDecimalColumnNative(value, from, assert_cast<const DataTypeDecimal<Decimal32> &>(*to), strict);
+    if (which_to.isDecimal64())
+        return convertToDecimalColumnNative(value, from, assert_cast<const DataTypeDecimal<Decimal64> &>(*to), strict);
+    if (which_to.isDecimal128())
+        return convertToDecimalColumnNative(value, from, assert_cast<const DataTypeDecimal<Decimal128> &>(*to), strict);
+    if (which_to.isDecimal256())
+        return convertToDecimalColumnNative(value, from, assert_cast<const DataTypeDecimal<Decimal256> &>(*to), strict);
+    return std::nullopt;
 }
 
 /// `IColumn::get` reconstructs a `Field` using the storage column's `NearestFieldType`, which does not
@@ -154,6 +266,11 @@ ColumnPtr convertColumnToTypeOrNull(
 
     if (auto native = tryConvertNumericColumnNative(unwrapped, from, to, convert_inexact_floats))
         return std::move(*native);
+
+    /// `X -> Decimal` column-native (an engaged optional whose value may be a null `ColumnPtr`, meaning
+    /// a strict-rejected lossy value; std::nullopt means "not handled here, use the `Field` fallback").
+    if (auto decimal = tryConvertToDecimalColumnNative(unwrapped, from, to, strict))
+        return std::move(*decimal);
 
     /// Fallback: materialize a `Field`, reuse `convertFieldToType`, rebuild a column. Column-native
     /// fast paths above shrink this over time; the differential test pins equivalence.

--- a/src/Interpreters/convertColumnToType.cpp
+++ b/src/Interpreters/convertColumnToType.cpp
@@ -19,6 +19,7 @@
 #include <DataTypes/DataTypesDecimal.h>
 #include <Common/Exception.h>
 #include <Common/FieldAccurateComparison.h>
+#include <Common/DateLUTImpl.h>
 #include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
 
@@ -187,6 +188,58 @@ std::optional<ColumnPtr> tryConvertToDecimalColumnNative(
     return std::nullopt;
 }
 
+/// Faithful column-native numeric -> date conversions - the `Date`/`Date32`/`DateTime` branches of
+/// `convertFieldToType`'s number-representable path. Reuses the proven native-number path
+/// (`tryConvertNumericColumnNative`, i.e. `accurate::convertNumeric`) for the accurate integer step and
+/// mirrors each target's quirk exactly: `Date` is a range-checked `UInt16`; `Date32` is an `Int32` day
+/// number restricted to the extended-range window `[DATE_LUT_MIN_EXTEND_DAY_NUM, DATE_LUT_MAX_EXTEND_DAY_NUM]`;
+/// `DateTime` keeps the value unchanged (no range check - `convertFieldToType` returns it as-is and it is
+/// then truncated into the `UInt32` column). Sources are native integers only (matching the `UInt64`/`Int64`
+/// field branches there); `Bool`, wide integers and floats fall through to the `Field` path, as do the
+/// cross-calendar (`Date`<->`DateTime`), `DateTime64`/`Time`/`Time64` conversions (a later increment).
+/// Returns the converted size-1 column, a null `ColumnPtr{}` for a not-representable value, or
+/// std::nullopt when not handled here. Pinned by `gtest_convert_column_to_type`.
+std::optional<ColumnPtr> tryConvertToDateColumnNative(
+    const IColumn & value, const DataTypePtr & from, const DataTypePtr & to, bool convert_inexact_floats)
+{
+    const WhichDataType which_from(from);
+    if (isBool(from) || !(which_from.isNativeInt() || which_from.isNativeUInt()))
+        return std::nullopt;
+
+    const WhichDataType which_to(to);
+
+    /// `Date` (UInt16): accurate range-checked conversion, identical to `convertNumericType<UInt16>`.
+    /// A `UInt16` result column is exactly a `Date` column.
+    if (which_to.isDate())
+        return tryConvertNumericColumnNative(value, from, std::make_shared<DataTypeUInt16>(), convert_inexact_floats);
+
+    /// `Date32` (Int32 day number): accurate to `Int64`, then restrict to the representable window.
+    if (which_to.isDate32())
+    {
+        auto as_int64 = tryConvertNumericColumnNative(value, from, std::make_shared<DataTypeInt64>(), convert_inexact_floats);
+        if (!as_int64 || !*as_int64)
+            return as_int64;  // std::nullopt (n/a) or null `ColumnPtr` (out of `Int64` range)
+        const Int64 day_num = (*as_int64)->getInt(0);
+        if (day_num < DATE_LUT_MIN_EXTEND_DAY_NUM || day_num > DATE_LUT_MAX_EXTEND_DAY_NUM)
+            return ColumnPtr{};
+        auto column = to->createColumn();
+        assert_cast<ColumnInt32 &>(*column).getData().push_back(static_cast<Int32>(day_num));
+        return column;
+    }
+
+    /// `DateTime` (UInt32): `convertFieldToType` returns the unsigned value unchanged, which is then
+    /// stored (truncated) into the `UInt32` column - no range check. `Int64` sources are not handled
+    /// there, so leave them on the `Field` path.
+    if (which_to.isDateTime() && which_from.isNativeUInt())
+    {
+        auto column = to->createColumn();
+        assert_cast<ColumnUInt32 &>(*column).getData().push_back(static_cast<UInt32>(value.getUInt(0)));
+        return column;
+    }
+
+    return std::nullopt;
+}
+
 /// `IColumn::get` reconstructs a `Field` using the storage column's `NearestFieldType`, which does not
 /// round-trip the `Field` tag for `Bool`: a `DataTypeBool` column is a plain `ColumnUInt8`, so `get`
 /// yields a `UInt64` `Field`. `convertFieldToType` keys on that tag (e.g. `Bool -> String` gives
@@ -271,6 +324,10 @@ ColumnPtr convertColumnToTypeOrNull(
     /// a strict-rejected lossy value; std::nullopt means "not handled here, use the `Field` fallback").
     if (auto decimal = tryConvertToDecimalColumnNative(unwrapped, from, to, strict))
         return std::move(*decimal);
+
+    /// numeric -> `Date`/`Date32`/`DateTime` column-native (same optional convention as above).
+    if (auto date = tryConvertToDateColumnNative(unwrapped, from, to, convert_inexact_floats))
+        return std::move(*date);
 
     /// Fallback: materialize a `Field`, reuse `convertFieldToType`, rebuild a column. Column-native
     /// fast paths above shrink this over time; the differential test pins equivalence.

--- a/src/Interpreters/convertColumnToType.cpp
+++ b/src/Interpreters/convertColumnToType.cpp
@@ -17,6 +17,8 @@
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <base/DayNum.h>
 #include <Common/Exception.h>
 #include <Common/FieldAccurateComparison.h>
 #include <Common/DateLUTImpl.h>
@@ -240,6 +242,45 @@ std::optional<ColumnPtr> tryConvertToDateColumnNative(
     return std::nullopt;
 }
 
+/// Faithful column-native cross-calendar conversions between `Date`/`Date32` and `DateTime` (the
+/// timezone-aware branches of `convertFieldToType`). Reads the underlying day number / timestamp
+/// directly from the size-1 column and applies the very same `DateLUTImpl::toDayNum`/`fromDayNum` as
+/// there (the timezone comes from the `DateTime` type, `from` or `to`). Reading the value from the
+/// typed column avoids the `Field`'s `NearestFieldType` widening (`Date32` -> `Int64`) entirely.
+/// `DateTime64`/`Time`/`Time64` cross-calendar conversions are a later increment. Returns std::nullopt
+/// when the pair is not one of these. Pinned by `gtest_convert_column_to_type`.
+std::optional<ColumnPtr> tryConvertBetweenDateAndDateTimeColumnNative(
+    const IColumn & value, const DataTypePtr & from, const DataTypePtr & to)
+{
+    const WhichDataType which_from(from);
+    const WhichDataType which_to(to);
+
+    if (which_to.isDateTime() && (which_from.isDate() || which_from.isDate32()))
+    {
+        const auto & time_zone = assert_cast<const DataTypeDateTime &>(*to).getTimeZone();
+        const UInt32 result = which_from.isDate()
+            ? static_cast<UInt32>(time_zone.fromDayNum(DayNum(static_cast<UInt16>(value.getUInt(0)))))
+            : static_cast<UInt32>(time_zone.fromDayNum(ExtendedDayNum(static_cast<Int32>(value.getInt(0)))));
+        auto column = to->createColumn();
+        assert_cast<ColumnUInt32 &>(*column).getData().push_back(result);
+        return column;
+    }
+
+    if ((which_to.isDate() || which_to.isDate32()) && which_from.isDateTime())
+    {
+        const auto & time_zone = assert_cast<const DataTypeDateTime &>(*from).getTimeZone();
+        const auto day_num = time_zone.toDayNum(value.getUInt(0)).toUnderType();
+        auto column = to->createColumn();
+        if (which_to.isDate())
+            assert_cast<ColumnUInt16 &>(*column).getData().push_back(static_cast<UInt16>(day_num));
+        else
+            assert_cast<ColumnInt32 &>(*column).getData().push_back(static_cast<Int32>(day_num));
+        return column;
+    }
+
+    return std::nullopt;
+}
+
 /// `IColumn::get` reconstructs a `Field` using the storage column's `NearestFieldType`, which does not
 /// round-trip the `Field` tag for `Bool`: a `DataTypeBool` column is a plain `ColumnUInt8`, so `get`
 /// yields a `UInt64` `Field`. `convertFieldToType` keys on that tag (e.g. `Bool -> String` gives
@@ -327,6 +368,10 @@ ColumnPtr convertColumnToTypeOrNull(
 
     /// numeric -> `Date`/`Date32`/`DateTime` column-native (same optional convention as above).
     if (auto date = tryConvertToDateColumnNative(unwrapped, from, to, convert_inexact_floats))
+        return std::move(*date);
+
+    /// cross-calendar `Date`/`Date32` <-> `DateTime` (timezone-aware).
+    if (auto date = tryConvertBetweenDateAndDateTimeColumnNative(unwrapped, from, to))
         return std::move(*date);
 
     /// Fallback: materialize a `Field`, reuse `convertFieldToType`, rebuild a column. Column-native

--- a/src/Interpreters/convertColumnToType.cpp
+++ b/src/Interpreters/convertColumnToType.cpp
@@ -30,19 +30,20 @@ namespace
 {
 
 /// Column-native conversion for the cases where CAST provably matches `convertFieldToType`:
-/// plain native-numeric-to-native-numeric, in the default AND `strict` modes. `castColumnAccurateOrNull`
-/// uses the same accurate numeric conversion (`accurate::convertNumeric`) as `convertFieldToType`'s
-/// default path (out-of-range / inexact-narrowing -> NULL). For native numbers `strict` and default
-/// agree with it too: `strict` only rejects additional cases for types that are already excluded here -
-/// `Bool` (10 is not a valid `Bool`) and `Decimal` (scale reduction; `castColumnAccurateOrNull` would
-/// round, so it must NOT be used for strict Decimal - and it isn't, `Decimal` is not a native number).
-/// The strict native-number equivalence is pinned by `gtest_convert_column_to_type`. Returns:
+/// native-numeric and wide-integer (`Int128`/`Int256`/`UInt128`/`UInt256`) values, in the default AND
+/// `strict` modes. `castColumnAccurateOrNull` uses the same accurate numeric conversion
+/// (`accurate::convertNumeric`) as `convertFieldToType`'s default path (out-of-range / inexact-narrowing
+/// -> NULL), and `convertFieldToType` dispatches wide integers through that same template, so they agree.
+/// For these types `strict` and default agree with it too: `strict` only rejects additional cases for
+/// types that are already excluded here - `Bool` (10 is not a valid `Bool`) and `Decimal` (scale
+/// reduction; `castColumnAccurateOrNull` would round, so it must NOT be used for strict Decimal - and it
+/// isn't, `Decimal` is excluded). The strict equivalence is pinned by `gtest_convert_column_to_type`. Returns:
 ///   - the converted size-1 column of `to` on success,
 ///   - a null `ColumnPtr{}` when not representable,
 ///   - std::nullopt when this fast path does not apply (caller falls back to the `Field` path).
 /// Excluded: `convert_inexact_floats` mode (allows rounding, so `castColumnAccurateOrNull` differs),
-/// `Bool` (clamp/validity semantics), and anything non-native-numeric
-/// (Decimal/Date/Enum/String/wide-int/wrappers/composite).
+/// `Bool` (clamp/validity semantics), `Decimal`/`BFloat16`, and anything non-numeric
+/// (Date/Enum/String/wrappers/composite).
 std::optional<ColumnPtr> tryConvertNumericColumnNative(
     const IColumn & value,
     const DataTypePtr & from,
@@ -51,7 +52,13 @@ std::optional<ColumnPtr> tryConvertNumericColumnNative(
 {
     if (convert_inexact_floats)
         return std::nullopt;
-    if (!isNativeNumber(from) || !isNativeNumber(to) || isBool(from) || isBool(to))
+    /// Native numbers plus wide integers (`Int128`/`Int256`/`UInt128`/`UInt256`): `convertFieldToType`
+    /// routes wide-integer sources and targets through the very same `accurate::convertNumeric<From, To>`
+    /// as native numbers, so `castColumnAccurateOrNull` matches it for them too (default AND `strict`).
+    /// `Decimal` and `BFloat16` stay on the `Field` path (a strict `Decimal` must reject scale loss that
+    /// the accurate cast would round; `BFloat16` has its own rounding semantics).
+    auto is_native_or_wide_number = [](const DataTypePtr & type) { return isNativeNumber(type) || isInteger(type); };
+    if (!is_native_or_wide_number(from) || !is_native_or_wide_number(to) || isBool(from) || isBool(to))
         return std::nullopt;
     /// `strict` is intentionally not a parameter: for native numbers it is equivalent to the default
     /// accurate path (both reject non-representable values), so this fast path serves strict too.

--- a/src/Interpreters/tests/gtest_convert_column_to_type.cpp
+++ b/src/Interpreters/tests/gtest_convert_column_to_type.cpp
@@ -106,6 +106,28 @@ TEST(ConvertColumnToType, MatchesConvertFieldToType)
         {"Int64", Field(Int64(-128)), "Int8"},
         {"Int64", Field(Int64(-129)), "Int8"},            // overflow -> null
 
+        /// wide integers (Int128/256, UInt128/256): `convertFieldToType` routes them through the same
+        /// `accurate::convertNumeric` as native numbers, so the column-native fast path serves them too.
+        {"Int64", Field(Int64(5)), "Int128"},                           // widen native -> wide
+        {"UInt64", Field(UInt64(5)), "UInt256"},                        // widen native -> wide
+        {"Int128", Field(Int128(5)), "Int64"},                          // wide -> native, in range
+        {"Int128", Field(Int128(5)), "Int256"},                         // widen wide -> wide
+        {"Int256", Field(Int256(200)), "UInt8"},                        // wide -> native, in range
+        {"Int256", Field(Int256(300)), "UInt8"},                        // overflow -> null
+        {"Int128", Field(Int128(-1)), "UInt64"},                        // negative -> null
+        {"Int128", Field(Int128(1) << 70), "Int64"},                    // wide overflows native -> null
+        {"Int128", Field(Int128(1) << 70), "Int256"},                   // wide -> wider, exact
+        {"UInt256", Field(UInt256(255)), "UInt8"},                      // wide -> native, in range
+        {"Float64", Field(Float64(5.0)), "Int128"},                     // float -> wide, exact
+        {"Int128", Field(Int128(5)), "Float64"},                        // wide -> float
+        /// wide integers, strict
+        {"Int128", Field(Int128(5)), "Int64", true},                    // in range -> 5
+        {"Int128", Field(Int128(1) << 70), "Int64", true},              // overflow -> null
+        {"Int256", Field(Int256(300)), "UInt8", true},                  // overflow -> null
+        {"Float64", Field(Float64(3.0)), "Int128", true},               // exact -> 3
+        {"Float64", Field(Float64(3.5)), "Int128", true},               // non-integer -> null
+        {"UInt64", Field(UInt64(5)), "Int256", true},                   // widen across sign -> 5
+
         /// floats: exact / inexact in all three modes / overflow / NaN / inf
         {"Float64", Field(Float64(0.5)), "Float32"},
         {"Float64", Field(Float64(0.1)), "Float32"},                      // default: exact -> null

--- a/src/Interpreters/tests/gtest_convert_column_to_type.cpp
+++ b/src/Interpreters/tests/gtest_convert_column_to_type.cpp
@@ -127,6 +127,11 @@ TEST(ConvertColumnToType, MatchesConvertFieldToType)
         {"Float64", Field(Float64(3.0)), "Int128", true},               // exact -> 3
         {"Float64", Field(Float64(3.5)), "Int128", true},               // non-integer -> null
         {"UInt64", Field(UInt64(5)), "Int256", true},                   // widen across sign -> 5
+        /// wide int -> float precision loss: strict must reject (this is what IN/set building relies on)
+        {"Int128", Field(Int128(9007199254740993ll)), "Float64"},        // 2^53+1: default -> nearest float
+        {"Int128", Field(Int128(9007199254740993ll)), "Float64", true},  // 2^53+1: strict -> null
+        {"UInt256", Field(UInt256(9007199254740993ull)), "Float64", true}, // strict -> null
+        {"Int128", Field(Int128(16777217)), "Float32", true},            // 2^24+1: strict -> null (Float32)
 
         /// floats: exact / inexact in all three modes / overflow / NaN / inf
         {"Float64", Field(Float64(0.5)), "Float32"},
@@ -190,6 +195,10 @@ TEST(ConvertColumnToType, MatchesConvertFieldToType)
         {"DateTime('UTC')", Field(UInt64(1641600000)), "Date"},          // -> day 19000
         {"Date32", Field(Int64(19000)), "DateTime('UTC')"},              // -> 1641600000
         {"DateTime('UTC')", Field(UInt64(1641600000)), "Date32"},        // -> day 19000
+        /// non-UTC: proves the timezone object of the DateTime type is actually consulted
+        {"Date32", Field(Int64(19000)), "DateTime('Europe/Berlin')"},    // fromDayNum in Berlin tz
+        {"DateTime('Europe/Berlin')", Field(UInt64(1641600000)), "Date"}, // toDayNum in Berlin tz
+        {"DateTime('Europe/Berlin')", Field(UInt64(1641600000)), "Date32"},
 
         /// nullable / lowcardinality wrappers
         {"Nullable(Int32)", Field(Int64(7)), "Int64"},

--- a/src/Interpreters/tests/gtest_convert_column_to_type.cpp
+++ b/src/Interpreters/tests/gtest_convert_column_to_type.cpp
@@ -186,6 +186,11 @@ TEST(ConvertColumnToType, MatchesConvertFieldToType)
         {"UInt64", Field(UInt64(1700000000)), "DateTime('UTC')"},        // fits UInt32
         {"UInt64", Field(UInt64(5000000000)), "DateTime('UTC')"},        // > UInt32 max -> truncates (raw, no range check)
 
+        /// cross-calendar Date/Date32 <-> DateTime (timezone-aware): day 19000 == 2022-01-08 == 1641600000 UTC
+        {"DateTime('UTC')", Field(UInt64(1641600000)), "Date"},          // -> day 19000
+        {"Date32", Field(Int64(19000)), "DateTime('UTC')"},              // -> 1641600000
+        {"DateTime('UTC')", Field(UInt64(1641600000)), "Date32"},        // -> day 19000
+
         /// nullable / lowcardinality wrappers
         {"Nullable(Int32)", Field(Int64(7)), "Int64"},
         {"Nullable(Int32)", Field(Null()), "Int64"},                     // null in, non-null to -> not representable

--- a/src/Interpreters/tests/gtest_convert_column_to_type.cpp
+++ b/src/Interpreters/tests/gtest_convert_column_to_type.cpp
@@ -174,6 +174,18 @@ TEST(ConvertColumnToType, MatchesConvertFieldToType)
         {"UInt16", Field(UInt64(19000)), "Date"},
         {"Date", Field(UInt64(19000)), "DateTime('UTC')"},
 
+        /// numeric -> date family (column-native path)
+        {"UInt64", Field(UInt64(19000)), "Date"},                         // 19000
+        {"Int64", Field(Int64(19000)), "Date"},                          // 19000
+        {"UInt64", Field(UInt64(70000)), "Date"},                        // out of UInt16 range -> null
+        {"Int64", Field(Int64(-1)), "Date"},                             // negative -> null
+        {"Int64", Field(Int64(19000)), "Date32"},                        // in window
+        {"UInt64", Field(UInt64(19000)), "Date32"},                      // in window
+        {"Int64", Field(Int64(3000000)), "Date32"},                      // > max extended day -> null
+        {"Int64", Field(Int64(-800000)), "Date32"},                      // < min extended day -> null
+        {"UInt64", Field(UInt64(1700000000)), "DateTime('UTC')"},        // fits UInt32
+        {"UInt64", Field(UInt64(5000000000)), "DateTime('UTC')"},        // > UInt32 max -> truncates (raw, no range check)
+
         /// nullable / lowcardinality wrappers
         {"Nullable(Int32)", Field(Int64(7)), "Int64"},
         {"Nullable(Int32)", Field(Null()), "Int64"},                     // null in, non-null to -> not representable

--- a/src/Interpreters/tests/gtest_convert_column_to_type.cpp
+++ b/src/Interpreters/tests/gtest_convert_column_to_type.cpp
@@ -150,6 +150,20 @@ TEST(ConvertColumnToType, MatchesConvertFieldToType)
         {"Decimal64(2)", Field(DecimalField<Decimal64>(Decimal64(3333), 2)), "Decimal64(1)", true, false}, // strict -> null
         {"Int64", Field(Int64(5)), "Decimal64(2)"},
 
+        /// more decimals (column-native path): int/wide/float/decimal sources into every width, default + strict
+        {"UInt64", Field(UInt64(42)), "Decimal64(2)"},                                                     // 42.00
+        {"Int64", Field(Int64(-5)), "Decimal64(2)"},                                                       // -5.00
+        {"UInt64", Field(UInt64(1000000000000000000ull)), "Decimal32(0)"},                                 // too big -> throws -> null
+        {"Int128", Field(Int128(5)), "Decimal128(3)"},                                                     // wide int -> 5.000
+        {"UInt256", Field(UInt256(7)), "Decimal256(2)"},                                                   // wide int -> 7.00
+        {"Float64", Field(Float64(0.5)), "Decimal64(2)"},                                                  // 0.50
+        {"Float64", Field(Float64(0.5)), "Decimal64(2)", true},                                            // exact -> 0.50
+        {"Float64", Field(Float64(0.125)), "Decimal64(2)", true},                                          // inexact -> null
+        {"Decimal32(2)", Field(DecimalField<Decimal32>(Decimal32(333), 2)), "Decimal64(4)"},               // widen 3.33 -> 3.3300
+        {"Decimal128(4)", Field(DecimalField<Decimal128>(Decimal128(12345), 4)), "Decimal64(2)"},          // narrow 1.2345 -> 1.23 (round)
+        {"Decimal128(4)", Field(DecimalField<Decimal128>(Decimal128(12345), 4)), "Decimal64(2)", true},    // narrow lossy -> null
+        {"Decimal64(1)", Field(DecimalField<Decimal64>(Decimal64(333), 1)), "Decimal128(3)", true},        // widen exact -> 33.300
+
         /// string <-> number
         {"String", Field(String("42")), "Int32"},
         {"String", Field(String("256")), "UInt8"},                       // out of range -> null


### PR DESCRIPTION
Grows the column-native fast paths in `convertColumnToType` so that more conversions no longer reconstruct a `Field` and delegate to `convertFieldToType` internally. This is one step of closing bridge **B3** in the `DB::Field`-removal effort (making `convertColumnToType` `Field`-free internally, so its callers - and eventually the whole `Field` API - can be removed).

This PR adds faithful column-native paths for:
- **wide integers** (`Int128`/`Int256`/`UInt128`/`UInt256`) - `convertFieldToType` dispatches them through the same `accurate::convertNumeric` template as native numbers, so the existing `castColumnAccurateOrNull` fast path serves them too;
- **`Decimal` targets** (integer/wide/float/Decimal sources, default and `strict`) - reusing the exact primitives `convertFieldToType`'s Decimal helpers call (`canStoreWhole`/`getScaleMultiplier`, `convertToDecimal`, `convertDecimals`, and `accurateEquals` for the strict exactness check);
- **numeric → `Date`/`Date32`/`DateTime`** - mirroring each target's quirk (range-checked `UInt16`; `Int32` day number in the extended window; raw truncation for `DateTime`);
- **cross-calendar `Date`/`Date32` ↔ `DateTime`** - the timezone-aware `toDayNum`/`fromDayNum` branches.

**Behaviour is unchanged**: every conversion above produced identical results through the `Field` fallback before; this only removes the per-value `Field` materialization for them. Note that `castColumn` is deliberately *not* used - it shares the low-level primitives but wraps them with different overflow/clamping semantics (`DECIMAL_OVERFLOW`, saturation to `MAX_DATETIME_TIMESTAMP`), so the shared primitives are called directly to match `convertFieldToType` bit for bit.

Equivalence is pinned throughout by the differential unit test `gtest_convert_column_to_type` (`convertColumnToType` must equal `convertFieldToType`), extended here with wide-integer, Decimal, and date-family cases (widen/narrow/overflow/sign, extended-window bounds, raw truncation, cross-calendar round-trips).

The remaining `convertFieldToType` surface (`DateTime64`/`Time`/`Time64`, composites, `String`, `IPv4`/`IPv6`/`UUID`, …) stays on the `Field` fallback and will be closed in follow-up PRs.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Internal refactoring (no user-visible change): `convertColumnToType` now performs wide-integer, `Decimal`, and `Date`/`DateTime` constant conversions column-natively instead of materializing a `Field`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
