### PR TITLE
Sync private changes

### DIFF
--- a/src/Databases/IDatabase.cpp
+++ b/src/Databases/IDatabase.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 #include <Databases/IDatabase.h>
+#include <Databases/RenderedCreateQuery.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/TableNameHints.h>
@@ -259,6 +260,18 @@ ASTPtr IDatabase::getCreateTableQueryImpl(const String & /*name*/, ContextPtr /*
     if (throw_on_error)
         throw Exception(ErrorCodes::CANNOT_GET_CREATE_TABLE_QUERY, "There is no SHOW CREATE TABLE query for Database{}", getEngineName());
     return nullptr;
+}
+
+RenderedCreateQueryPtr
+IDatabase::getRenderedCreateTableQuery(const String & name, ContextPtr context, const RenderedCreateQueryFields & fields) const
+{
+    return getRenderedCreateTableQueryImpl(name, context, resolveRenderOptions(context), fields);
+}
+
+RenderedCreateQueryPtr IDatabase::getRenderedCreateTableQueryImpl(
+    const String & name, ContextPtr context, const RenderOptions & options, const RenderedCreateQueryFields & fields) const
+{
+    return renderCreateQuery(tryGetCreateTableQuery(name, context), options, fields);
 }
 
 DiskPtr IDatabase::getDisk() const

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -39,6 +39,10 @@ using DictionariesWithID = std::vector<std::pair<String, UUID>>;
 struct ParsedTablesMetadata;
 struct QualifiedTableName;
 class IRestoreCoordination;
+struct RenderOptions;
+struct RenderedCreateQuery;
+struct RenderedCreateQueryFields;
+using RenderedCreateQueryPtr = std::shared_ptr<const RenderedCreateQuery>;
 
 /// This structure is returned when getLightweightTablesIterator is called
 /// It contains basic details of the table, currently only the table name
@@ -443,6 +447,10 @@ public:
     /// like the one produced for `SELECT` queries.
     ASTPtr getCreateTableQuery(const String & name, ContextPtr context) const;
 
+    /// The CREATE query rendered for `system.tables`. Never null. Read only the requested `fields`.
+    RenderedCreateQueryPtr
+    getRenderedCreateTableQuery(const String & name, ContextPtr context, const RenderedCreateQueryFields & fields) const;
+
     /// Get the CREATE DATABASE query for current database.
     ASTPtr getCreateDatabaseQuery() const
     {
@@ -531,6 +539,10 @@ public:
 protected:
     virtual ASTPtr getCreateDatabaseQueryImpl() const = 0;
     virtual ASTPtr getCreateTableQueryImpl(const String & /*name*/, ContextPtr /*context*/, bool throw_on_error) const;
+
+    /// Renders on every call. An override may serve a cached rendering of more fields than asked.
+    virtual RenderedCreateQueryPtr getRenderedCreateTableQueryImpl(
+        const String & name, ContextPtr context, const RenderOptions & options, const RenderedCreateQueryFields & fields) const;
 
     mutable std::mutex mutex;
     String database_name TSA_GUARDED_BY(mutex);

--- a/src/Databases/RenderedCreateQuery.cpp
+++ b/src/Databases/RenderedCreateQuery.cpp
@@ -1,0 +1,87 @@
+#include <Databases/RenderedCreateQuery.h>
+
+#include <Access/ContextAccess.h>
+#include <Core/Settings.h>
+#include <Core/UUID.h>
+#include <Interpreters/Context.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Common/StringUtils.h>
+
+namespace DB
+{
+namespace Setting
+{
+    extern const SettingsBool format_display_secrets_in_show_and_select;
+    extern const SettingsBool print_pretty_type_names;
+    extern const SettingsBool show_table_uuid_in_table_create_query_if_not_nil;
+    extern const SettingsIdentifierQuotingRule show_create_query_identifier_quoting_rule;
+    extern const SettingsIdentifierQuotingStyle show_create_query_identifier_quoting_style;
+}
+
+namespace
+{
+
+String formatWithOptions(const IAST & ast, const RenderOptions & options)
+{
+    return ast.formatWithPossiblyHidingSensitiveData(
+        /*max_length=*/0,
+        options.one_line,
+        options.show_secrets,
+        options.print_pretty_type_names,
+        options.quoting_rule,
+        options.quoting_style);
+}
+
+}
+
+RenderOptions resolveRenderOptions(const ContextPtr & context)
+{
+    const auto & settings = context->getSettingsRef();
+
+    RenderOptions options;
+    options.show_secrets = context->displaySecretsInShowAndSelect()
+        && settings[Setting::format_display_secrets_in_show_and_select]
+        && context->getAccess()->isGranted(AccessType::displaySecretsInShowAndSelect);
+    options.print_pretty_type_names = settings[Setting::print_pretty_type_names];
+    options.quoting_rule = settings[Setting::show_create_query_identifier_quoting_rule];
+    options.quoting_style = settings[Setting::show_create_query_identifier_quoting_style];
+    options.show_uuid = settings[Setting::show_table_uuid_in_table_create_query_if_not_nil];
+    options.masker = SensitiveDataMasker::getInstance();
+    return options;
+}
+
+RenderedCreateQueryPtr renderCreateQuery(const ASTPtr & ast, const RenderOptions & options, RenderedCreateQueryFields fields)
+{
+    auto rendered = std::make_shared<RenderedCreateQuery>();
+    if (!ast)
+        return rendered;
+
+    auto * ast_create = ast->as<ASTCreateQuery>();
+
+    if (ast_create && !options.show_uuid)
+    {
+        ast_create->uuid = UUIDHelpers::Nil;
+        if (ast_create->targets)
+            ast_create->targets->resetInnerUUIDs();
+    }
+
+    if (fields.create_table_query)
+        rendered->create_table_query = formatWithOptions(*ast, options);
+
+    if (fields.engine_full && ast_create && ast_create->storage)
+    {
+        rendered->engine_full = formatWithOptions(*ast_create->storage, options);
+
+        static const char * const extra_head = " ENGINE = ";
+        if (startsWith(rendered->engine_full, extra_head))
+            rendered->engine_full = rendered->engine_full.substr(strlen(extra_head));
+    }
+
+    if (fields.as_select && ast_create && ast_create->select)
+        rendered->as_select = formatWithOptions(*ast_create->select, options);
+
+    return rendered;
+}
+
+}

--- a/src/Databases/RenderedCreateQuery.h
+++ b/src/Databases/RenderedCreateQuery.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Common/SensitiveDataMasker.h>
+#include <Interpreters/Context_fwd.h>
+#include <Parsers/IAST_fwd.h>
+#include <Parsers/IdentifierQuotingStyle.h>
+#include <base/types.h>
+
+#include <memory>
+
+namespace DB
+{
+
+/// Everything the text of a CREATE query depends on besides the query itself.
+struct RenderOptions
+{
+    /// Arguments of `IAST::formatWithPossiblyHidingSensitiveData`.
+    bool one_line = true;
+    bool show_secrets = false;
+    bool print_pretty_type_names = false;
+    IdentifierQuotingRule quoting_rule = IdentifierQuotingRule::WhenNecessary;
+    IdentifierQuotingStyle quoting_style = IdentifierQuotingStyle::Backticks;
+
+    /// Applied to the query before formatting it.
+    bool show_uuid = false;
+
+    /// Recorded only, so that a cached rendering is dropped when the masking rules change.
+    std::shared_ptr<const SensitiveDataMasker> masker;
+
+    bool operator==(const RenderOptions & other) const = default;
+};
+
+/// The columns of `system.tables` that are rendered from the CREATE query of a table.
+struct RenderedCreateQuery
+{
+    String create_table_query;
+    String engine_full;
+    String as_select;
+};
+
+using RenderedCreateQueryPtr = std::shared_ptr<const RenderedCreateQuery>;
+
+/// Which of the fields above a reader needs, so the other ones are left unformatted.
+struct RenderedCreateQueryFields
+{
+    bool create_table_query = true;
+    bool engine_full = true;
+    bool as_select = true;
+
+    static RenderedCreateQueryFields all() { return {}; }
+};
+
+/// The only place that reads the settings, so a rendering cannot disagree with its options.
+RenderOptions resolveRenderOptions(const ContextPtr & context);
+
+/// Modifies `ast` in place when the UUID has to be hidden. A null `ast` renders as empty strings.
+RenderedCreateQueryPtr
+renderCreateQuery(const ASTPtr & ast, const RenderOptions & options, RenderedCreateQueryFields fields = {});
+
+}

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -19,6 +19,7 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <Databases/RenderedCreateQuery.h>
 #include <Disks/IStoragePolicy.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -52,7 +53,6 @@ namespace Setting
 {
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsUInt64 select_sequential_consistency;
-    extern const SettingsBool show_table_uuid_in_table_create_query_if_not_nil;
     extern const SettingsBool show_data_lake_catalogs_in_system_tables;
     extern const SettingsBool show_remote_databases_in_system_tables;
 }
@@ -827,45 +827,25 @@ protected:
                 if (columns_mask[src_index] || columns_mask[src_index + 1] || columns_mask[src_index + 2])
                 {
                     /// Skip the catalog query for a null-storage row (unresolvable DataLakeCatalog
-                    /// table, or one dropped concurrently with the scan): tryGetCreateTableQuery
-                    /// re-enters DatabaseDataLake::getCreateTableQueryImpl, which can throw again
-                    /// and abort the whole scan. A null ast makes the block below emit defaults.
-                    ASTPtr ast = table ? database->tryGetCreateTableQuery(table_name, context) : nullptr;
-                    auto * ast_create = ast ? ast->as<ASTCreateQuery>() : nullptr;
+                    /// table, or one dropped concurrently with the scan): it re-enters
+                    /// DatabaseDataLake::getCreateTableQueryImpl, which can throw again and abort
+                    /// the whole scan. Such a row renders as empty strings.
+                    const RenderedCreateQueryFields fields{
+                        .create_table_query = columns_mask[src_index] != 0,
+                        .engine_full = columns_mask[src_index + 1] != 0,
+                        .as_select = columns_mask[src_index + 2] != 0};
 
-                    if (ast_create && !context->getSettingsRef()[Setting::show_table_uuid_in_table_create_query_if_not_nil])
-                    {
-                        ast_create->uuid = UUIDHelpers::Nil;
-                        if (ast_create->targets)
-                            ast_create->targets->resetInnerUUIDs();
-                    }
+                    auto rendered = table ? database->getRenderedCreateTableQuery(table_name, context, fields)
+                                          : renderCreateQuery(nullptr, RenderOptions{}, fields);
 
                     if (columns_mask[src_index++])
-                        res_columns[res_index++]->insert(ast ? format({context, *ast}) : "");
+                        res_columns[res_index++]->insert(rendered->create_table_query);
 
                     if (columns_mask[src_index++])
-                    {
-                        String engine_full;
-
-                        if (ast_create && ast_create->storage)
-                        {
-                            engine_full = format({context, *ast_create->storage});
-
-                            static const char * const extra_head = " ENGINE = ";
-                            if (startsWith(engine_full, extra_head))
-                                engine_full = engine_full.substr(strlen(extra_head));
-                        }
-
-                        res_columns[res_index++]->insert(engine_full);
-                    }
+                        res_columns[res_index++]->insert(rendered->engine_full);
 
                     if (columns_mask[src_index++])
-                    {
-                        String as_select;
-                        if (ast_create && ast_create->select)
-                            as_select = format({context, *ast_create->select});
-                        res_columns[res_index++]->insert(as_select);
-                    }
+                        res_columns[res_index++]->insert(rendered->as_select);
                 }
                 else
                     src_index += 3;


### PR DESCRIPTION
Moves the `system.tables` CREATE-query rendering into a shared helper that a database engine can override to serve a cached rendering. No behaviour change.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115344&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115344](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115344+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
