### PR TITLE
Emit smaller SQL for PromQL binary operators over single-series operands

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.cpp
@@ -48,8 +48,11 @@ ASTPtr SelectQueryBuilder::getSelectQuery()
             auto table_join = make_intrusive<ASTTableJoin>();
             table_join->kind = join_kind;
             table_join->strictness = join_strictness;
-            table_join->on_expression = std::move(join_on);
-            table_join->children.emplace_back(table_join->on_expression);
+            if (join_on)
+            {
+                table_join->on_expression = std::move(join_on);
+                table_join->children.emplace_back(table_join->on_expression);
+            }
 
             table_exp = make_intrusive<ASTTableExpression>();
             table_exp->database_and_table_name = make_intrusive<ASTTableIdentifier>(std::move(join_table));

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
@@ -122,9 +122,10 @@ SQLQueryPiece applyAggregationOperatorQuantile(
     auto res = vector_arg;
     res.node = operator_node;
 
-    /// Step 1: aggregate over series, using `new_group` as an intermediate alias to avoid
-    /// ambiguity with the input `group` column when the alias and the source column share the same name.
-    ASTPtr aggregation_query;
+    /// Aggregate over series. The transformed group expression is aliased directly as `group`:
+    /// in `SELECT f(group) AS group ... GROUP BY group` the identifier inside the aliased expression
+    /// resolves to the source column while `GROUP BY group` resolves to the alias (this holds for
+    /// both the old and the new analyzer), so no extra column-renaming step is needed.
     {
         SelectQueryBuilder builder;
 
@@ -135,7 +136,7 @@ SQLQueryPiece applyAggregationOperatorQuantile(
             operator_node, make_intrusive<ASTIdentifier>(ColumnNames::Group), /*drop_metric_name=*/true, res.metric_name_dropped);
 
         builder.select_list.push_back(std::move(new_group));
-        builder.select_list.back()->setAlias(ColumnNames::NewGroup);
+        builder.select_list.back()->setAlias(ColumnNames::Group);
 
         ASTPtr quantile_expr;
         if (const_phi_out_of_range)
@@ -218,26 +219,13 @@ SQLQueryPiece applyAggregationOperatorQuantile(
         builder.select_list.back()->setAlias(ColumnNames::Values);
 
         if (operator_node->by || operator_node->without)
-            builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+            builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
 
         /// Drop empty-values rows.
         /// If the input has no rows then quantileExactInclusiveForEach(...)([]) returns [], but the number of values
         /// in array must always match the number of steps in SQLQueryPiece (see StoreMethod::VECTOR_GRID),
         /// so we just drop such rows.
         builder.having = makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::Values));
-
-        aggregation_query = builder.getSelectQuery();
-    }
-
-    /// Step 2: rename `new_group` back to `group`.
-    {
-        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(aggregation_query), SQLSubqueryType::TABLE});
-
-        SelectQueryBuilder builder;
-        builder.from_table = context.subqueries.back().name;
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
-        builder.select_list.back()->setAlias(ColumnNames::Group);
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
 
         res.select_query = builder.getSelectQuery();
     }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
@@ -125,7 +125,7 @@ SQLQueryPiece applyAggregationOperatorQuantile(
     /// Aggregate over series. The transformed group expression is aliased directly as `group`:
     /// in `SELECT f(group) AS group ... GROUP BY group` the identifier inside the aliased expression
     /// resolves to the source column while `GROUP BY group` resolves to the alias (this holds for
-    /// both the old and the new analyzer), so no extra column-renaming step is needed.
+    /// both `enable_analyzer=0` and `enable_analyzer=1`), so no extra column-renaming step is needed.
     {
         SelectQueryBuilder builder;
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
@@ -174,7 +174,7 @@ SQLQueryPiece applyOneArgumentAggregationOperator(
     /// The transformed group expression is aliased directly as `group`: in
     /// `SELECT f(group) AS group ... GROUP BY group` the identifier inside the aliased expression
     /// resolves to the source column while `GROUP BY group` resolves to the alias (this holds for
-    /// both the old and the new analyzer), so no extra column-renaming step is needed.
+    /// both `enable_analyzer=0` and `enable_analyzer=1`), so no extra column-renaming step is needed.
     {
         SelectQueryBuilder builder;
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
@@ -165,9 +165,16 @@ SQLQueryPiece applyOneArgumentAggregationOperator(
     auto res = argument;
     res.node = operator_node;
 
-    /// Step 1: aggregate over series, using `new_group` as an intermediate alias to avoid
-    /// ambiguity with the input `group` column when the alias and the source column share the same name.
-    ASTPtr aggregation_query;
+    /// Aggregate over series:
+    /// SELECT <transformed_group> AS group, <aggregationForEach>(values) AS values
+    /// FROM <subquery>
+    /// [GROUP BY group]
+    /// HAVING notEmpty(values)
+    ///
+    /// The transformed group expression is aliased directly as `group`: in
+    /// `SELECT f(group) AS group ... GROUP BY group` the identifier inside the aliased expression
+    /// resolves to the source column while `GROUP BY group` resolves to the alias (this holds for
+    /// both the old and the new analyzer), so no extra column-renaming step is needed.
     {
         SelectQueryBuilder builder;
 
@@ -178,32 +185,19 @@ SQLQueryPiece applyOneArgumentAggregationOperator(
             operator_node, make_intrusive<ASTIdentifier>(ColumnNames::Group), /*drop_metric_name=*/true, res.metric_name_dropped);
 
         builder.select_list.push_back(std::move(new_group));
-        builder.select_list.back()->setAlias(ColumnNames::NewGroup);
+        builder.select_list.back()->setAlias(ColumnNames::Group);
 
         builder.select_list.push_back(impl_info->transform_ast(make_intrusive<ASTIdentifier>(ColumnNames::Values), context.scalar_data_type));
         builder.select_list.back()->setAlias(ColumnNames::Values);
 
         if (operator_node->by || operator_node->without)
-            builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+            builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
 
         /// Drop empty-values rows.
         /// If the input has no rows then countForEach([]) returns [], but the number of values
         /// in array must always match the number of steps in SQLQueryPiece (see StoreMethod::VECTOR_GRID),
         /// so we just drop such rows.
         builder.having = makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::Values));
-
-        aggregation_query = builder.getSelectQuery();
-    }
-
-    /// Step 2: rename `new_group` back to `group`.
-    {
-        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(aggregation_query), SQLSubqueryType::TABLE});
-
-        SelectQueryBuilder builder;
-        builder.from_table = context.subqueries.back().name;
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
-        builder.select_list.back()->setAlias(ColumnNames::Group);
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
 
         res.select_query = builder.getSelectQuery();
     }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
@@ -9,6 +9,7 @@
 #include <Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/zeroGroup.h>
 #include <algorithm>
 
 
@@ -60,11 +61,13 @@ namespace
         String sides[2];
 
         left_argument = toVectorGrid(std::move(left_argument), context);
+        bool left_zero_group = producesConstantZeroGroup(left_argument.select_query);
         context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(left_argument.select_query), SQLSubqueryType::TABLE});
         sides[0] = context.subqueries.back().name;
         String & left = sides[0];
 
         right_argument = toVectorGrid(std::move(right_argument), context);
+        bool right_zero_group = producesConstantZeroGroup(right_argument.select_query);
         context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
         sides[1] = context.subqueries.back().name;
         String & right = sides[1];
@@ -72,6 +75,46 @@ namespace
         bool group_left = operator_node->group_left;
         bool group_right = operator_node->group_right;
         const auto & extra_labels = operator_node->extra_labels;
+
+        /// Fast path: if both sides provably contain at most one row whose `group` is the constant
+        /// zero group, i.e. a group with no tags (e.g. both sides of `sum(a) / sum(b)`), then vector
+        /// matching degenerates to combining two resultsets of at most one row each: the only possible
+        /// match is the empty label set against the empty label set, and the result is empty iff either
+        /// side is empty. That is exactly a CROSS JOIN of the two sides. A CROSS JOIN is used instead
+        /// of an equality join on `group` because it never takes the parallel-join path which would fan
+        /// both sides out to max_threads streams - pointless for two resultsets of at most one row.
+        if (!group_left && !group_right && !operator_node->on && !operator_node->ignoring && left_zero_group && right_zero_group)
+        {
+            /// SELECT CAST(0, 'UInt64') AS group,
+            ///        arrayMap(x, y -> f(x, y), left.values, right.values) AS values
+            /// FROM left CROSS JOIN right
+            SelectQueryBuilder builder;
+
+            builder.select_list.push_back(makeASTFunction("CAST", make_intrusive<ASTLiteral>(0u), make_intrusive<ASTLiteral>("UInt64")));
+            builder.select_list.back()->setAlias(ColumnNames::Group);
+
+            builder.select_list.push_back(makeASTFunction(
+                "arrayMap",
+                makeASTFunction(
+                    "lambda",
+                    makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y")),
+                    apply_function_to_ast(make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y"))),
+                make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
+                make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values})));
+            builder.select_list.back()->setAlias(ColumnNames::Values);
+
+            builder.from_table = left;
+            builder.join_table = right;
+            builder.join_kind = JoinKind::Cross;
+
+            SQLQueryPiece res{operator_node, operator_node->result_type, StoreMethod::VECTOR_GRID};
+            res.select_query = builder.getSelectQuery();
+            res.start_time = left_argument.start_time;
+            res.end_time = left_argument.end_time;
+            res.step = left_argument.step;
+            res.metric_name_dropped = true;
+            return res;
+        }
 
         /// Step 1:
         /// new_left:

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
@@ -89,13 +89,23 @@ namespace
         /// FROM right
         /// [GROUP BY join_group HAVING timeSeriesThrowDuplicateSeriesIf(count() > 1, join_group) = 0]
         ///
+        /// If the join key of a side is the bare `group` column (which happens whenever the metric name
+        /// has already been dropped from that side and there is no on()/ignoring() label surgery -
+        /// for example both sides of `sum(a) / sum(b)` or `sum by (pod) (a) / sum by (pod) (b)`),
+        /// the step above would be a pure rename `SELECT group AS original_group, group AS join_group, values`,
+        /// so it's skipped entirely and step 3 references the `group` column of that side directly.
         bool metric_name_dropped_from_join_group = false;
 
-        for (auto & side : sides)
+        /// The names of the columns of each side to be used in step 3 as the join key and the original group.
+        String join_group_columns[2] = {ColumnNames::JoinGroup, ColumnNames::JoinGroup};
+        String original_group_columns[2] = {ColumnNames::OriginalGroup, ColumnNames::OriginalGroup};
+
+        for (size_t side_index = 0; side_index != 2; ++side_index)
         {
+            String & side = sides[side_index];
             SelectQueryBuilder builder;
 
-            bool metric_name_dropped_from_group = (side == left) ? left_argument.metric_name_dropped : right_argument.metric_name_dropped;
+            bool metric_name_dropped_from_group = (side_index == 0) ? left_argument.metric_name_dropped : right_argument.metric_name_dropped;
             bool metric_name_dropped_from_join_group_on_side = metric_name_dropped_from_group;
 
             /// The join_group is always computed with `drop_metric_name=true` because the two sides typically
@@ -110,13 +120,24 @@ namespace
             /// If the metric name has dropped from the `join_group` either on left or on right then it's dropped.
             metric_name_dropped_from_join_group |= metric_name_dropped_from_join_group_on_side;
 
+            if (tryGetIdentifierName(join_group.get()) == ColumnNames::Group)
+            {
+                /// The join key is the bare `group` column, so this step would be a pure rename
+                /// (and no duplicate check is needed: values of `group` are already unique, see StoreMethod::VECTOR_GRID).
+                /// Skip the step and use the `group` column directly in step 3.
+                join_group_columns[side_index] = ColumnNames::Group;
+                original_group_columns[side_index] = ColumnNames::Group;
+                continue;
+            }
+
             /// If neither group_left not group_right is specified then it's one-to-one match.
             /// If there is group_left then it's many-to-one match.
             /// If there is group_right then it's one-to-many match.
-            bool group_on_side = (side == left) ? group_left : group_right;
+            bool group_on_side = (side_index == 0) ? group_left : group_right;
 
-            /// If `join_group` is the same as `group` then we already know it's unique.
-            bool check_side_one = !group_on_side && (tryGetIdentifierName(join_group.get()) != ColumnNames::Group);
+            /// `join_group` is computed here (it's not the bare `group` column), so its values
+            /// may collide and the side "one" needs the duplicate check.
+            bool check_side_one = !group_on_side;
 
             /// We add column `original_group` because we may need it at step 3.
             ASTPtr original_group = make_intrusive<ASTIdentifier>(ColumnNames::Group);
@@ -207,7 +228,8 @@ namespace
 
                 if (can_use_join_group_in_result)
                 {
-                    new_group = make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup);
+                    /// The left side's join key is used; it's equal to the right side's join key on every joined row.
+                    new_group = make_intrusive<ASTIdentifier>(Strings{left, join_group_columns[0]});
                     metric_name_dropped_from_result = metric_name_dropped_from_join_group;
                 }
                 else
@@ -215,7 +237,7 @@ namespace
                     metric_name_dropped_from_result = left_argument.metric_name_dropped;
                     new_group = transformGroupASTForBinaryOperator(
                         operator_node,
-                        make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::OriginalGroup}),
+                        make_intrusive<ASTIdentifier>(Strings{left, original_group_columns[0]}),
                         drop_metric_name,
                         metric_name_dropped_from_result);
                 }
@@ -241,15 +263,15 @@ namespace
 
                 /// Either group_left or group_right is specified.
                 /// There are two sides: "one" and "many".
-                String side_many;
-                String side_one;
+                size_t side_many_index;
+                size_t side_one_index;
                 bool metric_name_dropped_from_side_many = false;
                 bool metric_name_dropped_from_side_one = false;
 
                 if (group_left)
                 {
-                    side_many = left;
-                    side_one = right;
+                    side_many_index = 0;
+                    side_one_index = 1;
                     metric_name_dropped_from_side_many = left_argument.metric_name_dropped;
                     metric_name_dropped_from_side_one = right_argument.metric_name_dropped;
 
@@ -259,8 +281,8 @@ namespace
                 else
                 {
                     chassert(group_right);
-                    side_many = right;
-                    side_one = left;
+                    side_many_index = 1;
+                    side_one_index = 0;
                     metric_name_dropped_from_side_many = right_argument.metric_name_dropped;
                     metric_name_dropped_from_side_one = left_argument.metric_name_dropped;
 
@@ -268,10 +290,13 @@ namespace
                     join_kind = JoinKind::Right;
                 }
 
+                const String & side_many = sides[side_many_index];
+                const String & side_one = sides[side_one_index];
+
                 join_strictness = JoinStrictness::Semi;
 
                 /// Drop the metric name from the side "many".
-                new_group = make_intrusive<ASTIdentifier>(Strings{side_many, ColumnNames::OriginalGroup});
+                new_group = make_intrusive<ASTIdentifier>(Strings{side_many, original_group_columns[side_many_index]});
 
                 metric_name_dropped_from_result = metric_name_dropped_from_side_many;
 
@@ -304,7 +329,7 @@ namespace
                     new_group = makeASTFunction(
                         "timeSeriesCopyTags",
                         new_group,
-                        make_intrusive<ASTIdentifier>(Strings{side_one, ColumnNames::OriginalGroup}),
+                        make_intrusive<ASTIdentifier>(Strings{side_one, original_group_columns[side_one_index]}),
                         make_intrusive<ASTLiteral>(Array{tags_to_copy.begin(), tags_to_copy.end()}));
 
                     check_no_duplicate_groups = true;
@@ -337,8 +362,8 @@ namespace
 
             builder.join_on = makeASTFunction(
                 "equals",
-                make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::JoinGroup}),
-                make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::JoinGroup}));
+                make_intrusive<ASTIdentifier>(Strings{left, join_group_columns[0]}),
+                make_intrusive<ASTIdentifier>(Strings{right, join_group_columns[1]}));
 
             if (check_no_duplicate_groups)
             {

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
@@ -306,8 +306,8 @@ namespace
 
                 /// Either group_left or group_right is specified.
                 /// There are two sides: "one" and "many".
-                size_t side_many_index;
-                size_t side_one_index;
+                size_t side_many_index = 0;
+                size_t side_one_index = 0;
                 bool metric_name_dropped_from_side_many = false;
                 bool metric_name_dropped_from_side_one = false;
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.cpp
@@ -2,29 +2,12 @@
 
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/zeroGroup.h>
 #include <algorithm>
 
 
 namespace DB::PrometheusQueryToSQL
 {
-
-namespace
-{
-    /// Checks whether the specified AST is the zero group, i.e. either the literal 0 or CAST(0, 'UInt64').
-    bool isZeroGroupAST(const ASTPtr & group)
-    {
-        if (const auto * literal = group->as<const ASTLiteral>())
-            return literal->value == Field{0u};
-        if (const auto * function = group->as<const ASTFunction>(); function && (function->name == "CAST") && function->arguments
-            && (function->arguments->children.size() == 2))
-        {
-            const auto * value = function->arguments->children[0]->as<const ASTLiteral>();
-            const auto * type = function->arguments->children[1]->as<const ASTLiteral>();
-            return value && type && (value->value == Field{0u}) && (type->value == Field{"UInt64"});
-        }
-        return false;
-    }
-}
 
 ASTPtr transformGroupASTForBinaryOperator(
     const PrometheusQueryTree::BinaryOperator * operator_node,

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/zeroGroup.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/zeroGroup.cpp
@@ -1,0 +1,55 @@
+#include <Storages/TimeSeries/PrometheusQueryToSQL/zeroGroup.h>
+
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterDefs.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+bool isZeroGroupAST(const ASTPtr & group)
+{
+    if (const auto * literal = group->as<const ASTLiteral>())
+        return literal->value == Field{0u};
+    if (const auto * function = group->as<const ASTFunction>(); function && (function->name == "CAST") && function->arguments
+        && (function->arguments->children.size() == 2))
+    {
+        const auto * value = function->arguments->children[0]->as<const ASTLiteral>();
+        const auto * type = function->arguments->children[1]->as<const ASTLiteral>();
+        return value && type && (value->value == Field{0u}) && (type->value == Field{"UInt64"});
+    }
+    return false;
+}
+
+
+bool producesConstantZeroGroup(const ASTPtr & select_query)
+{
+    if (!select_query)
+        return false;
+
+    const auto * select_with_union = select_query->as<const ASTSelectWithUnionQuery>();
+    if (!select_with_union || !select_with_union->list_of_selects || (select_with_union->list_of_selects->children.size() != 1))
+        return false;
+
+    const auto * select = select_with_union->list_of_selects->children[0]->as<const ASTSelectQuery>();
+    if (!select)
+        return false;
+
+    const auto & select_expression_list = select->select();
+    if (!select_expression_list)
+        return false;
+
+    for (const auto & child : select_expression_list->children)
+    {
+        if (child->tryGetAlias() == ColumnNames::Group)
+            return isZeroGroupAST(child);
+    }
+
+    return false;
+}
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/zeroGroup.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/zeroGroup.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Parsers/IAST_fwd.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+/// Checks whether the specified AST is the zero group, i.e. either the literal 0 or CAST(0, 'UInt64').
+/// Group #0 always means a group with no tags.
+bool isZeroGroupAST(const ASTPtr & group);
+
+/// Checks whether a SELECT query built for StoreMethod::VECTOR_GRID provably outputs
+/// the constant zero group (i.e. a group with no tags) in its `group` column.
+/// Since values of `group` are unique in a VECTOR_GRID resultset (see StoreMethod::VECTOR_GRID),
+/// such a query provably returns at most one row.
+bool producesConstantZeroGroup(const ASTPtr & select_query);
+
+}

--- a/tests/performance/promql_instant_scalar_binop.xml
+++ b/tests/performance/promql_instant_scalar_binop.xml
@@ -1,0 +1,36 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+    </settings>
+
+    <!-- Benchmarks tiny instant PromQL stat queries of the shape sum(a)/sum(b): their server-side time is
+         dominated by the compilation (analysis/planning) of the transpiled SQL, not by execution,
+         so this measures the size/cost of the WITH chain emitted by the PromQL-to-SQL transpiler. -->
+
+    <create_query>
+        CREATE TABLE promql_scalar_binop_ts ENGINE = TimeSeries
+    </create_query>
+
+    <!-- 2 metrics x 100 series x 30 samples: small on purpose, the compilation cost is data-independent. -->
+    <fill_query>
+        INSERT INTO promql_scalar_binop_ts (metric_name, tags, time_series)
+        SELECT
+            'requests_total',
+            map('instance', toString(number)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), number + step), range(30))
+        FROM numbers(100)
+    </fill_query>
+    <fill_query>
+        INSERT INTO promql_scalar_binop_ts (metric_name, tags, time_series)
+        SELECT
+            'capacity_total',
+            map('instance', toString(number)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), number * 2 + 1), range(30))
+        FROM numbers(100)
+    </fill_query>
+
+    <query>SELECT * FROM prometheusQuery('promql_scalar_binop_ts', 'sum(requests_total) / sum(capacity_total)', 400) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQuery('promql_scalar_binop_ts', '1 - sum(requests_total) / sum(capacity_total)', 400) FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_scalar_binop_ts</drop_query>
+</test>

--- a/tests/queries/0_stateless/04908_promql_scalar_binary_operator_fast_path.reference
+++ b/tests/queries/0_stateless/04908_promql_scalar_binary_operator_fast_path.reference
@@ -1,0 +1,42 @@
+-- sum(m1) / sum(m2), instant
+[]	1970-01-01 00:02:10.000	0.5
+-- 1 - sum(m1) / sum(m2), instant
+[]	1970-01-01 00:02:10.000	0.5
+-- sum(m1) / sum(m2) * 100, instant
+[]	1970-01-01 00:02:10.000	50
+-- avg(m1) - max(m2), min(m1) + count(m2), instant
+[]	1970-01-01 00:02:10.000	-6
+[]	1970-01-01 00:02:10.000	3
+-- nested: sum(m1) / sum(m2) / sum(m2), instant
+[]	1970-01-01 00:02:10.000	0.041666666666666664
+-- sum(m1) % sum(m2), sum(m1) ^ sum(m2), instant
+[]	1970-01-01 00:02:10.000	6
+[]	1970-01-01 00:02:10.000	2176782336
+-- sum(m1) / sum(m2), range
+[]	[('1970-01-01 00:01:40.000',0.5),('1970-01-01 00:01:50.000',2.9166666666666665),('1970-01-01 00:02:00.000',1.5),('1970-01-01 00:02:10.000',0.5)]
+-- division by zero: +Inf, -Inf and NaN
+[]	1970-01-01 00:02:10.000	inf
+[]	1970-01-01 00:02:10.000	-inf
+[]	1970-01-01 00:02:10.000	nan
+-- NaN operand propagates
+[]	1970-01-01 00:02:10.000	nan
+[]	1970-01-01 00:02:10.000	nan
+-- one side is a metric with no such name: result is empty
+-- both sides have no such name: result is empty
+-- one side has no samples at the evaluation time: result is empty
+-- comparison operators: filter and bool
+[]	1970-01-01 00:02:10.000	6
+[]	1970-01-01 00:02:10.000	0
+[]	1970-01-01 00:02:10.000	1
+-- vector matching by labels keeps the general path
+[('host','h1')]	1970-01-01 00:02:10.000	0.25
+[('host','h3')]	1970-01-01 00:02:10.000	0.375
+[('host','h1')]	1970-01-01 00:02:10.000	0.25
+[('host','h3')]	1970-01-01 00:02:10.000	0.375
+[('host','h1')]	1970-01-01 00:02:10.000	0.25
+[('host','h3')]	1970-01-01 00:02:10.000	0.375
+-- group_left keeps the general path
+[('dc','a'),('host','h1')]	1970-01-01 00:02:10.000	0.25
+[('dc','b'),('host','h3')]	1970-01-01 00:02:10.000	0.375
+-- on() matching between two aggregated vectors
+[]	1970-01-01 00:02:10.000	0.5

--- a/tests/queries/0_stateless/04908_promql_scalar_binary_operator_fast_path.sql
+++ b/tests/queries/0_stateless/04908_promql_scalar_binary_operator_fast_path.sql
@@ -1,0 +1,80 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+
+-- Tests binary operators between two vectors aggregated to a single series with no tags
+-- (e.g. `sum(a) / sum(b)`): such shapes are transpiled to a simplified SQL query without
+-- the vector-matching machinery, and this test pins down that the results (including
+-- PromQL emptiness semantics and NaN/Inf propagation) stay the same.
+
+DROP TABLE IF EXISTS prometheus;
+
+SET session_timezone = 'UTC';
+SET allow_experimental_time_series_table = 1;
+
+CREATE TABLE prometheus ENGINE = TimeSeries;
+
+-- `m1` has 3 series, `m2` has 2 series, `mz` sums to zero, `mn` contains a NaN sample.
+-- `mlate` has samples only around timestamp 1000, i.e. it is empty at timestamp 130 at query time
+-- (while still known to the transpiler, unlike a completely nonexistent metric).
+INSERT INTO prometheus (metric_name, tags, time_series) VALUES
+    ('m1', map('host', 'h1', 'dc', 'a'), [(toDateTime64(100, 3), 1), (toDateTime64(110, 3), 10), (toDateTime64(120, 3), 4), (toDateTime64(130, 3), 1)]),
+    ('m1', map('host', 'h2', 'dc', 'a'), [(toDateTime64(100, 3), 2), (toDateTime64(110, 3), 20), (toDateTime64(120, 3), 3), (toDateTime64(130, 3), 2)]),
+    ('m1', map('host', 'h3', 'dc', 'b'), [(toDateTime64(100, 3), 3), (toDateTime64(110, 3), 5), (toDateTime64(120, 3), 2), (toDateTime64(130, 3), 3)]),
+    ('m2', map('host', 'h1', 'dc', 'a'), [(toDateTime64(100, 3), 4), (toDateTime64(110, 3), 8), (toDateTime64(120, 3), 1), (toDateTime64(130, 3), 4)]),
+    ('m2', map('host', 'h3', 'dc', 'b'), [(toDateTime64(100, 3), 8), (toDateTime64(110, 3), 4), (toDateTime64(120, 3), 5), (toDateTime64(130, 3), 8)]),
+    ('mz', map('host', 'h1'), [(toDateTime64(100, 3), 5), (toDateTime64(130, 3), 5)]),
+    ('mz', map('host', 'h2'), [(toDateTime64(100, 3), -5), (toDateTime64(130, 3), -5)]),
+    ('mn', map('host', 'h1'), [(toDateTime64(100, 3), nan), (toDateTime64(130, 3), nan)]),
+    ('mlate', map('host', 'h1'), [(toDateTime64(1000, 3), 7)]);
+
+SELECT '-- sum(m1) / sum(m2), instant';
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / sum(m2)', 130) ORDER BY tags;
+SELECT '-- 1 - sum(m1) / sum(m2), instant';
+SELECT * FROM prometheusQuery('prometheus', '1 - sum(m1) / sum(m2)', 130) ORDER BY tags;
+SELECT '-- sum(m1) / sum(m2) * 100, instant';
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / sum(m2) * 100', 130) ORDER BY tags;
+SELECT '-- avg(m1) - max(m2), min(m1) + count(m2), instant';
+SELECT * FROM prometheusQuery('prometheus', 'avg(m1) - max(m2)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'min(m1) + count(m2)', 130) ORDER BY tags;
+SELECT '-- nested: sum(m1) / sum(m2) / sum(m2), instant';
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / sum(m2) / sum(m2)', 130) ORDER BY tags;
+SELECT '-- sum(m1) % sum(m2), sum(m1) ^ sum(m2), instant';
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) % sum(m2)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) ^ sum(m2)', 130) ORDER BY tags;
+SELECT '-- sum(m1) / sum(m2), range';
+SELECT * FROM prometheusQueryRange('prometheus', 'sum(m1) / sum(m2)', 100, 130, 10) ORDER BY tags;
+
+SELECT '-- division by zero: +Inf, -Inf and NaN';
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / sum(mz)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', '(0 - sum(m1)) / sum(mz)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(mz) / sum(mz)', 130) ORDER BY tags;
+SELECT '-- NaN operand propagates';
+SELECT * FROM prometheusQuery('prometheus', 'sum(mn) / sum(m1)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / sum(mn)', 130) ORDER BY tags;
+
+SELECT '-- one side is a metric with no such name: result is empty';
+SELECT * FROM prometheusQuery('prometheus', 'sum(no_such_metric) / sum(m1)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / sum(no_such_metric)', 130) ORDER BY tags;
+SELECT '-- both sides have no such name: result is empty';
+SELECT * FROM prometheusQuery('prometheus', 'sum(no_such_metric) / sum(no_such_metric_2)', 130) ORDER BY tags;
+SELECT '-- one side has no samples at the evaluation time: result is empty';
+SELECT * FROM prometheusQuery('prometheus', 'sum(mlate) / sum(m1)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / sum(mlate)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', '1 - sum(m1) / sum(mlate)', 130) ORDER BY tags;
+
+SELECT '-- comparison operators: filter and bool';
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) > sum(m2)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) < sum(m2)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) > bool sum(m2)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) < bool sum(m2)', 130) ORDER BY tags;
+
+SELECT '-- vector matching by labels keeps the general path';
+SELECT * FROM prometheusQuery('prometheus', 'sum by (host) (m1) / sum by (host) (m2)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum by (host, dc) (m1) / on(host) sum by (host) (m2)', 130) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'sum by (host, dc) (m1) / ignoring(dc) sum by (host) (m2)', 130) ORDER BY tags;
+SELECT '-- group_left keeps the general path';
+SELECT * FROM prometheusQuery('prometheus', 'm1 / on(host) group_left sum by (host) (m2)', 130) ORDER BY tags;
+SELECT '-- on() matching between two aggregated vectors';
+SELECT * FROM prometheusQuery('prometheus', 'sum(m1) / on() sum(m2)', 130) ORDER BY tags;
+
+DROP TABLE prometheus;


### PR DESCRIPTION
Instant stat queries like `sum(a) / sum(b)` were dominated by query compilation: the
transpiler emitted an 11-step WITH chain with per-side rename steps, duplicate-check
aggregations and a parallel-hash `INNER ANY JOIN` — for operands that each hold at
most one row.

Three changes shrink the emitted SQL: aggregation operators alias the transformed
group directly instead of appending a rename-only step (every PromQL aggregation
loses one WITH step); binary operators whose side joins on the bare `group` column
skip the per-side rename and duplicate-check steps (group uniqueness is the grid
contract); and when both operands are provably aggregated to the constant zero group
(aggregation without `by`/`without` — at most one row with an empty label set), the
equality join is replaced by a CROSS JOIN, which preserves PromQL vector-matching
semantics for this case exactly (an empty side yields an empty result) and never
takes the parallel-hash path. `sum(a)/sum(b)` goes from 11 to 7 WITH steps and from
~192 to ~28 pipeline processors, 13 → 9 ms median server-side (measured over 120
runs per side with alternating server restarts). Shapes with grouping modifiers
(`on`, `ignoring`, `group_left`, `group_right`) and vector-matched division keep the
general path; results are byte-identical to the previous emission on both analyzers,
including empty operands, division by zero, NaN operands and comparison operators
with `bool`.

Related: https://github.com/ClickHouse/ClickHouse/pull/115170

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
PromQL binary operators over operands aggregated to a single series (for example `sum(a) / sum(b)` in stat panels) are transpiled to much smaller SQL without join machinery, reducing their latency by about a third; all PromQL aggregations also emit one CTE step less.
