### PR TITLE
Answer text-index materialization from the index read task

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -46,9 +46,13 @@ namespace FailPoints
 namespace
 {
 
+/// Answers from the same index object, and by the same predicate, that assigns the index reader
+/// in `getIndexReadTaskForReadStep`. A part this reports as materialized reads the virtual column
+/// from the index; every other part must instead read the columns its default expression needs.
 bool hasMaterializedTextIndex(
     const StorageSnapshotPtr & storage_snapshot,
     const IMergeTreeDataPartInfoForReader & data_part_info_for_reader,
+    const IndexReadTasks & index_read_tasks,
     const String & virtual_column_name)
 {
     if (storage_snapshot->metadata->virtuals.empty())
@@ -60,14 +64,19 @@ bool hasMaterializedTextIndex(
 
     /// Name of the text index is embedded as a comment to the virtual column.
     const auto & text_index_name = virtual_column->comment;
-    for (const auto & index_desc : storage_snapshot->metadata->getSecondaryIndices())
-    {
-        if (index_desc.type == "text" && index_desc.name == text_index_name)
-            if (const auto * loaded_part = dynamic_cast<const LoadedMergeTreeDataPartInfoForReader *>(&data_part_info_for_reader))
-                return loaded_part->getDataPart()->hasSecondaryIndex(index_desc.name, storage_snapshot->metadata);
-    }
+    auto index_task_it = index_read_tasks.find(text_index_name);
+    if (index_task_it == index_read_tasks.end())
+        return false;
 
-    return false;
+    const auto & index = index_task_it->second.index.index;
+    if (!index || !index->isTextIndex())
+        return false;
+
+    const auto * loaded_part = dynamic_cast<const LoadedMergeTreeDataPartInfoForReader *>(&data_part_info_for_reader);
+    if (!loaded_part)
+        return false;
+
+    return !!index->getDeserializedFormat(*loaded_part->getDataPart(), index->getFileName());
 }
 
 /// Columns absent in part may depend on other absent columns so we are
@@ -78,6 +87,7 @@ bool injectRequiredColumnsRecursively(
     const StorageSnapshotPtr & storage_snapshot,
     const AlterConversionsPtr & alter_conversions,
     const IMergeTreeDataPartInfoForReader & data_part_info_for_reader,
+    const IndexReadTasks & index_read_tasks,
     const GetColumnsOptions & options,
     Names & columns,
     NameSet & required_columns,
@@ -130,7 +140,8 @@ bool injectRequiredColumnsRecursively(
             add_column(column_in_storage->getNameInStorage());
             return true;
         }
-        else if (isTextIndexVirtualColumn(column_name_in_part) && hasMaterializedTextIndex(storage_snapshot, data_part_info_for_reader, column_name_in_part))
+        else if (isTextIndexVirtualColumn(column_name_in_part)
+            && hasMaterializedTextIndex(storage_snapshot, data_part_info_for_reader, index_read_tasks, column_name_in_part))
         {
             /// If there is a materialized text index in the part, use the virtual column directly.
             add_column(column_name);
@@ -160,7 +171,7 @@ bool injectRequiredColumnsRecursively(
     for (const auto & identifier : identifiers)
         result |= injectRequiredColumnsRecursively(
             identifier, storage_snapshot, alter_conversions, data_part_info_for_reader,
-            options, columns, required_columns, injected_columns);
+            index_read_tasks, options, columns, required_columns, injected_columns);
 
     return result;
 }
@@ -175,6 +186,7 @@ bool injectRequiredColumnsRecursively(
 NameSet injectRequiredColumns(
     const IMergeTreeDataPartInfoForReader & data_part_info_for_reader,
     const StorageSnapshotPtr & storage_snapshot,
+    const IndexReadTasks & index_read_tasks,
     bool with_subcolumns,
     Names & columns)
 {
@@ -204,6 +216,7 @@ NameSet injectRequiredColumns(
             storage_snapshot,
             alter_conversions,
             data_part_info_for_reader,
+            index_read_tasks,
             options,
             columns,
             required_columns,
@@ -481,7 +494,7 @@ MergeTreeReadTaskColumns getReadTaskColumns(
     Names column_to_read_after_prewhere = required_columns;
 
     /// Inject columns required for defaults evaluation
-    injectRequiredColumns(data_part_info_for_reader, storage_snapshot, with_subcolumns, column_to_read_after_prewhere);
+    injectRequiredColumns(data_part_info_for_reader, storage_snapshot, index_read_tasks, with_subcolumns, column_to_read_after_prewhere);
 
     auto options = GetColumnsOptions(GetColumnsOptions::All)
         .withVirtuals(VirtualsKind::All, VirtualsMaterializationPlace::Reader)
@@ -517,7 +530,7 @@ MergeTreeReadTaskColumns getReadTaskColumns(
         if (!step_column_names.empty() || !has_adaptive_granularity)
         {
             injectRequiredColumns(
-                data_part_info_for_reader, storage_snapshot,
+                data_part_info_for_reader, storage_snapshot, index_read_tasks,
                 with_subcolumns, step_column_names);
         }
 

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
@@ -15,6 +15,7 @@ class IMergeTreeDataPartInfoForReader;
 NameSet injectRequiredColumns(
     const IMergeTreeDataPartInfoForReader & data_part_info_for_reader,
     const StorageSnapshotPtr & storage_snapshot,
+    const IndexReadTasks & index_read_tasks,
     bool with_subcolumns,
     Names & columns);
 

--- a/tests/integration/test_text_index_orphan_read/test.py
+++ b/tests/integration/test_text_index_orphan_read/test.py
@@ -46,9 +46,10 @@ def part_path(table, part_name):
 
 
 def stop_merges(table):
-    # A merge rebuilds an index that is not accounted in the source part, so it destroys the
-    # carrier as well as the part names. The lock is held on the storage instance, so it must be
-    # re-taken after every ATTACH.
+    # Redundant second line of defence. The guard that actually holds is
+    # `max_bytes_to_merge_at_max_space_in_pool = 0` in the table metadata: this statement locks
+    # the storage instance, and `ATTACH TABLE` runs `startup` on a fresh instance before
+    # returning, so a merge can be selected before any later statement reaches the server.
     node.query(f"SYSTEM STOP MERGES {table}")
 
 
@@ -67,7 +68,9 @@ def make_partially_materialized(table, packed_max_bytes=0):
     # A partially materialized index is what arms the direct-read optimization while still
     # requiring the first part to be read through the virtual column's default expression.
     # `mm_k` gives the first part a skip-index file to copy from; the remaining settings keep
-    # index filenames and sizes predictable.
+    # index filenames and sizes predictable. A merge would rebuild the unaccounted index and
+    # repair the very shape these arms assert on, so merges are disabled in table metadata,
+    # which is checked before any merge selector runs and applies on every startup.
     node.query(f"DROP TABLE IF EXISTS {table} SYNC")
     node.query(
         f"""
@@ -77,7 +80,8 @@ def make_partially_materialized(table, packed_max_bytes=0):
                  packed_skip_index_max_bytes = {packed_max_bytes},
                  index_granularity = 100,
                  replace_long_file_name_to_hash = 0,
-                 columns_and_secondary_indices_sizes_lazy_calculation = 0
+                 columns_and_secondary_indices_sizes_lazy_calculation = 0,
+                 max_bytes_to_merge_at_max_space_in_pool = 0
         """
     )
     stop_merges(table)
@@ -94,8 +98,20 @@ def make_partially_materialized(table, packed_max_bytes=0):
 
 
 def reattach(table):
-    node.query(f"DETACH TABLE {table}")
+    # `DETACH` must be `SYNC`: an asynchronous detach leaves the instance tracked in
+    # `DatabaseAtomic::detached_tables` while another subsystem still holds a `StoragePtr`, and
+    # the following `ATTACH` then throws `TABLE_ALREADY_EXISTS` rather than waiting.
+    node.query(f"DETACH TABLE {table} SYNC")
     node.query(f"ATTACH TABLE {table}")
+    # The merge guard lives in table metadata so that it is already in force during the startup
+    # `ATTACH` performs before it returns; assert it survived rather than assuming it.
+    engine_full = scalar(
+        f"SELECT engine_full FROM system.tables "
+        f"WHERE database = currentDatabase() AND name = '{table}'"
+    )
+    assert "max_bytes_to_merge_at_max_space_in_pool = 0" in engine_full, (
+        f"merge guard missing from table metadata after reattach: {engine_full}"
+    )
     stop_merges(table)
 
 
@@ -212,12 +228,15 @@ def test_no_orphan_is_unaffected(started_cluster):
 def test_index_materialized_in_no_part(started_cluster):
     # An index materialized in no part disables the direct-read rewrite entirely, so no virtual
     # column is created and the predicate answers through the ordinary row-level path.
+    # The fixture inserts every row in one statement, so this arm has a single part and asserts
+    # only table-level counts; a two-part layout guard would never hold here.
     table = "orphan_read_unmaterialized"
     node.query(f"DROP TABLE IF EXISTS {table} SYNC")
     node.query(
         f"""
         CREATE TABLE {table} (k UInt64, s String) ENGINE = MergeTree ORDER BY k
-        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100,
+                 max_bytes_to_merge_at_max_space_in_pool = 0
         """
     )
     node.query(
@@ -253,7 +272,8 @@ def test_fully_materialized_index_still_prunes(started_cluster):
         CREATE TABLE {table}
         (k UInt64, s String, INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1)
         ENGINE = MergeTree ORDER BY k
-        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100,
+                 max_bytes_to_merge_at_max_space_in_pool = 0
         """
     )
     stop_merges(table)
@@ -347,7 +367,8 @@ def test_partially_materialized_index_without_corruption(started_cluster):
     node.query(
         f"""
         CREATE TABLE {table} (k UInt64, s String) ENGINE = MergeTree ORDER BY k
-        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100,
+                 max_bytes_to_merge_at_max_space_in_pool = 0
         """
     )
     stop_merges(table)
@@ -399,7 +420,8 @@ def test_orphan_index_file_on_compact_part(started_cluster):
         ENGINE = MergeTree ORDER BY k
         SETTINGS packed_skip_index_max_bytes = 0, index_granularity = 100,
                  replace_long_file_name_to_hash = 0,
-                 columns_and_secondary_indices_sizes_lazy_calculation = 0
+                 columns_and_secondary_indices_sizes_lazy_calculation = 0,
+                 max_bytes_to_merge_at_max_space_in_pool = 0
         """
     )
     stop_merges(table)

--- a/tests/integration/test_text_index_orphan_read/test.py
+++ b/tests/integration/test_text_index_orphan_read/test.py
@@ -5,27 +5,8 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True)
 
-ROWS_PER_PART = 1000
-TOTAL_ROWS = 2 * ROWS_PER_PART
-
-# The wrong answer needs the direct-read rewrite to run and the skip index to be applied while
-# reading data; asserting ground truth cannot detect a default flip, so every asserting query
-# pins these explicitly.
-ARMING_SETTINGS = (
-    "use_skip_indexes = 1, "
-    "use_skip_indexes_on_data_read = 1, "
-    "query_plan_direct_read_from_text_index = 1"
-)
-
-# `EXPLAIN indexes = 1` reports granule counts from analysis, which only happens when the index
-# is not applied while reading data. A query-level setting is applied after EXPLAIN forces that
-# off internally, so asking for data-read-time application here would report every granule as
-# read and the pruning assertion could never fail.
-EXPLAIN_SETTINGS = (
-    "use_skip_indexes = 1, "
-    "use_skip_indexes_on_data_read = 0, "
-    "query_plan_direct_read_from_text_index = 1"
-)
+# A background merge would rebuild the unaccounted index and repair the shape under test.
+NO_MERGES = "max_bytes_to_merge_at_max_space_in_pool = 0"
 
 
 @pytest.fixture(scope="module")
@@ -37,425 +18,73 @@ def started_cluster():
         cluster.shutdown()
 
 
-def part_path(table, part_name):
-    return node.query(
-        f"SELECT path FROM system.parts "
-        f"WHERE database = currentDatabase() AND table = '{table}' "
-        f"AND name = '{part_name}' AND active"
-    ).strip()
-
-
-def stop_merges(table):
-    # Redundant second line of defence. The guard that actually holds is
-    # `max_bytes_to_merge_at_max_space_in_pool = 0` in the table metadata: this statement locks
-    # the storage instance, and `ATTACH TABLE` runs `startup` on a fresh instance before
-    # returning, so a merge can be selected before any later statement reaches the server.
-    node.query(f"SYSTEM STOP MERGES {table}")
-
-
-def assert_two_parts(table):
-    parts = node.query(
-        f"SELECT groupArray(name) FROM ("
-        f"  SELECT name FROM system.parts "
-        f"  WHERE database = currentDatabase() AND table = '{table}' AND active "
-        f"  ORDER BY name)"
-    ).strip()
-    assert parts == "['all_1_1_0','all_2_2_0']", f"part layout changed: {parts}"
-
-
-def make_partially_materialized(table, packed_max_bytes=0):
-    # The first part predates the text index, so `tx` is materialized only in the second.
-    # A partially materialized index is what arms the direct-read optimization while still
-    # requiring the first part to be read through the virtual column's default expression.
-    # `mm_k` gives the first part a skip-index file to copy from; the remaining settings keep
-    # index filenames and sizes predictable. A merge would rebuild the unaccounted index and
-    # repair the very shape these arms assert on, so merges are disabled in table metadata,
-    # which is checked before any merge selector runs and applies on every startup.
-    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
-    node.query(
-        f"""
-        CREATE TABLE {table} (k UInt64, s String, INDEX mm_k k TYPE minmax GRANULARITY 1)
-        ENGINE = MergeTree ORDER BY k
-        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
-                 packed_skip_index_max_bytes = {packed_max_bytes},
-                 index_granularity = 100,
-                 replace_long_file_name_to_hash = 0,
-                 columns_and_secondary_indices_sizes_lazy_calculation = 0,
-                 max_bytes_to_merge_at_max_space_in_pool = 0
-        """
-    )
-    stop_merges(table)
-    node.query(
-        f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({ROWS_PER_PART})"
-    )
-    node.query(
-        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
-    )
-    node.query(
-        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, 'alpha beta' "
-        f"FROM numbers({ROWS_PER_PART})"
-    )
-
-
-def reattach(table):
-    # `DETACH` must be `SYNC`: an asynchronous detach leaves the instance tracked in
-    # `DatabaseAtomic::detached_tables` while another subsystem still holds a `StoragePtr`, and
-    # the following `ATTACH` then throws `TABLE_ALREADY_EXISTS` rather than waiting.
-    node.query(f"DETACH TABLE {table} SYNC")
-    node.query(f"ATTACH TABLE {table}")
-    # The merge guard lives in table metadata so that it is already in force during the startup
-    # `ATTACH` performs before it returns; assert it survived rather than assuming it.
-    engine_full = scalar(
-        f"SELECT engine_full FROM system.tables "
-        f"WHERE database = currentDatabase() AND name = '{table}'"
-    )
-    assert "max_bytes_to_merge_at_max_space_in_pool = 0" in engine_full, (
-        f"merge guard missing from table metadata after reattach: {engine_full}"
-    )
-    stop_merges(table)
-
-
-def inject_orphan_index_file(table, part_name="all_1_1_0"):
-    # Reproduces the corrupted-part shape of issue #109595: a skp_idx_tx.idx that exists on
-    # disk while checksums.txt does not account for it. The bytes are borrowed from the minmax
-    # index so the file is non-empty; its content is never decoded.
-    path = part_path(table, part_name)
-    source = node.exec_in_container(
-        ["bash", "-c", f"ls {path} | grep -E '^skp_idx_mm_k\\.idx' | head -1"],
-        privileged=True,
-    ).strip()
-    assert source, f"no minmax index file to copy from in {path}"
-
-    node.exec_in_container(
-        ["bash", "-c", f"head -c 512 {path}/{source} > {path}/skp_idx_tx.idx"],
-        privileged=True,
-    )
-    size = node.exec_in_container(
-        ["bash", "-c", f"stat -c%s {path}/skp_idx_tx.idx"], privileged=True
-    ).strip()
-    assert int(size) > 0, "orphan index file is empty"
-
-    accounted = node.exec_in_container(
-        ["bash", "-c", f"grep -c skp_idx_tx {path}/checksums.txt || true"],
-        privileged=True,
-    ).strip()
-    assert accounted == "0", "orphan index file must not be accounted in checksums.txt"
-
-    reattach(table)
-
-
-def scalar(query):
+def q(query):
     return node.query(query).strip()
 
 
 def test_orphan_index_file_does_not_drop_rows(started_cluster):
-    # An unaccounted index file used to make the read path treat the part as indexed while no
-    # index reader was assigned to it, so the part contributed no matches at all.
-    table = "orphan_read"
-    make_partially_materialized(table)
-    inject_orphan_index_file(table)
-    assert_two_parts(table)
+    q("DROP TABLE IF EXISTS t SYNC")
+    q(f"CREATE TABLE t (k UInt64, s String) ENGINE = MergeTree ORDER BY k SETTINGS {NO_MERGES}")
+    q("INSERT INTO t VALUES (1, 'alpha')")
+    q("ALTER TABLE t ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1")
+    q("INSERT INTO t VALUES (2, 'alpha')")
 
-    assert scalar(f"SELECT count() FROM {table}") == str(TOTAL_ROWS)
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 0"
-        )
-        == str(TOTAL_ROWS)
+    # An index file that exists on disk while checksums.txt does not account for it, as in #109595.
+    # Its content is never decoded.
+    path = q(
+        "SELECT path FROM system.parts WHERE database = currentDatabase() "
+        "AND table = 't' AND name = 'all_1_1_0' AND active"
     )
-    # Every row matches, so the predicate must answer with the full row count and its negation
-    # with zero. Before the fix these answered ROWS_PER_PART and ROWS_PER_PART.
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == str(TOTAL_ROWS)
+    node.exec_in_container(
+        ["bash", "-c", f"echo garbage > {path}/skp_idx_tx.idx"], privileged=True
     )
     assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
+        node.exec_in_container(
+            ["bash", "-c", f"grep -c skp_idx_tx {path}/checksums.txt || true"],
+            privileged=True,
+        ).strip()
         == "0"
     )
-    # Both parts must contribute; the aggregate above would also pass if one part returned
-    # every row twice.
-    assert (
-        scalar(
-            f"SELECT groupArray((_part, c)) FROM ("
-            f"  SELECT _part, count() AS c FROM {table} WHERE hasToken(s, 'alpha') "
-            f"  GROUP BY _part ORDER BY _part "
-            f"  SETTINGS {ARMING_SETTINGS}, query_plan_optimize_count_from_text_index = 0)"
-        )
-        == f"[('all_1_1_0',{ROWS_PER_PART}),('all_2_2_0',{ROWS_PER_PART})]"
-    )
-    # A row-returning query reads the same columns through the same injection path.
-    assert (
-        scalar(
-            f"SELECT count() FROM (SELECT k, s FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS})"
-        )
-        == str(TOTAL_ROWS)
-    )
+    q("DETACH TABLE t SYNC")
+    q("ATTACH TABLE t")
+
+    assert q("SELECT count() FROM t") == "2"
+    # Both rows match. Before the fix these answered 1 and 1.
+    assert q("SELECT count() FROM t WHERE hasToken(s, 'alpha')") == "2"
+    assert q("SELECT count() FROM t WHERE NOT hasToken(s, 'alpha')") == "0"
 
 
-def test_no_orphan_is_unaffected(started_cluster):
-    # Guards the fixture: the same table shape without the injected file must already be
-    # correct, so a failure above cannot be blamed on the partially materialized index alone.
-    table = "orphan_read_control"
-    make_partially_materialized(table)
-    reattach(table)
-    assert_two_parts(table)
+def test_materialized_index_is_still_read_from_index(started_cluster):
+    # A stricter read predicate must not stop using an index that is materialized.
+    q("DROP TABLE IF EXISTS m SYNC")
+    q(
+        "CREATE TABLE m (k UInt64, s String, "
+        "INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1) "
+        f"ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 100, {NO_MERGES}"
+    )
+    q("INSERT INTO m SELECT number, if(number < 400, 'alpha beta', 'gamma delta') FROM numbers(1000)")
 
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == str(TOTAL_ROWS)
-    )
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == "0"
-    )
+    assert q("SELECT count() FROM m WHERE hasToken(s, 'alpha')") == "400"
 
-
-def test_index_materialized_in_no_part(started_cluster):
-    # An index materialized in no part disables the direct-read rewrite entirely, so no virtual
-    # column is created and the predicate answers through the ordinary row-level path.
-    # The fixture inserts every row in one statement, so this arm has a single part and asserts
-    # only table-level counts; a two-part layout guard would never hold here.
-    table = "orphan_read_unmaterialized"
-    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
-    node.query(
-        f"""
-        CREATE TABLE {table} (k UInt64, s String) ENGINE = MergeTree ORDER BY k
-        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100,
-                 max_bytes_to_merge_at_max_space_in_pool = 0
-        """
-    )
-    node.query(
-        f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({TOTAL_ROWS})"
-    )
-    node.query(
-        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
-    )
-
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == str(TOTAL_ROWS)
-    )
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == "0"
-    )
-
-
-def test_fully_materialized_index_still_prunes(started_cluster):
-    # Anti-regression: a stricter read predicate must not silently disable the optimization.
-    # Granule pruning is asserted structurally, not by timing.
-    table = "orphan_read_materialized"
-    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
-    node.query(
-        f"""
-        CREATE TABLE {table}
-        (k UInt64, s String, INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1)
-        ENGINE = MergeTree ORDER BY k
-        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100,
-                 max_bytes_to_merge_at_max_space_in_pool = 0
-        """
-    )
-    stop_merges(table)
-    node.query(
-        f"INSERT INTO {table} SELECT number, if(number < 400, 'alpha beta', 'gamma delta') "
-        f"FROM numbers({ROWS_PER_PART})"
-    )
-    node.query(
-        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, "
-        f"if(number < 200, 'alpha beta', 'gamma delta') FROM numbers({ROWS_PER_PART})"
-    )
-    assert_two_parts(table)
-
-    expected = scalar(
-        f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') SETTINGS use_skip_indexes = 0"
-    )
-    assert expected == "600"
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == expected
-    )
-    # The count above is the correct answer whether it came from the index or from the base
-    # column, so it cannot see the predicate refusing a materialized part. Reading the match
-    # from the index reads one byte per row of the virtual column, while falling back reads the
-    # whole string column, so the bytes read distinguish the two routes.
+    # That count is correct whether it came from the index or from the base column, so it cannot
+    # see the predicate refusing the part. Reading the match from the index reads one byte per row;
+    # falling back reads the whole string column, so the bytes read distinguish the two routes.
     def bytes_read(direct_read):
-        log_comment = f"{table}_bytes_{direct_read}"
-        node.query(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, "
+        tag = f"m_bytes_{direct_read}"
+        q(
+            "SELECT count() FROM m WHERE hasToken(s, 'alpha') SETTINGS "
             f"query_plan_direct_read_from_text_index = {direct_read}, "
-            f"query_plan_optimize_count_from_text_index = 0, log_comment = '{log_comment}'"
+            f"query_plan_optimize_count_from_text_index = 0, log_comment = '{tag}'"
         )
-        node.query("SYSTEM FLUSH LOGS query_log")
+        q("SYSTEM FLUSH LOGS query_log")
         return int(
-            scalar(
-                f"SELECT ProfileEvents['SelectedBytes'] FROM system.query_log "
-                f"WHERE type = 'QueryFinish' AND current_database = currentDatabase() "
-                f"AND log_comment = '{log_comment}' "
-                f"ORDER BY event_time_microseconds DESC LIMIT 1"
+            q(
+                "SELECT ProfileEvents['SelectedBytes'] FROM system.query_log "
+                "WHERE type = 'QueryFinish' AND current_database = currentDatabase() "
+                f"AND log_comment = '{tag}' ORDER BY event_time_microseconds DESC LIMIT 1"
             )
         )
 
     from_index = bytes_read(1)
     from_column = bytes_read(0)
-    assert from_index < from_column, (
-        f"the predicate refused a materialized part: {from_index} bytes read with direct read "
-        f"from the index, {from_column} without it"
-    )
-
-    assert (
-        scalar(
-            f"SELECT count() > 0 FROM ("
-            f"  EXPLAIN indexes = 1 SELECT * FROM {table} WHERE hasToken(s, 'alpha') "
-            f"  SETTINGS {EXPLAIN_SETTINGS}) "
-            f"WHERE explain ILIKE '%Name: tx%'"
-        )
-        == "1"
-    )
-    # The index must actually drop granules, otherwise the arm above would pass on a plan that
-    # names the index and then reads everything. Read the reader's own granule count from the
-    # `Parts: N | Granules: M` line: the per-index `Granules: M/N` lines include the primary
-    # key's, which never prunes here.
-    def granules_read(settings):
-        return int(
-            scalar(
-                f"SELECT extract(explain, 'Granules: (\\\\d+)$') FROM ("
-                f"  EXPLAIN indexes = 1 SELECT * FROM {table} WHERE hasToken(s, 'alpha') "
-                f"  SETTINGS {settings}) "
-                f"WHERE explain ILIKE '%Parts:%|%Granules:%'"
-            )
-        )
-
-    with_index = granules_read(EXPLAIN_SETTINGS)
-    without_index = granules_read("use_skip_indexes = 0")
-    assert with_index < without_index, (
-        f"index did not prune granules: {with_index} read with the index, "
-        f"{without_index} without it"
-    )
-
-
-def test_partially_materialized_index_without_corruption(started_cluster):
-    # The ordinary partially materialized shape, with no injected file: the unindexed part is
-    # read through the default expression. This is the behaviour the fix routes the orphan case
-    # to, so it must keep answering ground truth.
-    table = "orphan_read_partial"
-    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
-    node.query(
-        f"""
-        CREATE TABLE {table} (k UInt64, s String) ENGINE = MergeTree ORDER BY k
-        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100,
-                 max_bytes_to_merge_at_max_space_in_pool = 0
-        """
-    )
-    stop_merges(table)
-    node.query(
-        f"INSERT INTO {table} SELECT number, if(number < 400, 'alpha beta', 'gamma delta') "
-        f"FROM numbers({ROWS_PER_PART})"
-    )
-    node.query(
-        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
-    )
-    node.query(
-        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, "
-        f"if(number < 200, 'alpha beta', 'gamma delta') FROM numbers({ROWS_PER_PART})"
-    )
-    assert_two_parts(table)
-
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == "600"
-    )
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == "1400"
-    )
-    assert (
-        scalar(
-            f"SELECT groupArray((_part, c)) FROM ("
-            f"  SELECT _part, count() AS c FROM {table} WHERE hasToken(s, 'alpha') "
-            f"  GROUP BY _part ORDER BY _part "
-            f"  SETTINGS {ARMING_SETTINGS}, query_plan_optimize_count_from_text_index = 0)"
-        )
-        == "[('all_1_1_0',400),('all_2_2_0',200)]"
-    )
-
-
-def test_orphan_index_file_on_compact_part(started_cluster):
-    # Part type is not a dimension of the defect; the predicate is about file accounting.
-    table = "orphan_read_compact"
-    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
-    node.query(
-        f"""
-        CREATE TABLE {table} (k UInt64, s String, INDEX mm_k k TYPE minmax GRANULARITY 1)
-        ENGINE = MergeTree ORDER BY k
-        SETTINGS packed_skip_index_max_bytes = 0, index_granularity = 100,
-                 replace_long_file_name_to_hash = 0,
-                 columns_and_secondary_indices_sizes_lazy_calculation = 0,
-                 max_bytes_to_merge_at_max_space_in_pool = 0
-        """
-    )
-    stop_merges(table)
-    node.query(
-        f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({ROWS_PER_PART})"
-    )
-    node.query(
-        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
-    )
-    node.query(
-        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, 'alpha beta' "
-        f"FROM numbers({ROWS_PER_PART})"
-    )
-    assert (
-        node.query(
-            f"SELECT part_type FROM system.parts WHERE database = currentDatabase() "
-            f"AND table = '{table}' AND name = 'all_1_1_0' AND active"
-        ).strip()
-        == "Compact"
-    )
-    inject_orphan_index_file(table)
-    assert_two_parts(table)
-
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == str(TOTAL_ROWS)
-    )
-    assert (
-        scalar(
-            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS {ARMING_SETTINGS}"
-        )
-        == "0"
-    )
+    assert from_index < from_column, f"index not used: {from_index} vs {from_column} bytes"

--- a/tests/integration/test_text_index_orphan_read/test.py
+++ b/tests/integration/test_text_index_orphan_read/test.py
@@ -8,6 +8,25 @@ node = cluster.add_instance("node", stay_alive=True)
 ROWS_PER_PART = 1000
 TOTAL_ROWS = 2 * ROWS_PER_PART
 
+# The wrong answer needs the direct-read rewrite to run and the skip index to be applied while
+# reading data; asserting ground truth cannot detect a default flip, so every asserting query
+# pins these explicitly.
+ARMING_SETTINGS = (
+    "use_skip_indexes = 1, "
+    "use_skip_indexes_on_data_read = 1, "
+    "query_plan_direct_read_from_text_index = 1"
+)
+
+# `EXPLAIN indexes = 1` reports granule counts from analysis, which only happens when the index
+# is not applied while reading data. A query-level setting is applied after EXPLAIN forces that
+# off internally, so asking for data-read-time application here would report every granule as
+# read and the pruning assertion could never fail.
+EXPLAIN_SETTINGS = (
+    "use_skip_indexes = 1, "
+    "use_skip_indexes_on_data_read = 0, "
+    "query_plan_direct_read_from_text_index = 1"
+)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -24,6 +43,23 @@ def part_path(table, part_name):
         f"WHERE database = currentDatabase() AND table = '{table}' "
         f"AND name = '{part_name}' AND active"
     ).strip()
+
+
+def stop_merges(table):
+    # A merge rebuilds an index that is not accounted in the source part, so it destroys the
+    # carrier as well as the part names. The lock is held on the storage instance, so it must be
+    # re-taken after every ATTACH.
+    node.query(f"SYSTEM STOP MERGES {table}")
+
+
+def assert_two_parts(table):
+    parts = node.query(
+        f"SELECT groupArray(name) FROM ("
+        f"  SELECT name FROM system.parts "
+        f"  WHERE database = currentDatabase() AND table = '{table}' AND active "
+        f"  ORDER BY name)"
+    ).strip()
+    assert parts == "['all_1_1_0','all_2_2_0']", f"part layout changed: {parts}"
 
 
 def make_partially_materialized(table, packed_max_bytes=0):
@@ -44,6 +80,7 @@ def make_partially_materialized(table, packed_max_bytes=0):
                  columns_and_secondary_indices_sizes_lazy_calculation = 0
         """
     )
+    stop_merges(table)
     node.query(
         f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({ROWS_PER_PART})"
     )
@@ -54,6 +91,12 @@ def make_partially_materialized(table, packed_max_bytes=0):
         f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, 'alpha beta' "
         f"FROM numbers({ROWS_PER_PART})"
     )
+
+
+def reattach(table):
+    node.query(f"DETACH TABLE {table}")
+    node.query(f"ATTACH TABLE {table}")
+    stop_merges(table)
 
 
 def inject_orphan_index_file(table, part_name="all_1_1_0"):
@@ -82,8 +125,7 @@ def inject_orphan_index_file(table, part_name="all_1_1_0"):
     ).strip()
     assert accounted == "0", "orphan index file must not be accounted in checksums.txt"
 
-    node.query(f"DETACH TABLE {table}")
-    node.query(f"ATTACH TABLE {table}")
+    reattach(table)
 
 
 def scalar(query):
@@ -96,6 +138,7 @@ def test_orphan_index_file_does_not_drop_rows(started_cluster):
     table = "orphan_read"
     make_partially_materialized(table)
     inject_orphan_index_file(table)
+    assert_two_parts(table)
 
     assert scalar(f"SELECT count() FROM {table}") == str(TOTAL_ROWS)
     assert (
@@ -110,14 +153,14 @@ def test_orphan_index_file_does_not_drop_rows(started_cluster):
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == str(TOTAL_ROWS)
     )
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == "0"
     )
@@ -128,7 +171,7 @@ def test_orphan_index_file_does_not_drop_rows(started_cluster):
             f"SELECT groupArray((_part, c)) FROM ("
             f"  SELECT _part, count() AS c FROM {table} WHERE hasToken(s, 'alpha') "
             f"  GROUP BY _part ORDER BY _part "
-            f"  SETTINGS use_skip_indexes = 1, query_plan_optimize_count_from_text_index = 0)"
+            f"  SETTINGS {ARMING_SETTINGS}, query_plan_optimize_count_from_text_index = 0)"
         )
         == f"[('all_1_1_0',{ROWS_PER_PART}),('all_2_2_0',{ROWS_PER_PART})]"
     )
@@ -136,7 +179,7 @@ def test_orphan_index_file_does_not_drop_rows(started_cluster):
     assert (
         scalar(
             f"SELECT count() FROM (SELECT k, s FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1)"
+            f"SETTINGS {ARMING_SETTINGS})"
         )
         == str(TOTAL_ROWS)
     )
@@ -147,28 +190,28 @@ def test_no_orphan_is_unaffected(started_cluster):
     # correct, so a failure above cannot be blamed on the partially materialized index alone.
     table = "orphan_read_control"
     make_partially_materialized(table)
-    node.query(f"DETACH TABLE {table}")
-    node.query(f"ATTACH TABLE {table}")
+    reattach(table)
+    assert_two_parts(table)
 
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == str(TOTAL_ROWS)
     )
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == "0"
     )
 
 
 def test_index_materialized_in_no_part(started_cluster):
-    # The index name is absent from the read tasks, which is the lookup-miss path of the read
-    # predicate. It must fall back to reading the base column rather than claim the index.
+    # An index materialized in no part disables the direct-read rewrite entirely, so no virtual
+    # column is created and the predicate answers through the ordinary row-level path.
     table = "orphan_read_unmaterialized"
     node.query(f"DROP TABLE IF EXISTS {table} SYNC")
     node.query(
@@ -187,14 +230,14 @@ def test_index_materialized_in_no_part(started_cluster):
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == str(TOTAL_ROWS)
     )
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == "0"
     )
@@ -213,6 +256,7 @@ def test_fully_materialized_index_still_prunes(started_cluster):
         SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
         """
     )
+    stop_merges(table)
     node.query(
         f"INSERT INTO {table} SELECT number, if(number < 400, 'alpha beta', 'gamma delta') "
         f"FROM numbers({ROWS_PER_PART})"
@@ -221,6 +265,7 @@ def test_fully_materialized_index_still_prunes(started_cluster):
         f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, "
         f"if(number < 200, 'alpha beta', 'gamma delta') FROM numbers({ROWS_PER_PART})"
     )
+    assert_two_parts(table)
 
     expected = scalar(
         f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') SETTINGS use_skip_indexes = 0"
@@ -229,15 +274,44 @@ def test_fully_materialized_index_still_prunes(started_cluster):
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == expected
     )
+    # The count above is the correct answer whether it came from the index or from the base
+    # column, so it cannot see the predicate refusing a materialized part. Reading the match
+    # from the index reads one byte per row of the virtual column, while falling back reads the
+    # whole string column, so the bytes read distinguish the two routes.
+    def bytes_read(direct_read):
+        log_comment = f"{table}_bytes_{direct_read}"
+        node.query(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, "
+            f"query_plan_direct_read_from_text_index = {direct_read}, "
+            f"query_plan_optimize_count_from_text_index = 0, log_comment = '{log_comment}'"
+        )
+        node.query("SYSTEM FLUSH LOGS query_log")
+        return int(
+            scalar(
+                f"SELECT ProfileEvents['SelectedBytes'] FROM system.query_log "
+                f"WHERE type = 'QueryFinish' AND current_database = currentDatabase() "
+                f"AND log_comment = '{log_comment}' "
+                f"ORDER BY event_time_microseconds DESC LIMIT 1"
+            )
+        )
+
+    from_index = bytes_read(1)
+    from_column = bytes_read(0)
+    assert from_index < from_column, (
+        f"the predicate refused a materialized part: {from_index} bytes read with direct read "
+        f"from the index, {from_column} without it"
+    )
+
     assert (
         scalar(
             f"SELECT count() > 0 FROM ("
             f"  EXPLAIN indexes = 1 SELECT * FROM {table} WHERE hasToken(s, 'alpha') "
-            f"  SETTINGS use_skip_indexes = 1) "
+            f"  SETTINGS {EXPLAIN_SETTINGS}) "
             f"WHERE explain ILIKE '%Name: tx%'"
         )
         == "1"
@@ -246,18 +320,18 @@ def test_fully_materialized_index_still_prunes(started_cluster):
     # names the index and then reads everything. Read the reader's own granule count from the
     # `Parts: N | Granules: M` line: the per-index `Granules: M/N` lines include the primary
     # key's, which never prunes here.
-    def granules_read(use_skip_indexes):
+    def granules_read(settings):
         return int(
             scalar(
                 f"SELECT extract(explain, 'Granules: (\\\\d+)$') FROM ("
                 f"  EXPLAIN indexes = 1 SELECT * FROM {table} WHERE hasToken(s, 'alpha') "
-                f"  SETTINGS use_skip_indexes = {use_skip_indexes}) "
+                f"  SETTINGS {settings}) "
                 f"WHERE explain ILIKE '%Parts:%|%Granules:%'"
             )
         )
 
-    with_index = granules_read(1)
-    without_index = granules_read(0)
+    with_index = granules_read(EXPLAIN_SETTINGS)
+    without_index = granules_read("use_skip_indexes = 0")
     assert with_index < without_index, (
         f"index did not prune granules: {with_index} read with the index, "
         f"{without_index} without it"
@@ -276,6 +350,7 @@ def test_partially_materialized_index_without_corruption(started_cluster):
         SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
         """
     )
+    stop_merges(table)
     node.query(
         f"INSERT INTO {table} SELECT number, if(number < 400, 'alpha beta', 'gamma delta') "
         f"FROM numbers({ROWS_PER_PART})"
@@ -287,18 +362,19 @@ def test_partially_materialized_index_without_corruption(started_cluster):
         f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, "
         f"if(number < 200, 'alpha beta', 'gamma delta') FROM numbers({ROWS_PER_PART})"
     )
+    assert_two_parts(table)
 
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == "600"
     )
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == "1400"
     )
@@ -307,7 +383,7 @@ def test_partially_materialized_index_without_corruption(started_cluster):
             f"SELECT groupArray((_part, c)) FROM ("
             f"  SELECT _part, count() AS c FROM {table} WHERE hasToken(s, 'alpha') "
             f"  GROUP BY _part ORDER BY _part "
-            f"  SETTINGS use_skip_indexes = 1, query_plan_optimize_count_from_text_index = 0)"
+            f"  SETTINGS {ARMING_SETTINGS}, query_plan_optimize_count_from_text_index = 0)"
         )
         == "[('all_1_1_0',400),('all_2_2_0',200)]"
     )
@@ -326,6 +402,7 @@ def test_orphan_index_file_on_compact_part(started_cluster):
                  columns_and_secondary_indices_sizes_lazy_calculation = 0
         """
     )
+    stop_merges(table)
     node.query(
         f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({ROWS_PER_PART})"
     )
@@ -344,18 +421,19 @@ def test_orphan_index_file_on_compact_part(started_cluster):
         == "Compact"
     )
     inject_orphan_index_file(table)
+    assert_two_parts(table)
 
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == str(TOTAL_ROWS)
     )
     assert (
         scalar(
             f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
-            f"SETTINGS use_skip_indexes = 1"
+            f"SETTINGS {ARMING_SETTINGS}"
         )
         == "0"
     )

--- a/tests/integration/test_text_index_orphan_read/test.py
+++ b/tests/integration/test_text_index_orphan_read/test.py
@@ -1,0 +1,361 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", stay_alive=True)
+
+ROWS_PER_PART = 1000
+TOTAL_ROWS = 2 * ROWS_PER_PART
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def part_path(table, part_name):
+    return node.query(
+        f"SELECT path FROM system.parts "
+        f"WHERE database = currentDatabase() AND table = '{table}' "
+        f"AND name = '{part_name}' AND active"
+    ).strip()
+
+
+def make_partially_materialized(table, packed_max_bytes=0):
+    # The first part predates the text index, so `tx` is materialized only in the second.
+    # A partially materialized index is what arms the direct-read optimization while still
+    # requiring the first part to be read through the virtual column's default expression.
+    # `mm_k` gives the first part a skip-index file to copy from; the remaining settings keep
+    # index filenames and sizes predictable.
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table} (k UInt64, s String, INDEX mm_k k TYPE minmax GRANULARITY 1)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+                 packed_skip_index_max_bytes = {packed_max_bytes},
+                 index_granularity = 100,
+                 replace_long_file_name_to_hash = 0,
+                 columns_and_secondary_indices_sizes_lazy_calculation = 0
+        """
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({ROWS_PER_PART})"
+    )
+    node.query(
+        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, 'alpha beta' "
+        f"FROM numbers({ROWS_PER_PART})"
+    )
+
+
+def inject_orphan_index_file(table, part_name="all_1_1_0"):
+    # Reproduces the corrupted-part shape of issue #109595: a skp_idx_tx.idx that exists on
+    # disk while checksums.txt does not account for it. The bytes are borrowed from the minmax
+    # index so the file is non-empty; its content is never decoded.
+    path = part_path(table, part_name)
+    source = node.exec_in_container(
+        ["bash", "-c", f"ls {path} | grep -E '^skp_idx_mm_k\\.idx' | head -1"],
+        privileged=True,
+    ).strip()
+    assert source, f"no minmax index file to copy from in {path}"
+
+    node.exec_in_container(
+        ["bash", "-c", f"head -c 512 {path}/{source} > {path}/skp_idx_tx.idx"],
+        privileged=True,
+    )
+    size = node.exec_in_container(
+        ["bash", "-c", f"stat -c%s {path}/skp_idx_tx.idx"], privileged=True
+    ).strip()
+    assert int(size) > 0, "orphan index file is empty"
+
+    accounted = node.exec_in_container(
+        ["bash", "-c", f"grep -c skp_idx_tx {path}/checksums.txt || true"],
+        privileged=True,
+    ).strip()
+    assert accounted == "0", "orphan index file must not be accounted in checksums.txt"
+
+    node.query(f"DETACH TABLE {table}")
+    node.query(f"ATTACH TABLE {table}")
+
+
+def scalar(query):
+    return node.query(query).strip()
+
+
+def test_orphan_index_file_does_not_drop_rows(started_cluster):
+    # An unaccounted index file used to make the read path treat the part as indexed while no
+    # index reader was assigned to it, so the part contributed no matches at all.
+    table = "orphan_read"
+    make_partially_materialized(table)
+    inject_orphan_index_file(table)
+
+    assert scalar(f"SELECT count() FROM {table}") == str(TOTAL_ROWS)
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 0"
+        )
+        == str(TOTAL_ROWS)
+    )
+    # Every row matches, so the predicate must answer with the full row count and its negation
+    # with zero. Before the fix these answered ROWS_PER_PART and ROWS_PER_PART.
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == str(TOTAL_ROWS)
+    )
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == "0"
+    )
+    # Both parts must contribute; the aggregate above would also pass if one part returned
+    # every row twice.
+    assert (
+        scalar(
+            f"SELECT groupArray((_part, c)) FROM ("
+            f"  SELECT _part, count() AS c FROM {table} WHERE hasToken(s, 'alpha') "
+            f"  GROUP BY _part ORDER BY _part "
+            f"  SETTINGS use_skip_indexes = 1, query_plan_optimize_count_from_text_index = 0)"
+        )
+        == f"[('all_1_1_0',{ROWS_PER_PART}),('all_2_2_0',{ROWS_PER_PART})]"
+    )
+    # A row-returning query reads the same columns through the same injection path.
+    assert (
+        scalar(
+            f"SELECT count() FROM (SELECT k, s FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1)"
+        )
+        == str(TOTAL_ROWS)
+    )
+
+
+def test_no_orphan_is_unaffected(started_cluster):
+    # Guards the fixture: the same table shape without the injected file must already be
+    # correct, so a failure above cannot be blamed on the partially materialized index alone.
+    table = "orphan_read_control"
+    make_partially_materialized(table)
+    node.query(f"DETACH TABLE {table}")
+    node.query(f"ATTACH TABLE {table}")
+
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == str(TOTAL_ROWS)
+    )
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == "0"
+    )
+
+
+def test_index_materialized_in_no_part(started_cluster):
+    # The index name is absent from the read tasks, which is the lookup-miss path of the read
+    # predicate. It must fall back to reading the base column rather than claim the index.
+    table = "orphan_read_unmaterialized"
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table} (k UInt64, s String) ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
+        """
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({TOTAL_ROWS})"
+    )
+    node.query(
+        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
+    )
+
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == str(TOTAL_ROWS)
+    )
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == "0"
+    )
+
+
+def test_fully_materialized_index_still_prunes(started_cluster):
+    # Anti-regression: a stricter read predicate must not silently disable the optimization.
+    # Granule pruning is asserted structurally, not by timing.
+    table = "orphan_read_materialized"
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table}
+        (k UInt64, s String, INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
+        """
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number, if(number < 400, 'alpha beta', 'gamma delta') "
+        f"FROM numbers({ROWS_PER_PART})"
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, "
+        f"if(number < 200, 'alpha beta', 'gamma delta') FROM numbers({ROWS_PER_PART})"
+    )
+
+    expected = scalar(
+        f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') SETTINGS use_skip_indexes = 0"
+    )
+    assert expected == "600"
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == expected
+    )
+    assert (
+        scalar(
+            f"SELECT count() > 0 FROM ("
+            f"  EXPLAIN indexes = 1 SELECT * FROM {table} WHERE hasToken(s, 'alpha') "
+            f"  SETTINGS use_skip_indexes = 1) "
+            f"WHERE explain ILIKE '%Name: tx%'"
+        )
+        == "1"
+    )
+    # The index must actually drop granules, otherwise the arm above would pass on a plan that
+    # names the index and then reads everything. Read the reader's own granule count from the
+    # `Parts: N | Granules: M` line: the per-index `Granules: M/N` lines include the primary
+    # key's, which never prunes here.
+    def granules_read(use_skip_indexes):
+        return int(
+            scalar(
+                f"SELECT extract(explain, 'Granules: (\\\\d+)$') FROM ("
+                f"  EXPLAIN indexes = 1 SELECT * FROM {table} WHERE hasToken(s, 'alpha') "
+                f"  SETTINGS use_skip_indexes = {use_skip_indexes}) "
+                f"WHERE explain ILIKE '%Parts:%|%Granules:%'"
+            )
+        )
+
+    with_index = granules_read(1)
+    without_index = granules_read(0)
+    assert with_index < without_index, (
+        f"index did not prune granules: {with_index} read with the index, "
+        f"{without_index} without it"
+    )
+
+
+def test_partially_materialized_index_without_corruption(started_cluster):
+    # The ordinary partially materialized shape, with no injected file: the unindexed part is
+    # read through the default expression. This is the behaviour the fix routes the orphan case
+    # to, so it must keep answering ground truth.
+    table = "orphan_read_partial"
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table} (k UInt64, s String) ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, index_granularity = 100
+        """
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number, if(number < 400, 'alpha beta', 'gamma delta') "
+        f"FROM numbers({ROWS_PER_PART})"
+    )
+    node.query(
+        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, "
+        f"if(number < 200, 'alpha beta', 'gamma delta') FROM numbers({ROWS_PER_PART})"
+    )
+
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == "600"
+    )
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == "1400"
+    )
+    assert (
+        scalar(
+            f"SELECT groupArray((_part, c)) FROM ("
+            f"  SELECT _part, count() AS c FROM {table} WHERE hasToken(s, 'alpha') "
+            f"  GROUP BY _part ORDER BY _part "
+            f"  SETTINGS use_skip_indexes = 1, query_plan_optimize_count_from_text_index = 0)"
+        )
+        == "[('all_1_1_0',400),('all_2_2_0',200)]"
+    )
+
+
+def test_orphan_index_file_on_compact_part(started_cluster):
+    # Part type is not a dimension of the defect; the predicate is about file accounting.
+    table = "orphan_read_compact"
+    node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+    node.query(
+        f"""
+        CREATE TABLE {table} (k UInt64, s String, INDEX mm_k k TYPE minmax GRANULARITY 1)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS packed_skip_index_max_bytes = 0, index_granularity = 100,
+                 replace_long_file_name_to_hash = 0,
+                 columns_and_secondary_indices_sizes_lazy_calculation = 0
+        """
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number, 'alpha beta' FROM numbers({ROWS_PER_PART})"
+    )
+    node.query(
+        f"ALTER TABLE {table} ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1"
+    )
+    node.query(
+        f"INSERT INTO {table} SELECT number + {ROWS_PER_PART}, 'alpha beta' "
+        f"FROM numbers({ROWS_PER_PART})"
+    )
+    assert (
+        node.query(
+            f"SELECT part_type FROM system.parts WHERE database = currentDatabase() "
+            f"AND table = '{table}' AND name = 'all_1_1_0' AND active"
+        ).strip()
+        == "Compact"
+    )
+    inject_orphan_index_file(table)
+
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == str(TOTAL_ROWS)
+    )
+    assert (
+        scalar(
+            f"SELECT count() FROM {table} WHERE NOT hasToken(s, 'alpha') "
+            f"SETTINGS use_skip_indexes = 1"
+        )
+        == "0"
+    )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/109595
Related: https://github.com/ClickHouse/ClickHouse/pull/115037
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/109595
Related: https://github.com/ClickHouse/ClickHouse/pull/115037

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a text index query silently returning too few rows when a part carries a `skp_idx_<index>.idx` file that `checksums.txt` does not account for. The read path decided which columns to read from file existence while the index reader was assigned from checksum accounting, so the affected part contributed no matches. Both are now answered by the same predicate.

### Description

```sql
CREATE TABLE t (k UInt64, s String) ENGINE = MergeTree ORDER BY k;
INSERT INTO t VALUES (1, 'alpha');
ALTER TABLE t ADD INDEX tx s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1;
INSERT INTO t VALUES (2, 'alpha');
-- in all_1_1_0/:  echo garbage > skp_idx_tx.idx
DETACH TABLE t SYNC; ATTACH TABLE t;

SELECT count() FROM t WHERE hasToken(s, 'alpha');      -- master: 1, expected 2
SELECT count() FROM t WHERE NOT hasToken(s, 'alpha');  -- master: 1, expected 0
```

Default settings. The unaccounted file is the corrupted-part shape of #109595; its content is never decoded.

Three read-path sites answer whether a text index is materialized in a part. `optimizeDirectReadFromTextIndex` and `getIndexReadTaskForReadStep` ask the index object via `getDeserializedFormat`, which requires the file to be accounted for and decodable. `hasMaterializedTextIndex` instead asked the part for a file on disk via `hasSecondaryIndex`, whose fallback is an unconditional `existsFile` with no accounting gate. An unaccounted file therefore reads as materialized only at that third site: `injectRequiredColumnsRecursively` takes its early return and never injects the base column, no index reader is created, and the virtual column's default expression is evaluated with its input missing.

`getReadTaskColumns` already receives `index_read_tasks`, keyed by index name and carrying the index object the reader-assignment site uses. Threading the map through makes the two agree via a map lookup, with no index construction on the read path. `hasSecondaryIndex` is left alone: its mutation and merge callers want the file-existence answer.

The reproducer needs one file write, so the test is an integration test (#111922 forbids fabricating part contents in a functional test). I found no pure-SQL carrier: `getDeserializedFormat`'s other two false routes are `isPartTypeCompatible`, where five SQL routes returned ground truth, and `isSystemColumnInvalidated`, which only covers `_block_number` / `_block_offset`, neither referenceable by a text index.

The carrier test fails on master and passes with the fix. The `02346_text_index*` and `00990_hasToken*` families are unchanged.
