### PR TITLE
Sum the adaptive aggregation seal normalization assertion over the three arms

### DIFF
--- a/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.reference
+++ b/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.reference
@@ -8,6 +8,4 @@ Nullable(UInt64)
 4873337004925605739
 4873337004925605739
 sealed chunks	1
-normalized string	1
-normalized uint128	1
-normalized nullable	1
+normalized	1

--- a/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.sql
+++ b/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.sql
@@ -108,25 +108,14 @@ WHERE current_database = currentDatabase() AND type = 'QueryFinish'
     AND event_date >= yesterday() AND event_time >= now() - 600
     AND log_comment LIKE '04676_seal_%';
 
--- Reaching the coalescing is not the same as reaching the normalization inside it: the batches
--- have to disagree at one argument position too. Values alone cannot tell the two apart, because
--- a wrapped first batch absorbs the mix on its own. Each arm is asserted separately, so a
--- normalized seal in one representation cannot vouch for another.
-SELECT 'normalized string', coalesce(sum(ProfileEvents['AdaptiveAggregationSealNormalizations']), 0) > 0
+-- The normalization inside the coalescing additionally needs the buffered batches to disagree at
+-- an argument position, and which blocks one producer buffers is not something the settings above
+-- pin, so the count is summed over the three arms rather than asserted for each.
+SELECT 'normalized', coalesce(sum(ProfileEvents['AdaptiveAggregationSealNormalizations']), 0) > 0
 FROM system.query_log
 WHERE current_database = currentDatabase() AND type = 'QueryFinish'
     AND event_date >= yesterday() AND event_time >= now() - 600
-    AND log_comment = '04676_seal_string';
-SELECT 'normalized uint128', coalesce(sum(ProfileEvents['AdaptiveAggregationSealNormalizations']), 0) > 0
-FROM system.query_log
-WHERE current_database = currentDatabase() AND type = 'QueryFinish'
-    AND event_date >= yesterday() AND event_time >= now() - 600
-    AND log_comment = '04676_seal_uint128';
-SELECT 'normalized nullable', coalesce(sum(ProfileEvents['AdaptiveAggregationSealNormalizations']), 0) > 0
-FROM system.query_log
-WHERE current_database = currentDatabase() AND type = 'QueryFinish'
-    AND event_date >= yesterday() AND event_time >= now() - 600
-    AND log_comment = '04676_seal_nullable';
+    AND log_comment LIKE '04676_seal_%';
 
 DROP TABLE t_adaptive_repl_left;
 DROP TABLE t_adaptive_repl_right;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115034
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/115034

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04676_adaptive_aggregation_replicated_argument`, which I added in #115034, is flaky: as of
2026-08-17 20:00 UTC it had failed 22 times across 22 unrelated pull requests against 1341 passes,
roughly 1.6%, and it is still firing. Every failure is one of three assertion lines flipping `1`
to `0`, for example `+normalized nullable 0`.
[Sample report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108431&sha=61e924073e8505f78ac3e3438e2a180a07c740df&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29)
(`Stateless tests (amd_debug, distributed plan, s3 storage, parallel)` on #108431).

The test asserted `AdaptiveAggregationSealNormalizations > 0` separately for each of its three
argument representations. That counter fires in `Aggregator::sealPendingChunks` only when the
batches one producer buffered together disagree at an argument position, which needs two batches
buffered in one producer, both representations reachable, and one producer holding blocks of both
kinds. The test pins only the second; the others are a read pool decision and thread scheduling,
so a non-zero count for a single query is not an engine guarantee. Randomization is not the cause:
it also reproduces with randomization off and with `enable_lazy_columns_replication 0`.

This sums the counter over the three arms instead, which is the property the engine does
guarantee, and changes nothing else. The three queries stay separate, so each keeps its own value
comparison and its own abort site; the `sealed chunks` assertion, the six value lines and the tags
are untouched. Within one run the test no longer proves that every representation reached the
normalization. `04654` already asserts the sibling `AdaptiveAggregationSealedChunks` in aggregate.

Validation: in one interleaved loop the old form failed twice while the new form passed 300 of 300.
Of 600 runs, 6 had an arm at zero and all 6 still had a non-zero total. With #115034's fix reverted
the new form aborts 20 of 20 with `Bad cast from type DB::ColumnReplicated to DB::ColumnVector` in
`sealPendingChunks`. 50 runs with randomized settings and 50 without both pass.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115204&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115204](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115204+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
