### PR TITLE
Fix `--skip-submodules` worker cleanup

### DIFF
--- a/utils/continue-all-prs.sh
+++ b/utils/continue-all-prs.sh
@@ -746,9 +746,11 @@ prepare_worktree_for_task()
         'git reset --hard -q HEAD && { git clean -ffdx -e "/build*/" || { echo "Retrying cleanup with elevated permissions: $PWD" >&2; sudo -n git -c safe.directory="$PWD" -C "$PWD" clean -ffdx -e "/build*/"; }; }' >/dev/null
     if (( SKIP_SUBMODULES )); then
         # Restore initialized submodules to the superproject gitlinks without
-        # initializing absent ones. Resetting each submodule above is not
-        # enough: it retains a stale but clean submodule `HEAD`.
-        git -C "$wt" submodule update --checkout --force --recursive --no-fetch
+        # initializing absent ones. `submodule update` can nevertheless
+        # initialize submodules selected by `submodule.active`, so check out
+        # the recorded SHA directly in the submodules that `foreach` found.
+        git -C "$wt" submodule foreach --quiet --recursive \
+            'git checkout --detach -q "$sha1"'
     else
         git -C "$wt" submodule update --init --checkout --force --recursive --no-fetch
     fi

--- a/utils/tests/test_continue_all_prs.sh
+++ b/utils/tests/test_continue_all_prs.sh
@@ -9,6 +9,11 @@ worktree_base="$scratch/worktree"
 pr_file="$scratch/prs"
 runner_pid=""
 
+# Keep this test independent of the host filesystem capacity. The production
+# default is deliberately high, but these assertions do not cover low-space
+# cleanup.
+export CONTINUE_ALL_PRS_MIN_FREE_GB=1
+
 cleanup()
 {
     [[ -z "$runner_pid" ]] || kill "$runner_pid" 2>/dev/null || true


### PR DESCRIPTION
Keep `--skip-submodules` from initializing absent submodules selected by `submodule.active`, and pin the worker-harness disk reserve so its existing assertions do not depend on host capacity.

Related: https://github.com/ClickHouse/ClickHouse/pull/115031

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115359&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115359](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115359+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1684` (included in `26.8` and later)
<!-- ch-version-info:end -->