### PR TITLE
Docs: More consistent statistics naming

### DIFF
--- a/docs/reference/statements/alter/statistics.mdx
+++ b/docs/reference/statements/alter/statistics.mdx
@@ -31,7 +31,7 @@ Also, they are replicated, syncing statistics metadata via ZooKeeper.
 Adding two statistics types to two columns:
 
 ```sql
-ALTER TABLE t1 MODIFY STATISTICS c, d TYPE TDigest, Uniq;
+ALTER TABLE t1 MODIFY STATISTICS c, d TYPE tdigest, uniq_v2;
 ```
 
 <Note>

--- a/docs/reference/statements/hypothetical-index.mdx
+++ b/docs/reference/statements/hypothetical-index.mdx
@@ -75,7 +75,7 @@ Estimation:
 To skip the in-memory empirical scan and estimate from [column statistics](/reference/engines/table-engines/mergetree-family/mergetree#column-statistics) instead, define them on the relevant columns first (they are off by default), wait for the materialize mutation to finish, then disable the empirical path:
 
 ```sql
-ALTER TABLE t ADD STATISTICS b TYPE TDigest;
+ALTER TABLE t ADD STATISTICS b TYPE tdigest;
 ALTER TABLE t MATERIALIZE STATISTICS b SETTINGS mutations_sync = 1;
 
 EXPLAIN WHATIF empirical = 0 SELECT * FROM t WHERE b < 10;


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115339&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115339](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115339+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
