### PR TITLE
Bind an unqualified dictGet name to the current database

### DIFF
--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -1397,6 +1397,41 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
         }
     }
 
+    /** Bind an unqualified dictionary name to the current database.
+      *
+      * The dictionary name of `dictGet` and its variations is resolved against the current database of
+      * the server that evaluates the function. A shard of a `Distributed` table evaluates it in a session
+      * whose current database comes from the cluster configuration - `default` unless `<default_database>`
+      * is set - and not from the initiator, so an unqualified name shipped to a shard either fails to
+      * resolve or, worse, silently resolves to a different dictionary that happens to have the same name.
+      * Bind the name here, while the current database of the initiator is still known. The old analyzer
+      * does the same in `AddDefaultDatabaseVisitor` for the query it sends to the shards.
+      *
+      * `arguments_projection_names` is already calculated at this point, so the column name of the
+      * expression stays exactly as it was written by the user.
+      *
+      * `qualifyDictionaryNameWithDatabase` leaves the name alone when it is already qualified, when it
+      * belongs to an XML dictionary, and when no such dictionary exists in the current database - in the
+      * last case the name may still be meant for a dictionary that only exists on the shards.
+      */
+    if (is_special_function_dict_get)
+    {
+        auto & dict_get_arguments = function_node_ptr->getArguments().getNodes();
+        if (!dict_get_arguments.empty())
+        {
+            const auto * dictionary_name_node = dict_get_arguments[0]->as<ConstantNode>();
+            if (dictionary_name_node && dictionary_name_node->getValue().getType() == Field::Types::String)
+            {
+                const auto & dictionary_name = dictionary_name_node->getValue().safeGet<String>();
+                auto qualified_dictionary_name = scope.context->getExternalDictionariesLoader()
+                    .qualifyDictionaryNameWithDatabase(dictionary_name, scope.context).getFullName();
+
+                if (qualified_dictionary_name != dictionary_name)
+                    dict_get_arguments[0] = std::make_shared<ConstantNode>(qualified_dictionary_name);
+            }
+        }
+    }
+
     auto & function_node = *function_node_ptr;
 
     /// Replace right IN function argument if it is table or table function with subquery that read ordinary columns

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.reference
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.reference
@@ -15,24 +15,24 @@ Equality, RHS, opt off
 1	a
 3	c
 Inequality <, LHS, no rewrite (default 0 < 10) - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE less(dictGetUInt64(\'colors\', \'n\', __table1.color_id), 10)\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE less(dictGetUInt64(\'default.colors\', \'n\', __table1.color_id), 10)\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 Inequality <, LHS, no rewrite (default 0 < 10)
 1	a
 2	b
 4	d
 5	R
 Inequality <, RHS, no rewrite (default 0 < 10) - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE greater(10, dictGetUInt64(\'colors\', \'n\', __table1.color_id))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE greater(10, dictGetUInt64(\'default.colors\', \'n\', __table1.color_id))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 Inequality <, RHS, no rewrite (default 0 < 10)
 1	a
 2	b
 4	d
 5	R
 Type mismatch not allowed, >= Int32 - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE greaterOrEquals(dictGetInt32(\'colors\', \'n\', __table1.color_id), 2)\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE greaterOrEquals(dictGetInt32(\'default.colors\', \'n\', __table1.color_id), 2)\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 Type mismatch not allowed, >= Int32
 LIKE - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE in(__table1.color_id, (\n    SELECT id AS id\n    FROM dictionary(\'colors\')\n    WHERE like(name, \'r%\')\n))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE in(__table1.color_id, (\n    SELECT id AS id\n    FROM dictionary(\'default.colors\')\n    WHERE like(name, \'r%\')\n))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 LIKE
 1	a
 3	c
@@ -40,7 +40,7 @@ LIKE, opt off
 1	a
 3	c
 ILIKE - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE in(__table1.color_id, (\n    SELECT id AS id\n    FROM dictionary(\'colors\')\n    WHERE ilike(name, \'r%\')\n))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE in(__table1.color_id, (\n    SELECT id AS id\n    FROM dictionary(\'default.colors\')\n    WHERE ilike(name, \'r%\')\n))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 ILIKE
 1	a
 3	c
@@ -58,24 +58,24 @@ equals(), opt off
 1
 3
 notEquals, no rewrite (default empty string != red) - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE notEquals(dictGetString(\'colors\', \'name\', __table1.color_id), \'red\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE notEquals(dictGetString(\'default.colors\', \'name\', __table1.color_id), \'red\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 notEquals, no rewrite (default empty string != red)
 2	b
 4	d
 5	R
 NOT LIKE r%, no rewrite (default empty string NOT LIKE r%) - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE notLike(dictGetString(\'colors\', \'name\', __table1.color_id), \'r%\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE notLike(dictGetString(\'default.colors\', \'name\', __table1.color_id), \'r%\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 NOT LIKE r%, no rewrite (default empty string NOT LIKE r%)
 2	b
 4	d
 5	R
 NOT ILIKE r%, no rewrite (default empty string NOT ILIKE r%) - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE notILike(dictGetString(\'colors\', \'name\', __table1.color_id), \'r%\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE notILike(dictGetString(\'default.colors\', \'name\', __table1.color_id), \'r%\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 NOT ILIKE r%, no rewrite (default empty string NOT ILIKE r%)
 2	b
 4	d
 match ^r - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE in(__table1.color_id, (\n    SELECT id AS id\n    FROM dictionary(\'colors\')\n    WHERE match(name, \'^r\')\n))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE in(__table1.color_id, (\n    SELECT id AS id\n    FROM dictionary(\'default.colors\')\n    WHERE match(name, \'^r\')\n))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 match ^r
 1	a
 3	c
@@ -93,7 +93,7 @@ NOT recursion, opt off
 4	d
 5	R
 AND/OR recursion - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE or(and(in(__table1.color_id, _CAST([1, 3], \'Array(UInt64)\')), less(dictGetUInt64(\'colors\', \'n\', __table1.color_id), 10)), equals(__table1.color_id, _CAST(4, \'UInt64\')))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE or(and(in(__table1.color_id, _CAST([1, 3], \'Array(UInt64)\')), less(dictGetUInt64(\'default.colors\', \'n\', __table1.color_id), 10)), equals(__table1.color_id, _CAST(4, \'UInt64\')))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 AND/OR recursion
 1	a
 4	d
@@ -101,7 +101,7 @@ AND/OR recursion, opt off
 1	a
 4	d
 NULL constant, no rewrite - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE equals(dictGetString(\'colors\', \'name\', __table1.color_id), _CAST(NULL, \'Nullable(Nothing)\'))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE equals(dictGetString(\'default.colors\', \'name\', __table1.color_id), _CAST(NULL, \'Nullable(Nothing)\'))\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 NULL constant, no rewrite
 PREWHERE - plan
 SELECT __table1.color_id AS color_id\nFROM default.t AS __table1\nPREWHERE in(__table1.color_id, _CAST([1, 3], \'Array(UInt64)\'))\nORDER BY __table1.color_id ASC
@@ -224,6 +224,6 @@ WINDOW PARTITION BY, opt off
 4	2
 5	3
 Negative: non-constant RHS - plan
-SELECT __table1.color_id AS color_id\nFROM default.t AS __table1\nWHERE equals(dictGetString(\'colors\', \'name\', __table1.color_id), __table1.payload)\nORDER BY __table1.color_id ASC
+SELECT __table1.color_id AS color_id\nFROM default.t AS __table1\nWHERE equals(dictGetString(\'default.colors\', \'name\', __table1.color_id), __table1.payload)\nORDER BY __table1.color_id ASC
 Negative: non-constant RHS
 Negative: non-constant RHS, opt off

--- a/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
+++ b/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
@@ -59,10 +59,10 @@ dictGetIPv6
 dictGetIPv6, opt off
 1	x
 dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization) - plan
-SELECT\n    __table1.id AS id,\n    __table1.payload AS payload\nFROM default.tab AS __table1\nWHERE equals(dictGetOrNull(\'dictionary_all\', \'name\', __table1.id), \'alpha\')\nORDER BY\n    __table1.id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.id AS id,\n    __table1.payload AS payload\nFROM default.tab AS __table1\nWHERE equals(dictGetOrNull(\'default.dictionary_all\', \'name\', __table1.id), \'alpha\')\nORDER BY\n    __table1.id ASC,\n    __table1.payload ASC
 dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization)
 1	x
 dictGetOrNull(String) IS NULL, no rewrite (dictGetOrNull is not supported by the optimization) - plan
-SELECT\n    __table1.id AS id,\n    __table1.payload AS payload\nFROM default.tab AS __table1\nWHERE isNull(dictGetOrNull(\'dictionary_all\', \'name\', __table1.id))\nORDER BY\n    __table1.id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.id AS id,\n    __table1.payload AS payload\nFROM default.tab AS __table1\nWHERE isNull(dictGetOrNull(\'default.dictionary_all\', \'name\', __table1.id))\nORDER BY\n    __table1.id ASC,\n    __table1.payload ASC
 dictGetOrNull(String) IS NULL, no rewrite (dictGetOrNull is not supported by the optimization)
 99	z

--- a/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.reference
+++ b/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.reference
@@ -1,5 +1,5 @@
 Less, LHS - plan
-SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE less(dictGetString(\'colors\', \'name\', __table1.color_id), \'red\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
+SELECT\n    __table1.color_id AS color_id,\n    __table1.payload AS payload\nFROM default.t AS __table1\nWHERE less(dictGetString(\'default.colors\', \'name\', __table1.color_id), \'red\')\nORDER BY\n    __table1.color_id ASC,\n    __table1.payload ASC
 Less, LHS
 2	b
 4	d

--- a/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.reference
+++ b/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.reference
@@ -1,91 +1,91 @@
 dictGet = default, missing key, no rewrite (default -1 = -1) - plan
-SELECT\n    __table1.id AS id,\n    dictGet(\'dict_int_default_minus1\', \'from\', toUInt64(__table1.id)) AS a,\n    equals(dictGet(\'dict_int_default_minus1\', \'from\', toUInt64(__table1.id)), -1) AS pred\nFROM default.data_int AS __table1\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT\n    __table1.id AS id,\n    dictGet(\'default.dict_int_default_minus1\', \'from\', toUInt64(__table1.id)) AS a,\n    equals(dictGet(\'default.dict_int_default_minus1\', \'from\', toUInt64(__table1.id)), -1) AS pred\nFROM default.data_int AS __table1\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 dictGet = default, missing key, no rewrite (default -1 = -1)
 53	-1	1
 dictGet = default, Nullable source, no rewrite (default -1 = -1) - plan
-SELECT\n    __table1.id AS id,\n    dictGet(\'dict_int_nullable_default_minus1\', \'from\', toUInt64(__table1.id)) AS a,\n    equals(dictGet(\'dict_int_nullable_default_minus1\', \'from\', toUInt64(__table1.id)), -1) AS pred\nFROM default.data_int AS __table1\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT\n    __table1.id AS id,\n    dictGet(\'default.dict_int_nullable_default_minus1\', \'from\', toUInt64(__table1.id)) AS a,\n    equals(dictGet(\'default.dict_int_nullable_default_minus1\', \'from\', toUInt64(__table1.id)), -1) AS pred\nFROM default.data_int AS __table1\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 dictGet = default, Nullable source, no rewrite (default -1 = -1)
 53	-1	1
 dictGetOrNull = const, no rewrite (dictGetOrNull is not supported by the optimization) - plan
-SELECT\n    __table1.id AS id,\n    equals(dictGetOrNull(\'dict_string\', \'name\', __table1.id), \'abc\') AS pred\nFROM default.data_str AS __table1\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT\n    __table1.id AS id,\n    equals(dictGetOrNull(\'default.dict_string\', \'name\', __table1.id), \'abc\') AS pred\nFROM default.data_str AS __table1\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 dictGetOrNull = const, no rewrite (dictGetOrNull is not supported by the optimization)
 1	1
 2	\N
 3	\N
 dictGet != non-default, no rewrite (default empty string != abc) - plan
-SELECT count() AS `count()`\nFROM default.data_str AS __table1\nWHERE notEquals(dictGet(\'dict_string\', \'name\', __table1.id), \'abc\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_str AS __table1\nWHERE notEquals(dictGet(\'default.dict_string\', \'name\', __table1.id), \'abc\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
 dictGet != non-default, no rewrite (default empty string != abc)
 2
 dictGet LIKE %, no rewrite (default empty string LIKE %) - plan
-SELECT count() AS `count()`\nFROM default.data_str AS __table1\nWHERE like(dictGet(\'dict_string\', \'name\', __table1.id), \'%\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_str AS __table1\nWHERE like(dictGet(\'default.dict_string\', \'name\', __table1.id), \'%\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
 dictGet LIKE %, no rewrite (default empty string LIKE %)
 3
 Nullable key, dictGetString != abc, no rewrite (default empty string != abc) - plan
-SELECT count() AS `count()`\nFROM default.data_str_nullable AS __table1\nWHERE notEquals(dictGetString(\'dict_string\', \'name\', __table1.id), \'abc\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_str_nullable AS __table1\nWHERE notEquals(dictGetString(\'default.dict_string\', \'name\', __table1.id), \'abc\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Nullable key, dictGetString != abc, no rewrite (default empty string != abc)
 1
 LC(Nullable) simple key, dictGetString != abc, no rewrite (default empty string != abc) - plan
-SELECT count() AS `count()`\nFROM default.data_str_lc_nullable AS __table1\nWHERE notEquals(dictGetString(\'dict_string\', \'name\', __table1.id), \'abc\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_str_lc_nullable AS __table1\nWHERE notEquals(dictGetString(\'default.dict_string\', \'name\', __table1.id), \'abc\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
 LC(Nullable) simple key, dictGetString != abc, no rewrite (default empty string != abc)
 1
 Composite key, Nullable component, no rewrite (skip to preserve dictGet throw on NULL component) - plan
-SELECT\n    __table1.k1 AS k1,\n    equals(dictGetString(\'dict_complex_str\', \'name\', tuple(__table1.k1, __table1.k2)), \'abc\') AS pred\nFROM default.data_complex AS __table1\nORDER BY __table1.k1 ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT\n    __table1.k1 AS k1,\n    equals(dictGetString(\'default.dict_complex_str\', \'name\', tuple(__table1.k1, __table1.k2)), \'abc\') AS pred\nFROM default.data_complex AS __table1\nORDER BY __table1.k1 ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Composite key, Nullable component, no rewrite (skip to preserve dictGet throw on NULL component)
 1	1
 2	0
 Composite key, LC(Nullable) component, no rewrite (skip to preserve throw) - plan
-SELECT\n    __table1.k1 AS k1,\n    equals(dictGetString(\'dict_complex_str\', \'name\', tuple(__table1.k1, __table1.k2)), \'abc\') AS pred\nFROM default.data_complex_lc_nullable AS __table1\nORDER BY __table1.k1 ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT\n    __table1.k1 AS k1,\n    equals(dictGetString(\'default.dict_complex_str\', \'name\', tuple(__table1.k1, __table1.k2)), \'abc\') AS pred\nFROM default.data_complex_lc_nullable AS __table1\nORDER BY __table1.k1 ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Composite key, LC(Nullable) component, no rewrite (skip to preserve throw)
 1	1
 2	0
 Composite key, dict declares Nullable key, Nullable data, no rewrite - plan
-SELECT count() AS `count()`\nFROM default.data_complex_nullable_dict_key AS __table1\nWHERE equals(dictGetString(\'dict_complex_nullable_dict_key\', \'name\', tuple(__table1.k1, __table1.k2)), \'nullhit\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_complex_nullable_dict_key AS __table1\nWHERE equals(dictGetString(\'default.dict_complex_nullable_dict_key\', \'name\', tuple(__table1.k1, __table1.k2)), \'nullhit\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Composite key, dict declares Nullable key, Nullable data, no rewrite
 1
 Nullable(Tuple(Nullable(K))), no rewrite - plan
-SELECT count() AS `count()`\nFROM default.data_outer_nullable_tuple AS __table1\nWHERE equals(dictGetString(\'dict_complex_nullable_dict_key\', \'name\', __table1.t), \'nullhit\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_outer_nullable_tuple AS __table1\nWHERE equals(dictGetString(\'default.dict_complex_nullable_dict_key\', \'name\', __table1.t), \'nullhit\')\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Nullable(Tuple(Nullable(K))), no rewrite
 1
 Nullable attr with stored NULL, isNull(predicate), no rewrite - plan
-SELECT __table1.id AS id\nFROM default.data_str AS __table1\nWHERE isNull(equals(dictGet(\'dict_nullable_attr_stored\', \'name\', __table1.id), \'abc\'))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_str AS __table1\nWHERE isNull(equals(dictGet(\'default.dict_nullable_attr_stored\', \'name\', __table1.id), \'abc\'))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Nullable attr with stored NULL, isNull(predicate), no rewrite
 2
 op equals, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE equals(dictGetUInt64(\'dict_ops\', \'n\', __table1.id), 0)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE equals(dictGetUInt64(\'default.dict_ops\', \'n\', __table1.id), 0)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op notEquals, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE notEquals(dictGetString(\'dict_ops\', \'name\', __table1.id), \'zzz\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE notEquals(dictGetString(\'default.dict_ops\', \'name\', __table1.id), \'zzz\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op less, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE less(dictGetUInt64(\'dict_ops\', \'n\', __table1.id), 100)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE less(dictGetUInt64(\'default.dict_ops\', \'n\', __table1.id), 100)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op lessOrEquals, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE lessOrEquals(dictGetUInt64(\'dict_ops\', \'n\', __table1.id), 0)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE lessOrEquals(dictGetUInt64(\'default.dict_ops\', \'n\', __table1.id), 0)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op greater, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE greater(\'apple\', dictGetString(\'dict_ops\', \'name\', __table1.id))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE greater(\'apple\', dictGetString(\'default.dict_ops\', \'name\', __table1.id))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op greaterOrEquals, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE greaterOrEquals(dictGetUInt64(\'dict_ops\', \'n\', __table1.id), 0)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE greaterOrEquals(dictGetUInt64(\'default.dict_ops\', \'n\', __table1.id), 0)\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op like, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_ops\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_ops\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op notLike, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE notLike(dictGetString(\'dict_ops\', \'name\', __table1.id), \'a%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE notLike(dictGetString(\'default.dict_ops\', \'name\', __table1.id), \'a%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op ilike, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE ilike(dictGetString(\'dict_ops\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE ilike(dictGetString(\'default.dict_ops\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op notILike, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE notILike(dictGetString(\'dict_ops\', \'name\', __table1.id), \'A%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE notILike(dictGetString(\'default.dict_ops\', \'name\', __table1.id), \'A%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 op match, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE match(dictGetString(\'dict_ops\', \'name\', __table1.id), \'.*\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE match(dictGetString(\'default.dict_ops\', \'name\', __table1.id), \'.*\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 layout Flat, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_flat\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_flat\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 layout Hashed, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_hashed\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_hashed\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 layout HashedArray, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_hashed_array\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_hashed_array\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 layout SparseHashed, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_sparse_hashed\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_sparse_hashed\', \'name\', __table1.id), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 layout ComplexKeyHashed, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_complex\', \'name\', tuple(__table1.id, \'a\')), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_complex\', \'name\', tuple(__table1.id, \'a\')), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 layout ComplexHashedArray, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_complex_array\', \'name\', tuple(__table1.id, \'a\')), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_complex_array\', \'name\', tuple(__table1.id, \'a\')), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 layout ComplexKeySparseHashed, no rewrite
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'dict_complex_sparse\', \'name\', tuple(__table1.id, \'a\')), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE like(dictGetString(\'default.dict_complex_sparse\', \'name\', tuple(__table1.id, \'a\')), \'%\')\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: equals on non-default - plan
 SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE equals(__table1.id, _CAST(1, \'UInt64\'))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: equals on non-default
@@ -93,23 +93,23 @@ rewrite: equals on non-default
 rewrite: equals on non-default, opt off
 1
 rewrite: greater than non-default - plan
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_ops\')\n    WHERE greater(n, 100)\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_ops\')\n    WHERE greater(n, 100)\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: greater than non-default
 rewrite: greater than non-default, opt off
 rewrite: != default (numeric) - plan
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_ops\')\n    WHERE notEquals(n, 0)\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_ops\')\n    WHERE notEquals(n, 0)\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: != default (numeric)
 1
 rewrite: != default (numeric), opt off
 1
 rewrite: NOT LIKE default (string) - plan
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_ops\')\n    WHERE notLike(name, \'\')\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_ops\')\n    WHERE notLike(name, \'\')\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: NOT LIKE default (string)
 1
 rewrite: NOT LIKE default (string), opt off
 1
 rewrite: NOT ILIKE default (string) - plan
-SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_ops\')\n    WHERE notILike(name, \'\')\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT __table1.id AS id\nFROM default.data_ops AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_ops\')\n    WHERE notILike(name, \'\')\n))\nORDER BY __table1.id ASC\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: NOT ILIKE default (string)
 1
 rewrite: NOT ILIKE default (string), opt off
@@ -121,13 +121,13 @@ rewrite: plain key
 rewrite: plain key, opt off
 1
 rewrite: Nullable(K) key - plan
-SELECT count() AS `count()`\nFROM default.data_str_nullable AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_string\')\n    WHERE equals(name, \'abc\')\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_str_nullable AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_string\')\n    WHERE equals(name, \'abc\')\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: Nullable(K) key
 1
 rewrite: Nullable(K) key, opt off
 1
 rewrite: LC(Nullable(K)) key - plan
-SELECT count() AS `count()`\nFROM default.data_str_lc_nullable AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_string\')\n    WHERE equals(name, \'abc\')\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT count() AS `count()`\nFROM default.data_str_lc_nullable AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_string\')\n    WHERE equals(name, \'abc\')\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
 rewrite: LC(Nullable(K)) key
 1
 rewrite: LC(Nullable(K)) key, opt off
@@ -137,7 +137,7 @@ short-circuited bad-regex match: optimization on, returns 0
 short-circuited bad-regex match: optimization on, returns 0, opt off
 0
 short-circuited bad-regex match, no rewrite - plan, optimize_redundant_comparisons = 0
-SELECT count() AS `count()`\nFROM default.data_ops AS __table1\nWHERE and(less(__table1.id, 0), match(dictGetString(\'dict_ops\', \'name\', __table1.id), \'[unclosed\'))\nSETTINGS optimize_inverse_dictionary_lookup = 1, optimize_redundant_comparisons = 0
+SELECT count() AS `count()`\nFROM default.data_ops AS __table1\nWHERE and(less(__table1.id, 0), match(dictGetString(\'default.dict_ops\', \'name\', __table1.id), \'[unclosed\'))\nSETTINGS optimize_inverse_dictionary_lookup = 1, optimize_redundant_comparisons = 0
 short-circuited bad-regex match, no rewrite - plan, optimize_redundant_comparisons = 1
 SELECT count() AS `count()`\nFROM default.data_ops AS __table1\nWHERE 0\nSETTINGS optimize_inverse_dictionary_lookup = 1, optimize_redundant_comparisons = 1
 max_rows_in_set + break, no rewrite - plan

--- a/tests/queries/0_stateless/04276_function_dict_get_keys_edge_cases.reference
+++ b/tests/queries/0_stateless/04276_function_dict_get_keys_edge_cases.reference
@@ -7,13 +7,13 @@ Float NaN, rewrite
 Float NaN, no rewrite
 []
 Date attr vs DateTime constant, rewrite - plan
-SELECT groupArray(__table1.id) AS `groupArray(id)`\nFROM default.data_date_attr AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_date_attr\')\n    WHERE equals(d, toDateTime(\'2025-01-01 12:00:00\'))\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT groupArray(__table1.id) AS `groupArray(id)`\nFROM default.data_date_attr AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_date_attr\')\n    WHERE equals(d, toDateTime(\'2025-01-01 12:00:00\'))\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Date attr vs DateTime constant, rewrite
 []
 Date attr vs DateTime constant, no rewrite
 []
 Decimal attr vs Float constant, rewrite - plan
-SELECT groupArray(__table1.id) AS `groupArray(id)`\nFROM default.data_decimal_attr AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'dict_decimal_attr\')\n    WHERE equals(p, toFloat64(1.234))\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
+SELECT groupArray(__table1.id) AS `groupArray(id)`\nFROM default.data_decimal_attr AS __table1\nWHERE in(__table1.id, (\n    SELECT id AS id\n    FROM dictionary(\'default.dict_decimal_attr\')\n    WHERE equals(p, toFloat64(1.234))\n))\nSETTINGS optimize_inverse_dictionary_lookup = 1
 Decimal attr vs Float constant, rewrite
 []
 Decimal attr vs Float constant, no rewrite

--- a/tests/queries/0_stateless/05023_dictget_distributed_current_database.reference
+++ b/tests/queries/0_stateless/05023_dictget_distributed_current_database.reference
@@ -1,0 +1,33 @@
+1	one
+1	one
+2	two
+2	two
+1	one
+1	one
+2	two
+2	two
+1	one
+1	one
+2	two
+2	two
+1	1
+1	1
+2	1
+2	1
+2
+2
+2
+2
+2
+1
+1
+2
+2
+1	one
+1	one
+2	two
+2	two
+dictGet(\'dict_current_database\', \'value\', code)
+one
+dictGet(\'dict_current_database\', \'value\', code)
+one

--- a/tests/queries/0_stateless/05023_dictget_distributed_current_database.sql
+++ b/tests/queries/0_stateless/05023_dictget_distributed_current_database.sql
@@ -1,0 +1,53 @@
+-- Tags: no-old-analyzer
+-- The old analyzer qualifies the dictionary name only in the query it sends to the shards, while the
+-- header it computes on the initiator keeps the unqualified column name, so these queries fail there
+-- with NOT_FOUND_COLUMN_IN_BLOCK. Only the analyzer resolves the name consistently on both sides.
+
+DROP DICTIONARY IF EXISTS dict_current_database;
+DROP TABLE IF EXISTS dict_source;
+DROP TABLE IF EXISTS local_table;
+DROP TABLE IF EXISTS distributed_table;
+
+CREATE TABLE dict_source (code UInt64, value String) ENGINE = MergeTree ORDER BY code;
+INSERT INTO dict_source VALUES (1, 'one'), (2, 'two');
+
+CREATE DICTIONARY dict_current_database (code UInt64, value String)
+PRIMARY KEY code
+SOURCE(CLICKHOUSE(HOST '127.0.0.1' PORT tcpPort() DB currentDatabase() TABLE 'dict_source'))
+LAYOUT(HASHED())
+LIFETIME(0);
+
+CREATE TABLE local_table (code UInt64) ENGINE = MergeTree ORDER BY code;
+INSERT INTO local_table VALUES (1), (2);
+
+CREATE TABLE distributed_table (code UInt64)
+ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), local_table, rand());
+
+-- Both shards of `test_cluster_two_shards` are addresses of this very server, so the initiator would
+-- run the shard queries locally - in its own session, where the dictionary resolves anyway. Force
+-- real connections, whose current database is `default` and not the database of this test.
+SET prefer_localhost_replica = 0;
+
+SELECT code, dictGet('dict_current_database', 'value', code) FROM distributed_table ORDER BY ALL;
+SELECT code, dictGet(dict_current_database, 'value', code) FROM distributed_table ORDER BY ALL;
+SELECT code, dictGetOrDefault('dict_current_database', 'value', code, 'none') FROM distributed_table ORDER BY ALL;
+SELECT code, dictHas('dict_current_database', code) FROM distributed_table ORDER BY ALL;
+
+-- The dictionary name has to be bound in every part of the query, not only in the projection.
+SELECT count() FROM distributed_table WHERE dictGet('dict_current_database', 'value', code) = 'one';
+SELECT count() FROM distributed_table GROUP BY dictGet('dict_current_database', 'value', code) ORDER BY ALL;
+SELECT code FROM distributed_table ORDER BY dictGet('dict_current_database', 'value', code) DESC, code;
+SELECT code FROM distributed_table WHERE code IN (SELECT code FROM local_table WHERE dictGet('dict_current_database', 'value', code) = 'two') ORDER BY ALL;
+
+SELECT code, dictGet('dict_current_database', 'value', code)
+FROM cluster(test_cluster_two_shards, currentDatabase(), local_table) ORDER BY ALL;
+
+-- Binding the name must not change the name of the column: it stays exactly as it was written,
+-- both for a distributed and for a local query.
+SELECT dictGet('dict_current_database', 'value', code) FROM distributed_table ORDER BY ALL LIMIT 1 FORMAT TSVWithNames;
+SELECT dictGet('dict_current_database', 'value', code) FROM local_table ORDER BY ALL LIMIT 1 FORMAT TSVWithNames;
+
+DROP TABLE distributed_table;
+DROP TABLE local_table;
+DROP DICTIONARY dict_current_database;
+DROP TABLE dict_source;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/85181
Related: https://github.com/ClickHouse/ClickHouse/issues/44301
Related: https://github.com/ClickHouse/ClickHouse/issues/46424

The dictionary name of `dictGet` and its variations is resolved against the current database of the server that *evaluates* the function. A shard of a `Distributed` table evaluates it in a session whose current database comes from the cluster configuration — `default` unless `<default_database>` is set — and not from the initiator. So:

```sql
USE demo;
SELECT code, dictGet('dict_test', 'value', code) FROM demo.test;
```

fails on the shards with

```
Code: 36. DB::Exception: Dictionary (`dict_test`) not found: In scope
SELECT __table1.code AS code, dictGet('dict_test', 'value', __table1.code) ... FROM demo.test_local AS __table1. (BAD_ARGUMENTS)
```

and — worse — when a dictionary of the same name also exists in the shard's own database, no error is raised at all and the values of the *wrong* dictionary are returned silently.

This binds the name in the analyzer, while the current database of the initiator is still known, so the bound name travels to the shards inside the query tree. The old analyzer already does the same in `AddDefaultDatabaseVisitor` for the query it sends to the shards.

The binding happens after the projection names of the arguments have been calculated, so the column name of the expression stays exactly as it was written by the user: `dictGet('dict_test', 'value', code)`, not `dictGet('demo.dict_test', 'value', code)`. `qualifyDictionaryNameWithDatabase` leaves the name alone when it is already qualified, when it belongs to an XML dictionary, and when no such dictionary exists in the current database — in the last case the name may still be meant for a dictionary that only exists on the shards.

Notes:

- The `EXPLAIN SYNTAX run_query_tree_passes=1` references of the inverse dictionary lookup tests now show the bound name; only the printed query changes there, no result changes.
- Existing test `04054_dictget_unqualified_name_distributed` deliberately runs in the `default` database so that the shard can resolve the unqualified name, which is why it never caught this. The new test runs in the test's own database with `prefer_localhost_replica = 0`, which is what makes the shard query travel over a real connection.
- The old analyzer keeps failing here with `NOT_FOUND_COLUMN_IN_BLOCK`, because the header it computes on the initiator keeps the unqualified column name while the query it ships to the shards carries the qualified one. Fixing that needs a separate change, so the new test is tagged `no-old-analyzer`.
- `joinGet` has the same defect (`Table default.jt does not exist. Maybe you meant demo.jt?`); its first argument is a table name with temporary-table and access-control semantics of its own, so it is left for a separate change.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `dictGet` and its variations in distributed queries: an unqualified dictionary name is now bound to the current database of the initiator, instead of being resolved against the current database of each shard, where it either was not found or resolved to a different dictionary of the same name.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115541&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115541](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115541+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1789` (included in `26.8` and later)
<!-- ch-version-info:end -->