### PR TITLE
Support GROUPING SETS in distributed plans built by the Cascades optimizer

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/AggregationImplementations.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/AggregationImplementations.cpp
@@ -283,13 +283,15 @@ bool TwoStageAggregationTransformation::checkPattern(GroupExpressionPtr expressi
     return agg_step != nullptr &&
         expression->strategy == nullptr &&
         agg_step->getFinal() &&
-        !agg_step->isGroupingSets() &&           /// distributed merging of grouping-set states is not supported
         !agg_step->getParams().overflow_row &&
         agg_step->getParams().max_rows_to_group_by == 0 &&  /// global row limit must be enforced by one aggregator
         !agg_step->getParams().only_merge &&     /// don't split a merge step that's already from a prior split
         /// `distributed_plan_force_shuffle_aggregation` forbids the partial + merge split
-        /// whenever the shuffle strategy is available (the aggregation has group keys).
-        !(memo.getContext().distributed_plan_force_shuffle_aggregation && !agg_step->getParams().keys.empty());
+        /// whenever the shuffle strategy is available (the aggregation has group keys). A
+        /// grouping-set aggregation has no shuffle strategy (see `isShuffleApplicable`), so the
+        /// setting does not apply to it.
+        !(memo.getContext().distributed_plan_force_shuffle_aggregation && !agg_step->getParams().keys.empty()
+            && !agg_step->isGroupingSets());
 }
 
 std::vector<GroupExpressionPtr> TwoStageAggregationTransformation::applyImpl(GroupExpressionPtr expression, const ExpressionProperties & /*required_properties*/, Memo & memo) const
@@ -311,8 +313,11 @@ std::vector<GroupExpressionPtr> TwoStageAggregationTransformation::applyImpl(Gro
     /// The memory-efficient merge below expects every input to deliver two-level buckets in
     /// ascending order. Force the partial step to emit them that way; otherwise a parallel
     /// flush unites several bucket sequences into one exchange stream out of order and the
-    /// merge emits some groups twice.
-    if (memo.getContext().distributed_aggregation_memory_efficient)
+    /// merge emits some groups twice. The memory-efficient merge does not support the per-set
+    /// states of grouping sets, so for them it stays off, the same as in the rule-based planner.
+    const bool memory_efficient_merge
+        = memo.getContext().distributed_aggregation_memory_efficient && !agg_step->isGroupingSets();
+    if (memory_efficient_merge)
         partial_step->setShouldProduceResultsInBucketOrder(true);
     partial_step->setStepDescription(fmt::format("Partial: {}", agg_step->getStepDescription()), 200);
 
@@ -322,14 +327,12 @@ std::vector<GroupExpressionPtr> TwoStageAggregationTransformation::applyImpl(Gro
     /// requestOnlyMergeForAggregateProjection which adapts them to finalized types.
     auto merge_params = agg_step->getParams();
     merge_params.only_merge = true;
-    /// Grouping sets never reach this rule (see checkPattern), so the memory-efficient
-    /// mode needs no grouping-sets guard here, unlike the rule-based planner.
     auto merge_step_ptr = std::make_unique<MergingAggregatedStep>(
         partial_step->getOutputHeader(),
         std::move(merge_params),
         agg_step->getGroupingSetsParamsList(),
         /*final_=*/true,
-        memo.getContext().distributed_aggregation_memory_efficient,
+        memory_efficient_merge,
         agg_step->getTemporaryDataMergeThreads(),
         agg_step->shouldProduceResultsInBucketOrder(),
         agg_step->getMaxBlockSize(),

--- a/tests/queries/0_stateless/05023_cascades_grouping_sets_distributes.reference
+++ b/tests/queries/0_stateless/05023_cascades_grouping_sets_distributes.reference
@@ -1,0 +1,36 @@
+-- the plan splits the grouping sets aggregation into partial and merge
+Expression (Project names)
+  Sorting
+    Expression ((Before ORDER BY + Projection))
+      MergingAggregated
+        GatherExchange
+          Aggregating
+            Expression ((Before GROUP BY + Change column names to column identifiers))
+              ReadFromMergeTree (ParallelRead default.t_gs_cascades)
+-- results
+	0	1	249500	500
+	0	2	499500	1000
+	1	1	250000	500
+k0	0	1	166833	334
+k1	0	1	166167	333
+k2	0	1	166500	333
+-- same result from the non-distributed baseline
+	0	1	249500	500
+	0	2	499500	1000
+	1	1	250000	500
+k0	0	1	166833	334
+k1	0	1	166167	333
+k2	0	1	166500	333
+-- memory-efficient setting on: no duplicate groups
+0
+0
+0
+-- the split still happens under distributed_plan_force_shuffle_aggregation
+Expression (Project names)
+  Sorting
+    Expression ((Before ORDER BY + Projection))
+      MergingAggregated
+        GatherExchange
+          Aggregating
+            Expression ((Before GROUP BY + Change column names to column identifiers))
+              ReadFromMergeTree (ParallelRead default.t_gs_cascades)

--- a/tests/queries/0_stateless/05023_cascades_grouping_sets_distributes.sql
+++ b/tests/queries/0_stateless/05023_cascades_grouping_sets_distributes.sql
@@ -1,0 +1,66 @@
+-- Tags: no-darwin, no-old-analyzer
+-- no-darwin: distributed execution uses the streaming exchange, which is implemented only on Linux.
+-- no-old-analyzer: distributed Cascades planning requires the analyzer, like the other make_distributed_plan tests.
+
+-- A `GROUPING SETS` aggregation distributes with the two-phase split: every worker builds
+-- partial states for every grouping set over its share of the data, tagged with
+-- `__grouping_set`, and one node merges them per set. The shuffle strategy stays inapplicable:
+-- rows of one subtotal group would land in several buckets and the group would be emitted
+-- several times.
+
+SET enable_analyzer = 1;
+SET enable_cascades_optimizer = 1;
+SET make_distributed_plan = 1;
+SET distributed_plan_execute_locally = 1;
+SET enable_parallel_replicas = 0;
+SET automatic_parallel_replicas_mode = 0;
+SET max_rows_to_group_by = 0;
+SET param__internal_cascades_cluster_node_count = 4;
+
+DROP TABLE IF EXISTS t_gs_cascades;
+
+CREATE TABLE t_gs_cascades (k1 String, k2 UInt64, v UInt64) ENGINE = MergeTree ORDER BY tuple() SETTINGS auto_statistics_types = '';
+
+INSERT INTO t_gs_cascades SELECT 'k' || (number % 3)::String, number % 2, number FROM numbers(1000);
+
+-- A large table-size hint makes Cascades pick the distributed two-phase plan (partial
+-- aggregation per worker, gathered and merged) rather than reading and aggregating everything
+-- on one node.
+SET param__internal_join_table_stat_hints = '{"t_gs_cascades": {"cardinality": 600000000, "avg_row_bytes": 24, "distinct_keys": {"k1": 3, "k2": 2}}}';
+
+SELECT '-- the plan splits the grouping sets aggregation into partial and merge';
+-- `distributed_aggregation_memory_efficient` is pinned on: the merge must keep it off for
+-- grouping sets, so no `Mode` line may appear in the dump.
+EXPLAIN distributed = 1 SELECT k1, k2, grouping(k1) + grouping(k2) AS g, sum(v)
+FROM t_gs_cascades GROUP BY GROUPING SETS ((k1), (k2)) ORDER BY ALL
+SETTINGS distributed_aggregation_memory_efficient = 1;
+
+SELECT '-- results';
+SELECT k1, k2, grouping(k1) + grouping(k2) AS g, sum(v), count()
+FROM t_gs_cascades GROUP BY GROUPING SETS ((k1), (k2), ()) ORDER BY ALL;
+
+SELECT '-- same result from the non-distributed baseline';
+SELECT k1, k2, grouping(k1) + grouping(k2) AS g, sum(v), count()
+FROM t_gs_cascades GROUP BY GROUPING SETS ((k1), (k2), ()) ORDER BY ALL
+SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
+
+-- Force the two-level aggregation and a parallel partial flush; with the memory-efficient merge
+-- wrongly enabled for grouping sets some groups would be emitted twice. The check is repeated
+-- because such duplication depends on chunk arrival order and would not appear on every run.
+SET distributed_aggregation_memory_efficient = 1;
+SET group_by_two_level_threshold = 1;
+SET max_threads = 4;
+
+SELECT '-- memory-efficient setting on: no duplicate groups';
+SELECT throwIf(count() != uniqExact((k1, k2, g)), 'duplicate grouping set groups') FROM (SELECT k1, k2, grouping(k1) + grouping(k2) AS g, sum(v) FROM t_gs_cascades GROUP BY GROUPING SETS ((k1), (k2)));
+SELECT throwIf(count() != uniqExact((k1, k2, g)), 'duplicate grouping set groups') FROM (SELECT k1, k2, grouping(k1) + grouping(k2) AS g, sum(v) FROM t_gs_cascades GROUP BY GROUPING SETS ((k1), (k2)));
+SELECT throwIf(count() != uniqExact((k1, k2, g)), 'duplicate grouping set groups') FROM (SELECT k1, k2, grouping(k1) + grouping(k2) AS g, sum(v) FROM t_gs_cascades GROUP BY GROUPING SETS ((k1), (k2)));
+
+SELECT '-- the split still happens under distributed_plan_force_shuffle_aggregation';
+-- The shuffle strategy does not exist for grouping sets, so the force-shuffle setting cannot
+-- push the aggregation back to a single node.
+EXPLAIN distributed = 1 SELECT k1, k2, grouping(k1) + grouping(k2) AS g, sum(v)
+FROM t_gs_cascades GROUP BY GROUPING SETS ((k1), (k2)) ORDER BY ALL
+SETTINGS distributed_plan_force_shuffle_aggregation = 1;
+
+DROP TABLE t_gs_cascades;


### PR DESCRIPTION
Support distributed `GROUPING SETS` aggregation in the Cascades optimizer. Follow-up to https://github.com/ClickHouse/ClickHouse/pull/114950, which added it to the rule-based distributed planner; with `enable_cascades_optimizer = 1` such an aggregation stayed on a single node.

- `TwoStageAggregationTransformation` accepts grouping-set aggregations: every worker builds partial states for every grouping set over its share of the data, and one node merges them per set. The shuffle strategy stays inapplicable, since it would split subtotal groups across buckets.
- The memory-efficient merge stays off for grouping sets, the same as in the rule-based planner (they do not work together, see https://github.com/ClickHouse/ClickHouse/issues/43989).
- `distributed_plan_force_shuffle_aggregation` no longer suppresses the split for grouping sets, because no shuffle strategy exists for them.

The test asserts the two-phase plan shape, compares the distributed results with the non-distributed baseline, and checks for duplicate groups under `distributed_aggregation_memory_efficient = 1`.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Support `GROUPING SETS` aggregation in distributed plans built by the Cascades optimizer (`make_distributed_plan = 1, enable_cascades_optimizer = 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115426&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115426](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115426+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
