### PR TITLE
Perf: fuse TimeSeries tag extraction and NULL map

### DIFF
--- a/src/Functions/TimeSeries/timeSeriesExtractTag.cpp
+++ b/src/Functions/TimeSeries/timeSeriesExtractTag.cpp
@@ -68,13 +68,10 @@ public:
         auto tag_to_extract = TimeSeriesTagsFunctionHelpers::extractConstTagNameFromArgument(name, arguments, 1);
 
         auto tag_values = ColumnString::create();
-        tags_collector->extractTag(groups, tag_to_extract, *tag_values);
-        chassert(tag_values->size() == input_rows_count);
-
         auto null_map = ColumnUInt8::create();
-        null_map->reserve(input_rows_count);
-        for (size_t i = 0; i != input_rows_count; ++i)
-            null_map->insertValue(tag_values->getDataAt(i).empty());
+        tags_collector->extractTag(groups, tag_to_extract, *tag_values, null_map->getData());
+        chassert(tag_values->size() == input_rows_count);
+        chassert(null_map->size() == input_rows_count);
 
         return ColumnNullable::create(std::move(tag_values), std::move(null_map));
     }

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1116,13 +1116,16 @@ void ContextTimeSeriesTagsCollector::extractTag(
             if (tag_name == tag_to_extract)
             {
                 out_column.insertData(tag_value.data(), tag_value.size());
+                null_map[i] = tag_value.empty();
                 found = true;
                 break;
             }
         }
         if (!found)
+        {
             out_column.insertDefault();
-        null_map[i] = !found;
+            null_map[i] = 1;
+        }
     }
 }
 

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.cpp
@@ -1095,12 +1095,18 @@ VectorWithMemoryTracking<String> ContextTimeSeriesTagsCollector::extractTag(cons
     return res;
 }
 
-void ContextTimeSeriesTagsCollector::extractTag(const VectorWithMemoryTracking<Group> & groups_, const String & tag_to_extract, ColumnString & out_column) const
+void ContextTimeSeriesTagsCollector::extractTag(
+    const VectorWithMemoryTracking<Group> & groups_,
+    const String & tag_to_extract,
+    ColumnString & out_column,
+    PaddedPODArray<UInt8> & null_map) const
 {
     out_column.reserve(groups_.size());
+    null_map.resize(groups_.size());
     SharedLockGuard lock{mutex};
-    for (Group group : groups_)
+    for (size_t i = 0; i != groups_.size(); ++i)
     {
+        Group group = groups_[i];
         if (group >= groups.size())
             throwGroupOutOfBound(group, groups.size());
         const auto & tags = *groups[group];
@@ -1116,6 +1122,7 @@ void ContextTimeSeriesTagsCollector::extractTag(const VectorWithMemoryTracking<G
         }
         if (!found)
             out_column.insertDefault();
+        null_map[i] = !found;
     }
 }
 

--- a/src/Interpreters/ContextTimeSeriesTagsCollector.h
+++ b/src/Interpreters/ContextTimeSeriesTagsCollector.h
@@ -86,7 +86,12 @@ public:
     /// Extracts the value of a specified tag, or an empty string if there is no such tag in the group.
     String extractTag(Group group, const String & tag_to_extract) const;
     VectorWithMemoryTracking<String> extractTag(const VectorWithMemoryTracking<Group> & groups_, const String & tag_to_extract) const;
-    void extractTag(const VectorWithMemoryTracking<Group> & groups_, const String & tag_to_extract, ColumnString & out_column) const;
+    /// Fills `null_map` with 1 for groups without the specified tag.
+    void extractTag(
+        const VectorWithMemoryTracking<Group> & groups_,
+        const String & tag_to_extract,
+        ColumnString & out_column,
+        PaddedPODArray<UInt8> & null_map) const;
 
     /// Fills `res` with the groups assigned to the sets of tags which were added to the collector
     /// with identifiers from a column. Throws an exception if some identifier is unknown.

--- a/tests/performance/timeseries_extract_tag.xml
+++ b/tests/performance/timeseries_extract_tag.xml
@@ -1,8 +1,8 @@
 <test>
     <!--
-        Benchmark extracting an absent tag from groups with 16 tags.
-        Keep group setup small and repeat the groups over many rows so the
-        tag lookup and output NULL-map construction dominate the query.
+        Benchmark extracting an early-hit, late-hit, and missing tag from
+        groups with 16 tags. Keep group setup small and repeat the groups over
+        many rows so tag lookup and NULL-map construction dominate the query.
     -->
     <query>
         WITH
@@ -33,7 +33,9 @@
                     ORDER BY number
                 )
             ) AS groups
-        SELECT timeSeriesExtractTag(groups[number % 4096 + 1], 'missing')
+        SELECT timeSeriesExtractTag(groups[number % 4096 + 1], 'tag00'),
+               timeSeriesExtractTag(groups[number % 4096 + 1], 'tag15'),
+               timeSeriesExtractTag(groups[number % 4096 + 1], 'missing')
         FROM numbers(20000000)
         SETTINGS max_threads = 1, max_block_size = 1000000
         FORMAT Null

--- a/tests/performance/timeseries_extract_tag.xml
+++ b/tests/performance/timeseries_extract_tag.xml
@@ -1,0 +1,41 @@
+<test>
+    <!--
+        Benchmark extracting an absent tag from groups with 16 tags.
+        Keep group setup small and repeat the groups over many rows so the
+        tag lookup and output NULL-map construction dominate the query.
+    -->
+    <query>
+        WITH
+            (
+                SELECT groupArray(group)
+                FROM
+                (
+                    SELECT number,
+                           timeSeriesTagsToGroup([
+                               ('tag00', toString(number)),
+                               ('tag01', 'value'),
+                               ('tag02', 'value'),
+                               ('tag03', 'value'),
+                               ('tag04', 'value'),
+                               ('tag05', 'value'),
+                               ('tag06', 'value'),
+                               ('tag07', 'value'),
+                               ('tag08', 'value'),
+                               ('tag09', 'value'),
+                               ('tag10', 'value'),
+                               ('tag11', 'value'),
+                               ('tag12', 'value'),
+                               ('tag13', 'value'),
+                               ('tag14', 'value'),
+                               ('tag15', 'value')
+                           ]) AS group
+                    FROM numbers(4096)
+                    ORDER BY number
+                )
+            ) AS groups
+        SELECT timeSeriesExtractTag(groups[number % 4096 + 1], 'missing')
+        FROM numbers(20000000)
+        SETTINGS max_threads = 1, max_block_size = 1000000
+        FORMAT Null
+    </query>
+</test>

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.reference
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.reference
@@ -7,6 +7,9 @@ timeSeriesStoreTags:
 timeSeriesExtractTag:
 1	http_requests_count	dev	\N	1	1
 
+timeSeriesExtractTag mixed rows:
+2	2	2
+
 timeSeriesCopyTag:
 [('__name__','http_codes'),('env','dev'),('region','eu')]	[('__name__','http_codes'),('code','404'),('env','dev'),('region','eu')]	1	1	[('__name__','http_codes'),('code','404'),('region','eu')]
 

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.reference
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.reference
@@ -5,7 +5,7 @@ timeSeriesStoreTags:
 1	1	1	1	1	1	1	1	1	1	[('__name__','http_requests'),('env','dev'),('region','eu')]	[('__name__','http_request_by_region'),('region','us')]	[('__name__','http_request_by_region'),('region','us')]	[('__name__','http_requests_total')]	[('__name__','http_requests_total')]	[('__name__','http_requests_total')]	[]	1	1	1	1	1	1	1	1	1	1
 
 timeSeriesExtractTag:
-1	http_requests_count	dev	\N
+1	http_requests_count	dev	\N	1	1
 
 timeSeriesCopyTag:
 [('__name__','http_codes'),('env','dev'),('region','eu')]	[('__name__','http_codes'),('code','404'),('env','dev'),('region','eu')]	1	1	[('__name__','http_codes'),('code','404'),('region','eu')]

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -79,6 +79,32 @@ SELECT timeSeriesTagsToGroup([('region', 'eu'), ('env', 'dev')], '__name__', 'ht
        isNull(timeSeriesExtractTag(group, 'instance'));
 
 SELECT '';
+SELECT 'timeSeriesExtractTag mixed rows:';
+
+WITH
+    (
+        SELECT groupArray(group)
+        FROM
+        (
+            SELECT number,
+                   if(number % 2 = 0,
+                      timeSeriesTagsToGroup([('env', 'dev')]),
+                      timeSeriesTagsToGroup([])) AS group
+            FROM numbers(4)
+            ORDER BY number
+        )
+    ) AS groups
+SELECT countIf(isNull(value)),
+       countIf(isNull(value) AND number % 2 = 1),
+       countIf(isNotNull(value) AND number % 2 = 0)
+FROM
+(
+    SELECT number,
+           timeSeriesExtractTag(groups[number + 1], 'env') AS value
+    FROM numbers(4)
+);
+
+SELECT '';
 SELECT 'timeSeriesCopyTag:';
 
 SELECT timeSeriesGroupToTags(group1),

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -74,7 +74,9 @@ SELECT 'timeSeriesExtractTag:';
 SELECT timeSeriesTagsToGroup([('region', 'eu'), ('env', 'dev')], '__name__', 'http_requests_count') AS group,
        timeSeriesExtractTag(group, '__name__'),
        timeSeriesExtractTag(group, 'env'),
-       timeSeriesExtractTag(group, 'instance');
+       timeSeriesExtractTag(group, 'instance'),
+       isNotNull(timeSeriesExtractTag(group, '__name__')),
+       isNull(timeSeriesExtractTag(group, 'instance'));
 
 SELECT '';
 SELECT 'timeSeriesCopyTag:';

--- a/tests/queries/0_stateless/05024_time_series_extract_tag_empty_input.reference
+++ b/tests/queries/0_stateless/05024_time_series_extract_tag_empty_input.reference
@@ -1,0 +1,1 @@
+timeSeriesExtractTag empty input:

--- a/tests/queries/0_stateless/05024_time_series_extract_tag_empty_input.sql
+++ b/tests/queries/0_stateless/05024_time_series_extract_tag_empty_input.sql
@@ -1,0 +1,4 @@
+SELECT 'timeSeriesExtractTag empty input:';
+
+SELECT timeSeriesExtractTag(number, 'env')
+FROM numbers(0);


### PR DESCRIPTION
### TL;DR

Fuse `timeSeriesExtractTag` value extraction and NULL-map construction into one pass.

The old path built the `ColumnString`, scanned every output again with `getDataAt(i).empty()`, and then inserted the NULL bits in a separate loop. The new path writes the value and its NULL bit together.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fuse TimeSeries extracted-tag value and NULL-map construction into one pass.

### Summary

`timeSeriesExtractTag` returns `Nullable(String)`. The collector already knows whether the requested tag was found and whether its value is empty, so it now fills the final `ColumnString` and NULL map in the same pass.

- Removes the second output scan.
- Removes the separate NULL-map insertion loop.
- Keeps the existing `Nullable(String)` result.
- Keeps the existing behavior for missing tags and empty values.

### Why this is safe

- Group validation and the shared lock are unchanged.
- Present tags use the same empty-value check as before.
- Missing tags still write an empty string and a NULL bit.
- The mixed-row test checks that NULL bits stay aligned with the output rows.

### Benchmark

Focused local C++ microbenchmark on arm64 macOS with Homebrew Clang 21. It uses 20M rows, 4,096 groups, 16 tags per group, one thread, and the median of 7 runs. It mirrors the collector and output loops used by the performance fixture.

| Lookup | Old two-pass | New fused | Speedup |
| --- | ---: | ---: | ---: |
| `tag00` | 123.195 ms | 108.002 ms | 1.14x |
| `tag15` | 944.334 ms | 934.782 ms | 1.01x |
| Missing tag | 190.328 ms | 175.978 ms | 1.08x |

Checksums matched for every lookup.

### Tests

- Extend `03779_time_series_tags_functions` with present-tag and missing-tag NULL checks.
- Add mixed-row coverage for NULL-map alignment.
- Add `tests/performance/timeseries_extract_tag.xml`.
- Compile the changed translation units with the existing Release compile commands.
- Run `git diff --check` and validate the benchmark XML.

Related to [#115656](https://github.com/ClickHouse/ClickHouse/pull/115656). That PR fuses tag-name and tag-value extraction for `timeSeriesTagsToGroup`; this PR fuses extracted values with NULL-map construction for `timeSeriesExtractTag`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115687&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115687](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115687+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
