### PR TITLE
Support bearer-token authentication in BuilderRWBufferFromHTTP (attempt 2)

### DIFF
--- a/src/Databases/DataLake/HTTPBasedCatalogUtils.cpp
+++ b/src/Databases/DataLake/HTTPBasedCatalogUtils.cpp
@@ -4,6 +4,7 @@
 #include <IO/ReadHelpers.h>
 #include <Core/Types.h>
 #include <Common/FailPoint.h>
+#include <Common/HTTPHeaderFilter.h>
 
 namespace DB::ErrorCodes
 {
@@ -19,18 +20,35 @@ namespace DB::FailPoints
 namespace DataLake
 {
 
+void validateBearerToken(const DB::ContextPtr & context, const std::string & bearer_token)
+{
+    /// `createWithBearerToken` turns a non-empty token into an `Authorization: Bearer <token>`
+    /// header. Validate that synthetic header the same way a user-supplied `auth_header` is
+    /// validated, so a token cannot inject additional headers (an embedded newline) or send an
+    /// `Authorization` header that `http_forbid_headers` forbids. An empty token sends no header.
+    if (bearer_token.empty())
+        return;
+
+    DB::HTTPHeaderEntries auth_header{{"Authorization", "Bearer " + bearer_token}};
+    context->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(auth_header);
+}
+
 DB::ReadWriteBufferFromHTTPPtr createReadBuffer(
     const std::string & endpoint,
     DB::ContextPtr context,
-    const Poco::Net::HTTPBasicCredentials & credentials,
+    const std::string & bearer_token,
     const Poco::URI::QueryParameters & params,
     const DB::HTTPHeaderEntries & headers,
     const std::string & method,
     std::function<void(std::ostream &)> out_stream_callaback)
 {
+    validateBearerToken(context, bearer_token);
+
     Poco::URI url(endpoint);
     if (!params.empty())
         url.setQueryParameters(params);
+
+    /// Catalogs authenticate with a bearer token; there are no HTTP Basic credentials
 
     return DB::BuilderRWBufferFromHTTP(url)
         .withConnectionGroup(DB::HTTPConnectionGroupType::HTTP)
@@ -42,13 +60,13 @@ DB::ReadWriteBufferFromHTTPPtr createReadBuffer(
         .withSkipNotFound(false)
         .withMethod(method)
         .withOutCallback(out_stream_callaback)
-        .create(credentials);
+        .createWithBearerToken(bearer_token);
 }
 
 std::pair<Poco::Dynamic::Var, std::string> makeHTTPRequestAndReadJSON(
     const std::string & endpoint,
     DB::ContextPtr context,
-    const Poco::Net::HTTPBasicCredentials & credentials,
+    const std::string & bearer_token,
     const Poco::URI::QueryParameters & params,
     const DB::HTTPHeaderEntries & headers,
     const std::string & method,
@@ -59,7 +77,7 @@ std::pair<Poco::Dynamic::Var, std::string> makeHTTPRequestAndReadJSON(
         throw DB::Exception(DB::ErrorCodes::FAULT_INJECTED, "Injecting fault when checking database");
     });
 
-    auto buf = createReadBuffer(endpoint, context, credentials, params, headers, method, out_stream_callaback);
+    auto buf = createReadBuffer(endpoint, context, bearer_token, params, headers, method, out_stream_callaback);
     if (buf->eof())
         return {};
 

--- a/src/Databases/DataLake/HTTPBasedCatalogUtils.h
+++ b/src/Databases/DataLake/HTTPBasedCatalogUtils.h
@@ -10,7 +10,7 @@ namespace DataLake
 DB::ReadWriteBufferFromHTTPPtr createReadBuffer(
     const std::string & endpoint,
     DB::ContextPtr context,
-    const Poco::Net::HTTPBasicCredentials & credentials,
+    const std::string & bearer_token,
     const Poco::URI::QueryParameters & params = {},
     const DB::HTTPHeaderEntries & headers = {},
     const std::string & method = Poco::Net::HTTPRequest::HTTP_GET,
@@ -19,10 +19,16 @@ DB::ReadWriteBufferFromHTTPPtr createReadBuffer(
 std::pair<Poco::Dynamic::Var, std::string> makeHTTPRequestAndReadJSON(
     const std::string & endpoint,
     DB::ContextPtr context,
-    const Poco::Net::HTTPBasicCredentials & credentials,
+    const std::string & bearer_token,
     const Poco::URI::QueryParameters & params = {},
     const DB::HTTPHeaderEntries & headers = {},
     const std::string & method = Poco::Net::HTTPRequest::HTTP_GET,
     std::function<void(std::ostream &)> out_stream_callaback = {});
+
+/// Validate a bearer token as the `Authorization: Bearer <token>` header that
+/// `createWithBearerToken` synthesizes, applying the same `http_forbid_headers` and
+/// control-character checks as a user-supplied `auth_header`. Throws BAD_ARGUMENTS on a forbidden
+/// or malformed token; an empty token is a no-op (no header is sent).
+void validateBearerToken(const DB::ContextPtr & context, const std::string & bearer_token);
 
 }

--- a/src/Databases/DataLake/PaimonRestCatalog.cpp
+++ b/src/Databases/DataLake/PaimonRestCatalog.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <Core/Names.h>
 #include <Databases/DataLake/Common.h>
+#include <Databases/DataLake/HTTPBasedCatalogUtils.h>
 #include <Databases/DataLake/ICatalog.h>
 #include <Databases/DataLake/PaimonRestCatalog.h>
 #include <Databases/DataLake/StorageCredentials.h>
@@ -128,7 +129,7 @@ void PaimonRestCatalog::loadConfig()
     }
 }
 
-void PaimonRestCatalog::createAuthHeaders(
+String PaimonRestCatalog::createAuthHeaders(
     DB::HTTPHeaderEntries & current_headers,
     const String & resource_path,
     const std::unordered_map<String, String> & query_params,
@@ -137,12 +138,13 @@ void PaimonRestCatalog::createAuthHeaders(
 {
     if (!token.has_value())
     {
-        return;
+        return "";
     }
     if (token->token_provider == "bearer")
     {
-        current_headers.emplace_back("Authorization", fmt::format("Bearer {}", token->bearer_token));
-        return;
+        /// The bearer token is applied by `create` (it fills the `Authorization` header), so it is
+        /// returned rather than spliced into `current_headers` here.
+        return token->bearer_token;
     }
     else if (token->token_provider == "dlf")
     {
@@ -258,7 +260,9 @@ void PaimonRestCatalog::createAuthHeaders(
         {
             current_headers.emplace_back(entry.first, entry.second);
         }
-        return;
+        /// The `dlf` provider signs the request with its own `Authorization` header (added above), so
+        /// there is no bearer token for `create`.
+        return "";
     }
     throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unknown token provider: {}", token->token_provider);
 }
@@ -279,8 +283,8 @@ DB::ReadWriteBufferFromHTTPPtr PaimonRestCatalog::createReadBuffer(
             query_parameters_map.emplace(entry.first, entry.second);
         }
         DB::HTTPHeaderEntries request_headers(headers);
-        createAuthHeaders(request_headers, endpoint, query_parameters_map, method);
-
+        const String bearer_token = createAuthHeaders(request_headers, endpoint, query_parameters_map, method);
+        validateBearerToken(context, bearer_token);
 
         DB::WriteBufferFromOwnString headers_string;
         headers_string << "{";
@@ -299,7 +303,7 @@ DB::ReadWriteBufferFromHTTPPtr PaimonRestCatalog::createReadBuffer(
             .withHeaders(request_headers)
             .withDelayInit(false)
             .withSkipNotFound(false)
-            .create(credentials);
+            .createWithBearerToken(bearer_token);
     };
 
     LOG_TRACE(log, "Requesting endpoint: {}", endpoint);

--- a/src/Databases/DataLake/PaimonRestCatalog.h
+++ b/src/Databases/DataLake/PaimonRestCatalog.h
@@ -109,10 +109,13 @@ private:
     String warehouse_root_path;
     std::optional<StorageType> storage_type;
     const LoggerPtr log;
-    Poco::Net::HTTPBasicCredentials credentials{};
 
     // void listDatabases();
-    void createAuthHeaders(
+    /// Adds provider-specific auth material for the request. For the `dlf` provider this appends the
+    /// signed headers to `current_headers` and returns an empty string; for the `bearer` provider it
+    /// returns the bearer token (to pass to `create`) without adding a header. Returns an empty
+    /// string when no token is configured.
+    String createAuthHeaders(
         DB::HTTPHeaderEntries & current_headers,
         const String & resource_path,
         const std::unordered_map<String, String> & query_params,

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -77,13 +77,13 @@ static UnityCatalogFullSchemaName parseFullSchemaName(const std::string & full_n
 std::pair<Poco::Dynamic::Var, std::string> UnityCatalog::getJSONRequest(const std::string & route, const Poco::URI::QueryParameters & params) const
 {
     const auto & context = getContext();
-    return makeHTTPRequestAndReadJSON(base_url / route, context, credentials, params, {auth_header});
+    return makeHTTPRequestAndReadJSON(base_url / route, context, bearer_token, params);
 }
 
 std::pair<Poco::Dynamic::Var, std::string> UnityCatalog::postJSONRequest(const std::string & route, std::function<void(std::ostream &)> out_stream_callaback) const
 {
     const auto & context = getContext();
-    return makeHTTPRequestAndReadJSON(base_url / route, context, credentials, {}, {auth_header}, Poco::Net::HTTPRequest::HTTP_POST, out_stream_callaback);
+    return makeHTTPRequestAndReadJSON(base_url / route, context, bearer_token, {}, {}, Poco::Net::HTTPRequest::HTTP_POST, out_stream_callaback);
 }
 
 bool UnityCatalog::empty() const
@@ -476,7 +476,7 @@ UnityCatalog::UnityCatalog(
     , DB::WithContext(context_)
     , base_url(base_url_)
     , log(getLogger("UnityCatalog(" + catalog_ + ")"))
-    , auth_header("Authorization", "Bearer " + catalog_credential_)
+    , bearer_token(catalog_credential_)
 {
 }
 

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -55,12 +55,10 @@ private:
     const std::filesystem::path base_url;
     const LoggerPtr log;
 
-    DB::HTTPHeaderEntry auth_header;
+    const std::string bearer_token;
 
     std::pair<Poco::Dynamic::Var, std::string> getJSONRequest(const std::string & route, const Poco::URI::QueryParameters & params = {}) const;
     std::pair<Poco::Dynamic::Var, std::string> postJSONRequest(const std::string & route, std::function<void(std::ostream &)> out_stream_callaback) const;
-
-    Poco::Net::HTTPBasicCredentials credentials{};
 
     DataLake::ICatalog::Namespaces getSchemas(const std::string & base_prefix, size_t limit = 0) const;
 

--- a/src/Databases/DataLake/tests/gtest_rest_catalog.cpp
+++ b/src/Databases/DataLake/tests/gtest_rest_catalog.cpp
@@ -7,6 +7,7 @@
 #include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
 #include <Common/tests/gtest_global_context.h>
+#include <Databases/DataLake/HTTPBasedCatalogUtils.h>
 #include <Databases/DataLake/RestCatalog.h>
 #include <IO/HTTPCommon.h>
 #include <Interpreters/Context.h>
@@ -578,6 +579,50 @@ TEST(RestCatalog, OneLakeApplySettingsChangesBearerMode)
     DB::SettingsChanges empty_value;
     empty_value.emplace_back("onelake_bearer_token", "");
     expectThrowsCode([&] { catalog.applySettingsChanges(empty_value); }, DB::ErrorCodes::BAD_ARGUMENTS);
+}
+
+TEST(RestCatalog, OneLakeRejectsMalformedBearerToken)
+{
+    auto context = DB::Context::createCopy(getContext().context);
+    context->makeQueryContext();
+
+    /// A pre-obtained bearer token becomes the `Authorization: Bearer <token>` header, so it must
+    /// pass the same validation as a user-supplied `auth_header`: a token with an embedded newline
+    /// would smuggle a second header into the request. The constructor validates the synthetic
+    /// header up front and must reject such a token before any request is issued.
+    expectThrowsCode(
+        [&]
+        {
+            OneLakeCatalog catalog(
+                "warehouse",
+                "http://127.0.0.1:1",
+                /* onelake_tenant_id */ "tenant",
+                /* onelake_client_id */ "",
+                /* onelake_client_secret */ "",
+                /* bearer_token */ "token\r\nX-Injected: evil",
+                /* refresh_token */ "",
+                /* auth_scope */ "",
+                /* oauth_server_uri */ "",
+                /* oauth_server_use_request_body */ false,
+                context);
+        },
+        DB::ErrorCodes::BAD_ARGUMENTS);
+}
+
+TEST(RestCatalog, ValidateBearerTokenRejectsMalformedHeader)
+{
+    auto context = DB::Context::createCopy(getContext().context);
+    context->makeQueryContext();
+
+    /// Every bearer-token catalog path (Unity, and Paimon via HTTPBasedCatalogUtils) runs this
+    /// shared check before the token becomes an `Authorization: Bearer <token>` header, matching
+    /// the explicit validation OneLake performs. A token with an embedded CR/LF would otherwise
+    /// smuggle a second header into the request.
+    expectThrowsCode([&] { validateBearerToken(context, "token\r\nX-Injected: evil"); }, DB::ErrorCodes::BAD_ARGUMENTS);
+
+    /// A well-formed token is accepted; an empty token sends no header and is a no-op.
+    EXPECT_NO_THROW(validateBearerToken(context, "good-token"));
+    EXPECT_NO_THROW(validateBearerToken(context, ""));
 }
 
 TEST(RestCatalog, OneLakeRefreshTokenTransparentRenewal)

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -807,6 +807,19 @@ ReadWriteBufferFromHTTP::HTTPFileInfo ReadWriteBufferFromHTTP::parseFileInfo(con
 
 ReadWriteBufferFromHTTPPtr BuilderRWBufferFromHTTP::create(const Poco::Net::HTTPBasicCredentials & credentials_)
 {
+    return createWithBearerToken(/*bearer_token_=*/ "", credentials_);
+}
+
+ReadWriteBufferFromHTTPPtr BuilderRWBufferFromHTTP::createWithBearerToken(const std::string & bearer_token_)
+{
+    /// The buffer keeps a reference to the credentials, hence the immutable static empty object.
+    static const Poco::Net::HTTPBasicCredentials no_credentials;
+    return createWithBearerToken(bearer_token_, no_credentials);
+}
+
+ReadWriteBufferFromHTTPPtr BuilderRWBufferFromHTTP::createWithBearerToken(
+    const std::string & bearer_token_, const Poco::Net::HTTPBasicCredentials & fallback_credentials_)
+{
     ProxyConfiguration proxy_configuration;
 
     if (!bypass_proxy)
@@ -814,6 +827,17 @@ ReadWriteBufferFromHTTPPtr BuilderRWBufferFromHTTP::create(const Poco::Net::HTTP
         auto proxy_protocol = ProxyConfiguration::protocolFromString(uri.getScheme());
         proxy_configuration = ProxyConfigurationResolverProvider::get(proxy_protocol)->resolve();
     }
+
+    /// A non-empty bearer token takes precedence: it and the Basic credentials occupy the
+    /// same `Authorization` header. The buffer keeps a reference to the credentials, hence
+    /// the immutable static for the bearer case (the fallback is then unused).
+    static const Poco::Net::HTTPBasicCredentials no_credentials;
+
+    /// Append the bearer header to a local copy so this does not mutate the builder:
+    /// the same builder can be reused without carrying over a stale `Authorization` header.
+    HTTPHeaderEntries header_entries = http_header_entries;
+    if (!bearer_token_.empty())
+        header_entries.emplace_back("Authorization", "Bearer " + bearer_token_);
 
     // todo it could be a problem if ReadWriteBufferFromHTTP throws
     std::unique_ptr<ReadWriteBufferFromHTTP> ptr(new ReadWriteBufferFromHTTP(
@@ -823,7 +847,7 @@ ReadWriteBufferFromHTTPPtr BuilderRWBufferFromHTTP::create(const Poco::Net::HTTP
         proxy_configuration,
         read_settings,
         timeouts,
-        credentials_,
+        bearer_token_.empty() ? fallback_credentials_ : no_credentials,
         remote_host_filter,
         buffer_size,
         max_redirects,
@@ -831,7 +855,7 @@ ReadWriteBufferFromHTTPPtr BuilderRWBufferFromHTTP::create(const Poco::Net::HTTP
         out_stream_callback,
         use_external_buffer,
         http_skip_not_found_url,
-        http_header_entries,
+        header_entries,
         redirect_callback,
         delay_initialization,
         /*file_info_=*/ std::nullopt));

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -255,7 +255,17 @@ public:
 #undef setterMember
 /// NOLINTEND(bugprone-macro-parentheses)
 
+    /// Authenticate with HTTP Basic credentials (no header is sent when they are empty).
     ReadWriteBufferFromHTTPPtr create(const Poco::Net::HTTPBasicCredentials & credentials_);
+
+    /// Authenticate with a bearer token (`Authorization: Bearer <token>`; no header when empty).
+    ReadWriteBufferFromHTTPPtr createWithBearerToken(const std::string & bearer_token_);
+
+    /// Authenticate with the bearer token when it is non-empty, otherwise with the Basic
+    /// credentials: both occupy the `Authorization` header, so a request carries one or the
+    /// other, never both.
+    ReadWriteBufferFromHTTPPtr createWithBearerToken(
+        const std::string & bearer_token_, const Poco::Net::HTTPBasicCredentials & fallback_credentials_);
 };
 
 /// Fills `credentials` from the userinfo component of `uri` (e.g. `http://user:pass@host`).


### PR DESCRIPTION
Recreated from #110313 with the same changes.

`BuilderRWBufferFromHTTP` had no way to authenticate with a bearer token: callers spliced an `Authorization: Bearer` entry into the header list themselves and had to remember not to pass HTTP Basic credentials at the same time, because both occupy the same header. `create` now takes the credential directly, in three overloads: Basic credentials, a bearer token, or both — with a non-empty token taking precedence, so the either/or rule lives in one place instead of in every caller. `create` also appends the bearer header to a local copy of the header list rather than mutating the builder, so a builder can be reused without carrying over a stale token.

Every bearer-token call site of the class is migrated to the new overloads:
- `HTTPBasedCatalogUtils` and `UnityCatalog`: built the header by hand and passed never-used HTTP Basic credentials alongside; now call `create` with the token.
- `RestCatalog`, `OneLakeCatalog`, `BigLakeCatalog`: `getAuthHeaders` now returns an `AuthHeaders` (a bearer token plus extra headers). The bearer goes to `create`; only genuine extra headers (a user-supplied `auth_header`, `x-goog-user-project`, `User-Agent`) stay in the header list. `OneLakeCatalog`'s pre-obtained token also moved from a spliced header to the bearer.
- `PaimonRestCatalog`: the `bearer` token provider (the `dlf` request-signing branch keeps its own signed headers).

Out of scope — different transport (plain Poco requests or S3-client headers), not `BuilderRWBufferFromHTTP`: `OpenAIProvider`, `CloudJWTProvider`, ArrowFlight `AuthMiddleware`, GCS `diskSettings`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110313&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/110313](https://github.com/search?q=head%3Async-upstream%2Fpr%2F110313+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1702` (included in `26.8` and later)
<!-- ch-version-info:end -->