### PR TITLE
Sync `BackupImpl` lock-file handling and the Cloud-only resume state

### DIFF
--- a/src/Backups/BackupFactory.h
+++ b/src/Backups/BackupFactory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config.h"
+
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -7,6 +9,9 @@
 #include <Access/Common/AccessType.h>
 #include <Backups/BackupDataFileNameGeneratorType.h>
 #include <Backups/BackupInfo.h>
+#if CLICKHOUSE_CLOUD
+#include <Backups/BackupResumeParams.h>
+#endif
 #include <Backups/IBackup.h>
 #include <Core/Types.h>
 #include <IO/ReadSettings.h>
@@ -52,6 +57,10 @@ public:
         bool azure_attempt_to_create_container = true;
         ReadSettings read_settings;
         WriteSettings write_settings;
+#if CLICKHOUSE_CLOUD
+        /// Set only when this attempt continues an interrupted one; see `BackupResumer`.
+        std::optional<BackupResumeParams> resume;
+#endif
 
         CreateParams getCreateParamsForBaseBackup(BackupInfo base_backup_info_, String old_password) const;
     };

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -23,13 +23,11 @@
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromFileBase.h>
-#include <IO/StdStreamFromReadBuffer.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/WriteHelpers.h>
 #include <IO/Operators.h>
 #include <IO/copyData.h>
 #include <Poco/Util/XMLConfiguration.h>
-#include <Poco/SAX/InputSource.h>
 #include <Poco/SAX/SAXParser.h>
 #include <Poco/SAX/XMLReader.h>
 
@@ -606,32 +604,6 @@ bool BackupImpl::hasPublishedMetadata() const
 {
     std::lock_guard lock{mutex};
     return metadata_already_published;
-}
-
-
-bool BackupImpl::publishedMetadataMatchesUUID() const
-{
-    const size_t metadata_size = writer->getFileSize(".backup");
-    StdIStreamFromReadBuffer metadata_stream(writer->readFile(".backup", metadata_size), metadata_size);
-    Poco::XML::InputSource input_source(metadata_stream);
-
-    std::optional<UUID> metadata_uuid;
-    BackupMetadataHandler handler;
-    handler.on_header = [&](const BackupMetadataHandler::Fields & fields)
-    {
-        auto it = fields.find("uuid");
-        if (it == fields.end())
-            throw Exception(ErrorCodes::BACKUP_DAMAGED, "Backup {} metadata has no UUID", backup_name_for_logging);
-        metadata_uuid = parse<UUID>(it->second);
-    };
-
-    Poco::XML::SAXParser xml_parser;
-    xml_parser.setContentHandler(&handler);
-    xml_parser.setFeature(Poco::XML::XMLReader::FEATURE_NAMESPACE_PREFIXES, true);
-    xml_parser.parse(&input_source);
-    if (handler.saved_exception)
-        std::rethrow_exception(handler.saved_exception);
-    return metadata_uuid == uuid;
 }
 
 

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -23,11 +23,13 @@
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromFileBase.h>
+#include <IO/StdStreamFromReadBuffer.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/WriteHelpers.h>
 #include <IO/Operators.h>
 #include <IO/copyData.h>
 #include <Poco/Util/XMLConfiguration.h>
+#include <Poco/SAX/InputSource.h>
 #include <Poco/SAX/SAXParser.h>
 #include <Poco/SAX/XMLReader.h>
 
@@ -51,6 +53,8 @@ namespace DB
 namespace FailPoints
 {
     extern const char backup_fail_before_writing_metadata[];
+    extern const char backup_fail_lock_file_removal[];
+    extern const char backup_pause_before_lock_file_creation[];
 }
 
 namespace ErrorCodes
@@ -242,19 +246,37 @@ void BackupImpl::open()
     else
     {
         ProfileEvents::increment(ProfileEvents::BackupsOpenedForWrite);
-        LOG_INFO(log, "Writing backup: {}", backup_name_for_logging);
         timestamp = std::time(nullptr);
-        if (!uuid)
-            uuid = UUIDHelpers::generateV4();
         lock_file_name = use_archive ? (archive_params.archive_name + ".lock") : ".lock";
         lock_file_before_first_file_checked = false;
         writing_finalized = false;
 
-        /// Check that we can write a backup there and create the lock file to own this destination.
-        checkBackupDoesntExist();
-        if (!params.is_internal_backup)
-            createLockFile();
-        checkLockFile(true);
+#if CLICKHOUSE_CLOUD
+        metadata_already_published = false;
+        if (params.resume)
+            metadata_already_published = BackupResumer(*this, *params.resume).openDestination();
+        else
+#endif
+        {
+            LOG_INFO(log, "Writing backup: {}", backup_name_for_logging);
+            if (!uuid)
+                uuid = UUIDHelpers::generateV4();
+
+            /// Check that we can write a backup there and create the lock file to own this destination.
+            checkBackupDoesntExist();
+            if (!params.is_internal_backup)
+                createLockFile();
+            try
+            {
+                checkLockFile(true);
+            }
+            catch (...)
+            {
+                if (!params.is_internal_backup)
+                    tryRemoveOwnLockFile();
+                throw;
+            }
+        }
     }
 
     if (use_archive)
@@ -432,6 +454,13 @@ void BackupImpl::writeBackupMetadata()
     chassert(!params.is_internal_backup);
     checkLockFile(true);
 
+#if CLICKHOUSE_CLOUD
+    /// A Keeper session can expire while this upload is in flight. The progress fingerprint covers every
+    /// input written to the manifest, so a new owner can only publish the same metadata bytes.
+    if (resume_check_owner)
+        resume_check_owner();
+#endif
+
     std::unique_ptr<WriteBuffer> out;
     if (use_archive)
         out = archive_writer->writeFile(".backup");
@@ -441,7 +470,14 @@ void BackupImpl::writeBackupMetadata()
     *out << "<config>";
     *out << "<version>" << (params.is_lightweight_snapshot ? CURRENT_BACKUP_VERSION : INITIAL_BACKUP_VERSION) << "</version>";
     *out << "<deduplicate_files>" << params.deduplicate_files << "</deduplicate_files>";
-    *out << "<timestamp>" << toString(LocalDateTime{timestamp}) << "</timestamp>";
+    *out << "<timestamp>"
+#if CLICKHOUSE_CLOUD
+         /// A continued attempt republishes the timestamp of the one it continues, byte for byte.
+         << (timestamp_text.empty() ? toString(LocalDateTime{timestamp}) : timestamp_text)
+#else
+         << toString(LocalDateTime{timestamp})
+#endif
+         << "</timestamp>";
     *out << "<uuid>" << toString(*uuid) << "</uuid>";
     if (!backup_id.empty())
         *out << "<backup_id>" << xml << backup_id << "</backup_id>";
@@ -553,10 +589,76 @@ void BackupImpl::writeBackupMetadata()
 
     out->finalize();
 
+#if CLICKHOUSE_CLOUD
+    if (resuming)
+        metadata_already_published = true;
+#endif
+
     uncompressed_size = size_of_entries + out->count();
 
     LOG_TRACE(log, "Backup {}: Metadata was written", backup_name_for_logging);
 }
+
+
+#if CLICKHOUSE_CLOUD
+bool BackupImpl::hasPublishedMetadata() const
+{
+    std::lock_guard lock{mutex};
+    return metadata_already_published;
+}
+
+
+bool BackupImpl::publishedMetadataMatchesUUID() const
+{
+    const size_t metadata_size = writer->getFileSize(".backup");
+    StdIStreamFromReadBuffer metadata_stream(writer->readFile(".backup", metadata_size), metadata_size);
+    Poco::XML::InputSource input_source(metadata_stream);
+
+    std::optional<UUID> metadata_uuid;
+    BackupMetadataHandler handler;
+    handler.on_header = [&](const BackupMetadataHandler::Fields & fields)
+    {
+        auto it = fields.find("uuid");
+        if (it == fields.end())
+            throw Exception(ErrorCodes::BACKUP_DAMAGED, "Backup {} metadata has no UUID", backup_name_for_logging);
+        metadata_uuid = parse<UUID>(it->second);
+    };
+
+    Poco::XML::SAXParser xml_parser;
+    xml_parser.setContentHandler(&handler);
+    xml_parser.setFeature(Poco::XML::XMLReader::FEATURE_NAMESPACE_PREFIXES, true);
+    xml_parser.parse(&input_source);
+    if (handler.saved_exception)
+        std::rethrow_exception(handler.saved_exception);
+    return metadata_uuid == uuid;
+}
+
+
+void BackupImpl::recalculateMetadataCounters()
+{
+    num_files = 0;
+    total_size = 0;
+    num_entries = 0;
+    size_of_entries = 0;
+
+    coordination->forEachFileInfoForAllHosts([&](const BackupFileInfo & info)
+    {
+        ++num_files;
+        total_size += info.size;
+        const bool has_entry = !params.deduplicate_files
+            || (info.size && info.size != info.base_size
+                && (info.data_file_name.empty()
+                    || info.data_file_name == getBackupDataFileName(info, data_file_name_generator, data_file_name_prefix_length)));
+        if (has_entry)
+        {
+            ++num_entries;
+            size_of_entries += info.size - info.base_size;
+        }
+    });
+
+    uncompressed_size = size_of_entries + writer->getFileSize(".backup");
+}
+#endif
 
 
 void BackupImpl::readBackupMetadata()
@@ -828,9 +930,62 @@ void BackupImpl::createLockFile()
     chassert(!params.is_internal_backup);
 
     chassert(uuid);
-    auto out = writer->writeFile(lock_file_name);
-    writeUUIDText(*uuid, *out);
-    out->finalize();
+    if (lock_file_contents.empty())
+        lock_file_contents = toString(*uuid);
+    const String completed_file = use_archive ? archive_params.archive_name : ".backup";
+    FailPointInjection::pauseFailPoint(FailPoints::backup_pause_before_lock_file_creation);
+    bool lock_created = false;
+    try
+    {
+        auto out = writer->writeFileIfNotExists(lock_file_name);
+        *out << lock_file_contents;
+        out->finalize();
+        lock_created = true;
+    }
+    catch (...)
+    {
+        auto exception = std::current_exception();
+        String actual_file_contents;
+        bool lock_contents_match = false;
+        try
+        {
+            lock_contents_match = writer->fileContentsEqual(lock_file_name, lock_file_contents, actual_file_contents);
+        }
+        catch (...)
+        {
+            /// The lock can be removed while we read it, by the backup that created it. The existence
+            /// checks below decide who owns the destination, and rethrow if they find nothing.
+            tryLogCurrentException(__PRETTY_FUNCTION__, fmt::format("Could not read lock file {}", lock_file_name));
+        }
+#if CLICKHOUSE_CLOUD
+        /// A continued attempt is allowed to find its own lock: it is the one that wrote it.
+        if (lock_contents_match && !resuming)
+#else
+        if (lock_contents_match)
+#endif
+            throw Exception(
+                ErrorCodes::BACKUP_ALREADY_EXISTS,
+                "A concurrent backup writing to the same destination {} detected",
+                backup_name_for_logging);
+        if (!lock_contents_match)
+        {
+            if (writer->fileExists(lock_file_name))
+                throw Exception(
+                    ErrorCodes::BACKUP_ALREADY_EXISTS,
+                    "A concurrent backup writing to the same destination {} detected",
+                    backup_name_for_logging);
+            if (writer->fileExists(completed_file))
+                throw Exception(ErrorCodes::BACKUP_ALREADY_EXISTS, "Backup {} already exists", backup_name_for_logging);
+            std::rethrow_exception(exception);
+        }
+    }
+
+    if (writer->fileExists(completed_file))
+    {
+        if (lock_created)
+            removeLockFile();
+        throw Exception(ErrorCodes::BACKUP_ALREADY_EXISTS, "Backup {} already exists", backup_name_for_logging);
+    }
 }
 
 bool BackupImpl::checkLockFile(bool throw_if_failed) const
@@ -842,9 +997,10 @@ bool BackupImpl::checkLockFile(bool throw_if_failed) const
             LOG_TRACE(log, "Checking lock file {}", lock_file_name);
             ProfileEvents::increment(ProfileEvents::BackupLockFileReads);
             String actual_file_contents;
-            if (writer->fileContentsEqual(lock_file_name, toString(*uuid), actual_file_contents))
+            const String expected_file_contents = lock_file_contents.empty() ? toString(*uuid) : lock_file_contents;
+            if (writer->fileContentsEqual(lock_file_name, expected_file_contents, actual_file_contents))
                 return true;
-            LOG_TRACE(log, "Lock file {} contents do not match, expected: {}, actual: {}", lock_file_name, toString(*uuid), actual_file_contents);
+            LOG_TRACE(log, "Lock file {} contents do not match, expected: {}, actual: {}", lock_file_name, expected_file_contents, actual_file_contents);
         }
     }
     catch (...)
@@ -876,10 +1032,36 @@ bool BackupImpl::checkLockFile(bool throw_if_failed) const
     return false;
 }
 
-void BackupImpl::removeLockFile()
+bool BackupImpl::removeLockFile()
 {
-    if (checkLockFile(false))
-        writer->removeFile(lock_file_name);
+    /// `checkLockFile(false)` returns false both for a foreign lock and for one it could not read, so a
+    /// caller cannot tell "the lock is not ours" from "we do not know" -- and in the second case the lock
+    /// is still there. Report that as a failure to remove: everything upstream that decides whether the
+    /// destination is clean has to treat an unverifiable lock as one that survived.
+    fiu_do_on(FailPoints::backup_fail_lock_file_removal, { return false; });
+    if (!checkLockFile(false))
+        return false;
+    writer->removeFile(lock_file_name);
+    return true;
+}
+
+bool BackupImpl::tryRemoveOwnLockFile() noexcept
+{
+    /// A failed `open` must leave the destination as it found it. Otherwise the lock it just created
+    /// outlives it and fences the destination against every later attempt, which cannot match it either:
+    /// a retry that finds no progress picks a fresh backup UUID, so the orphaned lock's UUID belongs to
+    /// nobody. `removeLockFile` only removes a lock this backup still owns, so a foreign lock -- which may
+    /// belong to a concurrent attempt that won the race -- is deliberately left alone. Never throws: it
+    /// runs from an exception handler, where throwing would hide the original error.
+    try
+    {
+        return removeLockFile();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+        return false;
+    }
 }
 
 bool BackupImpl::directoryExists(const String & directory) const
@@ -1303,6 +1485,11 @@ void BackupImpl::writeFile(const BackupFileInfo & info, BackupEntryPtr entry)
 
     {
         std::lock_guard lock{mutex};
+#if CLICKHOUSE_CLOUD
+        /// Only a continued attempt can find the manifest already published.
+        if (metadata_already_published)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Backup metadata is already published");
+#endif
         ++num_files;
         total_size += info.size;
     }
@@ -1399,9 +1586,20 @@ void BackupImpl::finalizeWriting()
         {
             throw Exception(ErrorCodes::FAULT_INJECTED, "Failpoint backup_fail_before_writing_metadata is triggered");
         });
-        writeBackupMetadata();
+#if CLICKHOUSE_CLOUD
+        /// A continued attempt whose manifest is already in the destination republishes nothing; it only
+        /// recomputes the counters it reports.
+        if (metadata_already_published)
+            recalculateMetadataCounters();
+        else
+#endif
+            writeBackupMetadata();
         closeArchive(/* finalize= */ true);
         setCompressedSize();
+#if CLICKHOUSE_CLOUD
+        if (resume_check_owner)
+            resume_check_owner();
+#endif
         removeLockFile();
         LOG_TRACE(log, "Finalized backup {}", backup_name_for_logging);
     }
@@ -1501,9 +1699,12 @@ bool BackupImpl::tryRemoveAllFiles() noexcept
             return false;
 
         writer->removeFiles(files_to_remove);
-        removeLockFile();
+        /// The lock is the last thing to go, and it can survive its removal: `removeLockFile` gives up
+        /// when it cannot verify the lock is still ours. Returning true then would tell the caller the
+        /// destination is empty while it is still fenced by a lock no later attempt can match.
+        const bool removed_lock_file = removeLockFile();
         writer->removeEmptyDirectories();
-        return true;
+        return removed_lock_file;
     }
     catch (...)
     {

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -456,8 +456,8 @@ void BackupImpl::writeBackupMetadata()
 #if CLICKHOUSE_CLOUD
     /// A Keeper session can expire while this upload is in flight. The progress fingerprint covers every
     /// input written to the manifest, so a new owner can only publish the same metadata bytes.
-    if (resume_check_owner)
-        resume_check_owner();
+    if (params.resume)
+        params.resume->check_owner();
 #endif
 
     std::unique_ptr<WriteBuffer> out;
@@ -472,7 +472,7 @@ void BackupImpl::writeBackupMetadata()
     *out << "<timestamp>"
 #if CLICKHOUSE_CLOUD
          /// A continued attempt republishes the timestamp of the one it continues, byte for byte.
-         << (timestamp_text.empty() ? toString(LocalDateTime{timestamp}) : timestamp_text)
+         << (params.resume ? params.resume->timestamp_text : toString(LocalDateTime{timestamp}))
 #else
          << toString(LocalDateTime{timestamp})
 #endif
@@ -589,7 +589,7 @@ void BackupImpl::writeBackupMetadata()
     out->finalize();
 
 #if CLICKHOUSE_CLOUD
-    if (resuming)
+    if (params.resume)
         metadata_already_published = true;
 #endif
 
@@ -932,7 +932,7 @@ void BackupImpl::createLockFile()
         }
 #if CLICKHOUSE_CLOUD
         /// A continued attempt is allowed to find its own lock: it is the one that wrote it.
-        if (lock_contents_match && !resuming)
+        if (lock_contents_match && !params.resume)
 #else
         if (lock_contents_match)
 #endif
@@ -1570,8 +1570,8 @@ void BackupImpl::finalizeWriting()
         closeArchive(/* finalize= */ true);
         setCompressedSize();
 #if CLICKHOUSE_CLOUD
-        if (resume_check_owner)
-            resume_check_owner();
+        if (params.resume)
+            params.resume->check_owner();
 #endif
         removeLockFile();
         LOG_TRACE(log, "Finalized backup {}", backup_name_for_logging);

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -254,7 +254,8 @@ void BackupImpl::open()
 #if CLICKHOUSE_CLOUD
         metadata_already_published = false;
         if (params.resume)
-            metadata_already_published = BackupResumer(*this, *params.resume).openDestination();
+            metadata_already_published = BackupResumer(*this, *params.resume).openDestination()
+                == BackupResumer::DestinationState::MetadataPublished;
         else
 #endif
         {

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -250,10 +250,8 @@ void BackupImpl::open()
         writing_finalized = false;
 
 #if CLICKHOUSE_CLOUD
-        metadata_already_published = false;
         if (params.resume)
-            metadata_already_published = BackupResumer(*this, *params.resume).openDestination()
-                == BackupResumer::DestinationState::MetadataPublished;
+            BackupResumer(*this, *params.resume).openDestination();
         else
 #endif
         {
@@ -588,11 +586,6 @@ void BackupImpl::writeBackupMetadata()
 
     out->finalize();
 
-#if CLICKHOUSE_CLOUD
-    if (params.resume)
-        metadata_already_published = true;
-#endif
-
     uncompressed_size = size_of_entries + out->count();
 
     LOG_TRACE(log, "Backup {}: Metadata was written", backup_name_for_logging);
@@ -600,13 +593,6 @@ void BackupImpl::writeBackupMetadata()
 
 
 #if CLICKHOUSE_CLOUD
-bool BackupImpl::hasPublishedMetadata() const
-{
-    std::lock_guard lock{mutex};
-    return metadata_already_published;
-}
-
-
 void BackupImpl::recalculateMetadataCounters()
 {
     num_files = 0;
@@ -1460,7 +1446,7 @@ void BackupImpl::writeFile(const BackupFileInfo & info, BackupEntryPtr entry)
         std::lock_guard lock{mutex};
 #if CLICKHOUSE_CLOUD
         /// Only a continued attempt can find the manifest already published.
-        if (metadata_already_published)
+        if (params.resume && params.resume->metadata_published())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Backup metadata is already published");
 #endif
         ++num_files;
@@ -1562,7 +1548,7 @@ void BackupImpl::finalizeWriting()
 #if CLICKHOUSE_CLOUD
         /// A continued attempt whose manifest is already in the destination republishes nothing; it only
         /// recomputes the counters it reports.
-        if (metadata_already_published)
+        if (params.resume && params.resume->metadata_published())
             recalculateMetadataCounters();
         else
 #endif

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -249,34 +249,42 @@ void BackupImpl::open()
         lock_file_before_first_file_checked = false;
         writing_finalized = false;
 
-#if CLICKHOUSE_CLOUD
-        if (params.resume)
-            BackupResumer(*this, *params.resume).openDestination();
-        else
-#endif
+        /// `open` runs from the constructor, so a throw anywhere below leaves no backup behind for
+        /// anything else to clean up. The lock must not outlive the attempt that created it: it fences
+        /// the destination against every later one, which cannot match it either, because a retry picks
+        /// a fresh backup UUID. That covers opening the archive as much as taking the lock.
+        try
         {
-            LOG_INFO(log, "Writing backup: {}", backup_name_for_logging);
-            if (!uuid)
-                uuid = UUIDHelpers::generateV4();
-
-            /// Check that we can write a backup there and create the lock file to own this destination.
-            checkBackupDoesntExist();
-            if (!params.is_internal_backup)
-                createLockFile();
-            try
+#if CLICKHOUSE_CLOUD
+            if (params.resume)
+                BackupResumer(*this, *params.resume).openDestination();
+            else
+#endif
             {
+                LOG_INFO(log, "Writing backup: {}", backup_name_for_logging);
+                if (!uuid)
+                    uuid = UUIDHelpers::generateV4();
+
+                /// Check that we can write a backup there and create the lock file to own this destination.
+                checkBackupDoesntExist();
+                if (!params.is_internal_backup)
+                    createLockFile();
                 checkLockFile(true);
             }
-            catch (...)
-            {
-                if (!params.is_internal_backup)
-                    tryRemoveOwnLockFile();
-                throw;
-            }
+
+            if (use_archive)
+                openArchive();
+        }
+        catch (...)
+        {
+            if (!params.is_internal_backup)
+                tryRemoveOwnLockFile();
+            throw;
         }
     }
 
-    if (use_archive)
+    /// A write opens the archive inside the guard above, where a failure still removes the lock.
+    if (use_archive && open_mode != OpenMode::WRITE)
         openArchive();
 
     if (open_mode == OpenMode::READ || open_mode == OpenMode::UNLOCK)

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -203,15 +203,6 @@ private:
     std::shared_ptr<IArchiveReader> archive_reader;
     std::shared_ptr<IArchiveWriter> archive_writer;
     String lock_file_name;
-#if CLICKHOUSE_CLOUD
-    /// Set when this attempt continues an interrupted one; `BackupResumer` fills these in while it
-    /// reopens a destination this backup already owns.
-    bool resuming = false;
-    /// The timestamp the attempt being continued wrote into `.backup`. Empty otherwise.
-    String timestamp_text;
-    /// Throws unless this attempt still owns the progress record. Unset unless resuming.
-    std::function<void()> resume_check_owner;
-#endif
     String lock_file_contents;
     std::atomic<bool> lock_file_before_first_file_checked = false;
 

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -93,9 +93,6 @@ public:
     size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const override;
     size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const override;
     void writeFile(const BackupFileInfo & info, BackupEntryPtr entry) override;
-#if CLICKHOUSE_CLOUD
-    bool hasPublishedMetadata() const;
-#endif
     bool supportsWritingInMultipleThreads() const override { return !use_archive; }
     void finalizeWriting() override;
     bool setIsCorrupted() noexcept override;
@@ -179,11 +176,6 @@ private:
     std::unordered_map<String, BackupFileInfo> lightweight_snapshot_file_infos TSA_GUARDED_BY(mutex);
 
     std::optional<UUID> uuid;
-#if CLICKHOUSE_CLOUD
-    /// Whether `.backup` is already in the destination: either the attempt being continued published
-    /// it, or this one did. Only a continued attempt can find it already there.
-    bool metadata_already_published TSA_GUARDED_BY(mutex) = false;
-#endif
     String backup_id; /// Set from params on write, from the manifest on read; empty for legacy backups without the field.
     time_t timestamp = 0;
     size_t num_files = 0;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -112,8 +112,7 @@ private:
     /// Writes the file ".backup" containing backup's metadata.
     void writeBackupMetadata() TSA_REQUIRES(mutex);
 #if CLICKHOUSE_CLOUD
-    /// Both are reached only while continuing an interrupted backup.
-    bool publishedMetadataMatchesUUID() const TSA_REQUIRES(mutex);
+    /// Reached only while continuing an interrupted backup, whose manifest is already published.
     void recalculateMetadataCounters() TSA_REQUIRES(mutex);
 #endif
     void readBackupMetadata() TSA_REQUIRES(mutex);

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -26,6 +26,11 @@ class IArchiveWriter;
 /// whether the base backup should be used for each entry.
 class BackupImpl : public IBackup
 {
+#if CLICKHOUSE_CLOUD
+    /// Reopens a destination this backup already owns; needs the write-open state below.
+    friend class BackupResumer;
+#endif
+
 public:
     struct ArchiveParams
     {
@@ -88,6 +93,9 @@ public:
     size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const override;
     size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const override;
     void writeFile(const BackupFileInfo & info, BackupEntryPtr entry) override;
+#if CLICKHOUSE_CLOUD
+    bool hasPublishedMetadata() const;
+#endif
     bool supportsWritingInMultipleThreads() const override { return !use_archive; }
     void finalizeWriting() override;
     bool setIsCorrupted() noexcept override;
@@ -103,6 +111,11 @@ private:
 
     /// Writes the file ".backup" containing backup's metadata.
     void writeBackupMetadata() TSA_REQUIRES(mutex);
+#if CLICKHOUSE_CLOUD
+    /// Both are reached only while continuing an interrupted backup.
+    bool publishedMetadataMatchesUUID() const TSA_REQUIRES(mutex);
+    void recalculateMetadataCounters() TSA_REQUIRES(mutex);
+#endif
     void readBackupMetadata() TSA_REQUIRES(mutex);
 
 #if CLICKHOUSE_CLOUD
@@ -127,7 +140,9 @@ private:
     /// Thus it will not be allowed to put any other backup to the same place (even if the BACKUP command is executed on a different node).
     void createLockFile();
     bool checkLockFile(bool throw_if_failed) const;
-    void removeLockFile();
+    /// Both return true only when the destination no longer holds this backup's lock file.
+    bool removeLockFile();
+    bool tryRemoveOwnLockFile() noexcept;
 
     /// Calculates and sets `compressed_size`.
     void setCompressedSize();
@@ -165,6 +180,11 @@ private:
     std::unordered_map<String, BackupFileInfo> lightweight_snapshot_file_infos TSA_GUARDED_BY(mutex);
 
     std::optional<UUID> uuid;
+#if CLICKHOUSE_CLOUD
+    /// Whether `.backup` is already in the destination: either the attempt being continued published
+    /// it, or this one did. Only a continued attempt can find it already there.
+    bool metadata_already_published TSA_GUARDED_BY(mutex) = false;
+#endif
     String backup_id; /// Set from params on write, from the manifest on read; empty for legacy backups without the field.
     time_t timestamp = 0;
     size_t num_files = 0;
@@ -184,6 +204,16 @@ private:
     std::shared_ptr<IArchiveReader> archive_reader;
     std::shared_ptr<IArchiveWriter> archive_writer;
     String lock_file_name;
+#if CLICKHOUSE_CLOUD
+    /// Set when this attempt continues an interrupted one; `BackupResumer` fills these in while it
+    /// reopens a destination this backup already owns.
+    bool resuming = false;
+    /// The timestamp the attempt being continued wrote into `.backup`. Empty otherwise.
+    String timestamp_text;
+    /// Throws unless this attempt still owns the progress record. Unset unless resuming.
+    std::function<void()> resume_check_owner;
+#endif
+    String lock_file_contents;
     std::atomic<bool> lock_file_before_first_file_checked = false;
 
     bool writing_finalized = false;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -27,7 +27,8 @@ class IArchiveWriter;
 class BackupImpl : public IBackup
 {
 #if CLICKHOUSE_CLOUD
-    /// Reopens a destination this backup already owns; needs the write-open state below.
+    /// Reopens a destination this backup already owns, which needs the writer, the lock file and the
+    /// helpers below that claim and release it.
     friend class BackupResumer;
 #endif
 

--- a/src/Backups/BackupSettings.cpp
+++ b/src/Backups/BackupSettings.cpp
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <Backups/BackupInfo.h>
 #include <Backups/BackupSettings.h>
 #include <Core/SettingsFields.h>
@@ -16,6 +18,14 @@ namespace ErrorCodes
     extern const int CANNOT_PARSE_BACKUP_SETTINGS;
     extern const int WRONG_BACKUP_SETTINGS;
 }
+
+#if CLICKHOUSE_CLOUD
+#define LIST_OF_CLOUD_BACKUP_SETTINGS(M) \
+    M(UInt64, resumable_backup_batch_size) \
+    M(UInt64, resumable_backup_batch_size_bytes)
+#else
+#define LIST_OF_CLOUD_BACKUP_SETTINGS(M)
+#endif
 
 /// List of backup settings except base_backup_name and cluster_host_ids.
 #define LIST_OF_BACKUP_SETTINGS(M) \
@@ -42,6 +52,7 @@ namespace ErrorCodes
     M(Bool, allow_checksums_from_remote_paths) \
     M(BackupDataFileNameGeneratorType, data_file_name_generator) \
     M(Bool, backup_data_from_refreshable_materialized_view_targets) \
+    LIST_OF_CLOUD_BACKUP_SETTINGS(M) \
     M(Bool, internal) \
     M(Bool, experimental_lightweight_snapshot) \
     M(String, host_id) \
@@ -86,6 +97,13 @@ BackupSettings BackupSettings::fromBackupQuery(const ASTBackupQuery & query)
 
     if (query.cluster_host_ids)
         res.cluster_host_ids = Util::clusterHostIDsFromAST(*query.cluster_host_ids);
+
+#if CLICKHOUSE_CLOUD
+    if (res.resumable_backup_batch_size == 0)
+        throw Exception(ErrorCodes::WRONG_BACKUP_SETTINGS, "Setting `resumable_backup_batch_size` must be greater than 0");
+    if (res.resumable_backup_batch_size_bytes == 0)
+        throw Exception(ErrorCodes::WRONG_BACKUP_SETTINGS, "Setting `resumable_backup_batch_size_bytes` must be greater than 0");
+#endif
 
     return res;
 }

--- a/src/Backups/BackupSettings.h
+++ b/src/Backups/BackupSettings.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config.h"
+
 #include <map>
 #include <optional>
 #include <Backups/BackupDataFileNameGeneratorType.h>
@@ -110,6 +112,19 @@ struct BackupSettings
     /// transient data that can be recomputed. Targets with APPEND or regular
     /// materialized views are always backed up because they may store history.
     bool backup_data_from_refreshable_materialized_view_targets = false;
+
+#if CLICKHOUSE_CLOUD
+    /// Maximum number of logical backup files processed between Keeper checkpoints. Each checkpoint is a
+    /// barrier: the writer pool drains and waits for the slowest file of the batch before the batch is
+    /// recorded, so a small value costs parallelism, not just Keeper round-trips. Backups of tens of
+    /// millions of files are ordinary for this feature, which is why the default is not in the thousands.
+    /// The replayed work after a failure stays bounded by `resumable_backup_batch_size_bytes` below.
+    UInt64 resumable_backup_batch_size = 50000;
+
+    /// Target number of unique new data bytes written between Keeper checkpoints. This is what bounds the
+    /// data a retry has to copy again; the file count above bounds per-file overhead for small files.
+    UInt64 resumable_backup_batch_size_bytes = 10ULL * 1024 * 1024 * 1024;
+#endif
 
     /// Internal, should not be specified by user.
     /// Whether this backup is a part of a distributed backup created by BACKUP ON CLUSTER.


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/clickhouse-private/pull/69709
-->

Related: https://github.com/ClickHouse/clickhouse-private/pull/69709

This is the public side of the private pull request above, and most of it is that sync. The shared files both touch -- `BackupImpl.h`, `BackupImpl.cpp`, `BackupSettings.h`, `BackupSettings.cpp`, `BackupFactory.h` -- are identical here and there, down to the blank lines, so `Check public build` can overlay the private ones unchanged and later syncs have nothing to reconcile in them. What stays private is where continuing an interrupted backup is implemented, because nothing outside ClickHouse Cloud resumes one.

The part that changes this build is the lock-file handling.

`open` runs from the constructor, so a failure there leaves no backup behind for anything else to clean up: whatever `open` does not undo, nothing will. It now removes the lock it created when anything that follows throws -- the verification, the rest of claiming the destination, and opening the archive. Otherwise the lock outlives the failed attempt and fences the destination against every later one, which cannot match it either: a retry picks a fresh backup UUID, so the orphaned lock belongs to nobody, and every subsequent `BACKUP` to that destination fails until someone deletes the file by hand.

`removeLockFile` now reports whether the destination still holds the lock. `checkLockFile(false)` is false both for a foreign lock and for one it could not read, so a caller could not tell "not ours" from "unknown" while the lock was still there; `tryRemoveAllFiles` reports that as a failure rather than claiming the destination is clean.

`createLockFile` asks for the lock with `writeFileIfNotExists` and, when that fails, compares what is there against what it would have written: its own contents mean a concurrent backup, a completed `.backup` means the backup already exists, and a lock that has since disappeared rethrows the original failure rather than guessing. `writeFileIfNotExists` is only exclusive where the storage can be -- `S3` and `Azure` implement it, every other writer falls back to an ordinary write.

### Known gaps

Two of them, both predating this change and both worth naming rather than implying they are fixed.

`File`, `Disk` and `Memory` destinations still have no exclusive create, so two backups started against one of them can each write `.lock`, each verify their own contents, and both proceed. The comparison above detects a lock that is already there; it cannot order two writers racing to create one. Closing this needs an exclusive create in those writers.

An archive whose type `createArchiveWriter` refuses -- an unsupported extension, a compiled-out library -- still leaves the archive object behind, because the buffer it is given is created before the type is checked. The lock is removed, but the next attempt finds the archive and reports the destination as an existing backup.

### The rest

Behind `CLICKHOUSE_CLOUD`, and compiling to nothing here: `CreateParams` carries the resume parameters, `open` hands them to a `BackupResumer` this build does not have, and the places that read them are the ownership check before anything becomes visible, the timestamp a continuation republishes, the lock a continuation is allowed to find, and the manifest it does not write again. `BackupSettings` carries the two batch-size settings that bound the work a continuation redoes; a macro list cannot hold a preprocessor conditional, so the conditional selects the list. `BackupImpl` keeps one member, `metadata_already_published`. So this build behaves as it did: it writes its own timestamp and always publishes metadata.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`BACKUP` no longer leaves a lock file behind in its destination when the attempt that created it fails before writing anything -- whether it fails while claiming the destination or while opening an archive. No later backup could match such a lock, so every retry to the same destination failed until the file was deleted by hand. Backups to `S3` and `Azure` destinations also create the lock exclusively, and a lock that belongs to another backup is reported as a concurrent backup rather than as whatever error the storage returned.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115387&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115387](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115387+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1800` (included in `26.8` and later)
<!-- ch-version-info:end -->