### PR TITLE
Report an expected failure when the bugfix-validation before-binary cannot compile the overlaid tests

### DIFF
--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -8,9 +8,14 @@ does not contain the new tests.
 
 Instead, this job builds a "before" binary from the merge-base sources with ONLY the
 PR's unit-test file changes overlaid on top (the test, but not the fix), and then
-runs the touched test suites on it — at least one must FAIL or crash (or the "before"
-binary must fail to build, which is the strongest possible proof that the test depends
-on the fix).
+runs the touched test suites on it — at least one must FAIL or crash. When the
+"before" binary fails to compile and every compiler error lies inside the overlaid
+test files, the changed test code depends on the interface the fix introduces (the
+typical case is a call site adapted to a changed function signature); the unit side
+then has nothing it can judge at runtime, the PR author cannot avoid the adaptation,
+and the job reports the build failure as expected (XFAIL, nothing to validate)
+instead of staying red forever. Any other build failure is an infrastructure or
+attribution problem and stays an ERROR (inconclusive).
 
 Like the functional/integration validators, this job only checks the "before" side.
 The complementary "the touched tests PASS on the PR binary" side is delegated to the
@@ -452,6 +457,42 @@ def compile_before_binary():
     return compile_result
 
 
+# A clang/gcc diagnostic line: "path:line[:col]: [fatal] error: ...". Notes and
+# warnings deliberately do not match — only hard errors attribute the build failure.
+_COMPILE_ERROR_LINE_RE = re.compile(
+    r"^(?P<path>[^\s:]+):\d+(?::\d+)?:\s*(?:fatal\s+)?error:", re.MULTILINE
+)
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def attribute_compile_errors(compile_result, test_files):
+    """Split the before-build's compile-error paths into the PR's overlaid test files
+    vs everything else.
+
+    Returns `(overlaid, other)` — sorted lists of error-carrying paths, repo-relative
+    for paths under the before-worktree. Both empty means the ninja failure produced
+    no parsable compiler diagnostic (compiler killed, link failure, ninja internal
+    error) — not attributable either way, so the caller must fail close.
+    """
+    test_file_set = set(test_files)
+    marker = f"{BEFORE_SRC}/"
+    overlaid = set()
+    other = set()
+    for log in compile_result.files or []:
+        try:
+            with open(log, "r", errors="replace") as f:
+                content = _ANSI_ESCAPE_RE.sub("", f.read())
+        except OSError as e:
+            print(f"WARNING: could not read compile log {log}: {e}")
+            continue
+        for m in _COMPILE_ERROR_LINE_RE.finditer(content):
+            path = m.group("path")
+            idx = path.find(marker)
+            rel = path[idx + len(marker) :] if idx != -1 else path
+            (overlaid if rel in test_file_set else other).add(rel)
+    return sorted(overlaid), sorted(other)
+
+
 def run_gtests(binary_path, gtest_filter, name):
     # ASan+UBSan build: do not wrap with gdb (LSan is incompatible with the debugger),
     # and disable the uninstrumented FIPS provider to avoid sanitizer false positives.
@@ -664,26 +705,60 @@ def main():
         return
 
     # 4b. Compile. A compile failure is NOT accepted as a reproduction: it only proves
-    # the overlaid test references *some* code the PR adds (a new header, helper, or
-    # symbol — even in a no-op test), not that it depends on the bug fix or reproduces
-    # the old behavior at runtime. We cannot attribute the failure to the touched
-    # regression case, so report it as inconclusive (fail close) rather than a pass. A
-    # genuine regression test should build against the merge-base and fail at runtime.
+    # the overlaid test references *some* code the PR adds, not that it catches the bug
+    # at runtime. Attribute the failure instead:
+    #  * every compiler error inside the overlaid test files → the changed test code
+    #    depends on the fix's interface (typically a call site adapted to a changed
+    #    signature). The PR author cannot avoid that adaptation and the unit side has
+    #    nothing left to judge, so report the step as an expected failure (XFAIL) with
+    #    nothing to validate — NOT as a reproduction. When the PR also carries
+    #    functional/integration tests, new_tests_check.py still demands a real
+    #    validation from those jobs; for a unit-only PR the merge gate already treats
+    #    inconclusive as non-blocking, so this changes report truthfulness, not gating.
+    #  * any error elsewhere (fix sources, contrib, the linker, no parsable diagnostic)
+    #    → cannot be attributed to the touched test changes; fail close (ERROR).
     compile_result = compile_before_binary()
     if not compile_result.is_ok():
+        overlaid_errors, other_errors = attribute_compile_errors(
+            compile_result, test_files
+        )
+        if overlaid_errors and not other_errors:
+            compile_result.set_label(Result.Label.XFAIL)
+            compile_result.set_status(Result.Status.XFAIL)
+            compile_result.set_info(
+                "The before-binary cannot compile the overlaid unit-test changes: every "
+                "compile error is inside the PR's changed test files ("
+                + ", ".join(overlaid_errors)
+                + "). The changed test code depends on the interface this PR introduces "
+                "(e.g. a call site adapted to a changed signature), so there is nothing "
+                "the unit side can validate on the merge base. This is expected, not an "
+                "error — and it is not counted as a reproduction either. "
+                + (compile_result.info or "")
+            )
+            results.append(compile_result)
+            finalize(
+                results,
+                "Nothing to validate on the unit side: the changed unit-test files do "
+                "not compile against the merge base because they depend on the fix's "
+                "interface. Regression coverage is judged by the functional/integration "
+                "Bugfix validation jobs (enforced by new_tests_check.py when such tests "
+                "exist).",
+            )
+            return
         compile_result.set_status(Result.Status.ERROR)
         compile_result.set_info(
-            "The before-binary FAILED TO COMPILE the overlaid test. This does not prove "
-            "the test reproduces the bug — it only shows the test depends on code this PR "
-            "adds (a new header/helper/symbol would fail to compile here too). Write a "
-            "regression test that builds against the merge-base and fails at runtime "
-            "without the fix. " + (compile_result.info or "")
+            "The before-binary FAILED TO COMPILE, and the errors cannot be attributed "
+            "to the overlaid test files alone"
+            + (f" (errors outside them: {', '.join(other_errors)})" if other_errors else "")
+            + ". This does not prove the test reproduces the bug. Write a regression "
+            "test that builds against the merge-base and fails at runtime without the "
+            "fix. " + (compile_result.info or "")
         )
         results.append(compile_result)
         finalize(
             results,
-            "Bugfix validation inconclusive: the before-binary failed to COMPILE the "
-            "overlaid test, which cannot be attributed to the touched regression case.",
+            "Bugfix validation inconclusive: the before-binary failed to COMPILE and "
+            "the failure cannot be attributed to the touched regression case.",
         )
         return
     build_result = compile_result


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113422

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Description

`Bugfix validation (unit tests)` overlays a PR's changed `src/**/tests/*` files onto the merge base and builds `unit_tests_dbms` without the fix, expecting a touched gtest suite to fail at runtime. When the fix changes a function signature that an existing gtest calls, the adapted call site can never compile against the merge base, so the job reports a permanent ERROR that the PR author cannot avoid: adapting the call site is mandatory for the PR itself to build, and making it compile against both signatures would only turn the truthful "inconclusive" into an untruthful "failed to reproduce" (the bystander suite passes on the merge base).

Concrete case: [PR #113422](https://github.com/ClickHouse/ClickHouse/pull/113422) adapts one call in `gtest_distributed_query.cpp` (2 lines) to `createExchangeLookup`'s new `execute_locally` parameter. The before-binary fails with `error: no matching function for call to 'createExchangeLookup'` in the overlaid test file, and the check stays red even though the real regression coverage — the functional test `04746_distributed_plan_execute_locally_subquery_settings` — is validated green by `Bugfix validation (functional tests)` on both arches. This signature-adaptation shape occurred in 18 rows across 7 PRs over the last 30 days.

The change attributes the before-build's compile errors instead of failing close unconditionally:

- every compiler error lies inside the overlaid test files → the changed test code depends on the interface the fix introduces; the compile step is reported as an expected failure (`XFAIL`, job OK) with "nothing to validate on the unit side". It is deliberately **not** counted as a reproduction — nothing proves the touched suite catches the bug.
- any error elsewhere (fix sources, contrib, a link error, or no parsable diagnostic at all) → fail close with ERROR, as before.

The merge gate is unchanged: `new_tests_check.py` still requires a real per-arch validation from the functional/integration jobs when such tests exist, and it already treats an inconclusive unit result as non-blocking for unit-only PRs. Only the report status becomes truthful instead of permanently red.

The attribution helper was verified against the actual compile log of the failing run (error attributed to the overlaid file; linker-error-only, mixed-error, ANSI-colored and `fatal error:` cases fail close or attribute correctly).

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113422&sha=latest&name_0=PR&name_1=Bugfix%20validation%20%28unit%20tests%29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115511&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115511](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115511+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1730` (included in `26.8` and later)
<!-- ch-version-info:end -->