### PR TITLE
Fix PromQL timestamp and duration overflow at Int64 boundary

### DIFF
--- a/src/Parsers/Prometheus/parseTimeSeriesTypes.cpp
+++ b/src/Parsers/Prometheus/parseTimeSeriesTypes.cpp
@@ -56,7 +56,7 @@ namespace
                             float_value, getTypeName<T>());
         }
         Float64 scaled_value = float_value * static_cast<Float64>(DecimalUtils::scaleMultiplier<T>(scale));
-        if ((scaled_value > static_cast<Float64>(std::numeric_limits<typename T::NativeType>::max())) ||
+        if ((scaled_value >= static_cast<Float64>(std::numeric_limits<typename T::NativeType>::max())) ||
             (scaled_value < static_cast<Float64>(std::numeric_limits<typename T::NativeType>::min())))
         {
             throw Exception(ErrorCodes::DECIMAL_OVERFLOW,

--- a/tests/queries/0_stateless/04337_prometheus_query_nan_timestamp.sql
+++ b/tests/queries/0_stateless/04337_prometheus_query_nan_timestamp.sql
@@ -45,9 +45,12 @@ SELECT timestamp, value FROM prometheusQuery('ts_ns', '1 + 2', inf); -- { server
 SELECT timestamp, value FROM prometheusQuery('ts_ns', '1 + 2', -inf); -- { serverError BAD_ARGUMENTS }
 SELECT timestamp, value FROM prometheusQuery('ts_ns', '1 + 2', 0. / 0.); -- { serverError BAD_ARGUMENTS }
 
+SELECT timestamp, value FROM prometheusQuery('ts_ns', '1 + 2', toFloat64(9223372036.854776)); -- { serverError DECIMAL_OVERFLOW }
+
 -- Duration path: getFromFloat<Decimal64> (the step argument of prometheusQueryRange).
 SELECT timestamp, value FROM prometheusQueryRange('ts_ns', '1 + 2', 1000, 2000, nan); -- { serverError BAD_ARGUMENTS }
 SELECT timestamp, value FROM prometheusQueryRange('ts_ns', '1 + 2', 1000, 2000, inf); -- { serverError BAD_ARGUMENTS }
+SELECT timestamp, value FROM prometheusQueryRange('ts_ns', '1 + 2', 1000, 2000, toFloat64(9223372036.854776)); -- { serverError DECIMAL_OVERFLOW }
 
 -- A finite float timestamp still works (sanity: the guard does not reject valid input).
 SELECT timestamp, value FROM prometheusQuery('ts_ns', '1 + 2', 1704067200.0);


### PR DESCRIPTION
### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
**Reject PromQL timestamps and durations that exceed the Int64 range.**

### Summary

PromQL timestamps and durations can be passed as floating-point values. ClickHouse scales them and converts them to Int64.

`INT64_MAX` is rounded to `2^63` when represented as `Float64`. The previous upper-bound check used `>` and allowed that value to reach the conversion even though `2^63` is outside the Int64 range. Converting it to Int64 is undefined behavior.

The upper-bound check now rejects equality as well.

### Tests

- Add a timestamp regression for the finite floating-point boundary.
- Add a duration regression for the same boundary.
- Compile the changed C++ translation unit.
- Run `git diff --check`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115682&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115682](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115682+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
