### PR TITLE
CI: raise Config Workflow timeout to avoid killing submodule cache prep

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -41,7 +41,11 @@ _workflow_config_job = Job.Config(
         else None
     ),
     command=f"{Settings.PYTHON_INTERPRETER} -m praktika.native_jobs '{Settings.CI_CONFIG_JOB_NAME}'",
-    timeout=600,
+    # On a submodule-cache miss this job does a full shallow clone of all
+    # submodules (see _prepare_submodule_cache), which can take well over 10
+    # minutes. Keep a generous timeout so the config job doesn't get killed
+    # mid-clone.
+    timeout=1800,
 )
 
 _docker_build_manifest_job = Job.Config(


### PR DESCRIPTION
Raise the `Config Workflow` job timeout from 600s to 1800s.

On a submodule-cache miss, the `Config Workflow` job performs a full shallow clone of all submodules in `_prepare_submodule_cache` (`git submodule update --depth=1 --single-branch --jobs 64`), which can take well over 10 minutes. The previous 600s job timeout killed the job mid-clone:

```
[2026-08-19 20:24:44] Submodule path 'contrib/rocksdb': checked out ...
[2026-08-19 20:24:54] Submodule path 'contrib/rust_vendor': checked out ...
[2026-08-19 20:24:56] WARNING: Timeout exceeded [600] for [10399]
[2026-08-19 20:24:56] WARNING: Job timed out: [Config Workflow], timeout [600], exit code [-15]
```

The clone itself is already parallel (`--jobs 64`); the only remaining fix is a more generous timeout so the config job survives a cache-miss clone. On a cache hit (the common case) the archive is restored from S3 and the job stays fast.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115614&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115614](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115614+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1778` (included in `26.8` and later)
<!-- ch-version-info:end -->