### PR TITLE
CI: do not authenticate an unused robot token in the Codex code review

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -6,9 +6,10 @@ Two backends are supported, selected by flag:
   --codex    OpenAI Codex CLI       (auth: OPENAI_API_KEY from `/ci/llm/openai_api_key`)
   --copilot  GitHub Copilot CLI     (auth: gh robot token from `/ci/robot-ch-test-poll-copilot`)
 
-Both agents shell out to `gh` to post inline review comments, so the gh CLI is
-always authenticated against a temporary `GH_CONFIG_DIR` with the robot token
-regardless of which backend runs the review itself.
+The backends reach GitHub as different identities. Copilot authenticates with a
+robot token, in a temporary `GH_CONFIG_DIR`. Codex shells out to `gh` with
+`GH_CONFIG_DIR` unset (`GH_PREFIX`), so it runs as the app the job requires to be
+authenticated up front (`enable_gh_auth=True`).
 
 The agent writes a free-form Markdown summary to `REVIEW_FILE`. The job script
 then posts that summary via `python3 -m ci.praktika.gh post-or-update --tag review`
@@ -16,9 +17,9 @@ so the top-level comment is always authored by the pre-authenticated app, not
 the agent's robot account.
 
 Each agent occasionally hits transient GitHub authorization errors mid-run
-("Authorization error, you may need to run /login"). The whole `gh auth` +
-agent sequence is wrapped in a retry loop with exponential backoff so a single
-transient API failure does not fail the Code Review job. Authorization-style
+("Authorization error, you may need to run /login"). The whole attempt is
+wrapped in a retry loop with exponential backoff so a single transient API
+failure does not fail the Code Review job. Authorization-style
 failures do not always surface as a Python exception — they show up as a
 non-zero exit code and a missing/empty review file — so both are checked here.
 """
@@ -40,18 +41,15 @@ from ci.praktika.result import Result
 REVIEW_FILE = "./ci/tmp/copilot_review.md"
 GH_PREFIX = "env -u GH_CONFIG_DIR"
 
-# Number of attempts at the full gh-auth + agent run. The agents fetch
-# auth state and make GitHub / model-provider API calls during execution;
-# either layer can hit a transient 5xx / authorization error that no
-# single inner subprocess controls. Re-authing and retrying the whole
-# sequence is the only reliable way to recover.
+# Number of attempts at a full agent run. The agents fetch auth state and make
+# GitHub / model-provider API calls during execution; either layer can hit a
+# transient 5xx / authorization error that no single inner subprocess controls.
+# Retrying the whole sequence is the only reliable way to recover.
 MAX_ATTEMPTS = 3
 
-# Robot gh tokens. Used by both backends — Copilot authenticates against
-# GitHub with one of these directly; Codex needs gh authed so the agent's
-# shelled-out `gh` calls (for posting inline comments) succeed. Each
-# attempt picks one in a randomised rotation so a single robot's rate
-# limit or token issue does not fail every attempt.
+# Robot gh tokens the Copilot CLI authenticates against GitHub with. Each
+# attempt picks one in a randomised rotation so a single robot's rate limit
+# or token issue does not fail every attempt.
 ROBOT_NAMES = [
     "/ci/robot-ch-test-poll-copilot",
     "/ci/robot-ch-test-poll-1-copilot",
@@ -261,8 +259,8 @@ def _run_copilot_once(prompt, robot_name):
         )
 
 
-def _run_codex_once(prompt, robot_name):
-    """Run a single attempt of `gh auth login` + `codex login` + `codex exec`.
+def _run_codex_once(prompt, _robot_name):
+    """Run a single attempt of `codex login` + `codex exec`.
 
     Codex stores credentials in `$CODEX_HOME/auth.json` and does NOT consult
     `OPENAI_API_KEY` directly when invoked — you have to run
@@ -271,12 +269,12 @@ def _run_codex_once(prompt, robot_name):
     temporary directory under `./ci/tmp` (not `/tmp`, which codex refuses
     to use for helper binaries) so the API key never lands on global runner
     state.
+
+    The agent's own `gh` calls run as the app authenticated before the job, so
+    no robot token takes part in this attempt.
     """
     _drop_stale_review_file()
-    with tempfile.TemporaryDirectory() as gh_config_dir, \
-         tempfile.TemporaryDirectory(dir="./ci/tmp") as codex_home:
-        _gh_auth_with_robot_token(gh_config_dir, robot_name)
-
+    with tempfile.TemporaryDirectory(dir="./ci/tmp") as codex_home:
         openai_key = Secret.Config(
             name=OPENAI_KEY_SECRET, type=Secret.Type.AWS_SSM_PARAMETER
         ).get_value()
@@ -291,8 +289,7 @@ def _run_codex_once(prompt, robot_name):
             # -m gpt-5.4: same model the Copilot CLI uses, so
             #   review quality stays comparable across backends.
             # -s workspace-write: writable workspace + /tmp + CODEX_HOME,
-            #   read-only elsewhere; sufficient for review output and
-            #   the gh CLI's /tmp config dir.
+            #   read-only elsewhere; sufficient for the review output.
             # sandbox_workspace_write.network_access=true: the agent
             #   shells out to `gh` to post inline comments, which needs
             #   network.
@@ -301,7 +298,6 @@ def _run_codex_once(prompt, robot_name):
             #   agent execute without blocking on an approval request.
             # --color never: no ANSI codes in the job log.
             command=f"CODEX_HOME={shlex.quote(codex_home)} "
-                    f"GH_CONFIG_DIR={shlex.quote(gh_config_dir)} "
                     f"codex exec "
                     f"-m gpt-5.4 -c 'model_reasoning_effort=xhigh' "
                     f"-s workspace-write "
@@ -316,9 +312,9 @@ def _run_codex_once(prompt, robot_name):
 def _run(prompt, run_once, agent_name):
     """Run the chosen agent with retries, then post the review comment.
 
-    Each attempt re-fetches secrets, re-auths the temporary `GH_CONFIG_DIR`,
-    and re-runs the agent. The attempt counts as success only if the
-    subprocess exits 0 AND `REVIEW_FILE` was written with non-empty content.
+    Each attempt re-fetches secrets and re-runs the agent. The attempt counts
+    as success only if the subprocess exits 0 AND `REVIEW_FILE` was written
+    with non-empty content.
     """
     last_error = None
     robots = ROBOT_NAMES.copy()

--- a/ci/tests/test_copilot_review_codex_auth.py
+++ b/ci/tests/test_copilot_review_codex_auth.py
@@ -1,0 +1,160 @@
+"""
+Tests for the identity each `ci/jobs/copilot_review_job.py` backend uses.
+
+The contract this pins down:
+  - the Codex backend runs on the ambient GitHub App token the runner mints
+    (`enable_gh_auth=True`), so it neither reads a robot secret, nor runs
+    `gh auth login`, nor scopes a `GH_CONFIG_DIR` for the agent;
+  - a robot token that cannot authenticate therefore cannot fail a Codex run,
+    and the retry budget is spent on agent failures instead;
+  - the Copilot backend still authenticates a robot token, which its CLI uses
+    directly.
+
+Everything external is scripted: no secret is read, no `gh`/`codex` process is
+started, and no attempt sleeps.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+# `ci/defs/job_configs.py` does `from praktika import ...` rather than
+# `from ci.praktika import ...`, so the `ci/` directory itself must be on the
+# path for `import praktika` to resolve to `ci/praktika`.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ci.jobs import copilot_review_job as job
+from ci.praktika.result import Result
+
+_ROBOT_PREFIX = "/ci/robot-ch-test-poll"
+
+
+class Recorder:
+    """Collects every scripted external interaction of one `_run` call."""
+
+    def __init__(self):
+        self.secret_names = []
+        self.argvs = []
+        self.commands = []
+
+    @property
+    def robot_secret_names(self):
+        return [n for n in self.secret_names if str(n).startswith(_ROBOT_PREFIX)]
+
+    @property
+    def gh_auth_login_argvs(self):
+        return [a for a in self.argvs if list(a[:3]) == ["gh", "auth", "login"]]
+
+
+@pytest.fixture
+def harness(monkeypatch, tmp_path):
+    """Script the job's whole outside world and return the Recorder.
+
+    `agent_outcomes` on the recorder drives the fake agent: each entry is a
+    `Result.Status` for one invocation, defaulting to OK forever.
+    """
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("./ci/tmp", exist_ok=True)
+    review_file = str(tmp_path / "copilot_review.md")
+    monkeypatch.setattr(job, "REVIEW_FILE", review_file)
+    monkeypatch.setattr(job.time, "sleep", lambda seconds: None)
+
+    rec = Recorder()
+    rec.agent_outcomes = []
+    rec.gh_auth_login_raises = False
+
+    def fake_get_value(self):
+        rec.secret_names.append(self.name)
+        return f"token-for-{self.name}"
+
+    def fake_run(argv, *args, **kwargs):
+        rec.argvs.append(list(argv))
+        if list(argv[:3]) == ["gh", "auth", "login"] and rec.gh_auth_login_raises:
+            raise subprocess.CalledProcessError(returncode=1, cmd=list(argv))
+        return subprocess.CompletedProcess(argv, 0)
+
+    def fake_from_commands_run(name, command, **kwargs):
+        rec.commands.append(command)
+        status = rec.agent_outcomes.pop(0) if rec.agent_outcomes else Result.Status.OK
+        if status == Result.Status.OK:
+            with open(review_file, "w", encoding="utf-8") as f:
+                f.write("#### AI Review\nfindings\n")
+        return Result(name=name, status=status)
+
+    monkeypatch.setattr(job.Secret.Config, "get_value", fake_get_value)
+    monkeypatch.setattr(job.subprocess, "run", fake_run)
+    monkeypatch.setattr(job.Result, "from_commands_run", fake_from_commands_run)
+    return rec
+
+
+def _run_codex(rec):
+    job._run("review this", job._run_codex_once, "Codex")
+
+
+def _run_copilot(rec):
+    job._run("review this", job._run_copilot_once, "Copilot")
+
+
+def test_codex_survives_every_robot_token_being_rejected(harness):
+    # Harsher than the observed outage, where only one of the two robots was dead.
+    harness.gh_auth_login_raises = True
+
+    _run_codex(harness)
+
+    assert harness.commands, "the agent never ran"
+
+
+def test_codex_reads_no_robot_secret(harness):
+    _run_codex(harness)
+
+    assert harness.robot_secret_names == []
+    assert job.OPENAI_KEY_SECRET in harness.secret_names
+
+
+def test_codex_runs_no_gh_auth_login(harness):
+    _run_codex(harness)
+
+    assert harness.gh_auth_login_argvs == []
+
+
+def test_codex_command_scopes_codex_home_but_not_gh_config_dir(harness):
+    _run_codex(harness)
+
+    assert len(harness.commands) == 1
+    assert "GH_CONFIG_DIR=" not in harness.commands[0]
+    assert "CODEX_HOME=" in harness.commands[0]
+
+
+def test_copilot_still_authenticates_a_robot_token(harness):
+    _run_copilot(harness)
+
+    assert len(harness.robot_secret_names) == 1
+    assert harness.robot_secret_names[0] in job.ROBOT_NAMES
+    assert len(harness.gh_auth_login_argvs) == 1
+
+
+def test_codex_retry_budget_is_spent_on_agent_failures(harness):
+    harness.agent_outcomes = [Result.Status.FAIL, Result.Status.FAIL]
+
+    _run_codex(harness)
+
+    assert len(harness.commands) == job.MAX_ATTEMPTS == 3
+    assert harness.gh_auth_login_argvs == []
+
+
+def test_code_review_job_pre_authenticates_the_github_app():
+    """The Codex backend has no identity of its own: every `gh` call it makes
+    reads the ambient config the runner authenticates before the job command
+    starts, which the agent reaches only because the job runs natively. A
+    containerized job gets that config as a `/ghconfig` mount named by
+    `GH_CONFIG_DIR`, and every agent command unsets that variable, so
+    containerizing this job would leave the agent unauthenticated. The tests
+    above pass either way because they stop at the job's own boundary."""
+    from ci.workflows.pull_request import workflow
+
+    code_review = next(j for j in workflow.jobs if j.name == "Code Review")
+    assert code_review.enable_gh_auth is True
+    assert code_review.run_in_docker == ""


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/113059

The `Code Review` job died on `gh auth login` for 10 pull requests in the 24 h to
2026-08-17, losing the automated review for those heads. A fork PR cannot re-run it,
so recovery needs a fresh push.

```
ERROR: Codex review failed after 3 attempts: CalledProcessError:
       Command '['gh', 'auth', 'login', '--with-token']' returned non-zero exit status 1.
```

- report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113059&sha=83188f6442a4f2d7e4376efe54c2bf3bad32dd50&name_0=PR&name_1=Code%20Review
- log: https://s3.amazonaws.com/clickhouse-test-reports/PRs/113059/83188f6442a4f2d7e4376efe54c2bf3bad32dd50/code_review/job.log

`_run_codex_once` authenticated a robot token before every attempt, under
`check=True`, but the Codex backend never uses it: `enable_gh_auth=True` has the
runner authenticate the app up front, and the prompt runs every agent `gh` call with
`GH_CONFIG_DIR` unset. Across the 25 job logs that reached the agent,
246 of 246 executed `gh` calls unset it and none used the scoped robot directory, so
that login could only fail the job. In those same logs
`/ci/robot-ch-test-poll-copilot` answered `HTTP 401: Bad credentials` on 27 of 27
attempts, the oldest on 2026-08-03, and `/ci/robot-ch-test-poll-1-copilot` never did.
Two robots
over three attempts rotate as `[X, Y, X]`, so the healthy one gets a single attempt
when the shuffle puts the dead one first, and one transient GraphQL 503 there fails
the job.

This removes that login and its temporary `GH_CONFIG_DIR` from the Codex attempt, so
it runs on the app identity it already used and retries serve agent failures.
`_run_copilot_once` keeps its login, which the Copilot CLI does use.

New `ci/tests/test_copilot_review_codex_auth.py`: 5 tests fail on the current code
with the error above and pass here; the 2 pinning unchanged behaviour were verified
by mutating the code they pin. No secret, process or sleep involved.

Out of scope: `/ci/robot-ch-test-poll-copilot` still needs rotating operationally
(`--copilot` would still need it); and 8 further failures that window are a separate
defect, `gh api -X PATCH` on `issues/comments/<id>` returning 503 after its retries.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115232&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115232](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115232+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.36` (included in `26.9` and later)
<!-- ch-version-info:end -->