### PR TITLE
Perf(PromQL): Optimize PromQL or for exact groups

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -15,6 +15,12 @@ namespace DB::PrometheusQueryToSQL
 
 namespace
 {
+    bool isExactGroup(const ASTPtr & group)
+    {
+        const auto * identifier = group->as<ASTIdentifier>();
+        return identifier && identifier->name() == ColumnNames::Group;
+    }
+
     ASTPtr makeOrMergeQuery(const String & left, const String & right)
     {
         SelectQueryBuilder builder;
@@ -102,8 +108,7 @@ SQLQueryPiece applyBinaryOperatorOr(
         /*drop_metric_name=*/ true,
         right_metric_name_dropped);
 
-    const bool exact_group_match = tryGetIdentifierName(left_join_group.get()) == ColumnNames::Group
-        && tryGetIdentifierName(right_join_group.get()) == ColumnNames::Group;
+    const bool exact_group_match = isExactGroup(left_join_group) && isExactGroup(right_join_group);
 
     context.subqueries.emplace_back(SQLSubquery{
         context.subqueries.size(),

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -21,6 +21,7 @@ namespace
         return identifier && identifier->name() == ColumnNames::Group;
     }
 
+    /// Merge two unique VECTOR_GRID inputs by group, preferring non-NULL values from the left input.
     ASTPtr makeOrMergeQuery(const String & left, const String & right)
     {
         SelectQueryBuilder builder;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -13,6 +13,56 @@
 namespace DB::PrometheusQueryToSQL
 {
 
+namespace
+{
+    ASTPtr makeOrMergeQuery(const String & left, const String & right)
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(makeASTFunction(
+            "if",
+            makeASTFunction("empty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
+            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Group}),
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group})));
+        builder.select_list.back()->setAlias(ColumnNames::Group);
+
+        builder.select_list.push_back(makeASTFunction(
+            "multiIf",
+            makeASTFunction(
+                "and",
+                makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
+                makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values}))),
+            makeASTFunction(
+                "arrayMap",
+                makeASTFunction(
+                    "lambda",
+                    makeASTFunction("tuple", make_intrusive<ASTIdentifier>("a"), make_intrusive<ASTIdentifier>("b")),
+                    makeASTFunction(
+                        "if",
+                        makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("a")),
+                        make_intrusive<ASTIdentifier>("a"),
+                        make_intrusive<ASTIdentifier>("b"))),
+                make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
+                make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values})),
+            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
+            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values})));
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        builder.from_table = left;
+        builder.join_kind = JoinKind::Full;
+        builder.join_strictness = JoinStrictness::All;
+        builder.join_table = right;
+
+        builder.join_on = makeASTFunction(
+            "equals",
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}),
+            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Group}));
+
+        return builder.getSelectQuery();
+    }
+}
+
 SQLQueryPiece applyBinaryOperatorOr(
     const PrometheusQueryTree::BinaryOperator * operator_node,
     SQLQueryPiece && left_argument,
@@ -37,14 +87,45 @@ SQLQueryPiece applyBinaryOperatorOr(
     }
 
     left_argument = toVectorGrid(std::move(left_argument), context);
-    /// The left grid is read twice - by the per-group presence step (Step 1) and by the final merge join (Step 3) -
-    /// so it's added as a materialized CTE to be evaluated once.
-    context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(left_argument.select_query), SQLSubqueryType::MATERIALIZED_TABLE});
-    String left = context.subqueries.back().name;
+    bool left_metric_name_dropped = left_argument.metric_name_dropped;
+    ASTPtr left_join_group = transformGroupASTForBinaryOperator(
+        operator_node,
+        make_intrusive<ASTIdentifier>(ColumnNames::Group),
+        /*drop_metric_name=*/ true,
+        left_metric_name_dropped);
 
     right_argument = toVectorGrid(std::move(right_argument), context);
+    bool right_metric_name_dropped = right_argument.metric_name_dropped;
+    ASTPtr right_join_group = transformGroupASTForBinaryOperator(
+        operator_node,
+        make_intrusive<ASTIdentifier>(ColumnNames::Group),
+        /*drop_metric_name=*/ true,
+        right_metric_name_dropped);
+
+    const bool exact_group_match = tryGetIdentifierName(left_join_group.get()) == ColumnNames::Group
+        && tryGetIdentifierName(right_join_group.get()) == ColumnNames::Group;
+
+    context.subqueries.emplace_back(SQLSubquery{
+        context.subqueries.size(),
+        std::move(left_argument.select_query),
+        exact_group_match ? SQLSubqueryType::TABLE : SQLSubqueryType::MATERIALIZED_TABLE});
+    String left = context.subqueries.back().name;
+
     context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
     String right = context.subqueries.back().name;
+
+    if (exact_group_match)
+    {
+        SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
+        res.select_query = makeOrMergeQuery(left, right);
+        res.metric_name_dropped = left_argument.metric_name_dropped && right_argument.metric_name_dropped;
+
+        res.start_time = left_argument.start_time;
+        res.end_time = left_argument.end_time;
+        res.step = left_argument.step;
+
+        return res;
+    }
 
     /// Step 1: Build the per-step presence mask per `join_group` on the left side.
     ///
@@ -57,12 +138,7 @@ SQLQueryPiece applyBinaryOperatorOr(
     {
         SelectQueryBuilder builder;
 
-        bool left_metric_name_dropped = left_argument.metric_name_dropped;
-        builder.select_list.push_back(transformGroupASTForBinaryOperator(
-            operator_node,
-            make_intrusive<ASTIdentifier>(ColumnNames::Group),
-            /*drop_metric_name=*/ true,
-            left_metric_name_dropped));
+        builder.select_list.push_back(std::move(left_join_group));
         builder.select_list.back()->setAlias(ColumnNames::JoinGroup);
 
         builder.select_list.push_back(makePresenceMask(make_intrusive<ASTIdentifier>(ColumnNames::Values)));
@@ -116,15 +192,10 @@ SQLQueryPiece applyBinaryOperatorOr(
         builder.join_strictness = JoinStrictness::Any;
         builder.join_table = right;
 
-        bool right_metric_name_dropped = right_argument.metric_name_dropped;
         builder.join_on = makeASTFunction(
             "equals",
             make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup),
-            transformGroupASTForBinaryOperator(
-                operator_node,
-                make_intrusive<ASTIdentifier>(ColumnNames::Group),
-                /*drop_metric_name=*/ true,
-                right_metric_name_dropped));
+            std::move(right_join_group));
 
         ASTPtr step2_ast = builder.getSelectQuery();
         context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(step2_ast), SQLSubqueryType::TABLE});
@@ -145,54 +216,7 @@ SQLQueryPiece applyBinaryOperatorOr(
     /// FROM left FULL ALL JOIN step2
     /// ON left.group == step2.group
     ///
-    ASTPtr step3;
-    {
-        SelectQueryBuilder builder;
-
-        builder.select_list.push_back(makeASTFunction(
-            "if",
-            makeASTFunction("empty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
-            make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Group}),
-            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group})));
-        builder.select_list.back()->setAlias(ColumnNames::Group);
-
-        builder.select_list.push_back(makeASTFunction(
-            "multiIf",
-            makeASTFunction(
-                "and",
-                makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
-                makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Values}))),
-            makeASTFunction(
-                "arrayMap",
-                makeASTFunction(
-                    "lambda",
-                    makeASTFunction("tuple", make_intrusive<ASTIdentifier>("a"), make_intrusive<ASTIdentifier>("b")),
-                    makeASTFunction(
-                        "if",
-                        makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("a")),
-                        make_intrusive<ASTIdentifier>("a"),
-                        make_intrusive<ASTIdentifier>("b"))),
-                make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
-                make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Values})),
-            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
-            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
-            make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Values})));
-        builder.select_list.back()->setAlias(ColumnNames::Values);
-
-        /// If the left grid is not materialized (the setting `enable_materialized_cte` is disabled), it's evaluated
-        /// here a second time, which is still correct because group ids are the same within one query.
-        builder.from_table = left;
-        builder.join_kind = JoinKind::Full;
-        builder.join_strictness = JoinStrictness::All;
-        builder.join_table = step2;
-
-        builder.join_on = makeASTFunction(
-            "equals",
-            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}),
-            make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Group}));
-
-        step3 = builder.getSelectQuery();
-    }
+    ASTPtr step3 = makeOrMergeQuery(left, step2);
 
     SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
     res.select_query = std::move(step3);

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -15,10 +15,15 @@ namespace DB::PrometheusQueryToSQL
 
 namespace
 {
-    bool isExactGroup(const ASTPtr & group)
+    bool canUseExactGroupMatch(
+        const PrometheusQueryTree::BinaryOperator * operator_node,
+        bool left_metric_name_dropped,
+        bool right_metric_name_dropped)
     {
-        const auto * identifier = group->as<ASTIdentifier>();
-        return identifier && identifier->name() == ColumnNames::Group;
+        /// This is the set of cases where transformGroupASTForBinaryOperator f returns the original group column.
+        return left_metric_name_dropped && right_metric_name_dropped
+            && !operator_node->on
+            && (!operator_node->ignoring || operator_node->labels.empty());
     }
 
     /// Merge two unique VECTOR_GRID inputs by group, preferring non-NULL values from the left input.
@@ -94,34 +99,23 @@ SQLQueryPiece applyBinaryOperatorOr(
     }
 
     left_argument = toVectorGrid(std::move(left_argument), context);
-    bool left_metric_name_dropped = left_argument.metric_name_dropped;
-    ASTPtr left_join_group = transformGroupASTForBinaryOperator(
-        operator_node,
-        make_intrusive<ASTIdentifier>(ColumnNames::Group),
-        /*drop_metric_name=*/ true,
-        left_metric_name_dropped);
-
-    right_argument = toVectorGrid(std::move(right_argument), context);
-    bool right_metric_name_dropped = right_argument.metric_name_dropped;
-    ASTPtr right_join_group = transformGroupASTForBinaryOperator(
-        operator_node,
-        make_intrusive<ASTIdentifier>(ColumnNames::Group),
-        /*drop_metric_name=*/ true,
-        right_metric_name_dropped);
-
-    const bool exact_group_match = isExactGroup(left_join_group) && isExactGroup(right_join_group);
-
-    context.subqueries.emplace_back(SQLSubquery{
-        context.subqueries.size(),
-        std::move(left_argument.select_query),
-        exact_group_match ? SQLSubqueryType::TABLE : SQLSubqueryType::MATERIALIZED_TABLE});
+    /// Keep the left grid materialized on the general path because it is read by both Step 1 and Step 3.
+    /// The subquery type is changed below if both transformed groups are the original unique group column.
+    const size_t left_subquery = context.subqueries.size();
+    context.subqueries.emplace_back(SQLSubquery{left_subquery, std::move(left_argument.select_query), SQLSubqueryType::MATERIALIZED_TABLE});
     String left = context.subqueries.back().name;
 
+    right_argument = toVectorGrid(std::move(right_argument), context);
     context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
     String right = context.subqueries.back().name;
 
+    const bool exact_group_match = canUseExactGroupMatch(
+        operator_node, left_argument.metric_name_dropped, right_argument.metric_name_dropped);
+
     if (exact_group_match)
     {
+        context.subqueries[left_subquery].subquery_type = SQLSubqueryType::TABLE;
+
         SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
         res.select_query = makeOrMergeQuery(left, right);
         res.metric_name_dropped = left_argument.metric_name_dropped && right_argument.metric_name_dropped;
@@ -132,6 +126,20 @@ SQLQueryPiece applyBinaryOperatorOr(
 
         return res;
     }
+
+    bool left_metric_name_dropped = left_argument.metric_name_dropped;
+    ASTPtr left_join_group = transformGroupASTForBinaryOperator(
+        operator_node,
+        make_intrusive<ASTIdentifier>(ColumnNames::Group),
+        /*drop_metric_name=*/ true,
+        left_metric_name_dropped);
+
+    bool right_metric_name_dropped = right_argument.metric_name_dropped;
+    ASTPtr right_join_group = transformGroupASTForBinaryOperator(
+        operator_node,
+        make_intrusive<ASTIdentifier>(ColumnNames::Group),
+        /*drop_metric_name=*/ true,
+        right_metric_name_dropped);
 
     /// Step 1: Build the per-step presence mask per `join_group` on the left side.
     ///

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -3571,6 +3571,19 @@ def test_set_binary_operators():
         ],
     )
 
+    # Empty ignoring() keeps the same matching key for already grouped inputs.
+    do_query_test(
+        '(sum by (shape, size) (last_over_time(foo{shape="circle"}[10])) or ignoring() sum by (shape, size) (last_over_time(bar{shape="circle"}[10])))[50:10]',
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "circle", "size": "l"}, "values": [[110, "16"], [120, "16"], [130, "16"], [150, "16"]]}]}',
+        [
+            [
+                "[('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:00.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+        ],
+    )
+
     do_query_test(
         "(last_over_time(foo[10]) and on(shape) last_over_time(bar[10]))[50:10]",
         150,

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -3544,6 +3544,34 @@ def test_set_binary_operators():
     )
 
     do_query_test(
+        "(sum by (shape, size) (last_over_time(foo[10])) or sum by (shape, size) (last_over_time(bar[10])))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "circle", "size": "l"}, "values": [[110, "16"], [120, "16"], [130, "16"], [150, "16"]]}, {"metric": {"shape": "rectangle", "size": "l"}, "values": [[110, "9"], [130, "90"]]}, {"metric": {"shape": "square", "size": "s"}, "values": [[110, "4"], [120, "40"], [130, "40"], [140, "700"]]}, {"metric": {"shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}, {"metric": {"shape": "triangle", "size": "xl"}, "values": [[110, "8"], [150, "30"]]}]}',
+        [
+            [
+                "[('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:00.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('shape','rectangle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',9),('1970-01-01 00:02:10.000',90)]",
+            ],
+            [
+                "[('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4),('1970-01-01 00:02:00.000',40),('1970-01-01 00:02:10.000',40),('1970-01-01 00:02:20.000',700)]",
+            ],
+            [
+                "[('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:00.000',80)]",
+            ],
+            [
+                "[('shape','triangle'),('size','xl')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:30.000',30)]",
+            ],
+        ],
+    )
+
+    do_query_test(
         "(last_over_time(foo[10]) and on(shape) last_over_time(bar[10]))[50:10]",
         150,
         '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"]]}]}',

--- a/tests/performance/promql_set_operators.xml
+++ b/tests/performance/promql_set_operators.xml
@@ -1,0 +1,24 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <create_query>
+        CREATE TABLE promql_set_operators_ts ENGINE = TimeSeries
+    </create_query>
+
+    <fill_query>
+        INSERT INTO promql_set_operators_ts (metric_name, tags, time_series)
+        SELECT
+            if(number &lt; 4000, 'foo', 'bar'),
+            map('instance', toString(number % 4000)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(300))
+        FROM numbers_mt(8000)
+    </fill_query>
+
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_ts', 'sum by (instance) (last_over_time(foo[10])) or sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_ts', 'sum by (instance) (last_over_time(foo[10])) or on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_set_operators_ts</drop_query>
+</test>


### PR DESCRIPTION
## What changed

- add a fast path for the PromQL set operator `or`
- use it when both inputs already match on the original `group` column
- decide the fast path from the operator modifiers and `metric_name_dropped` flags, without building temporary match-key ASTs
- send exact-group inputs directly to the existing `FULL ALL JOIN` merge
- use a compact per-step presence mask in the general `or` path instead of counting every non-NULL value
- keep `on(...)`, non-empty `ignoring(...)`, `on()`, and other transformed matching keys on the current general path
- treat empty `ignoring()` like default matching when both groups are already exact

## Why this is safe

`VECTOR_GRID` guarantees one row per `group`. The fast path is enabled only when the matching rules leave the original `group` column unchanged on both sides, so the join key is already unique and exact.

This includes normal matching and empty `ignoring()` after both inputs have already dropped `__name__`. `on(...)`, `on()`, non-empty `ignoring(...)`, and other transformed matching keys keep the existing general path.

The exact-group path removes the redundant per-group aggregation, the RHS masking join, the materialized left CTE, and the second left-grid read. The final merge still uses the existing element-wise left-side preference for overlapping samples.

For the general path, Step 1 only needs to know whether each timestamp has any left value. `groupBitOrForEach(arrayMap(isNotNull, values))` stores that presence mask directly instead of materializing a wider count array. The masking behavior is unchanged.

## Benchmark

These benchmarks use the same **8,000-series / 300-sample** workload. Higher QPS means higher throughput for the same query.

### End-to-end PromQL

Setup: `tests/performance/promql_set_operators.xml`, **10 measured runs** per server.

| Query | Baseline | Patch | Relative |
| --- | ---: | ---: | ---: |
| exact-group `or` | 146.8 ms | 128.9 ms | **1.14x speedup (-12.2%)** |
| exact-group `or`, repeat | 157.6 ms | 134.5 ms | **1.17x speedup (-14.7%)** |
| `or on(instance)` control | 143.9 ms | 145.9 ms | within noise |
| `or on(instance)` control, repeat | 155.5 ms | 158.1 ms | within noise |

The exact-group case is **1.14x to 1.17x faster** across the two runs. The control remains on the general path and the patch adds no extra scans or joins; the measured 1.4% to 1.7% variation is within normal run-to-run noise. The compact presence mask also reduces the size of the general-path intermediate state.

### Focused SQL lowering

Setup: persistent server, **20 measured runs**, `max_threads=4`, **8,000 rows / 4,000 groups / 300-step arrays**.

| Workload | General full lowering | Exact full merge | Relative |
| --- | ---: | ---: | ---: |
| Full lowering | 28.1 QPS | 56.5 QPS | **2.01x throughput (+101%)** |

Both forms returned **1,128,000** present samples.

## Tests

- add grouped `or` coverage where both sides have already dropped `__name__`, including empty `ignoring()`
- cover different missing timestamps and compare the result with Prometheus
- add `tests/performance/promql_set_operators.xml` with an exact-group query and an `or on(instance)` control
- document that the merge helper expects unique `VECTOR_GRID` groups

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
PromQL `or` expressions with an exact group key skip redundant matching stages and use compact presence masks for transformed matching.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115219&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115219](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115219+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
