### PR TITLE
Fix paimon rest catalog pagination

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -254,6 +254,7 @@ static struct InitFiu
     REGULAR(datalake_try_get_table_return_nullptr) \
     REGULAR(datalake_try_get_table_throw) \
     REGULAR(datalake_get_tables_throw) \
+    REGULAR(datalake_paimon_list_page_size_one) \
     REGULAR(datalake_simulate_missing_table_state) \
     PAUSEABLE_ONCE(drop_database_before_exclusive_ddl_lock) \
     PAUSEABLE_ONCE(create_or_replace_before_rename) \

--- a/src/Databases/DataLake/PaimonRestCatalog.cpp
+++ b/src/Databases/DataLake/PaimonRestCatalog.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <sstream>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <Core/Names.h>
 #include <Databases/DataLake/Common.h>
@@ -38,6 +39,7 @@
 #include <Poco/String.h>
 #include <Common/Base64.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/Logger.h>
 #include <Common/OpenSSLHelpers.h>
 #include <Common/logger_useful.h>
@@ -49,10 +51,48 @@ namespace DB::ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
+namespace DB::FailPoints
+{
+    extern const char datalake_paimon_list_page_size_one[];
+}
+
 
 namespace DataLake
 {
 using namespace DataLake::Paimon;
+
+/// Page size requested from the listing endpoints. A catalog with fewer items than one page still
+/// exercises the paginated walk under the failpoint, which is how the tests reach the code path that
+/// follows a cursor without needing a catalog holding more than `LIST_MAX_RESULTS` items.
+static UInt64 getListMaxResults()
+{
+    UInt64 max_results = LIST_MAX_RESULTS;
+    fiu_do_on(DB::FailPoints::datalake_paimon_list_page_size_one, { max_results = 1; });
+    return max_results;
+}
+
+/// Extracts the pagination cursor from a listing response. The Paimon REST pagination contract says
+/// the last page carries no `nextPageToken` (or a JSON `null` one), so an absent token must yield an
+/// empty string: keeping the previous page's token would make the caller re-request that page forever.
+static String extractNextPageToken(const Poco::JSON::Object::Ptr & json_ptr)
+{
+    if (json_ptr->has("nextPageToken") && !json_ptr->isNull("nextPageToken"))
+        return json_ptr->getValue<String>("nextPageToken");
+    return {};
+}
+
+/// Reads the array of listed items out of a listing response. A response without the expected key is
+/// a malformed catalog answer, not an empty page - report it instead of dereferencing a null pointer.
+static Poco::JSON::Array::Ptr getListingArray(const Poco::JSON::Object::Ptr & json_ptr, const String & key)
+{
+    auto array = json_ptr->getArray(key);
+    if (!array)
+        throw DB::Exception(
+            DB::ErrorCodes::DATALAKE_DATABASE_ERROR,
+            "Paimon REST catalog returned a listing response without the `{}` array.",
+            key);
+    return array;
+}
 
 static String md5(const String & input)
 {
@@ -309,19 +349,18 @@ DB::ReadWriteBufferFromHTTPPtr PaimonRestCatalog::createReadBuffer(
 void PaimonRestCatalog::forEachDatabase(DB::Strings & databases, StopCondition stop_condition, ExecuteFunc execute_func) const
 {
     auto json_ptr = requestRest(
-        std::filesystem::path(API_VERSION) / prefix / DATABASES_ENDPOINT, "GET", {{"maxResults", fmt::to_string(LIST_MAX_RESULTS)}});
-    auto databases_array = json_ptr->getArray("databases");
-    String next_page_token;
-    if (json_ptr->has("nextPageToken") && !json_ptr->isNull("nextPageToken"))
-    {
-        next_page_token = json_ptr->getValue<String>("nextPageToken");
-    }
-    bool first_iteration = true;
+        std::filesystem::path(API_VERSION) / prefix / DATABASES_ENDPOINT, "GET", {{"maxResults", fmt::to_string(getListMaxResults())}});
+    auto databases_array = getListingArray(json_ptr, "databases");
+    String next_page_token = extractNextPageToken(json_ptr);
+    /// Cycle-detection guard: tracks every non-empty `nextPageToken` we have seen on this request so
+    /// we can refuse to loop when a malformed catalog repeats a token. Covers both the immediate-repeat
+    /// case (`A -> A`) and longer cycles (`A -> B -> A -> ...`), since any revisit triggers a duplicate
+    /// `insert`.
+    std::unordered_set<String> seen_tokens;
     bool stop = false;
 
-    while (first_iteration || !next_page_token.empty())
+    while (true)
     {
-        first_iteration = false;
         for (unsigned int i = 0; i < databases_array->size(); ++i)
         {
             const String & database_name = databases_array->getElement<String>(i);
@@ -337,23 +376,27 @@ void PaimonRestCatalog::forEachDatabase(DB::Strings & databases, StopCondition s
                 break;
             }
         }
-        if (stop)
+        /// The cursor is examined only after the current page has been consumed, otherwise the last
+        /// page - the one that carries no `nextPageToken` - would be fetched and then dropped.
+        if (stop || next_page_token.empty())
         {
             break;
         }
+        if (!seen_tokens.insert(next_page_token).second)
+        {
+            throw DB::Exception(
+                DB::ErrorCodes::DATALAKE_DATABASE_ERROR,
+                "Paimon REST catalog returned a `nextPageToken` (`{}`) already seen on this request "
+                "while listing databases - refusing to loop.",
+                next_page_token);
+        }
         Poco::URI::QueryParameters params = {
-            {"maxResults", fmt::to_string(LIST_MAX_RESULTS)},
+            {"maxResults", fmt::to_string(getListMaxResults())},
+            {"pageToken", next_page_token},
         };
-        if (!next_page_token.empty())
-        {
-            params.emplace_back("pageToken", next_page_token);
-        }
         json_ptr = requestRest(std::filesystem::path(API_VERSION) / prefix / DATABASES_ENDPOINT, "GET", params);
-        databases_array = json_ptr->getArray("databases");
-        if (json_ptr->has("nextPageToken") && !json_ptr->isNull("nextPageToken"))
-        {
-            next_page_token = json_ptr->getValue<String>("nextPageToken");
-        }
+        databases_array = getListingArray(json_ptr, "databases");
+        next_page_token = extractNextPageToken(json_ptr);
     }
 }
 
@@ -363,19 +406,15 @@ void PaimonRestCatalog::forEachTables(
     auto json_ptr = requestRest(
         std::filesystem::path(API_VERSION) / prefix / DATABASES_ENDPOINT / database / TABLES_ENDPOINT,
         "GET",
-        {{"maxResults", fmt::to_string(LIST_MAX_RESULTS)}});
-    auto tables_array = json_ptr->getArray("tables");
-    String next_page_token;
-    if (json_ptr->has("nextPageToken") && !json_ptr->isNull("nextPageToken"))
-    {
-        next_page_token = json_ptr->getValue<String>("nextPageToken");
-    }
-    bool first_iteration = true;
+        {{"maxResults", fmt::to_string(getListMaxResults())}});
+    auto tables_array = getListingArray(json_ptr, "tables");
+    String next_page_token = extractNextPageToken(json_ptr);
+    /// See the cycle-detection comment in `forEachDatabase`.
+    std::unordered_set<String> seen_tokens;
     bool stop = false;
 
-    while (first_iteration || !next_page_token.empty())
+    while (true)
     {
-        first_iteration = false;
         for (unsigned int i = 0; i < tables_array->size(); ++i)
         {
             String table_name = tables_array->getElement<String>(i);
@@ -391,24 +430,28 @@ void PaimonRestCatalog::forEachTables(
                 break;
             }
         }
-        if (stop)
+        /// See the comment in `forEachDatabase` on why the cursor is examined here and not in the
+        /// loop condition.
+        if (stop || next_page_token.empty())
         {
             break;
         }
-        Poco::URI::QueryParameters params = {
-            {"maxResults", fmt::to_string(LIST_MAX_RESULTS)},
-        };
-        if (!next_page_token.empty())
+        if (!seen_tokens.insert(next_page_token).second)
         {
-            params.emplace_back("pageToken", next_page_token);
+            throw DB::Exception(
+                DB::ErrorCodes::DATALAKE_DATABASE_ERROR,
+                "Paimon REST catalog returned a `nextPageToken` (`{}`) already seen on this request "
+                "while listing tables of database `{}` - refusing to loop.",
+                next_page_token, database);
         }
+        Poco::URI::QueryParameters params = {
+            {"maxResults", fmt::to_string(getListMaxResults())},
+            {"pageToken", next_page_token},
+        };
         json_ptr
             = requestRest(std::filesystem::path(API_VERSION) / prefix / DATABASES_ENDPOINT / database / TABLES_ENDPOINT, "GET", params);
-        tables_array = json_ptr->getArray("tables");
-        if (json_ptr->has("nextPageToken") && !json_ptr->isNull("nextPageToken"))
-        {
-            next_page_token = json_ptr->getValue<String>("nextPageToken");
-        }
+        tables_array = getListingArray(json_ptr, "tables");
+        next_page_token = extractNextPageToken(json_ptr);
     }
 }
 

--- a/tests/integration/test_paimon_rest_catalog/test.py
+++ b/tests/integration/test_paimon_rest_catalog/test.py
@@ -12,6 +12,9 @@ DOCKER_COMPOSE_PATH = get_docker_compose_path()
 BEARER_PORT = 8001
 DLF_PORT = 8002
 
+# A listing walk that does not terminate never answers, so the paginated query is bounded.
+PAGED_QUERY_TIMEOUT = 60
+
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True, main_configs=[])
 
@@ -154,3 +157,37 @@ def test_paimon_rest_catalog(started_cluster):
     message = str(exc_info.value)
     assert "Code: 86" in message, message
     assert "401" in message, message
+
+
+def test_paginated_listing_terminates(started_cluster):
+    bearer_ip = cluster.get_instance_ip("paimon-rest-bearer")
+
+    node.query("DROP DATABASE IF EXISTS paimon_rest_db_paged SYNC;")
+    node.query(
+        f"CREATE DATABASE paimon_rest_db_paged ENGINE = DataLakeCatalog('http://{bearer_ip}:{BEARER_PORT}')"
+        f" SETTINGS catalog_type='paimon_rest', warehouse='restWarehouse',"
+        f" catalog_credential='bearer-token-xxx-xxx-xxx';",
+        settings={"allow_experimental_database_paimon_rest_catalog": 1},
+    )
+
+    # A page size of one makes every listing paginate: a Paimon REST catalog hands back the name of
+    # the last item of a page as `nextPageToken`, and a page that exactly fills `maxResults` still
+    # carries one. So the single database and the single table of this catalog each take two
+    # requests, and the second page comes back empty with no token at all. Walking them must
+    # terminate and yield every item exactly once - a cursor that is not cleared on the last page
+    # re-requests that page forever, hanging the query and duplicating its items.
+    node.query("SYSTEM ENABLE FAILPOINT datalake_paimon_list_page_size_one")
+    try:
+        # Covers both paginated walks: the database listing and the table listing of `test`.
+        assert (
+            node.query(
+                "SHOW TABLES;",
+                database="paimon_rest_db_paged",
+                timeout=PAGED_QUERY_TIMEOUT,
+            )
+            == "test.test_table\n"
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT datalake_paimon_list_page_size_one")
+
+    node.query("DROP DATABASE paimon_rest_db_paged SYNC;")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/115251
Related: https://github.com/ClickHouse/ClickHouse/issues/103674

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


Fixed `SHOW TABLES`, `system.tables` scans and table resolution hanging indefinitely against a `paimon_rest` catalog whose listings paginate — a warehouse with more than 100 databases, or a database with more than 100 tables. The pagination cursor was not cleared when the last page carried no `nextPageToken`, so the client re-requested that page forever and accumulated duplicate entries.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115534&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115534](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115534+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.396` (included in `26.10` and later)
<!-- ch-version-info:end -->