### PR TITLE
Docs: add ProbeDeck integration redirects

### DIFF
--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -9872,6 +9872,10 @@
     "source": "/jp/integrations/powerbi"
   },
   {
+    "destination": "/ja/integrations/connectors/sql-clients/probedeck",
+    "source": "/jp/integrations/probedeck"
+  },
+  {
     "destination": "/ja/products/cloud/features/monitoring/prometheus",
     "source": "/jp/integrations/prometheus"
   },
@@ -10006,6 +10010,10 @@
   {
     "destination": "/ja/integrations/connectors/sql-clients/jupysql",
     "source": "/jp/integrations/sql-clients/jupysql"
+  },
+  {
+    "destination": "/ja/integrations/connectors/sql-clients/probedeck",
+    "source": "/jp/integrations/sql-clients/probedeck"
   },
   {
     "destination": "/ja/integrations/connectors/sql-clients/qstudio",

--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -5024,6 +5024,10 @@
     "source": "/integrations/powerbi"
   },
   {
+    "destination": "/integrations/connectors/sql-clients/probedeck",
+    "source": "/integrations/probedeck"
+  },
+  {
     "destination": "/products/cloud/features/monitoring/prometheus",
     "source": "/integrations/prometheus"
   },
@@ -5158,6 +5162,10 @@
   {
     "destination": "/integrations/connectors/sql-clients/jupysql",
     "source": "/integrations/sql-clients/jupysql"
+  },
+  {
+    "destination": "/integrations/connectors/sql-clients/probedeck",
+    "source": "/integrations/sql-clients/probedeck"
   },
   {
     "destination": "/integrations/connectors/sql-clients/qstudio",

--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -20624,6 +20624,10 @@
     "source": "/ko/integrations/powerbi"
   },
   {
+    "destination": "/ko/integrations/connectors/sql-clients/probedeck",
+    "source": "/ko/integrations/probedeck"
+  },
+  {
     "destination": "/ko/products/cloud/features/monitoring/prometheus",
     "source": "/ko/integrations/prometheus"
   },
@@ -20758,6 +20762,10 @@
   {
     "destination": "/ko/integrations/connectors/sql-clients/jupysql",
     "source": "/ko/integrations/sql-clients/jupysql"
+  },
+  {
+    "destination": "/ko/integrations/connectors/sql-clients/probedeck",
+    "source": "/ko/integrations/sql-clients/probedeck"
   },
   {
     "destination": "/ko/integrations/connectors/sql-clients/qstudio",
@@ -32732,6 +32740,10 @@
     "source": "/ru/integrations/powerbi"
   },
   {
+    "destination": "/ru/integrations/connectors/sql-clients/probedeck",
+    "source": "/ru/integrations/probedeck"
+  },
+  {
     "destination": "/ru/products/cloud/features/monitoring/prometheus",
     "source": "/ru/integrations/prometheus"
   },
@@ -32866,6 +32878,10 @@
   {
     "destination": "/ru/integrations/connectors/sql-clients/jupysql",
     "source": "/ru/integrations/sql-clients/jupysql"
+  },
+  {
+    "destination": "/ru/integrations/connectors/sql-clients/probedeck",
+    "source": "/ru/integrations/sql-clients/probedeck"
   },
   {
     "destination": "/ru/integrations/connectors/sql-clients/qstudio",
@@ -46292,6 +46308,10 @@
     "source": "/zh/integrations/powerbi"
   },
   {
+    "destination": "/zh/integrations/connectors/sql-clients/probedeck",
+    "source": "/zh/integrations/probedeck"
+  },
+  {
     "destination": "/zh/products/cloud/features/monitoring/prometheus",
     "source": "/zh/integrations/prometheus"
   },
@@ -46426,6 +46446,10 @@
   {
     "destination": "/zh/integrations/connectors/sql-clients/jupysql",
     "source": "/zh/integrations/sql-clients/jupysql"
+  },
+  {
+    "destination": "/zh/integrations/connectors/sql-clients/probedeck",
+    "source": "/zh/integrations/sql-clients/probedeck"
   },
   {
     "destination": "/zh/integrations/connectors/sql-clients/qstudio",


### PR DESCRIPTION
Adds short redirects for the ProbeDeck ClickHouse integration guide:

- `/integrations/probedeck`
- `/integrations/sql-clients/probedeck`

Both paths redirect to `/integrations/connectors/sql-clients/probedeck`. The PR includes matching Korean, Russian, and Chinese aliases, plus the Japanese legacy `/jp` aliases that point to the current `/ja` page. The guide was added in #114508.

Related: https://github.com/ClickHouse/ClickHouse/pull/114508

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add short URLs for the ProbeDeck integration guide.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115564&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115564](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115564+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1781` (included in `26.8` and later)
<!-- ch-version-info:end -->