### PR TITLE
Don't store columns in Alias engine create_table_query

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2635,7 +2635,9 @@ void InterpreterCreateQuery::extendQueryLogElemImpl(QueryLogElement & elem, cons
 
 void InterpreterCreateQuery::addColumnsDescriptionToCreateQueryIfNecessary(ASTCreateQuery & create, const StoragePtr & storage)
 {
-    if (create.is_dictionary || (create.columns_list && create.columns_list->columns && !create.columns_list->columns->children.empty()))
+    if (create.is_dictionary
+        || storage->getName() == "Alias"
+        || (create.columns_list && create.columns_list->columns && !create.columns_list->columns->children.empty()))
         return;
 
     auto ast_storage = make_intrusive<ASTStorage>();

--- a/tests/queries/0_stateless/04267_alias_create_query_without_columns.reference
+++ b/tests/queries/0_stateless/04267_alias_create_query_without_columns.reference
@@ -1,0 +1,6 @@
+CREATE TABLE default.alias_create_query ENGINE = Alias(\'alias_create_query_target\')
+CREATE TABLE default.alias_create_query
+ENGINE = Alias('alias_create_query_target')
+id	UInt64
+value	String
+CREATE TABLE default.alias_create_query ENGINE = Alias(\'alias_create_query_target\')

--- a/tests/queries/0_stateless/04267_alias_create_query_without_columns.sql
+++ b/tests/queries/0_stateless/04267_alias_create_query_without_columns.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS alias_create_query;
+DROP TABLE IF EXISTS alias_create_query_target;
+
+CREATE TABLE alias_create_query_target (id UInt64) ENGINE = Memory;
+CREATE TABLE alias_create_query ENGINE = Alias('alias_create_query_target');
+
+SELECT create_table_query
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'alias_create_query';
+
+SHOW CREATE TABLE alias_create_query FORMAT TSVRaw;
+
+DETACH TABLE alias_create_query;
+ATTACH TABLE alias_create_query;
+
+ALTER TABLE alias_create_query_target ADD COLUMN value String;
+
+SELECT name, type
+FROM system.columns
+WHERE database = currentDatabase() AND table = 'alias_create_query'
+ORDER BY position;
+
+SELECT create_table_query
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'alias_create_query';
+
+DROP TABLE alias_create_query;
+DROP TABLE alias_create_query_target;


### PR DESCRIPTION
Before this change, table for Alias tables included the columns at the time of creation. This had mainly 2 problems:
 - The resulting query is not a  valid `CREATE TABLE` query, as columns are rejected for `Engine = Alias`
 - Columns will gets tale if the target table changes

After this PR, the query no longer includes the columns and is therefore a valid query. This is visible in:
 - `create_table_query` column in `system.tables`
 -  the `.sql` metadata file
 -  `SHOW CREATE TABLE`
 -  perhaps more places

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix create table query stored in metadata for Alias tables so it doesn't include columns, which is invalid.