### PR TITLE
Stop resolving the UTC time zone in `TimezoneMixin`

### DIFF
--- a/src/DataTypes/Serializations/SerializationDateTime.cpp
+++ b/src/DataTypes/Serializations/SerializationDateTime.cpp
@@ -84,6 +84,7 @@ inline bool tryReadText(
 
 SerializationDateTime::SerializationDateTime(const TimezoneMixin & time_zone_)
     : TimezoneMixin(time_zone_)
+    , utc_time_zone(DateLUT::instance("UTC"))
 {
 }
 

--- a/src/DataTypes/Serializations/SerializationDateTime.h
+++ b/src/DataTypes/Serializations/SerializationDateTime.h
@@ -32,6 +32,11 @@ public:
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
     bool tryDeserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
     void serializeTextHive(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const override;
+
+private:
+    /// Needed for ISO output and for the `best_effort` date/time input formats. Not in `TimezoneMixin`, so that
+    /// merely naming a `DateTime` type does not build a UTC lookup table; see the note there.
+    const DateLUTImpl & utc_time_zone;
 };
 
 class SerializationTime final : public SerializationNumber<Int32>

--- a/src/DataTypes/Serializations/SerializationDateTime64.cpp
+++ b/src/DataTypes/Serializations/SerializationDateTime64.cpp
@@ -22,6 +22,7 @@ SerializationDateTime64::SerializationDateTime64(
     UInt32 scale_, const TimezoneMixin & time_zone_)
     : SerializationDecimalBase<DateTime64>(DecimalUtils::max_precision<DateTime64>, scale_)
     , TimezoneMixin(time_zone_)
+    , utc_time_zone(DateLUT::instance("UTC"))
 {
 }
 

--- a/src/DataTypes/Serializations/SerializationDateTime64.h
+++ b/src/DataTypes/Serializations/SerializationDateTime64.h
@@ -33,6 +33,11 @@ public:
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
     bool tryDeserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
     void serializeTextHive(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const override;
+
+private:
+    /// Needed for ISO output and for the `best_effort` date/time input formats. Not in `TimezoneMixin`, so that
+    /// merely naming a `DateTime64` type does not build a UTC lookup table; see the note there.
+    const DateLUTImpl & utc_time_zone;
 };
 
 }

--- a/src/DataTypes/TimezoneMixin.h
+++ b/src/DataTypes/TimezoneMixin.h
@@ -6,6 +6,13 @@
 
 /** Mixin-class that manages timezone info for timezone-aware DateTime implementations
   * Could be used as a (second) base for a class implementing IDateType/ISerialization-interface.
+  *
+  * Note that the UTC time zone is deliberately not kept here, even though the `best_effort` date/time parsers and
+  * ISO output need it. Constructing a `DateLUTImpl` walks ~146k days through cctz, and the data types
+  * (`DataTypeDateTime`, `DataTypeDateTime64`) are constructed just to name a column type - e.g. when building the
+  * schemas of the system tables at startup - without ever touching UTC. Resolving UTC here made every such
+  * construction build a second, always-unused lookup table. The serializations that do need it declare their own
+  * `utc_time_zone` member instead, so the cost is paid once per formatter.
   */
 class TimezoneMixin
 {
@@ -15,7 +22,6 @@ public:
     explicit TimezoneMixin(std::string_view time_zone_name = "")
         : has_explicit_time_zone(!time_zone_name.empty())
         , time_zone(DateLUT::instance(time_zone_name))
-        , utc_time_zone(DateLUT::instance("UTC"))
     {
     }
 
@@ -27,5 +33,4 @@ protected:
     bool has_explicit_time_zone;
 
     const DateLUTImpl & time_zone;
-    const DateLUTImpl & utc_time_zone;
 };

--- a/src/Formats/JSONExtractTree.cpp
+++ b/src/Formats/JSONExtractTree.cpp
@@ -716,7 +716,10 @@ template <typename JSONParser>
 class DateTimeNode : public JSONExtractTreeNode<JSONParser>, public TimezoneMixin
 {
 public:
-    explicit DateTimeNode(const DataTypeDateTime & datetime_type) : TimezoneMixin(datetime_type) { }
+    explicit DateTimeNode(const DataTypeDateTime & datetime_type)
+        : TimezoneMixin(datetime_type), utc_time_zone(DateLUT::instance("UTC"))
+    {
+    }
 
     bool insertResultToColumn(
         IColumn & column,
@@ -808,6 +811,10 @@ public:
 
         return false;
     }
+
+    /// Needed for the `best_effort` date/time input formats. Not in `TimezoneMixin`, so that merely naming a
+    /// `DateTime` type does not build a UTC lookup table; see the note there.
+    const DateLUTImpl & utc_time_zone;
 };
 
 template <typename JSONParser>
@@ -943,7 +950,8 @@ template <typename JSONParser>
 class DateTime64Node : public JSONExtractTreeNode<JSONParser>, public TimezoneMixin
 {
 public:
-    explicit DateTime64Node(const DataTypeDateTime64 & datetime64_type) : TimezoneMixin(datetime64_type), scale(datetime64_type.getScale())
+    explicit DateTime64Node(const DataTypeDateTime64 & datetime64_type)
+        : TimezoneMixin(datetime64_type), utc_time_zone(DateLUT::instance("UTC")), scale(datetime64_type.getScale())
     {
     }
 
@@ -1057,6 +1065,9 @@ public:
     }
 
 private:
+    /// Needed for the `best_effort` date/time input formats. Not in `TimezoneMixin`, so that merely naming a
+    /// `DateTime64` type does not build a UTC lookup table; see the note there.
+    const DateLUTImpl & utc_time_zone;
     UInt32 scale;
 };
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112496
-->

While profiling `clickhouse local --query "SELECT 1"` it turned out that almost all of the run happens before the query: the query itself took 1ms of a 45ms run. This is one of the sources of that startup work, split out of #112496.

`TimezoneMixin` resolved the UTC time zone in its constructor, in addition to the named or default one. Building a `DateLUTImpl` walks ~146k days through cctz, about 70M instructions, and `DataTypeDateTime` / `DataTypeDateTime64` get constructed just to name a column type — for example when building the schemas of the system tables — without ever touching UTC.

Only the serializations need UTC, for ISO output and for the `best_effort` parsers, so `SerializationDateTime`, `SerializationDateTime64` and the `DateTime` / `DateTime64` nodes of `JSONExtractTree` declare their own `utc_time_zone` member instead. The cost is then paid once per formatter rather than once per named type.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Naming a `DateTime` or `DateTime64` type no longer builds a UTC time zone lookup table that nothing reads, which makes constructing these types — and therefore starting up `clickhouse local` and `clickhouse client` — faster.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115488&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115488](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115488+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1780` (included in `26.8` and later)
<!-- ch-version-info:end -->