### PR TITLE
Do not clean up an Iceberg commit whose outcome is unknown

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -227,6 +227,8 @@ static struct InitFiu
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     REGULAR(slowdown_skip_index_read_result_build) \
     ONCE(iceberg_writes_cleanup) \
+    ONCE(iceberg_metadata_commit_response_lost) \
+    REGULAR(iceberg_metadata_commit_reconcile_fail) \
     REGULAR(iceberg_slow_manifest_read) \
     REGULAR(storage_cluster_read_sleep) \
     ONCE(backup_add_empty_memory_table) \

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -945,6 +945,14 @@ static bool writeConsolidatedManifestFile(
             }
         }
     }
+    catch (const Exception & e)
+    {
+        /// An unestablished commit may have taken effect, which makes these consolidated manifests
+        /// and manifest list the ones the current snapshot references.
+        if (!Iceberg::isCommitStateUnknown(e))
+            cleanup();
+        throw;
+    }
     catch (...)
     {
         cleanup();

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -1325,6 +1325,14 @@ bool IcebergStorageSink::initializeMetadata()
         /// Invalidate the cache so the next reader gets the latest version, which a concurrent catalog update may have changed.
         persistent_table_components.invalidateMetadataCache();
     }
+    catch (const Exception & e)
+    {
+        /// An unestablished commit may have taken effect, which makes these manifests, manifest list
+        /// and data files the ones the current snapshot references.
+        if (!Iceberg::isCommitStateUnknown(e))
+            cleanup(false);
+        throw;
+    }
     catch (...)
     {
         cleanup(false);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -559,6 +559,14 @@ static bool writeMetadataFiles(
             }
         }
     }
+    catch (const Exception & e)
+    {
+        /// An unestablished commit may have taken effect, which makes these position-delete files,
+        /// rewritten data files, manifests and manifest list the ones the current snapshot references.
+        if (!Iceberg::isCommitStateUnknown(e))
+            cleanup();
+        throw;
+    }
     catch (...)
     {
         cleanup();

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -115,7 +115,6 @@ namespace DB::Setting
 
 /// Hard to imagine a hint file larger than 10 MB
 static constexpr size_t MAX_HINT_FILE_SIZE = 10 * 1024 * 1024;
-static constexpr auto MAX_TRANSACTION_RETRIES = 1000;
 
 static constexpr size_t MAX_LIST_RETRIES = 5;
 
@@ -340,6 +339,11 @@ void writeMessageToFile(
 static constexpr size_t COMMIT_RECONCILIATION_ATTEMPTS = 4;
 static constexpr uint64_t COMMIT_RECONCILIATION_DELAY_MS = 200;
 
+/// Number of attempts used to converge `version-hint.text` onto the committed version. Only a
+/// failure that a later attempt could survive is retried, so this bound covers a lost hint-write
+/// race and a transient read, both of which resolve within a few tries.
+static constexpr size_t VERSION_HINT_CONVERGENCE_ATTEMPTS = 4;
+
 /// What the object store holds at the commit's target path, relative to what this writer tried to
 /// put there. Only `LostRace` licenses a cleanup: it is the sole outcome that proves the commit did
 /// not happen.
@@ -449,8 +453,10 @@ static void convergeVersionHint(
     const ContextPtr & context,
     bool try_write_version_hint)
 {
-    size_t i = 0;
-    while (i < MAX_TRANSACTION_RETRIES)
+    auto log = getLogger("IcebergVersionHint");
+    std::string last_error;
+
+    for (size_t attempt = 0; attempt < VERSION_HINT_CONVERGENCE_ATTEMPTS; ++attempt)
     {
         try
         {
@@ -469,23 +475,37 @@ static void convergeVersionHint(
             else if (!try_write_version_hint)
             {
                 /// The file does not exist and this writer was not asked to create it.
-                break;
+                return;
             }
 
             Int32 old_version = 0;
             if (!version_hint_value.empty())
             {
-                if (std::all_of(version_hint_value.begin(), version_hint_value.end(), isdigit))
+                try
                 {
-                    old_version = parseMetadataVersion(version_hint_value, version_hint_value);
+                    if (std::all_of(version_hint_value.begin(), version_hint_value.end(), isdigit))
+                    {
+                        old_version = parseMetadataVersion(version_hint_value, version_hint_value);
+                    }
+                    else
+                    {
+                        old_version = getMetadataFileAndVersion(version_hint_value).version;
+                    }
                 }
-                else
+                catch (...)
                 {
-                    old_version = getMetadataFileAndVersion(version_hint_value).version;
+                    /// Whether the stored bytes name a version is a property of those bytes, so
+                    /// every further attempt reaches the same verdict.
+                    LOG_WARNING(
+                        log,
+                        "Version hint {} holds '{}', which names no metadata version, so it cannot be advanced to {}. "
+                        "Readers using the hint may observe an older snapshot: {}",
+                        storage_version_hint_path, version_hint_value, committed_version, getCurrentExceptionMessage(false));
+                    return;
                 }
             }
             if (old_version >= committed_version)
-                break;
+                return;
 
             /// Write just the version number for Spark/spec compatibility.
             Iceberg::writeMessageToFile(
@@ -495,14 +515,20 @@ static void convergeVersionHint(
                 context,
                 write_if_none_match,
                 /* write-if-match */ etag);
-            break;
+            return;
         }
         catch (...)
         {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
+            /// A lost hint-write race or a transient read; both can resolve on a later attempt.
+            last_error = getCurrentExceptionMessage(false);
+            LOG_DEBUG(log, "Attempt {} to advance version hint {} failed: {}", attempt + 1, storage_version_hint_path, last_error);
         }
-        ++i;
     }
+
+    LOG_WARNING(
+        log,
+        "Version hint {} did not reach version {} in {} attempts. Readers using the hint may observe an older snapshot: {}",
+        storage_version_hint_path, committed_version, VERSION_HINT_CONVERGENCE_ATTEMPTS, last_error);
 }
 
 bool isCommitStateUnknown(const Exception & e)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -62,6 +62,8 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSource.h>
 #include <Storages/ObjectStorage/Utils.h>
+#include <Common/FailPoint.h>
+#include <base/sleep.h>
 
 
 using namespace DB;
@@ -76,6 +78,14 @@ extern const int BAD_ARGUMENTS;
 extern const int ICEBERG_SPECIFICATION_VIOLATION;
 extern const int LOGICAL_ERROR;
 extern const int UNSUPPORTED_METHOD;
+extern const int UNKNOWN_STATUS_OF_TRANSACTION;
+extern const int NETWORK_ERROR;
+}
+
+namespace DB::FailPoints
+{
+extern const char iceberg_metadata_commit_response_lost[];
+extern const char iceberg_metadata_commit_reconcile_fail[];
 }
 
 namespace DB::DataLakeStorageSetting
@@ -323,6 +333,183 @@ void writeMessageToFile(
     }
 }
 
+/// Number of read-back attempts used to resolve an ambiguous commit outcome, and the pause between
+/// them. A failed conditional write may still be in flight: nothing cancels it server-side and there
+/// is no ordering fence, so a read issued right after a client-side timeout can legitimately precede
+/// the write becoming visible. Retrying bounds that window instead of concluding from one probe.
+static constexpr size_t COMMIT_RECONCILIATION_ATTEMPTS = 4;
+static constexpr uint64_t COMMIT_RECONCILIATION_DELAY_MS = 200;
+
+/// What the object store holds at the commit's target path, relative to what this writer tried to
+/// put there. Only `LostRace` licenses a cleanup: it is the sole outcome that proves the commit did
+/// not happen.
+enum class MetadataCommitOutcome : uint8_t
+{
+    Committed,
+    LostRace,
+    Unknown,
+};
+
+/// Reads the commit's target object back verbatim. All caches are bypassed: the question is what the
+/// store holds right now, which a cached copy cannot answer. Reads to EOF rather than stopping at
+/// the first balanced JSON object, so trailing bytes cannot hide behind a well-formed prefix.
+static std::string readMetadataFileContentUncached(
+    const std::string & storage_metadata_path,
+    CompressionMethod compression_method,
+    const ObjectStoragePtr & object_storage,
+    const ContextPtr & context)
+{
+    auto read_settings = context->getReadSettings();
+    read_settings.enable_filesystem_cache = false;
+    read_settings.use_page_cache_for_object_storage = false;
+    read_settings.use_page_cache_for_disks_without_file_cache = false;
+    read_settings.use_page_cache_with_distributed_cache = false;
+    read_settings.use_page_cache_for_local_disks = false;
+    read_settings.page_cache_settings.cache = nullptr;
+    read_settings.read_through_distributed_cache = false;
+
+    ObjectInfo object_info(storage_metadata_path);
+    auto source_buf = createReadBuffer(
+        object_info.relative_path_with_metadata,
+        object_storage,
+        context,
+        getLogger("IcebergCommitReconciliation"),
+        read_settings,
+        /* allow_page_cache */ false);
+
+    std::unique_ptr<ReadBuffer> buf;
+    if (compression_method != CompressionMethod::None)
+        /// The write path pins `SnappyMode::Basic`; the mode is not encoded in the file name, so both
+        /// sides must agree statically.
+        buf = wrapReadBufferWithCompressionMethod(std::move(source_buf), compression_method, /*zstd_window_log_max=*/ 0, SnappyMode::Basic);
+    else
+        buf = std::move(source_buf);
+
+    std::string content;
+    readStringUntilEOF(content, *buf);
+    return content;
+}
+
+/// Decides what actually happened to a conditional metadata write whose outcome the error does not
+/// reveal, by comparing the stored bytes against what was written. A conditional PUT whose response
+/// is lost after the store accepted it is indistinguishable, at the error, from a lost race, so the
+/// outcome is measured rather than inferred.
+static MetadataCommitOutcome reconcileMetadataCommit(
+    const std::string & storage_metadata_path,
+    const std::string & metadata_file_content,
+    CompressionMethod compression_method,
+    const ObjectStoragePtr & object_storage,
+    const ContextPtr & context)
+{
+    auto log = getLogger("IcebergCommitReconciliation");
+
+    for (size_t attempt = 0; attempt < COMMIT_RECONCILIATION_ATTEMPTS; ++attempt)
+    {
+        if (attempt != 0)
+            sleepForMilliseconds(COMMIT_RECONCILIATION_DELAY_MS);
+
+        try
+        {
+            fiu_do_on(FailPoints::iceberg_metadata_commit_reconcile_fail,
+            {
+                throw Exception(ErrorCodes::NETWORK_ERROR, "Failpoint for reconciliation read failure enabled");
+            });
+
+            if (!object_storage->exists(StoredObject(storage_metadata_path)))
+                continue;
+
+            auto stored_content
+                = readMetadataFileContentUncached(storage_metadata_path, compression_method, object_storage, context);
+            if (stored_content == metadata_file_content)
+                return MetadataCommitOutcome::Committed;
+
+            LOG_DEBUG(log, "Metadata file {} holds another writer's content, the commit was lost", storage_metadata_path);
+            return MetadataCommitOutcome::LostRace;
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+
+    /// The target is absent, or every read-back failed. Absence is not proof that the write did not
+    /// land, so this outcome stays unknown and the caller must not delete anything.
+    return MetadataCommitOutcome::Unknown;
+}
+
+/// Best-effort convergence of `version-hint.text` after the metadata commit has landed. Once any
+/// writer has created the hint, every subsequent writer must keep it in sync, otherwise readers with
+/// `iceberg_use_version_hint = 1` observe stale data when a writer without the setting advances the
+/// table. Every failure here is logged and swallowed: the commit is already durable, so escalating
+/// would send a committed snapshot into the callers' cleanup handlers.
+static void convergeVersionHint(
+    const std::string & storage_version_hint_path,
+    Int32 committed_version,
+    const ObjectStoragePtr & object_storage,
+    const ContextPtr & context,
+    bool try_write_version_hint)
+{
+    size_t i = 0;
+    while (i < MAX_TRANSACTION_RETRIES)
+    {
+        try
+        {
+            StoredObject object_info(storage_version_hint_path);
+            std::string version_hint_value;
+            std::string etag;
+            std::string write_if_none_match = "*";
+            if (object_storage->exists(object_info))
+            {
+                auto [object_data, object_metadata] = object_storage->readSmallObjectAndGetObjectMetadata(object_info, context->getReadSettings(), MAX_HINT_FILE_SIZE);
+                version_hint_value = object_data;
+                boost::algorithm::trim(version_hint_value);
+                etag = object_metadata.etag;
+                write_if_none_match.clear();
+            }
+            else if (!try_write_version_hint)
+            {
+                /// The file does not exist and this writer was not asked to create it.
+                break;
+            }
+
+            Int32 old_version = 0;
+            if (!version_hint_value.empty())
+            {
+                if (std::all_of(version_hint_value.begin(), version_hint_value.end(), isdigit))
+                {
+                    old_version = parseMetadataVersion(version_hint_value, version_hint_value);
+                }
+                else
+                {
+                    old_version = getMetadataFileAndVersion(version_hint_value).version;
+                }
+            }
+            if (old_version >= committed_version)
+                break;
+
+            /// Write just the version number for Spark/spec compatibility.
+            Iceberg::writeMessageToFile(
+                std::to_string(committed_version),
+                storage_version_hint_path,
+                object_storage,
+                context,
+                write_if_none_match,
+                /* write-if-match */ etag);
+            break;
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+        ++i;
+    }
+}
+
+bool isCommitStateUnknown(const Exception & e)
+{
+    return e.code() == ErrorCodes::UNKNOWN_STATUS_OF_TRANSACTION;
+}
+
 bool writeMetadataFileAndVersionHint(
     const IcebergPathResolver & resolver,
     const GeneratedMetadataFileWithInfo & metadata_file_info,
@@ -334,11 +521,18 @@ bool writeMetadataFileAndVersionHint(
 {
     auto storage_metadata_path = resolver.resolve(metadata_file_info.path);
     auto storage_version_hint_path = resolver.resolve(version_hint_path);
+
+    auto outcome = MetadataCommitOutcome::Committed;
+    /// Separates a failure before the conditional write from a failure of the write itself. Only the
+    /// latter can have committed, so only it is reconciled; for the former the target was never
+    /// touched, which makes a lost race the correct report.
+    bool put_started = false;
     try
     {
         if (object_storage->exists(StoredObject(storage_metadata_path)))
             return false;
 
+        put_started = true;
         Iceberg::writeMessageToFile(
             metadata_file_content,
             storage_metadata_path,
@@ -347,84 +541,45 @@ bool writeMetadataFileAndVersionHint(
             /* write-if-none-match */ "*",
             "",
             metadata_file_info.compression_method);
+
+        fiu_do_on(FailPoints::iceberg_metadata_commit_response_lost,
+        {
+            throw Exception(ErrorCodes::NETWORK_ERROR, "Failpoint for a lost commit response enabled");
+        });
     }
     catch (const Exception & e)
     {
         /// A backend that cannot express the commit's compare-and-swap will never be able to, so
         /// reporting a lost race would make the caller retry an operation that can never succeed.
-        /// Propagate instead; every other failure (including a genuinely lost CAS) stays retryable.
         if (e.code() == ErrorCodes::UNSUPPORTED_METHOD)
             throw;
         tryLogCurrentException(__PRETTY_FUNCTION__);
-        return false;
+        if (!put_started)
+            return false;
+        outcome = reconcileMetadataCommit(
+            storage_metadata_path, metadata_file_content, metadata_file_info.compression_method, object_storage, context);
     }
     catch (...)
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
+        if (!put_started)
+            return false;
+        outcome = reconcileMetadataCommit(
+            storage_metadata_path, metadata_file_content, metadata_file_info.compression_method, object_storage, context);
+    }
+
+    if (outcome == MetadataCommitOutcome::LostRace)
         return false;
-    }
 
-    /// Once any writer has created `version-hint.text`, every subsequent writer must keep it in
-    /// sync, otherwise readers with `iceberg_use_version_hint = 1` observe stale data when a
-    /// writer that does not have the setting enabled advances the table.
-    size_t i = 0;
-    while (i < MAX_TRANSACTION_RETRIES)
-    {
-        StoredObject object_info(storage_version_hint_path);
-        std::string version_hint_value;
-        std::string etag;
-        std::string write_if_none_match = "*";
-        if (object_storage->exists(object_info))
-        {
-            auto [object_data, object_metadata] = object_storage->readSmallObjectAndGetObjectMetadata(object_info, context->getReadSettings(), MAX_HINT_FILE_SIZE);
-            version_hint_value = object_data;
-            boost::algorithm::trim(version_hint_value);
-            etag = object_metadata.etag;
-            write_if_none_match.clear();
-        }
-        else if (!try_write_version_hint)
-        {
-            /// The file does not exist and this writer was not asked to create it.
-            break;
-        }
+    if (outcome == MetadataCommitOutcome::Unknown)
+        throw Exception(
+            ErrorCodes::UNKNOWN_STATUS_OF_TRANSACTION,
+            "Cannot determine whether the Iceberg commit of metadata file {} succeeded. The table is left untouched: "
+            "resolve the state manually before retrying, because the commit may have taken effect",
+            storage_metadata_path);
 
-        Int32 old_version = 0;
-        if (!version_hint_value.empty())
-        {
-            if (std::all_of(version_hint_value.begin(), version_hint_value.end(), isdigit))
-            {
-                old_version = parseMetadataVersion(version_hint_value, version_hint_value);
-            }
-            else
-            {
-                old_version = getMetadataFileAndVersion(version_hint_value).version;
-            }
-        }
-        if (old_version < metadata_file_info.version)
-        {
-            try
-            {
-                /// Write just the version number for Spark/spec compatibility.
-                Iceberg::writeMessageToFile(
-                    std::to_string(metadata_file_info.version),
-                    storage_version_hint_path,
-                    object_storage,
-                    context,
-                    write_if_none_match,
-                    /* write-if-match */ etag);
-                break;
-            }
-            catch (...)
-            {
-                tryLogCurrentException(__PRETTY_FUNCTION__);
-            }
-        }
-        else
-        {
-            break;
-        }
-        ++i;
-    }
+    convergeVersionHint(
+        storage_version_hint_path, metadata_file_info.version, object_storage, context, try_write_version_hint);
 
     return true;
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
@@ -16,6 +16,7 @@
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
 
+#include <Common/Exception.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <IO/CompressedReadBufferWrapper.h>
 #include <IO/CompressionMethod.h>
@@ -51,8 +52,15 @@ void writeMessageToFile(
     const std::string & write_if_match = "",
     DB::CompressionMethod compression_method = DB::CompressionMethod::None);
 
+/// True for the exception `writeMetadataFileAndVersionHint` throws when it cannot establish whether
+/// the commit took effect. A caller that deletes its staged files on the way out must let this one
+/// pass through untouched: those files may belong to the snapshot the table now points at.
+bool isCommitStateUnknown(const DB::Exception & e);
+
 /// Tries to write metadata file and version hint file. Uses If-None-Match header to avoid overwriting existing files.
-/// Maybe return false if failed to write metadata.json
+/// Returns false only when the commit is known not to have taken effect, which is what licenses the
+/// caller to delete the files it staged. An outcome that cannot be established either way throws
+/// `UNKNOWN_STATUS_OF_TRANSACTION` (see `isCommitStateUnknown`).
 /// Will try to write hint multiple times, but will not report failure to write hint.
 bool writeMetadataFileAndVersionHint(
     const IcebergPathResolver & resolver,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_commit_propagation.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_commit_propagation.cpp
@@ -8,8 +8,11 @@
 #include <Common/tests/gtest_global_context.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <IO/CompressionMethod.h>
+#include <IO/ReadBufferFromFileBase.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/FileNamesGenerator.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h>
+
+#include <optional>
 
 using namespace DB;
 
@@ -18,21 +21,63 @@ namespace DB::ErrorCodes
     extern const int UNSUPPORTED_METHOD;
     extern const int NETWORK_ERROR;
     extern const int LOGICAL_ERROR;
+    extern const int UNKNOWN_STATUS_OF_TRANSACTION;
 }
 
 namespace
 {
 
-/// `writeMetadataFileAndVersionHint` reports a failed commit as `false`, which every caller reads as
-/// a lost compare-and-swap and retries. A backend that cannot express the condition will never
-/// succeed, so that refusal has to propagate instead of being reported as a lost race. This stub
-/// makes both outcomes observable without an object storage: `exists` says the target is absent so
-/// the function proceeds to the write, and `writeObject` fails with a configurable error code.
-/// Everything else throws, so an unexpected call is loud rather than silently absorbed.
-class ThrowingObjectStorage : public IObjectStorage
+/// Serves a fixed body, so the commit's read-back sees a chosen document. Copies into the buffer the
+/// caller owns rather than pointing at its own storage, which is what the read pipeline requires
+/// when it supplies external memory.
+class StringReader : public ReadBufferFromFileBase
 {
 public:
-    explicit ThrowingObjectStorage(int write_error_code_) : write_error_code(write_error_code_) { }
+    explicit StringReader(std::string data_)
+        : ReadBufferFromFileBase(DBMS_DEFAULT_BUFFER_SIZE, /*existing_memory=*/nullptr, /*alignment=*/0, data_.size())
+        , data(std::move(data_))
+    {
+    }
+
+    bool nextImpl() override
+    {
+        if (file_pos >= data.size() || internal_buffer.empty())
+            return false;
+        const size_t n = std::min(internal_buffer.size(), data.size() - file_pos);
+        memcpy(internal_buffer.begin(), data.data() + file_pos, n);
+        working_buffer = Buffer(internal_buffer.begin(), internal_buffer.begin() + n);
+        pos = working_buffer.begin();
+        file_pos += n;
+        return n != 0;
+    }
+
+    off_t seek(off_t off, int) override
+    {
+        file_pos = static_cast<size_t>(off);
+        resetWorkingBuffer();
+        return off;
+    }
+    off_t getPosition() override { return static_cast<off_t>(file_pos) - static_cast<off_t>(available()); }
+    String getFileName() const override { return "string_reader"; }
+    bool supportsExternalBufferMode() const override { return true; }
+
+private:
+    std::string data;
+    size_t file_pos = 0;
+};
+
+/// Drives the real commit without an object storage. The conditional write always fails with
+/// `write_error_code`; what the store is then found to hold is `stored_content` (`std::nullopt` for
+/// an absent target), or the read-back itself fails when `read_throws` is set. That is exactly the
+/// input the commit has to distinguish: the error alone cannot tell a lost race from a response lost
+/// after the store accepted the object.
+class ReconcilingObjectStorage : public IObjectStorage
+{
+public:
+    ReconcilingObjectStorage(int write_error_code_, std::optional<std::string> stored_content_, bool read_throws_ = false)
+        : write_error_code(write_error_code_), stored_content(std::move(stored_content_)), read_throws(read_throws_)
+    {
+    }
 
     std::unique_ptr<WriteBufferFromFileBase> writeObject( /// NOLINT
         const StoredObject & object,
@@ -42,19 +87,39 @@ public:
         const WriteSettings & write_settings) override
     {
         /// The commit must ask for the metadata file to be created exclusively: without the
-        /// condition the write is a plain overwrite and one of two concurrent writers is lost. Only
-        /// the metadata write reaches this stub, because both tests leave the commit before the
-        /// version-hint write. `EXPECT_*` keeps the throw below reachable.
+        /// condition the write is a plain overwrite and one of two concurrent writers is lost.
+        /// `EXPECT_*` keeps the throw below reachable.
         EXPECT_EQ(write_settings.object_storage_write_if_none_match, "*");
         EXPECT_TRUE(write_settings.object_storage_write_if_match.empty());
 
+        ++writes;
         throw Exception(write_error_code, "Write of {} failed in the test stub", object.remote_path);
     }
 
-    /// The commit's existence probe: the metadata file is absent, so the write is attempted.
-    bool exists(const StoredObject &) const override { return false; }
+    /// Before the write the target is absent so the commit proceeds; afterwards it reports whatever
+    /// the store was configured to hold.
+    bool exists(const StoredObject &) const override { return writes > 0 && stored_content.has_value(); }
 
-    std::string getName() const override { return "ThrowingObjectStorage"; }
+    ObjectMetadata getObjectMetadata(const std::string &, bool) const override
+    {
+        ObjectMetadata metadata;
+        metadata.size_bytes = stored_content ? stored_content->size() : 0;
+        return metadata;
+    }
+
+    std::unique_ptr<ReadBufferFromFileBase> readObject( /// NOLINT
+        const StoredObject &,
+        const ReadSettings &,
+        std::optional<size_t>,
+        bool,
+        bool) const override
+    {
+        if (read_throws)
+            throw Exception(ErrorCodes::NETWORK_ERROR, "Read failed in the test stub");
+        return std::make_unique<StringReader>(stored_content.value_or(""));
+    }
+
+    std::string getName() const override { return "ReconcilingObjectStorage"; }
     ObjectStorageType getType() const override { return ObjectStorageType::None; }
     std::string getCommonKeyPrefix() const override { return ""; }
     std::string getDescription() const override { return "test stub"; }
@@ -63,19 +128,9 @@ public:
     void startup() override { }
     void shutdown() override { }
 
-    ObjectMetadata getObjectMetadata(const std::string &, bool) const override { unexpected("getObjectMetadata"); }
     std::optional<ObjectMetadata> tryGetObjectMetadata(const std::string &, bool) const override
     {
         unexpected("tryGetObjectMetadata");
-    }
-    std::unique_ptr<ReadBufferFromFileBase> readObject( /// NOLINT
-        const StoredObject &,
-        const ReadSettings &,
-        std::optional<size_t>,
-        bool,
-        bool) const override
-    {
-        unexpected("readObject");
     }
     void removeObjectIfExists(const StoredObject &) override { unexpected("removeObjectIfExists"); }
     void removeObjectsIfExist(const StoredObjects &) override { unexpected("removeObjectsIfExist"); }
@@ -97,10 +152,14 @@ private:
     }
 
     int write_error_code;
+    std::optional<std::string> stored_content;
+    bool read_throws;
+    mutable size_t writes = 0;
 };
 
-/// Drives the real commit against a stub whose write fails with `write_error_code`.
-bool commitWithFailingWrite(int write_error_code)
+constexpr auto committed_content = "{\"format-version\":2}";
+
+bool commitAgainst(int write_error_code, std::optional<std::string> stored_content, bool read_throws = false)
 {
     Iceberg::IcebergPathResolver resolver("/table", "/table");
     GeneratedMetadataFileWithInfo metadata_file_info{
@@ -112,9 +171,9 @@ bool commitWithFailingWrite(int write_error_code)
     return Iceberg::writeMetadataFileAndVersionHint(
         resolver,
         metadata_file_info,
-        "{}",
+        committed_content,
         Iceberg::IcebergPathFromMetadata::deserialize("/table/metadata/version-hint.text"),
-        std::make_shared<ThrowingObjectStorage>(write_error_code),
+        std::make_shared<ReconcilingObjectStorage>(write_error_code, std::move(stored_content), read_throws),
         getContext().context,
         /*try_write_version_hint=*/ false);
 }
@@ -127,7 +186,7 @@ TEST(IcebergCommitPropagation, RefusedConditionalWriteIsNotReportedAsALostRace)
     /// surface the refusal rather than return `false`, which callers read as a lost race.
     try
     {
-        bool committed = commitWithFailingWrite(ErrorCodes::UNSUPPORTED_METHOD);
+        bool committed = commitAgainst(ErrorCodes::UNSUPPORTED_METHOD, std::nullopt);
         FAIL() << "Expected the refusal to propagate, got " << committed;
     }
     catch (const Exception & e)
@@ -136,12 +195,51 @@ TEST(IcebergCommitPropagation, RefusedConditionalWriteIsNotReportedAsALostRace)
     }
 }
 
-TEST(IcebergCommitPropagation, OtherWriteFailuresStayRetryable)
+TEST(IcebergCommitPropagation, StoredContentOfThisWriterIsCommitted)
 {
-    /// Any other failure may succeed on a retry, including a genuinely lost race, so it keeps being
-    /// reported as an unsuccessful commit. Without this the test above would also pass against a
-    /// commit that propagates everything, which would make every transient error fatal.
-    EXPECT_FALSE(commitWithFailingWrite(ErrorCodes::NETWORK_ERROR));
+    /// The response was lost after the store accepted the object, so the commit did take effect and
+    /// the files it staged are the ones the table now points at. Reporting a lost race here is what
+    /// makes callers delete them.
+    EXPECT_TRUE(commitAgainst(ErrorCodes::NETWORK_ERROR, committed_content));
+}
+
+TEST(IcebergCommitPropagation, ContentOfAnotherWriterIsALostRace)
+{
+    /// Someone else's document occupies the version, which is the only outcome that proves this
+    /// commit did not happen, so the staged files are garbage and cleanup is correct.
+    EXPECT_FALSE(commitAgainst(ErrorCodes::NETWORK_ERROR, "{\"format-version\":2,\"other\":true}"));
+}
+
+TEST(IcebergCommitPropagation, AbsentTargetIsUnknownRatherThanALostRace)
+{
+    /// Nothing cancels a failed conditional write server-side and there is no ordering fence, so an
+    /// absent target does not prove the write will not land. Treating it as a lost race deletes the
+    /// files of a commit that then becomes visible.
+    try
+    {
+        bool committed = commitAgainst(ErrorCodes::NETWORK_ERROR, std::nullopt);
+        FAIL() << "Expected an unknown commit state, got " << committed;
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::UNKNOWN_STATUS_OF_TRANSACTION) << e.message();
+        EXPECT_TRUE(Iceberg::isCommitStateUnknown(e));
+    }
+}
+
+TEST(IcebergCommitPropagation, FailingReadBackIsUnknownRatherThanALostRace)
+{
+    /// The outcome could not be established at all, which is not the same claim as the commit not
+    /// having happened.
+    try
+    {
+        bool committed = commitAgainst(ErrorCodes::NETWORK_ERROR, committed_content, /*read_throws=*/ true);
+        FAIL() << "Expected an unknown commit state, got " << committed;
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::UNKNOWN_STATUS_OF_TRANSACTION) << e.message();
+    }
 }
 
 #endif

--- a/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.reference
+++ b/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.reference
@@ -1,13 +1,37 @@
 -- INSERT: a commit that landed upstream must be reported as committed
 9
+45
 yes
+data files: 3
+avro files: 6
 9
+45
 -- DELETE: the mutation commit path has the same shape
 4
+18
 yes
+data files: 3
+-- OPTIMIZE: manifest compaction commits through the same seam
+yes
+data files: 8
+36
+36
+-- OPTIMIZE, unknown outcome: the compaction unwind must not delete the consolidated manifests
+unknown status reported
+yes
+data files: 8
+36
+36
 -- Unknown outcome: throws, and leaves every staged file in place
 unknown status reported
-staged files kept
+data files: 3
+avro files: 6
 9
+45
+-- version hint: a hint that names no version must not unwind the commit
+data files: 2
+3
 -- control: with no failpoint armed, sequential commits still work
 4
+10
+data files: 4

--- a/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.reference
+++ b/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.reference
@@ -1,0 +1,13 @@
+-- INSERT: a commit that landed upstream must be reported as committed
+9
+yes
+9
+-- DELETE: the mutation commit path has the same shape
+4
+yes
+-- Unknown outcome: throws, and leaves every staged file in place
+unknown status reported
+staged files kept
+9
+-- control: with no failpoint armed, sequential commits still work
+4

--- a/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.reference
+++ b/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.reference
@@ -11,6 +11,13 @@ avro files: 6
 18
 yes
 data files: 3
+-- DELETE, unknown outcome: the mutation unwind must not delete the rewritten files
+unknown status reported
+yes
+data files: 3
+avro files: 6
+18
+18
 -- OPTIMIZE: manifest compaction commits through the same seam
 yes
 data files: 8

--- a/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.sh
+++ b/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.sh
@@ -20,13 +20,14 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 TABLE_INSERT="t_insert_${CLICKHOUSE_DATABASE}"
 TABLE_DELETE="t_delete_${CLICKHOUSE_DATABASE}"
+TABLE_DELETE_UNKNOWN="t_delete_unknown_${CLICKHOUSE_DATABASE}"
 TABLE_UNKNOWN="t_unknown_${CLICKHOUSE_DATABASE}"
 TABLE_OPTIMIZE="t_optimize_${CLICKHOUSE_DATABASE}"
 TABLE_OPTIMIZE_UNKNOWN="t_optimize_unknown_${CLICKHOUSE_DATABASE}"
 TABLE_HINT="t_hint_${CLICKHOUSE_DATABASE}"
 TABLE_CONTROL="t_control_${CLICKHOUSE_DATABASE}"
 ALL_TABLES=(
-    "${TABLE_INSERT}" "${TABLE_DELETE}" "${TABLE_UNKNOWN}"
+    "${TABLE_INSERT}" "${TABLE_DELETE}" "${TABLE_DELETE_UNKNOWN}" "${TABLE_UNKNOWN}"
     "${TABLE_OPTIMIZE}" "${TABLE_OPTIMIZE_UNKNOWN}" "${TABLE_HINT}" "${TABLE_CONTROL}"
 )
 
@@ -143,6 +144,20 @@ ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_DELETE}"
 scan_sum "${TABLE_DELETE}"
 current_manifest_list_present "${USER_FILES_PATH}/${TABLE_DELETE}/"
 echo "data files: $(stored_files "${USER_FILES_PATH}/${TABLE_DELETE}/" '*.parquet')"
+
+echo "-- DELETE, unknown outcome: the mutation unwind must not delete the rewritten files"
+create_and_seed "${TABLE_DELETE_UNKNOWN}"
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_reconcile_fail"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "DELETE FROM ${TABLE_DELETE_UNKNOWN} WHERE c0 < 3" 2>&1 \
+    | grep -qF 'UNKNOWN_STATUS_OF_TRANSACTION' && echo "unknown status reported" || echo "NOT REPORTED AS UNKNOWN"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_reconcile_fail"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_response_lost"
+current_manifest_list_present "${USER_FILES_PATH}/${TABLE_DELETE_UNKNOWN}/"
+echo "data files: $(stored_files "${USER_FILES_PATH}/${TABLE_DELETE_UNKNOWN}/" '*.parquet')"
+echo "avro files: $(stored_files "${USER_FILES_PATH}/${TABLE_DELETE_UNKNOWN}/" '*.avro')"
+scan_sum "${TABLE_DELETE_UNKNOWN}"
+scan_sum "icebergLocal('${USER_FILES_PATH}/${TABLE_DELETE_UNKNOWN}/', 'Parquet')"
 
 echo "-- OPTIMIZE: manifest compaction commits through the same seam"
 seed_for_compaction "${TABLE_OPTIMIZE}"

--- a/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.sh
+++ b/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+# Tag no-fasttest: Iceberg pulls in extra dependencies.
+# Tag no-parallel: toggles process-global failpoints.
+
+# The commit logs the injected failure before deciding what it means, and the client streams server
+# log lines to its stderr, where the harness reads any content as a test failure.
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The Iceberg commit writes v<N>.metadata.json conditionally. A response lost after the store
+# accepted the object is indistinguishable, at the error, from another writer having taken the
+# version. Treating it as the latter deletes the manifests, manifest list and data files of the
+# snapshot v<N>.metadata.json now makes current, leaving the table unreadable (issue #112081).
+# iceberg_metadata_commit_response_lost throws right after the store accepted the write, so the
+# ambiguous state is reachable without an object store.
+
+TABLE_INSERT="t_insert_${CLICKHOUSE_DATABASE}"
+TABLE_DELETE="t_delete_${CLICKHOUSE_DATABASE}"
+TABLE_UNKNOWN="t_unknown_${CLICKHOUSE_DATABASE}"
+TABLE_CONTROL="t_control_${CLICKHOUSE_DATABASE}"
+
+cleanup() {
+    for t in "${TABLE_INSERT}" "${TABLE_DELETE}" "${TABLE_UNKNOWN}" "${TABLE_CONTROL}"; do
+        rm -rf "${USER_FILES_PATH:?}/${t}" 2>/dev/null
+    done
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_response_lost" 2>/dev/null
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_reconcile_fail" 2>/dev/null
+}
+trap cleanup EXIT
+
+create_and_seed() {
+    local table="$1"
+    local table_path="${USER_FILES_PATH}/${table}/"
+    rm -rf "${table_path}"
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${table}"
+    ${CLICKHOUSE_CLIENT} --query "
+        CREATE TABLE ${table} (c0 Int32)
+        ENGINE = IcebergLocal('${table_path}', 'Parquet')
+        ORDER BY c0
+    "
+    # Two data files, so the retry path has previous snapshots to carry forward.
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${table} VALUES (1), (2), (3)"
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${table} VALUES (4), (5), (6)"
+}
+
+# Whether the manifest list of the metadata file the readers will pick up is actually stored.
+# A missing one is the corruption: readers resolve it and get a file-not-found.
+current_manifest_list_present() {
+    local table_path="$1"
+    python3 - "${table_path}" <<'PY'
+import glob, json, os, re, sys
+metadata_dir = os.path.join(sys.argv[1], "metadata")
+latest, latest_version = None, -1
+for path in glob.glob(os.path.join(metadata_dir, "v*.metadata.json")):
+    match = re.fullmatch(r"v(\d+)\.metadata\.json", os.path.basename(path))
+    if match and int(match.group(1)) > latest_version:
+        latest, latest_version = path, int(match.group(1))
+if latest is None:
+    print("no metadata")
+    sys.exit(0)
+metadata = json.load(open(latest))
+current = metadata.get("current-snapshot-id")
+for snapshot in metadata.get("snapshots", []):
+    if snapshot.get("snapshot-id") == current:
+        print("yes" if os.path.exists(snapshot.get("manifest-list", "")) else "no")
+        sys.exit(0)
+print("no snapshot")
+PY
+}
+
+echo "-- INSERT: a commit that landed upstream must be reported as committed"
+create_and_seed "${TABLE_INSERT}"
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${TABLE_INSERT} VALUES (7), (8), (9)"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_INSERT}"
+current_manifest_list_present "${USER_FILES_PATH}/${TABLE_INSERT}/"
+# A fresh reader over the same path resolves the metadata from scratch, with no cached state.
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM icebergLocal('${USER_FILES_PATH}/${TABLE_INSERT}/', 'Parquet')"
+
+echo "-- DELETE: the mutation commit path has the same shape"
+create_and_seed "${TABLE_DELETE}"
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "DELETE FROM ${TABLE_DELETE} WHERE c0 < 3"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_DELETE}"
+current_manifest_list_present "${USER_FILES_PATH}/${TABLE_DELETE}/"
+
+echo "-- Unknown outcome: throws, and leaves every staged file in place"
+create_and_seed "${TABLE_UNKNOWN}"
+FILES_BEFORE=$(find "${USER_FILES_PATH}/${TABLE_UNKNOWN}/" -name '*.parquet' -o -name '*.avro' | wc -l)
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
+# Reading the target back is what resolves the ambiguity; with every read failing the outcome
+# stays unknown, and an unknown outcome must not license deleting anything.
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_reconcile_fail"
+# Reported as an unknown outcome rather than a lost race. Presence, not a count: the write is
+# attempted once per retry of the enclosing loop, so how many times the code surfaces varies.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${TABLE_UNKNOWN} VALUES (7), (8), (9)" 2>&1 \
+    | grep -qF 'UNKNOWN_STATUS_OF_TRANSACTION' && echo "unknown status reported" || echo "NOT REPORTED AS UNKNOWN"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_reconcile_fail"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_response_lost"
+FILES_AFTER=$(find "${USER_FILES_PATH}/${TABLE_UNKNOWN}/" -name '*.parquet' -o -name '*.avro' | wc -l)
+# Strictly more files than before: the staged ones were added and none were removed.
+[ "${FILES_AFTER}" -gt "${FILES_BEFORE}" ] && echo "staged files kept" || echo "FILES DELETED: ${FILES_BEFORE} -> ${FILES_AFTER}"
+# Local storage publishes the conditional write before the failpoint fires, so the commit really did
+# take effect and its rows are readable. What is asserted is the table surviving the throw: the
+# reported failure must not have deleted anything the current snapshot references.
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_UNKNOWN}"
+
+echo "-- control: with no failpoint armed, sequential commits still work"
+CONTROL_PATH="${USER_FILES_PATH}/${TABLE_CONTROL}/"
+rm -rf "${CONTROL_PATH}"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE_CONTROL}"
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE ${TABLE_CONTROL} (c0 Int32)
+    ENGINE = IcebergLocal('${CONTROL_PATH}', 'Parquet')
+    ORDER BY c0
+"
+for v in 1 2 3 4; do
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${TABLE_CONTROL} VALUES (${v})"
+done
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_CONTROL}"
+
+for t in "${TABLE_INSERT}" "${TABLE_DELETE}" "${TABLE_UNKNOWN}" "${TABLE_CONTROL}"; do
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${t}"
+done

--- a/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.sh
+++ b/tests/queries/0_stateless/04929_iceberg_commit_state_unknown_no_cleanup.sh
@@ -21,10 +21,17 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 TABLE_INSERT="t_insert_${CLICKHOUSE_DATABASE}"
 TABLE_DELETE="t_delete_${CLICKHOUSE_DATABASE}"
 TABLE_UNKNOWN="t_unknown_${CLICKHOUSE_DATABASE}"
+TABLE_OPTIMIZE="t_optimize_${CLICKHOUSE_DATABASE}"
+TABLE_OPTIMIZE_UNKNOWN="t_optimize_unknown_${CLICKHOUSE_DATABASE}"
+TABLE_HINT="t_hint_${CLICKHOUSE_DATABASE}"
 TABLE_CONTROL="t_control_${CLICKHOUSE_DATABASE}"
+ALL_TABLES=(
+    "${TABLE_INSERT}" "${TABLE_DELETE}" "${TABLE_UNKNOWN}"
+    "${TABLE_OPTIMIZE}" "${TABLE_OPTIMIZE_UNKNOWN}" "${TABLE_HINT}" "${TABLE_CONTROL}"
+)
 
 cleanup() {
-    for t in "${TABLE_INSERT}" "${TABLE_DELETE}" "${TABLE_UNKNOWN}" "${TABLE_CONTROL}"; do
+    for t in "${ALL_TABLES[@]}"; do
         rm -rf "${USER_FILES_PATH:?}/${t}" 2>/dev/null
     done
     ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_response_lost" 2>/dev/null
@@ -72,25 +79,92 @@ print("no snapshot")
 PY
 }
 
+# Exact number of stored files of one kind. Absolute, not relative to a previous count: a relative
+# assertion is satisfied by a single survivor and cannot tell "nothing was deleted" from "almost
+# everything was deleted". One INSERT of one block writes exactly one data file and two Avro files
+# (its manifest and its manifest list), and none of the randomized settings changes that.
+stored_files() {
+    find "$1" -name "$2" | wc -l
+}
+
+# A scan that has to open the data files. count() alone is answered out of the manifests'
+# record_count (IcebergMetadata::totalRows), so it returns the right number with every Parquet file
+# deleted; summing a column cannot be.
+scan_sum() {
+    ${CLICKHOUSE_CLIENT} --query "SELECT sum(c0) FROM $1"
+}
+
+seed_for_compaction() {
+    local table="$1"
+    local table_path="${USER_FILES_PATH}/${table}/"
+    rm -rf "${table_path}"
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${table}"
+    ${CLICKHOUSE_CLIENT} --query "
+        CREATE TABLE ${table} (c0 Int32)
+        ENGINE = IcebergLocal('${table_path}', 'Parquet')
+        ORDER BY c0
+    "
+    # One manifest per INSERT, enough of them to put the manifest list above the threshold used below.
+    local inserts
+    inserts=$(for i in $(seq 1 8); do echo "INSERT INTO ${table} VALUES (${i});"; done)
+    ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --use_iceberg_metadata_files_cache=0 -m --query "${inserts}"
+}
+
+# Compaction rewrites the manifest layer and leaves the data files alone, so every one of them must
+# still be there and the sum must be unchanged whichever way the commit's outcome resolved.
+report_compacted_table() {
+    local table="$1"
+    local table_path="${USER_FILES_PATH}/${table}/"
+    current_manifest_list_present "${table_path}"
+    echo "data files: $(stored_files "${table_path}" '*.parquet')"
+    ${CLICKHOUSE_CLIENT} --use_iceberg_metadata_files_cache=0 --query "SELECT sum(c0) FROM ${table}"
+    ${CLICKHOUSE_CLIENT} --use_iceberg_metadata_files_cache=0 \
+        --query "SELECT sum(c0) FROM icebergLocal('${table_path}', 'Parquet')"
+}
+
 echo "-- INSERT: a commit that landed upstream must be reported as committed"
 create_and_seed "${TABLE_INSERT}"
 ${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${TABLE_INSERT} VALUES (7), (8), (9)"
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_INSERT}"
+scan_sum "${TABLE_INSERT}"
 current_manifest_list_present "${USER_FILES_PATH}/${TABLE_INSERT}/"
+echo "data files: $(stored_files "${USER_FILES_PATH}/${TABLE_INSERT}/" '*.parquet')"
+echo "avro files: $(stored_files "${USER_FILES_PATH}/${TABLE_INSERT}/" '*.avro')"
 # A fresh reader over the same path resolves the metadata from scratch, with no cached state.
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM icebergLocal('${USER_FILES_PATH}/${TABLE_INSERT}/', 'Parquet')"
+scan_sum "icebergLocal('${USER_FILES_PATH}/${TABLE_INSERT}/', 'Parquet')"
 
 echo "-- DELETE: the mutation commit path has the same shape"
 create_and_seed "${TABLE_DELETE}"
 ${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "DELETE FROM ${TABLE_DELETE} WHERE c0 < 3"
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_DELETE}"
+scan_sum "${TABLE_DELETE}"
 current_manifest_list_present "${USER_FILES_PATH}/${TABLE_DELETE}/"
+echo "data files: $(stored_files "${USER_FILES_PATH}/${TABLE_DELETE}/" '*.parquet')"
+
+echo "-- OPTIMIZE: manifest compaction commits through the same seam"
+seed_for_compaction "${TABLE_OPTIMIZE}"
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
+${CLICKHOUSE_CLIENT} --allow_experimental_iceberg_compaction=1 --use_iceberg_metadata_files_cache=0 \
+    --query "OPTIMIZE TABLE ${TABLE_OPTIMIZE} MANIFEST SETTINGS iceberg_manifest_min_count_to_compact=5"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_response_lost"
+report_compacted_table "${TABLE_OPTIMIZE}"
+
+echo "-- OPTIMIZE, unknown outcome: the compaction unwind must not delete the consolidated manifests"
+seed_for_compaction "${TABLE_OPTIMIZE_UNKNOWN}"
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
+${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_reconcile_fail"
+${CLICKHOUSE_CLIENT} --allow_experimental_iceberg_compaction=1 --use_iceberg_metadata_files_cache=0 \
+    --query "OPTIMIZE TABLE ${TABLE_OPTIMIZE_UNKNOWN} MANIFEST SETTINGS iceberg_manifest_min_count_to_compact=5" 2>&1 \
+    | grep -qF 'UNKNOWN_STATUS_OF_TRANSACTION' && echo "unknown status reported" || echo "NOT REPORTED AS UNKNOWN"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_reconcile_fail"
+${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_response_lost"
+report_compacted_table "${TABLE_OPTIMIZE_UNKNOWN}"
 
 echo "-- Unknown outcome: throws, and leaves every staged file in place"
 create_and_seed "${TABLE_UNKNOWN}"
-FILES_BEFORE=$(find "${USER_FILES_PATH}/${TABLE_UNKNOWN}/" -name '*.parquet' -o -name '*.avro' | wc -l)
 ${CLICKHOUSE_CLIENT} --query "SYSTEM ENABLE FAILPOINT iceberg_metadata_commit_response_lost"
 # Reading the target back is what resolves the ambiguity; with every read failing the outcome
 # stays unknown, and an unknown outcome must not license deleting anything.
@@ -101,13 +175,35 @@ ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${TABLE_
     | grep -qF 'UNKNOWN_STATUS_OF_TRANSACTION' && echo "unknown status reported" || echo "NOT REPORTED AS UNKNOWN"
 ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_reconcile_fail"
 ${CLICKHOUSE_CLIENT} --query "SYSTEM DISABLE FAILPOINT iceberg_metadata_commit_response_lost"
-FILES_AFTER=$(find "${USER_FILES_PATH}/${TABLE_UNKNOWN}/" -name '*.parquet' -o -name '*.avro' | wc -l)
-# Strictly more files than before: the staged ones were added and none were removed.
-[ "${FILES_AFTER}" -gt "${FILES_BEFORE}" ] && echo "staged files kept" || echo "FILES DELETED: ${FILES_BEFORE} -> ${FILES_AFTER}"
+echo "data files: $(stored_files "${USER_FILES_PATH}/${TABLE_UNKNOWN}/" '*.parquet')"
+echo "avro files: $(stored_files "${USER_FILES_PATH}/${TABLE_UNKNOWN}/" '*.avro')"
 # Local storage publishes the conditional write before the failpoint fires, so the commit really did
 # take effect and its rows are readable. What is asserted is the table surviving the throw: the
 # reported failure must not have deleted anything the current snapshot references.
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_UNKNOWN}"
+scan_sum "${TABLE_UNKNOWN}"
+
+echo "-- version hint: a hint that names no version must not unwind the commit"
+HINT_PATH="${USER_FILES_PATH}/${TABLE_HINT}/"
+rm -rf "${HINT_PATH}"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE_HINT}"
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE ${TABLE_HINT} (c0 Int32)
+    ENGINE = IcebergLocal('${HINT_PATH}')
+    SETTINGS iceberg_use_version_hint = 1
+"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${TABLE_HINT} VALUES (1)"
+# Advancing the hint happens after the metadata file is durable. Content that names no version makes
+# that step fail, which must stay a logged best-effort failure: escalating it reaches the caller's
+# cleanup and deletes the data files of the snapshot that just became current. No failpoint needed.
+printf 'not-a-version' > "${HINT_PATH}metadata/version-hint.text"
+# The table function resolves metadata by listing, so it reaches the hint only to keep it in sync.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "
+    INSERT INTO TABLE FUNCTION icebergLocal('${HINT_PATH}', 'Parquet', 'c0 Int32') (c0) VALUES (2)
+"
+echo "data files: $(stored_files "${HINT_PATH}" '*.parquet')"
+${CLICKHOUSE_CLIENT} --use_iceberg_metadata_files_cache=0 \
+    --query "SELECT sum(c0) FROM icebergLocal('${HINT_PATH}', 'Parquet')"
 
 echo "-- control: with no failpoint armed, sequential commits still work"
 CONTROL_PATH="${USER_FILES_PATH}/${TABLE_CONTROL}/"
@@ -122,7 +218,9 @@ for v in 1 2 3 4; do
     ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${TABLE_CONTROL} VALUES (${v})"
 done
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE_CONTROL}"
+scan_sum "${TABLE_CONTROL}"
+echo "data files: $(stored_files "${CONTROL_PATH}" '*.parquet')"
 
-for t in "${TABLE_INSERT}" "${TABLE_DELETE}" "${TABLE_UNKNOWN}" "${TABLE_CONTROL}"; do
+for t in "${ALL_TABLES[@]}"; do
     ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${t}"
 done


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/112081
Related: https://github.com/ClickHouse/ClickHouse/pull/114246
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed data loss on Iceberg writes when the response to the `metadata.json` compare-and-swap is lost after the object store already accepted it. ClickHouse read that as another writer having taken the version and deleted the manifests, manifest list and data files of the snapshot that had just become current, leaving the table unreadable. `INSERT`, `DELETE`/`UPDATE` and `OPTIMIZE` were affected. The commit outcome is now established by reading the target back instead of inferred from the error, so files are deleted only when the commit is known not to have taken effect; an outcome that cannot be established reports `UNKNOWN_STATUS_OF_TRANSACTION`. Closes #112081.

### Description

`writeMetadataFileAndVersionHint` returned `false` for every failure of the conditional
`v<N>.metadata.json` write except a backend refusal, and callers read `false` as "my commit did not
land" and clean up. That PUT is a compare-and-swap, so a response lost *after* the store accepted the
object is indistinguishable at the error from a lost race: the cleanup deletes the manifest list,
manifests and (on `INSERT`) the data files of the snapshot that write just made current, and readers
then 404. `false` asserts the commit did not happen; the code can only establish it is retryable. The
spec names this state `CommitStateUnknown` and requires no cleanup.

The outcome is now measured, not inferred. On a failed PUT the target is read back uncached and
compared byte-for-byte with what was written: identical means committed (no cleanup),
present-but-different means a lost race (cleanup, unchanged), absent or unreadable stays
unknown and throws. Absence is not proof the write will not land, since nothing cancels a failed
conditional PUT server-side, so it is bounded by a short retry. Classifying the error instead was
rejected; see below.

Five callers share this seam. The three that delete staged files while unwinding (`INSERT`,
`DELETE`/`UPDATE`, `OPTIMIZE`) now let that exception pass through, otherwise the new throw lands in
their `catch (...)` and the data loss survives. `ALTER` and expiration delete nothing there. The
post-commit `version-hint.text` steps also ran outside any handler, so a blip there reached those
same cleanup handlers *after* the commit had landed.

A failure raised before the write reaches the store is also reported unknown, so it leaks the staged
files rather than removing them. Erring that way is deliberate.

The catalog `updateMetadata` implementations share the defect but need a different oracle; follow-up.
#114246 touches only this function's `exists()` pre-check, so the hunks are disjoint.

<details>
<summary>Validation, and why error classification was rejected</summary>

Classifying the failure instead of reading the target back was rejected: a 412 arrives as a generic
`S3Exception` whose AWS code is private, each of the four backends implementing the condition would
need its own taxonomy, and an unclassified error would default into one bucket.

Each guard has its own arm, pinned by reverting that guard's single hunk: the revert reddens that arm
and leaves the other eight byte-identical. An error-code oracle would be vacuous here, since a guard
changes only the cleanup and never the throw; file counts are therefore absolute and every scan sums
a column (`count()` comes from the manifests' `record_count`, so it stays correct with every Parquet
file deleted). A/B against base `9e7d226ccfa5272`, failpoints in both arms, Build IDs asserted.

Stateless `04929_iceberg_commit_state_unknown_no_cleanup`, 7 arms and a control:

| Assertion | base | with fix |
|---|---|---|
| `INSERT`: rows, `sum(c0)`, fresh `icebergLocal()` | errors | 9, 45, 9, 45 |
| `INSERT`: manifest list, data + Avro files | absent, 2 + 4 | present, 3 + 6 |
| `DELETE`: rows, `sum(c0)`, manifest list | errors, absent | 4, 18, present |
| `DELETE`, unknown: reported, manifest list, files | no, absent, 2 + 4 | yes, present, 3 + 6 |
| `OPTIMIZE`, both arms: manifest list, `sum(c0)` | absent, errors | present, 36 |
| `INSERT`, unknown: reported, data + Avro files | no, 2 + 4 | yes, 3 + 6 |
| version hint naming no version: data files kept | 1 of 2 | 2 of 2 |
| control, nothing armed | 4, 10 | 4, 10 |

On base the reads fail with the reported signature, `No such file or directory
[.../metadata/snap-<id>-...avro`. The last row needs no failpoint at all.

`IcebergCommitPropagation` gtest: 3 new arms (committed, absent-is-unknown, read-back-fails) redden
on base; 2 pin what must not change - a refusal still propagates, and a lost race still cleans up.
100 randomized runs, all passed.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115390&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115390](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115390+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
