### PR TITLE
Keep the SeaweedFS mini admin gRPC port out of the ephemeral range

### DIFF
--- a/docs/guides/use-cases/data-warehousing/seaweedfs-catalog.mdx
+++ b/docs/guides/use-cases/data-warehousing/seaweedfs-catalog.mdx
@@ -65,7 +65,7 @@ For local development and testing, you can run SeaweedFS and ClickHouse with Doc
 services:
   seaweedfs:
     image: chrislusf/seaweedfs:latest
-    command: mini -dir=/data -s3.config=/etc/seaweedfs/s3config.json -tableBucket=analytics
+    command: mini -dir=/data -s3.config=/etc/seaweedfs/s3config.json -tableBucket=analytics -admin.port=12646
     ports:
       - "8333:8333"   # S3 endpoint
       - "8181:8181"   # Iceberg REST catalog
@@ -94,7 +94,7 @@ networks:
     driver: bridge
 ```
 
-The `mini` command starts the whole SeaweedFS stack in a single container. The `-tableBucket=analytics` flag pre-creates an S3 Tables bucket named `analytics`, which serves as the Iceberg warehouse.
+The `mini` command starts the whole SeaweedFS stack in a single container. The `-tableBucket=analytics` flag pre-creates an S3 Tables bucket named `analytics`, which serves as the Iceberg warehouse. `-admin.port=12646` keeps the admin gRPC port that SeaweedFS derives from it below the Linux ephemeral port range, where a startup connection could otherwise claim it first.
 
 **Step 3:** Run the following command to start the services:
 

--- a/docs/integrations/connectors/data-ingestion/s3-seaweedfs.mdx
+++ b/docs/integrations/connectors/data-ingestion/s3-seaweedfs.mdx
@@ -45,8 +45,10 @@ Then start the whole SeaweedFS stack in one container - the `-bucket` flag creat
 docker run -d --name seaweedfs -p 8333:8333 \
   -v "$(pwd)/s3config.json:/etc/seaweedfs/s3config.json" \
   chrislusf/seaweedfs:latest \
-  mini -dir=/data -s3.config=/etc/seaweedfs/s3config.json -bucket=clickhouse
+  mini -dir=/data -s3.config=/etc/seaweedfs/s3config.json -bucket=clickhouse -admin.port=12646
 ```
+
+`-admin.port=12646` keeps the admin gRPC port that SeaweedFS derives from it below the Linux ephemeral port range, where a startup connection could otherwise claim it first.
 
 The S3 endpoint listens on port 8333; wait for it to respond before continuing:
 

--- a/tests/integration/compose/docker_compose_iceberg_seaweedfs_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_seaweedfs_catalog.yml
@@ -17,7 +17,9 @@ services:
           ]
         }
         EOF
-        exec weed mini -dir=/data -s3 -s3.config=/etc/seaweedfs/s3.json -tableBucket=analytics
+        # admin.port + 10000 is the derived admin gRPC port; it must stay below the
+        # 32768 ephemeral floor, or an outbound dial can take it before admin binds it.
+        exec weed mini -dir=/data -s3 -s3.config=/etc/seaweedfs/s3.json -tableBucket=analytics -admin.port=12646
     ports:
       - "${ICEBERG_REST_CATALOG_PORT}:8181"
     healthcheck:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109368
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109368
Related: https://github.com/seaweedfs/seaweedfs/issues/10838


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_database_iceberg_seaweedfs_catalog` can fail in fixture setup with a `Connection refused` reading
as "the catalog never started"
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109368&sha=4443610796f2ef985ff5615a261456a7ea4155ea&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29),
tagged `retry_ok`). It did start: it answered 200 on all 314 polls; the refusal is the last poll,
after the container exited 255. Its log shows why.

```
E mini.go:1583 Admin server error: failed to listen on port 33646: bind: address already in use
F mini.go:1598 Admin server readiness check failed ... after 240 attempts
```

`weed mini` derives the admin gRPC port as `admin.port + 10000` = 33646, inside the Linux ephemeral
range (floor 32768), so one of mini's own startup dials can take it as a source port before admin
binds it. It is the only derived gRPC port above the floor; the other four land in 18333..19340.

The failure hides itself: `glog.Fatalf` skips `defer close(allServicesReady)`, and the call creating
`-tableBucket=analytics` runs only after `<-allServicesReady`. S3 and Iceberg keep answering 200
while `analytics` is never created, so `"analytics" in buckets` never becomes true and a longer wait
cannot help.

`-admin.port=12646` derives 22646: below the floor, and below the 22768 cap SeaweedFS derives for
this same problem in its own test port allocator (seaweedfs/seaweedfs#10209, which left the `mini`
default alone). That default is 23646 on 4.41, 4.42 and master, so an image bump does not help; it is
filed upstream. Raising `ip_local_port_range` via `sysctls`, as the Kafka composes do, would work too,
but for every dial mini makes.

It reaches users too: the SeaweedFS catalog guide and connector page both document `mini` on
`image: latest`, so the bucket each tells the reader to use never appears. Both are pinned here;
the guide's locale copies are left to the translation workflow.

Validated with `docker run --sysctl net.ipv4.ip_local_port_range="33646 33646"`: unpinned reproduces
the CI log verbatim, pinned creates the bucket, a default-range control is green.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115512&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115512](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115512+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1762` (included in `26.8` and later)
- Backported to: `26.7.7.71`, `26.6.5.102`
<!-- ch-version-info:end -->