### PR TITLE
Do not report "Server died" when only the liveness check failed

### DIFF
--- a/ci/jobs/revert_ci_regressions.py
+++ b/ci/jobs/revert_ci_regressions.py
@@ -92,6 +92,7 @@ SYNTHETIC_TEST_NAMES = frozenset(
         "Check failed",
         "Check errors",
         "Server died",
+        "Server liveness check failed",
         "Unknown error",
         "Unknown job error",
         "Parse failure error",

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -695,11 +695,10 @@ clickhouse-client --query "SELECT count() FROM test.visits"
     def run_test(self, cmd, timeout=7200):
         """Run a `clickhouse-test` command and return its integer exit code.
 
-        Returns 0 on success, non-zero on failure. In particular, exit code
-        `STOP_TESTING_EXIT_CODE` (2) signals that `clickhouse-test` aborted
-        the run via `StopTesting` (server died, hung check failed, etc.) and
-        is forwarded to `FTResultsProcessor.run` as `runner_exit_code` so it
-        can populate the synthetic "Server died" leaf.
+        Returns 0 on success, non-zero on failure. The code is forwarded
+        verbatim to `FTResultsProcessor.run` as `runner_exit_code`, which
+        distinguishes the abort causes `clickhouse-test` raises `StopTesting`
+        with and names the synthetic leaf accordingly.
         """
         print(f"Run test: [{cmd}]")
         with open(self.test_output_file, "w") as f:

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -247,32 +247,31 @@ class FTResultsProcessor:
             state = Result.Status.FAIL
             failed_results = [r for r in test_results if r.is_failure()]
             if len(failed_results) > 1:
-                # Multiple tests failed when the server died - this is a parallel
-                # run where we can't tell which test (if any) caused the crash.
+                # Multiple tests failed before the run was aborted - this is a
+                # parallel run where we can't tell which test (if any) caused it.
                 # Mark them all as UNKNOWN so they don't pollute failure reports.
-                # The actual failure is captured by the "Server died" / LOGICAL_ERROR
-                # entry added from the server log.
+                # The actual failure is captured by the synthetic leaf below and
+                # by the LOGICAL_ERROR entries added from the server log.
                 for result in failed_results:
                     result.status = Result.Status.UNKNOWN
             elif len(failed_results) == 1:
-                # Exactly one FAIL was captured before the server died. The
-                # runner may still have been parallel (`--jobs` is always
-                # passed), so this is best-effort attribution of the culprit,
-                # not proof of a single-test sequential run. Demote it to
-                # ERROR so a test that merely witnessed the server death is
-                # not reported as an ordinary test failure - except in bugfix
-                # validation, where the job runs only the PR's own changed
-                # tests: a server death while they run is the expected
-                # reproduction of the bug regardless of which of them got its
-                # FAIL printed first, so keep the FAIL for
+                # Exactly one FAIL was captured before the abort. The runner may
+                # still have been parallel (`--jobs` is always passed), so this
+                # is best-effort attribution of the culprit, not proof of a
+                # single-test sequential run. Demote it to ERROR so a test that
+                # merely witnessed the abort is not reported as an ordinary test
+                # failure - except in bugfix validation, where the job runs only
+                # the PR's own changed tests: a server death or hang while they
+                # run is the expected reproduction of the bug regardless of
+                # which of them got its FAIL printed first, so keep the FAIL for
                 # `invert_bugfix_validation_status` instead of tripping its
                 # fail-closed ERROR guard and reporting the run inconclusive
                 # (#105789). This matches the >1-failed path (UNKNOWN rows +
-                # flipped `Server died` row), which already validates the
+                # flipped synthetic row), which already validates the
                 # parallel-crash case. Accepted tradeoff:
                 # ABORTED_RUN_EXIT_CODES also covers host-caused kills (e.g.
                 # 128+SIGKILL from an OOM of the runner), so in bugfix
-                # validation such a death with a single failed test reads as
+                # validation such an abort with a single failed test reads as
                 # a reproduction too.
                 if not is_bugfix_validation:
                     failed_results[0].status = Result.Status.ERROR

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -23,6 +23,13 @@ _clickhouse_test_globals = runpy.run_path(str(_clickhouse_test))
 STOP_TESTING_EXIT_CODE = _clickhouse_test_globals["STOP_TESTING_EXIT_CODE"]
 GLOBAL_TIME_LIMIT_EXIT_CODE = _clickhouse_test_globals["GLOBAL_TIME_LIMIT_EXIT_CODE"]
 MAX_FAILURES_EXIT_CODE = _clickhouse_test_globals["MAX_FAILURES_EXIT_CODE"]
+HUNG_CHECK_EXIT_CODE = _clickhouse_test_globals["HUNG_CHECK_EXIT_CODE"]
+
+# Synthetic leaf names for an aborted run, keyed by exit code. The liveness name
+# claims only what its probe establishes - the check failed - because the check
+# also fails on a non-200 *response*.
+ABORTED_RUN_DEFAULT_LEAF = "Server died"
+ABORTED_RUN_LIVENESS_LEAF = "Server liveness check failed"
 
 # Exit codes that mean the run was aborted mid-flight, so per-test results
 # (if any) are incomplete and we cannot trust which test "caused" the
@@ -49,9 +56,13 @@ MAX_FAILURES_EXIT_CODE = _clickhouse_test_globals["MAX_FAILURES_EXIT_CODE"]
 # `MAX_FAILURES_EXIT_CODE` is likewise excluded: the run stopped early because
 # too many tests failed, but the server is alive and those failures are real
 # and already attributed - so they must be reported as FAIL, not "Server died".
+# `HUNG_CHECK_EXIT_CODE` IS included: the run was aborted mid-flight exactly as
+# for the other members, so the same demotion applies; only the synthetic leaf's
+# name differs.
 ABORTED_RUN_EXIT_CODES = frozenset(
     {
         STOP_TESTING_EXIT_CODE,
+        HUNG_CHECK_EXIT_CODE,
         128 + signal.SIGTERM,  # 143
         128 + signal.SIGKILL,  # 137
         -signal.SIGTERM,  # -15
@@ -265,7 +276,12 @@ class FTResultsProcessor:
                 # a reproduction too.
                 if not is_bugfix_validation:
                     failed_results[0].status = Result.Status.ERROR
-            test_results.append(Result("Server died", Result.Status.FAIL, info="Server died"))
+            leaf = (
+                ABORTED_RUN_LIVENESS_LEAF
+                if runner_exit_code == HUNG_CHECK_EXIT_CODE
+                else ABORTED_RUN_DEFAULT_LEAF
+            )
+            test_results.append(Result(leaf, Result.Status.FAIL, info=leaf))
         elif runner_exit_code == MAX_FAILURES_EXIT_CODE:
             # The run stopped early because too many tests failed
             # (`--max-failures` / `--max-failures-chain`). Unlike the aborted-run

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -90,6 +90,7 @@ TEST_FAILURE_PATTERNS = [
     "Test runs too long",
     "having exception in stdout",
     "server died",
+    "liveness check failed",
     "Test internal error:",
     # Common Integration tests failures
     "AssertionError",

--- a/ci/tests/test_functional_tests_results.py
+++ b/ci/tests/test_functional_tests_results.py
@@ -18,11 +18,22 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from ci.jobs.scripts.functional_tests_results import (
+    GLOBAL_TIME_LIMIT_EXIT_CODE,
+    HUNG_CHECK_EXIT_CODE,
     MAX_FAILURES_EXIT_CODE,
     STOP_TESTING_EXIT_CODE,
     FTResultsProcessor,
 )
 from ci.praktika.result import Result
+
+# Three passing tests and no failure at all - the shape of the reported bug, where
+# the aggregate said "Failed: 0, Passed: 3872" and the only failing leaf was
+# "Server died".
+_NO_FAILURES = (
+    "00001_a: [ OK ] 0.10 sec.\n"
+    "00002_b: [ OK ] 0.20 sec.\n"
+    "00003_c: [ OK ] 0.30 sec.\n"
+)
 
 # Two real failures from a parallel run that stopped early. No "All tests have
 # finished" line, because the run was aborted before completing.
@@ -155,3 +166,112 @@ def test_bugfix_validation_single_crash_counts_as_reproduction(tmp_path):
     culprit = _named(result, "04545_regression_test")[0]
     assert culprit.status == Result.Status.OK
     assert _named(result, "Server died")[0].status == Result.Status.OK
+
+
+# --- Hung-check exit code: the liveness leaf replaces "Server died" -----------
+#
+# `HUNG_CHECK_EXIT_CODE` is raised when a `check_server_liveness` probe failed.
+# It is an aborted run like the others (the per-test results are incomplete), so
+# only the synthetic leaf's NAME differs.
+
+_LIVENESS_LEAF = "Server liveness check failed"
+
+
+def test_hung_check_no_failures_reports_liveness_leaf_not_server_died(tmp_path):
+    """The reported bug: the probe failed, no test failed, and the job said the
+    server died. The aggregate stays FAIL (the run did abort), the leaf names
+    what was measured, and no "Server died" row is synthesized."""
+    result = _process(tmp_path, _NO_FAILURES, HUNG_CHECK_EXIT_CODE)
+
+    assert result.status == Result.Status.FAIL
+    leaves = _named(result, _LIVENESS_LEAF)
+    assert len(leaves) == 1
+    assert leaves[0].status == Result.Status.FAIL
+    assert not _named(result, "Server died")
+    assert result.info == "Failed: 0, Passed: 3, Skipped: 0"
+
+
+def test_hung_check_two_failures_still_demoted_to_unknown(tmp_path):
+    """The demotion lives INSIDE the aborted-run branch, so it must still apply
+    under the new exit code. A preceding `elif` for the new code would skip it."""
+    result = _process(tmp_path, _TWO_FAILURES, HUNG_CHECK_EXIT_CODE)
+
+    assert result.status == Result.Status.FAIL
+    assert len(_named(result, _LIVENESS_LEAF)) == 1
+    assert not _named(result, "Server died")
+    for name in ("00001_first_failing_test", "00002_second_failing_test"):
+        assert _named(result, name)[0].status == Result.Status.UNKNOWN, name
+
+
+def test_hung_check_single_failure_demoted_to_error(tmp_path):
+    """Same branch, the one-failure arm: the witness is demoted to ERROR outside
+    bugfix validation."""
+    result = _process(tmp_path, _ONE_FAILURE, HUNG_CHECK_EXIT_CODE)
+
+    assert result.status == Result.Status.FAIL
+    assert len(_named(result, _LIVENESS_LEAF)) == 1
+    assert _named(result, "04545_regression_test")[0].status == Result.Status.ERROR
+
+
+def test_stop_testing_code_still_reports_server_died(tmp_path):
+    """Narrowness guard: exit code 2 is still raised by an observed death (and by
+    generic catastrophic aborts), so its leaf must not be renamed."""
+    result = _process(tmp_path, _NO_FAILURES, STOP_TESTING_EXIT_CODE)
+
+    assert result.status == Result.Status.FAIL
+    assert len(_named(result, "Server died")) == 1
+    assert not _named(result, _LIVENESS_LEAF)
+
+
+def test_hung_check_bugfix_validation_counts_as_reproduction(tmp_path):
+    """A changed regression test can reproduce a defect by hanging the server just
+    as by killing it. The leaf is FAIL (not ERROR), so the culprit stays FAIL and
+    `invert_bugfix_validation_status` flips the run to a successful reproduction.
+    An ERROR leaf would trip the inverter's fail-closed guard instead."""
+    from ci.jobs.functional_tests import invert_bugfix_validation_status
+
+    result = _process(
+        tmp_path, _ONE_FAILURE, HUNG_CHECK_EXIT_CODE, is_bugfix_validation=True
+    )
+
+    culprit = _named(result, "04545_regression_test")[0]
+    assert culprit.status == Result.Status.FAIL
+    assert _named(result, _LIVENESS_LEAF)[0].status == Result.Status.FAIL
+
+    no_repro = invert_bugfix_validation_status(result)
+
+    assert no_repro is False
+    assert result.status == Result.Status.OK
+    assert culprit.status == Result.Status.OK
+    assert _named(result, _LIVENESS_LEAF)[0].status == Result.Status.OK
+
+
+def test_stop_testing_bugfix_validation_unchanged(tmp_path):
+    """The #105789 contract on exit code 2 is untouched by the new code path."""
+    from ci.jobs.functional_tests import invert_bugfix_validation_status
+
+    result = _process(
+        tmp_path, _ONE_FAILURE, STOP_TESTING_EXIT_CODE, is_bugfix_validation=True
+    )
+
+    assert _named(result, "04545_regression_test")[0].status == Result.Status.FAIL
+    assert invert_bugfix_validation_status(result) is False
+    assert result.status == Result.Status.OK
+    assert _named(result, "Server died")[0].status == Result.Status.OK
+
+
+def test_hung_check_not_conflated_with_time_limit_or_max_failures(tmp_path):
+    """Each abort cause keeps its own leaf: code 5 must not pick up code 3's
+    benign OK row or code 4's summary."""
+    liveness = _process(tmp_path, _NO_FAILURES, HUNG_CHECK_EXIT_CODE)
+    assert not _named(liveness, "Global time limit reached")
+    assert not _named(liveness, "Too many test failures")
+
+    timed_out = _process(tmp_path, _NO_FAILURES, GLOBAL_TIME_LIMIT_EXIT_CODE)
+    assert _named(timed_out, "Global time limit reached")[0].status == Result.Status.OK
+    assert not _named(timed_out, _LIVENESS_LEAF)
+    assert not _named(timed_out, "Server died")
+
+    too_many = _process(tmp_path, _TWO_FAILURES, MAX_FAILURES_EXIT_CODE)
+    assert _named(too_many, "Too many test failures")
+    assert not _named(too_many, _LIVENESS_LEAF)

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -691,9 +691,8 @@ def test_the_in_loop_handshake_is_not_vacuous():
 # The time limit is the one cause whose trigger is a clock, so end to end it can
 # only be ordered against another cause by a budget that is wide enough to reach
 # and narrow enough to lose - and process startup, including the manager and worker
-# forks, happens inside it. These arms own the clock instead, so the ordering does
-# not depend on how fast the runner is. The exit code still needs an e2e arm, which
-# is the only layer that can see `killpg` clobbering it.
+# forks, happens inside it, which is unbounded on a shared runner. These arms own
+# the clock instead, so the ordering does not depend on how fast the runner is.
 
 
 _DEADLINE = 1.0
@@ -1077,20 +1076,13 @@ if os.environ.get("STUB_HEALTH_CHECK_RAISES") == "1":
         raise RuntimeError("stub: health check send failed")
     ns["TestCase"].send_test_name_failed = _boom
 # lldb over every server process blocks up to 30s each and the collection itself
-# is not what these tests assert. STUB_STACKTRACE_SECONDS reinstates a blocking
-# window on purpose, so a detector that records its cause only after collecting
-# can be beaten by a later one.
-_stacktrace_seconds = float(os.environ.get("STUB_STACKTRACE_SECONDS", "0"))
+# is not what these tests assert, so it is replaced by a marker they can observe.
 def _stub_stacktraces(*a, **k):
     print("stub: print_c_stacktraces")
-    if _stacktrace_seconds:
-        import time as _time
-        _time.sleep(_stacktrace_seconds)
 ns["print_c_stacktraces"] = _stub_stacktraces
-# Prints one line per claim attempt. A denied attempt is otherwise invisible - the
-# "Global time limit reached" banner sits inside the granted branch - so an arm
-# asserting that one cause beat another cannot tell "the loser lost" from "the loser
-# never tried", and passes on a run where the two never competed.
+# Prints one line per claim attempt, granted or not. The "Global time limit reached"
+# banner sits inside the granted branch, so without this an attempt that was made and
+# refused is indistinguishable from one that was never made.
 if os.environ.get("STUB_TRACE_CLAIMS") == "1":
     _real_claim = ns["try_claim_stop_cause"]
     def _traced_claim(carrier, code):
@@ -1098,17 +1090,6 @@ if os.environ.get("STUB_TRACE_CLAIMS") == "1":
         print("stub: claim code=%d granted=%s" % (code, granted))
         return granted
     ns["try_claim_stop_cause"] = _traced_claim
-# Re-arms the deadline on entry to the monitor loop, so the budget measures that
-# loop rather than also covering database creation and worker startup.
-_stop_time_after_setup = float(os.environ.get("STUB_STOP_TIME_AFTER_SETUP", "0"))
-if _stop_time_after_setup:
-    _real_do_run_tests = ns["do_run_tests"]
-    def _do_run_tests(jobs, test_suite, args, *a, **k):
-        import time as _time
-        args.stop_time = _time.time() + _stop_time_after_setup
-        print("stub: re-armed stop_time on entry to do_run_tests")
-        return _real_do_run_tests(jobs, test_suite, args, *a, **k)
-    ns["do_run_tests"] = _do_run_tests
 exec(compile(guard + main_block, runner, "exec"), ns)
 '''
 
@@ -1132,8 +1113,6 @@ def _run_runner(
     extra_args,
     stub_liveness_fails,
     stub_health_check_raises=False,
-    stacktrace_seconds=0,
-    stop_time_after_setup=0,
     trace_claims=False,
     jobs=2,
     timeout=300,
@@ -1143,8 +1122,6 @@ def _run_runner(
     env = dict(os.environ)
     env["STUB_LIVENESS_FAILS"] = "1" if stub_liveness_fails else "0"
     env["STUB_HEALTH_CHECK_RAISES"] = "1" if stub_health_check_raises else "0"
-    env["STUB_STACKTRACE_SECONDS"] = str(stacktrace_seconds)
-    env["STUB_STOP_TIME_AFTER_SETUP"] = str(stop_time_after_setup)
     env["STUB_TRACE_CLAIMS"] = "1" if trace_claims else "0"
     return subprocess.run(
         [
@@ -1165,16 +1142,6 @@ def _run_runner(
         text=True,
         timeout=timeout,
     )
-
-
-# Printed by the shim when it re-arms the deadline. Any arm asserting an ordering
-# between the time limit and another cause must check it: without the re-arm the
-# budget also covers setup, and a slow runner then exits 3 on correct code.
-_STOP_TIME_REARMED = "stub: re-armed stop_time on entry to do_run_tests"
-
-# Printed by the shim's claim tracer under `trace_claims`.
-_CLAIM_DENIED_TIME_LIMIT = f"stub: claim code={GLOBAL_TIME_LIMIT_EXIT_CODE} granted=False"
-_CLAIM_GRANTED_HUNG_CHECK = f"stub: claim code={HUNG_CHECK_EXIT_CODE} granted=True"
 
 
 def _assert_exit_code(proc, expected):
@@ -1240,8 +1207,7 @@ def test_sequential_worker_probe_failure_exits_with_the_hung_check_code(tmp_path
     matches its substrings before consulting tags, so an empty `parallel_tests`
     makes `do_run_tests` skip the worker pool entirely and call `run_tests_array`
     with `is_concurrent=False`. Asserting the split is not decoration - without it
-    this arm silently degrades into a second copy of the parallel one, which is
-    the state it was found in.
+    this arm silently degrades into a second copy of the parallel one.
     """
     _make_suite(tmp_path, count=2, seconds=1)
     proc = _run_runner(
@@ -1296,51 +1262,10 @@ def test_max_failures_is_not_conflated_with_the_hung_check(tmp_path):
     _assert_exit_code(proc, MAX_FAILURES_EXIT_CODE)
 
 
-def test_time_limit_does_not_steal_a_cause_recorded_during_collection(tmp_path):
-    """Both causes fire in one run, end to end, and the process exits 5.
-
-    The ordering itself is asserted without a clock by
-    `test_the_time_limit_does_not_win_the_liveness_collection_window`; this arm
-    exists for the exit code, which is the only layer that can see `killpg`
-    clobbering it. A worker records the probe verdict and then collects stacktraces,
-    which blocks (lldb over every server process, up to 30 s each);
-    `stacktrace_seconds` holds that window open so the deadline expires inside it.
-    Master loses the verdict here and reports the benign `Global time limit reached`
-    at OK.
-
-    The budget below is generous because it no longer carries the ordering: all that
-    has to fit inside it is the worker's claim, ~20 ms against 4 s.
-    """
-    _make_suite(tmp_path, count=4, seconds=1)
-    proc = _run_runner(
-        tmp_path,
-        ["--testname", "--global_time_limit", "4"],
-        stub_liveness_fails=True,
-        stub_health_check_raises=True,
-        stacktrace_seconds=8,
-        stop_time_after_setup=4,
-        trace_claims=True,
-    )
-    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
-    assert _STOP_TIME_REARMED in proc.stdout, proc.stdout[-2000:]
-    # The time limit has to have tried and been refused. Its banner sits inside the
-    # granted branch, so the exit code alone cannot tell a refused claim from one
-    # that was never attempted, and a run whose deadline never expires exits 5
-    # without the two causes ever competing.
-    assert _CLAIM_DENIED_TIME_LIMIT in proc.stdout, (
-        "the time limit never contested the claim, so this run proves nothing about"
-        f" ordering\nstdout:\n{proc.stdout[-3000:]}"
-    )
-    assert _CLAIM_GRANTED_HUNG_CHECK in proc.stdout, proc.stdout[-3000:]
-
-
 def test_the_claim_tracer_sees_a_time_limit_that_wins(tmp_path):
-    """Positive control for the tracer assertion above.
-
-    `granted=False` for the time limit is the interesting outcome, so the tracer has
-    to be able to report `granted=True` for it as well - otherwise the assertion
-    could be reading a tracer that is simply broken for that code.
-    """
+    """The tracer reports `granted=True` for a time limit that does win, so a
+    `granted=False` reading from it distinguishes a refused claim from a broken
+    tracer."""
     _make_suite(tmp_path, count=2, seconds=8)
     proc = _run_runner(
         tmp_path,

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -837,6 +837,90 @@ def test_the_probe_runs_while_no_stop_is_pending():
     assert exit_code == HUNG_CHECK_EXIT_CODE
 
 
+def _parent_probe_carrier_with_a_competitor(competitor_code, handshake_timeout=30.0):
+    """Drive the parent's probe site with a competitor claiming inside its sweep.
+
+    The parent's carrier is created inside `do_run_tests`, so it is captured from
+    the first claim rather than injected. The competitor is then given that same
+    object, which is what makes the two claims genuinely compete.
+
+    The interleaving is a two-way handshake for the same reason as
+    `_drive_abort_site_with_a_competitor`: a pair of sleeps would let a claim moved
+    below the sweep win anyway on a slow run, and the arm would pass on the defect.
+    """
+    collection_started = threading.Event()
+    competitor_claimed = threading.Event()
+    carrier_seen = threading.Event()
+    carriers = []
+    saved = (
+        _runner.check_server_liveness,
+        _runner.print_c_stacktraces,
+        _runner.try_claim_stop_cause,
+    )
+    real_claim = _runner.try_claim_stop_cause
+
+    def capturing_claim(carrier, exit_code):
+        carriers.append(carrier)
+        carrier_seen.set()
+        return real_claim(carrier, exit_code)
+
+    def fake_collect(*a, **k):
+        collection_started.set()
+        if not carriers:
+            raise AssertionError(
+                "the sweep opened with no cause claimed, so the claim is below it"
+            )
+        if not competitor_claimed.wait(timeout=handshake_timeout):
+            raise RuntimeError(
+                "handshake missed: the competitor did not claim inside the"
+                f" sweep within {handshake_timeout}s"
+            )
+
+    def competitor():
+        if not collection_started.wait(timeout=handshake_timeout):
+            return
+        if not carrier_seen.is_set():
+            return
+        real_claim(carriers[0], competitor_code)
+        competitor_claimed.set()
+
+    _runner.check_server_liveness = lambda *a, **k: False
+    _runner.print_c_stacktraces = fake_collect
+    _runner.try_claim_stop_cause = capturing_claim
+    thread = threading.Thread(target=competitor, daemon=True)
+    thread.start()
+    try:
+        _drive_parent_monitor_loop(
+            _worker_signalling_nothing,
+            multiprocessing.Event(),
+            args=_runner_args(hung_check=True),
+        )
+    finally:
+        (
+            _runner.check_server_liveness,
+            _runner.print_c_stacktraces,
+            _runner.try_claim_stop_cause,
+        ) = saved
+        thread.join(timeout=handshake_timeout)
+    assert collection_started.is_set(), "the sweep never ran, so nothing competed"
+    assert competitor_claimed.is_set(), "the competitor never claimed in the sweep"
+    return carriers[0].value
+
+
+def test_the_parent_probe_claims_its_cause_before_collecting_stacktraces():
+    """The same claim-before-collect invariant at the parent's probe site.
+
+    The exit code cannot see this: under first-writer-wins a second claim loses
+    either way, so the observable is which cause the carrier holds. The competitor
+    uses the death code so the arm cannot pass merely because the hung-check code
+    is also what an uncontested run produces.
+    """
+    assert (
+        _parent_probe_carrier_with_a_competitor(STOP_TESTING_EXIT_CODE)
+        == HUNG_CHECK_EXIT_CODE
+    )
+
+
 def test_the_probe_is_gated_on_the_hung_check_flag():
     """The other half of the guard, and a second reason the counter is not
     vacuous: without `--hung-check` the probe is never started."""

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -19,6 +19,7 @@ job). They drive the probe with a stub instead of an unresponsive server, so the
 do not wait out the probe's real 65-165 s retry budget.
 """
 
+import ast
 import contextlib
 import http.client
 import io
@@ -173,6 +174,47 @@ def test_lock_scope_probe_rejects_an_unlocked_read_modify_write():
         assert "outside the lock" in str(e), e
     else:
         raise AssertionError("the probe accepted an unlocked read-modify-write")
+
+
+def test_every_carrier_write_goes_through_the_locked_helper():
+    """No site assigns the carrier directly.
+
+    The arms above pin the helper's own semantics, but each site starts from an
+    empty carrier and writes before anything competes, so a plain
+    `stop_exit_code.value = CODE` at any of them produces the same values and
+    keeps every test green. Only the write's spelling separates the two, so that
+    is what this asserts, over the whole file rather than a listed set of lines.
+    """
+    tree = ast.parse(_CLICKHOUSE_TEST.read_text(encoding="utf-8"))
+    helper = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "try_claim_stop_cause"
+    )
+    inside_helper = {n for n in ast.walk(helper)}
+
+    direct = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign) and node not in inside_helper
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+        and target.attr == "value"
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "stop_exit_code"
+    ]
+    assert not direct, f"carrier assigned outside try_claim_stop_cause at {direct}"
+
+    claims = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "try_claim_stop_cause"
+    ]
+    # Positive control: zero direct assignments is also what a file with no
+    # carrier writes at all would report.
+    assert len(claims) >= 5, f"expected every decision site to claim, found {claims}"
 
 
 # --- The four decision sites --------------------------------------------------

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -19,10 +19,15 @@ job). They drive the probe with a stub instead of an unresponsive server, so the
 do not wait out the probe's real 65-165 s retry budget.
 """
 
+import contextlib
+import http.client
+import io
 import multiprocessing
 import os
 import subprocess
 import sys
+import threading
+import time
 import types
 from pathlib import Path
 
@@ -94,36 +99,80 @@ def test_carrier_keeps_the_first_writer_for_every_ordered_pair():
             assert carrier.value == first, (first, second)
 
 
-def test_carrier_uses_the_value_lock():
+class _LockScopeProbe:
+    """A carrier whose reads and writes assert the lock is held at that moment.
+
+    Asserting only that the lock was entered passes on an empty critical section
+    with the read-modify-write outside it, which is the shape a refactor
+    produces and the shape the unlocked race lives in.
+    """
+
+    def __init__(self, real_lock):
+        self._real_lock = real_lock
+        self._value = 0
+        self.lock_held = False
+        self.entered = 0
+
+    def _check(self, what):
+        assert self.lock_held, f"{what} of the carrier happened outside the lock"
+
+    @property
+    def value(self):
+        self._check("read")
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        self._check("write")
+        self._value = new_value
+
+    def peek(self):
+        """Read for the test's own assertions, bypassing the lock check."""
+        return self._value
+
+    def get_lock(self):
+        outer = self
+
+        class RecordingLock:
+            def __enter__(self):
+                outer.entered += 1
+                outer.lock_held = True
+                return outer._real_lock.__enter__()
+
+            def __exit__(self, *exc):
+                outer.lock_held = False
+                return outer._real_lock.__exit__(*exc)
+
+        return RecordingLock()
+
+
+def test_carrier_reads_and_writes_inside_the_lock():
     """The read and the write must be one locked transition. Two workers can
     detect different causes at the same time, and an unlocked read-modify-write
     lets the later one displace the earlier."""
-    carrier = multiprocessing.Value("i", 0)
-    held = []
-
-    class RecordingLock:
-        def __init__(self, inner):
-            self._inner = inner
-
-        def __enter__(self):
-            held.append(True)
-            return self._inner.__enter__()
-
-        def __exit__(self, *exc):
-            return self._inner.__exit__(*exc)
-
-    real_lock = carrier.get_lock()
-
-    class Probe:
-        value = 0
-
-        def get_lock(self):
-            return RecordingLock(real_lock)
-
-    probe = Probe()
+    probe = _LockScopeProbe(multiprocessing.Value("i", 0).get_lock())
     assert _runner.try_claim_stop_cause(probe, HUNG_CHECK_EXIT_CODE) is True
-    assert probe.value == HUNG_CHECK_EXIT_CODE
-    assert held, "the claim did not take the carrier's lock"
+    assert probe.peek() == HUNG_CHECK_EXIT_CODE
+    assert probe.entered == 1, "the claim did not take the carrier's lock"
+
+
+def test_lock_scope_probe_rejects_an_unlocked_read_modify_write():
+    """The probe above is only an oracle if it actually rejects the defect. A
+    claim implemented with an empty critical section must not pass it."""
+
+    def claim_outside_the_lock(carrier, exit_code):
+        with carrier.get_lock():
+            pass
+        if carrier.value == 0:
+            carrier.value = exit_code
+
+    probe = _LockScopeProbe(multiprocessing.Value("i", 0).get_lock())
+    try:
+        claim_outside_the_lock(probe, HUNG_CHECK_EXIT_CODE)
+    except AssertionError as e:
+        assert "outside the lock" in str(e), e
+    else:
+        raise AssertionError("the probe accepted an unlocked read-modify-write")
 
 
 # --- The four decision sites --------------------------------------------------
@@ -260,6 +309,357 @@ def test_health_check_send_failure_with_a_live_server_is_not_the_probe(tmp_path)
     assert (
         _reason_for_failed_health_check(tmp_path, liveness=True)
         != FailureReason.LIVENESS_CHECK_FAILED
+    )
+
+
+def _reason_for_connection_error(tmp_path, liveness, exception):
+    """Drive `run`'s `except (ConnectionError, ImproperConnectionState)` handler.
+
+    The exception is raised from inside the try-block, past the health-check
+    site, so the reason comes from this handler's own probe and not from the
+    earlier one.
+    """
+    case = _make_test_case(tmp_path)
+    case.case = "00001_probe.sql"
+    case.case_file = str(tmp_path / "00001_probe.sql")
+    case.base_url_params = ""
+    case.base_client_options = ""
+    case.effective_settings = None
+    case.effective_merge_tree_settings = None
+    case.runs_count = 0
+
+    class Suite:
+        suite = "0_stateless"
+        suite_tmp_path = str(tmp_path)
+
+    class Args:
+        pass
+
+    args = Args()
+    args.testname = False
+    args.cloud = False
+
+    saved = {
+        "skip": _runner.TestCase.should_skip_test,
+        "configure": _runner.TestCase.configure_testcase_args,
+        "liveness": _runner.check_server_liveness,
+    }
+    _runner.TestCase.should_skip_test = lambda self, suite: None
+
+    def raise_connection_error(*a, **k):
+        raise exception
+
+    _runner.TestCase.configure_testcase_args = raise_connection_error
+    _runner.check_server_liveness = lambda *a, **k: liveness
+    try:
+        return case.run(args, Suite(), "").reason
+    finally:
+        _runner.TestCase.should_skip_test = saved["skip"]
+        _runner.TestCase.configure_testcase_args = saved["configure"]
+        _runner.check_server_liveness = saved["liveness"]
+
+
+def test_connection_error_with_a_failed_probe_reports_the_probe(tmp_path):
+    """The third probe-only site. A dropped connection plus a failed probe
+    establishes only that the probe failed."""
+    assert (
+        _reason_for_connection_error(
+            tmp_path, liveness=False, exception=ConnectionError("connection dropped")
+        )
+        == FailureReason.LIVENESS_CHECK_FAILED
+    )
+
+
+def test_connection_error_with_a_live_server_is_a_connection_error(tmp_path):
+    """Negative control: the fall-through arm is reached, so the reason above
+    comes from the probe rather than from the handler being entered at all."""
+    assert (
+        _reason_for_connection_error(
+            tmp_path, liveness=True, exception=ConnectionError("connection dropped")
+        )
+        == FailureReason.CONNECTION_ERROR
+    )
+
+
+def test_improper_connection_state_with_a_failed_probe_reports_the_probe(tmp_path):
+    """The handler catches two exception types and must treat them alike."""
+    assert (
+        _reason_for_connection_error(
+            tmp_path,
+            liveness=False,
+            exception=http.client.ImproperConnectionState("bad state"),
+        )
+        == FailureReason.LIVENESS_CHECK_FAILED
+    )
+
+
+# --- Consuming the carrier ----------------------------------------------------
+#
+# Claiming a cause is only half of it: both places that turn a claim into an exit
+# code have to read the carrier. These drive the two consumers directly, with the
+# interleaving forced rather than raced, so there are no sleeps and no flakiness.
+
+
+class _StubSuite:
+    suite = "0_stateless"
+    parallel_tests = ["00001_x"]
+    sequential_tests = []
+
+
+def _runner_args(**overrides):
+    class Args:
+        pass
+
+    args = Args()
+    args.jobs = 1
+    args.no_self_parallel = True
+    args.stop_time = None
+    args.hung_check = False
+    args.max_failures = 0
+    args.max_failures_chain = 10**9
+    args.client_option = []
+    args.force_color = False
+    args.sequential = None
+    args.timeout = 600
+    args.memory_limit = 0
+    args.no_random_settings = True
+    args.no_random_merge_tree_settings = True
+    for name, value in overrides.items():
+        setattr(args, name, value)
+    return args
+
+
+def _drive_sequential_stop_arm(carrier_value):
+    """Drive `run_tests_array`'s `stop_testing already set` arm as the sequential
+    runner, which owns the main process and raises rather than breaking."""
+    stop_testing = multiprocessing.Event()
+    stop_testing.set()
+    carrier = multiprocessing.Value("i", carrier_value)
+
+    saved = _runner.stop_tests
+    _runner.stop_tests = lambda: None
+    try:
+        _runner.run_tests_array(
+            (
+                ["00001_x"],
+                1,
+                _StubSuite(),
+                False,
+                _runner_args(),
+                multiprocessing.Value("i", 0),
+                stop_testing,
+                multiprocessing.Value("i", 0),
+                [],
+                1,
+                multiprocessing.Value("i", 0),
+                multiprocessing.Value("i", 0),
+                1,
+                carrier,
+            )
+        )
+        return None
+    except _runner.StopTesting as e:
+        return e.exit_code
+    finally:
+        _runner.stop_tests = saved
+
+
+def test_sequential_runner_forwards_a_claimed_cause():
+    """A suite with sequential tests reaches this arm after the parallel workers
+    are reaped, so it is the last chance to consume the carrier. Raising the
+    default here is what reports a liveness abort as `Server died`."""
+    assert _drive_sequential_stop_arm(HUNG_CHECK_EXIT_CODE) == HUNG_CHECK_EXIT_CODE
+    assert _drive_sequential_stop_arm(MAX_FAILURES_EXIT_CODE) == MAX_FAILURES_EXIT_CODE
+
+
+def test_sequential_runner_keeps_the_default_when_no_cause_was_claimed():
+    """Mirror arm. Without it the test above also passes on an implementation
+    that always returns the liveness code, and 0 must never become an exit
+    code."""
+    assert _drive_sequential_stop_arm(0) == STOP_TESTING_EXIT_CODE
+
+
+class _EventHiddenOnce:
+    """A real event whose first observation after `set()` reports False.
+
+    The parent checks `stop_testing` at the top of its monitor loop but reaps
+    workers at the bottom, and the reap is the loop's exit condition. This forces
+    the claim to land in that gap on every run instead of waiting for the parent
+    to be descheduled there.
+    """
+
+    def __init__(self):
+        self._inner = multiprocessing.Event()
+        self._observations_after_set = 0
+
+    def set(self):
+        self._inner.set()
+
+    def is_set(self):
+        if not self._inner.is_set():
+            return False
+        self._observations_after_set += 1
+        return self._observations_after_set > 1
+
+
+def _drive_parent_monitor_loop(worker, stop_testing):
+    saved = _runner.run_tests_process
+    _runner.run_tests_process = worker
+    output = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(output):
+            _runner.do_run_tests(
+                1,
+                _StubSuite(),
+                _runner_args(),
+                multiprocessing.Value("i", 0),
+                [],
+                stop_testing,
+                multiprocessing.Event(),
+            )
+        exit_code = None
+    except _runner.StopTesting as e:
+        exit_code = e.exit_code
+    finally:
+        _runner.run_tests_process = saved
+    # The in-loop consumer announces the teardown; the post-loop one does not.
+    took_in_loop_path = "terminating all processes" in output.getvalue()
+    return exit_code, took_in_loop_path
+
+
+def _worker_claiming(exit_code):
+    def worker(params):
+        _runner.try_claim_stop_cause(params[13], exit_code)
+        params[6].set()
+
+    return worker
+
+
+def _worker_claiming_nothing(params):
+    params[6].set()
+
+
+def test_parent_consumes_a_cause_claimed_after_its_last_check():
+    """A worker that claims and exits in the gap between the parent's check and
+    the reap that ends the loop. Without a post-loop consumer the run reports an
+    ordinary set of failures and the verdict is lost."""
+    exit_code, took_in_loop_path = _drive_parent_monitor_loop(
+        _worker_claiming(HUNG_CHECK_EXIT_CODE), _EventHiddenOnce()
+    )
+    assert exit_code == HUNG_CHECK_EXIT_CODE
+    assert not took_in_loop_path, "the in-loop consumer ran, so the gap was not hit"
+
+
+def test_parent_keeps_the_default_for_a_stop_with_no_claimed_cause():
+    """Mirror arm for the test above."""
+    exit_code, took_in_loop_path = _drive_parent_monitor_loop(
+        _worker_claiming_nothing, _EventHiddenOnce()
+    )
+    assert exit_code == STOP_TESTING_EXIT_CODE
+    assert not took_in_loop_path
+
+
+def test_parent_still_consumes_a_cause_seen_inside_the_loop():
+    """The unhidden path, so the two tests above cannot both pass on an
+    implementation that only ever consumes the carrier after the loop."""
+    exit_code, took_in_loop_path = _drive_parent_monitor_loop(
+        _worker_claiming(HUNG_CHECK_EXIT_CODE), multiprocessing.Event()
+    )
+    assert exit_code == HUNG_CHECK_EXIT_CODE
+    assert took_in_loop_path
+
+
+# --- Claiming before collecting -----------------------------------------------
+
+
+def _drive_abort_site_with_a_competitor(reason, competitor_code):
+    """Drive an abort site with a real stacktrace-collection window.
+
+    The competitor claims its own cause partway into the collection, which is the
+    only shape where the two claims genuinely compete. First-writer-wins keeps the
+    detected cause only because the site claims before it collects.
+    """
+    carrier = multiprocessing.Value("i", 0)
+    collect_seconds = 4.0
+    competitor_delay = 1.0
+
+    class FakeCase:
+        def __init__(self, suite, case, args, is_concurrent):
+            self.name = case
+
+        def run(self, args, suite, client_options):
+            return _runner.TestResult(
+                self.name, _runner.TestStatus.FAIL, reason, 0.1, "x"
+            )
+
+        def process_result(self, result, messages):
+            return result
+
+    collected = []
+
+    def fake_collect(*a, **k):
+        time.sleep(collect_seconds)
+        collected.append(True)
+
+    def competitor():
+        time.sleep(competitor_delay)
+        _runner.try_claim_stop_cause(carrier, competitor_code)
+
+    saved = (_runner.print_c_stacktraces, _runner.stop_tests, _runner.TestCase)
+    _runner.print_c_stacktraces = fake_collect
+    _runner.stop_tests = lambda: None
+    _runner.TestCase = FakeCase
+    thread = threading.Thread(target=competitor, daemon=True)
+    thread.start()
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            _runner.run_tests_array(
+                (
+                    ["00001_x"],
+                    1,
+                    _StubSuite(),
+                    False,
+                    _runner_args(),
+                    multiprocessing.Value("i", 0),
+                    multiprocessing.Event(),
+                    multiprocessing.Value("i", 0),
+                    [],
+                    1,
+                    multiprocessing.Value("i", 0),
+                    multiprocessing.Value("i", 0),
+                    1,
+                    carrier,
+                )
+            )
+    except _runner.StopTesting:
+        pass
+    finally:
+        (_runner.print_c_stacktraces, _runner.stop_tests, _runner.TestCase) = saved
+        thread.join(timeout=collect_seconds + 5)
+    assert collected, "the collection window did not run, so nothing competed"
+    return carrier.value
+
+
+def test_death_claims_its_cause_before_collecting_stacktraces():
+    """The death path's claim, and its position before the collection. Asserting
+    the raised code cannot see this: the sequential arm raises the default, which
+    equals the death code either way. The carrier is the observable."""
+    assert (
+        _drive_abort_site_with_a_competitor(
+            FailureReason.SERVER_DIED, HUNG_CHECK_EXIT_CODE
+        )
+        == STOP_TESTING_EXIT_CODE
+    )
+
+
+def test_liveness_claims_its_cause_before_collecting_stacktraces():
+    """The same invariant on the liveness path, with the causes swapped so the
+    test above cannot pass merely because the death code is also the default."""
+    assert (
+        _drive_abort_site_with_a_competitor(
+            FailureReason.LIVENESS_CHECK_FAILED, STOP_TESTING_EXIT_CODE
+        )
+        == HUNG_CHECK_EXIT_CODE
     )
 
 

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -879,58 +879,43 @@ def test_the_probe_runs_while_no_stop_is_pending():
     assert exit_code == HUNG_CHECK_EXIT_CODE
 
 
-def _parent_probe_carrier_with_a_competitor(competitor_code, handshake_timeout=30.0):
+def _parent_probe_carrier_with_a_competitor(competitor_code):
     """Drive the parent's probe site with a competitor claiming inside its sweep.
 
     The parent's carrier is created inside `do_run_tests`, so it is captured from
     the first claim rather than injected. The competitor is then given that same
     object, which is what makes the two claims genuinely compete.
 
-    The interleaving is a two-way handshake for the same reason as
-    `_drive_abort_site_with_a_competitor`: a pair of sleeps would let a claim moved
-    below the sweep win anyway on a slow run, and the arm would pass on the defect.
+    The competitor claims from inside the stubbed sweep rather than from a thread
+    racing it. That is deterministic where a race is not, and it keeps the driver
+    single-threaded: `do_run_tests` forks its workers, and forking a process that
+    has started a thread is a documented deadlock hazard.
     """
-    collection_started = threading.Event()
-    competitor_claimed = threading.Event()
-    carrier_seen = threading.Event()
-    carriers = []
+    collected = []
     saved = (
         _runner.check_server_liveness,
         _runner.print_c_stacktraces,
         _runner.try_claim_stop_cause,
     )
     real_claim = _runner.try_claim_stop_cause
+    carriers = []
 
     def capturing_claim(carrier, exit_code):
         carriers.append(carrier)
-        carrier_seen.set()
         return real_claim(carrier, exit_code)
 
     def fake_collect(*a, **k):
-        collection_started.set()
-        if not carriers:
-            raise AssertionError(
-                "the sweep opened with no cause claimed, so the claim is below it"
-            )
-        if not competitor_claimed.wait(timeout=handshake_timeout):
-            raise RuntimeError(
-                "handshake missed: the competitor did not claim inside the"
-                f" sweep within {handshake_timeout}s"
-            )
-
-    def competitor():
-        if not collection_started.wait(timeout=handshake_timeout):
-            return
-        if not carrier_seen.is_set():
-            return
+        # Reached only from inside the probe's abort block, which is the window
+        # the competing claim has to land in.
+        assert carriers, (
+            "the sweep opened with no cause claimed, so the claim is below it"
+        )
         real_claim(carriers[0], competitor_code)
-        competitor_claimed.set()
+        collected.append(1)
 
     _runner.check_server_liveness = lambda *a, **k: False
     _runner.print_c_stacktraces = fake_collect
     _runner.try_claim_stop_cause = capturing_claim
-    thread = threading.Thread(target=competitor, daemon=True)
-    thread.start()
     try:
         _drive_parent_monitor_loop(
             _worker_signalling_nothing,
@@ -943,9 +928,7 @@ def _parent_probe_carrier_with_a_competitor(competitor_code, handshake_timeout=3
             _runner.print_c_stacktraces,
             _runner.try_claim_stop_cause,
         ) = saved
-        thread.join(timeout=handshake_timeout)
-    assert collection_started.is_set(), "the sweep never ran, so nothing competed"
-    assert competitor_claimed.is_set(), "the competitor never claimed in the sweep"
+    assert collected, "the sweep never ran, so nothing competed"
     return carriers[0].value
 
 

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -24,6 +24,7 @@ import http.client
 import io
 import multiprocessing
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -527,16 +528,32 @@ class _EventVisibleOnFirstCheck:
         return True
 
 
-def _drive_parent_monitor_loop(worker, stop_testing, raise_sites=None):
+def _drive_parent_monitor_loop(
+    worker, stop_testing, raise_sites=None, args=None, clock=None
+):
     """Run the parent monitor loop against a fake worker.
 
     `raise_sites` collects the line number each `raise_stop_from_carrier` call was
     made from, which is what distinguishes the in-loop consumer from the post-loop
     one. The teardown banner cannot: it is printed before the in-loop raise, so it
     still appears when that raise is deleted.
+
+    `clock` replaces the runner's `time`, which is how an arm can decide when the
+    global time limit reads as expired instead of depending on how long the fixture
+    took to get here.
     """
-    saved = (_runner.run_tests_process, _runner.raise_stop_from_carrier)
+    saved = (
+        _runner.run_tests_process,
+        _runner.raise_stop_from_carrier,
+        _runner.time,
+    )
     _runner.run_tests_process = worker
+    if clock is not None:
+        _runner.time = clock
+    # The time-limit branch installs SIG_IGN for the rest of the run. In-process
+    # that would outlive the test and leave the whole pytest session unable to be
+    # terminated.
+    saved_sigterm = signal.getsignal(signal.SIGTERM)
 
     if raise_sites is not None:
         real_raise = _runner.raise_stop_from_carrier
@@ -553,7 +570,7 @@ def _drive_parent_monitor_loop(worker, stop_testing, raise_sites=None):
             _runner.do_run_tests(
                 1,
                 _StubSuite(),
-                _runner_args(),
+                args if args is not None else _runner_args(),
                 multiprocessing.Value("i", 0),
                 [],
                 stop_testing,
@@ -563,7 +580,12 @@ def _drive_parent_monitor_loop(worker, stop_testing, raise_sites=None):
     except _runner.StopTesting as e:
         exit_code = e.exit_code
     finally:
-        _runner.run_tests_process, _runner.raise_stop_from_carrier = saved
+        (
+            _runner.run_tests_process,
+            _runner.raise_stop_from_carrier,
+            _runner.time,
+        ) = saved
+        signal.signal(signal.SIGTERM, saved_sigterm)
     took_teardown_path = "terminating all processes" in output.getvalue()
     return exit_code, took_teardown_path
 
@@ -662,6 +684,156 @@ def test_the_in_loop_handshake_is_not_vacuous():
         assert "no worker signalled a stop" in str(e), e
     else:
         raise AssertionError("the driver accepted a run nothing signalled in")
+
+
+# --- Cause selection against an expired time limit ----------------------------
+#
+# The time limit is the one cause whose trigger is a clock, so end to end it can
+# only be ordered against another cause by a budget that is wide enough to reach
+# and narrow enough to lose - and process startup, including the manager and worker
+# forks, happens inside it. These arms own the clock instead, so the ordering does
+# not depend on how fast the runner is. The exit code still needs an e2e arm, which
+# is the only layer that can see `killpg` clobbering it.
+
+
+_DEADLINE = 1.0
+_PAST_THE_DEADLINE = 2.0
+
+
+class _ClockReadAfterAWorkerSignals:
+    """A clock whose every reading is past `_DEADLINE`, taken only once a worker has
+    signalled a stop.
+
+    Every detector claims its cause before setting `stop_testing`, so a set event
+    means the claim is already visible. Gating the reading on it puts the parent's
+    time-limit evaluation after the worker's claim on every run, with no sleep on
+    either side and no elapsed real time in the comparison: the deadline and the
+    reading are both constants. A missed handshake raises instead of hanging.
+    """
+
+    def __init__(self, signalled, timeout=30.0):
+        self._signalled = signalled
+        self._timeout = timeout
+
+    def __call__(self):
+        if not self._signalled.wait(timeout=self._timeout):
+            raise RuntimeError(
+                f"handshake missed: no worker signalled a stop within {self._timeout}s"
+            )
+        return _PAST_THE_DEADLINE
+
+
+def _stop_code_against_an_expired_deadline(worker, handshake_timeout=30.0):
+    stop_testing = multiprocessing.Event()
+    exit_code, _ = _drive_parent_monitor_loop(
+        worker,
+        stop_testing,
+        args=_runner_args(stop_time=_DEADLINE),
+        clock=_ClockReadAfterAWorkerSignals(stop_testing, handshake_timeout),
+    )
+    return exit_code
+
+
+def test_time_limit_does_not_displace_a_cause_claimed_before_it():
+    """A worker claims the probe verdict, and only then is the parent's expired time
+    limit evaluated. The parent must report 5, not 3.
+
+    Master loses the verdict here and reports the benign `Global time limit
+    reached`.
+    """
+    assert (
+        _stop_code_against_an_expired_deadline(_worker_claiming(HUNG_CHECK_EXIT_CODE))
+        == HUNG_CHECK_EXIT_CODE
+    )
+
+
+def test_an_expired_time_limit_still_claims_a_run_with_no_other_cause():
+    """Mirror arm. Without it the test above also passes on an implementation that
+    never claims the time limit at all, and the #106183 contract - a plain timeout is
+    the benign stop condition - would go unpinned at this layer."""
+    assert (
+        _stop_code_against_an_expired_deadline(_worker_claiming_nothing)
+        == GLOBAL_TIME_LIMIT_EXIT_CODE
+    )
+
+
+def test_the_deadline_handshake_is_not_vacuous():
+    """The clock above is only a forcing mechanism if an unmet handshake fails
+    loudly. With a worker that never signals a stop it must raise, not pass and not
+    hang - otherwise the two arms above could be reading the clock before the claim
+    and would be racing after all."""
+    try:
+        _stop_code_against_an_expired_deadline(
+            _worker_signalling_nothing, handshake_timeout=1.0
+        )
+    except RuntimeError as e:
+        assert "no worker signalled a stop" in str(e), e
+    else:
+        raise AssertionError("the driver accepted a run nothing signalled in")
+
+
+# --- Not starting the probe once a stop is already pending --------------------
+#
+# The probe takes 65-165 s to conclude and drags a stacktrace sweep (up to 30 s
+# per server process) behind it, so a run that is already tearing down must not
+# start one. Whether it ran is not visible in the exit code - a second claim loses
+# to the first either way - so the observable is the call count.
+
+
+def _probe_calls(stop_testing, worker, hung_check=True):
+    calls = []
+
+    saved = (_runner.check_server_liveness, _runner.print_c_stacktraces)
+
+    def counting_probe(*a, **k):
+        calls.append(1)
+        return False  # so a run that does probe still terminates
+
+    _runner.check_server_liveness = counting_probe
+    _runner.print_c_stacktraces = lambda *a, **k: None
+    try:
+        exit_code, _ = _drive_parent_monitor_loop(
+            worker, stop_testing, args=_runner_args(hung_check=hung_check)
+        )
+    finally:
+        _runner.check_server_liveness, _runner.print_c_stacktraces = saved
+    return len(calls), exit_code
+
+
+def test_a_pending_stop_prevents_a_new_liveness_probe():
+    """A worker has claimed and signalled before the parent reaches the probe.
+
+    `_EventVisibleOnFirstCheck` makes the guard's own `is_set()` wait for that
+    signal, so the ordering is forced rather than raced. The claimed cause also has
+    to survive, which is why the exit code is asserted too.
+    """
+    calls, exit_code = _probe_calls(
+        _EventVisibleOnFirstCheck(), _worker_claiming(MAX_FAILURES_EXIT_CODE)
+    )
+    assert calls == 0, "a probe was started on a run that was already stopping"
+    assert exit_code == MAX_FAILURES_EXIT_CODE
+
+
+def test_the_probe_runs_while_no_stop_is_pending():
+    """Positive control, mandatory: 0 calls is also what a run that never reached
+    the probe produces, so the arm above proves nothing without this one."""
+    calls, exit_code = _probe_calls(
+        multiprocessing.Event(), _worker_signalling_nothing
+    )
+    assert calls >= 1
+    assert exit_code == HUNG_CHECK_EXIT_CODE
+
+
+def test_the_probe_is_gated_on_the_hung_check_flag():
+    """The other half of the guard, and a second reason the counter is not
+    vacuous: without `--hung-check` the probe is never started."""
+    calls, exit_code = _probe_calls(
+        _EventVisibleOnFirstCheck(),
+        _worker_claiming(MAX_FAILURES_EXIT_CODE),
+        hung_check=False,
+    )
+    assert calls == 0
+    assert exit_code == MAX_FAILURES_EXIT_CODE
 
 
 # --- Claiming before collecting -----------------------------------------------
@@ -799,6 +971,22 @@ def test_the_competitor_handshake_is_not_vacuous():
         raise AssertionError("the driver accepted a window nothing competed in")
 
 
+def test_the_time_limit_does_not_win_the_liveness_collection_window():
+    """The competitor is the global time limit, which is the cause that can fire on
+    a clock while the worker is still collecting.
+
+    The e2e arm for this shape has to make the run outlast a deadline to get here,
+    which puts process startup inside the budget. Here the window is opened and
+    closed by a handshake, so the interleaving holds however slow the runner is.
+    """
+    assert (
+        _drive_abort_site_with_a_competitor(
+            FailureReason.LIVENESS_CHECK_FAILED, GLOBAL_TIME_LIMIT_EXIT_CODE
+        )
+        == HUNG_CHECK_EXIT_CODE
+    )
+
+
 def test_liveness_claims_its_cause_before_collecting_stacktraces():
     """The same invariant on the liveness path, with the causes swapped so the
     test above cannot pass merely because the death code is also the default."""
@@ -899,6 +1087,17 @@ def _stub_stacktraces(*a, **k):
         import time as _time
         _time.sleep(_stacktrace_seconds)
 ns["print_c_stacktraces"] = _stub_stacktraces
+# Prints one line per claim attempt. A denied attempt is otherwise invisible - the
+# "Global time limit reached" banner sits inside the granted branch - so an arm
+# asserting that one cause beat another cannot tell "the loser lost" from "the loser
+# never tried", and passes on a run where the two never competed.
+if os.environ.get("STUB_TRACE_CLAIMS") == "1":
+    _real_claim = ns["try_claim_stop_cause"]
+    def _traced_claim(carrier, code):
+        granted = _real_claim(carrier, code)
+        print("stub: claim code=%d granted=%s" % (code, granted))
+        return granted
+    ns["try_claim_stop_cause"] = _traced_claim
 # Re-arms the deadline on entry to the monitor loop, so the budget measures that
 # loop rather than also covering database creation and worker startup.
 _stop_time_after_setup = float(os.environ.get("STUB_STOP_TIME_AFTER_SETUP", "0"))
@@ -935,6 +1134,7 @@ def _run_runner(
     stub_health_check_raises=False,
     stacktrace_seconds=0,
     stop_time_after_setup=0,
+    trace_claims=False,
     jobs=2,
     timeout=300,
 ):
@@ -945,6 +1145,7 @@ def _run_runner(
     env["STUB_HEALTH_CHECK_RAISES"] = "1" if stub_health_check_raises else "0"
     env["STUB_STACKTRACE_SECONDS"] = str(stacktrace_seconds)
     env["STUB_STOP_TIME_AFTER_SETUP"] = str(stop_time_after_setup)
+    env["STUB_TRACE_CLAIMS"] = "1" if trace_claims else "0"
     return subprocess.run(
         [
             sys.executable,
@@ -970,6 +1171,10 @@ def _run_runner(
 # between the time limit and another cause must check it: without the re-arm the
 # budget also covers setup, and a slow runner then exits 3 on correct code.
 _STOP_TIME_REARMED = "stub: re-armed stop_time on entry to do_run_tests"
+
+# Printed by the shim's claim tracer under `trace_claims`.
+_CLAIM_DENIED_TIME_LIMIT = f"stub: claim code={GLOBAL_TIME_LIMIT_EXIT_CODE} granted=False"
+_CLAIM_GRANTED_HUNG_CHECK = f"stub: claim code={HUNG_CHECK_EXIT_CODE} granted=True"
 
 
 def _assert_exit_code(proc, expected):
@@ -1092,13 +1297,19 @@ def test_max_failures_is_not_conflated_with_the_hung_check(tmp_path):
 
 
 def test_time_limit_does_not_steal_a_cause_recorded_during_collection(tmp_path):
-    """Both causes fire in one run, and the window between them is real.
+    """Both causes fire in one run, end to end, and the process exits 5.
 
-    A worker records the probe verdict and then collects stacktraces, which blocks
-    (lldb over every server process, up to 30 s each). `stacktrace_seconds` makes
-    that window wide enough for the parent's time limit to expire inside it, which
-    is the only shape where the two claims genuinely compete. Master loses the
-    verdict here and reports the benign `Global time limit reached` at OK.
+    The ordering itself is asserted without a clock by
+    `test_the_time_limit_does_not_win_the_liveness_collection_window`; this arm
+    exists for the exit code, which is the only layer that can see `killpg`
+    clobbering it. A worker records the probe verdict and then collects stacktraces,
+    which blocks (lldb over every server process, up to 30 s each);
+    `stacktrace_seconds` holds that window open so the deadline expires inside it.
+    Master loses the verdict here and reports the benign `Global time limit reached`
+    at OK.
+
+    The budget below is generous because it no longer carries the ordering: all that
+    has to fit inside it is the worker's claim, ~20 ms against 4 s.
     """
     _make_suite(tmp_path, count=4, seconds=1)
     proc = _run_runner(
@@ -1108,22 +1319,39 @@ def test_time_limit_does_not_steal_a_cause_recorded_during_collection(tmp_path):
         stub_health_check_raises=True,
         stacktrace_seconds=8,
         stop_time_after_setup=4,
+        trace_claims=True,
     )
     _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
     assert _STOP_TIME_REARMED in proc.stdout, proc.stdout[-2000:]
+    # The time limit has to have tried and been refused. Its banner sits inside the
+    # granted branch, so the exit code alone cannot tell a refused claim from one
+    # that was never attempted, and a run whose deadline never expires exits 5
+    # without the two causes ever competing.
+    assert _CLAIM_DENIED_TIME_LIMIT in proc.stdout, (
+        "the time limit never contested the claim, so this run proves nothing about"
+        f" ordering\nstdout:\n{proc.stdout[-3000:]}"
+    )
+    assert _CLAIM_GRANTED_HUNG_CHECK in proc.stdout, proc.stdout[-3000:]
 
 
-def test_parent_time_limit_does_not_steal_a_worker_cause(tmp_path):
-    """The parent's own periodic probe against the same expiring time limit."""
+def test_the_claim_tracer_sees_a_time_limit_that_wins(tmp_path):
+    """Positive control for the tracer assertion above.
+
+    `granted=False` for the time limit is the interesting outcome, so the tracer has
+    to be able to report `granted=True` for it as well - otherwise the assertion
+    could be reading a tracer that is simply broken for that code.
+    """
     _make_suite(tmp_path, count=2, seconds=8)
     proc = _run_runner(
         tmp_path,
-        ["--hung-check", "--global_time_limit", "3"],
-        stub_liveness_fails=True,
-        stop_time_after_setup=3,
+        ["--global_time_limit", "3"],
+        stub_liveness_fails=False,
+        trace_claims=True,
     )
-    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
-    assert _STOP_TIME_REARMED in proc.stdout, proc.stdout[-2000:]
+    _assert_exit_code(proc, GLOBAL_TIME_LIMIT_EXIT_CODE)
+    assert (
+        f"stub: claim code={GLOBAL_TIME_LIMIT_EXIT_CODE} granted=True" in proc.stdout
+    ), proc.stdout[-3000:]
 
 
 def test_time_limit_still_claims_a_run_with_no_other_cause(tmp_path):

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -501,9 +501,52 @@ class _EventHiddenOnce:
         return self._observations_after_set > 1
 
 
-def _drive_parent_monitor_loop(worker, stop_testing):
-    saved = _runner.run_tests_process
+class _EventVisibleOnFirstCheck:
+    """A real event whose `is_set()` waits, bounded, for a worker to set it.
+
+    The inverse of `_EventHiddenOnce`: the parent's check at the top of the
+    monitor loop cannot answer False before a worker has signalled, so the
+    in-loop consumer is reached on every run instead of whenever the parent
+    happens to be scheduled before the reap. Every detector claims its cause
+    before setting the event, so a set event means the claim is already visible.
+    A missed handshake raises instead of hanging.
+    """
+
+    def __init__(self, timeout=30.0):
+        self._inner = multiprocessing.Event()
+        self._timeout = timeout
+
+    def set(self):
+        self._inner.set()
+
+    def is_set(self):
+        if not self._inner.wait(timeout=self._timeout):
+            raise RuntimeError(
+                f"handshake missed: no worker signalled a stop within {self._timeout}s"
+            )
+        return True
+
+
+def _drive_parent_monitor_loop(worker, stop_testing, raise_sites=None):
+    """Run the parent monitor loop against a fake worker.
+
+    `raise_sites` collects the line number each `raise_stop_from_carrier` call was
+    made from, which is what distinguishes the in-loop consumer from the post-loop
+    one. The teardown banner cannot: it is printed before the in-loop raise, so it
+    still appears when that raise is deleted.
+    """
+    saved = (_runner.run_tests_process, _runner.raise_stop_from_carrier)
     _runner.run_tests_process = worker
+
+    if raise_sites is not None:
+        real_raise = _runner.raise_stop_from_carrier
+
+        def recording_raise(carrier):
+            raise_sites.append(sys._getframe(1).f_lineno)
+            real_raise(carrier)
+
+        _runner.raise_stop_from_carrier = recording_raise
+
     output = io.StringIO()
     try:
         with contextlib.redirect_stdout(output):
@@ -520,10 +563,31 @@ def _drive_parent_monitor_loop(worker, stop_testing):
     except _runner.StopTesting as e:
         exit_code = e.exit_code
     finally:
-        _runner.run_tests_process = saved
-    # The in-loop consumer announces the teardown; the post-loop one does not.
-    took_in_loop_path = "terminating all processes" in output.getvalue()
-    return exit_code, took_in_loop_path
+        _runner.run_tests_process, _runner.raise_stop_from_carrier = saved
+    took_teardown_path = "terminating all processes" in output.getvalue()
+    return exit_code, took_teardown_path
+
+
+def _carrier_consumer_lines():
+    """The two `raise_stop_from_carrier` call sites in the monitor loop, in source
+    order: the in-loop consumer first, the post-loop one second.
+
+    Derived from the source rather than hardcoded, so a refactor that moves either
+    site keeps working - and one that adds or removes a site fails here loudly
+    instead of silently making the arms below compare against the wrong line.
+    """
+    lines = [
+        number
+        for number, text in enumerate(
+            _CLICKHOUSE_TEST.read_text(encoding="utf-8").splitlines(), start=1
+        )
+        if text.strip() == "raise_stop_from_carrier(stop_exit_code)"
+    ]
+    assert len(lines) == 2, f"expected 2 carrier consumers, found {lines}"
+    return lines
+
+
+_IN_LOOP_CONSUMER, _POST_LOOP_CONSUMER = _carrier_consumer_lines()
 
 
 def _worker_claiming(exit_code):
@@ -538,41 +602,78 @@ def _worker_claiming_nothing(params):
     params[6].set()
 
 
+def _worker_signalling_nothing(params):
+    """Exits without requesting a stop, which leaves the handshake unsatisfiable."""
+
+
 def test_parent_consumes_a_cause_claimed_after_its_last_check():
     """A worker that claims and exits in the gap between the parent's check and
     the reap that ends the loop. Without a post-loop consumer the run reports an
     ordinary set of failures and the verdict is lost."""
-    exit_code, took_in_loop_path = _drive_parent_monitor_loop(
-        _worker_claiming(HUNG_CHECK_EXIT_CODE), _EventHiddenOnce()
+    sites = []
+    exit_code, took_teardown_path = _drive_parent_monitor_loop(
+        _worker_claiming(HUNG_CHECK_EXIT_CODE), _EventHiddenOnce(), raise_sites=sites
     )
     assert exit_code == HUNG_CHECK_EXIT_CODE
-    assert not took_in_loop_path, "the in-loop consumer ran, so the gap was not hit"
+    assert sites == [_POST_LOOP_CONSUMER], sites
+    assert not took_teardown_path, "the in-loop path ran, so the gap was not hit"
 
 
 def test_parent_keeps_the_default_for_a_stop_with_no_claimed_cause():
     """Mirror arm for the test above."""
-    exit_code, took_in_loop_path = _drive_parent_monitor_loop(
-        _worker_claiming_nothing, _EventHiddenOnce()
+    sites = []
+    exit_code, took_teardown_path = _drive_parent_monitor_loop(
+        _worker_claiming_nothing, _EventHiddenOnce(), raise_sites=sites
     )
     assert exit_code == STOP_TESTING_EXIT_CODE
-    assert not took_in_loop_path
+    assert sites == [_POST_LOOP_CONSUMER], sites
+    assert not took_teardown_path
 
 
 def test_parent_still_consumes_a_cause_seen_inside_the_loop():
     """The unhidden path, so the two tests above cannot both pass on an
-    implementation that only ever consumes the carrier after the loop."""
-    exit_code, took_in_loop_path = _drive_parent_monitor_loop(
-        _worker_claiming(HUNG_CHECK_EXIT_CODE), multiprocessing.Event()
+    implementation that only ever consumes the carrier after the loop.
+
+    The observable is which consumer raised, not the teardown banner: that banner
+    is printed before the in-loop raise, so it survives deleting it. The event
+    blocks until the worker has claimed, so the in-loop path is reached on every
+    run rather than whenever the parent is scheduled first.
+    """
+    sites = []
+    exit_code, took_teardown_path = _drive_parent_monitor_loop(
+        _worker_claiming(HUNG_CHECK_EXIT_CODE),
+        _EventVisibleOnFirstCheck(),
+        raise_sites=sites,
     )
     assert exit_code == HUNG_CHECK_EXIT_CODE
-    assert took_in_loop_path
+    assert sites == [_IN_LOOP_CONSUMER], sites
+    assert took_teardown_path
+
+
+def test_the_in_loop_handshake_is_not_vacuous():
+    """`_EventVisibleOnFirstCheck` is only a forcing mechanism if an unmet
+    handshake fails loudly. With a worker that never signals a stop it must raise,
+    not pass and not hang."""
+    try:
+        _drive_parent_monitor_loop(
+            _worker_signalling_nothing, _EventVisibleOnFirstCheck(timeout=1.0)
+        )
+    except RuntimeError as e:
+        assert "no worker signalled a stop" in str(e), e
+    else:
+        raise AssertionError("the driver accepted a run nothing signalled in")
 
 
 # --- Claiming before collecting -----------------------------------------------
 
 
 def _drive_abort_site_with_a_competitor(
-    reason, competitor_code, start_competitor=True, handshake_timeout=30.0
+    reason,
+    competitor_code,
+    start_competitor=True,
+    handshake_timeout=30.0,
+    is_concurrent=False,
+    stop_tests_calls=None,
 ):
     """Drive an abort site with a real stacktrace-collection window.
 
@@ -590,13 +691,18 @@ def _drive_abort_site_with_a_competitor(
     `start_competitor=False` leaves the second handshake unsatisfiable, which is
     how `test_the_competitor_handshake_is_not_vacuous` drives this helper's own
     failure mode.
+
+    Passing a list as `stop_tests_calls` records each `stop_tests()` call instead
+    of discarding it, so a caller can assert whether the site broadcast SIGTERM.
+    The real function is never called: its `killpg` would signal this pytest
+    process.
     """
     carrier = multiprocessing.Value("i", 0)
     collection_started = threading.Event()
     competitor_claimed = threading.Event()
 
     class FakeCase:
-        def __init__(self, suite, case, args, is_concurrent):
+        def __init__(self, suite, case, args, concurrent):
             self.name = case
 
         def run(self, args, suite, client_options):
@@ -621,11 +727,17 @@ def _drive_abort_site_with_a_competitor(
         _runner.try_claim_stop_cause(carrier, competitor_code)
         competitor_claimed.set()
 
+    def record_stop_tests():
+        if stop_tests_calls is not None:
+            stop_tests_calls.append(1)
+
     saved = (_runner.print_c_stacktraces, _runner.stop_tests, _runner.TestCase)
     _runner.print_c_stacktraces = fake_collect
-    _runner.stop_tests = lambda: None
+    _runner.stop_tests = record_stop_tests
     _runner.TestCase = FakeCase
-    thread = threading.Thread(target=competitor, daemon=True) if start_competitor else None
+    thread = (
+        threading.Thread(target=competitor, daemon=True) if start_competitor else None
+    )
     if thread:
         thread.start()
     try:
@@ -635,7 +747,7 @@ def _drive_abort_site_with_a_competitor(
                     ["00001_x"],
                     1,
                     _StubSuite(),
-                    False,
+                    is_concurrent,
                     _runner_args(),
                     multiprocessing.Value("i", 0),
                     multiprocessing.Event(),
@@ -651,7 +763,7 @@ def _drive_abort_site_with_a_competitor(
     except _runner.StopTesting:
         pass
     finally:
-        (_runner.print_c_stacktraces, _runner.stop_tests, _runner.TestCase) = saved
+        _runner.print_c_stacktraces, _runner.stop_tests, _runner.TestCase = saved
         if thread:
             thread.join(timeout=handshake_timeout + 5)
     assert collection_started.is_set(), "the collection window did not open"
@@ -696,6 +808,34 @@ def test_liveness_claims_its_cause_before_collecting_stacktraces():
         )
         == HUNG_CHECK_EXIT_CODE
     )
+
+
+def _stop_tests_calls_on_the_liveness_path(is_concurrent):
+    calls = []
+    carrier = _drive_abort_site_with_a_competitor(
+        FailureReason.LIVENESS_CHECK_FAILED,
+        STOP_TESTING_EXIT_CODE,
+        is_concurrent=is_concurrent,
+        stop_tests_calls=calls,
+    )
+    # The claim happens at the same site, above the `stop_tests()` guard, so this
+    # separates "the branch was not taken" from "the site was never reached" - a
+    # count of zero means nothing without it.
+    assert carrier == HUNG_CHECK_EXIT_CODE, carrier
+    return len(calls)
+
+
+def test_only_the_sequential_runner_broadcasts_sigterm_on_the_liveness_path():
+    """`stop_tests()` is called on one side of the `is_concurrent` split only.
+
+    Both sides exit 5, so the exit code cannot see this. The parallel half is the
+    load-bearing one: `stop_tests()` broadcasts SIGTERM to the whole process group
+    via `killpg`, so a parallel worker calling it kills the parent with 143 before
+    it can re-raise, and 143 is itself reported as "Server died". The sequential
+    runner owns the main process, so it must call it to tear its own children down.
+    """
+    assert _stop_tests_calls_on_the_liveness_path(is_concurrent=False) == 1
+    assert _stop_tests_calls_on_the_liveness_path(is_concurrent=True) == 0
 
 
 # --- Reason-string and artifact consumers -------------------------------------
@@ -759,6 +899,17 @@ def _stub_stacktraces(*a, **k):
         import time as _time
         _time.sleep(_stacktrace_seconds)
 ns["print_c_stacktraces"] = _stub_stacktraces
+# Re-arms the deadline on entry to the monitor loop, so the budget measures that
+# loop rather than also covering database creation and worker startup.
+_stop_time_after_setup = float(os.environ.get("STUB_STOP_TIME_AFTER_SETUP", "0"))
+if _stop_time_after_setup:
+    _real_do_run_tests = ns["do_run_tests"]
+    def _do_run_tests(jobs, test_suite, args, *a, **k):
+        import time as _time
+        args.stop_time = _time.time() + _stop_time_after_setup
+        print("stub: re-armed stop_time on entry to do_run_tests")
+        return _real_do_run_tests(jobs, test_suite, args, *a, **k)
+    ns["do_run_tests"] = _do_run_tests
 exec(compile(guard + main_block, runner, "exec"), ns)
 '''
 
@@ -783,6 +934,7 @@ def _run_runner(
     stub_liveness_fails,
     stub_health_check_raises=False,
     stacktrace_seconds=0,
+    stop_time_after_setup=0,
     jobs=2,
     timeout=300,
 ):
@@ -792,6 +944,7 @@ def _run_runner(
     env["STUB_LIVENESS_FAILS"] = "1" if stub_liveness_fails else "0"
     env["STUB_HEALTH_CHECK_RAISES"] = "1" if stub_health_check_raises else "0"
     env["STUB_STACKTRACE_SECONDS"] = str(stacktrace_seconds)
+    env["STUB_STOP_TIME_AFTER_SETUP"] = str(stop_time_after_setup)
     return subprocess.run(
         [
             sys.executable,
@@ -811,6 +964,12 @@ def _run_runner(
         text=True,
         timeout=timeout,
     )
+
+
+# Printed by the shim when it re-arms the deadline. Any arm asserting an ordering
+# between the time limit and another cause must check it: without the re-arm the
+# budget also covers setup, and a slow runner then exits 3 on correct code.
+_STOP_TIME_REARMED = "stub: re-armed stop_time on entry to do_run_tests"
 
 
 def _assert_exit_code(proc, expected):
@@ -862,9 +1021,38 @@ def test_parallel_worker_probe_failure_exits_with_the_hung_check_code(tmp_path):
     assert proc.returncode != 128 + 15, "the parent was SIGTERM-killed by a worker"
 
 
+# `do_run_tests` prints this split before it picks a runner. `-j 1` only narrows
+# the worker count, so the split is the observable that separates the two
+# configurations.
+_ALL_SEQUENTIAL = "Found 0 parallel tests and 2 sequential tests"
+
+
 def test_sequential_worker_probe_failure_exits_with_the_hung_check_code(tmp_path):
     """The other side of the `is_concurrent` split: the sequential runner owns the
-    main process, so it does call `stop_tests()` and must still exit 5."""
+    main process, so it does call `stop_tests()` and must still exit 5.
+
+    `--sequential` is what puts the fixtures on that path: `is_sequential_test`
+    matches its substrings before consulting tags, so an empty `parallel_tests`
+    makes `do_run_tests` skip the worker pool entirely and call `run_tests_array`
+    with `is_concurrent=False`. Asserting the split is not decoration - without it
+    this arm silently degrades into a second copy of the parallel one, which is
+    the state it was found in.
+    """
+    _make_suite(tmp_path, count=2, seconds=1)
+    proc = _run_runner(
+        tmp_path,
+        ["--testname", "--sequential=sleep"],
+        stub_liveness_fails=True,
+        stub_health_check_raises=True,
+        jobs=1,
+    )
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert _ALL_SEQUENTIAL in proc.stdout, proc.stdout[-2000:]
+
+
+def test_the_parallel_arm_is_not_secretly_sequential(tmp_path):
+    """Negative control for the assertion above: the parallel arm's own
+    configuration must not satisfy it, or it distinguishes nothing."""
     _make_suite(tmp_path, count=2, seconds=1)
     proc = _run_runner(
         tmp_path,
@@ -874,6 +1062,7 @@ def test_sequential_worker_probe_failure_exits_with_the_hung_check_code(tmp_path
         jobs=1,
     )
     _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert _ALL_SEQUENTIAL not in proc.stdout, proc.stdout[-2000:]
 
 
 def test_responsive_server_finishes_normally(tmp_path):
@@ -918,8 +1107,10 @@ def test_time_limit_does_not_steal_a_cause_recorded_during_collection(tmp_path):
         stub_liveness_fails=True,
         stub_health_check_raises=True,
         stacktrace_seconds=8,
+        stop_time_after_setup=4,
     )
     _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert _STOP_TIME_REARMED in proc.stdout, proc.stdout[-2000:]
 
 
 def test_parent_time_limit_does_not_steal_a_worker_cause(tmp_path):
@@ -929,8 +1120,10 @@ def test_parent_time_limit_does_not_steal_a_worker_cause(tmp_path):
         tmp_path,
         ["--hung-check", "--global_time_limit", "3"],
         stub_liveness_fails=True,
+        stop_time_after_setup=3,
     )
     _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert _STOP_TIME_REARMED in proc.stdout, proc.stdout[-2000:]
 
 
 def test_time_limit_still_claims_a_run_with_no_other_cause(tmp_path):

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -1,0 +1,574 @@
+"""
+Tests for `HUNG_CHECK_EXIT_CODE` in `tests/clickhouse-test`.
+
+A failed `check_server_liveness` probe used to raise the default
+`STOP_TESTING_EXIT_CODE`, which the job side reports as "Server died" - so a
+harness-detected stall and a real death were indistinguishable in the report and
+in CIDB. The probe verdict now travels as its own exit code.
+
+Two layers are covered:
+
+* the stop-cause carrier and the four decision sites, in-process (fast, no
+  server);
+* the exit code the process actually returns, end-to-end through a real run -
+  the only layer that can see `killpg` clobbering the code, which is how the
+  original bug would silently return.
+
+The end-to-end tests need a running ClickHouse server (provided by the CI Tests
+job). They drive the probe with a stub instead of an unresponsive server, so they
+do not wait out the probe's real 65-165 s retry budget.
+"""
+
+import multiprocessing
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+# Repo root so `ci.*` resolves; the `ci` dir so the bare `from praktika...`
+# imports inside the job modules resolve the same way they do under the praktika
+# job runner.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CLICKHOUSE_TEST = _REPO_ROOT / "tests" / "clickhouse-test"
+
+_MAIN_GUARD = 'if __name__ == "__main__":'
+
+# A `<Fatal>` line as the server actually logs it. The leading space matters: the
+# site matches `" <Fatal> "`, and stderr is `.strip()`ed before the match, so a
+# bare `" <Fatal> ..."` fixture would silently stop matching.
+_FATAL_LINE = "2026.08.16 08:35:02.123456 [ 582 ] {} <Fatal> BaseDaemon: signal 11\n"
+
+
+def _load_runner():
+    """Import `tests/clickhouse-test` as a module, stopping at its main guard.
+
+    The file is not importable as-is (no `.py` suffix, and its `__main__` block
+    parses argv), so the definitions are executed into a fresh namespace. Patching
+    a name in that namespace is visible to every function defined in it, which is
+    how the liveness probe is stubbed below.
+    """
+    source = _CLICKHOUSE_TEST.read_text(encoding="utf-8")
+    definitions = source.split(_MAIN_GUARD, 1)[0]
+    module = types.ModuleType("clickhouse_test_under_test")
+    module.__file__ = str(_CLICKHOUSE_TEST)
+    exec(compile(definitions, str(_CLICKHOUSE_TEST), "exec"), module.__dict__)
+    return module
+
+
+_runner = _load_runner()
+
+HUNG_CHECK_EXIT_CODE = _runner.HUNG_CHECK_EXIT_CODE
+STOP_TESTING_EXIT_CODE = _runner.STOP_TESTING_EXIT_CODE
+GLOBAL_TIME_LIMIT_EXIT_CODE = _runner.GLOBAL_TIME_LIMIT_EXIT_CODE
+MAX_FAILURES_EXIT_CODE = _runner.MAX_FAILURES_EXIT_CODE
+FailureReason = _runner.FailureReason
+
+
+# --- The stop-cause carrier ---------------------------------------------------
+
+
+def test_carrier_keeps_the_first_writer_for_every_ordered_pair():
+    """First writer wins, in both directions for every pair of causes.
+
+    A one-sided check would also pass on a "always keep the last write"
+    implementation, so each pair is driven in both orders.
+    """
+    codes = (
+        STOP_TESTING_EXIT_CODE,
+        GLOBAL_TIME_LIMIT_EXIT_CODE,
+        MAX_FAILURES_EXIT_CODE,
+        HUNG_CHECK_EXIT_CODE,
+    )
+    for first in codes:
+        for second in codes:
+            if first == second:
+                continue
+            carrier = multiprocessing.Value("i", 0)
+            assert _runner.try_claim_stop_cause(carrier, first) is True
+            assert carrier.value == first
+            assert _runner.try_claim_stop_cause(carrier, second) is False
+            assert carrier.value == first, (first, second)
+
+
+def test_carrier_uses_the_value_lock():
+    """The read and the write must be one locked transition. Two workers can
+    detect different causes at the same time, and an unlocked read-modify-write
+    lets the later one displace the earlier."""
+    carrier = multiprocessing.Value("i", 0)
+    held = []
+
+    class RecordingLock:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __enter__(self):
+            held.append(True)
+            return self._inner.__enter__()
+
+        def __exit__(self, *exc):
+            return self._inner.__exit__(*exc)
+
+    real_lock = carrier.get_lock()
+
+    class Probe:
+        value = 0
+
+        def get_lock(self):
+            return RecordingLock(real_lock)
+
+    probe = Probe()
+    assert _runner.try_claim_stop_cause(probe, HUNG_CHECK_EXIT_CODE) is True
+    assert probe.value == HUNG_CHECK_EXIT_CODE
+    assert held, "the claim did not take the carrier's lock"
+
+
+# --- The four decision sites --------------------------------------------------
+
+
+def _make_test_case(tmp_path, stop=True):
+    class Args:
+        pass
+
+    args = Args()
+    args.stop = stop
+    args.debug_log_file = str(tmp_path / "debug.log")
+    args.bash_tracing_file = str(tmp_path / "bash.log")
+    args.testcase_database = "test_db"
+
+    case = _runner.TestCase.__new__(_runner.TestCase)
+    case.args = args
+    case.testcase_args = args
+    case.name = "00001_probe"
+    case.stdout_file = str(tmp_path / "stdout")
+    case.stderr_file = str(tmp_path / "stderr")
+    case.fatal_sanitizer_prefix = str(tmp_path / "sanitizer_")
+    case.tags = set()
+    return case
+
+
+class _FailedProc:
+    returncode = 1
+
+
+def _reason_for_stderr(tmp_path, stderr, liveness):
+    case = _make_test_case(tmp_path)
+    Path(case.stderr_file).write_text(stderr, encoding="utf-8")
+    saved = _runner.check_server_liveness
+    _runner.check_server_liveness = lambda *a, **k: liveness
+    try:
+        return case.process_result_impl(_FailedProc(), 1.0).reason
+    finally:
+        _runner.check_server_liveness = saved
+
+
+def test_probe_only_failure_is_not_reported_as_a_death(tmp_path):
+    """A connection error plus a failed probe establishes only that the probe
+    failed."""
+    reason = _reason_for_stderr(tmp_path, "Connection refused\n", liveness=False)
+    assert reason == FailureReason.LIVENESS_CHECK_FAILED
+
+
+def test_fatal_evidence_is_still_reported_as_a_death(tmp_path):
+    """The narrowness anchor: a `<Fatal>` line is evidence of a death and keeps
+    its own reason."""
+    reason = _reason_for_stderr(tmp_path, _FATAL_LINE, liveness=False)
+    assert reason == FailureReason.SERVER_DIED
+
+
+def test_fatal_evidence_outranks_a_failed_probe(tmp_path):
+    """Both signals in one stderr. The two tests are mutually exclusive branches,
+    so fatal evidence is never downgraded to a probe failure - as two independent
+    `if`s would do, the second overwriting the first."""
+    reason = _reason_for_stderr(
+        tmp_path, _FATAL_LINE + "Connection refused\n", liveness=False
+    )
+    assert reason == FailureReason.SERVER_DIED
+
+
+def test_connection_error_with_a_live_server_is_neither(tmp_path):
+    """Unchanged behaviour: a transient error against a responding server is an
+    ordinary test failure."""
+    reason = _reason_for_stderr(tmp_path, "Connection refused\n", liveness=True)
+    assert reason not in (
+        FailureReason.SERVER_DIED,
+        FailureReason.LIVENESS_CHECK_FAILED,
+    )
+
+
+def _reason_for_failed_health_check(tmp_path, liveness):
+    """Drive `run`'s health-check site: `send_test_name_failed` raises, and the
+    reason is then decided by the probe."""
+    case = _make_test_case(tmp_path)
+    case.case = "00001_probe.sql"
+    # `run`'s exception path restores the client environment on the way out.
+    case.base_url_params = ""
+    case.base_client_options = ""
+
+    class Suite:
+        suite = "0_stateless"
+
+    class Args:
+        pass
+
+    args = Args()
+    args.testname = True
+    args.cloud = False
+
+    def boom(self, suite, case_name):
+        raise RuntimeError("health check send failed")
+
+    saved = {
+        "send": _runner.TestCase.send_test_name_failed,
+        "skip": _runner.TestCase.should_skip_test,
+        "liveness": _runner.check_server_liveness,
+        "configure": _runner.TestCase.configure_testcase_args,
+    }
+    _runner.TestCase.send_test_name_failed = boom
+    _runner.TestCase.should_skip_test = lambda self, suite: None
+    # Reached only on the probe-passes arm, where the site under test is not
+    # taken; it stops the run at a known point instead of a real test execution.
+    _runner.TestCase.configure_testcase_args = lambda *a, **k: (_ for _ in ()).throw(
+        RuntimeError("stop after the health-check site")
+    )
+    _runner.check_server_liveness = lambda *a, **k: liveness
+    try:
+        return case.run(args, Suite(), "").reason
+    finally:
+        _runner.TestCase.send_test_name_failed = saved["send"]
+        _runner.TestCase.should_skip_test = saved["skip"]
+        _runner.TestCase.configure_testcase_args = saved["configure"]
+        _runner.check_server_liveness = saved["liveness"]
+
+
+def test_health_check_send_failure_reports_the_probe(tmp_path):
+    """`send_test_name_failed` plus a failed probe. Its own comment concedes the
+    ambiguity: the check "may fail because of memory exhaustion, for example"."""
+    assert (
+        _reason_for_failed_health_check(tmp_path, liveness=False)
+        == FailureReason.LIVENESS_CHECK_FAILED
+    )
+
+
+def test_health_check_send_failure_with_a_live_server_is_not_the_probe(tmp_path):
+    """Negative control for the test above: the reason comes from the probe, not
+    merely from `send_test_name_failed` raising. Without this arm, a fixture that
+    reached the site by accident would look like a pass."""
+    assert (
+        _reason_for_failed_health_check(tmp_path, liveness=True)
+        != FailureReason.LIVENESS_CHECK_FAILED
+    )
+
+
+# --- Reason-string and artifact consumers -------------------------------------
+
+
+def test_new_reason_is_matched_by_a_failure_pattern():
+    """`TestCase.process_result` writes `reason.value` into the per-test output,
+    and `ci/praktika/cidb.py` matches those strings to build the cause-filtered
+    CIDB history link. A reason value no pattern matches loses that link.
+
+    Only the new value is asserted: `INTERNAL_QUERY_FAIL` and `CONNECTION_ERROR`
+    have no matching pattern today, so an enum-wide invariant is already false on
+    master.
+    """
+    from ci.settings.settings import TEST_FAILURE_PATTERNS
+
+    value = FailureReason.LIVENESS_CHECK_FAILED.value
+    assert any(pattern in value for pattern in TEST_FAILURE_PATTERNS), value
+
+
+def test_new_leaf_is_excluded_from_auto_revert():
+    """A run-wide abort names no single change to revert."""
+    from ci.jobs.revert_ci_regressions import SYNTHETIC_TEST_NAMES
+
+    assert "Server liveness check failed" in SYNTHETIC_TEST_NAMES
+
+
+# --- End to end: the exit code the process returns ----------------------------
+#
+# Only this layer can see the failure mode the original bug returns through: a
+# worker's `stop_tests()` broadcasts SIGTERM to the whole process group via
+# `killpg`, killing the parent with 143 before it can re-raise - and 143 is
+# itself reported as "Server died". A test asserting only `TestResult.reason`
+# passes while the run still reports a death.
+
+_SHIM = r'''
+import os, sys
+runner = sys.argv.pop(1)
+sys.argv[0] = runner
+source = open(runner, encoding="utf-8").read()
+guard = 'if __name__ == "__main__":'
+definitions, main_block = source.split(guard, 1)
+ns = {"__name__": "__main__", "__file__": runner}
+exec(compile(definitions, runner, "exec"), ns)
+if os.environ.get("STUB_LIVENESS_FAILS") == "1":
+    ns["check_server_liveness"] = lambda *a, **k: False
+if os.environ.get("STUB_HEALTH_CHECK_RAISES") == "1":
+    # Reaches the WORKER decision site (`run`'s health-check block) rather than
+    # the parent's periodic probe.
+    def _boom(self, suite, case_name):
+        raise RuntimeError("stub: health check send failed")
+    ns["TestCase"].send_test_name_failed = _boom
+# lldb over every server process blocks up to 30s each and the collection itself
+# is not what these tests assert. STUB_STACKTRACE_SECONDS reinstates a blocking
+# window on purpose, so a detector that records its cause only after collecting
+# can be beaten by a later one.
+_stacktrace_seconds = float(os.environ.get("STUB_STACKTRACE_SECONDS", "0"))
+def _stub_stacktraces(*a, **k):
+    print("stub: print_c_stacktraces")
+    if _stacktrace_seconds:
+        import time as _time
+        _time.sleep(_stacktrace_seconds)
+ns["print_c_stacktraces"] = _stub_stacktraces
+exec(compile(guard + main_block, runner, "exec"), ns)
+'''
+
+
+def _make_suite(queries_dir: Path, count: int, seconds: int):
+    """`count` parallel-safe `.sh` tests that pass after `seconds`, so the parent
+    monitor loop gets a chance to run its periodic checks while they are in
+    flight."""
+    suite = queries_dir / "0_stateless"
+    suite.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        name = f"{i:05d}_sleep"
+        script = suite / f"{name}.sh"
+        script.write_text(f"#!/usr/bin/env bash\nsleep {seconds}\necho ok\n", encoding="utf-8")
+        script.chmod(0o755)
+        (suite / f"{name}.reference").write_text("ok\n", encoding="utf-8")
+
+
+def _run_runner(
+    queries_dir,
+    extra_args,
+    stub_liveness_fails,
+    stub_health_check_raises=False,
+    stacktrace_seconds=0,
+    jobs=2,
+    timeout=300,
+):
+    shim = Path(queries_dir) / "shim.py"
+    shim.write_text(_SHIM, encoding="utf-8")
+    env = dict(os.environ)
+    env["STUB_LIVENESS_FAILS"] = "1" if stub_liveness_fails else "0"
+    env["STUB_HEALTH_CHECK_RAISES"] = "1" if stub_health_check_raises else "0"
+    env["STUB_STACKTRACE_SECONDS"] = str(stacktrace_seconds)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(shim),
+            str(_CLICKHOUSE_TEST),
+            "--queries",
+            str(queries_dir),
+            "--no-stateful",
+            "-j",
+            str(jobs),
+            *extra_args,
+            "00",  # name filter: matches the fixtures above
+        ],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _assert_exit_code(proc, expected):
+    assert proc.returncode == expected, (
+        f"expected {expected}, got {proc.returncode}\n"
+        f"stdout:\n{proc.stdout[-4000:]}\nstderr:\n{proc.stderr[-4000:]}"
+    )
+
+
+def test_parent_hung_check_exits_with_the_hung_check_code(tmp_path):
+    """The reported run: the parent's periodic probe fails while tests are still
+    in flight. Master exits `STOP_TESTING_EXIT_CODE` here, which is reported as
+    "Server died"."""
+    _make_suite(tmp_path, count=2, seconds=6)
+    proc = _run_runner(tmp_path, ["--hung-check"], stub_liveness_fails=True)
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert "Hung check failed" in proc.stdout
+    # Not clobbered by a worker's SIGTERM broadcast.
+    assert proc.returncode != 128 + 15
+
+
+def test_hung_check_collects_stacktraces_before_stopping(tmp_path):
+    """Diagnostics are what a stall investigation has to work from, so the sweep
+    must still run on the new path."""
+    _make_suite(tmp_path, count=2, seconds=6)
+    proc = _run_runner(tmp_path, ["--hung-check"], stub_liveness_fails=True)
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert "stub: print_c_stacktraces" in proc.stdout
+
+
+def test_parallel_worker_probe_failure_exits_with_the_hung_check_code(tmp_path):
+    """A WORKER reaches the verdict, not the parent's periodic probe.
+
+    This is the arm that pins the `killpg` hazard: `stop_tests()` broadcasts
+    SIGTERM to the whole process group, so a parallel worker calling it kills the
+    parent with 143 before the parent can re-raise - and 143 is itself reported as
+    "Server died", silently restoring the original bug. Only the process exit code
+    can see that; a test inspecting `TestResult.reason` passes either way.
+    """
+    _make_suite(tmp_path, count=4, seconds=1)
+    proc = _run_runner(
+        tmp_path,
+        ["--testname"],
+        stub_liveness_fails=True,
+        stub_health_check_raises=True,
+        jobs=2,
+    )
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert proc.returncode != 128 + 15, "the parent was SIGTERM-killed by a worker"
+
+
+def test_sequential_worker_probe_failure_exits_with_the_hung_check_code(tmp_path):
+    """The other side of the `is_concurrent` split: the sequential runner owns the
+    main process, so it does call `stop_tests()` and must still exit 5."""
+    _make_suite(tmp_path, count=2, seconds=1)
+    proc = _run_runner(
+        tmp_path,
+        ["--testname"],
+        stub_liveness_fails=True,
+        stub_health_check_raises=True,
+        jobs=1,
+    )
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+
+
+def test_responsive_server_finishes_normally(tmp_path):
+    """Control: with the probe passing, `--hung-check` changes nothing."""
+    _make_suite(tmp_path, count=2, seconds=1)
+    proc = _run_runner(tmp_path, ["--hung-check"], stub_liveness_fails=False)
+    _assert_exit_code(proc, 0)
+
+
+def test_max_failures_is_not_conflated_with_the_hung_check(tmp_path):
+    """`--max-failures` keeps its own code even with `--hung-check` on."""
+    suite = tmp_path / "0_stateless"
+    suite.mkdir(parents=True, exist_ok=True)
+    for i in range(4):
+        name = f"{i:05d}_fail"
+        script = suite / f"{name}.sh"
+        script.write_text("#!/usr/bin/env bash\necho fail\n", encoding="utf-8")
+        script.chmod(0o755)
+        (suite / f"{name}.reference").write_text("ok\n", encoding="utf-8")
+
+    proc = _run_runner(
+        tmp_path,
+        ["--hung-check", "--max-failures", "0", "--max-failures-chain", "1"],
+        stub_liveness_fails=False,
+    )
+    _assert_exit_code(proc, MAX_FAILURES_EXIT_CODE)
+
+
+def test_time_limit_does_not_steal_a_cause_recorded_during_collection(tmp_path):
+    """Both causes fire in one run, and the window between them is real.
+
+    A worker records the probe verdict and then collects stacktraces, which blocks
+    (lldb over every server process, up to 30 s each). `stacktrace_seconds` makes
+    that window wide enough for the parent's time limit to expire inside it, which
+    is the only shape where the two claims genuinely compete. Master loses the
+    verdict here and reports the benign `Global time limit reached` at OK.
+    """
+    _make_suite(tmp_path, count=4, seconds=1)
+    proc = _run_runner(
+        tmp_path,
+        ["--testname", "--global_time_limit", "4"],
+        stub_liveness_fails=True,
+        stub_health_check_raises=True,
+        stacktrace_seconds=8,
+    )
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+
+
+def test_parent_time_limit_does_not_steal_a_worker_cause(tmp_path):
+    """The parent's own periodic probe against the same expiring time limit."""
+    _make_suite(tmp_path, count=2, seconds=8)
+    proc = _run_runner(
+        tmp_path,
+        ["--hung-check", "--global_time_limit", "3"],
+        stub_liveness_fails=True,
+    )
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+
+
+def test_time_limit_still_claims_a_run_with_no_other_cause(tmp_path):
+    """The mirror arm, without which the test above also passes on an
+    implementation that never claims the time limit at all. The #106183 contract
+    stays intact: a plain timeout is the benign stop condition."""
+    _make_suite(tmp_path, count=2, seconds=8)
+    proc = _run_runner(
+        tmp_path,
+        ["--global_time_limit", "3"],
+        stub_liveness_fails=False,
+    )
+    _assert_exit_code(proc, GLOBAL_TIME_LIMIT_EXIT_CODE)
+
+
+def _artifact_test_names(diagnostics_dir: Path):
+    import json
+
+    path = diagnostics_dir / _runner.RANDOM_SETTINGS_DIAGNOSTICS_FILE
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)["test_name"]
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_probe_failure_saves_no_random_settings_artifact(tmp_path):
+    """The artifact means "this test fails under these settings", which a
+    server-wide stall does not establish - and `--diagnose-random-settings`
+    replays it, so a stall would be re-run as if it were a settings bug.
+
+    The positive control is not optional: an empty artifact file is also what a
+    misconfigured harness produces, so the negative arm alone proves nothing.
+    Both arms run through the real guard in `run_tests_array`, driven by a real
+    run - asserting on a re-implementation of the condition would pass whatever
+    the runner actually does.
+    """
+    # Positive control: an ordinary output mismatch DOES get an artifact.
+    diff_dir = tmp_path / "diff_run"
+    diff_queries = tmp_path / "diff_queries"
+    suite = diff_queries / "0_stateless"
+    suite.mkdir(parents=True)
+    script = suite / "00001_mismatch.sh"
+    script.write_text("#!/usr/bin/env bash\necho fail\n", encoding="utf-8")
+    script.chmod(0o755)
+    (suite / "00001_mismatch.reference").write_text("ok\n", encoding="utf-8")
+
+    proc = _run_runner(
+        diff_queries,
+        ["--random-settings-diagnostics-dir", str(diff_dir)],
+        stub_liveness_fails=False,
+    )
+    assert proc.returncode != 0, proc.stdout[-2000:]
+    assert _artifact_test_names(diff_dir) == ["00001_mismatch"], (
+        "the positive control saved no artifact, so the negative arm below is "
+        f"vacuous\nstdout:\n{proc.stdout[-2000:]}"
+    )
+
+    # Negative arm: a failed liveness probe does NOT. This must go through the
+    # WORKER site, which is the only path where a per-test result carries the new
+    # reason and so reaches the guard - the parent's periodic probe aborts the run
+    # without ever producing such a result, which would make this arm vacuous.
+    hung_dir = tmp_path / "hung_run"
+    hung_queries = tmp_path / "hung_queries"
+    _make_suite(hung_queries, count=4, seconds=1)
+
+    proc = _run_runner(
+        hung_queries,
+        ["--testname", "--random-settings-diagnostics-dir", str(hung_dir)],
+        stub_liveness_fails=True,
+        stub_health_check_raises=True,
+    )
+    _assert_exit_code(proc, HUNG_CHECK_EXIT_CODE)
+    assert _artifact_test_names(hung_dir) == []

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -27,7 +27,6 @@ import os
 import subprocess
 import sys
 import threading
-import time
 import types
 from pathlib import Path
 
@@ -572,16 +571,29 @@ def test_parent_still_consumes_a_cause_seen_inside_the_loop():
 # --- Claiming before collecting -----------------------------------------------
 
 
-def _drive_abort_site_with_a_competitor(reason, competitor_code):
+def _drive_abort_site_with_a_competitor(
+    reason, competitor_code, start_competitor=True, handshake_timeout=30.0
+):
     """Drive an abort site with a real stacktrace-collection window.
 
-    The competitor claims its own cause partway into the collection, which is the
-    only shape where the two claims genuinely compete. First-writer-wins keeps the
-    detected cause only because the site claims before it collects.
+    The competitor claims its own cause from inside the collection window, which
+    is the only shape where the two claims genuinely compete. First-writer-wins
+    keeps the detected cause only because the site claims before it collects.
+
+    The interleaving is a two-way event handshake, not a pair of sleeps: the
+    window opens, the competitor claims inside it, and only then does the window
+    close. Sleeps would make the mutation-detection direction probabilistic - a
+    competitor thread not scheduled within the window lets a claim that was moved
+    below the collection win anyway, and the arm passes on the defect. Every wait
+    is bounded so a stuck thread fails loudly instead of hanging a CI job.
+
+    `start_competitor=False` leaves the second handshake unsatisfiable, which is
+    how `test_the_competitor_handshake_is_not_vacuous` drives this helper's own
+    failure mode.
     """
     carrier = multiprocessing.Value("i", 0)
-    collect_seconds = 4.0
-    competitor_delay = 1.0
+    collection_started = threading.Event()
+    competitor_claimed = threading.Event()
 
     class FakeCase:
         def __init__(self, suite, case, args, is_concurrent):
@@ -595,22 +607,27 @@ def _drive_abort_site_with_a_competitor(reason, competitor_code):
         def process_result(self, result, messages):
             return result
 
-    collected = []
-
     def fake_collect(*a, **k):
-        time.sleep(collect_seconds)
-        collected.append(True)
+        collection_started.set()
+        if not competitor_claimed.wait(timeout=handshake_timeout):
+            raise RuntimeError(
+                "handshake missed: the competitor did not claim inside the"
+                f" collection window within {handshake_timeout}s"
+            )
 
     def competitor():
-        time.sleep(competitor_delay)
+        if not collection_started.wait(timeout=handshake_timeout):
+            return
         _runner.try_claim_stop_cause(carrier, competitor_code)
+        competitor_claimed.set()
 
     saved = (_runner.print_c_stacktraces, _runner.stop_tests, _runner.TestCase)
     _runner.print_c_stacktraces = fake_collect
     _runner.stop_tests = lambda: None
     _runner.TestCase = FakeCase
-    thread = threading.Thread(target=competitor, daemon=True)
-    thread.start()
+    thread = threading.Thread(target=competitor, daemon=True) if start_competitor else None
+    if thread:
+        thread.start()
     try:
         with contextlib.redirect_stdout(io.StringIO()):
             _runner.run_tests_array(
@@ -635,8 +652,10 @@ def _drive_abort_site_with_a_competitor(reason, competitor_code):
         pass
     finally:
         (_runner.print_c_stacktraces, _runner.stop_tests, _runner.TestCase) = saved
-        thread.join(timeout=collect_seconds + 5)
-    assert collected, "the collection window did not run, so nothing competed"
+        if thread:
+            thread.join(timeout=handshake_timeout + 5)
+    assert collection_started.is_set(), "the collection window did not open"
+    assert competitor_claimed.is_set(), "the competitor's claim was not inside it"
     return carrier.value
 
 
@@ -650,6 +669,22 @@ def test_death_claims_its_cause_before_collecting_stacktraces():
         )
         == STOP_TESTING_EXIT_CODE
     )
+
+
+def test_the_competitor_handshake_is_not_vacuous():
+    """The handshake above is only an oracle if an unmet one fails loudly. With no
+    competitor thread the driver must raise, not pass and not hang."""
+    try:
+        _drive_abort_site_with_a_competitor(
+            FailureReason.SERVER_DIED,
+            HUNG_CHECK_EXIT_CODE,
+            start_competitor=False,
+            handshake_timeout=1.0,
+        )
+    except RuntimeError as e:
+        assert "the competitor did not claim" in str(e), e
+    else:
+        raise AssertionError("the driver accepted a window nothing competed in")
 
 
 def test_liveness_claims_its_cause_before_collecting_stacktraces():

--- a/ci/tests/test_hung_check_exit_code.py
+++ b/ci/tests/test_hung_check_exit_code.py
@@ -486,11 +486,17 @@ class _EventHiddenOnce:
     workers at the bottom, and the reap is the loop's exit condition. This forces
     the claim to land in that gap on every run instead of waiting for the parent
     to be descheduled there.
+
+    Hiding one observation is necessary but not sufficient: the reap only ends
+    the loop once every worker is dead, so the hidden observation must be spent
+    on an iteration that reaps the last one. Waiting for the children here makes
+    that a precondition rather than a scheduling accident.
     """
 
-    def __init__(self):
+    def __init__(self, timeout=30.0):
         self._inner = multiprocessing.Event()
         self._observations_after_set = 0
+        self._timeout = timeout
 
     def set(self):
         self._inner.set()
@@ -498,6 +504,14 @@ class _EventHiddenOnce:
     def is_set(self):
         if not self._inner.is_set():
             return False
+        if self._observations_after_set == 0:
+            for child in multiprocessing.active_children():
+                child.join(timeout=self._timeout)
+                if child.is_alive():
+                    raise AssertionError(
+                        f"worker {child.name} outlived the {self._timeout}s join, "
+                        "so the reap cannot end the loop on the hidden observation"
+                    )
         self._observations_after_set += 1
         return self._observations_after_set > 1
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1277,7 +1277,7 @@ def print_c_stacktraces(args) -> None:
     Every call site is one of two situations: we're aborting the whole
     run (SERVER_DIED, liveness check, hung-check, check_server_started)
     or terminating the one wedged test (timeout_handler).  lldb's "thread
-    backtrace all" pause is on the order of seconds — acceptable in both
+    backtrace all" pause is on the order of seconds - acceptable in both
     cases against the diagnostic value.
 
     Skipped under ASan, where attaching a debugger disables

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -77,9 +77,9 @@ def write_text_atomic(path: Path, text: str) -> None:
         print(f"Warning: could not write {path}: {e}", file=sys.stderr)
 
 # Exit code returned by `clickhouse-test` when the run was aborted early via
-# `stop_testing` (typically: server died / health check failed). Distinct from
-# the generic failure code 1 so the job side can populate the synthetic
-# "Server died" leaf without fragile log-line matching. Kept in sync with
+# `stop_testing` because a server death was observed. Distinct from the generic
+# failure code 1 so the job side can populate the synthetic "Server died" leaf
+# without fragile log-line matching. Kept in sync with
 # `STOP_TESTING_EXIT_CODE` in `ci/jobs/scripts/functional_tests_results.py`.
 STOP_TESTING_EXIT_CODE = 2
 
@@ -1274,10 +1274,10 @@ def print_c_stacktraces(args) -> None:
     exists and is debuggable, independent of whether SQL is reachable.
 
     Every call site is one of two situations: we're aborting the whole
-    run (SERVER_DIED, hung-check, check_server_started) or terminating
-    the one wedged test (timeout_handler).  lldb's "thread backtrace all"
-    pause is on the order of seconds — acceptable in both cases against
-    the diagnostic value.
+    run (SERVER_DIED, liveness check, hung-check, check_server_started)
+    or terminating the one wedged test (timeout_handler).  lldb's "thread
+    backtrace all" pause is on the order of seconds — acceptable in both
+    cases against the diagnostic value.
 
     Skipped under ASan, where attaching a debugger disables
     LeakSanitizer detections.
@@ -4793,8 +4793,10 @@ def run_tests_array(
                 # could re-raise with the real cause's exit code.
                 break
             stop_tests()
+            # An unset carrier is 0, which is not a valid exit code.
             raise StopTesting(
-                "another component requested stop (see earlier output for the cause)"
+                "another component requested stop (see earlier output for the cause)",
+                exit_code=stop_exit_code.value or STOP_TESTING_EXIT_CODE,
             )
 
         if args.stop_time and time() > args.stop_time:
@@ -5303,6 +5305,18 @@ def try_claim_stop_cause(stop_exit_code, exit_code: int) -> bool:
         return False
 
 
+def raise_stop_from_carrier(stop_exit_code):
+    """Abort the run with the claimed cause, or the default when none was claimed.
+
+    A worker raises `StopTesting` inside its own process, so the parent has only
+    the carrier to go on. Always raises.
+    """
+    raise StopTesting(
+        "test run was stopped (see earlier output for the cause)",
+        exit_code=stop_exit_code.value or STOP_TESTING_EXIT_CODE,
+    )
+
+
 def run_tests_process(*args_, **kwargs):
     return run_tests_array(*args_, **kwargs)
 
@@ -5449,9 +5463,9 @@ def do_run_tests(
             # Stop the whole run once the global time limit is reached. This is
             # the *expected* stop condition for the flaky and targeted checks,
             # which rerun the selected tests until the time budget is exhausted -
-            # distinct from a server death or a hung check below. The claim goes
-            # through the carrier rather than a separate check-then-set, because a
-            # worker can claim its own cause while the event is still clear.
+            # distinct from a server death or a hung check below. It goes through
+            # the carrier like every other cause, so a worker that claimed while
+            # the event was still clear keeps precedence.
             if args.stop_time and time() > args.stop_time:
                 if try_claim_stop_cause(
                     stop_exit_code, GLOBAL_TIME_LIMIT_EXIT_CODE
@@ -5468,7 +5482,8 @@ def do_run_tests(
                     stop_testing.set()
 
             # Periodically check the server for hangs
-            # and stop all processes in this case
+            # and stop all processes in this case. The probe takes 65-165 s to
+            # conclude, so it is not started once a stop is already pending.
             if args.hung_check and not stop_testing.is_set():
                 if not check_server_liveness(args):
                     print("Hung check failed: server is not responding")
@@ -5507,17 +5522,7 @@ def do_run_tests(
                         p.join(timeout=5)
                 finally:
                     signal.signal(signal.SIGTERM, old_sigterm_handler)
-                # A worker's own `StopTesting` never reaches here, so the cause
-                # comes from the carrier; without it the job side would report
-                # every stop as "Server died".
-                if stop_exit_code.value != 0:
-                    raise StopTesting(
-                        "test run was stopped (see earlier output for the cause)",
-                        exit_code=stop_exit_code.value,
-                    )
-                raise StopTesting(
-                    "test run was stopped (see earlier output for the cause)"
-                )
+                raise_stop_from_carrier(stop_exit_code)
 
             for p in processes[:]:
                 if not p.is_alive():
@@ -5528,6 +5533,11 @@ def do_run_tests(
                         )
                         runner_process_killed.set()
                     processes.remove(p)
+
+        # The reap above is the loop's exit condition, so a cause claimed after
+        # the check at the top of the iteration is only observable here.
+        if stop_testing.is_set():
+            raise_stop_from_carrier(stop_exit_code)
 
     if test_suite.sequential_tests:
         # Sequential runner shares the total_failures_shared counter with parallel workers

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1330,14 +1330,14 @@ def print_sql_stacktraces(args) -> None:
     Adds thread_name and query_id to the C-side picture, which is the
     only way to map a stuck thread to the query it was running.
 
-    Self-skips when the server is not answering queries — the SQL dump
-    would hit the same dead socket as the liveness check.  This keeps
+    Self-skips when the liveness check fails, because the SQL dump would
+    issue the same query the check just could not complete.  This keeps
     callers honest: they can invoke this from any context (per-test
-    timeout, end-of-run hung-check) without first checking whether the
-    server still responds.
+    timeout, end-of-run hung-check) without first probing the server
+    themselves.
     """
     if not check_server_liveness(args, max_retries=1):
-        print("Skipping system.stack_trace query: server is unreachable.")
+        print("Skipping system.stack_trace query: liveness check failed.")
         return
     print("\nCollecting stacktraces from system.stack_trace table:")
     bt = get_stacktraces_from_clickhouse(args)
@@ -3867,7 +3867,7 @@ class TestCase:
                             TestStatus.FAIL,
                             FailureReason.LIVENESS_CHECK_FAILED,
                             0.0,
-                            "\nServer does not respond to health check\n",
+                            "\nServer liveness check failed\n",
                         )
 
             self.runs_count += 1
@@ -5487,7 +5487,7 @@ def do_run_tests(
             # conclude, so it is not started once a stop is already pending.
             if args.hung_check and not stop_testing.is_set():
                 if not check_server_liveness(args):
-                    print("Hung check failed: server is not responding")
+                    print("Hung check failed: server liveness check failed")
                     # Claim before collecting: the sweep below can block ~30s per
                     # server process.
                     try_claim_stop_cause(stop_exit_code, HUNG_CHECK_EXIT_CODE)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -5004,11 +5004,13 @@ def run_tests_array(
 
 
 def check_server_liveness(args, max_retries=10) -> bool:
-    """Check if server is responding, with retries and exponential back-off.
+    """Run a trivial query, with retries and exponential back-off.
 
-    Used to distinguish a real server death from a transient network failure
-    (e.g. the server being briefly unresponsive due to memory pressure).
-    Returns True if the server responds within the retry window, False otherwise.
+    True means the query completed within the retry window. False establishes
+    only that it did not: every exception counts, including a non-200 response,
+    so the server may be alive and refusing. Retrying is what keeps a transient
+    failure (e.g. brief unresponsiveness under memory pressure) out of the
+    False case.
     """
     for attempt in range(max_retries):
         try:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -77,10 +77,11 @@ def write_text_atomic(path: Path, text: str) -> None:
         print(f"Warning: could not write {path}: {e}", file=sys.stderr)
 
 # Exit code returned by `clickhouse-test` when the run was aborted early via
-# `stop_testing` because a server death was observed. Distinct from the generic
-# failure code 1 so the job side can populate the synthetic "Server died" leaf
-# without fragile log-line matching. Kept in sync with
-# `STOP_TESTING_EXIT_CODE` in `ci/jobs/scripts/functional_tests_results.py`.
+# `stop_testing` and no more specific cause was claimed - an observed server death
+# or a generic catastrophic abort; a failed liveness probe uses
+# `HUNG_CHECK_EXIT_CODE` instead. Distinct from the generic failure code 1 so the
+# job side can populate the synthetic "Server died" leaf without fragile log-line
+# matching. Kept in sync with `ci/jobs/scripts/functional_tests_results.py`.
 STOP_TESTING_EXIT_CODE = 2
 
 # Exit code returned when the run stopped *gracefully* because the global time

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -100,6 +100,14 @@ GLOBAL_TIME_LIMIT_EXIT_CODE = 3
 # `ci/jobs/scripts/functional_tests_results.py`.
 MAX_FAILURES_EXIT_CODE = 4
 
+# Exit code returned when the run stopped because a `check_server_liveness`
+# probe failed. The probe establishes only that the check failed - it also fails
+# on a non-200 *response* - so this must NOT be conflated with
+# `STOP_TESTING_EXIT_CODE`, which the job side reports as "Server died". Kept in
+# sync with `HUNG_CHECK_EXIT_CODE` in
+# `ci/jobs/scripts/functional_tests_results.py`.
+HUNG_CHECK_EXIT_CODE = 5
+
 USE_JINJA = True
 try:
     import jinja2
@@ -1366,6 +1374,9 @@ class FailureReason(enum.Enum):
     # FAIL reasons
     TIMEOUT = "Timeout!"
     SERVER_DIED = "server died"
+    # Names the observation, not a diagnosis: `check_server_liveness` also fails
+    # on a non-200 response, so neither "died" nor "unresponsive" is established.
+    LIVENESS_CHECK_FAILED = "liveness check failed"
     EXIT_CODE = "return code: "
     STDERR = "having stderror: "
     EXCEPTION = "having exception in stdout: "
@@ -3367,10 +3378,10 @@ class TestCase:
                     description += debug_log
 
                 # Stop on fatal errors like segmentation fault. They are sent to client via logs.
+                # Mutually exclusive: stderr carrying both signals keeps SERVER_DIED.
                 if " <Fatal> " in stderr:
                     reason = FailureReason.SERVER_DIED
-
-                if (
+                elif (
                     self.testcase_args.stop
                     and (
                         "Connection refused" in stderr
@@ -3379,7 +3390,7 @@ class TestCase:
                     and "Received exception from server" not in stderr
                     and not check_server_liveness(self.args)
                 ):
-                    reason = FailureReason.SERVER_DIED
+                    reason = FailureReason.LIVENESS_CHECK_FAILED
 
                 if os.path.isfile(self.stdout_file):
                     description += ", result:\n\n"
@@ -3853,7 +3864,7 @@ class TestCase:
                         return TestResult(
                             self.name,
                             TestStatus.FAIL,
-                            FailureReason.SERVER_DIED,
+                            FailureReason.LIVENESS_CHECK_FAILED,
                             0.0,
                             "\nServer does not respond to health check\n",
                         )
@@ -3996,7 +4007,7 @@ class TestCase:
                 return TestResult(
                     self.name,
                     TestStatus.FAIL,
-                    FailureReason.SERVER_DIED,
+                    FailureReason.LIVENESS_CHECK_FAILED,
                     total_time,
                     exc_description,
                 )
@@ -4530,9 +4541,10 @@ class StopTesting(Exception):
     `exit_code` so the job side can distinguish the cause: the default
     `STOP_TESTING_EXIT_CODE` means the run was catastrophically interrupted
     (reported as "Server died"), `GLOBAL_TIME_LIMIT_EXIT_CODE` means a
-    benign, expected stop after the time budget was reached, and
+    benign, expected stop after the time budget was reached,
     `MAX_FAILURES_EXIT_CODE` means too many tests failed (real failures, server
-    still alive) so the run stopped early.
+    still alive) so the run stopped early, and `HUNG_CHECK_EXIT_CODE` means a
+    `check_server_liveness` probe failed.
     """
 
     def __init__(self, message, exit_code=STOP_TESTING_EXIT_CODE):
@@ -4859,7 +4871,11 @@ def run_tests_array(
             if (
                 test_result
                 and test_result.status == TestStatus.FAIL
-                and test_result.reason != FailureReason.SERVER_DIED
+                and test_result.reason
+                not in (
+                    FailureReason.SERVER_DIED,
+                    FailureReason.LIVENESS_CHECK_FAILED,
+                )
             ):
                 save_random_settings_artifact(
                     args,
@@ -4895,11 +4911,28 @@ def run_tests_array(
                 failures_total += 1
                 failures_chain += 1
                 if test_result.reason == FailureReason.SERVER_DIED:
+                    # Claim before collecting: the sweep below blocks up to 30s per
+                    # server process, and a cause claimed after it loses to any
+                    # cause claimed during it.
+                    try_claim_stop_cause(stop_exit_code, STOP_TESTING_EXIT_CODE)
                     print_c_stacktraces(args)
                     stop_tests()
                     stop_testing.set()
                     raise StopTesting(
                         f"ClickHouse server died during test '{test_case.name}'"
+                    )
+                if test_result.reason == FailureReason.LIVENESS_CHECK_FAILED:
+                    try_claim_stop_cause(stop_exit_code, HUNG_CHECK_EXIT_CODE)
+                    print_c_stacktraces(args)
+                    if not is_concurrent:
+                        # Sequential runner owns the main process, so there is no
+                        # parent to kill. See the --max-failures branch below for
+                        # why a parallel worker must not broadcast SIGTERM.
+                        stop_tests()
+                    stop_testing.set()
+                    raise StopTesting(
+                        f"server liveness check failed during test '{test_case.name}'",
+                        exit_code=HUNG_CHECK_EXIT_CODE,
                     )
                 if args.max_failures > 0:
                     with total_failures_shared.get_lock():
@@ -4912,7 +4945,9 @@ def run_tests_array(
                             # could re-raise with `MAX_FAILURES_EXIT_CODE`. Just
                             # signal the stop; the parent masks SIGTERM and then
                             # terminates the workers in an orderly way.
-                            stop_exit_code.value = MAX_FAILURES_EXIT_CODE
+                            try_claim_stop_cause(
+                                stop_exit_code, MAX_FAILURES_EXIT_CODE
+                            )
                             stop_testing.set()
                             raise StopTesting(
                                 f"reached --max-failures limit ({args.max_failures})",
@@ -4930,7 +4965,7 @@ def run_tests_array(
             # See the --max-failures branch above: skip `stop_tests()` so the
             # worker's SIGTERM broadcast does not kill the parent before it can
             # re-raise with `MAX_FAILURES_EXIT_CODE`.
-            stop_exit_code.value = MAX_FAILURES_EXIT_CODE
+            try_claim_stop_cause(stop_exit_code, MAX_FAILURES_EXIT_CODE)
             stop_testing.set()
             raise StopTesting(
                 f"reached --max-failures-chain limit ({args.max_failures_chain})",
@@ -5252,6 +5287,22 @@ def extract_key(key: str) -> str:
     )[1]
 
 
+def try_claim_stop_cause(stop_exit_code, exit_code: int) -> bool:
+    """Record `exit_code` as the cause the run stops with, first writer wins.
+
+    Returns True if this caller's code was recorded. 0 means unset, so no cause
+    may use it. The read and the write are one locked transition: several workers
+    and the parent can detect different causes concurrently, and an unlocked
+    read-modify-write would let a later detector displace an earlier one.
+    """
+    assert exit_code != 0, "0 means 'no cause recorded'"
+    with stop_exit_code.get_lock():
+        if stop_exit_code.value == 0:
+            stop_exit_code.value = exit_code
+            return True
+        return False
+
+
 def run_tests_process(*args_, **kwargs):
     return run_tests_array(*args_, **kwargs)
 
@@ -5283,11 +5334,11 @@ def do_run_tests(
     )
     total_tests = len(test_suite.sequential_tests) + len(test_suite.parallel_tests)
     progress_counter = multiprocessing.Value('i', 0)
-    # Exit code a worker wants the whole run to stop with. A worker raises
-    # `StopTesting` inside its own process, so that exception never reaches the
-    # parent; the parent only sees `stop_testing`. The worker records its exit
-    # code here (before setting `stop_testing`) so the parent can re-raise with
-    # the same code instead of defaulting to "Server died". 0 means unset.
+    # Exit code the run stops with. A worker raises `StopTesting` inside its own
+    # process, so that exception never reaches the parent; the parent only sees
+    # `stop_testing`. Every detector claims its code here via
+    # `try_claim_stop_cause` before setting `stop_testing`, so the parent
+    # re-raises with the cause detected first. 0 means unset.
     stop_exit_code = multiprocessing.Value('i', 0)
 
     if test_suite.parallel_tests:
@@ -5366,11 +5417,6 @@ def do_run_tests(
         MEMORY_PRESSURE_THRESHOLD = 0.8
         last_memory_check = time()
 
-        # Set when the parent stops the run because the global time limit was
-        # reached, so the final `StopTesting` is raised with the benign
-        # `GLOBAL_TIME_LIMIT_EXIT_CODE` rather than the "Server died" code.
-        global_time_limit_reached = False
-
         while processes:
             sleep(0.1)
             sys.stdout.flush()
@@ -5403,31 +5449,32 @@ def do_run_tests(
             # Stop the whole run once the global time limit is reached. This is
             # the *expected* stop condition for the flaky and targeted checks,
             # which rerun the selected tests until the time budget is exhausted -
-            # distinct from a server death or a hung check below. Only claim the
-            # time limit if nothing else has already requested a stop, so a real
-            # server death or `--max-failures` abort keeps precedence.
-            if (
-                args.stop_time
-                and time() > args.stop_time
-                and not stop_testing.is_set()
-            ):
-                print("Global time limit reached - stopping all tests gracefully.")
-                # Ignore SIGTERM in the parent for the rest of the run: when we
-                # terminate the workers below, each worker's KeyboardInterrupt
-                # handler re-broadcasts SIGTERM to the whole process group via
-                # `stop_tests()` -> `killpg`. Without this guard that signal
-                # would hit the parent and exit it with 143 instead of the
-                # graceful `GLOBAL_TIME_LIMIT_EXIT_CODE` (turning an expected
-                # timeout back into a "Server died" report).
-                signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                global_time_limit_reached = True
-                stop_testing.set()
+            # distinct from a server death or a hung check below. The claim goes
+            # through the carrier rather than a separate check-then-set, because a
+            # worker can claim its own cause while the event is still clear.
+            if args.stop_time and time() > args.stop_time:
+                if try_claim_stop_cause(
+                    stop_exit_code, GLOBAL_TIME_LIMIT_EXIT_CODE
+                ):
+                    print("Global time limit reached - stopping all tests gracefully.")
+                    # Ignore SIGTERM in the parent for the rest of the run: when we
+                    # terminate the workers below, each worker's KeyboardInterrupt
+                    # handler re-broadcasts SIGTERM to the whole process group via
+                    # `stop_tests()` -> `killpg`. Without this guard that signal
+                    # would hit the parent and exit it with 143 instead of the
+                    # graceful `GLOBAL_TIME_LIMIT_EXIT_CODE` (turning an expected
+                    # timeout back into a "Server died" report).
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                    stop_testing.set()
 
             # Periodically check the server for hangs
             # and stop all processes in this case
-            if args.hung_check:
+            if args.hung_check and not stop_testing.is_set():
                 if not check_server_liveness(args):
                     print("Hung check failed: server is not responding")
+                    # Claim before collecting: the sweep below can block ~30s per
+                    # server process.
+                    try_claim_stop_cause(stop_exit_code, HUNG_CHECK_EXIT_CODE)
                     print_c_stacktraces(args)
                     stop_testing.set()
 
@@ -5460,19 +5507,12 @@ def do_run_tests(
                         p.join(timeout=5)
                 finally:
                     signal.signal(signal.SIGTERM, old_sigterm_handler)
-                if global_time_limit_reached:
-                    raise StopTesting(
-                        "global time limit reached",
-                        exit_code=GLOBAL_TIME_LIMIT_EXIT_CODE,
-                    )
-                # A worker that hit `--max-failures` or `--max-failures-chain`
-                # recorded its exit code in `stop_exit_code` before setting
-                # `stop_testing`. The server is alive and the failing tests are
-                # real (and already attributed), so report this with the worker's
-                # code, not "Server died".
+                # A worker's own `StopTesting` never reaches here, so the cause
+                # comes from the carrier; without it the job side would report
+                # every stop as "Server died".
                 if stop_exit_code.value != 0:
                     raise StopTesting(
-                        "reached the --max-failures / --max-failures-chain limit",
+                        "test run was stopped (see earlier output for the cause)",
                         exit_code=stop_exit_code.value,
                     )
                 raise StopTesting(

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1330,8 +1330,8 @@ def print_sql_stacktraces(args) -> None:
     Adds thread_name and query_id to the C-side picture, which is the
     only way to map a stuck thread to the query it was running.
 
-    Self-skips when the liveness check fails, because the SQL dump would
-    issue the same query the check just could not complete.  This keeps
+    Self-skips when the liveness check fails, because this dump is another
+    query over the path the check just could not complete.  This keeps
     callers honest: they can invoke this from any context (per-test
     timeout, end-of-run hung-check) without first probing the server
     themselves.


### PR DESCRIPTION
Do not report "Server died" when only the liveness check failed

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110479
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110479

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Stateless tests (amd_tsan, flaky check)` on #110479 @ `038667a9c024` reported a single
failing leaf `Server died` while its own aggregate said `Failed: 0, Passed: 3872`. The server
did not die: no `<Fatal>` line, no sanitizer report, empty `dmesg`, clean shutdown. The
`--hung-check` liveness probe failed and the run was aborted.

Report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110479&sha=038667a9c024695126415fe5f37b76f7a06662fa&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20flaky%20check%29

Root cause: `tests/clickhouse-test` collapses every in-band abort cause into
`STOP_TESTING_EXIT_CODE = 2`, and the job side appends `Server died` for that code
unconditionally. Master already carved two causes out of code 2 for this reason; this is
the third.

This adds `HUNG_CHECK_EXIT_CODE = 5` and `FailureReason.LIVENESS_CHECK_FAILED`, with the leaf
`Server liveness check failed` at status FAIL. All four sites that conclude `SERVER_DIED` from
a failed probe are changed; the site concluding it from a `<Fatal>` line is untouched, and its
neighbour becomes an `elif` of it so fatal evidence is never downgraded. The stop cause travels
through one locked first-writer-wins carrier, replacing a `global_time_limit_reached` flag.

The leaf names the observation, not a diagnosis: `check_server_liveness` also fails on a
non-200 *response*. It is a NEW CIDB `test_name`. The aggregate stays FAIL, so bugfix
validation still counts a hang as a repro.

Not claimed: a remaining `Server died` row still does not prove a death. Code 2 is generic, and
a worker seeing a `<Fatal>` line reaches the parent through `stop_tests()`, exiting 143 -
correct there, but decided outside the carrier.

Validation: +50 tests asserting the process exit code end to end - the same command exits 2 on
master and 5 here. Each changed site has a mutation arm reddening a named case. `ci/tests`: 705
passed, 655 on master.

Successor to #112952, not an extension: that PR deliberately excludes exit code 2. Both touch
the same region of `functional_tests_results.py`, so the second to merge needs a rebase.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1807` (included in `26.8` and later)
<!-- ch-version-info:end -->