### PR TITLE
Document that a MATERIALIZED column calculated from an EPHEMERAL column is not recalculated by a mutation

### DIFF
--- a/docs/reference/statements/alter/update.mdx
+++ b/docs/reference/statements/alter/update.mdx
@@ -30,6 +30,45 @@ The synchronicity of the query processing is defined by the [mutations_sync](/re
 - [Lightweight `UPDATE`](/reference/statements/update) - Alternative lightweight update using patch parts
 - [`APPLY PATCHES`](/reference/statements/alter/apply-patches) - Manually apply patches from lightweight updates
 
+## Materialized columns {#materialized-columns}
+
+A [`MATERIALIZED`](/reference/statements/create/table#materialized) column whose expression reads an
+updated column is recalculated by the mutation, so its stored value stays consistent with the new data.
+
+### Columns calculated from EPHEMERAL columns {#columns-calculated-from-ephemeral-columns}
+
+An [`EPHEMERAL`](/reference/statements/create/table#ephemeral) column exists only for the duration of an
+`INSERT` and is never stored, so a `MATERIALIZED` column calculated from one cannot be recalculated by a
+mutation. Such a column keeps the value computed at `INSERT` time, which then no longer matches its
+expression:
+
+```sql
+CREATE TABLE test
+(
+    x Int32,
+    e Int32 EPHEMERAL 0,
+    m Int32 MATERIALIZED x + e
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO test (x, e) VALUES (1, 7);
+
+ALTER TABLE test UPDATE x = 2 WHERE 1;
+
+SELECT x, m FROM test;
+```
+
+```text
+┌─x─┬─m─┐
+│ 2 │ 8 │
+└───┴───┘
+```
+
+`m` is `8`, the value calculated during `INSERT`, and not `2 + 7`: the value of `e` is not available
+outside the `INSERT` that supplied it. The mutation writes a warning to the server log when it skips a
+column for this reason. To bring such a column up to date, re-`INSERT` the affected rows.
+
 ## Related content {#related-content}
 
 - Blog: [Handling Updates and Deletes in ClickHouse](https://clickhouse.com/blog/handling-updates-and-deletes-in-clickhouse)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114561

## Problem

Nothing documents what a mutation does to a `MATERIALIZED` column that is calculated from an
`EPHEMERAL` column. The behaviour is a deliberate trade-off, but a user can only discover it by
observing wrong-looking data:

```sql
CREATE TABLE test (x Int32, e Int32 EPHEMERAL 0, m Int32 MATERIALIZED x + e)
ENGINE = MergeTree ORDER BY tuple();
INSERT INTO test (x, e) VALUES (1, 7);        -- m = 8

ALTER TABLE test UPDATE x = 2 WHERE 1;
SELECT x, m FROM test;                        -- 2  8   <- not 2 + 7
```

`m` keeps its `INSERT`-time value and from then on does not match its own expression, because `e` does
not exist outside the `INSERT` that supplied it and cannot be read back to recalculate `m`.

Where a user would look today:

- **`ALTER TABLE ... UPDATE`** — does not mention `MATERIALIZED` or `EPHEMERAL` at all. Its only related
  statement is that updating a column used in the primary or partition key is unsupported.
- **`MATERIALIZED`** — says values are "automatically calculated ... when rows are inserted", and says
  nothing about mutations.
- **`EPHEMERAL`** — correctly says such columns are not stored, but does not draw out the consequence
  for mutations.

The mutation does log a warning when it skips a column for this reason, which is accurate and
actionable — but it appears only in the server log, at the moment it happens, and is not returned to the
client. So the only documentation of this behaviour is an after-the-fact log line.

## Solution

Add a `Materialized columns` section to the `ALTER TABLE ... UPDATE` page: a `MATERIALIZED` column whose
expression reads an updated column is recalculated, and a sub-section on the `EPHEMERAL` case with the
example above, the reason, and the existing advice to re-`INSERT` the affected rows.

The example's output was verified verbatim against a local server. Only the English page is edited;
localized pages are generated.

Documentation only — no behaviour change, and independent of any pending fix in this area: it states
what holds on `master` today and would still hold after https://github.com/ClickHouse/ClickHouse/pull/114561.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1616` (included in `26.8` and later)
<!-- ch-version-info:end -->