### PR TITLE
[DRAFT] jemalloc: try 4k page size for aarch64 in performance tests

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -198,6 +198,26 @@ else ()
     message (FATAL_ERROR "internal jemalloc: This arch is not supported")
 endif ()
 
+if (OS_LINUX AND ARCH_AARCH64)
+    # aarch64 kernels are built with 4KiB, 16KiB or 64KiB pages. jemalloc's page size is fixed at
+    # compile time and must not be smaller than the kernel page size, otherwise jemalloc fails to
+    # boot. 64KiB runs everywhere, at the cost of a higher memory footprint on smaller-page kernels
+    # (page-sized slabs, page-granular purging); pick a smaller size when the target kernel is known.
+    set (JEMALLOC_AARCH64_PAGE_SIZE_KIB 64 CACHE STRING "jemalloc page size on aarch64, in KiB (4, 16 or 64). Must not be less than the kernel page size.")
+    if (JEMALLOC_AARCH64_PAGE_SIZE_KIB EQUAL 4)
+        set (JEMALLOC_LG_PAGE 12)
+    elseif (JEMALLOC_AARCH64_PAGE_SIZE_KIB EQUAL 16)
+        set (JEMALLOC_LG_PAGE 14)
+    elseif (JEMALLOC_AARCH64_PAGE_SIZE_KIB EQUAL 64)
+        set (JEMALLOC_LG_PAGE 16)
+    else ()
+        message (FATAL_ERROR "Invalid JEMALLOC_AARCH64_PAGE_SIZE_KIB=${JEMALLOC_AARCH64_PAGE_SIZE_KIB}, must be 4, 16 or 64")
+    endif ()
+    # A PMD-level THP maps (page size / 8) entries of one page each: 2MiB/32MiB/512MiB for 4/16/64 KiB pages.
+    math (EXPR JEMALLOC_LG_HUGEPAGE "2 * ${JEMALLOC_LG_PAGE} - 3")
+    message (STATUS "jemalloc aarch64 page size: ${JEMALLOC_AARCH64_PAGE_SIZE_KIB}KiB (LG_PAGE=${JEMALLOC_LG_PAGE}, LG_HUGEPAGE=${JEMALLOC_LG_HUGEPAGE})")
+endif ()
+
 configure_file(${JEMALLOC_INCLUDE_PREFIX}/jemalloc/internal/jemalloc_internal_defs.h.in
     ${JEMALLOC_INCLUDE_PREFIX}/jemalloc/internal/jemalloc_internal_defs.h)
 target_include_directories(_jemalloc SYSTEM PRIVATE

--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -203,7 +203,7 @@ if (OS_LINUX AND ARCH_AARCH64)
     # compile time and must not be smaller than the kernel page size, otherwise jemalloc fails to
     # boot. 64KiB runs everywhere, at the cost of a higher memory footprint on smaller-page kernels
     # (page-sized slabs, page-granular purging); pick a smaller size when the target kernel is known.
-    set (JEMALLOC_AARCH64_PAGE_SIZE_KIB 64 CACHE STRING "jemalloc page size on aarch64, in KiB (4, 16 or 64). Must not be less than the kernel page size.")
+    set (JEMALLOC_AARCH64_PAGE_SIZE_KIB 4 CACHE STRING "jemalloc page size on aarch64, in KiB (4, 16 or 64). Must not be less than the kernel page size.")
     if (JEMALLOC_AARCH64_PAGE_SIZE_KIB EQUAL 4)
         set (JEMALLOC_LG_PAGE 12)
     elseif (JEMALLOC_AARCH64_PAGE_SIZE_KIB EQUAL 16)

--- a/contrib/jemalloc-cmake/include_linux_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -204,7 +204,7 @@
 /* #undef LG_QUANTUM */
 
 /* One page is 2^LG_PAGE bytes. */
-#define LG_PAGE 16
+#define LG_PAGE @JEMALLOC_LG_PAGE@
 
 /* Maximum number of regions in a slab. */
 /* #undef CONFIG_LG_SLAB_MAXREGS */
@@ -214,7 +214,7 @@
  * system does not explicitly support huge pages; system calls that require
  * explicit huge page support are separately configured.
  */
-#define LG_HUGEPAGE 29
+#define LG_HUGEPAGE @JEMALLOC_LG_HUGEPAGE@
 
 /*
  * If defined, adjacent virtual memory mappings with identical attributes

--- a/contrib/jemalloc-cmake/include_linux_aarch64_musl/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_aarch64_musl/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -200,7 +200,7 @@
 /* #undef LG_QUANTUM */
 
 /* One page is 2^LG_PAGE bytes. */
-#define LG_PAGE 16
+#define LG_PAGE @JEMALLOC_LG_PAGE@
 
 /* Maximum number of regions in a slab. */
 /* #undef CONFIG_LG_SLAB_MAXREGS */
@@ -210,7 +210,7 @@
  * system does not explicitly support huge pages; system calls that require
  * explicit huge page support are separately configured.
  */
-#define LG_HUGEPAGE 29
+#define LG_HUGEPAGE @JEMALLOC_LG_HUGEPAGE@
 
 /*
  * If defined, adjacent virtual memory mappings with identical attributes


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
jemalloc: try smaller page size for aarch64 in performance tests


### Results
- https://pastila.nl/?0b51146b/3a53ee275d2943d6435247b54fb1e4da#+qUNXLiJ3KLSkGFG7dlIbg==GCM
- microbench - https://gist.github.com/azat/5ec1f9794e6b079005c1f7951d1d4f02#file-4k-vs-64k-txt

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115427&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115427](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115427+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
