### PR TITLE
Make submodule cache upload write-once to fix ETag download race

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -272,9 +272,27 @@ def _prepare_submodule_cache(workflow, workflow_config: RunConfig) -> Result:
                 verbose=True,
                 strict=True,
             )
-            S3.copy_file_to_s3(s3_path=s3_path, local_path=archive_path, with_rename=True)
+            # Write-once conditional create (If-None-Match: *) instead of an
+            # unconditional overwrite. The object is content-addressed by the
+            # submodule SHAs, so it never legitimately changes; making it
+            # immutable closes a race where two concurrent writers (both saw a
+            # cache miss above) overwrite the same key while a third job is
+            # downloading it, causing the reader's multipart download to abort
+            # with an ETag mismatch. On a lost race S3.put returns False
+            # (PreconditionFailed) — the other writer already populated the
+            # object, so this is a success, not an error.
+            created = S3.put(
+                s3_path=s3_path,
+                local_path=archive_path,
+                if_none_matched=True,
+                no_strict=True,
+            )
             Shell.check(f"rm -f {archive_path}")
-            info = f"cache miss, created: {cache_hash}"
+            info = (
+                f"cache miss, created: {cache_hash}"
+                if created
+                else f"cache miss, created concurrently: {cache_hash}"
+            )
 
         workflow_config.submodule_cache_hash = cache_hash
         workflow_config.dump()


### PR DESCRIPTION
Makes the submodule cache upload write-once to fix an S3 ETag download race.

The submodule cache object is content-addressed by the submodule SHAs, so it never legitimately changes. Previously `_prepare_submodule_cache` uploaded it with an unconditional overwrite after a racy `head_object` existence check. Two workflow runs that both observed a cache miss could overwrite the same key while another job was downloading it. Because boto3's `download_file` validates ETag consistency across its ranged `GET`s, the reader aborted with:

```
ERROR: Failed to download S3 object [.../submodules/<hash>.tar.zst]: Contents of stored object
"..." in bucket "..." did not match expected ETag.
WARNING: Submodule cache download failed, will clone from GitHub
```

That failed the cache restore and forced a fallback GitHub clone, which could itself fail and fail the whole build (e.g. the `Checkout Submodules` stage).

The fix switches the upload to a write-once conditional create via `S3.put(..., if_none_matched=True)` (`aws s3api put-object --if-none-match "*"`). The object becomes immutable, so a downloader can never observe an ETag flip mid-transfer. On a lost race the put returns `False` (`PreconditionFailed`) — the other writer already populated the object, which is treated as success rather than an error. The existing `head_object` fast-path and the reader-side ETag fallback are kept as defense in depth.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115478&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115478](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115478+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1734` (included in `26.8` and later)
<!-- ch-version-info:end -->