### PR TITLE
Fix indefinitely waiting ReplicatedMergeTree startup after checkNoOldLeaders retries

### DIFF
--- a/src/Storages/MergeTree/LeaderElection.h
+++ b/src/Storages/MergeTree/LeaderElection.h
@@ -1,10 +1,17 @@
 #pragma once
 
 #include <filesystem>
+#include <Common/Exception.h>
 #include <Common/logger_useful.h>
 #include <base/sort.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/KeeperException.h>
+
+namespace DB::ErrorCodes
+{
+    extern const int REPLICA_STATUS_CHANGED;
+    extern const int SUPPORT_IS_DISABLED;
+}
 
 namespace fs = std::filesystem;
 
@@ -65,7 +72,10 @@ inline void checkNoOldLeaders(LoggerPtr log, ZooKeeper & zookeeper, const String
             }
 
             if (!identifier.ends_with(suffix))
-                throw Poco::Exception(fmt::format("Found leader replica ({}) with too old version (< 20.6). Stop it before upgrading", identifier));
+                throw DB::Exception(
+                    DB::ErrorCodes::SUPPORT_IS_DISABLED,
+                    "Found leader replica ({}) with too old version (< 20.6). Stop it before upgrading",
+                    identifier);
 
             /// Version does not matter, just check that it still exists.
             /// May fail with ZNONODE
@@ -84,7 +94,7 @@ inline void checkNoOldLeaders(LoggerPtr log, ZooKeeper & zookeeper, const String
             KeeperMultiException::check(code, ops, res);
     }
 
-    throw Poco::Exception("Cannot check that no old leaders exist");
+    throw DB::Exception(DB::ErrorCodes::REPLICA_STATUS_CHANGED, "Cannot check that no old leaders exist");
 }
 
 }


### PR DESCRIPTION
Loading the table at the start of the server may hang when startup task is not repeated due to exception in `checkNoOldLeaders`. `Poco::Exception` is not catched in `ReplicatedMergeTreeAttachThread::run()`, it should be changed to `DB::Exception` to assign retries

```
2026.08.04 13:10:21.936792 [ 4399 ] {} <Information> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): Table will be in readonly mode until initialization is finished
2026.08.04 13:10:21.936962 [ 4399 ] {} <Debug> AsyncLoader: Finish load job 'load table <table_name>' with status OK
2026.08.04 13:27:13.667527 [ 3139 ] {} <Debug> AsyncLoader: Prioritize load job 'startup table <table_name>': BackgrndStartup -> ForegroundLoad
2026.08.04 13:27:13.674912 [ 3139 ] {} <Debug> AsyncLoader: Schedule load job 'startup table <table_name>' into ForegroundLoad
2026.08.04 13:27:18.553450 [ 4528 ] {} <Debug> AsyncLoader: Execute load job 'startup table <table_name>' in ForegroundLoad
2026.08.04 13:27:18.718417 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Debug> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): Creating shared ID for table <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6)
2026.08.04 13:27:18.738817 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Debug> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): Initializing table shared ID with 2acf9026-fa03-4505-9332-88df0dffebf6
2026.08.04 13:27:18.792119 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Debug> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): Creating shared ID for table <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6)
2026.08.04 13:27:18.792128 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Information> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): Shared ID already set to 2acf9026-fa03-4505-9332-88df0dffebf6
2026.08.04 13:27:18.839803 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Information> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): LeaderElection: leader suddenly changed or new node appeared, will retry
......
2026.08.04 13:27:55.018853 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Information> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): LeaderElection: leader suddenly changed or new node appeared, will retry
2026.08.04 13:27:55.048123 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Information> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): LeaderElection: leader suddenly changed or new node appeared, will retry
2026.08.04 13:27:55.076894 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Information> <table_name> (2acf9026-fa03-4505-9332-88df0dffebf6): LeaderElection: leader suddenly changed or new node appeared, will retry
...
2026.08.04 13:27:55.109533 [ 3821 ] {BgSchPool::e40075b8-39d2-48c1-9219-54b0a9f5a1b9} <Error> void DB::BackgroundSchedulePoolTaskInfo::execute(BackgroundSchedulePool &): Poco::Exception. Code: 1000, e.code() = 0, Exception: Cannot check that no old leaders exist, Stack trace (when copying this message, always include the lines below):
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115433&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115433](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115433+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
