### PR TITLE
Fix UniqueKeyProbeTest.NewestLiveWinsOverOlder aborting unit_tests_dbms in Debug builds

### DIFF
--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_probe.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_probe.cpp
@@ -31,6 +31,10 @@
 #include <IO/SharedThreadPools.h>
 #include <Common/tests/gtest_global_context.h>
 
+#include <Poco/AutoPtr.h>
+#include <Poco/ConsoleChannel.h>
+#include <Poco/Logger.h>
+
 #include <rocksdb/env.h>
 #include <rocksdb/filter_policy.h>
 #include <rocksdb/options.h>
@@ -40,6 +44,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <string>
@@ -204,10 +209,14 @@ TEST_F(UniqueKeyProbeTest, SinglePartAllDead)
     EXPECT_EQ(probeKey(probe, 7).outcome, ProbeOutcome::FOUND_ALL_DEAD);
 }
 
-TEST_F(UniqueKeyProbeTest, NewestLiveWinsOverOlder)
+/// The newest part owns the live row and the older occurrence of the same key is bitmap-dead,
+/// which is what "a live key lives in <= 1 part" allows. Debug builds keep walking the snapshot
+/// after a key resolves (see `probe_validates_single_live_part`), so this also pins that the
+/// later dead hit does not downgrade the already-resolved result to `FOUND_ALL_DEAD`.
+TEST_F(UniqueKeyProbeTest, NewestLiveWinsOverOlderDead)
 {
     auto newest = makeTarget({{5, 9}});
-    auto older = makeTarget({{5, 1}});
+    auto older = makeTarget({{5, 1}}, /*dead_rows=*/{1});
     ASSERT_NE(newest, nullptr);
     ASSERT_NE(older, nullptr);
     auto probe = probeOver({newest, older}); /// newest-first
@@ -410,5 +419,42 @@ TEST_F(UniqueKeyProbeTest, DecodedRowOutOfPartBoundsThrows)
 
     storage->flushAndShutdown();
 }
+
+/// ---------- single-live-part invariant ----------
+
+/// INSERT-time dedup is meant to guarantee that a live key lives in at most one active part, so
+/// `UniqueKeyProbeSimple` verifies it: debug builds do not early-skip a resolved key, and a second
+/// live hit throws LOGICAL_ERROR. Release builds early-skip instead, so there is nothing to observe
+/// there — hence a debug-only death test (the LOGICAL_ERROR aborts rather than propagating, so it
+/// cannot be caught with EXPECT_THROW). Mirrors `ColumnArrayDeathTest.NonMonotonicOffsetsAreRejected`.
+///
+/// The guard tracks `probe_validates_single_live_part` in `UniqueKeyProbeSimple.cpp`: if that gate
+/// ever widens to `DEBUG_OR_SANITIZER_BUILD`, this one has to widen with it.
+#ifndef NDEBUG
+
+using UniqueKeyProbeDeathTest = UniqueKeyProbeTest;
+
+TEST_F(UniqueKeyProbeDeathTest, DuplicateLiveKeyAcrossPartsIsRejected)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+    /// `abortOnFailedAssertion` reports the message through the root logger, and this binary
+    /// installs no channel on it, so the LOG_FATAL would be dropped and the matcher below would
+    /// have no output to match. Attach a stderr channel for the duration of the test.
+    Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
+    Poco::Logger::root().setChannel(channel);
+    Poco::Logger::root().setLevel("fatal");
+
+    /// Key 5 live in two parts at once — the state the invariant forbids.
+    auto newest = makeTarget({{5, 9}});
+    auto older = makeTarget({{5, 1}});
+    ASSERT_NE(newest, nullptr);
+    ASSERT_NE(older, nullptr);
+    auto probe = probeOver({newest, older});
+
+    EXPECT_DEATH(probeKey(probe, 5), "live in more than one part");
+}
+
+#endif
 
 #endif

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_probe.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_probe.cpp
@@ -438,13 +438,6 @@ TEST_F(UniqueKeyProbeDeathTest, DuplicateLiveKeyAcrossPartsIsRejected)
 {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-    /// `abortOnFailedAssertion` reports the message through the root logger, and this binary
-    /// installs no channel on it, so the LOG_FATAL would be dropped and the matcher below would
-    /// have no output to match. Attach a stderr channel for the duration of the test.
-    Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
-    Poco::Logger::root().setChannel(channel);
-    Poco::Logger::root().setLevel("fatal");
-
     /// Key 5 live in two parts at once — the state the invariant forbids.
     auto newest = makeTarget({{5, 9}});
     auto older = makeTarget({{5, 1}});
@@ -452,7 +445,19 @@ TEST_F(UniqueKeyProbeDeathTest, DuplicateLiveKeyAcrossPartsIsRejected)
     ASSERT_NE(older, nullptr);
     auto probe = probeOver({newest, older});
 
-    EXPECT_DEATH(probeKey(probe, 5), "live in more than one part");
+    /// `abortOnFailedAssertion` reports through the root logger, which `LOG_IMPL` skips when no
+    /// channel is attached, so attach one to guarantee the matcher has the message to match.
+    /// The statement runs only in the death-test child, leaving the parent's logger state alone.
+    /// The matcher is a plain substring: gtest matches death-test patterns with POSIX extended
+    /// regular expressions or with its own simple engine depending on the platform.
+    EXPECT_DEATH(
+        {
+            Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
+            Poco::Logger::root().setChannel(channel);
+            Poco::Logger::root().setLevel("fatal");
+            probeKey(probe, 5);
+        },
+        "live in more than one part");
 }
 
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: https://github.com/ClickHouse/ClickHouse/issues/115405
Related: https://github.com/ClickHouse/ClickHouse/pull/106422
Related: https://github.com/ClickHouse/ClickHouse/pull/114469

## The problem

`UniqueKeyProbeSimple::probeBatch` validates the "a live key lives in <= 1 part" invariant when `probe_validates_single_live_part` is on: rather than early-skipping a key once it resolves live, debug builds probe every part for every key and throw `LOGICAL_ERROR` on a second live hit.

`UniqueKeyProbeTest.NewestLiveWinsOverOlder` sets up key `5` as live in **two** parts, which is precisely the state that invariant forbids. In release builds the early-skip fires and the second live hit is never observed, so the test passes. In Debug builds it is observed, and the `LOGICAL_ERROR` aborts the whole `unit_tests_dbms` process — so every test registered after it silently never runs.

## Why CI never saw it

`unit_tests_dbms` is only built and run in the ASan+UBSan, TSan, MSan and LLVM-coverage flavors. All four configure with `CMAKE_BUILD_TYPE=None`, which the top-level `CMakeLists.txt` rewrites to `RelWithDebInfo`, so `NDEBUG` is defined and the check is compiled out. The two Debug flavors (`amd_debug`, `arm_debug`) do compile the unit tests but publish only the `clickhouse` binary — no job consumes a Debug `unit_tests_dbms`. The abort is therefore reachable only from a local Debug build.

## Which side is wrong

The invariant. It was added as review fix M8 in `89bcecefacd`, at the reviewer's request on https://github.com/ClickHouse/ClickHouse/pull/106422, with the stated rationale that "a row should be present only in a single part of the snapshot". It is backed by the guard layer that keeps data in a state where it holds: merges disabled, and mutations, `ALTER ... PARTITION`, projections, TTL and lightweight updates all rejected on `UNIQUE KEY` tables. `MergeTreeData::supportsLightweightUpdate` rejects lightweight updates specifically because they would "produce duplicate live keys".

The test predates the gate (both were written in the same PR, six weeks apart) and was never updated. Note also that once the invariant holds, traversal order is not observable at all — with at most one live occurrence the result is that row regardless of walk order, so "newest live wins over older live" can only be demonstrated by violating the invariant. That is why the fixture had to build forbidden state.

## The change

Test-only; the production gate is left exactly as is.

- `NewestLiveWinsOverOlderDead` replaces `NewestLiveWinsOverOlder`, marking the older occurrence bitmap-dead. It preserves the original intent — the newest live row wins, an older part must not override it — while respecting the invariant. It also pins something the old test did not: the Debug walk continues after a key resolves, and a later dead hit must not downgrade the resolved `FOUND_LIVE` to `FOUND_ALL_DEAD`.
- `UniqueKeyProbeDeathTest.DuplicateLiveKeyAcrossPartsIsRejected` adds coverage for the invariant check itself. The `LOGICAL_ERROR` aborts rather than propagating, so it cannot be caught with `EXPECT_THROW`; it is a death test, mirroring `ColumnArrayDeathTest.NonMonotonicOffsetsAreRejected` (https://github.com/ClickHouse/ClickHouse/pull/114469), which fixed the same class of problem. It is guarded on `#ifndef NDEBUG` to match the gate rather than `DEBUG_OR_SANITIZER_BUILD`, since the throw only happens when the gate is on.

The death test attaches a stderr channel to the root logger from inside the `EXPECT_DEATH` statement: `abortOnFailedAssertion` reports through `Poco::Logger::root` and `LOG_IMPL` drops the record when no channel is attached, so this guarantees the matcher has the message to match. Keeping it inside the statement means it runs only in the death-test child — the parent process takes the overseer role and skips the statement — so no global logger state leaks into subsequent tests.

## Caveats

Not compile-verified locally: this environment has all 141 submodules uninitialized and no ccache/ninja, so building `unit_tests_dbms` was not feasible. The `amd_tidy` and `arm_tidy` jobs do configure with `CMAKE_BUILD_TYPE=Debug`, `ENABLE_TESTS=1` and an explicit `-UNDEBUG`, so CI does compile the `#ifndef NDEBUG` branch even though no job runs it.

The reduction's control flow was verified separately by transcribing the `probeBatch` loop into a standalone program and compiling it with and without `NDEBUG` — the old fixture throws under `-UNDEBUG` and returns row 9 under `-DNDEBUG`, the new one returns row 9 in both, and no neighbouring test in the file changes behaviour.

Because the new death test is `#ifndef NDEBUG`, it will not run in any current CI job — the same gap that hides the original bug. That is expected: the check it covers does not exist in the builds CI runs the unit suite with.

## Open question for the reviewers

@Michicosun — the gate uses `#ifndef NDEBUG`, while the abort it depends on keys on `DEBUG_OR_SANITIZER_BUILD`. Was "in debug builds" in the original review comment meant to include sanitizer builds? Widening the gate would give the invariant real unit-test CI coverage, but it has to happen after this fix, since today it would turn the abort into red ASan/TSan/MSan builds. Happy to follow up with that change if it is wanted.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-812657b8-8bd5-4308-bdd3-f85d34ec62c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-812657b8-8bd5-4308-bdd3-f85d34ec62c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115467&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115467](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115467+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
