### PR TITLE
Retry a job image pull that failed DNS resolution

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -36,6 +36,9 @@ _IMAGE_PULL_RETRY_ERRORS = [
     "TLS handshake timeout",
     "i/o timeout",
     "unexpected EOF",
+    # A nameserver answered badly (SERVFAIL), so the name can resolve next attempt.
+    # Its NXDOMAIN sibling `no such host` is permanent and is deliberately absent.
+    "server misbehaving",
     # What `timeout --verbose` writes when it kills a stalled attempt. Plain `timeout`
     # writes nothing, so without this entry a stall is not retried.
     "sending signal TERM to command",

--- a/ci/tests/test_job_image_pull_retry.py
+++ b/ci/tests/test_job_image_pull_retry.py
@@ -43,6 +43,15 @@ PRODUCTION_RESET = (
     "docker: failed to copy: read tcp 172.31.94.218:51334->54.231.230.177:443: "
     "read: connection reset by peer"
 )
+# The verbatim line the pull printed in the DNS failure, from that job's own log.
+# The resolver answered badly for the registry proxy's name, mid-transfer.
+PRODUCTION_DNS_SERVFAIL = (
+    "failed to copy: httpReadSeeker: failed open: failed to do request: Get "
+    '"http://dockerhub-proxy.dockerhub-proxy-zone:5000/v2/clickhouse/stateless-test'
+    "/blobs/sha256:180a6c6776d6b8af402bc3f036f2a9cd65e49d65b4ae2f4c4a4c6f5df000de79"
+    '?ns=docker.io": dial tcp: lookup dockerhub-proxy.dockerhub-proxy-zone on '
+    "127.0.0.53:53: server misbehaving"
+)
 # A permanent failure: must never be retried.
 PERMANENT_ERROR = (
     "Error response from daemon: pull access denied for foo, "
@@ -350,18 +359,76 @@ def test_allowlisted_phrase_on_stdout_does_not_trigger_a_retry(tmp_path):
         "TLS handshake timeout",
         "i/o timeout",
         "unexpected EOF",
+        "server misbehaving",
     ],
 )
 def test_each_transport_phrase_is_retried(tmp_path, phrase):
     """Arms 2 and 4b already pin `connection reset by peer` and arm 8 pins
     `sending signal TERM to command`; without these, dropping any of the other
-    four entries from the production list would leave the suite green."""
+    five entries from the production list would leave the suite green."""
     cmd, counter = _counting_command(tmp_path, [], [f"docker: {phrase}"], exit_code=1)
     rc = Shell.run(
         cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
     )
     assert rc != 0
     assert _attempts(counter) == _IMAGE_PULL_RETRIES
+
+
+# --------------------------------------------------------------------------- #
+# 4d. The production DNS failure, verbatim, against both lists.
+# --------------------------------------------------------------------------- #
+def test_the_production_dns_failure_is_retried(tmp_path):
+    """Arm 4c feeds a bare phrase, so it cannot tell whether the entry matches the
+    line docker actually prints, where the phrase is the tail of a nested resolver
+    error inside a URL. Feed that line verbatim instead.
+
+    The list with the entry dropped is the control: without it a pass here would
+    also be produced by some other entry matching, which is what the pre-fix job
+    disproved by stopping after one attempt."""
+    retried_dir = tmp_path / "retried"
+    retried_dir.mkdir()
+    cmd, counter = _counting_command(
+        retried_dir, [], [PRODUCTION_DNS_SERVFAIL], exit_code=1
+    )
+    seen = []
+    rc = Shell.run(
+        cmd,
+        retries=_IMAGE_PULL_RETRIES,
+        retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+        on_retry=lambda matched, attempt, attempts: seen.append(matched),
+    )
+    assert rc != 0
+    assert _attempts(counter) == _IMAGE_PULL_RETRIES
+    # The retry is reported, so an operator sees why the job took a second attempt.
+    assert seen == ["server misbehaving"] * (_IMAGE_PULL_RETRIES - 1)
+
+    without_dns = [e for e in _IMAGE_PULL_RETRY_ERRORS if e != "server misbehaving"]
+    assert len(without_dns) == len(_IMAGE_PULL_RETRY_ERRORS) - 1
+    control_dir = tmp_path / "control"
+    control_dir.mkdir()
+    cmd2, counter2 = _counting_command(
+        control_dir, [], [PRODUCTION_DNS_SERVFAIL], exit_code=1
+    )
+    assert Shell.run(cmd2, retries=_IMAGE_PULL_RETRIES, retry_errors=without_dns) != 0
+    assert _attempts(counter2) == 1
+
+
+def test_the_permanent_resolver_failure_is_not_retried(tmp_path):
+    """`no such host` is the resolver's NXDOMAIN verdict: the name does not exist, so
+    a typo'd image host must fail on attempt 1 rather than burn every attempt. Pins
+    that the entry above was not widened to `dial tcp` or `lookup `, either of which
+    would readmit this line."""
+    nxdomain = (
+        "failed to do request: Get "
+        '"http://dockerhub-proxy.dockerhub-proxy-zone:5000/v2/foo/bar/manifests/x": '
+        "dial tcp: lookup dockerhub-proxy.dockerhub-proxy-zone: no such host"
+    )
+    cmd, counter = _counting_command(tmp_path, [], [nxdomain], exit_code=1)
+    rc = Shell.run(
+        cmd, retries=_IMAGE_PULL_RETRIES, retry_errors=_IMAGE_PULL_RETRY_ERRORS
+    )
+    assert rc != 0
+    assert _attempts(counter) == 1
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113611
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113611


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Retry the praktika job's Docker image pull when the registry proxy's name fails to resolve, so a transient DNS failure no longer kills the whole job before any test runs.


### Description

The retried job image pull added in #113611 declines to retry a DNS resolution failure, so the job aborts with zero tests run. From a failing job's log:

```
Run command: [timeout --verbose 300 docker pull clickhouse/stateless-test:...]
failed to copy: ... dial tcp: lookup
    dockerhub-proxy.dockerhub-proxy-zone on 127.0.0.53:53: server misbehaving
Retry 1/3: command failed, exit code: 1
No retryable errors found, stopping retries
ERROR: command failed after 1/3 attempt(s), exit code: 1
```

**Root cause.** `_IMAGE_PULL_RETRY_ERRORS` allowlists transport-class phrases. Go's resolver renders a SERVFAIL as `server misbehaving`, absent from that list, so a transient DNS blip takes the `break` path meant for permanent errors and the pull's non-fatal failure falls through to the implicit `docker run` pull, which has no retry wrapper.

**The change** adds that one phrase: a nameserver was reached and answered badly, so the same name can resolve on a later attempt.

`no such host` is deliberately not added: that is NXDOMAIN, i.e. permanent, so a misnamed image host would burn all three attempts instead of failing fast, and it has 0 occurrences in 90 days. A broader substring (`dial tcp`, `lookup `) was rejected for the same reason, since both prefix NXDOMAIN too. A new arm pins that the NXDOMAIN line is still not retried.

**Breadth.** 4 jobs across 4 pull requests in 30 days, 0 on master, each carrying this phrase in the pull's own stderr. Each produced 0 test rows while sibling jobs on the same commit produced 55 to 950, so a whole check is lost, not one test.

**Validation.** The suite drives the real `Shell.run` loop, so its arms exercise the production matcher. Without the fix the new arms report 1 attempt instead of 3; with it, 25 passed, identical over 30 runs.

No related open issue found.

<details>
<summary>New test arms and their controls</summary>

The new arm feeds the verbatim production line rather than a bare phrase, because there the phrase is the tail of a nested resolver error inside a URL. It carries its own negative control: the same line matched against the allowlist with the entry removed must stop after one attempt. Without that control the arm could not distinguish this entry working from some other entry already matching, which is what the pre-fix job disproved by stopping after attempt 1.

Note also that the two errors in the log above differ, which is why the gap looks covered: the retried attempt got `server misbehaving`, the later `docker run` got the allowlisted `connection refused`, by which point no retry wrapper is in play. Only the second reaches the CI database, so the pull's own error appears only in the job log.

| Arm | Pre-fix | Post-fix |
|---|---|---|
| `test_each_transport_phrase_is_retried[server misbehaving]` | 1 attempt (red) | 3 attempts |
| `test_the_production_dns_failure_is_retried` | 1 attempt (red) | 3 attempts, `on_retry` reports the phrase |
| its in-arm control (entry removed) | 1 attempt | 1 attempt |
| `test_the_permanent_resolver_failure_is_not_retried` (`no such host`) | 1 attempt | 1 attempt |
| `test_permanent_error_is_not_retried`, `test_named_permanent_errors_are_not_retried` | green | green |

Deleting the entry reddens exactly the 2 arms that pin it and no others; widening it to `dial tcp` reddens the NXDOMAIN arm, so that arm is load-bearing rather than decorative.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115555&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115555](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115555+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
