### PR TITLE
add dimensional metrics for S3Queue

### DIFF
--- a/docs/reference/system-tables/dimensional_metrics.mdx
+++ b/docs/reference/system-tables/dimensional_metrics.mdx
@@ -77,9 +77,6 @@ Unix timestamp of the last-modified time of the newest object seen so far by an 
 ### `object_storage_queue_newest_committed_object_timestamp_seconds` {#object-storage-queue-newest-committed-object-timestamp-seconds}
 Unix timestamp of the last-modified time of the newest object fully processed so far by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table. Subtract from `object_storage_queue_newest_seen_object_timestamp_seconds` to estimate pipeline lag.
 
-### `object_storage_queue_oldest_open_file_timestamp_seconds` {#object-storage-queue-oldest-open-file-timestamp-seconds}
-Unix timestamp of the last-modified time of the oldest object currently claimed and not yet finished (processed, permanently failed, or reset for retry) by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table. Set to the current time when nothing is currently claimed. Unlike the lag metrics above, this flags a single file stuck retrying even while other files keep being processed normally.
-
 ## See also {#see-also}
 
 - [system.asynchronous_metrics](/reference/system-tables/asynchronous_metrics) — Contains periodically calculated metrics.

--- a/docs/reference/system-tables/dimensional_metrics.mdx
+++ b/docs/reference/system-tables/dimensional_metrics.mdx
@@ -71,6 +71,12 @@ Number of `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) failures, labelled by da
 ### `object_storage_queue_permanently_failed_files_total` {#object-storage-queue-permanently-failed-files-total}
 Number of `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) files given up on for good after exhausting retries (or with retries disabled), labelled by database and table. Each of these represents a file whose data will never be processed.
 
+### `object_storage_queue_newest_seen_object_timestamp_seconds` {#object-storage-queue-newest-seen-object-timestamp-seconds}
+Unix timestamp of the last-modified time of the newest object seen so far by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table.
+
+### `object_storage_queue_newest_committed_object_timestamp_seconds` {#object-storage-queue-newest-committed-object-timestamp-seconds}
+Unix timestamp of the last-modified time of the newest object fully processed so far by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table. Subtract from `object_storage_queue_newest_seen_object_timestamp_seconds` to estimate pipeline lag.
+
 ## See also {#see-also}
 
 - [system.asynchronous_metrics](/reference/system-tables/asynchronous_metrics) — Contains periodically calculated metrics.

--- a/docs/reference/system-tables/dimensional_metrics.mdx
+++ b/docs/reference/system-tables/dimensional_metrics.mdx
@@ -65,6 +65,12 @@ Number of file segments evicted from a filesystem cache, labelled by cache name 
 ### `filesystem_cache_evicted_bytes_by_user_total` {#filesystem-cache-evicted-bytes-by-user-total}
 Total bytes of file segments evicted from a filesystem cache, labelled by cache name and user id. Disabled by default; enable with `expose_prometheus_eviction_metrics` and `expose_prometheus_eviction_metrics_per_user`.
 
+### `object_storage_queue_failures_total` {#object-storage-queue-failures-total}
+Number of `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) failures, labelled by database, table, processing stage (`read`, `set_processing`, `insert`, `commit`) and error code.
+
+### `object_storage_queue_permanently_failed_files_total` {#object-storage-queue-permanently-failed-files-total}
+Number of `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) files given up on for good after exhausting retries (or with retries disabled), labelled by database and table. Each of these represents a file whose data will never be processed.
+
 ## See also {#see-also}
 
 - [system.asynchronous_metrics](/reference/system-tables/asynchronous_metrics) — Contains periodically calculated metrics.

--- a/docs/reference/system-tables/dimensional_metrics.mdx
+++ b/docs/reference/system-tables/dimensional_metrics.mdx
@@ -77,6 +77,9 @@ Unix timestamp of the last-modified time of the newest object seen so far by an 
 ### `object_storage_queue_newest_committed_object_timestamp_seconds` {#object-storage-queue-newest-committed-object-timestamp-seconds}
 Unix timestamp of the last-modified time of the newest object fully processed so far by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table. Subtract from `object_storage_queue_newest_seen_object_timestamp_seconds` to estimate pipeline lag.
 
+### `object_storage_queue_oldest_open_file_timestamp_seconds` {#object-storage-queue-oldest-open-file-timestamp-seconds}
+Unix timestamp of the last-modified time of the oldest object currently claimed and not yet finished (processed, permanently failed, or reset for retry) by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table. Set to the current time when nothing is currently claimed. Unlike the lag metrics above, this flags a single file stuck retrying even while other files keep being processed normally.
+
 ## See also {#see-also}
 
 - [system.asynchronous_metrics](/reference/system-tables/asynchronous_metrics) — Contains periodically calculated metrics.

--- a/docs/reference/system-tables/dimensional_metrics.mdx
+++ b/docs/reference/system-tables/dimensional_metrics.mdx
@@ -75,7 +75,7 @@ Number of `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) files given up on for go
 Unix timestamp of the last-modified time of the newest object seen so far by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table.
 
 ### `object_storage_queue_newest_committed_object_timestamp_seconds` {#object-storage-queue-newest-committed-object-timestamp-seconds}
-Unix timestamp of the last-modified time of the newest object fully processed so far by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table. Subtract from `object_storage_queue_newest_seen_object_timestamp_seconds` to estimate pipeline lag.
+Unix timestamp of the last-modified time of the newest object fully processed so far by an `ObjectStorageQueue` (`S3Queue`/`AzureQueue`) table, labelled by database and table.
 
 ## See also {#see-also}
 

--- a/src/Common/DimensionalMetrics.cpp
+++ b/src/Common/DimensionalMetrics.cpp
@@ -70,6 +70,12 @@ namespace DimensionalMetrics
         {"database", "table"}
     );
 
+    MetricFamily & ObjectStorageQueueOldestOpenFileTimestamp = Factory::instance().registerMetric(
+        "object_storage_queue_oldest_open_file_timestamp_seconds",
+        "Unix timestamp of the last-modified time of the oldest object currently claimed and not yet finished (processed, permanently failed, or reset for retry) by an ObjectStorageQueue (S3Queue/AzureQueue) table, labelled by database and table. Set to the current time when nothing is currently claimed. Flags a single file stuck retrying even while other files keep being processed normally.",
+        {"database", "table"}
+    );
+
     void Metric::set(Value value_)
     {
         value.store(value_, std::memory_order_relaxed);

--- a/src/Common/DimensionalMetrics.cpp
+++ b/src/Common/DimensionalMetrics.cpp
@@ -70,12 +70,6 @@ namespace DimensionalMetrics
         {"database", "table"}
     );
 
-    MetricFamily & ObjectStorageQueueOldestOpenFileTimestamp = Factory::instance().registerMetric(
-        "object_storage_queue_oldest_open_file_timestamp_seconds",
-        "Unix timestamp of the last-modified time of the oldest object currently claimed and not yet finished (processed, permanently failed, or reset for retry) by an ObjectStorageQueue (S3Queue/AzureQueue) table, labelled by database and table. Set to the current time when nothing is currently claimed. Flags a single file stuck retrying even while other files keep being processed normally.",
-        {"database", "table"}
-    );
-
     void Metric::set(Value value_)
     {
         value.store(value_, std::memory_order_relaxed);

--- a/src/Common/DimensionalMetrics.cpp
+++ b/src/Common/DimensionalMetrics.cpp
@@ -50,6 +50,14 @@ namespace DimensionalMetrics
         MetricType::Counter
     );
 
+    MetricFamily & ObjectStorageQueuePermanentlyFailedFiles = Factory::instance().registerMetric(
+        "object_storage_queue_permanently_failed_files_total",
+        "Number of ObjectStorageQueue (S3Queue/AzureQueue) files given up on for good after exhausting retries (or with retries disabled), labelled by database and table. Each of these represents a file whose data will never be processed.",
+        {"database", "table"},
+        {},
+        MetricType::Counter
+    );
+
     void Metric::set(Value value_)
     {
         value.store(value_, std::memory_order_relaxed);

--- a/src/Common/DimensionalMetrics.cpp
+++ b/src/Common/DimensionalMetrics.cpp
@@ -42,6 +42,14 @@ namespace DimensionalMetrics
         {"part_state", "part_type", "part_is_projection"}
     );
 
+    MetricFamily & ObjectStorageQueueFailures = Factory::instance().registerMetric(
+        "object_storage_queue_failures_total",
+        "Number of ObjectStorageQueue (S3Queue/AzureQueue) failures, labelled by database, table, processing stage (read, set_processing, insert, commit) and error code.",
+        {"database", "table", "stage", "error_code"},
+        {},
+        MetricType::Counter
+    );
+
     void Metric::set(Value value_)
     {
         value.store(value_, std::memory_order_relaxed);

--- a/src/Common/DimensionalMetrics.cpp
+++ b/src/Common/DimensionalMetrics.cpp
@@ -58,6 +58,18 @@ namespace DimensionalMetrics
         MetricType::Counter
     );
 
+    MetricFamily & ObjectStorageQueueNewestSeenTimestamp = Factory::instance().registerMetric(
+        "object_storage_queue_newest_seen_object_timestamp_seconds",
+        "Unix timestamp of the last-modified time of the newest object seen so far by an ObjectStorageQueue (S3Queue/AzureQueue) table, labelled by database and table. Compare against object_storage_queue_newest_committed_object_timestamp_seconds to estimate pipeline lag.",
+        {"database", "table"}
+    );
+
+    MetricFamily & ObjectStorageQueueNewestCommittedTimestamp = Factory::instance().registerMetric(
+        "object_storage_queue_newest_committed_object_timestamp_seconds",
+        "Unix timestamp of the last-modified time of the newest object fully processed so far by an ObjectStorageQueue (S3Queue/AzureQueue) table, labelled by database and table. Compare against object_storage_queue_newest_seen_object_timestamp_seconds to estimate pipeline lag.",
+        {"database", "table"}
+    );
+
     void Metric::set(Value value_)
     {
         value.store(value_, std::memory_order_relaxed);

--- a/src/Common/ZooKeeper/ZooKeeperRetries.h
+++ b/src/Common/ZooKeeper/ZooKeeperRetries.h
@@ -161,6 +161,7 @@ public:
     bool isRetry() const { return current_iteration > 0; }
 
     const std::string & getLastKeeperErrorMessage() const { return keeper_error.message; }
+    Coordination::Error getLastKeeperErrorCode() const { return keeper_error.code; }
 
     /// action will be called only once and only after latest failed retry
     /// NOTE: this one will be called only in case when retries finishes with Keeper exception

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -594,6 +594,8 @@ void ObjectStorageQueueIFileMetadata::prepareFailedRequestsImpl(
     {
         LOG_TEST(log, "File {} failed to process and will not be retried. ({})", path, failed_node_path);
 
+        permanently_failed = true;
+
         /// Remove Processing node.
         requests.push_back(zkutil::makeRemoveRequest(processing_node_path, -1));
         /// Create Failed node.
@@ -631,6 +633,8 @@ void ObjectStorageQueueIFileMetadata::prepareFailedRequestsImpl(
     if (node_metadata.retries >= max_loading_retries)
     {
         LOG_TEST(log, "File {} failed to process and will not be retried. ({})", path, failed_node_path);
+
+        permanently_failed = true;
 
         /// Remove Processing node.
         requests.push_back(zkutil::makeRemoveRequest(processing_node_path, -1));

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
@@ -185,6 +185,8 @@ public:
     /// Whether prepareFailedRequests just reset processing
     /// without actually marking the file as failed.
     bool wasProcessingResetWithoutFailure() const { return processing_reset_without_failure; }
+    /// Whether the file was given up on for good (see `permanently_failed`).
+    bool wasPermanentlyFailed() const { return permanently_failed; }
     /// Do some work after prepared requests to set file as Processing succeeded.
     /// `file_state` is a file state,
     /// which we find out after unsuccessfully attempting to set file as processing.
@@ -245,6 +247,10 @@ protected:
     /// Whether prepareFailedRequests just reset processing without actually
     /// marking the file as failed (when reduce_retry_count was false).
     bool processing_reset_without_failure = false;
+    /// Whether prepareFailedRequests gave up on the file for good, i.e. created
+    /// the terminal /failed node rather than a retriable one (retries exhausted,
+    /// or retries are disabled altogether).
+    bool permanently_failed = false;
     /// Id of the processor, which is put into processing node.
     /// Can be used to check if processing node was created by us or by someone else.
     std::string processor_info;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -15,6 +15,7 @@
 #include <Storages/StorageSnapshot.h>
 #include <base/sleep.h>
 #include <Common/CurrentThread.h>
+#include <Common/DimensionalMetrics.h>
 #include <Common/ThreadPool.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/ZooKeeperWithFaultInjection.h>
@@ -37,6 +38,12 @@ namespace CurrentMetrics
     extern const Metric ObjectStorageQueueMetadataCacheSizeBytes;
     extern const Metric ObjectStorageQueueMetadataCacheSizeElements;
 };
+
+namespace DimensionalMetrics
+{
+    extern MetricFamily & ObjectStorageQueueNewestSeenTimestamp;
+    extern MetricFamily & ObjectStorageQueueNewestCommittedTimestamp;
+}
 
 namespace DB
 {
@@ -708,6 +715,34 @@ namespace
             return info;
         }
     };
+}
+
+void ObjectStorageQueueMetadata::updateNewestSeenTimestamp(time_t timestamp, const StorageID & storage_id)
+{
+    std::lock_guard lock(pipeline_lag_watermarks_mutex);
+    auto & watermarks = pipeline_lag_watermarks[storage_id.getFullTableName()];
+    if (timestamp > watermarks.newest_seen)
+    {
+        watermarks.newest_seen = timestamp;
+        DimensionalMetrics::set(
+            DimensionalMetrics::ObjectStorageQueueNewestSeenTimestamp,
+            {storage_id.getDatabaseName(), storage_id.getTableName()},
+            static_cast<double>(timestamp));
+    }
+}
+
+void ObjectStorageQueueMetadata::updateNewestCommittedTimestamp(time_t timestamp, const StorageID & storage_id)
+{
+    std::lock_guard lock(pipeline_lag_watermarks_mutex);
+    auto & watermarks = pipeline_lag_watermarks[storage_id.getFullTableName()];
+    if (timestamp > watermarks.newest_committed)
+    {
+        watermarks.newest_committed = timestamp;
+        DimensionalMetrics::set(
+            DimensionalMetrics::ObjectStorageQueueNewestCommittedTimestamp,
+            {storage_id.getDatabaseName(), storage_id.getTableName()},
+            static_cast<double>(timestamp));
+    }
 }
 
 void ObjectStorageQueueMetadata::registerActive(const StorageID & storage_id)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -43,6 +43,7 @@ namespace DimensionalMetrics
 {
     extern MetricFamily & ObjectStorageQueueNewestSeenTimestamp;
     extern MetricFamily & ObjectStorageQueueNewestCommittedTimestamp;
+    extern MetricFamily & ObjectStorageQueueOldestOpenFileTimestamp;
 }
 
 namespace DB
@@ -743,6 +744,40 @@ void ObjectStorageQueueMetadata::updateNewestCommittedTimestamp(time_t timestamp
             {storage_id.getDatabaseName(), storage_id.getTableName()},
             static_cast<double>(timestamp));
     }
+}
+
+void ObjectStorageQueueMetadata::openFileForProcessing(time_t last_modified, const StorageID & storage_id)
+{
+    std::lock_guard lock(open_files_mutex);
+    auto & open_files = open_files_by_table[storage_id.getFullTableName()];
+    open_files.insert(last_modified);
+
+    DimensionalMetrics::set(
+        DimensionalMetrics::ObjectStorageQueueOldestOpenFileTimestamp,
+        {storage_id.getDatabaseName(), storage_id.getTableName()},
+        static_cast<double>(*open_files.begin()));
+}
+
+void ObjectStorageQueueMetadata::closeFileForProcessing(time_t last_modified, const StorageID & storage_id)
+{
+    std::lock_guard lock(open_files_mutex);
+    auto it = open_files_by_table.find(storage_id.getFullTableName());
+    if (it == open_files_by_table.end())
+        return;
+
+    auto & open_files = it->second;
+    auto entry_it = open_files.find(last_modified);
+    if (entry_it != open_files.end())
+        open_files.erase(entry_it);
+
+    const double value = open_files.empty()
+        ? static_cast<double>(getCurrentTime())
+        : static_cast<double>(*open_files.begin());
+
+    DimensionalMetrics::set(
+        DimensionalMetrics::ObjectStorageQueueOldestOpenFileTimestamp,
+        {storage_id.getDatabaseName(), storage_id.getTableName()},
+        value);
 }
 
 void ObjectStorageQueueMetadata::registerActive(const StorageID & storage_id)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -43,7 +43,6 @@ namespace DimensionalMetrics
 {
     extern MetricFamily & ObjectStorageQueueNewestSeenTimestamp;
     extern MetricFamily & ObjectStorageQueueNewestCommittedTimestamp;
-    extern MetricFamily & ObjectStorageQueueOldestOpenFileTimestamp;
 }
 
 namespace DB
@@ -744,40 +743,6 @@ void ObjectStorageQueueMetadata::updateNewestCommittedTimestamp(time_t timestamp
             {storage_id.getDatabaseName(), storage_id.getTableName()},
             static_cast<double>(timestamp));
     }
-}
-
-void ObjectStorageQueueMetadata::openFileForProcessing(time_t last_modified, const StorageID & storage_id)
-{
-    std::lock_guard lock(open_files_mutex);
-    auto & open_files = open_files_by_table[storage_id.getFullTableName()];
-    open_files.insert(last_modified);
-
-    DimensionalMetrics::set(
-        DimensionalMetrics::ObjectStorageQueueOldestOpenFileTimestamp,
-        {storage_id.getDatabaseName(), storage_id.getTableName()},
-        static_cast<double>(*open_files.begin()));
-}
-
-void ObjectStorageQueueMetadata::closeFileForProcessing(time_t last_modified, const StorageID & storage_id)
-{
-    std::lock_guard lock(open_files_mutex);
-    auto it = open_files_by_table.find(storage_id.getFullTableName());
-    if (it == open_files_by_table.end())
-        return;
-
-    auto & open_files = it->second;
-    auto entry_it = open_files.find(last_modified);
-    if (entry_it != open_files.end())
-        open_files.erase(entry_it);
-
-    const double value = open_files.empty()
-        ? static_cast<double>(getCurrentTime())
-        : static_cast<double>(*open_files.begin());
-
-    DimensionalMetrics::set(
-        DimensionalMetrics::ObjectStorageQueueOldestOpenFileTimestamp,
-        {storage_id.getDatabaseName(), storage_id.getTableName()},
-        value);
 }
 
 void ObjectStorageQueueMetadata::registerActive(const StorageID & storage_id)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <filesystem>
+#include <mutex>
 #include <optional>
+#include <unordered_map>
 #include <Core/BackgroundSchedulePoolTaskHolder.h>
 #include <Core/Types.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
@@ -198,6 +200,15 @@ public:
 
     size_t getKeeperMultireadBatchSize() const { return keeper_multiread_batch_size; }
 
+    /// Update the "newest object seen" watermark (used together with
+    /// updateNewestCommittedTimestamp() to estimate per-table pipeline lag).
+    /// `timestamp` is the object's own last-modified time, as reported by object storage.
+    /// Tracked per `storage_id`, because this metadata object can be shared by several
+    /// tables pointing at the same Keeper path.
+    void updateNewestSeenTimestamp(time_t timestamp, const StorageID & storage_id);
+    /// Update the "newest object committed" watermark, see updateNewestSeenTimestamp().
+    void updateNewestCommittedTimestamp(time_t timestamp, const StorageID & storage_id);
+
 private:
     void cleanupThreadFunc();
     void cleanupThreadFuncImpl();
@@ -231,6 +242,17 @@ private:
     std::atomic<size_t> cleanup_interval_max_ms;
     std::atomic<bool> use_persistent_processing_nodes;
     std::atomic<size_t> persistent_processing_node_ttl_seconds;
+
+    /// Watermarks for the pipeline-lag metrics, see updateNewestSeenTimestamp().
+    /// Keyed by `StorageID::getFullTableName()`, because this metadata object can be
+    /// shared by several tables pointing at the same Keeper path.
+    struct PipelineLagWatermarks
+    {
+        time_t newest_seen = 0;
+        time_t newest_committed = 0;
+    };
+    std::mutex pipeline_lag_watermarks_mutex;
+    std::unordered_map<String, PipelineLagWatermarks> pipeline_lag_watermarks;
 
     size_t buckets_num;
     std::unique_ptr<ThreadFromGlobalPool> update_registry_thread;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -3,7 +3,6 @@
 #include <filesystem>
 #include <mutex>
 #include <optional>
-#include <set>
 #include <unordered_map>
 #include <Core/BackgroundSchedulePoolTaskHolder.h>
 #include <Core/Types.h>
@@ -210,13 +209,6 @@ public:
     /// Update the "newest object committed" watermark, see updateNewestSeenTimestamp().
     void updateNewestCommittedTimestamp(time_t timestamp, const StorageID & storage_id);
 
-    /// Mark a file as claimed and not yet finished, for the "oldest open file" metric.
-    /// Call once per file when this server starts processing it.
-    void openFileForProcessing(time_t last_modified, const StorageID & storage_id);
-    /// Mark a file as no longer claimed (finished, permanently failed, or reset for retry).
-    /// Call once per file, matching a prior openFileForProcessing() call with the same `last_modified`.
-    void closeFileForProcessing(time_t last_modified, const StorageID & storage_id);
-
 private:
     void cleanupThreadFunc();
     void cleanupThreadFuncImpl();
@@ -261,13 +253,6 @@ private:
     };
     std::mutex pipeline_lag_watermarks_mutex;
     std::unordered_map<String, PipelineLagWatermarks> pipeline_lag_watermarks;
-
-    /// Last-modified timestamps of files currently claimed and not yet finished by this
-    /// server, for the "oldest open file" metric, see openFileForProcessing(). One multiset
-    /// per table (keyed the same way as `pipeline_lag_watermarks`), since several files can
-    /// be open concurrently (parallel processing threads) and can share a timestamp.
-    std::mutex open_files_mutex;
-    std::unordered_map<String, std::multiset<time_t>> open_files_by_table;
 
     size_t buckets_num;
     std::unique_ptr<ThreadFromGlobalPool> update_registry_thread;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <unordered_map>
 #include <Core/BackgroundSchedulePoolTaskHolder.h>
 #include <Core/Types.h>
@@ -209,6 +210,13 @@ public:
     /// Update the "newest object committed" watermark, see updateNewestSeenTimestamp().
     void updateNewestCommittedTimestamp(time_t timestamp, const StorageID & storage_id);
 
+    /// Mark a file as claimed and not yet finished, for the "oldest open file" metric.
+    /// Call once per file when this server starts processing it.
+    void openFileForProcessing(time_t last_modified, const StorageID & storage_id);
+    /// Mark a file as no longer claimed (finished, permanently failed, or reset for retry).
+    /// Call once per file, matching a prior openFileForProcessing() call with the same `last_modified`.
+    void closeFileForProcessing(time_t last_modified, const StorageID & storage_id);
+
 private:
     void cleanupThreadFunc();
     void cleanupThreadFuncImpl();
@@ -253,6 +261,13 @@ private:
     };
     std::mutex pipeline_lag_watermarks_mutex;
     std::unordered_map<String, PipelineLagWatermarks> pipeline_lag_watermarks;
+
+    /// Last-modified timestamps of files currently claimed and not yet finished by this
+    /// server, for the "oldest open file" metric, see openFileForProcessing(). One multiset
+    /// per table (keyed the same way as `pipeline_lag_watermarks`), since several files can
+    /// be open concurrently (parallel processing threads) and can share a timestamp.
+    std::mutex open_files_mutex;
+    std::unordered_map<String, std::multiset<time_t>> open_files_by_table;
 
     size_t buckets_num;
     std::unique_ptr<ThreadFromGlobalPool> update_registry_thread;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -256,19 +256,25 @@ ObjectStorageQueueSource::FileIterator::next()
                 LOG_TEST(log, "Filtered files: {} -> {} by path or filename", paths.size(), new_batch.size());
             }
 
-            for (const auto & object_info : new_batch)
-            {
-                auto object_metadata = object_info->getObjectMetadata();
-                if (object_metadata && object_metadata->is_last_modified_known)
-                    metadata->updateNewestSeenTimestamp(object_metadata->last_modified.epochTime(), storage_id);
-            }
-
             size_t previous_size = new_batch.size();
 
             /// Filter out files which we know we would not need to process.
             filterProcessableFiles(new_batch);
 
             LOG_TEST(log, "Filtered processed and failed files: {} -> {}", previous_size, new_batch.size());
+
+            /// Update the "seen" watermark only from files this table will actually process:
+            /// updating it before filterProcessableFiles() would also count objects already
+            /// resolved (processed/failed, e.g. kept around by after_processing=KEEP) and, in
+            /// hash-ring mode, objects owned by a different consumer - neither of which this
+            /// table will ever commit, which would otherwise make the lag estimate a false
+            /// positive (e.g. right after a restart, before anything has been committed yet).
+            for (const auto & object_info : new_batch)
+            {
+                auto object_metadata = object_info->getObjectMetadata();
+                if (object_metadata && object_metadata->is_last_modified_known)
+                    metadata->updateNewestSeenTimestamp(object_metadata->last_modified.epochTime(), storage_id);
+            }
 
             if (!new_batch.empty()
                 && enable_hash_ring_filtering
@@ -571,8 +577,24 @@ ObjectInfoPtr ObjectStorageQueueSource::FileIterator::next(size_t processor)
         if (!file_metadata)
         {
             file_metadata = metadata->getFileMetadata(object_info->getPath(), bucket_info);
-            if (!file_metadata->trySetProcessing())
-                continue;
+            try
+            {
+                if (!file_metadata->trySetProcessing())
+                    continue;
+            }
+            catch (const zkutil::KeeperException & e)
+            {
+                /// A plain `false` return from trySetProcessing() is a normal outcome (someone
+                /// else already claimed/resolved this file); this catches a genuine Keeper
+                /// communication failure escaping after retries are exhausted. Covers both the
+                /// default (non-hash-ring-batched) claim path and Ordered mode's bucketed path,
+                /// which both funnel through this same call when a bucket has no cached file
+                /// metadata yet (see bucket_info.keys.emplace_back(object_info, nullptr) above).
+                DimensionalMetrics::add(
+                    DimensionalMetrics::ObjectStorageQueueFailures,
+                    {storage_id.getDatabaseName(), storage_id.getTableName(), "set_processing", String(magic_enum::enum_name(e.code))});
+                throw;
+            }
         }
 
         if (file_deletion_on_processed_enabled && !object_storage->exists(StoredObject(object_info->getPath())))
@@ -1262,15 +1284,30 @@ Chunk ObjectStorageQueueSource::generateImpl()
                     auto metadata_with_tags = object_info_for_tags->getObjectMetadata();
                     if (metadata_with_tags && metadata_with_tags->tags.empty())
                     {
-                        fiu_do_on(FailPoints::object_storage_queue_fail_tags_fetch, {
-                            throw Exception(
-                                ErrorCodes::UNKNOWN_EXCEPTION,
-                                "Failpoint-triggered tag fetch failure for file: {}", file_metadata->getPath());
-                        });
+                        try
+                        {
+                            fiu_do_on(FailPoints::object_storage_queue_fail_tags_fetch, {
+                                throw Exception(
+                                    ErrorCodes::UNKNOWN_EXCEPTION,
+                                    "Failpoint-triggered tag fetch failure for file: {}", file_metadata->getPath());
+                            });
 
-                        metadata_with_tags->tags
-                            = object_storage->getObjectMetadata(object_info_for_tags->getPath(), /*with_tags=*/true).tags;
-                        object_info_for_tags->setObjectMetadata(*metadata_with_tags);
+                            metadata_with_tags->tags
+                                = object_storage->getObjectMetadata(object_info_for_tags->getPath(), /*with_tags=*/true).tags;
+                            object_info_for_tags->setObjectMetadata(*metadata_with_tags);
+                        }
+                        catch (...)
+                        {
+                            /// This file's rows were never pulled, so this is a read-path
+                            /// failure, not an insert failure: tag it the same way the
+                            /// pull-error handler below does, so prepareCommitRequests later
+                            /// labels it "read" instead of "insert". Rethrow immediately -
+                            /// only the label changes, not how this failure is handled.
+                            processed_files.back().state = FileState::ErrorOnRead;
+                            processed_files.back().exception_during_read = getCurrentExceptionMessage(true);
+                            processed_files.back().exception_during_read_code = getCurrentExceptionCode();
+                            throw;
+                        }
                     }
                 }
             }
@@ -1813,26 +1850,41 @@ void ObjectStorageQueueSource::commit(bool insert_succeeded, const std::string &
     const auto & settings = getContext()->getSettingsRef();
     Coordination::Error code = {};
     size_t try_num = 0;
-    zk_retry.retryLoop([&]
+    try
     {
-        if (zk_retry.isRetry())
+        zk_retry.retryLoop([&]
         {
-            LOG_TRACE(
-                log, "Failed to commit processed files at try {}/{}, will retry",
-                try_num, toString(settings[Setting::keeper_max_retries].value));
-        }
-        ++try_num;
-        code = zk_client->tryMulti(requests, responses);
-        fiu_do_on(FailPoints::object_storage_queue_fail_commit_after_success, {
-            if (code == Coordination::Error::ZOK)
-                throw zkutil::KeeperException::fromMessage(
-                    Coordination::Error::ZCONNECTIONLOSS,
-                    "Simulated connection loss after successful commit");
+            if (zk_retry.isRetry())
+            {
+                LOG_TRACE(
+                    log, "Failed to commit processed files at try {}/{}, will retry",
+                    try_num, toString(settings[Setting::keeper_max_retries].value));
+            }
+            ++try_num;
+            code = zk_client->tryMulti(requests, responses);
+            fiu_do_on(FailPoints::object_storage_queue_fail_commit_after_success, {
+                if (code == Coordination::Error::ZOK)
+                    throw zkutil::KeeperException::fromMessage(
+                        Coordination::Error::ZCONNECTIONLOSS,
+                        "Simulated connection loss after successful commit");
+            });
         });
-    });
+    }
+    catch (const zkutil::KeeperException & e)
+    {
+        /// See the analogous catch in StorageObjectStorageQueue::commit(): this covers
+        /// retries exhausted on a hardware error, which previously went uncounted entirely.
+        DimensionalMetrics::add(
+            DimensionalMetrics::ObjectStorageQueueFailures,
+            {storage_id.getDatabaseName(), storage_id.getTableName(), "commit", String(magic_enum::enum_name(e.code))});
+        throw;
+    }
 
     if (code != Coordination::Error::ZOK)
     {
+        DimensionalMetrics::add(
+            DimensionalMetrics::ObjectStorageQueueFailures,
+            {storage_id.getDatabaseName(), storage_id.getTableName(), "commit", String(magic_enum::enum_name(code))});
         if (try_num > 1)
             setUncertainCommit();
         throw zkutil::KeeperMultiException(code, requests, responses);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -1,4 +1,5 @@
 #include "config.h"
+#include <base/scope_guard.h>
 #include <base/sleep.h>
 #include <Common/CurrentThread.h>
 
@@ -1245,7 +1246,9 @@ Chunk ObjectStorageQueueSource::generateImpl()
             if (auto object_metadata = reader.getObjectInfo()->getObjectMetadata();
                 object_metadata && object_metadata->is_last_modified_known)
             {
-                processed_files.back().last_modified = object_metadata->last_modified.epochTime();
+                const auto last_modified = object_metadata->last_modified.epochTime();
+                processed_files.back().last_modified = last_modified;
+                files_metadata->openFileForProcessing(last_modified, storage_id);
             }
 
             /// Tags are not fetched during listing (it lists with with_tags = false), so populate
@@ -1663,6 +1666,14 @@ void ObjectStorageQueueSource::finalizeCommit(
     std::exception_ptr finalize_exception;
     for (const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code_, last_modified] : processed_files)
     {
+        /// Runs on every path out of this iteration (success, `continue`, or an exception
+        /// caught below), so a finalize failure can never leave this file stuck "open"
+        /// forever in the oldest-open-file tracking.
+        SCOPE_EXIT({
+            if (last_modified)
+                files_metadata->closeFileForProcessing(last_modified, storage_id);
+        });
+
         try
         {
             switch (file_state)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -1871,9 +1871,15 @@ void ObjectStorageQueueSource::commit(bool insert_succeeded, const std::string &
 
     if (code != Coordination::Error::ZOK)
     {
+        /// See the analogous comment in StorageObjectStorageQueue::commit(): prefer a stored
+        /// transport error from an earlier retried attempt over this "failed after operation"
+        /// replay code, if there is one.
+        const auto reported_code = zk_retry.getLastKeeperErrorCode() != Coordination::Error::ZOK
+            ? zk_retry.getLastKeeperErrorCode()
+            : code;
         DimensionalMetrics::add(
             DimensionalMetrics::ObjectStorageQueueFailures,
-            {storage_id.getDatabaseName(), storage_id.getTableName(), "commit", String(magic_enum::enum_name(code))});
+            {storage_id.getDatabaseName(), storage_id.getTableName(), "commit", String(magic_enum::enum_name(reported_code))});
         if (try_num > 1)
             setUncertainCommit();
         throw zkutil::KeeperMultiException(code, requests, responses);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -1,5 +1,4 @@
 #include "config.h"
-#include <base/scope_guard.h>
 #include <base/sleep.h>
 #include <Common/CurrentThread.h>
 
@@ -1268,9 +1267,7 @@ Chunk ObjectStorageQueueSource::generateImpl()
             if (auto object_metadata = reader.getObjectInfo()->getObjectMetadata();
                 object_metadata && object_metadata->is_last_modified_known)
             {
-                const auto last_modified = object_metadata->last_modified.epochTime();
-                processed_files.back().last_modified = last_modified;
-                files_metadata->openFileForProcessing(last_modified, storage_id);
+                processed_files.back().last_modified = object_metadata->last_modified.epochTime();
             }
 
             /// Tags are not fetched during listing (it lists with with_tags = false), so populate
@@ -1703,14 +1700,6 @@ void ObjectStorageQueueSource::finalizeCommit(
     std::exception_ptr finalize_exception;
     for (const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code_, last_modified] : processed_files)
     {
-        /// Runs on every path out of this iteration (success, `continue`, or an exception
-        /// caught below), so a finalize failure can never leave this file stuck "open"
-        /// forever in the oldest-open-file tracking.
-        SCOPE_EXIT({
-            if (last_modified)
-                files_metadata->closeFileForProcessing(last_modified, storage_id);
-        });
-
         try
         {
             switch (file_state)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -255,6 +255,13 @@ ObjectStorageQueueSource::FileIterator::next()
                 LOG_TEST(log, "Filtered files: {} -> {} by path or filename", paths.size(), new_batch.size());
             }
 
+            for (const auto & object_info : new_batch)
+            {
+                auto object_metadata = object_info->getObjectMetadata();
+                if (object_metadata && object_metadata->is_last_modified_known)
+                    metadata->updateNewestSeenTimestamp(object_metadata->last_modified.epochTime(), storage_id);
+            }
+
             size_t previous_size = new_batch.size();
 
             /// Filter out files which we know we would not need to process.
@@ -1235,6 +1242,12 @@ Chunk ObjectStorageQueueSource::generateImpl()
 
             processed_files.emplace_back(file_metadata);
 
+            if (auto object_metadata = reader.getObjectInfo()->getObjectMetadata();
+                object_metadata && object_metadata->is_last_modified_known)
+            {
+                processed_files.back().last_modified = object_metadata->last_modified.epochTime();
+            }
+
             /// Tags are not fetched during listing (it lists with with_tags = false), so populate
             /// them on demand here, once per file, only when _tags is requested. Must run after
             /// emplace_back so a fetch failure fails the already-claimed file through the normal
@@ -1514,14 +1527,14 @@ void ObjectStorageQueueSource::prepareCommitRequests(
     size_t processed_count = 0;
     if (!insert_succeeded && reduce_retry_count)
     {
-        for (const auto & [file_state, file_metadata_, exception_during_read_, exception_during_read_code_] : processed_files)
+        for (const auto & [file_state, file_metadata_, exception_during_read_, exception_during_read_code_, last_modified_] : processed_files)
             if (file_state == FileState::Processed)
                 ++processed_count;
     }
 
     for (size_t i = 0; i < processed_files.size(); ++i)
     {
-        const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code] = processed_files[i];
+        const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code, last_modified_] = processed_files[i];
         switch (file_state)
         {
             case FileState::Processed:
@@ -1648,7 +1661,7 @@ void ObjectStorageQueueSource::finalizeCommit(
         return;
 
     std::exception_ptr finalize_exception;
-    for (const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code_] : processed_files)
+    for (const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code_, last_modified] : processed_files)
     {
         try
         {
@@ -1659,6 +1672,9 @@ void ObjectStorageQueueSource::finalizeCommit(
                     if (insert_succeeded)
                     {
                         file_metadata->finalizeProcessed();
+
+                        if (last_modified)
+                            files_metadata->updateNewestCommittedTimestamp(last_modified, storage_id);
                     }
                     else if (file_metadata->wasProcessingResetWithoutFailure())
                     {

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -48,6 +48,7 @@ namespace ProfileEvents
 namespace DimensionalMetrics
 {
     extern MetricFamily & ObjectStorageQueueFailures;
+    extern MetricFamily & ObjectStorageQueuePermanentlyFailedFiles;
 }
 
 namespace DB
@@ -1513,7 +1514,7 @@ void ObjectStorageQueueSource::prepareCommitRequests(
     size_t processed_count = 0;
     if (!insert_succeeded && reduce_retry_count)
     {
-        for (const auto & [file_state, file_metadata_, exception_during_read_] : processed_files)
+        for (const auto & [file_state, file_metadata_, exception_during_read_, exception_during_read_code_] : processed_files)
             if (file_state == FileState::Processed)
                 ++processed_count;
     }
@@ -1647,7 +1648,7 @@ void ObjectStorageQueueSource::finalizeCommit(
         return;
 
     std::exception_ptr finalize_exception;
-    for (const auto & [file_state, file_metadata, exception_during_read] : processed_files)
+    for (const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code_] : processed_files)
     {
         try
         {
@@ -1671,6 +1672,12 @@ void ObjectStorageQueueSource::finalizeCommit(
                     {
                         file_metadata->finalizeFailed(exception_message);
                     }
+
+                    if (file_metadata->wasPermanentlyFailed())
+                        DimensionalMetrics::add(
+                            DimensionalMetrics::ObjectStorageQueuePermanentlyFailedFiles,
+                            {storage_id.getDatabaseName(), storage_id.getTableName()});
+
                     break;
                 }
                 case FileState::Cancelled: [[fallthrough]];
@@ -1688,12 +1695,24 @@ void ObjectStorageQueueSource::finalizeCommit(
                         file_metadata->finalizeResetProcessing();
                     else
                         file_metadata->finalizeFailed(exception_message);
+
+                    if (file_metadata->wasPermanentlyFailed())
+                        DimensionalMetrics::add(
+                            DimensionalMetrics::ObjectStorageQueuePermanentlyFailedFiles,
+                            {storage_id.getDatabaseName(), storage_id.getTableName()});
+
                     break;
                 }
                 case FileState::ErrorOnRead:
                 {
                     chassert(!exception_during_read.empty());
                     file_metadata->finalizeFailed(exception_during_read);
+
+                    if (file_metadata->wasPermanentlyFailed())
+                        DimensionalMetrics::add(
+                            DimensionalMetrics::ObjectStorageQueuePermanentlyFailedFiles,
+                            {storage_id.getDatabaseName(), storage_id.getTableName()});
+
                     break;
                 }
             }

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -3,7 +3,9 @@
 #include <Common/CurrentThread.h>
 
 #include <Common/Exception.h>
+#include <Common/ErrorCodes.h>
 #include <Common/ProfileEvents.h>
+#include <Common/DimensionalMetrics.h>
 #include <Common/FailPoint.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
@@ -41,6 +43,11 @@ namespace ProfileEvents
     extern const Event ObjectStorageQueueExceptionsDuringRead;
     extern const Event ObjectStorageQueueExceptionsDuringInsert;
     extern const Event ObjectStorageQueueCancelledFiles;
+}
+
+namespace DimensionalMetrics
+{
+    extern MetricFamily & ObjectStorageQueueFailures;
 }
 
 namespace DB
@@ -379,6 +386,9 @@ ObjectStorageQueueSource::FileIterator::next()
                 else
                 {
                     ProfileEvents::increment(ProfileEvents::ObjectStorageQueueFailedToBatchSetProcessing);
+                    DimensionalMetrics::add(
+                        DimensionalMetrics::ObjectStorageQueueFailures,
+                        {storage_id.getDatabaseName(), storage_id.getTableName(), "set_processing", String(magic_enum::enum_name(code))});
 
                     auto failed_idx = zkutil::getFailedOpIndex(code, responses);
 
@@ -1305,6 +1315,7 @@ Chunk ObjectStorageQueueSource::generateImpl()
 
             processed_files.back().state = FileState::ErrorOnRead;
             processed_files.back().exception_during_read = message;
+            processed_files.back().exception_during_read_code = getCurrentExceptionCode();
 
              if (file_status->processed_rows > 0)
              {
@@ -1509,7 +1520,7 @@ void ObjectStorageQueueSource::prepareCommitRequests(
 
     for (size_t i = 0; i < processed_files.size(); ++i)
     {
-        const auto & [file_state, file_metadata, exception_during_read] = processed_files[i];
+        const auto & [file_state, file_metadata, exception_during_read, exception_during_read_code] = processed_files[i];
         switch (file_state)
         {
             case FileState::Processed:
@@ -1543,6 +1554,9 @@ void ObjectStorageQueueSource::prepareCommitRequests(
                 else
                 {
                     ProfileEvents::increment(ProfileEvents::ObjectStorageQueueExceptionsDuringInsert);
+                    DimensionalMetrics::add(
+                        DimensionalMetrics::ObjectStorageQueueFailures,
+                        {storage_id.getDatabaseName(), storage_id.getTableName(), "insert", String(ErrorCodes::getName(error_code))});
 
                     file_metadata->prepareFailedRequests(
                         requests,
@@ -1568,6 +1582,11 @@ void ObjectStorageQueueSource::prepareCommitRequests(
                 else
                     ProfileEvents::increment(ProfileEvents::ObjectStorageQueueExceptionsDuringInsert);
 
+                if (file_state != FileState::Cancelled)
+                    DimensionalMetrics::add(
+                        DimensionalMetrics::ObjectStorageQueueFailures,
+                        {storage_id.getDatabaseName(), storage_id.getTableName(), "insert", String(ErrorCodes::getName(error_code))});
+
                 file_metadata->prepareFailedRequests(
                     requests,
                     exception_message,
@@ -1577,6 +1596,9 @@ void ObjectStorageQueueSource::prepareCommitRequests(
             case FileState::ErrorOnRead:
             {
                 ProfileEvents::increment(ProfileEvents::ObjectStorageQueueExceptionsDuringRead);
+                DimensionalMetrics::add(
+                    DimensionalMetrics::ObjectStorageQueueFailures,
+                    {storage_id.getDatabaseName(), storage_id.getTableName(), "read", String(ErrorCodes::getName(exception_during_read_code))});
 
                 chassert(!exception_during_read.empty());
                 file_metadata->prepareFailedRequests(

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -318,7 +318,7 @@ ObjectStorageQueueSource::FileIterator::next()
 
                 Coordination::Responses responses;
                 Coordination::Error code = {};
-                zk_retry.retryLoop([&]
+                auto set_processing_batch = [&]
                 {
                     auto zk_client = metadata->getZooKeeper();
                     if (zk_retry.isRetry())
@@ -381,7 +381,22 @@ ObjectStorageQueueSource::FileIterator::next()
                         }
                     }
                     code = zk_client->tryMulti(requests, responses);
-                });
+                };
+
+                try
+                {
+                    zk_retry.retryLoop(set_processing_batch);
+                }
+                catch (const zkutil::KeeperException & e)
+                {
+                    /// Retries were exhausted on a hardware error: the exception escapes the
+                    /// retry loop before `code` is set, so the `else` branch below (which
+                    /// records this metric for non-throwing failures) is never reached.
+                    DimensionalMetrics::add(
+                        DimensionalMetrics::ObjectStorageQueueFailures,
+                        {storage_id.getDatabaseName(), storage_id.getTableName(), "set_processing", String(magic_enum::enum_name(e.code))});
+                    throw;
+                }
 
                 if (code == Coordination::Error::ZOK)
                 {
@@ -1866,6 +1881,12 @@ void ObjectStorageQueueSource::commit(bool insert_succeeded, const std::string &
         DimensionalMetrics::add(
             DimensionalMetrics::ObjectStorageQueueFailures,
             {storage_id.getDatabaseName(), storage_id.getTableName(), "commit", String(magic_enum::enum_name(e.code))});
+
+        /// A tryMulti attempt may have succeeded in Keeper before the connection dropped -
+        /// the commit outcome is unknown, so destructors must check ownership before
+        /// removing processing nodes (see the analogous handling in
+        /// StorageObjectStorageQueue::commit()).
+        setUncertainCommit();
         throw;
     }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -296,6 +296,7 @@ private:
         FileState state;
         FileMetadataPtr metadata;
         std::string exception_during_read;
+        int exception_during_read_code = 0;
     };
     std::vector<ProcessedFile> processed_files;
     Source::ReaderHolder reader;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -297,6 +297,9 @@ private:
         FileMetadataPtr metadata;
         std::string exception_during_read;
         int exception_during_read_code = 0;
+        /// The object's own last-modified time, if object storage reported one.
+        /// Used to update the "newest object committed" pipeline-lag watermark.
+        time_t last_modified = 0;
     };
     std::vector<ProcessedFile> processed_files;
     Source::ReaderHolder reader;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1246,6 +1246,13 @@ void StorageObjectStorageQueue::commit(
         DimensionalMetrics::add(
             DimensionalMetrics::ObjectStorageQueueFailures,
             {getStorageID().getDatabaseName(), getStorageID().getTableName(), "commit", String(magic_enum::enum_name(e.code))});
+
+        /// A tryMulti attempt may have succeeded in Keeper before the connection dropped
+        /// ("failed after operation") - we never received its response, so the commit outcome
+        /// is unknown. Mark all metadata objects so their destructors check ownership before
+        /// removing the processing node, same as the replay-error branch below.
+        for (auto & source : sources)
+            source->setUncertainCommit();
         throw;
     }
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -39,6 +39,7 @@
 #include <Storages/prepareReadingFromFormat.h>
 #include <Storages/HivePartitioningUtils.h>
 #include <Common/CurrentThread.h>
+#include <Common/DimensionalMetrics.h>
 #include <Common/FailPoint.h>
 #include <Common/Macros.h>
 #include <Common/ProfileEvents.h>
@@ -64,6 +65,11 @@ namespace ProfileEvents
     extern const Event ObjectStorageQueueInsertIterations;
     extern const Event ObjectStorageQueueProcessedRows;
     extern const Event ZooKeeperWatchTriggeredObjectStorageQueue;
+}
+
+namespace DimensionalMetrics
+{
+    extern MetricFamily & ObjectStorageQueueFailures;
 }
 
 
@@ -1242,6 +1248,9 @@ void StorageObjectStorageQueue::commit(
     if (code.value() != Coordination::Error::ZOK)
     {
         ProfileEvents::increment(ProfileEvents::ObjectStorageQueueUnsuccessfulCommits);
+        DimensionalMetrics::add(
+            DimensionalMetrics::ObjectStorageQueueFailures,
+            {getStorageID().getDatabaseName(), getStorageID().getTableName(), "commit", String(magic_enum::enum_name(code.value()))});
         if (try_num > 1)
         {
             /// We had at least one hardware error retry, so the first attempt may have succeeded

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1243,8 +1243,6 @@ void StorageObjectStorageQueue::commit(
         /// `ZooKeeperRetriesControl::canTry()` rethrows the stored exception directly, so
         /// `code` below is never set and this never reaches the `!code.has_value()` branch
         /// (previously dead code: that branch could never actually be reached).
-        /// NOTE: if a retry succeeds but lands on a different non-OK code (the "failed after
-        /// operation" case below), the label there reflects that later code, not this one.
         DimensionalMetrics::add(
             DimensionalMetrics::ObjectStorageQueueFailures,
             {getStorageID().getDatabaseName(), getStorageID().getTableName(), "commit", String(magic_enum::enum_name(e.code))});
@@ -1264,9 +1262,16 @@ void StorageObjectStorageQueue::commit(
     if (code.value() != Coordination::Error::ZOK)
     {
         ProfileEvents::increment(ProfileEvents::ObjectStorageQueueUnsuccessfulCommits);
+        /// If an earlier attempt hit a hardware error (e.g. ZCONNECTIONLOSS) that got retried,
+        /// prefer that stored transport error over `code.value()`: this retry may have applied
+        /// the earlier attempt's operation and be replaying into a synthetic ZNODEEXISTS/ZNONODE,
+        /// which would otherwise hide the actual cause behind that replay error.
+        const auto reported_code = zk_retry.getLastKeeperErrorCode() != Coordination::Error::ZOK
+            ? zk_retry.getLastKeeperErrorCode()
+            : code.value();
         DimensionalMetrics::add(
             DimensionalMetrics::ObjectStorageQueueFailures,
-            {getStorageID().getDatabaseName(), getStorageID().getTableName(), "commit", String(magic_enum::enum_name(code.value()))});
+            {getStorageID().getDatabaseName(), getStorageID().getTableName(), "commit", String(magic_enum::enum_name(reported_code))});
         if (try_num > 1)
         {
             /// We had at least one hardware error retry, so the first attempt may have succeeded

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1208,32 +1208,48 @@ void StorageObjectStorageQueue::commit(
     std::optional<Coordination::Error> code;
     Coordination::Responses responses;
     size_t try_num = 0;
-    zk_retry.retryLoop([&]
+    try
     {
-        if (zk_retry.isRetry())
+        zk_retry.retryLoop([&]
         {
-            LOG_TRACE(
-                log, "Failed to commit processed files at try {}/{}, will retry",
-                try_num, toString(settings[Setting::keeper_max_retries].value));
-        }
-        ++try_num;
-        fiu_do_on(FailPoints::object_storage_queue_fail_commit, {
-            throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
-        });
-        fiu_do_on(FailPoints::object_storage_queue_fail_commit_once, {
-            throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
-        });
+            if (zk_retry.isRetry())
+            {
+                LOG_TRACE(
+                    log, "Failed to commit processed files at try {}/{}, will retry",
+                    try_num, toString(settings[Setting::keeper_max_retries].value));
+            }
+            ++try_num;
+            fiu_do_on(FailPoints::object_storage_queue_fail_commit, {
+                throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
+            });
+            fiu_do_on(FailPoints::object_storage_queue_fail_commit_once, {
+                throw zkutil::KeeperException::fromMessage(Coordination::Error::ZCONNECTIONLOSS, "Failed to commit processed files");
+            });
 
-        auto zk_client = getZooKeeper();
-        code = zk_client->tryMulti(requests, responses);
+            auto zk_client = getZooKeeper();
+            code = zk_client->tryMulti(requests, responses);
 
-        fiu_do_on(FailPoints::object_storage_queue_fail_commit_after_success, {
-            if (code == Coordination::Error::ZOK)
-                throw zkutil::KeeperException::fromMessage(
-                    Coordination::Error::ZCONNECTIONLOSS,
-                    "Simulated connection loss after successful commit");
+            fiu_do_on(FailPoints::object_storage_queue_fail_commit_after_success, {
+                if (code == Coordination::Error::ZOK)
+                    throw zkutil::KeeperException::fromMessage(
+                        Coordination::Error::ZCONNECTIONLOSS,
+                        "Simulated connection loss after successful commit");
+            });
         });
-    });
+    }
+    catch (const zkutil::KeeperException & e)
+    {
+        /// Retries were exhausted on a hardware error (e.g. ZCONNECTIONLOSS repeatedly):
+        /// `ZooKeeperRetriesControl::canTry()` rethrows the stored exception directly, so
+        /// `code` below is never set and this never reaches the `!code.has_value()` branch
+        /// (previously dead code: that branch could never actually be reached).
+        /// NOTE: if a retry succeeds but lands on a different non-OK code (the "failed after
+        /// operation" case below), the label there reflects that later code, not this one.
+        DimensionalMetrics::add(
+            DimensionalMetrics::ObjectStorageQueueFailures,
+            {getStorageID().getDatabaseName(), getStorageID().getTableName(), "commit", String(magic_enum::enum_name(e.code))});
+        throw;
+    }
 
     if (!code.has_value())
     {

--- a/tests/integration/test_storage_s3_queue/test_dimensional_metrics.py
+++ b/tests/integration/test_storage_s3_queue/test_dimensional_metrics.py
@@ -56,9 +56,8 @@ def get_dimensional_metric(node, metric, table_name, extra_where=""):
 
 def test_pipeline_lag_metrics(started_cluster):
     """Smoke test for the per-table pipeline-lag dimensional metrics:
-    object_storage_queue_newest_seen_object_timestamp_seconds,
-    object_storage_queue_newest_committed_object_timestamp_seconds,
-    object_storage_queue_oldest_open_file_timestamp_seconds.
+    object_storage_queue_newest_seen_object_timestamp_seconds and
+    object_storage_queue_newest_committed_object_timestamp_seconds.
     """
     node = started_cluster.instances["instance"]
     table_name = f"dim_metrics_lag_{generate_random_string()}"
@@ -103,16 +102,6 @@ def test_pipeline_lag_metrics(started_cluster):
     # Sanity: the objects were just uploaded, so the watermark should be close to "now",
     # not some stale value left over from a previous test using a shared metadata object.
     assert abs(newest_seen - test_start_time) < 300
-
-    # Nothing is claimed/in-flight anymore, so this must have been reset to "now" at the
-    # moment the last file was closed. It never updates again on its own (no periodic
-    # refresh, only event-driven), so check it right away rather than in a retry loop:
-    # retrying would only let it look staler, never fresher.
-    oldest_open = get_dimensional_metric(
-        node, "object_storage_queue_oldest_open_file_timestamp_seconds", table_name
-    )
-    assert oldest_open > 0
-    assert abs(oldest_open - time.time()) < 180
 
 
 def test_failure_metrics(started_cluster):

--- a/tests/integration/test_storage_s3_queue/test_dimensional_metrics.py
+++ b/tests/integration/test_storage_s3_queue/test_dimensional_metrics.py
@@ -1,0 +1,165 @@
+import logging
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.s3_queue_common import (
+    create_mv,
+    create_table,
+    generate_random_files,
+    generate_random_string,
+    put_s3_file_content,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "instance",
+            user_configs=["configs/users.xml"],
+            with_minio=True,
+            with_zookeeper=True,
+            main_configs=["configs/zookeeper.xml", "configs/s3queue_log.xml"],
+        )
+
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def run_with_retry(check_result, func, retries=120):
+    for _ in range(retries):
+        last = func()
+        if check_result(last):
+            return last
+        time.sleep(1)
+    raise RuntimeError(f"{last} did not match expectations in {retries} retries")
+
+
+def get_dimensional_metric(node, metric, table_name, extra_where=""):
+    where = f"labels['table'] = '{table_name}'"
+    if extra_where:
+        where += f" AND {extra_where}"
+    result = node.query(
+        f"SELECT sum(value) FROM system.dimensional_metrics "
+        f"WHERE metric = '{metric}' AND {where}"
+    ).strip()
+    return float(result) if result else 0.0
+
+
+def test_pipeline_lag_metrics(started_cluster):
+    """Smoke test for the per-table pipeline-lag dimensional metrics:
+    object_storage_queue_newest_seen_object_timestamp_seconds,
+    object_storage_queue_newest_committed_object_timestamp_seconds,
+    object_storage_queue_oldest_open_file_timestamp_seconds.
+    """
+    node = started_cluster.instances["instance"]
+    table_name = f"dim_metrics_lag_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    files_path = f"{table_name}_data"
+
+    files_num = 5
+    row_num = 3
+    test_start_time = time.time()
+
+    total_values = generate_random_files(
+        started_cluster, files_path, files_num, row_num=row_num
+    )
+
+    create_table(started_cluster, node, table_name, "unordered", files_path)
+    create_mv(node, table_name, dst_table_name)
+
+    def get_count():
+        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
+
+    run_with_retry(lambda x: x == len(total_values), get_count)
+
+    newest_seen = run_with_retry(
+        lambda x: x > 0,
+        lambda: get_dimensional_metric(
+            node, "object_storage_queue_newest_seen_object_timestamp_seconds", table_name
+        ),
+    )
+    newest_committed = run_with_retry(
+        lambda x: x > 0,
+        lambda: get_dimensional_metric(
+            node,
+            "object_storage_queue_newest_committed_object_timestamp_seconds",
+            table_name,
+        ),
+    )
+
+    # Both timestamps come from the objects' own last-modified time (not wall-clock "now"
+    # at listing/commit time), so once everything generated before the test started has
+    # drained, they must land on the exact same value: the last object's last-modified time.
+    assert newest_seen == newest_committed
+    # Sanity: the objects were just uploaded, so the watermark should be close to "now",
+    # not some stale value left over from a previous test using a shared metadata object.
+    assert abs(newest_seen - test_start_time) < 300
+
+    # Nothing is claimed/in-flight anymore, so this must have been reset to "now" at the
+    # moment the last file was closed. It never updates again on its own (no periodic
+    # refresh, only event-driven), so check it right away rather than in a retry loop:
+    # retrying would only let it look staler, never fresher.
+    oldest_open = get_dimensional_metric(
+        node, "object_storage_queue_oldest_open_file_timestamp_seconds", table_name
+    )
+    assert oldest_open > 0
+    assert abs(oldest_open - time.time()) < 180
+
+
+def test_failure_metrics(started_cluster):
+    """Smoke test for the per-table failure dimensional metrics:
+    object_storage_queue_failures_total and
+    object_storage_queue_permanently_failed_files_total.
+    """
+    node = started_cluster.instances["instance"]
+    table_name = f"dim_metrics_fail_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    files_path = f"{table_name}_data"
+    file_path = f"{files_path}/bad_row.csv"
+    retries_num = 2
+
+    # column1 is UInt32, "not_a_number" fails to parse, deterministically failing every
+    # attempt to read this file (as opposed to an insert- or commit-time failure).
+    put_s3_file_content(started_cluster, file_path, b"not_a_number,1,1\n")
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={
+            "s3queue_loading_retries": retries_num,
+            "polling_max_timeout_ms": 5000,
+            "polling_backoff_ms": 1000,
+        },
+    )
+    create_mv(node, table_name, dst_table_name)
+
+    permanently_failed = run_with_retry(
+        lambda x: x >= 1,
+        lambda: get_dimensional_metric(
+            node, "object_storage_queue_permanently_failed_files_total", table_name
+        ),
+    )
+    assert permanently_failed == 1
+
+    read_failures = get_dimensional_metric(
+        node,
+        "object_storage_queue_failures_total",
+        table_name,
+        extra_where="labels['stage'] = 'read'",
+    )
+    assert read_failures >= 1
+
+    # The file never parsed successfully, so nothing should have reached the destination.
+    assert 0 == int(node.query(f"SELECT count() FROM {dst_table_name}"))


### PR DESCRIPTION
Add some dimensional metrics for S3Queue.


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add some dimensional metrics for S3Queue.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115422&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115422](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115422+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.6` (included in `26.9` and later)
- Backported to: `26.8.1.2035`
<!-- ch-version-info:end -->