### PR TITLE
Fix `STREAM BOUNDED` returning no rows on a stale enrichment round

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -12843,15 +12843,7 @@ void MergeTreeData::triggerStreamingSubscriptionEnrichment() const
 
 bool MergeTreeData::scheduleStreamingJob(BackgroundJobsAssignee & assignee)
 {
-    /// Collect the subscriptions before reading the parts, never the other way round: every
-    /// subscription below was registered before this call, so the parts snapshot we take next is at
-    /// least as fresh as each of them. Reading the parts first would let a subscription registered
-    /// in between be credited with an enrichment round computed from a snapshot that predates it,
-    /// and a bounded stream treats its first round as authoritative — it would finish the query
-    /// early, silently returning fewer rows than were committed before the query started.
-    /// A subscription registered after this point is simply served by the next round: its own
-    /// `triggerStreamingSubscriptionEnrichment` re-schedules this job even while it is running.
-    auto subscriptions = subscription_manager.collectSubscriptions();
+    auto subscriptions = subscription_manager.takeAllSubscriptions();
     if (subscriptions.empty())
         return false;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -12843,7 +12843,16 @@ void MergeTreeData::triggerStreamingSubscriptionEnrichment() const
 
 bool MergeTreeData::scheduleStreamingJob(BackgroundJobsAssignee & assignee)
 {
-    if (subscription_manager.isEmpty())
+    /// Collect the subscriptions before reading the parts, never the other way round: every
+    /// subscription below was registered before this call, so the parts snapshot we take next is at
+    /// least as fresh as each of them. Reading the parts first would let a subscription registered
+    /// in between be credited with an enrichment round computed from a snapshot that predates it,
+    /// and a bounded stream treats its first round as authoritative — it would finish the query
+    /// early, silently returning fewer rows than were committed before the query started.
+    /// A subscription registered after this point is simply served by the next round: its own
+    /// `triggerStreamingSubscriptionEnrichment` re-schedules this job even while it is running.
+    auto subscriptions = subscription_manager.collectSubscriptions();
+    if (subscriptions.empty())
         return false;
 
     LocalPartsByPartition local_parts;
@@ -12853,12 +12862,12 @@ bool MergeTreeData::scheduleStreamingJob(BackgroundJobsAssignee & assignee)
     auto promoters = buildPromoters();
 
     bool any_enriched = false;
-    subscription_manager.executeOnEachSubscription([&](StreamSubscriptionPtr & subscription)
+    for (auto & subscription : subscriptions)
     {
         auto & bounds_subscription = *subscription->as<MergeTreeBoundsSubscription>();
         any_enriched |= enrichSubscription(bounds_subscription, local_parts, promoters);
         bounds_subscription.onEnrichmentRound();
-    });
+    }
 
     if (any_enriched)
         assignee.trigger();

--- a/src/Storages/MergeTree/Streaming/tests/gtest_bounds_subscription.cpp
+++ b/src/Storages/MergeTree/Streaming/tests/gtest_bounds_subscription.cpp
@@ -1,11 +1,13 @@
 #include <Storages/MergeTree/Streaming/MergeTreeBoundsSubscription.h>
 #include <Storages/MergeTree/Streaming/SubscriptionEnrichment.h>
+#include <Storages/Streaming/SubscriptionManager.h>
 
 #include <gtest/gtest.h>
 
 #include <poll.h>
 
 #include <map>
+#include <memory>
 #include <set>
 
 using namespace DB;
@@ -132,6 +134,77 @@ TEST(MergeTreeBoundsSubscription, EnrichmentRoundIsNoOpAfterDisable)
 
     pollfd p{.fd = sub.fd(), .events = POLLIN, .revents = 0};
     ASSERT_EQ(::poll(&p, 1, /*timeout_ms=*/0), 0);
+}
+
+TEST(StreamSubscriptionManager, CollectReturnsLiveSubscriptions)
+{
+    StreamSubscriptionManager manager;
+
+    auto first = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    auto second = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(first);
+    manager.registerSubscription(second);
+
+    ASSERT_FALSE(manager.isEmpty());
+    ASSERT_EQ(manager.collectSubscriptions().size(), 2u);
+}
+
+TEST(StreamSubscriptionManager, CollectSkipsExpiredSubscriptions)
+{
+    StreamSubscriptionManager manager;
+
+    auto alive = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(alive);
+    manager.registerSubscription(std::make_shared<MergeTreeBoundsSubscription>(1, 0));
+
+    /// The manager holds weak pointers, so the temporary above is already gone.
+    auto collected = manager.collectSubscriptions();
+    ASSERT_EQ(collected.size(), 1u);
+    ASSERT_EQ(collected.front().get(), alive.get());
+}
+
+TEST(StreamSubscriptionManager, CollectKeepsSubscriptionAlive)
+{
+    StreamSubscriptionManager manager;
+
+    std::weak_ptr<IStreamSubscription> weak;
+    std::vector<StreamSubscriptionPtr> collected;
+    {
+        auto subscription = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+        weak = subscription;
+        manager.registerSubscription(subscription);
+        collected = manager.collectSubscriptions();
+    }
+
+    /// The collected strong pointer must outlive the caller that registered it, so a round cannot
+    /// run against a half-destroyed subscription.
+    ASSERT_EQ(collected.size(), 1u);
+    ASSERT_FALSE(weak.expired());
+
+    collected.clear();
+    ASSERT_TRUE(weak.expired());
+}
+
+TEST(StreamSubscriptionManager, CollectExcludesLaterRegistrations)
+{
+    StreamSubscriptionManager manager;
+
+    auto first = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(first);
+
+    auto collected = manager.collectSubscriptions();
+    ASSERT_EQ(collected.size(), 1u);
+
+    /// A subscription registered after the collect must not be served by this round: the caller
+    /// reads the parts only after collecting, so that snapshot may predate this subscription.
+    auto second = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(second);
+
+    ASSERT_EQ(collected.size(), 1u);
+    ASSERT_EQ(collected.front().get(), first.get());
+
+    /// It is picked up by the next round instead.
+    ASSERT_EQ(manager.collectSubscriptions().size(), 2u);
 }
 
 TEST(SubscriptionEnrichment, NotEnrichedWhenPromotionBlocked)

--- a/src/Storages/MergeTree/Streaming/tests/gtest_bounds_subscription.cpp
+++ b/src/Storages/MergeTree/Streaming/tests/gtest_bounds_subscription.cpp
@@ -1,13 +1,11 @@
 #include <Storages/MergeTree/Streaming/MergeTreeBoundsSubscription.h>
 #include <Storages/MergeTree/Streaming/SubscriptionEnrichment.h>
-#include <Storages/Streaming/SubscriptionManager.h>
 
 #include <gtest/gtest.h>
 
 #include <poll.h>
 
 #include <map>
-#include <memory>
 #include <set>
 
 using namespace DB;
@@ -134,77 +132,6 @@ TEST(MergeTreeBoundsSubscription, EnrichmentRoundIsNoOpAfterDisable)
 
     pollfd p{.fd = sub.fd(), .events = POLLIN, .revents = 0};
     ASSERT_EQ(::poll(&p, 1, /*timeout_ms=*/0), 0);
-}
-
-TEST(StreamSubscriptionManager, CollectReturnsLiveSubscriptions)
-{
-    StreamSubscriptionManager manager;
-
-    auto first = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
-    auto second = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
-    manager.registerSubscription(first);
-    manager.registerSubscription(second);
-
-    ASSERT_FALSE(manager.isEmpty());
-    ASSERT_EQ(manager.collectSubscriptions().size(), 2u);
-}
-
-TEST(StreamSubscriptionManager, CollectSkipsExpiredSubscriptions)
-{
-    StreamSubscriptionManager manager;
-
-    auto alive = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
-    manager.registerSubscription(alive);
-    manager.registerSubscription(std::make_shared<MergeTreeBoundsSubscription>(1, 0));
-
-    /// The manager holds weak pointers, so the temporary above is already gone.
-    auto collected = manager.collectSubscriptions();
-    ASSERT_EQ(collected.size(), 1u);
-    ASSERT_EQ(collected.front().get(), alive.get());
-}
-
-TEST(StreamSubscriptionManager, CollectKeepsSubscriptionAlive)
-{
-    StreamSubscriptionManager manager;
-
-    std::weak_ptr<IStreamSubscription> weak;
-    std::vector<StreamSubscriptionPtr> collected;
-    {
-        auto subscription = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
-        weak = subscription;
-        manager.registerSubscription(subscription);
-        collected = manager.collectSubscriptions();
-    }
-
-    /// The collected strong pointer must outlive the caller that registered it, so a round cannot
-    /// run against a half-destroyed subscription.
-    ASSERT_EQ(collected.size(), 1u);
-    ASSERT_FALSE(weak.expired());
-
-    collected.clear();
-    ASSERT_TRUE(weak.expired());
-}
-
-TEST(StreamSubscriptionManager, CollectExcludesLaterRegistrations)
-{
-    StreamSubscriptionManager manager;
-
-    auto first = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
-    manager.registerSubscription(first);
-
-    auto collected = manager.collectSubscriptions();
-    ASSERT_EQ(collected.size(), 1u);
-
-    /// A subscription registered after the collect must not be served by this round: the caller
-    /// reads the parts only after collecting, so that snapshot may predate this subscription.
-    auto second = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
-    manager.registerSubscription(second);
-
-    ASSERT_EQ(collected.size(), 1u);
-    ASSERT_EQ(collected.front().get(), first.get());
-
-    /// It is picked up by the next round instead.
-    ASSERT_EQ(manager.collectSubscriptions().size(), 2u);
 }
 
 TEST(SubscriptionEnrichment, NotEnrichedWhenPromotionBlocked)

--- a/src/Storages/Streaming/SubscriptionManager.cpp
+++ b/src/Storages/Streaming/SubscriptionManager.cpp
@@ -19,7 +19,7 @@ void StreamSubscriptionManager::registerSubscription(StreamSubscriptionPtr subsc
     subscriptions.push_back(subscription);
 }
 
-std::vector<StreamSubscriptionPtr> StreamSubscriptionManager::collectSubscriptions()
+std::vector<StreamSubscriptionPtr> StreamSubscriptionManager::takeAllSubscriptions()
 {
     std::vector<StreamSubscriptionPtr> collected;
     bool need_clean = false;

--- a/src/Storages/Streaming/SubscriptionManager.cpp
+++ b/src/Storages/Streaming/SubscriptionManager.cpp
@@ -19,29 +19,28 @@ void StreamSubscriptionManager::registerSubscription(StreamSubscriptionPtr subsc
     subscriptions.push_back(subscription);
 }
 
-void StreamSubscriptionManager::executeOnEachSubscription(const std::function<void(StreamSubscriptionPtr & subscription)> & func)
+std::vector<StreamSubscriptionPtr> StreamSubscriptionManager::collectSubscriptions()
 {
-    auto lock = lockShared();
-
+    std::vector<StreamSubscriptionPtr> collected;
     bool need_clean = false;
-    for (const auto & subscription : subscriptions)
+
     {
-        auto locked_sub = subscription.lock();
+        auto lock = lockShared();
+        collected.reserve(subscriptions.size());
 
-        if (locked_sub == nullptr)
+        for (const auto & subscription : subscriptions)
         {
-            need_clean = true;
-            continue;
+            if (auto locked_sub = subscription.lock())
+                collected.push_back(std::move(locked_sub));
+            else
+                need_clean = true;
         }
-
-        func(locked_sub);
     }
 
     if (need_clean)
-    {
-        lock.unlock();
         clean();
-    }
+
+    return collected;
 }
 
 bool StreamSubscriptionManager::isEmpty() const

--- a/src/Storages/Streaming/SubscriptionManager.h
+++ b/src/Storages/Streaming/SubscriptionManager.h
@@ -5,15 +5,15 @@
 #include <Common/SharedMutex.h>
 
 #include <shared_mutex>
-#include <functional>
 #include <list>
+#include <vector>
 
 namespace DB
 {
 
 /// Utility for storing and managing multiple subscriptions.
 /// Registration only: holds weak pointers to subscriptions created elsewhere,
-/// and exposes `executeOnEachSubscription` for fan-out on events (e.g. commit
+/// and exposes `collectSubscriptions` for fan-out on events (e.g. commit
 /// notifications). Expired subscriptions are cleaned up lazily.
 class StreamSubscriptionManager
 {
@@ -27,8 +27,14 @@ public:
     /// adds subscription for manager, not transfers lifetime
     void registerSubscription(StreamSubscriptionPtr subscription);
 
-    /// runs function on every subscription
-    void executeOnEachSubscription(const std::function<void(StreamSubscriptionPtr & subscription)> & func);
+    /// Returns strong pointers to every live subscription, keeping them alive for the caller.
+    ///
+    /// A caller that serves the returned subscriptions from some shared state (e.g. a snapshot of
+    /// the visible parts) must collect the subscriptions *first* and read that state only
+    /// afterwards. Everything in the returned list was registered before this call, so a state read
+    /// after it is at least as fresh as every subscription in the list. Reading the state first
+    /// would let a subscription registered in between be served from a snapshot that predates it.
+    std::vector<StreamSubscriptionPtr> collectSubscriptions();
 
     /// returns true if no active subscriptions are registered in manager
     bool isEmpty() const;
@@ -39,7 +45,7 @@ public:
 private:
     /// Lock required for all changes with subscriptions:
     /// - Add new subscription
-    /// - Execute function
+    /// - Collect subscriptions
     mutable SharedMutex rwlock;
 
     /// List of all subscriptions

--- a/src/Storages/Streaming/SubscriptionManager.h
+++ b/src/Storages/Streaming/SubscriptionManager.h
@@ -12,40 +12,25 @@ namespace DB
 {
 
 /// Utility for storing and managing multiple subscriptions.
-/// Registration only: holds weak pointers to subscriptions created elsewhere,
-/// and exposes `collectSubscriptions` for fan-out on events (e.g. commit
-/// notifications). Expired subscriptions are cleaned up lazily.
 class StreamSubscriptionManager
 {
     void clean();
 
-    /// returns locked mutex
     std::shared_lock<SharedMutex> lockShared() const;
     std::unique_lock<SharedMutex> lockExclusive() const;
 
 public:
-    /// adds subscription for manager, not transfers lifetime
+    /// Adds subscription for manager, not transfers lifetime
     void registerSubscription(StreamSubscriptionPtr subscription);
 
-    /// Returns strong pointers to every live subscription, keeping them alive for the caller.
-    ///
-    /// A caller that serves the returned subscriptions from some shared state (e.g. a snapshot of
-    /// the visible parts) must collect the subscriptions *first* and read that state only
-    /// afterwards. Everything in the returned list was registered before this call, so a state read
-    /// after it is at least as fresh as every subscription in the list. Reading the state first
-    /// would let a subscription registered in between be served from a snapshot that predates it.
-    std::vector<StreamSubscriptionPtr> collectSubscriptions();
+    /// Returns all registered subscriptions
+    std::vector<StreamSubscriptionPtr> takeAllSubscriptions();
 
-    /// returns true if no active subscriptions are registered in manager
     bool isEmpty() const;
-
-    /// opposite to isEmpty
     bool hasSome() const;
 
 private:
-    /// Lock required for all changes with subscriptions:
-    /// - Add new subscription
-    /// - Collect subscriptions
+    /// Lock required for all changes with subscriptions
     mutable SharedMutex rwlock;
 
     /// List of all subscriptions

--- a/src/Storages/Streaming/tests/gtest_subscription_manager.cpp
+++ b/src/Storages/Streaming/tests/gtest_subscription_manager.cpp
@@ -1,0 +1,80 @@
+#include <Storages/MergeTree/Streaming/MergeTreeBoundsSubscription.h>
+#include <Storages/Streaming/SubscriptionManager.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+using namespace DB;
+
+TEST(StreamSubscriptionManager, TakeAllReturnsLiveSubscriptions)
+{
+    StreamSubscriptionManager manager;
+
+    auto first = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    auto second = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(first);
+    manager.registerSubscription(second);
+
+    ASSERT_FALSE(manager.isEmpty());
+    ASSERT_EQ(manager.takeAllSubscriptions().size(), 2u);
+}
+
+TEST(StreamSubscriptionManager, TakeAllSkipsExpiredSubscriptions)
+{
+    StreamSubscriptionManager manager;
+
+    auto alive = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(alive);
+    manager.registerSubscription(std::make_shared<MergeTreeBoundsSubscription>(1, 0));
+
+    /// The manager holds weak pointers, so the temporary above is already gone.
+    auto collected = manager.takeAllSubscriptions();
+    ASSERT_EQ(collected.size(), 1u);
+    ASSERT_EQ(collected.front().get(), alive.get());
+}
+
+TEST(StreamSubscriptionManager, TakeAllKeepsSubscriptionAlive)
+{
+    StreamSubscriptionManager manager;
+
+    std::weak_ptr<IStreamSubscription> weak;
+    std::vector<StreamSubscriptionPtr> collected;
+    {
+        auto subscription = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+        weak = subscription;
+        manager.registerSubscription(subscription);
+        collected = manager.takeAllSubscriptions();
+    }
+
+    /// The collected strong pointer must outlive the caller that registered it, so a round cannot
+    /// run against a half-destroyed subscription.
+    ASSERT_EQ(collected.size(), 1u);
+    ASSERT_FALSE(weak.expired());
+
+    collected.clear();
+    ASSERT_TRUE(weak.expired());
+}
+
+TEST(StreamSubscriptionManager, TakeAllExcludesLaterRegistrations)
+{
+    StreamSubscriptionManager manager;
+
+    auto first = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(first);
+
+    auto collected = manager.takeAllSubscriptions();
+    ASSERT_EQ(collected.size(), 1u);
+
+    /// A subscription registered after the take must not be served by this round: the caller
+    /// reads the parts only after collecting, so that snapshot may predate this subscription.
+    auto second = std::make_shared<MergeTreeBoundsSubscription>(1, 0);
+    manager.registerSubscription(second);
+
+    ASSERT_EQ(collected.size(), 1u);
+    ASSERT_EQ(collected.front().get(), first.get());
+
+    /// It is picked up by the next round instead.
+    ASSERT_EQ(manager.takeAllSubscriptions().size(), 2u);
+}


### PR DESCRIPTION
Caused by: https://github.com/ClickHouse/ClickHouse/pull/110653

`MergeTreeData::scheduleStreamingJob` read the visible parts *before* it iterated the registered subscriptions, so a subscription registered in that window was credited with an enrichment round computed from a parts snapshot taken before it existed.

For a subscribing stream that is harmless — the next round fixes the cursor. For a bounded stream it is not: `handleBoundedReconfiguration` treats the first completed round as authoritative, so an empty stale round makes the source finish immediately and the query silently returns fewer rows (usually none) than were committed before it started.

That is how `04545_streaming_queries_bounded` failed on master. The first query in the test (`STREAM BOUNDED` over the still-empty table) triggers the background streaming job; the job snapshots an empty part set and is then descheduled; by the time it reaches `executeOnEachSubscription` the two `INSERT`s and the second query have already run, so the second query's subscription is handed that empty round:

```
 empty	0
-all	10	45	450
+all	0	0	0
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8d5be603139a198bdfd2ea225d2e998554316178&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

The fix collects the subscriptions first and reads the parts only afterwards. Everything in the collected list was registered before the collect, so the parts snapshot is at least as fresh as every subscription served from it. A subscription registered after the collect is picked up by the next round instead: its own `triggerStreamingSubscriptionEnrichment` re-schedules the job even while the job is running, because `BackgroundSchedulePoolTaskInfo::execute` re-queues a task that was scheduled during execution.

`executeOnEachSubscription` is replaced by `collectSubscriptions`, which returns strong pointers under the shared lock — the callback form invited exactly this ordering mistake, and there was only one caller.

The race is timing-dependent (one failure in 2629 master runs of this test over 90 days), so there is no deterministic functional test for it; the added unit tests cover the `collectSubscriptions` contract the fix relies on, including that a subscription registered after a collect is not part of that round.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a race that could make a `STREAM BOUNDED` query return fewer rows than were committed before it started, usually none.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115543&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115543](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115543+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1779` (included in `26.8` and later)
<!-- ch-version-info:end -->