### PR TITLE
Add a test for lazy materialization over a shadowed constant

### DIFF
--- a/tests/queries/0_stateless/04894_lazy_materialization_shadowed_constant.reference
+++ b/tests/queries/0_stateless/04894_lazy_materialization_shadowed_constant.reference
@@ -1,0 +1,7 @@
+constant item, folded conjunct
+constant expression item
+several constant items
+constant item, matching rows
+97	2
+98	2
+99	2

--- a/tests/queries/0_stateless/04894_lazy_materialization_shadowed_constant.sql
+++ b/tests/queries/0_stateless/04894_lazy_materialization_shadowed_constant.sql
@@ -1,0 +1,35 @@
+-- Without plan optimizations the chain below the sort re-materializes the constant of a constant
+-- SELECT item while still receiving it as an input, so an `ExpressionStep` DAG holds a `COLUMN`
+-- node named as one of its inputs. Splitting such a DAG for lazy materialization renamed the node
+-- promoted to the lazy half, and the re-stacked `Sorting` step no longer resolved its sort
+-- description: `Not found column 2_UInt8 in block ... 2_UInt8_0` (issue #112209).
+-- Fixed by skipping the optimization for a DAG whose computed node shadows an input name.
+
+DROP TABLE IF EXISTS t_04894;
+CREATE TABLE t_04894 (v Int64, k UInt32) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_04894 SELECT number, number FROM numbers(100);
+
+SET query_plan_enable_optimizations = 0, query_plan_optimize_lazy_materialization = 1;
+SET query_plan_max_limit_for_lazy_materialization = 1000;
+
+SELECT 'constant item, folded conjunct';
+SELECT v, 2 FROM (SELECT v, k FROM t_04894 WHERE v) AS sub
+WHERE k = 5 AND (v BETWEEN 10 AND 5 AND 24576)
+ORDER BY ALL LIMIT 6;
+
+SELECT 'constant expression item';
+SELECT v, 1 = 1 FROM (SELECT v, k FROM t_04894 WHERE v) AS sub
+WHERE k = 5 AND (v BETWEEN 10 AND 5 AND 24576)
+ORDER BY ALL LIMIT 6;
+
+SELECT 'several constant items';
+SELECT v, 2, 3, 'x' FROM (SELECT v, k FROM t_04894 WHERE v) AS sub
+WHERE k = 5 AND (v BETWEEN 10 AND 5 AND 24576)
+ORDER BY ALL LIMIT 6;
+
+SELECT 'constant item, matching rows';
+SELECT v, 2 FROM (SELECT v, k FROM t_04894 WHERE v) AS sub
+WHERE k > 96
+ORDER BY ALL LIMIT 6;
+
+DROP TABLE t_04894;


### PR DESCRIPTION
Adds a regression test for https://github.com/ClickHouse/ClickHouse/issues/112209.

With `query_plan_enable_optimizations = 0` the first optimization pass never runs, so the chain below the sort keeps an `ExpressionStep` whose DAG re-materializes the constant of a constant `SELECT` item while still taking a same-named input (a `COLUMN` node named `2_UInt8` next to an `INPUT` of that name). Lazy materialization lives in the second pass, which that setting does not gate, so it split such a DAG; `ActionsDAG::split` renamed the node promoted to the lazy half (`avoid_duplicate_inputs`) to `2_UInt8_0`, while the re-stacked `Sorting` step still resolved `2_UInt8` by name, and `PartialSortingTransform` failed at pipeline build with `NOT_FOUND_COLUMN_IN_BLOCK`.

The query was fixed indirectly by https://github.com/ClickHouse/ClickHouse/pull/112326, which added `hasInputNameShadowedByComputedNode` and declines such plans upfront. That change was written for the row-policy `CAST(x, ...) AS x` shape and its test `04654_lazy_materialization_shadowed_input_name` covers only that variant, so this test pins the constant `SELECT` item with `ORDER BY ALL` as well. Verified: it throws on 26.8.1.203 (`ecb9cf7b997`) and passes from `f45cb411cbc` on.

Related: https://github.com/ClickHouse/ClickHouse/issues/112209
Related: https://github.com/ClickHouse/ClickHouse/pull/112326

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115161&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115161](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115161+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
