### PR TITLE
Do not require per-arch Bugfix Validation for edited-only tests

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -93,6 +93,12 @@ def has_new_integration_test_docker_images(changed_files):
 # responsible for the merge-blocking decision: validation passes iff at
 # least ONE per-arch job is OK (or new unit tests were added; unit tests
 # can't be auto-validated by re-running master HEAD).
+#
+# The per-arch requirement is merge-blocking only when the PR ADDS a
+# functional/integration test. When it merely edits pre-existing ones, no
+# per-arch job can ever report OK - a pre-existing test passes on master HEAD
+# by construction - so requiring one would be unsatisfiable; see
+# `adds_functional_or_integration_test`.
 _BUGFIX_VALIDATE_PER_ARCH_JOB_NAMES = (
     JobNames.BUGFIX_VALIDATE_FT_AMD,
     JobNames.BUGFIX_VALIDATE_FT_ARM,
@@ -168,6 +174,24 @@ def unit_bugfix_validation_refuted():
     return False
 
 
+def adds_functional_or_integration_test(added_files):
+    """Return True iff the PR ADDS a functional or integration test, so the per-arch Bugfix
+    Validation jobs have something they can reproduce against master HEAD.
+
+    `added_files` is `Info.get_added_files()`: None when the added-file subset was not
+    recorded (a run whose `Config Workflow` predates it, or a failed GitHub API read). None
+    is NOT "adds nothing" - we simply cannot tell an added test from an edited one, so return
+    True and keep the strict gate. Relaxing on an unknown would turn a transient API failure
+    into a silently weaker merge requirement."""
+    if added_files is None:
+        print(
+            "WARNING: the added-file list was not recorded - cannot tell a newly added test "
+            "from an edited one, so the strict per-arch requirement stays in force"
+        )
+        return True
+    return has_new_functional_tests(added_files) or has_new_integration_tests(added_files)
+
+
 def check():
     _title, _body, labels = GH.get_pr_title_body_labels()
     if not labels:
@@ -181,6 +205,7 @@ def check():
         return True
 
     changed_files = Info().get_changed_files()
+    added_files = Info().get_added_files()
     has_unit = has_new_unit_tests(changed_files)
     has_ft = has_new_functional_tests(changed_files)
     has_it = has_new_integration_tests(changed_files)
@@ -202,13 +227,28 @@ def check():
                 "At least one per-arch Bugfix Validation job validated the bug - pass"
             )
             return True
+        if adds_functional_or_integration_test(added_files):
+            print(
+                "No per-arch Bugfix Validation job validated the bug - the test "
+                "either passes on master HEAD on every arch (so it's not actually "
+                "a regression test for the fix) or every arch errored out. See "
+                "the per-arch Bugfix validation jobs in the report."
+            )
+            return False
+        # The PR only EDITS pre-existing functional/integration tests. Such a test passes on
+        # master HEAD by construction - that is what makes it pre-existing - so the per-arch
+        # jobs have nothing to reproduce and this branch could never be satisfied, no matter
+        # what the author does. Editing one is a normal part of a fix (pinning a setting whose
+        # meaning the fix changes, say), and the regression coverage then lives elsewhere, so
+        # fall through to the remaining evidence instead of blocking forever. An edited test
+        # that DOES reproduce still passes above, so nothing that used to validate stops
+        # validating. (Hit by PR #109722, whose regression test is a gtest while its only
+        # functional-test change pins settings in a test that a merged PR added.)
         print(
-            "No per-arch Bugfix Validation job validated the bug - the test "
-            "either passes on master HEAD on every arch (so it's not actually "
-            "a regression test for the fix) or every arch errored out. See "
-            "the per-arch Bugfix validation jobs in the report."
+            "The PR edits pre-existing functional/integration tests but adds none: such a "
+            "test passes on master HEAD by construction, so the per-arch Bugfix Validation "
+            "jobs have nothing to reproduce. Falling through to the remaining evidence."
         )
-        return False
 
     # Unit-only PR. The unit-test Bugfix Validation job builds a merge-base "before"
     # binary and runs the touched gtest suite against it. Block ONLY if that job
@@ -245,7 +285,13 @@ def check():
         )
         return True
 
-    # No new tests at all.
+    # Nothing left that could have validated the bug.
+    if has_ft or has_it:
+        print(
+            "Only pre-existing functional/integration tests were edited, and no unit test "
+            "or integration Docker image change backs the fix - nothing validated the bug"
+        )
+        return False
     print("No new tests have been added")
     return False
 

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -38,6 +38,52 @@ def _settings_history_entry_without_name(entry_body):
 SETTINGS_HISTORY_FILE = "src/Core/SettingsChangesHistory.cpp"
 
 
+def fetch_added_files(repo_name, pr_number):
+    """The paths this PR ADDS, per the GitHub API's per-file `status`.
+
+    `changed_files` deliberately cannot answer this: it flattens added, modified, renamed and
+    deleted paths into one list (and includes both sides of a rename), which is what every
+    other consumer wants. The bug-fix gate needs the distinction, because only a newly ADDED
+    functional or integration test can be reproduced against master HEAD - a pre-existing one
+    passes there by construction. See `new_tests_check.py`.
+
+    Only `added` counts. A `renamed` test is pre-existing content at a new path, so it does
+    not exist on master HEAD under that path and cannot be run there either; treating it as
+    added would make the gate unsatisfiable for exactly the same reason."""
+    return [
+        line.strip()
+        for line in GH.get_output_with_retries(
+            f"gh api repos/{repo_name}/pulls/{pr_number}/files --paginate "
+            "--jq '.[] | select(.status == \"added\") | .filename'",
+            verbose=True,
+            strict=True,
+        ).splitlines()
+        if line.strip()
+    ]
+
+
+def store_added_files(info):
+    """Record the added-file subset for the bug-fix gate.
+
+    Never raises: `changed_files` (stored just above by the caller) is what the merge-queue
+    flaky check and job filtering depend on, and this is a strictly additional signal, so a
+    GitHub API blip must not fail the whole workflow. On failure the key is simply left
+    unset, and `Info.get_added_files` then returns None - which every consumer must read as
+    "not known" and handle by keeping its strict behaviour."""
+    pr_number = info.pr_number
+    if pr_number <= 0 and info.is_merge_queue_event:
+        pr_number = info.linked_pr_number
+    if pr_number <= 0:
+        print("Not a PR / merge-queue run - skip storing added files")
+        return
+    try:
+        added_files = fetch_added_files(info.repo_name, pr_number)
+        info.store_kv_data("added_files", added_files)
+        print(f"Stored {len(added_files)} added files")
+    except Exception as e:
+        print(f"WARNING: failed to compute the added-file list: {e}")
+
+
 def fetch_settings_history_patch_and_file(
     repo_name, pr_number, path=SETTINGS_HISTORY_FILE
 ):
@@ -364,6 +410,9 @@ if __name__ == "__main__":
         or []
     )
     info.store_kv_data("changed_files", changed_files)
+
+    # Which of those files the change ADDS, for the bug-fix gate in `new_tests_check.py`.
+    store_added_files(info)
 
     # For the settings-history style check (check_style.py): when
     # src/Core/SettingsChangesHistory.cpp changed in a PR or merge-queue run, record the

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -277,6 +277,14 @@ class Info:
     def get_changed_files(self):
         return self.get_kv_data().get("changed_files", None)
 
+    def get_added_files(self):
+        """The subset of the changed files that this change ADDS, or None when it was not
+        recorded (a non-PR run, or a failed read - the storing hook never fails the workflow
+        over it). None means "not known", which is distinct from an empty list meaning "this
+        change adds no file at all", so consumers can keep their strict behaviour when the
+        distinction is unavailable."""
+        return self.get_kv_data().get("added_files", None)
+
     def store_traceback(self):
         self.env.TRACEBACKS.append(traceback.format_exc())
         self.env.dump()

--- a/ci/tests/test_new_tests_check.py
+++ b/ci/tests/test_new_tests_check.py
@@ -13,11 +13,18 @@ pre-hook auto-injects such a link into every upstream PR body, so it can no
 longer serve as operator-supplied evidence), so a Bug-Fix PR that adds no
 tests is rejected regardless of the links in its body.
 
-Invariant under test: when a Bug-Fix PR adds new functional or integration
-regression tests (`has_ft or has_it`), `check()` returns True iff at least
-one per-arch Bugfix Validation job is strict-success (`OK` or `XFAIL`). The
-unit-test presence shortcut may not override this; only the per-arch jobs
-decide.
+Invariant under test: when a Bug-Fix PR ADDS new functional or integration
+regression tests, `check()` returns True iff at least one per-arch Bugfix
+Validation job is strict-success (`OK` or `XFAIL`). The unit-test presence
+shortcut may not override this; only the per-arch jobs decide.
+
+The requirement is keyed on ADDED tests, not merely changed ones: a
+pre-existing functional/integration test passes on master HEAD by
+construction, so no per-arch job can ever report OK for it and demanding one
+would be unsatisfiable. A PR that only EDITS such tests therefore falls
+through to the remaining evidence - which is not a bypass, since every later
+branch keeps its own verdict and an edited test that does reproduce still
+validates above.
 
 See ClickHouse/ClickHouse#103541 (bot review, 2026-06-06).
 """
@@ -41,6 +48,12 @@ from ci.praktika.result import Result
 # `_install_stubs` replaces `has_new_unit_tests` with a path-classification stub; keep
 # the real one so a test can opt back into the actual gtest-macro parsing.
 _REAL_HAS_NEW_UNIT_TESTS = new_tests_check.has_new_unit_tests
+
+# Sentinel for `_install_stubs(added_files=...)`: unless a test says otherwise, every changed
+# file is treated as newly ADDED. That is what the truth-table cases below mean by "the PR
+# adds an FT regression test", and it keeps them exercising the strict per-arch requirement.
+# Pass `added_files=[]` for the edited-only case, or `added_files=None` for "not recorded".
+_ADDED_FILES_DEFAULT = object()
 
 
 # ---------------------------------------------------------------------------
@@ -68,14 +81,26 @@ class _StubInfo:
     `any_bugfix_validation_passed` touch is implemented.
     """
 
-    def __init__(self, *, workflow_name="PR", pr_body="", changed_files=None, labels=None):
+    def __init__(
+        self,
+        *,
+        workflow_name="PR",
+        pr_body="",
+        changed_files=None,
+        added_files=None,
+        labels=None,
+    ):
         self.workflow_name = workflow_name
         self.pr_body = pr_body
         self._changed_files = list(changed_files or [])
+        self._added_files = added_files
         self.pr_labels = list(labels or [])
 
     def get_changed_files(self):
         return list(self._changed_files)
+
+    def get_added_files(self):
+        return None if self._added_files is None else list(self._added_files)
 
 
 def _install_stubs(
@@ -86,6 +111,7 @@ def _install_stubs(
     workflow_subresults,
     title="A bug fix",
     labels=None,
+    added_files=_ADDED_FILES_DEFAULT,
 ):
     """Patch `Info`, `GH.get_pr_title_body_labels`, and `Result.from_fs` so
     `check()` and `any_bugfix_validation_passed()` run without external state.
@@ -94,6 +120,12 @@ def _install_stubs(
     not required to exist on disk: `has_new_*_tests` use `Path.is_file`, so
     the helpers in `new_tests_check` are also stubbed to return whether any
     matching path was provided.
+
+    `added_files` is the subset of `changed_files` that the PR ADDS, as
+    `Info.get_added_files` reports it. It defaults to all of `changed_files`
+    (every path treated as newly added), which is what the truth-table cases
+    below intend; pass `[]` for a PR that only edits pre-existing tests, or
+    `None` for a run where the subset was not recorded.
 
     `labels` drives the bug-fix gate, which `check()` keys on the
     `pr-bugfix` / `pr-critical-bugfix` labels (set by the
@@ -104,10 +136,13 @@ def _install_stubs(
     """
     if labels is None:
         labels = ["pr-bugfix"] if " Bug Fix" in pr_body else []
+    if added_files is _ADDED_FILES_DEFAULT:
+        added_files = list(changed_files)
     stub_info = _StubInfo(
         workflow_name="PR",
         pr_body=pr_body,
         changed_files=list(changed_files),
+        added_files=added_files,
         labels=labels,
     )
     monkeypatch.setattr(new_tests_check, "Info", lambda: stub_info)
@@ -446,6 +481,184 @@ def test_ft_present_with_xfail_per_arch_passes(monkeypatch):
         ],
     )
     assert new_tests_check.check() is True
+
+
+# ---------------------------------------------------------------------------
+# `check()` truth table: FT/IT only EDITED, none added
+# ---------------------------------------------------------------------------
+#
+# A pre-existing functional/integration test passes on master HEAD by construction, so no
+# per-arch job can ever report OK for it. Requiring one would make the gate unsatisfiable for
+# any fix that has to adjust an existing test (pin a setting whose meaning the fix changes,
+# say) while its actual regression coverage lives in a gtest. Such a PR must fall through to
+# the remaining evidence instead - but nothing that used to validate may stop validating.
+
+
+def test_ft_edited_only_falls_through_to_unit_branch(monkeypatch):
+    """Edited-only FT + a unit test the unit validator did not refute -> pass.
+
+    This is the PR #109722 shape: the gtest is the regression test, and the only
+    functional-test change pins settings in a test a merged PR added.
+    """
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=[
+            "tests/queries/0_stateless/04653_pre_existing.sql",
+            "src/Processors/QueryPlan/tests/gtest_my_unit.cpp",
+        ],
+        added_files=["src/Processors/QueryPlan/tests/gtest_my_unit.cpp"],
+        workflow_subresults=[
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_AMD, Result.Status.SKIPPED),
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_ARM, Result.Status.SKIPPED),
+            # Inconclusive: the before-binary cannot compile a gtest that uses
+            # PR-introduced API. Must not block.
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_UT, Result.Status.ERROR),
+        ],
+    )
+    assert new_tests_check.check() is True
+
+
+def test_ft_edited_only_still_blocks_when_unit_validation_refuted(monkeypatch):
+    """Falling through is not a bypass: the unit branch's own verdict still applies."""
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=[
+            "tests/queries/0_stateless/04653_pre_existing.sql",
+            "src/Processors/QueryPlan/tests/gtest_my_unit.cpp",
+        ],
+        added_files=["src/Processors/QueryPlan/tests/gtest_my_unit.cpp"],
+        workflow_subresults=[
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_AMD, Result.Status.SKIPPED),
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_UT, Result.Status.FAIL),
+        ],
+    )
+    assert new_tests_check.check() is False
+
+
+def test_ft_edited_only_and_no_other_evidence_still_blocks(monkeypatch):
+    """Edited-only FT and nothing else -> still rejected. The fall-through reaches the
+    remaining branches, and with no unit test and no Docker image change none of them
+    accepts, so the gate does not become a free pass."""
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=["tests/queries/0_stateless/04653_pre_existing.sql"],
+        added_files=[],
+        workflow_subresults=[
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_AMD, Result.Status.SKIPPED),
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_ARM, Result.Status.SKIPPED),
+        ],
+    )
+    assert new_tests_check.check() is False
+
+
+def test_ft_edited_only_that_does_reproduce_still_passes(monkeypatch):
+    """An EDITED test that does reproduce the bug on master HEAD is still full validation -
+    the per-arch check runs first, so relaxing the requirement takes nothing away."""
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=["tests/queries/0_stateless/04653_pre_existing.sql"],
+        added_files=[],
+        workflow_subresults=[
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_AMD, Result.Status.OK),
+        ],
+    )
+    assert new_tests_check.check() is True
+
+
+def test_ft_added_alongside_edited_keeps_the_strict_gate(monkeypatch):
+    """One newly added FT is enough to keep the strict requirement: the per-arch jobs CAN
+    reproduce against master HEAD, so an unvalidated added regression test is still rejected
+    even though the PR also edits a pre-existing test and adds a unit test."""
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=[
+            "tests/queries/0_stateless/04653_pre_existing.sql",
+            "tests/queries/0_stateless/04500_my_regression.sql",
+            "src/Functions/tests/gtest_my_unit.cpp",
+        ],
+        added_files=[
+            "tests/queries/0_stateless/04500_my_regression.sql",
+            "src/Functions/tests/gtest_my_unit.cpp",
+        ],
+        workflow_subresults=[
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_AMD, Result.Status.SKIPPED),
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_ARM, Result.Status.SKIPPED),
+        ],
+    )
+    assert new_tests_check.check() is False
+
+
+def test_it_edited_only_falls_through(monkeypatch):
+    """Same contract for integration tests."""
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=[
+            "tests/integration/test_my_thing/test.py",
+            "src/Functions/tests/gtest_my_unit.cpp",
+        ],
+        added_files=["src/Functions/tests/gtest_my_unit.cpp"],
+        workflow_subresults=[
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_IT_AMD, Result.Status.SKIPPED),
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_IT_ARM, Result.Status.SKIPPED),
+        ],
+    )
+    assert new_tests_check.check() is True
+
+
+def test_unrecorded_added_files_keep_the_strict_gate(monkeypatch):
+    """`added_files` unavailable (a run predating it, or a failed GitHub API read) is NOT
+    "adds nothing": we cannot tell an added test from an edited one, so the strict per-arch
+    requirement stays in force. A transient API failure must not silently weaken the gate."""
+    _install_stubs(
+        monkeypatch,
+        pr_body="A change.\n\n- [x]  Bug Fix\n",
+        changed_files=[
+            "tests/queries/0_stateless/04500_my_regression.sql",
+            "src/Functions/tests/gtest_my_unit.cpp",
+        ],
+        added_files=None,
+        workflow_subresults=[
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_AMD, Result.Status.SKIPPED),
+            _per_arch_job(JobNames.BUGFIX_VALIDATE_FT_ARM, Result.Status.SKIPPED),
+        ],
+    )
+    assert new_tests_check.check() is False
+
+
+# ---------------------------------------------------------------------------
+# `adds_functional_or_integration_test` itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "added_files, expected",
+    [
+        (None, True),  # not recorded -> keep the strict gate
+        ([], False),
+        (["src/Functions/tests/gtest_my_unit.cpp"], False),
+        (["tests/queries/0_stateless/04500_my_regression.sql"], True),
+        (["tests/integration/test_my_thing/test.py"], True),
+        # e2e integration tests cannot be executed by the validation jobs, so adding one
+        # gives the per-arch machinery nothing to run - same as adding no test.
+        (["tests/integration/test_e2e_my_thing/test.py"], False),
+    ],
+)
+def test_adds_functional_or_integration_test(monkeypatch, added_files, expected):
+    _install_stubs(
+        monkeypatch,
+        pr_body="",
+        changed_files=[],
+        workflow_subresults=[],
+    )
+    assert (
+        new_tests_check.adds_functional_or_integration_test(added_files) is expected
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The bug-fix gate `new_tests_check.py` requires at least one per-arch Bugfix Validation job to confirm that a functional or integration regression test reproduces on master HEAD. It selected that branch from `has_new_functional_tests` / `has_new_integration_tests`, which return true for **any** changed file under `tests/queries/0_stateless` or `tests/integration/test_*` — added or merely modified.

A pre-existing test passes on master HEAD by construction, so when a PR only *edits* one, the per-arch jobs report `Bug does not reproduce on this arch - bugfix validation N/A` and the requirement becomes unsatisfiable: no amount of work by the author can turn it green. Adjusting an existing test is a normal part of a fix — pinning a setting whose meaning the fix changes, say — with the actual regression coverage in a gtest, and such a PR was blocked forever.

This keys the requirement on the tests a PR **adds**:

- `store_data.py` records the added-file subset (from the GitHub API's per-file `status`) alongside `changed_files`, exposed as `Info.get_added_files`.
- When no functional or integration test is added, the hook explains why the per-arch jobs cannot decide and falls through to the remaining evidence (unit-test validation, integration Docker image change). Each of those keeps its own verdict, so a PR with nothing else is still rejected.
- An edited test that *does* reproduce is unaffected: the per-arch check still runs first, so nothing that used to validate stops validating. The per-arch jobs themselves keep running for edited tests, which is what makes that case still work.
- Only `added` counts, not `renamed`: renamed content does not exist on master HEAD under the new path either, so it cannot be reproduced there.
- When the added-file list is unavailable — a run predating it, or a failed API read — the strict requirement stays in force, so a transient failure cannot silently weaken the gate.

`ci/tests/test_new_tests_check.py` grows cases for the edited-only branch: fall-through to the unit branch, still blocking when the unit validation was refuted, still blocking with no other evidence, an edited test that does reproduce still passing, one added test alongside edited ones keeping the strict gate, and the unrecorded-`added_files` case. The pre-existing truth table is unchanged (its cases now declare their changed files as added, which is what they always meant).

Found while investigating https://github.com/ClickHouse/ClickHouse/pull/109722: its regression test is a gtest, and its only functional-test change pins settings in `04653_merging_aggregated_deserialized_thread_count.sql`, a test that merged PR #112506 added. That PR was red on `Finish Workflow` with no way for its author to fix it.

CI report for the investigated PR: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109722&sha=d2915820d70c637704b96deb5ad622b9a8d6d2f5&name_0=PR

Related: https://github.com/ClickHouse/ClickHouse/pull/109722
Related: https://github.com/ClickHouse/ClickHouse/pull/112506
Related: https://github.com/ClickHouse/ClickHouse/pull/103541

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115349&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115349](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115349+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
