### PR TITLE
Do not widen a Variant result type for an alternative that is NULL for every row

### DIFF
--- a/src/Functions/FunctionVariantAdaptor.cpp
+++ b/src/Functions/FunctionVariantAdaptor.cpp
@@ -841,12 +841,14 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
     }
 
     /// A NULL-only alternative contributes no type, because executeImpl inserts NULL for its rows
-    /// instead of a nested result, so it must not widen the declared type either.
+    /// instead of a nested result, so it must not widen the declared type either. Only Nullable(Nothing)
+    /// is dropped: a bare Nothing is produced without a type error, so it is present in both strictness
+    /// modes and dropping it would move the declared type of an already-accepted key or index.
     DataTypes real_result_types;
     real_result_types.reserve(result_types.size());
     for (const auto & type : result_types)
     {
-        if (!type->onlyNull() && !isNothing(type))
+        if (!type->onlyNull())
             real_result_types.push_back(type);
     }
     const bool has_null_only_alternative = real_result_types.size() != result_types.size();

--- a/src/Functions/FunctionVariantAdaptor.cpp
+++ b/src/Functions/FunctionVariantAdaptor.cpp
@@ -776,6 +776,7 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
     /// For each alternative in the Variant, build the function and get the actual result type.
     DataTypes result_types;
     result_types.reserve(variant_alternatives.size());
+    bool skipped_null_for_every_row_alternative = false;
 
     const auto process_list_element = tryGetProcessListElement();
     const auto function_name = function_overload_resolver->getName();
@@ -797,6 +798,14 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
         try
         {
             const auto func_base = function_overload_resolver->build(alt_columns_with_type);
+            /// Another argument may still be a Variant, so build() can return a nested adaptor. One that
+            /// matched no alternative is NULL for every row and carries no result type of its own.
+            const auto * nested_adaptor = typeid_cast<const FunctionBaseVariantAdaptor *>(func_base.get());
+            if (nested_adaptor && nested_adaptor->resolvedToNullForEveryRow())
+            {
+                skipped_null_for_every_row_alternative = true;
+                continue;
+            }
             /// Strip LowCardinality from result type for consistency with executeImpl,
             /// where we also strip LC from nested function results.
             result_types.push_back(removeLowCardinality(func_base->getResultType()));
@@ -823,6 +832,7 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
         if (!shouldThrowOnVariantTypeMismatch())
         {
             return_type = makeNullable(std::make_shared<DataTypeNothing>());
+            resolved_to_null_for_every_row = true;
             return;
         }
 
@@ -840,29 +850,15 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
             function_overload_resolver->getName());
     }
 
-    /// A NULL-only alternative contributes no type, because executeImpl inserts NULL for its rows
-    /// instead of a nested result, so it must not widen the declared type either. Only Nullable(Nothing)
-    /// is dropped: a bare Nothing is produced without a type error, so it is present in both strictness
-    /// modes and dropping it would move the declared type of an already-accepted key or index.
-    DataTypes real_result_types;
-    real_result_types.reserve(result_types.size());
-    for (const auto & type : result_types)
-    {
-        if (!type->onlyNull())
-            real_result_types.push_back(type);
-    }
-    const bool has_null_only_alternative = real_result_types.size() != result_types.size();
-    const DataTypes & considered_types = real_result_types.empty() ? result_types : real_result_types;
-
     /// If all result types are the same (ignoring Nullable), return Nullable(common).
     /// Otherwise, return Variant(R0, R1, ...) in the same order.
     /// Compare by name to handle custom types correctly (like Geometry subtypes)
     bool all_same = true;
-    DataTypePtr common_type = removeNullable(considered_types[0]);
+    DataTypePtr common_type = removeNullable(result_types[0]);
 
-    for (size_t i = 1; i < considered_types.size(); ++i)
+    for (size_t i = 1; i < result_types.size(); ++i)
     {
-        DataTypePtr current_type = removeNullable(considered_types[i]);
+        DataTypePtr current_type = removeNullable(result_types[i]);
         if (common_type->getName() != current_type->getName())
         {
             all_same = false;
@@ -870,9 +866,9 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
         }
     }
 
-    /// Dropping a NULL-only alternative is only safe if the collapsed type can hold NULL: makeNullableSafe
-    /// returns the type bare when it cannot, which would turn those NULL rows into default values.
-    if (all_same && (!has_null_only_alternative || common_type->canBeInsideNullable()))
+    /// A skipped alternative still needs its rows to be NULL, and makeNullableSafe returns the type bare
+    /// when it cannot be inside Nullable, which would make those rows default values instead.
+    if (all_same && (!skipped_null_for_every_row_alternative || common_type->canBeInsideNullable()))
     {
         return_type = makeNullableSafe(common_type);
     }

--- a/src/Functions/FunctionVariantAdaptor.cpp
+++ b/src/Functions/FunctionVariantAdaptor.cpp
@@ -840,15 +840,27 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
             function_overload_resolver->getName());
     }
 
+    /// A NULL-only alternative contributes no type, because executeImpl inserts NULL for its rows
+    /// instead of a nested result, so it must not widen the declared type either.
+    DataTypes real_result_types;
+    real_result_types.reserve(result_types.size());
+    for (const auto & type : result_types)
+    {
+        if (!type->onlyNull() && !isNothing(type))
+            real_result_types.push_back(type);
+    }
+    const bool has_null_only_alternative = real_result_types.size() != result_types.size();
+    const DataTypes & considered_types = real_result_types.empty() ? result_types : real_result_types;
+
     /// If all result types are the same (ignoring Nullable), return Nullable(common).
     /// Otherwise, return Variant(R0, R1, ...) in the same order.
     /// Compare by name to handle custom types correctly (like Geometry subtypes)
     bool all_same = true;
-    DataTypePtr common_type = removeNullable(result_types[0]);
+    DataTypePtr common_type = removeNullable(considered_types[0]);
 
-    for (size_t i = 1; i < result_types.size(); ++i)
+    for (size_t i = 1; i < considered_types.size(); ++i)
     {
-        DataTypePtr current_type = removeNullable(result_types[i]);
+        DataTypePtr current_type = removeNullable(considered_types[i]);
         if (common_type->getName() != current_type->getName())
         {
             all_same = false;
@@ -856,7 +868,9 @@ FunctionBaseVariantAdaptor::FunctionBaseVariantAdaptor(
         }
     }
 
-    if (all_same)
+    /// Dropping a NULL-only alternative is only safe if the collapsed type can hold NULL: makeNullableSafe
+    /// returns the type bare when it cannot, which would turn those NULL rows into default values.
+    if (all_same && (!has_null_only_alternative || common_type->canBeInsideNullable()))
     {
         return_type = makeNullableSafe(common_type);
     }

--- a/src/Functions/FunctionVariantAdaptor.h
+++ b/src/Functions/FunctionVariantAdaptor.h
@@ -78,12 +78,17 @@ public:
 
     bool isSpatialPredicate() const override { return function_overload_resolver->isSpatialPredicate(); }
 
+    /// True when no alternative of the Variant argument was compatible with the function, so the result
+    /// is NULL for every row. Such an adaptor carries no type information about the function's result.
+    bool resolvedToNullForEveryRow() const { return resolved_to_null_for_every_row; }
+
 private:
     /// We remember the original IFunctionOverloadResolver to be able to build function for types inside Variant column.
     std::shared_ptr<const IFunctionOverloadResolver> function_overload_resolver;
     DataTypes arguments;
     DataTypePtr return_type;
     size_t variant_argument_index;
+    bool resolved_to_null_for_every_row = false;
 };
 
 

--- a/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.reference
+++ b/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.reference
@@ -13,6 +13,9 @@ Variant(Map(UInt8, String))	{1:'x',2:'y'}	0
 Variant(Map(UInt8, String))	\N	1
 Variant(Array(UInt8))	[1,2,1,2]	0
 Variant(Array(UInt8))	\N	1
+-- a bare Nothing alternative is present in both modes, so it is kept
+Variant(UInt8)
+Variant(UInt8)
 -- every alternative incompatible
 Nullable(Nothing)
 -- Dynamic is unaffected
@@ -23,8 +26,11 @@ Nullable(Point)
 -- INSERT with such an expression in the key writes both part types
 compact	3
 wide	3
-skip index	2
+skip index	4
 t_04927_compact	Compact
 t_04927_wide	Wide
+skip index prunes	1
+parts before merge	2
+parts after merge	1
 after merge	4
 after reattach	5

--- a/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.reference
+++ b/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.reference
@@ -1,0 +1,30 @@
+-- declared type does not depend on variant_throw_on_type_mismatch
+Nullable(Float64)
+Nullable(Float64)
+Nullable(Float64)
+Nullable(Float64)
+Nullable(Float64)
+Nullable(Float64)
+-- rows of an incompatible alternative are NULL, matching the declared type
+Nullable(Float64)	44	0
+Nullable(Float64)	\N	1
+-- a result type that cannot be inside Nullable keeps the Variant wrapper
+Variant(Map(UInt8, String))	{1:'x',2:'y'}	0
+Variant(Map(UInt8, String))	\N	1
+Variant(Array(UInt8))	[1,2,1,2]	0
+Variant(Array(UInt8))	\N	1
+-- every alternative incompatible
+Nullable(Nothing)
+-- Dynamic is unaffected
+Nullable(Float64)	5
+Nullable(Float64)	5
+-- a custom-named result type is unaffected
+Nullable(Point)
+-- INSERT with such an expression in the key writes both part types
+compact	3
+wide	3
+skip index	2
+t_04927_compact	Compact
+t_04927_wide	Wide
+after merge	4
+after reattach	5

--- a/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.reference
+++ b/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.reference
@@ -13,9 +13,13 @@ Variant(Map(UInt8, String))	{1:'x',2:'y'}	0
 Variant(Map(UInt8, String))	\N	1
 Variant(Array(UInt8))	[1,2,1,2]	0
 Variant(Array(UInt8))	\N	1
--- a bare Nothing alternative is present in both modes, so it is kept
+-- an alternative that resolves to Nothing without a type error is kept
 Variant(UInt8)
 Variant(UInt8)
+Variant(UInt8)
+Variant(UInt8)
+Variant(String)
+Variant(String)
 -- every alternative incompatible
 Nullable(Nothing)
 -- Dynamic is unaffected
@@ -34,3 +38,8 @@ parts before merge	2
 parts after merge	1
 after merge	4
 after reattach	5
+-- a set index over a kept Nothing alternative survives a reload
+nothing index type	Variant(UInt8)
+nothing index match	1
+nothing index values	[10,30,50]
+nothing index prunes	1

--- a/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.sql
+++ b/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.sql
@@ -32,10 +32,16 @@ FROM (SELECT CAST([1, 2], 'Variant(Array(UInt8), UInt8)') AS a UNION ALL SELECT 
 ORDER BY 3
 SETTINGS variant_throw_on_type_mismatch = 0;
 
-SELECT '-- a bare Nothing alternative is present in both modes, so it is kept';
+SELECT '-- an alternative that resolves to Nothing without a type error is kept';
 
 SELECT toTypeName(arrayElement(v, 1)) FROM (SELECT CAST([1, 2], 'Variant(Array(Nothing), Array(UInt8))') AS v) SETTINGS variant_throw_on_type_mismatch = 1;
 SELECT toTypeName(arrayElement(v, 1)) FROM (SELECT CAST([1, 2], 'Variant(Array(Nothing), Array(UInt8))') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+
+SELECT toTypeName(arrayElementOrNull(v, 1)) FROM (SELECT CAST([1, 2], 'Variant(Array(Nothing), Array(UInt8))') AS v) SETTINGS variant_throw_on_type_mismatch = 1;
+SELECT toTypeName(arrayElementOrNull(v, 1)) FROM (SELECT CAST([1, 2], 'Variant(Array(Nothing), Array(UInt8))') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+
+SELECT toTypeName(arrayElementOrNull(v, 1)) FROM (SELECT CAST(map(1, 'x'), 'Variant(Map(UInt8, Nothing), Map(UInt8, String))') AS v) SETTINGS variant_throw_on_type_mismatch = 1;
+SELECT toTypeName(arrayElementOrNull(v, 1)) FROM (SELECT CAST(map(1, 'x'), 'Variant(Map(UInt8, Nothing), Map(UInt8, String))') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
 
 SELECT '-- every alternative incompatible';
 
@@ -88,9 +94,11 @@ SELECT 'skip index prunes', count() > 0
 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_04927_skip WHERE max2(c2, c2) = 44)
 WHERE explain ILIKE '%Granules: 1/4%';
 
+SYSTEM STOP MERGES t_04927_compact;
 INSERT INTO t_04927_compact (c2, c0) VALUES (55, 4);
 SELECT 'parts before merge', count() FROM system.parts
 WHERE database = currentDatabase() AND table = 't_04927_compact' AND active;
+SYSTEM START MERGES t_04927_compact;
 OPTIMIZE TABLE t_04927_compact FINAL;
 SELECT 'parts after merge', count() FROM system.parts
 WHERE database = currentDatabase() AND table = 't_04927_compact' AND active;
@@ -101,6 +109,30 @@ ATTACH TABLE t_04927_compact;
 INSERT INTO t_04927_compact (c2, c0) VALUES (66, 5);
 SELECT 'after reattach', count() FROM t_04927_compact;
 
+SELECT '-- a set index over a kept Nothing alternative survives a reload';
+
+DROP TABLE IF EXISTS t_04927_nothing_idx;
+
+CREATE TABLE t_04927_nothing_idx (c0 Int32, v Variant(Array(Nothing), Array(UInt8)),
+    INDEX idx arrayElementOrNull(v, 1) TYPE set(100) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY c0
+SETTINGS index_granularity = 1, allow_suspicious_indices = 1;
+
+INSERT INTO t_04927_nothing_idx VALUES (1, CAST([10, 20], 'Variant(Array(Nothing), Array(UInt8))')),
+                                       (2, CAST([30, 40], 'Variant(Array(Nothing), Array(UInt8))')),
+                                       (3, CAST([50, 60], 'Variant(Array(Nothing), Array(UInt8))'));
+
+DETACH TABLE t_04927_nothing_idx;
+ATTACH TABLE t_04927_nothing_idx;
+
+SELECT 'nothing index type', toTypeName(arrayElementOrNull(v, 1)) FROM t_04927_nothing_idx LIMIT 1;
+SELECT 'nothing index match', count() FROM t_04927_nothing_idx WHERE arrayElementOrNull(v, 1) = 30;
+SELECT 'nothing index values', groupArray(arrayElementOrNull(v, 1)) FROM t_04927_nothing_idx;
+SELECT 'nothing index prunes', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_04927_nothing_idx WHERE arrayElementOrNull(v, 1) = 30)
+WHERE explain ILIKE '%Granules: 1/3%';
+
+DROP TABLE t_04927_nothing_idx;
 DROP TABLE t_04927_compact;
 DROP TABLE t_04927_wide;
 DROP TABLE t_04927_skip;

--- a/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.sql
+++ b/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.sql
@@ -1,0 +1,93 @@
+SET allow_suspicious_variant_types = 1;
+
+SELECT '-- declared type does not depend on variant_throw_on_type_mismatch';
+
+SELECT toTypeName(max2(v, v)) FROM (SELECT CAST(1, 'Variant(UInt8)') AS v) SETTINGS variant_throw_on_type_mismatch = 1;
+SELECT toTypeName(max2(v, v)) FROM (SELECT CAST(1, 'Variant(UInt8)') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+SELECT toTypeName(max2(v, v)) FROM (SELECT CAST(1, 'Variant(UInt8, Int128)') AS v) SETTINGS variant_throw_on_type_mismatch = 1;
+SELECT toTypeName(max2(v, v)) FROM (SELECT CAST(1, 'Variant(UInt8, Int128)') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+SELECT toTypeName(min2(v, v)) FROM (SELECT CAST(1, 'Variant(UInt8, String)') AS v) SETTINGS variant_throw_on_type_mismatch = 1;
+SELECT toTypeName(min2(v, v)) FROM (SELECT CAST(1, 'Variant(UInt8, String)') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+
+SELECT '-- rows of an incompatible alternative are NULL, matching the declared type';
+
+SELECT toTypeName(max2(v, v)), max2(v, v), isNull(max2(v, v))
+FROM (SELECT CAST(44, 'Variant(UInt8, String)') AS v UNION ALL SELECT CAST('zz', 'Variant(UInt8, String)') AS v)
+ORDER BY 3
+SETTINGS variant_throw_on_type_mismatch = 0;
+
+SELECT '-- a result type that cannot be inside Nullable keeps the Variant wrapper';
+
+SELECT toTypeName(mapFromArrays(a, b)), mapFromArrays(a, b), isNull(mapFromArrays(a, b))
+FROM (
+    SELECT CAST([1, 2], 'Variant(Array(UInt8), UInt8)') AS a, CAST(['x', 'y'], 'Variant(Array(String), String)') AS b
+    UNION ALL
+    SELECT CAST(7, 'Variant(Array(UInt8), UInt8)') AS a, CAST('z', 'Variant(Array(String), String)') AS b
+)
+ORDER BY 3
+SETTINGS variant_throw_on_type_mismatch = 0;
+
+SELECT toTypeName(arrayConcat(a, a)), arrayConcat(a, a), isNull(arrayConcat(a, a))
+FROM (SELECT CAST([1, 2], 'Variant(Array(UInt8), UInt8)') AS a UNION ALL SELECT CAST(7, 'Variant(Array(UInt8), UInt8)') AS a)
+ORDER BY 3
+SETTINGS variant_throw_on_type_mismatch = 0;
+
+SELECT '-- every alternative incompatible';
+
+SELECT toTypeName(max2(v, v)) FROM (SELECT CAST('x', 'Variant(String, IPv4)') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+SELECT toTypeName(max2(v, v)) FROM (SELECT CAST('x', 'Variant(String, IPv4)') AS v) SETTINGS variant_throw_on_type_mismatch = 1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT '-- Dynamic is unaffected';
+
+SELECT toTypeName(max2(d, d)), max2(d, d) FROM (SELECT CAST(5, 'Dynamic') AS d) SETTINGS variant_throw_on_type_mismatch = 0, dynamic_throw_on_type_mismatch = 0;
+SELECT toTypeName(max2(d, d)), max2(d, d) FROM (SELECT CAST(5, 'Dynamic') AS d) SETTINGS variant_throw_on_type_mismatch = 1, dynamic_throw_on_type_mismatch = 1;
+
+SELECT '-- a custom-named result type is unaffected';
+
+SELECT toTypeName(readWKTPoint(v)) FROM (SELECT CAST('POINT(1 2)', 'Variant(String, UInt8)') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+
+SELECT '-- INSERT with such an expression in the key writes both part types';
+
+SET variant_throw_on_type_mismatch = 1;
+
+DROP TABLE IF EXISTS t_04927_compact;
+DROP TABLE IF EXISTS t_04927_wide;
+DROP TABLE IF EXISTS t_04927_skip;
+
+CREATE TABLE t_04927_compact (c0 Nullable(Int32), c2 Variant(UInt8, Time, UInt128, Decimal256(13), Int128))
+ENGINE = MergeTree ORDER BY (max2(c2, c2), c0) PRIMARY KEY (max2(c2, c2))
+SETTINGS index_granularity = 2, allow_nullable_key = 1, allow_suspicious_indices = 1, min_bytes_for_wide_part = 1000000000;
+
+CREATE TABLE t_04927_wide (c0 Nullable(Int32), c2 Variant(UInt8, Time, UInt128, Decimal256(13), Int128))
+ENGINE = MergeTree ORDER BY (max2(c2, c2), c0) PRIMARY KEY (max2(c2, c2))
+SETTINGS index_granularity = 2, allow_nullable_key = 1, allow_suspicious_indices = 1, min_bytes_for_wide_part = 0;
+
+CREATE TABLE t_04927_skip (c0 Nullable(Int32), c2 Variant(UInt8, String), INDEX idx max2(c2, c2) TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY c0
+SETTINGS allow_nullable_key = 1, allow_suspicious_indices = 1;
+
+SET variant_throw_on_type_mismatch = 0;
+
+INSERT INTO t_04927_compact (c2, c0) VALUES (44, 1), (7, 2), (99, 3);
+INSERT INTO t_04927_wide (c2, c0) VALUES (44, 1), (7, 2), (99, 3);
+INSERT INTO t_04927_skip (c2, c0) VALUES (44, 1), (7, 2);
+
+SELECT 'compact', count() FROM t_04927_compact;
+SELECT 'wide', count() FROM t_04927_wide;
+SELECT 'skip index', count() FROM t_04927_skip;
+SELECT table, part_type FROM system.parts
+WHERE database = currentDatabase() AND table IN ('t_04927_compact', 't_04927_wide') AND active
+ORDER BY table;
+
+INSERT INTO t_04927_compact (c2, c0) VALUES (55, 4);
+OPTIMIZE TABLE t_04927_compact FINAL;
+SELECT 'after merge', count() FROM t_04927_compact;
+
+DETACH TABLE t_04927_compact;
+ATTACH TABLE t_04927_compact;
+INSERT INTO t_04927_compact (c2, c0) VALUES (66, 5);
+SELECT 'after reattach', count() FROM t_04927_compact;
+
+DROP TABLE t_04927_compact;
+DROP TABLE t_04927_wide;
+DROP TABLE t_04927_skip;

--- a/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.sql
+++ b/tests/queries/0_stateless/04927_variant_adaptor_null_only_alternative_type.sql
@@ -32,6 +32,11 @@ FROM (SELECT CAST([1, 2], 'Variant(Array(UInt8), UInt8)') AS a UNION ALL SELECT 
 ORDER BY 3
 SETTINGS variant_throw_on_type_mismatch = 0;
 
+SELECT '-- a bare Nothing alternative is present in both modes, so it is kept';
+
+SELECT toTypeName(arrayElement(v, 1)) FROM (SELECT CAST([1, 2], 'Variant(Array(Nothing), Array(UInt8))') AS v) SETTINGS variant_throw_on_type_mismatch = 1;
+SELECT toTypeName(arrayElement(v, 1)) FROM (SELECT CAST([1, 2], 'Variant(Array(Nothing), Array(UInt8))') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
+
 SELECT '-- every alternative incompatible';
 
 SELECT toTypeName(max2(v, v)) FROM (SELECT CAST('x', 'Variant(String, IPv4)') AS v) SETTINGS variant_throw_on_type_mismatch = 0;
@@ -64,13 +69,13 @@ SETTINGS index_granularity = 2, allow_nullable_key = 1, allow_suspicious_indices
 
 CREATE TABLE t_04927_skip (c0 Nullable(Int32), c2 Variant(UInt8, String), INDEX idx max2(c2, c2) TYPE minmax GRANULARITY 1)
 ENGINE = MergeTree ORDER BY c0
-SETTINGS allow_nullable_key = 1, allow_suspicious_indices = 1;
+SETTINGS allow_nullable_key = 1, allow_suspicious_indices = 1, index_granularity = 1;
 
 SET variant_throw_on_type_mismatch = 0;
 
 INSERT INTO t_04927_compact (c2, c0) VALUES (44, 1), (7, 2), (99, 3);
 INSERT INTO t_04927_wide (c2, c0) VALUES (44, 1), (7, 2), (99, 3);
-INSERT INTO t_04927_skip (c2, c0) VALUES (44, 1), (7, 2);
+INSERT INTO t_04927_skip (c2, c0) VALUES (44, 1), (7, 2), (99, 3), ('zz', 4);
 
 SELECT 'compact', count() FROM t_04927_compact;
 SELECT 'wide', count() FROM t_04927_wide;
@@ -79,8 +84,16 @@ SELECT table, part_type FROM system.parts
 WHERE database = currentDatabase() AND table IN ('t_04927_compact', 't_04927_wide') AND active
 ORDER BY table;
 
+SELECT 'skip index prunes', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_04927_skip WHERE max2(c2, c2) = 44)
+WHERE explain ILIKE '%Granules: 1/4%';
+
 INSERT INTO t_04927_compact (c2, c0) VALUES (55, 4);
+SELECT 'parts before merge', count() FROM system.parts
+WHERE database = currentDatabase() AND table = 't_04927_compact' AND active;
 OPTIMIZE TABLE t_04927_compact FINAL;
+SELECT 'parts after merge', count() FROM system.parts
+WHERE database = currentDatabase() AND table = 't_04927_compact' AND active;
 SELECT 'after merge', count() FROM t_04927_compact;
 
 DETACH TABLE t_04927_compact;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `LOGICAL_ERROR` (`Bad cast from type DB::ColumnVariant to DB::ColumnNullable`) when inserting into a MergeTree table whose sorting or primary key applies a function to a `Variant` column, such as `ORDER BY max2(v, v)`. Where the function's common result type can be inside `Nullable`, its declared type no longer depends on `variant_throw_on_type_mismatch` and so can no longer disagree with the column produced.


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/112469

Found by the `BuzzHouse (amd_tsan)` fuzzer: [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102039&sha=0cb4588fe9c8c2e1a8bb292786f16269e537f09f&name_0=PR&name_1=BuzzHouse%20%28amd_tsan%29), STID 3520-704a. The `LOGICAL_ERROR` is thrown at `SerializationNullable.cpp:216` from `calculateAndSerializePrimaryIndexRow` (`:235`), aborting debug and sanitizer builds. PR 102039 is only the carrier.

`FunctionBaseVariantAdaptor` composed its declared return type by a different rule than its own execution uses. Execution drops an alternative that is NULL for every row (`:530`); type construction counted it, so one such alternative widened the type to `Variant(...)`.

Such an alternative arises through recursion: when another argument is still a `Variant`, the per-alternative build returns a nested adaptor, and one matching none of its own alternatives differs per strictness mode. Under the default it throws and the alternative is skipped, so `max2` over a `Variant` declares `Nullable(Float64)`, which the Variant-in-key check accepts and records as the key type; leniently it returns `Nullable(Nothing)` and the type widens. The part writer picks `SerializationNullable` from the recorded type and serializes the runtime column unconverted, so a strict `CREATE` plus a lenient `INSERT` handed it a `ColumnVariant` and the cast threw.

The composition now skips such an alternative, so the declared type describes the column the adaptor builds; storage is fixed as a consequence.

The discriminator is where the alternative came from, not what its type looks like: a `Nothing` or `Nullable(Nothing)` a function genuinely returns is kept, since `arrayElementOrNull` over an `Array(Nothing)` alternative produces one in both modes, and dropping it would move the declared type of a key or skip index accepted today. Collapsing is also skipped when the common type cannot be inside `Nullable`, which would turn those NULL rows into defaults. An alternative whose build *throws* still leaves the strict type bare for `Array` and `Map`: pre-existing, unchanged.

<details>
<summary>Declared type of <code>max2</code> over a <code>Variant</code>, before and after</summary>

| expression | before, strict | before, lenient | after, both |
|---|---|---|---|
| `Variant(UInt8)` | `Nullable(Float64)` | `Nullable(Float64)` | `Nullable(Float64)` |
| `Variant(UInt8, Int128)` | `Nullable(Float64)` | `Variant(Float64)` | `Nullable(Float64)` |
| `Variant(UInt8, String)` | `Nullable(Float64)` | `Variant(Float64)` | `Nullable(Float64)` |

Values are unchanged: rows of an incompatible alternative are NULL before and after. When the common type cannot be inside `Nullable`, the declared type and both row values are untouched:

| expression | common type | before and after |
|---|---|---|
| `mapFromArrays` over two Variants | `Map(UInt8, String)` | `Variant(Map(UInt8, String))`, rows `{1:'x',2:'y'}` / `NULL` |
| `arrayConcat` over a Variant | `Array(UInt8)` | `Variant(Array(UInt8))`, rows `[1,2,1,2]` / `NULL` |

New test covers compact and wide writers, two pruning skip indices, `OPTIMIZE FINAL` and `DETACH`/`ATTACH`, and pins the paths that must not change, including `arrayElement` and `arrayElementOrNull` over a `Nothing` alternative in both modes. A set index written by the pre-fix binary over such an expression is read back with values and pruning intact. 50/50 randomized runs passed.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115346&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115346](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115346+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
