### PR TITLE
Rewrite bucketIndexForTimestamp in 64-bit arithmetic

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -100,18 +100,18 @@ public:
         , end_timestamp(alignedEndTimestamp(start_timestamp_, grid_size, step))
         , timestamp_scale_multiplier(static_cast<TimestampType>(DecimalUtils::scaleMultiplier<Int64>(timestamp_scale_)))
         , window_remainder(windowRemainder(step, window))
-        , buckets_per_step(bucketsPerStep(window_remainder))
+        , buckets_per_step(bucketsPerStep(window, window_remainder))
         , buckets_per_window(bucketsPerWindow(step, window, window_remainder))
-        , buckets_per_first_window(bucketsPerFirstWindow(start_timestamp_, step, window_remainder, buckets_per_step, buckets_per_window))
+        , buckets_per_first_window(bucketsPerFirstWindow(start_timestamp_, step, window, window_remainder, buckets_per_step, buckets_per_window))
         , bucket_count(bucketCount(grid_size, buckets_per_first_window, buckets_per_step))
         , even_bucket_width(bucketWidth(false, step, window, window_remainder, buckets_per_step, buckets_per_first_window))
         , odd_bucket_width(bucketWidth(true, step, window, window_remainder, buckets_per_step, buckets_per_first_window))
-        , even_bucket_step(bucketStep(false, step, window_remainder, buckets_per_step, buckets_per_first_window))
-        , odd_bucket_step(bucketStep(true, step, window_remainder, buckets_per_step, buckets_per_first_window))
-        , first_bucket_end_time(firstBucketEndTimestamp(start_timestamp_, step, window_remainder, buckets_per_step, buckets_per_first_window))
-        , first_bucket_is_clamped(firstBucketIsClamped(first_bucket_end_time, even_bucket_width))
-        , fast_bucket_math(canUseFastBucketMath(start_timestamp, end_timestamp, step, window))
-        , step_divider(static_cast<Int64>(step) > 0 ? static_cast<Int64>(step) : 1)
+        , even_bucket_step(bucketStep(false, step, window, window_remainder, buckets_per_step, buckets_per_first_window))
+        , odd_bucket_step(bucketStep(true, step, window, window_remainder, buckets_per_step, buckets_per_first_window))
+        , first_bucket_end_time(firstBucketEndTimestamp(start_timestamp_, step, window, window_remainder, buckets_per_step, buckets_per_first_window))
+        , first_bucket_width(firstBucketWidth(window, even_bucket_width, first_bucket_end_time))
+        , first_bucket_start_time(firstBucketStartTimestamp(first_bucket_end_time, first_bucket_width))
+        , step_divider(step > 0 ? static_cast<UInt64>(step) : 1)
     {
     }
 
@@ -452,24 +452,25 @@ protected:
                                                         /// this multiplier is used for calculation rate per second (i.e. it is 1000 for
                                                         /// milliseconds or 1e6 for microseconds)
     const IntervalType window_remainder{};  /// (window % step) if (window > step)
-    const size_t buckets_per_step{};        /// 2 when window_remainder != 0 (each step is split), else 1
-    const size_t buckets_per_window{};      /// Number of buckets tiling each grid point's window
+    const size_t buckets_per_step{};        /// 2 when window_remainder != 0 (each step is split), else 1; 0 when window == 0
+    const size_t buckets_per_window{};      /// Number of buckets tiling each grid point's window (0 when window == 0)
     const size_t buckets_per_first_window{};/// Buckets in grid point #0's window (<= buckets_per_window; leading
                                             /// buckets that would fall below the type's minimum are dropped)
-    const size_t bucket_count{};            /// Number of buckets
+    const size_t bucket_count{};            /// Number of buckets (0 when window == 0)
 
     /// Bucket #0 properties; every other bucket follows by arithmetic (see `bucketEndTimestamp`).
-    const IntervalType even_bucket_width{};       /// Width (end - start) of even-indexed buckets
-    const IntervalType odd_bucket_width{};        /// Width of odd-indexed buckets (equals even_bucket_width when buckets_per_step == 1)
-    const IntervalType even_bucket_step{};        /// End-to-end spacing of even-indexed buckets (equals the width unless window < step)
-    const IntervalType odd_bucket_step{};         /// End-to-end spacing of odd-indexed buckets
-    const TimestampType first_bucket_end_time{};  /// End timestamp of bucket #0
-    const bool first_bucket_is_clamped{};         /// Whether bucket #0's start is below the type minimum (only it can be)
+    const IntervalType even_bucket_width{};         /// Width of even-indexed buckets
+    const IntervalType odd_bucket_width{};          /// Width of odd-indexed buckets (equals even_bucket_width when buckets_per_step == 1)
+    const IntervalType even_bucket_step{};          /// End-to-end spacing of even-indexed buckets (equals the width unless window < step)
+    const IntervalType odd_bucket_step{};           /// End-to-end spacing of odd-indexed buckets
+    const TimestampType first_bucket_end_time{};    /// End timestamp of bucket #0
+    const IntervalType first_bucket_width{};        /// Width of bucket #0: `even_bucket_width`, shortened when bucket #0
+                                                    /// is clamped at the type minimum.
+    const TimestampType first_bucket_start_time{};  /// Start (inclusive) of bucket #0.
+                                                    /// Samples before it are out of window for every grid point.
 
-    /// For grid parameters bounded by 2^61 only.
-    const bool fast_bucket_math{};
-    /// Reciprocal of `step` for the fast path (`step` is fixed at construction).
-    const libdivide::divider<Int64> step_divider{1};
+    /// Reciprocal of `step` for `classifySample` (`step` is fixed at construction).
+    const libdivide::divider<UInt64> step_divider{1};
 
 private:
     /// `HashMap` relocates cells with `memcpy`, so it requires position-independent buckets: trivially
@@ -542,9 +543,8 @@ private:
 
         /// Computed in Int128 to stay overflow-safe when the [start, end] span exceeds Int64 (e.g. DateTime64 from
         /// near INT64_MIN to near INT64_MAX). Runs once per aggregator, so width is preferred over speed.
-        const Int128 quotient = (static_cast<Int128>(static_cast<Int64>(end_timestamp))
-            - static_cast<Int128>(static_cast<Int64>(start_timestamp)))
-            / static_cast<Int128>(static_cast<Int64>(step));
+        const Int128 quotient = (static_cast<Int128>(toInt64(end_timestamp)) - toInt64(start_timestamp))
+            / static_cast<Int64>(step);
 
         if (quotient >= MAX_GRID_SIZE)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
@@ -560,8 +560,8 @@ private:
     {
         /// Computed in Int128 to stay overflow-safe for extreme inputs (e.g. start near INT64_MIN, large step);
         /// runs once per aggregator.
-        const Int128 aligned_end = static_cast<Int128>(static_cast<Int64>(start_timestamp))
-            + static_cast<Int128>(grid_size - 1) * static_cast<Int128>(static_cast<Int64>(step));
+        const Int128 aligned_end = toInt64(start_timestamp)
+            + static_cast<Int128>(grid_size - 1) * static_cast<Int64>(step);
         return static_cast<TimestampType>(static_cast<Int64>(aligned_end));
     }
 
@@ -574,16 +574,21 @@ private:
         return static_cast<IntervalType>(window % step);
     }
 
-    /// Calculates number of buckets that tile a window.
-    static size_t bucketsPerStep(IntervalType window_remainder)
+    /// Number of buckets that tile one step.
+    /// Returns 2 when the step is split, else 1, and 0 when window == 0 (so no buckets at all).
+    static size_t bucketsPerStep(IntervalType window, IntervalType window_remainder)
     {
+        if (window == 0)
+            return 0;
         return window_remainder != 0 ? 2 : 1;
     }
 
     /// Calculates number of buckets that tile a window.
     static size_t bucketsPerWindow(IntervalType step, IntervalType window, IntervalType window_remainder)
     {
-        if (step == 0 || window == 0)
+        if (window == 0)
+            return 0;  /// window == 0 means no buckets at all.
+        if (step == 0)
             return 1;
 
         const size_t whole_steps = static_cast<size_t>(window / step);
@@ -598,24 +603,25 @@ private:
     /// Number of buckets in grid point #0's window. Usually `buckets_per_window`, but fewer when `start_timestamp -
     /// window` reaches below the smallest representable timestamp: those leading buckets lie entirely below the type
     /// minimum, so they can never hold a sample and are dropped (which keeps every bucket's end timestamp in range).
-    static size_t bucketsPerFirstWindow(TimestampType start_timestamp, IntervalType step, IntervalType window_remainder,
-        size_t buckets_per_step, size_t buckets_per_window)
+    static size_t bucketsPerFirstWindow(TimestampType start_timestamp, IntervalType step, IntervalType window,
+        IntervalType window_remainder, size_t buckets_per_step, size_t buckets_per_window)
     {
+        if (window == 0)
+            return 0;  /// window == 0 means no buckets at all.
         if (step == 0)
             return 1;
 
-        const Int128 min_timestamp = std::is_unsigned_v<TimestampType>
-            ? static_cast<Int128>(0) : static_cast<Int128>(std::numeric_limits<Int64>::min());
-        const Int128 step_128 = static_cast<Int128>(static_cast<Int64>(step));
+        const Int128 min_timestamp = toInt64(minTimestamp());
+        const Int128 step_128 = static_cast<Int64>(step);
         /// How far `start_timestamp` sits above the smallest representable timestamp.
-        const Int128 headroom = static_cast<Int128>(static_cast<Int64>(start_timestamp)) - min_timestamp;
+        const Int128 headroom = toInt64(start_timestamp) - min_timestamp;
         const size_t whole_steps = static_cast<size_t>(headroom / step_128);
 
         /// Leading buckets reaching no deeper than `headroom` stay in range; deeper ones are dropped. A split step
         /// keeps one extra (before-split) bucket when the remainder of `headroom` still covers the split point.
         const size_t reachable = (buckets_per_step == 1)
             ? whole_steps + 1
-            : 2 * whole_steps + 1 + ((headroom % step_128 >= static_cast<Int128>(static_cast<Int64>(window_remainder))) ? 1 : 0);
+            : 2 * whole_steps + 1 + ((headroom % step_128 >= static_cast<Int64>(window_remainder)) ? 1 : 0);
 
         return std::min(buckets_per_window, reachable);
     }
@@ -626,7 +632,7 @@ private:
     {
         chassert(grid_size >= 1);
         /// Cannot overflow `size_t`: `grid_size <= MAX_GRID_SIZE` (16M, enforced by `gridSize`),
-        /// `buckets_per_step` is 1 or 2.
+        /// `buckets_per_step` is 0, 1 or 2.
         return buckets_per_first_window + (grid_size - 1) * buckets_per_step;
     }
 
@@ -634,6 +640,13 @@ private:
     static IntervalType bucketWidth(bool odd_bucket, IntervalType step, IntervalType window,
         IntervalType window_remainder, size_t buckets_per_step, size_t buckets_per_first_window)
     {
+        if (window == 0)
+        {
+            /// window == 0 means no buckets at all, so this width doesn't describe a real bucket.
+            return 0;
+        }
+        /// Every real bucket has a width of at least 1: the branches below return `window`, `step`,
+        /// `window_remainder` or `step - window_remainder`, all positive when `window > 0`.
         if (buckets_per_step == 1)
             return (step == 0 || window < step) ? window : step;
         /// Even-indexed bucket #0 is "before split" iff `buckets_per_first_window` is even; odd-indexed buckets are
@@ -645,9 +658,11 @@ private:
     /// End-to-end spacing of even- or odd-indexed buckets (how far a bucket's end is from the previous one's). Equals
     /// the bucket width, except for one bucket per step with `window < step`, where ends stay spaced by `step` even
     /// though each bucket is narrower. Static - used once, by the constructor.
-    static IntervalType bucketStep(bool odd_bucket, IntervalType step,
+    static IntervalType bucketStep(bool odd_bucket, IntervalType step, IntervalType window,
         IntervalType window_remainder, size_t buckets_per_step, size_t buckets_per_first_window)
     {
+        if (window == 0)
+            return 0;
         if (buckets_per_step == 1)
             return step;
         const bool before_split = (buckets_per_first_window % 2 == 0) != odd_bucket;
@@ -655,15 +670,21 @@ private:
     }
 
     /// End timestamp of bucket #0 (the deepest in-range bucket). Static - used once, by the constructor.
-    static TimestampType firstBucketEndTimestamp(TimestampType start_timestamp, IntervalType step,
+    static TimestampType firstBucketEndTimestamp(TimestampType start_timestamp, IntervalType step, IntervalType window,
         IntervalType window_remainder, size_t buckets_per_step, size_t buckets_per_first_window)
     {
+        if (window == 0)
+        {
+            /// window == 0 means no buckets at all, so there is no bucket #0.
+            return start_timestamp;
+        }
+
         /// Grid timestamp of bucket #0's step. Bucket #0's offset is `-(buckets_per_first_window - 1) <= 0`.
         /// Computed in `Int128` to avoid overflow (this runs once, at construction, so clarity beats speed).
         const Int128 offset = -(static_cast<Int128>(buckets_per_first_window) - 1);
         const Int128 grid_index = (buckets_per_step == 1) ? offset : offset / 2;
-        const Int128 grid_timestamp = static_cast<Int128>(static_cast<Int64>(start_timestamp))
-            + grid_index * static_cast<Int128>(static_cast<Int64>(step));
+        const Int128 grid_timestamp = toInt64(start_timestamp)
+            + grid_index * static_cast<Int64>(step);
 
         /// For a split step, bucket #0 ends `window_remainder` before the grid timestamp ("before split") iff
         /// `buckets_per_first_window` is even.
@@ -672,13 +693,37 @@ private:
             before_split ? grid_timestamp - static_cast<Int64>(window_remainder) : grid_timestamp));
     }
 
-    /// Whether bucket #0's start (its end minus its width) falls below the smallest representable timestamp. Only
-    /// bucket #0 can: buckets tile the timeline, so every later bucket starts where the previous one ends (in range).
-    static bool firstBucketIsClamped(TimestampType first_bucket_end_time, IntervalType even_bucket_width)
+    /// Width of bucket #0: `even_bucket_width`, shortened when bucket #0's start falls below the smallest
+    /// representable timestamp - bucket #0 then covers everything from that minimum up to its end. The
+    /// shortened width fits `IntervalType`: such clamping implies it is not greater than `window`.
+    static IntervalType firstBucketWidth(IntervalType window, IntervalType even_bucket_width, TimestampType first_bucket_end_time)
     {
-        const Int128 min_timestamp = std::is_unsigned_v<TimestampType>
-            ? static_cast<Int128>(0) : static_cast<Int128>(std::numeric_limits<Int64>::min());
-        return static_cast<Int128>(static_cast<Int64>(first_bucket_end_time)) - static_cast<Int64>(even_bucket_width) < min_timestamp;
+        if (window == 0)
+        {
+            /// window == 0 means no buckets at all, so there is no bucket #0.
+            return 0;
+        }
+        /// Every real bucket has a width of at least 1: `even_bucket_width >= 1` (see `bucketWidth`), and
+        /// `clamped_width >= 1` because bucket #0's end is always representable (`bucketsPerFirstWindow`
+        /// drops the buckets lying entirely below the type minimum).
+        const Int128 min_timestamp = toInt64(minTimestamp());
+        const Int128 clamped_width = toInt64(first_bucket_end_time) - min_timestamp + 1;
+        return static_cast<IntervalType>(static_cast<Int64>(
+            std::min(static_cast<Int128>(even_bucket_width), clamped_width)));
+    }
+
+    /// Calculates the start (inclusive) of bucket #0.
+    static TimestampType firstBucketStartTimestamp(TimestampType first_bucket_end_time, IntervalType first_bucket_width)
+    {
+        if (first_bucket_width == 0)
+        {
+            /// window == 0 means no buckets at all.
+            /// `classifySample` rejects every sample of such a grid.
+            return first_bucket_end_time;
+        }
+        /// The start is always representable (the width is shortened when bucket #0 is clamped at the type minimum),
+        /// so computing it as `end - (width - 1)` can't overflow.
+        return static_cast<TimestampType>(toInt64(first_bucket_end_time) - (static_cast<Int64>(first_bucket_width) - 1));
     }
 
     /// Compute the grid timestamp for a given grid index, i.e. `start_timestamp + grid_index * step`.
@@ -689,177 +734,194 @@ private:
     /// on the adversarial boundary values generated by the AST fuzzer.
     TimestampType timestampAtIndex(size_t grid_index) const
     {
-        const UInt64 start_bits = static_cast<UInt64>(static_cast<Int64>(start_timestamp));
-        const UInt64 step_bits = static_cast<UInt64>(static_cast<Int64>(step));
+        chassert(grid_index < grid_size);
+        const UInt64 start_bits = static_cast<UInt64>(toInt64(start_timestamp));
+        const UInt64 step_bits = static_cast<UInt64>(step);
         const UInt64 result_bits = start_bits + static_cast<UInt64>(grid_index) * step_bits;
         const TimestampType grid_point = static_cast<TimestampType>(static_cast<Int64>(result_bits));
         return grid_point;
     }
 
-    /// Returns whether a sample at `timestamp` is past the sliding-window cutoff for grid point `grid_timestamp`.
-    bool isSampleOutOfWindow(const TimestampType timestamp, const TimestampType grid_point) const
-    {
-        /// Compare as Int128 to avoid signed-overflow `TimestampType` when `window` is set near `INT64_MAX`.
-        const Int128 staleness_cutoff =
-            static_cast<Int128>(static_cast<Int64>(timestamp)) +
-            static_cast<Int128>(static_cast<Int64>(window));
-        return staleness_cutoff <= static_cast<Int128>(static_cast<Int64>(grid_point));
-    }
-
     static constexpr size_t NO_BUCKET = -1;
+
+    /// Closed timestamp range `[start_time, end_time]` of a bucket.
+    struct BucketTimeRange
+    {
+        TimestampType start_time;
+        TimestampType end_time;
+
+        bool contains(const TimestampType & timestamp) const
+        {
+            return timestamp >= start_time && timestamp <= end_time;
+        }
+    };
+
+    /// What the batch bucketing kernel (`addSamplesToBucketsImpl`) does with a sample: add it to bucket
+    /// `bucket_index`, or skip it (`bucket_index == NO_BUCKET`). Either way `time_range` is a timestamp
+    /// range whose samples all share this fate - the bucket's time range for an accepted sample, a range
+    /// of rejected timestamps for a skipped one - so the kernel handles the run of consecutive samples
+    /// within the range in one go. The classified sample itself is always inside the range.
+    struct SampleClass
+    {
+        size_t bucket_index;
+        BucketTimeRange time_range;
+    };
+
+    /// Classifies a sample: the bucket index to add it to (or NO_BUCKET to skip it), plus its `time_range`
+    /// for run detection. With `ReturnType == size_t` the range is neither computed nor returned - the
+    /// function returns just the bucket index (see `bucketIndexForTimestamp`).
+    template <typename ReturnType = SampleClass>
+    ALWAYS_INLINE ReturnType classifySample(const TimestampType timestamp) const
+    {
+        static_assert(std::is_same_v<ReturnType, SampleClass> || std::is_same_v<ReturnType, size_t>);
+        constexpr bool return_index = std::is_same_v<ReturnType, size_t>;
+
+        if (timestamp > end_timestamp)
+        {
+            if constexpr (return_index)
+                return NO_BUCKET;
+            else if (bucket_count == 0)
+                return {NO_BUCKET, {minTimestamp(), maxTimestamp()}};  /// A grid without buckets (`window == 0`) rejects everything.
+            else
+                return {NO_BUCKET, {static_cast<TimestampType>(toInt64(end_timestamp) + 1), maxTimestamp()}};  /// `end < timestamp`, so no overflow
+        }
+
+        /// A sample before bucket #0's start is out of window for every grid point (samples older than
+        /// the whole grid's windows are a common case). A start clamped to the type minimum rejects
+        /// nothing - then every timestamp is in window.
+        if (timestamp < first_bucket_start_time)
+        {
+            if constexpr (return_index)
+                return NO_BUCKET;
+            else if (bucket_count == 0)
+                return {NO_BUCKET, {minTimestamp(), maxTimestamp()}};  /// A grid without buckets (`window == 0`) rejects everything.
+            else
+                return {NO_BUCKET, {minTimestamp(), static_cast<TimestampType>(toInt64(first_bucket_start_time) - 1)}};  /// The check passed, so no underflow
+        }
+
+        /// All the arithmetic is 64-bit for any grid parameters: a difference of two Int64 timestamps can
+        /// overflow Int64, but every value computed here is non-negative and less than 2^64, so UInt64
+        /// arithmetic is exact throughout.
+        const Int64 ts = toInt64(timestamp);
+        const Int64 start = toInt64(start_timestamp);
+        const UInt64 step_u64 = static_cast<UInt64>(step);
+        const UInt64 window_u64 = static_cast<UInt64>(window);  /// `window >= 0`, see `checkWindow`
+        const UInt64 window_remainder_u64 = static_cast<UInt64>(window_remainder);
+        const UInt64 leading_buckets = buckets_per_first_window;  /// >= 1 when the grid has buckets
+
+        UInt64 bucket_index = 0;
+
+        if (ts > start)
+        {
+            /// The sample's grid point is #ceil(offset / step), counted up from grid point #0.
+            /// 0 < offset <= end - start, and `step > 0` because `start < end` (see `checkStep`).
+            const UInt64 offset = static_cast<UInt64>(ts) - static_cast<UInt64>(start);
+            const UInt64 whole_steps = offset / step_divider;
+            /// Distance down to the grid timestamp at or below the sample, in [0, step).
+            const UInt64 distance_from_grid_point = offset - whole_steps * step_u64;
+            /// Distance from the sample up to its grid point, in [0, step).
+            const UInt64 distance_to_grid_point = (distance_from_grid_point == 0) ? 0 : (step_u64 - distance_from_grid_point);
+
+            /// A sample out of its grid point's window is out of every window (windows of later grid points
+            /// start even higher), and so is everything in its step down to the window's start. Possible only
+            /// when `window < step` and the grid point is at or above `start + step`, so the bounds fit Int64.
+            /// (A zero window rejects every sample of this branch here.)
+            if (distance_to_grid_point >= window_u64)
+            {
+                if constexpr (return_index)
+                    return NO_BUCKET;
+                else
+                {
+                    const Int64 grid_timestamp = ts + static_cast<Int64>(distance_to_grid_point);
+                    return {NO_BUCKET, {static_cast<TimestampType>(grid_timestamp - static_cast<Int64>(step) + 1),
+                        static_cast<TimestampType>(grid_timestamp - static_cast<Int64>(window))}};
+                }
+            }
+
+            const UInt64 grid_index = whole_steps + (distance_from_grid_point != 0);
+
+            if (window_remainder == 0)
+            {
+                /// One bucket per step.
+                bucket_index = grid_index + leading_buckets - 1;
+            }
+            else
+            {
+                /// Each step is split at (grid timestamp - window_remainder): `before_split_point` means
+                /// timestamp <= grid timestamp - window_remainder.
+                const bool before_split_point = distance_to_grid_point >= window_remainder_u64;
+                bucket_index = 2 * grid_index + leading_buckets - 1 - (before_split_point ? 1 : 0);
+            }
+        }
+        else
+        {
+            /// A grid without buckets (`window == 0`) accepts nothing; the only such sample reaching this
+            /// branch is one exactly at `start` (everything below was rejected by the check against
+            /// bucket #0's start, which equals `start` then).
+            if (bucket_count == 0)
+            {
+                if constexpr (return_index)
+                    return NO_BUCKET;
+                else
+                    return {NO_BUCKET, {minTimestamp(), maxTimestamp()}};
+            }
+
+            /// The sample's grid point is #0, and its bucket is one of the leading buckets: 1 or 2 buckets
+            /// per whole step down from bucket #(leading_buckets - 1). The index can't go below 0: a sample
+            /// within the window and above the type minimum has its bucket (see `bucketsPerFirstWindow`).
+            /// 0 <= offset_below_start < window: samples at or before `start - window` were rejected by the early check.
+            const UInt64 offset_below_start = static_cast<UInt64>(start) - static_cast<UInt64>(ts);
+
+            if (step_u64 == 0)
+            {
+                /// A single-point grid (`start == end`, see `checkStep`) has a single bucket taking everything in window.
+                chassert(leading_buckets == 1);
+                bucket_index = 0;
+            }
+            else
+            {
+                const UInt64 whole_steps_below = offset_below_start / step_divider;
+                /// Distance from the sample up to the nearest step-aligned timestamp at or below `start`, in [0, step).
+                const UInt64 distance_to_grid_point = offset_below_start - whole_steps_below * step_u64;
+
+                if (window_remainder == 0)
+                {
+                    bucket_index = leading_buckets - 1 - whole_steps_below;
+                }
+                else
+                {
+                    const bool before_split_point = distance_to_grid_point >= window_remainder_u64;
+                    bucket_index = leading_buckets - 1 - 2 * whole_steps_below - (before_split_point ? 1 : 0);
+                }
+            }
+        }
+
+        chassert(bucket_index < bucket_count);
+        if constexpr (return_index)
+        {
+            return static_cast<size_t>(bucket_index);
+        }
+        else
+        {
+            const BucketTimeRange time_range = bucketTimeRange(static_cast<size_t>(bucket_index));
+            chassert(ts >= toInt64(time_range.start_time) && ts <= toInt64(time_range.end_time));
+            return {static_cast<size_t>(bucket_index), time_range};
+        }
+    }
 
     /// Returns the index of the bucket a sample at `timestamp` contributes to.
     /// The function returns NO_BUCKET if the specified timestamp can't contribute to any buckets
     /// because it's too early, or too late, or already out of window.
-    size_t bucketIndexForTimestamp(const TimestampType timestamp) const
+    size_t ALWAYS_INLINE bucketIndexForTimestamp(const TimestampType timestamp) const
     {
-        if (timestamp > end_timestamp)
-            return NO_BUCKET;
-
-        /// unclamped_grid_index = ceil((timestamp - start) / step), the grid point at the upper edge
-        /// of the sample's step.
-        /// It's unclamped: for timestamps at or before grid point #0 `unclamped_grid_index <= 0`.
-        /// Everything is computed in Int128 to stay overflow-safe when `start_timestamp` is
-        /// near INT64_MIN and `step` near INT64_MAX.
-        const Int128 offset = static_cast<Int128>(static_cast<Int64>(timestamp)) - static_cast<Int128>(static_cast<Int64>(start_timestamp));
-        const Int128 step_128 = static_cast<Int128>(static_cast<Int64>(step));
-
-        /// `step == 0` is possible only when `start == end` (a single grid point).
-        Int128 unclamped_grid_index = 0;
-        if (step > 0)
-        {
-            unclamped_grid_index = offset / step_128;
-            if ((offset % step_128) > 0)
-                ++unclamped_grid_index;
-        }
-
-        /// The related grid point's index is always non-negative.
-        const size_t grid_index = (unclamped_grid_index > 0) ? static_cast<size_t>(unclamped_grid_index) : 0;
-
-        /// Skip a sample that is already out of window.
-        if (isSampleOutOfWindow(timestamp, timestampAtIndex(grid_index)))
-            return NO_BUCKET;
-
-        const Int128 leading_buckets = static_cast<Int128>(buckets_per_first_window);
-        Int128 bucket_index;
-        if (window_remainder == 0)
-        {
-            /// One bucket per step.
-            bucket_index = unclamped_grid_index + leading_buckets - 1;
-        }
-        else
-        {
-            /// Each step is split at (grid timestamp - window_remainder).
-            const Int128 remainder = static_cast<Int128>(static_cast<Int64>(window_remainder));
-
-            /// `before_split_point` means timestamp <= grid timestamp - window_remainder,
-            /// i.e. offset + window_remainder <= unclamped_grid_index * step.
-            const bool before_split_point = (offset + remainder) <= (unclamped_grid_index * step_128);
-            bucket_index = 2 * unclamped_grid_index + leading_buckets - 1 - (before_split_point ? 1 : 0);
-        }
-
-        chassert(bucket_index >= 0 && bucket_index < static_cast<Int128>(bucket_count));
-        return static_cast<size_t>(bucket_index);
-    }
-
-    /// Whether all the arithmetic in `bucketIndexForTimestampFast` fits in Int64 for every sample
-    /// that passes its range checks. Bounding all grid parameters by 2^61 leaves headroom for the
-    /// sums and products of two such values. A single-point grid (`start == end`, `step == 0`,
-    /// see `checkStep`) has nothing to divide and uses the generic path.
-    static bool canUseFastBucketMath(TimestampType start, TimestampType end, IntervalType step_, IntervalType window_)
-    {
-        constexpr Int128 bound = Int128(1) << 61;
-        const Int128 start_128 = static_cast<Int128>(static_cast<Int64>(start));
-        const Int128 end_128 = static_cast<Int128>(static_cast<Int64>(end));
-        const Int128 step_128 = static_cast<Int128>(static_cast<Int64>(step_));
-        const Int128 window_128 = static_cast<Int128>(static_cast<Int64>(window_));
-        return (-bound < start_128 && start_128 < bound) && (-bound < end_128 && end_128 < bound)
-            && (0 < step_128 && step_128 < bound) && (0 <= window_128 && window_128 < bound);
-    }
-
-    /// What the batch bucketing kernel (`addSamplesToBucketsImpl`) does with a sample: add it to bucket
-    /// `bucket_index`, or skip it (`bucket_index == NO_BUCKET`). Either way `(lo, hi]` is a timestamp range
-    /// whose samples all share this fate - the bucket's time range for an accepted sample, a range of
-    /// rejected timestamps for a skipped one - so the kernel handles the run of consecutive samples within
-    /// the range in one go.
-    struct SampleClass
-    {
-        size_t bucket_index;
-        Int64 lo;
-        Int64 hi;
-    };
-
-    /// Same as `bucketIndexForTimestamp` with all arithmetic in Int64, plus the `(lo, hi]` range for run
-    /// detection. Requires `fast_bucket_math`, which bounds every expression here away from Int64 overflow.
-    ALWAYS_INLINE SampleClass classifySampleFast(const Int64 ts) const
-    {
-        if (ts > static_cast<Int64>(end_timestamp))
-            return {NO_BUCKET, static_cast<Int64>(end_timestamp), std::numeric_limits<Int64>::max()};
-
-        /// Samples at or below `start - window` are out of window for every grid point. (A sample at
-        /// `INT64_MIN` never falls into the returned skip range - the run scan then returns 0 and the
-        /// kernel consumes the sample by itself.)
-        const Int64 lowest = static_cast<Int64>(start_timestamp) - static_cast<Int64>(window);
-        if (ts <= lowest)
-            return {NO_BUCKET, std::numeric_limits<Int64>::min(), lowest};
-
-        const Int64 offset = ts - static_cast<Int64>(start_timestamp);
-        const Int64 step_64 = static_cast<Int64>(step);
-
-        Int64 unclamped_grid_index = offset / step_divider;
-        if (offset - unclamped_grid_index * step_64 > 0)
-            ++unclamped_grid_index;
-
-        const Int64 grid_index = std::max<Int64>(unclamped_grid_index, 0);
-        const Int64 grid_timestamp = static_cast<Int64>(start_timestamp) + grid_index * step_64;
-
-        /// A sample out of its grid point's window is out of every window (windows of later grid points
-        /// start even higher), and so is everything down to the previous bucket's end - hence the skip range.
-        if (ts + static_cast<Int64>(window) <= grid_timestamp)
-            return {NO_BUCKET, std::max(lowest, grid_timestamp - step_64), grid_timestamp - static_cast<Int64>(window)};
-
-        const Int64 leading_buckets = static_cast<Int64>(buckets_per_first_window);
-        Int64 bucket_index = 0;
-        if (window_remainder == 0)
-        {
-            bucket_index = unclamped_grid_index + leading_buckets - 1;
-        }
-        else
-        {
-            const Int64 remainder = static_cast<Int64>(window_remainder);
-            const bool before_split_point = (offset + remainder) <= (unclamped_grid_index * step_64);
-            bucket_index = 2 * unclamped_grid_index + leading_buckets - 1 - (before_split_point ? 1 : 0);
-        }
-
-        chassert(bucket_index >= 0 && bucket_index < static_cast<Int64>(bucket_count));
-        const auto [lo, hi] = bucketRangeFast(static_cast<size_t>(bucket_index));
-        chassert(ts > lo && ts <= hi);
-        return {static_cast<size_t>(bucket_index), lo, hi};
-    }
-
-    /// `Int64` counterpart of `bucketTimeRange` (as a `(lo, hi]` pair). Requires `fast_bucket_math`.
-    /// For a clamped bucket #0 (possible only for unsigned `DateTime` timestamps) `lo` may fall below zero,
-    /// which over the unsigned domain means the same as "no lower bound".
-    ALWAYS_INLINE std::pair<Int64, Int64> bucketRangeFast(size_t bucket_index) const
-    {
-        const Int64 num_even_buckets = static_cast<Int64>(bucket_index / 2);
-        const Int64 num_odd_buckets = static_cast<Int64>(bucket_index) - num_even_buckets;
-        const Int64 hi = static_cast<Int64>(first_bucket_end_time)
-            + num_odd_buckets * static_cast<Int64>(odd_bucket_step) + num_even_buckets * static_cast<Int64>(even_bucket_step);
-        const Int64 lo = hi - static_cast<Int64>((bucket_index % 2 != 0) ? odd_bucket_width : even_bucket_width);
-        return {lo, hi};
-    }
-
-    size_t ALWAYS_INLINE bucketIndex(const TimestampType timestamp) const
-    {
-        /// The unused range computation of `classifySampleFast` is eliminated after inlining.
-        return fast_bucket_math ? classifySampleFast(static_cast<Int64>(timestamp)).bucket_index : bucketIndexForTimestamp(timestamp);
+        return classifySample<size_t>(timestamp);
     }
 
     /// Returns a half-open range [first, last) of bucket indices that fall in a grid point's window. The range has
     /// `buckets_per_window` buckets, except early windows that are truncated at 0 by the dropped leading buckets.
     std::pair<size_t, size_t> bucketRangeInWindow(size_t grid_index) const
     {
+        chassert(grid_index < grid_size);
         const size_t window_begin = grid_index * buckets_per_step;
         const size_t skipped_leading_buckets = buckets_per_window - buckets_per_first_window;
         return {window_begin > skipped_leading_buckets ? window_begin - skipped_leading_buckets : 0, window_begin + buckets_per_first_window};
@@ -870,38 +932,24 @@ private:
     /// in-range end is recovered modulo 2^64.
     TimestampType ALWAYS_INLINE bucketEndTimestamp(size_t bucket_index) const
     {
+        chassert(bucket_index < bucket_count);
         const UInt64 num_even_buckets = bucket_index / 2;
         const UInt64 num_odd_buckets = bucket_index - num_even_buckets;
-        const UInt64 bucket_end_time = static_cast<UInt64>(static_cast<Int64>(first_bucket_end_time))
+        const UInt64 bucket_end_time = static_cast<UInt64>(toInt64(first_bucket_end_time))
             + num_odd_buckets * odd_bucket_step + num_even_buckets * even_bucket_step;
         return static_cast<TimestampType>(static_cast<Int64>(bucket_end_time));
     }
 
-    /// Half-open timestamp range `(start_time, end_time]` of a bucket.
-    struct BucketTimeRange
+    /// Returns the closed timestamp range of bucket `bucket_index`.
+    ALWAYS_INLINE BucketTimeRange bucketTimeRange(size_t bucket_index) const
     {
-        std::optional<TimestampType> start_time;  /// The lower bound is optional
-        TimestampType end_time;
-
-        bool contains(const TimestampType & timestamp) const
-        {
-            return (!start_time || timestamp > *start_time) && timestamp <= end_time;
-        }
-    };
-
-    /// Returns the timestamp range of bucket `bucket_index`.
-    BucketTimeRange bucketTimeRange(size_t bucket_index) const
-    {
-        const TimestampType bucket_end_time = bucketEndTimestamp(bucket_index);
-
-        /// Only the very first bucket can start below the type minimum; every later bucket starts where the previous
-        /// one ends, which is in range. `first_bucket_is_clamped` records that single case.
-        if (bucket_index == 0 && first_bucket_is_clamped)
-            return {std::nullopt, bucket_end_time};  /// No lower bound.
-
-        const IntervalType bucket_width = (bucket_index % 2 != 0) ? odd_bucket_width : even_bucket_width;
-        const auto bucket_start_time = static_cast<TimestampType>(static_cast<Int64>(bucket_end_time) - bucket_width);
-        return {bucket_start_time, bucket_end_time};
+        chassert(bucket_index < bucket_count);
+        const TimestampType end_time = bucketEndTimestamp(bucket_index);
+        const Int64 bucket_width = static_cast<Int64>(bucket_index == 0
+            ? first_bucket_width
+            : ((bucket_index % 2 != 0) ? odd_bucket_width : even_bucket_width));
+        /// `end - (width - 1)` is the bucket's start, which is always representable (`width >= 1`), so the arithmetic can't overflow.
+        return {static_cast<TimestampType>(toInt64(end_time) - (bucket_width - 1)), end_time};
     }
 
     static const State * data(ConstAggregateDataPtr __restrict place)
@@ -916,7 +964,7 @@ private:
 
     void ALWAYS_INLINE add(AggregateDataPtr __restrict place, TimestampType timestamp, ValueType value) const
     {
-        const size_t bucket_index = bucketIndex(timestamp);
+        const size_t bucket_index = bucketIndexForTimestamp(timestamp);
         if (bucket_index == NO_BUCKET)
             return;  /// The sample can't contribute to any bucket.
 
@@ -924,15 +972,38 @@ private:
         bucket.add(timestamp, value);
     }
 
-    static ALWAYS_INLINE Int64 toInt64(TimestampType timestamp)
+    static constexpr ALWAYS_INLINE Int64 toInt64(TimestampType timestamp)
     {
         return static_cast<Int64>(timestamp);
     }
 
-    /// Returns the number of leading samples of `timestamps[0, count)` with timestamps in `(lo, hi]`.
-    /// Checked in blocks so that the loop vectorizes; the samples of a partial block are re-checked one by one.
-    static ALWAYS_INLINE size_t scanSamplesInRange(const TimestampType * __restrict timestamps, size_t count, Int64 lo, Int64 hi)
+    /// The smallest representable timestamp.
+    static constexpr TimestampType minTimestamp()
     {
+        if constexpr (std::is_unsigned_v<TimestampType>)
+            return 0;
+        else
+            return static_cast<TimestampType>(std::numeric_limits<Int64>::min());
+    }
+
+    /// The largest representable timestamp.
+    static constexpr TimestampType maxTimestamp()
+    {
+        if constexpr (std::is_unsigned_v<TimestampType>)
+            return std::numeric_limits<TimestampType>::max();
+        else
+            return static_cast<TimestampType>(std::numeric_limits<Int64>::max());
+    }
+
+    /// Returns the number of leading samples of `timestamps[0, count)` with timestamps in `[lo, hi]`.
+    /// Checked in blocks so that the loop vectorizes; the samples of a partial block are re-checked one by one.
+    static ALWAYS_INLINE size_t scanSamplesInRange(const TimestampType * __restrict timestamps, size_t count, const BucketTimeRange & range)
+    {
+        /// Converted to Int64 once, outside the loops: comparing `TimestampType` (a `Decimal` for
+        /// `DateTime64`) per sample would call out-of-line comparison operators and prevent vectorization.
+        const Int64 lo = toInt64(range.start_time);
+        const Int64 hi = toInt64(range.end_time);
+
         constexpr size_t block_size = 16;
         size_t scanned = 0;
         while (scanned + block_size <= count)
@@ -941,7 +1012,7 @@ private:
             for (size_t j = 0; j < block_size; ++j)
             {
                 const Int64 timestamp = toInt64(timestamps[scanned + j]);
-                all_in_range &= static_cast<UInt8>(timestamp > lo) & static_cast<UInt8>(timestamp <= hi);
+                all_in_range &= static_cast<UInt8>(timestamp >= lo) & static_cast<UInt8>(timestamp <= hi);
             }
             if (!all_in_range)
                 break;
@@ -950,7 +1021,7 @@ private:
         while (scanned < count)
         {
             const Int64 timestamp = toInt64(timestamps[scanned]);
-            if (!(timestamp > lo && timestamp <= hi))
+            if (!(timestamp >= lo && timestamp <= hi))
                 break;
             ++scanned;
         }
@@ -969,20 +1040,21 @@ private:
         size_t i = row_begin;
         while (i < row_end)
         {
-            const SampleClass sample_class = classifySampleFast(toInt64(timestamps[i]));
-            const size_t run = scanSamplesInRange(timestamps + i, row_end - i, sample_class.lo, sample_class.hi);
+            const SampleClass sample_class = classifySample(timestamps[i]);
+            const size_t run = scanSamplesInRange(timestamps + i, row_end - i, sample_class.time_range);
+            /// The classified sample is inside its own range, so `run >= 1`; `max` only guards
+            /// against an infinite loop.
+            const size_t count = std::max<size_t>(run, static_cast<size_t>(1));
             if (sample_class.bucket_index != NO_BUCKET)
-                state->buckets[sample_class.bucket_index].addMany(timestamps + i, values + i, run);
-            /// A rejected sample is not always inside its own skip range (see `classifySampleFast`),
-            /// so the scan may return 0 - still consume one sample.
-            i += std::max<size_t>(run, static_cast<size_t>(1));
+                state->buckets[sample_class.bucket_index].addMany(timestamps + i, values + i, count);
+            i += count;
         }
     })
     )
 
     /// Entry point of the batch add path; `flags == nullptr` means every sample is included.
-    /// Flagged samples (a NULL map of a `Nullable` value column or a `-If` condition) and grids without the
-    /// Int64 bucket math stay on the plain per-sample path.
+    /// Flagged samples (a NULL map of a `Nullable` value column or a `-If` condition) stay on the
+    /// plain per-sample path.
     template <bool flag_value_to_include>
     void addSamples(AggregateDataPtr __restrict place,
         const TimestampType * __restrict timestamps,
@@ -991,7 +1063,7 @@ private:
         size_t row_begin,
         size_t row_end) const
     {
-        if (!fast_bucket_math || flags)
+        if (flags)
         {
             for (size_t i = row_begin; i < row_end; ++i)
                 if (!flags || (flags[i] != 0) == flag_value_to_include)
@@ -1122,24 +1194,23 @@ private:
 
     /// Drops buckets that have left grid point `grid_index`'s window from the front of the sliding `aggregator`. A bucket
     /// is out of window once all its samples are at or before the cutoff `grid_timestamp - window`; window-aligned
-    /// buckets are fully in or out, so the bucket's latest timestamp decides. The cutoff is computed in `Int128`
-    /// because `grid_timestamp - window` can be negative (`grid_timestamp < window`) or even underflow `Int64`
-    /// (`start_timestamp` near `INT64_MIN` with a huge window). When it is below the smallest representable
-    /// timestamp (`0` for unsigned `DateTime`, `INT64_MIN` for `DateTime64`) no bucket can be out of window, so
-    /// `removeBefore` is skipped - which also avoids wrapping a negative cutoff cast to an unsigned `TimestampType`.
+    /// buckets are fully in or out, so the bucket's latest timestamp decides.
     template <typename Aggregator>
     void removeOutOfWindow(Aggregator & aggregator, size_t grid_index) const
     {
-        static constexpr Int64 min_timestamp = std::is_unsigned_v<TimestampType> ? 0 : std::numeric_limits<Int64>::min();
-        const Int128 cut_off = static_cast<Int128>(static_cast<Int64>(timestampAtIndex(grid_index)))
-            - static_cast<Int128>(static_cast<Int64>(window));
-        if (cut_off >= static_cast<Int128>(min_timestamp))
-            aggregator.removeBefore(static_cast<TimestampType>(static_cast<Int64>(cut_off)));
+        /// A cutoff below the smallest representable timestamp can't drop anything and is skipped;
+        /// the check is rearranged as `grid_timestamp >= min_timestamp + window` so that neither side can overflow.
+        chassert(grid_index < grid_size);
+        static constexpr Int64 min_timestamp = toInt64(minTimestamp());
+        const Int64 grid_timestamp = toInt64(timestampAtIndex(grid_index));
+        if (grid_timestamp >= min_timestamp + static_cast<Int64>(window))
+            aggregator.removeBefore(static_cast<TimestampType>(grid_timestamp - static_cast<Int64>(window)));
     }
 
     /// Stores the window's result value (or NULL when there is no result) at grid point `grid_index`.
     void storeGridResult(size_t grid_index, const std::optional<ValueType> & result, ValueType * values, UInt8 * nulls) const
     {
+        chassert(grid_index < grid_size);
         if (result)
         {
             values[grid_index] = *result;

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesChanges.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesChanges.h
@@ -158,7 +158,7 @@ public:
         return {};
     }
 
-    static constexpr UInt16 FORMAT_VERSION = 2;
+    static constexpr UInt16 FORMAT_VERSION = 3;
     static constexpr bool DateTime64Supported = true;
 };
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesExtrapolatedValue.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesExtrapolatedValue.h
@@ -249,7 +249,7 @@ public:
         return Aggregator{Base::window, Base::timestamp_scale_multiplier};
     }
 
-    static constexpr UInt16 FORMAT_VERSION = 3;
+    static constexpr UInt16 FORMAT_VERSION = 4;
     static constexpr bool DateTime64Supported = true;
 };
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesInstantValue.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesInstantValue.h
@@ -116,7 +116,7 @@ public:
         return typename Traits::Aggregator{Base::timestamp_scale_multiplier};
     }
 
-    static constexpr UInt16 FORMAT_VERSION = 3;
+    static constexpr UInt16 FORMAT_VERSION = 4;
     static constexpr bool DateTime64Supported = true;
 };
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesLinearRegression.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesLinearRegression.h
@@ -214,7 +214,7 @@ public:
         return Aggregator{stack_size, Base::start_timestamp, predict_offset, Base::timestamp_scale_multiplier};
     }
 
-    static constexpr UInt16 FORMAT_VERSION = 2;
+    static constexpr UInt16 FORMAT_VERSION = 3;
     static constexpr bool DateTime64Supported = true;
 
 protected:

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesToGridSparse.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesToGridSparse.h
@@ -138,7 +138,7 @@ public:
         return {};
     }
 
-    static constexpr UInt16 FORMAT_VERSION = 3;
+    static constexpr UInt16 FORMAT_VERSION = 4;
     static constexpr bool DateTime64Supported = true;
 };
 

--- a/tests/performance/timeseries_to_grid_scalar_add.xml
+++ b/tests/performance/timeseries_to_grid_scalar_add.xml
@@ -15,8 +15,8 @@
         The data is dense: 200 series with one sample every 15 s over [1000000, 4000000), i.e. 200000
         samples per series, 40M rows total. The grid uses `step` = `window` = 300 s, so every in-range
         sample contributes to exactly one bucket and ~20 consecutive samples land in the same bucket -
-        exercising both the per-sample bucket math (Int64 fast path vs Int128 division) and the
-        cached-last-bucket optimization that skips the hash-map lookup for same-bucket runs.
+        exercising both the per-sample 64-bit bucket math and the cached-last-bucket optimization
+        that skips the hash-map lookup for same-bucket runs.
     -->
 
     <create_query>

--- a/tests/queries/0_stateless/04815_timeseries_to_grid_sorted_samples.sql
+++ b/tests/queries/0_stateless/04815_timeseries_to_grid_sorted_samples.sql
@@ -107,13 +107,13 @@ SELECT timeSeriesRateToGridMerge(100, 200, 20, 100)(st) = (SELECT timeSeriesRate
 DROP TABLE ts_agg_states;
 
 -- Servers of older versions serialize samples in hash-map order, so any wire order must be accepted. Both literals
--- are a FORMAT_VERSION 3 timeSeriesRateToGridState(100, 200, 20, 100) over samples (110, 1), (125, 3), (140, 2);
+-- are a FORMAT_VERSION 4 timeSeriesRateToGridState(100, 200, 20, 100) over samples (110, 1), (125, 3), (140, 2);
 -- in the second one the two 16-byte (timestamp, value) pairs of its two-sample bucket are swapped.
 -- Regenerate both literals if the serialization format ever changes.
 SELECT 'deserializing samples in a different wire order gives the same result (grid, 1):';
 WITH
-    CAST(unhex('03000A00000000000000020000000000000005000000000000000100000000000000B0AD010000000000000000000000F03F0600000000000000020000000000000048E80100000000000000000000000840E0220200000000000000000000000040'), 'AggregateFunction(timeSeriesRateToGrid(100, 200, 20, 100), DateTime64(3, \'UTC\'), Float64)') AS sorted_state,
-    CAST(unhex('03000A00000000000000020000000000000005000000000000000100000000000000B0AD010000000000000000000000F03F06000000000000000200000000000000E022020000000000000000000000004048E80100000000000000000000000840'), 'AggregateFunction(timeSeriesRateToGrid(100, 200, 20, 100), DateTime64(3, \'UTC\'), Float64)') AS swapped_state
+    CAST(unhex('04000A00000000000000020000000000000005000000000000000100000000000000B0AD010000000000000000000000F03F0600000000000000020000000000000048E80100000000000000000000000840E0220200000000000000000000000040'), 'AggregateFunction(timeSeriesRateToGrid(100, 200, 20, 100), DateTime64(3, \'UTC\'), Float64)') AS sorted_state,
+    CAST(unhex('04000A00000000000000020000000000000005000000000000000100000000000000B0AD010000000000000000000000F03F06000000000000000200000000000000E022020000000000000000000000004048E80100000000000000000000000840'), 'AggregateFunction(timeSeriesRateToGrid(100, 200, 20, 100), DateTime64(3, \'UTC\'), Float64)') AS swapped_state
 SELECT finalizeAggregation(sorted_state), finalizeAggregation(sorted_state) = finalizeAggregation(swapped_state);
 
 -- Scalar path: the same series stored as one sorted part and as two parts with interleaved timestamps.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Rewrite bucketIndexForTimestamp in 64-bit arithmetic

Replace the two-path design (Int128 generic path + Int64 fast path gated
by 2^61 parameter bounds) with a single `classifySample` that serves any
grid parameters: `fast_bucket_math`, `canUseFastBucketMath` and the
Int128 `bucketIndexForTimestamp` are gone, and the batch bucketing
kernel now runs for every grid.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115097&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115097](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115097+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
