### PR TITLE
CI: retry a run whose job was killed by a reclaimed runner

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -21,24 +21,32 @@ jobs:
           set -euo pipefail
 
           MAX_RERUNS=10
+          SCAN_LIMIT=1000
           rerun_count=0
           cutoff=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          scan_floor=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
 
           echo "Looking for failed PR workflow runs since $cutoff..."
           echo ""
 
-          # Get recent failed runs for the PR workflow that have not been retried yet.
-          # The window is measured from updatedAt (when the run finished), because a run
-          # only becomes listable once it completes: a run longer than the window would
-          # never be inside it when first seen. The list itself is ordered by createdAt,
-          # so a long run sits deep in it and the limit has to be well above the window.
-          run_ids=$(gh run list \
+          # Eligibility is by updatedAt (a run only becomes listable once it completes), but
+          # the listing is ordered by createdAt. Bounding the scan on createdAt makes it a
+          # contiguous prefix of that order, so no eligible run can sit behind newer ones.
+          runs=$(gh run list \
             --repo "$GH_REPO" \
             --workflow pull_request.yml \
             --status failure \
-            --limit 200 \
-            --json databaseId,attempt,updatedAt \
-            --jq ".[] | select(.attempt == 1 and .updatedAt >= \"$cutoff\") | .databaseId")
+            --created ">=$scan_floor" \
+            --limit "$SCAN_LIMIT" \
+            --json databaseId,attempt,updatedAt)
+
+          # A full page means the createdAt bound is no longer what ends the scan.
+          if [ "$(echo "$runs" | jq 'length')" -ge "$SCAN_LIMIT" ]; then
+            echo "WARNING: hit the $SCAN_LIMIT-run listing cap; the scan may be truncated."
+          fi
+
+          run_ids=$(echo "$runs" | jq -r \
+            ".[] | select(.attempt == 1 and .updatedAt >= \"$cutoff\") | .databaseId")
 
           if [ -z "$run_ids" ]; then
             echo "No recent failed runs found."

--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -27,14 +27,18 @@ jobs:
           echo "Looking for failed PR workflow runs since $cutoff..."
           echo ""
 
-          # Get recent failed runs for the PR workflow that have not been retried yet
+          # Get recent failed runs for the PR workflow that have not been retried yet.
+          # The window is measured from updatedAt (when the run finished), because a run
+          # only becomes listable once it completes: a run longer than the window would
+          # never be inside it when first seen. The list itself is ordered by createdAt,
+          # so a long run sits deep in it and the limit has to be well above the window.
           run_ids=$(gh run list \
             --repo "$GH_REPO" \
             --workflow pull_request.yml \
             --status failure \
-            --limit 50 \
-            --json databaseId,attempt,createdAt \
-            --jq ".[] | select(.attempt == 1 and .createdAt >= \"$cutoff\") | .databaseId")
+            --limit 200 \
+            --json databaseId,attempt,updatedAt \
+            --jq ".[] | select(.attempt == 1 and .updatedAt >= \"$cutoff\") | .databaseId")
 
           if [ -z "$run_ids" ]; then
             echo "No recent failed runs found."
@@ -62,6 +66,9 @@ jobs:
             #   not actual tests — always treated as infrastructure failure), or
             # - it never reached its main "Run" step (failed during checkout/setup), or
             # - the "Run" step was skipped, or
+            # - the "Run" step was cancelled while the job itself failed: the runner went
+            #   away mid-run. A user or cascade cancel makes the job itself "cancelled",
+            #   which the filter above excludes, so it never reaches this arm.
             # - the "Run" step failed almost immediately (under 2 minutes), indicating
             #   a setup/download issue (e.g. missing S3 credentials) rather than a real
             #   test failure
@@ -72,6 +79,7 @@ jobs:
                 [.steps[] | select(.name == "Run")] |
                 if length == 0 then true
                 elif .[0].conclusion == "skipped" then true
+                elif .[0].conclusion == "cancelled" then true
                 elif .[0].conclusion == "failure" then
                   ((.[0].completed_at | fromdateiso8601) -
                    (.[0].started_at | fromdateiso8601)) < 120


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

When a self-hosted runner is reclaimed mid-`Run`, the job ends `failure` with the `Run` step
`cancelled`. The check goes red having run zero tests and published zero CIDB rows, and the hourly
infra-retry workflow does not rerun it, for three reasons.

**No classifier arm for a `cancelled` `Run` step**: it falls into `else false` and is scored a real
failure, while the gate needs every failed job to be infra. The cron's log for run 32413924641
ends `Not an infrastructure failure, skipping.`

**The window was anchored on `createdAt`, but a run only becomes listable once it completes**, so a
run longer than the 6h window is already outside it when first seen. Against actual fire times,
175 of 399 recent failed runs are unreachable; under an `updatedAt` anchor, 0 are. The window
length is unchanged.

**The scan is bounded on `createdAt` rather than a fixed `--limit`**: the listing is ordered by
`createdAt` while eligibility is by `updatedAt`, so a fixed prefix truncates a different order than
the one filtered. The deepest eligible index reaches 214, so a 200 limit drops a run.

That floor is a second condition on top of `updatedAt`, so reaching it needs an attempt-1 lifetime
above 18h; across a complete 14-day population the longest is 9.42h, giving 1.56x spare. It cannot
widen, since the runs API stops at 1000 results and a 5-day floor needs 2339 at the worst fire.
Over 323 simulated fires, 24h under a 1000 cap misses nothing and never reaches it; 72h binds at
163. A warning fires if it does.

`MAX_RERUNS` is untouched, so a wider scan cannot add reruns. Verified on runs 32413924641
and 32306491684: `false` before, `true` after. Across 60 deliberately cancelled runs there are no
`(job failure, Run cancelled)` pairs, since such a run's conclusion is itself `cancelled`.

Related: https://github.com/ClickHouse/ClickHouse/pull/115569
Related: https://github.com/ClickHouse/ClickHouse/pull/113564
