### PR TITLE
Do not treat the CFI build as a sanitizer build in the test harnesses

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -212,6 +212,10 @@ class JobConfigs:
                 # two files, so a change to either must run this job.
                 "./tests/clickhouse-test",
                 "./tests/queries/shell_config.sh",
+                # The CFI build-classification guards read these two, so a change to either
+                # must run this job instead of reusing a cached result.
+                "./tests/config/install.sh",
+                "./tests/integration/helpers/cluster.py",
             ]
         ),
         post_hooks=["python3 ci/jobs/scripts/job_hooks/docker_volume_clean_up_hook.py"],

--- a/ci/tests/test_cfi_not_a_sanitizer_build.py
+++ b/ci/tests/test_cfi_not_a_sanitizer_build.py
@@ -23,6 +23,7 @@ See ClickHouse/ClickHouse#115122.
 """
 
 import os
+import subprocess
 import sys
 
 import pytest
@@ -117,16 +118,49 @@ def test_named_checks_distinguish_between_sanitizers(name):
         assert classify(flags).is_built_with_sanitizer(name) == expected, profile
 
 
-def test_installer_gates_symbolization_on_the_same_invariant():
-    """The functional-test installer decides symbolization from the same marker.
+def run_installer_predicate(tmp_path, flags):
+    """Run the installer's own is_sanitizer_build against a stub `clickhouse`.
 
-    Scoped to `is_sanitizer_build`: `is_fast_build` also tests for `-fsanitize=`,
-    but only the Fast test job calls it and that job builds without CFI.
+    The function shells out to a bare `clickhouse local --query`, so a stub earlier
+    on PATH answers the query. Returns its exit status: 0 means the installer would
+    install trace_log_no_symbolize.xml and disable symbolization.
     """
-    with open(INSTALLER, "r", encoding="utf-8") as f:
-        installer = f.read()
-    body = installer.split("function is_sanitizer_build()", 1)
-    assert len(body) == 2, "is_sanitizer_build is gone from the installer"
-    body = body[1].split("\n}", 1)[0]
-    assert "'%-DSANITIZER%'" in body
-    assert "LIKE '%-fsanitize=%'" not in body
+    stub = tmp_path / "clickhouse"
+    stub.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "flags = {!r}\n"
+        "query = sys.argv[sys.argv.index('--query') + 1]\n"
+        'start = query.index("\'") + 1\n'
+        "pattern = query[start : query.index(\"'\", start)].strip('%')\n"
+        "print(int(pattern in flags))\n".format(flags)
+    )
+    stub.chmod(0o755)
+
+    script = (
+        "set -e\n"
+        "source_lines=$(sed -n '/^function is_sanitizer_build()/,/^}/p' "
+        '"$1"' + ")\n"
+        'eval "$source_lines"\n'
+        "is_sanitizer_build\n"
+    )
+    env = dict(os.environ, PATH="{}:{}".format(tmp_path, os.environ["PATH"]))
+    return subprocess.run(
+        ["bash", "-c", script, "bash", INSTALLER], env=env, capture_output=True
+    ).returncode
+
+
+@pytest.mark.parametrize("profile", sorted(NON_SANITIZER_FLAGS))
+def test_installer_keeps_symbolization_without_a_sanitizer(tmp_path, profile):
+    """CFI, debug, release and coverage builds must keep query-profiler symbols.
+
+    Runs the installer's own predicate, so it fails if that function stops
+    depending on the build flags at all, not only if its text changes.
+    """
+    assert run_installer_predicate(tmp_path, NON_SANITIZER_FLAGS[profile]) != 0
+
+
+@pytest.mark.parametrize("profile", sorted(SANITIZER_FLAGS))
+def test_installer_disables_symbolization_under_a_sanitizer(tmp_path, profile):
+    """In-flush symbolization is too slow under a sanitizer runtime."""
+    assert run_installer_predicate(tmp_path, SANITIZER_FLAGS[profile]) == 0

--- a/ci/tests/test_cfi_not_a_sanitizer_build.py
+++ b/ci/tests/test_cfi_not_a_sanitizer_build.py
@@ -1,0 +1,132 @@
+"""
+Tests that the CFI build profile is not classified as a runtime sanitizer build.
+
+The `amd_cfi` profile compiles with Clang CFI, so `CMAKE_CXX_FLAGS_RELWITHDEBINFO`
+carries `-fsanitize=cfi-vcall,cfi-derived-cast` (CMakeLists.txt) and that lands in
+the `CXX_FLAGS` row of `system.build_options` via cmake/print_flags.cmake. A build
+predicate that tests for the bare substring `-fsanitize=` therefore matches CFI,
+even though CFI attaches no sanitizer runtime and runs at release speed. Consumers
+then apply sanitizer workarounds under CFI: the test-config installer disables
+query-profiler symbolization, which empties `symbols` and `lines` in
+`system.trace_log`, and integration tests skip themselves.
+
+A runtime sanitizer build is instead marked with `-DSANITIZER`
+(cmake/sanitize.cmake), which reaches `CMAKE_CXX_FLAGS` in every branch of the
+`if (SANITIZE)` block and is never set for CFI.
+
+Only `WeeklyCFI` builds this profile and it is a scheduled workflow, so no pull
+request can exercise these predicates against a real CFI binary. These tests pin
+the classification directly so that reverting it fails CI. The flag strings below
+are the measured `CXX_FLAGS` rows of real binaries.
+
+See ClickHouse/ClickHouse#115122.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../tests/integration"))
+
+from helpers.cluster import ClickHouseInstance
+
+INSTALLER = os.path.join(os.path.dirname(__file__), "../../tests/config/install.sh")
+
+# Measured CXX_FLAGS rows. CFI is from the amd_cfi binary of the WeeklyCFI job in
+# ClickHouse/ClickHouse#115122 (build ID e3992b92853623fcc8ebea13060c0d7603f98201).
+CFI = (
+    "-O2 -g -DNDEBUG -flto=thin -fwhole-program-vtables "
+    "-fsanitize=cfi-vcall,cfi-derived-cast -fno-sanitize-recover=cfi "
+    "-fvisibility=default -fno-pie"
+)
+ASAN = (
+    "-O2 -g -fno-omit-frame-pointer -DSANITIZER -fsanitize=address "
+    "-fsanitize-address-use-after-scope"
+)
+TSAN = "-O2 -g -fno-omit-frame-pointer -DSANITIZER -fsanitize=thread"
+MSAN = (
+    "-O2 -g -fno-omit-frame-pointer -DSANITIZER -fsanitize=memory "
+    "-fsanitize-memory-use-after-dtor"
+)
+UBSAN = (
+    "-O2 -g -fno-omit-frame-pointer -DSANITIZER -fsanitize=undefined "
+    "-fno-sanitize-recover=all"
+)
+ASAN_UBSAN = (
+    "-O2 -g -fno-omit-frame-pointer -DSANITIZER -fsanitize=address,undefined "
+    "-fsanitize-address-use-after-scope"
+)
+DEBUG = "-O0 -g"
+RELEASE = "-O3 -DNDEBUG -flto=thin -fwhole-program-vtables"
+COVERAGE = "-O2 -DNDEBUG -fsanitize-coverage=trace-pc-guard -DWITH_COVERAGE=1"
+
+SANITIZER_FLAGS = {
+    "asan": ASAN,
+    "tsan": TSAN,
+    "msan": MSAN,
+    "ubsan": UBSAN,
+    "asan_ubsan": ASAN_UBSAN,
+}
+NON_SANITIZER_FLAGS = {
+    "amd_cfi": CFI,
+    "debug": DEBUG,
+    "release": RELEASE,
+    "coverage": COVERAGE,
+}
+
+
+def classify(flags):
+    """Run the real predicate against a build whose CXX_FLAGS row is `flags`."""
+    instance = ClickHouseInstance.__new__(ClickHouseInstance)
+    instance.query = lambda *args, **kwargs: flags
+    return instance
+
+
+@pytest.mark.parametrize("profile", sorted(SANITIZER_FLAGS))
+def test_runtime_sanitizer_builds_are_detected(profile):
+    """Every runtime sanitizer profile must still be classified as sanitized."""
+    assert classify(SANITIZER_FLAGS[profile]).is_built_with_sanitizer()
+
+
+@pytest.mark.parametrize("profile", sorted(NON_SANITIZER_FLAGS))
+def test_non_sanitizer_builds_are_not_detected(profile):
+    """CFI, debug, release and coverage builds carry no sanitizer runtime."""
+    assert not classify(NON_SANITIZER_FLAGS[profile]).is_built_with_sanitizer()
+
+
+def test_cfi_flags_would_match_a_bare_fsanitize_test():
+    """Pin why the bare substring test is wrong, so this stays a live oracle.
+
+    Without this, a revert to `-fsanitize=` could look harmless.
+    """
+    assert "-fsanitize=" in CFI
+    assert "-DSANITIZER" not in CFI
+
+
+@pytest.mark.parametrize("name", ["address", "thread", "memory"])
+def test_named_checks_distinguish_between_sanitizers(name):
+    """The named checks must keep testing `-fsanitize=<name>`.
+
+    `-DSANITIZER` cannot tell sanitizers apart, and `test_crash_log` passes these
+    names through to pick the ASan/TSan/MSan-only cases.
+    """
+    for profile, flags in {**SANITIZER_FLAGS, **NON_SANITIZER_FLAGS}.items():
+        expected = "-fsanitize={}".format(name) in flags
+        assert classify(flags).is_built_with_sanitizer(name) == expected, profile
+
+
+def test_installer_gates_symbolization_on_the_same_invariant():
+    """The functional-test installer decides symbolization from the same marker.
+
+    Scoped to `is_sanitizer_build`: `is_fast_build` also tests for `-fsanitize=`,
+    but only the Fast test job calls it and that job builds without CFI.
+    """
+    with open(INSTALLER, "r", encoding="utf-8") as f:
+        installer = f.read()
+    body = installer.split("function is_sanitizer_build()", 1)
+    assert len(body) == 2, "is_sanitizer_build is gone from the installer"
+    body = body[1].split("\n}", 1)[0]
+    assert "'%-DSANITIZER%'" in body
+    assert "LIKE '%-fsanitize=%'" not in body

--- a/ci/tests/test_cfi_not_a_sanitizer_build.py
+++ b/ci/tests/test_cfi_not_a_sanitizer_build.py
@@ -118,12 +118,13 @@ def test_named_checks_distinguish_between_sanitizers(name):
         assert classify(flags).is_built_with_sanitizer(name) == expected, profile
 
 
-def run_installer_predicate(tmp_path, flags):
-    """Run the installer's own is_sanitizer_build against a stub `clickhouse`.
+def symbolization_is_disabled_by_installer(tmp_path, flags):
+    """Run the installer's own classification block against a stub `clickhouse`.
 
-    The function shells out to a bare `clickhouse local --query`, so a stub earlier
-    on PATH answers the query. Returns its exit status: 0 means the installer would
-    install trace_log_no_symbolize.xml and disable symbolization.
+    Executes `is_sanitizer_build` together with the `if` that consumes it, so both
+    the classification and its wiring to the symlink are covered, and reports
+    whether `trace_log_no_symbolize.xml` was installed. The function shells out to
+    a bare `clickhouse local --query`, so a stub earlier on PATH answers it.
     """
     stub = tmp_path / "clickhouse"
     stub.write_text(
@@ -137,30 +138,36 @@ def run_installer_predicate(tmp_path, flags):
     )
     stub.chmod(0o755)
 
+    dest = tmp_path / "dest"
+    (dest / "config.d").mkdir(parents=True)
     script = (
         "set -e\n"
-        "source_lines=$(sed -n '/^function is_sanitizer_build()/,/^}/p' "
-        '"$1"' + ")\n"
-        'eval "$source_lines"\n'
-        "is_sanitizer_build\n"
+        "block=$(sed -n '/^function is_sanitizer_build()/,/^fi$/p' \"$1\")\n"
+        'test -n "$block"\n'
+        'eval "$block"\n'
     )
-    env = dict(os.environ, PATH="{}:{}".format(tmp_path, os.environ["PATH"]))
-    return subprocess.run(
+    env = dict(
+        os.environ,
+        PATH="{}:{}".format(tmp_path, os.environ["PATH"]),
+        SRC_PATH=os.path.dirname(INSTALLER),
+        DEST_SERVER_PATH=str(dest),
+    )
+    run = subprocess.run(
         ["bash", "-c", script, "bash", INSTALLER], env=env, capture_output=True
-    ).returncode
+    )
+    assert run.returncode == 0, run.stderr.decode()
+    return (dest / "config.d" / "trace_log_no_symbolize.xml").is_symlink()
 
 
 @pytest.mark.parametrize("profile", sorted(NON_SANITIZER_FLAGS))
 def test_installer_keeps_symbolization_without_a_sanitizer(tmp_path, profile):
-    """CFI, debug, release and coverage builds must keep query-profiler symbols.
-
-    Runs the installer's own predicate, so it fails if that function stops
-    depending on the build flags at all, not only if its text changes.
-    """
-    assert run_installer_predicate(tmp_path, NON_SANITIZER_FLAGS[profile]) != 0
+    """CFI, debug, release and coverage builds must keep query-profiler symbols."""
+    assert not symbolization_is_disabled_by_installer(
+        tmp_path, NON_SANITIZER_FLAGS[profile]
+    )
 
 
 @pytest.mark.parametrize("profile", sorted(SANITIZER_FLAGS))
 def test_installer_disables_symbolization_under_a_sanitizer(tmp_path, profile):
     """In-flush symbolization is too slow under a sanitizer runtime."""
-    assert run_installer_predicate(tmp_path, SANITIZER_FLAGS[profile]) == 0
+    assert symbolization_is_disabled_by_installer(tmp_path, SANITIZER_FLAGS[profile])

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -224,7 +224,10 @@ ln -sf $SRC_PATH/config.d/threadpool_writer_pool_size.yaml $DEST_SERVER_PATH/con
 ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/config.d/
 function is_sanitizer_build()
 {
-    [ "$(clickhouse local --query "SELECT value LIKE '%-fsanitize=%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" = "1" ]
+    # A runtime sanitizer build is marked with -DSANITIZER (cmake/sanitize.cmake). Do not test for
+    # -fsanitize=, which also matches link-time-only checks such as CFI (cfi-vcall,
+    # cfi-derived-cast) whose builds symbolize at full speed.
+    [ "$(clickhouse local --query "SELECT value LIKE '%-DSANITIZER%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" = "1" ]
 }
 if is_sanitizer_build; then
     ln -sf $SRC_PATH/config.d/trace_log_no_symbolize.xml $DEST_SERVER_PATH/config.d/

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -225,8 +225,8 @@ ln -sf $SRC_PATH/config.d/serverwide_trace_collector.xml $DEST_SERVER_PATH/confi
 function is_sanitizer_build()
 {
     # A runtime sanitizer build is marked with -DSANITIZER (cmake/sanitize.cmake). Do not test for
-    # -fsanitize=, which also matches link-time-only checks such as CFI (cfi-vcall,
-    # cfi-derived-cast) whose builds symbolize at full speed.
+    # -fsanitize=, which also matches CFI (cfi-vcall, cfi-derived-cast): its checks trap on a bad
+    # vcall or cast without a sanitizer runtime, so symbolization runs at full speed.
     [ "$(clickhouse local --query "SELECT value LIKE '%-DSANITIZER%' FROM system.build_options WHERE name = 'CXX_FLAGS'")" = "1" ]
 }
 if is_sanitizer_build; then

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -5153,6 +5153,10 @@ class ClickHouseInstance:
         build_opts = self.query(
             "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'"
         )
+        if not sanitizer_name:
+            # A runtime sanitizer build is marked with -DSANITIZER (cmake/sanitize.cmake). -fsanitize=
+            # also matches CFI, which traps on a bad vcall or cast with no sanitizer runtime attached.
+            return "-DSANITIZER" in build_opts
         return "-fsanitize={}".format(sanitizer_name) in build_opts
 
     def is_debug_build(self):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115122   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes: #115122

Two test harnesses decide whether a build is a sanitizer build by testing `CXX_FLAGS LIKE
'%-fsanitize=%'`. The `amd_cfi` profile adds `-fsanitize=cfi-vcall,cfi-derived-cast`
(`CMakeLists.txt:527`), so the substring matches even though `-DSANITIZE=` is empty:

- `tests/config/install.sh:227` installs `config.d/trace_log_no_symbolize.xml`, so
  `TraceLog.cpp:298-299` inserts a zero-length array into `symbols` and `lines`, failing the two
  `03150_trace_log_*` tests.
- `tests/integration/helpers/cluster.py:5152` `is_built_with_sanitizer()` makes 50 no-argument call
  sites across 35 integration test files skip themselves, `test_trace_log_build_id` saying
  "trace_log is disabled with sanitizers", which is not true under CFI.

Both now test `-DSANITIZER`, which `cmake/sanitize.cmake:30` puts into `SAN_FLAGS` and which reaches
`CMAKE_CXX_FLAGS` in all 5 branches of `if (SANITIZE)` and nowhere else. The named `address` /
`thread` / `memory` checks keep testing `-fsanitize=<name>`.

**The reporter's open question is answered, and negatively: official release builds are not
affected.** `amd_cfi` and `amd_release` differ by exactly one flag (`-DENABLE_CFI=1` versus
`-DBUILD_STANDALONE_KEEPER=1`), so ThinLTO with split-debug and stripping is already the shipped
configuration.

Validated on the exact binary from the failing job (build ID `e3992b92...`): with the override
present both `03150_*` tests fail; with the patched script both pass. That binary is now classified
as not sanitized while a real ASan binary still is, the regression risk this PR's ASan/TSan/MSan
lanes cover.

No existing check can show the `03150_*` tests green: `WeeklyCFI` on master runs only build,
integration and stress (`ci/workflows/weekly_cfi.py:30-34`), and the stateless `amd_cfi` lane arrives
with #115036, still open. Since both consumers react by skipping work, a revert would stay green, so
`ci/tests/test_cfi_not_a_sanitizer_build.py` pins both predicates against the measured `CXX_FLAGS` of
nine profiles, running the installer's own function with a stub `clickhouse`. It runs on every PR,
and both predicate files are now `CI Tests` digest inputs so a later edit cannot reuse a cached pass.
#113107 edits the same block, so whichever lands second may need a rebase.

[CI report.](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115036&sha=30c47a7d9420ba1e86365979016e7765cbc080da&name_0=WeeklyCFI&name_1=Stateless%20tests%20%28amd_cfi%2C%20parallel%29)

<details>
<summary>Other users of an <code>-fsanitize</code> string test, left unchanged (click to expand)</summary>

I checked every in-tree consumer of the same "is this a sanitizer build" idea and changed the two
that are reachable under CFI and change test outcomes:

| consumer | reachable under CFI? | why left alone |
|---|---|---|
| `install.sh:92` `is_fast_build` | no | its only call site needs `FAST_TEST=1`, whose only producer builds with `-DENABLE_THINLTO=0` and no CFI, and CFI without ThinLTO is a cmake `FATAL_ERROR` |
| `tests/clickhouse-test:5135` `collect_build_flags` | yes | already correct: it maps sanitizer names, so CFI yields no flag and `SANITIZED` stays false. It must keep the name map to emit per-sanitizer `no-asan`/`no-tsan` tags, which a boolean marker cannot express |
| `tests/docker_scripts/upgrade_runner.sh:171` | no | there is no `amd_cfi` upgrade job |
| `tests/integration/test_userspace_page_cache/test.py:31` | yes | its own local probe, run before the cluster starts so it cannot use the helper. The consequence is one extra container under CFI, not a wrong result |
| `ci/jobs/scripts/functional_tests/setup_log_cluster.sh:102` | yes | the value is only echoed, never read again anywhere in the tree - a dead diagnostic |

`Stress test (amd_cfi)` also runs `install.sh` on master, so that predicate is exercised there, but
that suite asserts nothing about symbolized `trace_log`.

Each remaining one is a separate question with no observed consequence today, so widening this PR
to them would be unmeasured churn.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115591&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115591](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115591+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1830` (included in `26.8` and later)
<!-- ch-version-info:end -->