### PR TITLE
Fix building `unit_tests_dbms` without the full library set

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -963,7 +963,10 @@ if (ENABLE_TESTS)
         clickhouse_common_zookeeper
         # `ConnectionParameters` (exercised by a gtest) pulls in `readpassphrase` for the
         # interactive password prompt, so the unit test executable must link it too.
-        readpassphrase)
+        readpassphrase
+        # `gtest_lz4_decompress_branchless` includes `<lz4.h>` directly; the include path only
+        # propagates transitively in full-library builds, so declare the dependency explicitly.
+        ch_contrib::lz4)
 
     if (TARGET ch_contrib::krb5)
         target_link_libraries(unit_tests_dbms PRIVATE ch_contrib::krb5)

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_sst_probe.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_sst_probe.cpp
@@ -702,8 +702,7 @@ TEST(UniqueKeyNoRocksDB, StaticWritersThrowSupportIsDisabled)
 {
     auto tmp_path = std::filesystem::temp_directory_path()
         / ("gtest_unique_key_no_rocksdb_"
-           + std::to_string(::testing::UnitTest::GetInstance()->random_seed())
-           + "_" + std::to_string(reinterpret_cast<uintptr_t>(&tmp_path)));
+           + std::to_string(::testing::UnitTest::GetInstance()->random_seed()));
     std::filesystem::remove_all(tmp_path);
     std::filesystem::create_directories(tmp_path / "part");
     auto disk = std::make_shared<DiskLocal>("test_disk", tmp_path.string());
@@ -741,8 +740,7 @@ TEST(UniqueKeyNoRocksDB, ConstructorThrowsSupportIsDisabled)
 {
     auto tmp_path = std::filesystem::temp_directory_path()
         / ("gtest_unique_key_no_rocksdb_ctor_"
-           + std::to_string(::testing::UnitTest::GetInstance()->random_seed())
-           + "_" + std::to_string(reinterpret_cast<uintptr_t>(&tmp_path)));
+           + std::to_string(::testing::UnitTest::GetInstance()->random_seed()));
     std::filesystem::remove_all(tmp_path);
     std::filesystem::create_directories(tmp_path / "part");
     auto disk = std::make_shared<DiskLocal>("test_disk", tmp_path.string());
@@ -764,8 +762,7 @@ TEST(UniqueKeyNoRocksDB, WriteDenseIndexOnInsertThrowsSupportIsDisabled)
 {
     auto tmp_path = std::filesystem::temp_directory_path()
         / ("gtest_unique_key_no_rocksdb_insert_"
-           + std::to_string(::testing::UnitTest::GetInstance()->random_seed())
-           + "_" + std::to_string(reinterpret_cast<uintptr_t>(&tmp_path)));
+           + std::to_string(::testing::UnitTest::GetInstance()->random_seed()));
     std::filesystem::remove_all(tmp_path);
     std::filesystem::create_directories(tmp_path / "part");
     auto disk = std::make_shared<DiskLocal>("test_disk", tmp_path.string());


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/114559

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed building `unit_tests_dbms` in configurations without the full library set (`ENABLE_LIBRARIES=0` or `ENABLE_ROCKSDB=0`).

Two defects, both invisible to upstream CI because it always builds with the full library set:

- `unit_tests_dbms` never declares its dependency on lz4, although `gtest_lz4_decompress_branchless.cpp` includes `<lz4.h>` directly. In full-library builds the include path leaks in transitively through other contribs, but with `ENABLE_LIBRARIES=0` the compilation fails with `'lz4.h' file not found`. The dependency is now declared explicitly on the `unit_tests_dbms` target.

- The `UniqueKeyNoRocksDB` tests in `gtest_unique_key_sst_probe.cpp` sit in the `#else` branch of `#if USE_ROCKSDB`, so they are only compiled when RocksDB is *disabled* — and they don't compile: `tmp_path` is used in its own initializer, which is ill-formed for a variable declared with `auto`:

```
src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_sst_probe.cpp:706:64: error: variable 'tmp_path' declared with deduced type 'auto' cannot appear in its own initializer
  706 |            + "_" + std::to_string(reinterpret_cast<uintptr_t>(&tmp_path)));
```

  The address suffix (an imitation of the `reinterpret_cast<uintptr_t>(this)` pattern from the fixture in the RocksDB branch, where `this` does exist) is dropped: each of the three tests already uses a distinct directory name prefix, and they clean their directory with `remove_all` before use anyway.

Found while verifying https://github.com/ClickHouse/ClickHouse/pull/114559 locally with a minimal build configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115655&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115655](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115655+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1820` (included in `26.8` and later)
<!-- ch-version-info:end -->