### PR TITLE
Remove the rocks backend from Keeper stress tests

### DIFF
--- a/ci/jobs/keeper_stress_job.py
+++ b/ci/jobs/keeper_stress_job.py
@@ -367,6 +367,13 @@ def _load_all_scenario_ids(run_faults, run_no_faults):
     return ids
 
 
+def _matrix_backends():
+    """`KEEPER_MATRIX_BACKENDS` split, stripped and lowercased — the same normalization the
+    harness applies before selecting a backend, so every consumer sees identical values."""
+    raw = os.environ.get("KEEPER_MATRIX_BACKENDS", "default")
+    return [b.strip().lower() for b in raw.split(",") if b.strip()] or ["default"]
+
+
 def _scenario_ids_for_grafana(run_faults, run_no_faults):
     """Return fully-qualified scenario IDs for Grafana variables.
 
@@ -375,9 +382,7 @@ def _scenario_ids_for_grafana(run_faults, run_no_faults):
     """
     include_ids = os.environ.get("KEEPER_INCLUDE_IDS", "").strip()
     ids = [s.strip() for s in include_ids.split(",") if s.strip()] if include_ids else _load_all_scenario_ids(run_faults, run_no_faults)
-    backends_raw = os.environ.get("KEEPER_MATRIX_BACKENDS", "default").strip()
-    backends = [b.strip() for b in backends_raw.split(",") if b.strip()] or ["default"]
-    return [f"{sid}[{b}]" for sid in ids for b in backends]
+    return [f"{sid}[{b}]" for sid in ids for b in _matrix_backends()]
 
 
 def _add_grafana_links(result, commit_sha, stop_watch, run_faults, run_no_faults, scenario_filter=None, branch=None):
@@ -504,8 +509,7 @@ def main():
         return
 
     # Build RaftKeeper Docker image if the raftkeeper backend is enabled.
-    backends_raw = os.environ.get("KEEPER_MATRIX_BACKENDS", "")
-    if "raftkeeper" in backends_raw:
+    if "raftkeeper" in _matrix_backends():
         rk_image = os.environ.get("RAFTKEEPER_IMAGE", "raftkeeper:test")
         dockerfile = f"{REPO_DIR}/tests/integration/compose/Dockerfile.raftkeeper"
         if not Result.from_commands_run(

--- a/ci/jobs/keeper_stress_job.py
+++ b/ci/jobs/keeper_stress_job.py
@@ -78,8 +78,8 @@ def set_default_env():
 
     Mode is determined from Info().pr_number and Info().workflow_name:
       - PR (pr_number > 0): 3 no-fault scenarios, default backend, 15 min each.
-      - NightlyKeeperFaults: fault scenarios, default + rocks backends, 20 min each.
-      - NightlyKeeperNoFaults: no-fault scenarios, default + rocks backends, 20 min each.
+      - NightlyKeeperFaults: fault scenarios, default backend, 20 min each.
+      - NightlyKeeperNoFaults: no-fault scenarios, default backend, 20 min each.
       - Other/local: both fault and no-fault, nightly defaults.
 
     The legacy KEEPER_PR_MODE env var is still honoured for local runs.
@@ -124,7 +124,7 @@ def set_default_env():
     for k, v in {
         "KEEPER_DURATION": "1200",
         "KEEPER_FAULTS": "true",
-        "KEEPER_MATRIX_BACKENDS": "default,rocks",
+        "KEEPER_MATRIX_BACKENDS": "default",
         "KEEPER_METRICS_INTERVAL_S": "5",
         "KEEPER_JOB_TYPE": "nightly",
     }.items():
@@ -375,7 +375,7 @@ def _scenario_ids_for_grafana(run_faults, run_no_faults):
     """
     include_ids = os.environ.get("KEEPER_INCLUDE_IDS", "").strip()
     ids = [s.strip() for s in include_ids.split(",") if s.strip()] if include_ids else _load_all_scenario_ids(run_faults, run_no_faults)
-    backends_raw = os.environ.get("KEEPER_MATRIX_BACKENDS", "default,rocks").strip()
+    backends_raw = os.environ.get("KEEPER_MATRIX_BACKENDS", "default").strip()
     backends = [b.strip() for b in backends_raw.split(",") if b.strip()] or ["default"]
     return [f"{sid}[{b}]" for sid in ids for b in backends]
 

--- a/tests/stress/keeper/framework/core/cluster.py
+++ b/tests/stress/keeper/framework/core/cluster.py
@@ -503,6 +503,11 @@ class ClusterBuilder:
             return self._build_zookeeper_cluster(topology, opts)
         if backend_norm == "raftkeeper":
             return self._build_raftkeeper_cluster(topology, opts)
+        if backend_norm != "default":
+            # Fail close: an unknown backend previously fell through to the default Keeper
+            # build, so removed backends (e.g. `rocks` after Keeper RocksDB storage was
+            # dropped in #108000) silently produced duplicate `default` runs for months.
+            raise ValueError(f"unknown Keeper stress backend {backend!r}; supported: default, zookeeper, raftkeeper")
 
         self.cluster = ClickHouseCluster(self.file_anchor, name=self.cname)
         self.base_dir = pathlib.Path(self.cluster.base_dir)

--- a/tests/stress/keeper/pytest_plugins/scenario_loader.py
+++ b/tests/stress/keeper/pytest_plugins/scenario_loader.py
@@ -205,7 +205,10 @@ def _parse_include_ids(cfg):
 
 def _resolve_matrix_backends(cfg):
     mb_raw = _getopt(cfg, "--matrix-backends")
-    if mb := [x.strip() for x in mb_raw.split(",") if x.strip()]:
+    # Lowercase here so the backend spelling is identical everywhere it ends up:
+    # clone IDs (the warehouse `scenario` key), backend dispatch, and the Grafana
+    # links composed by the CI job (which normalizes the same way).
+    if mb := [x.strip().lower() for x in mb_raw.split(",") if x.strip()]:
         return mb
     return []
 
@@ -266,7 +269,7 @@ def pytest_generate_tests(metafunc):
 
 
 def expand_matrix_clones(s, backends, topologies):
-    backs = backends or [s.get("backend")]
+    backs = backends or [(s.get("backend") or "default").strip().lower()]
     topos = topologies or [int(s.get("topology"))]
     clones = []
     for b in backs:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Keeper RocksDB storage was removed in https://github.com/ClickHouse/ClickHouse/pull/108000 (2026-06-23), but the nightly Keeper stress matrix (`KEEPER_MATRIX_BACKENDS`) still ran a `rocks` variant of every scenario. The stress harness's cluster builder silently fell through to the default in-memory build for any backend name it didn't recognize, so every `[rocks]` run since then has been an exact duplicate of `[default]` — the `keeper_stress_tests` warehouse shows identical rps, p99, and `KeeperApproximateDataSize` for the two variants on every nightly since late June (e.g. `prod-mix-no-fault` on 2026-08-16: rps 5472 default vs 5467 rocks). This doubled the ~16 h nightly runtime while measuring nothing.

This PR:
- drops `rocks` from the default backend matrix in `ci/jobs/keeper_stress_job.py` (nightly runtime roughly halves);
- makes the cluster builder fail close on unknown backend names (`default`, `zookeeper`, `raftkeeper` remain supported), so a removed backend can no longer degrade into months of silent duplicate runs.

The harness README already documents the `rocks` backend as historical; when a replacement disk-backed storage lands, it can be added back to the matrix under its own name.

Related: https://github.com/ClickHouse/ClickHouse/pull/108000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115239&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115239](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115239+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1612` (included in `26.8` and later)
<!-- ch-version-info:end -->