### PR TITLE
Add a test for case-insensitive column name matching from #92851

### DIFF
--- a/tests/queries/0_stateless/04908_json_each_row_lowercase_field_names.reference
+++ b/tests/queries/0_stateless/04908_json_each_row_lowercase_field_names.reference
@@ -1,0 +1,1 @@
+hi!	universe

--- a/tests/queries/0_stateless/04908_json_each_row_lowercase_field_names.sql
+++ b/tests/queries/0_stateless/04908_json_each_row_lowercase_field_names.sql
@@ -1,0 +1,16 @@
+-- The exact scenario from https://github.com/ClickHouse/ClickHouse/issues/92851:
+-- the table columns are `Hello` and `World`, while the input data spells the field
+-- names in lowercase. With the default `input_format_column_name_matching_mode = 'auto'`
+-- the fields are matched case-insensitively, so the values are inserted instead of
+-- silently becoming empty strings.
+
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test (Hello String, World String) ENGINE = Memory;
+
+INSERT INTO test FORMAT JSONEachRow {"hello": "hi!", "world": "universe"}
+;
+
+SELECT * FROM test;
+
+DROP TABLE test;


### PR DESCRIPTION
Issue [#92851](https://github.com/ClickHouse/ClickHouse/issues/92851) asked for input formats that carry column names to match them case-insensitively when there is no ambiguity. That works now, through `input_format_column_name_matching_mode` (default `auto`), but the reproducer from the issue was not covered by a test.

The existing tests (`04027_json_input_format`, `04209_column_name_matching_mode_default`, and the `CSV`/`JSONColumns`/`BSON`/`RowBinaryWithNames` ones) exercise the mechanism only in the direction "lowercase table columns, uppercase input fields". The issue shows the opposite: a table with the columns `Hello` and `World`, fed by `JSONEachRow` data that spells the field names in lowercase, which used to silently insert empty strings.

The new test runs exactly that scenario with default settings. It is a real regression guard: with `input_format_column_name_matching_mode = 'match_case'` (or `compatibility = '26.4'`) it produces the empty strings from the issue instead of the values.

Related: https://github.com/ClickHouse/ClickHouse/issues/92851

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1544` (included in `26.8` and later)
<!-- ch-version-info:end -->