### PR TITLE
Fix flaky 04896_orfill_merge_group_by_overflow_any under randomized index_granularity_bytes

### DIFF
--- a/tests/queries/0_stateless/04896_orfill_merge_group_by_overflow_any.sql
+++ b/tests/queries/0_stateless/04896_orfill_merge_group_by_overflow_any.sql
@@ -12,13 +12,20 @@
 -- Merges stay stopped so the three parts below reach the SELECT separately: one projection
 -- part per part is what carries enough keys past the frozen hash table for a null place to
 -- appear, and over a single merged part every count below is 3000 instead.
+--
+-- `index_granularity_bytes = 0` turns adaptive granularity off so that the parts of `p` and of
+-- the parent table are cut into the same number of granules. `p` stores five aggregate states
+-- per row and is therefore several times wider than the parent's three `UInt64` columns, so
+-- under a small `index_granularity_bytes` — the test runner randomizes it down to 1 KiB — `p`
+-- takes more marks than the parent table, `optimizeUseAggregateProjections` discards it as
+-- "not better than the original table", and `force_optimize_projection_name` throws.
 
 DROP TABLE IF EXISTS t_orfill;
 
 CREATE TABLE t_orfill (k UInt64, k2 UInt64, v UInt64,
     PROJECTION p (SELECT k, sumOrNull(v), sumOrDefault(v), sumTupleOrNull(tuple(v)), sumOrNullTuple(tuple(v)) GROUP BY k),
     PROJECTION p2 (SELECT k, k2, sumOrNull(v) GROUP BY k, k2))
-ENGINE = MergeTree ORDER BY tuple();
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity_bytes = 0;
 
 SYSTEM STOP MERGES t_orfill;
 


### PR DESCRIPTION
`04896_orfill_merge_group_by_overflow_any` fails on master whenever the stateless-test runner randomizes `index_granularity_bytes` down to a small value:

```
Code: 117. DB::Exception: Projection p is specified in setting force_optimize_projection_name but not used. (INCORRECT_DATA)
```

The runner's own diagnosis isolated the culprit to `--index_granularity_bytes 21597` (182/182 runs failed with it, 249/249 passed without randomization).

Projection `p` stores five aggregate states per row, so its parts are several times wider than the parent table's three `UInt64` columns. With adaptive granularity on and a small `index_granularity_bytes`, the parts of `p` get cut into more granules than the parent parts — 5 marks against 2 at `--index_granularity_bytes 21597` — so `optimizeUseAggregateProjections` discards `p` as "not better than the original table with 2 marks", selects `p2` instead, and `force_optimize_projection_name = 'p'` throws.

This fix turns adaptive granularity off for the table so that `p` and the parent table are cut into the same number of granules and `p` stays selectable. The test does not depend on granularity in any other way, and `index_granularity` itself stays randomized. Verified locally on `aarch64`: the test reproduces the failure deterministically before the change under the CI settings, and matches its reference after the change under the full CI setting set as well as across a sweep of `index_granularity_bytes` / `index_granularity` / `min_bytes_for_wide_part` values.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=39e9002316ee472caf62fbb837832c776f10c06f&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

Related: https://github.com/ClickHouse/ClickHouse/pull/114740

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
