### PR TITLE
docs: clarify quota-exempt system tables

### DIFF
--- a/docs/concepts/features/configuration/server-config/quotas.mdx
+++ b/docs/concepts/features/configuration/server-config/quotas.mdx
@@ -117,17 +117,13 @@ If the limit is exceeded for at least one time interval, an exception is thrown 
 
 ## Queries excluded from quota accounting {#queries-excluded-from-quota-accounting}
 
-To allow quota configuration and usage to be inspected even when a quota is exhausted, queries whose only table source is one of the following system tables are not charged to quotas and are not subject to query-complexity limits:
+To allow quota configuration and usage to be inspected even when a quota is exhausted, `SELECT` queries that exclusively read from one of the following system tables are not charged to quotas and are not subject to query-complexity limits:
 
 - `system.quotas`
 - `system.quota_limits`
 - `system.quota_usage`
 - `system.quotas_usage`
 - `system.one`
-
-A `SELECT` query without a `FROM` clause reads from [`system.one`](/operations/system-tables/one). Therefore, `SELECT 1` is not charged to a quota and must not be used to verify a `queries` or `query_selects` limit.
-
-The exemption applies only when the listed system table is the query's only table source. Queries that access user tables, or combine an exempt system table with another table source, are subject to the applicable quota. These queries can still require the relevant access privileges.
 
 Quotas can use the "quota key" feature to report on resources for multiple keys independently. Here is an example of this:
 

--- a/docs/concepts/features/configuration/server-config/quotas.mdx
+++ b/docs/concepts/features/configuration/server-config/quotas.mdx
@@ -115,7 +115,8 @@ Here are the amounts that can be restricted:
 
 If the limit is exceeded for at least one time interval, an exception is thrown with a text about which restriction was exceeded, for which interval, and when the new interval begins (when queries can be sent again).
 
-## Queries excluded from quota accounting {#queries-excluded-from-quota-accounting}
+<Note>
+**Queries excluded from quota accounting**
 
 To allow quota configuration and usage to be inspected even when a quota is exhausted, `SELECT` queries that exclusively read from one of the following system tables are not charged to quotas and are not subject to query-complexity limits:
 
@@ -124,6 +125,7 @@ To allow quota configuration and usage to be inspected even when a quota is exha
 - `system.quota_usage`
 - `system.quotas_usage`
 - `system.one`
+</Note>
 
 Quotas can use the "quota key" feature to report on resources for multiple keys independently. Here is an example of this:
 

--- a/docs/concepts/features/configuration/server-config/quotas.mdx
+++ b/docs/concepts/features/configuration/server-config/quotas.mdx
@@ -115,6 +115,20 @@ Here are the amounts that can be restricted:
 
 If the limit is exceeded for at least one time interval, an exception is thrown with a text about which restriction was exceeded, for which interval, and when the new interval begins (when queries can be sent again).
 
+## Queries excluded from quota accounting {#queries-excluded-from-quota-accounting}
+
+To allow quota configuration and usage to be inspected even when a quota is exhausted, queries whose only table source is one of the following system tables are not charged to quotas and are not subject to query-complexity limits:
+
+- `system.quotas`
+- `system.quota_limits`
+- `system.quota_usage`
+- `system.quotas_usage`
+- `system.one`
+
+A `SELECT` query without a `FROM` clause reads from [`system.one`](/operations/system-tables/one). Therefore, `SELECT 1` is not charged to a quota and must not be used to verify a `queries` or `query_selects` limit.
+
+The exemption applies only when the listed system table is the query's only table source. Queries that access user tables, or combine an exempt system table with another table source, are subject to the applicable quota. These queries can still require the relevant access privileges.
+
 Quotas can use the "quota key" feature to report on resources for multiple keys independently. Here is an example of this:
 
 ```xml


### PR DESCRIPTION
Document the system tables excluded from quota accounting and clarify the conditions for the exemption.

This behavior is implemented in [`PlannerJoinTree.cpp`](https://github.com/ClickHouse/ClickHouse/blob/master/src/Planner/PlannerJoinTree.cpp#L401), but was not previously documented.
This PR adds the missing documentation, including that the exemption applies only when the system table is the query's sole table source.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

N/A (documentation-only change)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115741&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115741](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115741+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
