### PR TITLE
Make Jepsen node setup wait for apt's dpkg locks

### DIFF
--- a/tests/jepsen.clickhouse/src/jepsen/clickhouse/keeper/main.clj
+++ b/tests/jepsen.clickhouse/src/jepsen/clickhouse/keeper/main.clj
@@ -25,7 +25,7 @@
              [tests :as tests]
              [util :as util :refer [meh]]]
             [jepsen.control.util :as cu]
-            [jepsen.os.ubuntu :as ubuntu]
+            [jepsen.clickhouse.os :as chos]
             [jepsen.checker.timeline :as timeline]
             [clojure.java.io :as io]
             [zookeeper.data :as data]
@@ -112,7 +112,7 @@
     (merge tests/noop-test
            opts
            {:name (str "clickhouse-keeper-quorum=" quorum "-"  (name (:workload opts)) "-" (name (:nemesis opts)))
-            :os ubuntu/os
+            :os chos/os
             :db (get-db opts)
             :pure-generators true
             :client (:client workload)
@@ -138,7 +138,7 @@
     (merge tests/noop-test
            opts
            {:name (str "clickhouse-keeper-perf")
-            :os ubuntu/os
+            :os chos/os
             :db (get-db opts)
             :pure-generators true
             :client (bench/bench-client (get-port opts))

--- a/tests/jepsen.clickhouse/src/jepsen/clickhouse/os.clj
+++ b/tests/jepsen.clickhouse/src/jepsen/clickhouse/os.clj
@@ -1,0 +1,170 @@
+(ns jepsen.clickhouse.os
+  "Ubuntu OS setup that makes apt wait for the dpkg locks instead of failing.
+
+  apt's default lock timeout is 0, so an apt-get that finds a lock held exits
+  immediately rather than waiting. A node is booted seconds before a test runs
+  it, while the automatic apt jobs of a fresh boot still hold those locks, so
+  jepsen.os.ubuntu/setup! needs apt configured to wait before it installs."
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :refer [info warn]]
+            [jepsen.os :as os]
+            [jepsen.os.debian :as debian]
+            [jepsen.os.ubuntu :as ubuntu]
+            [jepsen.control :as c]
+            [jepsen.control.util :as cu]
+            [jepsen.util :as util]
+            [clj-commons.slingshot :refer [try+ throw+]]))
+
+(def apt-lock-conf-path
+  "/etc/apt/apt.conf.d/99-clickhouse-jepsen-dpkg-lock-timeout")
+
+(def apt-lock-timeout-seconds 600)
+
+(def apt-lock-retry-interval-ms 5000)
+
+(def apt-lock-conf-content
+  (str "DPkg::Lock::Timeout \"" apt-lock-timeout-seconds "\";\n"))
+
+(def lists-lock-error
+  "What apt prints when /var/lib/apt/lists/lock is held. DPkg::Lock::Timeout
+  does not cover this lock, so it needs its own retry."
+  "Could not get lock /var/lib/apt/lists/lock")
+
+(defn stop-apt-timers!
+  "Stops the timers that start automatic apt runs. Best effort: a node without
+  systemd, or with these units absent, is fine. Stops the timers and never the
+  services, so a package operation already in flight is left to finish."
+  []
+  (try+
+   (c/su (c/exec :systemctl :stop :apt-daily.timer :apt-daily-upgrade.timer))
+   (catch Object _
+     (warn "Could not stop the apt-daily timers; continuing"))))
+
+(def apt-lock-timeout-dumped
+  "The line `apt-config dump` prints for the timeout the drop-in sets. Matching
+  it anchored is what distinguishes an effective drop-in from an inert one: apt
+  always reports its own compiled-in Binary::apt::DPkg::Lock::Timeout, so an
+  unanchored match succeeds even with no drop-in at all."
+  (str "DPkg::Lock::Timeout \"" apt-lock-timeout-seconds "\";"))
+
+(defn assert-apt-lock-timeout!
+  "Asserts apt parses the drop-in and resolves the timeout to the value written.
+  apt-config echoes back an unknown key too, so this establishes that apt reads
+  the file, not that apt honours the option; that the timeout takes effect under
+  contention is what the install measurement shows. Catches a malformed drop-in
+  (apt-config then exits 100) and an inert one (no matching line). Takes no
+  lock, so it cannot block."
+  []
+  (let [dumped (try+
+                ;; As root: apt skips a config file it cannot read, with a warning and exit 0.
+                (c/su (c/exec :apt-config :dump))
+                (catch [:type :jepsen.control/nonzero-exit] {:keys [err]}
+                  (throw+ {:type ::apt-conf-unusable
+                           :err err}
+                          nil
+                          "apt cannot read its configuration, so %s does not parse:\n%s"
+                          apt-lock-conf-path err)))]
+    (when-not (some #{apt-lock-timeout-dumped} (str/split-lines dumped))
+      (throw+ {:type ::apt-lock-timeout-not-in-effect}
+              nil
+              "apt does not report %s, so %s is not in effect"
+              apt-lock-timeout-dumped apt-lock-conf-path))
+    (info "apt reports" apt-lock-timeout-dumped)))
+
+(def apt-updated-hosts
+  "Hosts on which this process has completed a setup, so their package lists
+  were fetched by an update we issued and saw succeed. Held in memory because
+  the node carries no state we can trust to be from this run, and read before
+  any apt call: apt's own caches are refreshed even by an update that failed to
+  take a lock and fetched nothing."
+  (atom #{}))
+
+(defn readable-package-index-count
+  "How many package indexes apt can currently read. `apt-get indextargets` lists
+  any or none with the same exit status, so the count is the answer and the status
+  is not. Counts only the records apt created from a Packages target: the
+  auxiliary targets (Translations, DEP-11, CNF) are listed alongside them and come
+  from the same Release file, so a node with no package index at all still lists
+  those and cannot install anything. Reports what is on the node rather than
+  whether every source was reachable, and takes no lock, so it neither blocks nor
+  rejects a node that fetched some suites and not others. Sources apt refuses to
+  parse are no readable index either, so that counts as none rather than failing
+  the count."
+  []
+  (try+
+   (count (filter #(= % "Created-By: Packages")
+                  (str/split-lines (c/exec :apt-get :indextargets))))
+   (catch [:type :jepsen.control/nonzero-exit] _
+     0)))
+
+(defn ensure-package-lists!
+  "Runs one apt-get update per host, retrying only while apt reports the lists
+  lock held. DPkg::Lock::Timeout does not cover that lock. The update's exit
+  status is the oracle in neither direction: apt exits 0 having fetched nothing
+  when every source is unreachable, and exits non-zero having fetched every
+  index that matters when one configured source is broken. The readable package
+  indexes it leaves behind are what decides, so a non-lock failure stops the
+  retrying and is then judged by that count rather than being fatal on its own."
+  []
+  (when-not (contains? @apt-updated-hosts c/*host*)
+    (let [start (System/currentTimeMillis)
+          deadline (+ start (* 1000 apt-lock-timeout-seconds))
+          swallowed-err
+          (loop []
+            (let [[kind err]
+                  (try+
+                   ;; debian/update! hardcodes its argv, so its lock is taken here.
+                   (util/with-named-lock debian/node-locks c/*host*
+                     (c/su (c/exec :apt-get
+                                   :--allow-releaseinfo-change :update)))
+                   nil
+                   (catch [:type :jepsen.control/nonzero-exit] {:keys [err]}
+                     (if (and (string? err) (str/includes? err lists-lock-error))
+                       [:lists-lock err]
+                       [:other err])))]
+              (case kind
+                nil nil
+                :other err
+                :lists-lock
+                (if (< (System/currentTimeMillis) deadline)
+                  (do (Thread/sleep (long apt-lock-retry-interval-ms))
+                      (recur))
+                  (let [waited (- (System/currentTimeMillis) start)]
+                    (throw+ {:type ::apt-lists-lock-unavailable
+                             :waited-ms waited
+                             :err err}
+                            nil
+                            "apt could not take /var/lib/apt/lists/lock after %d ms:\n%s"
+                            waited err))))))]
+      (let [indexes (readable-package-index-count)]
+        (when (zero? indexes)
+          (throw+ {:type ::apt-package-lists-empty
+                   :node c/*host*
+                   :index-count indexes
+                   :err swallowed-err}
+                  nil
+                  "apt reports no readable package index on %s:\n%s"
+                  c/*host*
+                  (or swallowed-err "the update apt called successful fetched none")))
+        (when swallowed-err
+          (warn "apt-get update failed on" c/*host* "but left" indexes
+                "readable package indexes, so setup continues:\n" swallowed-err))
+        (info "apt package lists fetched after"
+              (- (System/currentTimeMillis) start) "ms," indexes "package indexes")))))
+
+(def os
+  "Ubuntu, with apt made to wait for its own locks first."
+  (reify os/OS
+    (setup! [_ test node]
+      (info node "configuring apt to wait for the dpkg locks")
+      (stop-apt-timers!)
+      (c/su (cu/write-file! apt-lock-conf-content apt-lock-conf-path))
+      (assert-apt-lock-timeout!)
+      (ensure-package-lists!)
+      (os/setup! ubuntu/os test node)
+      ;; Recorded last, so the recorded fact is that a whole setup succeeded.
+      (swap! apt-updated-hosts conj c/*host*))
+
+    (teardown! [_ test node]
+      ;; apt-lock-conf-path stays: the rest of the tests in this run reuse the node.
+      (os/teardown! ubuntu/os test node))))

--- a/tests/jepsen.clickhouse/src/jepsen/clickhouse/server/main.clj
+++ b/tests/jepsen.clickhouse/src/jepsen/clickhouse/server/main.clj
@@ -15,7 +15,7 @@
              [set :as set]]
             [jepsen.clickhouse.utils :as chu]
             [jepsen.control.util :as cu]
-            [jepsen.os.ubuntu :as ubuntu]
+            [jepsen.clickhouse.os :as chos]
             [jepsen.checker.timeline :as timeline]
             [clojure.java.io :as io])
   (:import (ch.qos.logback.classic Level)
@@ -56,7 +56,7 @@
     (merge tests/noop-test
            opts
            {:name (str "clickhouse-server-"  (name (:workload opts)) "-" (name (:nemesis opts)))
-            :os ubuntu/os
+            :os chos/os
             :db (get-db opts)
             :pure-generators true
             :nemesis (:nemesis current-nemesis)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The nightly `ClickHouse Keeper Jepsen` check reported ERROR for **all 24 workloads** on master
`90a20ccf` ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=90a20ccf81cd348372f1406facf7544efa445f75&name_0=NightlyJepsen&name_1=ClickHouse%20Keeper%20Jepsen)):
`0 successes / 24 crashed` and no `:valid?` line anywhere, so it produced no linearizability signal
while reporting a red that reads like a Keeper defect. All 24 died in `jepsen.os.ubuntu/setup!`
(`ubuntu.clj:22` -> `debian.clj:117`) before any test body ran:
`E: Could not get lock /var/lib/dpkg/lock-frontend ... (unattended-upgr)`.

**Root cause.** `debian/install` runs a plain `apt-get install` with no lock-wait option, and apt's
default `DPkg::Lock::Timeout` is `0`, so it exits 100 the instant the lock is held. Nodes are scaled
0 -> 3 at job start, so each is seconds old, and Ubuntu's apt-daily timers carry `Persistent=true`,
firing the missed run at once on boot.

**Change.** A new `jepsen.clickhouse.os` wraps `ubuntu/os`: stop the two apt-daily timers (best
effort, never the services), write a `DPkg::Lock::Timeout "600"` drop-in, assert via
`apt-config dump` that apt resolves that timeout, fetch the package lists once per node, then
delegate. The three `:os` sites point at it; `server/db.clj` reaches its Keeper node via
`(:os test)`, so that 4th node is covered too.

**Validation.** Nightly-only and PR-gated on `jepsen-test`, so it cannot go green here. Holding the
lock with `fcntl.lockf` and running Jepsen's exact argv: without the drop-in `rc=100` in 0.06 s with
that error; with it `rc=0` after the 30 s hold, package installed. Pinning the timeout back to `"0"`,
or malforming the file, re-breaks it. Checked on Ubuntu 20.04/22.04/24.04 through Jepsen's real sshj
remote. Post-merge: 3 nightlies at 0 of 24 failures, with neither error string in `job.log`.

**Not fixed, deliberately.** 2026-07-16's 15/24 is a different cause (SSH `session-error`, no
dpkg-lock hits). Baking the packages into the AMI would be more robust, but is unreachable from here.

<details>
<summary>Why the lists lock needs a separate step, and why neither apt's cache nor its exit status is the postcondition</summary>

`DPkg::Lock::Timeout` covers the dpkg frontend lock only. The same automatic apt run also holds
`/var/lib/apt/lists/lock` during its update phase, and 6 of the 26 historical lock hits on this check
are lists-lock ones, so the lists are fetched by a step that retries only while apt reports that lock
held. Four candidate apt-native timeouts for that lock were tested and all fail in 0-1 s.

Its postcondition is neither apt's cache files nor its exit status. Measured: an `apt-get update` that
failed to take the lock still *creates* `/var/cache/apt/pkgcache.bin` having fetched zero indexes, so
a freshness check reads that as success and suppresses the update `ubuntu/setup!` would run. And the
status misreports both ways: **0** when every fetch failed and no index was written, **100** when one
configured source is broken while every index that matters was fetched.

So the step counts the *package* indexes apt can read afterwards (`apt-get indextargets`, restricted
to `Created-By: Packages`; needs no root, takes no lock), and a non-lock failure is judged by that
count rather than being fatal on its own. The restriction matters because apt lists one record per
target, so Translations/DEP-11/CNF appear beside the package indexes: a node with the Release files
but no package index reports a positive *total* while `apt-get install ntpdate faketime` finds no
installation candidate.

Measured on apt 2.8.3, as targets/package-indexes: 30/15 populated (install resolves) - 22/11 one
mirror host unreachable (accepted) - 30/15 a 404 suite made the update exit 100 (accepted) - 15/**0**
package indexes missing, auxiliary ones present (rejected) - 0/0 lists emptied, and after the
lock-failed update above. `Created-By:` is present on apt 2.0.10, 2.4.14 and 2.8.3, and in the stock
state package-indexes equals the total on all three.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115637&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115637](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115637+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1828` (included in `26.8` and later)
<!-- ch-version-info:end -->