### PR TITLE
Fix PromQL query_range step validation for equal start and end

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/NodeEvaluationRangeGetter.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/NodeEvaluationRangeGetter.cpp
@@ -69,7 +69,9 @@ NodeEvaluationRangeGetter::NodeEvaluationRangeGetter(std::shared_ptr<const Prome
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "end_time is not specified");
         if (*settings_.start_time > *settings_.end_time)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "start_time must not be greater than end_time");
-        if (*settings_.start_time < *settings_.end_time)
+        const bool has_range = *settings_.start_time < *settings_.end_time;
+        const bool is_query_range = settings_.mode == PrometheusQueryEvaluationMode::QUERY_RANGE;
+        if (has_range || is_query_range)
         {
             if (!settings_.step)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "step is not specified");
@@ -78,7 +80,7 @@ NodeEvaluationRangeGetter::NodeEvaluationRangeGetter(std::shared_ptr<const Prome
         }
         range.start_time = *settings_.start_time;
         range.end_time = *settings_.end_time;
-        range.step = (*settings_.start_time < *settings_.end_time) ? *settings_.step : DurationType{0};
+        range.step = (has_range || is_query_range) ? *settings_.step : DurationType{0};
     }
 
     query_start_time = range.start_time;

--- a/tests/integration/test_prometheus_protocols/test_query_api.py
+++ b/tests/integration/test_prometheus_protocols/test_query_api.py
@@ -130,6 +130,34 @@ def test_range_query_post_urlencoded():
     assert get_data == post_data
 
 
+def test_range_query_rejects_non_positive_step_for_equal_start_and_end():
+    for step in (0, -1):
+        error = execute_range_query_via_http_api(
+            node.ip_address,
+            9093,
+            "/api/v1/query_range",
+            "vector(1)",
+            10,
+            10,
+            step,
+            expect_error=True,
+        )
+        assert "step must be positive" in error
+
+
+def test_range_query_accepts_positive_step_for_equal_start_and_end():
+    result = execute_range_query_via_http_api(
+        node.ip_address,
+        9093,
+        "/api/v1/query_range",
+        "post_body_metric",
+        1000,
+        1000,
+        1,
+    )
+    assert result == '{"resultType": "matrix", "result": [{"metric": {"__name__": "post_body_metric", "job": "test"}, "values": [[1000, "1"]]}]}'
+
+
 def test_query_lookback_delta():
     query = 'foo{shape="circle"}'
     timestamp = 151


### PR DESCRIPTION
### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Reject zero and negative `step` values in one-point Prometheus range queries.**

### Summary

Prometheus rejects zero and negative query resolution steps for `/api/v1/query_range`, including requests where `start == end`.

ClickHouse currently skips step validation when the timestamps are equal. This means a request such as:

`query=vector(1)&start=10&end=10&step=0`

can return a successful one-point matrix instead of an error.

This change validates `step` for `QUERY_RANGE` independently of the timestamp range. Instant queries keep their internal `step=0` behavior.

### Why this matters

Prometheus-compatible clients expect the same validation for one-point range queries. Returning a successful result for an invalid request can hide client-side errors.

### Tests

- Add HTTP integration coverage for `step=0` and `step=-1` when `start == end`.
- Keep coverage for a valid positive-step one-point range.
- Validate the changed C++ translation unit and Python test syntax.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115679&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115679](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115679+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1948` (included in `26.8` and later)
<!-- ch-version-info:end -->