### PR TITLE
Resolve the default time zone from an absolute `TZ` path outside `TZDIR`

### DIFF
--- a/src/Common/DateLUT.cpp
+++ b/src/Common/DateLUT.cpp
@@ -22,6 +22,9 @@ namespace Setting
 }
 }
 
+/// Embedded timezones.
+std::string_view getTimeZone(const char * name);  /// NOLINT(misc-use-internal-linkage)
+
 namespace
 {
 
@@ -56,7 +59,8 @@ std::string determineDefaultTimeZone()
 
     if (tz_env_var)
     {
-        error_prefix = std::string("Could not determine time zone from TZ variable value: '") + tz_env_var + "': ";
+        error_prefix = std::string("Could not determine time zone from TZ variable value: '") + tz_env_var + "'"
+            " and tz database path: '" + tz_database_path.string() + "': ";
 
         if (*tz_env_var == ':')
             ++tz_env_var;
@@ -77,7 +81,7 @@ std::string determineDefaultTimeZone()
     }
     else
     {
-        error_prefix = "Could not determine local time zone: ";
+        error_prefix = "Could not determine local time zone and tz database path: '" + tz_database_path.string() + "' : ";
         tz_file_path = "/etc/localtime";
 
         /// No TZ variable and no tzdata installed (e.g. Docker)
@@ -111,6 +115,7 @@ std::string determineDefaultTimeZone()
                 return tz_name.empty() ? relative_path.string() : tz_name;
         }
 
+        const bool tz_file_path_was_absolute = tz_file_path.is_absolute();
         /// Try the same with full symlinks resolution
         {
             if (!tz_file_path.is_absolute())
@@ -121,6 +126,37 @@ std::string determineDefaultTimeZone()
             fs::path relative_path = tz_file_path.lexically_relative(tz_database_path);
             if (!relative_path.empty() && *relative_path.begin() != ".." && *relative_path.begin() != ".")
                 return tz_name.empty() ? relative_path.string() : tz_name;
+        }
+
+        /// Try to find the timezone by name in the embedded tz database.
+        /// Try only if tz_file_path was an absolute path set by TZ or TZ was not set.
+        /// tz_file_path is fully symlink resolved by this step.
+        if (tz_file_path_was_absolute)
+        {
+            fs::path suffix_path = tz_file_path.relative_path();
+            bool parent_dir_is_right = false;
+            while (!suffix_path.empty() && suffix_path != ".")
+            {
+                if (auto tz = getTimeZone(suffix_path.c_str()); !tz.empty())
+                {
+                    /// Consider the .../right/<tz_id> file as a file with leap seconds, which are not supported.
+                    /// This check is stricter than necessary, e.g. it'll reject the `/home/right/UTC` path, even
+                    /// if UTC tzdata hold no info about the leap seconds. Though it's arguably better than
+                    /// silently using the tzdata without leap seconds, while user explicitly requested the file with
+                    /// leap seconds.
+                    if (parent_dir_is_right)
+                    {
+                        throw Poco::Exception("tzdata files with leap seconds are not supported");
+                    }
+                    /// We do this check only if the initial tz_file_path was absolute, so tz_name
+                    /// should not be populated.
+                    return suffix_path.string();
+                }
+
+                parent_dir_is_right = *suffix_path.begin() == "right";
+
+                suffix_path = suffix_path.lexically_relative(*suffix_path.begin());
+            }
         }
 
         /// The file is not inside the tz_database_dir, so we hope that it was copied (not symlinked)

--- a/tests/queries/0_stateless/05023_tz_symlink_outside_tzdir.reference
+++ b/tests/queries/0_stateless/05023_tz_symlink_outside_tzdir.reference
@@ -1,0 +1,2 @@
+Europe/Amsterdam
+Europe/Amsterdam

--- a/tests/queries/0_stateless/05023_tz_symlink_outside_tzdir.sh
+++ b/tests/queries/0_stateless/05023_tz_symlink_outside_tzdir.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `TZ` is an absolute path to a symlink whose target lies outside of `TZDIR`, and `TZDIR` holds no
+# byte-identical copy of that target either, so the time zone id can only be recovered from the
+# path suffix. See https://github.com/ClickHouse/ClickHouse/issues/86495
+SOURCE_TZ_FILE=/usr/share/zoneinfo/Europe/Amsterdam
+
+if [ ! -f "$SOURCE_TZ_FILE" ]; then
+    # There is no system time zone database to build the fixture from.
+    echo "Europe/Amsterdam"
+    echo "Europe/Amsterdam"
+    exit 0
+fi
+
+WORK_DIR="$CLICKHOUSE_TMP/$CLICKHOUSE_TEST_UNIQUE_NAME"
+rm -rf "$WORK_DIR"
+# An empty time zone database: it exists, but contains neither the file nor a copy of its contents.
+mkdir -p "$WORK_DIR/store/zoneinfo/Europe" "$WORK_DIR/tzdir"
+# `TZ` has to be an absolute path, while `CLICKHOUSE_TMP` may be relative.
+WORK_DIR=$(cd "$WORK_DIR" && pwd)
+
+cp "$SOURCE_TZ_FILE" "$WORK_DIR/store/zoneinfo/Europe/Amsterdam"
+ln -s "$WORK_DIR/store/zoneinfo/Europe/Amsterdam" "$WORK_DIR/localtime"
+
+TZDIR="$WORK_DIR/tzdir" TZ="$WORK_DIR/localtime" ${CLICKHOUSE_LOCAL} --query "SELECT timezone()"
+# The same, in the POSIX form with the colon prefix, as in the report.
+TZDIR="$WORK_DIR/tzdir" TZ=":$WORK_DIR/localtime" ${CLICKHOUSE_LOCAL} --query "SELECT timezone()"
+
+rm -rf "$WORK_DIR"


### PR DESCRIPTION
If `TZ` contains an absolute path or is not set and the requested file is not inside the `TZDIR` directory, try to resolve the time zone id as the longest suffix recognized by the embedded time zone database.

If the parent dir of the found suffix is `right`, the file is rejected as we assume that it contains leap seconds and such files are not supported.

`glibc` ignores `TZDIR` when `TZ` is an absolute path, so this behavior is more aligned with `glibc` than failing to resolve at all.

If we fail to resolve the time zone id, the reported error message now also contains the time zone database directory that was used.

The embedded database is used as the oracle rather than `TZDIR` to avoid dependency on `TZDIR` if `TZ` contains an absolute path. It also doesn't need filesystem access and yields ids that `DateLUTImpl` is able to load.

Closes: https://github.com/ClickHouse/ClickHouse/issues/86495

### Out of scope

A `TZ` value that cannot be resolved still throws while initializing the `DateLUT` singleton, which terminates the process at startup. Matching `glibc` more closely would mean degrading to UTC with a clear warning for the operator; that is a separate behavioural change.


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The default time zone is now also determined when the `TZ` environment variable holds an absolute path to a time zone file located outside the time zone database directory (`TZDIR`). The time zone id is now recovered from the longest suffix of the path that names a time zone in the embedded time zone database. Files under a `right/` directory are rejected explicitly, since they are assumed to be encoded with leap seconds, which are not supported.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115483&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115483](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115483+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
