### PR TITLE
Docs: add Managed Postgres replica lag notification

### DIFF
--- a/docs/products/managed-postgres/monitoring/notifications.mdx
+++ b/docs/products/managed-postgres/monitoring/notifications.mdx
@@ -3,7 +3,7 @@ slug: /cloud/managed-postgres/monitoring/notifications
 sidebarTitle: 'Notifications'
 title: 'ClickHouse Managed Postgres notifications'
 description: 'Cloud console notifications for ClickHouse Managed Postgres services'
-keywords: ['managed postgres', 'notifications', 'alerts', 'storage', 'disk usage']
+keywords: ['managed postgres', 'notifications', 'alerts', 'storage', 'disk usage', 'replica lag', 'replication']
 doc_type: 'guide'
 ---
 
@@ -24,6 +24,7 @@ services.
 | Notify when | Specific alert condition | Default notification channels | Resolution steps |
 |---|---|---|---|
 | Postgres storage passed 85% threshold | When storage usage on a Managed Postgres service reaches 85% of capacity. Notification will only trigger once per calendar day. | UI, email | Storage scales automatically when usage reaches 90% (brief cutover downtime). No action is needed unless auto-scaling is already at its limit. |
+| Postgres replica lag passed 5 minute threshold | When replication lag on a high-availability standby or a read replica stays above 5 minutes. Notification will only trigger once per calendar day. | UI, email | For a standby, failover readiness is reduced until it catches up; for a read replica, reads may return stale data. Lag usually clears on its own once write load drops. If it keeps growing, check the replica's CPU, memory, and disk on the monitoring dashboard, or contact support. |
 
 ## Related pages {#related}
 


### PR DESCRIPTION
Adds the Postgres replica lag notification to the Managed Postgres notifications page, as a second row of the supported-notifications table alongside the storage alert (added in #113351).

Copy matches the shipped notification exactly (control-plane #37597): title "Postgres replica lag passed 5 minute threshold", fires when a high-availability standby or a read replica stays more than 5 minutes behind its source, once per calendar day, delivered via UI and email by default. The resolution column explains the impact per replica kind (reduced failover readiness for standbys, stale reads for read replicas) and points at the monitoring dashboard.

Keywords extended with "replica lag" and "replication".

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115365&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115365](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115365+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.760` (included in `26.9` and later)
<!-- ch-version-info:end -->