### PR TITLE
Test: cover `updateProgress` zero-progress fallback

### DIFF
--- a/tests/queries/0_stateless/05018_play_progress_bar_unit.sh
+++ b/tests/queries/0_stateless/05018_play_progress_bar_unit.sh
@@ -21,3 +21,7 @@ ${CLICKHOUSE_CURL} -sS "${URL}/play" | grep -cE "setProperty\('--progress', *'[^
 # the check above cannot pass merely because the assignments were spelled in some other way.
 ${CLICKHOUSE_CURL} -sS "${URL}/play" | grep -oF 'clearBar' | head -n1
 ${CLICKHOUSE_CURL} -sS "${URL}/play" | grep -oE "setProperty\('--progress', '0%'\)" | head -n1
+
+# `updateProgress` uses a multiline conditional expression, which the literal assignment check
+# above intentionally does not match. Check its zero-progress fallback separately.
+${CLICKHOUSE_CURL} -sS "${URL}/play" | grep -zqE "this\.style\.setProperty\('--progress',[[:space:]]*rows && total_rows \? \(100 \* rows / total_rows\) \+ '%' : '0%'\);"


### PR DESCRIPTION
Strengthen the Web UI progress-bar regression test to verify the multiline `updateProgress` zero-progress fallback also retains the `%` unit.

Related: https://github.com/ClickHouse/ClickHouse/pull/115245

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115337&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115337](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115337+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
