### PR TITLE
Prune the unasked-for right keys of a multi-disjunct join under the old analyzer too

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -135,13 +135,10 @@ static HashJoin::Type mergeJoinMethods(HashJoin::Type lhs, HashJoin::Type rhs)
 }
 
 /// The right columns a join with several disjuncts adds to the result. Every right key is read to build
-/// the maps, but only the keys the query asks for belong in the result; the analyzer is what says which
-/// those are, so without it every key is kept, as before.
+/// the maps, but only the keys the query asks for belong in the result; `requiredRightKeys` says which
+/// those are - the planner fills it in `setUsedColumns`, `TreeRewriter` in `addJoinedColumn`.
 static Block rightColumnsToAddWithSeveralDisjuncts(const TableJoin & table_join, const Block & right_columns)
 {
-    if (!table_join.enableAnalyzer())
-        return right_columns;
-
     NameSet key_names;
     for (const auto & clause : table_join.getClauses())
         key_names.insert(clause.key_names_right.begin(), clause.key_names_right.end());


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/115465, which stopped a join with several
disjuncts (`... ON a = b OR c = d`) from adding right key columns the query does not ask for. That
pruning was gated on `enableAnalyzer()`, out of caution about a path I had not measured, so on the
legacy planner every right key is still added.

`TableJoin::requiredRightKeys` works on both paths: the planner fills `columns_added_by_join` through
`setUsedColumns`, and `TreeRewriter::collectJoinedColumns` fills it through `addJoinedColumn`. So the
gate can go.

It matters beyond the columns themselves: the key-only join hash tables of
https://github.com/ClickHouse/ClickHouse/pull/115301 are chosen for `LEFT SEMI` only when the join
produces no right value at all, so with `enable_analyzer = 0` a query like
`SELECT count() FROM l SEMI LEFT JOIN r ON l.k = r.k OR l.s = r.s` would stay on the mapped tables
while the same query on the analyzer gets the key-only ones. With this change it gets them on both.

Checked against a build of the parent commit, all with `enable_analyzer = 0`:

- seven `OR` join shapes - `ALL`/`SEMI`/`ANTI`, `LEFT`/`RIGHT`/`FULL`, with and without a right key or
  a payload column selected - return the same results as with the analyzer;
- `05023_join_several_disjuncts_right_keys` passes;
- the `join` tests have the same six reference mismatches as the parent commit, all of them tests that
  read differently on the legacy planner (`00826_cross_to_inner_join`, `01115_join_with_dictionary`,
  `02220_array_join_format`, `02784_parallel_replicas_automatic_decision_join`,
  `04653_distributed_plan_auto_rewrite_in_to_join`, `04670_any_join_take_last_row_no_swap`).

Related: https://github.com/ClickHouse/ClickHouse/pull/115465
Related: https://github.com/ClickHouse/ClickHouse/pull/115301

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115684&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115684](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115684+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
