### PR TITLE
Support PromQL count_values

### DIFF
--- a/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
+++ b/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
@@ -1,0 +1,141 @@
+#include <Functions/FunctionFactory.h>
+
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionHelpers.h>
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <system_error>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_PRINT_FLOAT_OR_DOUBLE_NUMBER;
+    extern const int ILLEGAL_COLUMN;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace
+{
+    String formatPrometheusFloat(Float64 value)
+    {
+        if (std::isnan(value))
+            return "NaN";
+        if (std::isinf(value))
+            return (value > 0) ? "+Inf" : "-Inf";
+
+        std::array<char, 2048> buffer;
+        auto [ptr, ec] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::fixed);
+        if (ec != std::errc{})
+            throw Exception(ErrorCodes::CANNOT_PRINT_FLOAT_OR_DOUBLE_NUMBER, "Cannot print float or double number");
+
+        return {buffer.data(), ptr};
+    }
+
+    template <typename T>
+    bool executeNumber(const IColumn & column, ColumnString & result)
+    {
+        const auto * numbers = checkAndGetColumn<ColumnVector<T>>(&column);
+        if (!numbers)
+            return false;
+
+        for (const auto value : numbers->getData())
+        {
+            String formatted = formatPrometheusFloat(static_cast<Float64>(value));
+            result.insertData(formatted.data(), formatted.size());
+        }
+        return true;
+    }
+}
+
+/// Function timeSeriesPrometheusFormatFloat(value) formats a floating-point value the way Prometheus count_values() formats labels.
+class FunctionTimeSeriesPrometheusFormatFloat : public IFunction
+{
+public:
+    static constexpr auto name = "timeSeriesPrometheusFormatFloat";
+
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionTimeSeriesPrometheusFormatFloat>(); }
+
+    String getName() const override { return name; }
+
+    size_t getNumberOfArguments() const override { return 1; }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        checkArgumentTypes(arguments);
+        return std::make_shared<DataTypeString>();
+    }
+
+    static void checkArgumentTypes(const ColumnsWithTypeAndName & arguments)
+    {
+        if (arguments.size() != 1)
+        {
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Function {} must be called with one argument: {}(value)",
+                name,
+                name);
+        }
+
+        if (!isFloat(arguments[0].type))
+        {
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Argument of function {} must be a floating-point number (passed: {})",
+                name,
+                arguments[0].type->getName());
+        }
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /* result_type */, size_t input_rows_count) const override
+    {
+        auto column = arguments[0].column->convertToFullColumnIfConst();
+
+        auto result = ColumnString::create();
+        result->reserve(input_rows_count);
+
+        if (executeNumber<Float64>(*column, *result) || executeNumber<Float32>(*column, *result))
+            return result;
+
+        throw Exception(
+            ErrorCodes::ILLEGAL_COLUMN,
+            "Illegal column {} of argument of function {}, it must be Float32 or Float64",
+            column->getName(),
+            getName());
+    }
+};
+
+REGISTER_FUNCTION(TimeSeriesPrometheusFormatFloat)
+{
+    FunctionDocumentation::Description description = R"(
+Formats a floating-point value using Prometheus label formatting for `count_values()`.
+    )";
+    FunctionDocumentation::Syntax syntax = "timeSeriesPrometheusFormatFloat(value)";
+    FunctionDocumentation::Arguments arguments = {
+        {"value", "A floating-point value.", {"Float32", "Float64"}},
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns the Prometheus label representation of the value.", {"String"}};
+    FunctionDocumentation::Examples examples = {
+        {
+            "Example",
+            "SELECT timeSeriesPrometheusFormatFloat(toFloat64(0.0000001)), timeSeriesPrometheusFormatFloat(toFloat64('inf'))",
+            "0.0000001\t+Inf",
+        },
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 1};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::TimeSeries;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionTimeSeriesPrometheusFormatFloat>(documentation);
+}
+
+}

--- a/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
+++ b/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
@@ -31,7 +31,7 @@ namespace
         if (std::isinf(value))
             return (value > 0) ? "+Inf" : "-Inf";
 
-        std::array<char, 2048> buffer;
+        std::array<char, 2048> buffer{};
         auto [ptr, ec] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::fixed);
         if (ec != std::errc{})
             throw Exception(ErrorCodes::CANNOT_PRINT_FLOAT_OR_DOUBLE_NUMBER, "Cannot print float or double number");

--- a/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
+++ b/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
@@ -3,7 +3,7 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeString.h>
-#include <DataTypes/WhichDataType.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionHelpers.h>
 #include <IO/DoubleConverter.h>
 

--- a/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
+++ b/src/Functions/TimeSeries/timeSeriesPrometheusFormatFloat.cpp
@@ -3,12 +3,14 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/WhichDataType.h>
 #include <Functions/FunctionHelpers.h>
+#include <IO/DoubleConverter.h>
+
+#include <algorithm>
 #include <array>
-#include <charconv>
 #include <cmath>
-#include <system_error>
+#include <cstring>
 
 
 namespace DB
@@ -16,7 +18,6 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int CANNOT_PRINT_FLOAT_OR_DOUBLE_NUMBER;
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
@@ -24,19 +25,69 @@ namespace ErrorCodes
 
 namespace
 {
-    String formatPrometheusFloat(Float64 value)
+    /// A fixed representation of any Float64 needs at most 327 bytes:
+    /// "-0.", 323 leading zeroes, and the shortest significant digits.
+    constexpr size_t max_formatted_size = 512;
+
+    size_t formatPrometheusFloat(Float64 value, char * output)
     {
         if (std::isnan(value))
-            return "NaN";
+        {
+            std::memcpy(output, "NaN", 3);
+            return 3;
+        }
+
         if (std::isinf(value))
-            return (value > 0) ? "+Inf" : "-Inf";
+        {
+            if (std::signbit(value))
+            {
+                std::memcpy(output, "-Inf", 4);
+                return 4;
+            }
 
-        std::array<char, 2048> buffer{};
-        auto [ptr, ec] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value, std::chars_format::fixed);
-        if (ec != std::errc{})
-            throw Exception(ErrorCodes::CANNOT_PRINT_FLOAT_OR_DOUBLE_NUMBER, "Cannot print float or double number");
+            std::memcpy(output, "+Inf", 4);
+            return 4;
+        }
 
-        return {buffer.data(), ptr};
+        using Converter = double_conversion::DoubleToStringConverter;
+        std::array<char, Converter::kBase10MaximalLength + 1> digits{};
+        bool negative = false;
+        int digits_length = 0;
+        int decimal_point = 0;
+        Converter::DoubleToAscii(
+            value, Converter::SHORTEST, 0, digits.data(), static_cast<int>(digits.size()), &negative, &digits_length, &decimal_point);
+
+        size_t output_length = 0;
+        if (negative)
+            output[output_length++] = '-';
+
+        if (decimal_point <= 0)
+        {
+            output[output_length++] = '0';
+            output[output_length++] = '.';
+            std::fill_n(output + output_length, static_cast<size_t>(-decimal_point), '0');
+            output_length += static_cast<size_t>(-decimal_point);
+            std::memcpy(output + output_length, digits.data(), static_cast<size_t>(digits_length));
+            output_length += static_cast<size_t>(digits_length);
+        }
+        else if (decimal_point >= digits_length)
+        {
+            std::memcpy(output + output_length, digits.data(), static_cast<size_t>(digits_length));
+            output_length += static_cast<size_t>(digits_length);
+            std::fill_n(output + output_length, static_cast<size_t>(decimal_point - digits_length), '0');
+            output_length += static_cast<size_t>(decimal_point - digits_length);
+        }
+        else
+        {
+            std::memcpy(output + output_length, digits.data(), static_cast<size_t>(decimal_point));
+            output_length += static_cast<size_t>(decimal_point);
+            output[output_length++] = '.';
+            std::memcpy(output + output_length, digits.data() + decimal_point, static_cast<size_t>(digits_length - decimal_point));
+            output_length += static_cast<size_t>(digits_length - decimal_point);
+        }
+
+        chassert(output_length <= max_formatted_size);
+        return output_length;
     }
 
     template <typename T>
@@ -46,10 +97,11 @@ namespace
         if (!numbers)
             return false;
 
+        std::array<char, max_formatted_size> formatted{};
         for (const auto value : numbers->getData())
         {
-            String formatted = formatPrometheusFloat(static_cast<Float64>(value));
-            result.insertData(formatted.data(), formatted.size());
+            const size_t length = formatPrometheusFloat(static_cast<Float64>(value), formatted.data());
+            result.insertData(formatted.data(), length);
         }
         return true;
     }
@@ -86,11 +138,12 @@ public:
                 name);
         }
 
-        if (!isFloat(arguments[0].type))
+        const WhichDataType which(arguments[0].type);
+        if (!which.isFloat32() && !which.isFloat64())
         {
             throw Exception(
                 ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                "Argument of function {} must be a floating-point number (passed: {})",
+                "Argument #1 of function {} has wrong type {}, expected Float32 or Float64",
                 name,
                 arguments[0].type->getName());
         }
@@ -131,7 +184,7 @@ Formats a floating-point value using Prometheus label formatting for `count_valu
             "0.0000001\t+Inf",
         },
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {26, 1};
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 8};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::TimeSeries;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperator.cpp
@@ -4,6 +4,7 @@
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applyLimitAggregationOperator.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.h>
 
 
 namespace DB::ErrorCodes
@@ -28,6 +29,9 @@ SQLQueryPiece applyAggregationOperator(
 
     if (isLimitAggregationOperator(operator_name))
         return applyLimitAggregationOperator(operator_node, std::move(arguments), context);
+
+    if (isAggregationOperatorCountValues(operator_name))
+        return applyAggregationOperatorCountValues(operator_node, std::move(arguments), context);
 
     throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
                     "Aggregation operator '{}' is not implemented", operator_name);

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
@@ -30,6 +30,7 @@ namespace
     constexpr const char * point_index_column = "point_index";
     constexpr const char * value_label_column = "value_label";
     constexpr const char * counts_column = "counts";
+    constexpr const char * count_pairs_column = "count_pairs";
 
 bool isValidPrometheusLabelName(std::string_view label_name)
 {
@@ -181,11 +182,13 @@ SQLQueryPiece applyAggregationOperatorCountValues(
     auto & label_arg = arguments[0];
     auto & vector_arg = arguments[1];
 
-    /// If either argument is empty then the result is also empty.
-    if (label_arg.store_method == StoreMethod::EMPTY || vector_arg.store_method == StoreMethod::EMPTY)
+    /// Prometheus validates the destination label before evaluating the input vector.
+    String value_label_name = getValueLabelName(std::move(label_arg), context);
+
+    /// An empty input vector produces an empty result after the label has been validated.
+    if (vector_arg.store_method == StoreMethod::EMPTY)
         return SQLQueryPiece{operator_node, operator_node->result_type, StoreMethod::EMPTY};
 
-    String value_label_name = getValueLabelName(std::move(label_arg), context);
     vector_arg = toVectorGrid(std::move(vector_arg), context);
 
     auto res = vector_arg;
@@ -281,8 +284,8 @@ SQLQueryPiece applyAggregationOperatorCountValues(
         per_point_counts_query = builder.getSelectQuery();
     }
 
-    /// Step 4: pack sparse per-timestamp counts back onto the vector grid.
-    ASTPtr packed_counts_query;
+    /// Step 4: collect sparse per-timestamp counts as correlated index/count pairs.
+    ASTPtr paired_counts_query;
     {
         SelectQueryBuilder builder;
 
@@ -290,11 +293,41 @@ SQLQueryPiece applyAggregationOperatorCountValues(
         builder.from_table = context.subqueries.back().name;
 
         builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+        builder.select_list.push_back(makeASTFunction(
+            "groupArray",
+            makeASTFunction(
+                "tuple",
+                make_intrusive<ASTIdentifier>(point_index_column),
+                make_intrusive<ASTIdentifier>(ColumnNames::Value))));
+        builder.select_list.back()->setAlias(count_pairs_column);
+
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+
+        paired_counts_query = builder.getSelectQuery();
+    }
+
+    /// Step 5: turn the sparse pairs into a map keyed by the 1-based grid index.
+    ASTPtr packed_counts_query;
+    {
+        SelectQueryBuilder builder;
+
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(paired_counts_query), SQLSubqueryType::TABLE});
+        builder.from_table = context.subqueries.back().name;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
 
         builder.select_list.push_back(makeASTFunction(
             "mapFromArrays",
-            makeASTFunction("groupArray", make_intrusive<ASTIdentifier>(point_index_column)),
-            makeASTFunction("groupArray", make_intrusive<ASTIdentifier>(ColumnNames::Value))));
+            makeASTFunction(
+                "arrayMap",
+                makeASTLambda(
+                    {"pair"}, makeASTFunction("tupleElement", make_intrusive<ASTIdentifier>("pair"), make_intrusive<ASTLiteral>(1u))),
+                make_intrusive<ASTIdentifier>(count_pairs_column)),
+            makeASTFunction(
+                "arrayMap",
+                makeASTLambda(
+                    {"pair"}, makeASTFunction("tupleElement", make_intrusive<ASTIdentifier>("pair"), make_intrusive<ASTLiteral>(2u))),
+                make_intrusive<ASTIdentifier>(count_pairs_column))));
         builder.select_list.back()->setAlias(counts_column);
 
         builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
@@ -302,7 +335,7 @@ SQLQueryPiece applyAggregationOperatorCountValues(
         packed_counts_query = builder.getSelectQuery();
     }
 
-    /// Step 5: rename `new_group` back to `group` and materialize NULLs where a generated series has no sample.
+    /// Step 6: rename `new_group` back to `group` and materialize NULLs where a generated series has no sample.
     {
         SelectQueryBuilder builder;
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
@@ -1,0 +1,324 @@
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.h>
+
+#include <Common/Exception.h>
+#include <Common/isValidUTF8.h>
+#include <Common/quoteString.h>
+#include <DataTypes/WhichDataType.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/Prometheus/stepsInTimeSeriesRange.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
+#include <Storages/TimeSeries/timeSeriesTypesToAST.h>
+#include <algorithm>
+
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_EXECUTE_PROMQL_QUERY;
+}
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+namespace
+{
+    constexpr const char * point_column = "point";
+    constexpr const char * point_index_column = "point_index";
+    constexpr const char * value_label_column = "value_label";
+    constexpr const char * counts_column = "counts";
+
+bool isValidPrometheusLabelName(std::string_view label_name)
+{
+    return !label_name.empty()
+        && UTF8::isValidUTF8(reinterpret_cast<const UInt8 *>(label_name.data()), label_name.size());
+}
+
+void checkArgumentTypes(
+    const PQT::AggregationOperator * operator_node, const std::vector<SQLQueryPiece> & arguments, const ConverterContext & context)
+{
+    const auto & operator_name = operator_node->operator_name;
+
+    if (arguments.size() != 2)
+    {
+        throw Exception(
+            ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+            "Aggregation operator '{}' expects 2 arguments, but was called with {} arguments",
+            operator_name,
+            arguments.size());
+    }
+
+    const auto & label_arg = arguments[0];
+
+    if (label_arg.type != ResultType::STRING)
+    {
+        throw Exception(
+            ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+            "Aggregation operator '{}' expects first argument of type {}, but expression {} has type {}",
+            operator_name,
+            ResultType::STRING,
+            getPromQLText(label_arg, context),
+            label_arg.type);
+    }
+
+    const auto & vector_arg = arguments[1];
+
+    if (vector_arg.type != ResultType::INSTANT_VECTOR)
+    {
+        throw Exception(
+            ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+            "Aggregation operator '{}' expects second argument of type {}, but expression {} has type {}",
+            operator_name,
+            ResultType::INSTANT_VECTOR,
+            getPromQLText(vector_arg, context),
+            vector_arg.type);
+    }
+}
+
+String getValueLabelName(SQLQueryPiece && label_arg, const ConverterContext & context)
+{
+    if (label_arg.store_method != StoreMethod::CONST_STRING)
+        throwUnexpectedStoreMethod(label_arg, context);
+
+    if (!isValidPrometheusLabelName(label_arg.string_value))
+    {
+        throw Exception(
+            ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+            "Aggregation operator 'count_values' called with invalid label name {}",
+            quoteString(label_arg.string_value));
+    }
+
+    return std::move(label_arg.string_value);
+}
+
+ASTPtr makeFormattedValueLabel(ASTPtr value)
+{
+    return makeASTFunction("timeSeriesPrometheusFormatFloat", std::move(value));
+}
+
+ASTPtr makeGroupWithValueLabel(ASTPtr group, const String & value_label_name, ASTPtr value_label)
+{
+    auto group_as_uint64 = makeASTFunction("CAST", std::move(group), make_intrusive<ASTLiteral>("UInt64"));
+    return makeASTFunction(
+        "timeSeriesTagsToGroup",
+        makeASTFunction(
+            "timeSeriesGroupToTags",
+            makeASTFunction("timeSeriesRemoveTag", std::move(group_as_uint64), make_intrusive<ASTLiteral>(value_label_name))),
+        make_intrusive<ASTLiteral>(value_label_name),
+        std::move(value_label));
+}
+
+ASTPtr transformGroupASTForCountValues(
+    const PQT::AggregationOperator * operator_node,
+    ASTPtr && group_with_value_label,
+    const String & value_label_name,
+    bool input_metric_name_dropped,
+    bool & output_metric_name_dropped)
+{
+    if (operator_node->by)
+    {
+        std::vector<std::string_view> tags_to_keep{operator_node->labels.begin(), operator_node->labels.end()};
+        tags_to_keep.push_back(value_label_name);
+        std::sort(tags_to_keep.begin(), tags_to_keep.end());
+        tags_to_keep.erase(std::unique(tags_to_keep.begin(), tags_to_keep.end()), tags_to_keep.end());
+
+        bool keeps_metric_name = std::binary_search(tags_to_keep.begin(), tags_to_keep.end(), kMetricName);
+        output_metric_name_dropped = !((value_label_name == kMetricName) || (!input_metric_name_dropped && keeps_metric_name));
+
+        return makeASTFunction(
+            "timeSeriesRemoveAllTagsExcept",
+            std::move(group_with_value_label),
+            make_intrusive<ASTLiteral>(Array{tags_to_keep.begin(), tags_to_keep.end()}));
+    }
+
+    if (!operator_node->without)
+    {
+        output_metric_name_dropped = (value_label_name != kMetricName);
+        return makeASTFunction(
+            "timeSeriesRemoveAllTagsExcept", std::move(group_with_value_label), make_intrusive<ASTLiteral>(Array{value_label_name}));
+    }
+
+    std::vector<std::string_view> tags_to_remove{operator_node->labels.begin(), operator_node->labels.end()};
+    tags_to_remove.push_back(kMetricName);
+    std::sort(tags_to_remove.begin(), tags_to_remove.end());
+    tags_to_remove.erase(std::unique(tags_to_remove.begin(), tags_to_remove.end()), tags_to_remove.end());
+
+    output_metric_name_dropped = true;
+    return makeASTFunction(
+        "timeSeriesRemoveTags",
+        std::move(group_with_value_label),
+        make_intrusive<ASTLiteral>(Array{tags_to_remove.begin(), tags_to_remove.end()}));
+}
+
+ASTPtr makeCountValuesArray(TimestampType start_time, TimestampType end_time, DurationType step, const DataTypePtr & scalar_data_type)
+{
+    size_t num_steps = stepsInTimeSeriesRange(start_time, end_time, step);
+
+    auto count = makeASTFunction("arrayElement", make_intrusive<ASTIdentifier>(counts_column), make_intrusive<ASTIdentifier>("i"));
+
+    return makeASTFunction(
+        "arrayMap",
+        makeASTLambda(
+            {"i"},
+            makeASTFunction(
+                "if",
+                makeASTFunction("mapContains", make_intrusive<ASTIdentifier>(counts_column), make_intrusive<ASTIdentifier>("i")),
+                makeASTFunction("toNullable", timeSeriesScalarASTCast(std::move(count), scalar_data_type)),
+                make_intrusive<ASTLiteral>(Field{} /* NULL */))),
+        makeASTFunction("range", make_intrusive<ASTLiteral>(1u), make_intrusive<ASTLiteral>(num_steps + 1)));
+}
+}
+
+
+SQLQueryPiece applyAggregationOperatorCountValues(
+    const PQT::AggregationOperator * operator_node, std::vector<SQLQueryPiece> && arguments, ConverterContext & context)
+{
+    checkArgumentTypes(operator_node, arguments, context);
+
+    auto & label_arg = arguments[0];
+    auto & vector_arg = arguments[1];
+
+    /// If either argument is empty then the result is also empty.
+    if (label_arg.store_method == StoreMethod::EMPTY || vector_arg.store_method == StoreMethod::EMPTY)
+        return SQLQueryPiece{operator_node, operator_node->result_type, StoreMethod::EMPTY};
+
+    String value_label_name = getValueLabelName(std::move(label_arg), context);
+    vector_arg = toVectorGrid(std::move(vector_arg), context);
+
+    auto res = vector_arg;
+    res.node = operator_node;
+    const bool input_metric_name_dropped = res.metric_name_dropped;
+
+    /// Step 1: expand each series grid row into one row per timestamp position.
+    ASTPtr exploded_query;
+    {
+        SelectQueryBuilder builder;
+
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(vector_arg.select_query), SQLSubqueryType::TABLE});
+        builder.from_table = context.subqueries.back().name;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+
+        auto point = makeASTFunction(
+            "arrayJoin",
+            makeASTFunction(
+                "arrayZip",
+                makeASTFunction("arrayEnumerate", make_intrusive<ASTIdentifier>(ColumnNames::Values)),
+                make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        point->setAlias(point_column);
+        builder.select_list.push_back(std::move(point));
+
+        exploded_query = builder.getSelectQuery();
+    }
+
+    /// Step 2: keep present samples and format their values as Prometheus label strings.
+    ASTPtr present_samples_query;
+    {
+        SelectQueryBuilder builder;
+
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(exploded_query), SQLSubqueryType::TABLE});
+        builder.from_table = context.subqueries.back().name;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+
+        builder.select_list.push_back(
+            makeASTFunction("tupleElement", make_intrusive<ASTIdentifier>(point_column), make_intrusive<ASTLiteral>(1u)));
+        builder.select_list.back()->setAlias(point_index_column);
+
+        builder.select_list.push_back(makeFormattedValueLabel(makeASTFunction(
+            "ifNull",
+            makeASTFunction("tupleElement", make_intrusive<ASTIdentifier>(point_column), make_intrusive<ASTLiteral>(2u)),
+            timeSeriesScalarToAST(0, context.scalar_data_type))));
+        builder.select_list.back()->setAlias(value_label_column);
+
+        auto value = makeASTFunction(
+            "tupleElement", make_intrusive<ASTIdentifier>(point_column), make_intrusive<ASTLiteral>(2u));
+        builder.where = makeASTFunction("isNotNull", value->clone());
+
+        if (WhichDataType(context.scalar_data_type).isFloat64())
+        {
+            builder.where = makeASTFunction(
+                "and",
+                std::move(builder.where),
+                makeASTFunction(
+                    "notEquals",
+                    makeASTFunction("reinterpretAsUInt64", makeASTFunction("assumeNotNull", std::move(value))),
+                    make_intrusive<ASTLiteral>(0x7ff0000000000002ULL)));
+        }
+
+        present_samples_query = builder.getSelectQuery();
+    }
+
+    /// Step 3: count samples per timestamp and generated label set.
+    ASTPtr per_point_counts_query;
+    {
+        SelectQueryBuilder builder;
+
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(present_samples_query), SQLSubqueryType::TABLE});
+        builder.from_table = context.subqueries.back().name;
+
+        ASTPtr group_with_value_label = makeGroupWithValueLabel(
+            make_intrusive<ASTIdentifier>(ColumnNames::Group), value_label_name, make_intrusive<ASTIdentifier>(value_label_column));
+
+        ASTPtr new_group = transformGroupASTForCountValues(
+            operator_node, std::move(group_with_value_label), value_label_name, input_metric_name_dropped, res.metric_name_dropped);
+
+        builder.select_list.push_back(std::move(new_group));
+        builder.select_list.back()->setAlias(ColumnNames::NewGroup);
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(point_index_column));
+        builder.select_list.back()->setAlias(point_index_column);
+
+        builder.select_list.push_back(makeASTFunction("count"));
+        builder.select_list.back()->setAlias(ColumnNames::Value);
+
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(point_index_column));
+
+        per_point_counts_query = builder.getSelectQuery();
+    }
+
+    /// Step 4: pack sparse per-timestamp counts back onto the vector grid.
+    ASTPtr packed_counts_query;
+    {
+        SelectQueryBuilder builder;
+
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(per_point_counts_query), SQLSubqueryType::TABLE});
+        builder.from_table = context.subqueries.back().name;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+
+        builder.select_list.push_back(makeASTFunction(
+            "mapFromArrays",
+            makeASTFunction("groupArray", make_intrusive<ASTIdentifier>(point_index_column)),
+            makeASTFunction("groupArray", make_intrusive<ASTIdentifier>(ColumnNames::Value))));
+        builder.select_list.back()->setAlias(counts_column);
+
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+
+        packed_counts_query = builder.getSelectQuery();
+    }
+
+    /// Step 5: rename `new_group` back to `group` and materialize NULLs where a generated series has no sample.
+    {
+        SelectQueryBuilder builder;
+
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(packed_counts_query), SQLSubqueryType::TABLE});
+        builder.from_table = context.subqueries.back().name;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
+        builder.select_list.back()->setAlias(ColumnNames::Group);
+
+        builder.select_list.push_back(makeCountValuesArray(res.start_time, res.end_time, res.step, context.scalar_data_type));
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        res.select_query = builder.getSelectQuery();
+    }
+
+    return res;
+}
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
@@ -330,8 +330,6 @@ SQLQueryPiece applyAggregationOperatorCountValues(
                 make_intrusive<ASTIdentifier>(count_pairs_column))));
         builder.select_list.back()->setAlias(counts_column);
 
-        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
-
         packed_counts_query = builder.getSelectQuery();
     }
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.cpp
@@ -3,7 +3,7 @@
 #include <Common/Exception.h>
 #include <Common/isValidUTF8.h>
 #include <Common/quoteString.h>
-#include <DataTypes/WhichDataType.h>
+#include <DataTypes/IDataType.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
@@ -38,7 +38,7 @@ bool isValidPrometheusLabelName(std::string_view label_name)
 }
 
 void checkArgumentTypes(
-    const PQT::AggregationOperator * operator_node, const std::vector<SQLQueryPiece> & arguments, const ConverterContext & context)
+    const PrometheusQueryTree::AggregationOperator * operator_node, const std::vector<SQLQueryPiece> & arguments, const ConverterContext & context)
 {
     const auto & operator_name = operator_node->operator_name;
 
@@ -112,7 +112,7 @@ ASTPtr makeGroupWithValueLabel(ASTPtr group, const String & value_label_name, AS
 }
 
 ASTPtr transformGroupASTForCountValues(
-    const PQT::AggregationOperator * operator_node,
+    const PrometheusQueryTree::AggregationOperator * operator_node,
     ASTPtr && group_with_value_label,
     const String & value_label_name,
     bool input_metric_name_dropped,
@@ -174,7 +174,7 @@ ASTPtr makeCountValuesArray(TimestampType start_time, TimestampType end_time, Du
 
 
 SQLQueryPiece applyAggregationOperatorCountValues(
-    const PQT::AggregationOperator * operator_node, std::vector<SQLQueryPiece> && arguments, ConverterContext & context)
+    const PrometheusQueryTree::AggregationOperator * operator_node, std::vector<SQLQueryPiece> && arguments, ConverterContext & context)
 {
     checkArgumentTypes(operator_node, arguments, context);
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+struct ConverterContext;
+
+/// Returns whether the specified string is the name of the `count_values` aggregation operator.
+inline bool isAggregationOperatorCountValues(std::string_view operator_name)
+{
+    return operator_name == "count_values";
+}
+
+/// Applies the `count_values` aggregation operator.
+SQLQueryPiece applyAggregationOperatorCountValues(
+    const PQT::AggregationOperator * operator_node, std::vector<SQLQueryPiece> && arguments, ConverterContext & context);
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorCountValues.h
@@ -16,6 +16,6 @@ inline bool isAggregationOperatorCountValues(std::string_view operator_name)
 
 /// Applies the `count_values` aggregation operator.
 SQLQueryPiece applyAggregationOperatorCountValues(
-    const PQT::AggregationOperator * operator_node, std::vector<SQLQueryPiece> && arguments, ConverterContext & context);
+    const PrometheusQueryTree::AggregationOperator * operator_node, std::vector<SQLQueryPiece> && arguments, ConverterContext & context);
 
 }

--- a/src/TableFunctions/TableFunctionTimeSeries.cpp
+++ b/src/TableFunctions/TableFunctionTimeSeries.cpp
@@ -285,11 +285,10 @@ Unary operators `+` and `-`.
 
 ### Aggregation Operators {#aggregation-operators}
 
-`sum`, `avg`, `min`, `max`, `count`, `stddev`, `stdvar`, `group`, `quantile`, `topk`, `bottomk`, `limitk` — with optional `by()` or `without()` modifiers.
+`sum`, `avg`, `min`, `max`, `count`, `stddev`, `stdvar`, `group`, `quantile`, `topk`, `bottomk`, `limitk` — with optional `by()` or `without()` modifiers. `count_values` adds the formatted sample value as a label.
 
 ### Not yet supported {#not-yet-supported}
 
-- Aggregation operator `count_values`
 - Range functions `predict_linear`, `avg_over_time`, `min_over_time`, `max_over_time`, `sum_over_time`, `count_over_time`, `quantile_over_time`, `stddev_over_time`, `stdvar_over_time`, `present_over_time`, `absent_over_time`, `mad_over_time`, `first_over_time`, `ts_of_min_over_time`, `ts_of_max_over_time`, `ts_of_last_over_time`, `ts_of_first_over_time`
 - Function `absent`
 
@@ -362,11 +361,10 @@ Unary operators `+` and `-`.
 
 ### Aggregation Operators {#aggregation-operators}
 
-`sum`, `avg`, `min`, `max`, `count`, `stddev`, `stdvar`, `group`, `quantile`, `topk`, `bottomk`, `limitk` — with optional `by()` or `without()` modifiers.
+`sum`, `avg`, `min`, `max`, `count`, `stddev`, `stdvar`, `group`, `quantile`, `topk`, `bottomk`, `limitk` — with optional `by()` or `without()` modifiers. `count_values` adds the formatted sample value as a label.
 
 ### Not yet supported {#not-yet-supported}
 
-- Aggregation operator `count_values`
 - Range functions `predict_linear`, `avg_over_time`, `min_over_time`, `max_over_time`, `sum_over_time`, `count_over_time`, `quantile_over_time`, `stddev_over_time`, `stdvar_over_time`, `present_over_time`, `absent_over_time`, `mad_over_time`, `first_over_time`, `ts_of_min_over_time`, `ts_of_max_over_time`, `ts_of_last_over_time`, `ts_of_first_over_time`
 - Function `absent`
 

--- a/tests/integration/test_prometheus_protocols/test_compliance.py
+++ b/tests/integration/test_prometheus_protocols/test_compliance.py
@@ -309,6 +309,13 @@ COMPLIANCE_TEST_CASES = [
 
     # count_values
     ('count_values("value", demo_api_request_duration_seconds_bucket)', [], False),
+    ('count_values("value", demo_api_request_duration_seconds_bucket) without (instance)', [], False),
+    ('count_values("value", demo_api_request_duration_seconds_bucket) without (value)', [], False),
+    ('count_values("job", demo_api_request_duration_seconds_bucket) by (job)', [], False),
+    ('count_values("~value", demo_api_request_duration_seconds_bucket)', [], False),
+    ('count_values("", demo_api_request_duration_seconds_bucket)', [], True),
+    ('count_values("value", nonexistent_metric_name)', [], False),
+    ('count_values("value", vector(time()))', [], False),
 
     # absent
     ("absent(demo_memory_usage_bytes)", [], False),

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -4611,6 +4611,47 @@ def test_aggregation_operators():
     )
 
 
+def test_count_values_range_query():
+    do_range_query_test(
+        'count_values("value", {__name__=~"foo|bar",shape="triangle"})',
+        110,
+        130,
+        10,
+        '{"resultType": "matrix", "result": [{"metric": {"value": "8"}, "values": [[110, "2"], [120, "1"], [130, "1"]]}, {"metric": {"value": "80"}, "values": [[120, "1"], [130, "1"]]}]}',
+        [
+            ["[('value','8')]", "[('1970-01-01 00:01:50.000',2),('1970-01-01 00:02:00.000',1),('1970-01-01 00:02:10.000',1)]"],
+            ["[('value','80')]", "[('1970-01-01 00:02:00.000',1),('1970-01-01 00:02:10.000',1)]"],
+        ],
+    )
+
+    do_range_query_test(
+        'count_values("value", last_over_time(foo{shape="circle"}[1s]))',
+        100,
+        160,
+        10,
+        '{"resultType": "matrix", "result": [{"metric": {"value": "16"}, "values": [[110, "1"], [130, "1"], [150, "1"]]}]}',
+        [["[('value','16')]", "[('1970-01-01 00:01:50.000',1),('1970-01-01 00:02:10.000',1),('1970-01-01 00:02:30.000',1)]"]],
+    )
+
+    do_range_query_test(
+        'count_values("value", nonexistent_metric)',
+        100,
+        160,
+        10,
+        '{"resultType": "matrix", "result": []}',
+        [],
+    )
+
+
+def test_count_values_without_value_label():
+    do_query_test(
+        'count_values("value", {__name__=~"foo|bar",shape="triangle"}) without (shape,size,value)',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {}, "value": [120, "2"]}]}',
+        [["[]", "1970-01-01 00:02:00.000", 2]],
+    )
+
+
 def test_histogram_quantile():
     # The classic histogram `http_request_duration_seconds_bucket` has cumulative counts at t=300:
     #   le=0.1  -> 10   (10 observations in (-Inf, 0.1])

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -1,7 +1,10 @@
+import json
+import struct
+
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import tsv_close_to
+from helpers.test_tools import TSV, tsv_close_to
 import requests
 
 from .prometheus_test_utils import (
@@ -24,6 +27,10 @@ node = cluster.add_instance(
     with_prometheus_reader=True,
     with_prometheus_receiver=True,
 )
+
+PROMETHEUS_STALE_MARKER = struct.unpack(
+    "<d", struct.pack("<Q", 0x7FF0000000000002)
+)[0]
 
 
 # Sends data [ ({'label_name1': 'label_value1], ...}, {timestamp1: value1, ...} ), ... ]
@@ -172,6 +179,8 @@ def send_test_data():
             )
         ]
     )
+
+    send_data([({"__name__": "stale_marker"}, {110: PROMETHEUS_STALE_MARKER})])
 
     send_data(
         [
@@ -488,6 +497,44 @@ def do_query_test(
     assert (
         http_api_response_close_to(actual_result_from_http_api, result, eps=eps)
         == clickhouse_http_api_result_is_same_as_prometheus
+    ), f"actual_result_from_http_api: {actual_result_from_http_api}, expected: {result}"
+
+
+def _result_with_series_sorted(response):
+    data = json.loads(response)
+    if data.get("resultType") in ("vector", "matrix"):
+        data["result"].sort(
+            key=lambda series: json.dumps(series.get("metric", {}), sort_keys=True)
+        )
+    return data
+
+
+# Evaluates a query whose Prometheus vector/matrix series order is nondeterministic.
+def do_unordered_query_test(query, timestamp, result, chresult):
+    expected_result = _result_with_series_sorted(result)
+    assert (
+        _result_with_series_sorted(execute_query_in_prometheus_reader(query, timestamp))
+        == expected_result
+    )
+    assert (
+        _result_with_series_sorted(
+            execute_query_in_prometheus_receiver(query, timestamp)
+        )
+        == expected_result
+    )
+
+    actual_chresult = execute_query_in_clickhouse_sql(query, timestamp)
+    actual_chresult_sorted = TSV(actual_chresult)
+    actual_chresult_sorted.lines.sort()
+    expected_chresult_sorted = TSV(chresult)
+    expected_chresult_sorted.lines.sort()
+    assert (
+        actual_chresult_sorted == expected_chresult_sorted
+    ), f"actual result: {actual_chresult}, expected: {chresult}"
+
+    actual_result_from_http_api = execute_query_in_clickhouse_http_api(query, timestamp)
+    assert (
+        _result_with_series_sorted(actual_result_from_http_api) == expected_result
     ), f"actual_result_from_http_api: {actual_result_from_http_api}, expected: {result}"
 
 
@@ -3882,6 +3929,166 @@ def test_aggregation_operators():
             ["[('size','s')]", "[('1970-01-01 00:01:50.000',1),('1970-01-01 00:02:00.000',1),('1970-01-01 00:02:20.000',1)]"],
             ["[('size','xl')]", "[('1970-01-01 00:01:50.000',1),('1970-01-01 00:02:30.000',1)]"],
         ],
+    )
+
+    do_unordered_query_test(
+        "count_values(\"value\", foo)",
+        130,
+        '{"resultType": "vector", "result": [{"metric": {"value": "16"}, "value": [130, "1"]}, {"metric": {"value": "40"}, "value": [130, "1"]}, {"metric": {"value": "80"}, "value": [130, "1"]}]}',
+        [
+            ["[('value','16')]", "1970-01-01 00:02:10.000", 1],
+            ["[('value','40')]", "1970-01-01 00:02:10.000", 1],
+            ["[('value','80')]", "1970-01-01 00:02:10.000", 1],
+        ],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", {__name__=~"foo|bar"})',
+        110,
+        '{"resultType": "vector", "result": [{"metric": {"value": "10"}, "value": [110, "1"]}, {"metric": {"value": "16"}, "value": [110, "1"]}, {"metric": {"value": "3"}, "value": [110, "1"]}, {"metric": {"value": "4"}, "value": [110, "1"]}, {"metric": {"value": "8"}, "value": [110, "2"]}, {"metric": {"value": "9"}, "value": [110, "1"]}]}',
+        [
+            ["[('value','10')]", "1970-01-01 00:01:50.000", 1],
+            ["[('value','16')]", "1970-01-01 00:01:50.000", 1],
+            ["[('value','3')]", "1970-01-01 00:01:50.000", 1],
+            ["[('value','4')]", "1970-01-01 00:01:50.000", 1],
+            ["[('value','8')]", "1970-01-01 00:01:50.000", 2],
+            ["[('value','9')]", "1970-01-01 00:01:50.000", 1],
+        ],
+    )
+
+    do_unordered_query_test(
+        'count_values("shape", {__name__=~"foo|bar"}) by (shape)',
+        110,
+        '{"resultType": "vector", "result": [{"metric": {"shape": "10"}, "value": [110, "1"]}, {"metric": {"shape": "16"}, "value": [110, "1"]}, {"metric": {"shape": "3"}, "value": [110, "1"]}, {"metric": {"shape": "4"}, "value": [110, "1"]}, {"metric": {"shape": "8"}, "value": [110, "2"]}, {"metric": {"shape": "9"}, "value": [110, "1"]}]}',
+        [
+            ["[('shape','10')]", "1970-01-01 00:01:50.000", 1],
+            ["[('shape','16')]", "1970-01-01 00:01:50.000", 1],
+            ["[('shape','3')]", "1970-01-01 00:01:50.000", 1],
+            ["[('shape','4')]", "1970-01-01 00:01:50.000", 1],
+            ["[('shape','8')]", "1970-01-01 00:01:50.000", 2],
+            ["[('shape','9')]", "1970-01-01 00:01:50.000", 1],
+        ],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", foo) by (shape)',
+        110,
+        '{"resultType": "vector", "result": [{"metric": {"shape": "circle", "value": "16"}, "value": [110, "1"]}, {"metric": {"shape": "square", "value": "4"}, "value": [110, "1"]}, {"metric": {"shape": "triangle", "value": "8"}, "value": [110, "1"]}]}',
+        [
+            ["[('shape','circle'),('value','16')]", "1970-01-01 00:01:50.000", 1],
+            ["[('shape','square'),('value','4')]", "1970-01-01 00:01:50.000", 1],
+            ["[('shape','triangle'),('value','8')]", "1970-01-01 00:01:50.000", 1],
+        ],
+    )
+
+    do_unordered_query_test(
+        '(count_values("value", last_over_time(foo[1s])))[20:10]',
+        130,
+        '{"resultType": "matrix", "result": [{"metric": {"value": "16"}, "values": [[130, "1"]]}, {"metric": {"value": "40"}, "values": [[130, "1"]]}, {"metric": {"value": "80"}, "values": [[120, "1"]]}]}',
+        [
+            ["[('value','16')]", "[('1970-01-01 00:02:10.000',1)]"],
+            ["[('value','40')]", "[('1970-01-01 00:02:10.000',1)]"],
+            ["[('value','80')]", "[('1970-01-01 00:02:00.000',1)]"],
+        ],
+    )
+
+    do_unordered_query_test(
+        "count_values(\"value\", foo) without (shape)",
+        130,
+        '{"resultType": "vector", "result": [{"metric": {"size": "l", "value": "16"}, "value": [130, "1"]}, {"metric": {"size": "m", "value": "80"}, "value": [130, "1"]}, {"metric": {"size": "s", "value": "40"}, "value": [130, "1"]}]}',
+        [
+            ["[('size','l'),('value','16')]", "1970-01-01 00:02:10.000", 1],
+            ["[('size','m'),('value','80')]", "1970-01-01 00:02:10.000", 1],
+            ["[('size','s'),('value','40')]", "1970-01-01 00:02:10.000", 1],
+        ],
+    )
+
+    do_unordered_query_test(
+        "count_values(\"size\", foo) without (shape)",
+        130,
+        '{"resultType": "vector", "result": [{"metric": {"size": "16"}, "value": [130, "1"]}, {"metric": {"size": "40"}, "value": [130, "1"]}, {"metric": {"size": "80"}, "value": [130, "1"]}]}',
+        [
+            ["[('size','16')]", "1970-01-01 00:02:10.000", 1],
+            ["[('size','40')]", "1970-01-01 00:02:10.000", 1],
+            ["[('size','80')]", "1970-01-01 00:02:10.000", 1],
+        ],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", vector(1.5))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "1.5"}, "value": [120, "1"]}]}',
+        [["[('value','1.5')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", vector(-0))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "-0"}, "value": [120, "1"]}]}',
+        [["[('value','-0')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", vector(+Inf))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "+Inf"}, "value": [120, "1"]}]}',
+        [["[('value','+Inf')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", vector(-Inf))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "-Inf"}, "value": [120, "1"]}]}',
+        [["[('value','-Inf')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", vector(NaN))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "NaN"}, "value": [120, "1"]}]}',
+        [["[('value','NaN')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", vector(0.0000001))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "0.0000001"}, "value": [120, "1"]}]}',
+        [["[('value','0.0000001')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", vector(1e21))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "1000000000000000000000"}, "value": [120, "1"]}]}',
+        [["[('value','1000000000000000000000')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", stale_marker)',
+        110,
+        '{"resultType": "vector", "result": []}',
+        [],
+    )
+
+    do_unordered_query_test(
+        'count_values("value", nonexistent_metric)',
+        120,
+        '{"resultType": "vector", "result": []}',
+        [],
+    )
+
+    do_query_test(
+        'count_values("~value", vector(1))',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"~value": "1"}, "value": [120, "1"]}]}',
+        [["[('~value','1')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_query_test_expect_error(
+        'count_values("", vector(1))',
+        120,
+        "invalid label name",
+        "invalid label name",
     )
 
     do_query_test(

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -31,6 +31,9 @@ node = cluster.add_instance(
 PROMETHEUS_STALE_MARKER = struct.unpack(
     "<d", struct.pack("<Q", 0x7FF0000000000002)
 )[0]
+PROMETHEUS_FORMATTING_VALUE = struct.unpack(
+    "<d", struct.pack("<Q", 0x4351A819EB006F0C)
+)[0]
 
 
 # Sends data [ ({'label_name1': 'label_value1], ...}, {timestamp1: value1, ...} ), ... ]
@@ -181,6 +184,15 @@ def send_test_data():
     )
 
     send_data([({"__name__": "stale_marker"}, {110: PROMETHEUS_STALE_MARKER})])
+
+    send_data(
+        [
+            (
+                {"__name__": "prometheus_formatting"},
+                {120: PROMETHEUS_FORMATTING_VALUE},
+            )
+        ]
+    )
 
     send_data(
         [
@@ -4064,6 +4076,13 @@ def test_aggregation_operators():
     )
 
     do_unordered_query_test(
+        'count_values("value", prometheus_formatting)',
+        120,
+        '{"resultType": "vector", "result": [{"metric": {"value": "19879615497616430"}, "value": [120, "1"]}]}',
+        [["[('value','19879615497616430')]", "1970-01-01 00:02:00.000", 1]],
+    )
+
+    do_unordered_query_test(
         'count_values("value", stale_marker)',
         110,
         '{"resultType": "vector", "result": []}',
@@ -4086,6 +4105,13 @@ def test_aggregation_operators():
 
     do_query_test_expect_error(
         'count_values("", vector(1))',
+        120,
+        "invalid label name",
+        "invalid label name",
+    )
+
+    do_query_test_expect_error(
+        'count_values("", nonexistent_metric_name)',
         120,
         "invalid label name",
         "invalid label name",


### PR DESCRIPTION
**TL;DR**

- **Adds** PromQL `count_values` support for ClickHouse `TimeSeries` data.
- **Matches** Prometheus value-label, grouping, float-formatting, and stale-marker behavior.
- **Includes** integration tests, compliance cases, and user documentation.

**Why this matters**

- **PromQL compatibility:** Queries using `count_values` can run through the ClickHouse PromQL path instead of being rejected as unsupported.
- **State metrics:** This is useful for counting how many series currently have each value, such as service states, status codes, or rollout phases.
- **Existing queries:** Users can keep Prometheus queries that already use `by()` and `without()` without rewriting them for ClickHouse.
- **Correct results:** Matching label and float semantics is important for dashboards, recording rules, and alerts that compare ClickHouse results with Prometheus.

Adds native lowering for the PromQL `count_values` aggregation operator over ClickHouse `TimeSeries` data.

**What changed**

- **PromQL lowering:** Adds `count_values` to the PromQL-to-SQL aggregation path.
- **Value labels:** Formats every sample value as a Prometheus label string and stores it under the requested label name.
- **Grouping:** Applies the generated value label before `by()` and `without()` grouping, matching Prometheus label-set behavior.
- **Counting:** Counts equal values for each output label set and evaluation step.
- **Sparse results:** Packs the counts back into the vector-grid shape and keeps missing samples as `NULL`.
- **Float formatting:** Adds a dedicated formatter for `Float32` and `Float64` values.
- **Label validation:** Accepts non-empty valid UTF-8 label names and rejects empty names.
- **Special values:** Covers `NaN`, `+Inf`, `-Inf`, `-0`, and large values such as `1e21`.
- **Stale markers:** Filters the Prometheus stale-marker payload without dropping regular `NaN` values.

**Tests**

- **Integration coverage:** Adds `by()` grouping, UTF-8 label names, empty labels, stale markers, and float-formatting cases.
- **Compliance coverage:** Adds `by()`, `without()`, empty-vector, dynamic `time()`, and invalid-label cases.
- **Validation:** Python test files compile successfully and the patch passes whitespace checks.

### Changelog category (leave one):
- Experimental Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added native PromQL-to-SQL lowering for `count_values` over ClickHouse `TimeSeries` data.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115525&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115525](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115525+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
