### PR TITLE
CI: skip selected test jobs for docs-only changes

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -208,7 +208,12 @@ def should_skip_job(job_name):
         print("WARNING: no changed files found for PR - do not filter jobs")
         return False, ""
 
-    if job_name == JobNames.BUILD_PROFILE_DIFF and only_docs(changed_files):
+    # Selected-test jobs are uncached because their selection includes PR-local
+    # state, so digest filtering cannot skip their runners for docs-only changes.
+    if only_docs(changed_files) and (
+        job_name == JobNames.BUILD_PROFILE_DIFF
+        or (job_name.startswith(JobNames.STATELESS) and "selected tests" in job_name)
+    ):
         return True, "Skipped, only documentation changed"
 
     # Run Keeper Stress jobs only when there are changes in src/Coordination,

--- a/ci/tests/test_config_job_no_cidb.py
+++ b/ci/tests/test_config_job_no_cidb.py
@@ -186,6 +186,26 @@ def test_build_profile_diff_skipped_for_docs_only_changes(monkeypatch):
     )
 
 
+def test_selected_stateless_tests_skipped_for_docs_only_changes(monkeypatch):
+    _use_fake_info(
+        monkeypatch,
+        changed_files=("docs/products/cloud/features/large-single-replica-services.mdx",),
+    )
+
+    for job in fj.JobConfigs.stateless_tests_selected_pr_jobs:
+        assert fj.should_skip_job(job.name) == (
+            True,
+            "Skipped, only documentation changed",
+        )
+
+
+def test_selected_stateless_tests_run_for_non_docs_changes(monkeypatch):
+    _use_fake_info(monkeypatch, changed_files=("src/Core/Settings.cpp",))
+
+    for job in fj.JobConfigs.stateless_tests_selected_pr_jobs:
+        assert fj.should_skip_job(job.name) == (False, "")
+
+
 @pytest.mark.parametrize(
     "changed_files",
     [


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115423

Documentation-only pull requests currently start the uncached `selected tests` stateless jobs. Their selection depends on pull-request-local state and therefore bypasses digest filtering, even when there cannot be any tests covering the changed files. Besides wasting runners, a selection-service outage can fail such a pull request before any test executes.

Skip every selected stateless variant during workflow configuration when all changed files are documentation. Add regression coverage for every variant and verify that source changes still schedule them.

Validated with `uv run --no-project --with pytest --with requests --with unidiff --with PyYAML python -m pytest ci/tests/test_config_job_no_cidb.py -q` (15 passed).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Skip selected stateless test jobs for documentation-only pull requests.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115432&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115432](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115432+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
