### PR TITLE
Do not strip injective functions that hide argument nullability inside uniq

### DIFF
--- a/src/Analyzer/Passes/UniqInjectiveFunctionsEliminationPass.cpp
+++ b/src/Analyzer/Passes/UniqInjectiveFunctionsEliminationPass.cpp
@@ -11,6 +11,8 @@
 
 #include <Core/Settings.h>
 
+#include <DataTypes/IDataType.h>
+
 
 namespace DB
 {
@@ -64,6 +66,12 @@ public:
 
             const auto & arg_function = arg_typed->getFunction();
             if (!arg_function->isInjective({}))
+                return false;
+
+            /// The `Null` combinator makes `uniq*` skip rows where a Nullable argument is NULL: `uniq(tuple(x))`
+            /// counts the (NULL) row while `uniq(x)` skips it.
+            if (isNullableOrLowCardinalityNullable(arg->getResultType())
+                != isNullableOrLowCardinalityNullable(arg_arguments_nodes[0]->getResultType()))
                 return false;
 
             arg = arg_arguments_nodes[0];

--- a/tests/queries/0_stateless/04927_uniq_injective_tuple_nullable.reference
+++ b/tests/queries/0_stateless/04927_uniq_injective_tuple_nullable.reference
@@ -1,0 +1,31 @@
+tuple
+3	3	3	3	3
+3	3	3	3	3
+bitmaskToArray and bitPositionsToArray
+3	3
+3	3
+nested, LowCardinality and multiple arguments
+3	3
+3	3
+2
+2
+constant folding must not change the result
+1
+1
+1
+the optimization still applies to a not Nullable argument
+QUERY id: 0
+  PROJECTION COLUMNS
+    uniqExact((number)) UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: uniqExact, function_type: aggregate, result_type: UInt64
+        ARGUMENTS
+          LIST id: 3, nodes: 1
+            COLUMN id: 4, column_name: number, result_type: UInt64, source_id: 5
+  JOIN TREE
+    TABLE_FUNCTION id: 5, alias: __table1, table_function_name: numbers
+      ARGUMENTS
+        LIST id: 6, nodes: 1
+          CONSTANT id: 7, constant_value: UInt64_3, constant_value_type: UInt8
+  SETTINGS optimize_injective_functions_inside_uniq=1

--- a/tests/queries/0_stateless/04927_uniq_injective_tuple_nullable.sql
+++ b/tests/queries/0_stateless/04927_uniq_injective_tuple_nullable.sql
@@ -1,0 +1,47 @@
+-- Tags: no-old-analyzer
+-- The old analyzer rewrites the query before types are resolved and keeps the wrong results.
+-- https://github.com/ClickHouse/ClickHouse/issues/114784
+-- `uniq*` skips the rows where an argument is NULL. An injective function whose result cannot be Nullable
+-- hides that nullability - `tuple(NULL)` and `bitmaskToArray(NULL)` are values that get counted - so
+-- `optimize_injective_functions_inside_uniq` must not remove it.
+
+SELECT 'tuple';
+SELECT uniq(tuple(x)), uniqExact(tuple(x)), uniqHLL12(tuple(x)), uniqCombined(tuple(x)), uniqCombined64(tuple(x))
+FROM values('x Nullable(Int32)', 1, 2, NULL)
+SETTINGS optimize_injective_functions_inside_uniq = 1;
+
+SELECT uniq(tuple(x)), uniqExact(tuple(x)), uniqHLL12(tuple(x)), uniqCombined(tuple(x)), uniqCombined64(tuple(x))
+FROM values('x Nullable(Int32)', 1, 2, NULL)
+SETTINGS optimize_injective_functions_inside_uniq = 0;
+
+SELECT 'bitmaskToArray and bitPositionsToArray';
+SELECT uniqExact(bitmaskToArray(x)), uniqExact(bitPositionsToArray(x))
+FROM values('x Nullable(Int32)', 1, 2, NULL)
+SETTINGS optimize_injective_functions_inside_uniq = 1;
+
+SELECT uniqExact(bitmaskToArray(x)), uniqExact(bitPositionsToArray(x))
+FROM values('x Nullable(Int32)', 1, 2, NULL)
+SETTINGS optimize_injective_functions_inside_uniq = 0;
+
+SELECT 'nested, LowCardinality and multiple arguments';
+SELECT uniqExact(tuple(tuple(x))), uniqExact(tuple(toLowCardinality(x)))
+FROM values('x Nullable(Int32)', 1, 2, NULL)
+SETTINGS optimize_injective_functions_inside_uniq = 1;
+
+SELECT uniqExact(tuple(tuple(x))), uniqExact(tuple(toLowCardinality(x)))
+FROM values('x Nullable(Int32)', 1, 2, NULL)
+SETTINGS optimize_injective_functions_inside_uniq = 0;
+
+SELECT uniqExact(tuple(x), y) FROM values('x Nullable(Int32), y Nullable(Int32)', (1, 1), (2, NULL), (NULL, 3))
+SETTINGS optimize_injective_functions_inside_uniq = 1;
+
+SELECT uniqExact(tuple(x), y) FROM values('x Nullable(Int32), y Nullable(Int32)', (1, 1), (2, NULL), (NULL, 3))
+SETTINGS optimize_injective_functions_inside_uniq = 0;
+
+SELECT 'constant folding must not change the result';
+SELECT countDistinct(tuple(NULL));
+SELECT countDistinct(tuple(arrayJoin([NULL])));
+SELECT countDistinct(tuple(arrayJoin(emptyArrayToSingle([]::Array(Nullable(Int32))))));
+
+SELECT 'the optimization still applies to a not Nullable argument';
+EXPLAIN QUERY TREE SELECT uniqExact(tuple(number)) FROM numbers(3) SETTINGS optimize_injective_functions_inside_uniq = 1;


### PR DESCRIPTION
`optimize_injective_functions_inside_uniq` stripped any injective function from a `uniq*` argument, on the grounds that an injective function preserves the number of distinct values. That holds for the values, but not for the rows the aggregate sees: `AggregateFunctionFactory::get` wraps `uniq*` in the `Null` combinator when an argument is `Nullable`, and that combinator skips the rows where the argument is NULL.

An injective function whose result type cannot be `Nullable` hides the nullability of its argument, so removing it turns "count every row" into "skip the NULL rows":

```sql
SELECT uniqExact(tuple(x)) FROM values('x Nullable(Int32)', 1, 2, NULL);
-- 2 before this change; 3 with the optimization disabled, and 3 now
```

The pass now keeps a function whenever removing it would change the argument's nullability. The affected functions are `tuple`, `bitmaskToArray` and `bitPositionsToArray` (the injective ones whose result type cannot be `Nullable`, so `makeNullableSafe` leaves it off); the affected aggregates are `uniq`, `uniqExact`, `uniqHLL12` and `uniqTheta`. `uniqCombined` and `uniqCombined64` were already protected, because the `Null` combinator changes their result type to `Nullable(UInt64)` and the pass rejects that.

This also removes a discrepancy the same rewrite caused between expressions that differ only in being constant-foldable, reported in the issue: `countDistinct(tuple(NULL))` is folded into a `ConstantNode` and so escaped the pass, while `countDistinct(tuple(arrayJoin([NULL])))` did not. All the variants return 1 now.

With `enable_analyzer = 0` the same rewrite runs in `TreeOptimizer` before types are resolved, so the nullability cannot be checked there and the old results stand; the test is tagged `no-old-analyzer`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114784

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `uniq`, `uniqExact`, `uniqHLL12` and `uniqTheta` returning a wrong result for an argument wrapped in an injective function that hides nullability, such as `uniqExact(tuple(x))` over a `Nullable` column. The `optimize_injective_functions_inside_uniq` optimization removed the wrapping function, after which NULL rows were skipped instead of counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115466&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115466](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115466+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.5.8`, `26.6.4.8`, `26.5.8.9`, `26.3.21.7`, `25.8.33.3`
<!-- ch-version-info:end -->