### PR TITLE
Fix vacuous assertion in 04102_hash_join_stress_test step 14

### DIFF
--- a/tests/queries/0_stateless/04102_hash_join_stress_test.reference
+++ b/tests/queries/0_stateless/04102_hash_join_stress_test.reference
@@ -362,8 +362,10 @@ L5	5	R5b
 2	L2b	2	R2a
 2	L2b	2	R2b
 3	L3	3	R3a
---- ALL LEFT JOIN: many duplicates with max_rows_in_join ---
-5000
+--- ALL LEFT JOIN: many duplicates with max_joined_block_size_rows ---
+5000	Ok
+--- ALL LEFT JOIN: residual predicate with max_joined_block_size_rows ---
+5000	Ok
 --- INNER JOIN: string key ---
 banana	2	20
 cherry	3	30

--- a/tests/queries/0_stateless/04102_hash_join_stress_test.reference
+++ b/tests/queries/0_stateless/04102_hash_join_stress_test.reference
@@ -366,6 +366,8 @@ L5	5	R5b
 5000	Ok
 --- ALL LEFT JOIN: residual predicate with max_joined_block_size_rows ---
 5000	Ok
+--- ALL LEFT JOIN: residual predicate re-probes the left block ---
+Ok
 --- INNER JOIN: string key ---
 banana	2	20
 cherry	3	30

--- a/tests/queries/0_stateless/04102_hash_join_stress_test.sql
+++ b/tests/queries/0_stateless/04102_hash_join_stress_test.sql
@@ -425,16 +425,30 @@ SELECT l.id, l.val, r.id, r.val FROM t_left_dup l ALL FULL JOIN t_right_dup r ON
 
 
 -- ============================================================
--- 14. Verify max_joined_block_rows truncation path (need_replication + early break)
+-- 14. Verify max_joined_block_size_rows truncation: post-hoc split and early break
 -- ============================================================
 
-SELECT '--- ALL LEFT JOIN: many duplicates with max_rows_in_join ---';
-SELECT count() FROM (
-    SELECT l.id, r.val
+-- blockSize() observes truncation; count() is invariant to it. min_joined_block_size_rows/bytes = 0
+-- stops a downstream squash from re-merging the truncated blocks. SETTINGS is outside the subquery,
+-- where an unknown setting name raises UNKNOWN_SETTING instead of being discarded.
+
+SELECT '--- ALL LEFT JOIN: many duplicates with max_joined_block_size_rows ---';
+SELECT count(), if(max(bs) > 100, 'Error: ' || toString(max(bs)), 'Ok') FROM (
+    SELECT blockSize() AS bs, l.id, r.val
     FROM t_left_large l
     ALL LEFT JOIN t_right_large r ON l.id = r.id
-    SETTINGS max_joined_block_rows = 100
-);
+)
+SETTINGS max_joined_block_size_rows = 100, min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
+
+-- The residual predicate is always true on this fixture, so cardinality is unchanged;
+-- it routes the join through the additional-filter loop and its early break.
+SELECT '--- ALL LEFT JOIN: residual predicate with max_joined_block_size_rows ---';
+SELECT count(), if(max(bs) > 100, 'Error: ' || toString(max(bs)), 'Ok') FROM (
+    SELECT blockSize() AS bs, l.id, r.val
+    FROM t_left_large l
+    ALL LEFT JOIN t_right_large r ON l.id = r.id AND l.val < r.val
+)
+SETTINGS max_joined_block_size_rows = 100, min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
 
 
 -- ============================================================

--- a/tests/queries/0_stateless/04102_hash_join_stress_test.sql
+++ b/tests/queries/0_stateless/04102_hash_join_stress_test.sql
@@ -430,7 +430,7 @@ SELECT l.id, l.val, r.id, r.val FROM t_left_dup l ALL FULL JOIN t_right_dup r ON
 
 -- blockSize() observes truncation; count() is invariant to it. min_joined_block_size_rows/bytes = 0
 -- stops a downstream squash from re-merging the truncated blocks. SETTINGS is outside the subquery,
--- where an unknown setting name raises UNKNOWN_SETTING instead of being discarded.
+-- where an unknown setting name raises UNKNOWN_SETTING.
 
 SELECT '--- ALL LEFT JOIN: many duplicates with max_joined_block_size_rows ---';
 SELECT count(), if(max(bs) > 100, 'Error: ' || toString(max(bs)), 'Ok') FROM (
@@ -440,15 +440,35 @@ SELECT count(), if(max(bs) > 100, 'Error: ' || toString(max(bs)), 'Ok') FROM (
 )
 SETTINGS max_joined_block_size_rows = 100, min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
 
--- The residual predicate is always true on this fixture, so cardinality is unchanged;
--- it routes the join through the additional-filter loop and its early break.
+-- The residual predicate is always true on this fixture, so cardinality is unchanged; it routes the
+-- join through the additional-filter loop, which stops collecting candidates at
+-- max_joined_block_size_rows and re-probes the rest of the left block. Block sizes cannot observe
+-- that stop, since the post-hoc split caps them either way; the row counts asserted below can.
 SELECT '--- ALL LEFT JOIN: residual predicate with max_joined_block_size_rows ---';
 SELECT count(), if(max(bs) > 100, 'Error: ' || toString(max(bs)), 'Ok') FROM (
     SELECT blockSize() AS bs, l.id, r.val
     FROM t_left_large l
     ALL LEFT JOIN t_right_large r ON l.id = r.id AND l.val < r.val
 )
-SETTINGS max_joined_block_size_rows = 100, min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
+SETTINGS log_comment = '04102_residual_truncation',
+         max_joined_block_size_rows = 100, min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- Each side is read once per pass, so a join that reads no row twice accounts for exactly the 1500
+-- fixture rows, and re-probing pushes the total above that. Summing the two sides keeps this
+-- independent of which table the planner picks as the build side.
+SELECT '--- ALL LEFT JOIN: residual predicate re-probes the left block ---';
+SELECT if(build_rows + probe_rows > 1500, 'Ok', format('Error: build {} probe {}', build_rows, probe_rows))
+FROM (
+    SELECT ProfileEvents['JoinBuildTableRowCount'] AS build_rows,
+           ProfileEvents['JoinProbeTableRowCount'] AS probe_rows
+    FROM system.query_log
+    WHERE type = 'QueryFinish' AND event_date >= yesterday() AND current_database = currentDatabase()
+      AND log_comment = '04102_residual_truncation'
+    ORDER BY event_time_microseconds DESC
+    LIMIT 1
+);
 
 
 -- ============================================================

--- a/tests/queries/0_stateless/04102_hash_join_stress_test.sql
+++ b/tests/queries/0_stateless/04102_hash_join_stress_test.sql
@@ -450,14 +450,15 @@ SELECT count(), if(max(bs) > 100, 'Error: ' || toString(max(bs)), 'Ok') FROM (
     FROM t_left_large l
     ALL LEFT JOIN t_right_large r ON l.id = r.id AND l.val < r.val
 )
-SETTINGS log_comment = '04102_residual_truncation',
+SETTINGS log_comment = '04102_residual_truncation', enable_parallel_replicas = 0,
          max_joined_block_size_rows = 100, min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
 
 SYSTEM FLUSH LOGS query_log;
 
 -- Each side is read once per pass, so a join that reads no row twice accounts for exactly the 1500
 -- fixture rows, and re-probing pushes the total above that. Summing the two sides keeps this
--- independent of which table the planner picks as the build side.
+-- independent of which table the planner picks as the build side. The counters are local to the
+-- initiator, so both the join and this lookup have to run there.
 SELECT '--- ALL LEFT JOIN: residual predicate re-probes the left block ---';
 SELECT if(build_rows + probe_rows > 1500, 'Ok', format('Error: build {} probe {}', build_rows, probe_rows))
 FROM (
@@ -468,7 +469,8 @@ FROM (
       AND log_comment = '04102_residual_truncation'
     ORDER BY event_time_microseconds DESC
     LIMIT 1
-);
+)
+SETTINGS enable_parallel_replicas = 0;
 
 
 -- ============================================================


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Step 14 of `04102_hash_join_stress_test` pinned `max_joined_block_rows = 100`, a setting that
does not exist: the declared name is `max_joined_block_size_rows`. The clause sat inside a
subquery, where an unknown setting name is discarded silently, so the step never applied
truncation and stayed green because its assertion is inert. PR 115397, which tightens
nested-`SETTINGS` validation, turns that into a hard failure.

A rename alone leaves the step inert, so three things change:

- the setting name;
- the oracle. `count()` cannot observe truncation, which changes block geometry and not
  cardinality: 5000 rows either way. It is now `blockSize()`-based, the idiom of `02962` and
  `03633`, with `count()` kept; `min_joined_block_size_rows/bytes = 0` stops a squash from
  re-merging the truncated blocks;
- the `SETTINGS` placement, moved outside the subquery, where an unknown name raises
  `UNKNOWN_SETTING`.

Two arms: plain equality reaches the post-hoc block split, and a residual predicate routes
through `joinRightColumnsWithAdditionalFilter` and its early break (the predicate is always
true on this fixture, so cardinality is unchanged). Block sizes cannot observe that break,
since the post-hoc split caps every block either way, so a third assertion checks the join row
counters, where only a re-probed remainder is counted twice; the sides are summed because the
planner may swap them. Those counters are local to the initiator, so both statements pin
`enable_parallel_replicas = 0`. The multi-map disjunction break stays uncovered.

Each arm reddens when truncation is removed. With only the early break deleted, the counter
assertion reddens for every `query_plan_join_swap_table` value and every parallel-replica arm,
while the block-size one stays `Ok`. Runs pass with randomization on and off, six concurrent
copies, and 25 settings arms.

Report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115397&sha=3f9b9c92090140528a0eb86b3bb0e059efb8f842&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

No related open issue.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115513&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115513](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115513+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1737` (included in `26.8` and later)
<!-- ch-version-info:end -->