### PR TITLE
Keep clickhouse-local alive when a listener handler throws

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -842,6 +842,13 @@ void LocalServer::startServers(const ServerType & server_type)
             throw Exception(ErrorCodes::NETWORK_ERROR,
                 "Failed to start HTTP listener — check listen_host and http_port configuration");
 
+        /// While serving connections this process must log and continue like `clickhouse-server`: a
+        /// handler throws on client behavior it does not control, and terminating would let one client
+        /// end the process. Set before any accept thread starts, and never restored, since a handler
+        /// can still be draining after `stop`.
+        static ServerErrorHandler listener_error_handler;
+        Poco::ErrorHandler::set(&listener_error_handler);
+
         /// Phase 2: the whole requested set is bound and verified. Only now start the accept threads,
         /// so no listener admits a connection until the entire set is known-good. `createServer` no
         /// longer logs (it does not start the server), so emit the "Listening for ..." line here.

--- a/tests/queries/0_stateless/05024_local_listener_survives_handler_exception.reference
+++ b/tests/queries/0_stateless/05024_local_listener_survives_handler_exception.reference
@@ -1,0 +1,2 @@
+no signal death
+listener still serving

--- a/tests/queries/0_stateless/05024_local_listener_survives_handler_exception.sh
+++ b/tests/queries/0_stateless/05024_local_listener_survives_handler_exception.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# A clickhouse-local that has started a listener must keep serving when a connection makes its handler
+# fail. Sending an HTTP request to the native port is such a connection.
+#
+# OS-assigned ports (`--tcp_port 0 --http_port 0`) keep this parallel-safe; endpoints are built from
+# the actually bound ports via `getServerPort`.
+
+# The failure being guarded against kills the process, so the oracle is the exit status. The offending
+# query itself is expected to fail: what matters is that it fails as an error, not as an abort.
+$CLICKHOUSE_LOCAL \
+    --listen_host 127.0.0.1 --tcp_port 0 --http_port 0 \
+    --query "
+    SYSTEM START LISTEN QUERIES ALL;
+    SELECT * FROM url('http://127.0.0.1:' || toString(getServerPort('tcp_port')) || '/', LineAsString) FORMAT Null
+        SETTINGS http_max_tries = 1, http_receive_timeout = 5, http_send_timeout = 5;
+" >/dev/null 2>&1
+rc=$?
+# `clickhouse-local` exits with a ClickHouse error code, which the shell truncates to its low byte,
+# so an ordinary error can land in the same numeric range as a signal status. Name the statuses that
+# mean death by signal instead of testing the range.
+case "$rc" in
+    134) echo "died from signal 6" ;;
+    139) echo "died from signal 11" ;;
+    *) echo "no signal death" ;;
+esac
+
+# Exiting with an error is not enough, so keep a listener running past the offending connection and
+# check that it still answers. Reading stdin from a pipe is the configuration this covers.
+ports_file="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_ports.txt"
+fifo="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_stdin"
+rm -f "$ports_file" "$fifo"
+mkfifo "$fifo"
+sleep 60 > "$fifo" &
+sleep_pid=$!
+
+$CLICKHOUSE_LOCAL \
+    --listen_host 127.0.0.1 --tcp_port 0 --http_port 0 --interactive \
+    --query "SYSTEM START LISTEN QUERIES ALL; SELECT getServerPort('tcp_port'), getServerPort('http_port') FORMAT TSV" \
+    < "$fifo" > "$ports_file" 2>/dev/null &
+local_pid=$!
+
+# Closing the pipe ends the session, so the listener shuts down through the normal path. Runs on every
+# exit path, including the mandatory checks below, so a failure never leaves the listener behind.
+cleanup() {
+    kill "$sleep_pid" 2>/dev/null
+    for _ in {1..100}; do
+        kill -0 "$local_pid" 2>/dev/null || break
+        sleep 0.1
+    done
+    kill -9 "$local_pid" 2>/dev/null
+    wait "$local_pid" 2>/dev/null
+    rm -f "$ports_file" "$fifo"
+}
+trap cleanup EXIT
+
+for _ in {1..600}; do
+    [ -s "$ports_file" ] && break
+    sleep 0.1
+done
+read -r tcp_port http_port < "$ports_file"
+# Both steps below are mandatory: skipping either leaves the final query answering from a listener
+# that was never poked, which passes without testing anything.
+[ -n "$tcp_port" ] && [ -n "$http_port" ] || { echo "failed to read listener ports"; exit 1; }
+
+# The method matters: `GET` and `POST` are recognized as a wrong-port mistake and answered politely,
+# while any other verb is rejected as an unexpected packet, which is the case this test needs.
+exec 3<>"/dev/tcp/127.0.0.1/${tcp_port}" || { echo "failed to connect to the native port"; exit 1; }
+printf 'HEAD / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n' >&3
+head -c 20 <&3 >/dev/null 2>&1
+exec 3<&- 2>/dev/null
+exec 3>&- 2>/dev/null
+
+# The listener cannot answer this if the failed connection took the process down.
+${CLICKHOUSE_CURL} -sS --max-time 60 "http://127.0.0.1:${http_port}/?query=SELECT%20%27listener%20still%20serving%27"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115666
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/115666

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `clickhouse-local` terminating the whole process when a connection handler of a listener started with `SYSTEM START LISTEN` threw, for example because a client sent a malformed packet or reset a keep-alive socket. Such a process now logs the error and keeps serving, like `clickhouse-server` does.


### Description

Reported by @ pufit in #115666.

`clickhouse-local` installs Poco's `KillingErrorHandler` when stdin is not a TTY (`LocalServer.cpp:1195`), and it calls `std::terminate()` on any exception. Since 26.6 the same process can serve listeners (`SYSTEM START LISTEN`, #101143), where a handler routinely throws on client behavior it does not control. `TCPHandler::run` rethrows after logging, so the exception reaches the global handler and kills the process; with a persistent `--path` that takes down the served database. `clickhouse-server` and `clickhouse-keeper` install the log-and-continue `ServerErrorHandler` instead.

That handler predates listeners by four years and is right for a batch one-shot tool, where a background-thread exception should not be swallowed. So it stays, and is replaced only once the process starts serving: `startServers` installs `ServerErrorHandler` just before the accept threads start. Only `SYSTEM START LISTEN` reaches that code, so batch runs are unaffected. The switch is one-way, since a handler can still be draining after `SYSTEM STOP LISTEN` or a rolled-back partial start.

Reproduced on Linux with no concurrency and no timing window: one malformed native packet is enough, no reset needed. `clickhouse-local` exits with SIGABRT before the fix and an ordinary error after it; `clickhouse-server` given identical packets keeps serving. The new test asserts both no signal death and that the listener still answers, and fails on unpatched master on both counts. Batch output is byte-identical across the two binaries.

26.6 and 26.7 are affected as well (checked against the `v26.6.3.62` and `v26.7.4.58` tags); 26.5 predates the feature.

The report came from HTTP keep-alive resets on macOS. On Linux that reset is absorbed as a network exception and only the native path escapes, so I did not reproduce the HTTP variant directly; the fix is at the handler, so it covers both. `--interactive` does not opt out either, since `is_interactive` also requires a TTY.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115715&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115715](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115715+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1896` (included in `26.8` and later)
<!-- ch-version-info:end -->