### PR TITLE
CI: retain selected sequential tests for CI changes

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -86,6 +86,7 @@ class Targeting:
         "ci/jobs/scripts/workflow_hooks/filter_job.py",
         "ci/jobs/scripts/workflow_hooks/store_data.py",
         "ci/jobs/scripts/server_cleanup.py",
+        "ci/praktika/info.py",
         "ci/jobs/scripts/functional_tests/setup_log_cluster.sh",
         "ci/jobs/scripts/functional_tests/setup_seaweedfs.sh",
         "ci/praktika/cidb.py",

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -410,7 +410,10 @@ def should_skip_job(job_name):
     ):
         if JobNames.STATELESS in job_name:
             match = re.search(r"(\d)/\d", job_name)
-            if match and match.group(1) != "1" or "sequential" in job_name:
+            if (
+                (match and match.group(1) != "1")
+                or ("sequential" in job_name and "selected tests" not in job_name)
+            ):
                 return True, "Skipped: only CI scripts changed; running stateless batch 1 only"
 
         if JobNames.INTEGRATION in job_name:

--- a/ci/tests/test_config_job_no_cidb.py
+++ b/ci/tests/test_config_job_no_cidb.py
@@ -344,5 +344,17 @@ def test_get_changed_tests_issues_no_cidb_query(monkeypatch):
     assert calls == [], f"config-time CIDB requests: {calls}"
 
 
+def test_ci_script_change_keeps_sequential_selected_tests_job(monkeypatch):
+    _use_fake_info(monkeypatch, changed_files=("ci/jobs/functional_tests.py",))
+
+    assert fj.should_skip_job(
+        "Stateless tests (amd_tsan, sequential, selected tests)"
+    ) == (False, "")
+    assert fj.should_skip_job("Stateless tests (amd_tsan, sequential)") == (
+        True,
+        "Skipped: only CI scripts changed; running stateless batch 1 only",
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/ci/tests/test_selected_tests_run.py
+++ b/ci/tests/test_selected_tests_run.py
@@ -173,6 +173,19 @@ def test_selected_tests_add_smoke_tests_for_store_data_hook_change():
     ]
 
 
+def test_selected_tests_add_smoke_tests_for_info_change():
+    targeter = Targeting.__new__(Targeting)
+    targeter.info = SimpleNamespace(
+        is_local_run=False, get_changed_files=lambda: [], job_name="Stateless tests"
+    )
+    targeter._diff_text = "+++ b/ci/praktika/info.py\n"
+
+    assert targeter.get_changed_tests(include_harness_smoke=True) == [
+        "00001_select_1.",
+        "01109_exchange_tables.",
+    ]
+
+
 def test_selected_tests_add_smoke_tests_for_rendered_workflow_change():
     targeter = Targeting.__new__(Targeting)
     targeter.info = SimpleNamespace(


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114730

This follow-up addresses two unresolved CI-review findings from #114730. It keeps sequential `selected tests` sanitizer jobs enabled for CI-Python-only changes and treats `ci/praktika/info.py` as a stateless functional-test harness input, so such changes receive deterministic smoke-test coverage.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115350&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115350](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115350+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1670` (included in `26.8` and later)
<!-- ch-version-info:end -->