### PR TITLE
BuzzHouse: do not enable pauseable failpoints, which park a fuzzer query for the rest of the run

### DIFF
--- a/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
+++ b/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
@@ -961,11 +961,14 @@ void FuzzConfig::loadServerConfigurations()
     ///     logs the injected failure, so the thread continues with no group and the next `executeQuery` on it fails
     ///     with the `No thread group attached to the thread` logical error. They are meant for the in-process unit
     ///     test `gtest_thread_group_switcher`, which enables them around a single controlled switch.
+    /// pauseable, pauseable_once - Block the next thread to reach them until a NOTIFY or DISABLE names that same
+    ///     failpoint, with no timeout. Each statement below picks its name at random, so a resume rarely follows.
     loadServerSettings<String>(
         this->failpoints,
         "failpoints",
         "SELECT \"name\" FROM \"system\".\"fail_points\""
-        " WHERE \"name\" NOT IN ('keeper_leader_sets_invalid_digest', 'terminate_with_exception', "
+        " WHERE \"type\" NOT IN ('pauseable', 'pauseable_once')"
+        " AND \"name\" NOT IN ('keeper_leader_sets_invalid_digest', 'terminate_with_exception', "
         "'terminate_with_std_exception', 'libcxx_hardening_out_of_bounds_assertion', "
         "'trigger_sanitizer_error', 'tcp_handler_fail_connection_setup', 'attach_to_group_failure', "
         "'thread_group_switcher_post_attach_failure')");


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/104437
Related: https://github.com/ClickHouse/ClickHouse/pull/115264

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested by @ bacek on #104437.

`BuzzHouse (amd_msan)` on #104437 ([job](https://github.com/ClickHouse/ClickHouse/actions/runs/32196147115/job/95947500404), [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104437&sha=654c183b25ed6e7021752f09982a3ef6089cea7f&name_0=PR&name_1=BuzzHouse%20%28amd_msan%29)) reported `ERROR` with `Fuzzer runner aborted before writing status.tsv`. The fuzz phase finished normally, then the job went silent for 71 minutes and died with the container.

Root cause: the fuzzer enabled the pauseable failpoint `storage_merge_create_children_plans_pause` (`server.log:324783`) and never disabled it - the log has 67 `DISABLE FAILPOINT` lines for other names, none for this one. 13 minutes later it issued `SELECT elapsed, query FROM merge('system', '^processes$')`, which parked at `StorageMerge.cpp:923` and was that thread's last line. `pauseFailPoint` has no timeout and wakes only on a `NOTIFY` or `DISABLE` naming that same failpoint, so teardown never reached `clickhouse stop` and `status.tsv` was never written.

The selection query draws from all of `system.fail_points`, 84 rows of which are `pauseable` or `pauseable_once`, and each of the four failpoint statements picks its name independently at random, so the resume is unlikely to ever be generated. Filtering by type also covers failpoints added later, and follows `6e8e70e0384bf59`, which excluded the thread-group injections here.

Deliberate coverage reduction: all four statements draw from this one list, so `DISABLE`, `NOTIFY` and `WAIT` of pauseable failpoints go too. @ PedroTadim, that collides with the intent stated in #115264 - please say if you would rather I solved it another way. `enableFailPoint` creates a wait channel only for the two pauseable types, so afterwards a fuzzer `WAIT` returns at once and a `NOTIFY` throws `Cannot find channel`, as it already does for the other 215 names.

Validated locally: 299 names (84 pauseable) become 215 with none pauseable, `once` plus `regular` unchanged at 215; a BuzzHouse run loads 215 and still emits failpoint statements, none pauseable. 5 of the 140 stateless tests using failpoints gave identical results before and after. #115264's `ORDER BY rand() LIMIT 10` composes with this clause.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115554&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115554](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115554+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1760` (included in `26.8` and later)
<!-- ch-version-info:end -->