### PR TITLE
Text index: fix wrong result when a LIKE pattern contains an invalid backslash escape

### DIFF
--- a/src/Common/likePatternToRegexp.cpp
+++ b/src/Common/likePatternToRegexp.cpp
@@ -203,4 +203,25 @@ String likePatternWithCustomEscapeToLikePattern(std::string_view pattern, char e
     return res;
 }
 
+bool likePatternHasUnknownBackslashEscape(std::string_view pattern)
+{
+    const char * pos = pattern.data();
+    const char * const end = pattern.data() + pattern.size();
+
+    while (pos < end)
+    {
+        if (*pos == '\\')
+        {
+            ++pos;
+            if (pos == end)
+                return true;
+            if (*pos != '%' && *pos != '_' && *pos != '\\')
+                return true;
+        }
+        ++pos;
+    }
+
+    return false;
+}
+
 }

--- a/src/Common/likePatternToRegexp.h
+++ b/src/Common/likePatternToRegexp.h
@@ -18,4 +18,8 @@ bool likePatternIsSubstring(std::string_view pattern, String & res);
 /// Example: with escape_char='#': "50#%off" -> "50\%off"
 String likePatternWithCustomEscapeToLikePattern(std::string_view pattern, char escape_char);
 
+/// Checks if a LIKE pattern contains a backslash which does not form a valid escape sequence, i.e. one
+/// followed by a byte other than '%', '_' or '\', or a trailing backslash.
+bool likePatternHasUnknownBackslashEscape(std::string_view pattern);
+
 }

--- a/src/Common/likePatternToRegexp.h
+++ b/src/Common/likePatternToRegexp.h
@@ -18,8 +18,8 @@ bool likePatternIsSubstring(std::string_view pattern, String & res);
 /// Example: with escape_char='#': "50#%off" -> "50\%off"
 String likePatternWithCustomEscapeToLikePattern(std::string_view pattern, char escape_char);
 
-/// Checks if a LIKE pattern contains a backslash which does not form a valid escape sequence, i.e. one
-/// followed by a byte other than '%', '_' or '\', or a trailing backslash.
+/// Checks if a LIKE pattern contains a backslash which does not form a valid escape sequence,
+/// i.e. a backslash followed by a byte other than '%', '_' or '\', or a trailing backslash.
 bool likePatternHasUnknownBackslashEscape(std::string_view pattern);
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -2,6 +2,7 @@
 
 #include <Columns/ColumnArray.h>
 #include <Common/OptimizedRegularExpression.h>
+#include <Common/likePatternToRegexp.h>
 #include <Common/quoteString.h>
 #include <Interpreters/ITokenizer.h>
 #include <Interpreters/TokenizerFactory.h>
@@ -437,6 +438,19 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
     return false;
 }
 
+namespace
+{
+
+bool isLikePatternFunction(const String & function_name)
+{
+    return function_name == "like"
+        || function_name == "notLike"
+        || function_name == "mapContainsKeyLike"
+        || function_name == "mapContainsValueLike";
+}
+
+}
+
 bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
     const String & function_name,
     const RPNBuilderTreeNode & key_node,
@@ -468,6 +482,12 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
         return false;
 
     Field const_value = value_field;
+
+    /// `stringLikeToBloomFilter` tokenizes such a pattern differently than row-level matching
+    /// and could prune a granule holding matching rows.
+    if (isLikePatternFunction(function_name) && const_value.getType() == Field::Types::String
+        && likePatternHasUnknownBackslashEscape(const_value.safeGet<String>()))
+        return false;
 
     const auto column_name = key_node.getColumnName();
     auto key_index = getKeyIndex(column_name);

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -483,8 +483,8 @@ bool MergeTreeConditionBloomFilterText::traverseTreeEquals(
 
     Field const_value = value_field;
 
-    /// `stringLikeToBloomFilter` tokenizes such a pattern differently than row-level matching
-    /// and could prune a granule holding matching rows.
+    /// The tokenizer would tokenize such a pattern differently than the scan does and could prune a
+    /// granule holding matching rows.
     if (isLikePatternFunction(function_name) && const_value.getType() == Field::Types::String
         && likePatternHasUnknownBackslashEscape(const_value.safeGet<String>()))
         return false;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -6,6 +6,7 @@
 #include <Common/StringUtils.h>
 #include <Common/OptimizedRegularExpression.h>
 #include <Common/isValidUTF8.h>
+#include <Common/likePatternToRegexp.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/NestedUtils.h>
@@ -763,15 +764,15 @@ VectorWithMemoryTracking<String> MergeTreeIndexConditionText::stringLikeToTokens
 {
     VectorWithMemoryTracking<String> tokens;
     const String & raw = field.safeGet<String>();
-    if (has_preprocessor)
-    {
-        const String processed = preprocessor->processConstant(raw);
-        tokenizer->stringLikeToTokens(processed.data(), processed.size(), tokens);
-    }
-    else
-    {
-        tokenizer->stringLikeToTokens(raw.data(), raw.size(), tokens);
-    }
+    const String processed = has_preprocessor ? preprocessor->processConstant(raw) : String{};
+    const String & pattern = has_preprocessor ? processed : raw;
+
+    /// `nextInStringLike` tokenizes such a pattern differently than row-level matching and could prune a
+    /// granule holding matching rows. No tokens means "cannot prune", as for a pattern like `LIKE '%a%'`.
+    if (likePatternHasUnknownBackslashEscape(pattern))
+        return tokens;
+
+    tokenizer->stringLikeToTokens(pattern.data(), pattern.size(), tokens);
     if (!has_postprocessor)
         return tokenizer->compactTokens(tokens);
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -767,7 +767,7 @@ VectorWithMemoryTracking<String> MergeTreeIndexConditionText::stringLikeToTokens
     const String processed = has_preprocessor ? preprocessor->processConstant(raw) : String{};
     const String & pattern = has_preprocessor ? processed : raw;
 
-    /// `nextInStringLike` tokenizes such a pattern differently than row-level matching and could prune a
+    /// The tokenizer would tokenize such a pattern differently than the scan does and could prune a
     /// granule holding matching rows. No tokens means "cannot prune", as for a pattern like `LIKE '%a%'`.
     if (likePatternHasUnknownBackslashEscape(pattern))
         return tokens;

--- a/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.reference
+++ b/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.reference
@@ -1,0 +1,35 @@
+text index
+-- LIKE
+[1]
+[1]
+-- LIKE with a trailing backslash
+text index on Map
+-- mapContainsKeyLike
+[1]
+[1]
+-- mapContainsValueLike
+[2]
+[2]
+-- mapContainsKeyLike with a trailing backslash
+ngrambf_v1 index
+-- LIKE
+[1]
+[1]
+-- NOT LIKE
+[2,3]
+[2,3]
+-- LIKE with a trailing backslash
+tokenbf_v1 index
+-- LIKE
+[1]
+[1]
+-- LIKE with a trailing backslash
+valid patterns still prune
+-- no backslash
+Granules: 3/3
+Granules: 1/3
+-- valid escape
+[2]
+[2]
+Granules: 3/3
+Granules: 1/3

--- a/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.sql
+++ b/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.sql
@@ -1,0 +1,139 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/115578
+
+-- Each query is paired with the same query with `use_skip_indexes = 0`: a skip index must never change the result.
+
+SET enable_full_text_index = 1;
+
+DROP TABLE IF EXISTS tab;
+
+SELECT 'text index';
+
+CREATE TABLE tab (
+    id UInt32,
+    msg String,
+    INDEX idx(msg) TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree
+ORDER BY id SETTINGS index_granularity = 1;
+
+INSERT INTO tab VALUES (1, 'foo a\\b bar'), (2, 'foo ab bar'), (3, 'nothing here');
+
+SELECT '-- LIKE';
+
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% a\\b %';
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% a\\b %' SETTINGS use_skip_indexes = 0;
+
+SELECT '-- LIKE with a trailing backslash';
+
+SELECT count() FROM tab WHERE msg LIKE 'abc\\'; -- { serverError CANNOT_PARSE_ESCAPE_SEQUENCE }
+
+DROP TABLE tab;
+
+SELECT 'text index on Map';
+
+CREATE TABLE tab (
+    id UInt32,
+    m Map(String, String),
+    INDEX map_keys_idx mapKeys(m) TYPE text(tokenizer = splitByNonAlpha),
+    INDEX map_values_idx mapValues(m) TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree
+ORDER BY id SETTINGS index_granularity = 1;
+
+INSERT INTO tab VALUES (1, {'foo a\\b bar':'v1'}), (2, {'k2':'foo a\\b baz'}), (3, {'nothing':'here'});
+
+SELECT '-- mapContainsKeyLike';
+
+SELECT groupArray(id) FROM tab WHERE mapContainsKeyLike(m, '% a\\b %');
+SELECT groupArray(id) FROM tab WHERE mapContainsKeyLike(m, '% a\\b %') SETTINGS use_skip_indexes = 0;
+
+SELECT '-- mapContainsValueLike';
+
+SELECT groupArray(id) FROM tab WHERE mapContainsValueLike(m, '% a\\b %');
+SELECT groupArray(id) FROM tab WHERE mapContainsValueLike(m, '% a\\b %') SETTINGS use_skip_indexes = 0;
+
+SELECT '-- mapContainsKeyLike with a trailing backslash';
+
+SELECT count() FROM tab WHERE mapContainsKeyLike(m, 'abc\\'); -- { serverError CANNOT_PARSE_ESCAPE_SEQUENCE }
+
+DROP TABLE tab;
+
+SELECT 'ngrambf_v1 index';
+
+CREATE TABLE tab (
+    id UInt32,
+    msg String,
+    INDEX idx(msg) TYPE ngrambf_v1(3, 512, 2, 0)
+)
+ENGINE = MergeTree
+ORDER BY id SETTINGS index_granularity = 1;
+
+INSERT INTO tab VALUES (1, 'foo a\\b bar'), (2, 'foo ab bar'), (3, 'nothing here');
+
+SELECT '-- LIKE';
+
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% a\\b %';
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% a\\b %' SETTINGS use_skip_indexes = 0;
+
+SELECT '-- NOT LIKE';
+
+SELECT groupArray(id) FROM tab WHERE msg NOT LIKE '% a\\b %';
+SELECT groupArray(id) FROM tab WHERE msg NOT LIKE '% a\\b %' SETTINGS use_skip_indexes = 0;
+
+SELECT '-- LIKE with a trailing backslash';
+
+SELECT count() FROM tab WHERE msg LIKE 'abc\\'; -- { serverError CANNOT_PARSE_ESCAPE_SEQUENCE }
+
+DROP TABLE tab;
+
+SELECT 'tokenbf_v1 index';
+
+CREATE TABLE tab (
+    id UInt32,
+    msg String,
+    INDEX idx(msg) TYPE tokenbf_v1(512, 2, 0)
+)
+ENGINE = MergeTree
+ORDER BY id SETTINGS index_granularity = 1;
+
+INSERT INTO tab VALUES (1, 'foo a\\b bar'), (2, 'foo ab bar'), (3, 'nothing here');
+
+SELECT '-- LIKE';
+
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% a\\b %';
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% a\\b %' SETTINGS use_skip_indexes = 0;
+
+SELECT '-- LIKE with a trailing backslash';
+
+SELECT count() FROM tab WHERE msg LIKE 'abc\\'; -- { serverError CANNOT_PARSE_ESCAPE_SEQUENCE }
+
+DROP TABLE tab;
+
+SELECT 'valid patterns still prune';
+
+CREATE TABLE tab (
+    id UInt32,
+    msg String,
+    INDEX idx(msg) TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree
+ORDER BY id SETTINGS index_granularity = 1;
+
+INSERT INTO tab VALUES (1, 'alpha beta'), (2, 'gamma 50%off delta'), (3, 'epsilon zeta');
+
+SELECT '-- no backslash';
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM tab WHERE msg LIKE '% beta %'
+) WHERE explain LIKE '%Granules: %/%';
+
+SELECT '-- valid escape';
+
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% 50\\%off %';
+SELECT groupArray(id) FROM tab WHERE msg LIKE '% 50\\%off %' SETTINGS use_skip_indexes = 0;
+
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM tab WHERE msg LIKE '% 50\\%off %'
+) WHERE explain LIKE '%Granules: %/%';
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.sql
+++ b/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.sql
@@ -25,7 +25,8 @@ SELECT groupArray(id) FROM tab WHERE msg LIKE '% a\\b %' SETTINGS use_skip_index
 
 SELECT '-- LIKE with a trailing backslash';
 
-SELECT count() FROM tab WHERE msg LIKE 'abc\\'; -- { serverError CANNOT_PARSE_ESCAPE_SEQUENCE }
+SELECT count() FROM tab WHERE msg LIKE 'abc\\';                               -- { serverError CANNOT_PARSE_ESCAPE_SEQUENCE }
+SELECT count() FROM tab WHERE msg LIKE 'abc\\' SETTINGS use_skip_indexes = 0; -- { serverError CANNOT_PARSE_ESCAPE_SEQUENCE }
 
 DROP TABLE tab;
 

--- a/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.sql
+++ b/tests/queries/0_stateless/02346_text_index_like_unknown_backslash_escape.sql
@@ -123,7 +123,7 @@ INSERT INTO tab VALUES (1, 'alpha beta'), (2, 'gamma 50%off delta'), (3, 'epsilo
 
 SELECT '-- no backslash';
 
-SELECT trimLeft(explain) AS explain FROM (
+SELECT extract(explain, 'Granules: [0-9]+/[0-9]+') AS explain FROM (
     EXPLAIN indexes = 1 SELECT count() FROM tab WHERE msg LIKE '% beta %'
 ) WHERE explain LIKE '%Granules: %/%';
 
@@ -132,7 +132,7 @@ SELECT '-- valid escape';
 SELECT groupArray(id) FROM tab WHERE msg LIKE '% 50\\%off %';
 SELECT groupArray(id) FROM tab WHERE msg LIKE '% 50\\%off %' SETTINGS use_skip_indexes = 0;
 
-SELECT trimLeft(explain) AS explain FROM (
+SELECT extract(explain, 'Granules: [0-9]+/[0-9]+') AS explain FROM (
     EXPLAIN indexes = 1 SELECT count() FROM tab WHERE msg LIKE '% 50\\%off %'
 ) WHERE explain LIKE '%Granules: %/%';
 


### PR DESCRIPTION
The index-side tokenizers drop a backslash which does not form a valid LIKE escape sequence,
while row-level matching keeps it as a literal, so the index searched for a token the value
never produced and pruned granules holding matching rows. Index analysis now declines such
patterns and falls back to row-level evaluation.

Fixes https://github.com/ClickHouse/ClickHouse/issues/115578.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix invalid backslash escape characters in text, tokenbf_v1 and ngrambf_v1 indexes.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115634&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115634](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115634+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.21` (included in `26.9` and later)
<!-- ch-version-info:end -->