### PR TITLE
Fix wrong results from compiled `if`/`multiIf`/`CASE` mixing `Date`/`Date32` with `DateTime`/`DateTime64`

### DIFF
--- a/src/Functions/FunctionIfBase.h
+++ b/src/Functions/FunctionIfBase.h
@@ -32,9 +32,9 @@ public:
             auto type_removed_nullable = removeNullable(type);
             WhichDataType which(type_removed_nullable);
 
-            if (which.isDate())
+            if (which.isDateOrDate32())
                 has_date = true;
-            if (which.isDateTime())
+            if (which.isDateTimeOrDateTime64())
                 has_datetime = true;
 
             if (has_date && has_datetime)

--- a/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.reference
+++ b/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.reference
@@ -1,0 +1,15 @@
+Date32 + DateTime64(0)	1
+Date32 + DateTime64(3)	1
+Date32 + DateTime64(6)	1
+Date32 + DateTime64(9)	1
+Date + DateTime64(3)	1
+Date32 + DateTime	1
+Date + DateTime	1
+Date32 + Date	1
+branch order swapped	1
+date as a column	1
+multiIf	1
+CASE	1
+Nullable(Date32) + DateTime64(3)	1
+post-1970 date	1
+absolute value	['1900-01-01 00:00:00.000','1970-01-01 00:00:00.000']

--- a/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.reference
+++ b/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.reference
@@ -13,3 +13,5 @@ CASE	1
 Nullable(Date32) + DateTime64(3)	1
 post-1970 date	1
 absolute value	['1900-01-01 00:00:00.000','1970-01-01 00:00:00.000']
+mixed-unit shape is not compiled	1
+same-unit shape is still compiled	1

--- a/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.sql
+++ b/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.sql
@@ -44,3 +44,22 @@ SELECT 'post-1970 date', (SELECT groupArray(if(number % 2 = 0, toDate32('2000-01
     = (SELECT groupArray(if(number % 2 = 0, toDate32('2000-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 0);
 
 SELECT 'absolute value', groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 1;
+
+-- The rows above compare compiled against interpreted, so they would all pass if compilation stopped
+-- happening. These two pin which shapes compile. CompiledFunctionExecute counts executions of an
+-- already-compiled node, so it does not care whether the global compiled cache was already warm.
+SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2)
+    SETTINGS compile_expressions = 1, log_comment = '04930_mixed_unit' FORMAT Null;
+
+SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDate('1970-01-01'))) FROM numbers(2)
+    SETTINGS compile_expressions = 1, log_comment = '04930_same_unit' FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT 'mixed-unit shape is not compiled', ProfileEvents['CompiledFunctionExecute'] = 0 FROM system.query_log
+    WHERE current_database = currentDatabase() AND log_comment = '04930_mixed_unit' AND type = 'QueryFinish'
+    ORDER BY event_time_microseconds DESC LIMIT 1;
+
+SELECT 'same-unit shape is still compiled', ProfileEvents['CompiledFunctionExecute'] > 0 FROM system.query_log
+    WHERE current_database = currentDatabase() AND log_comment = '04930_same_unit' AND type = 'QueryFinish'
+    ORDER BY event_time_microseconds DESC LIMIT 1;

--- a/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.sql
+++ b/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.sql
@@ -1,0 +1,46 @@
+SET session_timezone = 'UTC';
+SET min_count_to_compile_expression = 0;
+
+SELECT 'Date32 + DateTime64(0)', (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 0))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 0))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Date32 + DateTime64(3)', (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Date32 + DateTime64(6)', (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 6))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 6))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Date32 + DateTime64(9)', (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 9))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 9))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Date + DateTime64(3)', (SELECT groupArray(if(number % 2 = 0, toDate('2000-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate('2000-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Date32 + DateTime', (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime('1970-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime('1970-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Date + DateTime', (SELECT groupArray(if(number % 2 = 0, toDate('2000-01-01'), toDateTime('1970-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate('2000-01-01'), toDateTime('1970-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Date32 + Date', (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDate('1970-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDate('1970-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'branch order swapped', (SELECT groupArray(if(number % 2 = 0, toDateTime64('1970-01-01', 3), toDate32('1900-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDateTime64('1970-01-01', 3), toDate32('1900-01-01'))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'date as a column', (SELECT groupArray(if(number % 2 = 0, materialize(toDate32('1900-01-01')), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, materialize(toDate32('1900-01-01')), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'multiIf', (SELECT groupArray(multiIf(number % 3 = 0, toDate32('1900-01-01'), number % 3 = 1, toDateTime64('1980-01-01', 3), toDateTime64('1990-01-01', 3))) FROM numbers(3) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(multiIf(number % 3 = 0, toDate32('1900-01-01'), number % 3 = 1, toDateTime64('1980-01-01', 3), toDateTime64('1990-01-01', 3))) FROM numbers(3) SETTINGS compile_expressions = 0);
+
+SELECT 'CASE', (SELECT groupArray(CASE WHEN number % 2 = 0 THEN toDate32('1900-01-01') ELSE toDateTime64('1970-01-01', 3) END) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(CASE WHEN number % 2 = 0 THEN toDate32('1900-01-01') ELSE toDateTime64('1970-01-01', 3) END) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'Nullable(Date32) + DateTime64(3)', (SELECT groupArray(if(number % 2 = 0, toNullable(toDate32('1900-01-01')), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toNullable(toDate32('1900-01-01')), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'post-1970 date', (SELECT groupArray(if(number % 2 = 0, toDate32('2000-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 1)
+    = (SELECT groupArray(if(number % 2 = 0, toDate32('2000-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 0);
+
+SELECT 'absolute value', groupArray(if(number % 2 = 0, toDate32('1900-01-01'), toDateTime64('1970-01-01', 3))) FROM numbers(2) SETTINGS compile_expressions = 1;

--- a/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.sql
+++ b/tests/queries/0_stateless/04930_jit_compiled_if_date_to_datetime.sql
@@ -1,3 +1,10 @@
+-- Tags: no-fasttest, no-msan
+-- no-fasttest: the Fast test build has no embedded compiler (ENABLE_EMBEDDED_COMPILER defaults to
+--              ENABLE_LIBRARIES, which that build sets to 0), so nothing is ever JIT-compiled and the
+--              "same-unit shape is still compiled" assertion cannot hold.
+-- no-msan: the MSan build also disables the embedded compiler (contrib/llvm-project-cmake/CMakeLists.txt),
+--          so the same assertion cannot hold there.
+
 SET session_timezone = 'UTC';
 SET min_count_to_compile_expression = 0;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115272
Related: https://github.com/ClickHouse/ClickHouse/pull/115146
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results from `if`, `multiIf` and `CASE` when one branch is a `Date` or `Date32` and the result type is `DateTime` or `DateTime64`. With `compile_expressions = 1` (the default) the compiled expression copied the date's day count into the timestamp column without converting days to seconds, so `if(cond, toDate32('1900-01-01'), toDateTime64('1970-01-01', 3))` returned `1969-12-31 23:59:34.433`. Closes #115272.


### Description

Reported by @ PedroTadim in [#115272](https://github.com/ClickHouse/ClickHouse/issues/115272), who asked me to fix it and have @Manerone review.

**Root cause.** `FunctionIfBase::isCompilableImpl` already intends to refuse these expressions -- its comment reads *"It's difficult to compare Date and DateTime - cannot use JIT compilation."* -- but it tested `WhichDataType::isDate()` and `isDateTime()`, which are exact `TypeIndex` equality, so it refused only `Date`+`DateTime` and admitted `Date32`+`DateTime64`, `Date`+`DateTime64` and `Date32`+`DateTime`. Those reach `nativeCast`, which correctly finds no scale for day-count types and falls through to a plain `CreateIntCast`: `-25567` days becomes `-25567` milliseconds. The predicates were never widened when `Date32` and `DateTime64` were added.

**The change** widens both predicates to `isDateOrDate32()` and `isDateTimeOrDateTime64()`, so the guard covers the whole family and the interpreted path runs. `if.cpp` and `multiIf.cpp` inherit this base, so one change covers all three. These expressions lose JIT, as the comment intended and as `Date`+`DateTime` always did. The commit message covers the rejected IR alternative.

**Validation.** New test `04930_jit_compiled_if_date_to_datetime` asserts the compiled result equals the `compile_expressions = 0` result over the reported matrix: scales 0/3/6/9, both date and both datetime types, both branch orders, constant and column dates, `if`/`multiIf`/`CASE`, `Nullable(Date32)`, pre/post-1970. 12 of its 14 comparison rows fail without the fix and all pass with it (50/50 runs). The 2 exceptions are controls green both ways: `Date`+`DateTime`, already refused, and same-unit `Date32`+`Date`, which must keep compiling.

Those rows are 1-vs-0 parity checks, so they would pass even if compilation stopped. Two further rows pin which shapes compile, via `ProfileEvents['CompiledFunctionExecute']`: it counts executions of an already-compiled node, so it needs no cache drop and the test stays parallel-safe. The mixed-unit row fails on an unpatched binary, so it tracks this change rather than asserting a constant. They are also why the test carries `no-fasttest, no-msan`: those builds have no embedded compiler.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115325&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115325](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115325+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.7.67`, `26.6.5.50`, `26.3.33.37`
<!-- ch-version-info:end -->