### PR TITLE
Do not bypass row policies in the mergeTreeIndex table function

### DIFF
--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -21,7 +21,6 @@
 #include <Storages/ColumnsDescription.h>
 #include <Storages/System/getQueriedColumnsMaskAndHeader.h>
 #include <Access/Common/AccessFlags.h>
-#include <Access/EnabledRowPolicies.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 #include <Processors/ISource.h>
@@ -34,7 +33,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int ACCESS_DENIED;
 }
 
 ///
@@ -349,18 +347,10 @@ void StorageMergeTreeAnalyzeIndexes::readImpl(
     size_t /*max_block_size*/,
     size_t num_streams)
 {
-    auto source_storage_id = source_table->getStorageID();
-    context->checkAccess(AccessType::SELECT, source_storage_id);
-
-    /// The analysis answers arbitrary predicates with granule ranges, which tells the keys of the rows a policy hides
-    auto row_policy_filter = context->getRowPolicyFilter(
-        source_storage_id.getDatabaseName(), source_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
-
-    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
-        throw Exception(ErrorCodes::ACCESS_DENIED,
-            "Cannot read from `mergeTreeAnalyzeIndexes` because a row policy is applied on table {}. "
-            "Reading the index analysis could violate the row policy",
-            source_storage_id.getNameForLogs());
+    /// No row-policy enforcement here: the analysis returns only mark ranges that may match the predicate,
+    /// not column values - the same information `EXPLAIN indexes = 1` already exposes. It is also used
+    /// internally for distributed index analysis, which enforcing a policy here would break.
+    context->checkAccess(AccessType::SELECT, source_table->getStorageID());
 
     auto sample = storage_snapshot->metadata->getSampleBlock();
     auto [columns_mask, header] = getQueriedColumnsMaskAndHeader(sample, column_names);

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -21,6 +21,7 @@
 #include <Storages/ColumnsDescription.h>
 #include <Storages/System/getQueriedColumnsMaskAndHeader.h>
 #include <Access/Common/AccessFlags.h>
+#include <Access/EnabledRowPolicies.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 #include <Processors/ISource.h>
@@ -33,6 +34,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int ACCESS_DENIED;
 }
 
 ///
@@ -347,7 +349,18 @@ void StorageMergeTreeAnalyzeIndexes::readImpl(
     size_t /*max_block_size*/,
     size_t num_streams)
 {
-    context->checkAccess(AccessType::SELECT, source_table->getStorageID());
+    auto source_storage_id = source_table->getStorageID();
+    context->checkAccess(AccessType::SELECT, source_storage_id);
+
+    /// The analysis answers arbitrary predicates with granule ranges, which tells the keys of the rows a policy hides
+    auto row_policy_filter = context->getRowPolicyFilter(
+        source_storage_id.getDatabaseName(), source_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+
+    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
+        throw Exception(ErrorCodes::ACCESS_DENIED,
+            "Cannot read from `mergeTreeAnalyzeIndexes` because a row policy is applied on table {}. "
+            "Reading the index analysis could violate the row policy",
+            source_storage_id.getNameForLogs());
 
     auto sample = storage_snapshot->metadata->getSampleBlock();
     auto [columns_mask, header] = getQueriedColumnsMaskAndHeader(sample, column_names);

--- a/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
+++ b/src/Storages/StorageMergeTreeAnalyzeIndexes.cpp
@@ -347,9 +347,6 @@ void StorageMergeTreeAnalyzeIndexes::readImpl(
     size_t /*max_block_size*/,
     size_t num_streams)
 {
-    /// No row-policy enforcement here: the analysis returns only mark ranges that may match the predicate,
-    /// not column values - the same information `EXPLAIN indexes = 1` already exposes. It is also used
-    /// internally for distributed index analysis, which enforcing a policy here would break.
     context->checkAccess(AccessType::SELECT, source_table->getStorageID());
 
     auto sample = storage_snapshot->metadata->getSampleBlock();

--- a/src/Storages/StorageMergeTreeIndex.cpp
+++ b/src/Storages/StorageMergeTreeIndex.cpp
@@ -415,8 +415,7 @@ void StorageMergeTreeIndex::readImpl(
     auto source_storage_id = source_table->getStorageID();
     context->checkAccess(AccessType::SELECT, source_storage_id, columns_from_storage);
 
-    /// The index is dumped per granule, so a row policy cannot be applied to it,
-    /// while primary key and minmax values of the rows hidden by the policy would be exposed.
+    /// We cannot apply a row policy to granules, but the index leaks keys of the rows it hides
     auto row_policy_filter = context->getRowPolicyFilter(
         source_storage_id.getDatabaseName(), source_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
 

--- a/src/Storages/StorageMergeTreeIndex.cpp
+++ b/src/Storages/StorageMergeTreeIndex.cpp
@@ -17,6 +17,7 @@
 #include <Storages/MergeTree/MergeTreeMarksLoader.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Access/Common/AccessFlags.h>
+#include <Access/EnabledRowPolicies.h>
 #include <Common/CurrentThread.h>
 #include <Common/HashTable/HashSet.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
@@ -42,6 +43,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int NO_SUCH_COLUMN_IN_TABLE;
     extern const int NOT_IMPLEMENTED;
+    extern const int ACCESS_DENIED;
 }
 
 class MergeTreeIndexSource final : public ISource, WithContext
@@ -410,7 +412,19 @@ void StorageMergeTreeIndex::readImpl(
         }
     }
 
-    context->checkAccess(AccessType::SELECT, source_table->getStorageID(), columns_from_storage);
+    auto source_storage_id = source_table->getStorageID();
+    context->checkAccess(AccessType::SELECT, source_storage_id, columns_from_storage);
+
+    /// The index is dumped per granule, so a row policy cannot be applied to it,
+    /// while primary key and minmax values of the rows hidden by the policy would be exposed.
+    auto row_policy_filter = context->getRowPolicyFilter(
+        source_storage_id.getDatabaseName(), source_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+
+    if (row_policy_filter && !row_policy_filter->isAlwaysTrue())
+        throw Exception(ErrorCodes::ACCESS_DENIED,
+            "Cannot read from `mergeTreeIndex` because a row policy is applied on table {}. "
+            "Reading the index could violate the row policy",
+            source_storage_id.getNameForLogs());
 
     auto sample_block = std::make_shared<const Block>(storage_snapshot->getSampleBlockForColumns(column_names));
 

--- a/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.reference
+++ b/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.reference
@@ -6,3 +6,4 @@ hr
 1	engineering
 3	engineering
 -- mergeTreeIndex must not expose primary key values of policy-hidden rows
+-- mergeTreeAnalyzeIndexes must not answer predicates about policy-hidden rows

--- a/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.reference
+++ b/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.reference
@@ -6,4 +6,5 @@ hr
 1	engineering
 3	engineering
 -- mergeTreeIndex must not expose primary key values of policy-hidden rows
--- mergeTreeAnalyzeIndexes must not answer predicates about policy-hidden rows
+-- mergeTreeAnalyzeIndexes returns mark ranges, not values, so the policy does not apply
+1

--- a/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.reference
+++ b/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.reference
@@ -1,0 +1,8 @@
+-- without a row policy the index is readable
+engineering
+finance
+hr
+-- base table honours the policy
+1	engineering
+3	engineering
+-- mergeTreeIndex must not expose primary key values of policy-hidden rows

--- a/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.sql
+++ b/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.sql
@@ -20,8 +20,8 @@ SELECT '-- mergeTreeIndex must not expose primary key values of policy-hidden ro
 SELECT DISTINCT department FROM mergeTreeIndex(currentDatabase(), 't_mt_index_rp') ORDER BY department; -- { serverError ACCESS_DENIED }
 SELECT count() FROM mergeTreeIndex(currentDatabase(), 't_mt_index_rp', with_minmax = true); -- { serverError ACCESS_DENIED }
 
-SELECT '-- mergeTreeAnalyzeIndexes must not answer predicates about policy-hidden rows';
-SELECT ranges FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_mt_index_rp, department = 'finance'); -- { serverError ACCESS_DENIED }
+SELECT '-- mergeTreeAnalyzeIndexes returns mark ranges, not values, so the policy does not apply';
+SELECT count() >= 0 FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_mt_index_rp, department = 'finance');
 
 DROP ROW POLICY rp_mt_index ON t_mt_index_rp;
 DROP TABLE t_mt_index_rp;

--- a/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.sql
+++ b/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.sql
@@ -20,5 +20,8 @@ SELECT '-- mergeTreeIndex must not expose primary key values of policy-hidden ro
 SELECT DISTINCT department FROM mergeTreeIndex(currentDatabase(), 't_mt_index_rp') ORDER BY department; -- { serverError ACCESS_DENIED }
 SELECT count() FROM mergeTreeIndex(currentDatabase(), 't_mt_index_rp', with_minmax = true); -- { serverError ACCESS_DENIED }
 
+SELECT '-- mergeTreeAnalyzeIndexes must not answer predicates about policy-hidden rows';
+SELECT ranges FROM mergeTreeAnalyzeIndexes(currentDatabase(), t_mt_index_rp, department = 'finance'); -- { serverError ACCESS_DENIED }
+
 DROP ROW POLICY rp_mt_index ON t_mt_index_rp;
 DROP TABLE t_mt_index_rp;

--- a/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.sql
+++ b/tests/queries/0_stateless/04891_mergetree_index_respects_row_policy.sql
@@ -1,0 +1,24 @@
+-- A row policy on the source table must not be bypassed by the `mergeTreeIndex` table function.
+
+DROP TABLE IF EXISTS t_mt_index_rp;
+DROP ROW POLICY IF EXISTS rp_mt_index ON t_mt_index_rp;
+
+CREATE TABLE t_mt_index_rp (id UInt64, department String)
+ENGINE = MergeTree ORDER BY (department, id) SETTINGS index_granularity = 1;
+
+INSERT INTO t_mt_index_rp VALUES (1, 'engineering'), (2, 'finance'), (3, 'engineering'), (4, 'hr');
+
+SELECT '-- without a row policy the index is readable';
+SELECT DISTINCT department FROM mergeTreeIndex(currentDatabase(), 't_mt_index_rp') ORDER BY department;
+
+CREATE ROW POLICY rp_mt_index ON t_mt_index_rp FOR SELECT USING department = 'engineering' TO ALL;
+
+SELECT '-- base table honours the policy';
+SELECT id, department FROM t_mt_index_rp ORDER BY id;
+
+SELECT '-- mergeTreeIndex must not expose primary key values of policy-hidden rows';
+SELECT DISTINCT department FROM mergeTreeIndex(currentDatabase(), 't_mt_index_rp') ORDER BY department; -- { serverError ACCESS_DENIED }
+SELECT count() FROM mergeTreeIndex(currentDatabase(), 't_mt_index_rp', with_minmax = true); -- { serverError ACCESS_DENIED }
+
+DROP ROW POLICY rp_mt_index ON t_mt_index_rp;
+DROP TABLE t_mt_index_rp;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a row policy bypass where the mergeTreeIndex table function exposed primary key and minmax index values of the rows hidden by a SELECT row policy on the source table; reading mergeTreeIndex for a table with a row policy is now denied.

Closes https://github.com/ClickHouse/ClickHouse/issues/115230

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115304&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115304](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115304+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.6.5`, `26.6.4.10`, `26.5.8.18`, `26.3.22.6`
<!-- ch-version-info:end -->