### PR TITLE
Perf(PromQL): Materialize tags only for unique groups

### DIFF
--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1708,6 +1708,41 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags2(c
         return res;
     }
 
+    /// When only a small fraction of pairs are repeated, materializing all input tags is cheaper than
+    /// building the additional component maps below. Keep the pair deduplication result and transform
+    /// only the first row of each pair.
+    constexpr size_t max_duplicate_pair_ratio_denominator = 10;
+    const size_t num_duplicate_pairs = groups1.size() - num_unique_pairs;
+    if (num_duplicate_pairs <= groups1.size() / max_duplicate_pair_ratio_denominator)
+    {
+        auto tags_vector1 = getTagsByGroup(groups1);
+        auto tags_vector2 = getTagsByGroup(groups2);
+        chassert(tags_vector1.size() == groups1.size());
+        chassert(tags_vector2.size() == groups2.size());
+
+        VectorWithMemoryTracking<TagNamesAndValuesPtr> new_tags_vector;
+        new_tags_vector.reserve(num_unique_pairs);
+
+        size_t next_pair_index = 0;
+        for (size_t i = 0; i != groups1.size(); ++i)
+        {
+            if (res[i] == next_pair_index)
+            {
+                new_tags_vector.push_back(transform_func(tags_vector1[i], tags_vector2[i]));
+                ++next_pair_index;
+            }
+        }
+        chassert(new_tags_vector.size() == num_unique_pairs);
+
+        auto new_groups = getGroupForTags(new_tags_vector);
+        for (auto & index : res)
+            index = new_groups.at(index);
+
+        return res;
+    }
+
+    /// Pair indexes are assigned in first-seen order. This second scan recovers the first row of each
+    /// pair without keeping the pair hash map alive while constructing the component maps below.
     VectorWithMemoryTracking<std::pair<Group, Group>> unique_pairs;
     unique_pairs.reserve(num_unique_pairs);
 

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1675,43 +1675,89 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags2(c
 {
     chassert(groups1.size() == groups2.size());
 
-    auto tags_vector1 = getTagsByGroup(groups1);
-    auto tags_vector2 = getTagsByGroup(groups2);
-    chassert(tags_vector1.size() == groups1.size());
-    chassert(tags_vector2.size() == groups2.size());
+    size_t num_unique_pairs = 0;
 
-    std::unordered_map<std::pair<Group, Group>, size_t, boost::hash<std::pair<Group, Group>>> indices_in_result_vector;
-    size_t num_new_tags = 0;
+    VectorWithMemoryTracking<Group> res;
+    res.resize(groups1.size());
 
-    for (size_t i = 0; i != groups1.size(); ++i)
     {
-        Group group1 = groups1[i];
-        Group group2 = groups2[i];
-        auto it = indices_in_result_vector.find(std::make_pair(group1, group2));
-        if (it == indices_in_result_vector.end())
+        std::unordered_map<std::pair<Group, Group>, size_t, boost::hash<std::pair<Group, Group>>> indices_in_result_vector;
+
+        for (size_t i = 0; i != groups1.size(); ++i)
         {
-            const auto & tags1 = tags_vector1[i];
-            const auto & tags2 = tags_vector2[i];
-            auto new_tags = transform_func(tags1, tags2);
-            indices_in_result_vector[std::make_pair(group1, group2)] = num_new_tags;
-            tags_vector1[num_new_tags++] = new_tags;
+            auto [it, inserted] = indices_in_result_vector.try_emplace(std::make_pair(groups1[i], groups2[i]), num_unique_pairs);
+            if (inserted)
+                ++num_unique_pairs;
+            res[i] = it->second;
         }
     }
 
-    tags_vector1.resize(num_new_tags);
+    if (num_unique_pairs == groups1.size())
+    {
+        auto tags_vector1 = getTagsByGroup(groups1);
+        auto tags_vector2 = getTagsByGroup(groups2);
+        chassert(tags_vector1.size() == groups1.size());
+        chassert(tags_vector2.size() == groups2.size());
 
-    auto new_groups = getGroupForTags(tags_vector1);
+        for (size_t i = 0; i != groups1.size(); ++i)
+            tags_vector1[i] = transform_func(tags_vector1[i], tags_vector2[i]);
 
-    VectorWithMemoryTracking<Group> res;
-    res.reserve(groups1.size());
+        auto new_groups = getGroupForTags(tags_vector1);
+        for (auto & index : res)
+            index = new_groups.at(index);
+        return res;
+    }
 
+    VectorWithMemoryTracking<std::pair<Group, Group>> unique_pairs;
+    unique_pairs.reserve(num_unique_pairs);
+
+    size_t next_pair_index = 0;
     for (size_t i = 0; i != groups1.size(); ++i)
     {
-        Group group1 = groups1[i];
-        Group group2 = groups2[i];
-        auto new_group = new_groups.at(indices_in_result_vector.at(std::make_pair(group1, group2)));
-        res.push_back(new_group);
+        if (res[i] == next_pair_index)
+        {
+            unique_pairs.emplace_back(groups1[i], groups2[i]);
+            ++next_pair_index;
+        }
     }
+    chassert(unique_pairs.size() == num_unique_pairs);
+
+    VectorWithMemoryTracking<TagNamesAndValuesPtr> new_tags_vector;
+    {
+        VectorWithMemoryTracking<Group> unique_groups1;
+        VectorWithMemoryTracking<Group> unique_groups2;
+        std::unordered_map<Group, size_t> indices_by_group1;
+        std::unordered_map<Group, size_t> indices_by_group2;
+
+        for (auto & [group1, group2] : unique_pairs)
+        {
+            auto [it1, inserted1] = indices_by_group1.try_emplace(group1, unique_groups1.size());
+            if (inserted1)
+                unique_groups1.push_back(group1);
+            group1 = it1->second;
+
+            auto [it2, inserted2] = indices_by_group2.try_emplace(group2, unique_groups2.size());
+            if (inserted2)
+                unique_groups2.push_back(group2);
+            group2 = it2->second;
+        }
+
+        auto tags_vector1 = getTagsByGroup(unique_groups1);
+        auto tags_vector2 = getTagsByGroup(unique_groups2);
+        chassert(tags_vector1.size() == unique_groups1.size());
+        chassert(tags_vector2.size() == unique_groups2.size());
+
+        new_tags_vector.resize(unique_pairs.size());
+        for (size_t i = 0; i != unique_pairs.size(); ++i)
+        {
+            const auto [group1, group2] = unique_pairs[i];
+            new_tags_vector[i] = transform_func(tags_vector1[group1], tags_vector2[group2]);
+        }
+    }
+
+    auto new_groups = getGroupForTags(new_tags_vector);
+    for (auto & index : res)
+        index = new_groups.at(index);
 
     return res;
 }

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1531,13 +1531,10 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags(co
     if (groups_.empty())
         return {};
 
-    auto tags_vector = getTagsByGroup(groups_);
-    chassert(tags_vector.size() == groups_.size());
-
     VectorWithMemoryTracking<Group> res;
     res.resize(groups_.size());
 
-    size_t num_new_tags = 0;
+    VectorWithMemoryTracking<Group> unique_groups;
 
     auto [min_group_it, max_group_it] = std::minmax_element(groups_.begin(), groups_.end());
     Group min_group = *min_group_it;
@@ -1559,8 +1556,8 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags(co
             size_t & index = indices_by_group[groups_[i] - min_group];
             if (index == not_found)
             {
-                index = num_new_tags;
-                tags_vector[num_new_tags++] = transform_func(tags_vector[i]);
+                index = unique_groups.size();
+                unique_groups.push_back(groups_[i]);
             }
             res[i] = index;
         }
@@ -1572,14 +1569,18 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags(co
         for (size_t i = 0; i != groups_.size(); ++i)
         {
             Group group = groups_[i];
-            auto [it, inserted] = indices_by_group.try_emplace(group, num_new_tags);
+            auto [it, inserted] = indices_by_group.try_emplace(group, unique_groups.size());
             if (inserted)
-                tags_vector[num_new_tags++] = transform_func(tags_vector[i]);
+                unique_groups.push_back(group);
             res[i] = it->second;
         }
     }
 
-    tags_vector.resize(num_new_tags);
+    auto tags_vector = getTagsByGroup(unique_groups);
+    chassert(tags_vector.size() == unique_groups.size());
+
+    for (auto & tags : tags_vector)
+        tags = transform_func(tags);
 
     auto new_groups = getGroupForTags(tags_vector);
 

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1534,50 +1534,53 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::transformTags(co
     VectorWithMemoryTracking<Group> res;
     res.resize(groups_.size());
 
-    VectorWithMemoryTracking<Group> unique_groups;
-
-    auto [min_group_it, max_group_it] = std::minmax_element(groups_.begin(), groups_.end());
-    Group min_group = *min_group_it;
-    Group group_range = *max_group_it - min_group;
-
-    /// Groups are dense integer indices, and a block usually contains a compact range of them.
-    /// Avoid a large lookup array when a block contains only a sparse subset of all known groups.
-    constexpr size_t max_dense_range_to_input_size_ratio = 4;
-    bool use_dense_mapping = group_range / groups_.size() < max_dense_range_to_input_size_ratio;
-
-    if (use_dense_mapping)
+    VectorWithMemoryTracking<TagNamesAndValuesPtr> tags_vector;
     {
-        const size_t not_found = groups_.size();
-        VectorWithMemoryTracking<size_t> indices_by_group;
-        indices_by_group.resize(static_cast<size_t>(group_range) + 1, not_found);
+        VectorWithMemoryTracking<Group> unique_groups;
 
-        for (size_t i = 0; i != groups_.size(); ++i)
+        auto [min_group_it, max_group_it] = std::minmax_element(groups_.begin(), groups_.end());
+        Group min_group = *min_group_it;
+        Group group_range = *max_group_it - min_group;
+
+        /// Groups are dense integer indices, and a block usually contains a compact range of them.
+        /// Avoid a large lookup array when a block contains only a sparse subset of all known groups.
+        constexpr size_t max_dense_range_to_input_size_ratio = 4;
+        bool use_dense_mapping = group_range / groups_.size() < max_dense_range_to_input_size_ratio;
+
+        if (use_dense_mapping)
         {
-            size_t & index = indices_by_group[groups_[i] - min_group];
-            if (index == not_found)
+            const size_t not_found = groups_.size();
+            VectorWithMemoryTracking<size_t> indices_by_group;
+            indices_by_group.resize(static_cast<size_t>(group_range) + 1, not_found);
+
+            for (size_t i = 0; i != groups_.size(); ++i)
             {
-                index = unique_groups.size();
-                unique_groups.push_back(groups_[i]);
+                size_t & index = indices_by_group[groups_[i] - min_group];
+                if (index == not_found)
+                {
+                    index = unique_groups.size();
+                    unique_groups.push_back(groups_[i]);
+                }
+                res[i] = index;
             }
-            res[i] = index;
         }
-    }
-    else
-    {
-        std::unordered_map<Group, size_t> indices_by_group;
-
-        for (size_t i = 0; i != groups_.size(); ++i)
+        else
         {
-            Group group = groups_[i];
-            auto [it, inserted] = indices_by_group.try_emplace(group, unique_groups.size());
-            if (inserted)
-                unique_groups.push_back(group);
-            res[i] = it->second;
-        }
-    }
+            std::unordered_map<Group, size_t> indices_by_group;
 
-    auto tags_vector = getTagsByGroup(unique_groups);
-    chassert(tags_vector.size() == unique_groups.size());
+            for (size_t i = 0; i != groups_.size(); ++i)
+            {
+                Group group = groups_[i];
+                auto [it, inserted] = indices_by_group.try_emplace(group, unique_groups.size());
+                if (inserted)
+                    unique_groups.push_back(group);
+                res[i] = it->second;
+            }
+        }
+
+        tags_vector = getTagsByGroup(unique_groups);
+        chassert(tags_vector.size() == unique_groups.size());
+    }
 
     for (auto & tags : tags_vector)
         tags = transform_func(tags);

--- a/tests/performance/promql_tags_transform.xml
+++ b/tests/performance/promql_tags_transform.xml
@@ -85,6 +85,230 @@
         FORMAT Null
     </query>
 
+    <!-- Exercise the vector-vector transformTags2() path with all unique pairs. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(200000)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(200000)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[number % 200000 + 1],
+                   src_groups[number % 200000 + 1],
+                   ['src'])
+        FROM numbers(2000000)
+        SETTINGS max_threads = 1, max_block_size = 200000
+        FORMAT Null
+    </query>
+
+    <!-- Exercise the vector-vector transformTags2() path with a small repeated pair set across multiple blocks. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(32)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(32)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[number % 32 + 1],
+                   src_groups[number % 32 + 1],
+                   ['src'])
+        FROM numbers(20000000)
+        SETTINGS max_threads = 1, max_block_size = 200000
+        FORMAT Null
+    </query>
+
+    <!-- Exercise the near-unique path with 99.9% unique pairs. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[if(number % 100000 &lt; 99900, number % 100000 + 1, 1)],
+                   src_groups[if(number % 100000 &lt; 99900, number % 100000 + 1, 1)],
+                   ['src'])
+        FROM numbers(1000000)
+        SETTINGS max_threads = 1, max_block_size = 100000
+        FORMAT Null
+    </query>
+
+    <!-- Exercise the near-unique path with 95% unique pairs. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[if(number % 100000 &lt; 95000, number % 100000 + 1, 1)],
+                   src_groups[if(number % 100000 &lt; 95000, number % 100000 + 1, 1)],
+                   ['src'])
+        FROM numbers(1000000)
+        SETTINGS max_threads = 1, max_block_size = 100000
+        FORMAT Null
+    </query>
+
+    <!-- Exercise the component-dedup path with 75% unique pairs. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[if(number % 100000 &lt; 75000, number % 100000 + 1, 1)],
+                   src_groups[if(number % 100000 &lt; 75000, number % 100000 + 1, 1)],
+                   ['src'])
+        FROM numbers(1000000)
+        SETTINGS max_threads = 1, max_block_size = 100000
+        FORMAT Null
+    </query>
+
+    <!-- Exercise the component-dedup path with 50% unique pairs. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[if(number % 100000 &lt; 50000, number % 100000 + 1, 1)],
+                   src_groups[if(number % 100000 &lt; 50000, number % 100000 + 1, 1)],
+                   ['src'])
+        FROM numbers(1000000)
+        SETTINGS max_threads = 1, max_block_size = 100000
+        FORMAT Null
+    </query>
+
+    <!-- Exercise the component-dedup path with 10% unique pairs. -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS dest_groups,
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([('src', toString(number))]) AS group
+                    FROM numbers(100000)
+                    ORDER BY number
+                )
+            ) AS src_groups
+        SELECT timeSeriesCopyTags(
+                   dest_groups[if(number % 100000 &lt; 10000, number % 100000 + 1, 1)],
+                   src_groups[if(number % 100000 &lt; 10000, number % 100000 + 1, 1)],
+                   ['src'])
+        FROM numbers(1000000)
+        SETTINGS max_threads = 1, max_block_size = 100000
+        FORMAT Null
+    </query>
+
     <!-- Exercise the same transformations through realistic instant PromQL aggregation and matching. -->
     <create_query>
         CREATE TABLE promql_tags_transform ENGINE = TimeSeries
@@ -103,6 +327,8 @@
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'sum by() (foo)', 100) SETTINGS max_threads = 1 FORMAT Null</query>
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'sum by (namespace) (foo)', 100) FORMAT Null</query>
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) bar', 100) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) group_left(namespace) bar', 100) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) group_right(namespace) bar', 100) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_tags_transform</drop_query>
 </test>

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.reference
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.reference
@@ -71,3 +71,18 @@ timeSeriesRemoveAllTagsExcept vectorized repeated dense groups:
 
 timeSeriesRemoveAllTagsExcept vectorized repeated sparse groups:
 5	1	[[('shared','value')]]
+
+timeSeriesRemoveTag vectorized repeated groups with row order:
+0	[('instance','0')]
+1	[('instance','1')]
+2	[('instance','0')]
+3	[('instance','2')]
+4	[('instance','1')]
+5	[('instance','0')]
+
+timeSeriesRemoveTag vectorized repeated sparse groups with row order:
+0	[('instance','0')]
+1	[('instance','24')]
+2	[('instance','0')]
+3	[('instance','24')]
+4	[('instance','0')]

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -434,3 +434,41 @@ FROM
     SELECT timeSeriesRemoveAllTagsExcept(groups[[1, 25, 1, 25, 1][number + 1]], ['shared']) AS new_group
     FROM numbers(5)
 );
+
+SELECT '';
+SELECT 'timeSeriesRemoveTag vectorized repeated groups with row order:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('instance', toString(number)), ('remove', 'value')]) AS group
+            FROM numbers(3)
+            ORDER BY number
+        )
+    ) AS groups
+SELECT number,
+       timeSeriesGroupToTags(timeSeriesRemoveTag(groups[[1, 2, 1, 3, 2, 1][number + 1]], 'remove'))
+FROM numbers(6)
+ORDER BY number;
+
+SELECT '';
+SELECT 'timeSeriesRemoveTag vectorized repeated sparse groups with row order:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('instance', toString(number)), ('remove', 'value')]) AS group
+            FROM numbers(32)
+            ORDER BY number
+        )
+    ) AS groups
+SELECT number,
+       timeSeriesGroupToTags(timeSeriesRemoveTag(groups[[1, 25, 1, 25, 1][number + 1]], 'remove'))
+FROM numbers(5)
+ORDER BY number;

--- a/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
+++ b/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
@@ -26,4 +26,4 @@ timeSeriesCopyTags vectorized repeated sparse pairs:
 4	[('dest','0'),('src','24')]
 
 timeSeriesCopyTags vectorized repeated pairs with identical results:
-3	1	[[('src','same')]]
+3	1	[[]]

--- a/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
+++ b/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
@@ -1,0 +1,14 @@
+timeSeriesCopyTags vectorized repeated dense pairs:
+0	[('dest','0'),('src','0')]
+1	[('dest','1'),('src','1')]
+2	[('dest','0'),('src','0')]
+3	[('dest','2'),('src','2')]
+4	[('dest','1'),('src','1')]
+5	[('dest','0'),('src','0')]
+
+timeSeriesCopyTags vectorized repeated sparse pairs:
+0	[('dest','0'),('src','0')]
+1	[('dest','24'),('src','24')]
+2	[('dest','0'),('src','0')]
+3	[('dest','24'),('src','24')]
+4	[('dest','0'),('src','0')]

--- a/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
+++ b/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
@@ -1,14 +1,29 @@
 timeSeriesCopyTags vectorized repeated dense pairs:
-0	[('dest','0'),('src','0')]
-1	[('dest','1'),('src','1')]
-2	[('dest','0'),('src','0')]
-3	[('dest','2'),('src','2')]
+0	[('dest','0'),('src','2')]
+1	[('dest','1'),('src','0')]
+2	[('dest','0'),('src','1')]
+3	[('dest','0'),('src','2')]
 4	[('dest','1'),('src','1')]
-5	[('dest','0'),('src','0')]
+5	[('dest','0'),('src','2')]
+
+timeSeriesCopyTags vectorized near-unique pairs:
+0	[('dest','0'),('src','9')]
+1	[('dest','1'),('src','8')]
+2	[('dest','2'),('src','7')]
+3	[('dest','3'),('src','6')]
+4	[('dest','4'),('src','5')]
+5	[('dest','5'),('src','4')]
+6	[('dest','6'),('src','3')]
+7	[('dest','7'),('src','2')]
+8	[('dest','8'),('src','1')]
+9	[('dest','0'),('src','9')]
 
 timeSeriesCopyTags vectorized repeated sparse pairs:
-0	[('dest','0'),('src','0')]
-1	[('dest','24'),('src','24')]
-2	[('dest','0'),('src','0')]
-3	[('dest','24'),('src','24')]
-4	[('dest','0'),('src','0')]
+0	[('dest','0'),('src','24')]
+1	[('dest','1'),('src','0')]
+2	[('dest','0'),('src','24')]
+3	[('dest','1'),('src','0')]
+4	[('dest','0'),('src','24')]
+
+timeSeriesCopyTags vectorized repeated pairs with identical results:
+3	1	[[('src','same')]]

--- a/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
+++ b/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.reference
@@ -1,3 +1,4 @@
+
 timeSeriesCopyTags vectorized repeated dense pairs:
 0	[('dest','0'),('src','2')]
 1	[('dest','1'),('src','0')]

--- a/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.sql
+++ b/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.sql
@@ -1,0 +1,59 @@
+SELECT '';
+SELECT 'timeSeriesCopyTags vectorized repeated dense pairs:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+            FROM numbers(3)
+            ORDER BY number
+        )
+    ) AS dest_groups,
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('src', toString(number))]) AS group
+            FROM numbers(3)
+            ORDER BY number
+        )
+    ) AS src_groups
+SELECT number,
+       timeSeriesGroupToTags(
+           timeSeriesCopyTags(dest_groups[[1, 2, 1, 3, 2, 1][number + 1]], src_groups[[1, 2, 1, 3, 2, 1][number + 1]], ['src']))
+FROM numbers(6)
+ORDER BY number;
+
+SELECT '';
+SELECT 'timeSeriesCopyTags vectorized repeated sparse pairs:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+            FROM numbers(32)
+            ORDER BY number
+        )
+    ) AS dest_groups,
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('src', toString(number))]) AS group
+            FROM numbers(32)
+            ORDER BY number
+        )
+    ) AS src_groups
+SELECT number,
+       timeSeriesGroupToTags(
+           timeSeriesCopyTags(dest_groups[[1, 25, 1, 25, 1][number + 1]], src_groups[[1, 25, 1, 25, 1][number + 1]], ['src']))
+FROM numbers(5)
+ORDER BY number;

--- a/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.sql
+++ b/tests/queries/0_stateless/04926_time_series_vectorized_copy_tags_repeated.sql
@@ -8,7 +8,7 @@ WITH
         (
             SELECT number,
                    timeSeriesTagsToGroup([('dest', toString(number))]) AS group
-            FROM numbers(3)
+            FROM numbers(2)
             ORDER BY number
         )
     ) AS dest_groups,
@@ -24,8 +24,38 @@ WITH
     ) AS src_groups
 SELECT number,
        timeSeriesGroupToTags(
-           timeSeriesCopyTags(dest_groups[[1, 2, 1, 3, 2, 1][number + 1]], src_groups[[1, 2, 1, 3, 2, 1][number + 1]], ['src']))
+           timeSeriesCopyTags(dest_groups[[1, 2, 1, 1, 2, 1][number + 1]], src_groups[[3, 1, 2, 3, 2, 3][number + 1]], ['src']))
 FROM numbers(6)
+ORDER BY number;
+
+SELECT '';
+SELECT 'timeSeriesCopyTags vectorized near-unique pairs:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+            FROM numbers(10)
+            ORDER BY number
+        )
+    ) AS dest_groups,
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('src', toString(number))]) AS group
+            FROM numbers(10)
+            ORDER BY number
+        )
+    ) AS src_groups
+SELECT number,
+       timeSeriesGroupToTags(
+           timeSeriesCopyTags(dest_groups[[1, 2, 3, 4, 5, 6, 7, 8, 9, 1][number + 1]], src_groups[[10, 9, 8, 7, 6, 5, 4, 3, 2, 10][number + 1]], ['src']))
+FROM numbers(10)
 ORDER BY number;
 
 SELECT '';
@@ -38,7 +68,7 @@ WITH
         (
             SELECT number,
                    timeSeriesTagsToGroup([('dest', toString(number))]) AS group
-            FROM numbers(32)
+            FROM numbers(2)
             ORDER BY number
         )
     ) AS dest_groups,
@@ -54,6 +84,36 @@ WITH
     ) AS src_groups
 SELECT number,
        timeSeriesGroupToTags(
-           timeSeriesCopyTags(dest_groups[[1, 25, 1, 25, 1][number + 1]], src_groups[[1, 25, 1, 25, 1][number + 1]], ['src']))
+           timeSeriesCopyTags(dest_groups[[1, 2, 1, 2, 1][number + 1]], src_groups[[25, 1, 25, 1, 25][number + 1]], ['src']))
 FROM numbers(5)
 ORDER BY number;
+
+SELECT '';
+SELECT 'timeSeriesCopyTags vectorized repeated pairs with identical results:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   timeSeriesTagsToGroup([('dest', toString(number))]) AS group
+            FROM numbers(2)
+            ORDER BY number
+        )
+    ) AS dest_groups,
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT timeSeriesTagsToGroup([('src', 'same')]) AS group
+        )
+    ) AS src_groups
+SELECT count(),
+       uniqExact(new_group),
+       groupUniqArray(timeSeriesGroupToTags(new_group))
+FROM
+(
+    SELECT timeSeriesCopyTags(dest_groups[[1, 2, 1][number + 1]], src_groups[1], ['dest']) AS new_group
+    FROM numbers(3)
+);


### PR DESCRIPTION
## What changed

- collect unique group IDs before looking up tags in vectorized one-input transforms
- deduplicate vectorized two-input group pairs before materializing tags
- materialize and transform tags once per unique group or pair
- keep a simple path for near-unique pair batches, so a small number of duplicates does not trigger the extra component maps
- preserve first-seen ordering and row order when remapping results

## Why

Vectorized TimeSeries transforms used to materialize tag pointers for every input row before deduplicating repeated groups or group pairs. Repeated PromQL rows therefore did extra lookup and remapping work.

The updated paths deduplicate first and only materialize the groups needed by the unique transforms. For two-input transforms, batches with at most roughly 10% duplicate pairs use the simpler materialization path and transform only the first occurrence of each pair. More repetitive batches keep the component-dedup path, where the extra indexing work is worth the saved tag materialization.

## Benchmark

Collector-path microbenchmark on an Apple M1 Pro with `clang++ -O3`, median of 7 runs after 3 warmup runs:

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| One-input dense repeated groups, 500,000 rows | 4.00 ms | 0.87 ms | 78% faster |
| One-input sparse repeated groups, 500,000 rows | 3.85 ms | 0.84 ms | 78% faster |
| One-input dense unique groups, 500,000 rows | 90.68 ms | 90.37 ms | unchanged |
| Two-input repeated pairs, 200,000 rows / 32 pairs | 2.97 ms | 0.88 ms | 70% faster |
| Two-input unique pairs, 200,000 rows | 80.88 ms | 77.48 ms | 4% faster |

The committed performance workload also covers 100%, 99.9%, 95%, 75%, 50%, and 10% unique pair batches, plus realistic `group_left` and `group_right` PromQL matching.

## Tests

- add crossed destination/source patterns instead of symmetric pair indexes
- cover near-unique pairs through the simple path
- cover sparse group IDs and repeated pairs whose transformed results collapse to one group
- add repeated dense and sparse one-input group coverage with row order
- add repeated dense and sparse two-input pair coverage with row order
- add the full pair-cardinality performance curve and `group_left`/`group_right` workloads

### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Avoid repeated tag materialization and extra remapping work for duplicate groups in vectorized TimeSeries transformations.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115223&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115223](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115223+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->