### PR TITLE
Refactor the skip index reader code path around `IMergeTreeDataPartInfoForReader`

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -4986,7 +4986,9 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, [[ma
 
         for (const auto & ranges : result.parts_with_ranges)
         {
-            read_ranges.emplace(ranges.part_index_in_query, ranges);
+            read_ranges.emplace(
+                ranges.part_index_in_query,
+                SkipIndexReadInput{ranges.ranges, ranges.read_hints, ranges.part_starting_offset_in_query});
             part_remaining_marks.emplace(ranges.part_index_in_query, ranges.getMarksCount());
         }
 

--- a/src/Processors/QueryPlan/ReadFromTextIndexCount.cpp
+++ b/src/Processors/QueryPlan/ReadFromTextIndexCount.cpp
@@ -8,8 +8,10 @@
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Storages/MergeTree/AlterConversions.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/IPostingListCodec.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/MergeTreeIndexReader.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Storages/MergeTree/TextIndexAnalyzer.h>
@@ -106,11 +108,13 @@ UInt64 computeCountForPart(
     /// A single-token count is answered directly from the dictionary cardinality, so posting list is never read.
     const bool single_token = resolved.query->getTokens().size() == 1;
 
+    LoadedMergeTreeDataPartInfoForReader part_info(data_part, std::make_shared<AlterConversions>());
+
     MergeTreeIndexDeserializationState state
     {
         .version = index_format.version,
         .condition = resolved.condition.get(),
-        .part = *data_part,
+        .part_info = part_info,
         .index = *index.index,
         .readable_ranges = nullptr,
         .skip_postings_deserialization = single_token,

--- a/src/Storages/MergeTree/ConditionTemplate.cpp
+++ b/src/Storages/MergeTree/ConditionTemplate.cpp
@@ -11,6 +11,7 @@
 #include <DataTypes/DataTypeUUID.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
+#include <Storages/MergeTree/IMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/KeyCondition.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreePartition.h>
@@ -194,11 +195,22 @@ const Cond & ConditionTemplate<Cond>::generateUnsubstituted() const
 template <typename Cond>
 const Cond & ConditionTemplate<Cond>::generateForPart(const MergeTreeDataPartPtr & part) const
 {
-    if (skip_folding || !dag || !dag->predicate || part->isProjectionPart())
+    return generateForPartition(part->partition, part->info.getPartitionId(), part->isProjectionPart());
+}
+
+template <typename Cond>
+const Cond & ConditionTemplate<Cond>::generateForPart(const IMergeTreeDataPartInfoForReader & part_info) const
+{
+    return generateForPartition(part_info.getPartition(), part_info.getPartInfo().getPartitionId(), part_info.isProjectionPart());
+}
+
+template <typename Cond>
+const Cond & ConditionTemplate<Cond>::generateForPartition(
+    const MergeTreePartition & partition, const String & partition_id, bool is_projection_part) const
+{
+    if (skip_folding || !dag || !dag->predicate || is_projection_part)
         return generateUnsubstituted();
 
-    const auto & partition = part->partition;
-    const auto & partition_id = part->info.getPartitionId();
     if (const auto * cond = lookupSubstituted(partition_id))
         return *cond;
 

--- a/src/Storages/MergeTree/ConditionTemplate.h
+++ b/src/Storages/MergeTree/ConditionTemplate.h
@@ -16,6 +16,7 @@ namespace DB
 
 class IMergeTreeDataPart;
 using MergeTreeDataPartPtr = std::shared_ptr<const IMergeTreeDataPart>;
+class IMergeTreeDataPartInfoForReader;
 
 /// Class that represents Key or Index condition template.
 template <class Cond>
@@ -28,6 +29,8 @@ class ConditionTemplate
 
     const Cond * lookupSubstituted(const std::string & cache_key) const;
     const Cond & setSubstituted(const std::string & cache_key, Cond && cond) const;
+
+    const Cond & generateForPartition(const MergeTreePartition & partition, const String & partition_id, bool is_projection_part) const;
 
 public:
     using Factory = std::function<Cond(const ActionsDAG *, const ActionsDAG::Node *)>;
@@ -47,6 +50,7 @@ public:
 
     /// Substitutes partition level constants into dag.
     const Cond & generateForPart(const MergeTreeDataPartPtr & part) const;
+    const Cond & generateForPart(const IMergeTreeDataPartInfoForReader & part_info) const;
 
     /// Maps already generated condition using provided lambda.
     void addTransformation(Transformer transformer_);

--- a/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
@@ -20,6 +20,7 @@ using MergeTreeSettingsPtr = std::shared_ptr<const MergeTreeSettings>;
 
 class MergeTreeIndexGranularity;
 struct MergeTreePartInfo;
+struct MergeTreePartition;
 struct MergeTreeDataPartChecksums;
 struct MergeTreeIndexGranularityInfo;
 
@@ -58,6 +59,8 @@ public:
     virtual const String & getPartName() const = 0;
 
     virtual const MergeTreePartInfo & getPartInfo() const = 0;
+
+    virtual const MergeTreePartition & getPartition() const = 0;
 
     virtual Int64 getMinDataVersion() const = 0;
 

--- a/src/Storages/MergeTree/IndexReadRangesRefiner.cpp
+++ b/src/Storages/MergeTree/IndexReadRangesRefiner.cpp
@@ -27,13 +27,15 @@ MarkRanges IndexReadRangesRefiner::refine(const MergeTreeReadTaskInfo & info, Ma
     if (!has_projection_ranges && !index_build_context->index_reader_pool->hasSkipIndexReader())
         return ranges;
 
-    const auto & part_ranges = index_build_context->read_ranges.at(info.part_index_in_query);
+    const auto & skip_index_input = index_build_context->read_ranges.at(info.part_index_in_query);
     const auto & all_updated_columns = info.alter_conversions->getAllUpdatedColumns();
 
     /// Built once per part; concurrent callers wait on a shared future inside the pool.
     /// The same cached result is later reused by MergeTreeReaderIndex for granule- and row-level filtering.
     auto index_read_result = index_build_context->index_reader_pool->getOrBuildIndexReadResult(
-        part_ranges,
+        info.part_index_in_query,
+        info.data_part_info,
+        skip_index_input,
         has_projection_ranges ? projection_it->second : RangesInDataParts{},
         metadata_snapshot,
         all_updated_columns);
@@ -71,7 +73,7 @@ MarkRanges IndexReadRangesRefiner::refine(const MergeTreeReadTaskInfo & info, Ma
         bool part_fully_processed = remaining_marks.fetch_sub(dropped_marks, std::memory_order_acq_rel) == dropped_marks;
 
         if (part_fully_processed)
-            index_build_context->index_reader_pool->clear(info.data_part_info->getDataPart());
+            index_build_context->index_reader_pool->clear(info.part_index_in_query);
     }
 
     return result;

--- a/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
@@ -30,6 +30,8 @@ public:
 
     const MergeTreePartInfo & getPartInfo() const override { return data_part->info; }
 
+    const MergeTreePartition & getPartition() const override { return data_part->partition; }
+
     Int64 getMinDataVersion() const override
     {
         return data_part->info.isPatch()

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -11,6 +11,7 @@
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndexReader.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/MergeTreeIndexMinMax.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/GenericExclusionSearch.h>
@@ -1122,6 +1123,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
 #endif
                 );
                 const auto & all_updated_columns = alter_conversions->getAllUpdatedColumns();
+                auto part_info_for_reader = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(ranges.data_part, alter_conversions);
 
                 auto can_use_index = [&](const MergeTreeIndexPtr & index) -> std::expected<void, PreformattedMessage>
                 {
@@ -1173,7 +1175,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
                             index_and_condition.index,
                             index_and_condition.condition_template->generateForPart(ranges.data_part),
                             key_condition_rpn_template->generateForPart(ranges.data_part),
-                            ranges.data_part,
+                            part_info_for_reader,
                             ranges.ranges,
                             ranges.read_hints,
                             reader_settings,
@@ -1194,7 +1196,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
 
                 if (use_skip_indexes_for_disjunctions && key_condition_rpn_template != nullptr)
                 {
-                    ranges.ranges = mergePartialResultsForDisjunctions(ranges.data_part,
+                    ranges.ranges = mergePartialResultsForDisjunctions(*part_info_for_reader,
                                         ranges.ranges, key_condition_rpn_template->generateForPart(ranges.data_part),
                                         partial_eval_results, reader_settings, log);
 
@@ -1209,7 +1211,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
             {
                 ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::FilteringMarksWithSecondaryKeysMicroseconds);
 
-                auto min_max_granules = getMinMaxIndexGranules(ranges.data_part,
+                auto min_max_granules = getMinMaxIndexGranules(std::make_shared<LoadedMergeTreeDataPartInfoForReader>(ranges.data_part, std::make_shared<AlterConversions>()),
                                             skip_indexes.skip_index_for_top_k_filtering,
                                             ranges.ranges,
                                             top_k_filter_info->direction,
@@ -1937,7 +1939,33 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
     const Settings & settings,
     LoggerPtr log)
 {
-    const auto & part = part_with_ranges.data_part;
+    return markRangesFromPKRange(
+        part_with_ranges.data_part,
+        part_with_ranges.ranges,
+        part_with_ranges.part_starting_offset_in_query,
+        metadata_snapshot,
+        key_condition,
+        part_offset_condition,
+        total_offset_condition,
+        exact_ranges,
+        pk_to_minmax_slot,
+        settings,
+        log);
+}
+
+MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
+    const MergeTreeData::DataPartPtr & part,
+    const MarkRanges & part_ranges,
+    size_t part_starting_offset_in_query,
+    const StorageMetadataPtr & metadata_snapshot,
+    const KeyCondition & key_condition,
+    const KeyCondition * part_offset_condition,
+    const KeyCondition * total_offset_condition,
+    MarkRanges * exact_ranges,
+    const std::vector<std::optional<size_t>> * pk_to_minmax_slot,
+    const Settings & settings,
+    LoggerPtr log)
+{
     MarkRanges res;
 
     size_t marks_count = part->index_granularity->getMarksCount();
@@ -1950,7 +1978,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
 
     /// If index is not used.
     if (!key_condition_useful && !part_offset_condition_useful && !total_offset_condition_useful)
-        return part_with_ranges.ranges;
+        return part_ranges;
 
     /// If conditions are relaxed, don't fill exact ranges.
     if (key_condition.isRelaxed() || (part_offset_condition && part_offset_condition->isRelaxed())
@@ -2314,8 +2342,8 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                 return BoolMask(false, true);
             }
 
-            part_offset_left[0] = begin + part_with_ranges.part_starting_offset_in_query;
-            part_offset_right[0] = end + part_with_ranges.part_starting_offset_in_query;
+            part_offset_left[0] = begin + part_starting_offset_in_query;
+            part_offset_right[0] = end + part_starting_offset_in_query;
             return total_offset_condition->checkInRange(
                 1, part_offset_left.data(), part_offset_right.data(), part_offset_types, initial_mask);
         };
@@ -2360,7 +2388,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
         };
 
         auto search_result = genericExclusionSearch(
-            part_with_ranges.ranges,
+            part_ranges,
             [&](const MarkRange & mark_range) { return check_in_range(mark_range, BoolMask()); },
             search_settings,
             exact_ranges != nullptr);
@@ -2393,7 +2421,7 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
 
         size_t steps = 0;
 
-        for (const auto & part_range : part_with_ranges.ranges)
+        for (const auto & part_range : part_ranges)
         {
             MarkRange result_range{};
 
@@ -2528,7 +2556,7 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
     MergeTreeIndexPtr index_helper,
     MergeTreeIndexConditionPtr condition,
     const std::optional<KeyCondition> & key_condition_rpn_template,
-    MergeTreeData::DataPartPtr part,
+    const MergeTreeDataPartInfoForReaderPtr & part_info,
     const MarkRanges & ranges,
     const RangesInDataPartReadHints & in_read_hints,
     const MergeTreeReaderSettings & reader_settings,
@@ -2539,10 +2567,10 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
     PartialDisjunctionResult & partial_disjunction_result,
     LoggerPtr log)
 {
-    if (!index_helper->getDeserializedFormat(*part, index_helper->getFileName()))
+    if (!index_helper->getDeserializedFormat(*part_info, index_helper->getFileName()))
     {
         LOG_DEBUG(log, "File for index {} does not exist ({}.*). Skipping it.", backQuote(index_helper->index.name),
-            (fs::path(part->getDataPartStorage().getFullPath()) / index_helper->getFileName()).string());
+            (fs::path(part_info->getDataPartStorage()->getFullPath()) / index_helper->getFileName()).string());
         return {ranges, in_read_hints};
     }
 
@@ -2550,13 +2578,15 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
     bool bulk_filtering = reader_settings.secondary_indices_enable_bulk_filtering && index_helper->supportsBulkFiltering() && !use_skip_indexes_for_disjunctions;
 
     auto skip_index_granularity = index_helper->index.granularity;
-    size_t marks_count = part->index_granularity->getMarksCountWithoutFinal();
+    const auto & index_granularity = part_info->getIndexGranularity();
+    size_t marks_count = index_granularity.getMarksCountWithoutFinal();
 
+    const auto & index_granularity_info = part_info->getIndexGranularityInfo();
     const size_t min_marks_for_seek = roundRowsOrBytesToMarks(
         reader_settings.merge_tree_min_rows_for_seek,
         reader_settings.merge_tree_min_bytes_for_seek,
-        part->index_granularity_info.fixed_index_granularity,
-        part->index_granularity_info.index_granularity_bytes);
+        index_granularity_info.fixed_index_granularity,
+        index_granularity_info.index_granularity_bytes);
 
     /// The vector similarity index can only be used if the PK did not prune some ranges within the part.
     /// (the vector index is built on the entire part).
@@ -2576,8 +2606,8 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
     }
 
     MergeTreeIndexReader reader(
-        index_helper, part,
-        part->index_granularity->getMarksCountForSkipIndex(skip_index_granularity),
+        index_helper, part_info,
+        index_granularity.getMarksCountForSkipIndex(skip_index_granularity),
         index_ranges,
         mark_cache,
         uncompressed_cache,
@@ -2626,8 +2656,8 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
 
         auto may_be_true_on_range = [&](size_t mark_begin, size_t mark_end, auto && disjunction_result_fn) -> bool
         {
-            size_t row_begin = part->index_granularity->getMarkStartingRow(mark_begin);
-            size_t row_end = part->index_granularity->getMarkStartingRow(mark_end);
+            size_t row_begin = index_granularity.getMarkStartingRow(mark_begin);
+            size_t row_end = index_granularity.getMarkStartingRow(mark_end);
 
             if (row_begin == row_end)
                 return false;
@@ -2685,7 +2715,7 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
             LOG_TRACE(
                 log,
                 "Used generic exclusion search over text index for part {} with {} steps{}",
-                part->name,
+                part_info->getPartName(),
                 search_result.num_steps,
                 search_result.reached_step_limit ? " (step limit reached, remaining ranges were accepted without further splitting)" : "");
         }
@@ -2794,7 +2824,7 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
                         if (!accumulated_results->distances.has_value())
                             accumulated_results->distances.emplace();
 
-                        const size_t first_row_in_index_granule = part->index_granularity->getMarkStartingRow(index_mark * skip_index_granularity);
+                        const size_t first_row_in_index_granule = index_granularity.getMarkStartingRow(index_mark * skip_index_granularity);
                         for (size_t result_pos = 0; result_pos < vector_search_results.rows.size(); ++result_pos)
                         {
                             accumulated_results->rows.push_back(first_row_in_index_granule + vector_search_results.rows[result_pos]);
@@ -2804,7 +2834,7 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
 
                     for (auto row : rows)
                     {
-                        size_t num_marks = part->index_granularity->countMarksForRows(index_mark * skip_index_granularity, row);
+                        size_t num_marks = index_granularity.countMarksForRows(index_mark * skip_index_granularity, row);
 
                         MarkRange data_range(
                             std::max(ranges[i].begin, (index_mark * skip_index_granularity) + num_marks),
@@ -2906,7 +2936,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::selectPartsToRead(
 
 /// Read and return index granules from a minmax index.
 MergeTreeIndexBulkGranulesMinMaxPtr MergeTreeDataSelectExecutor::getMinMaxIndexGranules(
-    MergeTreeData::DataPartPtr part,
+    const MergeTreeDataPartInfoForReaderPtr & part_info,
     MergeTreeIndexPtr skip_index_minmax,
     const MarkRanges & ranges,
     int direction,
@@ -2916,13 +2946,14 @@ MergeTreeIndexBulkGranulesMinMaxPtr MergeTreeDataSelectExecutor::getMinMaxIndexG
     UncompressedCache * uncompressed_cache,
     VectorSimilarityIndexCache * vector_similarity_index_cache)
 {
-    if (!skip_index_minmax->getDeserializedFormat(*part, skip_index_minmax->getFileName()))
+    if (!skip_index_minmax->getDeserializedFormat(*part_info, skip_index_minmax->getFileName()))
     {
         return nullptr;
     }
 
     auto skip_index_granularity = skip_index_minmax->index.granularity;
-    auto part_marks_count = part->index_granularity->getMarksCountWithoutFinal();
+    const auto & index_granularity = part_info->getIndexGranularity();
+    auto part_marks_count = index_granularity.getMarksCountWithoutFinal();
 
     MarkRanges index_ranges;
     for (const auto & range : ranges)
@@ -2935,8 +2966,8 @@ MergeTreeIndexBulkGranulesMinMaxPtr MergeTreeDataSelectExecutor::getMinMaxIndexG
 
     MergeTreeIndexReader reader(
             skip_index_minmax,
-            part,
-            part->index_granularity->getMarksCountForSkipIndex(skip_index_granularity),
+            part_info,
+            index_granularity.getMarksCountForSkipIndex(skip_index_granularity),
             index_ranges,
             mark_cache,
             uncompressed_cache,
@@ -2966,7 +2997,7 @@ MergeTreeIndexBulkGranulesMinMaxPtr MergeTreeDataSelectExecutor::getMinMaxIndexG
 /// rpn_template_for_eval_result is a "template" only. Hence the code
 /// below only processes 5 specific RPNElement types.
 MarkRanges MergeTreeDataSelectExecutor::mergePartialResultsForDisjunctions(
-    MergeTreeData::DataPartPtr part,
+    const IMergeTreeDataPartInfoForReader & part_info,
     const MarkRanges & ranges,
     const KeyCondition & rpn_template_for_eval_result,
     const PartialDisjunctionResult & partial_eval_results,
@@ -2978,13 +3009,14 @@ MarkRanges MergeTreeDataSelectExecutor::mergePartialResultsForDisjunctions(
     auto rpn_template_for_eval_result_string = rpn_template_for_eval_result.toString();
 
     LOG_DEBUG(log, "Entered mergePartialResultsForDisjunctions for part {}, rpn = {}",
-              part->name, rpn_template_for_eval_result_string);
+              part_info.getPartName(), rpn_template_for_eval_result_string);
 
+    const auto & index_granularity_info = part_info.getIndexGranularityInfo();
     const size_t min_marks_for_seek = roundRowsOrBytesToMarks(
                 reader_settings.merge_tree_min_rows_for_seek,
                 reader_settings.merge_tree_min_bytes_for_seek,
-                part->index_granularity_info.fixed_index_granularity,
-                part->index_granularity_info.index_granularity_bytes);
+                index_granularity_info.fixed_index_granularity,
+                index_granularity_info.index_granularity_bytes);
 
     /// Evaluate the RPN over all the ranges.
     auto rpn = rpn_template_for_eval_result.getRPN();

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.h
@@ -86,6 +86,19 @@ public:
         bool use_query_condition_cache = true) const;
 
     static MarkRanges markRangesFromPKRange(
+        const MergeTreeData::DataPartPtr & part,
+        const MarkRanges & part_ranges,
+        size_t part_starting_offset_in_query,
+        const StorageMetadataPtr & metadata_snapshot,
+        const KeyCondition & key_condition,
+        const KeyCondition * part_offset_condition,
+        const KeyCondition * total_offset_condition,
+        MarkRanges * exact_ranges,
+        const std::vector<std::optional<size_t>> * pk_to_minmax_slot,
+        const Settings & settings,
+        LoggerPtr log);
+
+    static MarkRanges markRangesFromPKRange(
         const RangesInDataPart & part_with_ranges,
         const StorageMetadataPtr & metadata_snapshot,
         const KeyCondition & key_condition,
@@ -100,7 +113,7 @@ public:
         MergeTreeIndexPtr index_helper,
         MergeTreeIndexConditionPtr condition,
         const std::optional<KeyCondition> & key_condition_rpn_template,
-        MergeTreeData::DataPartPtr part,
+        const MergeTreeDataPartInfoForReaderPtr & part_info,
         const MarkRanges & ranges,
         const RangesInDataPartReadHints & in_read_hints,
         const MergeTreeReaderSettings & reader_settings,
@@ -112,7 +125,7 @@ public:
         LoggerPtr log);
 
     static MergeTreeIndexBulkGranulesMinMaxPtr getMinMaxIndexGranules(
-        MergeTreeData::DataPartPtr part,
+        const MergeTreeDataPartInfoForReaderPtr & part_info,
         MergeTreeIndexPtr skip_index_minmax,
         const MarkRanges & ranges,
         int direction,
@@ -294,7 +307,7 @@ public:
     static RowLimits getRowLimits(const Settings & settings, const SelectQueryInfo & query_info);
 
     static MarkRanges mergePartialResultsForDisjunctions(
-        MergeTreeData::DataPartPtr part,
+        const IMergeTreeDataPartInfoForReader & part_info,
         const MarkRanges & ranges,
         const KeyCondition & rpn_template_for_eval_result,
         const PartialDisjunctionResult & partial_eval_results,

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -254,15 +254,13 @@ MergeTreeIndexConditionPtr MergeTreeIndexMinMax::createIndexCondition(
     return std::make_shared<MergeTreeIndexConditionMinMax>(index, filter_dag, context);
 }
 
-MergeTreeIndexFormat MergeTreeIndexMinMax::getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
+MergeTreeIndexFormat MergeTreeIndexMinMax::getPhysicalFormat(
+    const MergeTreeDataPartChecksums & checksums, const IDataPartStorage & storage, const std::string & relative_path_prefix) const
 {
-    const auto & checksums = part_info.getChecksums();
-    const auto * storage = part_info.getDataPartStorage().get();
-
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx2", storage))
+    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx2", &storage))
         return {2, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx2"}}};
 
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
+    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", &storage))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
 
     return {0 /* unknown */, {}};

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -254,12 +254,15 @@ MergeTreeIndexConditionPtr MergeTreeIndexMinMax::createIndexCondition(
     return std::make_shared<MergeTreeIndexConditionMinMax>(index, filter_dag, context);
 }
 
-MergeTreeIndexFormat MergeTreeIndexMinMax::getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
+MergeTreeIndexFormat MergeTreeIndexMinMax::getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
 {
-    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx2", &part.getDataPartStorage()))
+    const auto & checksums = part_info.getChecksums();
+    const auto * storage = part_info.getDataPartStorage().get();
+
+    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx2", storage))
         return {2, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx2"}}};
 
-    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx", &part.getDataPartStorage()))
+    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
 
     return {0 /* unknown */, {}};

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.h
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.h
@@ -88,7 +88,10 @@ public:
 
     MergeTreeIndexSubstreams getSubstreams() const override { return {{MergeTreeIndexSubstream::Type::Regular, "", ".idx2"}}; }
     using IMergeTreeIndex::getPhysicalFormat;
-    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const override;
+    MergeTreeIndexFormat getPhysicalFormat(
+        const MergeTreeDataPartChecksums & checksums,
+        const IDataPartStorage & storage,
+        const std::string & relative_path_prefix) const override;
     MergeTreeIndexSubstreams getAllSubstreamsInPart(
         const MergeTreeDataPartChecksums & checksums,
         const std::string & path_prefix,

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.h
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.h
@@ -87,7 +87,8 @@ public:
         const ActionsDAG::Node * predicate, ContextPtr context) const override;
 
     MergeTreeIndexSubstreams getSubstreams() const override { return {{MergeTreeIndexSubstream::Type::Regular, "", ".idx2"}}; }
-    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const override;
+    using IMergeTreeIndex::getPhysicalFormat;
+    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const override;
     MergeTreeIndexSubstreams getAllSubstreamsInPart(
         const MergeTreeDataPartChecksums & checksums,
         const std::string & path_prefix,

--- a/src/Storages/MergeTree/MergeTreeIndexReadResultPool.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReadResultPool.cpp
@@ -30,6 +30,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int LOGICAL_ERROR;
     extern const int MEMORY_LIMIT_EXCEEDED;
 }
 
@@ -74,18 +75,22 @@ bool MergeTreeSkipIndexReader::hasRuntimeFilters() const
     return dynamic_predicate_builder && (prune_primary_key || !dynamic_skip_indexes.empty());
 }
 
-SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & part, const StorageMetadataPtr & metadata_snapshot, const NameSet & all_updated_columns)
+SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(
+    const MergeTreeDataPartInfoForReaderPtr & part_info,
+    const SkipIndexReadInput & input,
+    const StorageMetadataPtr & metadata_snapshot,
+    const NameSet & all_updated_columns)
 {
     CurrentMetrics::Increment metric(CurrentMetrics::FilteringMarksWithSecondaryKeys);
 
-    auto ranges = part.ranges;
+    auto ranges = input.ranges;
     [[maybe_unused]] size_t total_granules = ranges.getNumberOfMarks();
 
     IndexGranulesMap index_granules;
 
     MergeTreeDataSelectExecutor::PartialDisjunctionResult partial_eval_results;
     if (use_for_disjunctions)
-        partial_eval_results.resize(part.data_part->index_granularity->getMarksCountWithoutFinal() * MergeTreeDataSelectExecutor::MAX_BITS_FOR_PARTIAL_DISJUNCTION_RESULT, true);
+        partial_eval_results.resize(part_info->getIndexGranularity().getMarksCountWithoutFinal() * MergeTreeDataSelectExecutor::MAX_BITS_FOR_PARTIAL_DISJUNCTION_RESULT, true);
     for (const auto & index_and_condition : skip_indexes.useful_indices)
     {
         if (is_cancelled)
@@ -98,17 +103,17 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
 
         if (auto result = MergeTreeDataSelectExecutor::canUseIndex(index_and_condition.index, metadata_snapshot, all_updated_columns); !result)
         {
-            LOG_TRACE(log, "Cannot use skip index for part {}. Reason: {}", part.data_part->name, result.error().text);
+            LOG_TRACE(log, "Cannot use skip index for part {}. Reason: {}", part_info->getPartName(), result.error().text);
             continue;
         }
 
         auto [filtered_ranges, filtered_hints] = MergeTreeDataSelectExecutor::filterMarksUsingIndex(
             index_and_condition.index,
-            index_and_condition.condition_template->generateForPart(part.data_part),
-            key_condition_rpn_template->generateForPart(part.data_part),
-            part.data_part,
+            index_and_condition.condition_template->generateForPart(*part_info),
+            key_condition_rpn_template->generateForPart(*part_info),
+            part_info,
             ranges,
-            part.read_hints,
+            input.read_hints,
             reader_settings,
             mark_cache.get(),
             uncompressed_cache.get(),
@@ -123,24 +128,31 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
             index_granules[name] = std::move(granule);
 
         LOG_DEBUG(log, "Index {} has dropped {}/{} granules in part {}", index_and_condition.index->index.name,
-                        (total_granules - ranges.getNumberOfMarks()), total_granules, part.data_part->name);
+                        (total_granules - ranges.getNumberOfMarks()), total_granules, part_info->getPartName());
         total_granules = ranges.getNumberOfMarks();
     }
 
     if (use_for_disjunctions)
     {
         ranges = MergeTreeDataSelectExecutor::mergePartialResultsForDisjunctions(
-                            part.data_part, ranges, key_condition_rpn_template->generateForPart(part.data_part),
+                            *part_info, ranges, key_condition_rpn_template->generateForPart(*part_info),
                             partial_eval_results, reader_settings, log);
 
         LOG_DEBUG(log, "Final set of granules after AND/OR processing : {} out of {} in part {}",
-                        ranges.getNumberOfMarks(), total_granules, part.data_part->name);
+                        ranges.getNumberOfMarks(), total_granules, part_info->getPartName());
         total_granules = ranges.getNumberOfMarks();
     }
 
     /// Prune with a predicate known only at read time (e.g. a JOIN's collected keys).
     if (dynamic_predicate_builder && !ranges.empty())
     {
+        /// Pruning by the primary key needs the part itself.
+        auto data_part = part_info->getDataPart();
+        if (!data_part)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Read-time dynamic predicate pruning is not supported for part {}, which has no concrete data part",
+                part_info->getPartName());
+
         ActionsDAG predicate_dag;
         const ActionsDAG::Node * predicate = dynamic_predicate_builder(predicate_dag);
         if (predicate)
@@ -153,10 +165,10 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
                 const auto & primary_key = metadata_snapshot->getPrimaryKey();
                 KeyCondition dynamic_key_condition(filter_dag, context, primary_key);
 
-                RangesInDataPart part_for_pk = part;
-                part_for_pk.ranges = ranges;
                 ranges = MergeTreeDataSelectExecutor::markRangesFromPKRange(
-                    part_for_pk,
+                    data_part,
+                    ranges,
+                    input.part_starting_offset_in_query,
                     metadata_snapshot,
                     dynamic_key_condition,
                     /*part_offset_condition=*/nullptr,
@@ -185,9 +197,9 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
                     index_helper,
                     condition,
                     /*key_condition_rpn_template=*/{},
-                    part.data_part,
+                    part_info,
                     ranges,
-                    part.read_hints,
+                    input.read_hints,
                     reader_settings,
                     mark_cache.get(),
                     uncompressed_cache.get(),
@@ -202,7 +214,7 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
             ProfileEvents::increment(ProfileEvents::RuntimeFilterGranulesConsidered, granules_before);
             ProfileEvents::increment(ProfileEvents::RuntimeFilterGranulesDropped, granules_before - granules_after);
             LOG_DEBUG(log, "Dynamic read-time predicate dropped {}/{} granules in part {}",
-                granules_before - granules_after, granules_before, part.data_part->name);
+                granules_before - granules_after, granules_before, part_info->getPartName());
         }
     }
 
@@ -217,7 +229,7 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
         return {};
 
     auto res = std::make_shared<SkipIndexReadResult>();
-    res->granules_selected.resize(part.data_part->index_granularity->getMarksCountWithoutFinal(), false);
+    res->granules_selected.resize(part_info->getIndexGranularity().getMarksCountWithoutFinal(), false);
     for (const auto & range : ranges)
     {
         for (auto i = range.begin; i < range.end; ++i)
@@ -229,7 +241,7 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
     if (skip_indexes.skip_index_for_top_k_filtering && skip_indexes.threshold_tracker)
     {
         res->min_max_index_for_top_k = MergeTreeDataSelectExecutor::getMinMaxIndexGranules(
-            part.data_part,
+            part_info,
             skip_indexes.skip_index_for_top_k_filtering,
             ranges,
             skip_indexes.threshold_tracker->getDirection(),
@@ -618,21 +630,27 @@ MergeTreeIndexReadResultPool::MergeTreeIndexReadResultPool(
 }
 
 MergeTreeIndexReadResultPtr
-MergeTreeIndexReadResultPool::getOrBuildIndexReadResult(const RangesInDataPart & part, const RangesInDataParts & projection_parts, const StorageMetadataPtr & metadata_snapshot, const NameSet & all_updated_columns)
+MergeTreeIndexReadResultPool::getOrBuildIndexReadResult(
+    size_t part_index,
+    const MergeTreeDataPartInfoForReaderPtr & part_info,
+    const SkipIndexReadInput & input,
+    const RangesInDataParts & projection_parts,
+    const StorageMetadataPtr & metadata_snapshot,
+    const NameSet & all_updated_columns)
 {
     std::unique_lock lock(index_read_result_registry_mutex);
-    auto it = index_read_result_registry.find(part.data_part.get());
+    auto it = index_read_result_registry.find(part_index);
 
     if (it == index_read_result_registry.end())
     {
-        auto promise = index_read_result_registry.emplace(part.data_part.get(), IndexReadResultEntry{}).first->second.promise;
+        auto promise = index_read_result_registry.emplace(part_index, IndexReadResultEntry{}).first->second.promise;
         lock.unlock();
         try
         {
             MergeTreeIndexReadResultPtr res;
             if (skip_index_reader)
             {
-                auto skip_index_res = skip_index_reader->read(part, metadata_snapshot, all_updated_columns);
+                auto skip_index_res = skip_index_reader->read(part_info, input, metadata_snapshot, all_updated_columns);
                 if (skip_index_res)
                 {
                     res = std::make_shared<MergeTreeIndexReadResult>();
@@ -668,10 +686,10 @@ MergeTreeIndexReadResultPool::getOrBuildIndexReadResult(const RangesInDataPart &
     }
 }
 
-void MergeTreeIndexReadResultPool::clear(const DataPartPtr & part)
+void MergeTreeIndexReadResultPool::clear(size_t part_index)
 {
     std::lock_guard lock(index_read_result_registry_mutex);
-    index_read_result_registry.erase(part.get());
+    index_read_result_registry.erase(part_index);
 }
 
 void MergeTreeIndexReadResultPool::cancel() noexcept

--- a/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
+++ b/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
@@ -4,6 +4,7 @@
 #include <Interpreters/ActionsDAG.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Storages/MergeTree/ConditionTemplate.h>
+#include <Storages/MergeTree/IMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/VectorSimilarityIndexCache.h>
 #include <Storages/MergeTree/MergeTreeIndexMinMax.h>
 #include <Storages/MergeTree/KeyCondition.h>
@@ -16,6 +17,8 @@ namespace DB
 
 class IMergeTreeDataPart;
 using DataPartPtr = std::shared_ptr<const IMergeTreeDataPart>;
+
+struct SkipIndexReadInput;
 
 struct SkipIndexReadResult
 {
@@ -52,7 +55,11 @@ public:
         ContextPtr context_,
         LoggerPtr log_);
 
-    SkipIndexReadResultPtr read(const RangesInDataPart & part, const StorageMetadataPtr & metadata_snapshot, const NameSet & all_updated_columns);
+    SkipIndexReadResultPtr read(
+        const MergeTreeDataPartInfoForReaderPtr & part_info,
+        const SkipIndexReadInput & input,
+        const StorageMetadataPtr & metadata_snapshot,
+        const NameSet & all_updated_columns);
 
     /// Whether `read` prunes by JOIN runtime filters. It snapshots them once per part, fail-open,
     /// so its result must not be built before the build side has published the filters.
@@ -232,12 +239,18 @@ public:
     /// Lazily constructs and caches the MergeTreeIndexReadResult for a given data part. If it is already being built by
     /// another thread, waits for its result. Throws if the builder fails.
     ///
-    /// This map uses raw pointer of data part as key because it is unique and stable for the lifetime of the part.
-    MergeTreeIndexReadResultPtr getOrBuildIndexReadResult(const RangesInDataPart & part, const RangesInDataParts & projection_parts, const StorageMetadataPtr & metadata_snapshot, const NameSet & all_updated_columns);
+    /// This map is keyed by `part_index_in_query`, which is unique and stable for the query.
+    MergeTreeIndexReadResultPtr getOrBuildIndexReadResult(
+        size_t part_index,
+        const MergeTreeDataPartInfoForReaderPtr & part_info,
+        const SkipIndexReadInput & input,
+        const RangesInDataParts & projection_parts,
+        const StorageMetadataPtr & metadata_snapshot,
+        const NameSet & all_updated_columns);
 
     /// Cleans up the cached MergeTreeIndexReadResult for a given part if it exists.
     /// Should be called when the last task for the part has finished.
-    void clear(const DataPartPtr & part);
+    void clear(size_t part_index);
 
     /// Whether index read results may include a skip index part (for any part of the query).
     bool hasSkipIndexReader() const { return skip_index_reader != nullptr; }
@@ -252,7 +265,7 @@ private:
     MergeTreeProjectionIndexReaderPtr projection_index_reader;
 
     /// Stores MergeTreeIndexReadResult instances per part to avoid redundant construction.
-    std::unordered_map<const IMergeTreeDataPart *, IndexReadResultEntry> index_read_result_registry;
+    std::unordered_map<size_t, IndexReadResultEntry> index_read_result_registry;
     SharedMutex index_read_result_registry_mutex;
 };
 

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -1,6 +1,7 @@
 #include <Storages/MergeTree/MergeTreeIndexReader.h>
 #include <Interpreters/Context.h>
-#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
+#include <Storages/MergeTree/MergeTreeIndexGranularityInfo.h>
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
 #include <Storages/MergeTree/VectorSimilarityIndexCache.h>
 
@@ -15,22 +16,23 @@ namespace ErrorCodes
 static std::unique_ptr<MergeTreeReaderStream> makeIndexReaderStream(
     const String & stream_name,
     const String & extension,
-    MergeTreeData::DataPartPtr part,
+    const MergeTreeDataPartInfoForReaderPtr & data_part_info,
     size_t marks_count,
     const MarkRanges & all_mark_ranges,
     MarkCache * mark_cache,
     UncompressedCache * uncompressed_cache,
     MergeTreeReaderSettings settings)
 {
-    auto context = part->storage.getContext();
+    auto context = data_part_info->getContext();
     auto * load_marks_threadpool = settings.load_marks_asynchronously ? &context->getLoadMarksThreadpool() : nullptr;
 
+    const auto & index_granularity_info = data_part_info->getIndexGranularityInfo();
     auto marks_loader = std::make_shared<MergeTreeMarksLoader>(
-        std::make_shared<LoadedMergeTreeDataPartInfoForReader>(part, std::make_shared<AlterConversions>()),
+        data_part_info,
         mark_cache,
-        part->index_granularity_info.getMarksFilePath(stream_name),
+        index_granularity_info.getMarksFilePath(stream_name),
         marks_count,
-        part->index_granularity_info,
+        index_granularity_info,
         settings.save_marks_in_cache,
         settings.read_settings,
         load_marks_threadpool,
@@ -39,10 +41,22 @@ static std::unique_ptr<MergeTreeReaderStream> makeIndexReaderStream(
 
     marks_loader->startAsyncLoad();
 
-    const size_t data_file_size = part->getFileSizeOrZeroResolved(stream_name, extension);
+    /// Mirrors IMergeTreeDataPart::getFileSizeOrZeroResolved: the on-disk name (original or hashed)
+    /// comes from checksums, and a stream with no checksums entry is sized via the storage.
+    const auto & part_storage = *data_part_info->getDataPartStorage();
+    size_t data_file_size = 0;
+    if (auto actual = IMergeTreeDataPart::getStreamNameOrHash(stream_name, extension, data_part_info->getChecksums()))
+    {
+        data_file_size = data_part_info->getFileSizeOrZero(*actual + extension);
+    }
+    else
+    {
+        const String file_name = stream_name + extension;
+        data_file_size = part_storage.existsFile(file_name) ? part_storage.getFileSize(file_name) : 0;
+    }
 
     return std::make_unique<MergeTreeReaderStreamSingleColumn>(
-        part->getDataPartStoragePtr(),
+        data_part_info->getDataPartStorage(),
         stream_name,
         extension,
         marks_count,
@@ -57,7 +71,7 @@ static std::unique_ptr<MergeTreeReaderStream> makeIndexReaderStream(
 
 MergeTreeIndexReader::MergeTreeIndexReader(
     MergeTreeIndexPtr index_,
-    MergeTreeData::DataPartPtr part_,
+    MergeTreeDataPartInfoForReaderPtr data_part_info_,
     size_t marks_count_,
     const MarkRanges & all_mark_ranges_,
     MarkCache * mark_cache_,
@@ -65,7 +79,7 @@ MergeTreeIndexReader::MergeTreeIndexReader(
     VectorSimilarityIndexCache * vector_similarity_index_cache_,
     MergeTreeReaderSettings settings_)
     : index(index_)
-    , part(std::move(part_))
+    , data_part_info(std::move(data_part_info_))
     , marks_count(marks_count_)
     , all_mark_ranges(all_mark_ranges_)
     , mark_cache(mark_cache_)
@@ -82,14 +96,15 @@ void MergeTreeIndexReader::initStreamIfNeeded()
     if (!streams.empty())
         return;
 
-    auto index_format = index->getDeserializedFormat(*part, index->getFileName());
+    const auto & checksums = data_part_info->getChecksums();
+    auto index_format = index->getDeserializedFormat(*data_part_info, index->getFileName());
     auto index_name = index->getFileName();
     auto last_mark = getLastMark(all_mark_ranges);
 
     for (const auto & substream : index_format.substreams)
     {
         auto full_stream_name = index_name + substream.suffix;
-        auto stream_name_opt = DB::IMergeTreeDataPart::getStreamNameOrHash(full_stream_name, substream.extension, part->checksums);
+        auto stream_name_opt = DB::IMergeTreeDataPart::getStreamNameOrHash(full_stream_name, substream.extension, checksums);
 
         /// If the stream doesn't exist (neither original nor hashed name), use the full name
         /// and let it fail later when trying to open the file. This preserves the original error
@@ -99,7 +114,7 @@ void MergeTreeIndexReader::initStreamIfNeeded()
         auto stream = makeIndexReaderStream(
             stream_name,
             substream.extension,
-            part,
+            data_part_info,
             marks_count,
             all_mark_ranges,
             mark_cache,
@@ -135,7 +150,7 @@ void MergeTreeIndexReader::read(size_t mark, const IMergeTreeIndexCondition * co
         {
             .version = version,
             .condition = condition,
-            .part = *part,
+            .part_info = *data_part_info,
             .index = *index,
             .readable_ranges = readable_ranges,
             .skip_postings_deserialization = false,
@@ -155,9 +170,11 @@ void MergeTreeIndexReader::read(size_t mark, const IMergeTreeIndexCondition * co
     /// Such parts will be removed soon and caching them is wasteful.
     /// Also note that the cache key must use `getRelativePathOfActivePart` (not `getFullPath`) to match
     /// the key used during eviction in `IMergeTreeDataPart::removeFromVectorIndexCache`.
-    if (index->isVectorSimilarityIndex() && part->getState() == MergeTreeDataPartState::Active)
+    /// The cache key needs the part itself; without one the granule is loaded directly.
+    auto concrete_part = data_part_info->getDataPart();
+    if (index->isVectorSimilarityIndex() && concrete_part && concrete_part->getState() == MergeTreeDataPartState::Active)
     {
-        VectorSimilarityIndexCacheKey key{part->getDataPartStorage().getDiskName() + ":" + part->getRelativePathOfActivePart(),
+        VectorSimilarityIndexCacheKey key{concrete_part->getDataPartStorage().getDiskName() + ":" + concrete_part->getRelativePathOfActivePart(),
                                           index->getFileName(),
                                           mark};
 

--- a/src/Storages/MergeTree/MergeTreeIndexReader.h
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <Storages/MergeTree/MergeTreeReaderStream.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
-#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/IMergeTreeDataPartInfoForReader.h>
 #include <Formats/MarkInCompressedFile.h>
 
 
@@ -19,7 +19,7 @@ public:
 
     MergeTreeIndexReader(
         MergeTreeIndexPtr index_,
-        MergeTreeData::DataPartPtr part_,
+        MergeTreeDataPartInfoForReaderPtr data_part_info_,
         size_t marks_count_,
         const MarkRanges & all_mark_ranges_,
         MarkCache * mark_cache,
@@ -37,7 +37,7 @@ public:
 
 private:
     MergeTreeIndexPtr index;
-    MergeTreeData::DataPartPtr part;
+    MergeTreeDataPartInfoForReaderPtr data_part_info;
     size_t marks_count;
     MarkRanges all_mark_ranges;
     MarkCache * mark_cache;

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1907,12 +1907,10 @@ MergeTreeIndexSubstreams MergeTreeIndexText::getSubstreams() const
     return substreams;
 }
 
-MergeTreeIndexFormat MergeTreeIndexText::getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
+MergeTreeIndexFormat MergeTreeIndexText::getPhysicalFormat(
+    const MergeTreeDataPartChecksums & checksums, const IDataPartStorage & storage, const std::string & relative_path_prefix) const
 {
-    const auto & checksums = part_info.getChecksums();
-    const auto * storage = part_info.getDataPartStorage().get();
-
-    if (!indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
+    if (!indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", &storage))
         return {0, {}};
 
     MergeTreeIndexSubstreams substreams =
@@ -1923,7 +1921,7 @@ MergeTreeIndexFormat MergeTreeIndexText::getPhysicalFormat(const IMergeTreeDataP
     };
 
     /// V2: positions file exists on disk.
-    if (indexFileExistsInChecksums(checksums, relative_path_prefix + ".pos", ".idx", storage))
+    if (indexFileExistsInChecksums(checksums, relative_path_prefix + ".pos", ".idx", &storage))
     {
         substreams.push_back({MergeTreeIndexSubstream::Type::TextIndexPositions, ".pos", ".idx"});
         return {2, std::move(substreams)};

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1,4 +1,5 @@
 #include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/IMergeTreeDataPartInfoForReader.h>
 #include <Storages/MergeTree/TextIndexAnalyzer.h>
 
 #include <Columns/ColumnArray.h>
@@ -489,7 +490,7 @@ void MergeTreeIndexGranuleText::deserializeBinaryWithMultipleStreams(MergeTreeIn
 
     if (index_id_for_caches.empty())
     {
-        const auto & part_storage = state.part.getDataPartStorage();
+        const auto & part_storage = *state.part_info.getDataPartStorage();
         index_id_for_caches = fmt::format("{}:{}:{}", part_storage.getDiskName(), part_storage.getFullPath(), state.index.getFileName());
     }
 
@@ -499,7 +500,7 @@ void MergeTreeIndexGranuleText::deserializeBinaryWithMultipleStreams(MergeTreeIn
     /// Push the row ranges still readable after the analysis of the primary key and prior skip indexes into the analyzer.
     if (state.readable_ranges)
     {
-        const auto & index_granularity = *state.part.index_granularity;
+        const auto & index_granularity = state.part_info.getIndexGranularity();
         std::vector<RowsRange> readable_row_ranges;
         readable_row_ranges.reserve(state.readable_ranges->size());
 
@@ -526,7 +527,7 @@ void MergeTreeIndexGranuleText::deserializeBinaryWithMultipleStreams(MergeTreeIn
         analyzePostings(postings_serialization, *postings_stream, state);
 
     const auto & settings = condition_text.getContext()->getSettingsRef();
-    analyzer->analyzeCardinalitiesAndBypassHints(static_cast<double>(settings[Setting::text_index_hint_max_selectivity]), state.part.rows_count);
+    analyzer->analyzeCardinalitiesAndBypassHints(static_cast<double>(settings[Setting::text_index_hint_max_selectivity]), state.part_info.getRowCount());
 
     /// Capture the codec after the analysis — for Pre-WithCodec parts the
     /// codec may have been lazily installed while decoding an IsCompressed posting list.
@@ -548,7 +549,7 @@ void MergeTreeIndexGranuleText::analyzeDictionaryForTokens(
 
     if (tokens_to_read.empty() || analyzer->alwaysFalse())
     {
-        cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part.rows_count);
+        cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part_info.getRowCount());
         return;
     }
 
@@ -557,7 +558,7 @@ void MergeTreeIndexGranuleText::analyzeDictionaryForTokens(
         = condition_text.getContext()->getSettingsRef()[Setting::use_text_index_negative_tokens_cache];
     cardinalities_cache->sortTokens(tokens_to_read);
 
-    LOG_TEST(getLogger("MergeTreeIndexGranuleText"), "Reading tokens {} from part {}", toString(tokens_to_read), state.part.getDataPartStorage().getFullPath());
+    LOG_TEST(getLogger("MergeTreeIndexGranuleText"), "Reading tokens {} from part {}", toString(tokens_to_read), state.part_info.getDataPartStorage()->getFullPath());
 
     /// Collect blocks ids in the same order as tokens are sorted by cardinality.
     std::vector<size_t> blocks_ids_to_read;
@@ -610,7 +611,7 @@ void MergeTreeIndexGranuleText::analyzeDictionaryForTokens(
 
         if (analyzer->alwaysFalse())
         {
-            cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part.rows_count);
+            cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part_info.getRowCount());
             return;
         }
 
@@ -631,12 +632,12 @@ void MergeTreeIndexGranuleText::analyzeDictionaryForTokens(
 
         if (analyzer->alwaysFalse())
         {
-            cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part.rows_count);
+            cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part_info.getRowCount());
             return;
         }
     }
 
-    cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part.rows_count);
+    cardinalities_cache->update(analyzer->getAllTokenInfos(), analyzer->getMissingTokens(), state.part_info.getRowCount());
 }
 
 void MergeTreeIndexGranuleText::analyzeDictionaryForPatterns(
@@ -1906,9 +1907,12 @@ MergeTreeIndexSubstreams MergeTreeIndexText::getSubstreams() const
     return substreams;
 }
 
-MergeTreeIndexFormat MergeTreeIndexText::getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
+MergeTreeIndexFormat MergeTreeIndexText::getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
 {
-    if (!indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx", &part.getDataPartStorage()))
+    const auto & checksums = part_info.getChecksums();
+    const auto * storage = part_info.getDataPartStorage().get();
+
+    if (!indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
         return {0, {}};
 
     MergeTreeIndexSubstreams substreams =
@@ -1919,7 +1923,7 @@ MergeTreeIndexFormat MergeTreeIndexText::getPhysicalFormat(const IMergeTreeDataP
     };
 
     /// V2: positions file exists on disk.
-    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix + ".pos", ".idx", part.getDataPartStoragePtr().get()))
+    if (indexFileExistsInChecksums(checksums, relative_path_prefix + ".pos", ".idx", storage))
     {
         substreams.push_back({MergeTreeIndexSubstream::Type::TextIndexPositions, ".pos", ".idx"});
         return {2, std::move(substreams)};

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -552,7 +552,10 @@ public:
 
     MergeTreeIndexSubstreams getSubstreams() const override;
     using IMergeTreeIndex::getPhysicalFormat;
-    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const override;
+    MergeTreeIndexFormat getPhysicalFormat(
+        const MergeTreeDataPartChecksums & checksums,
+        const IDataPartStorage & storage,
+        const std::string & relative_path_prefix) const override;
 
     MergeTreeIndexGranulePtr createIndexGranule() const override;
     MergeTreeIndexAggregatorPtr createIndexAggregator() const override;

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -551,7 +551,8 @@ public:
     bool isTextIndex() const override { return true; }
 
     MergeTreeIndexSubstreams getSubstreams() const override;
-    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const override;
+    using IMergeTreeIndex::getPhysicalFormat;
+    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const override;
 
     MergeTreeIndexGranulePtr createIndexGranule() const override;
     MergeTreeIndexAggregatorPtr createIndexAggregator() const override;

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -14,6 +14,7 @@
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Common/escapeForFileName.h>
 #include <Common/SipHash.h>
 
@@ -204,13 +205,13 @@ bool hasSameMeaning(const IDataType & from, const IDataType & to)
 ///
 /// Returns null when the part's own list answers neither way. For a subcolumn that is a
 /// DIFFERENCE, not an unknown, so the caller must not fall back to the cached description there.
-DataTypePtr tryGetPartOwnType(const IMergeTreeDataPart & part, const NameAndTypePair & required)
+DataTypePtr tryGetPartOwnType(const IMergeTreeDataPartInfoForReader & part_info, const NameAndTypePair & required)
 {
-    if (auto own = part.getColumns().tryGetByName(required.name))
+    if (auto own = part_info.getColumns().tryGetByName(required.name))
         return own->type;
 
     if (required.isSubcolumn())
-        if (auto parent = part.getColumns().tryGetByName(required.getNameInStorage()))
+        if (auto parent = part_info.getColumns().tryGetByName(required.getNameInStorage()))
             return parent->type->tryGetSubcolumnType(required.getSubcolumnName());
 
     return nullptr;
@@ -273,15 +274,15 @@ bool isSerializationDefinedSubcolumn(
 
 }
 
-bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPart & part) const
+bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPartInfoForReader & part_info) const
 {
     const auto & metadata_columns = metadata_snapshot->getColumns();
     /// The part's OWN list, for the same reason tryGetPartOwnType uses it rather than the cache.
-    const auto & part_columns = part.getColumns();
+    const auto & part_columns = part_info.getColumns();
 
     for (const auto & [column, metadata_type] : getColumnsWithTypesRequiredForIndexCalc())
     {
-        auto part_column = part.tryGetColumn(column);
+        auto part_column = part_info.tryGetColumn(column);
 
         /// The column is in the metadata but not in this part's column list, so there is no
         /// part-side type to compare against. That does NOT mean the part holds no granule: a part
@@ -302,7 +303,7 @@ bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPart & part) cons
         /// Prefer the part's own uncached list; see tryGetPartOwnType() for why the cached one cannot
         /// answer this question. tryGetColumn() above stays the EXISTENCE test: its nullopt is what
         /// drives the refusal right above, and it is what splits a subcolumn's name.
-        auto part_type = tryGetPartOwnType(part, *part_column);
+        auto part_type = tryGetPartOwnType(part_info, *part_column);
         if (!part_type)
         {
             /// The part's own parent type does not offer this subcolumn at all (its element was
@@ -346,34 +347,55 @@ bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPart & part) cons
     return true;
 }
 
-MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
+namespace
+{
+
+LoadedMergeTreeDataPartInfoForReader makeInfoForReader(const IMergeTreeDataPart & part)
+{
+    static const AlterConversionsPtr no_alter_conversions = std::make_shared<AlterConversions>();
+    return LoadedMergeTreeDataPartInfoForReader(part.shared_from_this(), no_alter_conversions);
+}
+
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
 {
     for (const auto & [column, _] : getColumnsWithTypesRequiredForIndexCalc())
-        if (part.isSystemColumnInvalidated(column))
+        if (part_info.isSystemColumnInvalidated(column))
             return {0 /*unknown*/, {}};
 
     /// Discover what is on disk first: a part that does not have this index at all cannot
     /// mis-decode anything, and asking the type question only about parts that DO have it lets the
     /// check refuse outright when the part records no type for a required column.
-    auto format = getPhysicalFormat(part, relative_path_prefix);
+    auto format = getPhysicalFormat(part_info, relative_path_prefix);
     if (!format)
         return format;
 
     /// The part's granules were written with types the metadata no longer declares, so decoding them
     /// under the new types reads garbage. Report the index as not materialized in this part; the
     /// query then answers correctly without it.
-    if (!isPartTypeCompatible(part))
+    if (!isPartTypeCompatible(part_info))
         return {0 /*unknown*/, {}};
 
     return format;
 }
 
-MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
+MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
 {
-    if (indexFileExistsInChecksums(part.checksums, relative_path_prefix, ".idx", &part.getDataPartStorage()))
+    return getDeserializedFormat(makeInfoForReader(part), relative_path_prefix);
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
+{
+    if (indexFileExistsInChecksums(part_info.getChecksums(), relative_path_prefix, ".idx", part_info.getDataPartStorage().get()))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
 
     return {0 /*unknown*/, {}};
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
+{
+    return getPhysicalFormat(makeInfoForReader(part), relative_path_prefix);
 }
 
 MergeTreeIndexSubstreams IMergeTreeIndex::getAllSubstreamsInPart(

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -14,7 +14,6 @@
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
-#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
 #include <Common/escapeForFileName.h>
 #include <Common/SipHash.h>
 
@@ -205,13 +204,14 @@ bool hasSameMeaning(const IDataType & from, const IDataType & to)
 ///
 /// Returns null when the part's own list answers neither way. For a subcolumn that is a
 /// DIFFERENCE, not an unknown, so the caller must not fall back to the cached description there.
-DataTypePtr tryGetPartOwnType(const IMergeTreeDataPartInfoForReader & part_info, const NameAndTypePair & required)
+template <typename Part>
+DataTypePtr tryGetPartOwnType(const Part & part, const NameAndTypePair & required)
 {
-    if (auto own = part_info.getColumns().tryGetByName(required.name))
+    if (auto own = part.getColumns().tryGetByName(required.name))
         return own->type;
 
     if (required.isSubcolumn())
-        if (auto parent = part_info.getColumns().tryGetByName(required.getNameInStorage()))
+        if (auto parent = part.getColumns().tryGetByName(required.getNameInStorage()))
             return parent->type->tryGetSubcolumnType(required.getSubcolumnName());
 
     return nullptr;
@@ -274,15 +274,27 @@ bool isSerializationDefinedSubcolumn(
 
 }
 
-bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPartInfoForReader & part_info) const
+namespace
 {
-    const auto & metadata_columns = metadata_snapshot->getColumns();
-    /// The part's OWN list, for the same reason tryGetPartOwnType uses it rather than the cache.
-    const auto & part_columns = part_info.getColumns();
 
-    for (const auto & [column, metadata_type] : getColumnsWithTypesRequiredForIndexCalc())
+/// The two part representations answer these questions with the same method names, so the checks
+/// below are written once. A concrete part must not be wrapped in a part-info here: the physical
+/// format is also asked from ~IMergeTreeDataPart, where the part can no longer be shared.
+const MergeTreeDataPartChecksums & getChecksums(const IMergeTreeDataPart & part) { return part.checksums; }
+const MergeTreeDataPartChecksums & getChecksums(const IMergeTreeDataPartInfoForReader & part) { return part.getChecksums(); }
+const IDataPartStorage & getStorage(const IMergeTreeDataPart & part) { return part.getDataPartStorage(); }
+const IDataPartStorage & getStorage(const IMergeTreeDataPartInfoForReader & part) { return *part.getDataPartStorage(); }
+
+template <typename Part>
+bool isPartTypeCompatibleImpl(const IMergeTreeIndex & skip_index, const Part & part)
+{
+    const auto & metadata_columns = skip_index.metadata_snapshot->getColumns();
+    /// The part's OWN list, for the same reason tryGetPartOwnType uses it rather than the cache.
+    const auto & part_columns = part.getColumns();
+
+    for (const auto & [column, metadata_type] : skip_index.getColumnsWithTypesRequiredForIndexCalc())
     {
-        auto part_column = part_info.tryGetColumn(column);
+        auto part_column = part.tryGetColumn(column);
 
         /// The column is in the metadata but not in this part's column list, so there is no
         /// part-side type to compare against. That does NOT mean the part holds no granule: a part
@@ -303,7 +315,7 @@ bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPartInfoForReader
         /// Prefer the part's own uncached list; see tryGetPartOwnType() for why the cached one cannot
         /// answer this question. tryGetColumn() above stays the EXISTENCE test: its nullopt is what
         /// drives the refusal right above, and it is what splits a subcolumn's name.
-        auto part_type = tryGetPartOwnType(part_info, *part_column);
+        auto part_type = tryGetPartOwnType(part, *part_column);
         if (!part_type)
         {
             /// The part's own parent type does not offer this subcolumn at all (its element was
@@ -337,7 +349,7 @@ bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPartInfoForReader
         /// Date column but UInt32 once that column becomes UInt16. Recovering the expression's
         /// part-side result type would mean running the analyzer per part on the query path, so a
         /// non-trivial expression is refused on any type difference.
-        if (!index.isSimpleSingleColumnIndex())
+        if (!skip_index.index.isSimpleSingleColumnIndex())
             return false;
 
         if (!isRepresentationPreservingConversion(part_type.get(), metadata_type.get()))
@@ -347,47 +359,57 @@ bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPartInfoForReader
     return true;
 }
 
-namespace
+template <typename Part>
+MergeTreeIndexFormat getDeserializedFormatImpl(
+    const IMergeTreeIndex & skip_index, const Part & part, const std::string & relative_path_prefix)
 {
-
-LoadedMergeTreeDataPartInfoForReader makeInfoForReader(const IMergeTreeDataPart & part)
-{
-    static const AlterConversionsPtr no_alter_conversions = std::make_shared<AlterConversions>();
-    return LoadedMergeTreeDataPartInfoForReader(part.shared_from_this(), no_alter_conversions);
-}
-
-}
-
-MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
-{
-    for (const auto & [column, _] : getColumnsWithTypesRequiredForIndexCalc())
-        if (part_info.isSystemColumnInvalidated(column))
+    for (const auto & [column, _] : skip_index.getColumnsWithTypesRequiredForIndexCalc())
+        if (part.isSystemColumnInvalidated(column))
             return {0 /*unknown*/, {}};
 
     /// Discover what is on disk first: a part that does not have this index at all cannot
     /// mis-decode anything, and asking the type question only about parts that DO have it lets the
     /// check refuse outright when the part records no type for a required column.
-    auto format = getPhysicalFormat(part_info, relative_path_prefix);
+    auto format = skip_index.getPhysicalFormat(getChecksums(part), getStorage(part), relative_path_prefix);
     if (!format)
         return format;
 
     /// The part's granules were written with types the metadata no longer declares, so decoding them
     /// under the new types reads garbage. Report the index as not materialized in this part; the
     /// query then answers correctly without it.
-    if (!isPartTypeCompatible(part_info))
+    if (!isPartTypeCompatibleImpl(skip_index, part))
         return {0 /*unknown*/, {}};
 
     return format;
 }
 
-MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
-{
-    return getDeserializedFormat(makeInfoForReader(part), relative_path_prefix);
 }
 
-MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
+bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPartInfoForReader & part_info) const
 {
-    if (indexFileExistsInChecksums(part_info.getChecksums(), relative_path_prefix, ".idx", part_info.getDataPartStorage().get()))
+    return isPartTypeCompatibleImpl(*this, part_info);
+}
+
+bool IMergeTreeIndex::isPartTypeCompatible(const IMergeTreeDataPart & part) const
+{
+    return isPartTypeCompatibleImpl(*this, part);
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(
+    const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
+{
+    return getDeserializedFormatImpl(*this, part_info, relative_path_prefix);
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
+{
+    return getDeserializedFormatImpl(*this, part, relative_path_prefix);
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(
+    const MergeTreeDataPartChecksums & checksums, const IDataPartStorage & storage, const std::string & relative_path_prefix) const
+{
+    if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", &storage))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
 
     return {0 /*unknown*/, {}};
@@ -395,7 +417,13 @@ MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(const IMergeTreeDataPart
 
 MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const
 {
-    return getPhysicalFormat(makeInfoForReader(part), relative_path_prefix);
+    return getPhysicalFormat(part.checksums, part.getDataPartStorage(), relative_path_prefix);
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getPhysicalFormat(
+    const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const
+{
+    return getPhysicalFormat(part_info.getChecksums(), *part_info.getDataPartStorage(), relative_path_prefix);
 }
 
 MergeTreeIndexSubstreams IMergeTreeIndex::getAllSubstreamsInPart(

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -20,6 +20,7 @@ namespace DB
 
 class IDataPartStorage;
 class IMergeTreeDataPart;
+class IMergeTreeDataPartInfoForReader;
 
 namespace Internal
 {
@@ -283,10 +284,14 @@ struct IMergeTreeIndex
     ///
     /// @part's storage is consulted so that packed substreams (whose virtual filenames are not in
     /// checksums.txt) can still be discovered via the skp_idx.packed overlay.
-    virtual MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const;
+    ///
+    /// Both are asked through IMergeTreeDataPartInfoForReader; the concrete-part overloads wrap the part.
+    virtual MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const;
+    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const;
 
     /// Deliberately NON-virtual: the usability checks below must not be bypassable by a format
     /// override. Reimplement getPhysicalFormat() instead.
+    MergeTreeIndexFormat getDeserializedFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const;
     MergeTreeIndexFormat getDeserializedFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const;
 
     /// True when @part's recorded physical types for the columns this index requires are
@@ -298,7 +303,7 @@ struct IMergeTreeIndex
     /// IDataType::equals() and therefore erases exactly those attributes. Ask this only about a part
     /// that HAS the index on disk: a required column whose type the part does not record is refused,
     /// because such a part can still carry the index's granules.
-    bool isPartTypeCompatible(const IMergeTreeDataPart & part) const;
+    bool isPartTypeCompatible(const IMergeTreeDataPartInfoForReader & part_info) const;
 
     /// Union of every checksummed or packed on-disk version present (unlike
     /// `getDeserializedFormat`, which returns only the preferred readable layout and reports

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -285,9 +285,14 @@ struct IMergeTreeIndex
     /// @part's storage is consulted so that packed substreams (whose virtual filenames are not in
     /// checksums.txt) can still be discovered via the skp_idx.packed overlay.
     ///
-    /// Both are asked through IMergeTreeDataPartInfoForReader; the concrete-part overloads wrap the part.
-    virtual MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const;
+    /// The physical question needs only the checksums and the storage, so it is answered without a part:
+    /// it is also asked from ~IMergeTreeDataPart, where the part can no longer be shared.
+    virtual MergeTreeIndexFormat getPhysicalFormat(
+        const MergeTreeDataPartChecksums & checksums,
+        const IDataPartStorage & storage,
+        const std::string & relative_path_prefix) const;
     MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPart & part, const std::string & relative_path_prefix) const;
+    MergeTreeIndexFormat getPhysicalFormat(const IMergeTreeDataPartInfoForReader & part_info, const std::string & relative_path_prefix) const;
 
     /// Deliberately NON-virtual: the usability checks below must not be bypassable by a format
     /// override. Reimplement getPhysicalFormat() instead.
@@ -304,6 +309,7 @@ struct IMergeTreeIndex
     /// that HAS the index on disk: a required column whose type the part does not record is refused,
     /// because such a part can still carry the index's granules.
     bool isPartTypeCompatible(const IMergeTreeDataPartInfoForReader & part_info) const;
+    bool isPartTypeCompatible(const IMergeTreeDataPart & part) const;
 
     /// Union of every checksummed or packed on-disk version present (unlike
     /// `getDeserializedFormat`, which returns only the preferred readable layout and reports

--- a/src/Storages/MergeTree/MergeTreeIndicesSerialization.h
+++ b/src/Storages/MergeTree/MergeTreeIndicesSerialization.h
@@ -25,7 +25,7 @@ inline bool looksLikePackedSkipIndexFile(std::string_view name)
 }
 
 class IMergeTreeIndexCondition;
-class IMergeTreeDataPart;
+class IMergeTreeDataPartInfoForReader;
 struct IMergeTreeIndex;
 struct MarkRanges;
 
@@ -78,7 +78,7 @@ struct MergeTreeIndexDeserializationState
 {
     MergeTreeIndexVersion version;
     const IMergeTreeIndexCondition * condition;
-    const IMergeTreeDataPart & part;
+    const IMergeTreeDataPartInfoForReader & part_info;
     const IMergeTreeIndex & index;
     const MarkRanges * readable_ranges;
     bool skip_postings_deserialization;

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
@@ -86,7 +86,7 @@ MergeTreeReaderTextIndex::MergeTreeReaderTextIndex(
     {
         .version = index_format.version,
         .condition = condition_text.get(),
-        .part = *data_part,
+        .part_info = *data_part_info_for_read,
         .index = *index.index,
         .readable_ranges = nullptr,
         .skip_postings_deserialization = false,

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -126,15 +126,17 @@ MergeTreeIndexBuildContext::MergeTreeIndexBuildContext(
 
 MergeTreeIndexReadResultPtr MergeTreeIndexBuildContext::getPreparedIndexReadResult(const MergeTreeReadTask & task) const
 {
-    const auto & part_ranges = read_ranges.at(task.getInfo().part_index_in_query);
-    auto it = projection_read_ranges.find(task.getInfo().part_index_in_query);
+    const size_t part_index = task.getInfo().part_index_in_query;
+    const auto & skip_input = read_ranges.at(part_index);
+    auto it = projection_read_ranges.find(part_index);
     static RangesInDataParts empty_parts_ranges;
     const auto & projection_parts_ranges = it != projection_read_ranges.end() ? it->second : empty_parts_ranges;
-    auto & remaining_marks = part_remaining_marks.at(task.getInfo().part_index_in_query).value;
+    auto & remaining_marks = part_remaining_marks.at(part_index).value;
 
     auto storage_snapshot = task.getMainReader().getStorageSnapshot();
     const auto & all_updated_columns = task.getInfo().alter_conversions->getAllUpdatedColumns();
-    auto index_read_result = index_reader_pool->getOrBuildIndexReadResult(part_ranges, projection_parts_ranges, storage_snapshot->metadata, all_updated_columns);
+    auto index_read_result = index_reader_pool->getOrBuildIndexReadResult(
+        part_index, task.getInfo().data_part_info, skip_input, projection_parts_ranges, storage_snapshot->metadata, all_updated_columns);
 
     /// Atomically subtract the number of marks this task will read from the total remaining marks. If the
     /// remaining marks after subtraction reach zero, this is the last task for the part, and we can trigger
@@ -143,13 +145,7 @@ MergeTreeIndexReadResultPtr MergeTreeIndexBuildContext::getPreparedIndexReadResu
     bool part_last_task = remaining_marks.fetch_sub(task_marks, std::memory_order_acq_rel) == task_marks;
 
     if (part_last_task)
-    {
-        /// The index-read-result pool is a coordinator-only (skip-index-on-data-read) feature,
-        /// so the concrete part is present here. Assert it so a future misuse that routes a borrowed
-        /// part through this path fails loudly instead of passing nullptr to the pool.
-        chassert(task.getInfo().data_part_info->getDataPart());
-        index_reader_pool->clear(task.getInfo().data_part_info->getDataPart());
-    }
+        index_reader_pool->clear(part_index);
 
     return index_read_result;
 }

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -63,7 +63,14 @@ private:
     const String stream_id;
 };
 
-using RangesByIndex = std::unordered_map<size_t, RangesInDataPart>;
+/// Per-part inputs for read-time skip-index filtering; the part itself comes from the read task.
+struct SkipIndexReadInput
+{
+    MarkRanges ranges;
+    RangesInDataPartReadHints read_hints;
+    size_t part_starting_offset_in_query = 0;
+};
+using RangesByIndex = std::unordered_map<size_t, SkipIndexReadInput>;
 using ProjectionRangesByIndex = std::unordered_map<size_t, RangesInDataParts>;
 class MergeTreeIndexReadResultPool;
 using MergeTreeIndexReadResultPoolPtr = std::shared_ptr<MergeTreeIndexReadResultPool>;

--- a/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
+++ b/src/Storages/MergeTree/PatchParts/RangesInPatchParts.cpp
@@ -2,6 +2,8 @@
 #include <Storages/MergeTree/PatchParts/PatchPartsUtils.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/IMergeTreeDataPartInfoForReader.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
+#include <Storages/MergeTree/AlterConversions.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/IndicesDescription.h>
 #include <Storages/MergeTree/MergeTreeIndexMinMax.h>
@@ -410,7 +412,7 @@ MaybeMinMaxStats getPatchMinMaxStats(const DataPartPtr & patch_part, const MarkR
 
     MergeTreeIndexReader reader(
         index_ptr,
-        patch_part,
+        std::make_shared<LoadedMergeTreeDataPartInfoForReader>(patch_part, std::make_shared<AlterConversions>()),
         total_marks_without_final,
         index_mark_ranges,
         mark_cache.get(),


### PR DESCRIPTION
Refactoring

### Changelog category
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115317&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115317](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115317+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.25` (included in `26.9` and later)
<!-- ch-version-info:end -->