### PR TITLE
Retry Azure client network and DNS errors instead of reporting a synthetic 500

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -80,6 +80,8 @@ static struct InitFiu
     ONCE(azure_inject_auth_failure_on_request_once) \
     REGULAR(azure_inject_poco_timeout) \
     ONCE(azure_inject_poco_timeout_once) \
+    REGULAR(azure_inject_poco_network_error) \
+    ONCE(azure_inject_poco_network_error_once) \
     REGULAR(azure_inject_bad_request) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -318,10 +318,7 @@ static bool containerExists(const ContainerClient & client)
         if (e.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound)
             return false;
 
-        /// Our HTTP client wraps transport-level failures (DNS, connection refused, etc.)
-        /// as InternalServerError. A transient network error should not prevent the server
-        /// from starting — assume the container exists and let actual I/O operations fail
-        /// with a clear error later if it doesn't.
+        /// A generic/unexpected server error shouldn't block startup — assume the container exists; real I/O fails later with a clear error.
         if (e.StatusCode == Azure::Core::Http::HttpStatusCode::InternalServerError)
         {
             LOG_WARNING(getLogger("AzureBlobStorageCommon"),
@@ -331,6 +328,13 @@ static bool containerExists(const ContainerClient & client)
         }
 
         throw;
+    }
+    catch (const Azure::Core::Http::TransportException & e)
+    {
+        /// Transport failure (DNS/connection/timeout) is retryable and shouldn't block startup — assume the container exists, like the 500 case above.
+        LOG_WARNING(getLogger("AzureBlobStorageCommon"),
+            "Transport error while checking container existence: {}. Assuming the container exists.", e.Message);
+        return true;
     }
 }
 

--- a/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
+++ b/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
@@ -16,6 +16,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/HTTPClientSession.h>
+#include <Poco/Net/NetException.h>
 #include <Poco/String.h>
 #include <Poco/URI.h>
 #include <azure/core/http/http.hpp>
@@ -39,6 +40,8 @@ namespace DB::FailPoints
     extern const char azure_inject_auth_failure_on_request_once[];
     extern const char azure_inject_poco_timeout[];
     extern const char azure_inject_poco_timeout_once[];
+    extern const char azure_inject_poco_network_error[];
+    extern const char azure_inject_poco_network_error_once[];
     extern const char azure_inject_bad_request[];
 }
 
@@ -384,6 +387,11 @@ std::unique_ptr<Azure::Core::Http::RawResponse> PocoAzureHTTPClient::makeRequest
             { throw Poco::TimeoutException("connect timed out (injected by failpoint)"); });
         fiu_do_on(DB::FailPoints::azure_inject_poco_timeout_once,
             { throw Poco::TimeoutException("connect timed out (injected by failpoint)"); });
+        /// Test-only: raise a real Poco network error so the IOException -> TransportException path is what's tested.
+        fiu_do_on(DB::FailPoints::azure_inject_poco_network_error,
+            { throw Poco::Net::ConnectionResetException("connection reset (injected by failpoint)"); });
+        fiu_do_on(DB::FailPoints::azure_inject_poco_network_error_once,
+            { throw Poco::Net::ConnectionResetException("connection reset (injected by failpoint)"); });
 
         Poco::Net::HTTPRequest poco_request(Poco::Net::HTTPRequest::HTTP_1_1);
 
@@ -564,6 +572,30 @@ std::unique_ptr<Azure::Core::Http::RawResponse> PocoAzureHTTPClient::makeRequest
         addMetric(method, AzureMetricType::Errors);
 
         /// Throw TransportException (retryable) for a timeout instead of a synthetic 408 that read as a broken part.
+        throw Azure::Core::Http::TransportException(getCurrentExceptionMessageAndPattern(true).text);
+    }
+    catch (const Poco::IOException &)
+    {
+        if (!latency_recorded)
+        {
+            observeLatency(method, AzureLatencyType::Connect, static_cast<HistogramMetrics::Value>(connect_time));
+            observeLatency(method, first_byte_latency_type, static_cast<HistogramMetrics::Value>(first_byte_time));
+        }
+
+        addMetric(method, AzureMetricType::Errors);
+
+        throw Azure::Core::Http::TransportException(getCurrentExceptionMessageAndPattern(true).text);
+    }
+    catch (const NetException &)
+    {
+        if (!latency_recorded)
+        {
+            observeLatency(method, AzureLatencyType::Connect, static_cast<HistogramMetrics::Value>(connect_time));
+            observeLatency(method, first_byte_latency_type, static_cast<HistogramMetrics::Value>(first_byte_time));
+        }
+
+        addMetric(method, AzureMetricType::Errors);
+
         throw Azure::Core::Http::TransportException(getCurrentExceptionMessageAndPattern(true).text);
     }
     catch (...)

--- a/tests/integration/test_azure_403_handling/test.py
+++ b/tests/integration/test_azure_403_handling/test.py
@@ -45,6 +45,12 @@ ERROR_KINDS = {
         "azure_inject_poco_timeout",
         "TransportException",
     ),
+    # Poco network/IO error (connection reset) -> TransportException, like timeout (r3767770811).
+    "network": (
+        "azure_inject_poco_network_error_once",
+        "azure_inject_poco_network_error",
+        "TransportException",
+    ),
 }
 
 ALL_FAILPOINTS = [fp for triple in ERROR_KINDS.values() for fp in triple[:2]] + [


### PR DESCRIPTION
#112871 fixed transient Azure timeouts being misreported as broken data parts. The
follow-up suggestion (https://github.com/ClickHouse/ClickHouse/pull/112871#discussion_r3767770811)
was to extend that to `Poco::Net::NetException`, `Poco::IOException` and `DB::NetException`,
which the Azure HTTP client still turns into a synthetic `500`.


Changes:
- added handling for `Poco::IOException`, which also covers `Poco::Net::NetException`
- added handling for `DB::NetException`
- also tolerate transport errors in the container-existence check so an unreachable Azure disk doesn't crash startup (covered by `test_azure_disk_unreachable`)
- added testing

Both new handlers throw `Azure::Core::Http::TransportException` (retryable, like the
existing timeout handler) and match the S3 client.

### Changelog category (leave one):
- Improvement

### Changelog entry:
Azure client-side network failures (connection reset/refused, DNS and TLS errors) are now
retried as transport errors instead of surfacing as a synthetic `500`, matching the S3
client.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115269&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115269](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115269+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1990` (included in `26.8` and later)
<!-- ch-version-info:end -->