### PR TITLE
Docs: Restore image backgrounds

### DIFF
--- a/docs/snippets/components/Image.jsx
+++ b/docs/snippets/components/Image.jsx
@@ -1,10 +1,15 @@
-export const Image = ({ img, alt, size = "lg" }) => {
+export const Image = ({ img, alt, size = "lg", background }) => {
   const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+  const backgroundColor = background === "white"
+    ? "white"
+    : background === "black"
+      ? "rgb(31 31 28)"
+      : undefined;
 
   return (
     <div className={`ch-image-${normalizedSize}`}>
       <Frame>
-        <img src={img} alt={alt} />
+        <img src={img} alt={alt} style={{ backgroundColor }} />
       </Frame>
     </div>
   );


### PR DESCRIPTION
Restore `background` support in the shared documentation `Image` component.

The Mintlify migration retained page-level values such as `background="black"`, but the new wrapper stopped applying them. Transparent diagrams therefore rendered against Mintlify's light frame in light mode, making light-colored labels difficult to read.

Validated with `npx --yes mintlify@latest dev` by checking the BYOC architecture diagram in both light and dark themes.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115494&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115494](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115494+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1723` (included in `26.8` and later)
<!-- ch-version-info:end -->