### PR TITLE
Fix flaky 04005_correlated_column_in_lambda by pinning row order

### DIFF
--- a/tests/queries/0_stateless/04005_correlated_column_in_lambda.sql
+++ b/tests/queries/0_stateless/04005_correlated_column_in_lambda.sql
@@ -7,4 +7,4 @@ SET enable_analyzer = 1;
 
 SELECT (SELECT arrayMap(x -> c0, [1])) FROM (SELECT 1 AS c0);
 SELECT (SELECT arrayMap(x -> c0 + x, [1, 2, 3])) FROM (SELECT 10 AS c0);
-SELECT (SELECT arrayMap(x -> c0 * x, [1, 2])) FROM (SELECT number AS c0 FROM numbers(3));
+SELECT (SELECT arrayMap(x -> c0 * x, [1, 2])) FROM (SELECT number AS c0 FROM numbers(3)) ORDER BY c0;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114550


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`04005_correlated_column_in_lambda` fails `Fast test` with `result differs with reference`. The last
query has no `ORDER BY`:

```sql
SELECT (SELECT arrayMap(x -> c0 * x, [1, 2])) FROM (SELECT number AS c0 FROM numbers(3));
```

Its correlated scalar subquery is decorrelated into a JOIN, and the resulting pipeline is
multi-stream (`EXPLAIN PIPELINE` shows the expression chain repeated once per stream, resized down
to one), so row order depends on which stream finishes first. The test never pinned it.

The failure is a pure permutation, never a value change. From the report below:

```
 [1]
 [11,12,13]
-[0,0]
-[1,2]
 [2,4]
+[1,2]
+[0,0]
```

Two *different* permutations occurred on the same commit `9cf364a8`, which rules out a deterministic
result change. I reproduced it on a build of pristine master carrying none of #114550: under
`max_block_size = 1` an interleaved 200-run A/B on one binary gave 4 distinct permutations
(20.5% deviation) without the fix and 200/200 identical output with it.

Fix: append `ORDER BY c0` to that one query. `c0` is unique across the three rows, so the order is
total. The `.reference` file is unchanged, because the pinned order is the order it already records.

This test guards #98285 (PLACEHOLDER nodes for correlated columns in lambdas, closes #85460), so I
verified the `ORDER BY` does not hide that regression: with `visitCorrelatedColumn` reverted to its
pre-#98285 form the fixed test still aborts and produces no output; restoring it makes the test pass
again.

Validation: 50/50 runs with randomization, 50/50 with `--no-random-settings` (the `Fast test`
shape), 25/25 via `clickhouse-test`. Control arm: the unfixed query under the same conditions fails
9 of 60 runs.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114550&sha=b5b2d025522dbb54b351249c588220b7311221c3&name_0=PR&name_1=Fast%20test

No related open issue found.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115324&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115324](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115324+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
