### PR TITLE
TimeSeries: fast paths for PromQL instant queries

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -764,7 +764,8 @@ private:
 
     /// Whether all the arithmetic in `bucketIndexForTimestampFast` fits in Int64 for every sample
     /// that passes its range checks. Bounding all grid parameters by 2^61 leaves headroom for the
-    /// sums and products of two such values.
+    /// sums and products of two such values. A single-point grid (`start == end`, `step == 0`,
+    /// see `checkStep`) has nothing to divide and uses the generic path.
     static bool canUseFastBucketMath(TimestampType start, TimestampType end, IntervalType step_, IntervalType window_)
     {
         constexpr Int128 bound = Int128(1) << 61;
@@ -772,10 +773,8 @@ private:
         const Int128 end_128 = static_cast<Int128>(static_cast<Int64>(end));
         const Int128 step_128 = static_cast<Int128>(static_cast<Int64>(step_));
         const Int128 window_128 = static_cast<Int128>(static_cast<Int64>(window_));
-        /// `step == 0` is possible only when `start == end` (see `checkStep`): a single-point grid,
-        /// handled by a dedicated branch of `classifySampleFast` with no division at all.
         return (-bound < start_128 && start_128 < bound) && (-bound < end_128 && end_128 < bound)
-            && (0 <= step_128 && step_128 < bound) && (0 <= window_128 && window_128 < bound);
+            && (0 < step_128 && step_128 < bound) && (0 <= window_128 && window_128 < bound);
     }
 
     /// What the batch bucketing kernel (`addSamplesToBucketsImpl`) does with a sample: add it to bucket
@@ -803,11 +802,6 @@ private:
         const Int64 lowest = static_cast<Int64>(start_timestamp) - static_cast<Int64>(window);
         if (ts <= lowest)
             return {NO_BUCKET, std::numeric_limits<Int64>::min(), lowest};
-
-        /// A single-point grid (`step == 0`, possible only when `start == end`, see `checkStep`):
-        /// everything in `(start - window, end]` falls into the only bucket.
-        if (step == 0)
-            return {0, lowest, static_cast<Int64>(end_timestamp)};
 
         const Int64 offset = ts - static_cast<Int64>(start_timestamp);
         const Int64 step_64 = static_cast<Int64>(step);

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -764,8 +764,7 @@ private:
 
     /// Whether all the arithmetic in `bucketIndexForTimestampFast` fits in Int64 for every sample
     /// that passes its range checks. Bounding all grid parameters by 2^61 leaves headroom for the
-    /// sums and products of two such values. A single-point grid (`start == end`, `step == 0`,
-    /// see `checkStep`) has nothing to divide and uses the generic path.
+    /// sums and products of two such values.
     static bool canUseFastBucketMath(TimestampType start, TimestampType end, IntervalType step_, IntervalType window_)
     {
         constexpr Int128 bound = Int128(1) << 61;
@@ -773,8 +772,10 @@ private:
         const Int128 end_128 = static_cast<Int128>(static_cast<Int64>(end));
         const Int128 step_128 = static_cast<Int128>(static_cast<Int64>(step_));
         const Int128 window_128 = static_cast<Int128>(static_cast<Int64>(window_));
+        /// `step == 0` is possible only when `start == end` (see `checkStep`): a single-point grid,
+        /// handled by a dedicated branch of `classifySampleFast` with no division at all.
         return (-bound < start_128 && start_128 < bound) && (-bound < end_128 && end_128 < bound)
-            && (0 < step_128 && step_128 < bound) && (0 <= window_128 && window_128 < bound);
+            && (0 <= step_128 && step_128 < bound) && (0 <= window_128 && window_128 < bound);
     }
 
     /// What the batch bucketing kernel (`addSamplesToBucketsImpl`) does with a sample: add it to bucket
@@ -802,6 +803,11 @@ private:
         const Int64 lowest = static_cast<Int64>(start_timestamp) - static_cast<Int64>(window);
         if (ts <= lowest)
             return {NO_BUCKET, std::numeric_limits<Int64>::min(), lowest};
+
+        /// A single-point grid (`step == 0`, possible only when `start == end`, see `checkStep`):
+        /// everything in `(start - window, end]` falls into the only bucket.
+        if (step == 0)
+            return {0, lowest, static_cast<Int64>(end_timestamp)};
 
         const Int64 offset = ts - static_cast<Int64>(start_timestamp);
         const Int64 step_64 = static_cast<Int64>(step);

--- a/src/Functions/TimeSeries/timeSeriesIdToGroup.cpp
+++ b/src/Functions/TimeSeries/timeSeriesIdToGroup.cpp
@@ -60,8 +60,6 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t input_rows_count) const override
     {
-        /// The groups are written into the result column directly: this function runs on every
-        /// read sample row, so an intermediate buffer plus a copy is a measurable cost.
         auto res = ColumnUInt64::create();
         tags_collector->getGroupByID(arguments[0].column, res->getData());
         chassert(res->size() == input_rows_count);

--- a/src/Functions/TimeSeries/timeSeriesIdToGroup.cpp
+++ b/src/Functions/TimeSeries/timeSeriesIdToGroup.cpp
@@ -1,5 +1,6 @@
 #include <Functions/FunctionFactory.h>
 
+#include <Columns/ColumnsNumber.h>
 #include <Functions/TimeSeries/TimeSeriesTagsFunctionHelpers.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/Context.h>
@@ -59,10 +60,12 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t input_rows_count) const override
     {
-        auto groups = tags_collector->getGroupByID(arguments[0].column);
-        chassert(groups.size() == input_rows_count);
-
-        return TimeSeriesTagsFunctionHelpers::makeColumnForGroup(groups);
+        /// The groups are written into the result column directly: this function runs on every
+        /// read sample row, so an intermediate buffer plus a copy is a measurable cost.
+        auto res = ColumnUInt64::create();
+        tags_collector->getGroupByID(arguments[0].column, res->getData());
+        chassert(res->size() == input_rows_count);
+        return res;
     }
 
 private:

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1264,20 +1264,20 @@ void ContextTimeSeriesTagsCollector::getGroupByIDTyped(
 
     /// Id columns arrive in long runs of equal values (samples are sorted by id), so reuse the previous row's group.
     IDType prev_id{};
-    bool has_prev = false;
     Group prev_group = INVALID_GROUP;
     for (size_t i = 0; i != num_rows; ++i)
     {
         IDType id = id_getter.get(i);
-        if (!has_prev || !(id == prev_id))
+        if ((id == prev_id) && (prev_group != INVALID_GROUP))
         {
-            const auto * it = id_map.find(id);
-            if (!it)
-                throwUnknownID(id_data, i);
-            prev_id = id;
-            has_prev = true;
-            prev_group = it->getMapped();
+            out[i] = prev_group;
+            continue;
         }
+        const auto * it = id_map.find(id);
+        if (!it)
+            throwUnknownID(id_data, i);
+        prev_id = id;
+        prev_group = it->getMapped();
         out[i] = prev_group;
     }
 }
@@ -1296,15 +1296,18 @@ void ContextTimeSeriesTagsCollector::getGroupByIDGeneric(const IColumn & id_data
     Group prev_group = INVALID_GROUP;
     for (size_t i = 0; i != num_rows; ++i)
     {
-        if ((i == 0) || id_data.compareAt(i, i - 1, id_data, /* nan_direction_hint = */ 1) != 0)
+        if ((i > 0) && id_data.compareAt(i, i - 1, id_data, /* nan_direction_hint = */ 1) == 0)
         {
-            const char * begin = nullptr;
-            auto id = id_data.serializeValueIntoArena(i, temp_arena, begin, /* settings = */ nullptr);
-            const auto * it = generic_id_map.map.find(id);
-            if (!it)
-                throwUnknownID(id_data, i);
-            prev_group = it->getMapped();
+            chassert(prev_group != INVALID_GROUP);
+            out[i] = prev_group;
+            continue;
         }
+        const char * begin = nullptr;
+        auto id = id_data.serializeValueIntoArena(i, temp_arena, begin, /* settings = */ nullptr);
+        const auto * it = generic_id_map.map.find(id);
+        if (!it)
+            throwUnknownID(id_data, i);
+        prev_group = it->getMapped();
         out[i] = prev_group;
     }
 }

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1,5 +1,7 @@
 #include <Interpreters/ContextTimeSeriesTagsCollector.h>
 
+#include <Common/PODArray.h>
+
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
@@ -1230,66 +1232,63 @@ void ContextTimeSeriesTagsCollector::storeTagsGeneric(
 }
 
 
-VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByID(const ColumnPtr & id_column) const
+void ContextTimeSeriesTagsCollector::getGroupByID(const ColumnPtr & id_column, PaddedPODArray<Group> & res) const
 {
     auto unwrapped = unwrapIDColumn(id_column);
     if (unwrapped.null_map)
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected Nullable column {} of identifiers", id_column->getName());
     size_t num_rows = unwrapped.data->size();
 
-    VectorWithMemoryTracking<Group> res;
     bool dispatched = dispatchIDType(*unwrapped.data, [&](const auto & id_getter)
     {
-        res = getGroupByIDTyped(id_getter, *unwrapped.data, num_rows);
+        getGroupByIDTyped(id_getter, *unwrapped.data, num_rows, res);
     });
     if (dispatched)
-        return res;
+        return;
 
-    return getGroupByIDGeneric(*unwrapped.data, num_rows);
+    getGroupByIDGeneric(*unwrapped.data, num_rows, res);
 }
 
 
 template <typename IDGetter>
-VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByIDTyped(
-    const IDGetter & id_getter, const IColumn & id_data, size_t num_rows) const
+void ContextTimeSeriesTagsCollector::getGroupByIDTyped(
+    const IDGetter & id_getter, const IColumn & id_data, size_t num_rows, PaddedPODArray<Group> & res) const
 {
     using IDType = typename IDGetter::IDType;
 
-    VectorWithMemoryTracking<Group> res;
-    res.reserve(num_rows);
+    res.resize(num_rows);
+    Group * __restrict out = res.data();
 
     SharedLockGuard lock{mutex};
     const auto & id_map = getTypedIDMap<IDType>().map;
 
     /// Id columns arrive in long runs of equal values (samples are sorted by id), so reuse the previous row's group.
     IDType prev_id{};
+    bool has_prev = false;
     Group prev_group = INVALID_GROUP;
     for (size_t i = 0; i != num_rows; ++i)
     {
         IDType id = id_getter.get(i);
-        if ((id == prev_id) && (prev_group != INVALID_GROUP))
+        if (!has_prev || !(id == prev_id))
         {
-            res.push_back(prev_group);
-            continue;
+            const auto * it = id_map.find(id);
+            if (!it)
+                throwUnknownID(id_data, i);
+            prev_id = id;
+            has_prev = true;
+            prev_group = it->getMapped();
         }
-        const auto * it = id_map.find(id);
-        if (!it)
-            throwUnknownID(id_data, i);
-        prev_id = id;
-        prev_group = it->getMapped();
-        res.push_back(prev_group);
+        out[i] = prev_group;
     }
-
-    return res;
 }
 
 
-VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByIDGeneric(const IColumn & id_data, size_t num_rows) const
+void ContextTimeSeriesTagsCollector::getGroupByIDGeneric(const IColumn & id_data, size_t num_rows, PaddedPODArray<Group> & res) const
 {
     Arena temp_arena;
 
-    VectorWithMemoryTracking<Group> res;
-    res.reserve(num_rows);
+    res.resize(num_rows);
+    Group * __restrict out = res.data();
 
     SharedLockGuard lock{mutex};
 
@@ -1297,22 +1296,17 @@ VectorWithMemoryTracking<Group> ContextTimeSeriesTagsCollector::getGroupByIDGene
     Group prev_group = INVALID_GROUP;
     for (size_t i = 0; i != num_rows; ++i)
     {
-        if ((i > 0) && id_data.compareAt(i, i - 1, id_data, /* nan_direction_hint = */ 1) == 0)
+        if ((i == 0) || id_data.compareAt(i, i - 1, id_data, /* nan_direction_hint = */ 1) != 0)
         {
-            chassert(prev_group != INVALID_GROUP);
-            res.push_back(prev_group);
-            continue;
+            const char * begin = nullptr;
+            auto id = id_data.serializeValueIntoArena(i, temp_arena, begin, /* settings = */ nullptr);
+            const auto * it = generic_id_map.map.find(id);
+            if (!it)
+                throwUnknownID(id_data, i);
+            prev_group = it->getMapped();
         }
-        const char * begin = nullptr;
-        auto id = id_data.serializeValueIntoArena(i, temp_arena, begin, /* settings = */ nullptr);
-        const auto * it = generic_id_map.map.find(id);
-        if (!it)
-            throwUnknownID(id_data, i);
-        prev_group = it->getMapped();
-        res.push_back(prev_group);
+        out[i] = prev_group;
     }
-
-    return res;
 }
 
 

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.h
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.h
@@ -4,6 +4,7 @@
 #include <Common/Arena.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/SharedMutex.h>
+#include <Common/PODArray_fwd.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <Core/Types.h>
 #include <city.h>
@@ -87,10 +88,10 @@ public:
     VectorWithMemoryTracking<String> extractTag(const VectorWithMemoryTracking<Group> & groups_, const String & tag_to_extract) const;
     void extractTag(const VectorWithMemoryTracking<Group> & groups_, const String & tag_to_extract, ColumnString & out_column) const;
 
-    /// Returns the groups assigned to the sets of tags which were added to the collector
+    /// Fills `res` with the groups assigned to the sets of tags which were added to the collector
     /// with identifiers from a column. Throws an exception if some identifier is unknown.
-    /// `id_column` must not be Nullable.
-    VectorWithMemoryTracking<Group> getGroupByID(const ColumnPtr & id_column) const;
+    /// `id_column` must not be Nullable. Any previous contents of `res` are discarded.
+    void getGroupByID(const ColumnPtr & id_column, PaddedPODArray<Group> & res) const;
 
     /// Returns the sets of tags which were added to the collector with identifiers from a column.
     /// Throws an exception if some identifier is unknown.
@@ -226,7 +227,7 @@ private:
                         size_t num_rows_to_store, const VectorWithMemoryTracking<TagNamesAndValuesPtr> & tags_vector);
 
     template <typename IDGetter>
-    VectorWithMemoryTracking<Group> getGroupByIDTyped(const IDGetter & id_getter, const IColumn & id_data, size_t num_rows) const;
+    void getGroupByIDTyped(const IDGetter & id_getter, const IColumn & id_data, size_t num_rows, PaddedPODArray<Group> & res) const;
 
     template <typename IDGetter>
     VectorWithMemoryTracking<TagNamesAndValuesPtr> getTagsByIDTyped(const IDGetter & id_getter, const IColumn & id_data, size_t num_rows) const;
@@ -236,7 +237,7 @@ private:
     void storeTagsGeneric(const IColumn & id_data, const UInt8 * null_map,
                           size_t num_rows_to_store, const VectorWithMemoryTracking<TagNamesAndValuesPtr> & tags_vector);
 
-    VectorWithMemoryTracking<Group> getGroupByIDGeneric(const IColumn & id_data, size_t num_rows) const;
+    void getGroupByIDGeneric(const IColumn & id_data, size_t num_rows, PaddedPODArray<Group> & res) const;
 
     VectorWithMemoryTracking<TagNamesAndValuesPtr> getTagsByIDGeneric(const IColumn & id_data, size_t num_rows) const;
 


### PR DESCRIPTION
Two independent fast paths for PromQL instant queries (a single-point evaluation grid):

- The SIMD bucket-classify fast path of the `timeSeries*ToGrid` aggregate functions now supports single-point grids (`step == 0`, which is how every PromQL instant query and every fixed `@` evaluation aggregates): a dedicated branch classifies each sample into the only bucket with two comparisons and no division, and out-of-window samples are skipped by the vectorized run scan. Previously such grids fell back to the generic per-sample path (`bucketIndexForTimestamp` plus one virtual `add` per sample).
- `timeSeriesIdToGroup` writes the group indexes into the result column directly instead of filling a temporary `VectorWithMemoryTracking` and copying it into a column. The function runs on every read sample row, so the extra buffer and copy were a measurable cost on long-range selectors.

Measured on the tsbench scale-64 corpus (71.4 billion samples): the instant query `sum by (namespace) (resets(container_cpu_usage_seconds_total{...}[24h]))` over 147M window samples goes from 0.89s to 0.77s warm; wide-grid range queries are unaffected (within noise in interleaved A/B runs against master on the same table). Results verified identical.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Faster evaluation of PromQL instant queries: the `timeSeries*ToGrid` aggregate functions use the vectorized sample-classification path for single-point grids, and `timeSeriesIdToGroup` fills its result column directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115267&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115267](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115267+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
