### PR TITLE
Support asynchronous inserts in the Prometheus remote-write protocol

### DIFF
--- a/docs/concepts/features/interfaces/prometheus.mdx
+++ b/docs/concepts/features/interfaces/prometheus.mdx
@@ -162,6 +162,15 @@ remote_write:
 
 Prometheus sends samples to the `prometheus.metrics` table.
 
+To batch data from many concurrent remote-write requests into fewer parts, enable [asynchronous inserts](/reference/settings/session-settings/async-insert#async_insert) by adding the `async_insert` setting to the URL (or by enabling it in the user profile):
+
+```yaml
+remote_write:
+  - url: https://clickhouse.example.com:8443/prometheus/api/v1/write?database=prometheus&table=metrics&async_insert=1
+```
+
+ClickHouse acknowledges an asynchronous remote-write request only after the data is flushed to all inner tables of the `TimeSeries` table, regardless of the [`wait_for_async_insert`](/reference/settings/session-settings/wait-for#wait_for_async_insert) setting: the remote-write protocol treats an acknowledged write as durable. If the flush fails, the request returns an error and Prometheus retries it.
+
 ### Query with PromQL {#promql-query-support}
 
 Use the instant-query endpoint to evaluate a PromQL expression at one point in time:

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -260,7 +260,10 @@ void insertBlockSync(ASTPtr insert_query, Block block, const ContextMutablePtr &
 void insertBlockAsync(ASTPtr insert_query, Block block, AsynchronousInsertQueue & queue, const ContextMutablePtr & context)
 {
     /// Deduplication on flush is not needed here: a flushed block combines data from multiple
-    /// remote-write requests, and the inner tables of the TimeSeries engine handle duplicates themselves.
+    /// remote-write requests (so its hash is different on every retry anyway), and the inner tables
+    /// of the TimeSeries engine handle duplicates themselves.
+    /// `deduplicate_insert` overrides `async_insert_deduplicate`, so both must be disabled.
+    context->setSetting("deduplicate_insert", String{"disable"});
     context->setSetting("async_insert_deduplicate", false);
 
     auto result = queue.pushQueryWithBlock(std::move(insert_query), std::move(block), context);

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -250,12 +250,6 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
     auto * queue = context->tryGetAsynchronousInsertQueue();
     const bool async_insert = queue && context->getSettingsRef()[Setting::async_insert];
 
-    if (async_insert)
-    {
-        context->setSetting("deduplicate_insert", String{"disable"});
-        context->setSetting("async_insert_deduplicate", false);
-    }
-
     auto [ast, io] = executeQuery(insert_query->formatWithSecretsOneLine(), context);
     try
     {

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -13,8 +13,10 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <IO/Progress.h>
 #include <Interpreters/AsynchronousInsertQueue.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Interpreters/executeQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTIdentifier.h>
@@ -26,7 +28,6 @@
 #include <Storages/TimeSeries/splitTimeSeriesType.h>
 
 #include <chrono>
-#include <tuple>
 
 
 namespace DB
@@ -265,7 +266,12 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
             if (result.future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::timeout)
                 throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
 
-            std::ignore = result.future.get();
+            const auto progress = result.future.get();
+            if (auto process_list_element = context->getProcessListElement())
+            {
+                process_list_element->updateProgressIn(Progress(ReadProgress(progress.rows, progress.bytes)));
+                process_list_element->updateProgressOut(Progress(WriteProgress(progress.rows, progress.bytes)));
+            }
         }
         else
         {

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -9,9 +9,11 @@
 #include <Columns/ColumnTuple.h>
 #include <Common/logger_useful.h>
 #include <Core/DecimalFunctions.h>
+#include <Core/Settings.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <Interpreters/AsynchronousInsertQueue.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/executeQuery.h>
 #include <Parsers/ASTExpressionList.h>
@@ -23,14 +25,25 @@
 #include <Storages/TimeSeries/TimeSeriesTagNames.h>
 #include <Storages/TimeSeries/splitTimeSeriesType.h>
 
+#include <chrono>
+#include <tuple>
+
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsBool async_insert;
+    extern const SettingsSeconds wait_for_async_insert_timeout;
+}
 
 namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TIME_SERIES_TAGS;
+    extern const int LOGICAL_ERROR;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -220,20 +233,8 @@ Block makeBlock(
     return block;
 }
 
-void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutablePtr & context)
+void insertBlockSync(ASTPtr insert_query, Block block, const ContextMutablePtr & context)
 {
-    if (!block.rows())
-        return;
-
-    auto insert_query = make_intrusive<ASTInsertQuery>();
-    insert_query->table_id = storage.getStorageID();
-    insert_query->format = "Native";
-
-    auto columns_ast = make_intrusive<ASTExpressionList>();
-    for (const auto & name : block.getNames())
-        columns_ast->children.emplace_back(make_intrusive<ASTIdentifier>(name));
-    insert_query->columns = columns_ast;
-
     auto [ast, io] = executeQuery(insert_query->formatWithSecretsOneLine(), context);
     try
     {
@@ -249,6 +250,50 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
     }
 
     finishExecutedQuery(io, {});
+}
+
+/// Inserts a block through the asynchronous insert queue so that data from multiple remote-write
+/// requests is batched together before forming parts. Waits until the data is flushed to all inner
+/// tables of the TimeSeries table regardless of the `wait_for_async_insert` setting: the remote-write
+/// protocol treats an acknowledged write as durable, so we can acknowledge only after the flush.
+/// If the flush fails, the exception is rethrown here and the client gets an error instead of an ack.
+void insertBlockAsync(ASTPtr insert_query, Block block, AsynchronousInsertQueue & queue, const ContextMutablePtr & context)
+{
+    /// Deduplication on flush is not needed here: a flushed block combines data from multiple
+    /// remote-write requests, and the inner tables of the TimeSeries engine handle duplicates themselves.
+    context->setSetting("async_insert_deduplicate", false);
+
+    auto result = queue.pushQueryWithBlock(std::move(insert_query), std::move(block), context);
+    if (result.status != AsynchronousInsertQueue::PushResult::OK)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected result of pushing a block to the asynchronous insert queue");
+
+    const auto timeout_ms = context->getSettingsRef()[Setting::wait_for_async_insert_timeout].totalMilliseconds();
+    if (result.future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::timeout)
+        throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
+
+    /// Rethrows the exception if the flush failed.
+    std::ignore = result.future.get();
+}
+
+void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutablePtr & context)
+{
+    if (!block.rows())
+        return;
+
+    auto insert_query = make_intrusive<ASTInsertQuery>();
+    insert_query->table_id = storage.getStorageID();
+    insert_query->format = "Native";
+
+    auto columns_ast = make_intrusive<ASTExpressionList>();
+    for (const auto & name : block.getNames())
+        columns_ast->children.emplace_back(make_intrusive<ASTIdentifier>(name));
+    insert_query->columns = columns_ast;
+
+    auto * queue = context->tryGetAsynchronousInsertQueue();
+    if (queue && context->getSettingsRef()[Setting::async_insert])
+        insertBlockAsync(std::move(insert_query), std::move(block), *queue, context);
+    else
+        insertBlockSync(std::move(insert_query), std::move(block), context);
 }
 
 }

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -233,51 +233,6 @@ Block makeBlock(
     return block;
 }
 
-void insertBlockSync(ASTPtr insert_query, Block block, const ContextMutablePtr & context)
-{
-    auto [ast, io] = executeQuery(insert_query->formatWithSecretsOneLine(), context);
-    try
-    {
-        PushingPipelineExecutor executor(io.pipeline);
-        executor.start();
-        executor.push(std::move(block));
-        executor.finish();
-    }
-    catch (...)
-    {
-        io.onException();
-        throw;
-    }
-
-    finishExecutedQuery(io, {});
-}
-
-/// Inserts a block through the asynchronous insert queue so that data from multiple remote-write
-/// requests is batched together before forming parts. Waits until the data is flushed to all inner
-/// tables of the TimeSeries table regardless of the `wait_for_async_insert` setting: the remote-write
-/// protocol treats an acknowledged write as durable, so we can acknowledge only after the flush.
-/// If the flush fails, the exception is rethrown here and the client gets an error instead of an ack.
-void insertBlockAsync(ASTPtr insert_query, Block block, AsynchronousInsertQueue & queue, const ContextMutablePtr & context)
-{
-    /// Deduplication on flush is not needed here: a flushed block combines data from multiple
-    /// remote-write requests (so its hash is different on every retry anyway), and the inner tables
-    /// of the TimeSeries engine handle duplicates themselves.
-    /// `deduplicate_insert` overrides `async_insert_deduplicate`, so both must be disabled.
-    context->setSetting("deduplicate_insert", String{"disable"});
-    context->setSetting("async_insert_deduplicate", false);
-
-    auto result = queue.pushQueryWithBlock(std::move(insert_query), std::move(block), context);
-    if (result.status != AsynchronousInsertQueue::PushResult::OK)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected result of pushing a block to the asynchronous insert queue");
-
-    const auto timeout_ms = context->getSettingsRef()[Setting::wait_for_async_insert_timeout].totalMilliseconds();
-    if (result.future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::timeout)
-        throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
-
-    /// Rethrows the exception if the flush failed.
-    std::ignore = result.future.get();
-}
-
 void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutablePtr & context)
 {
     if (!block.rows())
@@ -292,11 +247,64 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
         columns_ast->children.emplace_back(make_intrusive<ASTIdentifier>(name));
     insert_query->columns = columns_ast;
 
+    /// With the `async_insert` setting, the block goes through the asynchronous insert queue, so that
+    /// data from multiple remote-write requests is batched together before forming parts.
     auto * queue = context->tryGetAsynchronousInsertQueue();
-    if (queue && context->getSettingsRef()[Setting::async_insert])
-        insertBlockAsync(std::move(insert_query), std::move(block), *queue, context);
-    else
-        insertBlockSync(std::move(insert_query), std::move(block), context);
+    const bool async_insert = queue && context->getSettingsRef()[Setting::async_insert];
+
+    if (async_insert)
+    {
+        /// Deduplication on flush is not needed here: a flushed block combines data from multiple
+        /// remote-write requests (so its hash is different on every retry anyway), and the inner tables
+        /// of the TimeSeries engine handle duplicates themselves.
+        /// `deduplicate_insert` overrides `async_insert_deduplicate`, so both must be disabled.
+        context->setSetting("deduplicate_insert", String{"disable"});
+        context->setSetting("async_insert_deduplicate", false);
+    }
+
+    /// `executeQuery` is needed on the asynchronous path too: it registers the query in the process list
+    /// and attaches the current thread to the query, so the entry pushed to the queue captures the user
+    /// memory tracker of the current thread (the queue requires it and aborts in debug and sanitizer
+    /// builds otherwise), and the query gets its own query_log record and quota accounting.
+    auto [ast, io] = executeQuery(insert_query->formatWithSecretsOneLine(), context);
+    try
+    {
+        if (async_insert)
+        {
+            auto result = queue->pushQueryWithBlock(ast, std::move(block), context);
+            if (result.status != AsynchronousInsertQueue::PushResult::OK)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected result of pushing a block to the asynchronous insert queue");
+
+            /// The pipeline built by `executeQuery` is not needed: the flush of the queue inserts the data
+            /// itself. Reset it before waiting for the flush because it holds locks for the target tables.
+            io.resetPipeline(/*cancel=*/ true);
+
+            /// Wait until the data is flushed to all inner tables of the TimeSeries table regardless of
+            /// the `wait_for_async_insert` setting: the remote-write protocol treats an acknowledged write
+            /// as durable, so we can acknowledge only after the flush. If the flush fails, the exception
+            /// is rethrown here and the client gets an error instead of an ack.
+            const auto timeout_ms = context->getSettingsRef()[Setting::wait_for_async_insert_timeout].totalMilliseconds();
+            if (result.future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::timeout)
+                throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
+
+            /// Rethrows the exception if the flush failed.
+            std::ignore = result.future.get();
+        }
+        else
+        {
+            PushingPipelineExecutor executor(io.pipeline);
+            executor.start();
+            executor.push(std::move(block));
+            executor.finish();
+        }
+    }
+    catch (...)
+    {
+        io.onException();
+        throw;
+    }
+
+    finishExecutedQuery(io, {});
 }
 
 }

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -247,25 +247,15 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
         columns_ast->children.emplace_back(make_intrusive<ASTIdentifier>(name));
     insert_query->columns = columns_ast;
 
-    /// With the `async_insert` setting, the block goes through the asynchronous insert queue, so that
-    /// data from multiple remote-write requests is batched together before forming parts.
     auto * queue = context->tryGetAsynchronousInsertQueue();
     const bool async_insert = queue && context->getSettingsRef()[Setting::async_insert];
 
     if (async_insert)
     {
-        /// Deduplication on flush is not needed here: a flushed block combines data from multiple
-        /// remote-write requests (so its hash is different on every retry anyway), and the inner tables
-        /// of the TimeSeries engine handle duplicates themselves.
-        /// `deduplicate_insert` overrides `async_insert_deduplicate`, so both must be disabled.
         context->setSetting("deduplicate_insert", String{"disable"});
         context->setSetting("async_insert_deduplicate", false);
     }
 
-    /// `executeQuery` is needed on the asynchronous path too: it registers the query in the process list
-    /// and attaches the current thread to the query, so the entry pushed to the queue captures the user
-    /// memory tracker of the current thread (the queue requires it and aborts in debug and sanitizer
-    /// builds otherwise), and the query gets its own query_log record and quota accounting.
     auto [ast, io] = executeQuery(insert_query->formatWithSecretsOneLine(), context);
     try
     {
@@ -275,19 +265,12 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
             if (result.status != AsynchronousInsertQueue::PushResult::OK)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected result of pushing a block to the asynchronous insert queue");
 
-            /// The pipeline built by `executeQuery` is not needed: the flush of the queue inserts the data
-            /// itself. Reset it before waiting for the flush because it holds locks for the target tables.
             io.resetPipeline(/*cancel=*/ true);
 
-            /// Wait until the data is flushed to all inner tables of the TimeSeries table regardless of
-            /// the `wait_for_async_insert` setting: the remote-write protocol treats an acknowledged write
-            /// as durable, so we can acknowledge only after the flush. If the flush fails, the exception
-            /// is rethrown here and the client gets an error instead of an ack.
             const auto timeout_ms = context->getSettingsRef()[Setting::wait_for_async_insert_timeout].totalMilliseconds();
             if (result.future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::timeout)
                 throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
 
-            /// Rethrows the exception if the flush failed.
             std::ignore = result.future.get();
         }
         else

--- a/tests/integration/test_prometheus_protocols/test_async_insert.py
+++ b/tests/integration/test_prometheus_protocols/test_async_insert.py
@@ -1,0 +1,115 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from .prometheus_test_utils import (
+    convert_metrics_metadata_to_protobuf,
+    convert_time_series_to_protobuf,
+    get_response_to_remote_write,
+    send_protobuf_to_remote_write,
+)
+
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=["configs/allow_experimental_time_series_table.xml"],
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    try:
+        yield
+    finally:
+        node.query("DROP TABLE IF EXISTS prometheus SYNC")
+        node.query("DROP TABLE IF EXISTS samples SYNC")
+
+
+def get_async_insert_query_count():
+    return int(
+        node.query(
+            "SELECT sum(value) FROM system.events WHERE event = 'AsyncInsertQuery'"
+        )
+    )
+
+
+# The remote-write handler acknowledges an asynchronous insert only after the data is flushed
+# to all inner tables of the TimeSeries table, so the data must be visible right after the ack.
+def test_async_insert_acknowledged_after_flush():
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+
+    async_insert_queries_before = get_async_insert_query_count()
+
+    time_series = [
+        (
+            {"__name__": "async_metric", "job": "test"},
+            {1724112000: 1.5, 1724112015: 2.5},
+        )
+    ]
+    send_protobuf_to_remote_write(
+        node.ip_address,
+        9093,
+        "/write?async_insert=1",
+        convert_time_series_to_protobuf(time_series),
+    )
+
+    metrics_metadata = [("async_metric", "GAUGE", "Test metric", "seconds")]
+    send_protobuf_to_remote_write(
+        node.ip_address,
+        9093,
+        "/write?async_insert=1",
+        convert_metrics_metadata_to_protobuf(metrics_metadata),
+    )
+
+    # No retries here: the acknowledgement means the data is already written.
+    assert node.query("SELECT count() FROM timeSeriesData(prometheus)") == "2\n"
+    assert (
+        node.query(
+            "SELECT tags['job'] FROM timeSeriesTags(prometheus) "
+            "WHERE metric_name = 'async_metric'"
+        )
+        == "test\n"
+    )
+    assert (
+        node.query(
+            "SELECT type, help, unit FROM timeSeriesMetrics(prometheus) "
+            "WHERE metric_family_name = 'async_metric'"
+        )
+        == "gauge\tTest metric\tseconds\n"
+    )
+
+    # Both inserts must have gone through the asynchronous insert queue.
+    assert get_async_insert_query_count() == async_insert_queries_before + 2
+
+
+# If the insertion into an inner table fails, the remote-write request must fail too,
+# so that the sender retries it later.
+def test_async_insert_no_acknowledgement_on_failure():
+    node.query(
+        "CREATE TABLE samples (id UUID, timestamp DateTime64(3), value Float64, "
+        "CONSTRAINT reject_all CHECK value < 0) ENGINE=MergeTree ORDER BY (id, timestamp)"
+    )
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries DATA samples")
+
+    time_series = [({"__name__": "async_metric"}, {1724112000: 1.5})]
+    response = get_response_to_remote_write(
+        node.ip_address,
+        9093,
+        "/write?async_insert=1",
+        convert_time_series_to_protobuf(time_series),
+    )
+
+    assert not response.ok
+    assert "VIOLATED_CONSTRAINT" in response.text
+    assert node.query("SELECT count() FROM samples") == "0\n"

--- a/tests/integration/test_prometheus_protocols/test_async_insert.py
+++ b/tests/integration/test_prometheus_protocols/test_async_insert.py
@@ -44,8 +44,6 @@ def get_async_insert_query_count():
     )
 
 
-# The remote-write handler acknowledges an asynchronous insert only after the data is flushed
-# to all inner tables of the TimeSeries table, so the data must be visible right after the ack.
 def test_async_insert_acknowledged_after_flush():
     node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
 
@@ -72,7 +70,6 @@ def test_async_insert_acknowledged_after_flush():
         convert_metrics_metadata_to_protobuf(metrics_metadata),
     )
 
-    # No retries here: the acknowledgement means the data is already written.
     assert node.query("SELECT count() FROM timeSeriesData(prometheus)") == "2\n"
     assert (
         node.query(
@@ -89,12 +86,9 @@ def test_async_insert_acknowledged_after_flush():
         == "gauge\tTest metric\tseconds\n"
     )
 
-    # Both inserts must have gone through the asynchronous insert queue.
     assert get_async_insert_query_count() == async_insert_queries_before + 2
 
 
-# If the insertion into an inner table fails, the remote-write request must fail too,
-# so that the sender retries it later.
 def test_async_insert_no_acknowledgement_on_failure():
     node.query(
         "CREATE TABLE samples (id UUID, timestamp DateTime64(3), value Float64, "


### PR DESCRIPTION
The Prometheus remote-write protocol handler now honors the `async_insert` setting (enabled in the user profile or passed as a URL query parameter of the handler): data from multiple concurrent remote-write requests is batched in the asynchronous insert queue before forming parts, which reduces the number of parts created in the inner tables of a `TimeSeries` table under a high rate of small remote-write requests. Since `async_insert` is enabled by default, remote-write requests are batched by default; add `async_insert=0` to the handler URL or disable the setting for the user to keep the previous synchronous behavior.

A request is acknowledged only after the data is flushed to all inner tables of the `TimeSeries` table, regardless of the `wait_for_async_insert` setting, because the remote-write protocol treats an acknowledged write as durable. If the flush fails, the request returns an error instead of an acknowledgement, so the sender retries it.

Deduplication on flush is forcibly disabled on this path (both `deduplicate_insert` and `async_insert_deduplicate`, since the former overrides the latter): a flushed block combines data from multiple remote-write requests, so its hash differs on every retry anyway, and the inner tables of the `TimeSeries` engine handle duplicates themselves.

Verified manually with a local server and real remote-write requests: a request without settings goes through the asynchronous insert queue and the data is visible immediately after the acknowledgement; `async_insert=0` keeps the synchronous path; four concurrent requests are flushed as a single batch insert; a failing inner table (a `CHECK` constraint on an external `DATA` target table) returns HTTP 500 with no acknowledgement and no data written.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The Prometheus remote-write protocol now supports asynchronous inserts: data from multiple concurrent remote-write requests is batched before forming parts, following the `async_insert` setting (enabled by default; add `async_insert=0` to the handler URL to keep the synchronous behavior). A request is acknowledged only after the data is flushed to all inner tables of the target `TimeSeries` table.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115688&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115688](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115688+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1964` (included in `26.8` and later)
<!-- ch-version-info:end -->