### PR TITLE
Report which destination made the macOS self-extracting copy fail

### DIFF
--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cerrno>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -412,6 +413,39 @@ static uint64_t getInode(const char * self)
 
 #endif
 
+#if defined(OS_DARWIN)
+
+/// The entry and its target differ exactly when the entry is a symlink, and only
+/// the followed pair is comparable with copy_file's equivalence test.
+/// `followed` is filled only when 0 is returned.
+static int reportPathIdentity(std::ostream & out, const char * label, const char * path, struct stat & followed)
+{
+    struct stat entry{};
+    if (0 == lstat(path, &entry))
+    {
+        const char * type = S_ISLNK(entry.st_mode) ? "link" : (S_ISREG(entry.st_mode) ? "reg" : "other");
+        out << ' ' << label << "=lstat(type=" << type
+            << ",dev=" << entry.st_dev << ",ino=" << entry.st_ino
+            << ",mode=0" << std::oct << entry.st_mode << std::dec
+            << ",uid=" << entry.st_uid << ",gid=" << entry.st_gid
+            << ",size=" << entry.st_size << ",mtime=" << entry.st_mtime << ')';
+    }
+    else
+        out << ' ' << label << "=lstat(errno=" << errno << ' ' << strerror(errno) << ')'; // NOLINT(concurrency-mt-unsafe)
+
+    if (0 != stat(path, &followed))
+    {
+        out << ' ' << label << "=stat(errno=" << errno << ' ' << strerror(errno) << ')'; // NOLINT(concurrency-mt-unsafe)
+        return 1;
+    }
+
+    out << ' ' << label << "=stat(dev=" << followed.st_dev << ",ino=" << followed.st_ino
+        << ",mode=0" << std::oct << followed.st_mode << std::dec << ')';
+    return 0;
+}
+
+#endif
+
 int main(int/* argc*/, char* argv[])
 {
     char self[4096] = {0};
@@ -541,7 +575,17 @@ int main(int/* argc*/, char* argv[])
         std::filesystem::copy_file(static_cast<char *>(decompressed_name.data()), static_cast<char *>(self), ec);
         if (ec)
         {
-            std::cerr << ec.message() << std::endl;
+            std::cerr << "copy_file(self): " << ec.message() << " [" << ec.value() << "] dst=" << self
+                      << " src=" << decompressed_name.data();
+            struct stat dst_followed{};
+            struct stat src_followed{};
+            int dst_rc = reportPathIdentity(std::cerr, "dst", self, dst_followed);
+            int src_rc = reportPathIdentity(std::cerr, "src", decompressed_name.data(), src_followed);
+            /// copy_file reports EEXIST when this holds of the followed pair.
+            if (0 == dst_rc && 0 == src_rc)
+                std::cerr << " equivalent=" << (dst_followed.st_dev == src_followed.st_dev
+                                                && dst_followed.st_ino == src_followed.st_ino);
+            std::cerr << " wrapper=(dev=" << input_info.st_dev << ",ino=" << input_info.st_ino << ')' << std::endl;
             return 1;
         }
 #else


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`Fast test (arm_darwin)` fails a few times a day on unrelated PRs with
`Permission denied` on `ci/tmp/clickhouse`:
[job 95461613722](https://github.com/ClickHouse/ClickHouse/actions/runs/32041145440/job/95461613722)
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114125&sha=88ab20e7768865da5426a0aaa8a204f6ad43e6f5&name_0=PR&name_1=Fast%20test%20%28arm_darwin%29)),
also jobs `95537845886`, `95306463154`, `95222719292`, across three unrelated PRs.

The binary is the self-extracting bundle and it destroys itself. In
`decompressor.cpp` `unlink(self)` succeeds, the Darwin-only
`std::filesystem::copy_file(tmp -> self)` then fails `EEXIST`, and the error
return happens before the `chmod` restoring the executable bit, so the process
exits having removed its own binary. The progress dots appear exactly once in
the log, immediately followed by that `copy_file`'s `File exists`.

Why the destination exists after a successful `unlink` is not established, and I
could not reproduce it: this is macOS-only and I have no macOS host. Two
mechanisms remain possible (path resolution through
`_NSGetExecutablePath`/`realpath`/APFS naming a different entry than `unlink`
removed, or a symlink-following equivalence match); an unlabelled `File exists`
cannot tell them apart.

So instead of guessing at a fix, this reports the destination's identity and
keeps the failure closed: `lstat` and symlink-following `stat` for destination
and source, the equivalence flag from the followed pair (what libc++ compares
before returning `EEXIST`), and the original wrapper's dev/inode. It is confined
to that failure branch plus an `OS_DARWIN`-only helper; one real occurrence
identifies the mechanism.

Two candidate fixes were dropped on measurement: `copy_options::overwrite_existing`
is a no-op against the equivalence case and truncates an unknown object
otherwise; staging the temp file executable would publish a partial executable.

Validated by an oracle harness compiling this code verbatim over three
destination shapes that must differ (they collapse without the change), a
`-DOS_DARWIN` type-check with an injected-error control, byte-identical Linux
`.text`, and a standalone self-extracting round trip unchanged before and after.

A green `Fast test (arm_darwin)` here is not evidence the diagnostic works, since
it only fires on failure: this makes the next occurrence diagnosable, not rarer.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115236&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115236](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115236+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
