### PR TITLE
Allow using integer reference vectors for approximate nearest neighbor search

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -1,4 +1,5 @@
 #include <Columns/ColumnConst.h>
+#include <Common/FieldVisitorConvertToNumber.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <Core/Field.h>
 #include <Core/SortDescription.h>
@@ -36,7 +37,7 @@ namespace DB::QueryPlanOptimizations
 /// where
 /// - distance_function is function 'L2Distance', 'cosineDistance', or 'dotProduct',
 /// - vec is a column of tab (*),
-/// - reference_vec is a literal of type Array(Float32/Float64)
+/// - reference_vec is a literal of type Array(Float32 / Float64 / BFloat16 / (U)Int8 / (U)Int16 / (U)Int32 / (U)Int64)
 ///
 /// This function extracts distance_function, reference_vec, and N from the query plan without rewriting it.
 /// The extracted values are then passed to ReadFromMergeTree which can then use the vector similarity index
@@ -184,16 +185,13 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
         }
         else if (child->type == ActionsDAG::ActionType::COLUMN)
         {
-            /// Is it an Array(Float32), Array(Float64) or Array(BFloat16) column?
+            /// Is it an Array(Float32), Array(Float64), Array(BFloat16), Array((U)Int8/16/32/64) column?
             const DataTypePtr & data_type = child->result_type;
             const auto * data_type_array = typeid_cast<const DataTypeArray *>(data_type.get());
             if (data_type_array == nullptr)
                 continue;
-            DataTypePtr data_type_array_nested = data_type_array->getNestedType();
-            const auto * data_type_nested_float64 = typeid_cast<const DataTypeFloat64 *>(data_type_array_nested.get());
-            const auto * data_type_nested_float32 = typeid_cast<const DataTypeFloat32 *>(data_type_array_nested.get());
-            const auto * data_type_nested_bfloat16 = typeid_cast<const DataTypeBFloat16 *>(data_type_array_nested.get());
-            if (data_type_nested_float64 == nullptr && data_type_nested_float32 == nullptr && data_type_nested_bfloat16 == nullptr)
+            WhichDataType which_data_type_array_nested(data_type_array->getNestedType());
+            if (!which_data_type_array_nested.isFloat() && !which_data_type_array_nested.isNativeInteger())
                 continue;
 
             /// Read value from column
@@ -205,9 +203,10 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
             for (const auto & field_array_value : field_array)
             {
                 Field::Types::Which field_array_value_type = field_array_value.getType();
-                if (field_array_value_type != Field::Types::Float64)
+                if (field_array_value_type != Field::Types::Float64 && field_array_value_type != Field::Types::UInt64
+                    && field_array_value_type != Field::Types::Int64)
                     return no_layers_updated;
-                Float64 float64 = field_array_value.safeGet<Float64>();
+                Float64 float64 = applyVisitor(FieldVisitorConvertToNumber<Float64>(), field_array_value);
                 reference_vector.push_back(float64);
             }
         }

--- a/tests/queries/0_stateless/02354_vector_search_bug112233.reference
+++ b/tests/queries/0_stateless/02354_vector_search_bug112233.reference
@@ -1,0 +1,16 @@
+-- Unsigned integer reference vector: index usage expected
+Description: vector_similarity GRANULARITY 100000000
+-- Signed integer reference vector: index usage expected
+Description: vector_similarity GRANULARITY 100000000
+-- Mixed integer and float reference vector: index usage expected
+Description: vector_similarity GRANULARITY 100000000
+-- BFloat16 reference vector: index usage expected
+Description: vector_similarity GRANULARITY 100000000
+-- Reference vector above the Float32 mantissa: index usage expected
+Description: vector_similarity GRANULARITY 100000000
+-- Extremal integer reference vectors: index usage expected
+Description: vector_similarity GRANULARITY 100000000
+Description: vector_similarity GRANULARITY 100000000
+-- Integer and float spellings of the same reference vector return the same result
+5
+5

--- a/tests/queries/0_stateless/02354_vector_search_bug112233.sql
+++ b/tests/queries/0_stateless/02354_vector_search_bug112233.sql
@@ -1,0 +1,107 @@
+-- Tags: no-fasttest, no-ordinary-database
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/112233
+-- An integer reference vector such as [1, 2] denotes the same point as [1.0, 2.0], so it must use the index as well.
+
+SET explain_query_plan_default = 'legacy';
+
+SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to force local plan for parallel replicas
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id Int32,
+    vec Array(Float32),
+    INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 2)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 2;
+
+INSERT INTO tab VALUES
+  (0, [1.0, 0.0]),
+  (1, [1.1, 0.0]),
+  (2, [1.2, 0.0]),
+  (3, [1.3, 0.0]),
+  (4, [1.4, 0.0]),
+  (5, [0.0, 2.0]),
+  (6, [0.0, 2.1]),
+  (7, [0.0, 2.2]),
+  (8, [0.0, 2.3]),
+  (9, [0.0, 2.4]);
+
+SELECT '-- Unsigned integer reference vector: index usage expected';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM tab
+    ORDER BY L2Distance(vec, [0, 2])
+    LIMIT 1
+)
+WHERE explain LIKE '%vector_similarity%';
+
+SELECT '-- Signed integer reference vector: index usage expected';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM tab
+    ORDER BY L2Distance(vec, [-1, -2])
+    LIMIT 1
+)
+WHERE explain LIKE '%vector_similarity%';
+
+SELECT '-- Mixed integer and float reference vector: index usage expected';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM tab
+    ORDER BY L2Distance(vec, [0, 2.0])
+    LIMIT 1
+)
+WHERE explain LIKE '%vector_similarity%';
+
+SELECT '-- BFloat16 reference vector: index usage expected';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM tab
+    ORDER BY L2Distance(vec, [0, 2]::Array(BFloat16))
+    LIMIT 1
+)
+WHERE explain LIKE '%vector_similarity%';
+
+-- Integer-to-float conversion is lossy in general, not only above some magnitude, so these tests only pin down that the
+-- index is used.
+SELECT '-- Reference vector above the Float32 mantissa: index usage expected';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM tab
+    ORDER BY L2Distance(vec, [16777217, 2])
+    LIMIT 1
+)
+WHERE explain LIKE '%vector_similarity%';
+
+SELECT '-- Extremal integer reference vectors: index usage expected';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM tab
+    ORDER BY L2Distance(vec, [4294967295, 2])
+    LIMIT 1
+)
+WHERE explain LIKE '%vector_similarity%';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id
+    FROM tab
+    ORDER BY L2Distance(vec, [-2147483648, 2])
+    LIMIT 1
+)
+WHERE explain LIKE '%vector_similarity%';
+
+SELECT '-- Integer and float spellings of the same reference vector return the same result';
+SELECT id FROM tab ORDER BY L2Distance(vec, [0, 2]) LIMIT 1;
+SELECT id FROM tab ORDER BY L2Distance(vec, [0.0, 2.0]) LIMIT 1;
+
+DROP TABLE tab;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/112233

This PR is a continuation of https://github.com/ClickHouse/ClickHouse/pull/114316. I get a permission denied error when pushing to the PR.

Courtesy to @hamidr

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Vector search queries can now use the vector similarity index when the reference vector is an integer array literal, e.g. `ORDER BY L2Distance(vec, [1, 2])`. Previously, such queries silently fell back to a brute-force scan.
