### PR TITLE
Add missing keeper component for reading text index for various optimizations

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -1,6 +1,7 @@
 #include <Access/ContextAccess.h>
 #include <Columns/ColumnConst.h>
 #include <Common/FieldVisitorToString.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/assert_cast.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -163,6 +164,8 @@ String optimizationInfoToString(const IndexReadColumns & added_columns, const Na
 /// Collects index conditions from the given ReadFromMergeTree step and stores them in text_index_read_infos.
 void collectTextIndexReadInfos(const ReadFromMergeTree * read_from_merge_tree_step, TextIndexReadInfos & text_index_read_infos)
 {
+    auto component_guard = Coordination::setCurrentComponent("optimizeDirectReadFromTextIndex");
+
     const auto & indexes = read_from_merge_tree_step->getIndexes();
     if (!indexes || indexes->skip_indexes.useful_indices.empty())
         return;

--- a/src/Processors/QueryPlan/Optimizations/optimizeTrivialCountFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTrivialCountFromTextIndex.cpp
@@ -11,6 +11,7 @@
 #include <Access/EnabledRowPolicies.h>
 #include <AggregateFunctions/AggregateFunctionCount.h>
 #include <Core/Settings.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
 #include <Interpreters/ActionsDAG.h>
@@ -328,6 +329,8 @@ String makeStepDescription(const ResolvedQuery & resolved)
 
 bool optimizeTrivialCountFromTextIndex(QueryPlan::Node & node, QueryPlan::Nodes & nodes, const QueryPlanOptimizationSettings & settings)
 {
+    auto component_guard = Coordination::setCurrentComponent("optimizeTrivialCountFromTextIndex");
+
     /// `ReadFromTextIndexCount` is not serializable, so it must not end up in a distributed plan fragment.
     /// `applyParallelReplicas` runs first and builds such fragments around the `ReadFromMergeTree` we would
     /// replace, so bail and let the reader be distributed across replicas as before.
@@ -364,7 +367,7 @@ bool optimizeTrivialCountFromTextIndex(QueryPlan::Node & node, QueryPlan::Nodes 
         return false;
     }
 
-    /// Split the parts by index materialization (checksum lookups, no I/O).
+    /// Split the parts by index materialization (checksum lookups if materialized)
     const auto & text_index = *search_query->index.index;
     auto is_materialized_part = [&](const RangesInDataPart & part_with_ranges)
     {

--- a/src/Processors/QueryPlan/ReadFromTextIndexCount.cpp
+++ b/src/Processors/QueryPlan/ReadFromTextIndexCount.cpp
@@ -1,6 +1,7 @@
 #include <Processors/QueryPlan/ReadFromTextIndexCount.h>
 
 #include <AggregateFunctions/AggregateFunctionCount.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <Interpreters/ProcessList.h>
 #include <Processors/ISource.h>
@@ -250,6 +251,8 @@ public:
 protected:
     Chunk generate() override
     {
+        auto component_guard = Coordination::setCurrentComponent("TextIndexCountSource::generate");
+
         size_t part_idx = state->next_part.fetch_add(1);
         if (part_idx >= state->parts.size())
             return {};


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Examples:
- https://pastila.clickhouse.com/?000ea8ae/aa2cad57e73762e75de63b0c6f86cc04#dtYvYrqz3juo9HPETh8/8g==GCM
- https://pastila.clickhouse.com/?00031478/4582943089f1f40609a3a3a82cc86c35#ZWANMqRuO7ygCKSrLBAaUw==GCM


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1580` (included in `26.8` and later)
<!-- ch-version-info:end -->