### PR TITLE
Docs: document the Cloud Prometheus HTTP service discovery endpoint

### DIFF
--- a/docs/products/cloud/features/monitoring/prometheus.mdx
+++ b/docs/products/cloud/features/monitoring/prometheus.mdx
@@ -7,6 +7,7 @@ keywords: ['prometheus', 'grafana', 'monitoring', 'metrics', 'exporter']
 doc_type: 'reference'
 ---
 
+import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 import { Image } from "/snippets/components/Image.jsx";
 
 The feature supports integrating [Prometheus](https://prometheus.io/) to monitor ClickHouse Cloud services. Access to Prometheus metrics is exposed via the [ClickHouse Cloud API](/products/cloud/features/admin-features/api/api-overview) endpoint that allows you to securely connect and export metrics into your Prometheus metrics collector. These metrics can be integrated with dashboards e.g., Grafana, Datadog for visualization.
@@ -23,6 +24,7 @@ If you're looking for the equivalent endpoint for [ClickHouse Managed Postgres](
 | ------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
 | GET    | `https://api.clickhouse.cloud/v1/organizations/:organizationId/services/:serviceId/prometheus?filtered_metrics=[true \| false]` | Returns metrics for a specific service |
 | GET    | `https://api.clickhouse.cloud/v1/organizations/:organizationId/prometheus?filtered_metrics=[true \| false]` | Returns metrics for all services in an organization |
+| GET    | `https://api.clickhouse.cloud/v1/organizations/:organizationId/prometheus/discovery?filtered_metrics=[true \| false]` | Returns Prometheus scrape targets for all services in an organization, in the [HTTP service discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) format |
 
 **Request Parameters**
 
@@ -178,6 +180,54 @@ scrape_configs:
 ```
 
 Note the `honor_labels` configuration parameter needs to be set to `true` for the instance label to be properly populated.  Additionally, `filtered_metrics` is set to `true` in the above example, but should be configured based on user preference.
+
+### Automatic service discovery {#automatic-service-discovery}
+
+<BetaBadge />
+
+The discovery endpoint returns one scrape target per service in your organization, in the Prometheus [HTTP service discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) (`http_sd`) format. Prometheus refreshes the target list on every discovery poll and scrapes each discovered target, so newly created services are picked up automatically and deleted services are dropped from the target list. Only services your API key is authorized to view are included; services that are being deleted or have been deleted are omitted.
+
+To use it, point an [`http_sd_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config) job at the discovery endpoint:
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "clickhouse"
+    http_sd_configs:
+      - url: https://api.clickhouse.cloud/v1/organizations/<ORG_ID>/prometheus/discovery
+        refresh_interval: 60s
+        basic_auth:
+          username: <KEY_ID>
+          password: <KEY_SECRET>
+    basic_auth:
+      username: <KEY_ID>
+      password: <KEY_SECRET>
+    honor_labels: true
+```
+
+Set `basic_auth` in both places: the block under `http_sd_configs` authenticates the discovery polls, and the block on the scrape job authenticates the per-service metric scrapes. As with the static configuration, set `honor_labels: true` so the instance label is properly populated.
+
+A sample discovery response:
+
+```json
+[
+  {
+    "targets": ["api.clickhouse.cloud"],
+    "labels": {
+      "__scheme__": "https",
+      "__metrics_path__": "/v1/organizations/<ORG_ID>/services/<SERVICE_ID>/prometheus",
+      "__param_filtered_metrics": "true",
+      "clickhouse_org_id": "<ORG_ID>",
+      "clickhouse_service_id": "<SERVICE_ID>",
+      "clickhouse_discovery_service_name": "my service"
+    }
+  }
+]
+```
+
+Discovered targets scrape with `filtered_metrics=true`. To discover targets that scrape the full metric set, add `?filtered_metrics=false` to the discovery URL.
 
 ## Integrating with Grafana {#integrating-with-grafana}
 

--- a/docs/products/cloud/features/monitoring/prometheus.mdx
+++ b/docs/products/cloud/features/monitoring/prometheus.mdx
@@ -34,6 +34,8 @@ If you're looking for the equivalent endpoint for [ClickHouse Managed Postgres](
 | Service ID       | Endpoint address | uuid (optional)               |
 | filtered_metrics | Query param | boolean (optional) |
 
+Full request and response schemas for these endpoints are available in the [Cloud API reference](/products/cloud/api-reference/prometheus).
+
 ### Authentication {#authentication}
 
 Use your ClickHouse Cloud API key for basic authentication:
@@ -227,7 +229,7 @@ A sample discovery response:
 ]
 ```
 
-Discovered targets scrape with `filtered_metrics=true`. To discover targets that scrape the full metric set, add `?filtered_metrics=false` to the discovery URL.
+Discovered targets scrape with `filtered_metrics=true`. To discover targets that scrape the full metric set, add `?filtered_metrics=false` to the discovery URL. The full endpoint specification is available in the [Cloud API reference](/products/cloud/api-reference/prometheus/organization-prometheus-discovery-get).
 
 ## Integrating with Grafana {#integrating-with-grafana}
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation

Adds the `GET /v1/organizations/:organizationId/prometheus/discovery` endpoint (beta) to the ClickHouse Cloud Prometheus integration page:

- API reference table row, plus links to the [Cloud API reference](https://clickhouse.com/docs/products/cloud/api-reference/prometheus)
- A new "Automatic service discovery" section with an `http_sd_configs` scrape example, a note that `basic_auth` is required both on the discovery config and on the scrape job, a sample discovery response, and the `filtered_metrics` behavior

Draft until the endpoint is generally available in ClickHouse Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115342&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115342](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115342+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1767` (included in `26.8` and later)
<!-- ch-version-info:end -->