### PR TITLE
Add a preliminary DISTINCT to UNION DISTINCT

### DIFF
--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -325,12 +325,24 @@ void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
             /// Add distinct transform
             SizeLimits limits(settings[Setting::max_rows_in_distinct], settings[Setting::max_bytes_in_distinct], settings[Setting::distinct_overflow_mode]);
 
+            /// UNION keeps one stream per branch, so a preliminary DISTINCT deduplicates each of them
+            /// in parallel and shrinks what the final single-stream DISTINCT has to merge.
+            auto pre_distinct_step = std::make_unique<DistinctStep>(
+                query_plan.getCurrentHeader(),
+                limits,
+                0,
+                result_header->getNames(),
+                true);
+            pre_distinct_step->setStepDescription("Preliminary DISTINCT");
+            query_plan.addStep(std::move(pre_distinct_step));
+
             auto distinct_step = std::make_unique<DistinctStep>(
                 query_plan.getCurrentHeader(),
                 limits,
                 0,
                 result_header->getNames(),
                 false);
+            distinct_step->setStepDescription("DISTINCT");
 
             query_plan.addStep(std::move(distinct_step));
         }

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -325,8 +325,8 @@ void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
             /// Add distinct transform
             SizeLimits limits(settings[Setting::max_rows_in_distinct], settings[Setting::max_bytes_in_distinct], settings[Setting::distinct_overflow_mode]);
 
-            /// UNION keeps one stream per branch, so a preliminary DISTINCT deduplicates each of them
-            /// in parallel and shrinks what the final single-stream DISTINCT has to merge.
+            /// UNION concatenates its branches' streams instead of merging them, so a preliminary
+            /// DISTINCT runs in parallel and shrinks what the final single-stream DISTINCT must merge.
             auto pre_distinct_step = std::make_unique<DistinctStep>(
                 query_plan.getCurrentHeader(),
                 limits,
@@ -342,7 +342,6 @@ void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
                 0,
                 result_header->getNames(),
                 false);
-            distinct_step->setStepDescription("DISTINCT");
 
             query_plan.addStep(std::move(distinct_step));
         }

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -327,14 +327,17 @@ void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
 
             /// UNION concatenates its branches' streams instead of merging them, so a preliminary
             /// DISTINCT runs in parallel and shrinks what the final single-stream DISTINCT must merge.
-            auto pre_distinct_step = std::make_unique<DistinctStep>(
-                query_plan.getCurrentHeader(),
-                limits,
-                0,
-                result_header->getNames(),
-                true);
-            pre_distinct_step->setStepDescription("Preliminary DISTINCT");
-            query_plan.addStep(std::move(pre_distinct_step));
+            if (preliminaryDistinctIsUseful(max_threads))
+            {
+                auto pre_distinct_step = std::make_unique<DistinctStep>(
+                    query_plan.getCurrentHeader(),
+                    limits,
+                    0,
+                    result_header->getNames(),
+                    true);
+                pre_distinct_step->setStepDescription("Preliminary DISTINCT");
+                query_plan.addStep(std::move(pre_distinct_step));
+            }
 
             auto distinct_step = std::make_unique<DistinctStep>(
                 query_plan.getCurrentHeader(),

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2102,12 +2102,31 @@ void Planner::buildPlanForUnionNode()
         /// Add distinct transform
         SizeLimits limits(settings[Setting::max_rows_in_distinct], settings[Setting::max_bytes_in_distinct], settings[Setting::distinct_overflow_mode]);
 
+        /// UNION keeps one stream per branch, so a preliminary DISTINCT deduplicates each of them in
+        /// parallel and shrinks what the final single-stream DISTINCT has to merge. INTERSECT/EXCEPT
+        /// already narrow their output to one stream, so a preliminary step there is pure overhead.
+        const bool add_pre_distinct = union_mode == SelectUnionMode::UNION_DISTINCT;
+
+        if (add_pre_distinct)
+        {
+            auto pre_distinct_step = std::make_unique<DistinctStep>(
+                query_plan.getCurrentHeader(),
+                limits,
+                0 /*limit hint*/,
+                query_plan.getCurrentHeader()->getNames(),
+                true /*pre distinct*/);
+            pre_distinct_step->setStepDescription("Preliminary DISTINCT");
+            query_plan.addStep(std::move(pre_distinct_step));
+        }
+
         auto distinct_step = std::make_unique<DistinctStep>(
             query_plan.getCurrentHeader(),
             limits,
             0 /*limit hint*/,
             query_plan.getCurrentHeader()->getNames(),
             false /*pre distinct*/);
+        if (add_pre_distinct)
+            distinct_step->setStepDescription("DISTINCT");
         query_plan.addStep(std::move(distinct_step));
     }
 

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2102,8 +2102,8 @@ void Planner::buildPlanForUnionNode()
         /// Add distinct transform
         SizeLimits limits(settings[Setting::max_rows_in_distinct], settings[Setting::max_bytes_in_distinct], settings[Setting::distinct_overflow_mode]);
 
-        /// UNION keeps one stream per branch, so a preliminary DISTINCT deduplicates each of them in
-        /// parallel and shrinks what the final single-stream DISTINCT has to merge. INTERSECT/EXCEPT
+        /// UNION concatenates its branches' streams instead of merging them, so a preliminary DISTINCT
+        /// runs in parallel and shrinks what the final single-stream DISTINCT must merge. INTERSECT/EXCEPT
         /// already narrow their output to one stream, so a preliminary step there is pure overhead.
         const bool add_pre_distinct = union_mode == SelectUnionMode::UNION_DISTINCT;
 

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2105,7 +2105,7 @@ void Planner::buildPlanForUnionNode()
         /// UNION concatenates its branches' streams instead of merging them, so a preliminary DISTINCT
         /// runs in parallel and shrinks what the final single-stream DISTINCT must merge. INTERSECT/EXCEPT
         /// already narrow their output to one stream, so a preliminary step there is pure overhead.
-        const bool add_pre_distinct = union_mode == SelectUnionMode::UNION_DISTINCT;
+        const bool add_pre_distinct = union_mode == SelectUnionMode::UNION_DISTINCT && preliminaryDistinctIsUseful(max_threads);
 
         if (add_pre_distinct)
         {

--- a/src/Processors/QueryPlan/DistinctStep.cpp
+++ b/src/Processors/QueryPlan/DistinctStep.cpp
@@ -25,6 +25,11 @@ namespace ErrorCodes
     extern const int INCORRECT_DATA;
 }
 
+bool preliminaryDistinctIsUseful(size_t max_threads)
+{
+    return max_threads > 1;
+}
+
 static ITransformingStep::Traits getTraits(bool pre_distinct)
 {
     const bool preserves_number_of_streams = pre_distinct;

--- a/src/Processors/QueryPlan/DistinctStep.h
+++ b/src/Processors/QueryPlan/DistinctStep.h
@@ -5,6 +5,12 @@
 namespace DB
 {
 
+/// Whether adding a hashing preliminary DISTINCT can pay off, given the effective number of threads the
+/// caller has already resolved. Such a step deduplicates each stream on its own so that the final,
+/// single-stream DISTINCT has fewer rows left to merge, which takes a second stream to be worth
+/// anything: at one thread it only hashes every row a second time.
+bool preliminaryDistinctIsUseful(size_t max_threads);
+
 /// Execute DISTINCT for specified columns.
 class DistinctStep : public ITransformingStep
 {

--- a/tests/queries/0_stateless/01556_explain_select_with_union_query.reference
+++ b/tests/queries/0_stateless/01556_explain_select_with_union_query.reference
@@ -12,85 +12,113 @@ Union
     ReadFromSystemOne
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne
-Distinct
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-Distinct
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-Distinct
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-Distinct
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
 Union
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne
-  Distinct
+  Distinct (DISTINCT)
     Union
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-  Distinct
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+  Distinct (DISTINCT)
     Union
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-Distinct
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-Distinct
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-Distinct
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
 Union
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne
@@ -112,30 +140,39 @@ Union
     ReadFromSystemOne
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne
-Distinct
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-Distinct
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-Distinct
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+Distinct (DISTINCT)
   Union
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
-    Expression ((Project names + (Projection + Change column names to column identifiers)))
-      ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
+    Distinct (Preliminary DISTINCT)
+      Expression ((Project names + (Projection + Change column names to column identifiers)))
+        ReadFromSystemOne
 Union
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne
@@ -151,16 +188,20 @@ Union
     ReadFromSystemOne
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne
-  Distinct
+  Distinct (DISTINCT)
     Union
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
-      Expression ((Project names + (Projection + Change column names to column identifiers)))
-        ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
+      Distinct (Preliminary DISTINCT)
+        Expression ((Project names + (Projection + Change column names to column identifiers)))
+          ReadFromSystemOne
 Union
   Expression ((Project names + (Projection + Change column names to column identifiers)))
     ReadFromSystemOne

--- a/tests/queries/0_stateless/01556_explain_select_with_union_query.sql
+++ b/tests/queries/0_stateless/01556_explain_select_with_union_query.sql
@@ -2,6 +2,11 @@ SET explain_query_plan_default = 'legacy';
 SET enable_analyzer = 1;
 SET union_default_mode = 'DISTINCT';
 
+-- The plans below contain a preliminary DISTINCT, which a single stream does not get. The
+-- memory-pressure limiter can lower max_threads to one, so it is disabled here too.
+SET max_threads = 2;
+SET max_threads_min_free_memory_per_thread = 0;
+
 set enable_global_with_statement = 1;
 
 EXPLAIN SELECT 1 UNION ALL SELECT 1 UNION ALL SELECT 1;

--- a/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.reference
+++ b/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.reference
@@ -1,12 +1,15 @@
--- analyzer: UNION DISTINCT has a preliminary DISTINCT
-1
+-- analyzer: UNION DISTINCT has one preliminary DISTINCT per branch
+2
+3
 -- analyzer: the rewrite plans the same way
-1
+2
+3
 -- analyzer: INTERSECT/EXCEPT DISTINCT keep a single DISTINCT
 0
 0
--- old analyzer: UNION DISTINCT has a preliminary DISTINCT
-1
+-- old analyzer: UNION DISTINCT has one preliminary DISTINCT per branch
+2
+3
 -- results match the rewrite, per type
 300	13284647348874942505
 300	13284647348874942505
@@ -32,5 +35,5 @@
 [0,1,2,3,4]
 14
 -- size limits are enforced the same way as in the rewrite
-600
-600
+100
+100

--- a/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.reference
+++ b/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.reference
@@ -1,0 +1,36 @@
+-- analyzer: UNION DISTINCT has a preliminary DISTINCT
+1
+-- analyzer: the rewrite plans the same way
+1
+-- analyzer: INTERSECT/EXCEPT DISTINCT keep a single DISTINCT
+0
+0
+-- old analyzer: UNION DISTINCT has a preliminary DISTINCT
+1
+-- results match the rewrite, per type
+300	13284647348874942505
+300	13284647348874942505
+281	17873542345449711264
+281	17873542345449711264
+300	7293200561121895776
+300	7293200561121895776
+30	5782002969319538614
+30	5782002969319538614
+-- branch types are coerced, not compared raw
+2	5394436415501699917
+-- a branch header that diverges structurally still deduplicates
+1
+2
+-- chains and nesting
+400	79800
+900	144550
+400	79800
+-- a bare UNION under union_default_mode takes the same path
+300	44850
+-- LIMIT does not truncate the preliminary phase
+20
+[0,1,2,3,4]
+14
+-- size limits are enforced the same way as in the rewrite
+600
+600

--- a/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.reference
+++ b/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.reference
@@ -34,6 +34,12 @@
 20
 [0,1,2,3,4]
 14
+-- max_threads = 1: no preliminary step is added, and the result is unchanged
+0
+1
+300	13284647348874942505
+0
+300	13284647348874942505
 -- size limits are enforced the same way as in the rewrite
 100
 100

--- a/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.sql
+++ b/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.sql
@@ -1,0 +1,121 @@
+-- UNION DISTINCT gets a preliminary per-stream DISTINCT, so it plans like its
+-- SELECT DISTINCT over UNION ALL rewrite. INTERSECT/EXCEPT DISTINCT already emit a
+-- single stream, so they keep the single final DISTINCT.
+
+SET enable_analyzer = 1;
+
+SELECT '-- analyzer: UNION DISTINCT has a preliminary DISTINCT';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
+) WHERE explain ILIKE '%Preliminary DISTINCT%';
+
+SELECT '-- analyzer: the rewrite plans the same way';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN SELECT DISTINCT * FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x)
+) WHERE explain ILIKE '%Preliminary DISTINCT%';
+
+SELECT '-- analyzer: INTERSECT/EXCEPT DISTINCT keep a single DISTINCT';
+SELECT count() FROM (
+    EXPLAIN PLAN SELECT 1 AS x INTERSECT DISTINCT SELECT 1 AS x
+) WHERE explain ILIKE '%Preliminary%';
+SELECT count() FROM (
+    EXPLAIN PLAN SELECT 1 AS x EXCEPT DISTINCT SELECT 2 AS x
+) WHERE explain ILIKE '%Preliminary%';
+
+SET enable_analyzer = 0;
+
+SELECT '-- old analyzer: UNION DISTINCT has a preliminary DISTINCT';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
+) WHERE explain ILIKE '%Preliminary DISTINCT%';
+
+SET enable_analyzer = 1;
+
+SELECT '-- results match the rewrite, per type';
+CREATE TEMPORARY TABLE src (i UInt64);
+INSERT INTO src SELECT number FROM numbers(600);
+
+SELECT count(), sum(cityHash64(x)) FROM (
+    (SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src)
+);
+SELECT count(), sum(cityHash64(x)) FROM (SELECT DISTINCT * FROM (
+    (SELECT i % 200 AS x FROM src) UNION ALL (SELECT i % 300 AS x FROM src)
+));
+
+SELECT count(), sum(cityHash64(x)) FROM (
+    (SELECT if(i % 7 = 0, NULL, i % 200)::Nullable(UInt64) AS x FROM src)
+    UNION DISTINCT (SELECT if(i % 5 = 0, NULL, i % 300)::Nullable(UInt64) AS x FROM src)
+);
+SELECT count(), sum(cityHash64(x)) FROM (SELECT DISTINCT * FROM (
+    (SELECT if(i % 7 = 0, NULL, i % 200)::Nullable(UInt64) AS x FROM src)
+    UNION ALL (SELECT if(i % 5 = 0, NULL, i % 300)::Nullable(UInt64) AS x FROM src)
+));
+
+SELECT count(), sum(cityHash64(x)) FROM (
+    (SELECT toLowCardinality(toString(i % 200)) AS x FROM src)
+    UNION DISTINCT (SELECT toLowCardinality(toString(i % 300)) AS x FROM src)
+);
+SELECT count(), sum(cityHash64(x)) FROM (SELECT DISTINCT * FROM (
+    (SELECT toLowCardinality(toString(i % 200)) AS x FROM src)
+    UNION ALL (SELECT toLowCardinality(toString(i % 300)) AS x FROM src)
+));
+
+SELECT count(), sum(cityHash64(x)) FROM (
+    (SELECT [i % 20, i % 10] AS x FROM src) UNION DISTINCT (SELECT [i % 30, i % 10] AS x FROM src)
+);
+SELECT count(), sum(cityHash64(x)) FROM (SELECT DISTINCT * FROM (
+    (SELECT [i % 20, i % 10] AS x FROM src) UNION ALL (SELECT [i % 30, i % 10] AS x FROM src)
+));
+
+SELECT '-- branch types are coerced, not compared raw';
+SELECT count(), sum(cityHash64(x)) FROM (SELECT 1::UInt8 AS x UNION DISTINCT SELECT -5::Int64 AS x);
+
+SELECT '-- a branch header that diverges structurally still deduplicates';
+SELECT x FROM (SELECT 1 AS x UNION DISTINCT SELECT materialize(1) AS x);
+SELECT count() FROM (
+    SELECT sumState(i) AS s FROM src UNION DISTINCT SELECT sumState(number) AS s FROM numbers(10)
+);
+
+SELECT '-- chains and nesting';
+SELECT count(), sum(x) FROM (
+    (SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src)
+    UNION DISTINCT (SELECT i % 400 AS x FROM src)
+);
+SELECT count(), sum(x) FROM (
+    (SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src)
+    UNION ALL (SELECT i % 400 AS x FROM src)
+);
+SELECT count(), sum(x) FROM (
+    ((SELECT i % 200 AS x FROM src) UNION ALL (SELECT i % 300 AS x FROM src))
+    UNION DISTINCT (SELECT i % 400 AS x FROM src)
+);
+
+SELECT '-- a bare UNION under union_default_mode takes the same path';
+SELECT count(), sum(x) FROM (
+    (SELECT i % 200 AS x FROM src) UNION (SELECT i % 300 AS x FROM src)
+) SETTINGS union_default_mode = 'DISTINCT';
+
+SELECT '-- LIMIT does not truncate the preliminary phase';
+SELECT count() FROM (
+    SELECT x FROM ((SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src)) LIMIT 20
+);
+SELECT groupArray(x) FROM (
+    SELECT x FROM ((SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src))
+    ORDER BY x LIMIT 5
+);
+SELECT count() FROM (
+    SELECT x, x % 7 AS g FROM ((SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src))
+    LIMIT 2 BY g
+);
+
+SELECT '-- size limits are enforced the same way as in the rewrite';
+SELECT count() FROM (
+    (SELECT i AS x FROM src) UNION DISTINCT (SELECT i AS x FROM src)
+) SETTINGS max_rows_in_distinct = 100, distinct_overflow_mode = 'break', max_block_size = 50;
+SELECT count() FROM (SELECT DISTINCT * FROM (
+    (SELECT i AS x FROM src) UNION ALL (SELECT i AS x FROM src)
+)) SETTINGS max_rows_in_distinct = 100, distinct_overflow_mode = 'break', max_block_size = 50;
+
+SELECT count() FROM (
+    (SELECT i AS x FROM src) UNION DISTINCT (SELECT i AS x FROM src)
+) SETTINGS max_rows_in_distinct = 100, distinct_overflow_mode = 'throw'; -- { serverError SET_SIZE_LIMIT_EXCEEDED }

--- a/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.sql
+++ b/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.sql
@@ -2,17 +2,28 @@
 -- SELECT DISTINCT over UNION ALL rewrite. INTERSECT/EXCEPT DISTINCT already emit a
 -- single stream, so they keep the single final DISTINCT.
 
+-- The counts below are exact: one preliminary step per branch, and one DistinctTransform per
+-- branch plus the final one. A presence-only assertion would also pass on a step that is
+-- labelled preliminary but merges the streams, which is the whole regression.
+SET query_plan_lift_up_union = 1;
+
 SET enable_analyzer = 1;
 
-SELECT '-- analyzer: UNION DISTINCT has a preliminary DISTINCT';
-SELECT count() > 0 FROM (
+SELECT '-- analyzer: UNION DISTINCT has one preliminary DISTINCT per branch';
+SELECT count() FROM (
     EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
 ) WHERE explain ILIKE '%Preliminary DISTINCT%';
+SELECT count() FROM (
+    EXPLAIN PIPELINE SELECT 1 AS x UNION DISTINCT SELECT 2 AS x SETTINGS max_threads = 4
+) WHERE explain ILIKE '%DistinctTransform%';
 
 SELECT '-- analyzer: the rewrite plans the same way';
-SELECT count() > 0 FROM (
+SELECT count() FROM (
     EXPLAIN PLAN SELECT DISTINCT * FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x)
 ) WHERE explain ILIKE '%Preliminary DISTINCT%';
+SELECT count() FROM (
+    EXPLAIN PIPELINE SELECT DISTINCT * FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x) SETTINGS max_threads = 4
+) WHERE explain ILIKE '%DistinctTransform%';
 
 SELECT '-- analyzer: INTERSECT/EXCEPT DISTINCT keep a single DISTINCT';
 SELECT count() FROM (
@@ -24,10 +35,13 @@ SELECT count() FROM (
 
 SET enable_analyzer = 0;
 
-SELECT '-- old analyzer: UNION DISTINCT has a preliminary DISTINCT';
-SELECT count() > 0 FROM (
+SELECT '-- old analyzer: UNION DISTINCT has one preliminary DISTINCT per branch';
+SELECT count() FROM (
     EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
 ) WHERE explain ILIKE '%Preliminary DISTINCT%';
+SELECT count() FROM (
+    EXPLAIN PIPELINE SELECT 1 AS x UNION DISTINCT SELECT 2 AS x SETTINGS max_threads = 4
+) WHERE explain ILIKE '%DistinctTransform%';
 
 SET enable_analyzer = 1;
 
@@ -109,13 +123,15 @@ SELECT count() FROM (
 );
 
 SELECT '-- size limits are enforced the same way as in the rewrite';
+-- The source is numbers(), not src: a Memory table ignores max_block_size, so the whole 600 rows
+-- arrive as one chunk and the limit is only checked after they are all emitted.
 SELECT count() FROM (
-    (SELECT i AS x FROM src) UNION DISTINCT (SELECT i AS x FROM src)
+    (SELECT number AS x FROM numbers(600)) UNION DISTINCT (SELECT number AS x FROM numbers(600))
 ) SETTINGS max_rows_in_distinct = 100, distinct_overflow_mode = 'break', max_block_size = 50;
 SELECT count() FROM (SELECT DISTINCT * FROM (
-    (SELECT i AS x FROM src) UNION ALL (SELECT i AS x FROM src)
+    (SELECT number AS x FROM numbers(600)) UNION ALL (SELECT number AS x FROM numbers(600))
 )) SETTINGS max_rows_in_distinct = 100, distinct_overflow_mode = 'break', max_block_size = 50;
 
 SELECT count() FROM (
-    (SELECT i AS x FROM src) UNION DISTINCT (SELECT i AS x FROM src)
+    (SELECT number AS x FROM numbers(600)) UNION DISTINCT (SELECT number AS x FROM numbers(600))
 ) SETTINGS max_rows_in_distinct = 100, distinct_overflow_mode = 'throw'; -- { serverError SET_SIZE_LIMIT_EXCEEDED }

--- a/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.sql
+++ b/tests/queries/0_stateless/04951_union_distinct_preliminary_distinct.sql
@@ -7,6 +7,12 @@
 -- labelled preliminary but merges the streams, which is the whole regression.
 SET query_plan_lift_up_union = 1;
 
+-- max_threads is set at session level: a trailing SETTINGS clause on a UNION query binds to its last
+-- branch and never reaches the union itself. The counts depend on it, because a single stream gets no
+-- preliminary step, and the memory-pressure limiter below can otherwise lower it to one.
+SET max_threads = 2;
+SET max_threads_min_free_memory_per_thread = 0;
+
 SET enable_analyzer = 1;
 
 SELECT '-- analyzer: UNION DISTINCT has one preliminary DISTINCT per branch';
@@ -14,7 +20,7 @@ SELECT count() FROM (
     EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
 ) WHERE explain ILIKE '%Preliminary DISTINCT%';
 SELECT count() FROM (
-    EXPLAIN PIPELINE SELECT 1 AS x UNION DISTINCT SELECT 2 AS x SETTINGS max_threads = 4
+    EXPLAIN PIPELINE SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
 ) WHERE explain ILIKE '%DistinctTransform%';
 
 SELECT '-- analyzer: the rewrite plans the same way';
@@ -22,7 +28,7 @@ SELECT count() FROM (
     EXPLAIN PLAN SELECT DISTINCT * FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x)
 ) WHERE explain ILIKE '%Preliminary DISTINCT%';
 SELECT count() FROM (
-    EXPLAIN PIPELINE SELECT DISTINCT * FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x) SETTINGS max_threads = 4
+    EXPLAIN PIPELINE SELECT DISTINCT * FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x)
 ) WHERE explain ILIKE '%DistinctTransform%';
 
 SELECT '-- analyzer: INTERSECT/EXCEPT DISTINCT keep a single DISTINCT';
@@ -40,7 +46,7 @@ SELECT count() FROM (
     EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
 ) WHERE explain ILIKE '%Preliminary DISTINCT%';
 SELECT count() FROM (
-    EXPLAIN PIPELINE SELECT 1 AS x UNION DISTINCT SELECT 2 AS x SETTINGS max_threads = 4
+    EXPLAIN PIPELINE SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
 ) WHERE explain ILIKE '%DistinctTransform%';
 
 SET enable_analyzer = 1;
@@ -121,6 +127,27 @@ SELECT count() FROM (
     SELECT x, x % 7 AS g FROM ((SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src))
     LIMIT 2 BY g
 );
+
+SELECT '-- max_threads = 1: no preliminary step is added, and the result is unchanged';
+SET max_threads = 1;
+SELECT count() FROM (
+    EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
+) WHERE explain ILIKE '%Preliminary DISTINCT%';
+SELECT count() FROM (
+    EXPLAIN PIPELINE SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
+) WHERE explain ILIKE '%DistinctTransform%';
+SELECT count(), sum(cityHash64(x)) FROM (
+    (SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src)
+);
+SET enable_analyzer = 0;
+SELECT count() FROM (
+    EXPLAIN PLAN SELECT 1 AS x UNION DISTINCT SELECT 2 AS x
+) WHERE explain ILIKE '%Preliminary DISTINCT%';
+SELECT count(), sum(cityHash64(x)) FROM (
+    (SELECT i % 200 AS x FROM src) UNION DISTINCT (SELECT i % 300 AS x FROM src)
+);
+SET enable_analyzer = 1;
+SET max_threads = 2;
 
 SELECT '-- size limits are enforced the same way as in the rewrite';
 -- The source is numbers(), not src: a Memory table ignores max_block_size, so the whole 600 rows


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115104   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/114550
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/115104
Related: https://github.com/ClickHouse/ClickHouse/pull/114550

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`A UNION DISTINCT B` now deduplicates each branch in parallel before merging them, the same way its `SELECT DISTINCT * FROM (A UNION ALL B)` rewrite already did. Previously every row funnelled through a single `DistinctTransform`, so the query did not scale with `max_threads`.

### Description

`A UNION DISTINCT B` and `SELECT DISTINCT * FROM (A UNION ALL B)` are the same query but got different pipelines: the rewrite deduplicates each branch before the merge, `UNION DISTINCT` did not.

**Root cause.** The union branch of `Planner::buildPlanForUnionNode` (and its old-analyzer twin in `InterpreterSelectWithUnionQuery`) added one `DistinctStep` with `pre_distinct = false`. `DistinctStep::getTraits` sets `returns_single_stream = !pre_distinct`, so that one step both merged to one stream and deduplicated.

**The change** adds a `pre_distinct = true` step before the existing one, in both planners, when `max_threads > 1`. `liftUpUnion` then clones it into each branch, which is how the rewrite gets its per-branch distinct. No new setting.

Scoped to `UNION_DISTINCT`: `INTERSECT`/`EXCEPT DISTINCT` share the `is_distinct` branch, but `IntersectOrExceptStep` already emits one stream and `liftUpUnion` does not handle it, so a preliminary step there is overhead. Their plans are unchanged.

**Measured** (release build, 8M rows/branch, 2000 distinct values, best of 7):

| max_threads | before | after |
|---|---|---|
| 1  | 60 ms | 61 ms |
| 8  | 44 ms | 13 ms |
| 16 | 59 ms |  9 ms |

The rewrite scores 13 ms / 8 ms here, so the two forms now agree. A density sweep found the step detrimental only at one thread (worst cell 1.77x, all-distinct data), where it cannot reduce anything, so a shared `preliminaryDistinctIsUseful` predicate skips it: `max_threads = 1` plans stay byte-identical to master.

The step carries the same `max_rows_in_distinct` / `max_bytes_in_distinct`, so as in the rewrite they bind per stream as well as globally; both overflow modes measured identical to the rewrite.

The new test asserts plan shape, not timing, and checks results against the rewrite across `Nullable`, `LowCardinality`, `Array`, aggregate-state and coerced-type branches, chains, `LIMIT` and size limits, at one and several threads.

<details>
<summary>Interaction with #114550 (measured)</summary>

#114550 "Deduplicate the final DISTINCT in parallel" attacks the same bottleneck from the other side and edits the same two functions. Measured on its head `1e783f46`, same fixture and method:

| arm | t1 | t8 | t16 |
|---|---|---|---|
| master | 60 ms | 44 ms | 59 ms |
| #114550 alone | 57 ms | 22 ms | 17 ms |
| this PR alone | 61 ms | 13 ms | 9 ms |
| #114550 + this PR | 60 ms | 11 ms | 7 ms |

#114550 parallelizes the final dedup; this PR reduces how many rows reach it. They stack, and #114550 alone does not close the reported gap. It keeps `pre_distinct = false` at the union site, so the conflict is textual only - whoever merges second rebases.

</details>
