### PR TITLE
Docs: document Iceberg write compatibility limitations

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -646,10 +646,10 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         {
             if (type->getCustomName() && type->getCustomName()->getName() == "Geometry")
                 return {Iceberg::f_geometry, false};
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
         }
         default:
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
     }
 }
 
@@ -674,7 +674,7 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         case TypeIndex::DateTime64:
         {
             if (getDecimalScale(*type) != 6)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
 
             Poco::JSON::Object::Ptr timestamp_type = new Poco::JSON::Object;
             timestamp_type->set("type", "long");
@@ -701,7 +701,7 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
             return union_array;
         }
         default:
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
     }
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -646,10 +646,10 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         {
             if (type->getCustomName() && type->getCustomName()->getName() == "Geometry")
                 return {Iceberg::f_geometry, false};
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
         }
         default:
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
     }
 }
 
@@ -674,7 +674,7 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         case TypeIndex::DateTime64:
         {
             if (getDecimalScale(*type) != 6)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
 
             Poco::JSON::Object::Ptr timestamp_type = new Poco::JSON::Object;
             timestamp_type->set("type", "long");
@@ -701,7 +701,7 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
             return union_array;
         }
         default:
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for Iceberg {}", type->getName());
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
     }
 }
 

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -1244,8 +1244,8 @@ The following table shows how Iceberg data types are mapped to ClickHouse data t
 
 The data type mappings above apply to reads. The following limitations apply when writing:
 
-- ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation returns an `Unsupported type for iceberg` exception. This does not prevent inserting `Bool` or `Decimal` values into existing Iceberg columns.
-- ClickHouse cannot write to an Iceberg table that uses a `Decimal` column as a direct partition field. The operation returns an `Unsupported type for iceberg` exception.
+- ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation returns an `Unsupported type for Iceberg` exception. This does not prevent inserting `Bool` or `Decimal` values into existing Iceberg columns.
+- ClickHouse cannot write to an Iceberg table that uses a `Decimal` column as a direct partition field. The operation returns an `Unsupported type for Iceberg` exception.
 - For data files containing types whose bounds ClickHouse cannot serialize, including `Bool` and `Decimal`, ClickHouse omits all lower and upper column bounds from the Iceberg manifest entry. Column sizes and null counts are still included, and the data remains correct, but readers cannot use manifest-level min-max pruning for those files.
 
 ## Schema evolution {#schema-evolution}

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -1240,15 +1240,13 @@ The following table shows how Iceberg data types are mapped to ClickHouse data t
 | `map` | `Map` |
 | `struct` | `Tuple` |
 
-## Writing data {#writing-data}
-
-### Limitations {#writing-limitations}
+## Writing compatibility limitations {#writing-compatibility-limitations}
 
 The data type mappings above apply to reads. The following limitations apply when writing:
 
-- ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation returns an `Unsupported type for iceberg` exception. This limitation does not prevent inserting `Decimal` values into existing Iceberg tables when the column is not used as a direct partition field.
-- Direct partition fields do not support `Bool`, `Decimal`, or `FixedString`. A `DateTime64` direct partition field must have scale `6`.
-- For data files containing types whose bounds ClickHouse cannot serialize, including `Bool` and `Decimal`, ClickHouse omits all lower and upper column bounds from the Iceberg manifest entry. The data remains correct, but ClickHouse and other Iceberg readers might read more files because manifest-level min-max pruning is unavailable.
+- ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation returns an `Unsupported type for iceberg` exception. This does not prevent inserting `Bool` or `Decimal` values into existing Iceberg columns.
+- ClickHouse cannot write to an Iceberg table that uses a `Decimal` column as a direct partition field. The operation returns an `Unsupported type for iceberg` exception.
+- For data files containing types whose bounds ClickHouse cannot serialize, including `Bool` and `Decimal`, ClickHouse omits all lower and upper column bounds from the Iceberg manifest entry. Column sizes and null counts are still included, and the data remains correct, but readers cannot use manifest-level min-max pruning for those files.
 
 ## Schema evolution {#schema-evolution}
 ClickHouse supports reading Iceberg tables whose schema has evolved over time. This includes tables where columns have been added, removed, or reordered, as well as columns changed from required to nullable. Additionally, the following type casts are supported:

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -1240,9 +1240,9 @@ The following table shows how Iceberg data types are mapped to ClickHouse data t
 | `map` | `Map` |
 | `struct` | `Tuple` |
 
-## Writing compatibility limitations {#writing-compatibility-limitations}
+## Schema and write compatibility limitations {#schema-and-write-compatibility-limitations}
 
-The data type mappings above apply to reads. The following limitations apply when writing:
+The data type mappings above apply to reads. The following limitations apply when ClickHouse creates or evolves Iceberg schemas and writes data:
 
 - ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation returns an `Unsupported type for Iceberg` exception. This does not prevent inserting `Bool` or `Decimal` values into existing Iceberg columns.
 - ClickHouse cannot write to an Iceberg table that uses a `Decimal` column as a direct partition field. The operation returns an `Unsupported type for Iceberg` exception.

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -1240,6 +1240,16 @@ The following table shows how Iceberg data types are mapped to ClickHouse data t
 | `map` | `Map` |
 | `struct` | `Tuple` |
 
+## Writing data {#writing-data}
+
+### Limitations {#writing-limitations}
+
+The data type mappings above apply to reads. The following limitations apply when writing:
+
+- ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation returns an `Unsupported type for iceberg` exception. This limitation does not prevent inserting `Decimal` values into existing Iceberg tables when the column is not used as a direct partition field.
+- Direct partition fields do not support `Bool`, `Decimal`, or `FixedString`. A `DateTime64` direct partition field must have scale `6`.
+- For data files containing types whose bounds ClickHouse cannot serialize, including `Bool` and `Decimal`, ClickHouse omits all lower and upper column bounds from the Iceberg manifest entry. The data remains correct, but ClickHouse and other Iceberg readers might read more files because manifest-level min-max pruning is unavailable.
+
 ## Schema evolution {#schema-evolution}
 ClickHouse supports reading Iceberg tables whose schema has evolved over time. This includes tables where columns have been added, removed, or reordered, as well as columns changed from required to nullable. Additionally, the following type casts are supported:
 

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -1245,6 +1245,7 @@ The following table shows how Iceberg data types are mapped to ClickHouse data t
 The data type mappings above apply to reads. The following limitations apply when ClickHouse creates or evolves Iceberg schemas and writes data:
 
 - ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation fails with an unsupported-type exception. This does not prevent inserting `Bool` or `Decimal` values into existing Iceberg columns.
+- When ClickHouse creates or evolves an Iceberg schema, it maps every `DateTime` and `DateTime64` column to Iceberg `timestamp`, which has microsecond precision and no timezone. ClickHouse cannot generate `timestamptz`, `timestamp_ns`, or `timestamptz_ns` schema types, so higher precision and timezone semantics are not represented in the Iceberg schema.
 - ClickHouse cannot write to an Iceberg table that uses a `decimal`, `fixed`, `timestamp_ns`, or `timestamptz_ns` column as a direct partition field. The operation fails with an unsupported-type exception.
 - For data files containing types whose bounds ClickHouse cannot serialize, including `Bool` and `Decimal`, ClickHouse omits all lower and upper column bounds from the Iceberg manifest entry. Column sizes and null counts are still included, and the data remains correct, but readers cannot use manifest-level min-max pruning for those files.
 

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -1244,8 +1244,8 @@ The following table shows how Iceberg data types are mapped to ClickHouse data t
 
 The data type mappings above apply to reads. The following limitations apply when ClickHouse creates or evolves Iceberg schemas and writes data:
 
-- ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation returns an `Unsupported type for Iceberg` exception. This does not prevent inserting `Bool` or `Decimal` values into existing Iceberg columns.
-- ClickHouse cannot write to an Iceberg table that uses a `Decimal` column as a direct partition field. The operation returns an `Unsupported type for Iceberg` exception.
+- ClickHouse cannot create an Iceberg schema containing `Bool`, `Decimal`, `FixedString`, `Int8`, `UInt8`, `Int16`, or `UInt16`, or add or modify a column to one of these types. The operation fails with an unsupported-type exception. This does not prevent inserting `Bool` or `Decimal` values into existing Iceberg columns.
+- ClickHouse cannot write to an Iceberg table that uses a `decimal`, `fixed`, `timestamp_ns`, or `timestamptz_ns` column as a direct partition field. The operation fails with an unsupported-type exception.
 - For data files containing types whose bounds ClickHouse cannot serialize, including `Bool` and `Decimal`, ClickHouse omits all lower and upper column bounds from the Iceberg manifest entry. Column sizes and null counts are still included, and the data remains correct, but readers cannot use manifest-level min-max pruning for those files.
 
 ## Schema evolution {#schema-evolution}


### PR DESCRIPTION
Documents the operation-specific compatibility limits of writes through the Iceberg table engines. The reference now distinguishes schema creation and evolution from writing values into existing columns, documents the direct `Decimal` partition restriction, and explains the correctness and pruning consequences when manifest bounds are omitted.

The behavior was verified with a focused integration probe against the exact current `master` binary at `d5011f599b4c`: ClickHouse and Spark cross-engine reads passed for existing `Bool` and `Decimal` columns, direct `Bool` and `DateTime64(9)` partitions were confirmed supported, and the documented restrictions were reproduced.

Tracks [DOC-989](https://linear.app/clickhouse/issue/DOC-989/document-iceberg-write-compatibility-limitations).

Related: https://github.com/ClickHouse/ClickHouse/pull/115218

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115335&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115335](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115335+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1825` (included in `26.8` and later)
<!-- ch-version-info:end -->