### PR TITLE
Stop copying a system table's metadata twice to set its comment

### DIFF
--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -258,6 +258,17 @@ public:
         metadata.set(std::make_unique<StorageInMemoryMetadata>(metadata_));
     }
 
+    /// Replace only the table comment, keeping the rest of the metadata as it is.
+    /// Attaching the system tables used to fetch the table back from `DatabaseCatalog` and copy its whole
+    /// `StorageInMemoryMetadata` - which carries the full `ColumnsDescription` - just to fill in the comment,
+    /// copying every system table's schema twice at every startup.
+    void setInMemoryMetadataComment(const String & comment)
+    {
+        auto updated = std::make_unique<StorageInMemoryMetadata>(*metadata.get());
+        updated->setComment(comment);
+        metadata.set(std::move(updated));
+    }
+
     VectorWithMemoryTracking<String> getAllRegisteredNames() const override;
 
     NameDependencies getDependentViewsByColumn(ContextPtr context) const;

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -258,10 +258,6 @@ public:
         metadata.set(std::make_unique<StorageInMemoryMetadata>(metadata_));
     }
 
-    /// Replace only the table comment, keeping the rest of the metadata as it is.
-    /// Attaching the system tables used to fetch the table back from `DatabaseCatalog` and copy its whole
-    /// `StorageInMemoryMetadata` - which carries the full `ColumnsDescription` - just to fill in the comment,
-    /// copying every system table's schema twice at every startup.
     void setInMemoryMetadataComment(const String & comment)
     {
         auto updated = std::make_unique<StorageInMemoryMetadata>(*metadata.get());

--- a/src/Storages/System/attachSystemTablesImpl.h
+++ b/src/Storages/System/attachSystemTablesImpl.h
@@ -18,14 +18,11 @@ void attachImpl(ContextPtr context, IDatabase & system_database, const String & 
     chassert(system_database.getDatabaseName() == DatabaseCatalog::SYSTEM_DATABASE);
 
     auto table_id = StorageID::createEmpty();
+    String path;
     if (system_database.getUUID() == UUIDHelpers::Nil)
     {
         /// Attach to Ordinary database.
         table_id = StorageID(DatabaseCatalog::SYSTEM_DATABASE, table_name);
-        if constexpr (with_description)
-            system_database.attachTable(context, table_name, std::make_shared<StorageT>(table_id, StorageT::getColumnsDescription(), std::forward<StorageArgs>(args)...), {});
-        else
-            system_database.attachTable(context, table_name, std::make_shared<StorageT>(table_id, std::forward<StorageArgs>(args)...), {});
     }
     else
     {
@@ -34,20 +31,20 @@ void attachImpl(ContextPtr context, IDatabase & system_database, const String & 
         /// and path is actually not used
         table_id = StorageID(DatabaseCatalog::SYSTEM_DATABASE, table_name, UUIDHelpers::generateV4());
         DatabaseCatalog::instance().addUUIDMapping(table_id.uuid);
-        String path = DatabaseCatalog::getStoreDirPath(table_id.uuid);
-        if constexpr (with_description)
-            system_database.attachTable(context, table_name, std::make_shared<StorageT>(table_id, StorageT::getColumnsDescription(), std::forward<StorageArgs>(args)...), path);
-        else
-            system_database.attachTable(context, table_name, std::make_shared<StorageT>(table_id, std::forward<StorageArgs>(args)...), path);
+        path = DatabaseCatalog::getStoreDirPath(table_id.uuid);
     }
 
-    /// Set the comment
-    auto table = DatabaseCatalog::instance().getTable(table_id, context);
-    chassert(table);
-    auto metadata_snapshot = table->getInMemoryMetadataPtr(context, false);
-    StorageInMemoryMetadata metadata = *metadata_snapshot;
-    metadata.comment = comment;
-    table->setInMemoryMetadata(metadata);
+    std::shared_ptr<StorageT> storage;
+    if constexpr (with_description)
+        storage = std::make_shared<StorageT>(table_id, StorageT::getColumnsDescription(), std::forward<StorageArgs>(args)...);
+    else
+        storage = std::make_shared<StorageT>(table_id, std::forward<StorageArgs>(args)...);
+
+    /// Set the comment on the storage before attaching it, so that we neither look the table back up in
+    /// `DatabaseCatalog` nor copy its whole metadata (including the full `ColumnsDescription`) an extra time.
+    storage->setInMemoryMetadataComment(comment);
+
+    system_database.attachTable(context, table_name, storage, path);
 }
 
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112496
-->

Noticed while profiling start-up for #112496.

Attaching a system table fetched the table back from `DatabaseCatalog` and copied its whole `StorageInMemoryMetadata` — which carries the full `ColumnsDescription` — twice, only to fill in the comment. Since there are ~164 system tables, every start-up copied every system table's schema two extra times.

`IStorage::setInMemoryMetadataComment` replaces only the comment, and it is now applied to the storage before it is attached, so the catalog lookup goes away as well.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Attaching the system tables no longer copies each table's metadata, including its full column description, twice just to set the table comment.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115490&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115490](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115490+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1833` (included in `26.8` and later)
<!-- ch-version-info:end -->