### PR TITLE
Perf(PromQL): Optimize PromQL and for exact groups

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
@@ -13,6 +13,56 @@
 namespace DB::PrometheusQueryToSQL
 {
 
+namespace
+{
+    bool canUseExactGroupMatch(
+        const PrometheusQueryTree::BinaryOperator * operator_node,
+        bool left_metric_name_dropped,
+        bool right_metric_name_dropped)
+    {
+        /// This is the set of cases where transformGroupASTForBinaryOperator returns the original group column.
+        return left_metric_name_dropped && right_metric_name_dropped
+            && !operator_node->on
+            && (!operator_node->ignoring || operator_node->labels.empty());
+    }
+
+    /// Filter the left values by right-side presence for two unique VECTOR_GRID inputs with the same group key.
+    ASTPtr makeExactGroupAndQuery(const String & left, const String & right)
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}));
+        builder.select_list.back()->setAlias(ColumnNames::Group);
+
+        builder.select_list.push_back(makeASTFunction(
+            "arrayMap",
+            makeASTFunction(
+                "lambda",
+                makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y")),
+                makeASTFunction(
+                    "if",
+                    makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("y")),
+                    make_intrusive<ASTIdentifier>("x"),
+                    make_intrusive<ASTLiteral>(Field{} /* NULL */))),
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
+            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values})));
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        builder.from_table = left;
+        builder.join_kind = JoinKind::Inner;
+        builder.join_strictness = JoinStrictness::All;
+        builder.join_table = right;
+
+        builder.join_on = makeASTFunction(
+            "equals",
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}),
+            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Group}));
+
+        return builder.getSelectQuery();
+    }
+}
+
+
 SQLQueryPiece applyBinaryOperatorAnd(
     const PrometheusQueryTree::BinaryOperator * operator_node,
     SQLQueryPiece && left_argument,
@@ -34,6 +84,20 @@ SQLQueryPiece applyBinaryOperatorAnd(
     right_argument = toVectorGrid(std::move(right_argument), context);
     context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
     String right = context.subqueries.back().name;
+
+    if (canUseExactGroupMatch(
+            operator_node, left_argument.metric_name_dropped, right_argument.metric_name_dropped))
+    {
+        SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
+        res.select_query = makeExactGroupAndQuery(left, right);
+        res.metric_name_dropped = left_argument.metric_name_dropped;
+
+        res.start_time = left_argument.start_time;
+        res.end_time = left_argument.end_time;
+        res.step = left_argument.step;
+
+        return res;
+    }
 
     /// Step 1:
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
@@ -41,11 +41,11 @@ namespace
                 makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y")),
                 makeASTFunction(
                     "if",
-                    makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("y")),
+                    makeASTFunction("greater", make_intrusive<ASTIdentifier>("y"), make_intrusive<ASTLiteral>(0u)),
                     make_intrusive<ASTIdentifier>("x"),
                     make_intrusive<ASTLiteral>(Field{} /* NULL */))),
             make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
-            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values})));
+            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::JoinPresence})));
         builder.select_list.back()->setAlias(ColumnNames::Values);
 
         builder.from_table = left;
@@ -57,6 +57,21 @@ namespace
             "equals",
             make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}),
             make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Group}));
+
+        return builder.getSelectQuery();
+    }
+
+    ASTPtr makeExactGroupPresenceQuery(const String & right)
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+        builder.select_list.back()->setAlias(ColumnNames::Group);
+
+        builder.select_list.push_back(makePresenceArray(make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        builder.select_list.back()->setAlias(ColumnNames::JoinPresence);
+
+        builder.from_table = right;
 
         return builder.getSelectQuery();
     }
@@ -88,8 +103,12 @@ SQLQueryPiece applyBinaryOperatorAnd(
     if (canUseExactGroupMatch(
             operator_node, left_argument.metric_name_dropped, right_argument.metric_name_dropped))
     {
+        context.subqueries.emplace_back(SQLSubquery{
+            context.subqueries.size(), makeExactGroupPresenceQuery(right), SQLSubqueryType::TABLE});
+        String right_presence = context.subqueries.back().name;
+
         SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
-        res.select_query = makeExactGroupAndQuery(left, right);
+        res.select_query = makeExactGroupAndQuery(left, right_presence);
         res.metric_name_dropped = left_argument.metric_name_dropped;
 
         res.start_time = left_argument.start_time;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.cpp
@@ -54,16 +54,19 @@ void checkArgumentTypesForSetBinaryOperator(
     }
 }
 
-ASTPtr makePresenceMask(ASTPtr values)
+ASTPtr makePresenceArray(ASTPtr values)
 {
     auto lambda = makeASTFunction(
         "lambda",
         makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x")),
         makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x")));
 
-    return makeASTFunction(
-        "groupBitOrForEach",
-        makeASTFunction("arrayMap", std::move(lambda), std::move(values)));
+    return makeASTFunction("arrayMap", std::move(lambda), std::move(values));
+}
+
+ASTPtr makePresenceMask(ASTPtr values)
+{
+    return makeASTFunction("groupBitOrForEach", makePresenceArray(std::move(values)));
 }
 
 }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorSet.h
@@ -16,4 +16,6 @@ void checkArgumentTypesForSetBinaryOperator(
 /// Build a compact per-step presence mask for a vector grid.
 ASTPtr makePresenceMask(ASTPtr values);
 
+ASTPtr makePresenceArray(ASTPtr values);
+
 }

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -3492,6 +3492,35 @@ def test_set_binary_operators():
     )
 
     do_query_test(
+        "(sum by (shape, size) (last_over_time(foo[10])) and sum by (shape, size) (last_over_time(bar[10])))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"shape": "square", "size": "s"}, "values": [[110, "4"]]}]}',
+        [
+            [
+                "[('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4)]",
+            ],
+        ],
+    )
+
+    # Empty ignoring() keeps the same matching key for already grouped inputs.
+    do_query_test(
+        '(sum by (shape, size) (last_over_time(foo{shape="circle"}[10])) and ignoring() sum by (shape, size) (last_over_time(bar{shape="circle"}[10])))[50:10]',
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}]}',
+        [
+            [
+                "[('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+        ],
+    )
+
+    do_query_test(
         "(last_over_time(foo[10]) unless last_over_time(bar[10]))[50:10]",
         150,
         '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',

--- a/tests/performance/promql_set_operators_and.xml
+++ b/tests/performance/promql_set_operators_and.xml
@@ -1,0 +1,24 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <create_query>
+        CREATE TABLE promql_set_operators_and_ts ENGINE = TimeSeries
+    </create_query>
+
+    <fill_query>
+        INSERT INTO promql_set_operators_and_ts (metric_name, tags, time_series)
+        SELECT
+            if(number &lt; 4000, 'foo', 'bar'),
+            map('instance', toString(number % 4000)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(300))
+        FROM numbers_mt(8000)
+    </fill_query>
+
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_set_operators_and_ts</drop_query>
+</test>

--- a/tests/performance/promql_set_operators_and.xml
+++ b/tests/performance/promql_set_operators_and.xml
@@ -11,14 +11,14 @@
     <fill_query>
         INSERT INTO promql_set_operators_and_ts (metric_name, tags, time_series)
         SELECT
-            if(number &lt; 4000, 'foo', 'bar'),
-            map('instance', toString(number % 4000)),
-            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(300))
-        FROM numbers_mt(8000)
+            if(number &lt; 100000, 'foo', 'bar'),
+            map('instance', toString(number % 100000)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(30))
+        FROM numbers_mt(200000)
     </fill_query>
 
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and sum by (instance) (last_over_time(bar[10]))', 100, 390, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 390, 10) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_and_ts</drop_query>
 </test>

--- a/tests/performance/promql_set_operators_and.xml
+++ b/tests/performance/promql_set_operators_and.xml
@@ -19,6 +19,8 @@
 
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and sum by (instance) (last_over_time(bar[10]))', 100, 390, 10) FORMAT Null</query>
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 390, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and sum by (instance) (last_over_time(bar[10]))', 100, 399, 1) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_and_ts', 'sum by (instance) (last_over_time(foo[10])) and on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 399, 1) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_and_ts</drop_query>
 </test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
PromQL `and` expressions with an exact group key skip redundant matching stages.

## What changed

- add a fast path for the PromQL set operator `and`
- use it when both inputs already match on the original `group` column
- join the unique left and right `VECTOR_GRID` inputs directly
- keep the left-hand values and filter them by right-side sample presence
- keep `on(...)`, non-empty `ignoring(...)`, `on()`, and other transformed matching keys on the existing general path
- add exact-output coverage for grouped `and` expressions
- cover empty `ignoring()` when both inputs already have exact groups
- add a performance fixture with an exact-group query and an `and on(instance)` control

## Why this is safe

`VECTOR_GRID` guarantees one row per `group`. The fast path is enabled only when the matching rules leave the original `group` column unchanged on both sides, so the join key is already unique and exact.

The exact-group path removes the right-side per-group count aggregation and the transformed-key join. It returns the left value only when the corresponding right value is present, which is the existing `and` masking behavior.

`on(...)`, non-empty `ignoring(...)`, and other cases that transform the matching key keep the current general lowering. Empty `ignoring()` is treated like default matching when both inputs already have exact groups.

## Benchmark

Ran `tests/performance/promql_set_operators_and.xml` on Apple Silicon with the Release build from this PR.

- 8,000 series
- 4,000 matching groups
- 300 samples per series
- 7 measured runs per query on each of two local server instances

The table shows the average of the two per-server medians.

Both queries are equivalent for this fixture. The default query uses the new exact-group fast path. The `and on(instance)` query keeps the existing generic implementation.

| Query | Median |
| --- | ---: |
| exact-group `and` | 130.2 ms |
| equivalent `and on(instance)` query | 139.8 ms |

The exact-group query took 130.2 ms versus 139.8 ms for the existing implementation, which is 6.9% faster in this test.

## Tests

- add grouped exact-output coverage for `and`
- add exact-output coverage for empty `ignoring()`
- keep the existing ungrouped and transformed-key `and` coverage
- compile the changed translation unit with the ClickHouse warning set and `-Werror`

Related: https://github.com/ClickHouse/ClickHouse/pull/115219

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115374&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115374](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115374+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
