### PR TITLE
Do not admit non-clonable read steps into the MergeTree direct join

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -3025,9 +3025,9 @@ void tryMakeDirectJoinWithMergeTree(const JoinOperator & join_operator,
         return;
 
     const auto * children_step = root_node->children.front()->step.get();
+    /// Only steps that support clone(), because the lookup plan below is cloned per lookup batch.
     bool is_allowed_storage = typeid_cast<const ReadFromMergeTree *>(children_step)
-                           || typeid_cast<const ReadNothingStep *>(children_step)
-                           || typeid_cast<const ReadFromPreparedSource *>(children_step);
+                           || typeid_cast<const ReadNothingStep *>(children_step);
     if (!is_allowed_storage)
         return;
 

--- a/tests/queries/0_stateless/04926_direct_join_prepared_source.reference
+++ b/tests/queries/0_stateless/04926_direct_join_prepared_source.reference
@@ -1,0 +1,9 @@
+left join, empty buffer: graceful refusal
+left join, non-empty buffer: graceful refusal
+inner join, non-empty buffer: graceful refusal
+--- hash join over the same shape
+1	A	1	B
+--- direct join, MergeTree right side
+1	A	1	C
+--- direct join, empty MergeTree right side
+1	A	0	

--- a/tests/queries/0_stateless/04926_direct_join_prepared_source.sh
+++ b/tests/queries/0_stateless/04926_direct_join_prepared_source.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A right side that reads through ReadFromPreparedSource cannot be cloned, so the direct join
+# must decline it and report the same refusal as any other unsupported storage. The assertion is
+# on the message: both the refusal and the clone failure are NOT_IMPLEMENTED, so a bare
+# serverError annotation cannot tell them apart.
+expect_refusal() {
+    local label="$1"
+    local query="$2"
+    local out
+    out=$(${CLICKHOUSE_CLIENT} --query "$query" 2>&1)
+
+    if [[ "$out" == *"Cannot clone"* ]]; then
+        echo "$label: clone failure"
+    elif [[ "$out" == *"Can't execute any of specified algorithms"* ]]; then
+        echo "$label: graceful refusal"
+    else
+        echo "$label: unexpected: ${out//$'\n'/ }"
+    fi
+}
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE t_left (id UInt64, name String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t_right_mt (id UInt64, val String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t_right_empty (id UInt64, val String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t_right_buf AS t_right_mt
+    ENGINE = Buffer(currentDatabase(), t_right_mt, 1, 1000, 1000, 10000, 10000, 10000000, 10000000);
+INSERT INTO t_left VALUES (1, 'A');
+"
+
+expect_refusal "left join, empty buffer" "
+    SELECT * FROM t_left AS l LEFT JOIN t_right_buf AS r ON l.id = r.id
+    SETTINGS enable_analyzer = 1, join_algorithm = 'direct'"
+
+${CLICKHOUSE_CLIENT} --query "INSERT INTO t_right_buf VALUES (1, 'B')"
+
+expect_refusal "left join, non-empty buffer" "
+    SELECT * FROM t_left AS l LEFT JOIN t_right_buf AS r ON l.id = r.id
+    SETTINGS enable_analyzer = 1, join_algorithm = 'direct'"
+
+expect_refusal "inner join, non-empty buffer" "
+    SELECT * FROM t_left AS l INNER JOIN t_right_buf AS r ON l.id = r.id
+    SETTINGS enable_analyzer = 1, join_algorithm = 'direct'"
+
+echo "--- hash join over the same shape"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT * FROM t_left AS l LEFT JOIN t_right_buf AS r ON l.id = r.id
+    ORDER BY l.id
+    SETTINGS enable_analyzer = 1, join_algorithm = 'hash'"
+
+echo "--- direct join, MergeTree right side"
+${CLICKHOUSE_CLIENT} --query "
+    INSERT INTO t_right_mt VALUES (1, 'C')"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT * FROM t_left AS l LEFT JOIN t_right_mt AS r ON l.id = r.id
+    ORDER BY l.id
+    SETTINGS enable_analyzer = 1, join_algorithm = 'direct'"
+
+echo "--- direct join, empty MergeTree right side"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT * FROM t_left AS l LEFT JOIN t_right_empty AS r ON l.id = r.id
+    ORDER BY l.id
+    SETTINGS enable_analyzer = 1, join_algorithm = 'direct'"

--- a/tests/queries/0_stateless/04926_direct_join_prepared_source.sh
+++ b/tests/queries/0_stateless/04926_direct_join_prepared_source.sh
@@ -7,7 +7,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # A right side that reads through ReadFromPreparedSource cannot be cloned, so the direct join
 # must decline it and report the same refusal as any other unsupported storage. The assertion is
 # on the message: both the refusal and the clone failure are NOT_IMPLEMENTED, so a bare
-# serverError annotation cannot tell them apart.
+# serverError annotation cannot tell them apart. The refusal is matched on the invariant part of
+# the wording rather than the whole sentence, which has already been reworded once.
 expect_refusal() {
     local label="$1"
     local query="$2"
@@ -16,7 +17,7 @@ expect_refusal() {
 
     if [[ "$out" == *"Cannot clone"* ]]; then
         echo "$label: clone failure"
-    elif [[ "$out" == *"Can't execute any of specified algorithms"* ]]; then
+    elif [[ "$out" == *"(NOT_IMPLEMENTED)"* && "$out" == *"storage type"* ]]; then
         echo "$label: graceful refusal"
     else
         echo "$label: unexpected: ${out//$'\n'/ }"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/103473
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `Cannot clone ReadFromPreparedSource plan step` (`NOT_IMPLEMENTED`) when joining against a `Buffer` table with `join_algorithm = 'direct'`. Such a right side is now declined with the same message as any other unsupported storage.


### Description

`tryMakeDirectJoinWithMergeTree` admitted `ReadFromPreparedSource` as a right-side read step, then cloned the right plan unconditionally. That step has no `clone()` override, so the clone reached the throwing base `IQueryPlanStep::clone()`:

```sql
CREATE TABLE t_left (id UInt64, name String) ENGINE = MergeTree ORDER BY id;
CREATE TABLE t_right_mt (id UInt64, val String) ENGINE = MergeTree ORDER BY id;
CREATE TABLE t_right_buf AS t_right_mt
  ENGINE = Buffer(currentDatabase(), t_right_mt, 1, 1000, 1000, 10000, 10000, 10000000, 10000000);
INSERT INTO t_left VALUES (1, 'A');

SELECT * FROM t_left AS l LEFT JOIN t_right_buf AS r ON l.id = r.id
SETTINGS enable_analyzer = 1, join_algorithm = 'direct';
-- Code: 48. DB::Exception: Cannot clone ReadFromPreparedSource plan step. (NOT_IMPLEMENTED)
```

That arm never had a working case: `typeid_cast` matches the exact type, and neither `ReadFromPreparedSource` nor its subclasses implement `clone()`, so every plan it admitted threw. This removes it. The other two arms are kept, and `ReadNothingStep` (which does implement `clone()`) carries the empty-MergeTree case from #95935.

The query now takes the pre-existing refusal for unsupported right-side storages, `Can't execute any of specified algorithms ...`, which is what a `Memory` or `StripeLog` right side already returns.

This is the "make the exception message better" change @ vdimir asked for when he closed #103473 as not planned: `direct` does not support `Buffer`, so the right behaviour is the ordinary unsupported-storage refusal rather than a clone failure. It deliberately does not make `Buffer` work with `direct`.

Two notes beyond the report. The failure is not limited to an empty underlying table as the issue title suggests: it also reproduces with a non-empty `Buffer` and with `INNER JOIN`. And it does not touch the second entry point @ zlareb1 reported, where correlated-subquery decorrelation clones the same step: that path does not go through this allow-list. Hence `Related:` below rather than `Closes:`.

Related: https://github.com/ClickHouse/ClickHouse/issues/103473

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115309&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115309](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115309+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.118` (included in `26.9` and later)
<!-- ch-version-info:end -->