### PR TITLE
Perf(PromQL): Optimize PromQL unless for exact groups

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
@@ -15,8 +15,6 @@ namespace DB::PrometheusQueryToSQL
 
 namespace
 {
-    constexpr const char * right_group_present = "right_group_present";
-
     bool canUseExactGroupMatch(
         const PrometheusQueryTree::BinaryOperator * operator_node,
         bool left_metric_name_dropped,
@@ -38,10 +36,7 @@ namespace
 
         builder.select_list.push_back(makeASTFunction(
             "if",
-            makeASTFunction(
-                "equals",
-                make_intrusive<ASTIdentifier>(Strings{right, right_group_present}),
-                make_intrusive<ASTLiteral>(1u)),
+            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values})),
             makeASTFunction(
                 "arrayMap",
                 makeASTFunction(
@@ -104,18 +99,6 @@ SQLQueryPiece applyBinaryOperatorUnless(
 
     if (exact_group_match)
     {
-        /// Add an explicit marker because an unmatched LEFT JOIN row and a matched row whose values are all NULL
-        /// must take different branches below.
-        SelectQueryBuilder builder;
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
-        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
-        builder.select_list.push_back(make_intrusive<ASTLiteral>(1u));
-        builder.select_list.back()->setAlias(right_group_present);
-        builder.from_table = right;
-
-        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), builder.getSelectQuery(), SQLSubqueryType::TABLE});
-        right = context.subqueries.back().name;
-
         SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
         res.select_query = makeExactGroupUnlessQuery(left, right);
         res.metric_name_dropped = left_argument.metric_name_dropped;

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
@@ -13,6 +13,64 @@
 namespace DB::PrometheusQueryToSQL
 {
 
+namespace
+{
+    constexpr const char * right_group_present = "right_group_present";
+
+    bool canUseExactGroupMatch(
+        const PrometheusQueryTree::BinaryOperator * operator_node,
+        bool left_metric_name_dropped,
+        bool right_metric_name_dropped)
+    {
+        /// This is the set of cases where transformGroupASTForBinaryOperator returns the original group column.
+        return left_metric_name_dropped && right_metric_name_dropped
+            && !operator_node->on
+            && (!operator_node->ignoring || operator_node->labels.empty());
+    }
+
+    /// Keep left values where the matching right value is NULL for two unique VECTOR_GRID inputs with the same group key.
+    ASTPtr makeExactGroupUnlessQuery(const String & left, const String & right)
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}));
+        builder.select_list.back()->setAlias(ColumnNames::Group);
+
+        builder.select_list.push_back(makeASTFunction(
+            "if",
+            makeASTFunction(
+                "equals",
+                make_intrusive<ASTIdentifier>(Strings{right, right_group_present}),
+                make_intrusive<ASTLiteral>(1u)),
+            makeASTFunction(
+                "arrayMap",
+                makeASTFunction(
+                    "lambda",
+                    makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y")),
+                    makeASTFunction(
+                        "if",
+                        makeASTFunction("isNull", make_intrusive<ASTIdentifier>("y")),
+                        make_intrusive<ASTIdentifier>("x"),
+                        make_intrusive<ASTLiteral>(Field{} /* NULL */))),
+                make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
+                make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Values})),
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})));
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        builder.from_table = left;
+        builder.join_kind = JoinKind::Left;
+        builder.join_strictness = JoinStrictness::All;
+        builder.join_table = right;
+
+        builder.join_on = makeASTFunction(
+            "equals",
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}),
+            make_intrusive<ASTIdentifier>(Strings{right, ColumnNames::Group}));
+
+        return builder.getSelectQuery();
+    }
+}
+
 SQLQueryPiece applyBinaryOperatorUnless(
     const PrometheusQueryTree::BinaryOperator * operator_node,
     SQLQueryPiece && left_argument,
@@ -40,6 +98,34 @@ SQLQueryPiece applyBinaryOperatorUnless(
     right_argument = toVectorGrid(std::move(right_argument), context);
     context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
     String right = context.subqueries.back().name;
+
+    const bool exact_group_match = canUseExactGroupMatch(
+        operator_node, left_argument.metric_name_dropped, right_argument.metric_name_dropped);
+
+    if (exact_group_match)
+    {
+        /// Add an explicit marker because an unmatched LEFT JOIN row and a matched row whose values are all NULL
+        /// must take different branches below.
+        SelectQueryBuilder builder;
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
+        builder.select_list.push_back(make_intrusive<ASTLiteral>(1u));
+        builder.select_list.back()->setAlias(right_group_present);
+        builder.from_table = right;
+
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), builder.getSelectQuery(), SQLSubqueryType::TABLE});
+        right = context.subqueries.back().name;
+
+        SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
+        res.select_query = makeExactGroupUnlessQuery(left, right);
+        res.metric_name_dropped = left_argument.metric_name_dropped;
+
+        res.start_time = left_argument.start_time;
+        res.end_time = left_argument.end_time;
+        res.step = left_argument.step;
+
+        return res;
+    }
 
     /// Step 1:
     /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -3508,6 +3508,35 @@ def test_set_binary_operators():
     )
 
     do_query_test(
+        "(sum by (shape, size) (last_over_time(foo[10])) unless sum by (shape, size) (last_over_time(bar[10])))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "square", "size": "s"}, "values": [[130, "40"]]}, {"metric": {"shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',
+        [
+            [
+                "[('shape','square'),('size','s')]",
+                "[('1970-01-01 00:02:10.000',40)]",
+            ],
+            [
+                "[('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:00.000',80)]",
+            ],
+        ],
+    )
+
+    # Empty ignoring() keeps the same matching key for already grouped inputs.
+    do_query_test(
+        '(sum by (shape, size) (last_over_time(foo{shape="square"}[10])) unless ignoring() sum by (shape, size) (last_over_time(bar{shape="square"}[10])))[50:10]',
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "square", "size": "s"}, "values": [[130, "40"]]}]}',
+        [
+            [
+                "[('shape','square'),('size','s')]",
+                "[('1970-01-01 00:02:10.000',40)]",
+            ],
+        ],
+    )
+
+    do_query_test(
         "(last_over_time(foo[10]) or last_over_time(bar[10]))[50:10]",
         150,
         '{"resultType": "matrix", "result": [{"metric": {"__name__": "bar", "shape": "circle", "size": "l"}, "values": [[120, "16"]]}, {"metric": {"__name__": "bar", "shape": "rectangle", "size": "l"}, "values": [[110, "9"], [130, "90"]]}, {"metric": {"__name__": "bar", "shape": "square", "size": "s"}, "values": [[120, "40"], [140, "700"]]}, {"metric": {"__name__": "bar", "shape": "triangle", "size": "xl"}, "values": [[110, "8"], [150, "30"]]}, {"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"], [130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -3536,6 +3536,28 @@ def test_set_binary_operators():
         ],
     )
 
+    # The RHS still has matching VECTOR_GRID rows, but filtering removes every sample.
+    # The exact-group path must treat those rows as present and preserve the full LHS arrays.
+    do_query_test(
+        "(sum by (shape, size) (last_over_time(foo[10])) unless ((last_over_time(bar[10]) > 10000) + 0))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"shape": "square", "size": "s"}, "values": [[110, "4"], [130, "40"]]}, {"metric": {"shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',
+        [
+            [
+                "[('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4),('1970-01-01 00:02:10.000',40)]",
+            ],
+            [
+                "[('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:00.000',80)]",
+            ],
+        ],
+    )
+
     do_query_test(
         "(last_over_time(foo[10]) or last_over_time(bar[10]))[50:10]",
         150,

--- a/tests/performance/promql_set_operators_unless.xml
+++ b/tests/performance/promql_set_operators_unless.xml
@@ -1,0 +1,24 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_table>1</allow_experimental_time_series_table>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <create_query>
+        CREATE TABLE promql_set_operators_unless_ts ENGINE = TimeSeries
+    </create_query>
+
+    <fill_query>
+        INSERT INTO promql_set_operators_unless_ts (metric_name, tags, time_series)
+        SELECT
+            if(number &lt; 4000, 'foo', 'bar'),
+            map('instance', toString(number % 4000)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(300))
+        FROM numbers_mt(8000)
+    </fill_query>
+
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_ts</drop_query>
+</test>

--- a/tests/performance/promql_set_operators_unless.xml
+++ b/tests/performance/promql_set_operators_unless.xml
@@ -32,8 +32,8 @@
 
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless last_over_time(bar[10])', 100, 250, 10) FORMAT Null</query>
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 250, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'sum by (instance) (last_over_time(foo[10])) unless sum by (instance) (last_over_time(bar[10]))', 100, 250, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'sum by (instance) (last_over_time(foo[10])) unless on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 250, 10) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_high_card_ts</drop_query>
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_ts</drop_query>

--- a/tests/performance/promql_set_operators_unless.xml
+++ b/tests/performance/promql_set_operators_unless.xml
@@ -19,6 +19,8 @@
 
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'last_over_time(foo[10]) unless last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_ts</drop_query>
 </test>

--- a/tests/performance/promql_set_operators_unless.xml
+++ b/tests/performance/promql_set_operators_unless.xml
@@ -24,16 +24,16 @@
     <fill_query>
         INSERT INTO promql_set_operators_unless_high_card_ts (metric_name, tags, time_series)
         SELECT
-            if(number &lt; 32000, 'foo', 'bar'),
-            map('instance', toString(number % 32000)),
-            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(60))
-        FROM numbers_mt(64000)
+            if(number &lt; 262144, 'foo', 'bar'),
+            map('instance', toString(number % 262144)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(16))
+        FROM numbers_mt(524288)
     </fill_query>
 
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless last_over_time(bar[10])', 100, 690, 10) FORMAT Null</query>
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 690, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless last_over_time(bar[10])', 100, 250, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 250, 10) FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_high_card_ts</drop_query>
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_ts</drop_query>

--- a/tests/performance/promql_set_operators_unless.xml
+++ b/tests/performance/promql_set_operators_unless.xml
@@ -8,6 +8,10 @@
         CREATE TABLE promql_set_operators_unless_ts ENGINE = TimeSeries
     </create_query>
 
+    <create_query>
+        CREATE TABLE promql_set_operators_unless_high_card_ts ENGINE = TimeSeries
+    </create_query>
+
     <fill_query>
         INSERT INTO promql_set_operators_unless_ts (metric_name, tags, time_series)
         SELECT
@@ -17,10 +21,20 @@
         FROM numbers_mt(8000)
     </fill_query>
 
+    <fill_query>
+        INSERT INTO promql_set_operators_unless_high_card_ts (metric_name, tags, time_series)
+        SELECT
+            if(number &lt; 32000, 'foo', 'bar'),
+            map('instance', toString(number % 32000)),
+            arrayMap(step -> (toDateTime64(100 + step * 10, 3), (sipHash64(number, step) % 1000000) / 1000), range(60))
+        FROM numbers_mt(64000)
+    </fill_query>
+
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
     <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'sum by (instance) (last_over_time(foo[10])) unless on(instance) sum by (instance) (last_over_time(bar[10]))', 100, 3090, 10) FORMAT Null</query>
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'last_over_time(foo[10]) unless last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
-    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 3090, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless last_over_time(bar[10])', 100, 690, 10) FORMAT Null</query>
+    <query>SELECT * FROM prometheusQueryRange('promql_set_operators_unless_high_card_ts', 'last_over_time(foo[10]) unless on(instance) last_over_time(bar[10])', 100, 690, 10) FORMAT Null</query>
 
+    <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_high_card_ts</drop_query>
     <drop_query>DROP TABLE IF EXISTS promql_set_operators_unless_ts</drop_query>
 </test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
PromQL `unless` expressions with an exact group key skip redundant matching stages.

## What changed

- add an **exact-group fast path** for the PromQL set operator `unless`
- use it when both inputs already dropped `__name__`, there is no `on(...)`, and `ignoring()` is empty or absent
- join the unique left and right `VECTOR_GRID` inputs directly on `group`
- remove the RHS `GROUP BY`, `countForEach`, and transformed `join_group` work from this path
- preserve the full LHS array when the RHS group is missing
- preserve each LHS sample when the matching RHS sample is NULL
- keep `on(...)`, `on()`, non-empty `ignoring(...)`, and other transformed matching keys on the existing general path

## Why this is safe

`VECTOR_GRID` guarantees one row per `group`. The fast path is enabled only when the matching rules leave the original `group` column unchanged on both sides, so the join key is already unique and exact.

The RHS projection adds a literal group-present marker. This keeps a missing RHS row distinct from a real RHS row whose values are NULL at some timestamps. The exact path then applies the same element-wise `unless` behavior as the existing lowering.

The generic path is unchanged for matching rules that transform or collapse the group key. Empty `ignoring()` is treated like default matching when both inputs already have exact groups.

## Benchmark fixture

`tests/performance/promql_set_operators_unless.xml` uses the same workload as the related set-operator benchmarks:

- 8,000 series
- 4,000 matching groups
- 300 samples per series
- exact-group `unless` compared with an equivalent `unless on(instance)` control

The default query uses the new fast path. The `on(instance)` query keeps the existing general implementation.

## Tests

- add grouped exact-output coverage for `unless`
- add exact-output coverage for empty `ignoring()`
- keep the existing default and non-empty `ignoring(...)` coverage on the general path
- add the paired performance fixture
- run focused Python, XML, and diff checks

Related: #115219, #115374

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115476&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115476](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115476+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
