### PR TITLE
Unify requests to cidb, sleep on errors

### DIFF
--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -45,7 +45,9 @@ class CIDB:
         if legacy is not None:
             return legacy
         # Already a legacy string — pass through for idempotency
-        assert status in cls._STATUS_TO_CIDB.values(), f"Invalid status [{status}] for CIDB check_status"
+        assert (
+            status in cls._STATUS_TO_CIDB.values()
+        ), f"Invalid status [{status}] for CIDB check_status"
         return status
 
     @dataclasses.dataclass
@@ -242,6 +244,31 @@ ORDER BY day DESC
                 record.test_context_raw = result_.info
                 yield json.dumps(dataclasses.asdict(record))
 
+    def _post_with_retries(self, params, data, timeout, retries, what):
+        """POST to CI DB, backing off progressively on transport errors and on
+        non-OK responses alike: `requests` does not raise for 4xx/5xx."""
+        retry = 0
+        while True:
+            retry += 1
+            try:
+                response = requests.post(
+                    url=self.url,
+                    params=params,
+                    data=data,
+                    headers=self.auth,
+                    timeout=timeout,
+                )
+                if response.ok:
+                    return response
+                error = f"{what} failed, response code [{response.status_code}], body [{response.text}]"
+            except Exception as ex:
+                error = f"{what} failed, exception [{ex}]"
+
+            print(f"WARNING: CIDB {error} - attempt {retry}/{retries}")
+            if retry >= retries:
+                raise RuntimeError(f"CIDB {error}")
+            time.sleep(2**retry)
+
     def query(self, query: str, retries: int = 5, log_level="warning"):
         """
         Executes a SELECT query on CI DB with retry support.
@@ -257,32 +284,13 @@ ORDER BY day DESC
         if log_level:
             params["send_logs_level"] = log_level
 
-        for attempt in range(1, retries + 1):
-            try:
-                response = requests.post(
-                    url=self.url,
-                    params=params,
-                    data=query.encode(),
-                    headers=self.auth,
-                    timeout=Settings.CI_DB_QUERY_TIMEOUT_SEC,
-                )
-
-                if response.ok:
-                    return response.text
-                else:
-                    print(
-                        f"WARNING: CIDB query failed (status {response.status_code}) - Attempt {attempt}"
-                    )
-                    if attempt == retries:
-                        raise RuntimeError(
-                            f"Failed to query CI DB. Response code: {response.status_code}, Body: {response.text}"
-                        )
-
-            except Exception as ex:
-                print(f"ERROR: Exception during CI DB query attempt {attempt}: {ex}")
-                if attempt == retries:
-                    raise ex
-                time.sleep(2**attempt)
+        return self._post_with_retries(
+            params=params,
+            data=query.encode(),
+            timeout=Settings.CI_DB_QUERY_TIMEOUT_SEC,
+            retries=retries,
+            what="query",
+        ).text
 
     @staticmethod
     def _prepare_request_body(data):
@@ -303,27 +311,15 @@ ORDER BY day DESC
             "send_logs_level": "warning",
         }
 
-        for retry in range(retries):
-            try:
-                response = requests.post(
-                    url=self.url,
-                    params=params,
-                    data=self._prepare_request_body("\n".join(jsons)),
-                    headers=self.auth,
-                    timeout=Settings.CI_DB_INSERT_TIMEOUT_SEC,
-                )
-                print(response.text)
-                if response.ok:
-                    print(f"INFO: {len(jsons)} rows inserted into CIDB")
-                    break
-                else:
-                    if retry == retries - 1:
-                        raise RuntimeError(
-                            f"Failed to write to CI DB, response code [{response.status_code}]"
-                        )
-            except Exception as ex:
-                if retry == retries - 1:
-                    raise ex
+        response = self._post_with_retries(
+            params=params,
+            data=self._prepare_request_body("\n".join(jsons)),
+            timeout=Settings.CI_DB_INSERT_TIMEOUT_SEC,
+            retries=retries,
+            what="insert",
+        )
+        print(response.text)
+        print(f"INFO: {len(jsons)} rows inserted into CIDB")
 
     def insert(self, result: Result, result_name_for_cidb=""):
         jsons = []
@@ -409,26 +405,27 @@ ORDER BY day DESC
             "database": Settings.CI_DB_DB_NAME,
             "query": "SELECT 1",
         }
-        error = ""
-        for retry in range(2):
-            try:
-                response = requests.post(
-                    url=self.url,
-                    params=params,
-                    data="",
-                    headers=self.auth,
-                    timeout=Settings.CI_DB_INSERT_TIMEOUT_SEC,
-                )
-                if not response.ok:
-                    error = f"ERROR: No connection to CI DB [{response.status_code}/{response.reason}]"
-                elif not response.json() == 1:
-                    print("ERROR: CI DB smoke test failed select 1 == 1")
-                    error = f"ERROR: CI DB smoke test failed [select 1 ==> {response.json()}]"
-                else:
-                    return True, ""
+        try:
+            response = self._post_with_retries(
+                params=params,
+                data="",
+                timeout=Settings.CI_DB_INSERT_TIMEOUT_SEC,
+                retries=3,
+                what="smoke test",
+            )
+        except Exception as ex:
+            return False, f"CIDB: ERROR: no connection to CI DB [{ex}]"
 
-            except Exception as ex:
-                print(f"ERROR: Exception [{ex}]")
-                error = f"CIDB: ERROR: Exception [{ex}]"
+        # A 200 with a non-JSON body (proxy or login page) stays a failed
+        # precheck instead of aborting workflow generation
+        try:
+            payload = response.json()
+        except ValueError as ex:
+            return (
+                False,
+                f"ERROR: CI DB smoke test got a non-JSON body [{ex}]: {response.text[:200]}",
+            )
 
-        return False, error
+        if not payload == 1:
+            return False, f"ERROR: CI DB smoke test failed [select 1 ==> {payload}]"
+        return True, ""


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Sleep progressively on errors in requests to CIDB; address issues with too-quick failures.

### Example
```
[2026-08-19 10:17:30] WARNING: CIDB query failed (status 500) - Attempt 1
[2026-08-19 10:17:30] WARNING: CIDB query failed (status 500) - Attempt 2
[2026-08-19 10:17:30] WARNING: CIDB query failed (status 500) - Attempt 3
[2026-08-19 10:17:30] WARNING: CIDB query failed (status 500) - Attempt 4
[2026-08-19 10:17:30] WARNING: CIDB query failed (status 500) - Attempt 5
```

See the timestamps.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115436&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115436](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115436+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1766` (included in `26.8` and later)
<!-- ch-version-info:end -->