### PR TITLE
Document that JSON parsing requires valid UTF-8

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4496,7 +4496,7 @@ Reject patterns which will likely be expensive to evaluate with hyperscan (due t
 Allow using simdjson library in 'JSON*' functions if AVX2 instructions are available. If disabled rapidjson will be used.
 
 :::note
-simdjson rejects `String` values which are not valid UTF-8, as the JSON specification requires. Reading such values requires this setting disabled, so that rapidjson is used instead. This applies where the parser is chosen by this setting: the `JSON` data type and the `JSONExtract*` function family.
+simdjson rejects `String` values which are not valid UTF-8, as the JSON specification requires. Reading or writing such values requires this setting disabled, so that rapidjson is used instead. This setting selects the parser for the `JSON` data type, for the legacy JSON functions (`JSONExtract*`, `JSONHas`, `JSONLength`, `JSONType`, `JSONKey`, `isValidJSON`) and for `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY`. Functions which choose their parser at build time, such as `JSONArrayLength`, are unaffected.
 
 Disabling it also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable for any input: those functions have no rapidjson implementation and throw `NOT_IMPLEMENTED`.
 :::

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4496,7 +4496,7 @@ Reject patterns which will likely be expensive to evaluate with hyperscan (due t
 Allow using simdjson library in 'JSON*' functions if AVX2 instructions are available. If disabled rapidjson will be used.
 
 :::note
-simdjson rejects `String` values which are not valid UTF-8, as the JSON specification requires. Reading such values requires this setting disabled, so that rapidjson is used instead.
+simdjson rejects `String` values which are not valid UTF-8, as the JSON specification requires. Reading such values requires this setting disabled, so that rapidjson is used instead. This applies where the parser is chosen by this setting: the `JSON` data type and the `JSONExtract*` function family.
 
 Disabling it also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable for any input: those functions have no rapidjson implementation and throw `NOT_IMPLEMENTED`.
 :::

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4494,6 +4494,12 @@ Reject patterns which will likely be expensive to evaluate with hyperscan (due t
 )", 0) \
     DECLARE(Bool, allow_simdjson, true, R"(
 Allow using simdjson library in 'JSON*' functions if AVX2 instructions are available. If disabled rapidjson will be used.
+
+:::note
+simdjson rejects `String` values which are not valid UTF-8, as the JSON specification requires. Reading such values requires this setting disabled, so that rapidjson is used instead.
+
+Disabling it also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable for any input: those functions have no rapidjson implementation and throw `NOT_IMPLEMENTED`.
+:::
 )", 0) \
     DECLARE(Bool, allow_introspection_functions, false, R"(
 Enables or disables [introspection functions](/reference/functions/regular-functions/introspection) for query profiling.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -4496,9 +4496,7 @@ Reject patterns which will likely be expensive to evaluate with hyperscan (due t
 Allow using simdjson library in 'JSON*' functions if AVX2 instructions are available. If disabled rapidjson will be used.
 
 :::note
-simdjson rejects `String` values which are not valid UTF-8, as the JSON specification requires. Reading or writing such values requires this setting disabled, so that rapidjson is used instead. This setting selects the parser for the `JSON` data type, for the legacy JSON functions (`JSONExtract*`, `JSONHas`, `JSONLength`, `JSONType`, `JSONKey`, `isValidJSON`) and for `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY`. Functions which choose their parser at build time, such as `JSONArrayLength`, are unaffected.
-
-Disabling it also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable for any input: those functions have no rapidjson implementation and throw `NOT_IMPLEMENTED`.
+simdjson supports only valid UTF-8, as the JSON specification requires. Values containing invalid UTF-8 cannot be parsed unless this setting is disabled.
 :::
 )", 0) \
     DECLARE(Bool, allow_introspection_functions, false, R"(

--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -956,6 +956,12 @@ SELECT json FROM test;
 
 It is possible to cast various types using the special syntax `::JSON`.
 
+<Note>
+By default the simdjson parser is used, and it supports only valid UTF-8. Casting a value which contains
+invalid UTF-8 raises `INCORRECT_DATA`. Set [`allow_simdjson`](/reference/settings/session-settings/allow#allow_simdjson)
+to `0` to fall back to rapidjson, which parses such values.
+</Note>
+
 #### CAST from `String` to `JSON` {#cast-from-string-to-json}
 
 ```sql title="Query"
@@ -993,16 +999,6 @@ SELECT map('a', map('b', 42), 'c', [1,2,3], 'd', 'Hello, World!')::JSON AS json;
 │ {"a":{"b":"42"},"c":["1","2","3"],"d":"Hello, World!"} │
 └────────────────────────────────────────────────────────┘
 ```
-
-<Note>
-Every `String` value being cast must be valid UTF-8. A value which is not raises `INCORRECT_DATA`,
-because the default JSON parser is simdjson, which rejects such values as the JSON specification requires.
-
-Setting [`allow_simdjson`](/reference/settings/session-settings/allow#allow_simdjson) to `0` selects rapidjson,
-which parses them. That also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable, and it lets the
-`JSONExtract*` functions parse such input instead of silently returning a default value; the byte-returning
-variants then preserve the invalid bytes.
-</Note>
 
 <Note>
 JSON paths are stored flattened. This means that when a JSON object is formatted from a path like `a.b.c`

--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -999,8 +999,9 @@ Every `String` value being cast must be valid UTF-8. A value which is not raises
 because the default JSON parser is simdjson, which rejects such values as the JSON specification requires.
 
 Setting [`allow_simdjson`](/reference/settings/session-settings/allow#allow_simdjson) to `0` selects rapidjson,
-which parses them. That also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable, and it changes
-`JSONExtract*` from silently returning a default value for such input to returning the bytes.
+which parses them. That also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable, and it lets the
+`JSONExtract*` functions parse such input instead of silently returning a default value; the byte-returning
+variants then preserve the invalid bytes.
 </Note>
 
 <Note>

--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -995,6 +995,15 @@ SELECT map('a', map('b', 42), 'c', [1,2,3], 'd', 'Hello, World!')::JSON AS json;
 ```
 
 <Note>
+Every `String` value being cast must be valid UTF-8. A value which is not raises `INCORRECT_DATA`,
+because the default JSON parser is simdjson, which rejects such values as the JSON specification requires.
+
+Setting [`allow_simdjson`](/reference/settings/session-settings/allow#allow_simdjson) to `0` selects rapidjson,
+which parses them. That also makes `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY` unavailable, and it changes
+`JSONExtract*` from silently returning a default value for such input to returning the bytes.
+</Note>
+
+<Note>
 JSON paths are stored flattened. This means that when a JSON object is formatted from a path like `a.b.c`
 it is not possible to know whether the object should be constructed as `{ "a.b.c" : ... }` or `{ "a": { "b": { "c": ... } } }`.
 Our implementation will always assume the latter.


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/113053
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/113053

A value holding bytes that are not valid UTF-8 cannot be parsed into the `JSON` type, and
nothing said so. The reporter's `Tuple(test String)` cast raised `Code: 117 INCORRECT_DATA`
with no hint at the cause or the workaround. @ Avogar ruled the behaviour correct on
2026-08-05 (simdjson accepts only valid UTF-8, as the JSON specification requires) and
asked, with @ PedroTadim, for a documentation remark. This is that remark.

Two source docstrings are extended, because they generate the two pages a user lands on:
`src/Core/Settings.cpp` (`allow_simdjson`) generates
`docs/reference/settings/session-settings/allow.mdx`, and
`src/DataTypes/DataTypeObject.cpp` (the `JSON` type) generates
`docs/reference/data-types/newjson.mdx`. There the note sits at the top of
`Using CAST with ::JSON`, so it covers the `String`, `Tuple` and `Map` casts alike; the
reporter's case was a `Tuple` cast. No `.mdx` is touched: both bodies are inside
`AUTOGENERATED` regions, and `nightly_docs_autogen.yml` has no `pull_request` trigger, so
no regeneration is owed here.

Validation: both notes reach `system.settings.description` and `system.documentation` on a
rebuilt binary and are absent on the base binary; `01324_settings_documentation` and
`04412_settings_documentation_empty_default` pass with byte-identical reference output;
`check_autogenerated_regions.py` reports no edits inside generated regions.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115660&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115660](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115660+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
