### PR TITLE
Rename refresh dependencies when restoring under a new name

### DIFF
--- a/src/Databases/DDLRenamingVisitor.cpp
+++ b/src/Databases/DDLRenamingVisitor.cpp
@@ -12,6 +12,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTRefreshStrategy.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Poco/Net/NetException.h>
@@ -134,6 +135,33 @@ namespace
         expr.replace(
             expr.database_and_table_name,
             make_intrusive<ASTTableIdentifier>(new_qualified_name.database, new_qualified_name.table));
+    }
+
+    /// `REFRESH ... DEPENDS ON db.tbl` names other tables, so the dependency list is a table reference
+    /// like any other. The refresh scheduler keys its dependency graph on these full names, so a
+    /// dependency naming the pre-rename database occupies a different graph slot than the renamed table.
+    void visitRefreshStrategy(ASTRefreshStrategy & refresh, const DDLRenamingVisitor::Data & data)
+    {
+        if (!refresh.dependencies)
+            return;
+
+        for (auto & child : refresh.dependencies->children)
+        {
+            const auto * identifier = child ? child->as<ASTTableIdentifier>() : nullptr;
+            /// A parameterized name is only known when the view is called, so it has no name to rename.
+            if (!identifier || identifier->isParam())
+                continue;
+
+            QualifiedTableName qualified_name{identifier->getDatabaseName(), identifier->shortName()};
+            if (qualified_name.database.empty() || qualified_name.table.empty())
+                continue;
+
+            auto new_qualified_name = data.renaming_map.getNewTableName(qualified_name);
+            if (new_qualified_name == qualified_name)
+                continue;
+
+            child = make_intrusive<ASTTableIdentifier>(new_qualified_name.database, new_qualified_name.table);
+        }
     }
 
     /// ASTDictionary keeps a dictionary definition, for example
@@ -305,6 +333,8 @@ void DDLRenamingVisitor::visit(ASTPtr ast, const Data & data)
         visitCreateQuery(*create, data);
     else if (auto * expr = ast->as<ASTTableExpression>())
         visitTableExpression(*expr, data);
+    else if (auto * refresh = ast->as<ASTRefreshStrategy>())
+        visitRefreshStrategy(*refresh, data);
     else if (auto * function = ast->as<ASTFunction>())
         visitFunction(*function, data);
     else if (auto * dictionary = ast->as<ASTDictionary>())

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.reference
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.reference
@@ -1,0 +1,14 @@
+BACKUP_CREATED
+RESTORED
+1. inner-table view restored under a new database name:
+DST.parent		DST.parent
+2. TO-target view restored under a new database name:
+DST.parent	DST.dst	DST.parent
+3. control, dependency outside the restored set stays unchanged:
+OUT.p		DST.raw
+4. renamed dependency appears once, source database name is gone:
+1	0
+BACKUP_CREATED
+RESTORED
+5. control, table-level rename leaves a dependency that is not renamed:
+SRC.parent		SRC.parent

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.reference
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.reference
@@ -10,5 +10,11 @@ OUT.p		DST.raw
 1	0
 BACKUP_CREATED
 RESTORED
-5. control, table-level rename leaves a dependency that is not renamed:
+5. renamed at backup time rather than at restore time:
+DST2.parent		DST2.parent
+6. control, dependency outside the backed-up set stays unchanged:
+OUT.p		DST2.raw
+BACKUP_CREATED
+RESTORED
+7. control, table-level rename leaves a dependency that is not renamed:
 SRC.parent		SRC.parent

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database, atomic-database
+# no-fasttest: needs the `backups` disk, which the fast-test config does not define.
+# no-replicated-database: creates its own databases and restores one under a new name.
+# atomic-database: refreshable materialized views require an Atomic database.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `RESTORE ... AS <new name>` rewrote every table reference in a stored refreshable MV definition
+# except the `REFRESH ... DEPENDS ON` list, so a restored view kept a dependency on the source
+# database. The refresh scheduler keys its dependency graph on the full name, so the restored view
+# refreshed in response to a table it no longer read and ignored refreshes of its own parent.
+#
+# The oracle below is the persisted definition, not refresh timing: a narrow projection of
+# `DEPENDS ON` / `TO` / `FROM` out of `create_table_query`, with the database names substituted to
+# stable placeholders. No clock, no polling.
+
+SRC="${CLICKHOUSE_DATABASE}_src"
+DST="${CLICKHOUSE_DATABASE}_dst"
+OUT="${CLICKHOUSE_DATABASE}_out"
+BACKUP_DB="${CLICKHOUSE_TEST_UNIQUE_NAME}_db"
+BACKUP_TBL="${CLICKHOUSE_TEST_UNIQUE_NAME}_tbl"
+
+drop_all() {
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$SRC\` SYNC"
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$DST\` SYNC"
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$OUT\` SYNC"
+}
+
+# An interrupted earlier run must not make this one fail with TABLE_ALREADY_EXISTS.
+drop_all
+
+# Print the renameable references of a view, with the database names replaced by placeholders so the
+# reference is independent of $CLICKHOUSE_DATABASE.
+show_refs() {
+    local db="$1" view="$2"
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT extract(create_table_query, 'DEPENDS ON ([^ ]+)') AS depends_on,
+               extract(create_table_query, ' TO ([^ ]+)') AS to_target,
+               extract(create_table_query, ' FROM ([^ ]+)') AS select_from
+        FROM system.tables WHERE database = '$db' AND name = '$view' FORMAT TSV" \
+    | sed -e "s/$SRC/SRC/g" -e "s/$DST/DST/g" -e "s/$OUT/OUT/g"
+}
+
+# A refreshable MV outside the backed-up set, used by the control arm below. `EVERY 1 YEAR` keeps it
+# from refreshing on its own during the test.
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$OUT\`"
+${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW \`$OUT\`.p REFRESH EVERY 1 YEAR
+    (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT 1 AS a"
+
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$SRC\`"
+${CLICKHOUSE_CLIENT} --multiquery -q "
+    CREATE TABLE \`$SRC\`.raw (a UInt64) ENGINE = MergeTree ORDER BY a;
+    CREATE TABLE \`$SRC\`.dst (a UInt64) ENGINE = MergeTree ORDER BY a;
+    CREATE MATERIALIZED VIEW \`$SRC\`.parent REFRESH EVERY 1 YEAR
+        (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT a FROM \`$SRC\`.raw;
+    CREATE MATERIALIZED VIEW \`$SRC\`.child REFRESH AFTER 1 SECOND DEPENDS ON \`$SRC\`.parent
+        (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT a FROM \`$SRC\`.parent;
+    CREATE MATERIALIZED VIEW \`$SRC\`.child_to REFRESH AFTER 1 SECOND DEPENDS ON \`$SRC\`.parent
+        TO \`$SRC\`.dst AS SELECT a FROM \`$SRC\`.parent;
+    CREATE MATERIALIZED VIEW \`$SRC\`.child_out REFRESH AFTER 1 SECOND DEPENDS ON \`$OUT\`.p
+        (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT a FROM \`$SRC\`.raw;
+"
+
+${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE \`$SRC\` TO Disk('backups', '$BACKUP_DB')" | grep -o "BACKUP_CREATED"
+${CLICKHOUSE_CLIENT} -q "RESTORE DATABASE \`$SRC\` AS \`$DST\` FROM Disk('backups', '$BACKUP_DB')" | grep -o "RESTORED"
+
+echo "1. inner-table view restored under a new database name:"
+show_refs "$DST" child
+
+echo "2. TO-target view restored under a new database name:"
+show_refs "$DST" child_to
+
+echo "3. control, dependency outside the restored set stays unchanged:"
+show_refs "$DST" child_out
+
+# The dependency must be rewritten exactly once and the pre-rename name must be gone entirely: a
+# renamed reference appended next to the original one would leave both in the definition.
+echo "4. renamed dependency appears once, source database name is gone:"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT countMatches(create_table_query, 'DEPENDS ON ' || '$DST' || '\.parent') AS new_name,
+           countMatches(create_table_query, '$SRC') AS old_name
+    FROM system.tables WHERE database = '$DST' AND name = 'child' FORMAT TSV"
+
+# Control: a per-table rename whose dependency is not itself renamed. The renaming map holds only
+# child -> child2, so the dependency on `parent` must be left alone.
+${CLICKHOUSE_CLIENT} -q "BACKUP TABLE \`$SRC\`.child TO Disk('backups', '$BACKUP_TBL')" | grep -o "BACKUP_CREATED"
+${CLICKHOUSE_CLIENT} -q "RESTORE TABLE \`$SRC\`.child AS \`$SRC\`.child2 FROM Disk('backups', '$BACKUP_TBL')" | grep -o "RESTORED"
+
+echo "5. control, table-level rename leaves a dependency that is not renamed:"
+show_refs "$SRC" child2
+
+drop_all

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
@@ -51,10 +51,9 @@ show_refs() {
 }
 
 # The views below are created `EMPTY` with their next refresh a year out, so none of them refreshes
-# while a `BACKUP DATABASE` of them is scanning. A non-append refresh replaces its target through
-# CREATE OR REPLACE, which the scan reports as an inconsistency warning on stderr, and the harness
-# fails any test that writes to stderr. The oracle reads only `DEPENDS ON` / `TO` / `FROM`, never
-# the schedule.
+# while a `BACKUP DATABASE` of them is scanning. A non-append refresh swaps its target through an
+# EXCHANGE, which the scan reports as an inconsistency warning on stderr, and the harness fails any
+# test that writes to stderr. The oracle reads only `DEPENDS ON` / `TO` / `FROM`, never the schedule.
 ${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$OUT\`"
 ${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW \`$OUT\`.p REFRESH EVERY 1 YEAR
     (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT 1 AS a"

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-replicated-database, atomic-database
-# no-fasttest: needs the `backups` disk, which the fast-test config does not define.
+# Tags: no-replicated-database, atomic-database
 # no-replicated-database: creates its own databases and restores one under a new name.
 # atomic-database: refreshable materialized views require an Atomic database.
 
@@ -51,7 +50,7 @@ ${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW \`$OUT\`.p REFRESH EVERY 1 YEA
     (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT 1 AS a"
 
 ${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$SRC\`"
-${CLICKHOUSE_CLIENT} --multiquery -q "
+${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE \`$SRC\`.raw (a UInt64) ENGINE = MergeTree ORDER BY a;
     CREATE TABLE \`$SRC\`.dst (a UInt64) ENGINE = MergeTree ORDER BY a;
     CREATE MATERIALIZED VIEW \`$SRC\`.parent REFRESH EVERY 1 YEAR

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
@@ -50,10 +50,11 @@ show_refs() {
     | sed -e "s/$SRC/SRC/g" -e "s/$DST2/DST2/g" -e "s/$DST/DST/g" -e "s/$OUT/OUT/g"
 }
 
-# No view here may ever refresh. A non-append refresh replaces its target through CREATE OR REPLACE,
-# which a concurrent `BACKUP DATABASE` scan reports as an inconsistency warning on stderr. `EMPTY`
-# skips the initial refresh and `EVERY 1 YEAR` puts the next one a year out. Neither keyword is
-# printed back into `create_table_query`, so the oracle is unaffected.
+# The views below are created `EMPTY` with their next refresh a year out, so none of them refreshes
+# while a `BACKUP DATABASE` of them is scanning. A non-append refresh replaces its target through
+# CREATE OR REPLACE, which the scan reports as an inconsistency warning on stderr, and the harness
+# fails any test that writes to stderr. The oracle reads only `DEPENDS ON` / `TO` / `FROM`, never
+# the schedule.
 ${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$OUT\`"
 ${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW \`$OUT\`.p REFRESH EVERY 1 YEAR
     (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT 1 AS a"

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
@@ -18,15 +18,22 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 SRC="${CLICKHOUSE_DATABASE}_src"
 DST="${CLICKHOUSE_DATABASE}_dst"
+DST2="${CLICKHOUSE_DATABASE}_dst2"
 OUT="${CLICKHOUSE_DATABASE}_out"
 BACKUP_DB="${CLICKHOUSE_TEST_UNIQUE_NAME}_db"
+BACKUP_AS="${CLICKHOUSE_TEST_UNIQUE_NAME}_as"
 BACKUP_TBL="${CLICKHOUSE_TEST_UNIQUE_NAME}_tbl"
 
 drop_all() {
     ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$SRC\` SYNC"
     ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$DST\` SYNC"
+    ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$DST2\` SYNC"
     ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$OUT\` SYNC"
 }
+
+# These databases live outside $CLICKHOUSE_DATABASE, so the harness does not reclaim them: drop them
+# on every exit path, not just the successful one.
+trap drop_all EXIT
 
 # An interrupted earlier run must not make this one fail with TABLE_ALREADY_EXISTS.
 drop_all
@@ -40,27 +47,29 @@ show_refs() {
                extract(create_table_query, ' TO ([^ ]+)') AS to_target,
                extract(create_table_query, ' FROM ([^ ]+)') AS select_from
         FROM system.tables WHERE database = '$db' AND name = '$view' FORMAT TSV" \
-    | sed -e "s/$SRC/SRC/g" -e "s/$DST/DST/g" -e "s/$OUT/OUT/g"
+    | sed -e "s/$SRC/SRC/g" -e "s/$DST2/DST2/g" -e "s/$DST/DST/g" -e "s/$OUT/OUT/g"
 }
 
-# A refreshable MV outside the backed-up set, used by the control arm below. `EVERY 1 YEAR` keeps it
-# from refreshing on its own during the test.
+# No view here may ever refresh. A non-append refresh replaces its target through CREATE OR REPLACE,
+# which a concurrent `BACKUP DATABASE` scan reports as an inconsistency warning on stderr. `EMPTY`
+# skips the initial refresh and `EVERY 1 YEAR` puts the next one a year out. Neither keyword is
+# printed back into `create_table_query`, so the oracle is unaffected.
 ${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$OUT\`"
 ${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW \`$OUT\`.p REFRESH EVERY 1 YEAR
-    (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT 1 AS a"
+    (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT 1 AS a"
 
 ${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$SRC\`"
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE \`$SRC\`.raw (a UInt64) ENGINE = MergeTree ORDER BY a;
     CREATE TABLE \`$SRC\`.dst (a UInt64) ENGINE = MergeTree ORDER BY a;
     CREATE MATERIALIZED VIEW \`$SRC\`.parent REFRESH EVERY 1 YEAR
-        (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT a FROM \`$SRC\`.raw;
-    CREATE MATERIALIZED VIEW \`$SRC\`.child REFRESH AFTER 1 SECOND DEPENDS ON \`$SRC\`.parent
-        (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT a FROM \`$SRC\`.parent;
-    CREATE MATERIALIZED VIEW \`$SRC\`.child_to REFRESH AFTER 1 SECOND DEPENDS ON \`$SRC\`.parent
-        TO \`$SRC\`.dst AS SELECT a FROM \`$SRC\`.parent;
-    CREATE MATERIALIZED VIEW \`$SRC\`.child_out REFRESH AFTER 1 SECOND DEPENDS ON \`$OUT\`.p
-        (a UInt64) ENGINE = MergeTree ORDER BY a AS SELECT a FROM \`$SRC\`.raw;
+        (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT a FROM \`$SRC\`.raw;
+    CREATE MATERIALIZED VIEW \`$SRC\`.child REFRESH EVERY 1 YEAR DEPENDS ON \`$SRC\`.parent
+        (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT a FROM \`$SRC\`.parent;
+    CREATE MATERIALIZED VIEW \`$SRC\`.child_to REFRESH EVERY 1 YEAR DEPENDS ON \`$SRC\`.parent
+        TO \`$SRC\`.dst EMPTY AS SELECT a FROM \`$SRC\`.parent;
+    CREATE MATERIALIZED VIEW \`$SRC\`.child_out REFRESH EVERY 1 YEAR DEPENDS ON \`$OUT\`.p
+        (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT a FROM \`$SRC\`.raw;
 "
 
 ${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE \`$SRC\` TO Disk('backups', '$BACKUP_DB')" | grep -o "BACKUP_CREATED"
@@ -83,12 +92,20 @@ ${CLICKHOUSE_CLIENT} -q "
            countMatches(create_table_query, '$SRC') AS old_name
     FROM system.tables WHERE database = '$DST' AND name = 'child' FORMAT TSV"
 
+# `BACKUP ... AS` renames while writing the backup, through a different pair of call sites than the
+# restore path uses. The stored definition is already renamed, so restoring it needs no rename.
+${CLICKHOUSE_CLIENT} -q "BACKUP DATABASE \`$SRC\` AS \`$DST2\` TO Disk('backups', '$BACKUP_AS')" | grep -o "BACKUP_CREATED"
+${CLICKHOUSE_CLIENT} -q "RESTORE DATABASE \`$DST2\` FROM Disk('backups', '$BACKUP_AS')" | grep -o "RESTORED"
+
+echo "5. renamed at backup time rather than at restore time:"
+show_refs "$DST2" child
+echo "6. control, dependency outside the backed-up set stays unchanged:"
+show_refs "$DST2" child_out
+
 # Control: a per-table rename whose dependency is not itself renamed. The renaming map holds only
 # child -> child2, so the dependency on `parent` must be left alone.
 ${CLICKHOUSE_CLIENT} -q "BACKUP TABLE \`$SRC\`.child TO Disk('backups', '$BACKUP_TBL')" | grep -o "BACKUP_CREATED"
 ${CLICKHOUSE_CLIENT} -q "RESTORE TABLE \`$SRC\`.child AS \`$SRC\`.child2 FROM Disk('backups', '$BACKUP_TBL')" | grep -o "RESTORED"
 
-echo "5. control, table-level rename leaves a dependency that is not renamed:"
+echo "7. control, table-level rename leaves a dependency that is not renamed:"
 show_refs "$SRC" child2
-
-drop_all

--- a/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
+++ b/tests/queries/0_stateless/05024_restore_rename_rewrites_refresh_depends_on.sh
@@ -55,20 +55,20 @@ show_refs() {
 # EXCHANGE, which the scan reports as an inconsistency warning on stderr, and the harness fails any
 # test that writes to stderr. The oracle reads only `DEPENDS ON` / `TO` / `FROM`, never the schedule.
 ${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$OUT\`"
-${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW \`$OUT\`.p REFRESH EVERY 1 YEAR
+${CLICKHOUSE_CLIENT} -q "CREATE MATERIALIZED VIEW \`$OUT\`.p REFRESH AFTER 1 YEAR
     (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT 1 AS a"
 
 ${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$SRC\`"
 ${CLICKHOUSE_CLIENT} -q "
     CREATE TABLE \`$SRC\`.raw (a UInt64) ENGINE = MergeTree ORDER BY a;
     CREATE TABLE \`$SRC\`.dst (a UInt64) ENGINE = MergeTree ORDER BY a;
-    CREATE MATERIALIZED VIEW \`$SRC\`.parent REFRESH EVERY 1 YEAR
+    CREATE MATERIALIZED VIEW \`$SRC\`.parent REFRESH AFTER 1 YEAR
         (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT a FROM \`$SRC\`.raw;
-    CREATE MATERIALIZED VIEW \`$SRC\`.child REFRESH EVERY 1 YEAR DEPENDS ON \`$SRC\`.parent
+    CREATE MATERIALIZED VIEW \`$SRC\`.child REFRESH AFTER 1 YEAR DEPENDS ON \`$SRC\`.parent
         (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT a FROM \`$SRC\`.parent;
-    CREATE MATERIALIZED VIEW \`$SRC\`.child_to REFRESH EVERY 1 YEAR DEPENDS ON \`$SRC\`.parent
+    CREATE MATERIALIZED VIEW \`$SRC\`.child_to REFRESH AFTER 1 YEAR DEPENDS ON \`$SRC\`.parent
         TO \`$SRC\`.dst EMPTY AS SELECT a FROM \`$SRC\`.parent;
-    CREATE MATERIALIZED VIEW \`$SRC\`.child_out REFRESH EVERY 1 YEAR DEPENDS ON \`$OUT\`.p
+    CREATE MATERIALIZED VIEW \`$SRC\`.child_out REFRESH AFTER 1 YEAR DEPENDS ON \`$OUT\`.p
         (a UInt64) ENGINE = MergeTree ORDER BY a EMPTY AS SELECT a FROM \`$SRC\`.raw;
 "
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/115645


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `RESTORE ... AS <new name>` leaving the `REFRESH ... DEPENDS ON` list of a refreshable materialized view pointing at the original database. The restored view refreshed in response to a table it no longer read, ignored refreshes of its own parent, and stopped refreshing entirely once the original database was dropped.

### Description

`RESTORE DATABASE db AS db_restored` rewrote every table reference in a stored refreshable
materialized view definition except the `REFRESH ... DEPENDS ON` list:

```
CREATE MATERIALIZED VIEW db_restored.child REFRESH AFTER 1 SECOND DEPENDS ON db.parent
  ... AS SELECT a FROM db_restored.parent
                            ^^ TO/FROM rewritten, DEPENDS ON not
```

`DDLRenamingVisitor::visit` dispatches on `ASTCreateQuery`, `ASTTableExpression`, `ASTFunction`,
`ASTDictionary` and `ASTStorage`; `ASTRefreshStrategy` was missing, so the node was walked but never
touched. The refresh scheduler keys its dependency graph on the full table name, so a dependency
naming the pre-restore database occupies a different graph slot than the restored parent. Measured:
refreshing the *source* parent fired the restored child, three consecutive refreshes of its *own*
parent did not, and dropping the source database left the restored view at `MissingDependencies`.

The fix adds the missing visit, running the renaming map over the dependency list exactly as the
existing `create.targets` loop does. `AddDefaultDatabaseVisitor` already visits this node to qualify
the same list at CREATE time, so this is the renaming counterpart of an established pass. The visitor
is the only transform applied at all four sites that rewrite a stored definition, so this covers
backup-side and restore-side renaming together, and the corrected definition is what gets persisted,
so later `ATTACH`es are right with no separate fixup.

A dependency pointing outside the restored set is left alone, and so is one whose table is not itself
renamed by a `RESTORE TABLE ... AS`; the test pins both as controls. A backup written without
backup-side renaming still restores correctly on a fixed server, including under `RESTORE ... AS`,
since the rename happens at restore time (verified against a backup taken by an unfixed binary). A
backup an unfixed server wrote with `BACKUP ... AS` is not repaired: its stored definition already
carries the pre-rename dependency and the restore map cannot infer it. Re-take such a backup.

No settings or formats change; a definition without `DEPENDS ON` is untouched.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115689&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115689](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115689+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.64` (included in `26.9` and later)
<!-- ch-version-info:end -->