### PR TITLE
Do not leave metadata referencing a dropped named collection

### DIFF
--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
@@ -50,8 +50,8 @@ NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_nc"
 NOEXT_NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_noext_nc"
 ABS_NOEXT_NC="${USER_FILES_PATH}/${NOEXT_NC}"
 printf '{"a":1,"b":"Hello"}\n{"a":2,"b":"World"}\n' > "$ABS_NOEXT_NC"
-# Reuse a leftover collection instead of dropping and recreating it: an interrupted previous run can
-# leave the table behind too, and then the drop is refused because that table still references it.
+# Reuse a leftover collection rather than recreating it: dropping it is refused while a leftover table
+# still references it.
 ${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = 'file://${ABS_NOEXT_NC}'"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n ENGINE = URL(${NC})"
@@ -62,6 +62,5 @@ ${CLICKHOUSE_CLIENT} -q "DETACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 rm -f "$ABS_NOEXT_NC"
 ${CLICKHOUSE_CLIENT} -q "ATTACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
-# Chained: the collection must outlive the table, or a restart between the two drops leaves metadata
-# referencing a missing collection.
+# Chained so the collection outlives the table: metadata must never reference a missing collection.
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"

--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
@@ -50,8 +50,9 @@ NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_nc"
 NOEXT_NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_noext_nc"
 ABS_NOEXT_NC="${USER_FILES_PATH}/${NOEXT_NC}"
 printf '{"a":1,"b":"Hello"}\n{"a":2,"b":"World"}\n' > "$ABS_NOEXT_NC"
-${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION IF EXISTS ${NC}"
-${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION ${NC} AS url = 'file://${ABS_NOEXT_NC}'"
+# Reuse a leftover collection instead of dropping and recreating it: an interrupted previous run can
+# leave the table behind too, and then the drop is refused because that table still references it.
+${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = 'file://${ABS_NOEXT_NC}'"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n ENGINE = URL(${NC})"
 # The persisted engine definition carries a concrete format, not 'auto' (quoted literal, see above).
@@ -61,5 +62,6 @@ ${CLICKHOUSE_CLIENT} -q "DETACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 rm -f "$ABS_NOEXT_NC"
 ${CLICKHOUSE_CLIENT} -q "ATTACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
-${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"
+# Chained: the collection must outlive the table, or a restart between the two drops leaves metadata
+# referencing a missing collection.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"

--- a/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
+++ b/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
@@ -17,9 +17,8 @@ NC="s3queue_creds_nc_${DB}"
 
 # A named collection that asks for the server's environment credentials (`use_environment_credentials = 1`
 # overrides the global default). The setting is explicit so the test does not depend on the server's global
-# `use_environment_credentials` value. A leftover collection is reused instead of dropped and recreated:
-# an interrupted previous run can leave the table behind too, and then the drop is refused because that
-# table still references it.
+# `use_environment_credentials` value. A leftover collection is reused rather than recreated: dropping it
+# is refused while a leftover table still references it.
 $CLICKHOUSE_CLIENT -q "
     CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS
         url = 'http://localhost:11111/test/${DB}_q/',
@@ -43,6 +42,5 @@ $CLICKHOUSE_CLIENT -q "
 "
 echo "s3queue_override: created"
 
-# Chained: the collection must outlive the table, or a restart between the two drops leaves metadata
-# referencing a missing collection.
+# Chained so the collection outlives the table: metadata must never reference a missing collection.
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE} SYNC" && $CLICKHOUSE_CLIENT -q "DROP NAMED COLLECTION IF EXISTS ${NC}"

--- a/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
+++ b/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
@@ -15,16 +15,18 @@ DB="$CLICKHOUSE_DATABASE"
 TABLE="s3queue_creds_${DB}"
 NC="s3queue_creds_nc_${DB}"
 
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE} SYNC"
-
 # A named collection that asks for the server's environment credentials (`use_environment_credentials = 1`
 # overrides the global default). The setting is explicit so the test does not depend on the server's global
-# `use_environment_credentials` value.
+# `use_environment_credentials` value. A leftover collection is reused instead of dropped and recreated:
+# an interrupted previous run can leave the table behind too, and then the drop is refused because that
+# table still references it.
 $CLICKHOUSE_CLIENT -q "
-    CREATE NAMED COLLECTION ${NC} AS
+    CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS
         url = 'http://localhost:11111/test/${DB}_q/',
         use_environment_credentials = 1
 "
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE} SYNC"
 
 # Without the override the S3Queue would resolve the server's environment credentials, so it is rejected.
 $CLICKHOUSE_CLIENT -q "
@@ -41,5 +43,6 @@ $CLICKHOUSE_CLIENT -q "
 "
 echo "s3queue_override: created"
 
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE} SYNC"
-$CLICKHOUSE_CLIENT -q "DROP NAMED COLLECTION IF EXISTS ${NC}"
+# Chained: the collection must outlive the table, or a restart between the two drops leaves metadata
+# referencing a missing collection.
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE} SYNC" && $CLICKHOUSE_CLIENT -q "DROP NAMED COLLECTION IF EXISTS ${NC}"

--- a/tests/queries/0_stateless/04512_remote_missing_named_collection.sh
+++ b/tests/queries/0_stateless/04512_remote_missing_named_collection.sh
@@ -20,10 +20,9 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # keep working for that form; the arms below pin both directions.
 #
 # Named collections are server-global, so the collection names are scoped to the (unique) test
-# database to avoid collisions across concurrent runs. A table left DETACHED while its collection
-# is missing keeps on-disk metadata that cannot be loaded, so each such table is re-attached and
-# dropped as soon as its assertion is made: a restart between the assertion and the cleanup is
-# what turned this defect into a startup failure in the first place.
+# database to avoid collisions across concurrent runs. The arms detach PERMANENTLY so that a server
+# restart while the collection is missing still boots: startup skips a permanently detached table
+# without constructing its storage, while `ATTACH TABLE` still replays the on-disk definition.
 NC_TF="nc_missing_tf_${CLICKHOUSE_DATABASE}"
 NC_SK="nc_missing_sk_${CLICKHOUSE_DATABASE}"
 NC_LIVE="nc_live_${CLICKHOUSE_DATABASE}"
@@ -56,7 +55,7 @@ ${CLICKHOUSE_CLIENT} --query "
 SET check_named_collection_dependencies = 0;
 CREATE TABLE t_engine_tf ENGINE = Remote(${NC_TF}, database = merge(currentDatabase(), '^nc_target\$'));
 SELECT count() FROM t_engine_tf;
-DETACH TABLE t_engine_tf SYNC;
+DETACH TABLE t_engine_tf PERMANENTLY SYNC;
 DROP NAMED COLLECTION ${NC_TF};
 "
 run_and_classify '(a) engine, database = merge(...):' "${NC_TF}" "ATTACH TABLE t_engine_tf"
@@ -76,7 +75,7 @@ ${CLICKHOUSE_CLIENT} --query "
 SET check_named_collection_dependencies = 0;
 CREATE TABLE t_engine_sk ENGINE = Remote(${NC_SK}, sharding_key = rand());
 SELECT count() FROM t_engine_sk;
-DETACH TABLE t_engine_sk SYNC;
+DETACH TABLE t_engine_sk PERMANENTLY SYNC;
 DROP NAMED COLLECTION ${NC_SK};
 "
 run_and_classify '(b) engine, sharding_key = rand():' "${NC_SK}" "ATTACH TABLE t_engine_sk"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->

Related: https://github.com/ClickHouse/ClickHouse/issues/77366
Related: https://github.com/ClickHouse/ClickHouse/pull/112805


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Three stateless tests briefly leave table metadata on disk referencing a named collection that no longer
exists. The stress test kills and restarts the server at arbitrary points and randomizes
`async_load_databases=false`; in that mode `loadMetadata` waits every table load job and rethrows, so the
server cannot boot:

```
Caught exception while loading metadata: Code: 722 ... Code: 695 ... Code: 669 ...
There is no named collection `nc_missing_sk_test_3`: Cannot attach table ... ENGINE = Remote(...)
```

Measured: 16 occurrences across 13 PRs and 2 master runs in 30 days.

Changes, copying the pattern already in `04626_s3_base_setting.sh`:

- `04512_remote_missing_named_collection.sh` detaches `PERMANENTLY`. Startup skips a permanently
  detached table without constructing its storage, while `ATTACH TABLE` still replays the on-disk
  definition, so every assertion is unchanged and the `.reference` file is untouched.
- `04320_url_engine_dispatch_partition_and_format.sh` and `04327_s3queue_server_credentials.sh` create
  the collection before dropping a possible leftover table, and chain the two teardown drops so the
  collection outlives the table.

Validation. A restart injected where the stress kill lands reproduces the abort deterministically on
master and boots cleanly with the change; restarting at every statement boundary of the changed regions
shows two boundaries dying before and none after. Each change was reverted one at a time and each
reverted half reddens on its own oracle, and pointing an arm at a live collection makes it fail, so the
arms are not vacuous. 200/200 randomized runs of these tests plus `04626` pass.

Server startup behaviour is unchanged, so the underlying gap remains: dropping a collection while a
dependent table is detached still leaves an unstartable server when `async_load_databases = 0`. That was
reported in #77366 and closed in favour of a drop-side guard (#96181), which #112805 is extending to
detached tables.

Tests only: no setting, default or serialization change, so no `SettingsChangesHistory.cpp` entry.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115326&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115326](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115326+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1687` (included in `26.8` and later)
<!-- ch-version-info:end -->