### PR TITLE
Normalize the plan check in 04061_analyzer_inline_view

### DIFF
--- a/tests/queries/0_stateless/04061_analyzer_inline_view.reference
+++ b/tests/queries/0_stateless/04061_analyzer_inline_view.reference
@@ -34,12 +34,9 @@ QUERY id: 0
       SORT id: 16, sort_direction: ASCENDING, with_fill: 0
         EXPRESSION name
           COLUMN id: 2, column_name: name, result_type: String, source_id: 3
-Expression (Project names)
-  Sorting (Sorting for ORDER BY)
-    Expression ((Before ORDER BY + Projection))
-      MergingAggregated
-        Expression (Convert distributed names)
-          ReadFromRemoteParallelReplicas (Query: SELECT `__table1`.`name` AS `name`, sum(`__table1`.`age`) AS `sum(age)` FROM (SELECT `__table2`.`name` AS `name`, `__table2`.`age` AS `age` FROM `default`.`users` AS `__table2`) AS `__table1` WHERE `__table1`.`name` > \'\' GROUP BY `__table1`.`name` ORDER BY `__table1`.`name` ASC Replicas: 127.0.0.1:9000, 127.0.0.2:9000, 127.0.0.3:9000)
+Sorting
+MergingAggregated
+ReadFromParallelReplicas
 Alice	50
 John	33
 Ksenia	48

--- a/tests/queries/0_stateless/04061_analyzer_inline_view.sql
+++ b/tests/queries/0_stateless/04061_analyzer_inline_view.sql
@@ -21,12 +21,22 @@ WHERE name > ''
 GROUP BY name
 ORDER BY name;
 
-EXPLAIN
-SELECT name, sum(age)
-FROM uv
-WHERE name > ''
-GROUP BY name
-ORDER BY name;
+-- Print the plan without step descriptions, drop the `Expression` steps and normalize the name of
+-- the step reading from the replicas, so that the result does not depend on how reading with
+-- parallel replicas is planned.
+SELECT if(step IN ('ReadFromRemoteParallelReplicas', 'ReadFromParallelReplicas'), 'ReadFromParallelReplicas', step)
+FROM
+(
+    SELECT rowNumberInAllBlocks() AS n, trim(explain) AS step
+    FROM (EXPLAIN description = 0
+        SELECT name, sum(age)
+        FROM uv
+        WHERE name > ''
+        GROUP BY name
+        ORDER BY name)
+)
+WHERE step != 'Expression'
+ORDER BY n;
 
 SELECT name, sum(age)
 FROM uv


### PR DESCRIPTION
`04061_analyzer_inline_view` pinned the full `EXPLAIN` output, including the step description of `ReadFromRemoteParallelReplicas`, which embeds the whole query sent to the replicas. That makes the reference sensitive to unrelated changes in query formatting, and it breaks outright once reading with parallel replicas is planned differently: the step is then called `ReadFromParallelReplicas` and it is not wrapped into `Expression (Convert distributed names)`.

Print the plan with `description = 0`, drop the `Expression` steps and fold both names of the reading step into one, so the check keeps asserting what the test is about - the shape of the plan built for an inlined view - without depending on how reading from the replicas is planned.

Related: https://github.com/ClickHouse/ClickHouse/pull/112351

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115597&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115597](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115597+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1787` (included in `26.8` and later)
<!-- ch-version-info:end -->