### PR TITLE
Perf(PromQL): Optimize vectorized two-input tag transformations

### DIFF
--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1677,37 +1677,35 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags2(c
     chassert(tags_vector2.size() == groups2.size());
 
     std::unordered_map<std::pair<Group, Group>, size_t, boost::hash<std::pair<Group, Group>>> indices_in_result_vector;
+    indices_in_result_vector.reserve(groups1.size());
+
+    VectorWithMemoryTracking<Group> res;
+    res.resize(groups1.size());
+
     size_t num_new_tags = 0;
 
     for (size_t i = 0; i != groups1.size(); ++i)
     {
         Group group1 = groups1[i];
         Group group2 = groups2[i];
-        auto it = indices_in_result_vector.find(std::make_pair(group1, group2));
-        if (it == indices_in_result_vector.end())
+        auto [it, inserted] = indices_in_result_vector.try_emplace(std::make_pair(group1, group2), num_new_tags);
+        if (inserted)
         {
             const auto & tags1 = tags_vector1[i];
             const auto & tags2 = tags_vector2[i];
             auto new_tags = transform_func(tags1, tags2);
-            indices_in_result_vector[std::make_pair(group1, group2)] = num_new_tags;
             tags_vector1[num_new_tags++] = new_tags;
         }
+
+        res[i] = it->second;
     }
 
     tags_vector1.resize(num_new_tags);
 
     auto new_groups = getGroupForTags(tags_vector1);
 
-    VectorWithMemoryTracking<Group> res;
-    res.reserve(groups1.size());
-
-    for (size_t i = 0; i != groups1.size(); ++i)
-    {
-        Group group1 = groups1[i];
-        Group group2 = groups2[i];
-        auto new_group = new_groups.at(indices_in_result_vector.at(std::make_pair(group1, group2)));
-        res.push_back(new_group);
-    }
+    for (auto & index : res)
+        index = new_groups.at(index);
 
     return res;
 }

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1677,7 +1677,6 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags2(c
     chassert(tags_vector2.size() == groups2.size());
 
     std::unordered_map<std::pair<Group, Group>, size_t, boost::hash<std::pair<Group, Group>>> indices_in_result_vector;
-    indices_in_result_vector.reserve(groups1.size());
 
     VectorWithMemoryTracking<Group> res;
     res.resize(groups1.size());

--- a/tests/performance/promql_tags_transform.xml
+++ b/tests/performance/promql_tags_transform.xml
@@ -26,7 +26,7 @@
         FORMAT Null
     </query>
 
-    <!-- Exercise the untouched vector-vector transformTags2() path with many unique pairs. -->
+    <!-- Exercise the vector-vector transformTags2() path with many unique pairs. -->
     <query>
         WITH
             (

--- a/tests/performance/promql_tags_transform.xml
+++ b/tests/performance/promql_tags_transform.xml
@@ -58,6 +58,38 @@
         FORMAT Null
     </query>
 
+    <!-- Exercise the vector-vector transformTags2() path with a small repeated pair set across multiple blocks. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(32)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(32)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[number % 32 + 1],
+                   src_groups[number % 32 + 1],
+                   ['src'])
+        FROM numbers(20000000)
+        SETTINGS max_threads = 1, max_block_size = 200000
+        FORMAT Null
+    </query>
+
     <query>
         WITH
             (

--- a/tests/performance/promql_tags_transform.xml
+++ b/tests/performance/promql_tags_transform.xml
@@ -26,6 +26,38 @@
         FORMAT Null
     </query>
 
+    <!-- Exercise the untouched vector-vector transformTags2() path with many unique pairs. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(200000)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(200000)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[number % 200000 + 1],
+                   src_groups[number % 200000 + 1],
+                   ['src'])
+        FROM numbers(2000000)
+        SETTINGS max_threads = 1, max_block_size = 200000
+        FORMAT Null
+    </query>
+
     <query>
         WITH
             (
@@ -103,6 +135,8 @@
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'sum by() (foo)', 100) SETTINGS max_threads = 1 FORMAT Null</query>
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'sum by (namespace) (foo)', 100) FORMAT Null</query>
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) bar', 100) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) group_left(namespace) bar', 100) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) group_right(namespace) bar', 100) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_tags_transform</drop_query>
 </test>

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.reference
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.reference
@@ -73,7 +73,7 @@ timeSeriesRemoveAllTagsExcept vectorized repeated sparse groups:
 5	1	[[('shared','value')]]
 
 timeSeriesCopyTag vectorized two groups:
-6	3	[[('dest','0'),('src','10')],[('dest','1'),('src','11')],[('dest','2'),('src','12')]]
+6	3	[[('dest','0'),('src','10')],[('dest','1'),('src','11')],[('dest','2'),('src','12')]]	[[('dest','0'),('src','10')],[('dest','1'),('src','11')],[('dest','0'),('src','10')],[('dest','2'),('src','12')],[('dest','1'),('src','11')],[('dest','0'),('src','10')]]
 
 timeSeriesCopyTags vectorized two groups with collapsed outputs:
-4	2	[[('dest','0'),('src','same')],[('dest','1'),('src','same')]]
+4	2	[[('dest','0'),('src','same')],[('dest','1'),('src','same')]]	[[('dest','0'),('src','same')],[('dest','1'),('src','same')],[('dest','0'),('src','same')],[('dest','1'),('src','same')]]

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.reference
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.reference
@@ -71,3 +71,9 @@ timeSeriesRemoveAllTagsExcept vectorized repeated dense groups:
 
 timeSeriesRemoveAllTagsExcept vectorized repeated sparse groups:
 5	1	[[('shared','value')]]
+
+timeSeriesCopyTag vectorized two groups:
+6	3	[[('dest','0'),('src','10')],[('dest','1'),('src','11')],[('dest','2'),('src','12')]]
+
+timeSeriesCopyTags vectorized two groups with collapsed outputs:
+4	2	[[('dest','0'),('src','same')],[('dest','1'),('src','same')]]

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -434,3 +434,79 @@ FROM
     SELECT timeSeriesRemoveAllTagsExcept(groups[[1, 25, 1, 25, 1][number + 1]], ['shared']) AS new_group
     FROM numbers(5)
 );
+
+SELECT '';
+SELECT 'timeSeriesCopyTag vectorized two groups:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+            FROM numbers(3)
+            ORDER BY number
+        )
+    ) AS dest_groups,
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('src', toString(number + 10))]) AS group
+            FROM numbers(3)
+            ORDER BY number
+        )
+    ) AS src_groups
+SELECT count(),
+       uniqExact(new_group),
+       groupUniqArray(timeSeriesGroupToTags(new_group))
+FROM
+(
+    SELECT timeSeriesCopyTag(dest_group, src_group, 'src') AS new_group
+    FROM
+    (
+        SELECT dest_groups[[1, 2, 1, 3, 2, 1]] AS dests,
+               src_groups[[1, 2, 1, 3, 2, 1]] AS srcs
+    )
+    ARRAY JOIN dests AS dest_group, srcs AS src_group
+);
+
+SELECT '';
+SELECT 'timeSeriesCopyTags vectorized two groups with collapsed outputs:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+            FROM numbers(2)
+            ORDER BY number
+        )
+    ) AS dest_groups,
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('src', 'same'), ('ignored', toString(number))]) AS group
+            FROM numbers(2)
+            ORDER BY number
+        )
+    ) AS src_groups
+SELECT count(),
+       uniqExact(new_group),
+       groupUniqArray(timeSeriesGroupToTags(new_group))
+FROM
+(
+    SELECT timeSeriesCopyTags(dest_group, src_group, ['src']) AS new_group
+    FROM
+    (
+        SELECT dest_groups[[1, 2, 1, 2]] AS dests,
+               src_groups[[1, 2, 2, 1]] AS srcs
+    )
+    ARRAY JOIN dests AS dest_group, srcs AS src_group
+);

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -461,7 +461,7 @@ WITH
     ) AS src_groups
 SELECT count(),
        uniqExact(new_group),
-       groupUniqArray(timeSeriesGroupToTags(new_group))
+       arraySort(groupUniqArray(timeSeriesGroupToTags(new_group)))
 FROM
 (
     SELECT timeSeriesCopyTag(dest_group, src_group, 'src') AS new_group
@@ -499,7 +499,7 @@ WITH
     ) AS src_groups
 SELECT count(),
        uniqExact(new_group),
-       groupUniqArray(timeSeriesGroupToTags(new_group))
+       arraySort(groupUniqArray(timeSeriesGroupToTags(new_group)))
 FROM
 (
     SELECT timeSeriesCopyTags(dest_group, src_group, ['src']) AS new_group

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -461,7 +461,8 @@ WITH
     ) AS src_groups
 SELECT count(),
        uniqExact(new_group),
-       arraySort(groupUniqArray(timeSeriesGroupToTags(new_group)))
+       arraySort(groupUniqArray(timeSeriesGroupToTags(new_group))),
+       groupArray(timeSeriesGroupToTags(new_group))
 FROM
 (
     SELECT timeSeriesCopyTag(dest_group, src_group, 'src') AS new_group
@@ -499,7 +500,8 @@ WITH
     ) AS src_groups
 SELECT count(),
        uniqExact(new_group),
-       arraySort(groupUniqArray(timeSeriesGroupToTags(new_group)))
+       arraySort(groupUniqArray(timeSeriesGroupToTags(new_group))),
+       groupArray(timeSeriesGroupToTags(new_group))
 FROM
 (
     SELECT timeSeriesCopyTags(dest_group, src_group, ['src']) AS new_group


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Avoid repeated pair hash lookups in vectorized two-input TimeSeries tag transformations.**

### Summary

This removes one unnecessary pair hash lookup per row from vectorized two-input TimeSeries tag transformations.

`transformTags2(groups1, groups2, ...)` is used by `timeSeriesCopyTag` and `timeSeriesCopyTags`. PromQL `group_left` and `group_right` use these functions when labels are copied during vector matching.

The old code transformed each unique `(group1, group2)` pair once, then walked every input row again and rebuilt the pair key to find the result slot. The new code stores that compact slot during the first pass and remaps all slots to final groups after tag registration.

It also uses `try_emplace` and keeps the pair map sparse. The pair deduplication and final-tag deduplication behavior is unchanged, including cases where different input pairs produce the same final tags.

### Changes

- Store the compact result slot during the first pass.
- Remap all slots to final groups after tag registration.
- Use `try_emplace` and keep the pair map sparse.
- Keep the existing pair deduplication and final-tag deduplication behavior.

### Benchmark

Coverage includes:

- 200,000 unique pairs over 2,000,000 rows.
- 32 repeated pairs over 20,000,000 rows and 100 blocks.
- PromQL aggregation plus `group_left` and `group_right` workloads.

The standalone loop benchmark over 200,000 rows showed the following results:

| Unique input pairs | Before | After | Speedup |
|---:|---:|---:|---:|
| 2 | 0.74 ms | 0.67 ms | **1.10x** |
| 10,000 | 1.23 ms | 1.06 ms | **1.16x** |
| 200,000 | 7.44 ms | 6.84 ms | **1.09x** |

Each result is the median of 5 process runs. Each process warmed up for 3 rounds and measured 9 samples for each implementation.

### Tests

- Add vectorized `timeSeriesCopyTag` coverage with repeated input pairs.
- Add vectorized `timeSeriesCopyTags` coverage where different input pairs collapse to the same final tag group.
- Sort the multi-result `groupUniqArray` assertions so they do not depend on hash-table iteration order.
- Run `git diff --check`.
- Run `xmllint --noout tests/performance/promql_tags_transform.xml`.
- Run focused vectorized TimeSeries queries using the available ClickHouse binary.
- Compile `ContextTimeSeriesTagsCollector.cpp` for C++ syntax.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115200&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115200](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115200+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->