### PR TITLE
Report a clean error when a table expression has no columns to read

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -483,8 +483,16 @@ NameAndTypePair chooseSmallestColumnToReadFromStorage(const StoragePtr & storage
     if (!columns_with_sizes.empty())
         result = std::min_element(columns_with_sizes.begin(), columns_with_sizes.end())->column;
     else
+    {
+        /// A table expression can resolve to no columns at all, for example a table function over a
+        /// table whose schema is unavailable. `getSmallestColumn` treats an empty list as a logical error.
+        if (column_names_and_types.empty())
+            throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
+                "Cannot read from table expression with no columns");
+
         /// If we have no information about columns sizes, choose a column of minimum size of its data type
         result = ExpressionActions::getSmallestColumn(column_names_and_types);
+    }
 
     return result;
 }

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns.reference
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns.reference
@@ -1,0 +1,13 @@
+-- loop() over an alias whose target was dropped
+-- reading the dangling alias directly still names the missing target
+-- the dangling alias remains enumerable in the system tables
+loop_no_columns_alias	Alias
+0
+-- structure inference over the dangling alias stays empty and does not throw
+-- a parameterized view has no columns by design, with and without an alias
+-- a healthy alias keeps working
+1
+1
+1
+1
+c0	Int32					

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns.sql
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns.sql
@@ -1,0 +1,44 @@
+DROP TABLE IF EXISTS loop_no_columns_target;
+DROP TABLE IF EXISTS loop_no_columns_alias;
+DROP TABLE IF EXISTS loop_no_columns_base;
+DROP VIEW IF EXISTS loop_no_columns_parameterized;
+DROP TABLE IF EXISTS loop_no_columns_alias_to_view;
+
+CREATE TABLE loop_no_columns_target (c0 Int32) ENGINE = Memory;
+CREATE TABLE loop_no_columns_alias ENGINE = Alias(currentDatabase(), loop_no_columns_target);
+DROP TABLE loop_no_columns_target;
+
+SELECT '-- loop() over an alias whose target was dropped';
+SELECT count() FROM loop(currentDatabase(), 'loop_no_columns_alias'); -- { serverError UNSUPPORTED_METHOD }
+SELECT 1 FROM loop(currentDatabase(), 'loop_no_columns_alias'); -- { serverError UNSUPPORTED_METHOD }
+
+SELECT '-- reading the dangling alias directly still names the missing target';
+SELECT count() FROM loop_no_columns_alias; -- { serverError UNKNOWN_TABLE }
+DESCRIBE TABLE loop_no_columns_alias; -- { serverError UNKNOWN_TABLE }
+
+SELECT '-- the dangling alias remains enumerable in the system tables';
+SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name = 'loop_no_columns_alias';
+SELECT count() FROM system.columns WHERE database = currentDatabase() AND table = 'loop_no_columns_alias';
+
+SELECT '-- structure inference over the dangling alias stays empty and does not throw';
+DESCRIBE TABLE loop(currentDatabase(), 'loop_no_columns_alias');
+
+SELECT '-- a parameterized view has no columns by design, with and without an alias';
+CREATE TABLE loop_no_columns_base (a Int32) ENGINE = Memory;
+CREATE VIEW loop_no_columns_parameterized AS SELECT * FROM loop_no_columns_base WHERE a = {p:Int32};
+SELECT count() FROM loop(currentDatabase(), 'loop_no_columns_parameterized'); -- { serverError UNSUPPORTED_METHOD }
+CREATE TABLE loop_no_columns_alias_to_view ENGINE = Alias(currentDatabase(), loop_no_columns_parameterized);
+SELECT count() FROM loop(currentDatabase(), 'loop_no_columns_alias_to_view'); -- { serverError UNSUPPORTED_METHOD }
+DESCRIBE TABLE loop(currentDatabase(), 'loop_no_columns_parameterized');
+
+SELECT '-- a healthy alias keeps working';
+CREATE TABLE loop_no_columns_target (c0 Int32) ENGINE = Memory;
+INSERT INTO loop_no_columns_target VALUES (1), (2), (3);
+SELECT 1 FROM loop(currentDatabase(), 'loop_no_columns_alias') LIMIT 4;
+DESCRIBE TABLE loop(currentDatabase(), 'loop_no_columns_alias');
+
+DROP TABLE loop_no_columns_alias_to_view;
+DROP VIEW loop_no_columns_parameterized;
+DROP TABLE loop_no_columns_base;
+DROP TABLE loop_no_columns_alias;
+DROP TABLE loop_no_columns_target;

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns.sql
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns.sql
@@ -1,3 +1,6 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: the guard lives in the planner, so the old analyzer returns UNKNOWN_TABLE here.
+
 DROP TABLE IF EXISTS loop_no_columns_target;
 DROP TABLE IF EXISTS loop_no_columns_alias;
 DROP TABLE IF EXISTS loop_no_columns_base;

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.reference
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.reference
@@ -1,0 +1,4 @@
+Without SELECT on the loop table
+ACCESS_DENIED
+With SELECT on the loop table
+UNSUPPORTED_METHOD

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.reference
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.reference
@@ -2,3 +2,8 @@ Without SELECT on the loop table
 ACCESS_DENIED
 With SELECT on the loop table
 UNSUPPORTED_METHOD
+With SELECT on a live alias but not on its target
+ACCESS_DENIED
+With SELECT on a live alias and on its target
+1
+1

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
@@ -10,10 +10,16 @@ ${CLICKHOUSE_CLIENT} -m --query "
     DROP USER IF EXISTS ${username};
     DROP TABLE IF EXISTS loop_access_target;
     DROP TABLE IF EXISTS loop_access_alias;
+    DROP TABLE IF EXISTS loop_access_live_target;
+    DROP TABLE IF EXISTS loop_access_live_alias;
 
     CREATE TABLE loop_access_target (c0 Int32) ENGINE = Memory;
     CREATE TABLE loop_access_alias ENGINE = Alias(currentDatabase(), loop_access_target);
     DROP TABLE loop_access_target;
+
+    CREATE TABLE loop_access_live_target (c0 Int32) ENGINE = Memory;
+    INSERT INTO loop_access_live_target SELECT number FROM numbers(3);
+    CREATE TABLE loop_access_live_alias ENGINE = Alias(currentDatabase(), loop_access_live_target);
 
     CREATE USER ${username} NOT IDENTIFIED;
     GRANT CREATE TEMPORARY TABLE ON *.* TO ${username};
@@ -31,7 +37,20 @@ ${CLICKHOUSE_CLIENT} --user="${username}" --query \
     "SELECT count() FROM loop(currentDatabase(), 'loop_access_alias');" 2>&1 |
     grep -o "UNSUPPORTED_METHOD" | uniq
 
+echo "With SELECT on a live alias but not on its target"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON loop_access_live_alias TO ${username};"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT 1 FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 2;" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+echo "With SELECT on a live alias and on its target"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON loop_access_live_target TO ${username};"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT 1 FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 2;"
+
 ${CLICKHOUSE_CLIENT} -m --query "
     DROP USER IF EXISTS ${username};
     DROP TABLE IF EXISTS loop_access_alias;
+    DROP TABLE IF EXISTS loop_access_live_alias;
+    DROP TABLE IF EXISTS loop_access_live_target;
 "

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CUR_DIR"/../shell_config.sh
+
+username="user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+${CLICKHOUSE_CLIENT} -m --query "
+    DROP USER IF EXISTS ${username};
+    DROP TABLE IF EXISTS loop_access_target;
+    DROP TABLE IF EXISTS loop_access_alias;
+
+    CREATE TABLE loop_access_target (c0 Int32) ENGINE = Memory;
+    CREATE TABLE loop_access_alias ENGINE = Alias(currentDatabase(), loop_access_target);
+    DROP TABLE loop_access_target;
+
+    CREATE USER ${username} NOT IDENTIFIED;
+    GRANT CREATE TEMPORARY TABLE ON *.* TO ${username};
+"
+
+echo "Without SELECT on the loop table"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT count() FROM loop(currentDatabase(), 'loop_access_alias');" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON loop_access_alias TO ${username};"
+
+echo "With SELECT on the loop table"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT count() FROM loop(currentDatabase(), 'loop_access_alias');" 2>&1 |
+    grep -o "UNSUPPORTED_METHOD" | uniq
+
+${CLICKHOUSE_CLIENT} -m --query "
+    DROP USER IF EXISTS ${username};
+    DROP TABLE IF EXISTS loop_access_alias;
+"

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-old-analyzer
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/101005
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `LOGICAL_ERROR: No available columns` when a query reads no columns from a table expression that has no columns at all, for example `SELECT count() FROM loop(db, tbl)` where `tbl` is an `Alias` table whose target was dropped, or a parameterized view. Such a query now fails with `UNSUPPORTED_METHOD` instead of aborting the server in debug and sanitizer builds.

### Description

Found by the BuzzHouse fuzzer (`BuzzHouse (amd_msan)`, STID 3938-27bd, [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115586&sha=c2aff39bbb1c833322107a522af2fd6a316adc10&name_0=PR&name_1=BuzzHouse%20%28amd_msan%29)). No related open issue.

Reproducer, deterministic, no experimental settings:

```sql
CREATE TABLE t (c0 Int32) ENGINE = Memory;
CREATE TABLE a ENGINE = Alias(currentDatabase(), t);
DROP TABLE t;
SELECT count() FROM loop(currentDatabase(), 'a');
```

Root cause. When a query needs no columns from a table expression, the planner synthesises a cheapest column to count rows. For a table or table function it calls `chooseSmallestColumnToReadFromStorage`, which, with no column sizes available, falls through to `ExpressionActions::getSmallestColumn` -- and that treats an empty column list as a logical error. An `Alias` whose target is gone reports column-less metadata by design, `StorageLoop` copies it onto itself, and the planner hands the empty list down.

The sibling branch of the same `if (columns_names.empty())` block already guards its degenerate case with `UNSUPPORTED_METHOD "Cannot read from subquery with empty projection"`. This adds the missing counterpart to the storage branch. `getSmallestColumn`'s `LOGICAL_ERROR` stays as an internal assertion and becomes unreachable from this caller.

The message is cause-neutral because a parameterized view has no columns by design, so naming a missing table would be wrong. Two further carriers that also aborted are covered: a bare parameterized view, and an `Alias` to a live one.

Validation. Both directions on builds of the same revision, all four carriers: unpatched aborts with the CI stack, patched returns `UNSUPPORTED_METHOD`. The new test aborts an unpatched server, so it cannot pass vacuously. Authorization ordering is unchanged and pinned by a test: without a grant the query still fails `ACCESS_DENIED` on both builds. Reading the alias directly, enumerating it in `system.tables`/`system.columns`, and `DESCRIBE` over the table function are unchanged; the existing `Alias` tests pass unmodified. 50 randomized runs, plus a matched before/after run of 399 planner, alias and table-function tests, show no new failure.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115716&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115716](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115716+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.7.89`, `26.6.5.117`, `26.3.33.67`
<!-- ch-version-info:end -->