### PR TITLE
Web UI: fix the invisible final stats of a finished query

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -2173,8 +2173,20 @@ class QueryProgressElement extends HTMLElement
         this._stats.innerText = '';
         this._progress.style.display = 'none';
         this._progressText.innerText = '';
-        this.style.setProperty('--progress', '0%');
+        this.clearBar();
         this.resetResources();
+    }
+
+    /// Remove the progress-bar fill, leaving the line as plain gray text. Used once the query has
+    /// finished, when the bar no longer carries information but its final stats stay on screen.
+    /// The value must carry the `%` unit: `--progress` is substituted into the color stops and into
+    /// a `calc` of both gradients of `#progress`, and a unitless `0` is a `<number>` there, which
+    /// makes the gradients - and with them the whole `background` - invalid. That drops the text
+    /// mask which colors the line, and as the text itself is transparent and only shows through
+    /// that mask, the entire line, final stats included, would be rendered invisible.
+    clearBar()
+    {
+        this.style.setProperty('--progress', '0%');
     }
 
     /// Reset the realtime resource meters (CPU/memory/disk). CPU usage is derived from the
@@ -9840,7 +9852,7 @@ async function postSingle(tab, posted_request_num, query, history_query_text, pa
         progressEl.finish();
         paintDownloadCopy(tab);
         progressEl.updateText(el.rowCount, el.elapsedNs, el.incompleteResult);
-        progressEl.style.setProperty('--progress', '0');
+        progressEl.clearBar();
         document.documentElement.style.setProperty('--background-color-rotate', queryToColor(query));
     }
 
@@ -10063,7 +10075,7 @@ async function postMulti(tab, posted_request_num, parsed, paramValuesSnapshot, e
             progressEl.finish();
             elapsed_ns = tab.finalStats.elapsedNs;
             progressEl.updateText(total_rows, tab.finalStats.elapsedNs, any_incomplete);
-            progressEl.style.setProperty('--progress', '0');
+            progressEl.clearBar();
             document.documentElement.style.setProperty('--background-color-rotate', queryToColor(parsed[0].query));
         }
     }
@@ -11286,7 +11298,7 @@ function syncActiveTabChrome() {
         progressEl.finish();
         if (tab.progress) progressEl.updateProgress(tab.progress);
         progressEl.updateText(tab.finalStats.rowCount, tab.finalStats.elapsedNs, tab.finalStats.incomplete);
-        progressEl.style.setProperty('--progress', '0');
+        progressEl.clearBar();
     }
 
     /// The resource meters (CPU/RAM/disk) are tab-owned - profile-event increments keep

--- a/tests/queries/0_stateless/05018_play_progress_bar_unit.reference
+++ b/tests/queries/0_stateless/05018_play_progress_bar_unit.reference
@@ -1,0 +1,3 @@
+0
+clearBar
+setProperty('--progress', '0%')

--- a/tests/queries/0_stateless/05018_play_progress_bar_unit.sh
+++ b/tests/queries/0_stateless/05018_play_progress_bar_unit.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The progress line of the Web UI paints its text through a gradient text mask keyed to the
+# `--progress` custom property: the text itself is transparent and shows only through that mask.
+# `--progress` is substituted into the color stops of the gradients and into a `calc`, where a
+# unitless `0` is a `<number>` instead of a `<length-percentage>`, which makes the gradients - and
+# with them the whole `background` - invalid. The mask then disappears and the line, including the
+# final stats of a finished query ("130 rows in result, 0.14 sec. ... Read 237.31 M rows, ..."), is
+# rendered in an invisible color. So every value assigned to `--progress` must carry a unit.
+
+URL="${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}"
+
+# The count of assignments of a literal without a unit is zero.
+${CLICKHOUSE_CURL} -sS "${URL}/play" | grep -cE "setProperty\('--progress', *'[^%']*'\)" ||:
+
+# The reset applied once a query has finished goes through `clearBar`, which carries the unit, so
+# the check above cannot pass merely because the assignments were spelled in some other way.
+${CLICKHOUSE_CURL} -sS "${URL}/play" | grep -oF 'clearBar' | head -n1
+${CLICKHOUSE_CURL} -sS "${URL}/play" | grep -oE "setProperty\('--progress', '0%'\)" | head -n1


### PR DESCRIPTION
The progress line of the Web UI (`/play`) paints its text through a gradient text mask keyed to the `--progress` custom property: the text itself is transparent and shows only through that mask.

Once a query finished, the three call sites that clear the bar assigned the unitless string `0` to `--progress`. That value is substituted into the color stops of the gradients and into a `calc` of `#progress`, where a unitless `0` is a `<number>` rather than a `<length-percentage>`, which makes both gradients — and with them the whole `background` — invalid. The text mask then disappeared while the text stayed transparent, so the final stats of the query were rendered in an invisible color:

```
130 rows in result, 0.14 sec. 748.87 MB RAM
Read 237.31 M rows, 5.12 GB (1.64 G/sec, 35.50 GB/sec)
```

Confirmed in a headless browser driving the page itself: with the unitless value the computed `background-image` of `#progress` is `none`, and with the unit it is the expected gray gradient.

The reset is now routed through a single `clearBar` method that carries the `%` unit, so the invariant lives in one place instead of being repeated at every call site, and a test guards that no value is assigned to `--progress` without a unit.

Caused by: https://github.com/ClickHouse/ClickHouse/pull/109425

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the final statistics of a finished query (`N rows in result`, `Read ... rows`) being rendered in an invisible color in the Web UI.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115245&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115245](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115245+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
