### PR TITLE
Fix primary indexes of newly written parts staying in memory forever when PK cache is enabled

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2711,7 +2711,7 @@ void InterpreterSystemQuery::prewarmMarkCache()
         CurrentMetrics::MergeTreePartsLoaderThreadsScheduled,
         getContext()->getSettingsRef()[Setting::max_threads]);
 
-    MergeTreeData::CachesToPrewarm caches;
+    CachesToPrewarm caches;
     caches.mark_cache = getContext()->getMarkCache();
     caches.index_mark_cache = getContext()->getIndexMarkCache();
     merge_tree->prewarmCaches(pool, caches);
@@ -2739,7 +2739,7 @@ void InterpreterSystemQuery::prewarmPrimaryIndexCache()
         CurrentMetrics::MergeTreePartsLoaderThreadsScheduled,
         getContext()->getSettingsRef()[Setting::max_threads]);
 
-    MergeTreeData::CachesToPrewarm caches;
+    CachesToPrewarm caches;
     caches.primary_index_cache = index_cache;
     merge_tree->prewarmCaches(pool, caches);
 }

--- a/src/Storages/MergeTree/CachesToPrewarm.h
+++ b/src/Storages/MergeTree/CachesToPrewarm.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+
+namespace DB
+{
+
+class MarkCache;
+using MarkCachePtr = std::shared_ptr<MarkCache>;
+
+class PrimaryIndexCache;
+using PrimaryIndexCachePtr = std::shared_ptr<PrimaryIndexCache>;
+
+/// Which caches to prewarm with the data of a part being written. Computed once per
+/// insert/merge/mutation from one settings snapshot; the writers and the move of the
+/// index into the cache after commit use the same decision.
+struct CachesToPrewarm
+{
+    MarkCachePtr mark_cache;
+    MarkCachePtr index_mark_cache;
+    PrimaryIndexCachePtr primary_index_cache;
+
+    /// The cache in use, regardless of prewarm; when set, the index must not stay
+    /// in the part after commit.
+    PrimaryIndexCachePtr used_primary_index_cache;
+
+    /// Nothing to prewarm; the cache pointer only selects whether to keep the index in memory.
+    static CachesToPrewarm noPrewarm(PrimaryIndexCachePtr used_primary_index_cache_)
+    {
+        CachesToPrewarm res;
+        res.used_primary_index_cache = std::move(used_primary_index_cache_);
+        return res;
+    }
+
+    bool hasAny() const { return mark_cache || index_mark_cache || primary_index_cache; }
+
+    /// Save marks in memory if prewarm is enabled to avoid re-reading marks file.
+    bool saveMarksInCache() const { return mark_cache || index_mark_cache; }
+
+    /// Save primary index in memory if cache is disabled or is enabled with prewarm
+    /// to avoid re-reading primary index file. In the latter case the index is moved
+    /// into the cache after the part is committed (see `IMergeTreeDataPart::moveIndexToCache`).
+    bool savePrimaryIndexInMemory() const { return !used_primary_index_cache || primary_index_cache; }
+};
+
+}

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -774,6 +774,9 @@ void IMergeTreeDataPart::unloadIndex()
 {
     std::scoped_lock lock(index_mutex);
     index.reset();
+
+    for (const auto & [_, projection] : projection_parts)
+        projection->unloadIndex();
 }
 
 bool IMergeTreeDataPart::isIndexLoaded() const

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -710,18 +710,29 @@ IMergeTreeDataPart::IndexPtr IMergeTreeDataPart::loadIndexToCache(PrimaryIndexCa
     return index_cache.getOrSet(key, callback);
 }
 
-void IMergeTreeDataPart::moveIndexToCache(PrimaryIndexCache & index_cache)
+void IMergeTreeDataPart::moveIndexToCache(const CachesToPrewarm & prewarm_caches)
 {
-    std::scoped_lock lock(index_mutex);
-    if (!index)
-        return;
+    if (!prewarm_caches.primary_index_cache)
+    {
+        /// Without prewarm the index is not saved in memory during write,
+        /// otherwise it would stay in the part, unevictable.
+        chassert(!prewarm_caches.used_primary_index_cache || !isIndexLoaded());
+    }
+    else
+    {
+        std::scoped_lock lock(index_mutex);
+        if (index)
+        {
+            auto key = PrimaryIndexCache::hash(getDataPartStorage().getDiskName() + ":" + getRelativePathOfActivePart());
+            prewarm_caches.primary_index_cache->set(key, std::const_pointer_cast<Index>(index));
+            index.reset();
+        }
+    }
 
-    auto key = PrimaryIndexCache::hash(getDataPartStorage().getDiskName() + ":" + getRelativePathOfActivePart());
-    index_cache.set(key, std::const_pointer_cast<Index>(index));
-    index.reset();
-
+    /// The projections' writers save their indexes under the same decision, even when
+    /// this part's own index is absent (e.g. a mutation that rebuilds only a projection).
     for (const auto & [_, projection] : projection_parts)
-        projection->moveIndexToCache(index_cache);
+        projection->moveIndexToCache(prewarm_caches);
 }
 
 void IMergeTreeDataPart::removeIndexFromCache(PrimaryIndexCache * index_cache) const

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -11,6 +11,7 @@
 #include <Storages/ColumnsDescription.h>
 #include <Storages/IStorage_fwd.h>
 #include <Storages/MergeTree/AlterConversions.h>
+#include <Storages/MergeTree/CachesToPrewarm.h>
 #include <Storages/MergeTree/ColumnsSubstreams.h>
 #include <Storages/MergeTree/SharedPartColumns.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
@@ -488,7 +489,10 @@ public:
 
     IndexPtr getIndex() const;
     IndexPtr loadIndexToCache(PrimaryIndexCache & index_cache) const;
-    void moveIndexToCache(PrimaryIndexCache & index_cache);
+    /// Moves the in-memory index into the cache; call after commit under the final part
+    /// name (the cache key is the part path). Without prewarm asserts that there is no
+    /// in-memory index while the cache is enabled (it would stay there, unevictable).
+    void moveIndexToCache(const CachesToPrewarm & prewarm_caches);
     void removeIndexFromCache(PrimaryIndexCache * index_cache) const;
 
     /// Returns nullptr if pk isn't loaded

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
@@ -106,7 +106,7 @@ IMergeTreeDataPartWriter::IMergeTreeDataPartWriter(
 
 std::optional<Columns> IMergeTreeDataPartWriter::releaseIndexColumns()
 {
-    if (!settings.save_primary_index_in_memory)
+    if (!settings.caches_to_prewarm.savePrimaryIndexInMemory())
         return {};
 
     /// The memory for index was allocated without thread memory tracker.

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -74,7 +74,7 @@ public:
     PlainMarksByName releaseCachedIndexMarks();
 
     MergeTreeIndexGranularityPtr getIndexGranularity() const { return index_granularity; }
-    MergeTreeWriterSettings getWriterSettings() const { return settings; }
+    const MergeTreeWriterSettings & getWriterSettings() const { return settings; }
 
     virtual const Block & getColumnsSample() const = 0;
 

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.h
@@ -41,7 +41,7 @@ public:
         return writer->getIndexGranularity();
     }
 
-    MergeTreeWriterSettings getWriterSettings() const
+    const MergeTreeWriterSettings & getWriterSettings() const
     {
         return writer->getWriterSettings();
     }

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -407,6 +407,8 @@ bool MergeFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrite
     part = merge_task->getFuture().get();
     auto cached_marks = merge_task->releaseCachedMarks();
     auto cached_index_marks = merge_task->releaseCachedIndexMarks();
+    /// Copy: the task is reset before the post-commit use.
+    auto prewarm_caches = merge_task->getCachesToPrewarm();
     projections_merge_time = merge_task->grabProjectionsMergeTime();
 #if CLICKHOUSE_CLOUD
     part->is_prewarmed = true;
@@ -494,18 +496,13 @@ bool MergeFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrite
     finish_callback = [storage_ptr = &storage]() { storage_ptr->merge_selecting_task->schedule(); };
     ProfileEvents::increment(ProfileEvents::ReplicatedPartMerges);
 
-    auto prewarm_caches = storage.getCachesToPrewarm(part->getBytesUncompressedOnDisk());
-
     if (prewarm_caches.mark_cache)
         addMarksToCache(*part, cached_marks, prewarm_caches.mark_cache.get());
 
     if (prewarm_caches.index_mark_cache)
         addMarksToCache(*part, cached_index_marks, prewarm_caches.index_mark_cache.get());
 
-    /// Move index to cache and reset it here because we need
-    /// a correct part name after rename for a key of cache entry.
-    if (prewarm_caches.primary_index_cache)
-        part->moveIndexToCache(*prewarm_caches.primary_index_cache);
+    part->moveIndexToCache(prewarm_caches);
 
     write_part_log({});
     StorageReplicatedMergeTree::incrementMergedPartsProfileEvent(part->getType());

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -163,7 +163,7 @@ void MergePlainMergeTreeTask::finish()
     ThreadFuzzer::maybeInjectSleep();
     ThreadFuzzer::maybeInjectMemoryLimitException();
 
-    auto prewarm_caches = storage.getCachesToPrewarm(new_part->getBytesUncompressedOnDisk());
+    auto prewarm_caches = merge_task->getCachesToPrewarm();
 
     if (prewarm_caches.mark_cache)
     {
@@ -177,12 +177,7 @@ void MergePlainMergeTreeTask::finish()
         addMarksToCache(*new_part, index_marks, prewarm_caches.index_mark_cache.get());
     }
 
-    if (prewarm_caches.primary_index_cache)
-    {
-        /// Move index to cache and reset it here because we need
-        /// a correct part name after rename for a key of cache entry.
-        new_part->moveIndexToCache(*prewarm_caches.primary_index_cache);
-    }
+    new_part->moveIndexToCache(prewarm_caches);
 
     write_part_log({});
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1114,6 +1114,8 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         global_ctx->new_data_part->index_granularity_info,
         ctx->blocks_are_granules_size);
 
+    global_ctx->caches_to_prewarm = global_ctx->data->getCachesToPrewarm(ctx->sum_uncompressed_bytes_upper_bound);
+
     global_ctx->to = std::make_shared<MergedBlockOutputStream>(
         global_ctx->new_data_part,
         merge_tree_settings,
@@ -1123,7 +1125,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         global_ctx->compression_codec,
         std::move(index_granularity_ptr),
         global_ctx->txn ? global_ctx->txn->tid : Tx::NonTransactionalTID,
-        global_ctx->merge_list_element_ptr->total_size_bytes_compressed,
+        global_ctx->caches_to_prewarm,
         /*reset_columns=*/true,
         ctx->blocks_are_granules_size,
         global_ctx->context->getWriteSettings(),
@@ -1528,7 +1530,8 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::calculateProjectionForBlock(
     {
         auto result = projection_squash_plan.getHeader()->cloneWithColumns(squashed_chunk.detachColumns());
         auto tmp_part = MergeTreeDataWriter::writeTempProjectionPart(
-            *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context);
+            *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context,
+            global_ctx->caches_to_prewarm);
 
         tmp_part->finalize();
         tmp_part->part->getDataPartStorage().commitTransaction();
@@ -1570,7 +1573,8 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::finalizeProjections() const
         {
             auto result = projection_squash_plan.getHeader()->cloneWithColumns(squashed_chunk.detachColumns());
             auto temp_part = MergeTreeDataWriter::writeTempProjectionPart(
-                *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context);
+                *global_ctx->data, result, projection, global_ctx->new_data_part.get(), ++ctx->projection_block_num, global_ctx->context,
+                global_ctx->caches_to_prewarm);
 
             temp_part->finalize();
             temp_part->part->getDataPartStorage().commitTransaction();
@@ -2065,7 +2069,7 @@ void MergeTask::VerticalMergeStage::prepareVerticalMergeForOneColumn() const
         column_pipepline.indexes_to_recalc,
         global_ctx->compression_codec,
         global_ctx->to->getIndexGranularity(),
-        global_ctx->merge_list_element_ptr->total_size_bytes_uncompressed,
+        global_ctx->caches_to_prewarm,
         &global_ctx->written_offset_substreams,
         /*try_adaptive_codec=*/ !global_ctx->is_explicit_recompression,
         global_ctx->to->getSkipIndicesPackedWriter());
@@ -3098,10 +3102,10 @@ void MergeTask::addBuildTextIndexesStep(QueryPlan & plan, const IMergeTreeDataPa
         global_ctx->new_data_part,
         global_ctx->new_data_part->index_granularity_info.mark_type.adaptive,
         /*rewrite_primary_key=*/ false,
-        /*save_marks_in_cache=*/ false,
-        /*save_primary_index_in_memory=*/ false,
+        /// Writes text index files, not column data; nothing to prewarm.
+        CachesToPrewarm::noPrewarm(global_ctx->data->getPrimaryIndexCache()),
         /*blocks_are_granules_size=*/ false,
-        /*try_adaptive_codec=*/ false); /// Writes text index files, not column data.
+        /*try_adaptive_codec=*/ false);
 
     auto transform = std::make_shared<BuildTextIndexTransform>(
         plan.getCurrentHeader(),

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -174,6 +174,11 @@ public:
         return std::move(global_ctx->projections_merge_time);
     }
 
+    const CachesToPrewarm & getCachesToPrewarm() const
+    {
+        return global_ctx->caches_to_prewarm;
+    }
+
     bool execute();
 
     void cancel() noexcept;
@@ -285,6 +290,8 @@ private:
         WrittenOffsetSubstreams written_offset_substreams{};
         PlainMarksByName cached_marks;
         PlainMarksByName cached_index_marks;
+        /// Computed once per merge; also used to move the index and marks into the caches after commit.
+        CachesToPrewarm caches_to_prewarm;
 
         MergeTreeTransactionPtr txn;
         String suffix;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6231,6 +6231,8 @@ void MergeTreeData::changeSettings(
         UInt64 has_refresh_statistics_interval_changed
             = (*storage_settings.get())[MergeTreeSetting::refresh_statistics_interval].totalSeconds() != (*copy)[MergeTreeSetting::refresh_statistics_interval].totalSeconds();
 
+        bool has_primary_index_cache_been_enabled = getPrimaryIndexCache(*copy) && !getPrimaryIndexCache(*storage_settings.get());
+
         storage_settings.set(std::move(copy));
 
         /// Route the new `StorageInMemoryMetadata` clone (and the deeper clone produced by
@@ -6259,6 +6261,10 @@ void MergeTreeData::changeSettings(
         {
             startStatisticsCache();
         }
+
+        /// Indexes loaded in parts while the cache was disabled would stay there, unevictable.
+        if (has_primary_index_cache_been_enabled)
+            unloadPrimaryKeys();
     }
 }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3645,19 +3645,23 @@ void MergeTreeData::stopOutdatedAndUnexpectedDataPartsLoadingTask()
 
 PrimaryIndexCachePtr MergeTreeData::getPrimaryIndexCache() const
 {
-    bool use_primary_key_cache = (*getSettings())[MergeTreeSetting::use_primary_key_cache];
-    bool primary_key_lazy_load = (*getSettings())[MergeTreeSetting::primary_key_lazy_load];
+    return getPrimaryIndexCache(*getSettings());
+}
 
-    if (!use_primary_key_cache || !primary_key_lazy_load)
+PrimaryIndexCachePtr MergeTreeData::getPrimaryIndexCache(const MergeTreeSettings & settings) const
+{
+    if (!settings[MergeTreeSetting::use_primary_key_cache] || !settings[MergeTreeSetting::primary_key_lazy_load])
         return nullptr;
 
     return getContext()->getPrimaryIndexCache();
 }
 
-MergeTreeData::CachesToPrewarm MergeTreeData::getCachesToPrewarm(size_t part_uncompressed_bytes) const
+CachesToPrewarm MergeTreeData::getCachesToPrewarm(size_t part_uncompressed_bytes) const
 {
     CachesToPrewarm result;
     auto settings = getSettings();
+
+    result.used_primary_index_cache = getPrimaryIndexCache(*settings);
 
     /// Do not load data to caches for small parts because
     /// they will be likely replaced by merge immediately.
@@ -3667,7 +3671,7 @@ MergeTreeData::CachesToPrewarm MergeTreeData::getCachesToPrewarm(size_t part_unc
         return result;
 
     if ((*settings)[MergeTreeSetting::prewarm_primary_key_cache])
-        result.primary_index_cache = getPrimaryIndexCache();
+        result.primary_index_cache = result.used_primary_index_cache;
 
     if ((*settings)[MergeTreeSetting::prewarm_mark_cache])
     {
@@ -12606,7 +12610,8 @@ std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> MergeTreeData::createE
         compression_codec,
         std::make_shared<MergeTreeIndexGranularityAdaptive>(),
         txn ? txn->tid : Tx::NonTransactionalTID,
-        /*part_uncompressed_bytes=*/0,
+        /// Nothing to prewarm for an empty part.
+        CachesToPrewarm::noPrewarm(getPrimaryIndexCache()),
         /*reset_columns_=*/false,
         /*blocks_are_granules_size=*/false,
         /*write_settings=*/{},

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -15,6 +15,7 @@
 #include <Processors/Merges/Algorithms/Graphite.h>
 #include <Storages/MergeTree/ActiveDataPartSet.h>
 #include <Storages/MergeTree/BackgroundJobsAssignee.h>
+#include <Storages/MergeTree/CachesToPrewarm.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreePartInfo.h>
 #include <Storages/MergeTree/MergeTreeMutationStatus.h>
@@ -709,15 +710,7 @@ public:
 
     /// Returns a pointer to primary index cache if it is enabled.
     PrimaryIndexCachePtr getPrimaryIndexCache() const;
-
-    struct CachesToPrewarm
-    {
-        MarkCachePtr mark_cache;
-        MarkCachePtr index_mark_cache;
-        PrimaryIndexCachePtr primary_index_cache;
-
-        bool hasAny() const { return mark_cache || index_mark_cache || primary_index_cache; }
-    };
+    PrimaryIndexCachePtr getPrimaryIndexCache(const MergeTreeSettings & settings) const;
 
     /// Returns caches that should be prewarmed for a part of the given size.
     CachesToPrewarm getCachesToPrewarm(size_t part_uncompressed_bytes) const;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -72,7 +72,7 @@ MergeTreeDataPartWriterCompact::MergeTreeDataPartWriterCompact(
         marks_source_hashing = std::make_unique<HashingWriteBuffer>(*marks_compressor);
     }
 
-    if (settings.save_marks_in_cache)
+    if (settings.caches_to_prewarm.saveMarksInCache())
         cached_marks[MergeTreeDataPartCompact::DATA_FILE_NAME] = std::make_unique<MarksInCompressedFile::PlainArray>();
 }
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -215,7 +215,7 @@ void MergeTreeDataPartWriterOnDisk::initSkipIndices()
             index_streams[index_substream.type] = stream.get();
             skip_indices_streams_holders.push_back(std::move(stream));
 
-            if (settings.save_marks_in_cache)
+            if (settings.caches_to_prewarm.saveMarksInCache())
                 cached_index_marks.emplace(on_disk_stream_name, std::make_unique<MarksInCompressedFile::PlainArray>());
         }
 
@@ -234,7 +234,7 @@ void MergeTreeDataPartWriterOnDisk::calculateAndSerializePrimaryIndexRow(const B
         const auto & column = index_block.getByPosition(i).column;
         index_serializations[i]->serializeBinary(*column, row, index_stream, {});
 
-        if (settings.save_primary_index_in_memory)
+        if (settings.caches_to_prewarm.savePrimaryIndexInMemory())
             index_columns[i]->insertFrom(*column, row);
     }
 }
@@ -257,7 +257,7 @@ void MergeTreeDataPartWriterOnDisk::calculateAndSerializePrimaryIndex(const Bloc
         /// memory-tracker blocker above.
         ScopedJemallocThreadArena mergetree_arena_scope(JemallocMergeTreeArena::getArenaIndex());
 
-        if (settings.save_primary_index_in_memory && index_columns.empty())
+        if (settings.caches_to_prewarm.savePrimaryIndexInMemory() && index_columns.empty())
         {
             index_columns = primary_index_block.cloneEmptyColumns();
         }

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -116,7 +116,7 @@ MergeTreeDataPartWriterWide::MergeTreeDataPartWriterWide(
             default_codec_, settings_, std::move(index_granularity_),
             written_offset_substreams_)
 {
-    if (settings.save_marks_in_cache)
+    if (settings.caches_to_prewarm.saveMarksInCache())
     {
         auto columns_vec = getColumnsToPrewarmMarks(*storage_settings, columns_list);
         columns_to_load_marks = NameSet(columns_vec.begin(), columns_vec.end());

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -467,31 +467,26 @@ void MergeTreeTemporaryPart::finalize()
 /// because a correct path is required for the keys of caches.
 void MergeTreeTemporaryPart::prewarmCaches()
 {
-    auto prewarm_caches = part->storage.getCachesToPrewarm(part->getBytesUncompressedOnDisk());
-
-    if (prewarm_caches.mark_cache)
+    if (caches_to_prewarm.mark_cache)
     {
         for (const auto & stream : streams)
         {
             auto marks = stream.stream->releaseCachedMarks();
-            addMarksToCache(*part, marks, prewarm_caches.mark_cache.get());
+            addMarksToCache(*part, marks, caches_to_prewarm.mark_cache.get());
         }
     }
 
-    if (prewarm_caches.index_mark_cache)
+    if (caches_to_prewarm.index_mark_cache)
     {
         for (const auto & stream : streams)
         {
             auto index_marks = stream.stream->releaseCachedIndexMarks();
-            addMarksToCache(*part, index_marks, prewarm_caches.index_mark_cache.get());
+            addMarksToCache(*part, index_marks, caches_to_prewarm.index_mark_cache.get());
         }
     }
 
-    if (prewarm_caches.primary_index_cache)
-    {
-        /// Index was already set during writing. Now move it to cache.
-        part->moveIndexToCache(*prewarm_caches.primary_index_cache);
-    }
+    /// Index was already set during writing. Now move it to cache.
+    part->moveIndexToCache(caches_to_prewarm);
 }
 
 BlocksWithPartition MergeTreeDataWriter::splitBlockIntoParts(
@@ -1017,6 +1012,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
     IMergedBlockOutputStream::GatheredData gathered_data;
     gathered_data.statistics = std::move(statistics);
 
+    temp_part->caches_to_prewarm = data.getCachesToPrewarm(block.bytes());
+
     auto out = std::make_unique<MergedBlockOutputStream>(
         new_data_part,
         data_settings,
@@ -1026,7 +1023,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         compression_codec,
         std::move(index_granularity_ptr),
         (data.supportsTransactions() && context->getCurrentTransaction()) ? context->getCurrentTransaction()->tid : Tx::NonTransactionalTID,
-        block.bytes(),
+        temp_part->caches_to_prewarm,
         /*reset_columns=*/false,
         /*blocks_are_granules_size=*/false,
         context->getWriteSettings(),
@@ -1065,7 +1062,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
             if (projection_block.rows())
             {
                 auto proj_temp_part
-                    = writeProjectionPart(data, projection_block, projection, new_data_part.get(), /*merge_is_needed=*/false, context);
+                    = writeProjectionPart(data, projection_block, projection, new_data_part.get(), /*merge_is_needed=*/false, context, temp_part->caches_to_prewarm);
                 new_data_part->addProjectionPart(projection.name, std::move(proj_temp_part->part));
 
                 if (global_settings[Setting::finalize_projection_parts_synchronously])
@@ -1113,7 +1110,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
     const ProjectionDescription & projection,
     MergeTreeIndices indices,
     bool merge_is_needed,
-    bool try_adaptive_codec)
+    bool try_adaptive_codec,
+    const CachesToPrewarm & caches_to_prewarm)
 {
     auto temp_part = std::make_unique<MergeTreeTemporaryPart>();
     const auto & metadata_snapshot = projection.metadata;
@@ -1218,6 +1216,9 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
         new_data_part->index_granularity_info,
         /*blocks_are_granules=*/ false);
 
+    /// The parent part's decision: the projection is published (or not) together with it.
+    temp_part->caches_to_prewarm = caches_to_prewarm;
+
     auto out = std::make_unique<MergedBlockOutputStream>(
         new_data_part,
         data_settings,
@@ -1227,7 +1228,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
         compression_codec,
         std::move(index_granularity_ptr),
         Tx::NonTransactionalTID,
-        block.bytes(),
+        temp_part->caches_to_prewarm,
         /*reset_columns=*/ false,
         /*blocks_are_granules_size=*/ false,
         data.getContext()->getWriteSettings(),
@@ -1254,7 +1255,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPart(
     const ProjectionDescription & projection,
     IMergeTreeDataPart * parent_part,
     bool merge_is_needed,
-    ContextPtr context)
+    ContextPtr context,
+    const CachesToPrewarm & caches_to_prewarm)
 {
     const auto & query_settings = context->getSettingsRef();
     auto indices = collectSkipIndicesToMaterialize(
@@ -1273,7 +1275,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPart(
         projection,
         std::move(indices),
         merge_is_needed,
-        /*try_adaptive_codec=*/ false);
+        /*try_adaptive_codec=*/ false,
+        caches_to_prewarm);
 }
 
 /// This is used for projection materialization process which may contain multiple stages of
@@ -1284,7 +1287,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempProjectionPart(
     const ProjectionDescription & projection,
     IMergeTreeDataPart * parent_part,
     size_t block_num,
-    ContextPtr context)
+    ContextPtr context,
+    const CachesToPrewarm & caches_to_prewarm)
 {
     const auto & table_settings = data.getSettings();
     auto indices = collectSkipIndicesToMaterialize(
@@ -1304,7 +1308,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempProjectionPart(
         projection,
         std::move(indices),
         /*merge_is_needed=*/ true,
-        /*try_adaptive_codec=*/ true);
+        /*try_adaptive_codec=*/ true,
+        caches_to_prewarm);
 
     new_part->part->temp_projection_block_number = block_num;
     return new_part;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.h
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.h
@@ -40,6 +40,9 @@ struct MergeTreeTemporaryPart
 
     MergeTreeData::MutableDataPartPtr part;
 
+    /// Computed once per part; also used to move the index and marks into the caches after commit.
+    CachesToPrewarm caches_to_prewarm;
+
     struct Stream
     {
         std::unique_ptr<MergedBlockOutputStream> stream;
@@ -115,7 +118,8 @@ public:
         const ProjectionDescription & projection,
         IMergeTreeDataPart * parent_part,
         bool merge_is_needed,
-        ContextPtr context);
+        ContextPtr context,
+        const CachesToPrewarm & caches_to_prewarm);
 
     /// For mutation: MATERIALIZE PROJECTION.
     static MergeTreeTemporaryPartPtr writeTempProjectionPart(
@@ -124,7 +128,8 @@ public:
         const ProjectionDescription & projection,
         IMergeTreeDataPart * parent_part,
         size_t block_num,
-        ContextPtr context);
+        ContextPtr context,
+        const CachesToPrewarm & caches_to_prewarm);
 
     static Block mergeBlock(
         Block && block,
@@ -152,7 +157,8 @@ private:
         const ProjectionDescription & projection,
         MergeTreeIndices indices,
         bool merge_is_needed,
-        bool try_adaptive_codec);
+        bool try_adaptive_codec,
+        const CachesToPrewarm & caches_to_prewarm);
 
     MergeTreeData & data;
     LoggerPtr log;

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -75,8 +75,7 @@ MergeTreeWriterSettings::MergeTreeWriterSettings(
     const MergeTreeDataPartPtr & data_part,
     bool can_use_adaptive_granularity_,
     bool rewrite_primary_key_,
-    bool save_marks_in_cache_,
-    bool save_primary_index_in_memory_,
+    CachesToPrewarm caches_to_prewarm_,
     bool blocks_are_granules_size_,
     bool try_adaptive_codec_)
     : min_compress_block_size(std::min<size_t>(
@@ -92,8 +91,7 @@ MergeTreeWriterSettings::MergeTreeWriterSettings(
     , primary_key_compress_block_size(std::min<size_t>((*storage_settings)[MergeTreeSetting::primary_key_compress_block_size], MAX_COMPRESS_BLOCK_SIZE))
     , can_use_adaptive_granularity(can_use_adaptive_granularity_)
     , rewrite_primary_key(rewrite_primary_key_)
-    , save_marks_in_cache(save_marks_in_cache_)
-    , save_primary_index_in_memory(save_primary_index_in_memory_)
+    , caches_to_prewarm(std::move(caches_to_prewarm_))
     , blocks_are_granules_size(blocks_are_granules_size_)
     , query_write_settings(query_write_settings_)
     , low_cardinality_max_dictionary_size(global_settings[Setting::low_cardinality_max_dictionary_size])

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstddef>
 #include <Compression/ICompressionCodec.h>
+#include <Storages/MergeTree/CachesToPrewarm.h>
 #include <Core/MergeTreeSerializationEnums.h>
 #include <IO/ReadSettings.h>
 #include <IO/WriteSettings.h>
@@ -109,8 +110,7 @@ struct MergeTreeWriterSettings
         const MergeTreeDataPartPtr & data_part,
         bool can_use_adaptive_granularity_,
         bool rewrite_primary_key_,
-        bool save_marks_in_cache_,
-        bool save_primary_index_in_memory_,
+        CachesToPrewarm caches_to_prewarm_,
         bool blocks_are_granules_size_,
         bool try_adaptive_codec_);
 
@@ -130,8 +130,7 @@ struct MergeTreeWriterSettings
 
     bool can_use_adaptive_granularity{};
     bool rewrite_primary_key{};
-    bool save_marks_in_cache{};
-    bool save_primary_index_in_memory{};
+    CachesToPrewarm caches_to_prewarm;
     bool blocks_are_granules_size{};
     WriteSettings query_write_settings;
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -38,7 +38,7 @@ MergedBlockOutputStream::MergedBlockOutputStream(
     CompressionCodecPtr default_codec_,
     MergeTreeIndexGranularityPtr index_granularity_ptr,
     TransactionID tid,
-    size_t part_uncompressed_bytes,
+    const CachesToPrewarm & prewarm_caches,
     bool reset_columns_,
     bool blocks_are_granules_size,
     const WriteSettings & write_settings_,
@@ -49,12 +49,6 @@ MergedBlockOutputStream::MergedBlockOutputStream(
     , columns_list(columns_list_)
     , default_codec(default_codec_)
 {
-    /// Save marks in memory if prewarm is enabled to avoid re-reading marks file.
-    auto prewarm_caches = data_part->storage.getCachesToPrewarm(part_uncompressed_bytes);
-    bool save_marks_in_cache = prewarm_caches.mark_cache != nullptr || prewarm_caches.index_mark_cache != nullptr;
-    /// Save primary index in memory if cache is disabled or is enabled with prewarm to avoid re-reading primary index file.
-    bool save_primary_index_in_memory = !data_part->storage.getPrimaryIndexCache() || prewarm_caches.primary_index_cache;
-
     writer_settings = MergeTreeWriterSettings(
         data_part->storage.getContext()->getSettingsRef(),
         write_settings_,
@@ -62,8 +56,7 @@ MergedBlockOutputStream::MergedBlockOutputStream(
         data_part,
         data_part->index_granularity_info.mark_type.adaptive,
         /* rewrite_primary_key = */ true,
-        save_marks_in_cache,
-        save_primary_index_in_memory,
+        prewarm_caches,
         blocks_are_granules_size,
         try_adaptive_codec);
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -23,7 +23,7 @@ public:
         CompressionCodecPtr default_codec_,
         MergeTreeIndexGranularityPtr index_granularity_ptr,
         TransactionID tid,
-        size_t part_uncompressed_bytes,
+        const CachesToPrewarm & prewarm_caches,
         bool reset_columns_,
         bool blocks_are_granules_size,
         const WriteSettings & write_settings,

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -15,7 +15,7 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
     const MergeTreeIndices & indices_to_recalc,
     CompressionCodecPtr default_codec,
     MergeTreeIndexGranularityPtr index_granularity_ptr,
-    size_t part_uncompressed_bytes,
+    const CachesToPrewarm & prewarm_caches,
     WrittenOffsetSubstreams * written_offset_substreams,
     bool try_adaptive_codec,
     PackedFilesWriter * external_packed_skip_indices_writer)
@@ -26,12 +26,6 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
           columns_list_,
           /*reset_columns=*/true)
 {
-    /// Save marks in memory if prewarm is enabled to avoid re-reading marks file.
-    auto prewarm_caches = data_part->storage.getCachesToPrewarm(part_uncompressed_bytes);
-    bool save_marks_in_cache = prewarm_caches.mark_cache != nullptr || prewarm_caches.index_mark_cache != nullptr;
-    /// Save primary index in memory if cache is disabled or is enabled with prewarm to avoid re-reading primary index file.
-    bool save_primary_index_in_memory = !data_part->storage.getPrimaryIndexCache() || prewarm_caches.primary_index_cache;
-
     /// Granularity is never recomputed while writing only columns.
     MergeTreeWriterSettings writer_settings(
         data_part->storage.getContext()->getSettingsRef(),
@@ -40,8 +34,7 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
         data_part,
         data_part->index_granularity_info.mark_type.adaptive,
         /*rewrite_primary_key=*/ false,
-        save_marks_in_cache,
-        save_primary_index_in_memory,
+        prewarm_caches,
         /*blocks_are_granules_size=*/ false,
         try_adaptive_codec);
 

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
@@ -23,7 +23,7 @@ public:
         const MergeTreeIndices & indices_to_recalc,
         CompressionCodecPtr default_codec,
         MergeTreeIndexGranularityPtr index_granularity_ptr,
-        size_t part_uncompressed_bytes,
+        const CachesToPrewarm & prewarm_caches,
         WrittenOffsetSubstreams * written_offset_substreams,
         bool try_adaptive_codec,
         class PackedFilesWriter * external_packed_skip_indices_writer = nullptr);

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -384,6 +384,12 @@ bool MutateFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrit
 
     finish_callback = [storage_ptr = &storage]() { storage_ptr->merge_selecting_task->schedule(); };
     ProfileEvents::increment(ProfileEvents::ReplicatedPartMutations);
+
+    /// Move index to cache and reset it here because we need
+    /// a correct part name after rename for a key of cache entry.
+    if (auto index_cache = storage.getPrimaryIndexCache())
+        new_part->moveIndexToCache(*index_cache);
+
     write_part_log({});
 
     return true;

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -325,6 +325,8 @@ bool MutateFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrit
     /// LOGICAL_ERROR if the old guard is still alive. Resetting the task here
     /// releases these guards before the fallback fetch can run.
     auto hardlinked_files = mutate_task->getHardlinkedFiles();
+    /// Copy: the task is reset before the post-commit use.
+    auto prewarm_caches = mutate_task->getCachesToPrewarm();
     mutate_task->updateProfileEvents();
     mutate_task.reset();
 
@@ -385,10 +387,7 @@ bool MutateFromLogEntryTask::finalize(ReplicatedMergeMutateTaskBase::PartLogWrit
     finish_callback = [storage_ptr = &storage]() { storage_ptr->merge_selecting_task->schedule(); };
     ProfileEvents::increment(ProfileEvents::ReplicatedPartMutations);
 
-    /// Move index to cache and reset it here because we need
-    /// a correct part name after rename for a key of cache entry.
-    if (auto index_cache = storage.getPrimaryIndexCache())
-        new_part->moveIndexToCache(*index_cache);
+    new_part->moveIndexToCache(prewarm_caches);
 
     write_part_log({});
 

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -135,10 +135,7 @@ bool MutatePlainMergeTreeTask::executeStep()
                     transaction.commit(lock);
                 }
 
-                /// Move index to cache and reset it here because we need
-                /// a correct part name after rename for a key of cache entry.
-                if (auto index_cache = storage.getPrimaryIndexCache())
-                    new_part->moveIndexToCache(*index_cache);
+                new_part->moveIndexToCache(mutate_task->getCachesToPrewarm());
 
                 mutate_task->updateProfileEvents();
 

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -135,6 +135,11 @@ bool MutatePlainMergeTreeTask::executeStep()
                     transaction.commit(lock);
                 }
 
+                /// Move index to cache and reset it here because we need
+                /// a correct part name after rename for a key of cache entry.
+                if (auto index_cache = storage.getPrimaryIndexCache())
+                    new_part->moveIndexToCache(*index_cache);
+
                 mutate_task->updateProfileEvents();
 
                 /// Write the part log entry before reporting the mutation as done, otherwise a

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1558,6 +1558,7 @@ static void finalizeMutatedPart(
     const CompressionCodecPtr & codec,
     ContextPtr context,
     StorageMetadataPtr metadata_snapshot,
+    const CachesToPrewarm & caches_to_prewarm,
     bool sync)
 {
     std::vector<std::unique_ptr<WriteBufferFromFileBase>> written_files;
@@ -1709,7 +1710,7 @@ static void finalizeMutatedPart(
     }
 
     /// It's important to set index after index granularity.
-    if (!new_data_part->storage.getPrimaryIndexCache())
+    if (caches_to_prewarm.savePrimaryIndexInMemory())
         new_data_part->setIndex(*source_part->getIndex());
 
     /// Load rest projections which are hardlinked
@@ -1836,6 +1837,9 @@ struct MutationContext
     ExecuteTTLType execute_ttl_type{ExecuteTTLType::NONE};
 
     MergeTreeTransactionPtr txn;
+
+    /// Computed once per mutation; also used to move the index into the cache after commit.
+    CachesToPrewarm caches_to_prewarm;
 
     HardlinkedFiles hardlinked_files;
 
@@ -2190,7 +2194,8 @@ void PartMergerWriter::writeTempProjectionPart(size_t projection_idx, Chunk chun
         projection,
         ctx->new_data_part.get(),
         ++projection_block_num,
-        ctx->context);
+        ctx->context,
+        ctx->caches_to_prewarm);
 
     tmp_part->finalize();
     tmp_part->part->getDataPartStorage().commitTransaction();
@@ -2741,7 +2746,7 @@ private:
             ctx->compression_codec,
             std::move(index_granularity_ptr),
             ctx->txn ? ctx->txn->tid : Tx::NonTransactionalTID,
-            ctx->source_part->getBytesUncompressedOnDisk(),
+            ctx->caches_to_prewarm,
             /*reset_columns=*/ true,
             /*blocks_are_granules_size=*/ false,
             ctx->context->getWriteSettings(),
@@ -3109,7 +3114,7 @@ private:
                 std::vector<MergeTreeIndexPtr>(ctx->indices_to_recalc.begin(), ctx->indices_to_recalc.end()),
                 ctx->compression_codec,
                 ctx->source_part->index_granularity,
-                ctx->source_part->getBytesUncompressedOnDisk(),
+                ctx->caches_to_prewarm,
                 static_cast<WrittenOffsetSubstreams *>(nullptr),
                 /*try_adaptive_codec=*/ !is_explicit_recompression);
 
@@ -3230,6 +3235,7 @@ private:
             ctx->compression_codec,
             ctx->context,
             ctx->metadata_snapshot,
+            ctx->caches_to_prewarm,
             ctx->need_sync);
     }
 
@@ -3370,6 +3376,12 @@ MutateTask::MutateTask(
     ctx->storage_columns = metadata_snapshot_->getColumns().getAllPhysical();
     ctx->txn = txn;
     ctx->source_part = ctx->future_part->parts[0];
+    ctx->caches_to_prewarm = ctx->data->getCachesToPrewarm(ctx->source_part->getBytesUncompressedOnDisk());
+}
+
+const CachesToPrewarm & MutateTask::getCachesToPrewarm() const
+{
+    return ctx->caches_to_prewarm;
 }
 
 

--- a/src/Storages/MergeTree/MutateTask.h
+++ b/src/Storages/MergeTree/MutateTask.h
@@ -51,6 +51,8 @@ public:
 
     const HardlinkedFiles & getHardlinkedFiles() const;
 
+    const CachesToPrewarm & getCachesToPrewarm() const;
+
 private:
 
     bool prepare();

--- a/tests/queries/0_stateless/04926_primary_index_cache_mutation.reference
+++ b/tests/queries/0_stateless/04926_primary_index_cache_mutation.reference
@@ -1,0 +1,17 @@
+-- { echoOn }
+INSERT INTO t_pk_cache_mutation SELECT number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation' AND active;
+0
+ALTER TABLE t_pk_cache_mutation DELETE WHERE a % 2 = 0 SETTINGS mutations_sync = 1;
+SELECT count() FROM t_pk_cache_mutation WHERE a > 100 AND a < 1000;
+450
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation' AND active;
+0
+INSERT INTO t_pk_cache_mutation_rmt SELECT number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation_rmt' AND active;
+0
+ALTER TABLE t_pk_cache_mutation_rmt DELETE WHERE a % 2 = 0 SETTINGS mutations_sync = 2;
+SELECT count() FROM t_pk_cache_mutation_rmt WHERE a > 100 AND a < 1000;
+450
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation_rmt' AND active;
+0

--- a/tests/queries/0_stateless/04926_primary_index_cache_mutation.sql
+++ b/tests/queries/0_stateless/04926_primary_index_cache_mutation.sql
@@ -1,0 +1,31 @@
+-- Tags: zookeeper
+
+DROP TABLE IF EXISTS t_pk_cache_mutation;
+DROP TABLE IF EXISTS t_pk_cache_mutation_rmt;
+
+-- A mutation rewriting the whole part must leave the new part's primary index
+-- in the cache (evictable), not pinned in memory.
+
+CREATE TABLE t_pk_cache_mutation (a UInt64, b UInt64)
+ENGINE = MergeTree ORDER BY a
+SETTINGS use_primary_key_cache = 1, prewarm_primary_key_cache = 1, index_granularity = 64;
+
+CREATE TABLE t_pk_cache_mutation_rmt (a UInt64, b UInt64)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_pk_cache_mutation_rmt', '1') ORDER BY a
+SETTINGS use_primary_key_cache = 1, prewarm_primary_key_cache = 1, index_granularity = 64;
+
+-- { echoOn }
+INSERT INTO t_pk_cache_mutation SELECT number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation' AND active;
+ALTER TABLE t_pk_cache_mutation DELETE WHERE a % 2 = 0 SETTINGS mutations_sync = 1;
+SELECT count() FROM t_pk_cache_mutation WHERE a > 100 AND a < 1000;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation' AND active;
+INSERT INTO t_pk_cache_mutation_rmt SELECT number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation_rmt' AND active;
+ALTER TABLE t_pk_cache_mutation_rmt DELETE WHERE a % 2 = 0 SETTINGS mutations_sync = 2;
+SELECT count() FROM t_pk_cache_mutation_rmt WHERE a > 100 AND a < 1000;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_mutation_rmt' AND active;
+-- { echoOff }
+
+DROP TABLE t_pk_cache_mutation;
+DROP TABLE t_pk_cache_mutation_rmt;

--- a/tests/queries/0_stateless/04927_primary_index_cache_prewarm_size_gate.reference
+++ b/tests/queries/0_stateless/04927_primary_index_cache_prewarm_size_gate.reference
@@ -1,0 +1,17 @@
+-- { echoOn }
+INSERT INTO t_pk_cache_size_gate SELECT number, number, number FROM numbers(100000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_size_gate' AND active;
+0
+ALTER TABLE t_pk_cache_size_gate DELETE WHERE a >= 10000 SETTINGS mutations_sync = 1;
+SELECT count() FROM t_pk_cache_size_gate;
+10000
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_size_gate' AND active;
+0
+INSERT INTO t_pk_cache_size_gate_merge SELECT number, number, number FROM numbers(30000);
+INSERT INTO t_pk_cache_size_gate_merge SELECT number, number, number FROM numbers(30000);
+SYSTEM START MERGES t_pk_cache_size_gate_merge;
+OPTIMIZE TABLE t_pk_cache_size_gate_merge FINAL;
+SELECT count() FROM t_pk_cache_size_gate_merge;
+30000
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_size_gate_merge' AND active;
+0

--- a/tests/queries/0_stateless/04927_primary_index_cache_prewarm_size_gate.sql
+++ b/tests/queries/0_stateless/04927_primary_index_cache_prewarm_size_gate.sql
@@ -1,0 +1,33 @@
+-- A part that shrinks below `min_bytes_to_prewarm_caches` between the write-time
+-- estimate and the actual committed size (rows deleted by a mutation, duplicates
+-- collapsed by a merge) must not keep its primary index pinned in memory.
+
+DROP TABLE IF EXISTS t_pk_cache_size_gate;
+DROP TABLE IF EXISTS t_pk_cache_size_gate_merge;
+
+CREATE TABLE t_pk_cache_size_gate (a UInt64, b UInt64, c UInt64)
+ENGINE = MergeTree ORDER BY a
+SETTINGS use_primary_key_cache = 1, prewarm_primary_key_cache = 1, min_bytes_to_prewarm_caches = 1000000;
+
+CREATE TABLE t_pk_cache_size_gate_merge (a UInt64, b UInt64, c UInt64)
+ENGINE = ReplacingMergeTree ORDER BY a
+SETTINGS use_primary_key_cache = 1, prewarm_primary_key_cache = 1, min_bytes_to_prewarm_caches = 1000000;
+
+SYSTEM STOP MERGES t_pk_cache_size_gate_merge;
+
+-- { echoOn }
+INSERT INTO t_pk_cache_size_gate SELECT number, number, number FROM numbers(100000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_size_gate' AND active;
+ALTER TABLE t_pk_cache_size_gate DELETE WHERE a >= 10000 SETTINGS mutations_sync = 1;
+SELECT count() FROM t_pk_cache_size_gate;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_size_gate' AND active;
+INSERT INTO t_pk_cache_size_gate_merge SELECT number, number, number FROM numbers(30000);
+INSERT INTO t_pk_cache_size_gate_merge SELECT number, number, number FROM numbers(30000);
+SYSTEM START MERGES t_pk_cache_size_gate_merge;
+OPTIMIZE TABLE t_pk_cache_size_gate_merge FINAL;
+SELECT count() FROM t_pk_cache_size_gate_merge;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_size_gate_merge' AND active;
+-- { echoOff }
+
+DROP TABLE t_pk_cache_size_gate;
+DROP TABLE t_pk_cache_size_gate_merge;

--- a/tests/queries/0_stateless/04928_unload_primary_key_on_enabling_cache.reference
+++ b/tests/queries/0_stateless/04928_unload_primary_key_on_enabling_cache.reference
@@ -1,0 +1,11 @@
+-- { echoOn }
+INSERT INTO t_pk_unload_on_enable SELECT number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) > 0 FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_unload_on_enable' AND active;
+1
+ALTER TABLE t_pk_unload_on_enable MODIFY SETTING use_primary_key_cache = 1;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_unload_on_enable' AND active;
+0
+SELECT count() FROM t_pk_unload_on_enable WHERE a > 100 AND a < 1000;
+899
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_unload_on_enable' AND active;
+0

--- a/tests/queries/0_stateless/04928_unload_primary_key_on_enabling_cache.sql
+++ b/tests/queries/0_stateless/04928_unload_primary_key_on_enabling_cache.sql
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS t_pk_unload_on_enable;
+
+-- Enabling the cache must unload indexes loaded in parts while it was disabled.
+
+CREATE TABLE t_pk_unload_on_enable (a UInt64, b UInt64)
+ENGINE = MergeTree ORDER BY a
+SETTINGS use_primary_key_cache = 0, index_granularity = 64;
+
+-- { echoOn }
+INSERT INTO t_pk_unload_on_enable SELECT number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) > 0 FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_unload_on_enable' AND active;
+ALTER TABLE t_pk_unload_on_enable MODIFY SETTING use_primary_key_cache = 1;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_unload_on_enable' AND active;
+SELECT count() FROM t_pk_unload_on_enable WHERE a > 100 AND a < 1000;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_unload_on_enable' AND active;
+-- { echoOff }
+
+DROP TABLE t_pk_unload_on_enable;

--- a/tests/queries/0_stateless/04929_primary_index_cache_projections.reference
+++ b/tests/queries/0_stateless/04929_primary_index_cache_projections.reference
@@ -1,0 +1,19 @@
+-- { echoOn }
+INSERT INTO t_pk_cache_proj SELECT number, number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+0
+SELECT sum(primary_key_bytes_in_memory) FROM system.projection_parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+0
+ALTER TABLE t_pk_cache_proj UPDATE b = b + 1 WHERE 1 SETTINGS mutations_sync = 1;
+SELECT count() FROM t_pk_cache_proj WHERE b > 100;
+9900
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+0
+SELECT sum(primary_key_bytes_in_memory) FROM system.projection_parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+0
+INSERT INTO t_pk_cache_proj SELECT number, number, number FROM numbers(10000);
+OPTIMIZE TABLE t_pk_cache_proj FINAL;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+0
+SELECT sum(primary_key_bytes_in_memory) FROM system.projection_parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+0

--- a/tests/queries/0_stateless/04929_primary_index_cache_projections.sql
+++ b/tests/queries/0_stateless/04929_primary_index_cache_projections.sql
@@ -1,0 +1,25 @@
+-- Projection parts must not keep their primary indexes pinned in memory either,
+-- including a mutation that rebuilds only the projection (the main part's index
+-- is hardlinked and stays absent).
+
+DROP TABLE IF EXISTS t_pk_cache_proj;
+
+CREATE TABLE t_pk_cache_proj (a UInt64, b UInt64, c UInt64, PROJECTION p (SELECT b, a ORDER BY b))
+ENGINE = MergeTree ORDER BY a
+SETTINGS use_primary_key_cache = 1, prewarm_primary_key_cache = 1, index_granularity = 64;
+
+-- { echoOn }
+INSERT INTO t_pk_cache_proj SELECT number, number, number FROM numbers(10000);
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+SELECT sum(primary_key_bytes_in_memory) FROM system.projection_parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+ALTER TABLE t_pk_cache_proj UPDATE b = b + 1 WHERE 1 SETTINGS mutations_sync = 1;
+SELECT count() FROM t_pk_cache_proj WHERE b > 100;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+SELECT sum(primary_key_bytes_in_memory) FROM system.projection_parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+INSERT INTO t_pk_cache_proj SELECT number, number, number FROM numbers(10000);
+OPTIMIZE TABLE t_pk_cache_proj FINAL;
+SELECT sum(primary_key_bytes_in_memory) FROM system.parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+SELECT sum(primary_key_bytes_in_memory) FROM system.projection_parts WHERE database = currentDatabase() AND table = 't_pk_cache_proj' AND active;
+-- { echoOff }
+
+DROP TABLE t_pk_cache_proj;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix primary indexes of newly written parts staying in memory forever (unevictable, visible as `primary_key_bytes_in_memory` in `system.parts`) when the primary index cache is enabled (`use_primary_key_cache`). This affected parts produced by mutations, projections rebuilt by mutations, and parts that shrank below `min_bytes_to_prewarm_caches` during a merge or mutation. Additionally, enabling `use_primary_key_cache` via `ALTER TABLE ... MODIFY SETTING` now unloads primary indexes (including projections) that were loaded while the cache was disabled, without requiring `SYSTEM UNLOAD PRIMARY KEY` or a server restart.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115314&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115314](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115314+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
