### PR TITLE
Reject a lossy codec on columns backing the partition key

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1024,13 +1024,16 @@ void MergeTreeData::checkProperties(
         if (const auto * index_function = typeid_cast<ASTFunction *>(new_sorting_key.definition_ast.get()))
             checkSuspiciousIndices(index_function);
 
-    /// Check that the table sorting column is not compressed by a lossy codec (e.g. SZ3). Lossy codecs
-    /// lose precision and may destroy the sorting. Not on attach, so a table stored by an earlier version
-    /// stays loadable.
+    /// The sorting key, the partition id and the part minmax index are computed from the block before
+    /// compression, so a lossy codec (e.g. SZ3) on a column backing either key leaves them describing values
+    /// the data on disk no longer holds. Not on attach, so a table stored by an earlier version stays loadable.
     if (!attach)
     {
-        /// Collecting the sort key columns.
-        for (const auto & name : new_metadata.getColumnsRequiredForSortingKey())
+        Names key_columns = new_metadata.getColumnsRequiredForSortingKey();
+        const Names partition_key_columns = new_metadata.getColumnsRequiredForPartitionKey();
+        key_columns.insert(key_columns.end(), partition_key_columns.begin(), partition_key_columns.end());
+
+        for (const auto & name : key_columns)
         {
             const auto column = new_metadata.columns.tryGetColumnDescription(
                 GetColumnsOptions(GetColumnsOptions::AllPhysical), name);
@@ -1051,7 +1054,8 @@ void MergeTreeData::checkProperties(
 
             if (is_lossy)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "Column {} is used in the sorting key, so it cannot be compressed with a lossy codec",
+                    "Column {} is used in the sorting key or the partition key, so it cannot be compressed "
+                    "with a lossy codec",
                     backQuoteIfNeed(name));
         }
     }

--- a/tests/queries/0_stateless/04791_lossy_codec_key_column.reference
+++ b/tests/queries/0_stateless/04791_lossy_codec_key_column.reference
@@ -3,3 +3,6 @@ CREATE, accepted
 ALTER, rejected
 ALTER, accepted
 3
+ALTER on the partition key, rejected
+ALTER on the partition key, accepted
+3

--- a/tests/queries/0_stateless/04791_lossy_codec_key_column.sql
+++ b/tests/queries/0_stateless/04791_lossy_codec_key_column.sql
@@ -1,7 +1,7 @@
 -- Tags: no-fasttest
 -- no-fasttest: needs sz3 library
 
--- Test that the table primary key cannot be compressed by a lossy codec like SZ3.
+-- Test that the table primary key and partition key cannot be compressed by a lossy codec like SZ3.
 
 SET allow_experimental_codecs = 1;
 
@@ -28,6 +28,15 @@ ENGINE = MergeTree ORDER BY c; -- { serverError BAD_ARGUMENTS }
 CREATE TABLE tab (t Tuple(Float64, Float64) CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)), f Int64)
 ENGINE = MergeTree ORDER BY t.1; -- { serverError BAD_ARGUMENTS }
 
+CREATE TABLE tab (i Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)), f Int64)
+ENGINE = MergeTree ORDER BY f PARTITION BY intDiv(toInt64(i), 100); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tab (c Array(Float64) CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)), f Int64)
+ENGINE = MergeTree ORDER BY f PARTITION BY toInt64(c[1]); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tab (i Float64, m Float64 MATERIALIZED i + 1 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)), f Int64)
+ENGINE = MergeTree ORDER BY f PARTITION BY intDiv(toInt64(m), 100); -- { serverError BAD_ARGUMENTS }
+
 SELECT 'CREATE, accepted';
 
 CREATE TABLE tab (k Int64, i Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)))
@@ -40,6 +49,14 @@ DROP TABLE tab;
 CREATE TABLE tab (c Array(Int64) CODEC(T64), f Int64) ENGINE = MergeTree ORDER BY c;
 DROP TABLE tab;
 
+CREATE TABLE tab (i Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)), f Int64)
+ENGINE = MergeTree ORDER BY f PARTITION BY f;
+DROP TABLE tab;
+
+CREATE TABLE tab (i Float64 CODEC(Delta, LZ4), f Int64)
+ENGINE = MergeTree ORDER BY f PARTITION BY intDiv(toInt64(i), 100);
+DROP TABLE tab;
+
 SELECT 'ALTER, rejected';
 
 CREATE TABLE tab (k Int64, i Float64) ENGINE = MergeTree ORDER BY (k, i);
@@ -49,6 +66,19 @@ ALTER TABLE tab MODIFY COLUMN i Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 
 ALTER TABLE tab ADD COLUMN n Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)), MODIFY ORDER BY (k, i, n); -- { serverError BAD_ARGUMENTS }
 
 SELECT 'ALTER, accepted';
+
+ALTER TABLE tab ADD COLUMN z Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01));
+SELECT count() FROM system.columns WHERE database = currentDatabase() AND table = 'tab';
+
+DROP TABLE tab;
+
+SELECT 'ALTER on the partition key, rejected';
+
+CREATE TABLE tab (k Int64, i Float64) ENGINE = MergeTree ORDER BY k PARTITION BY intDiv(toInt64(i), 100);
+
+ALTER TABLE tab MODIFY COLUMN i Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01)); -- { serverError BAD_ARGUMENTS }
+
+SELECT 'ALTER on the partition key, accepted';
 
 ALTER TABLE tab ADD COLUMN z Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01));
 SELECT count() FROM system.columns WHERE database = currentDatabase() AND table = 'tab';


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/114406
Related: https://github.com/ClickHouse/ClickHouse/issues/115533
Related: https://github.com/ClickHouse/ClickHouse/pull/114531

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`CREATE TABLE` and `ALTER TABLE` now reject a lossy codec such as `SZ3` on a column used in the partition key.


### Description

Follow-up to #114531, which added this check for the sorting key only. #115533 reported the same problem
for the partition key, and @rschu1ze asked for it to be covered too.

A partition value and a part minmax index are both computed from the block before compression, so they
record the exact input while the data on disk decompresses to a different value. Pruning trusts that
metadata and discards parts that do hold matching rows. With
`i Float64 CODEC(SZ3('ALGO_INTERP_LORENZO', 'REL', 0.01))` and `PARTITION BY intDiv(toInt64(i), 100)`
over 1000 rows, 6 rows read back a value contradicting their own partition, and a pruning query returns
91 rows where a full scan returns 92. Not a regression from #114531: the same numbers reproduce on an
earlier build.

The change extends the existing loop in `MergeTreeData::checkProperties` to the partition-key columns
and generalises the message. Per-substream lossiness resolution is reused unchanged, so type wrappers
and codec chains behave as before. `CREATE` and `ALTER TABLE ... MODIFY COLUMN` both reach the check;
`ATTACH` stays exempt, so existing tables stay loadable.

Two costs, both already carried by the shipped sorting-key check, verified. The check is keyed on column
names, since neither key accessor exposes substreams, so a provably exact key such as
`PARTITION BY length(arr)` over `Array(Float64) CODEC(SZ3(...))` is now rejected although only the
lossless sizes substream is read (measured: 82611 payload values differ from what was written, yet no row
lands in the wrong partition and pruning is exact). And a table created earlier with a lossy
partition-key column refuses further `ALTER`s while that codec remains, the metadata entry stalling on
an upgraded replica in a mixed-version cluster.

Tests were added to `04791_lossy_codec_key_column`: the partition key through a plain expression,
through an `Array` element and through a `MATERIALIZED` column, plus the `ALTER` path and accepted cases.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115626&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115626](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115626+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
