### PR TITLE
docs: link ClickStack isolation guide from onboarding

### DIFF
--- a/docs/clickstack/getting-started/managed.mdx
+++ b/docs/clickstack/getting-started/managed.mdx
@@ -17,7 +17,7 @@ ClickHouse Cloud operates the ClickHouse backend while you retain control over t
 
 - Automatic scaling of compute, independent of storage
 - Low-cost and effectively unlimited retention based on object storage
-- Independent isolation of read and write workloads with [warehouses](/products/cloud/features/infrastructure/warehouses)
+- Independent isolation of read and write workloads with [isolated read/write workloads](/clickstack/managing/isolating-read-write)
 - Integrated authentication
 - Automated backups
 - Security and compliance features


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A

## Summary

Link the ClickStack isolation guide from the Managed ClickStack onboarding getting-started benefits list, replacing the generic warehouses link with a direct path to the isolating-read-write guide.

Closes #114851.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115520&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115520](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115520+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
