### PR TITLE
Fix the master build: pass the join analyze mode in the starved totals unit test

### DIFF
--- a/src/Processors/tests/gtest_merge_join_starved_totals.cpp
+++ b/src/Processors/tests/gtest_merge_join_starved_totals.cpp
@@ -45,7 +45,7 @@ std::vector<std::pair<UInt64, UInt64>> runFullJoinWithStarvedTotals(
     auto right_header = keyHeader("rk");
 
     Settings settings;
-    auto table_join = std::make_shared<TableJoin>(settings, nullptr, nullptr);
+    auto table_join = std::make_shared<TableJoin>(settings, JoinAnalyzeMode::None, nullptr, nullptr);
     table_join->getTableJoin().kind = JoinKind::Full;
     table_join->getTableJoin().strictness = JoinStrictness::All;
     table_join->addDisjunct();


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110892
Related: https://github.com/ClickHouse/ClickHouse/pull/113936
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110892
Related: https://github.com/ClickHouse/ClickHouse/pull/113936

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The master build is currently broken on every configuration that enables tests.
`src/Processors/tests/gtest_merge_join_starved_totals.cpp:48` calls the three
argument `TableJoin(const Settings &, VolumePtr, TemporaryDataOnDiskScopePtr)`
constructor, but `b1a380dc1c04` (#110892) inserted a `JoinAnalyzeMode analyze_mode_`
parameter in the second position, so the call no longer resolves:

```
error: no matching function for call to '__construct_at'
  note: in instantiation of 'std::make_shared<DB::TableJoin, DB::Settings &, std::nullptr_t, std::nullptr_t, 0>'
        requested here  src/Processors/tests/gtest_merge_join_starved_totals.cpp:48:28
```

This is base drift, not a bad merge. The test file was written on 2026-08-09,
#110892 merged on 2026-08-14, and #113936 merged on 2026-08-17. The merge queue
builds the pull request head, where the old signature was still current, while
MasterCI builds the post merge tree, so the break only appeared after the merge.
It fails `unit_tests_dbms`, which stops `ninja clickhouse-bundle` before the
binary exists, so `Build (amd_debug)`, `Build (amd_msan)`, `Build (amd_tsan)`,
`Build (amd_asan_ubsan)`, `Build (arm_debug)`, `Build (arm_msan)`,
`Build (arm_tsan)`, `Build (arm_asan_ubsan)`, `Build (arm_tidy)` and
`Build (llvm_coverage_build)` are all red, and every downstream check that needs
those binaries cannot run.

The fix passes `JoinAnalyzeMode::None`, which is exactly what the test used to
get: before the parameter existed, `analyze_mode` stayed at its in class default
of `None`. It also leaves the assertion intact. The only behavioural reader of
the mode on this path is `MergeJoin::runPostBuildPhase`, whose condition is
`is_right || is_full || (is_all_join && collectExactMatches())`, and the test
builds a `JoinKind::Full` join, so `is_full` already selects the branch.

Validation: the failing translation unit reproduces the CI error at master
`6061d1c0df7e`; with the change `unit_tests_dbms` and `clickhouse` both link and
`MergeJoinStarvedTotals.FullJoinKeepsRightRows` passes. To show the test is still
a live oracle and not merely compiling, `hasPostBuildPhase` was flipped to
`false`, which reproduced the original wrong results
(`{(0,0),(1,0),(2,0)}` instead of `{(0,0),(0,3),(1,1),(2,0)}`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1560` (included in `26.8` and later)
<!-- ch-version-info:end -->