### PR TITLE
Fix SLRU cache admitting no new entries once max_count entries were used twice

### DIFF
--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -41,6 +41,7 @@ public:
         , max_size_in_bytes(max_size_in_bytes_)
         , max_protected_size(calculateMaxProtectedSize(max_size_in_bytes_, size_ratio_))
         , max_count(max_count_)
+        , max_protected_count(calculateMaxProtectedCount(max_count_, size_ratio_))
         , size_ratio(size_ratio_)
         , current_size_in_bytes_metric(size_in_bytes_metric_)
         , count_metric(count_metric_)
@@ -75,7 +76,9 @@ public:
 
     void setMaxCount(size_t max_count_) override
     {
+        max_protected_count = calculateMaxProtectedCount(max_count_, size_ratio);
         max_count = max_count_;
+
         removeOverflow(protected_queue, max_protected_size, current_protected_size, /*is_protected=*/true);
         removeOverflow(probationary_queue, max_size_in_bytes, current_size_in_bytes, /*is_protected=*/false);
     }
@@ -267,6 +270,7 @@ private:
     size_t max_size_in_bytes;
     size_t max_protected_size;
     size_t max_count;
+    size_t max_protected_count;
     const double size_ratio;
     size_t current_protected_size = 0;
     size_t current_size_in_bytes = 0;
@@ -280,6 +284,15 @@ private:
     static size_t calculateMaxProtectedSize(size_t max_size_in_bytes, double size_ratio)
     {
         return static_cast<size_t>(static_cast<double>(max_size_in_bytes) * std::max(0.0, std::min(1.0, size_ratio)));
+    }
+
+    /// The protected queue never occupies the whole cache: at least one slot always stays available for the probationary queue.
+    static size_t calculateMaxProtectedCount(size_t max_count, double size_ratio)
+    {
+        if (max_count == 0)
+            return 0;
+        const size_t protected_count = static_cast<size_t>(static_cast<double>(max_count) * std::max(0.0, std::min(1.0, size_ratio)));
+        return std::min(protected_count, max_count - 1);
     }
 
     void removeOverflow(SLRUQueue & queue, size_t max_weight_size, size_t & current_weight_size, bool is_protected)
@@ -299,7 +312,7 @@ private:
             /// because protected elements move to probationary part and still remain in cache.
             need_remove = [&]()
             {
-                return ((max_count != 0 && cells.size() - probationary_queue.size() > max_count)
+                return ((max_count != 0 && cells.size() - probationary_queue.size() > max_protected_count)
                 || (current_weight_size > max_weight_size)) && (queue_size > 0);
             };
         }

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -39,9 +39,9 @@ public:
         OnRemoveEntryFunction on_remove_entry_function_)
         : Base(std::make_unique<NoCachePolicyUserQuota>())
         , max_size_in_bytes(max_size_in_bytes_)
-        , max_protected_size(calculateMaxProtectedSize(max_size_in_bytes_, size_ratio_))
+        , max_protected_size(calculateMaxProtectedValue(max_size_in_bytes_, size_ratio_))
         , max_count(max_count_)
-        , max_protected_count(calculateMaxProtectedCount(max_count_, size_ratio_))
+        , max_protected_count(calculateMaxProtectedValue(max_count_, size_ratio_))
         , size_ratio(size_ratio_)
         , current_size_in_bytes_metric(size_in_bytes_metric_)
         , count_metric(count_metric_)
@@ -76,7 +76,7 @@ public:
 
     void setMaxCount(size_t max_count_) override
     {
-        max_protected_count = calculateMaxProtectedCount(max_count_, size_ratio);
+        max_protected_count = calculateMaxProtectedValue(max_count_, size_ratio);
         max_count = max_count_;
 
         removeOverflow(protected_queue, max_protected_size, current_protected_size, /*is_protected=*/true);
@@ -85,7 +85,7 @@ public:
 
     void setMaxSizeInBytes(size_t max_size_in_bytes_) override
     {
-        max_protected_size = calculateMaxProtectedSize(max_size_in_bytes_, size_ratio);
+        max_protected_size = calculateMaxProtectedValue(max_size_in_bytes_, size_ratio);
         max_size_in_bytes = max_size_in_bytes_;
 
         removeOverflow(protected_queue, max_protected_size, current_protected_size, /*is_protected=*/true);
@@ -281,22 +281,15 @@ private:
     WeightFunction weight_function;
     OnRemoveEntryFunction on_remove_entry_function;
 
-    static size_t calculateMaxProtectedSize(size_t max_size_in_bytes, double size_ratio)
+    /// Applies size_ratio to a cache limit, in bytes or in entries.
+    /// static_cast<double>(std::numeric_limits<size_t>::max()) rounds up to 2^64, which is not representable
+    /// in size_t, so the product is compared against the limit before it is converted back.
+    static size_t calculateMaxProtectedValue(size_t max_value, double size_ratio)
     {
-        return static_cast<size_t>(static_cast<double>(max_size_in_bytes) * std::max(0.0, std::min(1.0, size_ratio)));
-    }
-
-    /// The protected queue never occupies the whole cache: at least one slot always stays available for the probationary queue.
-    static size_t calculateMaxProtectedCount(size_t max_count, double size_ratio)
-    {
-        if (max_count == 0)
-            return 0;
-
-        const size_t max_protected_count = max_count - 1;
-        const double protected_count = static_cast<double>(max_count) * std::max(0.0, std::min(1.0, size_ratio));
-        if (protected_count >= static_cast<double>(max_protected_count))
-            return max_protected_count;
-        return static_cast<size_t>(protected_count);
+        const double max_protected_value = static_cast<double>(max_value) * std::max(0.0, std::min(1.0, size_ratio));
+        if (max_protected_value >= static_cast<double>(max_value))
+            return max_value;
+        return static_cast<size_t>(max_protected_value);
     }
 
     void removeOverflow(SLRUQueue & queue, size_t max_weight_size, size_t & current_weight_size, bool is_protected)

--- a/src/Common/SLRUCachePolicy.h
+++ b/src/Common/SLRUCachePolicy.h
@@ -291,8 +291,12 @@ private:
     {
         if (max_count == 0)
             return 0;
-        const size_t protected_count = static_cast<size_t>(static_cast<double>(max_count) * std::max(0.0, std::min(1.0, size_ratio)));
-        return std::min(protected_count, max_count - 1);
+
+        const size_t max_protected_count = max_count - 1;
+        const double protected_count = static_cast<double>(max_count) * std::max(0.0, std::min(1.0, size_ratio));
+        if (protected_count >= static_cast<double>(max_protected_count))
+            return max_protected_count;
+        return static_cast<size_t>(protected_count);
     }
 
     void removeOverflow(SLRUQueue & queue, size_t max_weight_size, size_t & current_weight_size, bool is_protected)

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -248,20 +248,45 @@ TEST(SLRUCache, MaxCountDoesNotStarveProbationary)
     size_t x = 5;
     auto load_func = [&] { return std::make_shared<size_t>(x); };
 
-    SimpleCacheBase slru_cache("SLRU", CurrentMetrics::end(), CurrentMetrics::end(),
-                               /*max_size_in_bytes=*/1'000'000'000,
-                               /*max_count=*/4,
-                               /*size_ratio*/0.5);
+    /// Large enough that the byte limbs never bind, so only the count limbs are exercised.
+    static constexpr size_t max_size_in_bytes = 1'000'000'000;
 
-    /// A second access promotes an entry into the protected queue.
-    for (int i = 0; i < 4; ++i)
+    for (double size_ratio : {0.0, 0.5, 1.0})
     {
-        slru_cache.getOrSet(i, load_func);
-        slru_cache.getOrSet(i, load_func);
+        for (size_t max_count = 1; max_count <= 8; max_count *= 2)
+        {
+            SimpleCacheBase slru_cache("SLRU", CurrentMetrics::end(), CurrentMetrics::end(),
+                                       max_size_in_bytes, max_count, size_ratio);
+
+            /// A second access promotes an entry into the protected queue.
+            for (size_t i = 0; i < max_count; ++i)
+            {
+                slru_cache.getOrSet(static_cast<int>(i), load_func);
+                slru_cache.getOrSet(static_cast<int>(i), load_func);
+            }
+
+            slru_cache.getOrSet(100, load_func);
+            EXPECT_NE(slru_cache.get(100), nullptr)
+                << "max_count = " << max_count << ", size_ratio = " << size_ratio;
+        }
     }
 
-    slru_cache.getOrSet(100, load_func);
-    ASSERT_NE(slru_cache.get(100), nullptr);
+    /// setMaxCount is the second entry point into the protected bound: on shrink it walks the
+    /// protected queue down to the new limit.
+    {
+        SimpleCacheBase slru_cache("SLRU", CurrentMetrics::end(), CurrentMetrics::end(),
+                                   max_size_in_bytes, /*max_count=*/8, /*size_ratio*/0.5);
+        for (size_t i = 0; i < 8; ++i)
+        {
+            slru_cache.getOrSet(static_cast<int>(i), load_func);
+            slru_cache.getOrSet(static_cast<int>(i), load_func);
+        }
+
+        slru_cache.setMaxCount(4);
+
+        slru_cache.getOrSet(100, load_func);
+        EXPECT_NE(slru_cache.get(100), nullptr) << "after setMaxCount(4)";
+    }
 }
 
 TEST(SLRUCache, noOnRemoveEntryCallback)

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -252,7 +252,9 @@ TEST(SLRUCache, MaxCountDoesNotStarveProbationary)
     /// Large enough that the byte limbs never bind, so only the count limbs are exercised.
     static constexpr size_t max_size_in_bytes = 1'000'000'000;
 
-    for (double size_ratio : {0.0, 0.5, 1.0})
+    /// A ratio of 1.0 hands the whole cache to the protected queue, so nothing can stay
+    /// probationary. That is a misconfiguration rather than a case to protect against.
+    for (double size_ratio : {0.0, 0.25, 0.5})
     {
         for (size_t max_count = 1; max_count <= 8; max_count *= 2)
         {
@@ -337,9 +339,9 @@ TEST(SLRUCache, MaxCountProtectedBoundHonoursSizeRatio)
     EXPECT_EQ(count_scan_survivors(8, 0.25), 2u);
     EXPECT_EQ(count_scan_survivors(4, 0.25), 1u);
 
-    /// A ratio of 1.0 is clamped to max_count - 1, not to max_count.
-    EXPECT_EQ(count_scan_survivors(4, 1.0), 3u);
-    EXPECT_EQ(count_scan_survivors(8, 1.0), 7u);
+    /// A ratio of 1.0 protects the whole cache, so a scan evicts nothing.
+    EXPECT_EQ(count_scan_survivors(4, 1.0), 4u);
+    EXPECT_EQ(count_scan_survivors(8, 1.0), 8u);
 }
 
 TEST(SLRUCache, noOnRemoveEntryCallback)

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -241,6 +241,29 @@ TEST(SLRUCache, MaxCount)
     }
 }
 
+TEST(SLRUCache, MaxCountDoesNotStarveProbationary)
+{
+    using SimpleCacheBase = DB::CacheBase<int, size_t, std::hash<int>, ValueWeight>;
+
+    size_t x = 5;
+    auto load_func = [&] { return std::make_shared<size_t>(x); };
+
+    SimpleCacheBase slru_cache("SLRU", CurrentMetrics::end(), CurrentMetrics::end(),
+                               /*max_size_in_bytes=*/1'000'000'000,
+                               /*max_count=*/4,
+                               /*size_ratio*/0.5);
+
+    /// A second access promotes an entry into the protected queue.
+    for (int i = 0; i < 4; ++i)
+    {
+        slru_cache.getOrSet(i, load_func);
+        slru_cache.getOrSet(i, load_func);
+    }
+
+    slru_cache.getOrSet(100, load_func);
+    ASSERT_NE(slru_cache.get(100), nullptr);
+}
+
 TEST(SLRUCache, noOnRemoveEntryCallback)
 {
     DB::SLRUCachePolicy<std::string, size_t> slru_cache = {CurrentMetrics::end(), CurrentMetrics::end(), 20, 1, 0.5, {}};

--- a/src/Common/tests/gtest_slru_cache.cpp
+++ b/src/Common/tests/gtest_slru_cache.cpp
@@ -1,4 +1,5 @@
 #include <iomanip>
+#include <limits>
 #include <gtest/gtest.h>
 #include <Common/CacheBase.h>
 #include <Common/CurrentMetrics.h>
@@ -287,6 +288,58 @@ TEST(SLRUCache, MaxCountDoesNotStarveProbationary)
         slru_cache.getOrSet(100, load_func);
         EXPECT_NE(slru_cache.get(100), nullptr) << "after setMaxCount(4)";
     }
+
+    /// max_entries is an unclamped server setting, so the protected bound must stay computable at
+    /// the extremes of size_t.
+    for (size_t max_count : {std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max() - 1024})
+    {
+        SimpleCacheBase slru_cache("SLRU", CurrentMetrics::end(), CurrentMetrics::end(),
+                                   max_size_in_bytes, max_count, /*size_ratio*/1.0);
+        slru_cache.getOrSet(7, load_func);
+        EXPECT_NE(slru_cache.get(7), nullptr) << "max_count = " << max_count;
+    }
+}
+
+TEST(SLRUCache, MaxCountProtectedBoundHonoursSizeRatio)
+{
+    using SimpleCacheBase = DB::CacheBase<int, size_t, std::hash<int>, ValueWeight>;
+
+    size_t x = 5;
+    auto load_func = [&] { return std::make_shared<size_t>(x); };
+
+    static constexpr size_t max_size_in_bytes = 1'000'000'000;
+
+    /// The protected bound is size_ratio * max_count, and exactly that many promoted entries
+    /// survive a scan of fresh single-use keys. contains() is used to count them because get()
+    /// would promote and reorder, changing the set being measured.
+    auto count_scan_survivors = [&](size_t max_count, double size_ratio)
+    {
+        SimpleCacheBase slru_cache("SLRU", CurrentMetrics::end(), CurrentMetrics::end(),
+                                   max_size_in_bytes, max_count, size_ratio);
+
+        for (size_t i = 0; i < max_count; ++i)
+        {
+            slru_cache.getOrSet(static_cast<int>(i), load_func);
+            slru_cache.getOrSet(static_cast<int>(i), load_func);
+        }
+
+        for (size_t j = 0; j < 2 * max_count; ++j)
+            slru_cache.getOrSet(static_cast<int>(1000 + j), load_func);
+
+        size_t survivors = 0;
+        for (size_t i = 0; i < max_count; ++i)
+            survivors += slru_cache.contains(static_cast<int>(i)) ? 1 : 0;
+        return survivors;
+    };
+
+    EXPECT_EQ(count_scan_survivors(4, 0.5), 2u);
+    EXPECT_EQ(count_scan_survivors(8, 0.5), 4u);
+    EXPECT_EQ(count_scan_survivors(8, 0.25), 2u);
+    EXPECT_EQ(count_scan_survivors(4, 0.25), 1u);
+
+    /// A ratio of 1.0 is clamped to max_count - 1, not to max_count.
+    EXPECT_EQ(count_scan_survivors(4, 1.0), 3u);
+    EXPECT_EQ(count_scan_survivors(8, 1.0), 7u);
 }
 
 TEST(SLRUCache, noOnRemoveEntryCallback)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed caches configured by a maximum number of entries (`SLRU` policy) silently stopping to admit new entries once that many entries had been accessed at least twice. Affected caches include the Iceberg and Paimon metadata file caches, the Parquet metadata cache, the text index caches, the vector similarity index cache, the compiled expression cache and the ObjectStorageQueue file status cache.


### Description

Found by reading `SLRUCachePolicy`'s eviction arithmetic; there is no public issue for it. The case
below rests only on the source and on the added test, which fails on unpatched master.

`SLRUCachePolicy` bounds its protected queue by bytes (`max_protected_size`) but has no count
equivalent, so the protected arm of `removeOverflow` compares the protected queue's size against
`max_count`, the *total* entry limit. The probationary arm runs last on every `set()` and already
enforces `cells.size() <= max_count`, which makes that comparison unsatisfiable: the protected queue
is never shrunk under count pressure.

Once `max_count` entries have each been accessed twice (a second `set`, or any `get`, promotes an
entry), the protected queue holds all of them. The next insertion overflows, and the only eviction
candidate in the probationary queue is the entry just inserted. Lowering `max_entries` at runtime
reaches the same state at once, because `setMaxCount` demotes the protected queue to exactly
`max_count` entries.

The fix bounds protected count the way protected bytes already is:
`max_protected_count = min(trunc(max_count * size_ratio), max_count - 1)`, so the probationary queue
always keeps one slot, and recomputes it in `setMaxCount`. `SLRUFileCachePriority` ratio-splits both
`max_size_` and `max_elements_` the same way. `cells.size() <= max_count` is unchanged, so
`max_entries` keeps its meaning and no setting is added.

Eviction behaviour does change for the affected caches: a protected entry can now be demoted to
probationary under count pressure, where previously only byte pressure could. That is what makes
these caches admit new entries at all. Splitting the count bound by `size_ratio` mirrors the byte
side rather than following from a measurement.

The existing suite exercised the count limit only with distinct keys, where entries stay
probationary and the protected queue stays empty, so the defect was unreachable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115517&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115517](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115517+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1771` (included in `26.8` and later)
<!-- ch-version-info:end -->