### PR TITLE
Bound the response wait of the GCP OAuth token request instead of inheriting the caller's request timeout

### DIFF
--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -1271,10 +1271,12 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> AwsAuthSTSAssumeRoleCredentia
     auto sts_retry_strategy = sts_client_configuration.retry_strategy;
     sts_retry_strategy.max_retries = std::min(sts_retry_strategy.max_retries, static_cast<decltype(sts_retry_strategy.max_retries)>(3));
     sts_client_configuration.retryStrategy = std::make_shared<Client::RetryStrategy>(sts_retry_strategy);
-    if (sts_client_configuration.connectTimeoutMs <= 0 || sts_client_configuration.connectTimeoutMs > 1000)
-        sts_client_configuration.connectTimeoutMs = 1000;
-    if (sts_client_configuration.requestTimeoutMs <= 0 || sts_client_configuration.requestTimeoutMs > 10000)
-        sts_client_configuration.requestTimeoutMs = 10000;
+    static constexpr auto connect_cap_ms = static_cast<long>(DEFAULT_CONNECT_TIMEOUT_MS);
+    static constexpr auto request_cap_ms = static_cast<long>(DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS);
+    if (sts_client_configuration.connectTimeoutMs <= 0 || sts_client_configuration.connectTimeoutMs > connect_cap_ms)
+        sts_client_configuration.connectTimeoutMs = connect_cap_ms;
+    if (sts_client_configuration.requestTimeoutMs <= 0 || sts_client_configuration.requestTimeoutMs > request_cap_ms)
+        sts_client_configuration.requestTimeoutMs = request_cap_ms;
 
     auto client = std::make_shared<AWSAssumeRoleClient>(credentials_provider, sts_client_configuration, sts_endpoint_override);
     auto session_name = session_name_.empty() ? "ClickHouseSession" : std::move(session_name_);

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -1271,8 +1271,9 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> AwsAuthSTSAssumeRoleCredentia
     auto sts_retry_strategy = sts_client_configuration.retry_strategy;
     sts_retry_strategy.max_retries = std::min(sts_retry_strategy.max_retries, static_cast<decltype(sts_retry_strategy.max_retries)>(3));
     sts_client_configuration.retryStrategy = std::make_shared<Client::RetryStrategy>(sts_retry_strategy);
-    static constexpr auto connect_cap_ms = static_cast<long>(DEFAULT_CONNECT_TIMEOUT_MS);
-    static constexpr auto request_cap_ms = static_cast<long>(DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS);
+    static constexpr auto connect_cap_ms = static_cast<decltype(sts_client_configuration.connectTimeoutMs)>(DEFAULT_CONNECT_TIMEOUT_MS);
+    static constexpr auto request_cap_ms
+        = static_cast<decltype(sts_client_configuration.requestTimeoutMs)>(DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS);
     if (sts_client_configuration.connectTimeoutMs <= 0 || sts_client_configuration.connectTimeoutMs > connect_cap_ms)
         sts_client_configuration.connectTimeoutMs = connect_cap_ms;
     if (sts_client_configuration.requestTimeoutMs <= 0 || sts_client_configuration.requestTimeoutMs > request_cap_ms)

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -805,6 +805,27 @@ constexpr auto DEFAULT_SERVICE_ACCOUNT = "default";
 constexpr auto DEFAULT_METADATA_SERVICE = "metadata.google.internal";
 constexpr auto DEFAULT_REQUEST_TOKEN_PATH = "computeMetadata/v1/instance/service-accounts";
 
+/// A non-positive timespan means "no limit" to both `ConnectionTimeouts::saturate` and Poco's socket
+/// layer, so it must be replaced by the cap and not merely compared against it.
+Poco::Timespan capTimespan(Poco::Timespan timespan, Poco::Timespan cap)
+{
+    if (timespan.totalMicroseconds() <= 0)
+        return cap;
+    return std::min(timespan, cap);
+}
+
+}
+
+ConnectionTimeouts getCredentialAcquisitionTimeouts(const ConnectionTimeouts & timeouts)
+{
+    const Poco::Timespan connect_cap(DEFAULT_CONNECT_TIMEOUT_MS * 1000);
+    const Poco::Timespan request_cap(DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS * 1000);
+
+    return ConnectionTimeouts(timeouts)
+        .withConnectionTimeout(capTimespan(timeouts.connection_timeout, connect_cap))
+        .withSecureConnectionTimeout(capTimespan(timeouts.secure_connection_timeout, connect_cap))
+        .withSendTimeout(capTimespan(timeouts.send_timeout, request_cap))
+        .withReceiveTimeout(capTimespan(timeouts.receive_timeout, request_cap));
 }
 
 PocoHTTPClientGCPOAuth::PocoHTTPClientGCPOAuth(const PocoHTTPClientConfiguration & client_configuration)
@@ -878,7 +899,7 @@ PocoHTTPClientGCPOAuth::BearerToken PocoHTTPClientGCPOAuth::requestBearerToken()
         LOG_TEST(log, "Make request to: {}", url.toString());
 
     auto group = for_disk_s3 ? HTTPConnectionGroupType::DISK : HTTPConnectionGroupType::STORAGE;
-    auto session = makeHTTPSession(group, url, timeouts);
+    auto session = makeHTTPSession(group, url, getCredentialAcquisitionTimeouts(timeouts));
     session->sendRequest(request);
 
     Poco::Net::HTTPResponse response;
@@ -915,7 +936,8 @@ PocoHTTPClientGCPOAuth::BearerToken PocoHTTPClientGCPOAuth::requestBearerToken()
 PocoHTTPClientGCPOAuth::BearerToken PocoHTTPClientGCPOAuth::requestBearerTokenFromADC() const
 {
     auto group = for_disk_s3 ? HTTPConnectionGroupType::DISK : HTTPConnectionGroupType::STORAGE;
-    auto result = fetchGCPOAuthToken(google_adc_client_id, google_adc_client_secret, google_adc_refresh_token, timeouts, group);
+    auto result = fetchGCPOAuthToken(
+        google_adc_client_id, google_adc_client_secret, google_adc_refresh_token, getCredentialAcquisitionTimeouts(timeouts), group);
     return
     {
         .token = std::move(result.access_token),

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -805,8 +805,9 @@ constexpr auto DEFAULT_SERVICE_ACCOUNT = "default";
 constexpr auto DEFAULT_METADATA_SERVICE = "metadata.google.internal";
 constexpr auto DEFAULT_REQUEST_TOKEN_PATH = "computeMetadata/v1/instance/service-accounts";
 
-/// A non-positive timespan means "no limit" to both `ConnectionTimeouts::saturate` and Poco's socket
-/// layer, so it must be replaced by the cap and not merely compared against it.
+/// A non-positive receive timeout is unbounded downstream: Poco maps it to INT_MAX microseconds in
+/// `SecureSocketImpl::getMaxTimeoutOrLimit`, so it must be replaced by the cap rather than compared
+/// against it.
 Poco::Timespan capTimespan(Poco::Timespan timespan, Poco::Timespan cap)
 {
     if (timespan.totalMicroseconds() <= 0)
@@ -818,12 +819,9 @@ Poco::Timespan capTimespan(Poco::Timespan timespan, Poco::Timespan cap)
 
 ConnectionTimeouts getCredentialAcquisitionTimeouts(const ConnectionTimeouts & timeouts)
 {
-    const Poco::Timespan connect_cap(DEFAULT_CONNECT_TIMEOUT_MS * 1000);
     const Poco::Timespan request_cap(DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS * 1000);
 
     return ConnectionTimeouts(timeouts)
-        .withConnectionTimeout(capTimespan(timeouts.connection_timeout, connect_cap))
-        .withSecureConnectionTimeout(capTimespan(timeouts.secure_connection_timeout, connect_cap))
         .withSendTimeout(capTimespan(timeouts.send_timeout, request_cap))
         .withReceiveTimeout(capTimespan(timeouts.receive_timeout, request_cap));
 }

--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -46,6 +46,11 @@ namespace DB::S3
 /// HTTP 400 from S3 with non-empty `x-amz-bucket-region` (wrong SigV4 signing region for the bucket).
 bool isS3WrongSigningRegionBadRequest(int status_code, const Poco::Net::HTTPMessage & response);
 
+/// Bounds a credential-acquisition round trip independently of the data-transfer timeouts it is
+/// derived from, which callers such as backups legitimately raise to an hour. A component already
+/// tighter than the cap is kept; a non-positive one means "no limit" downstream, so it takes the cap.
+ConnectionTimeouts getCredentialAcquisitionTimeouts(const ConnectionTimeouts & timeouts);
+
 class ClientFactory;
 class PocoHTTPClient;
 

--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -46,9 +46,9 @@ namespace DB::S3
 /// HTTP 400 from S3 with non-empty `x-amz-bucket-region` (wrong SigV4 signing region for the bucket).
 bool isS3WrongSigningRegionBadRequest(int status_code, const Poco::Net::HTTPMessage & response);
 
-/// Bounds a credential-acquisition round trip independently of the data-transfer timeouts it is
-/// derived from, which callers such as backups legitimately raise to an hour. A component already
-/// tighter than the cap is kept; a non-positive one means "no limit" downstream, so it takes the cap.
+/// Bounds only the response wait of a credential-acquisition round trip; the connect timeout stays
+/// as the caller set it. An already tighter wait is kept, a non-positive one is unbounded downstream
+/// and so takes the cap.
 ConnectionTimeouts getCredentialAcquisitionTimeouts(const ConnectionTimeouts & timeouts);
 
 class ClientFactory;

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -1104,4 +1104,98 @@ TEST(IOTestAwsS3Client, ReadWithMatchingIfMatchSucceeds)
     EXPECT_EQ(content, body);
 }
 
+/// A credential round trip is bounded by the credential caps whatever the data-transfer timeouts are:
+/// a looser component is lowered to the cap, a non-positive one (no limit downstream) takes the cap,
+/// and a component already tighter than the cap is kept rather than raised.
+TEST(IOTestAwsS3Client, CredentialAcquisitionTimeoutsAreCapped)
+{
+    const Poco::Timespan connect_cap(DB::S3::DEFAULT_CONNECT_TIMEOUT_MS * 1000);
+    const Poco::Timespan request_cap(DB::S3::DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS * 1000);
+
+    struct Case
+    {
+        const char * name;
+        Poco::Timespan input;
+        Poco::Timespan expected;
+    };
+
+    const Case request_cases[] = {
+        {"one hour is lowered to the cap", Poco::Timespan(60 * 60, 0), request_cap},
+        {"no limit takes the cap", Poco::Timespan(0), request_cap},
+        {"tighter than the cap is kept", Poco::Timespan(2, 0), Poco::Timespan(2, 0)},
+        {"exactly the cap is kept", request_cap, request_cap},
+    };
+
+    for (const auto & c : request_cases)
+    {
+        auto timeouts = DB::ConnectionTimeouts().withSendTimeout(c.input).withReceiveTimeout(c.input);
+        auto capped = DB::S3::getCredentialAcquisitionTimeouts(timeouts);
+        EXPECT_EQ(capped.receive_timeout, c.expected) << c.name;
+        EXPECT_EQ(capped.send_timeout, c.expected) << c.name;
+    }
+
+    const Case connect_cases[] = {
+        {"ten seconds is lowered to the cap", Poco::Timespan(10, 0), connect_cap},
+        {"no limit takes the cap", Poco::Timespan(0), connect_cap},
+        {"tighter than the cap is kept", Poco::Timespan(0, 500 * 1000), Poco::Timespan(0, 500 * 1000)},
+    };
+
+    for (const auto & c : connect_cases)
+    {
+        auto timeouts = DB::ConnectionTimeouts().withConnectionTimeout(c.input);
+        auto capped = DB::S3::getCredentialAcquisitionTimeouts(timeouts);
+        EXPECT_EQ(capped.connection_timeout, c.expected) << c.name;
+        EXPECT_EQ(capped.secure_connection_timeout, c.expected) << c.name;
+    }
+}
+
+namespace
+{
+
+/// `timeouts` is protected, so reading the data-plane value the client actually serves requests with
+/// needs a subclass rather than a friend declaration.
+class GCPOAuthClientWithVisibleTimeouts : public DB::S3::PocoHTTPClientGCPOAuth
+{
+public:
+    using DB::S3::PocoHTTPClientGCPOAuth::PocoHTTPClientGCPOAuth;
+
+    const DB::ConnectionTimeouts & getDataPlaneTimeouts() const { return timeouts; }
+};
+
+}
+
+/// Capping the credential round trip must not touch the data plane: a backup keeps the one-hour
+/// per-request timeout it sets for large multipart transfers.
+TEST(IOTestAwsS3Client, CredentialCapDoesNotAffectDataPlaneTimeouts)
+{
+    DB::RemoteHostFilter remote_host_filter;
+    auto client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
+        "eu-west-1",
+        remote_host_filter,
+        /* s3_max_redirects = */ 10,
+        DB::S3::PocoHTTPClientConfiguration::RetryStrategy{},
+        /* s3_slow_all_threads_after_network_error = */ true,
+        /* s3_slow_all_threads_after_retryable_error = */ true,
+        /* enable_s3_requests_logging = */ false,
+        /* for_disk_s3 = */ false,
+        /* opt_disk_name = */ {},
+        /* request_throttler = */ {},
+        "http");
+
+    /// The values BackupIO_S3 sets for a backup.
+    client_configuration.connectTimeoutMs = 10 * 1000;
+    client_configuration.requestTimeoutMs = 60 * 60 * 1000;
+
+    GCPOAuthClientWithVisibleTimeouts client(client_configuration);
+
+    const auto & data_plane = client.getDataPlaneTimeouts();
+    EXPECT_EQ(data_plane.receive_timeout, Poco::Timespan(60 * 60, 0));
+    EXPECT_EQ(data_plane.send_timeout, Poco::Timespan(60 * 60, 0));
+    EXPECT_EQ(data_plane.connection_timeout, Poco::Timespan(10, 0));
+
+    auto credential = DB::S3::getCredentialAcquisitionTimeouts(data_plane);
+    EXPECT_EQ(credential.receive_timeout, Poco::Timespan(DB::S3::DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS * 1000));
+    EXPECT_EQ(credential.connection_timeout, Poco::Timespan(DB::S3::DEFAULT_CONNECT_TIMEOUT_MS * 1000));
+}
+
 #endif

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -1104,12 +1104,12 @@ TEST(IOTestAwsS3Client, ReadWithMatchingIfMatchSucceeds)
     EXPECT_EQ(content, body);
 }
 
-/// A credential round trip is bounded by the credential caps whatever the data-transfer timeouts are:
-/// a looser component is lowered to the cap, a non-positive one (no limit downstream) takes the cap,
-/// and a component already tighter than the cap is kept rather than raised.
+/// The response wait of a credential round trip is bounded by the credential cap whatever the
+/// data-transfer timeouts are: a looser component is lowered to the cap, a non-positive one
+/// (unbounded downstream) takes the cap, and one already tighter than the cap is kept rather than
+/// raised. The connect timeout is passed through untouched.
 TEST(IOTestAwsS3Client, CredentialAcquisitionTimeoutsAreCapped)
 {
-    const Poco::Timespan connect_cap(DB::S3::DEFAULT_CONNECT_TIMEOUT_MS * 1000);
     const Poco::Timespan request_cap(DB::S3::DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS * 1000);
 
     struct Case
@@ -1135,9 +1135,9 @@ TEST(IOTestAwsS3Client, CredentialAcquisitionTimeoutsAreCapped)
     }
 
     const Case connect_cases[] = {
-        {"ten seconds is lowered to the cap", Poco::Timespan(10, 0), connect_cap},
-        {"no limit takes the cap", Poco::Timespan(0), connect_cap},
-        {"tighter than the cap is kept", Poco::Timespan(0, 500 * 1000), Poco::Timespan(0, 500 * 1000)},
+        {"the backup's ten seconds is kept", Poco::Timespan(10, 0), Poco::Timespan(10, 0)},
+        {"a custom metadata service budget is kept", Poco::Timespan(30, 0), Poco::Timespan(30, 0)},
+        {"no limit is kept", Poco::Timespan(0), Poco::Timespan(0)},
     };
 
     for (const auto & c : connect_cases)
@@ -1195,7 +1195,7 @@ TEST(IOTestAwsS3Client, CredentialCapDoesNotAffectDataPlaneTimeouts)
 
     auto credential = DB::S3::getCredentialAcquisitionTimeouts(data_plane);
     EXPECT_EQ(credential.receive_timeout, Poco::Timespan(DB::S3::DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS * 1000));
-    EXPECT_EQ(credential.connection_timeout, Poco::Timespan(DB::S3::DEFAULT_CONNECT_TIMEOUT_MS * 1000));
+    EXPECT_EQ(credential.connection_timeout, Poco::Timespan(10, 0));
 }
 
 #endif

--- a/src/IO/S3Defines.h
+++ b/src/IO/S3Defines.h
@@ -8,6 +8,9 @@ namespace DB::S3
 inline static constexpr uint64_t DEFAULT_EXPIRATION_WINDOW_SECONDS = 120;
 inline static constexpr uint64_t DEFAULT_CONNECT_TIMEOUT_MS = 1000;
 inline static constexpr uint64_t DEFAULT_REQUEST_TIMEOUT_MS = 30000;
+/// A credential-acquisition round trip is bounded by this, independently of the data-transfer
+/// request timeout, which callers such as backups legitimately raise to an hour.
+inline static constexpr uint64_t DEFAULT_CREDENTIAL_REQUEST_TIMEOUT_MS = 10000;
 inline static constexpr uint64_t DEFAULT_MAX_CONNECTIONS = 1024;
 inline static constexpr uint64_t DEFAULT_KEEP_ALIVE_TIMEOUT = 5;
 inline static constexpr uint64_t DEFAULT_KEEP_ALIVE_MAX_REQUESTS = 100;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109455
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a hang of up to one hour in `BACKUP`/`RESTORE ... TO S3`, GCS disks and the `s3` table function when the named collection sets `http_client = 'gcp_oauth'` and the Google OAuth2 token endpoint accepts the connection but never answers. The bearer token request no longer inherits the caller's data transfer request timeout; its response wait is bounded at 10 seconds, matching the STS `AssumeRole` request cap.

### Description

Found in CI: `BACKUP TABLE ... TO S3(<collection with http_client = 'gcp_oauth'>)` sat for 695 s with `read_rows: 0` until the test budget expired and the job reported `Some queries hung`. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107108&sha=7b0f0efd7803a3f3a603fe10adf92811bf16f468&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20WasmEdge%2C%20parallel%2C%203%2F3%29

`BackupIO_S3.cpp` sets `requestTimeoutMs = 60 * 60 * 1000` because backup data transfers can legitimately take that long. That single value becomes both the send and the receive socket timeout, and `PocoHTTPClientGCPOAuth` reuses the same `timeouts` member for its bearer token round trip, so a credential request that should take milliseconds parked in the TLS header read for an hour (`SecureSocketImpl::mustRetry` under `HTTPHeaderStreamBuf::readFromDevice`). The S3 endpoint in the failing case is plain HTTP on localhost, so the TLS peer can only be the hardcoded Google token URL.

This bounds the response wait of that round trip at 10 seconds, independently of the data transfer timeouts, at both mint sites (explicit ADC triple, and the metadata service branch). The connect timeout is left as the caller set it: `metadata_service` is a user-configurable host, so its connect budget belongs to the deployment that configured it, and connect was never the unbounded phase (`BackupIO_S3` already bounds it at 10 s). Data plane requests keep the full hour, and an already tighter timeout is kept. The 10 s matches the STS `AssumeRole` request cap, so it is named once in `S3Defines.h`.

Validated against a mock that accepts and never answers: the value passed before was still blocked after 40 s, the value passed now fails in 10.0 s. Exactly one request arrived in each arm, so `backup_restore_s3_retry_attempts` (default 1000) does not multiply the mint.

Not bounded here: session creation is retried up to 5 times, each attempt carrying the caller's connect budget, and the mint is not cancellation aware within the 10 s.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115531&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115531](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115531+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1803` (included in `26.8` and later)
<!-- ch-version-info:end -->