### PR TITLE
Document Cloud API endpoints and Terraform resources for UDFs in Cloud

### DIFF
--- a/docs/products/cloud/features/sql-console-features/user-defined-functions.mdx
+++ b/docs/products/cloud/features/sql-console-features/user-defined-functions.mdx
@@ -227,7 +227,7 @@ The official [ClickHouse Terraform provider](https://registry.terraform.io/provi
 - [`clickhouse_udf_attachment`](https://github.com/ClickHouse/terraform-provider-clickhouse/blob/main/docs/resources/udf_attachment.md) attaches a UDF version to a service. A service holds at most one version of a function at a time. You can pin a fixed version number, or reference `clickhouse_udf.<name>.version` to automatically roll services forward to the latest version.
 
 <Note>
-These resources are in alpha and are only available in [alpha releases of the provider](/cloud/manage/api/api-overview#terraform-provider-releases), which must be explicitly pinned. Their behavior may change in future provider versions.
+These resources are available in provider version 3.24.0 and later. They are in alpha status and their behavior may change in future provider versions.
 </Note>
 
 For example, to deploy the `isBusinessHours` UDF from the earlier example with Terraform:

--- a/docs/products/cloud/features/sql-console-features/user-defined-functions.mdx
+++ b/docs/products/cloud/features/sql-console-features/user-defined-functions.mdx
@@ -11,9 +11,11 @@ import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 
 User-defined functions (UDF) allow users to extend the behavior of ClickHouse beyond what is offered by over a thousand different out-of-box [functions](/reference/functions/regular-functions/overview).
 
-In ClickHouse Cloud, there are two ways to create user-defined functions:
+In ClickHouse Cloud, there are several ways to create and manage user-defined functions:
 1. Using SQL
 2. Using the UI and your own code (public beta)
+3. Using the [Cloud API](#manage-udfs-with-the-cloud-api) (beta)
+4. Using [Terraform](#manage-udfs-with-terraform) (alpha)
 
 ## SQL user-defined functions {#sql-udfs}
 
@@ -180,3 +182,76 @@ To change a UDF's code, create a new version. The **Edit** panel only manages wh
 You have successfully added your first user-defined function via the UI, confirmed it runs and seen how to create a new version of it if needed.
 </Step>
 </Steps>
+
+## Manage UDFs with the Cloud API {#manage-udfs-with-the-cloud-api}
+
+<BetaBadge/>
+
+Everything available in the UI is also available programmatically through the [ClickHouse Cloud API](/cloud/manage/api/api-overview).
+The UDF endpoints let you script the full lifecycle of a UDF: uploading source archives, creating functions and versions, attaching them to services, and cleaning them up.
+
+<Note>
+These endpoints are in beta and the API contract may change.
+</Note>
+
+The typical workflow to create and deploy a UDF via the API is:
+
+1. [Create an upload URL](/products/cloud/api-reference/udf/udf-upload-session-create) to receive a presigned `application/zip` upload URL, then upload your ZIP archive to it. Each upload ID may be used for only one create or version attempt; request a new upload URL when retrying.
+2. [Create the UDF](/products/cloud/api-reference/udf/udf-create) from the uploaded archive, specifying the function name, runtime, arguments, and return type.
+3. [Attach the UDF to a service](/products/cloud/api-reference/udf/udf-attach). When the version is omitted, the latest ready version is attached. The service must be running; idle services can be woken up first.
+
+The full set of endpoints:
+
+| Endpoint | Description |
+|----------|-------------|
+| [Create UDF upload URL](/products/cloud/api-reference/udf/udf-upload-session-create) | Creates an org-scoped presigned `application/zip` upload URL |
+| [Create UDF](/products/cloud/api-reference/udf/udf-create) | Creates a new UDF from an uploaded archive |
+| [List UDFs](/products/cloud/api-reference/udf/udf-list) | Returns the latest version of each UDF in the organization |
+| [Get UDF](/products/cloud/api-reference/udf/udf-get) | Returns the latest version of a UDF |
+| [Delete UDF](/products/cloud/api-reference/udf/udf-delete) | Deletes every version of a UDF and detaches it from all services |
+| [Create UDF version](/products/cloud/api-reference/udf/udf-version-create) | Consumes a source archive, assigns a version, and starts the UDF build |
+| [List UDF versions](/products/cloud/api-reference/udf/udf-version-list) | Returns all versions of a UDF |
+| [Delete UDF version](/products/cloud/api-reference/udf/udf-version-delete) | Deletes a UDF version that is not attached to any service |
+| [Attach UDF to service](/products/cloud/api-reference/udf/udf-attach) | Attaches one UDF version to a service, replacing the current version when necessary |
+| [List UDF attachments](/products/cloud/api-reference/udf/udf-attachment-list) | Returns the current service attachments for a UDF |
+| [Get UDF attachment](/products/cloud/api-reference/udf/udf-attachment-get) | Returns the current attachment of a UDF to one service |
+| [Detach UDF from service](/products/cloud/api-reference/udf/udf-detach) | Detaches a UDF from a service |
+
+See the [UDF API reference](/products/cloud/api-reference/udf/udf-create) for request and response schemas.
+
+## Manage UDFs with Terraform {#manage-udfs-with-terraform}
+
+The official [ClickHouse Terraform provider](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) includes two resources for managing UDFs as Infrastructure as Code:
+
+- [`clickhouse_udf`](https://github.com/ClickHouse/terraform-provider-clickhouse/blob/main/docs/resources/udf.md) manages the function itself. It takes a ZIP archive with the function source code and publishes a new version whenever the archive hash changes, waiting for the build to complete.
+- [`clickhouse_udf_attachment`](https://github.com/ClickHouse/terraform-provider-clickhouse/blob/main/docs/resources/udf_attachment.md) attaches a UDF version to a service. A service holds at most one version of a function at a time. You can pin a fixed version number, or reference `clickhouse_udf.<name>.version` to automatically roll services forward to the latest version.
+
+<Note>
+These resources are in alpha and are only available in [alpha releases of the provider](/cloud/manage/api/api-overview#terraform-provider-releases), which must be explicitly pinned. Their behavior may change in future provider versions.
+</Note>
+
+For example, to deploy the `isBusinessHours` UDF from the earlier example with Terraform:
+
+```terraform
+resource "clickhouse_udf" "is_business_hours" {
+  function_name = "isBusinessHours"
+  runtime       = "python3.11"
+  type          = "executable_pool"
+  return_type   = "Bool"
+
+  arguments = [
+    { name = "timestamp", type = "DateTime" },
+  ]
+
+  source_archive_path = "${path.module}/is_business_hours.zip"
+  source_archive_hash = filebase64sha256("${path.module}/is_business_hours.zip")
+}
+
+resource "clickhouse_udf_attachment" "production" {
+  function_name = clickhouse_udf.is_business_hours.function_name
+  service_id    = var.service_id
+  version       = clickhouse_udf.is_business_hours.version
+}
+```
+
+Attaching only succeeds for versions that are ready, and can take several minutes; idle services are woken up automatically. Deleting a `clickhouse_udf` resource removes all versions of the function and detaches it from all services.


### PR DESCRIPTION
Extend the [User-defined functions in Cloud](https://clickhouse.com/docs/products/cloud/features/sql-console-features/user-defined-functions) page to cover the two new programmatic ways of managing executable UDFs, alongside the existing SQL and UI flows:

- A new "Manage UDFs with the Cloud API" section describing the beta OpenAPI endpoints: the typical upload-URL → create → attach workflow, plus a table of all twelve endpoints (`udfUploads/url`, UDF create/list/get/delete, version create/list/delete, and attachment attach/get/list/detach) linked to their pages under `docs/products/cloud/api-reference/udf/`.
- A new "Manage UDFs with Terraform" section describing the alpha `clickhouse_udf` and `clickhouse_udf_attachment` provider resources, with an HCL example deploying the same `isBusinessHours` function used elsewhere on the page, and a note that these resources require an explicitly pinned alpha release of the provider.
- The intro list of ways to create UDFs now links to both new sections.

References:
- https://clickhouse.com/docs/products/cloud/api-reference/udf/
- https://github.com/ClickHouse/terraform-provider-clickhouse/blob/main/docs/resources/udf.md
- https://github.com/ClickHouse/terraform-provider-clickhouse/blob/main/docs/resources/udf_attachment.md

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115313&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115313](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115313+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1667` (included in `26.8` and later)
<!-- ch-version-info:end -->