### PR TITLE
Support the delayed set-building step when decorrelating a subquery

### DIFF
--- a/src/Planner/PlannerCorrelatedSubqueries.cpp
+++ b/src/Planner/PlannerCorrelatedSubqueries.cpp
@@ -33,6 +33,7 @@
 #include <Processors/QueryPlan/AggregatingStep.h>
 #include <Processors/QueryPlan/CommonSubplanReferenceStep.h>
 #include <Processors/QueryPlan/CommonSubplanStep.h>
+#include <Processors/QueryPlan/CreatingSetsStep.h>
 #include <Processors/QueryPlan/DistinctStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
@@ -390,6 +391,17 @@ QueryPlan decorrelateQueryPlan(
             filter_step->getExpression().tryRestoreColumn(column.name);
 
         node->step->updateInputHeader(input_header);
+
+        decorrelated_query_plan.addStep(std::move(node->step));
+        return decorrelated_query_plan;
+    }
+    if (typeid_cast<DelayedCreatingSetsStep *>(node->step.get()))
+    {
+        auto decorrelated_query_plan = decorrelateQueryPlan(context, node->children.front());
+
+        /// The step is a placeholder whose output header equals its input, and the sets it carries
+        /// cannot reference the correlated columns, so only the header has to be refreshed.
+        node->step->updateInputHeader(decorrelated_query_plan.getCurrentHeader());
 
         decorrelated_query_plan.addStep(std::move(node->step));
         return decorrelated_query_plan;

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
@@ -1,0 +1,63 @@
+-- dictGet comparison rewritten to an IN set inside a correlated EXISTS
+100
+100
+-- plain IN (SELECT ...) inside a correlated EXISTS
+100
+100
+-- partially matching IN set
+60
+60
+-- empty IN set
+0
+0
+-- per-row equality against the constant-set rewrite
+0
+-- Nullable key
+60
+60
+-- LowCardinality key
+20
+20
+-- LowCardinality(Nullable) key
+20
+20
+-- tuple key
+100
+100
+-- constant on the left of IN
+0
+0
+-- correlated scalar subquery
+51
+51
+-- NOT IN
+100
+100
+-- GLOBAL IN
+100
+-- correlated NOT EXISTS
+40
+40
+-- IN set in one arm of a UNION ALL body
+100
+100
+-- IN set beneath an aggregation
+51
+51
+-- two independent IN sets in one body
+100
+100
+-- two-level nested correlated subquery, IN set in the inner body
+100
+100
+-- a correlated set subquery is still rejected
+-- a materialized CTE body without an IN set is unaffected
+100
+-- unchanged with parallel replicas enabled
+100
+-- the set is built once, before the main query, and no delayed step survives
+1
+0
+-- the same query without a set subquery builds no set at all
+0
+0

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
@@ -55,13 +55,13 @@
 20
 20
 -- two-level nested correlated subquery, IN set in the inner body
-100
-100
+60
+60
 -- a correlated set subquery is still rejected
 -- an ordinary CTE body without an IN set is unaffected
 100
 -- unchanged when parallel replicas are requested
-100
+60
 -- the delayed step is expanded before execution and does not survive
 1
 0

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
@@ -4,11 +4,15 @@
 -- plain IN (SELECT ...) inside a correlated EXISTS
 100
 100
+20
+20
 -- partially matching IN set
 60
 60
--- empty IN set
+-- IN set with no matching value
 0
+0
+-- empty IN set
 0
 -- per-row equality against the constant-set rewrite
 0
@@ -22,8 +26,8 @@
 20
 20
 -- tuple key
-100
-100
+60
+60
 -- constant on the left of IN
 0
 0
@@ -31,10 +35,11 @@
 51
 51
 -- NOT IN
-100
-100
+80
+80
 -- GLOBAL IN
-100
+60
+60
 -- correlated NOT EXISTS
 40
 40
@@ -45,17 +50,17 @@
 51
 51
 -- two independent IN sets in one body
-100
-100
+20
+20
 -- two-level nested correlated subquery, IN set in the inner body
 100
 100
 -- a correlated set subquery is still rejected
--- a materialized CTE body without an IN set is unaffected
+-- an ordinary CTE body without an IN set is unaffected
 100
 -- unchanged with parallel replicas enabled
 100
--- the set is built once, before the main query, and no delayed step survives
+-- the delayed step is expanded before execution and does not survive
 1
 0
 -- the same query without a set subquery builds no set at all

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
@@ -45,9 +45,9 @@
 -- correlated NOT EXISTS
 40
 40
--- IN set in one arm of a UNION ALL body
-100
-100
+-- IN sets in both arms of a UNION ALL body
+80
+80
 -- IN set beneath an aggregation
 51
 51

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.reference
@@ -1,6 +1,8 @@
 -- dictGet comparison rewritten to an IN set inside a correlated EXISTS
 100
 100
+1
+0
 -- plain IN (SELECT ...) inside a correlated EXISTS
 100
 100
@@ -58,7 +60,7 @@
 -- a correlated set subquery is still rejected
 -- an ordinary CTE body without an IN set is unaffected
 100
--- unchanged with parallel replicas enabled
+-- unchanged when parallel replicas are requested
 100
 -- the delayed step is expanded before execution and does not survive
 1

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
@@ -39,6 +39,20 @@ SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i
     WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3)
 SETTINGS optimize_inverse_dictionary_lookup = 0;
+-- The rows above are equal either way, so they cannot witness the rewrite. These two assert that the
+-- rewrite is what plants the set: a set step exists only when the rewrite is enabled.
+SELECT count() > 0 FROM (
+    EXPLAIN SELECT count() FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i
+        WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3)
+    SETTINGS optimize_inverse_dictionary_lookup = 1
+) WHERE explain ILIKE '%CreatingSets%';
+SELECT count() FROM (
+    EXPLAIN SELECT count() FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i
+        WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3)
+    SETTINGS optimize_inverse_dictionary_lookup = 0
+) WHERE explain ILIKE '%CreatingSets%';
 
 SELECT '-- plain IN (SELECT ...) inside a correlated EXISTS';
 SELECT count() FROM t_main AS o WHERE EXISTS (
@@ -67,13 +81,16 @@ SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val > 200));
 
 SELECT '-- per-row equality against the constant-set rewrite';
+-- Each arm selects a strict subset of the outer rows, so a per-row divergence would surface as a
+-- non-zero symmetric difference. `join_use_nulls` is required: without it the unmatched side is
+-- filled with defaults and `IS NULL` never holds.
 SELECT count() FROM (
     SELECT o.k FROM t_main AS o WHERE EXISTS (
-        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (SELECT val FROM t_src WHERE val = 3))
 ) AS a
 FULL JOIN (
     SELECT o.k FROM t_main AS o WHERE EXISTS (
-        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6))
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3))
 ) AS b ON a.k = b.k
 WHERE a.k IS NULL OR b.k IS NULL
 SETTINGS join_use_nulls = 1;
@@ -154,12 +171,14 @@ SELECT count() FROM t_main AS o WHERE o.g >= (
     ) GROUP BY g);
 
 SELECT '-- two independent IN sets in one body';
+-- Both sets must narrow the result: dropping either one changes the count (80 without the g-set,
+-- 40 without the k-set), so neither conjunct is implied by `i.k < 8`.
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 8
-      AND i.g IN (SELECT val FROM t_src WHERE val = 3)
-      AND i.k IN (SELECT id FROM t_src WHERE id < 50));
+      AND i.g IN (SELECT val FROM t_src WHERE val IN (3, 4))
+      AND i.k IN (SELECT id FROM t_src WHERE id < 4));
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 8 AND i.g IN (3) AND i.k < 50);
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 8 AND i.g IN (3, 4) AND i.k < 4);
 
 SELECT '-- two-level nested correlated subquery, IN set in the inner body';
 SELECT count() FROM t_main AS o WHERE EXISTS (
@@ -177,7 +196,10 @@ SELECT '-- an ordinary CTE body without an IN set is unaffected';
 WITH c AS (SELECT k, g, s FROM t_main)
 SELECT count() FROM t_main AS o WHERE EXISTS (SELECT 1 FROM c AS i WHERE i.s = o.s);
 
-SELECT '-- unchanged with parallel replicas enabled';
+SELECT '-- unchanged when parallel replicas are requested';
+-- Parallel replicas are declined for this shape whatever is requested: the query-tree path disables
+-- them for any correlated query, and the plan-based path runs a plan carrying an unmaterialized set
+-- locally. So this asserts the request is harmless, not that replicas were used.
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3;

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
@@ -2,6 +2,8 @@ DROP TABLE IF EXISTS t_src;
 DROP TABLE IF EXISTS t_main;
 DROP DICTIONARY IF EXISTS d_src;
 
+SET enable_analyzer = 1;
+
 CREATE TABLE t_src (id UInt64, val UInt32) ENGINE = MergeTree ORDER BY id;
 INSERT INTO t_src SELECT number, number % 97 FROM numbers(500);
 
@@ -31,7 +33,8 @@ FROM numbers(100);
 SELECT '-- dictGet comparison rewritten to an IN set inside a correlated EXISTS';
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i
-    WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3);
+    WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3)
+SETTINGS optimize_inverse_dictionary_lookup = 1;
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i
     WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3)
@@ -42,6 +45,10 @@ SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6));
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 8 AND i.g IN (SELECT val FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 8 AND i.g IN (3));
 
 SELECT '-- partially matching IN set';
 SELECT count() FROM t_main AS o WHERE EXISTS (
@@ -49,11 +56,15 @@ SELECT count() FROM t_main AS o WHERE EXISTS (
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3));
 
-SELECT '-- empty IN set';
+SELECT '-- IN set with no matching value';
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val > 90));
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (91, 92, 93, 94, 95, 96));
+
+SELECT '-- empty IN set';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val > 200));
 
 SELECT '-- per-row equality against the constant-set rewrite';
 SELECT count() FROM (
@@ -64,7 +75,8 @@ FULL JOIN (
     SELECT o.k FROM t_main AS o WHERE EXISTS (
         SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6))
 ) AS b ON a.k = b.k
-WHERE a.k IS NULL OR b.k IS NULL;
+WHERE a.k IS NULL OR b.k IS NULL
+SETTINGS join_use_nulls = 1;
 
 SELECT '-- Nullable key';
 SELECT count() FROM t_main AS o WHERE EXISTS (
@@ -86,10 +98,10 @@ SELECT count() FROM t_main AS o WHERE EXISTS (
 
 SELECT '-- tuple key';
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND (i.g, i.k) IN (SELECT val, id FROM t_src WHERE id < 20));
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND (i.g, i.k) IN (SELECT val, id FROM t_src WHERE id < 3));
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND (i.g, i.k) IN (
-        SELECT number % 7, number FROM numbers(20)));
+        SELECT number, number FROM numbers(3)));
 
 SELECT '-- constant on the left of IN';
 SELECT count() FROM t_main AS o WHERE EXISTS (
@@ -105,13 +117,15 @@ SELECT count() FROM t_main AS o WHERE o.g >= (
 
 SELECT '-- NOT IN';
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g NOT IN (SELECT val FROM t_src WHERE val <= 2));
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 12 AND i.g NOT IN (SELECT val FROM t_src WHERE val <= 2));
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g NOT IN (0, 1, 2));
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 12 AND i.g NOT IN (0, 1, 2));
 
 SELECT '-- GLOBAL IN';
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g GLOBAL IN (SELECT val FROM t_src WHERE val <= 6));
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g GLOBAL IN (SELECT val FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3));
 
 SELECT '-- correlated NOT EXISTS';
 SELECT count() FROM t_main AS o WHERE NOT EXISTS (
@@ -141,11 +155,11 @@ SELECT count() FROM t_main AS o WHERE o.g >= (
 
 SELECT '-- two independent IN sets in one body';
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s
-      AND i.g IN (SELECT val FROM t_src WHERE val <= 6)
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 8
+      AND i.g IN (SELECT val FROM t_src WHERE val = 3)
       AND i.k IN (SELECT id FROM t_src WHERE id < 50));
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6) AND i.k < 50);
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 8 AND i.g IN (3) AND i.k < 50);
 
 SELECT '-- two-level nested correlated subquery, IN set in the inner body';
 SELECT count() FROM t_main AS o WHERE EXISTS (
@@ -159,7 +173,7 @@ SELECT '-- a correlated set subquery is still rejected';
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT g FROM t_main WHERE s = o.s)); -- { serverError NOT_IMPLEMENTED }
 
-SELECT '-- a materialized CTE body without an IN set is unaffected';
+SELECT '-- an ordinary CTE body without an IN set is unaffected';
 WITH c AS (SELECT k, g, s FROM t_main)
 SELECT count() FROM t_main AS o WHERE EXISTS (SELECT 1 FROM c AS i WHERE i.s = o.s);
 
@@ -168,7 +182,7 @@ SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3;
 
-SELECT '-- the set is built once, before the main query, and no delayed step survives';
+SELECT '-- the delayed step is expanded before execution and does not survive';
 SELECT count() > 0 FROM (
     EXPLAIN SELECT count() FROM t_main AS o WHERE EXISTS (
         SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
@@ -1,0 +1,193 @@
+DROP TABLE IF EXISTS t_src;
+DROP TABLE IF EXISTS t_main;
+DROP DICTIONARY IF EXISTS d_src;
+
+CREATE TABLE t_src (id UInt64, val UInt32) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_src SELECT number, number % 97 FROM numbers(500);
+
+CREATE DICTIONARY d_src (id UInt64, val UInt32 DEFAULT 0)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 't_src' DB currentDatabase()))
+LIFETIME(0)
+LAYOUT(FLAT());
+
+CREATE TABLE t_main (
+    k UInt32,
+    g Int32,
+    g_null Nullable(Int32),
+    g_lc LowCardinality(String),
+    g_lc_null LowCardinality(Nullable(String)),
+    s String
+) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_main SELECT
+    number,
+    number % 7,
+    if(number % 13 = 0, NULL, number % 7),
+    toString(number % 5),
+    if(number % 11 = 0, NULL, toString(number % 5)),
+    toString(number % 5)
+FROM numbers(100);
+
+SELECT '-- dictGet comparison rewritten to an IN set inside a correlated EXISTS';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i
+    WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3);
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i
+    WHERE i.s = o.s AND dictGet(currentDatabase() || '.d_src', 'val', toUInt64(i.k)) >= 3)
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT '-- plain IN (SELECT ...) inside a correlated EXISTS';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6));
+
+SELECT '-- partially matching IN set';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (SELECT val FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3));
+
+SELECT '-- empty IN set';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val > 90));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (91, 92, 93, 94, 95, 96));
+
+SELECT '-- per-row equality against the constant-set rewrite';
+SELECT count() FROM (
+    SELECT o.k FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
+) AS a
+FULL JOIN (
+    SELECT o.k FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6))
+) AS b ON a.k = b.k
+WHERE a.k IS NULL OR b.k IS NULL;
+
+SELECT '-- Nullable key';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g_null IN (SELECT val FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g_null IN (3));
+
+SELECT '-- LowCardinality key';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g_lc IN (SELECT toString(val) FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g_lc IN ('3'));
+
+SELECT '-- LowCardinality(Nullable) key';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g_lc_null IN (SELECT toString(val) FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g_lc_null IN ('3'));
+
+SELECT '-- tuple key';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND (i.g, i.k) IN (SELECT val, id FROM t_src WHERE id < 20));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND (i.g, i.k) IN (
+        SELECT number % 7, number FROM numbers(20)));
+
+SELECT '-- constant on the left of IN';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND 999 IN (SELECT val FROM t_src WHERE val <= 6));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND 999 IN (0, 1, 2, 3, 4, 5, 6));
+
+SELECT '-- correlated scalar subquery';
+SELECT count() FROM t_main AS o WHERE o.g >= (
+    SELECT count() FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (SELECT val FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE o.g >= (
+    SELECT count() FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3));
+
+SELECT '-- NOT IN';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g NOT IN (SELECT val FROM t_src WHERE val <= 2));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g NOT IN (0, 1, 2));
+
+SELECT '-- GLOBAL IN';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g GLOBAL IN (SELECT val FROM t_src WHERE val <= 6));
+
+SELECT '-- correlated NOT EXISTS';
+SELECT count() FROM t_main AS o WHERE NOT EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (SELECT val FROM t_src WHERE val = 3));
+SELECT count() FROM t_main AS o WHERE NOT EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3));
+
+SELECT '-- IN set in one arm of a UNION ALL body';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6)
+    UNION ALL
+    SELECT 1 FROM t_main AS j WHERE j.s = o.s AND j.g > 100);
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6)
+    UNION ALL
+    SELECT 1 FROM t_main AS j WHERE j.s = o.s AND j.g > 100);
+
+SELECT '-- IN set beneath an aggregation';
+SELECT count() FROM t_main AS o WHERE o.g >= (
+    SELECT count() FROM (
+        SELECT i.g FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (SELECT val FROM t_src WHERE val = 3)
+    ) GROUP BY g);
+SELECT count() FROM t_main AS o WHERE o.g >= (
+    SELECT count() FROM (
+        SELECT i.g FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3)
+    ) GROUP BY g);
+
+SELECT '-- two independent IN sets in one body';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s
+      AND i.g IN (SELECT val FROM t_src WHERE val <= 6)
+      AND i.k IN (SELECT id FROM t_src WHERE id < 50));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6) AND i.k < 50);
+
+SELECT '-- two-level nested correlated subquery, IN set in the inner body';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS m WHERE m.s = o.s AND EXISTS (
+        SELECT 1 FROM t_main AS n WHERE n.k = m.k AND n.g IN (SELECT val FROM t_src WHERE val <= 6)));
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS m WHERE m.s = o.s AND EXISTS (
+        SELECT 1 FROM t_main AS n WHERE n.k = m.k AND n.g IN (0, 1, 2, 3, 4, 5, 6)));
+
+SELECT '-- a correlated set subquery is still rejected';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT g FROM t_main WHERE s = o.s)); -- { serverError NOT_IMPLEMENTED }
+
+SELECT '-- a materialized CTE body without an IN set is unaffected';
+WITH c AS (SELECT k, g, s FROM t_main)
+SELECT count() FROM t_main AS o WHERE EXISTS (SELECT 1 FROM c AS i WHERE i.s = o.s);
+
+SELECT '-- unchanged with parallel replicas enabled';
+SELECT count() FROM t_main AS o WHERE EXISTS (
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3;
+
+SELECT '-- the set is built once, before the main query, and no delayed step survives';
+SELECT count() > 0 FROM (
+    EXPLAIN SELECT count() FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
+) WHERE explain ILIKE '%CreatingSets%';
+SELECT count() FROM (
+    EXPLAIN SELECT count() FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
+) WHERE explain ILIKE '%DelayedCreatingSets%';
+
+SELECT '-- the same query without a set subquery builds no set at all';
+SELECT count() > 0 FROM (
+    EXPLAIN SELECT count() FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6))
+) WHERE explain ILIKE '%CreatingSets%';
+SELECT count() FROM (
+    EXPLAIN SELECT count() FROM t_main AS o WHERE EXISTS (
+        SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6))
+) WHERE explain ILIKE '%DelayedCreatingSets%';
+
+DROP DICTIONARY d_src;
+DROP TABLE t_main;
+DROP TABLE t_src;

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
@@ -150,15 +150,15 @@ SELECT count() FROM t_main AS o WHERE NOT EXISTS (
 SELECT count() FROM t_main AS o WHERE NOT EXISTS (
     SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3));
 
-SELECT '-- IN set in one arm of a UNION ALL body';
+SELECT '-- IN sets in both arms of a UNION ALL body';
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6)
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (SELECT val FROM t_src WHERE val = 3)
     UNION ALL
-    SELECT 1 FROM t_main AS j WHERE j.s = o.s AND j.g > 100);
+    SELECT 1 FROM t_main AS j WHERE j.s = o.s AND j.k < 20 AND j.g IN (SELECT val FROM t_src WHERE val = 5));
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (0, 1, 2, 3, 4, 5, 6)
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (3)
     UNION ALL
-    SELECT 1 FROM t_main AS j WHERE j.s = o.s AND j.g > 100);
+    SELECT 1 FROM t_main AS j WHERE j.s = o.s AND j.k < 20 AND j.g IN (5));
 
 SELECT '-- IN set beneath an aggregation';
 SELECT count() FROM t_main AS o WHERE o.g >= (

--- a/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
+++ b/tests/queries/0_stateless/04917_correlated_subquery_with_in_set.sql
@@ -183,10 +183,10 @@ SELECT count() FROM t_main AS o WHERE EXISTS (
 SELECT '-- two-level nested correlated subquery, IN set in the inner body';
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS m WHERE m.s = o.s AND EXISTS (
-        SELECT 1 FROM t_main AS n WHERE n.k = m.k AND n.g IN (SELECT val FROM t_src WHERE val <= 6)));
+        SELECT 1 FROM t_main AS n WHERE n.k = m.k AND n.k < 20 AND n.g IN (SELECT val FROM t_src WHERE val = 3)));
 SELECT count() FROM t_main AS o WHERE EXISTS (
     SELECT 1 FROM t_main AS m WHERE m.s = o.s AND EXISTS (
-        SELECT 1 FROM t_main AS n WHERE n.k = m.k AND n.g IN (0, 1, 2, 3, 4, 5, 6)));
+        SELECT 1 FROM t_main AS n WHERE n.k = m.k AND n.k < 20 AND n.g IN (3)));
 
 SELECT '-- a correlated set subquery is still rejected';
 SELECT count() FROM t_main AS o WHERE EXISTS (
@@ -201,7 +201,7 @@ SELECT '-- unchanged when parallel replicas are requested';
 -- them for any correlated query, and the plan-based path runs a plan carrying an unmaterialized set
 -- locally. So this asserts the request is harmless, not that replicas were used.
 SELECT count() FROM t_main AS o WHERE EXISTS (
-    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.g IN (SELECT val FROM t_src WHERE val <= 6))
+    SELECT 1 FROM t_main AS i WHERE i.s = o.s AND i.k < 20 AND i.g IN (SELECT val FROM t_src WHERE val = 3))
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3;
 
 SELECT '-- the delayed step is expanded before execution and does not survive';


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/113182


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `NOT_IMPLEMENTED` error `Cannot decorrelate query, because 'DelayedCreatingSets' step is not supported` for a correlated subquery whose body contains an `IN (SELECT ...)` set. This included queries with no explicit `IN`, because `optimize_inverse_dictionary_lookup` (enabled by default) rewrites a `dictGet(...)` comparison into such a set.

### Description

A valid query failed to plan when a correlated subquery body contained an `IN` set.

```
Code: 48. DB::Exception: Cannot decorrelate query, because 'DelayedCreatingSets' step is not supported. (NOT_IMPLEMENTED)
```

**Root cause.** The correlated body is planned by a nested `Planner`, which appends a
`DelayedCreatingSetsStep` whenever the body used an `IN (subquery)` set. `decorrelateQueryPlan` has
one handler per step type and throws for anything else.

**The reported query is one spelling of it.** `optimize_inverse_dictionary_lookup` merely rewrites
`dictGet(...) >= c` into a set, planting the step. A hand-written `IN (SELECT ...)` reproduces it
with no dictionary, as do `GLOBAL IN`, `NOT IN`, correlated `NOT EXISTS` and the scalar form.
Guarding the pass would leave those failing, so the fix is in the decorrelator.

**The change** adds a handler for that step, mirroring the existing unary handlers: recurse into the
child, refresh the header, re-add the step. The step is a planning-time placeholder whose output
header equals its input, and a set reaching the decorrelator cannot reference the correlated columns,
since a correlated subquery on either side of `IN` is already rejected during analysis. So it stays
where the planner put it, and no set is rebuilt per outer row.

**Validation.** New stateless test, both directions confirmed on locally built binaries. Every
expected value comes from rewriting the query with an equivalent constant `IN`, never from the fixed
binary's own output; the plan is asserted with `EXPLAIN` plus a positive control, since an empty step
is optimized out and rows alone cannot witness it. 50 randomized runs pass, as do the
`--replicated-database` and `optimize_inverse_dictionary_lookup=0` arms.

Sibling issue #112030 is not covered: same producer, unrelated carrier, no decorrelator involvement.
If you want the test smaller, tell me which cases to keep and I will trim it.