### PR TITLE
Docs: add 2026-08-17 Cloud changelog

### DIFF
--- a/docs/resources/changelogs/cloud/2026.mdx
+++ b/docs/resources/changelogs/cloud/2026.mdx
@@ -13,7 +13,7 @@ import { Image } from "/snippets/components/Image.jsx";
 In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibility](/products/cloud/guides/cloud-compatibility) page.
 
 
-<Update label="2026-08-17">
+<Update label="August 17, 2026">
 
 This week's updates bring broader platform reach and better operational visibility. Managed Postgres is now available on GCP for selected design partners, ClickStack resources can be managed through the official Terraform provider, and new billing notifications give customers early warning before credits expire or service is interrupted. We also shipped improved tracing for ClickHouse Agents and a smoother SAML sign-in experience.
 

--- a/docs/resources/changelogs/cloud/2026.mdx
+++ b/docs/resources/changelogs/cloud/2026.mdx
@@ -13,6 +13,33 @@ import { Image } from "/snippets/components/Image.jsx";
 In addition to this ClickHouse Cloud changelog, please see the [Cloud Compatibility](/products/cloud/guides/cloud-compatibility) page.
 
 
+<Update label="2026-08-17">
+
+This week's updates bring broader platform reach and better operational visibility. Managed Postgres is now available on GCP for selected design partners, ClickStack resources can be managed through the official Terraform provider, and new billing notifications give customers early warning before credits expire or service is interrupted. We also shipped improved tracing for ClickHouse Agents and a smoother SAML sign-in experience.
+
+### Managed Postgres now available on GCP {#managed-postgres-now-available-on-gcp}
+
+[ClickHouse Cloud Managed Postgres](/products/managed-postgres/overview) is now available on GCP for selected design partners across all public GCP regions, with `us-west1` as the first private region. This extends Managed Postgres to customers building on GCP, with Private Preview planned for 2026-08.
+
+### Manage ClickStack resources with Terraform {#manage-clickstack-resources-with-terraform}
+
+ClickStack support is now available in beta through version 3.25.0 of the official [`ClickHouse/clickhouse` Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs#clickstack-alpha). Teams can create, update, import, and remove dashboards, alerts, sources, saved searches, connections, and webhooks using the standard `terraform plan` and `terraform apply` workflow. The integration supports both Managed ClickStack and self-hosted deployments.
+
+### New billing notifications for credits and payments {#new-billing-notifications-for-credits-and-payments}
+
+Billing notifications are now managed through the ClickHouse Cloud Notification Center, with delivery through the console, email, and Slack. Customers receive advance notice when prepaid or trial credits are about to expire or run out, as well as notifications when credits are added, payment methods change, or an account enters a non-payment grace period. This provides more time to renew, add credits, or resolve payment issues before service is interrupted.
+
+### Open Langfuse session traces from ClickHouse Agents {#open-langfuse-session-traces-from-clickhouse-agents}
+
+Organization administrators can now open the corresponding Langfuse session directly from a [ClickHouse Agents](/products/cloud/features/ai-ml/agents/index) chat and inspect traces for the entire conversation. This makes it easier to investigate agent behavior and debug multi-step runs. The improvement is available in Public Beta for newly created chats.
+
+### SAML redirects help prevent duplicate accounts {#saml-redirects-help-prevent-duplicate-accounts}
+
+When a user attempts to sign in with Google or Microsoft while SAML is configured for their organization, ClickHouse Cloud now redirects them to the correct SAML sign-in flow. This helps prevent users from accidentally creating a separate organization when they intended to access an existing account.
+
+</Update>
+
+
 <Update label="July 13, 2026">
 
 This week's updates include sticky replica routing over plain HTTPS, custom billing period start dates, and new initial-load controls for object storage ClickPipes.


### PR DESCRIPTION
Adds the 2026-08-17 ClickHouse Cloud changelog entry, covering Managed Postgres availability on GCP for selected design partners, ClickStack support in the Terraform provider, billing notifications, ClickHouse Agents trace navigation, and SAML sign-in redirects.

This keeps the public Cloud release notes current with the product changes published for the week of 2026-08-10–2026-08-17.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1572` (included in `26.8` and later)
<!-- ch-version-info:end -->