### PR TITLE
Do not assert scan-progress values decided by an async race in test_early_return_limit

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -5358,24 +5358,16 @@ def test_early_return_limit(started_cluster, use_delta_kernel):
 
     assert first_check_hits > 0 or queue_check_hits > 0
 
-    assert 1 == int(instance.query(
-        f"SELECT count() FROM system.text_log WHERE query_id = '{query_id}' AND message LIKE '%List batch size is 1/1, shutdown: true%'"
-    ))
-
 
     # Early return should scan significantly fewer files
     # With s3_list_object_keys_size=1, queue pauses frequently forcing shutdown checks
     # Should stop very early after consuming just a few files
     assert scanned_files < full_scan_files, \
         f"Early return should scan fewer files: {scanned_files} >= {full_scan_files}"
-    # 3 because:
-    # we have async reader creation with 2 existing readers at a moment of time,
-    # each calls next() and consumes 2 files from the scan.
-    # It takes 1 file for the query to stop because of LIMIT 1.
-    # But because scan is also asynchronous and continues once batch limit is not reached,
-    # we get +1 scanned file.
-    assert scanned_files == 3, \
-        f"Early return should scan 3 files with LIMIT 1, but scanned {scanned_files}"
+    # At most 3: two async readers each consume one file, plus one the scan produces before
+    # it observes shutdown. Fewer is legal when shutdown lands earlier.
+    assert scanned_files <= 3, \
+        f"Early return should scan at most 3 files with LIMIT 1, but scanned {scanned_files}"
 
 
 def test_struct_dotted_field_names(started_cluster):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115661   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/115661

`test_storage_delta/test.py::test_early_return_limit` pins two values an async interleaving
decides. 5 hits in 90 days across three job families, two on master, so not
parametrization-specific. Latest master failure:
[`Integration tests (arm_binary, distributed plan, 1/4)` @ 0c80ff614e89](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0c80ff614e89817cf0936f09d57f8d67b3bfb7d2&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29)

Root cause: the scan producer appends to a bounded deque and logs the LIVE queue depth
(`List batch size is {}/{}`); consumers pop under the same mutex. With
`s3_list_object_keys_size = 1` the capacity is one, so the last log legitimately reads `1/1`
or `0/1` depending on which thread reaches the mutex first. `DeltaLakeScannedFiles` is
incremented after both callback shutdown exits, so the count is 2 or 3 for the same reason.
Both orderings are correct.

Two test-only changes:

- The assertion counting `List batch size is 1/1, shutdown: true` is **removed**, not
  relaxed: even relaxed it is implied by `assert first_check_hits > 0 or
  queue_check_hits > 0` three lines above, which runs first. A callback returning false
  cannot stop the producer reaching that batch log.
- `assert scanned_files == 3` becomes `<= 3`, restoring the bound the test was written
  with: `a33799ba6fb63ee` added `scanned_files < 10`; `95e6f488a0917b` ("Make exact
  comparison in test") tightened it to `== 3` days later. `scanned_files > 0` bounds the
  other side.

Validated with a forced-interleaving probe in the scan callback: unpatched fails with the CI
signature on the drained ordering, patched passes on it. Deleting both callback shutdown exits
makes it fail at `assert 997 <= 3`, so the bound still catches an early-return regression.
20/20 runs pass.

The retained assertion is not race-proof either: both counters are logged inside the callback,
so a shutdown seen by the parked producer skips it. That ordering has 0 of 38 failures in 90
days over 97538 runs, against 5 for the one removed here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115693&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115693](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115693+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.39` (included in `26.9` and later)
<!-- ch-version-info:end -->