### PR TITLE
Fix the argument position and type reported in geoToH3 error messages

### DIFF
--- a/src/Functions/geoToH3.cpp
+++ b/src/Functions/geoToH3.cpp
@@ -34,12 +34,6 @@ namespace ErrorCodes
 namespace
 {
 
-/// Coordinate arguments are consumed as ColumnFloat64, so no other float type is acceptable.
-bool isFloat64Exactly(const IDataType & type)
-{
-    return WhichDataType(type).isFloat64();
-}
-
 /// Implements the function geoToH3 which takes 3 arguments (latitude, longitude and h3 resolution)
 /// and returns h3 index of this point
 class FunctionGeoToH3 final : public IFunction
@@ -65,12 +59,12 @@ public:
     {
         FunctionArgumentDescriptors mandatory_args = geotoh3_argument_order == GeoToH3ArgumentOrder::LON_LAT
             ? FunctionArgumentDescriptors{
-                {"longitude", &isFloat64Exactly, nullptr, "Float64"},
-                {"latitude", &isFloat64Exactly, nullptr, "Float64"},
+                {"longitude", &isFloat, nullptr, "Float64"},
+                {"latitude", &isFloat, nullptr, "Float64"},
                 {"resolution", &isUInt8, nullptr, "UInt8"}}
             : FunctionArgumentDescriptors{
-                {"latitude", &isFloat64Exactly, nullptr, "Float64"},
-                {"longitude", &isFloat64Exactly, nullptr, "Float64"},
+                {"latitude", &isFloat, nullptr, "Float64"},
+                {"longitude", &isFloat, nullptr, "Float64"},
                 {"resolution", &isUInt8, nullptr, "UInt8"}};
         validateFunctionArguments(*this, arguments, mandatory_args);
 

--- a/src/Functions/geoToH3.cpp
+++ b/src/Functions/geoToH3.cpp
@@ -34,6 +34,12 @@ namespace ErrorCodes
 namespace
 {
 
+/// Coordinate arguments are consumed as ColumnFloat64, so no other float type is acceptable.
+bool isFloat64Exactly(const IDataType & type)
+{
+    return WhichDataType(type).isFloat64();
+}
+
 /// Implements the function geoToH3 which takes 3 arguments (latitude, longitude and h3 resolution)
 /// and returns h3 index of this point
 class FunctionGeoToH3 final : public IFunction
@@ -59,12 +65,12 @@ public:
     {
         FunctionArgumentDescriptors mandatory_args = geotoh3_argument_order == GeoToH3ArgumentOrder::LON_LAT
             ? FunctionArgumentDescriptors{
-                {"longitude", &isFloat, nullptr, "Float64"},
-                {"latitude", &isFloat, nullptr, "Float64"},
+                {"longitude", &isFloat64Exactly, nullptr, "Float64"},
+                {"latitude", &isFloat64Exactly, nullptr, "Float64"},
                 {"resolution", &isUInt8, nullptr, "UInt8"}}
             : FunctionArgumentDescriptors{
-                {"latitude", &isFloat, nullptr, "Float64"},
-                {"longitude", &isFloat, nullptr, "Float64"},
+                {"latitude", &isFloat64Exactly, nullptr, "Float64"},
+                {"longitude", &isFloat64Exactly, nullptr, "Float64"},
                 {"resolution", &isUInt8, nullptr, "UInt8"}};
         validateFunctionArguments(*this, arguments, mandatory_args);
 
@@ -84,24 +90,29 @@ public:
 
         const ColumnFloat64 * col_lat = nullptr;
         const ColumnFloat64 * col_lon = nullptr;
+        size_t lat_arg = 0;
+        size_t lon_arg = 0;
 
         if (geotoh3_argument_order == GeoToH3ArgumentOrder::LON_LAT)
         {
-            col_lon = checkAndGetColumn<ColumnFloat64>(non_const_arguments[0].column.get());
-            col_lat = checkAndGetColumn<ColumnFloat64>(non_const_arguments[1].column.get());
+            lon_arg = 0;
+            lat_arg = 1;
         }
         else
         {
-            col_lat = checkAndGetColumn<ColumnFloat64>(non_const_arguments[0].column.get());
-            col_lon = checkAndGetColumn<ColumnFloat64>(non_const_arguments[1].column.get());
+            lat_arg = 0;
+            lon_arg = 1;
         }
+
+        col_lat = checkAndGetColumn<ColumnFloat64>(non_const_arguments[lat_arg].column.get());
+        col_lon = checkAndGetColumn<ColumnFloat64>(non_const_arguments[lon_arg].column.get());
 
         if (!col_lat)
             throw Exception(
                 ErrorCodes::ILLEGAL_COLUMN,
                 "Illegal type {} of argument {} of function {}. Must be Float64.",
-                arguments[1].type->getName(),
-                2,
+                arguments[lat_arg].type->getName(),
+                lat_arg + 1,
                 getName());
 
         const auto & data_lat = col_lat->getData();
@@ -110,8 +121,8 @@ public:
             throw Exception(
                 ErrorCodes::ILLEGAL_COLUMN,
                 "Illegal type {} of argument {} of function {}. Must be Float64.",
-                arguments[0].type->getName(),
-                1,
+                arguments[lon_arg].type->getName(),
+                lon_arg + 1,
                 getName());
         const auto & data_lon = col_lon->getData();
 

--- a/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.reference
+++ b/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.reference
@@ -1,0 +1,6 @@
+as 1st argument 'latitude' to function 'geoToH3'. Expected: Float64, got: Float32
+as 2nd argument 'longitude' to function 'geoToH3'. Expected: Float64, got: Float32
+as 1st argument 'latitude' to function 'geoToH3'. Expected: Float64, got: BFloat16
+as 1st argument 'longitude' to function 'geoToH3'. Expected: Float64, got: Float32
+as 2nd argument 'latitude' to function 'geoToH3'. Expected: Float64, got: Float32
+644325524706363025

--- a/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.reference
+++ b/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.reference
@@ -1,6 +1,8 @@
-as 1st argument 'latitude' to function 'geoToH3'. Expected: Float64, got: Float32
-as 2nd argument 'longitude' to function 'geoToH3'. Expected: Float64, got: Float32
-as 1st argument 'latitude' to function 'geoToH3'. Expected: Float64, got: BFloat16
-as 1st argument 'longitude' to function 'geoToH3'. Expected: Float64, got: Float32
-as 2nd argument 'latitude' to function 'geoToH3'. Expected: Float64, got: Float32
+Illegal type Float32 of argument 1 of function geoToH3
+Illegal type Float32 of argument 2 of function geoToH3
+Illegal type BFloat16 of argument 1 of function geoToH3
+Illegal type Float32 of argument 1 of function geoToH3
+Illegal type Float32 of argument 2 of function geoToH3
+kept
+kept
 644325524706363025

--- a/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.sh
+++ b/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.sh
@@ -7,7 +7,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 extract_error() {
-    grep -m1 -oE "as [0-9]+(st|nd|rd|th) argument '[a-z]+' to function 'geoToH3'\. Expected: [A-Za-z0-9]+, got: [A-Za-z0-9]+"
+    grep -m1 -oE "Illegal type [A-Za-z0-9]+ of argument [0-9]+ of function geoToH3"
 }
 
 # Default order: geoToH3(latitude, longitude, resolution)
@@ -18,6 +18,16 @@ $CLICKHOUSE_CLIENT --query "SELECT geoToH3(toBFloat16(55.71), toFloat64(37.79), 
 # Legacy order: geoToH3(longitude, latitude, resolution)
 $CLICKHOUSE_CLIENT --query "SET geotoh3_argument_order = 'lon_lat'; SELECT geoToH3(toFloat32(37.79), toFloat64(55.71), toUInt8(15))" 2>&1 | extract_error
 $CLICKHOUSE_CLIENT --query "SET geotoh3_argument_order = 'lon_lat'; SELECT geoToH3(toFloat64(37.79), toFloat32(55.71), toUInt8(15))" 2>&1 | extract_error
+
+# A stored expression over Float32 coordinates keeps loading: unrelated columns stay readable
+# and an unrelated ALTER still succeeds.
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t_04830"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE t_04830 (f32 Float32, f64 Float64, other String, h UInt64 ALIAS geoToH3(f32, f64, 15)) ENGINE = MergeTree ORDER BY tuple()"
+$CLICKHOUSE_CLIENT --query "INSERT INTO t_04830 VALUES (55.71, 37.79, 'kept')"
+$CLICKHOUSE_CLIENT --query "SELECT other FROM t_04830"
+$CLICKHOUSE_CLIENT --query "ALTER TABLE t_04830 MODIFY COMMENT 'unrelated'"
+$CLICKHOUSE_CLIENT --query "SELECT other FROM t_04830"
+$CLICKHOUSE_CLIENT --query "DROP TABLE t_04830"
 
 # Float64 coordinates are accepted
 $CLICKHOUSE_CLIENT --query "SELECT geoToH3(toFloat64(55.71), toFloat64(37.79), toUInt8(15))"

--- a/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.sh
+++ b/tests/queries/0_stateless/04830_geotoh3_argument_order_error_message.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: the fast-test build does not include the H3 library
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+extract_error() {
+    grep -m1 -oE "as [0-9]+(st|nd|rd|th) argument '[a-z]+' to function 'geoToH3'\. Expected: [A-Za-z0-9]+, got: [A-Za-z0-9]+"
+}
+
+# Default order: geoToH3(latitude, longitude, resolution)
+$CLICKHOUSE_CLIENT --query "SELECT geoToH3(toFloat32(55.71), toFloat64(37.79), toUInt8(15))" 2>&1 | extract_error
+$CLICKHOUSE_CLIENT --query "SELECT geoToH3(toFloat64(55.71), toFloat32(37.79), toUInt8(15))" 2>&1 | extract_error
+$CLICKHOUSE_CLIENT --query "SELECT geoToH3(toBFloat16(55.71), toFloat64(37.79), toUInt8(15))" 2>&1 | extract_error
+
+# Legacy order: geoToH3(longitude, latitude, resolution)
+$CLICKHOUSE_CLIENT --query "SET geotoh3_argument_order = 'lon_lat'; SELECT geoToH3(toFloat32(37.79), toFloat64(55.71), toUInt8(15))" 2>&1 | extract_error
+$CLICKHOUSE_CLIENT --query "SET geotoh3_argument_order = 'lon_lat'; SELECT geoToH3(toFloat64(37.79), toFloat32(55.71), toUInt8(15))" 2>&1 | extract_error
+
+# Float64 coordinates are accepted
+$CLICKHOUSE_CLIENT --query "SELECT geoToH3(toFloat64(55.71), toFloat64(37.79), toUInt8(15))"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/101813   (auto-closes the issue when this PR is merged into the default branch)
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/101813

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the error message of `geoToH3` naming the wrong argument position and the wrong type when a coordinate is not `Float64`. Under the default `geotoh3_argument_order = 'lat_lon'` the message pointed at the other argument and printed that argument's type. Closes #101813.

### Description

`executeImpl` binds both coordinates with `checkAndGetColumn<ColumnFloat64>`, but the two error paths hardcoded the argument index and read the type off that same index. Those literals hold only for the legacy `geotoh3_argument_order = 'lon_lat'`, so under the default `lat_lon` the message named the other argument and printed its type:

```
SELECT geoToH3(toFloat32(55.71), toFloat64(37.79), toUInt8(15));
-- was: Illegal type Float64 of argument 2 of function geoToH3. Must be Float64.
-- now: Illegal type Float32 of argument 1 of function geoToH3. Must be Float64.
```

Both indices are now derived from `geotoh3_argument_order` next to the column lookup. `lon_lat` was already right and is unchanged.

An earlier revision also narrowed the declared coordinate types to exactly `Float64`, moving rejection into analysis. Measured on two servers sharing one data directory, a table created beforehand with `h UInt64 ALIAS geoToH3(f32, f64, 15)` still loads, but `SELECT` of an unrelated column, an unrelated `ALTER ... MODIFY COMMENT` and `ALTER ... DROP COLUMN h` all begin failing, because `validateCreateQuery` re-resolves every stored default on ordinary `ALTER`s. `DatabasesCommon.cpp` already records that rule for virtual columns: a legacy table may carry such a default and an unrelated `ALTER` must not fail on it. A function cannot honour it, since `getReturnTypeImpl` receives only argument types.

That leaves the underlying mismatch open: `getReturnTypeImpl` declares `isFloat` while execution requires `Float64`. Widening execution with a cast would be backward compatible and matches `geoDistance` and `geohashEncode`, which accept `Float32`; `pointInEllipses` rejects it. I left that design decision alone. `s2CapUnion` has the same mismatch but a fixed argument order, so its indices are correct.

The test asserts position and type for each coordinate slot under both setting values, plus `BFloat16`, a `Float64` case that must still succeed, and a stored `Float32` expression whose table stays readable and alterable. Red on master, green here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115503&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115503](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115503+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1747` (included in `26.8` and later)
<!-- ch-version-info:end -->