### PR TITLE
Fix `removePartAndCoveredParts` Outcome for Existing Part Removal

### DIFF
--- a/src/Storages/MergeTree/ActiveDataPartSet.h
+++ b/src/Storages/MergeTree/ActiveDataPartSet.h
@@ -74,11 +74,10 @@ public:
     bool removePartAndCoveredParts(const MergeTreePartInfo & part_info)
     {
         Strings parts_covered_by = getPartsCoveredBy(part_info);
-        bool result = remove(part_info);
         for (const auto & part : parts_covered_by)
-            result &= remove(part);
+            remove(part);
 
-        return result;
+        return !parts_covered_by.empty();
     }
 
     /// Remove only covered parts from active set


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixes `removePartAndCoveredParts` when it is being called for a part that is actually present in the active data part set. The problem was that part itself will always be in `parts_covered_by,` so the subsequent remove in the loop will not be able to remove it twice.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115640&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115640](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115640+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.6.58`, `26.6.4.60`, `26.3.28.5`
<!-- ch-version-info:end -->