### PR TITLE
Fix a wedged mutation after a patch-mode lightweight delete

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -679,28 +679,6 @@ static void addRenamedColumnToColumnsSubstreams(
         new_columns_substreams.addSubstreamToLastColumn(ISerialization::getFileNameForRenamedColumnStream(old_name, new_name, substream));
 }
 
-static bool isDeletedMaskUpdated(const MutationCommand & command, const NameSet & storage_columns_set)
-{
-    if (storage_columns_set.contains(RowExistsColumn::name))
-        return false;
-
-    if (command.type == MutationCommand::READ_COLUMN)
-        return command.read_for_patch && command.column_name == RowExistsColumn::name;
-
-    if (command.type == MutationCommand::UPDATE)
-    {
-        auto alter = command.ast();
-        if (!alter || !alter->update_assignments)
-            return false;
-        return std::ranges::any_of(alter->update_assignments->children, [](const ASTPtr & child)
-        {
-            return child->as<ASTAssignment &>().column_name == RowExistsColumn::name;
-        });
-    }
-
-    return false;
-}
-
 /// Get the columns list of the resulting part in the same order as storage_columns.
 static std::tuple<NamesAndTypesList, SerializationInfoByName, ColumnsSubstreams>
 getColumnsForNewDataPart(
@@ -723,9 +701,7 @@ getColumnsForNewDataPart(
     ColumnsDescription part_columns(source_part->getColumns());
     NamesAndTypesList system_columns;
 
-    bool deleted_mask_updated = false;
     bool affects_all_columns = false;
-    bool supports_lightweight_deletes = source_part->supportLightweightDeleteMutate();
 
     NameSet storage_columns_set;
     for (const auto & [name, _] : storage_columns)
@@ -734,9 +710,6 @@ getColumnsForNewDataPart(
     for (const auto & command : all_commands)
     {
         affects_all_columns |= command.affectsAllColumns();
-
-        if (supports_lightweight_deletes)
-            deleted_mask_updated |= isDeletedMaskUpdated(command, storage_columns_set);
 
         /// If we don't have this column in source part, than we don't need to materialize it
         if (!part_columns.has(command.column_name))
@@ -776,7 +749,7 @@ getColumnsForNewDataPart(
 
         bool need_column = false;
         if (name == RowExistsColumn::name)
-            need_column = deleted_mask_updated || (part_columns.has(name) && !affects_all_columns);
+            need_column = updated_header.has(name) || (part_columns.has(name) && !affects_all_columns);
         else if (name == BlockNumberColumn::name || name == BlockOffsetColumn::name)
             need_column = part_columns.has(name) || updated_header.has(name);
         else

--- a/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.reference
+++ b/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.reference
@@ -1,0 +1,155 @@
+-- lightweight_update: heavyweight DELETE after a patch-mode lightweight DELETE
+0
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23
+0
+-- alter_update mode produces the same rows (oracle)
+0
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23
+-- both modes agree
+1
+-- lightweight_update_force
+0
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23
+-- APPLY DELETED MASK and REWRITE PARTS reach the same code path
+0
+2	2
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23
+0
+0
+2	2
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23
+-- a partial update keeps the mask, so masked rows stay hidden
+0
+1	101
+2	2
+4	4
+5	105
+7	107
+8	8
+10	10
+11	111
+13	113
+14	14
+16	16
+17	117
+19	119
+20	20
+22	22
+23	123
+1
+-- a heavyweight DELETE matching no rows keeps the pending patch
+0
+16	0
+-- compact parts
+0
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23
+-- with a projection
+0
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23
+-- ReplicatedMergeTree
+0
+4	4
+5	5
+7	7
+8	8
+10	10
+11	11
+13	13
+14	14
+16	16
+17	17
+19	19
+20	20
+22	22
+23	23

--- a/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.sql
+++ b/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.sql
@@ -1,0 +1,182 @@
+-- Tags: no-replicated-database
+-- no-replicated-database: fails due to additional shard.
+
+SET insert_keeper_fault_injection_probability = 0.0;
+SET enable_lightweight_update = 1;
+SET mutations_sync = 2, alter_sync = 2, lightweight_deletes_sync = 2;
+
+-- A lightweight delete in patch mode supplies _row_exists from a patch part rather than from the
+-- source part's own columns. A later mutation that rewrites all columns applies that mask on read
+-- and physically drops the masked rows, so its result must not be declared to carry the mask.
+
+SELECT '-- lightweight_update: heavyweight DELETE after a patch-mode lightweight DELETE';
+
+DROP TABLE IF EXISTS t_lwu SYNC;
+CREATE TABLE t_lwu (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_lwu SELECT number, number FROM numbers(24);
+
+DELETE FROM t_lwu WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_lwu UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_lwu WHERE k = 1 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_lwu DELETE WHERE k = 2;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_lwu' AND NOT is_done;
+SELECT k, v FROM t_lwu ORDER BY k;
+SELECT count() FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_lwu' AND active
+  AND column = '_row_exists' AND name NOT LIKE 'patch%' AND name LIKE '2\_%';
+
+SELECT '-- alter_update mode produces the same rows (oracle)';
+
+DROP TABLE IF EXISTS t_alter SYNC;
+CREATE TABLE t_alter (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_alter SELECT number, number FROM numbers(24);
+
+DELETE FROM t_alter WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'alter_update';
+ALTER TABLE t_alter UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_alter WHERE k = 1 SETTINGS lightweight_delete_mode = 'alter_update';
+ALTER TABLE t_alter DELETE WHERE k = 2;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_alter' AND NOT is_done;
+SELECT k, v FROM t_alter ORDER BY k;
+
+SELECT '-- both modes agree';
+SELECT (SELECT groupArray((k, v)) FROM (SELECT k, v FROM t_lwu ORDER BY k))
+     = (SELECT groupArray((k, v)) FROM (SELECT k, v FROM t_alter ORDER BY k));
+
+SELECT '-- lightweight_update_force';
+
+DROP TABLE IF EXISTS t_force SYNC;
+CREATE TABLE t_force (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_force SELECT number, number FROM numbers(24);
+
+DELETE FROM t_force WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update_force';
+ALTER TABLE t_force UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_force WHERE k = 1 SETTINGS lightweight_delete_mode = 'lightweight_update_force';
+ALTER TABLE t_force DELETE WHERE k = 2;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_force' AND NOT is_done;
+SELECT k, v FROM t_force ORDER BY k;
+
+SELECT '-- APPLY DELETED MASK and REWRITE PARTS reach the same code path';
+
+DROP TABLE IF EXISTS t_mask SYNC;
+CREATE TABLE t_mask (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_mask SELECT number, number FROM numbers(24);
+
+DELETE FROM t_mask WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_mask UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_mask WHERE k = 1 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_mask APPLY DELETED MASK;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_mask' AND NOT is_done;
+SELECT k, v FROM t_mask ORDER BY k;
+SELECT count() FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_mask' AND active
+  AND column = '_row_exists' AND name NOT LIKE 'patch%';
+
+DROP TABLE IF EXISTS t_rewrite SYNC;
+CREATE TABLE t_rewrite (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_rewrite SELECT number, number FROM numbers(24);
+
+DELETE FROM t_rewrite WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_rewrite UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_rewrite WHERE k = 1 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_rewrite REWRITE PARTS;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_rewrite' AND NOT is_done;
+SELECT k, v FROM t_rewrite ORDER BY k;
+
+SELECT '-- a partial update keeps the mask, so masked rows stay hidden';
+
+DROP TABLE IF EXISTS t_partial SYNC;
+CREATE TABLE t_partial (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_partial SELECT number, number FROM numbers(24);
+
+DELETE FROM t_partial WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_partial UPDATE v = v + 100 WHERE k % 2 = 1;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_partial' AND NOT is_done;
+SELECT k, v FROM t_partial ORDER BY k;
+SELECT count() > 0 FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_partial' AND active
+  AND column = '_row_exists' AND name NOT LIKE 'patch%';
+
+SELECT '-- a heavyweight DELETE matching no rows keeps the pending patch';
+
+DROP TABLE IF EXISTS t_noop SYNC;
+CREATE TABLE t_noop (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_noop SELECT number, number FROM numbers(24);
+
+DELETE FROM t_noop WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_noop DELETE WHERE 1 = 2;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_noop' AND NOT is_done;
+SELECT count(), countIf(k % 3 = 0) FROM t_noop;
+
+SELECT '-- compact parts';
+
+DROP TABLE IF EXISTS t_compact SYNC;
+CREATE TABLE t_compact (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = '10G', min_rows_for_wide_part = 1000000;
+INSERT INTO t_compact SELECT number, number FROM numbers(24);
+
+DELETE FROM t_compact WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_compact UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_compact WHERE k = 1 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_compact DELETE WHERE k = 2;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_compact' AND NOT is_done;
+SELECT k, v FROM t_compact ORDER BY k;
+
+SELECT '-- with a projection';
+
+DROP TABLE IF EXISTS t_proj SYNC;
+CREATE TABLE t_proj (k UInt64, v UInt64, PROJECTION p (SELECT v, count() GROUP BY v))
+ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0,
+         deduplicate_merge_projection_mode = 'rebuild', lightweight_mutation_projection_mode = 'rebuild';
+INSERT INTO t_proj SELECT number, number FROM numbers(24);
+
+DELETE FROM t_proj WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_proj UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_proj WHERE k = 1 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_proj DELETE WHERE k = 2;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_proj' AND NOT is_done;
+SELECT k, v FROM t_proj ORDER BY k;
+
+SELECT '-- ReplicatedMergeTree';
+
+DROP TABLE IF EXISTS t_repl SYNC;
+CREATE TABLE t_repl (k UInt64, v UInt64)
+ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_repl/', '1') PARTITION BY (k % 4) ORDER BY k
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_repl SELECT number, number FROM numbers(24);
+
+DELETE FROM t_repl WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_repl UPDATE v = v + 1 WHERE k = 1;
+DELETE FROM t_repl WHERE k = 1 SETTINGS lightweight_delete_mode = 'lightweight_update';
+ALTER TABLE t_repl DELETE WHERE k = 2;
+
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_repl' AND NOT is_done;
+SELECT k, v FROM t_repl ORDER BY k;
+
+DROP TABLE t_lwu SYNC;
+DROP TABLE t_alter SYNC;
+DROP TABLE t_force SYNC;
+DROP TABLE t_mask SYNC;
+DROP TABLE t_rewrite SYNC;
+DROP TABLE t_partial SYNC;
+DROP TABLE t_noop SYNC;
+DROP TABLE t_compact SYNC;
+DROP TABLE t_proj SYNC;
+DROP TABLE t_repl SYNC;

--- a/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.sql
+++ b/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.sql
@@ -13,7 +13,8 @@ SELECT '-- lightweight_update: heavyweight DELETE after a patch-mode lightweight
 
 DROP TABLE IF EXISTS t_lwu SYNC;
 CREATE TABLE t_lwu (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_lwu SELECT number, number FROM numbers(24);
 
 DELETE FROM t_lwu WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
@@ -31,7 +32,8 @@ SELECT '-- alter_update mode produces the same rows (oracle)';
 
 DROP TABLE IF EXISTS t_alter SYNC;
 CREATE TABLE t_alter (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_alter SELECT number, number FROM numbers(24);
 
 DELETE FROM t_alter WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'alter_update';
@@ -50,7 +52,8 @@ SELECT '-- lightweight_update_force';
 
 DROP TABLE IF EXISTS t_force SYNC;
 CREATE TABLE t_force (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_force SELECT number, number FROM numbers(24);
 
 DELETE FROM t_force WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update_force';
@@ -65,7 +68,8 @@ SELECT '-- APPLY DELETED MASK and REWRITE PARTS reach the same code path';
 
 DROP TABLE IF EXISTS t_mask SYNC;
 CREATE TABLE t_mask (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_mask SELECT number, number FROM numbers(24);
 
 DELETE FROM t_mask WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
@@ -81,7 +85,8 @@ WHERE database = currentDatabase() AND table = 't_mask' AND active
 
 DROP TABLE IF EXISTS t_rewrite SYNC;
 CREATE TABLE t_rewrite (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_rewrite SELECT number, number FROM numbers(24);
 
 DELETE FROM t_rewrite WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
@@ -96,7 +101,8 @@ SELECT '-- a partial update keeps the mask, so masked rows stay hidden';
 
 DROP TABLE IF EXISTS t_partial SYNC;
 CREATE TABLE t_partial (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_partial SELECT number, number FROM numbers(24);
 
 DELETE FROM t_partial WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
@@ -112,7 +118,8 @@ SELECT '-- a heavyweight DELETE matching no rows keeps the pending patch';
 
 DROP TABLE IF EXISTS t_noop SYNC;
 CREATE TABLE t_noop (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_noop SELECT number, number FROM numbers(24);
 
 DELETE FROM t_noop WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
@@ -126,7 +133,8 @@ SELECT '-- compact parts';
 DROP TABLE IF EXISTS t_compact SYNC;
 CREATE TABLE t_compact (k UInt64, v UInt64) ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
 SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
-         min_bytes_for_wide_part = '10G', min_rows_for_wide_part = 1000000;
+         min_bytes_for_wide_part = '10G', min_rows_for_wide_part = 1000000,
+         min_bytes_for_full_part_storage = 0;
 INSERT INTO t_compact SELECT number, number FROM numbers(24);
 
 DELETE FROM t_compact WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';
@@ -142,7 +150,8 @@ SELECT '-- with a projection';
 DROP TABLE IF EXISTS t_proj SYNC;
 CREATE TABLE t_proj (k UInt64, v UInt64, PROJECTION p (SELECT v, count() GROUP BY v))
 ENGINE = MergeTree PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0,
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0,
          deduplicate_merge_projection_mode = 'rebuild', lightweight_mutation_projection_mode = 'rebuild';
 INSERT INTO t_proj SELECT number, number FROM numbers(24);
 
@@ -159,7 +168,8 @@ SELECT '-- ReplicatedMergeTree';
 DROP TABLE IF EXISTS t_repl SYNC;
 CREATE TABLE t_repl (k UInt64, v UInt64)
 ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_repl/', '1') PARTITION BY (k % 4) ORDER BY k
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, min_bytes_for_wide_part = 0;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
 INSERT INTO t_repl SELECT number, number FROM numbers(24);
 
 DELETE FROM t_repl WHERE k % 3 = 0 SETTINGS lightweight_delete_mode = 'lightweight_update';

--- a/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.sql
+++ b/tests/queries/0_stateless/04798_mutation_row_exists_from_patch_part.sql
@@ -1,4 +1,7 @@
--- Tags: no-replicated-database
+-- Tags: no-replicated-database, long
+-- long: one run of this file goes past the flaky check's 180s per-run budget under ASan
+-- with S3 storage and metadata in Keeper, where every statement pays an object-storage
+-- round trip. Untagged, that budget fails the check outright rather than reporting a flake.
 -- no-replicated-database: fails due to additional shard.
 
 SET insert_keeper_fault_injection_probability = 0.0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115570
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `NOT_FOUND_COLUMN_IN_BLOCK` (`Not found column _row_exists in block`) that permanently blocked all further mutations of a `MergeTree` table after a lightweight `DELETE` run with `lightweight_delete_mode = 'lightweight_update'` was followed by a heavyweight `ALTER TABLE ... UPDATE` and then by another mutation rewriting all columns. Closes #115570.


### Description

Closes #115570.

A lightweight `DELETE` in patch mode supplies `_row_exists` from a patch part, not from the source part's own columns, so `MutateTask` synthesizes a `READ_COLUMN{read_for_patch = true}` command for it. For a mutation that rewrites all columns, `MutationsInterpreter` correctly omits the mask from its output header: that mutation applies the mask on read and physically drops the masked rows, so the new part must not carry a mask.

`getColumnsForNewDataPart` disagreed with it. Its `_row_exists` entry derived the answer from a command proxy, which is true for that synthetic command, so the mask was added to the new part's column list while the pipeline block did not contain it. The part writer enumerates the column list and looks each name up in the block, so it threw on the first write and the mutation was re-queued forever. Every later mutation queued behind it, leaving the table unmutable until `KILL MUTATION`.

`_row_exists` was the only entry in that loop asking a command proxy. Its siblings `_block_number` and `_block_offset` already ask the pipeline header, and two other sites in this file already treat the header as the mask authority, so I made `_row_exists` ask it too. The second disjunct is kept: it preserves an existing on-disk mask for a partial rewrite.

I validated by row-set equality against `lightweight_delete_mode = 'alter_update'`, the mode that does not wedge, rather than by the exception disappearing: same rows, same checksum, same per-part mask layout. A partial `ALTER UPDATE` still materializes the mask and hides the deleted rows, so no lightweight-deleted row is resurrected. All three commands that rewrite all columns (`DELETE`, `APPLY DELETED MASK`, `REWRITE PARTS`) reproduce and are fixed.

Not addressed here: a deterministically failing mutation is still re-queued indefinitely. That is a separate retry policy question, and fixing the exception removes the wedge.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115665&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115665](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115665+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.251` (included in `26.10` and later)
<!-- ch-version-info:end -->