### PR TITLE
Docs: Bring the insert deduplication guide up to date

### DIFF
--- a/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
+++ b/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
@@ -122,6 +122,8 @@ Choose the path that matches what you want a retry to mean. Additionally, when y
 
 Asynchronous inserts ([`async_insert`](/reference/settings/session-settings/async-insert#async_insert), enabled by default since version 26.2) are deduplicated on retries in the same way as synchronous inserts. `deduplicate_insert` controls both, so no separate switch is needed.
 
+The two insert types also share one deduplication log and compute `block_id`s the same way. You can therefore switch a client between synchronous and asynchronous inserts without breaking deduplication, and a retry sent in one mode is still recognized as a duplicate of an attempt sent in the other. Moving a workload from synchronous to asynchronous inserts stays safe on a table that relies on deduplication.
+
 <Note>
 Before version 26.2, deduplication of asynchronous inserts was disabled by default and was controlled by `async_insert_deduplicate`. That setting is now read only when `deduplicate_insert` is `backward_compatible_choice`.
 </Note>

--- a/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
+++ b/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
@@ -147,7 +147,7 @@ The `DuplicatedAsyncInserts` and `SelfDuplicatedAsyncInserts` events in [`system
 
 Deduplication of asynchronous inserts works together with dependent materialized views. The rule is simple: one block in, one block out. If the inner query of a view turns one input block into one output block, deduplication works. If the view emits a second block, ClickHouse throws a `NOT_IMPLEMENTED` exception.
 
-The number of rows does not matter by itself. Only the number of blocks matters, and [`max_block_size`](/reference/settings/session-settings/max#max_block_size) sets how many rows fit in one block. Column transformations, filtering, and aggregation never add rows, so they always stay in one block. A `JOIN` can add rows. It works while the result stays under `max_block_size`, and it fails above that.
+A view emits a second block when its output no longer fits in one. [`max_block_size`](/reference/settings/session-settings/max#max_block_size) sets how many rows fit. Column transformations, filtering, and aggregation never add rows, so they always stay in one block. A `JOIN` can add rows. It works while the result stays under `max_block_size`, and it fails above that.
 
 To insert through a view that emits more than one block, either set `deduplicate_blocks_in_dependent_materialized_views = 0` or use synchronous inserts.
 

--- a/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
+++ b/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
@@ -111,7 +111,12 @@ The setting `deduplicate_insert_select` chooses what to do:
 
 `enable_when_possible` and `enable_even_for_bad_queries` also honor `deduplicate_insert`: if it is `disable`, the query isn't deduplicated. `force_enable` overrides `deduplicate_insert`.
 
-Keep in mind that the selected table can be updated between retries. The result data then changes and deduplication doesn't occur. Additionally, when you insert large amounts of data, the number of blocks can overflow the deduplication log window, and ClickHouse won't know to deduplicate the blocks.
+Keep in mind that the selected table can be updated between retries. The two paths then behave in opposite ways:
+
+- Without `insert_deduplication_token`, the `block_id`s are computed from the data. The changed result produces different `block_id`s, deduplication doesn't occur, and the retry inserts the new data on top of whatever the first attempt already wrote.
+- With `insert_deduplication_token`, the token alone identifies the insert. The retry is recognized as a duplicate and is dropped, even though it would have inserted different data.
+
+Choose the path that matches what you want a retry to mean. Additionally, when you insert large amounts of data, the number of blocks can overflow the deduplication log window, and ClickHouse won't know to deduplicate the blocks.
 
 ## Deduplication for asynchronous inserts {#deduplication-for-asynchronous-inserts}
 
@@ -123,7 +128,7 @@ Before version 26.2, deduplication of asynchronous inserts was disabled by defau
 
 ### Deduplication granularity {#asynchronous-insert-deduplication-granularity}
 
-The server collects several asynchronous inserts into one batch and writes that batch as a single part. Deduplication works per user query, not per batch:
+The server collects several asynchronous inserts into one batch and writes that batch as one or more parts, at least one per distinct partition key value. Deduplication works per user query, not per batch:
 
 - Each queued query contributes one deduplication token to the batch.
 - A token is either the value of `insert_deduplication_token`, when the query provides one, or a hash of the rows that this query contributed.
@@ -131,16 +136,16 @@ The server collects several asynchronous inserts into one batch and writes that 
 
 This has two consequences:
 
-- When one query in a batch is a duplicate, ClickHouse removes only the rows of that query. The rest of the batch is inserted normally. The part is skipped entirely only when every row is removed.
-- When two queries in the same batch carry the same token, the second one is dropped before the part is written.
+- When one query in a batch is a duplicate, ClickHouse removes only the rows of that query. The rest of the batch is inserted normally. A part is skipped entirely only when every row in it is removed.
+- When two queries in the same batch carry the same token, the second one is dropped before the part is written. This applies per partition: if the two queries write rows to different partitions, both survive.
 
 The `DuplicatedAsyncInserts` and `SelfDuplicatedAsyncInserts` events in [`system.events`](/reference/system-tables/events) count these two cases.
 
 ### Asynchronous inserts and materialized views {#asynchronous-inserts-and-materialized-views}
 
-Deduplication of asynchronous inserts works together with dependent materialized views. One restriction applies: the inner query of a view must not produce more rows than it reads.
+Deduplication of asynchronous inserts works together with dependent materialized views. One restriction applies: the inner query of a view must not emit more than one block for one block of input. ClickHouse throws a `NOT_IMPLEMENTED` exception as soon as a view emits a second block.
 
-Column transformations, filtering, and aggregation are therefore all allowed, because none of them increases the row count. A `JOIN` that expands the result is not allowed. When a view inflates the row count, ClickHouse throws a `NOT_IMPLEMENTED` exception. To insert through such a view asynchronously, either set `deduplicate_blocks_in_dependent_materialized_views = 0` or use synchronous inserts.
+In practice this means the view must not produce more rows than it reads. Column transformations, filtering, and aggregation stay within the restriction, because none of them increases the row count. A `JOIN` that expands the result does not. To insert through such a view asynchronously, either set `deduplicate_blocks_in_dependent_materialized_views = 0` or use synchronous inserts.
 
 ## Insert deduplication with materialized views {#insert-deduplication-with-materialized-views}
 

--- a/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
+++ b/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
@@ -2,13 +2,15 @@
 slug: /guides/developer/deduplicating-inserts-on-retries
 title: 'Deduplicating inserts on retries'
 description: 'Preventing duplicate data when retrying insert operations'
-keywords: ['deduplication', 'deduplicate', 'insert retries', 'inserts']
+keywords: ['deduplication', 'deduplicate', 'insert retries', 'inserts', 'asynchronous inserts']
 doc_type: 'guide'
 ---
 
-Insert operations can sometimes fail due to errors such as timeouts. When inserts fail, data may or may not have been successfully inserted. This guide covers how to enable deduplication on insert retries such that the same data doesn't get inserted more than once.
+Insert operations can sometimes fail due to errors such as timeouts. When inserts fail, data may or may not have been successfully inserted. This guide covers how deduplication on insert retries works, so that the same data doesn't get inserted more than once.
 
 When an insert is retried, ClickHouse tries to determine whether the data has already been successfully inserted. If the inserted data is marked as a duplicate, ClickHouse doesn't insert it into the destination table. However, the user will still receive a successful operation status as if the data had been inserted normally.
+
+Deduplication covers synchronous inserts, asynchronous inserts, and `INSERT ... SELECT` queries. One setting, `deduplicate_insert`, controls synchronous and asynchronous inserts. `INSERT ... SELECT` needs extra care and has a setting of its own. See [Settings that control insert deduplication](#settings-that-control-insert-deduplication).
 
 ## Limitations {#limitations}
 
@@ -20,19 +22,62 @@ The user must retry the insert operation until it succeeds. If all retries fail,
 
 If more than `*_deduplication_window` other insert operations occur during the retry sequence, deduplication may not work as intended. In this case, the same data can be inserted multiple times.
 
-## Enabling insert deduplication on retries {#enabling-insert-deduplication-on-retries}
+## Settings that control insert deduplication {#settings-that-control-insert-deduplication}
 
-### Insert deduplication for tables {#insert-deduplication-for-tables}
+ClickHouse deduplicates an insert only when both of the following hold:
+
+1. The destination table keeps a deduplication log. This is a table-level setting.
+2. Deduplication is enabled for the query. This is a query-level setting.
+
+### Table-level settings {#insert-deduplication-for-tables}
 
 **Only `*MergeTree` engines support deduplication on insertion.**
 
-For `*ReplicatedMergeTree` engines, insert deduplication is enabled by default and is controlled by the [`replicated_deduplication_window`](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window) and [`replicated_deduplication_window_seconds`](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window_seconds) settings. For non-replicated `*MergeTree` engines, deduplication is controlled by the [`non_replicated_deduplication_window`](/reference/settings/merge-tree-settings/other#non_replicated_deduplication_window) setting.
+For `*ReplicatedMergeTree` engines, the deduplication log is enabled by default and is controlled by the [`replicated_deduplication_window`](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window) and [`replicated_deduplication_window_seconds`](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window_seconds) settings. For non-replicated `*MergeTree` engines, the log is controlled by the [`non_replicated_deduplication_window`](/reference/settings/merge-tree-settings/other#non_replicated_deduplication_window) setting, which is `0` by default. A plain `MergeTree` table therefore deduplicates nothing until you set that window to a positive value.
 
 The settings above determine the parameters of the deduplication log for a table. The deduplication log stores a finite number of `block_id`s, which determine how deduplication works (see below).
 
-### Query-level insert deduplication {#query-level-insert-deduplication}
+<Note>
+[`replicated_deduplication_window_for_async_inserts`](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window_for_async_inserts) and [`replicated_deduplication_window_seconds_for_async_inserts`](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window_seconds_for_async_inserts) are legacy settings. Synchronous and asynchronous inserts now share one deduplication log, so `replicated_deduplication_window` governs both. The legacy settings only bound the old ClickHouse Keeper directory, which matters during a rolling upgrade.
+</Note>
 
-The setting `insert_deduplicate=1` enables deduplication at the query level. Note that if you insert data with `insert_deduplicate=0`, that data can't be deduplicated even if you retry an insert with `insert_deduplicate=1`. This is because the `block_id`s aren't written for blocks during inserts with `insert_deduplicate=0`.
+### Query-level settings {#query-level-insert-deduplication}
+
+| Setting | Applies to | Default | Purpose |
+|---------|------------|---------|---------|
+| [`deduplicate_insert`](/reference/settings/session-settings/deduplicate-insert#deduplicate_insert) | Every `INSERT`, synchronous or asynchronous | `enable` | Main switch for insert deduplication |
+| [`deduplicate_insert_select`](/reference/settings/session-settings/deduplicate-insert#deduplicate_insert_select) | `INSERT ... SELECT` | `enable_when_possible` | Decides what to do when the `SELECT` result isn't reproducible |
+| [`insert_deduplication_token`](/reference/settings/session-settings/insert#insert_deduplication_token) | Every `INSERT` | `''` | Identifies the insert by a user-supplied string instead of by the data |
+| [`deduplicate_blocks_in_dependent_materialized_views`](/reference/settings/session-settings/other#deduplicate_blocks_in_dependent_materialized_views) | Tables under materialized views | `1` | Extends deduplication to the destinations of dependent materialized views |
+
+`deduplicate_insert` accepts three values:
+
+- `enable` — deduplication is enabled for the `INSERT` query.
+- `disable` — deduplication is disabled for the `INSERT` query.
+- `backward_compatible_choice` — the decision is delegated to the legacy settings `insert_deduplicate` (synchronous inserts) and `async_insert_deduplicate` (asynchronous inserts).
+
+Note that a query which runs with `deduplicate_insert = disable` writes no `block_id`s for its blocks. Such data can't be deduplicated later, even if you retry the insert with `deduplicate_insert = enable`. The same holds when the destination table keeps no deduplication log: nothing is recorded, so nothing can be matched on a retry.
+
+### Precedence {#precedence}
+
+1. For an `INSERT ... SELECT` query, `deduplicate_insert_select` decides. See [Deduplication for INSERT ... SELECT](#deduplication-for-insert-select).
+2. For every other `INSERT`, `deduplicate_insert` decides.
+3. `insert_deduplicate` and `async_insert_deduplicate` are read only when `deduplicate_insert` is `backward_compatible_choice`.
+
+### Legacy and obsolete settings {#legacy-and-obsolete-settings}
+
+| Setting | Status | Use instead |
+|---------|--------|-------------|
+| [`insert_deduplicate`](/reference/settings/session-settings/insert#insert_deduplicate) | Legacy. Read only when `deduplicate_insert = backward_compatible_choice` | `deduplicate_insert` |
+| [`async_insert_deduplicate`](/reference/settings/session-settings/async-insert#async_insert_deduplicate) | Legacy. Read only when `deduplicate_insert = backward_compatible_choice` | `deduplicate_insert` |
+| `insert_select_deduplicate` | Obsolete. Has no effect | `deduplicate_insert_select` |
+| `update_insert_deduplication_token_in_dependent_materialized_views` | Obsolete. Has no effect | — |
+
+<Warning>
+Since version 26.2, `deduplicate_insert` defaults to `enable`. Setting `insert_deduplicate = 0` therefore no longer turns deduplication off on its own. To disable deduplication, set `deduplicate_insert = disable`.
+</Warning>
+
+Version 26.2 also changed the defaults of `async_insert` and `deduplicate_blocks_in_dependent_materialized_views` to enabled. The [`compatibility`](/reference/settings/session-settings/compatibility#compatibility) setting governs all three. If you set `compatibility` to a version earlier than `26.2`, these settings keep their old defaults: `deduplicate_insert` becomes `backward_compatible_choice`, which hands the decision to `insert_deduplicate` and `async_insert_deduplicate`. A setting you assign explicitly is always honored and is never affected by `compatibility`.
 
 ## How insert deduplication works {#how-insert-deduplication-works}
 
@@ -40,12 +85,62 @@ When data is inserted into ClickHouse, it splits data into blocks based on the n
 
 For tables using `*MergeTree` engines, each block is assigned a unique `block_id`, which is a hash of the data in that block. This `block_id` is used as a unique key for the insert operation. If the same `block_id` is found in the deduplication log, the block is considered a duplicate and isn't inserted into the table.
 
-This approach works well for cases where inserts contain different data. However, if the same data is inserted multiple times intentionally, you need to use the `insert_deduplication_token` setting to control the deduplication process. This setting allows you to specify a unique token for each insert, which ClickHouse uses to determine whether the data is a duplicate.
+This approach works well for cases where inserts contain different data. However, if the same data is inserted multiple times intentionally, you need to use the `insert_deduplication_token` setting to control the deduplication process. This setting allows you to specify a unique token for each insert, which ClickHouse uses to determine whether the data is a duplicate. `insert_deduplication_token` has higher priority: ClickHouse doesn't use the hash sum of the data when the token is provided.
 
 For `INSERT ... VALUES` queries, splitting the inserted data into blocks is deterministic and is determined by settings. Therefore, you should retry insertions with the same settings values as the initial operation.
 
-For `INSERT ... SELECT` queries, it's important that the `SELECT` part of the query returns the same data in the same order for each operation. Note, this is hard to achieve in practice. To ensure stable data order on retries, define a `ORDER BY ALL` section in the `SELECT` part of the query. Right now you have to use exactly `ORDER BY ALL` in the query. Support for `ORDER BY` isn't implemented yet and the `SELECT` part of the query wouldn't be considered as stable. Keep in mind that it is possible that the selected table could be updated between retries - the result data could have changed and deduplication won't occur. Additionally, in situations where you're inserting large amounts of data, it is possible that the number of blocks after inserts can overflow the deduplication log window, and ClickHouse won't know to deduplicate the blocks.
-Right now, the behavior for `INSERT ... SELECT` is controlled by the `insert_select_deduplicate` setting. This setting determines whether deduplication is applied to data inserted using `INSERT ... SELECT` queries. See the linked documentation for details and usage examples.
+## Deduplication for `INSERT ... SELECT` {#deduplication-for-insert-select}
+
+For `INSERT ... SELECT` queries, the `SELECT` part must return the same data in the same order on every attempt. Otherwise the blocks differ, the `block_id`s differ, and the retry isn't recognized as a duplicate.
+
+ClickHouse can't verify that the source data is unchanged, but it can check whether the query itself produces a reproducible result. A `SELECT` is treated as **stable** when both of the following hold:
+
+- The query carries an `ORDER BY ALL` clause. Only the literal `ORDER BY ALL` is recognized. A plain `ORDER BY <expressions>` isn't, and a `UNION` of two or more `SELECT`s is never stable.
+- The reading pipeline ends in a single stream.
+
+A non-empty `insert_deduplication_token` is an equivalent substitute for stability, because the token, and not the data, then identifies the insert.
+
+The setting `deduplicate_insert_select` chooses what to do:
+
+| Value | Behavior |
+|-------|----------|
+| `enable_when_possible` (default) | Deduplicate when the `SELECT` is stable or a token is set. Otherwise skip deduplication and write a message to the server log. |
+| `force_enable` | Always deduplicate. If the `SELECT` isn't stable and no token is set, throw the `DEDUPLICATION_IS_NOT_POSSIBLE` exception. |
+| `enable_even_for_bad_queries` | Deduplicate regardless of stability. Kept for backward compatibility. With an unstable `SELECT`, the retry is usually not recognized as a duplicate, so prefer another value. |
+| `disable` | Never deduplicate `INSERT ... SELECT`. |
+
+`enable_when_possible` and `enable_even_for_bad_queries` also honor `deduplicate_insert`: if it is `disable`, the query isn't deduplicated. `force_enable` overrides `deduplicate_insert`.
+
+Keep in mind that the selected table can be updated between retries. The result data then changes and deduplication doesn't occur. Additionally, when you insert large amounts of data, the number of blocks can overflow the deduplication log window, and ClickHouse won't know to deduplicate the blocks.
+
+## Deduplication for asynchronous inserts {#deduplication-for-asynchronous-inserts}
+
+Asynchronous inserts ([`async_insert`](/reference/settings/session-settings/async-insert#async_insert), enabled by default since version 26.2) are deduplicated on retries in the same way as synchronous inserts. `deduplicate_insert` controls both, so no separate switch is needed.
+
+<Note>
+Before version 26.2, deduplication of asynchronous inserts was disabled by default and was controlled by `async_insert_deduplicate`. That setting is now read only when `deduplicate_insert` is `backward_compatible_choice`.
+</Note>
+
+### Deduplication granularity {#asynchronous-insert-deduplication-granularity}
+
+The server collects several asynchronous inserts into one batch and writes that batch as a single part. Deduplication works per user query, not per batch:
+
+- Each queued query contributes one deduplication token to the batch.
+- A token is either the value of `insert_deduplication_token`, when the query provides one, or a hash of the rows that this query contributed.
+- Batching doesn't influence the tokens, and `insert_deduplication_token` doesn't influence how queries are grouped into batches.
+
+This has two consequences:
+
+- When one query in a batch is a duplicate, ClickHouse removes only the rows of that query. The rest of the batch is inserted normally. The part is skipped entirely only when every row is removed.
+- When two queries in the same batch carry the same token, the second one is dropped before the part is written.
+
+The `DuplicatedAsyncInserts` and `SelfDuplicatedAsyncInserts` events in [`system.events`](/reference/system-tables/events) count these two cases.
+
+### Asynchronous inserts and materialized views {#asynchronous-inserts-and-materialized-views}
+
+Deduplication of asynchronous inserts works together with dependent materialized views. One restriction applies: the inner query of a view must not produce more rows than it reads.
+
+Column transformations, filtering, and aggregation are therefore all allowed, because none of them increases the row count. A `JOIN` that expands the result is not allowed. When a view inflates the row count, ClickHouse throws a `NOT_IMPLEMENTED` exception. To insert through such a view asynchronously, either set `deduplicate_blocks_in_dependent_materialized_views = 0` or use synchronous inserts.
 
 ## Insert deduplication with materialized views {#insert-deduplication-with-materialized-views}
 
@@ -57,8 +152,7 @@ You can control this process using the following settings for the source table:
 - [`replicated_deduplication_window_seconds`](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window_seconds)
 - [`non_replicated_deduplication_window`](/reference/settings/merge-tree-settings/other#non_replicated_deduplication_window)
 
-You have to also enable the user profile setting [`deduplicate_blocks_in_dependent_materialized_views`](/reference/settings/session-settings/other#deduplicate_blocks_in_dependent_materialized_views).
-With enabled setting `insert_deduplicate=1` an inserted data is deduplicated in source table. The setting `deduplicate_blocks_in_dependent_materialized_views=1` additionally enables deduplication in dependant tables. You have to enable both if full deduplication is desired.
+Deduplication in the tables under materialized views is additionally governed by the user profile setting [`deduplicate_blocks_in_dependent_materialized_views`](/reference/settings/session-settings/other#deduplicate_blocks_in_dependent_materialized_views), which is enabled by default since version 26.2. Both switches must allow it: `deduplicate_insert` deduplicates the data inserted into the source table, and `deduplicate_blocks_in_dependent_materialized_views` additionally deduplicates the data in the dependent tables. Enable both if you want full deduplication.
 
 When inserting blocks into tables under materialized views, ClickHouse calculates the `block_id` by hashing a string that combines the `block_id`s from the source table and additional identifiers. This ensures accurate deduplication within materialized views, allowing data to be distinguished based on its original insertion, regardless of any transformations applied before reaching the destination table under the materialized view.
 
@@ -102,11 +196,11 @@ SET min_insert_block_size_bytes=0;
 
 The settings above allow us to select from a table with a series of blocks containing only one row. These small blocks aren't squashed and remain the same until they're inserted into a table.
 
+We make deduplication in the materialized view explicit, although it is enabled by default:
+
 ```sql
 SET deduplicate_blocks_in_dependent_materialized_views=1;
 ```
-
-We need to enable deduplication in materialized view:
 
 ```sql
 INSERT INTO dst SELECT

--- a/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
+++ b/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
@@ -145,9 +145,9 @@ The `DuplicatedAsyncInserts` and `SelfDuplicatedAsyncInserts` events in [`system
 
 ### Asynchronous inserts and materialized views {#asynchronous-inserts-and-materialized-views}
 
-Deduplication of asynchronous inserts works together with dependent materialized views. One restriction applies: the inner query of a view must not emit more than one block for one block of input. ClickHouse throws a `NOT_IMPLEMENTED` exception as soon as a view emits a second block.
+Deduplication of asynchronous inserts works together with dependent materialized views. The rule is simple: one block in, one block out. If the inner query of a view turns one input block into one output block, deduplication works. If the view emits a second block, ClickHouse throws a `NOT_IMPLEMENTED` exception.
 
-The row count itself is not the criterion. A view may emit more rows than it reads and still pass, as long as the result fits in one block. `max_block_size` sets that bound, so a `JOIN` that expands the input is the shape most likely to trip the guard: it passes while the expanded result stays under `max_block_size` and fails once it crosses that bound. Column transformations, filtering, and aggregation never increase the row count, so they always stay within the restriction.
+The number of rows does not matter by itself. Only the number of blocks matters, and [`max_block_size`](/reference/settings/session-settings/max#max_block_size) sets how many rows fit in one block. Column transformations, filtering, and aggregation never add rows, so they always stay in one block. A `JOIN` can add rows. It works while the result stays under `max_block_size`, and it fails above that.
 
 To insert through a view that emits more than one block, either set `deduplicate_blocks_in_dependent_materialized_views = 0` or use synchronous inserts.
 

--- a/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
+++ b/docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
@@ -147,7 +147,9 @@ The `DuplicatedAsyncInserts` and `SelfDuplicatedAsyncInserts` events in [`system
 
 Deduplication of asynchronous inserts works together with dependent materialized views. One restriction applies: the inner query of a view must not emit more than one block for one block of input. ClickHouse throws a `NOT_IMPLEMENTED` exception as soon as a view emits a second block.
 
-In practice this means the view must not produce more rows than it reads. Column transformations, filtering, and aggregation stay within the restriction, because none of them increases the row count. A `JOIN` that expands the result does not. To insert through such a view asynchronously, either set `deduplicate_blocks_in_dependent_materialized_views = 0` or use synchronous inserts.
+The row count itself is not the criterion. A view may emit more rows than it reads and still pass, as long as the result fits in one block. `max_block_size` sets that bound, so a `JOIN` that expands the input is the shape most likely to trip the guard: it passes while the expanded result stays under `max_block_size` and fails once it crosses that bound. Column transformations, filtering, and aggregation never increase the row count, so they always stay within the restriction.
+
+To insert through a view that emits more than one block, either set `deduplicate_blocks_in_dependent_materialized_views = 0` or use synchronous inserts.
 
 ## Insert deduplication with materialized views {#insert-deduplication-with-materialized-views}
 

--- a/docs/snippets/_async_inserts.mdx
+++ b/docs/snippets/_async_inserts.mdx
@@ -59,9 +59,11 @@ Despite using async inserts, you can still encounter ["too many parts"](/resourc
 
 ### Deduplication and reliability {#deduplication-and-reliability}
 
-By default, ClickHouse performs automatic deduplication for synchronous inserts, which makes retries safe in failure scenarios. However, this is disabled for asynchronous inserts unless explicitly enabled (this shouldn't be enabled if you have dependent materialized views — [see issue](https://github.com/ClickHouse/ClickHouse/issues/66003)).
+Since version 26.2, ClickHouse performs automatic deduplication for asynchronous inserts as well as for synchronous ones, which makes retries safe in failure scenarios. Both are controlled by [`deduplicate_insert`](/reference/settings/session-settings/deduplicate-insert#deduplicate_insert), which defaults to `enable`. Dependent materialized views are supported.
 
-In practice, if deduplication is turned on and the same insert is retried — due to, for instance, a timeout or network drop — ClickHouse can safely ignore the duplicate. This helps maintain idempotency and avoids double-writing data.
+In practice, if the same insert is retried — due to, for instance, a timeout or network drop — ClickHouse can safely ignore the duplicate. This helps maintain idempotency and avoids double-writing data. For asynchronous inserts, deduplication works per user query rather than per flushed batch, so a duplicate query does not discard the other queries batched with it.
+
+For details, and for the one restriction that applies to materialized views under asynchronous inserts, see [Deduplicating inserts on retries](/concepts/features/operations/insert/deduplicating-inserts-on-retries#deduplication-for-asynchronous-inserts).
 
 ### Enabling asynchronous inserts {#enabling-asynchronous-inserts}
 

--- a/docs/snippets/_async_inserts.mdx
+++ b/docs/snippets/_async_inserts.mdx
@@ -59,7 +59,7 @@ Despite using async inserts, you can still encounter ["too many parts"](/resourc
 
 ### Deduplication and reliability {#deduplication-and-reliability}
 
-Since version 26.2, ClickHouse performs automatic deduplication for asynchronous inserts as well as for synchronous ones, which makes retries safe in failure scenarios. Both are controlled by [`deduplicate_insert`](/reference/settings/session-settings/deduplicate-insert#deduplicate_insert), which defaults to `enable`. Dependent materialized views are supported.
+Since version 26.2, ClickHouse performs automatic deduplication for asynchronous inserts as well as for synchronous ones, which makes retries safe on tables that keep a deduplication log. `*ReplicatedMergeTree` engines keep one by default; a plain `MergeTree` table needs `non_replicated_deduplication_window` set to a positive value. Both insert types are controlled by [`deduplicate_insert`](/reference/settings/session-settings/deduplicate-insert#deduplicate_insert), which defaults to `enable`. Dependent materialized views are supported.
 
 In practice, if the same insert is retried — due to, for instance, a timeout or network drop — ClickHouse can safely ignore the duplicate. This helps maintain idempotency and avoids double-writing data. For asynchronous inserts, deduplication works per user query rather than per flushed batch, so a duplicate query does not discard the other queries batched with it.
 

--- a/src/Core/DeduplicateInsert.cpp
+++ b/src/Core/DeduplicateInsert.cpp
@@ -53,7 +53,8 @@ bool isDeduplicationEnabledForInsertSelect(bool select_query_sorted, const Setti
                 throw Exception(ErrorCodes::DEDUPLICATION_IS_NOT_POSSIBLE,
                     "Deduplication for INSERT SELECT with non-stable SELECT is not possible"
                     " (the SELECT part can return different results on each execution)."
-                    " You can disable it by setting `insert_deduplicate` or `async_insert_deduplicate` to 0."
+                    " You can set `deduplicate_insert_select` to 'enable_when_possible' to skip deduplication"
+                    " for such queries, or to 'disable' to turn it off."
                     " Or make SELECT query stable (for example, by adding ORDER BY all to the query)"
                     " or provide `insert_deduplication_token`.");
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2299,21 +2299,24 @@ Possible values:
 \
     DECLARE(DeduplicateInsertMode, deduplicate_insert, DeduplicateInsertMode::ENABLE, R"(
 Enables or disables block deduplication of  `INSERT INTO` (for Replicated\* tables).
-The setting overrides `insert_deduplicate` and `async_insert_deduplicate` settings.
+The setting applies to both synchronous and asynchronous inserts, and it supersedes the `insert_deduplicate` and `async_insert_deduplicate` settings.
 That setting has three possible values:
 - disable — Deduplication is disabled for `INSERT INTO` query.
 - enable — Deduplication is enabled for `INSERT INTO` query.
 - backward_compatible_choice — Deduplication is enabled if `insert_deduplicate` or `async_insert_deduplicate` are enabled for specific insert type.
+
+For `INSERT SELECT` queries, [`deduplicate_insert_select`](#deduplicate_insert_select) is consulted first. Deduplication also requires the destination table to keep a deduplication log, see [replicated_deduplication_window](/reference/settings/merge-tree-settings/replicated-deduplication-window#replicated_deduplication_window) and [non_replicated_deduplication_window](/reference/settings/merge-tree-settings/other#non_replicated_deduplication_window).
 )", 0) \
 \
     DECLARE(DeduplicateInsertSelectMode, deduplicate_insert_select, DeduplicateInsertSelectMode::ENABLE_WHEN_POSSIBLE, R"(
 Enables or disables block deduplication of `INSERT SELECT` (for Replicated\* tables).
-The setting overrids `insert_deduplicate` and `deduplicate_insert` for `INSERT SELECT` queries.
+For `INSERT SELECT` queries this setting is consulted before [`deduplicate_insert`](#deduplicate_insert).
+A `SELECT` is stable when it carries `ORDER BY ALL` and its pipeline ends in a single stream. A non-empty [`insert_deduplication_token`](#insert_deduplication_token) is an equivalent substitute for stability.
 That setting has four possible values:
 - disable — Deduplication is disabled for `INSERT SELECT` query.
-- force_enable — Deduplication is enabled for `INSERT SELECT` query. If select result is not stable, exception is thrown.
-- enable_when_possible — Deduplication is enabled if `insert_deduplicate` is enable and select result is stable, otherwise disabled.
-- enable_even_for_bad_queries - Deduplication is enabled if `insert_deduplicate` is enable. If select result is not stable, warning is logged, but query is executed with deduplication. This option is for backward compatibility. Consider to use other options instead as it may lead to unexpected results.
+- force_enable — Deduplication is enabled for `INSERT SELECT` query, regardless of `deduplicate_insert`. If select result is not stable and no token is provided, exception is thrown.
+- enable_when_possible — Deduplication is enabled if it is enabled by `deduplicate_insert` and the select result is stable, otherwise disabled.
+- enable_even_for_bad_queries - Deduplication is enabled if it is enabled by `deduplicate_insert`, regardless of whether the select result is stable. If select result is not stable, a message is logged, but query is executed with deduplication. This option is for backward compatibility. Consider to use other options instead as it may lead to unexpected results.
 )", 0) \
 \
     DECLARE(Bool, insert_deduplicate, true, R"(

--- a/tests/queries/0_stateless/05024_sync_async_insert_cross_deduplication.reference
+++ b/tests/queries/0_stateless/05024_sync_async_insert_cross_deduplication.reference
@@ -1,0 +1,5 @@
+case: sync insert then async insert of the same data	1	one line
+case: async insert then sync insert of the same data	2	other line
+case: sync then async with the same insert_deduplication_token	3	sync value
+case: sync then async, deduplicate_insert=\'disable\'	5	one line
+case: sync then async, deduplicate_insert=\'disable\'	5	one line

--- a/tests/queries/0_stateless/05024_sync_async_insert_cross_deduplication.sql
+++ b/tests/queries/0_stateless/05024_sync_async_insert_cross_deduplication.sql
@@ -1,0 +1,69 @@
+-- Deduplication spans synchronous and asynchronous inserts: both write the same
+-- unified hash, so a retry sent in one mode is a duplicate of an attempt sent in
+-- the other. See docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx
+
+CREATE TABLE test
+    (id UInt64, value String)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test/test_table', '1')
+ORDER BY id;
+
+SET deduplicate_insert = 'enable';
+SET async_insert_use_adaptive_busy_timeout = 0, async_insert_busy_timeout_min_ms = 10000, async_insert_busy_timeout_max_ms = 50000;
+
+-- Synchronous insert first, then the same data asynchronously.
+
+TRUNCATE TABLE test;
+
+SET async_insert = 0;
+INSERT INTO test VALUES (1, 'one line');
+
+SET async_insert = 1, wait_for_async_insert = 0;
+INSERT INTO test VALUES (1, 'one line');
+SYSTEM FLUSH ASYNC INSERT QUEUE test;
+
+SELECT 'case: sync insert then async insert of the same data', * FROM test ORDER BY id;
+
+-- Asynchronous insert first, then the same data synchronously.
+
+TRUNCATE TABLE test;
+
+SET async_insert = 1, wait_for_async_insert = 0;
+INSERT INTO test VALUES (2, 'other line');
+SYSTEM FLUSH ASYNC INSERT QUEUE test;
+
+SET async_insert = 0;
+INSERT INTO test VALUES (2, 'other line');
+
+SELECT 'case: async insert then sync insert of the same data', * FROM test ORDER BY id;
+
+-- The same crossing with a user token instead of a data hash. The token, and not
+-- the data, identifies the insert, so the async attempt is dropped even though it
+-- carries different values.
+
+TRUNCATE TABLE test;
+
+SET async_insert = 0;
+INSERT INTO test SETTINGS insert_deduplication_token = 'shared_token' VALUES (3, 'sync value');
+
+SET async_insert = 1, wait_for_async_insert = 0;
+INSERT INTO test SETTINGS insert_deduplication_token = 'shared_token' VALUES (4, 'async value');
+SYSTEM FLUSH ASYNC INSERT QUEUE test;
+
+SELECT 'case: sync then async with the same insert_deduplication_token', * FROM test ORDER BY id;
+
+-- With deduplication off the crossing must not deduplicate.
+
+TRUNCATE TABLE test;
+
+SET deduplicate_insert = 'disable';
+
+SET async_insert = 0;
+INSERT INTO test VALUES (5, 'one line');
+
+SET async_insert = 1, wait_for_async_insert = 0;
+INSERT INTO test VALUES (5, 'one line');
+SYSTEM FLUSH ASYNC INSERT QUEUE test;
+
+SELECT 'case: sync then async, deduplicate_insert=\'disable\'', * FROM test ORDER BY id;
+
+DROP TABLE test SYNC;


### PR DESCRIPTION
The guide `Deduplicating inserts on retries` no longer matched the code.

It presented `insert_deduplicate` as the query-level switch and named `insert_select_deduplicate` for `INSERT ... SELECT`. Both are superseded. `deduplicate_insert` is the main switch and defaults to `enable` since 26.2, `deduplicate_insert_select` governs `INSERT ... SELECT`, and `insert_select_deduplicate` is obsolete. The guide also said nothing about asynchronous inserts, although they are deduplicated by default since 26.2.

Changes to `docs/concepts/features/operations/insert/deduplicating-inserts-on-retries.mdx`:

- New `Settings that control insert deduplication` section. It separates the table-level requirement (a deduplication log) from the query-level one, and lists `deduplicate_insert`, `deduplicate_insert_select`, `insert_deduplication_token`, and `deduplicate_blocks_in_dependent_materialized_views` with their current defaults.
- New `Precedence` subsection and a `Legacy and obsolete settings` table, plus a note on how the `compatibility` setting affects the 26.2 defaults.
- New `Deduplication for INSERT ... SELECT` section. It defines when a `SELECT` is stable and documents the four values of `deduplicate_insert_select`.
- New `Deduplication for asynchronous inserts` section. It covers the per-user-query deduplication granularity, the `DuplicatedAsyncInserts` and `SelfDuplicatedAsyncInserts` events, and the materialized view restriction.
- Corrected the statement that non-replicated tables deduplicate by default. `non_replicated_deduplication_window` is `0`.
- Corrected the materialized view section. `deduplicate_blocks_in_dependent_materialized_views` is enabled by default since 26.2.

Changes to `docs/snippets/_async_inserts.mdx`: the snippet still claimed that deduplication is disabled for asynchronous inserts and must not be enabled with dependent materialized views. That restriction was removed by https://github.com/ClickHouse/ClickHouse/pull/89140.

English content only. The locale trees are generated.

Related: https://github.com/ClickHouse/ClickHouse/issues/66003
Related: https://github.com/ClickHouse/ClickHouse/pull/89140

### Changelog category (leave one):
- Documentation (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115575&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115575](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115575+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1842` (included in `26.8` and later)
<!-- ch-version-info:end -->