### PR TITLE
Text index: update docs to include the trivial count optimization

### DIFF
--- a/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
+++ b/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
@@ -1401,13 +1401,15 @@ A query that only counts the rows matching a text-search predicate
 ```sql
 SELECT count()
 FROM [...]
-WHERE string_search_function(column_with_text_index)
+WHERE hasToken(column_with_text_index, 'token')
+-- or: hasAllTokens(column_with_text_index, ['token', ...])
+-- or: hasAnyTokens(column_with_text_index, ['token', ...])
 ```
 
 is answered from the text index, without reading the matching rows.
 ClickHouse takes the count from the posting-list cardinalities in the index, skipping the virtual column that marks matching rows and the aggregation over it. A single token needs only its dictionary cardinality, so no posting list is read; multi-token predicates read the postings just to union (`hasAnyTokens`) or intersect (`hasAllTokens`) them. As a text index covers the whole part, the count is exact and stays fast even on very large parts.
 
-The optimization applies to a bare `count()` filtered by a single [supported](#direct-read) text-search predicate. An extra filter (e.g. `... AND id > 10`), selecting anything besides the count, or phrase or `LIKE`/pattern search makes the query read rows instead. Parts without a materialized index are still counted correctly by reading their rows.
+The optimization applies to a bare `count()` filtered by a single `hasToken`, `hasAnyTokens`, or `hasAllTokens` predicate (or an `Array`/`Map` equivalent). Predicates combined with `AND`/`OR`/`NOT`, an extra filter (e.g. `... AND id > 10`), a hint-mode predicate like `m['key'] = 'value'`, selecting anything besides the count, or phrase or `LIKE`/pattern search makes the query read rows instead. Parts without a materialized index are still counted correctly by reading their rows.
 
 To confirm the optimization is engaged, check for `ReadFromTextIndexCount` in the query plan:
 
@@ -1422,7 +1424,7 @@ Aggregating
 └──ReadFromTextIndexCount (Trivial count from text index (idx, token = 'sometoken'))
 ```
 
-The optimization is controlled by [query_plan_optimize_count_from_text_index](/reference/settings/session-settings/query-plan#query_plan_optimize_count_from_text_index) (on by default). It builds on [direct read](#direct-read), so [query_plan_direct_read_from_text_index](/reference/settings/session-settings/query-plan#query_plan_direct_read_from_text_index) and [optimize_trivial_count_query](/reference/settings/session-settings/optimize-trivial#optimize_trivial_count_query) must be enabled too (both on by default).
+The optimization is controlled by [query_plan_optimize_count_from_text_index](/reference/settings/session-settings/query-plan#query_plan_optimize_count_from_text_index) (on by default). It builds on [direct read](#direct-read), so [query_plan_direct_read_from_text_index](/reference/settings/session-settings/query-plan#query_plan_direct_read_from_text_index), [use_skip_indexes](/reference/settings/session-settings/use-skip-indexes#use_skip_indexes), and [optimize_trivial_count_query](/reference/settings/session-settings/optimize-trivial#optimize_trivial_count_query) must be enabled too (all on by default).
 
 ### Caching {#caching}
 

--- a/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
+++ b/docs/reference/engines/table-engines/mergetree-family/textindexes.mdx
@@ -1394,6 +1394,36 @@ The fallback mechanism is controlled by two settings:
 
 This optimization supports only functions `like` and `ilike`.
 
+### Trivial count queries {#count-queries-perf}
+
+A query that only counts the rows matching a text-search predicate
+
+```sql
+SELECT count()
+FROM [...]
+WHERE string_search_function(column_with_text_index)
+```
+
+is answered from the text index, without reading the matching rows.
+ClickHouse takes the count from the posting-list cardinalities in the index, skipping the virtual column that marks matching rows and the aggregation over it. A single token needs only its dictionary cardinality, so no posting list is read; multi-token predicates read the postings just to union (`hasAnyTokens`) or intersect (`hasAllTokens`) them. As a text index covers the whole part, the count is exact and stays fast even on very large parts.
+
+The optimization applies to a bare `count()` filtered by a single [supported](#direct-read) text-search predicate. An extra filter (e.g. `... AND id > 10`), selecting anything besides the count, or phrase or `LIKE`/pattern search makes the query read rows instead. Parts without a materialized index are still counted correctly by reading their rows.
+
+To confirm the optimization is engaged, check for `ReadFromTextIndexCount` in the query plan:
+
+```sql
+EXPLAIN
+SELECT count() FROM table WHERE hasToken(col, 'sometoken')
+```
+
+```text
+[...]
+Aggregating
+└──ReadFromTextIndexCount (Trivial count from text index (idx, token = 'sometoken'))
+```
+
+The optimization is controlled by [query_plan_optimize_count_from_text_index](/reference/settings/session-settings/query-plan#query_plan_optimize_count_from_text_index) (on by default). It builds on [direct read](#direct-read), so [query_plan_direct_read_from_text_index](/reference/settings/session-settings/query-plan#query_plan_direct_read_from_text_index) and [optimize_trivial_count_query](/reference/settings/session-settings/optimize-trivial#optimize_trivial_count_query) must be enabled too (both on by default).
+
 ### Caching {#caching}
 
 Different server-wide caches exist to buffer parts of the text index in memory (see section [Implementation Details](#implementation)):


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1568` (included in `26.8` and later)
<!-- ch-version-info:end -->