### PR TITLE
Validate Variant discriminator in ColumnVariant arena deserialization

### DIFF
--- a/src/Columns/ColumnVariant.cpp
+++ b/src/Columns/ColumnVariant.cpp
@@ -858,6 +858,8 @@ void ColumnVariant::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn
     Discriminator global_discr = 0;
     readBinaryLittleEndian<Discriminator>(global_discr, in);
 
+    checkDiscriminatorValue(global_discr, variants.size(), /* allow_logical_error= */ false);
+
     Discriminator local_discr = localDiscriminatorByGlobal(global_discr);
     getLocalDiscriminators().push_back(local_discr);
     if (local_discr == NULL_DISCRIMINATOR)
@@ -877,6 +879,8 @@ void ColumnVariant::skipSerializedInArena(ReadBuffer & in) const
 
     if (global_discr == NULL_DISCRIMINATOR)
         return;
+
+    checkDiscriminatorValue(global_discr, variants.size(), /* allow_logical_error= */ true);
 
     variants[localDiscriminatorByGlobal(global_discr)]->skipSerializedInArena(in);
 }

--- a/tests/queries/0_stateless/05023_variant_arena_deserialize_bad_discriminator.sql
+++ b/tests/queries/0_stateless/05023_variant_arena_deserialize_bad_discriminator.sql
@@ -1,0 +1,3 @@
+SELECT groupArrayDistinctMerge(
+    CAST(unhex('010110') AS AggregateFunction(groupArrayDistinct, Variant(UInt8, String)))
+); -- { serverError INCORRECT_DATA }


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/2051
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Validate Variant discriminator in ColumnVariant arena deserialization

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115443&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115443](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115443+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.116` (included in `26.9` and later)
- Backported to: `26.8.1.2011`, `26.7.6.17`, `26.6.4.37`, `26.3.32.10`
<!-- ch-version-info:end -->