### PR TITLE
Warm up the parser before measuring AST allocations in the parser memory profiler

### DIFF
--- a/src/Parsers/examples/parser_memory_profiler.cpp
+++ b/src/Parsers/examples/parser_memory_profiler.cpp
@@ -309,6 +309,15 @@ try
     std::string profile_before_path;
     std::string profile_after_path;
 
+    /// The measured window must hold only allocations of this parse. Lazy one-time initialization
+    /// reachable from parseQuery is charged to the first parse in the process, so parse once here
+    /// first. The same text is used, and it may throw exactly as the measured parse would.
+    {
+        ParserQuery warmup_parser(query.data() + query.size());
+        [[maybe_unused]] ASTPtr warmup_ast
+            = parseQuery(warmup_parser, query.data(), query.data() + query.size(), "", 0, 0, 0);
+    }
+
     if (enable_profiling)
     {
         if (!isProfilingCompiled())


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113491
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Since 2026-08-20 `Parser memory check` has failed 5 PRs across 154 test rows, every row reporting
exactly `+1,280 bytes`: #115301 (37 queries), #114577 (37), #110180, #115630 and #100371 (2 each).
None touches the parser. The same window credits 8 further PRs with the mirror-image `-1,280 B`
improvement, so the check can both fail innocent PRs and pass one adding a genuine 1,280 byte
regression.

The cause is in the instrument. `parser_memory_profiler` parses one query per process with no
warm-up, so lazy one-time initialization reachable from `parseQuery` is charged to that query:
2,400 bytes over five allocations on Query 64. The largest is one 1,280 byte `calloc` during
the first call into the expression parser (`ParserExpressionImpl::tryParseOperand`), whose two leaf
frames sit in a shared object absent from the executable's symbol table, so the profiler leaves them
unresolved. Whether these land inside the window is a property of the binary, not the SQL, so the two
arms, being different builds, can differ by the whole amount with identical parser source, which
clears both thresholds (1,280 B, 34.7%).

Parsing once before the window opens leaves only this parse's allocations. With the job's own
analyzer on Query 64: 4,968 -> 2,568 bytes, the 1,280 byte stack present to absent, reverting
restores it. Over all 100 queries it appears on exactly 64 and 99 before, none after; an injected
per-parse 4,096 byte allocation still reports +4,112 B, so the check is not blind.

@ qoega, two consequences to rule on. Reported values drop for 37 of 100 queries, and for about one
master build a warmed PR arm is scored against an unwarmed baseline, inflating apparent
improvements; that self-heals and I added no compensating logic. New expensive lazy initialization
is also no longer visible here, which fits a per-query AST check.

Related: https://github.com/ClickHouse/ClickHouse/pull/113491
Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115630&sha=042aecf702d2050e274706aa20011eabedb78542&name_0=PR&name_1=Parser%20memory%20check

<details>
<summary>Query 64: the 2,400 bytes of one-time initialization, by allocating frame</summary>

Multiset of per-stack byte diffs removed by the warm-up, attributed to the allocator frame that
actually appears in the symbolized heap (not to an inlined neighbour):

| bytes | allocator | initialization |
|---|---|---|
| 1,280 | `je_calloc` / `__libc_calloc`, two unresolved shared-object frames | during the first call into `ParserExpressionImpl::tryParseOperand` |
| 608 | `operator new` / `unordered_set::insert` | `isIntegerTypeName` static set (`ParserDataType.cpp`) |
| 224 | `operator new` / `unordered_set::insert` | `isArrayQuantifierPredicate` static set (`ExpressionListParsers.cpp`) |
| 192 | `operator new` / `unordered_set::insert` | `isIntegerTypeName`, second allocation |
| 96 | `operator new` / `unordered_set::insert` | `isArrayQuantifierPredicate`, second allocation |

The 7 element `isArrayQuantifierPredicate` set and the 19 element `isIntegerTypeName` set match
`sizeof(__hash_node<string_view, void*>) = 32` bytes per element (224 and 608), which is why the
1,280 byte `calloc` is not attributed to either of them.

The two unresolved frames do resolve against the profile's own `MAPPED_LIBRARIES`, and on this host
they are glibc's atexit registration: `libc.so.6` is mapped at `0x74e6aae00000`, and the offsets
`0x470bd` / `0x47231` land in `__new_exitfn` and `__cxa_atexit+65`. The callee at `0x470b8` is
`calloc(1, 0x410)`, i.e. one 1,040 byte `struct exit_function_list`, which jemalloc rounds up to its
1,280 byte size class. That is allocated once, when the first function-local static with a
non-trivial destructor inside the parser registers it. The same two frames below `main` in that stack
resolve to `__libc_start_main`, which is how the offsets were checked. The exact figure is a property
of this glibc, so the profiler is right to leave it unnamed; the point that matters here is only that
it is one-time.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115739&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115739](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115739+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1850` (included in `26.8` and later)
<!-- ch-version-info:end -->