### PR TITLE
Do not read the master-only system.parts.files column in 04550_restore_fsync_after_insert

### DIFF
--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
@@ -33,11 +33,10 @@ $CLICKHOUSE_CLIENT -m -q "
     INSERT INTO t_restore_fsync_off SELECT number, toString(number), [] FROM numbers(1000);
 "
 
-# Count the physical files RESTORE actually copies (and therefore must fsync). This is the real target,
-# larger than system.parts.files (= checksums entries) - it includes checksums.txt, columns.txt and the
-# zero-byte arr.bin - but excludes the version-metadata files RESTORE deliberately skips (see
-# restorePartFromBackup: txn_version.txt[.tmp] and metadata_version.txt are not copied). The restored
-# part has the same on-disk file set.
+# Count the physical files RESTORE actually copies (and therefore must fsync): every file in the part
+# except the version-metadata files RESTORE deliberately skips (see restorePartFromBackup:
+# txn_version.txt[.tmp] and metadata_version.txt are not copied). The restored part has the same
+# on-disk file set.
 part_path=$($CLICKHOUSE_CLIENT -q "SELECT path FROM system.parts WHERE database = currentDatabase() AND table = 't_restore_fsync_on' AND active")
 copied_files=$(find "$part_path" -type f \
     ! -name 'txn_version.txt' ! -name 'txn_version.txt.tmp' ! -name 'metadata_version.txt' | wc -l)
@@ -79,6 +78,8 @@ $CLICKHOUSE_CLIENT -m -q "DROP TABLE t_restore_fsync_on SYNC; DROP TABLE t_resto
 # Encrypted incremental restore: files that come entirely from the base backup are copied via
 # getBaseBackup()->copyFileToDisk(..., sync). That branch must forward the encrypted read (else the
 # restore fails with CANNOT_RESTORE_TO_NONENCRYPTED_DISK) and still fsync the files when requested.
+# The table below has the same schema, data and part-layout settings as t_restore_fsync_on, so its
+# part holds the same file set and $copied_files is its restore-copied file count too.
 enc_disk="disk(type = encrypted, disk = disk(type = local, path = '${CLICKHOUSE_DISKS_FILES}/${CLICKHOUSE_TEST_UNIQUE_NAME}_enc/'), key = '1234567812345678')"
 $CLICKHOUSE_CLIENT -q "
     DROP TABLE IF EXISTS t_restore_fsync_enc;
@@ -86,7 +87,6 @@ $CLICKHOUSE_CLIENT -q "
     SETTINGS fsync_after_insert = 1, fsync_part_directory = 1, min_bytes_for_wide_part = 0, disk = $enc_disk;
     INSERT INTO t_restore_fsync_enc SELECT number, toString(number), [] FROM numbers(1000);
 "
-enc_files=$($CLICKHOUSE_CLIENT -q "SELECT files FROM system.parts WHERE database = currentDatabase() AND table = 't_restore_fsync_enc' AND active")
 
 # Full backup, then an unchanged incremental backup so every file is served by the base backup.
 $CLICKHOUSE_CLIENT -q "BACKUP TABLE t_restore_fsync_enc TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_enc_base')" > /dev/null
@@ -100,7 +100,7 @@ $CLICKHOUSE_CLIENT --query_id "$qid_enc" -q "RESTORE TABLE t_restore_fsync_enc F
 echo "encrypted incremental count: $($CLICKHOUSE_CLIENT -q "SELECT count() FROM t_restore_fsync_enc")"
 
 $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
-$CLICKHOUSE_CLIENT --param_query_id "$qid_enc" --param_files "$enc_files" -q "
+$CLICKHOUSE_CLIENT --param_query_id "$qid_enc" --param_files "$copied_files" -q "
     SELECT 'encrypted incremental restore with fsync_after_insert=1, all part files fsynced: ',
            ProfileEvents['FileSync'] >= {files:UInt64}
     FROM system.query_log


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111378
Related: https://github.com/ClickHouse/ClickHouse/pull/115088
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04550_restore_fsync_after_insert.sh` (added by #111378) read the `files` column of
`system.parts` to size the encrypted-incremental-restore fsync assertion. That column was added
by 476e9fcb3bb3f26 in January, after 25.8 forked, so the automated 25.8 backport #115088 fails at
runtime even though the cherry-pick applied cleanly and the script is byte-identical:

```
Code: 47. Unknown expression identifier `files` in scope
  SELECT files FROM system.parts WHERE ... AND (`table` = 't_restore_fsync_enc'). (UNKNOWN_IDENTIFIER)
Code: 32. Attempt to read after eof: value  cannot be parsed as UInt64 for query parameter 'files'.
```

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115088&sha=980e9739e2ff0687cec113ed6460d38af75034f6&name_0=BackportPR&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%20parallel%2C%201%2F2%29

The count the assertion wants is how many files RESTORE copies and must therefore fsync. The test
already measures exactly that for its first table, with `SELECT path FROM system.parts` plus
`find`. This drops the `system.parts.files` read and feeds the encrypted arm the same count. The
two tables have identical schema, data and part-layout settings, so their parts hold the same file
set; the assertion gets stronger, since the physical count also covers `checksums.txt`,
`columns.txt` and the zero-byte `arr.bin` that the checksums map does not enumerate. `.reference`
is unchanged.

Validation: on the official 25.8 binary the old test reproduces both errors above and the new one
runs to completion. On master the encrypted restore performs 20 `FileSync` events against a
required 18, and the two arms' part file lists are identical on both branches (18 files on master,
15 on 25.8), so the reuse does not depend on a master-specific layout. Disabling
`fsync_after_insert` on the encrypted table still fails the test, so the assertion is not vacuous.
50/50 runs green with randomized settings.

Note that #115088 cannot pick this up by regeneration: the backport tree is built from #111378's
merge commit, so a regenerated backport carries the same broken line.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1602` (included in `26.8` and later)
<!-- ch-version-info:end -->