### PR TITLE
docs(tf-provider-beta): change tf provider mentions of alpha to beta

### DIFF
--- a/docs/products/cloud/features/admin-features/api/api-overview.mdx
+++ b/docs/products/cloud/features/admin-features/api/api-overview.mdx
@@ -57,20 +57,30 @@ You will now also be able to specify the `num_replicas` field as a property of t
 
 ## Terraform provider releases {#terraform-provider-releases}
 
-ClickHouse maintains two official Terraform providers — the ClickHouse Cloud provider for cloud infrastructure and the DBops provider for database-level objects. Both follow the same release model.
+ClickHouse maintains two official Terraform providers - the ClickHouse Cloud provider for cloud infrastructure and the DBops provider for database-level objects. Both follow the same release model.
 
-### Stable versus alpha {#stable-vs-alpha}
+### GA versus Beta resources {#ga-vs-beta-resources}
 
-Stable versions (e.g. 3.11.1, 1.9.0) only include resources for GA features. Alpha versions (e.g. 3.12.0-alpha2, 1.10.0-alpha1) include everything in stable plus resources for features still in beta or private preview, and must be explicitly pinned to use.
+Every release is a single build that contains all resources. Resources for features that have not yet reached general availability ship alongside GA ones, marked as **beta** — there is no separate build and nothing to pin to use them.
+
+A beta resource announces itself in two places:
+
+- **At plan and apply time**, as a `Beta Resource` warning. Terraform never fails on warnings, so the run proceeds normally.
+- **In its documentation**, with a callout reading "This resource is in beta".
+
+Beta means the schema and behavior may change in a future provider version. Anything without the marker is GA and covered by the usual compatibility guarantees.
+
+> **Note:** Before v3.25.2, the provider marked these resources as *alpha* rather than *beta*, and the plan-time warning read `Alpha Resource`. Only the wording changed — no schema, behavior, or state migration is involved — but tooling that greps plan output for `Alpha Resource` will silently stop matching. Earlier releases also published a separate alpha build.
 
 ### Versioning {#versioning}
 
-Both providers use semantic versioning (MAJOR.MINOR.PATCH). The major version is incremented for breaking changes, the minor version for new features or resources, and the
-patch version for bug fixes. Alpha releases append a pre-release suffix to the next minor version (e.g. 3.12.0-alpha1), with the alpha number incrementing as additional fixes or changes are added before promotion (e.g. alpha1 → alpha2 → alpha3). Releases are cut on demand rather than on a fixed schedule. A new alpha is created when a resource is added for a feature not yet GA, or when a fix needs early validation. A new stable is created once accumulated changes — including any features that have since reached GA — are ready for production, typically after a period of customer feedback. Multiple alpha minor versions may accumulate before being consolidated into a single stable release.
+Both providers use semantic versioning (MAJOR.MINOR.PATCH). The major version is incremented for breaking changes, the minor version for new features or resources, and the patch version for bug fixes. Releases are cut on demand rather than on a fixed schedule.
 
-### Promotion from alpha to stable {#promotion}
+Versions with an `-alphaN` suffix (e.g., `3.15.0-alpha3`) predate the single-build model. They remain available but are no longer produced.
 
-When a Terraform feature is ready for GA, the Terraform resource is promoted from alpha to stable in the next stable release. Until then, the resource is only available in alpha builds.
+### Promotion from beta to GA {#promotion}
+
+When a feature reaches general availability, its resource drops the beta marker in the next provider release: the plan-time warning stops appearing, and the docs callout is removed. Nothing else changes — no configuration edits, no state migration, and no switching between builds.
 
 ## Terraform and OpenAPI New Pricing: Replica Settings Explained {#terraform-and-openapi-new-pricing---replica-settings-explained}
 

--- a/docs/products/cloud/features/admin-features/api/api-overview.mdx
+++ b/docs/products/cloud/features/admin-features/api/api-overview.mdx
@@ -70,7 +70,9 @@ A beta resource announces itself in two places:
 
 Beta means the schema and behavior may change in a future provider version. Anything without the marker is GA and covered by the usual compatibility guarantees.
 
-> **Note:** Before v3.25.2, the provider marked these resources as *alpha* rather than *beta*, and the plan-time warning read `Alpha Resource`. Only the wording changed — no schema, behavior, or state migration is involved — but tooling that greps plan output for `Alpha Resource` will silently stop matching. Earlier releases also published a separate alpha build.
+<Note>
+Before v3.25.2, the provider marked these resources as *alpha* rather than *beta*, and the plan-time warning read `Alpha Resource`. Only the wording changed — no schema, behavior, or state migration is involved — but tooling that greps plan output for `Alpha Resource` will silently stop matching. Earlier releases also published a separate alpha build.
+</Note>
 
 ### Versioning {#versioning}
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115582&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115582](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115582+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1765` (included in `26.8` and later)
<!-- ch-version-info:end -->