### PR TITLE
Do not fan out the single-row output of an aggregation without keys

### DIFF
--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -805,6 +805,11 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
         return;
     }
 
+    /// An aggregation without keys produces at most one row, so fanning its output out to
+    /// multiple streams would only add processors and scheduling overhead to every downstream
+    /// step (and to the whole pipeline execution) without any parallelism to gain.
+    const size_t streams_after_aggregation = (should_produce_results_in_order_of_bucket_number || params.keys.empty()) ? 1 : max_threads;
+
     /// If there are several sources, then we perform parallel aggregation
     if (pipeline.getNumStreams() > 1)
     {
@@ -833,7 +838,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                     dataflow_cache_updater);
             });
 
-        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : max_threads, false, settings.min_outstreams_per_resize_after_split);
+        pipeline.resize(streams_after_aggregation, false, settings.min_outstreams_per_resize_after_split);
 
         aggregating = collector.detachProcessors(static_cast<size_t>(AggregatingStage::PartialAggregation));
     }
@@ -842,7 +847,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
         pipeline.addSimpleTransform([&](const SharedHeader & header)
                                     { return std::make_shared<AggregatingTransform>(header, transform_params, dataflow_cache_updater); });
 
-        pipeline.resize(should_produce_results_in_order_of_bucket_number ? 1 : max_threads);
+        pipeline.resize(streams_after_aggregation);
 
         aggregating = collector.detachProcessors(static_cast<size_t>(AggregatingStage::PartialAggregation));
     }

--- a/tests/queries/0_stateless/00172_early_constant_folding.reference
+++ b/tests/queries/0_stateless/00172_early_constant_folding.reference
@@ -1,12 +1,11 @@
 (Expression)
-ExpressionTransform × 10
+ExpressionTransform
   (Aggregating)
-  Resize 1 → 10
-    AggregatingTransform
-      (Expression)
-      ExpressionTransform
-        (ReadFromPreparedSource)
-        SourceFromSingleChunk 0 → 1
+  AggregatingTransform
+    (Expression)
+    ExpressionTransform
+      (ReadFromPreparedSource)
+      SourceFromSingleChunk 0 → 1
 (Expression)
 ExpressionTransform
   (MergingAggregated)

--- a/tests/queries/0_stateless/01091_num_threads.sql
+++ b/tests/queries/0_stateless/01091_num_threads.sql
@@ -31,7 +31,9 @@ WITH
         ORDER BY event_time DESC
         LIMIT 1
     ) AS id
-SELECT uniqExact(thread_id) > 2
+-- `numbers` is a single-stream source and an aggregation without keys keeps a single
+-- output stream, so this query must not fan out to `max_threads` worker threads.
+SELECT uniqExact(thread_id) <= 2
 FROM system.query_thread_log
 WHERE (event_date >= (today() - 1)) AND (query_id = id) AND (thread_id != master_thread_id);
 

--- a/tests/queries/0_stateless/02210_processors_profile_log_2.reference
+++ b/tests/queries/0_stateless/02210_processors_profile_log_2.reference
@@ -8,5 +8,4 @@ LimitsCheckingTransform	1	8	1	8
 NullSource	0	0	0	0
 NumbersRange	0	0	1000000	8000000
 Resize	1	8	1	8
-Resize	1	8	1	8
 1

--- a/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
+++ b/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.reference
@@ -4,26 +4,26 @@
 select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=32, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
-  Resize 16 → 32
+  Resize 16 → 1
         MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
 -- Without asynchronous_read, max_streams_for_merge_tree_reading limits max_streams * max_streams_to_max_threads_ratio
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=0, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
-  Resize 16 → 4
+  Resize 16 → 1
         MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
 -- With asynchronous_read, read in max_streams_for_merge_tree_reading async streams and resize to max_threads
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
-  Resize 4 → 4
+  Resize 4 → 1
         Resize 16 → 4
           MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
--- With asynchronous_read, read using max_streams * max_streams_to_max_threads_ratio async streams, resize to max_streams_for_merge_tree_reading outp[ut streams, resize to max_threads after aggregation
+-- With asynchronous_read, read using max_streams * max_streams_to_max_threads_ratio async streams, resize to max_streams_for_merge_tree_reading output streams; the aggregation without keys then collapses the output to a single stream
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8;
 49999995000000
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
-  Resize 16 → 4
+  Resize 16 → 1
         Resize 32 → 16
           MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 32 0 → 1
 -- For read-in-order, disable everything
@@ -31,8 +31,6 @@ set query_plan_remove_redundant_sorting=0; -- to keep reading in order
 select sum(x) from (select x from t order by x) settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, optimize_read_in_order=1, query_plan_read_in_order=1;
 49999995000000
 select * from (explain pipeline select sum(x) from (select x from t order by x) settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, optimize_read_in_order=1, query_plan_read_in_order=1) where explain like '%Resize%';
-  Resize 1 → 4
 select sum(x) from (select x from t order by x) settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8, optimize_read_in_order=1, query_plan_read_in_order=1;
 49999995000000
 select * from (explain pipeline select sum(x) from (select x from t order by x) settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8, optimize_read_in_order=1, query_plan_read_in_order=1) where explain like '%Resize%';
-  Resize 1 → 4

--- a/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.sql
+++ b/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.sql
@@ -15,8 +15,8 @@ set read_in_order_two_level_merge_threshold = 100;
 -- The pipeline shape depends on the exact thread count;
 -- disable the free-memory limiter to keep `max_threads` as set in the queries.
 -- Without this, on `per_test_coverage` and other memory-constrained builds
--- `max_threads=32` is clamped to fewer threads and `Resize 16 → 32` becomes
--- e.g. `Resize 16 → 24`. See PR #100383.
+-- `max_threads` is clamped to fewer threads and e.g. `Resize 16 → 4` becomes
+-- `Resize 16 → 3`. See PR #100383.
 set max_threads_min_free_memory_per_thread = 0;
 set max_insert_threads_min_free_memory_per_thread = 0;
 
@@ -34,7 +34,7 @@ select * from (explain pipeline select sum(x) from t settings max_threads=4, max
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1;
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
 
--- With asynchronous_read, read using max_streams * max_streams_to_max_threads_ratio async streams, resize to max_streams_for_merge_tree_reading outp[ut streams, resize to max_threads after aggregation
+-- With asynchronous_read, read using max_streams * max_streams_to_max_threads_ratio async streams, resize to max_streams_for_merge_tree_reading output streams; the aggregation without keys then collapses the output to a single stream
 select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8;
 select * from (explain pipeline select sum(x) from t settings max_threads=4, max_streams_for_merge_tree_reading=16, allow_asynchronous_read_from_io_pool_for_merge_tree=1, max_streams_to_max_threads_ratio=8) where explain like '%Resize%' or explain like '%MergeTreeSelect%';
 


### PR DESCRIPTION
After `AggregatingStep`, the pipeline was unconditionally resized to `max_threads`
output streams. For an aggregation with `GROUP BY` keys that is what enables
downstream parallelism, but an aggregation without keys produces at most one row:
fanning that single row out to `max_threads` streams cannot create any parallelism —
the only chunk still goes to one stream — while every downstream step instantiates
`max_threads` processors that are created, scheduled and profiled for nothing.

`AggregatingStep::transformPipeline` now keeps a single output stream when
`params.keys` is empty (the same way it already does when results must be produced
in order of bucket number). For example, `EXPLAIN PIPELINE SELECT count() FROM t`
loses the `Resize 1 → <max_threads>` node and the `× <max_threads>` fan-out of every
subsequent transform (see the update of `00172_early_constant_folding`).

This was found while profiling tiny instant PromQL stat queries of the shape
`sum(a) / sum(b)` over `TimeSeries` tables, where the emitted SQL contains several
keyless aggregations and the fan-out multiplied the pipeline size; the effect is
generic and this change is independent of the PromQL transpiler.

Related: https://github.com/ClickHouse/ClickHouse/pull/115171

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

An aggregation without `GROUP BY` keys no longer fans its single-row output out to `max_threads` streams, so queries whose plan continues after such an aggregation get a much smaller pipeline (fewer processors to create, schedule and profile) without losing any parallelism.
