### PR TITLE
Fix timezoneOffset losing the whole-day component of the UTC offset

### DIFF
--- a/src/Common/DateLUTImpl.h
+++ b/src/Common/DateLUTImpl.h
@@ -884,21 +884,15 @@ public:
 
         const LUTIndex index = findIndexInRange(t);
 
-        /// Calculate daylight saving offset first.
-        /// Because the "amount_of_offset_change" in LUT entry only exists in the change day, it's costly to scan it from the very begin.
-        /// but we can figure out all the accumulated offsets from 1970-01-01 to that day just by get the whole difference between lut[].date,
-        /// and then, we can directly subtract multiple 86400s to get the real DST offsets for the leap seconds is not considered now.
-        Time res = (lut[index].date - lut[daynum_offset_epoch].date) % 86400;
-
-        /// As so far to know, the maximal DST offset couldn't be more than 2 hours, so after the modulo operation the remainder
-        /// will sits between [-offset --> 0 --> offset] which respectively corresponds to moving clock forward or backward.
-        res = res > 43200 ? (86400 - res) : (0 - res);
+        /// The offset at the start of the day: local midnight is `day_number * 86400` seconds of local
+        /// time from the epoch, while `date` is the UTC instant of that same midnight.
+        Time res = (static_cast<Int64>(index.toUnderType()) - daynum_offset_epoch) * 86400 - lut[index].date;
 
         /// Check if has a offset change during this day. Add the change when cross the line
         if (lut[index].amount_of_offset_change() != 0 && t >= lut[index].date + lut[index].time_at_offset_change())
             res += lut[index].amount_of_offset_change();
 
-        return res + offset_at_start_of_epoch;
+        return res;
     }
 
 

--- a/tests/queries/0_stateless/01252_weird_time_zone.reference
+++ b/tests/queries/0_stateless/01252_weird_time_zone.reference
@@ -5,3 +5,42 @@ Pacific/Kwajalein	2020-01-02 03:04:05	2020-01-02 00:00:00	3
 Pacific/Apia	2020-01-02 03:04:05	2020-01-02 00:00:00	3
 Pacific/Enderbury	2020-01-02 03:04:05	2020-01-02 00:00:00	3
 Pacific/Fakaofo	2020-01-02 03:04:05	2020-01-02 00:00:00	3
+--- offset of zones that crossed the international date line
+Pacific/Kiritimati	50400
+Pacific/Apia	46800
+Pacific/Fakaofo	46800
+Pacific/Enderbury	46800
+Pacific/Kanton	46800
+Pacific/Kwajalein	43200
+Kwajalein	43200
+--- the same zones before their jump, and a +13:45 zone, must not move
+Pacific/Apia	-39600
+Pacific/Fakaofo	-39600
+Pacific/Chatham	49500
+Pacific/Chatham	45900
+--- negative offsets before the epoch
+Africa/Abidjan	-968
+Africa/Accra	-52
+Africa/Addis_Ababa	9320
+Europe/Moscow	9017
+--- parseDateTime agrees with toDateTime on an affected zone
+1
+1
+1
+1
+1
+1
+--- other consumers of the offset
+14	0
++1400
+2025-06-14 22:00:00	2025-06-16 02:00:00
+2025-06-14 22:00:00.500	2025-06-16 02:00:00.500
+--- consumers that reduce the offset modulo a day must be unaffected
+12:00:00	12:00:00.500
+12:00:00	2025-06-15 00:00:00	12	2025-06-15
+--- daylight saving transitions keep their sub-day offset
+-18000	-14400	-18000
+--- inside and outside the lookup table window report the same offset
+1
+--- every zone agrees with rendering the instant as local text and reading it back as UTC
+0

--- a/tests/queries/0_stateless/01252_weird_time_zone.sql
+++ b/tests/queries/0_stateless/01252_weird_time_zone.sql
@@ -13,3 +13,57 @@ SELECT 'Pacific/Kwajalein', rand() as r, toHour(toDateTime(r, 'Pacific/Kwajalein
 SELECT 'Pacific/Apia', rand() as r, toHour(toDateTime(r, 'Pacific/Apia') AS t) AS h, t, toTypeName(t) FROM numbers(1000000) WHERE h < 0 OR h > 23 ORDER BY h LIMIT 1 BY h;
 SELECT 'Pacific/Enderbury', rand() as r, toHour(toDateTime(r, 'Pacific/Enderbury') AS t) AS h, t, toTypeName(t) FROM numbers(1000000) WHERE h < 0 OR h > 23 ORDER BY h LIMIT 1 BY h;
 SELECT 'Pacific/Fakaofo', rand() as r, toHour(toDateTime(r, 'Pacific/Fakaofo') AS t) AS h, t, toTypeName(t) FROM numbers(1000000) WHERE h < 0 OR h > 23 ORDER BY h LIMIT 1 BY h;
+
+-- timezoneOffset must report the true UTC offset, including its whole-day component (issue #115281).
+SELECT '--- offset of zones that crossed the international date line';
+SELECT 'Pacific/Kiritimati', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+SELECT 'Pacific/Apia', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Pacific/Apia'));
+SELECT 'Pacific/Fakaofo', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Pacific/Fakaofo'));
+SELECT 'Pacific/Enderbury', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Pacific/Enderbury'));
+SELECT 'Pacific/Kanton', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Pacific/Kanton'));
+SELECT 'Pacific/Kwajalein', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Pacific/Kwajalein'));
+SELECT 'Kwajalein', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Kwajalein'));
+
+SELECT '--- the same zones before their jump, and a +13:45 zone, must not move';
+SELECT 'Pacific/Apia', timeZoneOffset(toDateTime('2010-01-01 12:00:00', 'Pacific/Apia'));
+SELECT 'Pacific/Fakaofo', timeZoneOffset(toDateTime('2010-01-01 12:00:00', 'Pacific/Fakaofo'));
+SELECT 'Pacific/Chatham', timeZoneOffset(toDateTime('2010-01-01 12:00:00', 'Pacific/Chatham'));
+SELECT 'Pacific/Chatham', timeZoneOffset(toDateTime('2025-06-15 12:00:00', 'Pacific/Chatham'));
+
+SELECT '--- negative offsets before the epoch';
+SELECT 'Africa/Abidjan', timeZoneOffset(toDateTime64(-1900000000, 0, 'Africa/Abidjan'));
+SELECT 'Africa/Accra', timeZoneOffset(toDateTime64(-1900000000, 0, 'Africa/Accra'));
+SELECT 'Africa/Addis_Ababa', timeZoneOffset(toDateTime64(-1900000000, 0, 'Africa/Addis_Ababa'));
+SELECT 'Europe/Moscow', timeZoneOffset(toDateTime64(-1900000000, 0, 'Europe/Moscow'));
+
+SELECT '--- parseDateTime agrees with toDateTime on an affected zone';
+SELECT toUnixTimestamp(parseDateTime('2025-06-15 12:00:00', '%Y-%m-%d %H:%i:%S', 'Pacific/Kiritimati')) = toUnixTimestamp(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+SELECT toUnixTimestamp(parseDateTimeOrNull('2025-06-15 12:00:00', '%Y-%m-%d %H:%i:%S', 'Pacific/Kiritimati')) = toUnixTimestamp(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+SELECT toUnixTimestamp(parseDateTime64('2025-06-15 12:00:00', '%Y-%m-%d %H:%i:%S', 'Pacific/Kiritimati')) = toUnixTimestamp(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+SELECT toUnixTimestamp(parseDateTimeInJodaSyntax('2025-06-15 12:00:00', 'yyyy-MM-dd HH:mm:ss', 'Pacific/Kiritimati')) = toUnixTimestamp(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+SELECT toUnixTimestamp(parseDateTimeBestEffort('2025-06-15 12:00:00', 'Pacific/Kiritimati')) = toUnixTimestamp(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+SELECT toUnixTimestamp(parseDateTimeInJodaSyntax('2025-06-15 12:00:00 Pacific/Kiritimati', 'yyyy-MM-dd HH:mm:ss z')) = toUnixTimestamp(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+
+SELECT '--- other consumers of the offset';
+SELECT EXTRACT(TIMEZONE_HOUR FROM toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati')), EXTRACT(TIMEZONE_MINUTE FROM toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+SELECT formatDateTime(toDateTime64(1750000000, 0, 'UTC'), '%z', 'Pacific/Kiritimati');
+SELECT toUTCTimestamp(CAST('2025-06-15 12:00:00' AS DateTime), 'Pacific/Kiritimati'), fromUTCTimestamp(CAST('2025-06-15 12:00:00' AS DateTime), 'Pacific/Kiritimati');
+SELECT toUTCTimestamp(CAST('2025-06-15 12:00:00.500' AS DateTime64(3)), 'Pacific/Kiritimati'), fromUTCTimestamp(CAST('2025-06-15 12:00:00.500' AS DateTime64(3)), 'Pacific/Kiritimati');
+
+SELECT '--- consumers that reduce the offset modulo a day must be unaffected';
+SELECT CAST(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati') AS Time), CAST(toDateTime64('2025-06-15 12:00:00.5', 3, 'Pacific/Kiritimati') AS Time64(3));
+SELECT toTime(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati')), toStartOfDay(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati')), toHour(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati')), toDate(toDateTime('2025-06-15 12:00:00', 'Pacific/Kiritimati'));
+
+SELECT '--- daylight saving transitions keep their sub-day offset';
+SELECT timeZoneOffset(toDateTime('2025-03-09 01:00:00', 'America/New_York')), timeZoneOffset(toDateTime('2025-03-09 03:00:00', 'America/New_York')), timeZoneOffset(toDateTime('2025-11-02 03:00:00', 'America/New_York'));
+
+SELECT '--- inside and outside the lookup table window report the same offset';
+SELECT timeZoneOffset(toDateTime64(1750000000, 0, 'Pacific/Kiritimati')) = timeZoneOffset(toDateTime64(90000000000, 0, 'Pacific/Kiritimati'));
+
+SELECT '--- every zone agrees with rendering the instant as local text and reading it back as UTC';
+WITH
+    arrayJoin([toDateTime64(1262347200, 0, 'UTC'), toDateTime64(1750000000, 0, 'UTC'), toDateTime64(2000000000, 0, 'UTC')]) AS ts,
+    formatDateTime(ts, '%z', time_zone) AS z,
+    (toInt64(substring(z, 2, 2)) * 3600 + toInt64(substring(z, 4, 2)) * 60) * multiIf(substring(z, 1, 1) = '-', -1, 1) AS reported,
+    toInt64(toDateTime(formatDateTime(ts, '%Y-%m-%d %H:%i:%S', time_zone), 'UTC')) - toInt64(ts) AS expected
+SELECT count() FROM system.time_zones WHERE reported != expected;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115281
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `timezoneOffset` (alias `timeZoneOffset`) returning an offset wrong by exactly one day for time zones whose UTC offset differs from their 1970-01-01 offset by a whole day, such as `Pacific/Kiritimati` and `Pacific/Apia` after they crossed the international date line, and for most zones before 1970. This also fixes `parseDateTime`, `parseDateTimeOrNull`, `parseDateTime64`, `parseDateTimeInJodaSyntax`, `EXTRACT(TIMEZONE_HOUR / TIMEZONE_MINUTE ...)`, `formatDateTime`'s `%z`, `toUTCTimestamp` and `fromUTCTimestamp`, which consume that offset. Closes #115281.


### Description

Reported by @ PedroTadim in https://github.com/ClickHouse/ClickHouse/issues/115281#issuecomment-5327580058.

`timezoneOffset` did not read the offset, it reconstructed it as `(lut[index].date - lut[epoch].date) % 86400` plus `offset_at_start_of_epoch`. That difference is `days * 86400 - (offset_now - offset_epoch)`, so the modulo keeps only the sub-day part of the change since the epoch and discards any whole-day part; the date-line zones stayed pinned at their pre-jump offset, correct before the jump and wrong after. Separately, `%` takes the sign of the dividend, so on a pre-epoch day the remainder is negative, the `res > 43200` wrap never fired, and the result came out near `+86400` instead of a small negative offset.

The fix computes the offset directly as `day_number * 86400 - lut[index].date`: local midnight is that many seconds of local time from the epoch, and `date` is the UTC instant of the same midnight. Exact for either sign, no modulo, no wrap branches. The same-day `amount_of_offset_change` correction is unchanged.

All 12 in-tree call sites checked. Seven were wrong and are repaired by this one change: the function itself, the `parseDateTime` family (including a zone named in the format string), `EXTRACT(TIMEZONE_HOUR / TIMEZONE_MINUTE ...)`, `formatDateTime`'s `%z`, and `toUTCTimestamp` / `fromUTCTimestamp`. The other five reduce the offset modulo a day (`CAST ... AS Time` / `Time64`, `localtime`), so an exact one-day error already cancelled; the test pins those as controls.

Over all 597 rows of `system.time_zones` at 14 instants from 1900 to 2300, against Python `zoneinfo` as an independent oracle: 500 wrong samples across 307 zones before, 18 after, all 18 being `tzdata` differences between the bundled 2025a and the system 2026a. All 488 changed samples differ by exactly one day, so nothing sub-day moved.

<details>
<summary>Validation</summary>

Both directions through `tests/clickhouse-test`: on the base master debug snapshot (build id `09e3d57a4bbe30cd`) `01252_weird_time_zone` fails with a 39-line reference diff; with the fix (build id `485b33ed0bf6e99c`) it passes, including 50 of 50 randomized runs.

`unit_tests_dbms --gtest_filter='*DateLUT*:*DateTime*:*Date*'` passes 7906 tests, so no calendar component moved. The `timezone` stateless suite passes 42 of 42. Six failures in the wider `datetime` and `extract` suites are pre-existing gaps in my local environment (no `remote()` cluster config, no parquet/iceberg fixtures, no `test.hits`) and reproduce identically on the base binary.

New arms: the seven reported zones after their jump; the same zones before it and `Pacific/Chatham` (+13:45) as controls that must not move; the pre-1970 class; agreement between `parseDateTime*` and `toDateTime`; the other offset consumers; the modulo-a-day consumers as regression controls; DST transition days; agreement between the in-range and out-of-range paths; and a sweep over `system.time_zones` with no zone list hardcoded, comparing the reported offset to rendering the instant as local text and reading it back as UTC.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115332&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115332](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115332+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1888` (included in `26.8` and later)
<!-- ch-version-info:end -->