### PR TITLE
Keep table aliases in stored query bodies when restoring under a new name

### DIFF
--- a/src/Databases/DDLRenamingVisitor.cpp
+++ b/src/Databases/DDLRenamingVisitor.cpp
@@ -129,6 +129,14 @@ namespace
         if (new_qualified_name == qualified_name)
             return;
 
+        /// A table reference carries state besides its name, notably the alias the surrounding query
+        /// refers to, so rename it in place instead of substituting a newly built node.
+        if (auto * table_reference = expr.database_and_table_name->as<ASTTableIdentifier>())
+        {
+            table_reference->resetTable(new_qualified_name.database, new_qualified_name.table);
+            return;
+        }
+
         /// `database_and_table_name` is registered as a child, so appending the renamed identifier
         /// would leave the pre-rename one behind next to it. `replace` swaps both slots at once.
         expr.replace(

--- a/tests/queries/0_stateless/05027_restore_rename_keeps_table_alias.reference
+++ b/tests/queries/0_stateless/05027_restore_rename_keeps_table_alias.reference
@@ -1,0 +1,63 @@
+BACKUP_CREATED
+-- restore the database under a new name
+RESTORED
+v_plain
+(`id` UInt64) AS SELECT a.id FROM db.t1 AS a
+1
+2
+v_final
+(`id` UInt64) AS SELECT a.id FROM db.t1 AS a FINAL
+1
+2
+v_comma
+(`id` UInt64, `y` String) AS SELECT a.id, b.y FROM db.t1 AS a, db.t2 AS b WHERE a.id = b.id
+1	p
+2	q
+v_comma_final
+(`id` UInt64, `y` String) AS SELECT a.id, b.y FROM db.t1 AS a FINAL, db.t2 AS b WHERE a.id = b.id
+1	p
+2	q
+v_join
+(`id` UInt64, `y` String) AS SELECT a.id, b.y FROM db.t1 AS a INNER JOIN db.t2 AS b ON a.id = b.id
+1	p
+2	q
+v_subquery_alias
+(`id` UInt64) AS SELECT s.id FROM (SELECT id FROM db.t1) AS s
+1
+2
+-- restore the database under its original name
+RESTORED
+v_plain
+(`id` UInt64) AS SELECT a.id FROM db.t1 AS a
+1
+2
+v_final
+(`id` UInt64) AS SELECT a.id FROM db.t1 AS a FINAL
+1
+2
+v_comma
+(`id` UInt64, `y` String) AS SELECT a.id, b.y FROM db.t1 AS a, db.t2 AS b WHERE a.id = b.id
+1	p
+2	q
+v_comma_final
+(`id` UInt64, `y` String) AS SELECT a.id, b.y FROM db.t1 AS a FINAL, db.t2 AS b WHERE a.id = b.id
+1	p
+2	q
+v_join
+(`id` UInt64, `y` String) AS SELECT a.id, b.y FROM db.t1 AS a INNER JOIN db.t2 AS b ON a.id = b.id
+1	p
+2	q
+v_subquery_alias
+(`id` UInt64) AS SELECT s.id FROM (SELECT id FROM db.t1) AS s
+1
+2
+-- restore a view together with the table it reads, both under new names
+RESTORED
+(`id` UInt64) AS SELECT a.id FROM db.t1 AS a
+1
+2
+-- restore a view alone, leaving the table it reads where it is
+RESTORED
+(`id` UInt64) AS SELECT a.id FROM source_db.t1 AS a
+1
+2

--- a/tests/queries/0_stateless/05027_restore_rename_keeps_table_alias.sh
+++ b/tests/queries/0_stateless/05027_restore_rename_keeps_table_alias.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+src="${CLICKHOUSE_DATABASE}_src"
+renamed="${CLICKHOUSE_DATABASE}_renamed"
+tables="${CLICKHOUSE_DATABASE}_tables"
+backup_name="${CLICKHOUSE_DATABASE}_backup"
+
+views="v_plain v_final v_comma v_comma_final v_join v_subquery_alias"
+
+for d in "${src}" "${renamed}" "${tables}"
+do
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${d} SYNC"
+done
+
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE ${src}"
+${CLICKHOUSE_CLIENT} -nq "
+CREATE TABLE ${src}.t1 (id UInt64, x String) ENGINE = ReplacingMergeTree ORDER BY id;
+CREATE TABLE ${src}.t2 (id UInt64, y String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ${src}.t1 VALUES (1, 'a'), (2, 'b');
+INSERT INTO ${src}.t2 VALUES (1, 'p'), (2, 'q');
+CREATE VIEW ${src}.v_plain AS SELECT a.id FROM ${src}.t1 AS a;
+CREATE VIEW ${src}.v_final AS SELECT a.id FROM ${src}.t1 AS a FINAL;
+CREATE VIEW ${src}.v_comma AS SELECT a.id, b.y FROM ${src}.t1 AS a, ${src}.t2 AS b WHERE a.id = b.id;
+CREATE VIEW ${src}.v_comma_final AS SELECT a.id, b.y FROM ${src}.t1 AS a FINAL, ${src}.t2 AS b WHERE a.id = b.id;
+CREATE VIEW ${src}.v_join AS SELECT a.id, b.y FROM ${src}.t1 AS a JOIN ${src}.t2 AS b ON a.id = b.id;
+CREATE VIEW ${src}.v_subquery_alias AS SELECT s.id FROM (SELECT id FROM ${src}.t1) AS s;
+"
+
+${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE ${src} TO Disk('backups', '${backup_name}')" | grep -o "BACKUP_CREATED"
+
+# Database names are unique per run, so print them as fixed placeholders.
+show_body()
+{
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT replaceAll(replaceAll(replaceOne(create_table_query, 'CREATE VIEW ${1}.${2} ', ''), '${1}', 'db'), '${src}', 'source_db')
+        FROM system.tables WHERE database = '${1}' AND name = '${2}'"
+}
+
+echo "-- restore the database under a new name"
+${CLICKHOUSE_CLIENT} -q "RESTORE DATABASE ${src} AS ${renamed} FROM Disk('backups', '${backup_name}')" | grep -o "RESTORED"
+for v in $views
+do
+    echo "${v}"
+    show_body "${renamed}" "${v}"
+    ${CLICKHOUSE_CLIENT} -q "SELECT * FROM ${renamed}.${v} ORDER BY id"
+done
+
+echo "-- restore the database under its original name"
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${src} SYNC"
+${CLICKHOUSE_CLIENT} -q "RESTORE DATABASE ${src} FROM Disk('backups', '${backup_name}')" | grep -o "RESTORED"
+for v in $views
+do
+    echo "${v}"
+    show_body "${src}" "${v}"
+    ${CLICKHOUSE_CLIENT} -q "SELECT * FROM ${src}.${v} ORDER BY id"
+done
+
+echo "-- restore a view together with the table it reads, both under new names"
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE ${tables}"
+${CLICKHOUSE_CLIENT} -q "RESTORE TABLE ${src}.t1 AS ${tables}.t1, TABLE ${src}.v_plain AS ${tables}.v_plain FROM Disk('backups', '${backup_name}')" | grep -o "RESTORED"
+show_body "${tables}" "v_plain"
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM ${tables}.v_plain ORDER BY id"
+
+echo "-- restore a view alone, leaving the table it reads where it is"
+${CLICKHOUSE_CLIENT} -q "RESTORE TABLE ${src}.v_plain AS ${tables}.v_alone FROM Disk('backups', '${backup_name}')" | grep -o "RESTORED"
+show_body "${tables}" "v_alone"
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM ${tables}.v_alone ORDER BY id"
+
+for d in "${src}" "${renamed}" "${tables}"
+do
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${d} SYNC"
+done


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115479   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a bug where restoring a database or table under a new name dropped the table aliases from the bodies of stored views, so reading a restored view failed with `UNKNOWN_IDENTIFIER`. Closes #115479.

### Description

Closes: #115479

A renaming restore rewrote the table references inside a stored view body but discarded the alias on each one, so the view was permanently broken: its `FROM` named a table with no alias while its projection still qualified columns by that alias.

```sql
CREATE VIEW v AS SELECT a.id FROM testdb.t1 AS a;
BACKUP DATABASE testdb TO Disk('backups', 'r');
RESTORE DATABASE testdb AS renamed FROM Disk('backups', 'r');
SELECT * FROM renamed.v;  -- Code: 47. UNKNOWN_IDENTIFIER: Unknown expression identifier `a.id`
```

Root cause: the alias is state on the reference node itself, not on the `ASTTableExpression`. `DDLRenamingVisitor::visitTableExpression` substituted a freshly built `ASTTableIdentifier` for the reference, so every field other than the name was lost, and the formatted body was persisted into the restored metadata.

The fix renames the reference in place with `ASTTableIdentifier::resetTable`, so the alias, `parametrised_alias` and `prefer_alias_to_column_name` survive by construction. This is option 2 from the issue. Its `has_uuid` caveat does not apply on master: `ASTTableIdentifier` has no `formatImplWithoutAlias` override there and nothing reads `has_uuid` on the node past parse time, so a stale flag is inert; #114277 already carries the clearing line, so either merge order is correct. `resetTable` itself is untouched, and its only other caller, `InJoinSubqueriesPreprocessor`, requires a non-empty alias.

Sibling carrier, so you do not have to ask: `replaceTableNameInArgument` rebuilds the reference the same way for `joinGet`/`dictGet`/`IN`. An alias does parse there but is not resolvable (`SELECT 1 IN (db.t AS a), a` already fails with `UNKNOWN_IDENTIFIER`), so dropping it has no reachable consequence and is left alone.

`RESTORE TABLE db.v AS other.v` alone does not reproduce: only the view is remapped, so the visitor early-returns. Already-written backups are not repaired.

Validated by a new `.sh` test: five aliased shapes plus four boundary controls, red before and green after, plus 50/50 randomized runs.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115645&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115645](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115645+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1859` (included in `26.8` and later)
<!-- ch-version-info:end -->