### PR TITLE
Fix flaky test 03100_lwu_22_detach_attach_patches

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_22_detach_attach_patches.sql
+++ b/tests/queries/0_stateless/03100_lwu_22_detach_attach_patches.sql
@@ -11,14 +11,18 @@ ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_lwu_on_fly/', '1')
 ORDER BY a PARTITION BY id
 SETTINGS
     enable_block_number_column = 1,
-    enable_block_offset_column = 1;
+    enable_block_offset_column = 1,
+    merge_selecting_sleep_ms = 100,
+    max_merge_selecting_sleep_ms = 200;
 
 CREATE TABLE t_detach_attach_patches_dst AS t_detach_attach_patches
 ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_lwu_on_fly_dst/', '1')
 ORDER BY a PARTITION BY id
 SETTINGS
     enable_block_number_column = 1,
-    enable_block_offset_column = 1;
+    enable_block_offset_column = 1,
+    merge_selecting_sleep_ms = 100,
+    max_merge_selecting_sleep_ms = 200;
 
 SET apply_patch_parts = 1;
 SET mutations_sync = 2;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110178
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.


### Description

`03100_lwu_22_detach_attach_patches` hits the 60 second per-test cap in `Fast test`
(`Timeout! Killing process group`). Measured over 30 days: 7 failures across 7 distinct
pull requests, 0 on master. Example report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115234&sha=3d3a0b0cfb7379259dd3158099a5035c6d7099fe&name_0=PR&name_1=Fast%20test

Root cause. Every merge-selection round that selects nothing multiplies the table's
merge-selecting interval by `merge_selecting_sleep_slowdown_factor`, up to
`max_merge_selecting_sleep_ms` (default 60000). Externally woken rounds count too, and
`mutate()` schedules one for every `UPDATE` and `APPLY PATCHES`, so the interval saturates
at the 60 second ceiling within a second of `CREATE TABLE`. Any later statement that has to
wait for the next selection round then pays that interval. This test issues `APPLY PATCHES`
under `mutations_sync = 2`, so a single such wait consumes the whole 60 second budget.

Measured locally on one server, reading the interval the engine itself logs
(`Scheduling next merge selecting task after Nms`): unpinned, the interval reaches 60000 ms
and the longest observed wait between selection rounds is 54832 ms; with the pin the
interval never exceeds 200 ms and the longest wait is 121 ms. Over 20 unpinned randomized
runs, 7 took more than 30 seconds (max 57.51 s, i.e. a near miss of the cap); with the pin,
100 runs all finished in under 3 seconds.

The fix pins `merge_selecting_sleep_ms` and `max_merge_selecting_sleep_ms` on the test's two
tables, which is what the merged #110178 did for `02676_optimize_old_parts_replicated` and
what `03047_on_fly_mutations_basics_rmt` already does. Test only, no product code change.

I did not change the engine here. That the interval grows on externally woken rounds is a
scheduling policy question that affects merge latency and Keeper load for every replicated
table, and justifying a change to it needs multi-replica measurements this PR does not have.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115279&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115279](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115279+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
