### PR TITLE
CI: request docs review only for documentation-only changes

### DIFF
--- a/ci/jobs/scripts/team_review_requests.py
+++ b/ci/jobs/scripts/team_review_requests.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from ci.praktika.gh import GH
 
 DOCS_PREFIX = "docs/"
-SOURCE_PREFIX = "src/"
 CLICKPIPES_DOCS_PREFIX = "docs/integrations/clickpipes/"
 INTEGRATIONS_DOCS_PREFIXES = (
     "docs/integrations/language-clients/",
@@ -28,20 +27,16 @@ def normalize_path(file):
 
 def get_docs_teams_to_request(changed_files):
     files = [normalize_path(file) for file in changed_files]
-    if any(file.startswith(SOURCE_PREFIX) for file in files):
-        return []
-
-    docs_files = [file for file in files if file.startswith(DOCS_PREFIX)]
-    if not docs_files:
+    if not files or not all(file.startswith(DOCS_PREFIX) for file in files):
         return []
 
     teams = []
-    if any(file.startswith(CLICKPIPES_DOCS_PREFIX) for file in docs_files):
+    if any(file.startswith(CLICKPIPES_DOCS_PREFIX) for file in files):
         teams.append(CLICKPIPES_TEAM)
 
     if any(
         file.startswith(prefix)
-        for file in docs_files
+        for file in files
         for prefix in INTEGRATIONS_DOCS_PREFIXES
     ):
         teams.append(INTEGRATIONS_ECOSYSTEM_TEAM)

--- a/ci/tests/test_team_review_requests.py
+++ b/ci/tests/test_team_review_requests.py
@@ -49,10 +49,11 @@ def make_event(*, internal, labels=None):
         ),
         (
             [
-                "ci/jobs/scripts/team_review_requests.py",
-                "docs/integrations/clickpipes/home.mdx",
+                "docker/keeper/Dockerfile",
+                "docs/changelogs/v26.5.7.64-stable.md",
+                "utils/list-versions/version_date.tsv",
             ],
-            ["clickpipes", "docs"],
+            [],
         ),
         (["src/Core/TypeId.h"], []),
         ([], []),


### PR DESCRIPTION
Pull requests that changed documentation alongside arbitrary non-documentation files requested a review from the docs team. Only changes under `src/` suppressed the request, so the automated release pull request below requested docs review even though it also changed Dockerfiles and version metadata.

Require every changed path to be under `docs/` before routing documentation team reviewers. Documentation-only changes continue to request the relevant specialized teams and the general docs team. The file mix from the affected release pull request is covered by a regression test; all 16 focused tests pass.

Related: https://github.com/ClickHouse/ClickHouse/pull/115414


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115435&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115435](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115435+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
