### PR TITLE
Assert the socket timeout exception instead of wall-clock time in test_secure_socket

### DIFF
--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -51,13 +51,14 @@ def started_cluster():
         cluster.shutdown()
 
 
-def assert_socket_receive_timeout(error):
-    # Only the wording common to all three settings combinations is matched, because each of
-    # them reports the timeout from a different place. 5000 ms is the receive_timeout=5 asked
-    # for in the query, so it is what distinguishes this timeout from any other one.
+def assert_socket_receive_timeout(error, expected_origin):
+    # receive_timeout=5 must surface as SOCKET_TIMEOUT reporting the 5000 ms it asked for.
     assert "Timeout exceeded while reading from socket" in error
     assert "5000 ms" in error
     assert "(SOCKET_TIMEOUT)" in error
+    # Each settings combination must raise from its own place, otherwise an ignored
+    # async_socket_for_remote or use_hedged_requests would silently collapse the arms.
+    assert expected_origin in error, f"expected {expected_origin} in: {error}"
 
 
 def test(started_cluster):
@@ -85,22 +86,16 @@ def test(started_cluster):
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=0;"
     )
 
-    assert_socket_receive_timeout(error)
+    assert_socket_receive_timeout(error, "ReadBufferFromPocoSocket")
 
     error = NODES["node1"].query_and_get_error(
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=1;"
     )
 
-    assert_socket_receive_timeout(error)
-
-    # Check that exception about timeout wasn't thrown from DB::ReadBufferFromPocoSocket::nextImpl().
-    assert error.find("DB::ReadBufferFromPocoSocket::nextImpl()") == -1
+    assert_socket_receive_timeout(error, "checkTimeout")
 
     error = NODES["node1"].query_and_get_error(
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=1, async_socket_for_remote=1;"
     )
 
-    assert_socket_receive_timeout(error)
-
-    # Check that exception about timeout wasn't thrown from DB::ReadBufferFromPocoSocket::nextImpl().
-    assert error.find("DB::ReadBufferFromPocoSocket::nextImpl()") == -1
+    assert_socket_receive_timeout(error, "HedgedConnections")

--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -51,6 +51,15 @@ def started_cluster():
         cluster.shutdown()
 
 
+def assert_socket_receive_timeout(error):
+    # Only the wording common to all three settings combinations is matched, because each of
+    # them reports the timeout from a different place. 5000 ms is the receive_timeout=5 asked
+    # for in the query, so it is what distinguishes this timeout from any other one.
+    assert "Timeout exceeded while reading from socket" in error
+    assert "5000 ms" in error
+    assert "(SOCKET_TIMEOUT)" in error
+
+
 def test(started_cluster):
     NODES["node2"].replace_config(
         "/etc/clickhouse-server/users.d/users.xml",
@@ -72,31 +81,26 @@ def test(started_cluster):
 
     assert attempts < 1000
 
-    start = time.time()
-    NODES["node1"].query_and_get_error(
+    error = NODES["node1"].query_and_get_error(
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=0;"
     )
-    end = time.time()
-    assert end - start < 10
 
-    start = time.time()
+    assert_socket_receive_timeout(error)
+
     error = NODES["node1"].query_and_get_error(
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=1;"
     )
-    end = time.time()
 
-    assert end - start < 10
+    assert_socket_receive_timeout(error)
 
     # Check that exception about timeout wasn't thrown from DB::ReadBufferFromPocoSocket::nextImpl().
     assert error.find("DB::ReadBufferFromPocoSocket::nextImpl()") == -1
 
-    start = time.time()
     error = NODES["node1"].query_and_get_error(
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=1, async_socket_for_remote=1;"
     )
-    end = time.time()
 
-    assert end - start < 10
+    assert_socket_receive_timeout(error)
 
     # Check that exception about timeout wasn't thrown from DB::ReadBufferFromPocoSocket::nextImpl().
     assert error.find("DB::ReadBufferFromPocoSocket::nextImpl()") == -1

--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -53,6 +53,8 @@ def started_cluster():
 
 def assert_socket_receive_timeout(error, expected_origin):
     # receive_timeout=5 must surface as SOCKET_TIMEOUT reporting the 5000 ms it asked for.
+    # send_timeout stays distinct from it, or this value is ambiguous between the two settings,
+    # and stays below it, since a blocking secure read waits max(receive_timeout, send_timeout).
     assert "Timeout exceeded while reading from socket" in error
     assert "5000 ms" in error
     assert "(SOCKET_TIMEOUT)" in error
@@ -83,19 +85,19 @@ def test(started_cluster):
     assert attempts < 1000
 
     error = NODES["node1"].query_and_get_error(
-        "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=0;"
+        "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=4, use_hedged_requests=0, async_socket_for_remote=0;"
     )
 
     assert_socket_receive_timeout(error, "socket (peer: ")
 
     error = NODES["node1"].query_and_get_error(
-        "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=1;"
+        "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=4, use_hedged_requests=0, async_socket_for_remote=1;"
     )
 
     assert_socket_receive_timeout(error, "socket (socket (")
 
     error = NODES["node1"].query_and_get_error(
-        "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=1, async_socket_for_remote=1;"
+        "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=4, use_hedged_requests=1, async_socket_for_remote=1;"
     )
 
     assert_socket_receive_timeout(error, "socket (node2:9440, receive timeout")

--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -56,8 +56,8 @@ def assert_socket_receive_timeout(error, expected_origin):
     assert "Timeout exceeded while reading from socket" in error
     assert "5000 ms" in error
     assert "(SOCKET_TIMEOUT)" in error
-    # Each settings combination must raise from its own place, otherwise an ignored
-    # async_socket_for_remote or use_hedged_requests would silently collapse the arms.
+    # Each combination formats the socket description differently, so an ignored
+    # async_socket_for_remote or use_hedged_requests would show up as another arm's wording.
     assert expected_origin in error, f"expected {expected_origin} in: {error}"
 
 
@@ -86,16 +86,16 @@ def test(started_cluster):
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=0;"
     )
 
-    assert_socket_receive_timeout(error, "ReadBufferFromPocoSocket")
+    assert_socket_receive_timeout(error, "socket (peer: ")
 
     error = NODES["node1"].query_and_get_error(
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=0, async_socket_for_remote=1;"
     )
 
-    assert_socket_receive_timeout(error, "checkTimeout")
+    assert_socket_receive_timeout(error, "socket (socket (")
 
     error = NODES["node1"].query_and_get_error(
         "SELECT * FROM distributed_table settings receive_timeout=5, send_timeout=5, use_hedged_requests=1, async_socket_for_remote=1;"
     )
 
-    assert_socket_receive_timeout(error, "HedgedConnections")
+    assert_socket_receive_timeout(error, "socket (node2:9440, receive timeout")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112938
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_secure_socket` guarded each of its three timeout arms with `assert end - start < 10`. That bound
measures host load, not the behaviour under test, so it fails on a loaded CI host even when the timeout
is honoured. It failed at 35.47 s here:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112938&sha=81483c13ee7fed39a69f62b13e5a98827ae7357a&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%204%2F6%29

Root cause is a whole-host scheduling stall, not a timeout defect: unrelated periodic tasks and another
pytest worker froze over the same window. CIDB over 90 days: 4 failures, 0 on master.

The three literals are replaced by an assertion on the `SOCKET_TIMEOUT` exception each arm must produce,
which is what the test means: `receive_timeout=5` is honoured instead of the query hanging on the
remote's `sleep_in_send_data_ms = 1000000`. Each arm also asserts the socket description its own code
path formats, so an ignored `async_socket_for_remote` or `use_hedged_requests` cannot collapse two arms.
Arm 1 had none before.

Two `assert error.find("DB::ReadBufferFromPocoSocket::nextImpl()") == -1` guards go too: vacuous since
`89205d78a688793` moved `nextImpl()` to `ReadBufferFromPocoSocketBase`, so `find()` returned -1 always.
The per-arm assertions cover their intent.

`send_timeout` drops from 5 to 4 so the asserted `5000 ms` is attributable: at 5 both settings render
the same value, so a regression reading the send timeout on the read path stayed green. It goes below
`receive_timeout` rather than to its default because a blocking secure read waits
`max(receive_timeout, send_timeout)`, so raising it left the assertion unchanged while elapsed time went
to 9.10 s at 9 and 300.11 s at the default.

Hang detection is unchanged (`pytest.ini` sets `timeout = 900`). Latency tightness is given up: the
asserted `5000 ms` is the configured value the message prints, not the elapsed time. Widening was
rejected, that bound already went 6 to 10 in `ed6363b88bd1b43` and failed again. Every assertion is
mutation-validated both ways, each mutation reddening only its intended arm.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115572&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115572](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115572+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1786` (included in `26.8` and later)
<!-- ch-version-info:end -->