### PR TITLE
Add only the required right keys when a join has several disjuncts

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -134,6 +134,29 @@ static HashJoin::Type mergeJoinMethods(HashJoin::Type lhs, HashJoin::Type rhs)
     return Type::hashed;
 }
 
+/// The right columns a join with several disjuncts adds to the result. Every right key is read to build
+/// the maps, but only the keys the query asks for belong in the result; the analyzer is what says which
+/// those are, so without it every key is kept, as before.
+static Block rightColumnsToAddWithSeveralDisjuncts(const TableJoin & table_join, const Block & right_columns)
+{
+    if (!table_join.enableAnalyzer())
+        return right_columns;
+
+    NameSet key_names;
+    for (const auto & clause : table_join.getClauses())
+        key_names.insert(clause.key_names_right.begin(), clause.key_names_right.end());
+
+    const NameSet required_keys = table_join.requiredRightKeys();
+
+    Block columns_to_add;
+    for (const auto & column : right_columns)
+    {
+        if (!key_names.contains(column.name) || required_keys.contains(column.name))
+            columns_to_add.insert(column);
+    }
+    return columns_to_add;
+}
+
 HashJoin::HashJoin(
     std::shared_ptr<TableJoin> table_join_,
     SharedHeader right_sample_block_,
@@ -197,8 +220,12 @@ HashJoin::HashJoin(
     }
     else
     {
-        /// required right keys concept does not work well if multiple disjuncts, we need all keys
-        sample_block_with_columns_to_add = right_table_keys = materializeBlock(right_sample_block);
+        /// With several disjuncts a right key can differ from the left key it matched - the match may
+        /// have come from another clause - so it cannot be restored from the left column the way
+        /// `required_right_keys` does it, and a key the query asks for stays a column the join adds.
+        /// The keys nobody asks for are needed to build the maps and for nothing else.
+        right_table_keys = materializeBlock(right_sample_block);
+        sample_block_with_columns_to_add = rightColumnsToAddWithSeveralDisjuncts(*table_join, right_table_keys);
     }
 
     /// Detect a single non-nullable LowCardinality key before the keys are materialized below, so it

--- a/tests/performance/join_several_disjuncts_right_keys.xml
+++ b/tests/performance/join_several_disjuncts_right_keys.xml
@@ -1,0 +1,21 @@
+<test>
+    <!--
+        A join with several disjuncts adds to its result only the right key columns the query asks for.
+        It used to add all of them and copy the values out of the matched right rows for every result
+        row, and the plan then dropped the columns right after the join.
+    -->
+
+    <settings>
+        <max_threads>8</max_threads>
+        <join_algorithm>hash</join_algorithm>
+    </settings>
+
+    <!-- Nothing is taken from the right side, so neither key is added. -->
+    <query>SELECT count() FROM numbers_mt(200000000) AS l ALL LEFT JOIN (SELECT number * 2 AS a, number * 3 AS b FROM numbers(1000)) AS r ON l.number = r.a OR l.number = r.b FORMAT Null</query>
+    <!-- The same with keys whose values are expensive to copy. -->
+    <query>SELECT count() FROM (SELECT concat('key_', toString(number)) AS k FROM numbers_mt(20000000)) AS l ALL LEFT JOIN (SELECT concat('key_', toString(number * 2)) AS a, concat('key_', toString(number * 3)) AS b FROM numbers(1000)) AS r ON l.k = r.a OR l.k = r.b FORMAT Null</query>
+    <!-- RIGHT emits the non-joined right rows as well, from per-row used flags. -->
+    <query>SELECT count() FROM numbers_mt(50000000) AS l ALL RIGHT JOIN (SELECT number AS a, number + 1000000000 AS b FROM numbers(100000)) AS r ON l.number = r.a OR l.number = r.b FORMAT Null</query>
+    <!-- A key the query does ask for is still read from the matched right row. -->
+    <query>SELECT sum(r.a) FROM numbers_mt(200000000) AS l ALL LEFT JOIN (SELECT number * 2 AS a, number * 3 AS b FROM numbers(1000)) AS r ON l.number = r.a OR l.number = r.b FORMAT Null</query>
+</test>

--- a/tests/queries/0_stateless/05023_join_several_disjuncts_right_keys.reference
+++ b/tests/queries/0_stateless/05023_join_several_disjuncts_right_keys.reference
@@ -1,0 +1,53 @@
+-- both keys selected: the right value comes from the matched row
+1	10	1	99
+2	20	7	20
+3	30	0	0
+-- one key selected
+1	99
+2	20
+3	0
+-- no right column selected
+1
+2
+3
+3
+-- a right payload column, keys not selected
+1	r1
+2	r2
+3	
+-- INNER
+1	1	r1
+2	7	r2
+2
+-- RIGHT, which emits the non-joined right rows too
+1	1	r1
+2	7	r2
+0	9	r3
+3
+1	r1
+2	r2
+0	r3
+-- FULL
+0	9
+1	1
+2	7
+3	0
+4
+-- ANY
+1	1
+2	7
+3	0
+-- SEMI and ANTI, which emit the left row alone
+1
+2
+2
+3
+1
+-- a residual condition reads a right column that nothing else selects
+1	l1
+2	l2
+3	l3
+-- and with join_use_nulls
+1	1
+2	7
+3	\N

--- a/tests/queries/0_stateless/05023_join_several_disjuncts_right_keys.sql
+++ b/tests/queries/0_stateless/05023_join_several_disjuncts_right_keys.sql
@@ -1,0 +1,57 @@
+-- A join with several disjuncts adds to the result the right key columns the query asks for, and only
+-- those. A key value has to come from the matched right row: with `a = a OR b = b` a row matched through
+-- the second clause has a right `a` of its own, unrelated to the left one.
+
+CREATE TABLE l (a UInt64, b UInt64, lp String) ENGINE = Memory;
+CREATE TABLE r (a UInt64, b UInt64, rp String) ENGINE = Memory;
+
+INSERT INTO l VALUES (1, 10, 'l1'), (2, 20, 'l2'), (3, 30, 'l3');
+-- (7, 20) matches l(2, 20) through `b` alone, so its right `a` is 7, not 2. (9, 90) matches nothing,
+-- so a RIGHT or FULL join has a non-joined right row to emit.
+INSERT INTO r VALUES (1, 99, 'r1'), (7, 20, 'r2'), (9, 90, 'r3');
+
+SELECT '-- both keys selected: the right value comes from the matched row';
+SELECT l.a, l.b, r.a, r.b FROM l ALL LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+
+SELECT '-- one key selected';
+SELECT l.a, r.b FROM l ALL LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+
+SELECT '-- no right column selected';
+SELECT l.a FROM l ALL LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+SELECT count() FROM l ALL LEFT JOIN r ON l.a = r.a OR l.b = r.b;
+
+SELECT '-- a right payload column, keys not selected';
+SELECT l.a, r.rp FROM l ALL LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+
+SELECT '-- INNER';
+SELECT l.a, r.a, r.rp FROM l ALL INNER JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+SELECT count() FROM l ALL INNER JOIN r ON l.a = r.a OR l.b = r.b;
+
+SELECT '-- RIGHT, which emits the non-joined right rows too';
+SELECT l.a, r.a, r.rp FROM l ALL RIGHT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY r.a;
+SELECT count() FROM l ALL RIGHT JOIN r ON l.a = r.a OR l.b = r.b;
+-- no right key selected, so none is added to the result, and the non-joined right row still comes out
+SELECT l.a, r.rp FROM l ALL RIGHT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY r.rp;
+
+SELECT '-- FULL';
+SELECT l.a, r.a FROM l ALL FULL JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a, r.a;
+SELECT count() FROM l ALL FULL JOIN r ON l.a = r.a OR l.b = r.b;
+
+SELECT '-- ANY';
+SELECT l.a, r.a FROM l ANY LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+
+SELECT '-- SEMI and ANTI, which emit the left row alone';
+SELECT l.a FROM l SEMI LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+SELECT count() FROM l SEMI LEFT JOIN r ON l.a = r.a OR l.b = r.b;
+SELECT l.a FROM l ANTI LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a;
+SELECT count() FROM l ANTI LEFT JOIN r ON l.a = r.a OR l.b = r.b;
+
+SELECT '-- a residual condition reads a right column that nothing else selects';
+-- the old analyzer does not support a residual condition next to the disjuncts
+SELECT l.a, l.lp FROM l ALL LEFT JOIN r ON (l.a = r.a OR l.b = r.b) AND l.lp < r.rp ORDER BY l.a SETTINGS enable_analyzer = 1;
+
+SELECT '-- and with join_use_nulls';
+SELECT l.a, r.a FROM l ALL LEFT JOIN r ON l.a = r.a OR l.b = r.b ORDER BY l.a SETTINGS join_use_nulls = 1;
+
+DROP TABLE l;
+DROP TABLE r;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A `JOIN` whose `ON` section has several `OR`-ed equalities no longer materializes the right-hand key columns that the query does not select.

---

<img width="814" height="133" alt="Screenshot 2026-08-20 at 12 50 00" src="https://github.com/user-attachments/assets/cfcf7b10-fd1d-4559-9267-cf11d7e6a421" />

<img width="911" height="54" alt="Screenshot 2026-08-20 at 12 51 28" src="https://github.com/user-attachments/assets/663bd337-5c71-4bd5-87ee-2265d05050f2" />


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1795` (included in `26.8` and later)
<!-- ch-version-info:end -->
