### PR TITLE
Widen the Keeper request-size TSan suppression to the whole `bytesSize` subtree

### DIFF
--- a/base/base/sanitizer_options.h
+++ b/base/base/sanitizer_options.h
@@ -70,12 +70,21 @@ const char * __tsan_default_suppressions()
     /// name would also match this header's file name and the unrelated asynchronous logging queue.
     /// Keep them narrow: a `race:` entry also hides heap-use-after-free reports through the frame
     /// it names.
-    /// The same handoff orders the request: its vptr is written only by the constructor, and the
-    /// payload fields `bytesSize` reads are never assigned after publication. `race_top` matches
-    /// the innermost frame only; the request's other virtual calls are not listed.
+    /// The same handoff orders the request, so reports on the request the dispatch thread just
+    /// popped are not real races either: `KeeperTCPHandler::receiveRequest` writes every payload
+    /// field before publishing the request with `putRequest`, and `getRequestBytesCost` only reads
+    /// the vptr and those fields.
+    ///
+    /// Its entry has to be `race:` rather than `race_top:`. `race_top:` matches the innermost frame
+    /// only, so it covered the vptr read, which is attributed to the call site inside
+    /// `getRequestBytesCost` - and suppressing that just moved the report one frame down, to the
+    /// `path` read inside `bytesSize`, which aborted the Keeper container all the same. `race:`
+    /// matches any frame, so it covers the whole callee subtree. That subtree is only
+    /// `bytesSize`, a read-only size computation, and a use-after-free blinded there still
+    /// surfaces on the next access to the same request in `dispatchThread`.
     return "race:^NonblockingBoundedQueue<DB::KeeperRequestForSession>::tryPush\n"
            "race:^NonblockingBoundedQueue<DB::KeeperResponseForSession>::tryPush\n"
-           "race_top:^DB::getRequestBytesCost\n";
+           "race:^DB::getRequestBytesCost\n";
 }
 #endif
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113552
Related: https://github.com/ClickHouse/ClickHouse/pull/112695

On `amd_tsan` integration shards the Keeper container occasionally writes a ThreadSanitizer report for the request the dispatch thread just popped, which aborts the container. `helpers/cluster.py` then raises `Sanitizer assert found for instance zooN` during `cluster.shutdown()`, and whichever test happened to run last goes red - the victim is incidental. This time it was `test_database_replicated_settings/test.py::test_database_replicated_with_internal_replication[1-1]`:

```
WARNING: ThreadSanitizer: data race (pid=1)
  Read of size 1 ... by thread T32:
    #0 std::__1::basic_string<...>::__is_long() const
    #2 Coordination::GetRequest::bytesSize() const           src/Common/ZooKeeper/IKeeper.h:532
    #4 DB::getRequestBytesCost(...)                          src/Coordination/KeeperRequestDispatcher.cpp:94
    #5 DB::KeeperRequestDispatcher::tryPopRequest(...)       src/Coordination/KeeperRequestDispatcher.cpp:434
  Previous write of size 8 ... by thread T5:
    #3 Coordination::GetRequest::GetRequest()                src/Common/ZooKeeper/IKeeper.h:525
    #18 Coordination::ZooKeeperRequestFactory::get(...)      src/Common/ZooKeeper/ZooKeeperCommon.cpp:1786
    #19 DB::KeeperTCPHandler::receiveRequest()               src/Server/KeeperTCPHandler.cpp:787
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=dddf61ccff5828bb6937cfe680874a04be35932f&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29

There is no real race. `KeeperTCPHandler::receiveRequest` writes every payload field of the request - `xid`, then `readImpl`, then the tracing context - before publishing it with `putRequest`; the only post-publication write is on the consumer's own side. `getRequestBytesCost` reads the vptr and those fields.

#113552 added the entry for this report as `race_top:^DB::getRequestBytesCost`. `race_top:` matches the innermost frame only, so it covered the vptr read, which ThreadSanitizer attributes to the call site inside `getRequestBytesCost`. Suppressing that does not stop the run: the very next racy access is the `path` read inside `Coordination::GetRequest::bytesSize`, one frame below, and it aborts the container all the same. That is the report above. So this switches the entry to `race:`, which matches any frame and therefore covers the whole callee subtree. The subtree is only `bytesSize`, a read-only size computation, and a use-after-free blinded there still surfaces on the next access to the same request in `dispatchThread`.

### Validation

Against the real ThreadSanitizer runtime, with a harness whose handoff is deliberately unsynchronized so a report is produced on every run and the only variable is which patterns match the frame shape. Arms differ only in the string returned by `__tsan_default_suppressions`. `banner` counts runs printing the `==================` line, which is exactly what the integration harness greps to raise the assert.

| suppression string | vptr shape (#113552) | `bytesSize` shape (this report) |
|---|---|---|
| (empty) | 8/10 | 10/10 |
| `race_top:^DB::getRequestBytesCost` | 8/10 | 9/10 |
| `race:^DB::getRequestBytesCost` | **0/20** | **0/20** |

In the `race_top:` / vptr-shape cell the surviving report is exactly the one master hit: `race_top:` suppresses the vptr read, the run continues, and the `path.size()` read inside `bytesSize` is reported instead.

Controls: a typo'd pattern (`race:^DB::getRequestBytesCostXX`) parses but suppresses nothing (10/10 banner), so the entry's liveness is not assumed; a mangled type token (`raceX:`) makes the runtime die with `failed to parse suppressions`, confirming this hook is the live channel; `print_suppressions=1` shows the new entry being hit. `ci/jobs/scripts/check_style/check_cpp.sh` passes. Non-TSan builds are unaffected - the hook is inside `#ifdef THREAD_SANITIZER`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115524&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115524](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115524+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
