### PR TITLE
Add test: `set` index bail-out for a non-reconcilable key-column type is untested

### DIFF
--- a/tests/queries/0_stateless/05023_set_index_expression_widened_operand.reference
+++ b/tests/queries/0_stateless/05023_set_index_expression_widened_operand.reference
@@ -1,0 +1,10 @@
+index_consulted	1
+granules_plain	Granules: 5/50
+granules_widened	Granules: 50/50
+granules_widened_nullable	Granules: 50/50
+plain	5
+widened	5
+widened_nullable	5
+no_skip_indexes	5
+nobulk_widened	5
+nobulk_widened_nullable	5

--- a/tests/queries/0_stateless/05023_set_index_expression_widened_operand.sql
+++ b/tests/queries/0_stateless/05023_set_index_expression_widened_operand.sql
@@ -14,7 +14,7 @@ SET use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, use_query_condition
 
 -- `t % toInt64(19)` renders as `t MOD 19`, the same name as the index expression, but its result
 -- type is UInt64 while the granule holds UInt8.
-SELECT 'index_consulted', countIf(explain LIKE '%Name: t_set%')
+SELECT 'index_consulted', countIf(explain LIKE '%Name: t_set%') > 0
 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_widened_operand WHERE t % toInt64(19) = 16);
 
 SELECT 'granules_plain', extract(explain, 'Granules: [0-9]+/[0-9]+')

--- a/tests/queries/0_stateless/05023_set_index_expression_widened_operand.sql
+++ b/tests/queries/0_stateless/05023_set_index_expression_widened_operand.sql
@@ -1,0 +1,41 @@
+-- A `set` skip index on an expression when the query spells the same expression with a wider
+-- operand type: the index must not prune with the mismatched type and the query must still work.
+
+DROP TABLE IF EXISTS t_widened_operand;
+
+CREATE TABLE t_widened_operand (t UInt32, INDEX t_set t % 19 TYPE set(4) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 2;
+
+INSERT INTO t_widened_operand SELECT number FROM numbers(100) SETTINGS max_insert_threads = 1;
+
+SET use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, use_query_condition_cache = 0,
+    secondary_indices_enable_bulk_filtering = 1, enable_parallel_replicas = 0;
+
+-- `t % toInt64(19)` renders as `t MOD 19`, the same name as the index expression, but its result
+-- type is UInt64 while the granule holds UInt8.
+SELECT 'index_consulted', countIf(explain LIKE '%Name: t_set%')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_widened_operand WHERE t % toInt64(19) = 16);
+
+SELECT 'granules_plain', extract(explain, 'Granules: [0-9]+/[0-9]+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_widened_operand WHERE t % 19 = 16)
+WHERE explain LIKE '%Granules: %/%';
+
+SELECT 'granules_widened', extract(explain, 'Granules: [0-9]+/[0-9]+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_widened_operand WHERE t % toInt64(19) = 16)
+WHERE explain LIKE '%Granules: %/%';
+
+SELECT 'granules_widened_nullable', extract(explain, 'Granules: [0-9]+/[0-9]+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_widened_operand WHERE t % (SELECT toInt64(19)) = 16)
+WHERE explain LIKE '%Granules: %/%';
+
+SELECT 'plain', count() FROM t_widened_operand WHERE t % 19 = 16;
+SELECT 'widened', count() FROM t_widened_operand WHERE t % toInt64(19) = 16;
+SELECT 'widened_nullable', count() FROM t_widened_operand WHERE t % (SELECT toInt64(19)) = 16;
+SELECT 'no_skip_indexes', count() FROM t_widened_operand WHERE t % toInt64(19) = 16 SETTINGS use_skip_indexes = 0;
+
+SET secondary_indices_enable_bulk_filtering = 0;
+SELECT 'nobulk_widened', count() FROM t_widened_operand WHERE t % toInt64(19) = 16;
+SELECT 'nobulk_widened_nullable', count() FROM t_widened_operand WHERE t % (SELECT toInt64(19)) = 16;
+
+DROP TABLE t_widened_operand;


### PR DESCRIPTION
_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #113244](https://github.com/ClickHouse/ClickHouse/pull/113244).
That PR: Fixes a `LOGICAL_ERROR` when a `set` skip index is defined on an expression and the query's copy of that expression carries a `Nullable` operand. `MergeTreeIndexConditionSet::key_columns` becomes a name->type map; `atomFromDAG` now binds the granule input with the index type and re-wraps it in …

**1. `set` index bail-out for a non-reconcilable key-column type is untested**
  `src/Storages/MergeTree/MergeTreeIndexSet.cpp:677`, `src/Storages/MergeTree/MergeTreeIndexSet.cpp:672`
  **Risk:** `MergeTreeIndexConditionSet::atomFromDAG` matches key columns by name; the new guard at `MergeTreeIndexSet.cpp:677` rejects a match whose query-side type is not `Nullable`-of the index type. If that guard is removed or loosened, the granule column (`UInt8` here) is wrapped in `toNullable` and fed …
  **Unique vs PR tests:** The PR's `04700_set_index_nullable_operand_in_expression.sql` only exercises operands typed `Nullable` of the granule type, which take the `toNullable` restore path. This test exercises the opposite outcome of the same check — a type the guard must refuse (`UInt64` and `Nullable(UInt64)` against a …

cc @george-larionov (author of #113244), @alexey-milovidov (merged/approved #113244) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115392&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115392](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115392+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1741` (included in `26.8` and later)
<!-- ch-version-info:end -->