### PR TITLE
Performance test for ARRAY JOIN lazy replication over serialized plans

### DIFF
--- a/tests/performance/array_join_lazy_replication_serialized_plan.xml
+++ b/tests/performance/array_join_lazy_replication_serialized_plan.xml
@@ -1,0 +1,17 @@
+<test>
+    <settings>
+        <serialize_query_plan>1</serialize_query_plan>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <!-- The payload must be a wide String and must reach the sink unwrapped:
+         isLazyReplicationUseful declines fixed-width columns of 8 bytes or less,
+         and a function applied to the column converts it to a full column. -->
+    <query>
+        SELECT wide
+        FROM remote('127.0.0.{{2,3}}',
+             view(SELECT repeat(toString(number), 1000) AS wide, range(500) AS arr FROM numbers(500)))
+        ARRAY JOIN arr
+        FORMAT Null
+    </query>
+</test>

--- a/tests/performance/array_join_lazy_replication_serialized_plan.xml
+++ b/tests/performance/array_join_lazy_replication_serialized_plan.xml
@@ -2,6 +2,9 @@
     <settings>
         <serialize_query_plan>1</serialize_query_plan>
         <max_threads>1</max_threads>
+        <enable_analyzer>1</enable_analyzer>
+        <enable_lazy_columns_replication>1</enable_lazy_columns_replication>
+        <distributed_group_by_no_merge>0</distributed_group_by_no_merge>
     </settings>
 
     <!-- The payload must be a wide String and must reach the sink unwrapped:

--- a/tests/performance/scripts/config/config.d/process_query_plan_packet.xml
+++ b/tests/performance/scripts/config/config.d/process_query_plan_packet.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <process_query_plan_packet>true</process_query_plan_packet>
+</clickhouse>


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112330
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/112330

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The performance test @ alexey-milovidov asked for on #112330, which made `ArrayJoinStep` carry
`enable_lazy_columns_replication` in its serialized flags. Before it, a shard running a serialized plan
fragment fell back to the plan default `false` and replicated ARRAY JOIN payloads eagerly. That path
had no performance coverage.

One query: `remote('127.0.0.{2,3}', view(...))` with ARRAY JOIN and `serialize_query_plan = 1`, so the
shard really runs `ArrayJoinStep::deserialize` (`EXPLAIN distributed=1` shows `ArrayJoin` under
`ReadFromRemote`).

Two constraints decide whether this measures anything. The payload must be a wide `String`, because
`isLazyReplicationUseful` declines fixed-width columns of 8 bytes or less (also why
`tests/performance/array_join.xml` could not be extended). And no function may touch it, since that
converts the replicated column to a full one in both arms, hence the bare `SELECT wide`.

Four settings gate the measured path, so all four are pinned: flipping any one collapses the
pre-fix/post-fix ratio from 68x to about 1x while the test still passes.

Also adds `process_query_plan_packet` to the perf harness config: it defaults to `false` here, so
without it the query fails with `SUPPORT_IS_DISABLED` rather than running slower. It predates every
active release base, so the reference binary accepts it.

Measured with `perf.py` between release builds `f61ce92` (pre-fix) and `fbf131e`: median 0.762 s versus
0.016 s, about 49x, p = 4.1e-12; peak memory on the initiator 1677 MiB versus 12.5 MiB.

Scope: on a pull request both sides carry the fix, so this reports parity and acts as a regression
guard. The 49x is my own before/after measurement between those builds, not something this PR's run will
show. The `release_base` job reverts `tests/performance` to the release base, so it skips this test
rather than comparing across the fix. Worst gated per-run figure 0.47 s against a 2 s limit.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115364&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115364](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115364+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1746` (included in `26.8` and later)
<!-- ch-version-info:end -->