### PR TITLE
Fix read_rows/read_bytes/written_rows/written_bytes in system.query_thread_log

### DIFF
--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -541,6 +541,8 @@ void ThreadStatus::initPerformanceCounters()
     performance_counters.resetCounters();
     memory_tracker.resetCounters();
     memory_tracker.setDescription("Thread");
+    progress_in.reset();
+    progress_out.reset();
 
     // query_start_time.nanoseconds cannot be used here since RUsageCounters expect CLOCK_MONOTONIC
     *last_rusage = RUsageCounters::current();

--- a/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.reference
+++ b/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.reference
@@ -1,8 +1,8 @@
-SELECT arm: queries finished, distinct threads, distinct read_rows values
-4	1	1
-INSERT arm: queries finished, distinct threads, distinct written_rows values
-4	1	1
+SELECT arm: queries finished, distinct threads, distinct read_rows values, rows per query
+4	1	1	4
+INSERT arm: queries finished, distinct threads, distinct written_rows values, rows per query
+4	1	1	4
 SELECT arm: read_rows vs ProfileEvents, and vs query_log
 0	0	0
-INSERT arm: written_rows vs ProfileEvents, and vs query_log
-0	0
+INSERT arm: written_rows and written_bytes vs ProfileEvents, and vs query_log
+0	0	0

--- a/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.reference
+++ b/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.reference
@@ -1,0 +1,8 @@
+SELECT arm: queries finished, distinct threads, distinct read_rows values
+4	1	1
+INSERT arm: queries finished, distinct threads, distinct written_rows values
+4	1	1
+SELECT arm: read_rows vs ProfileEvents, and vs query_log
+0	0	0
+INSERT arm: written_rows vs ProfileEvents, and vs query_log
+0	0

--- a/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.sh
+++ b/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.sh
@@ -6,12 +6,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 # The queries go over HTTP because the value is only observable on a thread that both initiates the
-# query and performs the reads: over the native protocol the reads happen on a separate pipeline
-# thread, so the row of the initiating thread reads nothing and would assert nothing. Parallel
-# replicas move the reads off the initiating thread the same way, hence the no-parallel-replicas
+# query and performs the reads.
+# Parallel replicas move the reads off the initiating thread the same way, hence the no-parallel-replicas
 # tag. The four queries of an arm are sent as one curl invocation with --next, so they share a
-# single keep-alive connection and therefore a single handler thread; the test asserts that
-# precondition below rather than relying on the connection pool to reuse a thread by chance.
+# single keep-alive connection and therefore a single handler thread.
 URL="${CLICKHOUSE_URL}&log_queries=1&log_query_threads=1&log_profile_events=1"
 
 ${CLICKHOUSE_CLIENT} -q "

--- a/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.sh
+++ b/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel-replicas
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -7,10 +7,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # The queries go over HTTP because the value is only observable on a thread that both initiates the
 # query and performs the reads: over the native protocol the reads happen on a separate pipeline
-# thread, so the row of the initiating thread reads nothing and would assert nothing. The four
-# queries of an arm are sent as one curl invocation with --next, so they share a single keep-alive
-# connection and therefore a single handler thread; the test asserts that precondition below rather
-# than relying on the connection pool to reuse a thread by chance.
+# thread, so the row of the initiating thread reads nothing and would assert nothing. Parallel
+# replicas move the reads off the initiating thread the same way, hence the no-parallel-replicas
+# tag. The four queries of an arm are sent as one curl invocation with --next, so they share a
+# single keep-alive connection and therefore a single handler thread; the test asserts that
+# precondition below rather than relying on the connection pool to reuse a thread by chance.
 URL="${CLICKHOUSE_URL}&log_queries=1&log_query_threads=1&log_profile_events=1"
 
 ${CLICKHOUSE_CLIENT} -q "
@@ -37,30 +38,55 @@ for i in 1 2 3 4; do
 done
 ${CLICKHOUSE_CURL} -sSg "${insert_args[@]}" > /dev/null
 
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log, query_thread_log"
+# The query_log entry is written after the HTTP response is sent, so flushing once can race the
+# last query. Retry until all eight queries have landed in both tables.
+for _ in $(seq 1 60); do
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log, query_thread_log"
+    landed=$(${CLICKHOUSE_CLIENT} -q "
+        SELECT uniqExactIf(query_id, t = 'ql') = 8 AND uniqExactIf(query_id, t = 'qtl') = 8
+        FROM (
+            SELECT 'ql' AS t, query_id FROM system.query_log
+            WHERE current_database = currentDatabase() AND type = 'QueryFinish'
+              AND query_id LIKE '${CLICKHOUSE_DATABASE}\_%'
+            UNION ALL
+            SELECT 'qtl' AS t, query_id FROM system.query_thread_log
+            WHERE current_database = currentDatabase() AND thread_id = master_thread_id
+              AND query_id LIKE '${CLICKHOUSE_DATABASE}\_%'
+        )
+    ")
+    [ "$landed" = "1" ] && break
+    sleep 1
+done
 
 # Precondition, checked rather than assumed: four successful queries, one reused handler thread.
-# Without it the equalities below could hold trivially and the test would assert nothing.
-echo 'SELECT arm: queries finished, distinct threads, distinct read_rows values'
+# Without it the equalities below could hold trivially and the test would assert nothing. The last
+# column is a positivity floor: it pins the thread-level value to the per-query amount, so a row
+# whose initiating thread read nothing cannot satisfy the equalities. The exact value is safe to
+# pin only alongside uniqExact, which stays 1 for a per-query value and grows for a running total.
+echo 'SELECT arm: queries finished, distinct threads, distinct read_rows values, rows per query'
 ${CLICKHOUSE_CLIENT} -q "
     SELECT
         countIf(ql.type = 'QueryFinish' AND ql.read_rows = 200000),
         uniqExact(qtl.thread_id),
-        uniqExact(qtl.read_rows)
+        uniqExact(qtl.read_rows),
+        countIf(ql.type = 'QueryFinish' AND qtl.read_rows = 200000 AND qtl.read_bytes > 0)
     FROM system.query_thread_log qtl
     JOIN system.query_log ql ON ql.query_id = qtl.query_id
-    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_sel_%' AND qtl.thread_id = qtl.master_thread_id
+    WHERE qtl.current_database = currentDatabase()
+      AND qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_sel_%' AND qtl.thread_id = qtl.master_thread_id
 "
 
-echo 'INSERT arm: queries finished, distinct threads, distinct written_rows values'
+echo 'INSERT arm: queries finished, distinct threads, distinct written_rows values, rows per query'
 ${CLICKHOUSE_CLIENT} -q "
     SELECT
         countIf(ql.type = 'QueryFinish' AND ql.written_rows = 50000),
         uniqExact(qtl.thread_id),
-        uniqExact(qtl.written_rows)
+        uniqExact(qtl.written_rows),
+        countIf(ql.type = 'QueryFinish' AND qtl.written_rows = 50000 AND qtl.written_bytes > 0)
     FROM system.query_thread_log qtl
     JOIN system.query_log ql ON ql.query_id = qtl.query_id
-    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_ins_%' AND qtl.thread_id = qtl.master_thread_id
+    WHERE qtl.current_database = currentDatabase()
+      AND qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_ins_%' AND qtl.thread_id = qtl.master_thread_id
 "
 
 # The same row's ProfileEvents come from the performance counters, which are reset per attach, so
@@ -73,18 +99,21 @@ ${CLICKHOUSE_CLIENT} -q "
         countIf(qtl.read_rows > ql.read_rows)
     FROM system.query_thread_log qtl
     JOIN system.query_log ql ON ql.query_id = qtl.query_id
-    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_sel_%' AND qtl.thread_id = qtl.master_thread_id
+    WHERE qtl.current_database = currentDatabase()
+      AND qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_sel_%' AND qtl.thread_id = qtl.master_thread_id
       AND ql.type = 'QueryFinish'
 "
 
-echo 'INSERT arm: written_rows vs ProfileEvents, and vs query_log'
+echo 'INSERT arm: written_rows and written_bytes vs ProfileEvents, and vs query_log'
 ${CLICKHOUSE_CLIENT} -q "
     SELECT
         countIf(qtl.written_rows != CAST(qtl.ProfileEvents, 'Map(String, UInt64)')['InsertedRows']),
+        countIf(qtl.written_bytes != CAST(qtl.ProfileEvents, 'Map(String, UInt64)')['InsertedBytes']),
         countIf(qtl.written_rows > ql.written_rows)
     FROM system.query_thread_log qtl
     JOIN system.query_log ql ON ql.query_id = qtl.query_id
-    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_ins_%' AND qtl.thread_id = qtl.master_thread_id
+    WHERE qtl.current_database = currentDatabase()
+      AND qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_ins_%' AND qtl.thread_id = qtl.master_thread_id
       AND ql.type = 'QueryFinish'
 "
 

--- a/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.sh
+++ b/tests/queries/0_stateless/05023_query_thread_log_progress_per_query.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# The queries go over HTTP because the value is only observable on a thread that both initiates the
+# query and performs the reads: over the native protocol the reads happen on a separate pipeline
+# thread, so the row of the initiating thread reads nothing and would assert nothing. The four
+# queries of an arm are sent as one curl invocation with --next, so they share a single keep-alive
+# connection and therefore a single handler thread; the test asserts that precondition below rather
+# than relying on the connection pool to reuse a thread by chance.
+URL="${CLICKHOUSE_URL}&log_queries=1&log_query_threads=1&log_profile_events=1"
+
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t_progress_src;
+    DROP TABLE IF EXISTS t_progress_dst;
+    CREATE TABLE t_progress_src (id UInt64) ENGINE = MergeTree ORDER BY id;
+    CREATE TABLE t_progress_dst (id UInt64) ENGINE = MergeTree ORDER BY id;
+    INSERT INTO t_progress_src SELECT number FROM numbers(200000);
+"
+
+select_args=()
+for i in 1 2 3 4; do
+    [ "$i" -gt 1 ] && select_args+=(--next)
+    select_args+=("${URL}&query_id=${CLICKHOUSE_DATABASE}_sel_$i"
+                  --data-binary "SELECT sum(id) FROM t_progress_src SETTINGS max_threads = 1")
+done
+${CLICKHOUSE_CURL} -sSg "${select_args[@]}" > /dev/null
+
+insert_args=()
+for i in 1 2 3 4; do
+    [ "$i" -gt 1 ] && insert_args+=(--next)
+    insert_args+=("${URL}&query_id=${CLICKHOUSE_DATABASE}_ins_$i"
+                  --data-binary "INSERT INTO t_progress_dst SELECT number FROM numbers(50000) SETTINGS max_insert_threads = 1, max_threads = 1")
+done
+${CLICKHOUSE_CURL} -sSg "${insert_args[@]}" > /dev/null
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log, query_thread_log"
+
+# Precondition, checked rather than assumed: four successful queries, one reused handler thread.
+# Without it the equalities below could hold trivially and the test would assert nothing.
+echo 'SELECT arm: queries finished, distinct threads, distinct read_rows values'
+${CLICKHOUSE_CLIENT} -q "
+    SELECT
+        countIf(ql.type = 'QueryFinish' AND ql.read_rows = 200000),
+        uniqExact(qtl.thread_id),
+        uniqExact(qtl.read_rows)
+    FROM system.query_thread_log qtl
+    JOIN system.query_log ql ON ql.query_id = qtl.query_id
+    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_sel_%' AND qtl.thread_id = qtl.master_thread_id
+"
+
+echo 'INSERT arm: queries finished, distinct threads, distinct written_rows values'
+${CLICKHOUSE_CLIENT} -q "
+    SELECT
+        countIf(ql.type = 'QueryFinish' AND ql.written_rows = 50000),
+        uniqExact(qtl.thread_id),
+        uniqExact(qtl.written_rows)
+    FROM system.query_thread_log qtl
+    JOIN system.query_log ql ON ql.query_id = qtl.query_id
+    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_ins_%' AND qtl.thread_id = qtl.master_thread_id
+"
+
+# The same row's ProfileEvents come from the performance counters, which are reset per attach, so
+# they are the reference the progress columns of that row must agree with.
+echo 'SELECT arm: read_rows vs ProfileEvents, and vs query_log'
+${CLICKHOUSE_CLIENT} -q "
+    SELECT
+        countIf(qtl.read_rows != CAST(qtl.ProfileEvents, 'Map(String, UInt64)')['SelectedRows']),
+        countIf(qtl.read_bytes != CAST(qtl.ProfileEvents, 'Map(String, UInt64)')['SelectedBytes']),
+        countIf(qtl.read_rows > ql.read_rows)
+    FROM system.query_thread_log qtl
+    JOIN system.query_log ql ON ql.query_id = qtl.query_id
+    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_sel_%' AND qtl.thread_id = qtl.master_thread_id
+      AND ql.type = 'QueryFinish'
+"
+
+echo 'INSERT arm: written_rows vs ProfileEvents, and vs query_log'
+${CLICKHOUSE_CLIENT} -q "
+    SELECT
+        countIf(qtl.written_rows != CAST(qtl.ProfileEvents, 'Map(String, UInt64)')['InsertedRows']),
+        countIf(qtl.written_rows > ql.written_rows)
+    FROM system.query_thread_log qtl
+    JOIN system.query_log ql ON ql.query_id = qtl.query_id
+    WHERE qtl.query_id LIKE '${CLICKHOUSE_DATABASE}_ins_%' AND qtl.thread_id = qtl.master_thread_id
+      AND ql.type = 'QueryFinish'
+"
+
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE t_progress_src;
+    DROP TABLE t_progress_dst;
+"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/105246


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `read_rows`, `read_bytes`, `written_rows` and `written_bytes` in `system.query_thread_log` reporting a thread lifetime running total instead of the values for the logged query. Rows of long-lived pooled threads, in particular the query's initiating `HTTPHandler` thread, were affected.

### Description

`ThreadStatus::progress_in` and `progress_out` live as long as the OS thread, and the four progress columns are read straight off them. Nothing ever cleared them, so for a pooled thread the row reported everything that thread had ever served. Worker threads get a fresh `ThreadStatus`, so the victim is the row with `thread_id = master_thread_id`.

`ThreadStatus::initPerformanceCounters()` already exists for this, runs on attach to a thread group, and says "Clear stats from previous query if a new query is started". It resets `performance_counters` and `memory_tracker` but never these two members, which predate it. The fix adds them.

Before the fix, over HTTP on one connection, four identical `SELECT`s each reading 200000 rows:

| `query_log.read_rows` | `query_thread_log.read_rows` | same row's `ProfileEvents['SelectedRows']` |
|---|---|---|
| 200000 | 1000000 | 200000 |
| 200000 | 1200000 | 200000 |
| 200000 | 1400000 | 200000 |
| 200000 | 1600000 | 200000 |

After the fix all three agree. Four identical `INSERT`s behaved the same way on `written_rows`, and are covered.

One semantic point to confirm, since it is a choice: this reset runs per attach to a thread group, not per query, so a thread logged on several rows for one query reports each attach cycle separately. `ProfileEvents` on the same row already behaves this way, so the two become consistent rather than gaining a new convention. Populating the columns from `SelectedRows`/`InsertedRows` instead was rejected: it redefines them and would tie them to `log_profile_events`.

Query-level accounting is untouched: `query_log`, `system.processes`, `max_rows_to_read`, leaf limits, throttling and quotas read the separate `QueryStatus` object, and I checked each of those.

The test drives the queries over HTTP on one keep-alive connection: over the native protocol the reads happen on a separate pipeline thread, so the initiating thread's row would assert nothing. It fails on master.

@PedroTadim

<details>
<summary>Validation</summary>

- Negative control on a pristine master binary: all four assertion lines move (distinct `read_rows` 1 to 4, distinct `written_rows` 1 to 4, and every column comparing a progress value against `ProfileEvents` moves on both arms). Reproduced under randomized settings too.
- New test passes on the fixed build, 50 of 50 randomized runs, and 12 concurrent copies over 6 workers.
- Of the ten other stateless tests touching `query_thread_log`, the eight runnable in my sandbox still pass; the remaining two need a listener this sandbox does not provide, and neither reads the four columns.
- Verified `progress_in`/`progress_out` on `ThreadStatus` have two writers (`CurrentThread::updateProgressIn`/`Out`), one reader (the log site), and no other reference in `src/`, `programs/`, `base/`, `utils/`.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115596&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115596](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115596+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1838` (included in `26.8` and later)
- Backported to: `26.7.6.28`, `26.6.4.9`, `26.3.29.9`, `25.8.34.9`
<!-- ch-version-info:end -->