### PR TITLE
Disable distributed index analysis with projections (wrong results)

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3411,6 +3411,10 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
         bool is_initial_query = context_->getClientInfo().query_kind == ClientInfo::QueryKind::INITIAL_QUERY;
 
         bool distributed_index_analysis_enabled = !final_second_pass
+            /// Projection parts are identified only by the projection name, which is identical in every
+            /// parent part, so per-part analysis results cannot be attributed back, and remote replicas
+            /// resolve part names against the parent table. Analyze projection parts locally.
+            && !projection_parts_exist
             && settings[Setting::distributed_index_analysis]
             && (settings[Setting::distributed_index_analysis_for_non_shared_merge_tree] || data.isSharedStorage())
             && (total_parts >= distributed_index_analysis_min_parts_to_activate)

--- a/tests/queries/0_stateless/04891_distributed_index_analysis_projections.reference
+++ b/tests/queries/0_stateless/04891_distributed_index_analysis_projections.reference
@@ -1,0 +1,15 @@
+-- { echo }
+-- The filter matches all rows in all parts (the projection is analyzed, but rejected as not better)
+select count(), sum(key) from test_dia_proj where value >= 0 settings distributed_index_analysis=0;
+3000000	4499998500000
+select count(), sum(key) from test_dia_proj where value >= 0 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+3000000	4499998500000
+-- The filter matches one row in the first part and one row in the last part (the projection is selected for reading)
+select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings distributed_index_analysis=0;
+2	3000000
+select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+2	3000000
+distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas>0=0
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas>0=1
+distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas>0=0
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas>0=1

--- a/tests/queries/0_stateless/04891_distributed_index_analysis_projections.sql
+++ b/tests/queries/0_stateless/04891_distributed_index_analysis_projections.sql
@@ -1,0 +1,62 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings
+-- - no-random-merge-tree-settings -- may change number of parts
+
+drop table if exists test_dia_proj;
+create table test_dia_proj
+(
+    key Int,
+    value Int,
+    projection prj_value
+    (
+        select key, value order by value
+    )
+)
+engine=MergeTree()
+order by key
+settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+
+system stop merges test_dia_proj;
+insert into test_dia_proj select number, number from numbers(0, 1000000);
+insert into test_dia_proj select number, number from numbers(1000000, 1000000);
+insert into test_dia_proj select number, number from numbers(2000000, 1000000);
+
+set allow_experimental_parallel_reading_from_replicas=0;
+set cluster_for_parallel_replicas='';
+set max_parallel_replicas=100;
+set distributed_index_analysis_for_non_shared_merge_tree=1;
+-- Ranges cached by the first (correct) run would narrow the analysis of the second run
+set use_query_condition_cache=0;
+
+--- Ignore warnings when replica does not respond, and analysis is done on initiator
+set send_logs_level='error';
+
+-- { echo }
+-- The filter matches all rows in all parts (the projection is analyzed, but rejected as not better)
+select count(), sum(key) from test_dia_proj where value >= 0 settings distributed_index_analysis=0;
+select count(), sum(key) from test_dia_proj where value >= 0 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+
+-- The filter matches one row in the first part and one row in the last part (the projection is selected for reading)
+select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings distributed_index_analysis=0;
+select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+
+-- { echoOff }
+system flush logs query_log;
+select format(
+  'distributed_index_analysis={}, DistributedIndexAnalysisMicroseconds>0={}, DistributedIndexAnalysisMissingParts={}, DistributedIndexAnalysisScheduledReplicas>0={}',
+  Settings['distributed_index_analysis'],
+  ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0,
+  ProfileEvents['DistributedIndexAnalysisMissingParts'],
+  ProfileEvents['DistributedIndexAnalysisScheduledReplicas'] > 0
+)
+from system.query_log
+where
+  current_database = currentDatabase()
+  and event_date >= yesterday() AND event_time >= now() - 600
+  and type = 'QueryFinish'
+  and query_kind = 'Select'
+  and is_initial_query
+  and has(Settings, 'distributed_index_analysis')
+  and endsWith(log_comment, '-' || currentDatabase())
+order by event_time_microseconds;
+
+drop table test_dia_proj;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable distributed index analysis with projections (wrong results)

Parts are identified by name, but projection parts share the projection's name across all parent parts, so analysis collapsed them into one entry and then filtered out valid parent parts, dropping rows. Skip distributed index analysis for projection parts (analyze locally); proper support needs parent part name + projection name on the wire.

Note, that the problem not only for applied projections: 

https://github.com/ClickHouse/ClickHouse/blob/7604e8de0caf5940d9e66872bcfb8dffcc602c5b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp#L617-L637

But for any tables with usable projections, since we try to filter out parts based on the analysis from projections as well:

https://github.com/ClickHouse/ClickHouse/blob/7604e8de0caf5940d9e66872bcfb8dffcc602c5b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp#L418

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115132&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115132](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115132+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.4.58`, `26.6.4.26`, `26.5.7.64`, `26.3.20.5`
<!-- ch-version-info:end -->