### PR TITLE
Retry a job whose "Run" step reported no conclusion

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -62,6 +62,8 @@ jobs:
             #   not actual tests — always treated as infrastructure failure), or
             # - it never reached its main "Run" step (failed during checkout/setup), or
             # - the "Run" step was skipped, or
+            # - the "Run" step produced no conclusion at all (GitHub finalized the job
+            #   while its main step was still unreported), or
             # - the "Run" step failed almost immediately (under 2 minutes), indicating
             #   a setup/download issue (e.g. missing S3 credentials) rather than a real
             #   test failure
@@ -72,6 +74,7 @@ jobs:
                 [.steps[] | select(.name == "Run")] |
                 if length == 0 then true
                 elif .[0].conclusion == "skipped" then true
+                elif .[0].conclusion == null then true
                 elif .[0].conclusion == "failure" then
                   ((.[0].completed_at | fromdateiso8601) -
                    (.[0].started_at | fromdateiso8601)) < 120


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114027
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`retry_infra_failures.yml` classifies each failed job as infrastructure-vs-real and re-runs the
workflow when all of them are infrastructure. The classifier had no arm for a `Run` step whose
`conclusion` is `null`, so it scored that job a real failure, and because the run-level gate
requires all verdicts true, one such job suppressed the retry for the whole run.

A null conclusion means GitHub finalized the job while its main step had never reported
(`completed_at` also null): the same "no verdict produced" class the adjacent `length == 0` and
`"skipped"` arms already treat as infrastructure. A test that actually ran and failed reports
`conclusion="failure"` with both timestamps set, so this arm cannot absorb real failures.

Found on #114027 head `99c09b1b`, where `AST fuzzer (amd_debug, targeted, old_compatibility)` was
killed mid-`Run` ("The self-hosted runner lost communication with the server"). It and two other
jobs reported `failure` having run zero tests and published zero CIDB rows. Why the runner went
away is not established and this PR asserts nothing about it: the logs are purged.

Validated against real captured job payloads, the jq extracted verbatim from the file in both arms:

- Run [32270257975](https://github.com/ClickHouse/ClickHouse/actions/runs/32270257975), 171 jobs:
  `false true true` -> `should_rerun=false` before, `true true true` -> `true` after. The `false`
  is exactly the killed job.
- 60 recent failed `pull_request.yml` runs (10264 jobs, 158 failed): classification identical
  before and after. A 17-case matrix over the whole step-conclusion domain changes exactly one
  case, the intended one; `cancelled` is left alone.

Two limits worth stating. The state is rare: zero occurrences in those 60 runs. And this does not
recover the run that prompted it, which is `attempt=3` while the workflow selects `.attempt == 1`
by design; widening that anti-loop bound is a separate question. `MAX_RERUNS`, the attempt gate and
the cutoff are unchanged.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115569&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115569](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115569+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.252` (included in `26.10` and later)
<!-- ch-version-info:end -->