### PR TITLE
perf: make `clearConflictsInEntitiesList` linear

### DIFF
--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -22,7 +22,6 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/algorithm/copy.hpp>
 
 
@@ -800,57 +799,64 @@ UUID IAccessStorage::generateRandomID()
 
 void IAccessStorage::clearConflictsInEntitiesList(std::vector<std::pair<UUID, AccessEntityPtr>> & entities, LoggerPtr log_)
 {
-    std::unordered_map<UUID, size_t> positions_by_id;
-    std::unordered_map<std::string_view, size_t> positions_by_type_and_name[static_cast<size_t>(AccessEntityType::MAX)];
-    std::vector<size_t> positions_to_remove;
+    std::vector<bool> positions_to_remove(entities.size(), false);
+    bool has_conflicts = false;
 
-    for (size_t pos = 0; pos != entities.size(); ++pos)
     {
-        const auto & [id, entity] = entities[pos];
+        std::unordered_map<UUID, size_t> positions_by_id;
+        std::unordered_map<std::string_view, size_t> positions_by_type_and_name[static_cast<size_t>(AccessEntityType::MAX)];
 
-        if (auto it = positions_by_id.find(id); it == positions_by_id.end())
+        auto mark_conflict = [&](size_t pos, size_t conflicting_pos)
         {
-            positions_by_id[id] = pos;
-        }
-        else if (it->second != pos)
-        {
-            /// Conflict: same ID is used for multiple entities. We will ignore them.
-            positions_to_remove.emplace_back(pos);
-            positions_to_remove.emplace_back(it->second);
-        }
+            positions_to_remove[pos] = true;
+            positions_to_remove[conflicting_pos] = true;
+            has_conflicts = true;
+        };
 
-        std::string_view entity_name = entity->getName();
-        auto & positions_by_name = positions_by_type_and_name[static_cast<size_t>(entity->getType())];
-        if (auto it = positions_by_name.find(entity_name); it == positions_by_name.end())
+        for (size_t pos = 0; pos != entities.size(); ++pos)
         {
-            positions_by_name[entity_name] = pos;
-        }
-        else if (it->second != pos)
-        {
-            /// Conflict: same name and type are used for multiple entities. We will ignore them.
-            positions_to_remove.emplace_back(pos);
-            positions_to_remove.emplace_back(it->second);
+            const auto & [id, entity] = entities[pos];
+
+            auto [id_it, id_inserted] = positions_by_id.emplace(id, pos);
+            if (!id_inserted)
+            {
+                /// Conflict: same ID is used for multiple entities. We will ignore them.
+                mark_conflict(pos, id_it->second);
+            }
+
+            std::string_view entity_name = entity->getName();
+            auto & positions_by_name = positions_by_type_and_name[static_cast<size_t>(entity->getType())];
+            auto [name_it, name_inserted] = positions_by_name.emplace(entity_name, pos);
+            if (!name_inserted)
+            {
+                /// Conflict: same name and type are used for multiple entities. We will ignore them.
+                mark_conflict(pos, name_it->second);
+            }
         }
     }
 
-    if (positions_to_remove.empty())
+    if (!has_conflicts)
         return;
 
-    std::sort(positions_to_remove.begin(), positions_to_remove.end());
-    positions_to_remove.erase(std::unique(positions_to_remove.begin(), positions_to_remove.end()), positions_to_remove.end());
-
-    for (size_t pos : positions_to_remove)
+    size_t write_pos = 0;
+    for (size_t pos = 0; pos != entities.size(); ++pos)
     {
-        LOG_WARNING(
-            log_,
-            "Skipping {} (id={}) due to conflicts with other access entities",
-            entities[pos].second->formatTypeWithName(),
-            toString(entities[pos].first));
+        if (positions_to_remove[pos])
+        {
+            LOG_WARNING(
+                log_,
+                "Skipping {} (id={}) due to conflicts with other access entities",
+                entities[pos].second->formatTypeWithName(),
+                toString(entities[pos].first));
+            continue;
+        }
+
+        if (write_pos != pos)
+            entities[write_pos] = std::move(entities[pos]);
+        ++write_pos;
     }
 
-    /// Remove conflicting entities.
-    for (size_t pos : positions_to_remove | boost::adaptors::reversed) /// Must remove in reversive order.
-        entities.erase(entities.begin() + pos);
+    entities.erase(entities.begin() + write_pos, entities.end());
 }
 
 

--- a/src/Access/tests/gtest_memory_access_storage.cpp
+++ b/src/Access/tests/gtest_memory_access_storage.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <Access/MemoryAccessStorage.h>
+#include <Access/Role.h>
+#include <Access/User.h>
+#include <Core/UUID.h>
+#include <IO/WriteHelpers.h>
+#include <Common/Logger.h>
+
+#include <Poco/AutoPtr.h>
+#include <Poco/StreamChannel.h>
+
+#include <memory>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+
+using namespace DB;
+
+namespace
+{
+
+class MemoryAccessStorageTestAdapter : public MemoryAccessStorage
+{
+public:
+    using MemoryAccessStorage::clearConflictsInEntitiesList;
+};
+
+template <typename Entity>
+AccessEntityPtr makeEntity(const String & name)
+{
+    auto entity = std::make_shared<Entity>();
+    entity->setName(name);
+    return entity;
+}
+
+using EntityWithID = std::pair<UUID, AccessEntityPtr>;
+
+String makeConflictWarning(const EntityWithID & entity)
+{
+    return "Skipping " + entity.second->formatTypeWithName() + " (id=" + toString(entity.first)
+        + ") due to conflicts with other access entities\n";
+}
+
+}
+
+TEST(MemoryAccessStorage, ConflictCleanupKeepsNonConflictingEntities)
+{
+    std::vector<EntityWithID> entities{
+        {UUIDHelpers::generateV4(), makeEntity<User>("shared_name")},
+        {UUIDHelpers::generateV4(), makeEntity<Role>("shared_name")},
+        {UUIDHelpers::generateV4(), makeEntity<User>("other_name")},
+    };
+    const auto expected_entities = entities;
+
+    MemoryAccessStorageTestAdapter::clearConflictsInEntitiesList(entities, getLogger("MemoryAccessStorageNoConflictsTest"));
+
+    EXPECT_EQ(entities, expected_entities);
+}
+
+TEST(MemoryAccessStorage, ConflictCleanupRemovesOverlappingConflictsOnce)
+{
+    const auto shared_id = UUIDHelpers::generateV4();
+    std::vector<EntityWithID> entities{
+        {UUIDHelpers::generateV4(), makeEntity<User>("first")},
+        {shared_id, makeEntity<User>("alpha")},
+        {UUIDHelpers::generateV4(), makeEntity<Role>("alpha")},
+        {shared_id, makeEntity<User>("beta")},
+        {UUIDHelpers::generateV4(), makeEntity<User>("beta")},
+        {UUIDHelpers::generateV4(), makeEntity<User>("last")},
+    };
+
+    const std::vector<EntityWithID> expected_entities{entities[0], entities[2], entities[5]};
+    const String expected_warnings = makeConflictWarning(entities[1]) + makeConflictWarning(entities[3]) + makeConflictWarning(entities[4]);
+
+    std::ostringstream warnings; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    auto channel = Poco::AutoPtr<Poco::StreamChannel>(new Poco::StreamChannel(warnings));
+    auto log = createLogger("MemoryAccessStorageOverlappingConflictsTest", channel.get());
+
+    MemoryAccessStorageTestAdapter::clearConflictsInEntitiesList(entities, log);
+
+    EXPECT_EQ(entities, expected_entities);
+    EXPECT_EQ(warnings.str(), expected_warnings);
+}


### PR DESCRIPTION
Replace the sorted list of conflict positions and repeated vector erases in `clearConflictsInEntitiesList` with a bit mask and one stable compaction pass. This preserves conflict handling, warning order, and survivor order while making the removal phase linear. Focused unit tests cover duplicate IDs, duplicate names, overlapping conflicts, and stable ordering.


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved loading of large access configurations that contain conflicting entities.
