### PR TITLE
Fix flaky 04511_reader_executor_disk_cache

### DIFF
--- a/tests/queries/0_stateless/04511_reader_executor_disk_cache.sql
+++ b/tests/queries/0_stateless/04511_reader_executor_disk_cache.sql
@@ -27,6 +27,15 @@ SET remote_filesystem_read_method = 'read';
 SET enable_filesystem_cache = 1;
 SET read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0;
 
+-- One reading thread, so the cold read populates the cache completely and the warm read is a pure
+-- cache hit. With several threads each stream gets its own `ReaderExecutor` over the same file, and
+-- `DiskCacheWriter` appends only at the segment's live write offset: whichever stream loses the
+-- downloader race contributes nothing, so the cold read leaves the segment PARTIALLY populated. The
+-- warm read then re-fetches such a segment from its start (`claimLeadRole`'s `available` prefix is
+-- deliberately unused - see the "Coarse by design" note in `ReaderExecutor::readThroughCaches`), which
+-- can cost MORE source bytes than the cold read did and made the assertion below flaky.
+SET max_threads = 1;
+
 -- Cold read: nothing cached yet, so the executor reads from source and populates the cache. Warm read:
 -- the same bytes must now be served from the cache. Both aggregates prove the served bytes are correct.
 SELECT count(), sum(k) FROM t_re_disk_cache SETTINGS log_comment = 'reader_executor_cold';
@@ -36,8 +45,10 @@ SYSTEM FLUSH LOGS query_log;
 
 -- The read-through contract end to end on the real DiskCacheProvider: the cold read pulled bytes from
 -- source (so the executor engaged) AND populated the cache ITSELF (`ReaderExecutorCachePopulateRequests`
--- > 0, not just the disk's incidental cache-on-read), and the warm reread then served those bytes from
--- that cache, reading strictly fewer source bytes. These counters are emitted only by the executor.
+-- > 0, not just the disk's incidental cache-on-read), and the warm reread then served every byte from
+-- that cache, touching the source not at all. These counters are emitted only by the executor.
+-- `warm = 0` rather than `warm < cold`: the latter compares two source-byte totals that both include
+-- over-read, so it is a proxy that a partially populated cache can invert.
 SELECT check_name, ok
 FROM
 (
@@ -47,7 +58,7 @@ FROM
         SELECT arrayJoin([
             (1, 'cold_read_from_source', cold > 0),
             (2, 'executor_populated_cache', cold_pop > 0),
-            (3, 'warm_served_from_cache', warm < cold)
+            (3, 'warm_served_from_cache', warm = 0)
         ]) AS row
         FROM
         (


### PR DESCRIPTION
`04511_reader_executor_disk_cache` fails on master with

```
 cold_read_from_source	1
 executor_populated_cache	1
-warm_served_from_cache	1
+warm_served_from_cache	0
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2101f9b0850389d7fddfefd04d2577162c8958c3&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20sequential%2C%202%2F2%29

It also fails on unrelated pull requests in `Stateless tests (amd_msan, WasmEdge, sequential, 2/2)` (4 of 14 reruns there). No tracking issue exists.

### What goes wrong

The third check asserted `warm < cold`, comparing the `ReaderExecutorBytesFromSource` totals of a cold and a warm `SELECT`. That is a proxy, and a partially populated cache inverts it.

With more than one reading thread each stream builds its own `ReaderExecutor` over the same file. `DiskCacheWriter` appends only at the segment's live write offset, so whichever stream loses the downloader race contributes nothing, and the cold read leaves the segment partially populated. The warm read then re-fetches such a segment from its start — `claimLeadRole`'s `available` prefix is deliberately unused, see the *\"Coarse by design\"* note in `ReaderExecutor::readThroughCaches` — so it can move *more* source bytes than the cold read did.

The failing job's server log and `query_log` show exactly that: the cold read populated 285856 of the 801126-byte segment and read 1658884 bytes from source; the warm read then read 2480460. Across the 28 runs of that job the cold total was a constant 1658884 while the warm total was 0, 801126, 1372817, 1479995 or 2480460, purely as a function of how the streams interleaved.

### The fix

Pin the reads to a single thread, so the cold read populates the segment completely, and assert the strong property instead of the proxy: the warm read must touch the source not at all (`warm = 0`).

Verified over 54 runs of the test with randomized settings against a local minio: `cold` is now a stable 800461 (one clean pass over the file instead of two or three overlapping ones) and `warm` is 0 in every run.

The re-fetch-from-segment-start behaviour itself is left alone — it is a documented limitation of the experimental `ReaderExecutor` with a follow-up already noted in the code, not something to change in a CI fix.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115643&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115643](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115643+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
