### PR TITLE
Add min_ttl_age_to_delete_merge_seconds to pace TTL delete merges

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1461,6 +1461,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
 
         addSettingsChanges(merge_tree_settings_changes_history, "26.8",
         {
+            {"min_ttl_age_to_delete_merge_seconds", 0, 0, "New setting. Paces TTL delete merges from the part's own TTL metadata instead of the in-memory per-partition map behind `merge_with_ttl_timeout`, so the delay survives restarts and resolves identically on every replica. Defaults to 0, which disables the check and preserves the previous behavior."},
             {"merge_use_batch_sorting_queue", false, false, "New setting to use the batch sorting queue for ordinary `MergeTree` merges."},
             {"always_fetch_mutated_part", false, false, "New setting to make a replica fetch mutated parts instead of executing mutations locally"},
             {"packed_skip_index_max_bytes", 0, 1024 * 1024, "Promote to BETA and enable by default: pack skip-index substreams whose serialized on-disk size is at most 1 MiB into a single `skp_idx.packed` archive per part, cutting object count and read requests on object storage. Larger substreams keep the standalone `skp_idx_<name>.idx2` / `.mrk2` layout. Set to 0 to restore the previous behavior (no packing)."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1451,6 +1451,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     {
         addSettingsChanges(merge_tree_settings_changes_history, "26.9",
         {
+            {"min_ttl_age_to_delete_merge_seconds", 0, 0, "New setting. Paces TTL delete merges from the part's own TTL metadata instead of the in-memory per-partition map behind `merge_with_ttl_timeout`, so the delay survives restarts and resolves identically on every replica. Defaults to 0, which disables the check and preserves the previous behavior."},
             {"patch_parts_version", "v1", "v2", "New setting to control the on-disk serialization version of patch parts produced by lightweight updates. Older compatibility modes keep writing v1 patches, which all replicas in a mixed-version cluster can read."},
             {"shared_merge_tree_use_blobs_list_for_parts", false, false, "New setting which stores a SharedMergeTree part's per-file blob map in one consolidated Keeper node instead of one node per file"},
             {"shared_merge_tree_blobs_list_inline_file_max_bytes", 0, 0, "New setting which stores small files of a blob-list part inline in the consolidated blobs.list instead of separate blobs"},
@@ -1461,7 +1462,6 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
 
         addSettingsChanges(merge_tree_settings_changes_history, "26.8",
         {
-            {"min_ttl_age_to_delete_merge_seconds", 0, 0, "New setting. Paces TTL delete merges from the part's own TTL metadata instead of the in-memory per-partition map behind `merge_with_ttl_timeout`, so the delay survives restarts and resolves identically on every replica. Defaults to 0, which disables the check and preserves the previous behavior."},
             {"merge_use_batch_sorting_queue", false, false, "New setting to use the batch sorting queue for ordinary `MergeTree` merges."},
             {"always_fetch_mutated_part", false, false, "New setting to make a replica fetch mutated parts instead of executing mutations locally"},
             {"packed_skip_index_max_bytes", 0, 1024 * 1024, "Promote to BETA and enable by default: pack skip-index substreams whose serialized on-disk size is at most 1 MiB into a single `skp_idx.packed` archive per part, cutting object count and read requests on object storage. Larger substreams keep the standalone `skp_idx_<name>.idx2` / `.mrk2` layout. Set to 0 to restore the previous behavior (no packing)."},

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -23,6 +23,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool min_age_to_force_merge_on_partition_only;
     extern const MergeTreeSettingsUInt64 min_age_to_force_merge_seconds;
     extern const MergeTreeSettingsBool ttl_only_drop_parts;
+    extern const MergeTreeSettingsInt64 min_ttl_age_to_delete_merge_seconds;
     extern const MergeTreeSettingsUInt64 parts_to_throw_insert;
     extern const MergeTreeSettingsMergeSelectorAlgorithm merge_selector_algorithm;
     extern const MergeTreeSettingsBool merge_selector_enable_heuristic_to_remove_small_parts_at_right;
@@ -86,7 +87,8 @@ MergeSelectorChoices tryChooseTTLMerge(const ChooseContext & ctx)
     /// Delete rows - 2 priority
     if (!ctx.merge_constraints.empty() && !ctx.merge_tree_settings[MergeTreeSetting::ttl_only_drop_parts])
     {
-        TTLRowDeleteMergeSelector delete_ttl_selector(ctx.next_delete_times, ctx.current_time);
+        TTLRowDeleteMergeSelector delete_ttl_selector(
+            ctx.next_delete_times, ctx.current_time, ctx.merge_tree_settings[MergeTreeSetting::min_ttl_age_to_delete_merge_seconds]);
 
         if (auto merge_ranges = delete_ttl_selector.select(ctx.ranges, ctx.merge_constraints, ctx.range_filter); !merge_ranges.empty())
             return pack(ctx, std::move(merge_ranges), MergeType::TTLDelete);

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.cpp
@@ -3,9 +3,19 @@
 namespace DB
 {
 
-static bool canIncludeToRange(size_t part_size, size_t part_rows, time_t part_ttl, time_t current_time, size_t usable_memory, size_t usable_rows)
+/// Shared by center selection and range expansion. Both have to apply it: gating only the
+/// center would still let a merge started on an old-enough part pull in a neighbour whose
+/// rows expired a moment ago and delete those too, which is not what the setting promises.
+static bool isOldEnoughForTTLMerge(time_t part_ttl, time_t current_time, time_t min_ttl_age)
 {
-    return (0 < part_ttl && part_ttl <= current_time) && usable_memory >= part_size && usable_rows >= part_rows;
+    return !min_ttl_age || current_time - part_ttl >= min_ttl_age;
+}
+
+static bool canIncludeToRange(size_t part_size, size_t part_rows, time_t part_ttl, time_t current_time, time_t min_ttl_age, size_t usable_memory, size_t usable_rows)
+{
+    return (0 < part_ttl && part_ttl <= current_time)
+        && isOldEnoughForTTLMerge(part_ttl, current_time, min_ttl_age)
+        && usable_memory >= part_size && usable_rows >= part_rows;
 }
 
 class ITTLMergeSelector::MergeRangesConstructor
@@ -119,7 +129,7 @@ std::vector<ITTLMergeSelector::CenterPosition> ITTLMergeSelector::findCenters(co
             /// reproduces the merge_with_ttl_timeout cadence without any in-memory
             /// state: after a TTL merge the resulting part only holds rows with a
             /// later TTL, so its ttl moves forward by at least the same interval.
-            if (min_ttl_age && current_time - ttl < min_ttl_age)
+            if (!isOldEnoughForTTLMerge(ttl, current_time, min_ttl_age))
                 continue;
 
             centers.emplace_back(range, part, ttl);
@@ -151,7 +161,7 @@ PartsIterator ITTLMergeSelector::findLeftRangeBorder(
             break;
 
         auto ttl = getTTLForPart(*next_to_check);
-        if (!canIncludeToRange(next_to_check->size, next_to_check->rows, ttl, current_time, usable_memory, usable_rows))
+        if (!canIncludeToRange(next_to_check->size, next_to_check->rows, ttl, current_time, min_ttl_age, usable_memory, usable_rows))
             break;
 
         usable_memory -= next_to_check->size;
@@ -184,7 +194,7 @@ PartsIterator ITTLMergeSelector::findRightRangeBorder(
             break;
 
         auto ttl = getTTLForPart(*right);
-        if (!canIncludeToRange(right->size, right->rows, ttl, current_time, usable_memory, usable_rows))
+        if (!canIncludeToRange(right->size, right->rows, ttl, current_time, min_ttl_age, usable_memory, usable_rows))
             break;
 
         usable_memory -= right->size;

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.cpp
@@ -115,6 +115,13 @@ std::vector<ITTLMergeSelector::CenterPosition> ITTLMergeSelector::findCenters(co
             if (!ttl || ttl > current_time)
                 continue;
 
+            /// Postpone the part until its rows have been expired long enough. This
+            /// reproduces the merge_with_ttl_timeout cadence without any in-memory
+            /// state: after a TTL merge the resulting part only holds rows with a
+            /// later TTL, so its ttl moves forward by at least the same interval.
+            if (min_ttl_age && current_time - ttl < min_ttl_age)
+                continue;
+
             centers.emplace_back(range, part, ttl);
         }
     }
@@ -192,10 +199,12 @@ PartsIterator ITTLMergeSelector::findRightRangeBorder(
 ITTLMergeSelector::ITTLMergeSelector(
     const PartitionIdToTTLs * merge_due_times_,
     time_t current_time_,
-    size_t max_parts_to_merge_at_once_)
+    size_t max_parts_to_merge_at_once_,
+    time_t min_ttl_age_)
     : current_time(current_time_)
     , merge_due_times(merge_due_times_)
     , max_parts_to_merge_at_once(max_parts_to_merge_at_once_)
+    , min_ttl_age(min_ttl_age_)
 {
 }
 
@@ -236,8 +245,8 @@ bool TTLPartDropMergeSelector::canConsiderPart(const PartProperties & part) cons
     return part.general_ttl_info->has_any_non_finished_ttls;
 }
 
-TTLRowDeleteMergeSelector::TTLRowDeleteMergeSelector(const PartitionIdToTTLs & merge_due_times_, time_t current_time_)
-    : ITTLMergeSelector(&merge_due_times_, current_time_)
+TTLRowDeleteMergeSelector::TTLRowDeleteMergeSelector(const PartitionIdToTTLs & merge_due_times_, time_t current_time_, time_t min_ttl_age_)
+    : ITTLMergeSelector(&merge_due_times_, current_time_, /*max_parts_to_merge_at_once_=*/0, min_ttl_age_)
 {
 }
 

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.h
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.h
@@ -20,7 +20,7 @@ class ITTLMergeSelector : public IMergeSelector
     friend class MergeRangesConstructor;
 
 public:
-    ITTLMergeSelector(const PartitionIdToTTLs * merge_due_times_, time_t current_time_, size_t max_parts_to_merge_at_once_ = 0);
+    ITTLMergeSelector(const PartitionIdToTTLs * merge_due_times_, time_t current_time_, size_t max_parts_to_merge_at_once_ = 0, time_t min_ttl_age_ = 0);
 
     PartsRanges select(
         const PartsRanges & parts_ranges,
@@ -63,6 +63,10 @@ private:
     const time_t current_time;
     const PartitionIdToTTLs * merge_due_times;
     const size_t max_parts_to_merge_at_once;
+    /// If non-zero, a part is only considered once its earliest expired row has
+    /// been expired for at least this long. Derived from the part itself, so it
+    /// survives restarts and agrees across replicas.
+    const time_t min_ttl_age;
 };
 
 /// Select parts that must be fully deleted because of ttl for part.
@@ -82,7 +86,7 @@ private:
 class TTLRowDeleteMergeSelector : public ITTLMergeSelector
 {
 public:
-    explicit TTLRowDeleteMergeSelector(const PartitionIdToTTLs & merge_due_times_, time_t current_time_);
+    explicit TTLRowDeleteMergeSelector(const PartitionIdToTTLs & merge_due_times_, time_t current_time_, time_t min_ttl_age_ = 0);
 
 private:
     time_t getTTLForPart(const PartProperties & part) const override;

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1874,6 +1874,17 @@ Compress in memory values of index granularity if it is possible
     DECLARE(Int64, merge_with_ttl_timeout, 3600 * 4, R"(
 Minimum delay in seconds before repeating a merge with delete TTL.
 )", 0) \
+    DECLARE(Int64, min_ttl_age_to_delete_merge_seconds, 0, R"(
+Minimum time in seconds that rows must have been expired before the part holding
+them may be selected for a TTL delete merge.
+
+`merge_with_ttl_timeout` enforces its delay through in-memory state, so the delay
+is lost when the server restarts and is not shared between replicas. This setting
+derives the delay from the part's own TTL metadata instead, so it survives
+restarts and resolves identically on every replica.
+
+The default value `0` disables the check and preserves the existing behaviour.
+)", 0) \
     DECLARE(Int64, merge_with_recompression_ttl_timeout, 3600 * 4, R"(
 Minimum delay in seconds before repeating a merge with recompression TTL.
 )", 0) \

--- a/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.reference
+++ b/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.reference
@@ -1,2 +1,1 @@
-before: ['old','young']
-young
+only the old part merged

--- a/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.reference
+++ b/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.reference
@@ -1,0 +1,2 @@
+before: ['old','young']
+young

--- a/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.sh
+++ b/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Tags: no-random-merge-tree-settings, no-random-settings
 #
-# min_ttl_age_to_delete_merge_seconds must gate every part in a TTLDelete merge, not just the
-# part the range is centred on. A merge centred on a long-expired part must NOT drag in an
-# adjacent part whose rows expired a moment ago and delete those rows early.
+# min_ttl_age_to_delete_merge_seconds must gate every part in a TTLDelete merge, not only the
+# part the range is centred on. Before the fix, findCenters applied the age gate but
+# findLeftRangeBorder/findRightRangeBorder did not, so a merge centred on a long-expired part
+# still pulled in an adjacent part whose rows had only just expired.
+#
+# The assertion is on merge COMPOSITION, not on which rows survive: every merge purges expired
+# rows from the parts it touches, so a plain background merge would delete the young part's
+# rows too and tell us nothing about the selector. part_log.merged_from is what actually
+# answers "did the young part participate in the TTLDelete merge".
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -11,8 +17,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_min_ttl_age"
 
-# merge_with_ttl_timeout = 0 removes the in-memory per-partition cooldown from the picture, so
-# the only thing deciding eligibility is the new age gate.
+# merge_with_ttl_timeout = 0 takes the in-memory per-partition cooldown out of the picture, so
+# the age gate is the only thing deciding eligibility.
 $CLICKHOUSE_CLIENT -q "
 CREATE TABLE t_min_ttl_age (d DateTime, tag String)
 ENGINE = MergeTree ORDER BY tag
@@ -24,25 +30,34 @@ SETTINGS min_ttl_age_to_delete_merge_seconds = 3600,
 $CLICKHOUSE_CLIENT -q "SYSTEM STOP MERGES t_min_ttl_age"
 
 # 'old'   — expired two days ago, far past the 3600s gate: a valid merge centre.
-# 'young' — expired seconds ago, well inside the gate: must survive this round.
+# 'young' — expired seconds ago, well inside the gate: must not join old's TTLDelete merge.
 $CLICKHOUSE_CLIENT -q "INSERT INTO t_min_ttl_age VALUES (now() - INTERVAL 2 DAY, 'old')"
 $CLICKHOUSE_CLIENT -q "INSERT INTO t_min_ttl_age VALUES (now() - INTERVAL 5 SECOND, 'young')"
 
-echo "before: $($CLICKHOUSE_CLIENT -q "SELECT groupArray(tag) FROM (SELECT tag FROM t_min_ttl_age ORDER BY tag)")"
-
 $CLICKHOUSE_CLIENT -q "SYSTEM START MERGES t_min_ttl_age"
 
-# Wait for the TTLDelete merge to reclaim 'old'. Bounded: if it never happens the final
-# SELECT still reports what is there and the reference catches it.
-for _ in {0..100}; do
-    remaining=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM t_min_ttl_age WHERE tag = 'old'")
-    if [ "$remaining" = "0" ]; then
+for _ in {0..150}; do
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS part_log" 2>/dev/null
+    n=$($CLICKHOUSE_CLIENT -q "
+        SELECT count() FROM system.part_log
+        WHERE database = currentDatabase() AND table = 't_min_ttl_age'
+          AND event_type = 'MergeParts' AND merge_reason = 'TTLDeleteMerge'")
+    if [ "$n" != "0" ]; then
         break
     fi
     sleep 0.3
 done
 
-# 'old' reclaimed, 'young' untouched — the gate held on the neighbour.
-$CLICKHOUSE_CLIENT -q "SELECT tag FROM t_min_ttl_age ORDER BY tag"
+# Every TTLDelete merge must have taken exactly one source part — the old one. Without the
+# gate on range expansion this reports 2 source parts. Reported distinctly from "no TTLDelete
+# merge happened at all", which would mean the test never exercised the path.
+$CLICKHOUSE_CLIENT -q "
+SELECT multiIf(
+        count() = 0, 'no TTLDelete merge observed',
+        countIf(length(merged_from) != 1) > 0, 'young part joined the merge',
+        'only the old part merged')
+FROM system.part_log
+WHERE database = currentDatabase() AND table = 't_min_ttl_age'
+  AND event_type = 'MergeParts' AND merge_reason = 'TTLDeleteMerge'"
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE t_min_ttl_age"

--- a/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.sh
+++ b/tests/queries/0_stateless/04700_min_ttl_age_to_delete_merge_seconds.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: no-random-merge-tree-settings, no-random-settings
+#
+# min_ttl_age_to_delete_merge_seconds must gate every part in a TTLDelete merge, not just the
+# part the range is centred on. A merge centred on a long-expired part must NOT drag in an
+# adjacent part whose rows expired a moment ago and delete those rows early.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_min_ttl_age"
+
+# merge_with_ttl_timeout = 0 removes the in-memory per-partition cooldown from the picture, so
+# the only thing deciding eligibility is the new age gate.
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE t_min_ttl_age (d DateTime, tag String)
+ENGINE = MergeTree ORDER BY tag
+TTL d + INTERVAL 1 SECOND DELETE
+SETTINGS min_ttl_age_to_delete_merge_seconds = 3600,
+         merge_with_ttl_timeout = 0,
+         min_bytes_for_wide_part = 0;"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM STOP MERGES t_min_ttl_age"
+
+# 'old'   — expired two days ago, far past the 3600s gate: a valid merge centre.
+# 'young' — expired seconds ago, well inside the gate: must survive this round.
+$CLICKHOUSE_CLIENT -q "INSERT INTO t_min_ttl_age VALUES (now() - INTERVAL 2 DAY, 'old')"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t_min_ttl_age VALUES (now() - INTERVAL 5 SECOND, 'young')"
+
+echo "before: $($CLICKHOUSE_CLIENT -q "SELECT groupArray(tag) FROM (SELECT tag FROM t_min_ttl_age ORDER BY tag)")"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM START MERGES t_min_ttl_age"
+
+# Wait for the TTLDelete merge to reclaim 'old'. Bounded: if it never happens the final
+# SELECT still reports what is there and the reference catches it.
+for _ in {0..100}; do
+    remaining=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM t_min_ttl_age WHERE tag = 'old'")
+    if [ "$remaining" = "0" ]; then
+        break
+    fi
+    sleep 0.3
+done
+
+# 'old' reclaimed, 'young' untouched — the gate held on the neighbour.
+$CLICKHOUSE_CLIENT -q "SELECT tag FROM t_min_ttl_age ORDER BY tag"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_min_ttl_age"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Added the `min_ttl_age_to_delete_merge_seconds` MergeTree setting, which paces TTL delete merges based on how long a part's rows have been expired. Unlike `merge_with_ttl_timeout`, the delay survives server restarts and is consistent across replicas. Disabled by default.

### Documentation entry for user-facing changes

Setting documentation is included inline in the `DECLARE` block in `MergeTreeSettings.cpp`.

---

## Problem

`merge_with_ttl_timeout` is documented as "Minimum delay in seconds before repeating a merge with delete TTL." In practice that delay only holds **within a single server uptime window, on a single replica**.

The cooldown lives in `MergeTreeDataMergerMutator::next_delete_ttl_merge_times_by_partition`, a plain `std::map<String, time_t>` member that is never persisted. It is written when a `TTLDelete` merge is selected:

```cpp
next_delete_ttl_merge_times_by_partition[partition_id]
    = current_time + (*settings)[MergeTreeSetting::merge_with_ttl_timeout];
```

and read by `ITTLMergeSelector::needToPostponePartition`, which treats a partition with no entry as eligible:

```cpp
if (merge_due_times)
    if (auto it = merge_due_times->find(partition_id); it != merge_due_times->end())
        return it->second > current_time;
return false;   // no entry => not postponed => eligible now
```

Two consequences:

1. **The delay does not survive a restart.** The map starts empty, so on startup every partition holding expired rows is immediately eligible again, regardless of when its last TTL merge ran.
2. **The delay is not shared between replicas.** Each server keeps its own map, so the same partition can be selected independently on each.

On deployments that restart frequently the effective cadence becomes one TTL delete merge per partition, per replica, per restart, and the configured value stops mattering. We observed `merge_with_ttl_timeout = 604800` behaving identically to `86400`, because uptime rarely reached 24h.

This matters most when parts cannot be dropped wholesale. Where a table is partitioned such that every partition spans the full retention window, no part is ever entirely expired, so `ttl_only_drop_parts` does not apply and each TTL enforcement is a full rewrite of a multi-GB part to remove a small fraction of rows.

## Approach

Rather than persisting the map, derive the delay from state that is **already stored in the part**.

`part_min_ttl` is written to the part's `ttl.txt` and is exactly what `TTLRowDeleteMergeSelector::getTTLForPart` already returns. So the selector can ask *"how long have this part's oldest rows been expired?"* instead of *"when did I last merge this partition?"*:

```cpp
 time_t ttl = getTTLForPart(*part);
 if (!ttl || ttl > current_time)
     continue;

+if (min_ttl_age && current_time - ttl < min_ttl_age)
+    continue;
```

The cadence is self-regulating: after a TTL delete merge the resulting part contains only rows with a later TTL, so `part_min_ttl` moves forward by at least the configured interval before that part becomes eligible again.

Properties:

- survives restarts, since the value lives on disk with the part
- resolves identically on every replica reading the same part, with no coordination
- no new state, no Keeper traffic, no znode lifecycle
- applies to plain `MergeTree` as well as Replicated/Shared

The check is scoped to `TTLRowDeleteMergeSelector`. `TTLPartDropMergeSelector` stays ungated, since dropping a wholly expired part is cheap and should not be delayed.

`min_ttl_age_to_delete_merge_seconds` defaults to `0`, which disables the check entirely and preserves existing behaviour.

## Note on semantics

This is deliberately *not* wired into `merge_with_ttl_timeout` itself, because the two are not equivalent. The existing setting delays *repeats*, so the first TTL merge after rows expire fires immediately. The new check also delays that first merge. Keeping it as a separate, default-off setting avoids changing behaviour for anyone who does not opt in.

## Open questions for reviewers

1. Is this the shape you would want, or would you prefer the delay to be persisted (Keeper) so `merge_with_ttl_timeout` itself becomes durable? We opted against that: it adds Keeper traffic to merge selection, needs a separate path for non-replicated `MergeTree`, and introduces znode lifecycle and rolling-upgrade concerns for the same outcome.
2. Would you rather see this as a startup grace period (seeding the map at table start) instead? That is a smaller change but does not address the per-replica duplication.
3. Naming: `min_ttl_age_to_delete_merge_seconds` was chosen to parallel `min_age_to_force_merge_seconds`. Happy to rename.

**Opened as a draft.** We have not been able to build ClickHouse locally, so this is unverified beyond review of the surrounding code, and no tests are included yet. If the approach looks acceptable we will add functional test coverage and address any naming or placement feedback.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115256&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115256](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115256+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
