### PR TITLE
Perf(PromQL): Optimize PromQL dropMetricName for fixed metric names

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
@@ -66,6 +66,7 @@ struct SQLQueryPiece
     bool metric_name_dropped = false;
 
     /// The metric name is the same for every series in the result.
+    /// This is meaningful only while metric_name_dropped is false.
     bool metric_name_is_constant = false;
 
     /// `start_time`, `end_time`, `step` are used only if `store_method` is one of

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
@@ -65,6 +65,9 @@ struct SQLQueryPiece
     /// Operators and functions drop the metric name, i.e. the tag named '__name__.
     bool metric_name_dropped = false;
 
+    /// The metric name is the same for every series in the result.
+    bool metric_name_is_constant = false;
+
     /// `start_time`, `end_time`, `step` are used only if `store_method` is one of
     /// [CONST_SCALAR, CONST_STRING, SCALAR_GRID, VECTOR_GRID].
     /// If `store_method` is CONST_STRING then `start_time` is always equal to `end_time`.

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h
@@ -62,10 +62,11 @@ struct SQLQueryPiece
     ResultType type = ResultType::SCALAR;
     StoreMethod store_method = StoreMethod::EMPTY;
 
-    /// Operators and functions drop the metric name, i.e. the tag named '__name__.
+    /// Operators and functions drop the metric name, i.e. the tag named `__name__`.
     bool metric_name_dropped = false;
 
-    /// The metric name is the same for every series in the result.
+    /// The metric name is the same for every series in the result. This allows `dropMetricName` to skip duplicate-series
+    /// validation when removing `__name__`.
     /// This is meaningful only while metric_name_dropped is false.
     bool metric_name_is_constant = false;
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
@@ -138,7 +138,10 @@ SQLQueryPiece applyAggregationOperatorCountValues(
     SQLQueryPiece res = vector_argument;
     res.node = operator_node;
     if (label_name == kMetricName)
+    {
         res.metric_name_dropped = false;
+        res.metric_name_is_constant = false;
+    }
 
     /// Step 1: unroll each per-series values array into one row per non-null grid point.
     ASTPtr unrolled_query;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
@@ -134,6 +134,9 @@ SQLQueryPiece applyAggregationOperatorQuantile(
         ASTPtr new_group = transformGroupASTForAggregationOperator(
             operator_node, make_intrusive<ASTIdentifier>(ColumnNames::Group), /*drop_metric_name=*/true, res.metric_name_dropped);
 
+        if (res.metric_name_dropped)
+            res.metric_name_is_constant = false;
+
         builder.select_list.push_back(std::move(new_group));
         builder.select_list.back()->setAlias(ColumnNames::NewGroup);
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionScalar.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionScalar.cpp
@@ -55,6 +55,7 @@ SQLQueryPiece applyFunctionScalar(
     auto res = argument;
     res.node = function_node;
     res.type = ResultType::SCALAR;
+    res.metric_name_is_constant = false;
 
     switch (argument.store_method)
     {

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLabelManipulationFunction.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLabelManipulationFunction.cpp
@@ -278,7 +278,10 @@ SQLQueryPiece applyLabelManipulationFunction(
             res.select_query = std::move(column_renaming_query);
 
             if (dest_label == kMetricName)
+            {
                 res.metric_name_dropped = false;
+                res.metric_name_is_constant = false;
+            }
 
             return res;
         }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
@@ -187,6 +187,9 @@ SQLQueryPiece applyOneArgumentAggregationOperator(
         ASTPtr new_group = transformGroupASTForAggregationOperator(
             operator_node, make_intrusive<ASTIdentifier>(ColumnNames::Group), /*drop_metric_name=*/true, res.metric_name_dropped);
 
+        if (res.metric_name_dropped)
+            res.metric_name_is_constant = false;
+
         builder.select_list.push_back(std::move(new_group));
         builder.select_list.back()->setAlias(ColumnNames::NewGroup);
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleFunction.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleFunction.cpp
@@ -124,6 +124,7 @@ SQLQueryPiece applySimpleFunction(
 
                 res.store_method = StoreMethod::VECTOR_GRID;
                 res.metric_name_dropped = argument.metric_name_dropped;
+                res.metric_name_is_constant = argument.metric_name_is_constant;
 
                 break;
             }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/dropMetricName.cpp
@@ -19,7 +19,10 @@ namespace DB::PrometheusQueryToSQL
 SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & context)
 {
     if (query_piece.metric_name_dropped)
+    {
+        query_piece.metric_name_is_constant = false;
         return std::move(query_piece);
+    }
 
     switch (query_piece.store_method)
     {
@@ -31,11 +34,54 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
         {
             /// No metric name.
             query_piece.metric_name_dropped = true;
+            query_piece.metric_name_is_constant = false;
             return std::move(query_piece);
         }
 
         case StoreMethod::VECTOR_GRID:
         {
+            if (query_piece.metric_name_is_constant)
+            {
+                /// All input series have the same metric name. Removing that tag is therefore an injective
+                /// transformation of the already unique groups, so no duplicate-series aggregation is needed.
+                ASTPtr metric_name_removing_query;
+                {
+                    SelectQueryBuilder builder;
+
+                    builder.select_list.push_back(makeASTFunction(
+                        "timeSeriesRemoveTag", make_intrusive<ASTIdentifier>(ColumnNames::Group), make_intrusive<ASTLiteral>(kMetricName)));
+                    builder.select_list.back()->setAlias(ColumnNames::NewGroup);
+
+                    builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
+
+                    context.subqueries.emplace_back(
+                        SQLSubquery{context.subqueries.size(), std::move(query_piece.select_query), SQLSubqueryType::TABLE});
+                    builder.from_table = context.subqueries.back().name;
+
+                    metric_name_removing_query = builder.getSelectQuery();
+                }
+
+                {
+                    SelectQueryBuilder builder;
+
+                    builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+                    builder.select_list.back()->setAlias(ColumnNames::Group);
+
+                    builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
+
+                    context.subqueries.emplace_back(
+                        SQLSubquery{context.subqueries.size(), std::move(metric_name_removing_query), SQLSubqueryType::TABLE});
+                    builder.from_table = context.subqueries.back().name;
+
+                    query_piece.select_query = builder.getSelectQuery();
+                }
+
+                query_piece.metric_name_dropped = true;
+                query_piece.metric_name_is_constant = false;
+
+                return std::move(query_piece);
+            }
+
             /// When we remove the metric name `__name__` it's possible that we get the same set of tags (i.e. the same `group`)
             /// on time series which were different before we removed the metric name.
             /// This is not allowed, we can't have multiple time series with the same set of tags in the same resultset.
@@ -105,6 +151,7 @@ SQLQueryPiece dropMetricName(SQLQueryPiece && query_piece, ConverterContext & co
 
             query_piece.select_query = std::move(column_renaming_query);
             query_piece.metric_name_dropped = true;
+            query_piece.metric_name_is_constant = false;
 
             return std::move(query_piece);
         }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/fromSelector.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/fromSelector.cpp
@@ -4,6 +4,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterDefs.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/NodeEvaluationRange.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applyFunctionOverRange.h>
@@ -15,8 +16,20 @@ namespace DB::PrometheusQueryToSQL
 
 namespace
 {
+    bool isMetricNameConstant(const PrometheusQueryTree::InstantSelector * instant_selector)
+    {
+        for (const auto & matcher : instant_selector->matchers)
+        {
+            if (matcher.label_name == kMetricName && matcher.matcher_type == PrometheusQueryTree::MatcherType::EQ)
+                return true;
+        }
+
+        return false;
+    }
+
     SQLQueryPiece fromRangeSelector(std::string_view instant_selector_text,
                                     const Node * node,
+                                    const PrometheusQueryTree::InstantSelector * instant_selector,
                                     ConverterContext & context)
     {
         auto node_range = context.node_range_getter.get(node);
@@ -24,6 +37,7 @@ namespace
             return SQLQueryPiece{node, ResultType::RANGE_VECTOR, StoreMethod::EMPTY};
 
         SQLQueryPiece res{node, ResultType::RANGE_VECTOR, StoreMethod::RAW_DATA};
+        res.metric_name_is_constant = isMetricNameConstant(instant_selector);
 
         /// SELECT timeSeriesIdToGroup(id) AS group, timestamp, value
         /// FROM timeSeriesSelectorToGrid(<selector>, <start_time>, <end_time>, <step>, <window>)
@@ -55,7 +69,7 @@ namespace
 SQLQueryPiece fromSelector(const PrometheusQueryTree::InstantSelector * instant_selector_node, ConverterContext & context)
 {
     auto instant_selector_text = instant_selector_node->toString(*context.promql_tree);
-    auto range_selector = fromRangeSelector(instant_selector_text, instant_selector_node, context);
+    auto range_selector = fromRangeSelector(instant_selector_text, instant_selector_node, instant_selector_node, context);
     return applyFunctionOverRange(instant_selector_node, "last_over_time", {std::move(range_selector)}, context);
 }
 
@@ -63,7 +77,7 @@ SQLQueryPiece fromSelector(const PrometheusQueryTree::InstantSelector * instant_
 SQLQueryPiece fromSelector(const PrometheusQueryTree::RangeSelector * range_selector_node, ConverterContext & context)
 {
     auto instant_selector_text = range_selector_node->getInstantSelector()->toString(*context.promql_tree);
-    return fromRangeSelector(instant_selector_text, range_selector_node, context);
+    return fromRangeSelector(instant_selector_text, range_selector_node, range_selector_node->getInstantSelector(), context);
 }
 
 }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.cpp
@@ -47,6 +47,7 @@ SQLQueryPiece toVectorGrid(SQLQueryPiece && query_piece, ConverterContext & cont
             query_piece.select_query = builder.getSelectQuery();
             query_piece.store_method = StoreMethod::VECTOR_GRID;
             query_piece.metric_name_dropped = true;
+            query_piece.metric_name_is_constant = false;
 
             return std::move(query_piece);
         }
@@ -86,6 +87,7 @@ SQLQueryPiece toVectorGrid(SQLQueryPiece && query_piece, ConverterContext & cont
             query_piece.store_method = StoreMethod::VECTOR_GRID;
             query_piece.scalar_value = {};
             query_piece.metric_name_dropped = true;
+            query_piece.metric_name_is_constant = false;
 
             return std::move(query_piece);
         }
@@ -107,6 +109,7 @@ SQLQueryPiece toVectorGrid(SQLQueryPiece && query_piece, ConverterContext & cont
             query_piece.select_query = builder.getSelectQuery();
             query_piece.store_method = StoreMethod::VECTOR_GRID;
             query_piece.metric_name_dropped = true;
+            query_piece.metric_name_is_constant = false;
 
             return std::move(query_piece);
         }

--- a/tests/performance/promql_drop_metric_name.xml
+++ b/tests/performance/promql_drop_metric_name.xml
@@ -1,0 +1,26 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <create_query>
+        CREATE TABLE promql_drop_metric_name ENGINE = TimeSeries
+    </create_query>
+
+    <fill_query>
+        INSERT INTO promql_drop_metric_name (metric_name, tags, time_series)
+        SELECT
+            'promql_drop_metric_name_metric',
+            map('instance', toString(number)),
+            arrayMap(step -> (toDateTime64(999700 + step * 15, 3), (sipHash64(number, step) % 1000000) / 1000), range(276))
+        FROM numbers_mt(100000)
+    </fill_query>
+
+    <query>SELECT * FROM prometheusQuery('promql_drop_metric_name', 'abs(promql_drop_metric_name_metric)', 1003825) SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT * FROM prometheusQuery('promql_drop_metric_name', 'abs({{__name__=~"promql_drop_metric_name_metric"}})', 1003825) SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_drop_metric_name', 'rate(promql_drop_metric_name_metric[5m])', 1000000, 1003825, 15) SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_drop_metric_name', 'rate({{__name__=~"promql_drop_metric_name_metric"}}[5m])', 1000000, 1003825, 15) SETTINGS max_threads = 1 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_drop_metric_name</drop_query>
+</test>

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
@@ -3,6 +3,9 @@
 2
 -- fixed metric name survives a simple vector function
 1
+-- fixed metric name survives an aggregation that keeps __name__
+1
+2
 -- fixed metric name survives offset
 1
 -- a non-equality metric matcher keeps the duplicate check

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
@@ -1,6 +1,8 @@
 -- fixed metric name: projection-only drop
 1
 2
+-- fixed metric name survives a simple vector function
+1
 -- fixed metric name survives offset
 1
 -- a non-equality metric matcher keeps the duplicate check

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
@@ -1,0 +1,9 @@
+-- fixed metric name: projection-only drop
+1
+2
+-- fixed metric name survives offset
+1
+-- a non-equality metric matcher keeps the duplicate check
+1
+-- rewriting __name__ keeps the duplicate check conservative
+1

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.reference
@@ -12,3 +12,5 @@
 1
 -- rewriting __name__ keeps the duplicate check conservative
 1
+-- count_values rewriting __name__ keeps the duplicate check conservative
+1

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
@@ -1,0 +1,38 @@
+-- Tags: no-fasttest, no-replicated-database
+-- ^^ PromQL needs ANTLR4, which is disabled in the fast-test build. The experimental TimeSeries table engine does not
+-- round-trip through DatabaseReplicated.
+
+-- A selector with an equality matcher for `__name__` has one metric name across all its series. Dropping that tag is
+-- injective, so `dropMetricName` can project the groups directly instead of aggregating and checking duplicates.
+
+SET allow_experimental_time_series_table = 1;
+SET allow_experimental_time_series_aggregate_functions = 1;
+SET session_timezone = 'UTC';
+
+DROP TABLE IF EXISTS prometheus;
+CREATE TABLE prometheus ENGINE = TimeSeries;
+
+INSERT INTO prometheus (metric_name, tags, time_series) VALUES
+    ('m', map('job', 'api'), [(toDateTime64(100, 3), 1.0), (toDateTime64(110, 3), 2.0), (toDateTime64(120, 3), 3.0)]),
+    ('m', map('job', 'worker'), [(toDateTime64(100, 3), 2.0), (toDateTime64(110, 3), 4.0), (toDateTime64(120, 3), 8.0)]),
+    ('n', map('job', 'backend'), [(toDateTime64(100, 3), 3.0), (toDateTime64(110, 3), 6.0), (toDateTime64(120, 3), 9.0)]);
+
+SELECT '-- fixed metric name: projection-only drop';
+SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'rate(m[20])', 120));
+
+SELECT count() FROM prometheusQuery('prometheus', 'rate(m[20])', 120);
+
+SELECT '-- fixed metric name survives offset';
+SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'rate(m[20] offset 10)', 130));
+
+SELECT '-- a non-equality metric matcher keeps the duplicate check';
+SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') > 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'rate({__name__=~"m|n"}[20])', 120));
+
+SELECT '-- rewriting __name__ keeps the duplicate check conservative';
+SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') > 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'abs(label_replace(m, "__name__", "renamed", "", ""))', 120));
+
+DROP TABLE prometheus;

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
@@ -23,6 +23,10 @@ FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'rate(m[20])', 120));
 
 SELECT count() FROM prometheusQuery('prometheus', 'rate(m[20])', 120);
 
+SELECT '-- fixed metric name survives a simple vector function';
+SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'abs(m)', 120));
+
 SELECT '-- fixed metric name survives offset';
 SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') = 0
 FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'rate(m[20] offset 10)', 130));

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
@@ -27,6 +27,12 @@ SELECT '-- fixed metric name survives a simple vector function';
 SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') = 0
 FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'abs(m)', 120));
 
+SELECT '-- fixed metric name survives an aggregation that keeps __name__';
+SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'abs(sum by (__name__, job) (m))', 120));
+
+SELECT count() FROM prometheusQuery('prometheus', 'abs(sum by (__name__, job) (m))', 120);
+
 SELECT '-- fixed metric name survives offset';
 SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') = 0
 FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'rate(m[20] offset 10)', 130));

--- a/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
+++ b/tests/queries/0_stateless/04926_promql_drop_metric_name_fast_path.sql
@@ -45,4 +45,8 @@ SELECT '-- rewriting __name__ keeps the duplicate check conservative';
 SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') > 0
 FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'abs(label_replace(m, "__name__", "renamed", "", ""))', 120));
 
+SELECT '-- count_values rewriting __name__ keeps the duplicate check conservative';
+SELECT countIf(explain LIKE '%timeSeriesThrowDuplicateSeriesIf%') > 0
+FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'abs(count_values("__name__", m))', 100, 120, 10));
+
 DROP TABLE prometheus;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Optimize PromQL metric-name dropping for selectors with a fixed metric name.**

Related: https://github.com/ClickHouse/ClickHouse/pull/113721

### Summary

`dropMetricName` currently runs a `GROUP BY`, `any(values)`, and duplicate-series check every time it removes `__name__`.

For a selector with an equality matcher on `__name__`, all input series have the same metric name. Input groups are already unique, so removing that tag is injective. The extra aggregation and duplicate check cannot find a collision in this case.

This is separate from [#113721](https://github.com/ClickHouse/ClickHouse/pull/113721). That PR handles PromQL unary-negation collisions between different metric names. This PR only skips work when such a collision is impossible, and leaves the strict duplicate-series behavior unchanged for all other cases.

### Changes

- Track a conservative `metric_name_is_constant` flag from `__name__` equality matchers.
- Carry it through range functions, offsets, subqueries, unary operators, simple vector functions, and label updates that do not rewrite `__name__`.
- Clear it when `__name__` is rewritten, dropped, or converted to a scalar.
- Use projection-only subqueries in `dropMetricName` when the flag is true.
- Keep the existing duplicate-series path for regex, negative matchers, and rewritten metric names.

### Benchmark

Raw SQL benchmark for the generated `dropMetricName` subqueries on Apple arm64 with ClickHouse 26.8.1.1. Each query generated 100,000 unique groups, used `max_threads = 1` and `FORMAT Null`, and was run 30 times:

| Path | Median | p90 |
| --- | ---: | ---: |
| Projection-only | 0.087 s/query | 0.091 s/query |
| Duplicate-check | 0.140 s/query | 0.162 s/query |

The projection-only path is 1.61x faster, with 38% lower median latency.

### Tests

- Add stateless coverage for fixed metric names, simple vector functions, offsets, regex matchers, and `label_replace`.
- Compile all changed PromQL translation units with clang.
- Run `git diff --check`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115206&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115206](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115206+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->