### PR TITLE
Add `SYMBOL_SECTIONS=gnu_debugdata` packaging mode with MiniDebugInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,26 @@ endif ()
 # Optionally split binaries and debug symbols.
 option(DISABLE_ALL_DEBUG_SYMBOLS "Disable debug symbols, independently of which build type is used" OFF)
 option(SPLIT_DEBUG_SYMBOLS "Split binaries and debug symbols" OFF)
+set(SYMBOL_SECTIONS "symtab" CACHE STRING "Symbol table format retained in packaged binaries")
+set_property(CACHE SYMBOL_SECTIONS PROPERTY STRINGS symtab gnu_debugdata)
+
+if (NOT SYMBOL_SECTIONS STREQUAL "symtab" AND NOT SYMBOL_SECTIONS STREQUAL "gnu_debugdata")
+    message(FATAL_ERROR "Unsupported SYMBOL_SECTIONS value '${SYMBOL_SECTIONS}'. Expected 'symtab' or 'gnu_debugdata'.")
+endif()
+
+if (SYMBOL_SECTIONS STREQUAL "gnu_debugdata")
+    if (NOT SPLIT_DEBUG_SYMBOLS)
+        message(FATAL_ERROR "SYMBOL_SECTIONS=gnu_debugdata requires SPLIT_DEBUG_SYMBOLS=ON")
+    endif()
+
+    ch_find_program(XZ_PATH NAMES "xz")
+    if (XZ_PATH)
+        message(STATUS "Using xz: ${XZ_PATH}")
+    else()
+        message(FATAL_ERROR "Cannot find xz required by SYMBOL_SECTIONS=gnu_debugdata")
+    endif()
+endif()
+
 if (SPLIT_DEBUG_SYMBOLS)
     message(STATUS "Will split binaries and debug symbols")
     set(SPLIT_DEBUG_SYMBOLS_DIR "stripped" CACHE STRING "A separate directory for stripped information")

--- a/cmake/split_debug_symbols.cmake
+++ b/cmake/split_debug_symbols.cmake
@@ -22,7 +22,7 @@ macro(clickhouse_split_debug_symbols)
        set(MINI_DEBUGINFO_PATH "${STRIP_DESTINATION_DIR}/lib/debug/bin/${STRIP_TARGET}.mini_debuginfo")
        list(APPEND GNU_DEBUGDATA_COMMANDS
            COMMAND "${OBJCOPY_PATH}" --strip-debug "${STRIP_DESTINATION_DIR}/lib/debug/bin/${STRIP_TARGET}.debug" "${MINI_DEBUGINFO_PATH}"
-           COMMAND "${XZ_PATH}" -9 -T0 -f "${MINI_DEBUGINFO_PATH}"
+           COMMAND "${XZ_PATH}" -9 -T1 -f "${MINI_DEBUGINFO_PATH}"
            COMMAND "${OBJCOPY_PATH}" --add-section ".gnu_debugdata=${MINI_DEBUGINFO_PATH}.xz" --remove-section=.symtab --remove-section=.strtab "${STRIP_DESTINATION_DIR}/bin/${STRIP_TARGET}"
            COMMAND "${CMAKE_COMMAND}" -E rm -f "${MINI_DEBUGINFO_PATH}" "${MINI_DEBUGINFO_PATH}.xz"
        )

--- a/cmake/split_debug_symbols.cmake
+++ b/cmake/split_debug_symbols.cmake
@@ -17,6 +17,17 @@ macro(clickhouse_split_debug_symbols)
        message(FATAL_ERROR "Destination directory for stripped binary must be provided")
    endif()
 
+   set(GNU_DEBUGDATA_COMMANDS)
+   if (SYMBOL_SECTIONS STREQUAL "gnu_debugdata")
+       set(MINI_DEBUGINFO_PATH "${STRIP_DESTINATION_DIR}/lib/debug/bin/${STRIP_TARGET}.mini_debuginfo")
+       list(APPEND GNU_DEBUGDATA_COMMANDS
+           COMMAND "${OBJCOPY_PATH}" --strip-debug "${STRIP_DESTINATION_DIR}/lib/debug/bin/${STRIP_TARGET}.debug" "${MINI_DEBUGINFO_PATH}"
+           COMMAND "${XZ_PATH}" -9 -T0 -f "${MINI_DEBUGINFO_PATH}"
+           COMMAND "${OBJCOPY_PATH}" --add-section ".gnu_debugdata=${MINI_DEBUGINFO_PATH}.xz" --remove-section=.symtab --remove-section=.strtab "${STRIP_DESTINATION_DIR}/bin/${STRIP_TARGET}"
+           COMMAND "${CMAKE_COMMAND}" -E rm -f "${MINI_DEBUGINFO_PATH}" "${MINI_DEBUGINFO_PATH}.xz"
+       )
+   endif()
+
    add_custom_command(TARGET ${STRIP_TARGET} POST_BUILD
        COMMAND mkdir -p "${STRIP_DESTINATION_DIR}/lib/debug/bin"
        COMMAND mkdir -p "${STRIP_DESTINATION_DIR}/bin"
@@ -28,8 +39,12 @@ macro(clickhouse_split_debug_symbols)
        COMMAND "${STRIP_PATH}" --strip-debug --remove-section=.comment --remove-section=.note "${STRIP_BINARY_PATH}" -o "${STRIP_DESTINATION_DIR}/bin/${STRIP_TARGET}"
        # Associate stripped binary with debug symbols:
        COMMAND "${OBJCOPY_PATH}" --add-gnu-debuglink "${STRIP_DESTINATION_DIR}/lib/debug/bin/${STRIP_TARGET}.debug" "${STRIP_DESTINATION_DIR}/bin/${STRIP_TARGET}"
+       ${GNU_DEBUGDATA_COMMANDS}
        COMMENT "Stripping clickhouse binary" VERBATIM
    )
+
+   unset(GNU_DEBUGDATA_COMMANDS)
+   unset(MINI_DEBUGINFO_PATH)
 
    install(PROGRAMS ${STRIP_DESTINATION_DIR}/bin/${STRIP_TARGET} DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT clickhouse)
    cmake_path(SET DEBUG_PATH NORMALIZE "${CMAKE_INSTALL_LIBDIR}/debug/${CMAKE_INSTALL_FULL_BINDIR}")

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -8,6 +8,8 @@
 #include <Common/SymbolIndex.h>
 
 #include <algorithm>
+#include <exception>
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -392,7 +394,16 @@ bool decompressGNUDebugData(const Elf::Section & section, std::vector<char> & de
     if (!valid_index)
         return false;
 
-    decompressed.resize(static_cast<size_t>(uncompressed_size));
+    constexpr size_t max_expansion_ratio = 1024;
+    /// MiniDebugInfo normally expands about 20 times; this bound rejects corrupt indexes before allocation.
+    const size_t max_uncompressed_size = section.size() > std::numeric_limits<size_t>::max() / max_expansion_ratio
+        ? std::numeric_limits<size_t>::max()
+        : section.size() * max_expansion_ratio;
+    const size_t decompressed_size = static_cast<size_t>(uncompressed_size);
+    if (decompressed_size > max_uncompressed_size)
+        return false;
+
+    decompressed.resize(decompressed_size);
 
     uint64_t decoder_memory_limit = memory_limit;
     size_t input_position = 0;
@@ -445,7 +456,7 @@ void searchAndCollectSymbolsFromGNUDebugData(SymbolIndex::Object & object, std::
             object.gnu_debugdata_elf = std::move(gnu_debugdata_elf);
         }
     }
-    catch (const Exception &)
+    catch (const std::exception &) // Ok: MiniDebugInfo lookup is best-effort, not critical
     {
         symbols.resize(initial_symbol_count);
     }

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -3,13 +3,17 @@
 #include <base/MemorySanitizer.h>
 #include <base/hex.h>
 #include <base/sort.h>
+#include <Common/Exception.h>
 #include <Common/MemoryTrackerUntrackedAllocationsBlockerInThread.h>
 #include <Common/SymbolIndex.h>
 
 #include <algorithm>
 #include <optional>
+#include <utility>
 
 #include <filesystem>
+
+#include <lzma.h>
 
 #if defined(OS_DARWIN)
 #include <Common/MachO.h>
@@ -343,6 +347,111 @@ bool searchAndCollectSymbolsFromELFSymbolTable(
 }
 
 
+bool decompressGNUDebugData(const Elf::Section & section, std::vector<char> & decompressed)
+{
+    if (section.size() < 2 * LZMA_STREAM_HEADER_SIZE)
+        return false;
+
+    const auto * compressed = reinterpret_cast<const uint8_t *>(section.begin());
+    const size_t footer_offset = section.size() - LZMA_STREAM_HEADER_SIZE;
+
+    /// The xz footer locates the Index, which records the uncompressed size
+    /// across all blocks in this single stream.
+    lzma_stream_flags footer_flags{};
+    if (lzma_stream_footer_decode(&footer_flags, compressed + footer_offset) != LZMA_OK
+        || footer_flags.version != 0
+        || footer_flags.backward_size < LZMA_BACKWARD_SIZE_MIN
+        || !std::in_range<size_t>(footer_flags.backward_size))
+        return false;
+
+    const size_t index_size = static_cast<size_t>(footer_flags.backward_size);
+    if (index_size > footer_offset - LZMA_STREAM_HEADER_SIZE)
+        return false;
+
+    constexpr uint64_t memory_limit = 500ULL << 20;
+    uint64_t index_memory_limit = memory_limit;
+    lzma_index * index = nullptr;
+    size_t index_position = 0;
+    const lzma_ret index_result = lzma_index_buffer_decode(
+        &index,
+        &index_memory_limit,
+        nullptr,
+        compressed + footer_offset - index_size,
+        &index_position,
+        index_size);
+
+    if (index_result != LZMA_OK)
+        return false;
+
+    const lzma_vli uncompressed_size = lzma_index_uncompressed_size(index);
+    const bool valid_index = index_position == index_size
+        && lzma_index_size(index) == footer_flags.backward_size
+        && std::in_range<size_t>(uncompressed_size);
+    lzma_index_end(index, nullptr);
+
+    if (!valid_index)
+        return false;
+
+    decompressed.resize(static_cast<size_t>(uncompressed_size));
+
+    uint64_t decoder_memory_limit = memory_limit;
+    size_t input_position = 0;
+    size_t output_position = 0;
+    const lzma_ret result = lzma_stream_buffer_decode(
+        &decoder_memory_limit,
+        LZMA_CONCATENATED,
+        nullptr,
+        compressed,
+        &input_position,
+        section.size(),
+        reinterpret_cast<uint8_t *>(decompressed.data()),
+        &output_position,
+        decompressed.size());
+
+    if (result != LZMA_OK || input_position != section.size())
+        return false;
+
+    if (output_position < decompressed.size())
+    {
+        decompressed.resize(output_position);
+        decompressed.shrink_to_fit();
+    }
+
+    return true;
+}
+
+
+void searchAndCollectSymbolsFromGNUDebugData(SymbolIndex::Object & object, std::vector<SymbolIndex::Symbol> & symbols)
+{
+    const size_t initial_symbol_count = symbols.size();
+
+    try
+    {
+        auto section = object.elf->findSectionByName(".gnu_debugdata");
+        if (!section)
+            return;
+
+        auto gnu_debugdata = std::make_shared<std::vector<char>>();
+        if (!decompressGNUDebugData(*section, *gnu_debugdata))
+            return;
+
+        auto gnu_debugdata_elf = std::make_shared<Elf>(gnu_debugdata->data(), gnu_debugdata->size(), object.name + "(.gnu_debugdata)");
+
+        searchAndCollectSymbolsFromELFSymbolTable(*gnu_debugdata_elf, SectionHeaderType::SYMTAB, ".strtab", symbols);
+
+        if (symbols.size() != initial_symbol_count)
+        {
+            object.gnu_debugdata = std::move(gnu_debugdata);
+            object.gnu_debugdata_elf = std::move(gnu_debugdata_elf);
+        }
+    }
+    catch (const Exception &)
+    {
+        symbols.resize(initial_symbol_count);
+    }
+}
+
+
 void collectSymbolsFromELF(
     DynamicLinkingProgramHeaderInfo * info,
     std::vector<SymbolIndex::Symbol> & symbols,
@@ -460,7 +569,10 @@ void collectSymbolsFromELF(
     object.name = object_name;
     objects.push_back(std::move(object));
 
+    const size_t initial_symbol_count = symbols.size();
     searchAndCollectSymbolsFromELFSymbolTable(*objects.back().elf, SectionHeaderType::SYMTAB, ".strtab", symbols);
+    if (symbols.size() == initial_symbol_count)
+        searchAndCollectSymbolsFromGNUDebugData(objects.back(), symbols);
 
     /// Unneeded if they were parsed from "program headers" of loaded objects.
 #if defined USE_MUSL

--- a/src/Common/SymbolIndex.h
+++ b/src/Common/SymbolIndex.h
@@ -40,6 +40,11 @@ public:
         const void * address_end{};
         std::string name;
         std::shared_ptr<Elf> elf;
+#if defined(__ELF__)
+        /// Owns the storage referenced by `gnu_debugdata_elf` and the symbol names collected from it.
+        std::shared_ptr<std::vector<char>> gnu_debugdata;
+        std::shared_ptr<Elf> gnu_debugdata_elf;
+#endif
 #if defined(OS_DARWIN)
         /// ASLR slide for this image. Subtract from runtime address to get linked (DWARF) address.
         uintptr_t slide = 0;


### PR DESCRIPTION
Release binaries deliberately keep `.symtab`/`.strtab` after stripping so that `SymbolIndex` can symbolize stack traces at runtime — 147.8 MiB (20.3%) of the official 26.7 binary. This PR adds an opt-in packaging mode `SYMBOL_SECTIONS=gnu_debugdata` (requires `SPLIT_DEBUG_SYMBOLS`) that replaces them with the ecosystem-standard `.gnu_debugdata` section ([MiniDebugInfo](https://sourceware.org/gdb/current/onlinedocs/gdb.html/MiniDebugInfo.html)): an xz-compressed mini-ELF holding only the symbol table, understood by gdb ≥ 7.6, lldb, elfutils/libdwfl (`eu-stack`, `systemd-coredump`) and perf since Linux 6.15.

Production side is three commands appended to the `POST_BUILD` step in `clickhouse_split_debug_symbols`: `objcopy --strip-debug` on the already-split `.debug` file, `xz -9 -T0`, and `objcopy --add-section .gnu_debugdata=... --remove-section=.symtab --remove-section=.strtab`. The external `.debug` file and `--add-gnu-debuglink` keep working as before, so the `clickhouse-common-static-dbg` package remains the best debug source and `.gnu_debugdata` is the fallback, matching gdb precedence.

Read side: when the ELF chosen by `collectSymbolsFromELF` has no `.symtab`, `SymbolIndex` probes `.gnu_debugdata`, takes the exact uncompressed size from the xz stream footer/index, decompresses the section with liblzma in a single pass (xz is already in contrib and linked into `clickhouse_common_io`), and feeds the inner ELF to the existing symbol collection path. The decompressed buffer is owned by the corresponding `Object` for the lifetime of the process.

Measured on a minimal build (x86-64, clang 22, `SPLIT_DEBUG_SYMBOLS=ON`):

- packaged binary: 471 MiB → 365 MiB, `.gnu_debugdata` is 5.4 MiB;
- symbol count and stack-trace symbolization are identical to the `.symtab` build;
- gdb resolves symbols from the stripped binary out of the box;
- self-symbolization costs ~110 MB of anonymous RSS for the decompressed mini-ELF (peak 307 MB vs 156 MB baseline on a full `system.symbols` scan). This trade-off is inherent to this mode and is addressed separately by the compact `.clickhouse.symbols` section (see the issue and the sibling PR).

The default (`SYMBOL_SECTIONS=symtab`) is unchanged; nothing changes for existing builds and packages.

Related: https://github.com/ClickHouse/ClickHouse/issues/115303
Related: https://github.com/ClickHouse/ClickHouse/pull/115323

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added an optional packaging mode `SYMBOL_SECTIONS=gnu_debugdata` that replaces `.symtab`/`.strtab` in release binaries (~148 MiB on the official build) with the standard compressed `.gnu_debugdata` (MiniDebugInfo) section (~10 MiB), readable by gdb, lldb, elfutils and perf; `SymbolIndex` reads it as a fallback, so stack traces keep working.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115322&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115322](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115322+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
