### PR TITLE
Deduplicate the adaptive write buffer growth into BufferWithOwnMemory

### DIFF
--- a/src/Compression/CompressedWriteBuffer.cpp
+++ b/src/Compression/CompressedWriteBuffer.cpp
@@ -61,12 +61,7 @@ void CompressedWriteBuffer::nextImpl()
         out.write(compressed_buffer.data(), compressed_size);
     }
 
-    /// Increase buffer size for next data if adaptive buffer size is used and nextImpl was called because of end of buffer.
-    if (!available() && use_adaptive_buffer_size && memory.size() < adaptive_buffer_max_size)
-    {
-        memory.resize(std::min(memory.size() * 2, adaptive_buffer_max_size));
-        BufferBase::set(memory.data(), memory.size(), 0);
-    }
+    growAdaptiveBufferAfterFlush();
 }
 
 void CompressedWriteBuffer::finalizeImpl()
@@ -79,14 +74,11 @@ void CompressedWriteBuffer::finalizeImpl()
 
 CompressedWriteBuffer::CompressedWriteBuffer(
     WriteBuffer & out_, CompressionCodecPtr codec_, size_t buf_size, bool use_adaptive_buffer_size_, size_t adaptive_buffer_initial_size)
-    /// The adaptive buffer grows from the initial size up to buf_size (the max), so the
-    /// initial allocation must not exceed it (see WriteBufferFromFileDescriptor for details).
-    : BufferWithOwnMemory<WriteBuffer>(use_adaptive_buffer_size_ ? std::min(adaptive_buffer_initial_size, buf_size) : buf_size)
+    : BufferWithOwnMemory<WriteBuffer>(adaptiveBufferInitialSize(use_adaptive_buffer_size_, adaptive_buffer_initial_size, buf_size))
     , out(out_)
     , codec(std::move(codec_))
-    , use_adaptive_buffer_size(use_adaptive_buffer_size_)
-    , adaptive_buffer_max_size(buf_size)
 {
+    enableAdaptiveBufferGrowth(use_adaptive_buffer_size_, buf_size);
     if (!codec)
         codec = CompressionCodecFactory::instance().getDefaultCodec();
 }

--- a/src/Compression/CompressedWriteBuffer.h
+++ b/src/Compression/CompressedWriteBuffer.h
@@ -59,12 +59,6 @@ private:
     WriteBuffer & out;
     CompressionCodecPtr codec;
 
-    /// If true, the size of internal buffer will be exponentially increased up to
-    /// adaptive_buffer_max_size after each nextImpl call. It can be used to avoid
-    /// large buffer allocation when actual size of written data is small.
-    bool use_adaptive_buffer_size;
-    size_t adaptive_buffer_max_size;
-
     PODArray<char> compressed_buffer;
 };
 

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -78,10 +78,10 @@ public:
         const String & filename_,
         const size_t & size_,
         const size_t buf_size_,
-        bool use_adaptive_buffer_size_,
+        bool use_adaptive_whole_file_buffer_,
         size_t adaptive_buffer_max_size_)
         : WriteBufferFromFileBase(buf_size_, nullptr, 0)
-        , use_adaptive_buffer_size(use_adaptive_buffer_size_)
+        , use_adaptive_whole_file_buffer(use_adaptive_whole_file_buffer_)
         , adaptive_max_buffer_size(adaptive_buffer_max_size_)
         , archive_writer(archive_writer_)
         , filename(filename_)
@@ -107,7 +107,7 @@ public:
 
     void finalizeImpl() override
     {
-        if (use_adaptive_buffer_size)
+        if (use_adaptive_whole_file_buffer)
         {
             if (offset())
                 writeDataChunk();
@@ -124,7 +124,7 @@ public:
 private:
     void nextImpl() override
     {
-        if (use_adaptive_buffer_size)
+        if (use_adaptive_whole_file_buffer)
         {
             if (!available())
             {
@@ -195,7 +195,7 @@ private:
             entry = nullptr;
         }
         /// Bytes counter is incorrect for adaptive buffer because of adjusted nextimpl_working_buffer_offset.
-        if (throw_if_error and (!use_adaptive_buffer_size and bytes != expected_size))
+        if (throw_if_error and (!use_adaptive_whole_file_buffer and bytes != expected_size))
         {
             throw Exception(
                 ErrorCodes::CANNOT_PACK_ARCHIVE,
@@ -220,7 +220,7 @@ private:
 
     void checkResult(int code) { checkResultCodeImpl(code, filename); }
 
-    const bool use_adaptive_buffer_size;
+    const bool use_adaptive_whole_file_buffer;
     const size_t adaptive_max_buffer_size;
 
     std::weak_ptr<LibArchiveWriter> archive_writer;
@@ -273,7 +273,7 @@ std::unique_ptr<WriteBufferFromFileBase> LibArchiveWriter::writeFile(const Strin
         filename,
         size,
         buf_size,
-        /*use_adaptive_buffer_size*/ false,
+        /*use_adaptive_whole_file_buffer*/ false,
         adaptive_buffer_max_size);
 }
 
@@ -286,7 +286,7 @@ std::unique_ptr<WriteBufferFromFileBase> LibArchiveWriter::writeFile(const Strin
         filename,
         /*size*/ 0,
         buf_size,
-        /*use_adaptive_buffer_size*/ true,
+        /*use_adaptive_whole_file_buffer*/ true,
         adaptive_buffer_max_size);
 }
 

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <IO/BufferBase.h>
 #include <boost/noncopyable.hpp>
 
 #include <Common/Allocator.h>
@@ -104,6 +105,37 @@ class BufferWithOwnMemory : public Base
 protected:
     Memory<> memory{};
     const bool use_existing_memory;
+
+    /// Adaptive sizing of a write buffer (see `use_adaptive_write_buffer` in WriteSettings): the
+    /// buffer starts at a small initial size and `growAdaptiveBufferAfterFlush` doubles it after
+    /// every full flush, up to `adaptive_buffer_max_size`, so one of many rarely-filled buffers
+    /// (e.g. one per column stream of a wide part) only pays for the memory it actually needs.
+    bool use_adaptive_buffer_size = false;
+    size_t adaptive_buffer_max_size = 0;
+
+    /// The initial allocation of an adaptive buffer. The maximum caps it, so an out-of-range
+    /// initial size is never passed straight to the allocator (e.g. a fuzzed
+    /// adaptive_write_buffer_initial_size).
+    static size_t adaptiveBufferInitialSize(bool use_adaptive, size_t initial_size, size_t max_size)
+    {
+        return use_adaptive ? std::min(initial_size, max_size) : max_size;
+    }
+
+    void enableAdaptiveBufferGrowth(bool use_adaptive, size_t max_size)
+    {
+        use_adaptive_buffer_size = use_adaptive;
+        adaptive_buffer_max_size = max_size;
+    }
+
+    /// Call at the end of nextImpl; grows only when the flush used the whole buffer.
+    void growAdaptiveBufferAfterFlush()
+    {
+        if (!Base::available() && use_adaptive_buffer_size && memory.size() < adaptive_buffer_max_size)
+        {
+            memory.resize(std::min(memory.size() * 2, adaptive_buffer_max_size));
+            this->BufferBase::set(memory.data(), memory.size(), 0);
+        }
+    }
 
 public:
     /// If non-nullptr 'existing_memory' is passed,

--- a/src/IO/WriteBufferFromEncryptedFile.cpp
+++ b/src/IO/WriteBufferFromEncryptedFile.cpp
@@ -16,15 +16,12 @@ WriteBufferFromEncryptedFile::WriteBufferFromEncryptedFile(
     size_t old_file_size,
     bool use_adaptive_buffer_size_,
     size_t adaptive_buffer_initial_size)
-    /// The adaptive buffer grows from the initial size up to buffer_size_ (the max), so the
-    /// initial allocation must not exceed it (see WriteBufferFromFileDescriptor for details).
-    : WriteBufferDecorator<WriteBufferFromFileBase>(std::move(out_), use_adaptive_buffer_size_ ? std::min(adaptive_buffer_initial_size, buffer_size_) : buffer_size_, nullptr, 0)
+    : WriteBufferDecorator<WriteBufferFromFileBase>(std::move(out_), adaptiveBufferInitialSize(use_adaptive_buffer_size_, adaptive_buffer_initial_size, buffer_size_), nullptr, 0)
     , header(header_)
     , flush_header(!old_file_size)
     , encryptor(header.algorithm, key_, header.init_vector)
-    , use_adaptive_buffer_size(use_adaptive_buffer_size_)
-    , adaptive_buffer_max_size(buffer_size_)
 {
+    enableAdaptiveBufferGrowth(use_adaptive_buffer_size_, buffer_size_);
     encryptor.setOffset(old_file_size);
 }
 
@@ -66,12 +63,7 @@ void WriteBufferFromEncryptedFile::nextImpl()
 
     encryptor.encrypt(working_buffer.begin(), offset(), *out);
 
-    /// Increase buffer size for next data if adaptive buffer size is used and nextImpl was called because of end of buffer.
-    if (!available() && use_adaptive_buffer_size && memory.size() < adaptive_buffer_max_size)
-    {
-        memory.resize(std::min(memory.size() * 2, adaptive_buffer_max_size));
-        BufferBase::set(memory.data(), memory.size(), 0);
-    }
+    growAdaptiveBufferAfterFlush();
 }
 
 }

--- a/src/IO/WriteBufferFromEncryptedFile.h
+++ b/src/IO/WriteBufferFromEncryptedFile.h
@@ -45,8 +45,6 @@ private:
 
     LoggerPtr log = getLogger("WriteBufferFromEncryptedFile");
 
-    bool use_adaptive_buffer_size;
-    size_t adaptive_buffer_max_size;
 };
 
 }

--- a/src/IO/WriteBufferFromFileDescriptor.cpp
+++ b/src/IO/WriteBufferFromFileDescriptor.cpp
@@ -83,12 +83,7 @@ void WriteBufferFromFileDescriptor::nextImpl()
     ProfileEvents::increment(ProfileEvents::DiskWriteElapsedMicroseconds, watch.elapsedMicroseconds());
     ProfileEvents::increment(ProfileEvents::WriteBufferFromFileDescriptorWriteBytes, bytes_written);
 
-    /// Increase buffer size for next data if adaptive buffer size is used and nextImpl was called because of end of buffer.
-    if (!available() && use_adaptive_buffer_size && memory.size() < adaptive_max_buffer_size)
-    {
-        memory.resize(std::min(memory.size() * 2, adaptive_max_buffer_size));
-        BufferBase::set(memory.data(), memory.size(), 0);
-    }
+    growAdaptiveBufferAfterFlush();
 }
 
 /// NOTE: This class can be used as a very low-level building block, for example
@@ -103,16 +98,12 @@ WriteBufferFromFileDescriptor::WriteBufferFromFileDescriptor(
     std::string file_name_,
     bool use_adaptive_buffer_size_,
     size_t adaptive_buffer_initial_size)
-    /// The adaptive buffer grows from the initial size up to buf_size (the max), so the
-    /// initial allocation must not exceed it. An out-of-range initial size would otherwise
-    /// be passed straight to the allocator (e.g. a fuzzed adaptive_write_buffer_initial_size).
-    : WriteBufferFromFileBase(use_adaptive_buffer_size_ ? std::min(adaptive_buffer_initial_size, buf_size) : buf_size, existing_memory, alignment)
+    : WriteBufferFromFileBase(adaptiveBufferInitialSize(use_adaptive_buffer_size_, adaptive_buffer_initial_size, buf_size), existing_memory, alignment)
     , fd(fd_)
     , throttler(throttler_)
     , file_name(std::move(file_name_))
-    , use_adaptive_buffer_size(use_adaptive_buffer_size_)
-    , adaptive_max_buffer_size(buf_size)
 {
+    enableAdaptiveBufferGrowth(use_adaptive_buffer_size_, buf_size);
 }
 
 void WriteBufferFromFileDescriptor::finalizeImpl()

--- a/src/IO/WriteBufferFromFileDescriptor.h
+++ b/src/IO/WriteBufferFromFileDescriptor.h
@@ -56,12 +56,6 @@ protected:
     /// If file has name contains filename, otherwise contains string "(fd=...)"
     std::string file_name;
 
-    /// If true, the size of internal buffer will be exponentially increased up to
-    /// adaptive_buffer_max_size after each nextImpl call. It can be used to avoid
-    /// large buffer allocation when actual size of written data is small.
-    bool use_adaptive_buffer_size;
-    size_t adaptive_max_buffer_size;
-
     void finalizeImpl() override;
 };
 


### PR DESCRIPTION

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Just move shared logic in a single place.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115440&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115440](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115440+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1848` (included in `26.8` and later)
<!-- ch-version-info:end -->