### PR TITLE
Perf: use compact presence masks for PromQL set operators

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
@@ -59,15 +59,14 @@ void checkArgumentTypesForSetBinaryOperator(
 
 ASTPtr makePresenceMask(ASTPtr values)
 {
+    auto lambda = makeASTFunction(
+        "lambda",
+        makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x")),
+        makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x")));
+
     return makeASTFunction(
         "groupBitOrForEach",
-        makeASTFunction(
-            "arrayMap",
-            makeASTFunction(
-                "lambda",
-                makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x")),
-                makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x"))),
-            std::move(values)));
+        makeASTFunction("arrayMap", std::move(lambda), std::move(values)));
 }
 
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
@@ -57,6 +57,19 @@ void checkArgumentTypesForSetBinaryOperator(
     }
 }
 
+ASTPtr makePresenceMask(ASTPtr values)
+{
+    return makeASTFunction(
+        "maxForEach",
+        makeASTFunction(
+            "arrayMap",
+            makeASTFunction(
+                "lambda",
+                makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x")),
+                makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x"))),
+            std::move(values)));
+}
+
 
 SQLQueryPiece applyBinaryOperatorAnd(
     const PrometheusQueryTree::BinaryOperator * operator_node,
@@ -82,7 +95,7 @@ SQLQueryPiece applyBinaryOperatorAnd(
 
     /// Step 1:
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
-    ///        countForEach(values) AS join_count
+    ///        maxForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
     /// GROUP BY join_group
     /// FROM right
     ///
@@ -98,8 +111,8 @@ SQLQueryPiece applyBinaryOperatorAnd(
             right_metric_name_dropped));
         builder.select_list.back()->setAlias(ColumnNames::JoinGroup);
 
-        builder.select_list.push_back(makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
-        builder.select_list.back()->setAlias(ColumnNames::JoinCount);
+        builder.select_list.push_back(makePresenceMask(make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        builder.select_list.back()->setAlias(ColumnNames::JoinPresence);
 
         builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
 
@@ -112,7 +125,7 @@ SQLQueryPiece applyBinaryOperatorAnd(
 
     /// Step 2:
     /// SELECT group,
-    ///        arrayMap(x, y -> if(y > 0, x, NULL), values, join_count) AS values
+    ///        arrayMap(x, y -> if(y > 0, x, NULL), values, join_presence) AS values
     /// FROM left LEFT SEMI JOIN step1
     /// ON timeSeriesRemoveAllTagsExcept(group, on_tags) == join_group
     ///
@@ -133,7 +146,7 @@ SQLQueryPiece applyBinaryOperatorAnd(
                     make_intrusive<ASTIdentifier>("x"),
                     make_intrusive<ASTLiteral>(Field{} /* NULL */))),
             make_intrusive<ASTIdentifier>(ColumnNames::Values),
-            make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)));
+            make_intrusive<ASTIdentifier>(ColumnNames::JoinPresence)));
 
         builder.select_list.back()->setAlias(ColumnNames::Values);
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
@@ -5,70 +5,13 @@
 #include <Parsers/ASTLiteral.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.h>
 
 
-namespace DB::ErrorCodes
-{
-    extern const int CANNOT_EXECUTE_PROMQL_QUERY;
-}
-
-
 namespace DB::PrometheusQueryToSQL
 {
-
-void checkArgumentTypesForSetBinaryOperator(
-    const PrometheusQueryTree::BinaryOperator * operator_node,
-    const SQLQueryPiece & left_argument,
-    const SQLQueryPiece & right_argument,
-    const ConverterContext & context)
-{
-    std::string_view operator_name = operator_node->operator_name;
-
-    if (left_argument.type != ResultType::INSTANT_VECTOR)
-    {
-        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
-                        "Binary operator '{}' expects two arguments of type {}, but expression {} has type {}",
-                        operator_name, ResultType::INSTANT_VECTOR,
-                        getPromQLText(left_argument, context), left_argument.type);
-    }
-
-    if (right_argument.type != ResultType::INSTANT_VECTOR)
-    {
-        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
-                        "Binary operator '{}' expects two arguments of type {}, but expression {} has type {}",
-                        operator_name, ResultType::INSTANT_VECTOR,
-                        getPromQLText(right_argument, context), right_argument.type);
-    }
-
-    if (operator_node->group_left)
-    {
-        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
-                        "Binary operator '{}' doesn't allow group_left",
-                        operator_name);
-    }
-
-    if (operator_node->group_right)
-    {
-        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
-                        "Binary operator '{}' doesn't allow group_right",
-                        operator_name);
-    }
-}
-
-ASTPtr makePresenceMask(ASTPtr values)
-{
-    auto lambda = makeASTFunction(
-        "lambda",
-        makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x")),
-        makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x")));
-
-    return makeASTFunction(
-        "groupBitOrForEach",
-        makeASTFunction("arrayMap", std::move(lambda), std::move(values)));
-}
-
 
 SQLQueryPiece applyBinaryOperatorAnd(
     const PrometheusQueryTree::BinaryOperator * operator_node,

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
@@ -60,7 +60,7 @@ void checkArgumentTypesForSetBinaryOperator(
 ASTPtr makePresenceMask(ASTPtr values)
 {
     return makeASTFunction(
-        "maxForEach",
+        "groupBitOrForEach",
         makeASTFunction(
             "arrayMap",
             makeASTFunction(
@@ -95,7 +95,7 @@ SQLQueryPiece applyBinaryOperatorAnd(
 
     /// Step 1:
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
-    ///        maxForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
+    ///        groupBitOrForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
     /// GROUP BY join_group
     /// FROM right
     ///

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h
@@ -22,4 +22,7 @@ void checkArgumentTypesForSetBinaryOperator(
     const SQLQueryPiece & right_argument,
     const ConverterContext & context);
 
+/// Build a compact per-step presence mask for a vector grid.
+ASTPtr makePresenceMask(ASTPtr values);
+
 }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h
@@ -15,14 +15,4 @@ SQLQueryPiece applyBinaryOperatorAnd(
     SQLQueryPiece && right_argument,
     ConverterContext & context);
 
-/// Check argument types for set binary operator (i.e. one of "and", "or", "unless").
-void checkArgumentTypesForSetBinaryOperator(
-    const PrometheusQueryTree::BinaryOperator * operator_node,
-    const SQLQueryPiece & left_argument,
-    const SQLQueryPiece & right_argument,
-    const ConverterContext & context);
-
-/// Build a compact per-step presence mask for a vector grid.
-ASTPtr makePresenceMask(ASTPtr values);
-
 }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -37,7 +37,7 @@ SQLQueryPiece applyBinaryOperatorOr(
     }
 
     left_argument = toVectorGrid(std::move(left_argument), context);
-    /// The left grid is read twice - by the per-group counting step (Step 1) and by the final merge join (Step 3) -
+    /// The left grid is read twice - by the per-group presence step (Step 1) and by the final merge join (Step 3) -
     /// so it's added as a materialized CTE to be evaluated once.
     context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(left_argument.select_query), SQLSubqueryType::MATERIALIZED_TABLE});
     String left = context.subqueries.back().name;
@@ -49,7 +49,7 @@ SQLQueryPiece applyBinaryOperatorOr(
     /// Step 1: Build the per-step presence mask per `join_group` on the left side.
     ///
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
-    ///        maxForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
+    ///        groupBitOrForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
     /// GROUP BY join_group
     /// FROM left
     ///

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -5,7 +5,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
-#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.h>
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -46,10 +46,10 @@ SQLQueryPiece applyBinaryOperatorOr(
     context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
     String right = context.subqueries.back().name;
 
-    /// Step 1: Count the non-NULL values per `join_group` on the left side, per timestamp.
+    /// Step 1: Build the per-step presence mask per `join_group` on the left side.
     ///
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
-    ///        countForEach(values) AS join_count
+    ///        maxForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
     /// GROUP BY join_group
     /// FROM left
     ///
@@ -65,8 +65,8 @@ SQLQueryPiece applyBinaryOperatorOr(
             left_metric_name_dropped));
         builder.select_list.back()->setAlias(ColumnNames::JoinGroup);
 
-        builder.select_list.push_back(makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
-        builder.select_list.back()->setAlias(ColumnNames::JoinCount);
+        builder.select_list.push_back(makePresenceMask(make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        builder.select_list.back()->setAlias(ColumnNames::JoinPresence);
 
         builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
 
@@ -82,7 +82,7 @@ SQLQueryPiece applyBinaryOperatorOr(
     /// Rows whose `join_group` is absent from the left side pass through unchanged.
     ///
     /// SELECT group,
-    ///        if(notEmpty(join_count), arrayMap(x, y -> if(x = 0, y, NULL), join_count, values), values) AS values
+    ///        if(notEmpty(join_presence), arrayMap(x, y -> if(x = 0, y, NULL), join_presence, values), values) AS values
     /// FROM step1 RIGHT ANY JOIN right
     /// ON join_group == timeSeriesRemoveAllTagsExcept(group, on_tags)
     ///
@@ -94,7 +94,7 @@ SQLQueryPiece applyBinaryOperatorOr(
 
         builder.select_list.push_back(makeASTFunction(
             "if",
-            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)),
+            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::JoinPresence)),
             makeASTFunction(
                 "arrayMap",
                 makeASTFunction(
@@ -105,7 +105,7 @@ SQLQueryPiece applyBinaryOperatorOr(
                         makeASTFunction("equals", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTLiteral>(0u)),
                         make_intrusive<ASTIdentifier>("y"),
                         make_intrusive<ASTLiteral>(Field{} /* NULL */))),
-                make_intrusive<ASTIdentifier>(ColumnNames::JoinCount),
+                make_intrusive<ASTIdentifier>(ColumnNames::JoinPresence),
                 make_intrusive<ASTIdentifier>(ColumnNames::Values)),
             make_intrusive<ASTIdentifier>(ColumnNames::Values)));
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.cpp
@@ -1,0 +1,69 @@
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h>
+
+#include <Common/Exception.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
+
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_EXECUTE_PROMQL_QUERY;
+}
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+void checkArgumentTypesForSetBinaryOperator(
+    const PrometheusQueryTree::BinaryOperator * operator_node,
+    const SQLQueryPiece & left_argument,
+    const SQLQueryPiece & right_argument,
+    const ConverterContext & context)
+{
+    std::string_view operator_name = operator_node->operator_name;
+
+    if (left_argument.type != ResultType::INSTANT_VECTOR)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' expects two arguments of type {}, but expression {} has type {}",
+                        operator_name, ResultType::INSTANT_VECTOR,
+                        getPromQLText(left_argument, context), left_argument.type);
+    }
+
+    if (right_argument.type != ResultType::INSTANT_VECTOR)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' expects two arguments of type {}, but expression {} has type {}",
+                        operator_name, ResultType::INSTANT_VECTOR,
+                        getPromQLText(right_argument, context), right_argument.type);
+    }
+
+    if (operator_node->group_left)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' doesn't allow group_left",
+                        operator_name);
+    }
+
+    if (operator_node->group_right)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' doesn't allow group_right",
+                        operator_name);
+    }
+}
+
+ASTPtr makePresenceMask(ASTPtr values)
+{
+    auto lambda = makeASTFunction(
+        "lambda",
+        makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x")),
+        makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x")));
+
+    return makeASTFunction(
+        "groupBitOrForEach",
+        makeASTFunction("arrayMap", std::move(lambda), std::move(values)));
+}
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+/// Check argument types for set binary operator (i.e. one of "and", "or", "unless").
+void checkArgumentTypesForSetBinaryOperator(
+    const PrometheusQueryTree::BinaryOperator * operator_node,
+    const SQLQueryPiece & left_argument,
+    const SQLQueryPiece & right_argument,
+    const ConverterContext & context);
+
+/// Build a compact per-step presence mask for a vector grid.
+ASTPtr makePresenceMask(ASTPtr values);
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
@@ -43,7 +43,7 @@ SQLQueryPiece applyBinaryOperatorUnless(
 
     /// Step 1:
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
-    ///        maxForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
+    ///        groupBitOrForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
     /// GROUP BY join_group
     /// FROM right
     ///

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
@@ -43,7 +43,7 @@ SQLQueryPiece applyBinaryOperatorUnless(
 
     /// Step 1:
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
-    ///        countForEach(values) AS join_count
+    ///        maxForEach(arrayMap(x -> isNotNull(x), values)) AS join_presence
     /// GROUP BY join_group
     /// FROM right
     ///
@@ -59,8 +59,8 @@ SQLQueryPiece applyBinaryOperatorUnless(
             right_metric_name_dropped));
         builder.select_list.back()->setAlias(ColumnNames::JoinGroup);
 
-        builder.select_list.push_back(makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
-        builder.select_list.back()->setAlias(ColumnNames::JoinCount);
+        builder.select_list.push_back(makePresenceMask(make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        builder.select_list.back()->setAlias(ColumnNames::JoinPresence);
 
         builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
 
@@ -73,7 +73,7 @@ SQLQueryPiece applyBinaryOperatorUnless(
 
     /// Step 2:
     /// SELECT group,
-    ///        if(notEmpty(join_count), arrayMap(x, y -> if(y = 0, x, NULL), values, join_count), values) AS values
+    ///        if(notEmpty(join_presence), arrayMap(x, y -> if(y = 0, x, NULL), values, join_presence), values) AS values
     /// FROM left LEFT ANY JOIN step1
     /// ON timeSeriesRemoveAllTagsExcept(group, on_tags) == join_group
     ///
@@ -85,7 +85,7 @@ SQLQueryPiece applyBinaryOperatorUnless(
 
         builder.select_list.push_back(makeASTFunction(
             "if",
-            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)),
+            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::JoinPresence)),
             makeASTFunction(
                 "arrayMap",
                 makeASTFunction(
@@ -97,7 +97,7 @@ SQLQueryPiece applyBinaryOperatorUnless(
                         make_intrusive<ASTIdentifier>("x"),
                         make_intrusive<ASTLiteral>(Field{} /* NULL */))),
                 make_intrusive<ASTIdentifier>(ColumnNames::Values),
-                make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)),
+                make_intrusive<ASTIdentifier>(ColumnNames::JoinPresence)),
             make_intrusive<ASTIdentifier>(ColumnNames::Values)));
 
         builder.select_list.back()->setAlias(ColumnNames::Values);

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
@@ -5,7 +5,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
-#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.h>
 

--- a/src/Storages/TimeSeries/TimeSeriesColumnNames.h
+++ b/src/Storages/TimeSeries/TimeSeriesColumnNames.h
@@ -43,7 +43,7 @@ struct TimeSeriesColumnNames
     static constexpr const char * NewGroup = "new_group";
     static constexpr const char * OriginalGroup = "original_group";
     static constexpr const char * JoinGroup = "join_group";
-    static constexpr const char * JoinCount = "join_count";
+    static constexpr const char * JoinPresence = "join_presence";
     static constexpr const char * Values = "values";
     static constexpr const char * SelectedGroups = "selected_groups";
     static constexpr const char * StepsMask = "steps_mask";

--- a/tests/performance/promql_set_operator_presence_mask.xml
+++ b/tests/performance/promql_set_operator_presence_mask.xml
@@ -15,11 +15,26 @@
             map('instance', toString(number % 4000)),
             arrayMap(step -&gt; (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(300))
         FROM numbers_mt(8000)
+        UNION ALL
+        SELECT
+            if(number &lt; 4000, 'foo_sparse', 'bar_sparse'),
+            map(
+                'instance', toString(intDiv(number, 4) % 1000),
+                'replica', toString(number % 4)),
+            arrayMap(
+                step -&gt; (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000),
+                arrayFilter(step -&gt; sipHash64(number, step) % 2 = 0, range(300)))
+        FROM numbers_mt(8000)
     </fill_query>
 
     <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo[10]) and on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
     <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo[10]) or on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
     <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
+
+    <!-- Four physical replicas per instance with staggered sample gaps. -->
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo_sparse[10]) and on(instance) last_over_time(bar_sparse[10])', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo_sparse[10]) or on(instance) last_over_time(bar_sparse[10])', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo_sparse[10]) unless on(instance) last_over_time(bar_sparse[10])', 100, 3090, 10) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_set_operator_presence_mask_ts</drop_query>
 </test>

--- a/tests/performance/promql_set_operator_presence_mask.xml
+++ b/tests/performance/promql_set_operator_presence_mask.xml
@@ -1,0 +1,25 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <create_query>
+        CREATE TABLE promql_set_operator_presence_mask_ts ENGINE = TimeSeries
+    </create_query>
+
+    <fill_query>
+        INSERT INTO promql_set_operator_presence_mask_ts (metric_name, tags, time_series)
+        SELECT
+            if(number &lt; 4000, 'foo', 'bar'),
+            map('instance', toString(number % 4000)),
+            arrayMap(step -&gt; (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(300))
+        FROM numbers_mt(8000)
+    </fill_query>
+
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo[10]) and on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo[10]) or on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operator_presence_mask_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_set_operator_presence_mask_ts</drop_query>
+</test>

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.reference
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.reference
@@ -24,6 +24,12 @@
 [('__name__','m'),('dc','b'),('host','h4')]	[('1970-01-01 00:01:40.000',4),('1970-01-01 00:02:10.000',4)]
 -- or: the left side is evaluated once: two samples reads in total (left materialized + right inlined)
 2	1
+-- and uses a compact per-step presence mask
+1	1
+-- or uses a compact per-step presence mask
+1	1
+-- unless uses a compact per-step presence mask
+1	1
 -- subqueries referenced once stay inlined: plain sum(rate(...)) reads the samples table once, nothing is materialized
 1	0
 -- subqueries referenced once stay inlined: a binary operator reads each of its two operands once, nothing is materialized

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.reference
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.reference
@@ -22,6 +22,16 @@
 [('__name__','m'),('dc','a'),('host','h2')]	[('1970-01-01 00:01:50.000',20),('1970-01-01 00:02:00.000',3)]
 [('__name__','m'),('dc','b'),('host','h3')]	[('1970-01-01 00:01:40.000',3),('1970-01-01 00:02:10.000',3)]
 [('__name__','m'),('dc','b'),('host','h4')]	[('1970-01-01 00:01:40.000',4),('1970-01-01 00:02:10.000',4)]
+-- sparse or preserves both sides at different steps
+2	4
+-- sparse and keeps only right-present steps
+1	2
+-- sparse unless keeps only right-absent steps
+1	2
+-- empty left vector remains empty for and
+0
+-- empty right vector leaves unless left unchanged
+1	4
 -- or: the left side is evaluated once: two samples reads in total (left materialized + right inlined)
 2	1
 -- and uses a compact per-step presence mask

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
@@ -3,7 +3,7 @@
 -- Tag no-parallel-replicas: the test asserts on the query plan shape (the number of reads of the samples table).
 
 -- The SQL generated from a PromQL query may reference a named subquery more than once: the left side of `or`
--- feeds both the per-group counting step and the final merge join, and the topk/bottomk/limitk operand grid
+-- feeds both the per-group presence-mask step and the final merge join, and the topk/bottomk/limitk operand grid
 -- feeds both the group-selecting aggregation and the value-masking join. Such subqueries must be marked
 -- AS MATERIALIZED and evaluated once, while subqueries referenced once must stay inlined and must not be materialized.
 

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
@@ -60,17 +60,17 @@ SELECT countIf(explain LIKE '%ReadFromMergeTree%samples_table%') AS samples_tabl
 FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10));
 
 SELECT '-- and uses a compact per-step presence mask';
-SELECT countIf(explain LIKE '%maxForEach%') > 0 AS uses_presence_mask,
+SELECT countIf(explain LIKE '%groupBitOrForEach%') > 0 AS uses_presence_mask,
        countIf(explain LIKE '%countForEach%') = 0 AS avoids_count_aggregate
 FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) and last_over_time(n[10])', 100, 130, 10));
 
 SELECT '-- or uses a compact per-step presence mask';
-SELECT countIf(explain LIKE '%maxForEach%') > 0 AS uses_presence_mask,
+SELECT countIf(explain LIKE '%groupBitOrForEach%') > 0 AS uses_presence_mask,
        countIf(explain LIKE '%countForEach%') = 0 AS avoids_count_aggregate
 FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10));
 
 SELECT '-- unless uses a compact per-step presence mask';
-SELECT countIf(explain LIKE '%maxForEach%') > 0 AS uses_presence_mask,
+SELECT countIf(explain LIKE '%groupBitOrForEach%') > 0 AS uses_presence_mask,
        countIf(explain LIKE '%countForEach%') = 0 AS avoids_count_aggregate
 FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) unless last_over_time(n[10])', 100, 130, 10));
 

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
@@ -42,7 +42,13 @@ INSERT INTO prometheus (metric_name, tags, time_series) VALUES
     ('m', map('host', 'h3', 'dc', 'b'), [(toDateTime64(100, 3), 3), (toDateTime64(110, 3), 5), (toDateTime64(120, 3), 2), (toDateTime64(130, 3), 3)]),
     ('m', map('host', 'h4', 'dc', 'b'), [(toDateTime64(100, 3), 4), (toDateTime64(130, 3), 4)]),
     ('n', map('host', 'h5', 'dc', 'a'), [(toDateTime64(100, 3), 7), (toDateTime64(110, 3), 7), (toDateTime64(120, 3), 7), (toDateTime64(130, 3), 7)]),
-    ('n', map('host', 'h6', 'dc', 'b'), [(toDateTime64(100, 3), 8), (toDateTime64(110, 3), 8), (toDateTime64(120, 3), 8), (toDateTime64(130, 3), 8)]);
+    ('n', map('host', 'h6', 'dc', 'b'), [(toDateTime64(100, 3), 8), (toDateTime64(110, 3), 8), (toDateTime64(120, 3), 8), (toDateTime64(130, 3), 8)]),
+    ('sparse_or_left', map('test_case', 'or'), [(toDateTime64(100, 3), 1), (toDateTime64(130, 3), 4)]),
+    ('dense_or_right', map('test_case', 'or'), [(toDateTime64(100, 3), 7), (toDateTime64(110, 3), 7), (toDateTime64(120, 3), 7), (toDateTime64(130, 3), 7)]),
+    ('dense_and_left', map('test_case', 'and'), [(toDateTime64(100, 3), 1), (toDateTime64(110, 3), 1), (toDateTime64(120, 3), 1), (toDateTime64(130, 3), 1)]),
+    ('sparse_and_right', map('test_case', 'and'), [(toDateTime64(100, 3), 2), (toDateTime64(130, 3), 2)]),
+    ('dense_unless_left', map('test_case', 'unless'), [(toDateTime64(100, 3), 1), (toDateTime64(110, 3), 1), (toDateTime64(120, 3), 1), (toDateTime64(130, 3), 1)]),
+    ('sparse_unless_right', map('test_case', 'unless'), [(toDateTime64(100, 3), 2), (toDateTime64(130, 3), 2)]);
 
 SELECT '-- or, range';
 SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10) ORDER BY tags;
@@ -53,6 +59,41 @@ SELECT '-- topk(2), range';
 SELECT * FROM prometheusQueryRange('prometheus', 'topk(2, last_over_time(m[10]))', 100, 130, 10) ORDER BY tags;
 SELECT '-- topk(2), range: identical result with materialization disabled';
 SELECT * FROM prometheusQueryRange('prometheus', 'topk(2, last_over_time(m[10]))', 100, 130, 10) ORDER BY tags SETTINGS enable_materialized_cte = 0;
+
+SELECT '-- sparse or preserves both sides at different steps';
+SELECT count() AS series_count, sum(length(time_series)) AS sample_count
+FROM prometheusQueryRange(
+    'prometheus',
+    'last_over_time(sparse_or_left[10]) or on(test_case) last_over_time(dense_or_right[10])',
+    100, 130, 10);
+
+SELECT '-- sparse and keeps only right-present steps';
+SELECT count() AS series_count, sum(length(time_series)) AS sample_count
+FROM prometheusQueryRange(
+    'prometheus',
+    'last_over_time(dense_and_left[10]) and on(test_case) last_over_time(sparse_and_right[10])',
+    100, 130, 10);
+
+SELECT '-- sparse unless keeps only right-absent steps';
+SELECT count() AS series_count, sum(length(time_series)) AS sample_count
+FROM prometheusQueryRange(
+    'prometheus',
+    'last_over_time(dense_unless_left[10]) unless on(test_case) last_over_time(sparse_unless_right[10])',
+    100, 130, 10);
+
+SELECT '-- empty left vector remains empty for and';
+SELECT count() AS series_count
+FROM prometheusQueryRange(
+    'prometheus',
+    'last_over_time(missing_metric[10]) and last_over_time(dense_and_left[10])',
+    100, 130, 10);
+
+SELECT '-- empty right vector leaves unless left unchanged';
+SELECT count() AS series_count, sum(length(time_series)) AS sample_count
+FROM prometheusQueryRange(
+    'prometheus',
+    'last_over_time(dense_unless_left[10]) unless last_over_time(missing_metric[10])',
+    100, 130, 10);
 
 SELECT '-- or: the left side is evaluated once: two samples reads in total (left materialized + right inlined)';
 SELECT countIf(explain LIKE '%ReadFromMergeTree%samples_table%') AS samples_table_reads,

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
@@ -59,6 +59,21 @@ SELECT countIf(explain LIKE '%ReadFromMergeTree%samples_table%') AS samples_tabl
        countIf(explain LIKE '%MaterializingCTEs%') > 0 AS uses_materialized_cte
 FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10));
 
+SELECT '-- and uses a compact per-step presence mask';
+SELECT countIf(explain LIKE '%maxForEach%') > 0 AS uses_presence_mask,
+       countIf(explain LIKE '%countForEach%') = 0 AS avoids_count_aggregate
+FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) and last_over_time(n[10])', 100, 130, 10));
+
+SELECT '-- or uses a compact per-step presence mask';
+SELECT countIf(explain LIKE '%maxForEach%') > 0 AS uses_presence_mask,
+       countIf(explain LIKE '%countForEach%') = 0 AS avoids_count_aggregate
+FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10));
+
+SELECT '-- unless uses a compact per-step presence mask';
+SELECT countIf(explain LIKE '%maxForEach%') > 0 AS uses_presence_mask,
+       countIf(explain LIKE '%countForEach%') = 0 AS avoids_count_aggregate
+FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) unless last_over_time(n[10])', 100, 130, 10));
+
 SELECT '-- subqueries referenced once stay inlined: plain sum(rate(...)) reads the samples table once, nothing is materialized';
 SELECT countIf(explain LIKE '%ReadFromMergeTree%samples_table%') AS samples_table_reads,
        countIf(explain LIKE '%MaterializingCTEs%') > 0 AS uses_materialized_cte


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Use compact presence masks for PromQL set operators.**

### Summary

The PromQL `and`, `or`, and `unless` lowering only needs to know whether a value is present at each step.

This targets the general set-operator path. The exact-group fast path is separate.

### Changes

- Use `Array(UInt8)` presence masks instead of `Array(UInt64)` counts.
- Use `groupBitOrForEach` for the per-step presence reduction.
- Share the mask expression between `and`, `or`, and `unless`.
- Keep the shared set-operator validation and presence-mask construction in a common lowering helper.
- Keep the existing NULL filtering and join behavior.
- Cover all three operators in the plan-shape test.
- Keep the original 8,000-series baseline workload.
- Add a sparse fan-in workload with 1,000 matching groups and four physical replicas per group, with `replica` excluded by `on(instance)`.

The compact presence mask is built with:

```sql
groupBitOrForEach(arrayMap(x -> isNotNull(x), values))
```

Because `isNotNull()` produces a `UInt8` 0/1 value, bitwise OR is exactly the presence reduction needed by the set operators. The aggregate state is a zero-initialized `UInt8`, avoiding the generic `max(UInt8)` initialized-state bookkeeping.

### Benchmark

The checked-in workload contains two variants, each using 300 query steps:

- Baseline: 8,000 series with one series per matching group.
- Sparse fan-in: 8,000 series with four replicas per matching group and staggered 50% sample presence. Queries match on `instance` while retaining `replica` in the physical labels.

The second variant exercises the actual per-step presence reduction across multiple rows in each `on(...)` group.

### Benchmark result

This operator-step microbenchmark runs the old `countForEach(values)` expression and the new `groupBitOrForEach(arrayMap(x -> isNotNull(x), values))` expression over the same workload shapes.

- ClickHouse 26.7.3.19
- 200 iterations per case
- QPS from `clickhouse-benchmark`
- Memory from `system.query_log`

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| Baseline | 68.3 QPS, p50 13 ms, 40.0 MiB | 79.6 QPS, p50 11 ms, 30.1 MiB | +16.5% QPS, -24.9% memory |
| Sparse fan-in | 119.4 QPS, p50 7 ms, 30.0 MiB | 122.7 QPS, p50 7 ms, 30.0 MiB | +2.8% QPS, no material memory change |

### Tests

- Verified that `groupBitOr` is registered for integer inputs and that the `ForEach` combinator accepts array arguments.
- Updated the plan-shape checks for `and`, `or`, and `unless` to require `groupBitOrForEach` and reject `countForEach`.
- Existing end-to-end set-operator coverage continues to exercise mixed, NULL, and missing-step behavior.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115224&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115224](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115224+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1796` (included in `26.8` and later)
<!-- ch-version-info:end -->