### PR TITLE
Support projections in distributed index analysis

### DIFF
--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -27,6 +27,7 @@
 #include <Common/logger_useful.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/setThreadName.h>
+#include <Common/quoteString.h>
 #include <IO/ConnectionTimeouts.h>
 #include <Columns/ColumnString.h>
 #include <Parsers/ASTLiteral.h>
@@ -141,6 +142,7 @@ Scalars buildPartsScalars(const std::vector<std::string_view> & parts)
 }
 
 std::pair<Scalars, std::string> buildAnalyzeIndexQuery(const StorageID & storage_id, const std::optional<std::string> & filter,
+    const std::optional<String> & projection_name,
     const OptionalVectorSearchParameters & vector_search_parameters,
     const std::vector<std::string_view> & parts)
 {
@@ -152,6 +154,10 @@ std::pair<Scalars, std::string> buildAnalyzeIndexQuery(const StorageID & storage
         query += fmt::format(", ['{}']", fmt::join(parts, "','"));
     else
         query += fmt::format(", __getScalar('parts')");
+    /// Note, servers without projection support reject the argument count, and the initiator
+    /// falls back to local analysis for such replicas.
+    if (projection_name)
+        query += fmt::format(", {}", quoteString(*projection_name));
     if (vector_search_parameters)
     {
         query += fmt::format(", 'vector_search_index_analysis', array('{}', '{}', {}, {}, {}, {})",
@@ -205,10 +211,11 @@ void parseIndexAnalysisBlock(Block block, IndexAnalysisPartsRanges & result)
 }
 
 IndexAnalysisPartsRanges getIndexAnalysisFromReplicaSync(const LoggerPtr & logger, const StorageID & storage_id, const std::optional<std::string> & filter,
+                                                     const std::optional<String> & projection_name,
                                                      const OptionalVectorSearchParameters & vector_search_parameters, ContextPtr context, const Tables & external_tables,
                                                      const std::vector<std::string_view> & parts, Connection & connection)
 {
-    auto [scalars, query] = buildAnalyzeIndexQuery(storage_id, filter, vector_search_parameters, parts);
+    auto [scalars, query] = buildAnalyzeIndexQuery(storage_id, filter, projection_name, vector_search_parameters, parts);
     auto sample_block = indexAnalysisSampleBlock();
 
     auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(connection, query, sample_block, context, ThrottlerPtr{}, scalars, external_tables);
@@ -248,11 +255,13 @@ public:
         ASTPtr sampling_filter,
         const NameSet & indexes_column_names,
         const RangesInDataParts & parts_with_ranges_,
+        const std::optional<String> & projection_name_,
         const OptionalVectorSearchParameters & vector_search_parameters_,
         LocalIndexAnalysisCallback local_index_analysis_callback_,
         ContextPtr context_)
         : storage_id(storage_id_)
         , parts_with_ranges(parts_with_ranges_)
+        , projection_name(projection_name_)
         , vector_search_parameters(vector_search_parameters_)
         , local_index_analysis_callback(std::move(local_index_analysis_callback_))
         , context(std::move(context_))
@@ -522,7 +531,7 @@ private:
         {
             chassert(part_ranges.exact_ranges.empty());
 
-            const auto & part_name = part_ranges.data_part->name;
+            const auto & part_name = part_ranges.getAnalysisPartName();
             const auto hash_slot = partReplica(part_name, active_original_indexes.size());
             const auto original_index = active_original_indexes[hash_slot];
             if (original_index == local_original_index)
@@ -623,7 +632,7 @@ private:
                 continue;
 
             ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisScheduledReplicas);
-            auto [scalars, query] = buildAnalyzeIndexQuery(storage_id, filter_query, vector_search_parameters, remote_parts[i]);
+            auto [scalars, query] = buildAnalyzeIndexQuery(storage_id, filter_query, projection_name, vector_search_parameters, remote_parts[i]);
             auto executor = std::make_shared<RemoteQueryExecutor>(*connection, query, sample_block, execution_context, ThrottlerPtr{}, scalars, external_tables);
             executor->setLogger(logger);
 
@@ -769,7 +778,7 @@ private:
                 {
                     LOG_TRACE(logger, "Sending {} parts ({} marks, {} rows) to {}: {}",
                         remote_parts[i].size(), remote_marks[i], remote_rows[i], replica_addresses[i], remote_parts[i]);
-                    auto parts_ranges = getIndexAnalysisFromReplicaSync(logger, storage_id, filter_query, vector_search_parameters, execution_context, external_tables, remote_parts[i], *connection);
+                    auto parts_ranges = getIndexAnalysisFromReplicaSync(logger, storage_id, filter_query, projection_name, vector_search_parameters, execution_context, external_tables, remote_parts[i], *connection);
                     LOG_TRACE(logger, "Received {} parts from {}: {}", parts_ranges.size(), replica_addresses[i], parts_ranges);
                     res[i].second = std::move(parts_ranges);
                 }
@@ -807,7 +816,7 @@ private:
         size_t missing_parts_rows = 0;
         for (const auto & part_ranges : parts_with_ranges)
         {
-            const auto & part_name = part_ranges.data_part->name;
+            const auto & part_name = part_ranges.getAnalysisPartName();
             if (resolved_parts.contains(part_name))
                 continue;
             missing_parts.push_back(part_name);
@@ -828,6 +837,7 @@ private:
 
     const StorageID & storage_id;
     const RangesInDataParts & parts_with_ranges;
+    const std::optional<String> projection_name;
     const OptionalVectorSearchParameters & vector_search_parameters;
     LocalIndexAnalysisCallback local_index_analysis_callback;
     ContextPtr context;
@@ -877,6 +887,7 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     ASTPtr sampling_filter,
     const NameSet & indexes_column_names,
     const RangesInDataParts & parts_with_ranges,
+    const std::optional<String> & projection_name,
     const OptionalVectorSearchParameters & vector_search_parameters,
     LocalIndexAnalysisCallback local_index_analysis_callback,
     ContextPtr context)
@@ -894,6 +905,7 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
         std::move(sampling_filter),
         indexes_column_names,
         parts_with_ranges,
+        projection_name,
         vector_search_parameters,
         std::move(local_index_analysis_callback),
         std::move(context_copy));

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -898,6 +898,12 @@ DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     /// Disable parallel replicas to avoid O(N^2) spawned queries when the predicate has a subquery,
     /// because each replica would independently spawn parallel replicas for the subquery.
     context_copy->setSetting("enable_parallel_replicas", false);
+    /// Read/result limits belong to the user's query and stay enforced on the initiator (the
+    /// runtime check of the reading); on the analyze queries they would only fire spuriously:
+    /// the rows estimate there covers a single replica subset, and the analysis output itself
+    /// is a query result.
+    for (const auto & setting : {"max_rows_to_read", "max_bytes_to_read", "max_rows_to_read_leaf", "max_bytes_to_read_leaf", "max_result_rows", "max_result_bytes"})
+        context_copy->setSetting(setting, Field(0));
 
     DistributedIndexAnalyzer analyzer(
         storage_id,

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.h
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.h
@@ -27,12 +27,17 @@ using LocalIndexAnalysisCallback = std::function<IndexAnalysisPartsRanges(const 
 /// in case of any failures the analysis will be done on local replica.
 ///
 /// For local replica uses LocalIndexAnalysisCallback (can be called multiple times).
+///
+/// When projection parts are analyzed, all parts must belong to the same projection
+/// (projection_name), and everywhere (parts_with_ranges, callback, result) the parts are
+/// identified by the parent part name.
 DistributedIndexAnalysisPartsRanges distributedIndexAnalysisOnReplicas(
     const StorageID & storage_id,
     const ActionsDAG * filter_actions_dag,
     ASTPtr sampling_filter,
     const NameSet & indexes_column_names,
     const RangesInDataParts & parts_with_ranges,
+    const std::optional<String> & projection_name,
     const OptionalVectorSearchParameters & vector_search_parameters,
     LocalIndexAnalysisCallback local_index_analysis_callback,
     ContextPtr context);

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3166,8 +3166,9 @@ static IndexAnalysisPartsRanges filterPartsNamesByPrimaryKeyAndSkipIndexes(Merge
     IndexAnalysisPartsRanges res;
     for (const auto & part_ranges : parts_ranges_res)
     {
-        const auto & part_name = part_ranges.data_part->name;
+        const auto & part_name = part_ranges.getAnalysisPartName();
         res[part_name].insert(res[part_name].end(), part_ranges.ranges.begin(), part_ranges.ranges.end());
+        processed_parts.insert(part_name);
     }
 
     /// Add empty parts back, to take it into account in "Parts send"
@@ -3411,10 +3412,6 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
         bool is_initial_query = context_->getClientInfo().query_kind == ClientInfo::QueryKind::INITIAL_QUERY;
 
         bool distributed_index_analysis_enabled = !final_second_pass
-            /// Projection parts are identified only by the projection name, which is identical in every
-            /// parent part, so per-part analysis results cannot be attributed back, and remote replicas
-            /// resolve part names against the parent table. Analyze projection parts locally.
-            && !projection_parts_exist
             && settings[Setting::distributed_index_analysis]
             && (settings[Setting::distributed_index_analysis_for_non_shared_merge_tree] || data.isSharedStorage())
             && (total_parts >= distributed_index_analysis_min_parts_to_activate)
@@ -3436,9 +3433,17 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
         }
         else
         {
+            /// A single analysis never mixes projections (or projection parts with parent parts).
+            std::optional<String> projection_name;
+            if (projection_parts_exist)
+            {
+                chassert(std::ranges::all_of(res_parts, [](const auto & part) { return part.data_part->isProjectionPart(); }));
+                projection_name = res_parts.front().data_part->name;
+            }
+
             std::unordered_map<std::string, const RangesInDataPart *> parts_ranges_map;
             for (const auto & part_ranges : res_parts)
-                parts_ranges_map[part_ranges.data_part->name] = &part_ranges;
+                parts_ranges_map[part_ranges.getAnalysisPartName()] = &part_ranges;
 
             LocalIndexAnalysisCallback local_index_analysis_callback = [&filter_context, &parts_ranges_map](const std::vector<std::string_view> & parts_to_analyze) -> IndexAnalysisPartsRanges
             {
@@ -3450,6 +3455,7 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
                 result.sampling.filter_function,
                 indexes_column_names,
                 res_parts,
+                projection_name,
                 vector_search_parameters,
                 local_index_analysis_callback,
                 context_);

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3147,6 +3147,25 @@ void ReadFromMergeTree::applyFilters(ActionDAGNodes added_filter_nodes)
     }
 }
 
+static MarkRanges intersectRanges(const MarkRanges & lhs, const MarkRanges & rhs)
+{
+    MarkRanges res;
+    const auto * l = lhs.begin();
+    const auto * r = rhs.begin();
+    while (l != lhs.end() && r != rhs.end())
+    {
+        size_t begin = std::max(l->begin, r->begin);
+        size_t end = std::min(l->end, r->end);
+        if (begin < end)
+            res.emplace_back(begin, end);
+        if (l->end < r->end)
+            ++l;
+        else
+            ++r;
+    }
+    return res;
+}
+
 using PartsRangesMap = std::unordered_map<std::string, const RangesInDataPart *>;
 /// Same as filterPartsByPrimaryKeyAndSkipIndexes(), but accept part names and parts map to transform parts names to parts
 /// Used for distributed index analysis
@@ -3433,9 +3452,34 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
         }
         else
         {
+            /// Filters over part offsets do not survive the trip to a remote replica (and the per-part
+            /// starting offsets there are numbered over the replica subset), so apply them upfront
+            /// via the regular per-part analysis under a no-op key condition (the offset conditions
+            /// are pure arithmetic over the granularity, the primary key index is not loaded); the
+            /// received ranges are then intersected with the ranges narrowed here.
+            if (indexes->part_offset_condition || indexes->total_offset_condition)
+            {
+                ActionsDAGWithInversionPushDown empty_predicate(nullptr, context_, /*boolean_context=*/ false);
+                KeyCondition no_key_condition(empty_predicate, context_, metadata_snapshot->getPrimaryKey(), /*single_point_=*/ false);
+                for (auto & part_ranges : res_parts)
+                {
+                    part_ranges.ranges = MergeTreeDataSelectExecutor::markRangesFromPKRange(
+                        part_ranges,
+                        metadata_snapshot,
+                        no_key_condition,
+                        indexes->part_offset_condition ? &indexes->part_offset_condition->generateForPart(part_ranges.data_part) : nullptr,
+                        indexes->total_offset_condition ? &indexes->total_offset_condition->generateForPart(part_ranges.data_part) : nullptr,
+                        /*exact_ranges=*/ nullptr,
+                        /*pk_to_minmax_slot=*/ nullptr,
+                        settings,
+                        log);
+                }
+                std::erase_if(res_parts, [](const auto & part_ranges) { return part_ranges.ranges.empty(); });
+            }
+
             /// A single analysis never mixes projections (or projection parts with parent parts).
             std::optional<String> projection_name;
-            if (projection_parts_exist)
+            if (projection_parts_exist && !res_parts.empty())
             {
                 chassert(std::ranges::all_of(res_parts, [](const auto & part) { return part.data_part->isProjectionPart(); }));
                 projection_name = res_parts.front().data_part->name;
@@ -3512,11 +3556,13 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
             for (const auto & [part_name, ranges] : analyzed_parts_ranges)
             {
                 auto part_range_info = *parts_ranges_map.at(part_name);
-                /// Note: part_range_info.ranges may have been split by Query Condition Cache,
-                /// so we cannot assert ranges.size() == 1 here.
                 chassert(part_range_info.exact_ranges.empty());
 
-                part_range_info.ranges = ranges;
+                /// A remote replica analyzes whole parts, so keep only what the local narrowing
+                /// (the query condition cache, the part offset conditions) already allowed.
+                part_range_info.ranges = intersectRanges(part_range_info.ranges, ranges);
+                if (part_range_info.ranges.empty())
+                    continue;
                 result_parts_ranges.push_back(part_range_info);
             }
 

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1955,8 +1955,9 @@ BoolMask MergeTreeDataSelectExecutor::checkOffsetConditionsInRange(
         left[0] = begin;
         right[0] = end;
 
-        left[1] = part->name;
-        right[1] = part->name;
+        /// The user-visible _part of a projection read resolves to the parent part name.
+        left[1] = part_with_ranges.getAnalysisPartName();
+        right[1] = left[1];
 
         result = result & part_offset_condition->checkInRange(2, left.data(), right.data(), part_offset_types, initial_mask);
     }

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1964,7 +1964,8 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
     const KeyOrder & key_order = key_condition.getKeyOrder();
     chassert(key_order.matchesPrefix(metadata_snapshot->getSortingKey().reverse_flags, primary_key.column_names.size()));
 
-    const auto index = part->getIndex();
+    /// The offset conditions are pure arithmetic over the granularity, they need no index.
+    const IMergeTreeDataPart::IndexPtr index = key_condition_useful ? part->getIndex() : nullptr;
     const bool use_sparse_pk_representation
         = settings[Setting::use_lightweight_primary_key_index_analysis];
 
@@ -1980,13 +1981,13 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
     /// index cannot distinguish may still contain rows the filter rejects. The exact-range invariant below
     /// therefore only holds when the index resolves the whole used prefix.
     /// Only consulted by the debug-only consistency check on the exact ranges.
-    [[maybe_unused]] const bool used_key_prefix_loaded_in_memory = used_key_prefix_size <= index->size();
+    [[maybe_unused]] const bool used_key_prefix_loaded_in_memory = !key_condition_useful || used_key_prefix_size <= index->size();
 
     /// Do not touch the part's minmax index unless some key column the filter uses has a partition-minmax
     /// bound to consume: `getMinMaxIndex` may lazy-load `minmax_*.idx` from disk, and a bound at a key
     /// position the filter never references cannot affect the analysis. The minmax index may also be
     /// absent or uninitialized (e.g. for projection parts); such a part has no usable bounds either.
-    const bool partition_bound_usable = pk_to_minmax_slot
+    const bool partition_bound_usable = key_condition_useful && pk_to_minmax_slot
         && std::any_of(pk_to_minmax_slot->begin(),
                        pk_to_minmax_slot->begin() + std::min(pk_to_minmax_slot->size(), used_key_prefix_size),
                        [](const auto & slot) { return slot.has_value(); });
@@ -2024,7 +2025,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
     DataTypes sparse_key_types;
     std::vector<UInt8> equal_boundaries_mask;
 
-    if (use_sparse_pk_representation)
+    if (key_condition_useful && use_sparse_pk_representation)
     {
         /// If earlier columns have high cardinality, then later columns may not be loaded
         const size_t num_index_columns_loaded = index->size();
@@ -2100,7 +2101,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
         /// for intermediate columns we never create `Range`, `FieldRef`, or `Field` in `KeyCondition`.
         equal_boundaries_mask.resize(num_used_prefix_key_columns_loaded_in_memory);
     }
-    else
+    else if (key_condition_useful)
     {
         num_analyzed_key_columns = key_condition.getNumKeyColumns();
         if (num_analyzed_key_columns > 0)

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <array>
 #include <optional>
 #include <DataTypes/DataTypeString.h>
 #include <Common/CurrentThread.h>
@@ -1923,6 +1924,54 @@ size_t MergeTreeDataSelectExecutor::minMarksForConcurrentRead(
     return std::max(marks, min_marks);
 }
 
+BoolMask MergeTreeDataSelectExecutor::checkOffsetConditionsInRange(
+    const RangesInDataPart & part_with_ranges,
+    const MarkRange & range,
+    const KeyCondition * part_offset_condition,
+    const KeyCondition * total_offset_condition,
+    BoolMask initial_mask)
+{
+    const auto & part = part_with_ranges.data_part;
+
+    auto begin = part->index_granularity->getMarkStartingRow(range.begin);
+    auto end = part->index_granularity->getMarkStartingRow(range.end) - 1;
+    if (begin > end)
+    {
+        /// Empty mark (final mark)
+        return {false, true};
+    }
+
+    /// For _part_offset and _part virtual columns
+    static const DataTypes part_offset_types
+        = {std::make_shared<DataTypeUInt64>(), std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())};
+
+    std::array<FieldRef, 2> left;
+    std::array<FieldRef, 2> right;
+
+    BoolMask result(true, false);
+
+    if (part_offset_condition)
+    {
+        left[0] = begin;
+        right[0] = end;
+
+        left[1] = part->name;
+        right[1] = part->name;
+
+        result = result & part_offset_condition->checkInRange(2, left.data(), right.data(), part_offset_types, initial_mask);
+    }
+
+    if (total_offset_condition)
+    {
+        left[0] = begin + part_with_ranges.part_starting_offset_in_query;
+        right[0] = end + part_with_ranges.part_starting_offset_in_query;
+
+        result = result & total_offset_condition->checkInRange(1, left.data(), right.data(), part_offset_types, initial_mask);
+    }
+
+    return result;
+}
+
 /// Calculates a set of mark ranges, that could possibly contain keys, required by condition.
 /// In other words, it removes subranges from whole range, that definitely could not contain required keys.
 /// If @exact_ranges is not null, fill it with ranges containing marks of fully matched records.
@@ -2172,12 +2221,6 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
         }
     }
 
-    /// For _part_offset and _part virtual columns
-    DataTypes part_offset_types
-        = {std::make_shared<DataTypeUInt64>(), std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())};
-    std::vector<FieldRef> part_offset_left(2);
-    std::vector<FieldRef> part_offset_right(2);
-
     auto check_in_range = [&](const MarkRange & range, BoolMask initial_mask = {})
     {
         auto check_key_condition = [&]() -> BoolMask
@@ -2285,52 +2328,20 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
             return key_condition.checkInRange(used_key_size, index_left.data(), index_right.data(), key_types, initial_mask, &index_bounds);
         };
 
-        auto check_part_offset_condition = [&]()
-        {
-            auto begin = part->index_granularity->getMarkStartingRow(range.begin);
-            auto end = part->index_granularity->getMarkStartingRow(range.end) - 1;
-            if (begin > end)
-            {
-                /// Empty mark (final mark)
-                return BoolMask(false, true);
-            }
-
-            part_offset_left[0] = begin;
-            part_offset_right[0] = end;
-
-            part_offset_left[1] = part->name;
-            part_offset_right[1] = part->name;
-
-            return part_offset_condition->checkInRange(
-                2, part_offset_left.data(), part_offset_right.data(), part_offset_types, initial_mask);
-        };
-
-        auto check_total_offset_condition = [&]()
-        {
-            auto begin = part->index_granularity->getMarkStartingRow(range.begin);
-            auto end = part->index_granularity->getMarkStartingRow(range.end) - 1;
-            if (begin > end)
-            {
-                /// Empty mark (final mark)
-                return BoolMask(false, true);
-            }
-
-            part_offset_left[0] = begin + part_with_ranges.part_starting_offset_in_query;
-            part_offset_right[0] = end + part_with_ranges.part_starting_offset_in_query;
-            return total_offset_condition->checkInRange(
-                1, part_offset_left.data(), part_offset_right.data(), part_offset_types, initial_mask);
-        };
-
         BoolMask result(true, false);
 
         if (key_condition_useful)
             result = result & check_key_condition();
 
-        if (part_offset_condition_useful)
-            result = result & check_part_offset_condition();
-
-        if (total_offset_condition_useful)
-            result = result & check_total_offset_condition();
+        if (part_offset_condition_useful || total_offset_condition_useful)
+        {
+            result = result & checkOffsetConditionsInRange(
+                part_with_ranges,
+                range,
+                part_offset_condition_useful ? part_offset_condition : nullptr,
+                total_offset_condition_useful ? total_offset_condition : nullptr,
+                initial_mask);
+        }
 
         return result;
     };

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -96,6 +96,15 @@ public:
         const Settings & settings,
         LoggerPtr log);
 
+    /// Whether the conditions over part offsets can be true / false for the rows of the mark range.
+    /// Pure arithmetic over the index granularity and the query-wide part numbering.
+    static BoolMask checkOffsetConditionsInRange(
+        const RangesInDataPart & part_with_ranges,
+        const MarkRange & range,
+        const KeyCondition * part_offset_condition,
+        const KeyCondition * total_offset_condition,
+        BoolMask initial_mask = {});
+
     static std::pair<MarkRanges, RangesInDataPartReadHints> filterMarksUsingIndex(
         MergeTreeIndexPtr index_helper,
         MergeTreeIndexConditionPtr condition,

--- a/src/Storages/MergeTree/RangesInDataPart.cpp
+++ b/src/Storages/MergeTree/RangesInDataPart.cpp
@@ -141,6 +141,12 @@ RangesInDataPartDescription RangesInDataPart::getDescription() const
     };
 }
 
+const String & RangesInDataPart::getAnalysisPartName() const
+{
+    chassert(!data_part->isProjectionPart() || parent_part);
+    return data_part->isProjectionPart() ? parent_part->name : data_part->name;
+}
+
 size_t RangesInDataPart::getMarksCount() const
 {
     return ranges.getNumberOfMarks();

--- a/src/Storages/MergeTree/RangesInDataPart.h
+++ b/src/Storages/MergeTree/RangesInDataPart.h
@@ -138,6 +138,10 @@ struct RangesInDataPart
 
     RangesInDataPartDescription getDescription() const;
 
+    /// Part identity for index analysis: a projection part is identified by its parent part name,
+    /// since all projection parts of one projection share the same name.
+    const String & getAnalysisPartName() const;
+
     size_t getMarksCount() const;
     size_t getRowsCount() const;
 };

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -358,14 +358,17 @@ StorageMergeTreeAnalyzeIndexes::StorageMergeTreeAnalyzeIndexes(
         {
             const auto & created_projections = parent_part->getProjectionParts();
             auto it = created_projections.find(projection_name);
-            if (it == created_projections.end() || it->second->is_broken)
-                continue;
-            analysis_parts.emplace_back(
-                /*data_part*/ it->second,
-                /*parent_part*/ parent_part,
-                /*part_index_in_query*/ analysis_parts.size(),
-                /*part_starting_offset_in_query*/ starting_offset);
-            starting_offset += it->second->rows_count;
+            if (it != created_projections.end() && !it->second->is_broken)
+            {
+                analysis_parts.emplace_back(
+                    /*data_part*/ it->second,
+                    /*parent_part*/ parent_part,
+                    /*part_index_in_query*/ analysis_parts.size(),
+                    /*part_starting_offset_in_query*/ starting_offset);
+            }
+            /// Projection reads keep the parent numbering, so must the analysis
+            /// (the projection may not preserve the row count of the parent).
+            starting_offset += parent_part->rows_count;
         }
     }
 

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -48,8 +48,7 @@ public:
         StorageMetadataPtr metadata_snapshot_,
         const SelectQueryInfo & query_info_,
         size_t num_streams_,
-        MergeTreeData::DataPartsVector data_parts_,
-        MergeTreeData::DataPartsVector projection_parts_,
+        RangesInDataParts analysis_parts_,
         String projection_name_,
         MergeTreeSettingsPtr table_settings_,
         const ASTPtr & predicate_,
@@ -65,8 +64,7 @@ public:
         , num_streams(num_streams_)
         , predicate(predicate_)
         , vector_search_parameters(vector_search_parameters_)
-        , data_parts(std::move(data_parts_))
-        , projection_parts(std::move(projection_parts_))
+        , analysis_parts(std::move(analysis_parts_))
         , projection_name(std::move(projection_name_))
         , table_settings(std::move(table_settings_))
     {
@@ -80,7 +78,7 @@ protected:
         if (std::exchange(analyzed, true))
             return {};
 
-        if (data_parts.empty())
+        if (analysis_parts.empty())
             return {};
 
         auto component_guard = Coordination::setCurrentComponent("MergeTreeAnalyzeIndexSource::generate");
@@ -110,15 +108,16 @@ protected:
         }
 
         /// Add existing parts, but filtered out into the result.
-        for (const auto & part : data_parts)
+        for (const auto & part : analysis_parts)
         {
-            if (processed_parts.contains(part->name))
+            const auto & part_name = part.getAnalysisPartName();
+            if (processed_parts.contains(part_name))
                 continue;
 
             size_t src_index = 0;
             size_t res_index = 0;
             if (columns_mask[src_index++])
-                res_columns[res_index++]->insert(part->name);
+                res_columns[res_index++]->insert(part_name);
             if (columns_mask[src_index++])
                 res_columns[res_index++]->insertDefault();
         }
@@ -191,26 +190,6 @@ protected:
             filter_dag.emplace(std::move(actions));
         }
 
-        RangesInDataParts parts_ranges;
-        if (projection_name.empty())
-        {
-            parts_ranges = RangesInDataParts{data_parts};
-        }
-        else
-        {
-            parts_ranges.reserve(data_parts.size());
-            size_t starting_offset = 0;
-            for (size_t i = 0; i < data_parts.size(); ++i)
-            {
-                parts_ranges.emplace_back(
-                    /*part*/ projection_parts[i],
-                    /*parent_part*/ data_parts[i],
-                    /*part_index_in_query*/ i,
-                    /*part_starting_offset_in_query*/ starting_offset);
-                starting_offset += projection_parts[i]->rows_count;
-            }
-        }
-
         const StorageSnapshotPtr storage_snapshot = storage->getStorageSnapshot(metadata_snapshot, context);
         const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
 
@@ -224,7 +203,7 @@ protected:
             indexes,
             filter_dag ? &filter_dag.value() : nullptr,
             *merge_tree_data,
-            parts_ranges,
+            analysis_parts,
             vector_search_parameters,
             /*top_k_filter_info=*/ std::nullopt,
             context,
@@ -253,7 +232,7 @@ protected:
             .check_row_limits = true,
             .result = analysis_result,
         };
-        return MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipIndexes(filter_context, parts_ranges, analysis_result.index_stats);
+        return MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipIndexes(filter_context, analysis_parts, analysis_result.index_stats);
     }
 
 private:
@@ -265,8 +244,7 @@ private:
     size_t num_streams;
     ASTPtr predicate;
     OptionalVectorSearchParameters vector_search_parameters;
-    MergeTreeData::DataPartsVector data_parts;
-    MergeTreeData::DataPartsVector projection_parts;
+    RangesInDataParts analysis_parts;
     String projection_name;
     MergeTreeSettingsPtr table_settings;
 
@@ -314,7 +292,7 @@ private:
 void ReadFromMergeTreeAnalyzeIndexes::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
     LOG_DEBUG(log, "Analyzing index from {} parts of table {}",
-        storage->data_parts.size(),
+        storage->analysis_parts.size(),
         storage->source_table->getStorageID().getNameForLogs());
 
     pipeline.init(Pipe(std::make_shared<MergeTreeAnalyzeIndexSource>(
@@ -324,8 +302,7 @@ void ReadFromMergeTreeAnalyzeIndexes::initializePipeline(QueryPipelineBuilder & 
         storage->source_metadata_snapshot,
         getQueryInfo(),
         num_streams,
-        storage->data_parts,
-        storage->projection_parts,
+        storage->analysis_parts,
         storage->projection_name,
         storage->table_settings,
         storage->predicate,
@@ -357,7 +334,7 @@ StorageMergeTreeAnalyzeIndexes::StorageMergeTreeAnalyzeIndexes(
     if (!merge_tree_data)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage MergeTreeAnalyzeIndexes expected MergeTree table, got: {}", source_table->getName());
 
-    data_parts = merge_tree_data->getDataPartsVectorForInternalUsage();
+    auto data_parts = merge_tree_data->getDataPartsVectorForInternalUsage();
     std::erase_if(data_parts, [](const MergeTreeData::DataPartPtr & part) { return part->isEmpty(); });
     if (!parts_.empty())
     {
@@ -365,25 +342,31 @@ StorageMergeTreeAnalyzeIndexes::StorageMergeTreeAnalyzeIndexes(
         std::erase_if(data_parts, [&](const MergeTreeData::DataPartPtr & part) { return !parts_set.contains(part->name); });
     }
 
-    if (!projection_name.empty())
+    if (projection_name.empty())
+    {
+        analysis_parts = RangesInDataParts{data_parts};
+    }
+    else
     {
         if (!source_metadata_snapshot->projections.has(projection_name))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "There is no projection {} in table {}",
                 projection_name, source_table->getStorageID().getNameForLogs());
 
-        MergeTreeData::DataPartsVector parent_parts;
-        parent_parts.reserve(data_parts.size());
-        projection_parts.reserve(data_parts.size());
+        analysis_parts.reserve(data_parts.size());
+        size_t starting_offset = 0;
         for (const auto & parent_part : data_parts)
         {
             const auto & created_projections = parent_part->getProjectionParts();
             auto it = created_projections.find(projection_name);
             if (it == created_projections.end() || it->second->is_broken)
                 continue;
-            parent_parts.push_back(parent_part);
-            projection_parts.push_back(it->second);
+            analysis_parts.emplace_back(
+                /*data_part*/ it->second,
+                /*parent_part*/ parent_part,
+                /*part_index_in_query*/ analysis_parts.size(),
+                /*part_starting_offset_in_query*/ starting_offset);
+            starting_offset += it->second->rows_count;
         }
-        data_parts = std::move(parent_parts);
     }
 
     table_settings = merge_tree_data->getSettings();

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -45,9 +45,12 @@ public:
         SharedHeader header_,
         std::vector<UInt8> columns_mask_,
         const StoragePtr & storage_,
+        StorageMetadataPtr metadata_snapshot_,
         const SelectQueryInfo & query_info_,
         size_t num_streams_,
         MergeTreeData::DataPartsVector data_parts_,
+        MergeTreeData::DataPartsVector projection_parts_,
+        String projection_name_,
         MergeTreeSettingsPtr table_settings_,
         const ASTPtr & predicate_,
         const OptionalVectorSearchParameters & vector_search_parameters_,
@@ -57,11 +60,14 @@ public:
         , header(std::move(header_))
         , columns_mask(std::move(columns_mask_))
         , storage(storage_)
+        , metadata_snapshot(std::move(metadata_snapshot_))
         , query_info(query_info_)
         , num_streams(num_streams_)
         , predicate(predicate_)
         , vector_search_parameters(vector_search_parameters_)
         , data_parts(std::move(data_parts_))
+        , projection_parts(std::move(projection_parts_))
+        , projection_name(std::move(projection_name_))
         , table_settings(std::move(table_settings_))
     {
     }
@@ -89,7 +95,7 @@ protected:
             size_t src_index = 0;
             size_t res_index = 0;
             if (columns_mask[src_index++])
-                res_columns[res_index++]->insert(ranges_in_part.data_part->name);
+                res_columns[res_index++]->insert(ranges_in_part.getAnalysisPartName());
 
             /// ranges
             if (columns_mask[src_index++])
@@ -100,7 +106,7 @@ protected:
                 res_columns[res_index++]->insert(std::move(field));
             }
 
-            processed_parts.insert(ranges_in_part.data_part->name);
+            processed_parts.insert(ranges_in_part.getAnalysisPartName());
         }
 
         /// Add existing parts, but filtered out into the result.
@@ -127,10 +133,15 @@ protected:
 
         auto reader_settings = MergeTreeReaderSettings::createForQuery(context, *table_settings, query_info);
 
-        const auto metadata_snapshot = storage->getInMemoryMetadataPtr(context, false);
         const auto * merge_tree_data = dynamic_cast<const MergeTreeData *>(storage.get());
         if (!merge_tree_data)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage MergeTreeAnalyzeIndexes expected MergeTree table, got: {}", storage->getName());
+
+        /// Projection parts are analyzed with the projection's own metadata (columns, primary key,
+        /// skip indexes), the parent table provides only the parts and the settings.
+        StorageMetadataPtr analysis_metadata_snapshot = metadata_snapshot;
+        if (!projection_name.empty())
+            analysis_metadata_snapshot = metadata_snapshot->projections.get(projection_name).metadata;
 
         std::optional<ActionsDAG> filter_dag;
         if (predicate)
@@ -140,7 +151,7 @@ protected:
 
             auto expression = buildQueryTree(predicate, execution_context);
 
-            auto dummy_storage = std::make_shared<StorageDummy>(StorageID{"dummy", "dummy"}, metadata_snapshot->getColumns());
+            auto dummy_storage = std::make_shared<StorageDummy>(StorageID{"dummy", "dummy"}, analysis_metadata_snapshot->getColumns());
             auto fake_table_expression = std::make_shared<TableNode>(dummy_storage, execution_context);
 
             QueryAnalyzer analyzer(false);
@@ -180,10 +191,33 @@ protected:
             filter_dag.emplace(std::move(actions));
         }
 
-        const auto & parts_ranges = RangesInDataParts{data_parts};
+        RangesInDataParts parts_ranges;
+        if (projection_name.empty())
+        {
+            parts_ranges = RangesInDataParts{data_parts};
+        }
+        else
+        {
+            parts_ranges.reserve(data_parts.size());
+            size_t starting_offset = 0;
+            for (size_t i = 0; i < data_parts.size(); ++i)
+            {
+                parts_ranges.emplace_back(
+                    /*part*/ projection_parts[i],
+                    /*parent_part*/ data_parts[i],
+                    /*part_index_in_query*/ i,
+                    /*part_starting_offset_in_query*/ starting_offset);
+                starting_offset += projection_parts[i]->rows_count;
+            }
+        }
 
         const StorageSnapshotPtr storage_snapshot = storage->getStorageSnapshot(metadata_snapshot, context);
         const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
+
+        /// The initiator analyzes projection parts with an empty mutations snapshot, do the same.
+        auto mutations_snapshot = snapshot_data.mutations_snapshot;
+        if (!projection_name.empty())
+            mutations_snapshot = mutations_snapshot->cloneEmpty();
 
         std::optional<ReadFromMergeTree::Indexes> indexes;
         ReadFromMergeTree::buildIndexes(
@@ -195,7 +229,7 @@ protected:
             /*top_k_filter_info=*/ std::nullopt,
             context,
             query_info,
-            metadata_snapshot);
+            analysis_metadata_snapshot);
 
         /// TODO: we may also want to support query condition cache here as well
 
@@ -204,8 +238,8 @@ protected:
         indexes->use_skip_indexes_if_final_exact_mode = false; /// not supported in distributed index analysis
         MergeTreeDataSelectExecutor::IndexAnalysisContext filter_context
         {
-            .metadata_snapshot = metadata_snapshot,
-            .mutations_snapshot = snapshot_data.mutations_snapshot,
+            .metadata_snapshot = analysis_metadata_snapshot,
+            .mutations_snapshot = mutations_snapshot,
             .query_info = query_info,
             .context = context,
             .indexes = *indexes,
@@ -226,11 +260,14 @@ private:
     SharedHeader header;
     std::vector<UInt8> columns_mask;
     const StoragePtr storage;
+    StorageMetadataPtr metadata_snapshot;
     SelectQueryInfo query_info;
     size_t num_streams;
     ASTPtr predicate;
     OptionalVectorSearchParameters vector_search_parameters;
     MergeTreeData::DataPartsVector data_parts;
+    MergeTreeData::DataPartsVector projection_parts;
+    String projection_name;
     MergeTreeSettingsPtr table_settings;
 
     bool analyzed = false;
@@ -284,9 +321,12 @@ void ReadFromMergeTreeAnalyzeIndexes::initializePipeline(QueryPipelineBuilder & 
         getOutputHeader(),
         columns_mask,
         storage->source_table,
+        storage->source_metadata_snapshot,
         getQueryInfo(),
         num_streams,
         storage->data_parts,
+        storage->projection_parts,
+        storage->projection_name,
         storage->table_settings,
         storage->predicate,
         storage->vector_search_parameters,
@@ -302,10 +342,14 @@ StorageMergeTreeAnalyzeIndexes::StorageMergeTreeAnalyzeIndexes(
     const StoragePtr & source_table_,
     const ColumnsDescription & columns,
     std::vector<String> parts_,
+    String projection_name_,
     const ASTPtr & predicate_,
-    const OptionalVectorSearchParameters & vector_search_parameters_)
+    const OptionalVectorSearchParameters & vector_search_parameters_,
+    ContextPtr context)
     : StorageWithCommonVirtualColumns(table_id_)
     , source_table(source_table_)
+    , source_metadata_snapshot(source_table->getInMemoryMetadataPtr(context, false))
+    , projection_name(std::move(projection_name_))
     , predicate(predicate_)
     , vector_search_parameters(vector_search_parameters_)
 {
@@ -319,6 +363,27 @@ StorageMergeTreeAnalyzeIndexes::StorageMergeTreeAnalyzeIndexes(
     {
         std::unordered_set<String> parts_set(std::make_move_iterator(parts_.begin()), std::make_move_iterator(parts_.end()));
         std::erase_if(data_parts, [&](const MergeTreeData::DataPartPtr & part) { return !parts_set.contains(part->name); });
+    }
+
+    if (!projection_name.empty())
+    {
+        if (!source_metadata_snapshot->projections.has(projection_name))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "There is no projection {} in table {}",
+                projection_name, source_table->getStorageID().getNameForLogs());
+
+        MergeTreeData::DataPartsVector parent_parts;
+        parent_parts.reserve(data_parts.size());
+        projection_parts.reserve(data_parts.size());
+        for (const auto & parent_part : data_parts)
+        {
+            const auto & created_projections = parent_part->getProjectionParts();
+            auto it = created_projections.find(projection_name);
+            if (it == created_projections.end() || it->second->is_broken)
+                continue;
+            parent_parts.push_back(parent_part);
+            projection_parts.push_back(it->second);
+        }
+        data_parts = std::move(parent_parts);
     }
 
     table_settings = merge_tree_data->getSettings();

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.h
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.h
@@ -40,11 +40,11 @@ private:
 
     StoragePtr source_table;
     StorageMetadataHandle source_metadata_snapshot;
-    MergeTreeData::DataPartsVector data_parts;
-    /// Parallel to data_parts when projection_name is set; data_parts then keeps the parent
-    /// parts (their names identify the projection parts in the result), and parents without
-    /// a usable projection part are dropped so that the initiator analyzes them itself.
-    MergeTreeData::DataPartsVector projection_parts;
+    /// The parts to analyze, with their full ranges. For a projection each entry holds the
+    /// projection part with its parent (whose name identifies the part in the result), and
+    /// parents without a usable projection part are dropped so that the initiator analyzes
+    /// them itself.
+    RangesInDataParts analysis_parts;
     String projection_name;
     MergeTreeSettingsPtr table_settings;
     ASTPtr predicate;

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.h
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.h
@@ -16,8 +16,10 @@ public:
         const StoragePtr & source_table_,
         const ColumnsDescription & columns,
         std::vector<String> parts_,
+        String projection_name_,
         const ASTPtr & primary_key_predicate_,
-        const OptionalVectorSearchParameters & vector_search_parameters_);
+        const OptionalVectorSearchParameters & vector_search_parameters_,
+        ContextPtr context);
 
     void readImpl(
         QueryPlan & query_plan,
@@ -37,7 +39,13 @@ private:
     friend class ReadFromMergeTreeAnalyzeIndexes;
 
     StoragePtr source_table;
+    StorageMetadataHandle source_metadata_snapshot;
     MergeTreeData::DataPartsVector data_parts;
+    /// Parallel to data_parts when projection_name is set; data_parts then keeps the parent
+    /// parts (their names identify the projection parts in the result), and parents without
+    /// a usable projection part are dropped so that the initiator analyzes them itself.
+    MergeTreeData::DataPartsVector projection_parts;
+    String projection_name;
     MergeTreeSettingsPtr table_settings;
     ASTPtr predicate;
     OptionalVectorSearchParameters vector_search_parameters;

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -109,6 +109,8 @@ private:
 
     void parseArgumentsUUID(const ASTs & args_func, ContextPtr context);
     void parseArgumentsDatabaseTable(const ASTs & args_func, ContextPtr context);
+    /// Parses the arguments after the table identity: condition, parts_array, projection, optimizations.
+    void parseTrailingArguments(ASTs & args, ContextPtr context, size_t condition_index);
 
     /// 2 features will benefit from distributed index load + analysis:
     /// a) vector search with large vector indexes
@@ -156,29 +158,7 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsUUID(const ASTs & args_
     args[0] = evaluateConstantExpressionAsLiteral(args[0], context);
     auto uuid = parseFromString<UUID>(checkAndGetLiteralArgument<String>(args[0], "UUID"));
 
-    if (args.size() > 1)
-        predicate = args[1]->clone();
-
-    if (args.size() > 2)
-        parts = extractParts(args[2], context);
-
-    /// The projection argument is recognized by argument count alone (4 - projection,
-    /// 5 - optimization pair, 6 - both), and servers unaware of it reject counts 4 and 6,
-    /// which keeps mixed-version distributed index analysis fail-closed.
-    size_t optimization_index = 3;
-    if (args.size() == 4 || args.size() == 6)
-    {
-        args[3] = evaluateConstantExpressionAsLiteral(args[3], context);
-        projection_name = checkAndGetLiteralArgument<String>(args[3], "projection");
-        optimization_index = 4;
-    }
-
-    if (args.size() > optimization_index)
-    {
-        if (args.size() != optimization_index + 2)
-            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Not enough arguments: no args_array for optimization");
-        parseArgumentsForOptimizations(args, context, optimization_index);
-    }
+    parseTrailingArguments(args, context, /*condition_index=*/ 1);
 
     source_table_id = StorageID{/*database=*/ "", /*table=*/ "", uuid};
 }
@@ -196,21 +176,29 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsDatabaseTable(const AST
     args[1] = evaluateConstantExpressionOrIdentifierAsLiteral(args[1], context);
     auto table = checkAndGetLiteralArgument<String>(args[1], "table");
 
-    if (args.size() > 2)
-        predicate = args[2]->clone();
+    parseTrailingArguments(args, context, /*condition_index=*/ 2);
 
-    if (args.size() > 3)
-        parts = extractParts(args[3], context);
+    source_table_id = StorageID{database, table};
+}
 
-    /// The projection argument is recognized by argument count alone (5 - projection,
-    /// 6 - optimization pair, 7 - both), and servers unaware of it reject counts 5 and 7,
-    /// which keeps mixed-version distributed index analysis fail-closed.
-    size_t optimization_index = 4;
-    if (args.size() == 5 || args.size() == 7)
+void TableFunctionMergeTreeAnalyzeIndexes::parseTrailingArguments(ASTs & args, ContextPtr context, size_t condition_index)
+{
+    if (args.size() > condition_index)
+        predicate = args[condition_index]->clone();
+
+    size_t parts_index = condition_index + 1;
+    if (args.size() > parts_index)
+        parts = extractParts(args[parts_index], context);
+
+    /// The projection argument is recognized by argument count alone (either it is the last
+    /// argument, or the optimization pair follows it), and servers unaware of it reject those
+    /// counts, which keeps mixed-version distributed index analysis fail-closed.
+    size_t optimization_index = parts_index + 1;
+    if (args.size() == optimization_index + 1 || args.size() == optimization_index + 3)
     {
-        args[4] = evaluateConstantExpressionAsLiteral(args[4], context);
-        projection_name = checkAndGetLiteralArgument<String>(args[4], "projection");
-        optimization_index = 5;
+        args[optimization_index] = evaluateConstantExpressionAsLiteral(args[optimization_index], context);
+        projection_name = checkAndGetLiteralArgument<String>(args[optimization_index], "projection");
+        ++optimization_index;
     }
 
     if (args.size() > optimization_index)
@@ -219,8 +207,6 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsDatabaseTable(const AST
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Not enough arguments: no args_array for optimization");
         parseArgumentsForOptimizations(args, context, optimization_index);
     }
-
-    source_table_id = StorageID{database, table};
 }
 
 void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsForOptimizations(const ASTs & args, ContextPtr context, size_t start_index)

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -119,6 +119,7 @@ private:
     const bool resolve_by_uuid;
     StorageID source_table_id{StorageID::createEmpty()};
     Strings parts;
+    String projection_name;
     ASTPtr predicate;
     OptionalVectorSearchParameters vector_search_parameters;
 };
@@ -148,9 +149,9 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsUUID(const ASTs & args_
 {
     ASTs & args = args_func.at(0)->children;
     /// clang-tidy suggest to use args.empty() over args.size() < 1, which looks wrong here, but OK, let's use empty()
-    if (args.empty() || args.size() > 5)
+    if (args.empty() || args.size() > 6)
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-            "Table function '{}' must have from 1 to 3 or 5 arguments (UUID, condition[, parts_array], [, optimization, args_array]), got: {}", getName(), args.size());
+            "Table function '{}' must have from 1 to 6 arguments (UUID[, condition[, parts_array[, projection]]][, optimization, args_array]), got: {}", getName(), args.size());
 
     args[0] = evaluateConstantExpressionAsLiteral(args[0], context);
     auto uuid = parseFromString<UUID>(checkAndGetLiteralArgument<String>(args[0], "UUID"));
@@ -161,11 +162,22 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsUUID(const ASTs & args_
     if (args.size() > 2)
         parts = extractParts(args[2], context);
 
-    if (args.size() > 3)
+    /// The projection argument is recognized by argument count alone (4 - projection,
+    /// 5 - optimization pair, 6 - both), and servers unaware of it reject counts 4 and 6,
+    /// which keeps mixed-version distributed index analysis fail-closed.
+    size_t optimization_index = 3;
+    if (args.size() == 4 || args.size() == 6)
     {
-        if (args.size() < 5)
+        args[3] = evaluateConstantExpressionAsLiteral(args[3], context);
+        projection_name = checkAndGetLiteralArgument<String>(args[3], "projection");
+        optimization_index = 4;
+    }
+
+    if (args.size() > optimization_index)
+    {
+        if (args.size() != optimization_index + 2)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Not enough arguments: no args_array for optimization");
-        parseArgumentsForOptimizations(args, context, 3);
+        parseArgumentsForOptimizations(args, context, optimization_index);
     }
 
     source_table_id = StorageID{/*database=*/ "", /*table=*/ "", uuid};
@@ -174,9 +186,9 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsUUID(const ASTs & args_
 void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsDatabaseTable(const ASTs & args_func, ContextPtr context)
 {
     ASTs & args = args_func.at(0)->children;
-    if (args.size() < 2 || args.size() > 6)
+    if (args.size() < 2 || args.size() > 7)
         throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
-            "Table function '{}' must have from 2 to 4 or 6 arguments (database, table, condition[, parts_array], [, optimization, args_array]), got: {}", getName(), args.size());
+            "Table function '{}' must have from 2 to 7 arguments (database, table[, condition[, parts_array[, projection]]][, optimization, args_array]), got: {}", getName(), args.size());
 
     args[0] = evaluateConstantExpressionForDatabaseName(args[0], context);
     auto database = checkAndGetLiteralArgument<String>(args[0], "database");
@@ -190,11 +202,22 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsDatabaseTable(const AST
     if (args.size() > 3)
         parts = extractParts(args[3], context);
 
-    if (args.size() > 4)
+    /// The projection argument is recognized by argument count alone (5 - projection,
+    /// 6 - optimization pair, 7 - both), and servers unaware of it reject counts 5 and 7,
+    /// which keeps mixed-version distributed index analysis fail-closed.
+    size_t optimization_index = 4;
+    if (args.size() == 5 || args.size() == 7)
     {
-        if (args.size() < 6)
+        args[4] = evaluateConstantExpressionAsLiteral(args[4], context);
+        projection_name = checkAndGetLiteralArgument<String>(args[4], "projection");
+        optimization_index = 5;
+    }
+
+    if (args.size() > optimization_index)
+    {
+        if (args.size() != optimization_index + 2)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Not enough arguments: no args_array for optimization");
-        parseArgumentsForOptimizations(args, context, 4);
+        parseArgumentsForOptimizations(args, context, optimization_index);
     }
 
     source_table_id = StorageID{database, table};
@@ -266,8 +289,10 @@ StoragePtr TableFunctionMergeTreeAnalyzeIndexes::executeImpl(
         std::move(source_table),
         std::move(columns),
         parts,
+        projection_name,
         predicate,
-        vector_search_parameters);
+        vector_search_parameters,
+        context);
     res->startup();
     return res;
 }
@@ -279,7 +304,7 @@ void registerTableFunctionMergeTreeAnalyzeIndexes(TableFunctionFactory & factory
         []() { return std::make_shared<TableFunctionMergeTreeAnalyzeIndexes>(/* resolve_by_uuid_= */ false); },
         {
             .description = "Internal function for index analysis",
-            .examples = {{"mergeTreeAnalyzeIndexes", "SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), mt_table, predicate[, ['part1', 'part2']])", ""}},
+            .examples = {{"mergeTreeAnalyzeIndexes", "SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), mt_table, predicate[, ['part1', 'part2'][, projection]])", ""}},
             .category = FunctionDocumentation::Category::TableFunction
         },
         {.allow_readonly = true}
@@ -289,7 +314,7 @@ void registerTableFunctionMergeTreeAnalyzeIndexes(TableFunctionFactory & factory
         []() { return std::make_shared<TableFunctionMergeTreeAnalyzeIndexes>(/* resolve_by_uuid_= */ true); },
         {
             .description = "Internal function for index analysis",
-            .examples = {{"mergeTreeAnalyzeIndexesUUID", "SELECT * FROM mergeTreeAnalyzeIndexesUUID('table_uuid', predicate[, ['part1', 'part2']])", ""}},
+            .examples = {{"mergeTreeAnalyzeIndexesUUID", "SELECT * FROM mergeTreeAnalyzeIndexesUUID('table_uuid', predicate[, ['part1', 'part2'][, projection]])", ""}},
             .category = FunctionDocumentation::Category::TableFunction
         },
         {.allow_readonly = true}

--- a/tests/queries/0_stateless/04891_distributed_index_analysis_projections.reference
+++ b/tests/queries/0_stateless/04891_distributed_index_analysis_projections.reference
@@ -9,6 +9,9 @@ select count(), sum(key) from test_dia_proj where value in (500000, 2500000) set
 2	3000000
 select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
 2	3000000
+-- The rows limit fits reading via the projection, but not a full scan (see the failing query above)
+select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1, max_rows_to_read=1000000;
+2	3000000
 distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas>0=0
 distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas>0=1
 distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, DistributedIndexAnalysisMissingParts=0, DistributedIndexAnalysisScheduledReplicas>0=0

--- a/tests/queries/0_stateless/04891_distributed_index_analysis_projections.sql
+++ b/tests/queries/0_stateless/04891_distributed_index_analysis_projections.sql
@@ -20,12 +20,17 @@ insert into test_dia_proj select number, number from numbers(0, 1000000);
 insert into test_dia_proj select number, number from numbers(1000000, 1000000);
 insert into test_dia_proj select number, number from numbers(2000000, 1000000);
 
+set allow_experimental_analyzer=1;
+set max_rows_to_read=0;
 set allow_experimental_parallel_reading_from_replicas=0;
 set cluster_for_parallel_replicas='';
 set max_parallel_replicas=100;
 set distributed_index_analysis_for_non_shared_merge_tree=1;
 -- Ranges cached by the first (correct) run would narrow the analysis of the second run
 set use_query_condition_cache=0;
+
+-- The rows limit fits reading via the projection (one granule per matching part), but not a full scan
+select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings max_rows_to_read=1000000, optimize_use_projections=0; -- { serverError TOO_MANY_ROWS }
 
 --- Ignore warnings when replica does not respond, and analysis is done on initiator
 set send_logs_level='error';
@@ -38,6 +43,9 @@ select count(), sum(key) from test_dia_proj where value >= 0 settings cluster_fo
 -- The filter matches one row in the first part and one row in the last part (the projection is selected for reading)
 select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings distributed_index_analysis=0;
 select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+
+-- The rows limit fits reading via the projection, but not a full scan (see the failing query above)
+select count(), sum(key) from test_dia_proj where value in (500000, 2500000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1, max_rows_to_read=1000000;
 
 -- { echoOff }
 system flush logs query_log;
@@ -56,6 +64,10 @@ where
   and query_kind = 'Select'
   and is_initial_query
   and has(Settings, 'distributed_index_analysis')
+  -- The limited query is excluded: replicas check the rows limit against their own subset of
+  -- parts, so whether some replica fails (and its parts are resolved on the initiator) depends
+  -- on the distribution of parts over replicas
+  and Settings['max_rows_to_read'] = '0'
   and endsWith(log_comment, '-' || currentDatabase())
 order by event_time_microseconds;
 

--- a/tests/queries/0_stateless/04892_mergetree_analyze_indexes_projection.reference
+++ b/tests/queries/0_stateless/04892_mergetree_analyze_indexes_projection.reference
@@ -1,0 +1,18 @@
+-- { echo }
+-- Projection parts are identified by the parent part name, ranges are pruned by the projection sorting key;
+-- the part that has no projection part is absent from the result
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_1_1_0', 'all_2_2_0', 'all_3_3_0'], 'prj_value') order by part_name;
+all_2_2_0	[(6,7)]
+all_3_3_0	[]
+-- Without the projection the table primary key cannot prune by value
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_2_2_0']) order by part_name;
+all_2_2_0	[(0,12)]
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_2_2_0'], 'no_such_projection'); -- { serverError BAD_ARGUMENTS }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_2_2_0'], 'prj_value', 'vector_search_index_analysis', [], 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+--- Ignore warnings when replica does not respond, and analysis is done on initiator
+set send_logs_level='error';
+-- The first matching row comes from the table (its part has no projection part), the other two are read via the projection
+select count(), sum(key) from test_mtai_proj where value in (50000, 150000, 250000) settings distributed_index_analysis=0;
+3	450000
+select count(), sum(key) from test_mtai_proj where value in (50000, 150000, 250000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+3	450000

--- a/tests/queries/0_stateless/04892_mergetree_analyze_indexes_projection.sql
+++ b/tests/queries/0_stateless/04892_mergetree_analyze_indexes_projection.sql
@@ -1,0 +1,37 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings
+-- - no-random-merge-tree-settings -- may change number of parts and granules
+
+drop table if exists test_mtai_proj;
+create table test_mtai_proj (key Int, value Int) engine=MergeTree() order by key
+settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+
+system stop merges test_mtai_proj;
+-- The first part is created before the projection is added, so it has no projection part
+insert into test_mtai_proj select number, number from numbers(0, 100000);
+alter table test_mtai_proj add projection prj_value (select key, value order by value);
+insert into test_mtai_proj select number, number from numbers(100000, 100000);
+insert into test_mtai_proj select number, number from numbers(200000, 100000);
+
+set allow_experimental_parallel_reading_from_replicas=0;
+set cluster_for_parallel_replicas='';
+set max_parallel_replicas=100;
+set distributed_index_analysis_for_non_shared_merge_tree=1;
+set use_query_condition_cache=0;
+
+-- { echo }
+-- Projection parts are identified by the parent part name, ranges are pruned by the projection sorting key;
+-- the part that has no projection part is absent from the result
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_1_1_0', 'all_2_2_0', 'all_3_3_0'], 'prj_value') order by part_name;
+-- Without the projection the table primary key cannot prune by value
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_2_2_0']) order by part_name;
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_2_2_0'], 'no_such_projection'); -- { serverError BAD_ARGUMENTS }
+select * from mergeTreeAnalyzeIndexes(currentDatabase(), test_mtai_proj, value = 150000, ['all_2_2_0'], 'prj_value', 'vector_search_index_analysis', [], 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+--- Ignore warnings when replica does not respond, and analysis is done on initiator
+set send_logs_level='error';
+-- The first matching row comes from the table (its part has no projection part), the other two are read via the projection
+select count(), sum(key) from test_mtai_proj where value in (50000, 150000, 250000) settings distributed_index_analysis=0;
+select count(), sum(key) from test_mtai_proj where value in (50000, 150000, 250000) settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+
+-- { echoOff }
+
+drop table test_mtai_proj;

--- a/tests/queries/0_stateless/04929_distributed_index_analysis_part_offset.reference
+++ b/tests/queries/0_stateless/04929_distributed_index_analysis_part_offset.reference
@@ -1,0 +1,43 @@
+-- { echo }
+-- Filters over part offsets are applied on the initiator (remote replicas cannot evaluate them),
+-- so the marks stay pruned under the distributed analysis - see `SelectedMarks` below, and the
+-- rows limit that does not fit a full scan
+select count(), sum(key) from test_dia_offset where _part_offset >= 90000 settings max_rows_to_read=60000, distributed_index_analysis=0;
+30000	5849985000
+select count(), sum(key) from test_dia_offset where _part_offset >= 90000 settings max_rows_to_read=60000, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+30000	5849985000
+select count(), sum(key) from test_dia_offset where _part_offset >= 90000 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+30000	5849985000
+select count(), sum(key) from test_dia_offset where _part_offset + _part_starting_offset >= 250000 settings max_rows_to_read=60000, distributed_index_analysis=0;
+50000	13749975000
+select count(), sum(key) from test_dia_offset where _part_offset + _part_starting_offset >= 250000 settings max_rows_to_read=60000, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+50000	13749975000
+select count(), sum(key) from test_dia_offset where _part_offset + _part_starting_offset >= 250000 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+50000	13749975000
+-- Control query, to prove that the check below can see the distributed analysis when it happens
+select count(), sum(key) from test_dia_offset where key >= 0 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+300000	44999850000
+-- { echo }
+-- Total offsets from a subquery: the set is applied on the initiator (`SelectedMarks` below
+-- cover both the inner and the outer reading)
+select count() from test_dia_offset_in where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_in where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, distributed_index_analysis=0;
+5
+select count() from test_dia_offset_in where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_in where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+5
+-- The same with a projection over `_part_offset`: the subquery reads it (3 marks of the total 8),
+-- the outer query still reads the table (the projection cannot serve the total offsets filter better)
+select count() from test_dia_offset_prj where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_prj where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, distributed_index_analysis=0;
+5
+select count() from test_dia_offset_prj where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_prj where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+5
+distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, SelectedMarks=6
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, SelectedMarks=6
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, SelectedMarks=6
+distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, SelectedMarks=6
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, SelectedMarks=6
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, SelectedMarks=6
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, SelectedMarks=36
+distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, SelectedMarks=41
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, SelectedMarks=41
+distributed_index_analysis=0, DistributedIndexAnalysisMicroseconds>0=0, SelectedMarks=8
+distributed_index_analysis=1, DistributedIndexAnalysisMicroseconds>0=1, SelectedMarks=8

--- a/tests/queries/0_stateless/04929_distributed_index_analysis_part_offset.sql
+++ b/tests/queries/0_stateless/04929_distributed_index_analysis_part_offset.sql
@@ -1,0 +1,84 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings
+-- - no-random-merge-tree-settings -- test relies on the number of rows per granule
+
+drop table if exists test_dia_offset;
+create table test_dia_offset (key Int) engine=MergeTree() order by key
+settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+
+system stop merges test_dia_offset;
+insert into test_dia_offset select number from numbers(0, 100000);
+insert into test_dia_offset select number from numbers(100000, 100000);
+insert into test_dia_offset select number from numbers(200000, 100000);
+
+set allow_experimental_parallel_reading_from_replicas=0;
+set cluster_for_parallel_replicas='';
+set max_parallel_replicas=100;
+set distributed_index_analysis_for_non_shared_merge_tree=1;
+set use_query_condition_cache=0;
+
+--- Ignore warnings when replica does not respond, and analysis is done on initiator
+set send_logs_level='error';
+
+-- { echo }
+-- Filters over part offsets are applied on the initiator (remote replicas cannot evaluate them),
+-- so the marks stay pruned under the distributed analysis - see `SelectedMarks` below, and the
+-- rows limit that does not fit a full scan
+select count(), sum(key) from test_dia_offset where _part_offset >= 90000 settings max_rows_to_read=60000, distributed_index_analysis=0;
+select count(), sum(key) from test_dia_offset where _part_offset >= 90000 settings max_rows_to_read=60000, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+select count(), sum(key) from test_dia_offset where _part_offset >= 90000 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+select count(), sum(key) from test_dia_offset where _part_offset + _part_starting_offset >= 250000 settings max_rows_to_read=60000, distributed_index_analysis=0;
+select count(), sum(key) from test_dia_offset where _part_offset + _part_starting_offset >= 250000 settings max_rows_to_read=60000, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+select count(), sum(key) from test_dia_offset where _part_offset + _part_starting_offset >= 250000 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+-- Control query, to prove that the check below can see the distributed analysis when it happens
+select count(), sum(key) from test_dia_offset where key >= 0 settings cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+
+-- { echoOff }
+
+drop table if exists test_dia_offset_in;
+create table test_dia_offset_in (user_id Int, val Int) engine=MergeTree() order by val
+settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+system stop merges test_dia_offset_in;
+insert into test_dia_offset_in select if(number in (11111, 22222), 42, number + 1000000), number from numbers(0, 100000);
+insert into test_dia_offset_in select if(number in (133333, 144444), 42, number + 1000000), number from numbers(100000, 100000);
+insert into test_dia_offset_in select if(number = 255555, 42, number + 1000000), number from numbers(200000, 100000);
+
+drop table if exists test_dia_offset_prj;
+create table test_dia_offset_prj (user_id Int, val Int, projection prj (select user_id, _part_offset order by user_id)) engine=MergeTree() order by val
+settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+system stop merges test_dia_offset_prj;
+insert into test_dia_offset_prj select if(number in (11111, 22222), 42, number + 1000000), number from numbers(0, 100000);
+insert into test_dia_offset_prj select if(number in (133333, 144444), 42, number + 1000000), number from numbers(100000, 100000);
+insert into test_dia_offset_prj select if(number = 255555, 42, number + 1000000), number from numbers(200000, 100000);
+
+-- { echo }
+-- Total offsets from a subquery: the set is applied on the initiator (`SelectedMarks` below
+-- cover both the inner and the outer reading)
+select count() from test_dia_offset_in where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_in where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, distributed_index_analysis=0;
+select count() from test_dia_offset_in where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_in where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+-- The same with a projection over `_part_offset`: the subquery reads it (3 marks of the total 8),
+-- the outer query still reads the table (the projection cannot serve the total offsets filter better)
+select count() from test_dia_offset_prj where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_prj where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, distributed_index_analysis=0;
+select count() from test_dia_offset_prj where _part_starting_offset + _part_offset in (select _part_starting_offset + _part_offset from test_dia_offset_prj where user_id = 42) settings enable_shared_storage_snapshot_in_query=1, cluster_for_parallel_replicas='parallel_replicas', distributed_index_analysis=1;
+
+-- { echoOff }
+system flush logs query_log;
+select format(
+  'distributed_index_analysis={}, DistributedIndexAnalysisMicroseconds>0={}, SelectedMarks={}',
+  Settings['distributed_index_analysis'],
+  ProfileEvents['DistributedIndexAnalysisMicroseconds'] > 0,
+  ProfileEvents['SelectedMarks']
+)
+from system.query_log
+where
+  current_database = currentDatabase()
+  and event_date >= yesterday() AND event_time >= now() - 600
+  and type = 'QueryFinish'
+  and query_kind = 'Select'
+  and is_initial_query
+  and has(Settings, 'distributed_index_analysis')
+  and endsWith(log_comment, '-' || currentDatabase())
+order by event_time_microseconds;
+
+drop table test_dia_offset;
+drop table test_dia_offset_in;
+drop table test_dia_offset_prj;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support projections in distributed index analysis

Identify projection parts by the parent part name (unique within one analysis - a single analysis never mixes projections) and pass the projection name to mergeTreeAnalyzeIndexes{,UUID}() as an optional positional argument after the parts array, so replicas analyze projection parts with the projection metadata.

Servers unaware of the argument reject the argument count and the initiator falls back to local analysis for them, keeping mixed-version clusters correct.

Replaces the quick fix that disabled the distributed path for projection parts (https://github.com/ClickHouse/ClickHouse/pull/115132)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115158&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115158](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115158+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
