### PR TITLE
Reject a bare carriage return in HTTP header names and values

### DIFF
--- a/src/Common/HTTPHeaderFilter.cpp
+++ b/src/Common/HTTPHeaderFilter.cpp
@@ -21,7 +21,10 @@ void HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries & entries) con
 
     for (auto & entry : entries)
     {
-        if (entry.name.contains('\n') || entry.value.contains('\n'))
+        /// A bare CR or LF in a header name or value terminates the header line, so a header
+        /// carrying one could smuggle a second header into the request (request/response splitting).
+        if (entry.name.contains('\n') || entry.value.contains('\n')
+            || entry.name.contains('\r') || entry.value.contains('\r'))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "HTTP header \"{}\" has invalid character", entry.name);
         /// Strip whitespace and control characters from header name for validation
         std::string & normalized_name = entry.name;

--- a/src/Common/tests/gtest_http_header_filter.cpp
+++ b/src/Common/tests/gtest_http_header_filter.cpp
@@ -195,3 +195,25 @@ TEST(HTTPHeaderFilter, EmptyConfigForbidsNothing)
     HTTPHeaderFilter filter;
     EXPECT_FALSE(isForbidden(filter, "Authorization"));
 }
+
+/// A bare CR or LF in a header name or value terminates the header line, so it could smuggle an
+/// extra header into the request. Both must be rejected (not only LF), for names and values,
+/// independently of the http_forbid_headers blocklist.
+TEST(HTTPHeaderFilter, RejectsCarriageReturnAndNewline)
+{
+    HTTPHeaderFilter filter;
+
+    auto rejects = [&](const std::string & name, const std::string & value)
+    {
+        HTTPHeaderEntries entries{{name, value}};
+        try { filter.checkAndNormalizeHeaders(entries); }
+        catch (const Exception &) { return true; }
+        return false;
+    };
+
+    EXPECT_TRUE(rejects("Authorization", "Bearer token\rX-Injected: evil"));
+    EXPECT_TRUE(rejects("Authorization", "Bearer token\nX-Injected: evil"));
+    EXPECT_TRUE(rejects("Authorization", "Bearer token\r\nX-Injected: evil"));
+    EXPECT_TRUE(rejects("Bad\rName", "value"));
+    EXPECT_FALSE(rejects("Authorization", "Bearer good-token"));
+}


### PR DESCRIPTION
`HTTPHeaderFilter::checkAndNormalizeHeaders` rejected an embedded line feed (`\n`) in HTTP header names and values, but not a bare carriage return (`\r`). A lone `\r` also terminates a header line, so a value such as `token\rX-Injected: evil` could still smuggle a second header into an outgoing request (request/response splitting). This rejects `\r` alongside `\n`, for both header names and values, in the shared filter.

This covers the callers that route header names/values through `HTTPHeaderFilter` — the SQL-facing paths where headers are supplied per query: the `url` table function and engine, HTTP dictionaries, S3/Web configuration, and the DataLake/REST catalogs. Outbound HTTP clients that build headers without this filter (for example the AI providers and the BigQuery client, whose header values come from named collections, OAuth tokens, or DDL configuration) are not affected by this change; enforcing the same invariant at the shared HTTP send path for those clients is left to a separate follow-up.

Deferred from #110313 to keep that pull request focused on refactoring.

Related: https://github.com/ClickHouse/ClickHouse/pull/110313

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject a bare carriage return (`\r`), in addition to a line feed (`\n`), in HTTP header names and values that pass through the HTTP header filter. This closes an HTTP header injection (request/response splitting) gap for features that pass user-provided headers, such as the `url` table function and engine, HTTP dictionaries, and data lake catalogs.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1790` (included in `26.8` and later)
- Backported to: `26.7.7.44`, `26.6.5.28`, `26.3.33.23`
<!-- ch-version-info:end -->