### PR TITLE
Docs: add ProbeDeck to GUI tools list

### DIFF
--- a/docs/integrations/connectors/tools/gui.mdx
+++ b/docs/integrations/connectors/tools/gui.mdx
@@ -498,6 +498,25 @@ Features:
 
 ## Commercial {#commercial}
 
+<Accordion title="ProbeDeck">
+
+[ProbeDeck](https://probedeck.app) is an iOS and iPadOS client for monitoring and querying ClickHouse.
+
+Features:
+
+- ProbeDeck shows running queries, replicas, parts, merges, mutations, disks, and server metrics.
+- You can stop queries with `KILL QUERY` and mutations with `KILL MUTATION`.
+- You can browse schemas and data or run SQL in the editor.
+- ProbeDeck connects over HTTP(S) through the device network or an SSH tunnel.
+- ProbeDeck stores credentials in the iOS Keychain and supports a read-only mode for each connection.
+- The app includes an offline demo with bundled data.
+
+Free users can monitor a server and run read-only SQL. They can save one connection. ProbeDeck Pro adds kill controls, writes, DDL, and unlimited saved connections.
+
+See [Connect ProbeDeck to ClickHouse](/integrations/connectors/sql-clients/probedeck) for connection instructions.
+
+</Accordion>
+
 <Accordion title="DataGrip">
 
 [DataGrip](https://www.jetbrains.com/datagrip/) is a database IDE from JetBrains with dedicated support for ClickHouse. It is also embedded in other IntelliJ-based tools: PyCharm, IntelliJ IDEA, GoLand, PhpStorm and others.


### PR DESCRIPTION
Adds ProbeDeck to the third-party GUI tools list. The entry summarizes its monitoring, SQL, connection, and safety features and links to the connection guide added in #114508.

Related: https://github.com/ClickHouse/ClickHouse/pull/114508

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add ProbeDeck to the third-party GUI tools list.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115563&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115563](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115563+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
