### PR TITLE
Plant the materialization gate in a nested set subquery's own plan

### DIFF
--- a/src/Planner/CollectMaterializedCTE.cpp
+++ b/src/Planner/CollectMaterializedCTE.cpp
@@ -37,11 +37,12 @@ OrderedMaterializedCTEs collectMaterializedCTEs(const QueryTreeNodePtr & node, c
         if (auto * table_node = current_node->as<TableNode>())
         {
             const auto & cte = table_node->getMaterializedCTE();
-            /// Skip a subquery-less reference that is not plan-backed: it is the CTE's temp storage
-            /// resolved by name (e.g. a per-shard local plan reading the table the initiator shipped
-            /// as an external table). It has no subquery to materialize, so it is read directly and
-            /// must not be wrapped in a materializing step.
-            if (cte && (table_node->isMaterializedCTE() || cte->hasPlanOrBuilt()))
+            /// A subquery-less, non-plan-backed reference is the CTE's temp storage resolved by name
+            /// (e.g. a per-shard local plan reading a shipped external table): nothing to materialize.
+            /// A plan that may run as a standalone pipeline is the exception - nothing above it can
+            /// gate its readers, so it plants its own gate.
+            if (cte && (table_node->isMaterializedCTE() || cte->hasPlanOrBuilt()
+                        || select_query_options.force_materialize_cte))
             {
                 auto [it, _] = materialized_ctes.emplace(cte, MaterializedCteWithLevel{current_node, level});
 
@@ -52,12 +53,13 @@ OrderedMaterializedCTEs collectMaterializedCTEs(const QueryTreeNodePtr & node, c
             }
         }
     },
-    [&level](const QueryTreeNodePtr & current_node)
+    [&level, &select_query_options](const QueryTreeNodePtr & current_node)
     {
         if (auto * table_node = current_node->as<TableNode>())
         {
             const auto & cte = table_node->getMaterializedCTE();
-            if (cte && (table_node->isMaterializedCTE() || cte->hasPlanOrBuilt()))
+            if (cte && (table_node->isMaterializedCTE() || cte->hasPlanOrBuilt()
+                        || select_query_options.force_materialize_cte))
                 --level;
         }
     });

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -1944,6 +1944,14 @@ void addBuildSubqueriesForMaterializedCTEsIfNeeded(
             if (!materialized_cte->hasPlanOrBuilt())
             {
                 auto cte_subquery = cte_table_node->getMaterializedCTESubquery();
+                /// A by-name reference carries no subquery, but a standalone pipeline still needs a
+                /// gate for it, and the handle alone is enough to build one. The writer stays with
+                /// whoever holds the subquery.
+                if (!cte_subquery && select_query_options.force_materialize_cte)
+                {
+                    ctes.push_back(materialized_cte);
+                    continue;
+                }
                 if (!cte_subquery)
                     throw Exception(ErrorCodes::LOGICAL_ERROR,
                         "CTE '{}' does not have query tree, but was not planned yet",

--- a/src/Processors/QueryPlan/MaterializingCTEStep.cpp
+++ b/src/Processors/QueryPlan/MaterializingCTEStep.cpp
@@ -155,6 +155,11 @@ std::vector<DelayedMaterializingCTEsStep::ClaimedCTE> DelayedMaterializingCTEsSt
     std::vector<ClaimedCTE> claimed;
     for (auto & materialized_cte : step.ctes)
     {
+        /// Every claimed entry carries a plan, so the attach site can dereference it. Skipping
+        /// before the claim leaves the flag for whoever holds the subquery that will plan it.
+        if (!materialized_cte->plan)
+            continue;
+
         if (materialized_cte->is_materialization_planned.exchange(true))
             continue;
 

--- a/src/Processors/QueryPlan/MaterializingCTEStep.cpp
+++ b/src/Processors/QueryPlan/MaterializingCTEStep.cpp
@@ -124,6 +124,12 @@ void DelayedMaterializingCTEsStep::optimizePlans(const QueryPlanOptimizationSett
 {
     for (const auto & cte : ctes)
     {
+        /// The plan is absent when `makePlansForCTEs` already moved it out, or when the
+        /// reference reached this list before its plan was built. Skipping before the
+        /// claim leaves the flag for whoever holds the plan, so that plan is optimized.
+        if (!cte->plan)
+            continue;
+
         /// Multiple `DelayedMaterializingCTEsStep` instances can reference the
         /// same `MaterializedCTE` (e.g. a UNION-level step plus one per UNION
         /// branch, all planted by `addBuildSubqueriesForMaterializedCTEsIfNeeded`).
@@ -134,13 +140,7 @@ void DelayedMaterializingCTEsStep::optimizePlans(const QueryPlanOptimizationSett
         if (cte->is_plan_optimized.exchange(true))
             continue;
 
-        /// `cte->plan` can already be `nullptr` if a recursive `buildSetInplace`
-        /// path won an earlier `is_materialization_planned` race and
-        /// `std::move`d the plan out via `makePlansForCTEs`. Skip the call
-        /// rather than throwing an exception; the materialization has
-        /// already run inplace.
-        if (cte->plan)
-            cte->plan->optimize(optimization_settings);
+        cte->plan->optimize(optimization_settings);
     }
 }
 

--- a/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.reference
+++ b/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.reference
@@ -1,0 +1,19 @@
+-- nested IN over Distributed, empty middle table
+0
+-- nested IN over Distributed, populated middle table
+1
+-- same shape over a local table
+0
+1
+-- PREWHERE over an empty Distributed table, CTE declared after its reader
+0
+-- without the in-with-subqueries index path
+0
+-- without a local replica preference
+0
+-- GLOBAL IN, and a GLOBAL JOIN reading the CTE
+1
+3
+-- the index is still used to prune granules
+Parts: 1 | Granules: 1
+Granules: 1/1

--- a/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.reference
+++ b/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.reference
@@ -14,6 +14,7 @@
 -- GLOBAL IN, and a GLOBAL JOIN reading the CTE
 1
 3
--- the index is still used to prune granules
-Parts: 1 | Granules: 1
-Granules: 1/1
+-- the primary key still prunes granules under the gate
+1	1
+-- and it does not prune when the in-with-subqueries index path is off
+0	0

--- a/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.reference
+++ b/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.reference
@@ -13,7 +13,8 @@
 0
 -- GLOBAL IN, and a GLOBAL JOIN reading the CTE
 1
-3
+3	1
+1
 -- the primary key still prunes granules under the gate
 1	1
 -- and it does not prune when the in-with-subqueries index path is off

--- a/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.sql
+++ b/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.sql
@@ -1,0 +1,85 @@
+-- A materialized CTE read from inside a nested IN subquery over a Distributed table.
+-- The set subquery's plan is executed as a standalone pipeline, so it has to carry its own
+-- materialization gate: nothing above it can gate its readers.
+
+SET enable_analyzer = 1;
+SET enable_materialized_cte = 1;
+SET use_index_for_in_with_subqueries = 1;
+
+DROP TABLE IF EXISTS t_gate;
+DROP TABLE IF EXISTS dist_gate;
+DROP TABLE IF EXISTS t_empty;
+DROP TABLE IF EXISTS dist_empty;
+DROP TABLE IF EXISTS mid_empty;
+DROP TABLE IF EXISTS mid_pop;
+
+CREATE TABLE t_gate (c Int32) ENGINE = MergeTree ORDER BY c;
+INSERT INTO t_gate SELECT number + 1 FROM numbers(3);
+
+CREATE TABLE dist_gate AS t_gate ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_gate);
+
+CREATE TABLE t_empty (c Int32) ENGINE = MergeTree ORDER BY c;
+CREATE TABLE dist_empty AS t_empty ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_empty);
+
+CREATE TABLE mid_empty (c Int32) ENGINE = MergeTree ORDER BY c;
+
+CREATE TABLE mid_pop (c Int32) ENGINE = MergeTree ORDER BY c;
+INSERT INTO mid_pop SELECT 1;
+
+SELECT '-- nested IN over Distributed, empty middle table';
+WITH ct AS MATERIALIZED (SELECT 1 AS c),
+     rs AS MATERIALIZED (SELECT * FROM dist_gate WHERE c IN (SELECT c FROM mid_empty WHERE c IN (SELECT c FROM ct)))
+SELECT count() FROM rs AS a, rs AS b;
+
+SELECT '-- nested IN over Distributed, populated middle table';
+WITH ct AS MATERIALIZED (SELECT 1 AS c),
+     rs AS MATERIALIZED (SELECT * FROM dist_gate WHERE c IN (SELECT c FROM mid_pop WHERE c IN (SELECT c FROM ct)))
+SELECT count() FROM rs AS a, rs AS b;
+
+SELECT '-- same shape over a local table';
+WITH ct AS MATERIALIZED (SELECT 1 AS c),
+     rs AS MATERIALIZED (SELECT * FROM t_gate WHERE c IN (SELECT c FROM mid_empty WHERE c IN (SELECT c FROM ct)))
+SELECT count() FROM rs AS a, rs AS b;
+
+WITH ct AS MATERIALIZED (SELECT 1 AS c),
+     rs AS MATERIALIZED (SELECT * FROM t_gate WHERE c IN (SELECT c FROM mid_pop WHERE c IN (SELECT c FROM ct)))
+SELECT count() FROM rs AS a, rs AS b;
+
+SELECT '-- PREWHERE over an empty Distributed table, CTE declared after its reader';
+WITH rs AS MATERIALIZED (SELECT * FROM dist_empty PREWHERE c IN (SELECT c FROM ct)),
+     ct AS MATERIALIZED (SELECT 1 AS c)
+SELECT count() FROM rs AS a, rs AS b;
+
+SELECT '-- without the in-with-subqueries index path';
+WITH ct AS MATERIALIZED (SELECT 1 AS c),
+     rs AS MATERIALIZED (SELECT * FROM dist_gate WHERE c IN (SELECT c FROM mid_empty WHERE c IN (SELECT c FROM ct)))
+SELECT count() FROM rs AS a, rs AS b
+SETTINGS use_index_for_in_with_subqueries = 0;
+
+SELECT '-- without a local replica preference';
+WITH ct AS MATERIALIZED (SELECT 1 AS c),
+     rs AS MATERIALIZED (SELECT * FROM dist_gate WHERE c IN (SELECT c FROM mid_empty WHERE c IN (SELECT c FROM ct)))
+SELECT count() FROM rs AS a, rs AS b
+SETTINGS prefer_localhost_replica = 0;
+
+SELECT '-- GLOBAL IN, and a GLOBAL JOIN reading the CTE';
+WITH ct AS MATERIALIZED (SELECT 1 AS c),
+     rs AS MATERIALIZED (SELECT * FROM dist_gate WHERE c GLOBAL IN (SELECT c FROM mid_pop WHERE c IN (SELECT c FROM ct)))
+SELECT count() FROM rs AS a, rs AS b;
+
+WITH ct AS MATERIALIZED (SELECT 1 AS c)
+SELECT count() FROM dist_gate GLOBAL ANY LEFT JOIN ct USING (c);
+
+SELECT '-- the index is still used to prune granules';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    WITH ct AS MATERIALIZED (SELECT 2 AS c)
+    SELECT count() FROM t_gate WHERE c IN (SELECT c FROM ct)
+) WHERE explain ILIKE '%Granules:%';
+
+DROP TABLE t_gate;
+DROP TABLE dist_gate;
+DROP TABLE t_empty;
+DROP TABLE dist_empty;
+DROP TABLE mid_empty;
+DROP TABLE mid_pop;

--- a/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.sql
+++ b/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.sql
@@ -75,8 +75,21 @@ WITH ct AS MATERIALIZED (SELECT 1 AS c),
      rs AS MATERIALIZED (SELECT * FROM dist_gate WHERE c GLOBAL IN (SELECT c FROM mid_pop WHERE c IN (SELECT c FROM ct)))
 SELECT count() FROM rs AS a, rs AS b;
 
+-- The CTE is named twice so it stays materialized instead of being inlined, and the second
+-- column is fed by the joined right-hand side, so it drops to 0 if the CTE contributes no rows.
 WITH ct AS MATERIALIZED (SELECT 1 AS c)
-SELECT count() FROM dist_gate GLOBAL ANY LEFT JOIN ct USING (c);
+SELECT count(), sum(j1.c) FROM dist_gate
+GLOBAL ANY LEFT JOIN ct AS j1 USING (c)
+GLOBAL ANY LEFT JOIN ct AS j2 USING (c);
+
+-- ... and that arm reads a materialized CTE rather than an inlined subquery.
+SELECT count() > 0 FROM (
+    EXPLAIN
+    WITH ct AS MATERIALIZED (SELECT 1 AS c)
+    SELECT count(), sum(j1.c) FROM dist_gate
+    GLOBAL ANY LEFT JOIN ct AS j1 USING (c)
+    GLOBAL ANY LEFT JOIN ct AS j2 USING (c)
+) WHERE explain ILIKE '%MaterializingCTEs%';
 
 -- The primary key still prunes granules in the gated plan: one line names the index path that
 -- ran, the other requires the selected granule count to be strictly below the total. Both need a

--- a/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.sql
+++ b/tests/queries/0_stateless/05026_materialized_cte_nested_set_subquery_gate.sql
@@ -12,11 +12,19 @@ DROP TABLE IF EXISTS t_empty;
 DROP TABLE IF EXISTS dist_empty;
 DROP TABLE IF EXISTS mid_empty;
 DROP TABLE IF EXISTS mid_pop;
+DROP TABLE IF EXISTS t_idx;
+DROP TABLE IF EXISTS dist_idx;
 
 CREATE TABLE t_gate (c Int32) ENGINE = MergeTree ORDER BY c;
 INSERT INTO t_gate SELECT number + 1 FROM numbers(3);
 
 CREATE TABLE dist_gate AS t_gate ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_gate);
+
+-- index_granularity is pinned so the plan below keeps several granules to prune.
+CREATE TABLE t_idx (c Int32) ENGINE = MergeTree ORDER BY c SETTINGS index_granularity = 4;
+INSERT INTO t_idx SELECT number FROM numbers(64);
+
+CREATE TABLE dist_idx AS t_idx ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_idx);
 
 CREATE TABLE t_empty (c Int32) ENGINE = MergeTree ORDER BY c;
 CREATE TABLE dist_empty AS t_empty ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_empty);
@@ -70,12 +78,36 @@ SELECT count() FROM rs AS a, rs AS b;
 WITH ct AS MATERIALIZED (SELECT 1 AS c)
 SELECT count() FROM dist_gate GLOBAL ANY LEFT JOIN ct USING (c);
 
-SELECT '-- the index is still used to prune granules';
-SELECT trimLeft(explain) FROM (
+-- The primary key still prunes granules in the gated plan: one line names the index path that
+-- ran, the other requires the selected granule count to be strictly below the total. Both need a
+-- local MergeTree read in the plan, so the shard is read locally and index_granularity is pinned.
+SELECT '-- the primary key still prunes granules under the gate';
+SELECT
+    countIf(explain LIKE '%Condition: (c in 1-element set)%') AS pk_condition_lines,
+    countIf(match(explain, 'Granules: [0-9]+/[0-9]+')
+            AND toUInt32(extract(explain, 'Granules: ([0-9]+)/'))
+              < toUInt32(extract(explain, 'Granules: [0-9]+/([0-9]+)'))) AS strictly_pruned_lines
+FROM (
     EXPLAIN indexes = 1
-    WITH ct AS MATERIALIZED (SELECT 2 AS c)
-    SELECT count() FROM t_gate WHERE c IN (SELECT c FROM ct)
-) WHERE explain ILIKE '%Granules:%';
+    WITH ct AS MATERIALIZED (SELECT 1 AS c),
+         rs AS MATERIALIZED (SELECT * FROM dist_idx WHERE c IN (SELECT c FROM mid_pop WHERE c IN (SELECT c FROM ct)))
+    SELECT count() FROM rs AS a, rs AS b
+    SETTINGS prefer_localhost_replica = 1
+);
+
+SELECT '-- and it does not prune when the in-with-subqueries index path is off';
+SELECT
+    countIf(explain LIKE '%Condition: (c in 1-element set)%') AS pk_condition_lines,
+    countIf(match(explain, 'Granules: [0-9]+/[0-9]+')
+            AND toUInt32(extract(explain, 'Granules: ([0-9]+)/'))
+              < toUInt32(extract(explain, 'Granules: [0-9]+/([0-9]+)'))) AS strictly_pruned_lines
+FROM (
+    EXPLAIN indexes = 1
+    WITH ct AS MATERIALIZED (SELECT 1 AS c),
+         rs AS MATERIALIZED (SELECT * FROM dist_idx WHERE c IN (SELECT c FROM mid_pop WHERE c IN (SELECT c FROM ct)))
+    SELECT count() FROM rs AS a, rs AS b
+    SETTINGS prefer_localhost_replica = 1, use_index_for_in_with_subqueries = 0
+);
 
 DROP TABLE t_gate;
 DROP TABLE dist_gate;
@@ -83,3 +115,5 @@ DROP TABLE t_empty;
 DROP TABLE dist_empty;
 DROP TABLE mid_empty;
 DROP TABLE mid_pop;
+DROP TABLE t_idx;
+DROP TABLE dist_idx;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/113184
Related: https://github.com/ClickHouse/ClickHouse/pull/108924
-->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `LOGICAL_ERROR` "Reading from materialized CTE 'X' before its materialization completed - DelayedPortsProcessor gate is missing in the query plan" when a `MATERIALIZED` CTE is read from inside an `IN` subquery over a `Distributed` table. Closes #113184.


### Description

Closes #113184. A `MATERIALIZED` CTE read from inside an `IN` subquery over a `Distributed` table failed with `Code: 49. Reading from materialized CTE 'ct' before its materialization completed - DelayedPortsProcessor gate is missing in the query plan`. Reproducer in #113184:

```sql
WITH ct AS MATERIALIZED (SELECT 1 AS c),
     rs AS MATERIALIZED (SELECT * FROM dist_t WHERE c IN (SELECT c FROM ct))
SELECT count() FROM rs AS a, rs AS b;
```

**Root cause.** A set subquery is planned with `forceMaterializeCTE` because `buildOrderedSetInplace` may execute it as a standalone pipeline, with no outer processor to gate its CTE readers. But `collectMaterializedCTEs` declined the reference: inside a set subquery it has `isMaterializedCTE() == false` (the subquery child was detached by `detachQueryTree`) and `hasPlanOrBuilt() == false`. Nothing was collected, `addBuildSubqueriesForMaterializedCTEsIfNeeded` returned early, and the readers ran with nothing ordering them after the writer.

**The change.** The by-name carve-out is correct for a plan shipped to a remote shard, which must not be wrapped, but misfires on a plan executed in process. Accept the reference when `force_materialize_cte` is set, in both lambdas of the traversal. Such a reference carries no subquery, so push the CTE handle; the writer stays with whoever holds the subquery. The widened predicate also admits by-name references under callers that plan a tree standalone, so `makePlansForCTEs` now tests for a built plan before consuming the materialization claim.

**Validation.** The query above returns the expected `1`. The test covers 9 shapes (`PREWHERE`, `GLOBAL IN`, `GLOBAL JOIN`, empty and populated middle tables) plus index-pruning and materialization assertions, and passes 50/50 under randomization. On the ordinary main-query path `force_materialize_cte` is false and `EXPLAIN` output is byte-identical to master.

A three-level CTE chain behind the same nested subquery still fails identically on unpatched master: a separate pre-existing defect, not addressed here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115740&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115740](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115740+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
