### PR TITLE
Docs: clarify ClickStack version requirements for Cloud

### DIFF
--- a/docs/clickstack/managing/performance-tuning.mdx
+++ b/docs/clickstack/managing/performance-tuning.mdx
@@ -560,12 +560,33 @@ connected server version (`SELECT version()`, cached per connection) and only
 emits the rewritten form when the server is at or above the threshold. Older
 servers fall back to the original Map subscript form automatically.
 
-| ClickHouse branch | Minimum version |
+<Tabs>
+<Tab title="ClickHouse Cloud">
+
+| ClickHouse branch | Minimum Cloud version |
 |---|---|
-| 26.2 | 26.2.19.43 |
-| 26.3 | 26.3.12.3 |
-| 26.4 | 26.4.3.37 |
+| 26.2 | `26.2.19.*` |
+| 26.3 | `26.3.12.*` |
+| 26.4 | `26.4.3.*` |
 | 26.5+ | All versions |
+
+The wildcard (`*`) matches any Cloud build number.
+
+</Tab>
+<Tab title="Self-managed">
+
+For self-managed ClickHouse, compare the complete version number with the
+minimum version below.
+
+| ClickHouse branch | Minimum self-managed version |
+|---|---|
+| 26.2 | `26.2.19.43` |
+| 26.3 | `26.3.12.3` |
+| 26.4 | `26.4.3.37` |
+| 26.5+ | All versions |
+
+</Tab>
+</Tabs>
 
 <Info>
 **Why ALIAS, not MATERIALIZED**

--- a/docs/clickstack/managing/performance-tuning.mdx
+++ b/docs/clickstack/managing/performance-tuning.mdx
@@ -555,25 +555,32 @@ reference `LogAttributes['key']` see the speedup without any change.
 ### ClickHouse version requirements {#map-direct-read-version}
 
 The query rewrite requires a ClickHouse version that supports direct
-token-level pruning on text-indexed array columns.
+token-level pruning on text-indexed array columns. ClickStack detects the
+connected server version (`SELECT version()`, cached per connection) and only
+emits the rewritten form when the server meets the corresponding threshold
+below. Older versions fall back to the original Map subscript form
+automatically.
 
 <Tabs>
 <Tab title="ClickHouse Cloud">
 
-The query rewrite is supported in ClickHouse Cloud. Cloud builds and
-self-managed releases use independent version lines, so their version numbers
-are not directly comparable. If the rewrite does not apply in ClickHouse
-Cloud, an insufficient ClickHouse version is not the cause.
+ClickHouse Cloud builds and open-source releases use independent version lines.
+Use the Cloud minimum versions below.
+
+| ClickHouse branch | Minimum Cloud version |
+|---|---|
+| 26.2 | `26.2.1.307` |
+| 26.3 | `26.3.0.0` |
+| 26.4 | `26.4.1.1740` |
+| 26.5+ | All versions |
+
+The `26.3.0.0` minimum is the floor of the branch, so all `26.3` builds are
+supported.
 
 </Tab>
-<Tab title="Self-managed">
+<Tab title="Open source">
 
-ClickStack detects the connected server version (`SELECT version()`, cached per
-connection) and only emits the rewritten form when the server is at or above
-the threshold below. Older servers fall back to the original Map subscript
-form automatically.
-
-| ClickHouse branch | Minimum self-managed version |
+| ClickHouse branch | Minimum open-source version |
 |---|---|
 | 26.2 | `26.2.19.43` |
 | 26.3 | `26.3.12.3` |

--- a/docs/clickstack/managing/performance-tuning.mdx
+++ b/docs/clickstack/managing/performance-tuning.mdx
@@ -555,28 +555,23 @@ reference `LogAttributes['key']` see the speedup without any change.
 ### ClickHouse version requirements {#map-direct-read-version}
 
 The query rewrite requires a ClickHouse version that supports direct
-token-level pruning on text-indexed array columns. ClickStack detects the
-connected server version (`SELECT version()`, cached per connection) and only
-emits the rewritten form when the server is at or above the threshold. Older
-servers fall back to the original Map subscript form automatically.
+token-level pruning on text-indexed array columns.
 
 <Tabs>
 <Tab title="ClickHouse Cloud">
 
-| ClickHouse branch | Minimum Cloud version |
-|---|---|
-| 26.2 | `26.2.19.*` |
-| 26.3 | `26.3.12.*` |
-| 26.4 | `26.4.3.*` |
-| 26.5+ | All versions |
-
-The wildcard (`*`) matches any Cloud build number.
+The query rewrite is supported in ClickHouse Cloud. Cloud builds and
+self-managed releases use independent version lines, so their version numbers
+are not directly comparable. If the rewrite does not apply in ClickHouse
+Cloud, an insufficient ClickHouse version is not the cause.
 
 </Tab>
 <Tab title="Self-managed">
 
-For self-managed ClickHouse, compare the complete version number with the
-minimum version below.
+ClickStack detects the connected server version (`SELECT version()`, cached per
+connection) and only emits the rewritten form when the server is at or above
+the threshold below. Older servers fall back to the original Map subscript
+form automatically.
 
 | ClickHouse branch | Minimum self-managed version |
 |---|---|


### PR DESCRIPTION
Separates the query rewrite version requirements for ClickHouse Cloud and
open-source ClickHouse. Cloud builds and public releases use independent
version lines, so they require different minimum-version tables.

The Cloud tab lists the exact backport minimum for each supported branch,
including the `26.3.0.0` branch floor. The open-source tab retains the public
release thresholds.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Documented separate ClickStack query rewrite version requirements for ClickHouse Cloud and open-source releases.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115268&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115268](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115268+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1764` (included in `26.8` and later)
<!-- ch-version-info:end -->