### PR TITLE
Allow unknown settings in query plan serialization

### DIFF
--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -93,12 +93,22 @@ static constexpr auto DBMS_MERGE_TREE_PART_INFO_VERSION = 1;
 /// per-field version gate; the rest rely on the whole stream being rejected by its leading version.
 /// Version 9 registers the `Rollup` and `Cube` steps, so a plan with `GROUP BY ... WITH ROLLUP`
 /// or `WITH CUBE` can be shipped under `make_distributed_plan`.
-static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 9;
+/// Version 10 changes how the plan settings of a step are written: as name, flags and a length-prefixed
+/// value, the format query settings have always used between client and server, instead of a name and a
+/// typed binary value. A reader can then step over a setting it does not know, so a setting introduced
+/// after this version needs a gate of its own only when the receiver ignoring it would change the
+/// result - that is what the `IMPORTANT` flag on a plan setting declares, and an unknown name carrying
+/// it is still rejected. Versions 5 and 7 exist because the format below this one had no way to skip.
+static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 10;
 /// The parallel-replicas remote plan is serialized once (at DBMS_QUERY_PLAN_SERIALIZATION_VERSION) and
 /// that one blob is reused for every replica, so a replica below this version must be excluded up front
 /// rather than sent a blob it cannot parse. Tied to DBMS_QUERY_PLAN_SERIALIZATION_VERSION itself so a
 /// future bump can't silently leave this gate behind.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_PARALLEL_REPLICAS = DBMS_QUERY_PLAN_SERIALIZATION_VERSION;
+/// First query-plan serialization version whose plan settings can be skipped by a reader that does not
+/// know their names. Below it every name in the stream must be known to the receiver, which is what the
+/// per-setting gates above exist for.
+static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS = 10;
 /// First query-plan serialization version that registers a "Window" step. Used to gate serializing a
 /// `WindowStep` for `make_distributed_plan`.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_WINDOW_STEP = 4;

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -93,22 +93,30 @@ static constexpr auto DBMS_MERGE_TREE_PART_INFO_VERSION = 1;
 /// per-field version gate; the rest rely on the whole stream being rejected by its leading version.
 /// Version 9 registers the `Rollup` and `Cube` steps, so a plan with `GROUP BY ... WITH ROLLUP`
 /// or `WITH CUBE` can be shipped under `make_distributed_plan`.
-/// Version 10 changes how the plan settings of a step are written: as name, flags and a length-prefixed
+/// Version 10 adds the part storage-type tag (with the blob-list manifest payload) to the worker read
+/// step, in the slot of the former `is_packed` flag. The values 0/1 are wire-compatible with the flag;
+/// only the new tag 2 requires this version, and the serializer refuses to emit it towards older peers.
+/// Version 11 changes how the plan settings of a step are written: as name, flags and a length-prefixed
 /// value, the format query settings have always used between client and server, instead of a name and a
 /// typed binary value. A reader can then step over a setting it does not know, so a setting introduced
 /// after this version needs a gate of its own only when the receiver ignoring it would change the
 /// result - that is what the `IMPORTANT` flag on a plan setting declares, and an unknown name carrying
 /// it is still rejected. Versions 5 and 7 exist because the format below this one had no way to skip.
-static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 10;
+static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 11;
+
+/// First query-plan serialization version whose plan settings can be skipped by a reader that does not
+/// know their names. Below it every name in the stream must be known to the receiver, which is what the
+/// per-setting gates above exist for.
+static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS = 11;
+
+static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_BLOBS_LIST_PARTS = 10;
+
 /// The parallel-replicas remote plan is serialized once (at DBMS_QUERY_PLAN_SERIALIZATION_VERSION) and
 /// that one blob is reused for every replica, so a replica below this version must be excluded up front
 /// rather than sent a blob it cannot parse. Tied to DBMS_QUERY_PLAN_SERIALIZATION_VERSION itself so a
 /// future bump can't silently leave this gate behind.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_PARALLEL_REPLICAS = DBMS_QUERY_PLAN_SERIALIZATION_VERSION;
-/// First query-plan serialization version whose plan settings can be skipped by a reader that does not
-/// know their names. Below it every name in the stream must be known to the receiver, which is what the
-/// per-setting gates above exist for.
-static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS = 10;
+
 /// First query-plan serialization version that registers a "Window" step. Used to gate serializing a
 /// `WindowStep` for `make_distributed_plan`.
 static constexpr auto DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_WINDOW_STEP = 4;

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
@@ -1,5 +1,6 @@
 #include <Core/BaseSettings.h>
 #include <Core/BaseSettingsFwdMacrosImpl.h>
+#include <Core/ProtocolDefines.h>
 #include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
 
 /**
@@ -9,7 +10,12 @@
  *
  * Macro structure:
  *  DECLARE(Type, name, default, description, flags)
- *  "flags" originate from BaseSettings (e.g. IMPORTANT) and may influence exposure or validation.
+ *  "flags" originate from BaseSettings. `IMPORTANT` marks a setting a receiver may not ignore: from
+ *  `DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS` on, a peer that does not know a
+ *  name skips it and keeps its own default, and rejects the plan only when the name carries this flag.
+ *  So a setting is `IMPORTANT` when running without it would change what the query returns - a limit
+ *  that truncates, an overflow mode, a threshold that decides which rows come back - and `0` when it
+ *  only decides how fast, or in what shape, the same result is produced.
  */
 
 namespace DB
@@ -20,13 +26,13 @@ namespace DB
 #define PLAN_SERIALIZATION_SETTINGS(DECLARE, ALIAS) \
     DECLARE(UInt64, max_block_size, DEFAULT_BLOCK_SIZE, "Maximum block size in rows for reading", 0) \
     \
-    DECLARE(UInt64, max_rows_in_distinct, 0, "Maximum number of elements during execution of DISTINCT.", 0) \
-    DECLARE(UInt64, max_bytes_in_distinct, 0, "Maximum total size of state (in uncompressed bytes) in memory for the execution of DISTINCT.", 0) \
-    DECLARE(OverflowMode, distinct_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
+    DECLARE(UInt64, max_rows_in_distinct, 0, "Maximum number of elements during execution of DISTINCT.", IMPORTANT) \
+    DECLARE(UInt64, max_bytes_in_distinct, 0, "Maximum total size of state (in uncompressed bytes) in memory for the execution of DISTINCT.", IMPORTANT) \
+    DECLARE(OverflowMode, distinct_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", IMPORTANT) \
     \
-    DECLARE(UInt64, max_rows_to_sort, 0, "If more than the specified amount of records have to be processed for ORDER BY operation, the behavior will be determined by the 'sort_overflow_mode' which by default is - throw an exception", 0) \
-    DECLARE(UInt64, max_bytes_to_sort, 0, "If more than the specified amount of (uncompressed) bytes have to be processed for ORDER BY operation, the behavior will be determined by the 'sort_overflow_mode' which by default is - throw an exception", 0) \
-    DECLARE(OverflowMode, sort_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
+    DECLARE(UInt64, max_rows_to_sort, 0, "If more than the specified amount of records have to be processed for ORDER BY operation, the behavior will be determined by the 'sort_overflow_mode' which by default is - throw an exception", IMPORTANT) \
+    DECLARE(UInt64, max_bytes_to_sort, 0, "If more than the specified amount of (uncompressed) bytes have to be processed for ORDER BY operation, the behavior will be determined by the 'sort_overflow_mode' which by default is - throw an exception", IMPORTANT) \
+    DECLARE(OverflowMode, sort_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", IMPORTANT) \
     \
     DECLARE(UInt64, prefer_external_sort_block_bytes, DEFAULT_BLOCK_SIZE * 256, "Prefer maximum block bytes for external sort, reduce the memory usage during merging.", 0) \
     DECLARE(UInt64, max_bytes_before_external_sort, 0, "If memory usage during ORDER BY operation is exceeding this threshold in bytes, activate the 'external sorting' mode (spill data to disk). Recommended value is half of available system memory.", 0) \
@@ -39,12 +45,12 @@ namespace DB
     DECLARE(Bool, aggregation_in_order_memory_bound_merging, true, "Enable memory bound merging strategy when in-order is applied.", 0) \
     DECLARE(Bool, aggregation_sort_result_by_bucket_number, true, "Send intermediate aggregation result in order of bucket number.", 0) \
     \
-    DECLARE(UInt64, max_rows_to_group_by, 0, "If aggregation during GROUP BY is generating more than the specified number of rows (unique GROUP BY keys), the behavior will be determined by the 'group_by_overflow_mode' which by default is - throw an exception, but can be also switched to an approximate GROUP BY mode.", 0) \
-    DECLARE(OverflowModeGroupBy, group_by_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
-    DECLARE(UInt64, group_by_two_level_threshold, 100000, "From what number of keys, a two-level aggregation starts. 0 - the threshold is not set.", 0) \
-    DECLARE(UInt64, group_by_two_level_threshold_bytes, 50000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", 0) \
+    DECLARE(UInt64, max_rows_to_group_by, 0, "If aggregation during GROUP BY is generating more than the specified number of rows (unique GROUP BY keys), the behavior will be determined by the 'group_by_overflow_mode' which by default is - throw an exception, but can be also switched to an approximate GROUP BY mode.", IMPORTANT) \
+    DECLARE(OverflowModeGroupBy, group_by_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", IMPORTANT) \
+    DECLARE(UInt64, group_by_two_level_threshold, 100000, "From what number of keys, a two-level aggregation starts. 0 - the threshold is not set.", IMPORTANT) \
+    DECLARE(UInt64, group_by_two_level_threshold_bytes, 50000000, "From what size of the aggregation state in bytes, a two-level aggregation begins to be used. 0 - the threshold is not set. Two-level aggregation is used when at least one of the thresholds is triggered.", IMPORTANT) \
     DECLARE(UInt64, max_bytes_before_external_group_by, 0, "If memory usage during GROUP BY operation is exceeding this threshold in bytes, activate the 'external aggregation' mode (spill data to disk). Recommended value is half of available system memory.", 0) \
-    DECLARE(Bool, empty_result_for_aggregation_by_empty_set, false, "Return empty result when aggregating without keys on empty set.", 0) \
+    DECLARE(Bool, empty_result_for_aggregation_by_empty_set, false, "Return empty result when aggregating without keys on empty set.", IMPORTANT) \
     DECLARE(Bool, compile_aggregate_expressions, true, "Compile aggregate functions to native code.", 0) \
     DECLARE(UInt64, min_count_to_compile_aggregate_expression, 3, "The number of identical aggregate expressions before they are JIT-compiled", 0) \
     DECLARE(Bool, enable_software_prefetch_in_aggregation, true, "Enable use of software prefetch in aggregation", 0) \
@@ -55,19 +61,19 @@ namespace DB
     DECLARE(UInt64, max_size_to_preallocate_for_aggregation, 100'000'000, "For how many elements it is allowed to preallocate space in all hash tables in total before aggregation", 0) \
     DECLARE(Bool, enable_producing_buckets_out_of_order_in_aggregation, true, "Allow aggregation to produce buckets out of order.", 0) \
     DECLARE(Bool, enable_parallel_single_level_merge, false, "Parallelize the final merge of the single-level aggregation hash tables by splitting the key space into disjoint hash partitions that the threads merge independently.", 0) \
-    DECLARE(Bool, enable_packed_string_keys_in_aggregation, true, "Use the PackedStringRef-based hash table for single-String-key aggregation.", 0) \
+    DECLARE(Bool, enable_packed_string_keys_in_aggregation, true, "Use the PackedStringRef-based hash table for single-String-key aggregation.", IMPORTANT) \
     DECLARE(Bool, enable_adaptive_aggregator, false, "Enable the adaptive GROUP BY algorithm: each thread's local hash table freezes once it reaches adaptive_aggregator_freeze_threshold keys, and new keys are aggregated exactly once, inside the bucket-parallel merge.", 0) \
     DECLARE(UInt64, adaptive_aggregator_freeze_threshold, 0, "The number of keys at which the adaptive aggregator freezes a thread's local hash table.", 0) \
     DECLARE(Bool, distributed_aggregation_memory_efficient, true, "Is the memory-saving mode of distributed aggregation enabled", 0) \
     \
     DECLARE(TotalsMode, totals_mode, TotalsMode::AFTER_HAVING_EXCLUSIVE, "How to calculate TOTALS when HAVING is present, as well as when max_rows_to_group_by and group_by_overflow_mode = 'any' are present.", IMPORTANT) \
-    DECLARE(Float, totals_auto_threshold, 0.5, "The threshold for totals_mode = 'auto'.", 0) \
+    DECLARE(Float, totals_auto_threshold, 0.5, "The threshold for totals_mode = 'auto'.", IMPORTANT) \
     \
     DECLARE(JoinAlgorithm, join_algorithm, "direct,parallel_hash,hash", "Specifies which JOIN algorithm is used.", 0) \
     \
-    DECLARE(UInt64, max_rows_in_join, 0, "Maximum size of the hash table for JOIN (in number of rows).", 0) \
-    DECLARE(UInt64, max_bytes_in_join, 0, "Maximum size of the hash table for JOIN (in number of bytes in memory).", 0) \
-    DECLARE(UInt64, default_max_bytes_in_join, 1000000000, "Maximum size of right-side table if limit is required but max_bytes_in_join is not set.", 0) \
+    DECLARE(UInt64, max_rows_in_join, 0, "Maximum size of the hash table for JOIN (in number of rows).", IMPORTANT) \
+    DECLARE(UInt64, max_bytes_in_join, 0, "Maximum size of the hash table for JOIN (in number of bytes in memory).", IMPORTANT) \
+    DECLARE(UInt64, default_max_bytes_in_join, 1000000000, "Maximum size of right-side table if limit is required but max_bytes_in_join is not set.", IMPORTANT) \
     DECLARE(UInt64, max_joined_block_size_rows, DEFAULT_BLOCK_SIZE, "Maximum block size for JOIN result (if join algorithm supports it). 0 means unlimited.", 0) \
     DECLARE(UInt64, max_joined_block_size_bytes, 4 * 1024 * 1024, "Maximum block size in bytes for JOIN result (if join algorithm supports it). 0 means unlimited.", 0) \
     DECLARE(UInt64, min_joined_block_size_rows, DEFAULT_BLOCK_SIZE, "Minimum block size in rows for JOIN input and output blocks (if join algorithm supports it). Small blocks will be squashed. 0 means unlimited.", 0) \
@@ -77,8 +83,8 @@ namespace DB
     \
     DECLARE(Bool, use_join_disjunctions_push_down, false, "Enable JOIN disjunction pushdown: allows pushing safe OR-branch predicates from JOIN conditions down to the respective left/right inputs so storages can pre-filter. Applied only when each top-level OR branch contributes a deterministic predicate for the target side.", 0) \
     \
-    DECLARE(OverflowMode, join_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", 0) \
-    DECLARE(Bool, join_any_take_last_row, false, "Changes the behaviour of join operations with `ANY` strictness.", 0) \
+    DECLARE(OverflowMode, join_overflow_mode, OverflowMode::THROW, "What to do when the limit is exceeded.", IMPORTANT) \
+    DECLARE(Bool, join_any_take_last_row, false, "Changes the behaviour of join operations with `ANY` strictness.", IMPORTANT) \
     \
     DECLARE(UInt64, cross_join_min_rows_to_compress, 10000000, "Minimal count of rows to compress block in CROSS JOIN. Zero value means - disable this threshold. This block is compressed when any of the two thresholds (by rows or by bytes) are reached.", 0) \
     DECLARE(UInt64, cross_join_min_bytes_to_compress, 1_GiB, "Minimal size of block to compress in CROSS JOIN. Zero value means - disable this threshold. This block is compressed when any of the two thresholds (by rows or by bytes) are reached.", 0) \
@@ -114,7 +120,7 @@ namespace DB
     DECLARE(Double, join_runtime_bloom_filter_max_ratio_of_set_bits, 0.7, "If the number of set bits in a runtime bloom filter exceeds this ratio the filter is completely disabled to reduce the overhead.", 0) \
     DECLARE(Bool, enable_lazy_columns_replication, false, "When enabled, replication of columns data during ARRAY JOIN and JOIN is performed lazily", 0) \
     DECLARE(Bool, enable_software_prefetch_in_join, true, "Enable use of software prefetch in hash join probe phase", 0) \
-    DECLARE(Bool, serialize_string_in_memory_with_zero_byte, true, "Serialize String values during aggregation with zero byte at the end. Enable to keep compatibility when querying cluster of incompatible versions.", 0) \
+    DECLARE(Bool, serialize_string_in_memory_with_zero_byte, true, "Serialize String values during aggregation with zero byte at the end. Enable to keep compatibility when querying cluster of incompatible versions.", IMPORTANT) \
     DECLARE(Bool, use_hash_table_stats_for_join_reordering, false, "Enable using collected hash table statistics for cardinality estimation during join reordering", 0) \
     DECLARE(Bool, enable_join_fixed_hash_table_conversion, true, R"(Enable converting the hash table to a flat array for joins when the key is a single integer with a small value range)", 0) \
     DECLARE(Bool, join_runtime_filter_from_fixed_hash_table, true, R"(When the hash join build side was converted to a FixedHashMap (see `enable_join_fixed_hash_table_conversion`), use that hash map directly as the runtime filter.)", 0) \
@@ -136,13 +142,21 @@ QueryPlanSerializationSettings::QueryPlanSerializationSettings(const QueryPlanSe
 
 QueryPlanSerializationSettings::~QueryPlanSerializationSettings() = default;
 
-void QueryPlanSerializationSettings::writeChangedBinary(WriteBuffer & out) const
+void QueryPlanSerializationSettings::writeChangedBinary(WriteBuffer & out, UInt64 version) const
 {
-    impl->writeChangedBinary(out);
+    /// The form a peer at this version or above can read past a name it does not know: every value is
+    /// written as a string of its own length, behind the flags that say whether skipping it is allowed.
+    if (version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS)
+        impl->write(out, SettingsWriteFormat::STRINGS_WITH_FLAGS);
+    else
+        impl->writeChangedBinary(out);
 }
-void QueryPlanSerializationSettings::readBinary(ReadBuffer & in)
+void QueryPlanSerializationSettings::readBinary(ReadBuffer & in, UInt64 version)
 {
-    impl->readBinary(in);
+    if (version >= DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS)
+        impl->read(in, SettingsWriteFormat::STRINGS_WITH_FLAGS);
+    else
+        impl->readBinary(in);
 }
 
 QUERY_PLAN_SERIALIZATION_SETTINGS_SUPPORTED_TYPES(QueryPlanSerializationSettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.h
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/BaseSettingsFwdMacros.h>
+#include <Core/Types.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
 
@@ -54,10 +55,13 @@ struct QueryPlanSerializationSettings
     QueryPlanSerializationSettings(const QueryPlanSerializationSettings & settings);
     ~QueryPlanSerializationSettings();
 
-    /// Serialize only settings that differ from defaults.
-    void writeChangedBinary(WriteBuffer & out) const;
-    /// Read settings updating only those present in the stream; missing ones keep defaults.
-    void readBinary(ReadBuffer & in);
+    /// Serialize only settings that differ from defaults, in the form `version` prescribes: from
+    /// `DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS` on, one a reader can step over
+    /// name by name; below it, one where every name has to be known.
+    void writeChangedBinary(WriteBuffer & out, UInt64 version) const;
+    /// Read settings updating only those present in the stream; missing ones keep defaults. A name this
+    /// version does not know is skipped unless it is declared `IMPORTANT`, which is rejected.
+    void readBinary(ReadBuffer & in, UInt64 version);
 
     /// Generated operator[] overloads for each supported type category.
     QUERY_PLAN_SERIALIZATION_SETTINGS_SUPPORTED_TYPES(QueryPlanSerializationSettings, DECLARE_SETTING_SUBSCRIPT_OPERATOR)

--- a/src/Processors/QueryPlan/Serialization.cpp
+++ b/src/Processors/QueryPlan/Serialization.cpp
@@ -141,7 +141,7 @@ void QueryPlan::serialize(WriteBuffer & out, const SerializationFlags & flags) c
         QueryPlanSerializationSettings settings;
         node->step->serializeSettings(settings, flags.version);
 
-        settings.writeChangedBinary(out);
+        settings.writeChangedBinary(out, flags.version);
 
         IQueryPlanStep::Serialization ctx{out, registry};
         ctx.version = flags.version;
@@ -233,7 +233,7 @@ QueryPlanAndSets QueryPlan::deserialize(ReadBuffer & in, const ContextPtr & cont
         auto output_header  = std::make_shared<const Block>(deserializeHeader(in, max_type_complexity));
 
         QueryPlanSerializationSettings settings;
-        settings.readBinary(in);
+        settings.readBinary(in, flags.version);
 
         SharedHeaders input_headers;
         input_headers.reserve(frame.children.size());

--- a/src/Processors/QueryPlan/tests/gtest_adaptive_aggregator_plan_setting.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_adaptive_aggregator_plan_setting.cpp
@@ -77,7 +77,7 @@ QueryPlanSerializationSettings serializeAggregatingStep(bool enable_adaptive_agg
 bool wireCarries(const QueryPlanSerializationSettings & settings, std::string_view name)
 {
     WriteBufferFromOwnString out;
-    settings.writeChangedBinary(out);
+    settings.writeChangedBinary(out, DBMS_QUERY_PLAN_SERIALIZATION_VERSION);
     return out.str().contains(name);
 }
 

--- a/src/Processors/QueryPlan/tests/gtest_aggregating_step_settings_roundtrip.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_aggregating_step_settings_roundtrip.cpp
@@ -33,11 +33,11 @@ bool roundTripSerializeStringWithZeroByte(const IQueryPlanStep & step, UInt64 ve
     step.serializeSettings(written, version);
 
     WriteBufferFromOwnString out;
-    written.writeChangedBinary(out);
+    written.writeChangedBinary(out, version);
 
     ReadBufferFromString in(out.str());
     QueryPlanSerializationSettings read;
-    read.readBinary(in);
+    read.readBinary(in, version);
 
     return read[QueryPlanSerializationSetting::serialize_string_in_memory_with_zero_byte];
 }
@@ -49,7 +49,7 @@ bool wireCarriesSerializeStringWithZeroByte(const IQueryPlanStep & step, UInt64 
     step.serializeSettings(written, version);
 
     WriteBufferFromOwnString out;
-    written.writeChangedBinary(out);
+    written.writeChangedBinary(out, version);
 
     return out.str().contains("serialize_string_in_memory_with_zero_byte");
 }

--- a/src/Processors/QueryPlan/tests/gtest_packed_string_keys_plan_setting.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_packed_string_keys_plan_setting.cpp
@@ -45,10 +45,10 @@ Aggregator::Params makeParams(const Names & keys, bool enable_packed_string_keys
 }
 
 /// The name as it appears in the binary settings stream written by `writeChangedBinary`.
-bool wireCarriesSetting(const QueryPlanSerializationSettings & settings)
+bool wireCarriesSetting(const QueryPlanSerializationSettings & settings, UInt64 version = DBMS_QUERY_PLAN_SERIALIZATION_VERSION)
 {
     WriteBufferFromOwnString out;
-    settings.writeChangedBinary(out);
+    settings.writeChangedBinary(out, version);
     return out.str().contains("enable_packed_string_keys_in_aggregation");
 }
 

--- a/src/Processors/QueryPlan/tests/gtest_query_plan_settings_skippable.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_query_plan_settings_skippable.cpp
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+
+#include <Core/BaseSettings.h>
+#include <Core/SettingsEnums.h>
+#include <Core/ProtocolDefines.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+#include <Processors/QueryPlan/QueryPlanSerializationSettings.h>
+
+namespace DB
+{
+namespace QueryPlanSerializationSetting
+{
+    extern const QueryPlanSerializationSettingsUInt64 max_block_size;
+    extern const QueryPlanSerializationSettingsNonZeroUInt64 grace_hash_join_initial_buckets;
+    extern const QueryPlanSerializationSettingsBool aggregation_in_order_memory_bound_merging;
+    extern const QueryPlanSerializationSettingsFloat remerge_sort_lowered_memory_bytes_ratio;
+    extern const QueryPlanSerializationSettingsDouble max_bytes_ratio_before_external_sort;
+    extern const QueryPlanSerializationSettingsString temporary_files_codec;
+    extern const QueryPlanSerializationSettingsJoinAlgorithm join_algorithm;
+    extern const QueryPlanSerializationSettingsOverflowMode distinct_overflow_mode;
+    extern const QueryPlanSerializationSettingsOverflowModeGroupBy group_by_overflow_mode;
+    extern const QueryPlanSerializationSettingsTotalsMode totals_mode;
+}
+}
+
+using namespace DB;
+
+/// From `DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS` on, the plan settings of a step are
+/// written so that a peer can read past a name it does not know. That is what keeps a setting added to the list from
+/// making every plan - including the ones the setting cannot affect - unreadable by a peer of the previous release,
+/// and it is why such a setting no longer needs a version gate of its own. A name the writer declared `IMPORTANT`
+/// is still rejected: ignoring it would change what the query returns.
+namespace
+{
+
+constexpr UInt64 skippable_version = DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS;
+constexpr UInt64 strict_version = DBMS_MIN_QUERY_PLAN_SERIALIZATION_VERSION_WITH_SKIPPABLE_SETTINGS - 1;
+
+/// A settings stream as a peer one release ahead would write it: the settings this version knows, plus one it does
+/// not. `BaseSettingsHelpers` is what `BaseSettings::write` itself writes with, so this is the same encoding.
+String streamWithUnknownSetting(std::string_view unknown_name, bool important)
+{
+    WriteBufferFromOwnString out;
+
+    BaseSettingsHelpers::writeString("max_block_size", out);
+    BaseSettingsHelpers::writeFlags({}, out);
+    BaseSettingsHelpers::writeString("4096", out);
+
+    BaseSettingsHelpers::writeString(unknown_name, out);
+    BaseSettingsHelpers::writeFlags(important ? BaseSettingsHelpers::Flags::IMPORTANT : BaseSettingsHelpers::Flags{}, out);
+    BaseSettingsHelpers::writeString("1", out);
+
+    /// The empty name that ends the settings of a step.
+    BaseSettingsHelpers::writeString(std::string_view{}, out);
+    return out.str();
+}
+
+}
+
+TEST(QueryPlanSettingsSkippable, ValuesSurviveTheRoundTrip)
+{
+    /// A value now travels as the string the setting prints itself as, so every type the list declares has to come
+    /// back from its own text - one setting of each is exercised here, the floating-point ones with a value that
+    /// says whether the text was rounded.
+    QueryPlanSerializationSettings written;
+    written[QueryPlanSerializationSetting::max_block_size] = 4096;
+    written[QueryPlanSerializationSetting::grace_hash_join_initial_buckets] = 8;
+    written[QueryPlanSerializationSetting::aggregation_in_order_memory_bound_merging] = true;
+    written[QueryPlanSerializationSetting::remerge_sort_lowered_memory_bytes_ratio] = 0.3f;
+    written[QueryPlanSerializationSetting::max_bytes_ratio_before_external_sort] = 0.1;
+    written[QueryPlanSerializationSetting::temporary_files_codec] = "NONE";
+    written[QueryPlanSerializationSetting::join_algorithm] = "direct,parallel_hash,hash";
+    written[QueryPlanSerializationSetting::distinct_overflow_mode] = OverflowMode::BREAK;
+    written[QueryPlanSerializationSetting::group_by_overflow_mode] = OverflowMode::ANY;
+    written[QueryPlanSerializationSetting::totals_mode] = TotalsMode::AFTER_HAVING_INCLUSIVE;
+
+    WriteBufferFromOwnString out;
+    written.writeChangedBinary(out, skippable_version);
+
+    ReadBufferFromString in(out.str());
+    QueryPlanSerializationSettings read;
+    read.readBinary(in, skippable_version);
+
+    EXPECT_EQ(read[QueryPlanSerializationSetting::max_block_size], 4096u);
+    EXPECT_EQ(read[QueryPlanSerializationSetting::grace_hash_join_initial_buckets], 8u);
+    EXPECT_EQ(read[QueryPlanSerializationSetting::aggregation_in_order_memory_bound_merging], true);
+    EXPECT_EQ(read[QueryPlanSerializationSetting::remerge_sort_lowered_memory_bytes_ratio], 0.3f);
+    EXPECT_EQ(read[QueryPlanSerializationSetting::max_bytes_ratio_before_external_sort], 0.1);
+    EXPECT_EQ(read[QueryPlanSerializationSetting::temporary_files_codec].value, "NONE");
+    EXPECT_EQ(read[QueryPlanSerializationSetting::join_algorithm].toString(), "direct,parallel_hash,hash");
+    EXPECT_EQ(read[QueryPlanSerializationSetting::distinct_overflow_mode], OverflowMode::BREAK);
+    EXPECT_EQ(read[QueryPlanSerializationSetting::group_by_overflow_mode], OverflowMode::ANY);
+    EXPECT_EQ(read[QueryPlanSerializationSetting::totals_mode], TotalsMode::AFTER_HAVING_INCLUSIVE);
+}
+
+TEST(QueryPlanSettingsSkippable, TheOlderFormStillRoundTrips)
+{
+    QueryPlanSerializationSettings written;
+    written[QueryPlanSerializationSetting::max_block_size] = 8192;
+
+    WriteBufferFromOwnString out;
+    written.writeChangedBinary(out, strict_version);
+
+    ReadBufferFromString in(out.str());
+    QueryPlanSerializationSettings read;
+    read.readBinary(in, strict_version);
+
+    EXPECT_EQ(read[QueryPlanSerializationSetting::max_block_size], 8192u);
+}
+
+TEST(QueryPlanSettingsSkippable, AnUnknownSettingIsSkipped)
+{
+    auto stream = streamWithUnknownSetting("a_setting_from_a_later_release", /*important=*/ false);
+
+    ReadBufferFromString in(stream);
+    QueryPlanSerializationSettings read;
+    ASSERT_NO_THROW(read.readBinary(in, skippable_version));
+
+    /// The settings around the unknown one are read, and it leaves this version at its own default.
+    EXPECT_EQ(read[QueryPlanSerializationSetting::max_block_size], 4096u);
+}
+
+TEST(QueryPlanSettingsSkippable, AnUnknownImportantSettingIsRejected)
+{
+    auto stream = streamWithUnknownSetting("a_setting_that_changes_the_result", /*important=*/ true);
+
+    ReadBufferFromString in(stream);
+    QueryPlanSerializationSettings read;
+    EXPECT_THROW(read.readBinary(in, skippable_version), Exception);
+}


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114184

Adding a plan setting has meant bumping `DBMS_QUERY_PLAN_SERIALIZATION_VERSION` and gating the write on it — twice already, for versions 5 and 7 — because the settings of a step were written as a name and a typed binary value. A reader that met a name it did not know could not tell where the value ended, so `QueryPlanSerializationSettings::readBinary` threw `UNKNOWN_SETTING`. That fenced off far more than the feature being added: the name goes into every plan that touches the step, so a setting a given plan cannot even use made that plan unreadable to the previous release. Fencing a feature is what the step registry does, by rejecting an unknown step.

Plan settings are now written the way query settings have always travelled between client and server (`SettingsWriteFormat::STRINGS_WITH_FLAGS`): name, flags, and the value as a string of its own length. A reader steps over a name it does not know and keeps its own default for it, and rejects the plan only when the name carries `IMPORTANT` — the flag that already means "affects query results, cannot be ignored by older versions". Which form is written is decided by the version of the stream, which `QueryPlan::serialize` already negotiates as the minimum of ours and the peer's, so a peer below version 9 keeps receiving the old form and nothing changes for it.

The plan settings that decide a result rather than a way of producing it are marked `IMPORTANT` accordingly: the row and byte limits of `DISTINCT`, `ORDER BY`, `GROUP BY` and `JOIN` with their overflow modes, the two-level aggregation thresholds, `empty_result_for_aggregation_by_empty_set`, `join_any_take_last_row`, `totals_auto_threshold`, and the two settings that decide how aggregation states are laid out. The existing per-setting gates stay — peers below version 9 still need them — but a setting added from now on needs one only when it belongs in that group.

`gtest_query_plan_settings_skippable` covers the round trip of every declared setting type through its string form, the old form at the previous version, an unknown setting being skipped, and an unknown `IMPORTANT` setting being rejected. The 58 stateless tests that set `serialize_query_plan` were run against the new format locally (56 pass; two fail only for want of `s3_disk` and `https_port` in the local server config).

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A query plan serialized with `serialize_query_plan = 1` no longer becomes unreadable to a peer that does not know one of the plan's settings: a setting the peer can ignore is skipped, and only one whose absence would change the query result is rejected.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115627&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115627](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115627+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
