### PR TITLE
Assert what the build profile diff job's scheduling actually depends on

### DIFF
--- a/ci/tests/test_build_profile_diff_scheduling.py
+++ b/ci/tests/test_build_profile_diff_scheduling.py
@@ -170,6 +170,7 @@ def test_inherited_carriers_are_not_listed_on_the_job_itself(changed_files):
     [
         pytest.param(["ci/defs/job_configs.py"], id="job-registry"),
         pytest.param(["ci/defs/defs.py"], id="defs-registry"),
+        pytest.param(["ci/workflows/pull_request.py"], id="workflow-registry"),
     ],
 )
 def test_the_job_does_not_track_the_registry_that_declares_it(changed_files):
@@ -180,6 +181,29 @@ def test_the_job_does_not_track_the_registry_that_declares_it(changed_files):
     must arrive through `requires` rather than through a registry path of its own.
     """
     assert not _job(BPD).is_affected_by(changed_files)
+
+
+@pytest.mark.parametrize(
+    "changed_files",
+    [
+        pytest.param(["ci/defs/job_configs.py"], id="job-registry"),
+        pytest.param(["ci/defs/defs.py"], id="defs-registry"),
+        pytest.param(["ci/workflows/pull_request.py"], id="workflow-registry"),
+    ],
+)
+def test_a_registry_edit_schedules_the_job_only_through_the_build(changed_files):
+    """A job can also be scheduled without being affected: the rescue pass keeps it when
+    an affected job requires it, which is how a registry edit reaches the profiled build.
+
+    Reaching this job that way would run it with nothing to compare, and the assertion on
+    its own digest above cannot see it, because the rescue reads `requires` and `provides`
+    and never consults `digest_config`. The build being affected is the other admissible
+    outcome: the registry declares the build, so an edit to it can move the build's own
+    key, and then there is a fresh profile and the comparison is real.
+    """
+    assert BPD in _schedule(changed_files) or _job(PROFILED_BUILD).is_affected_by(
+        changed_files
+    )
 
 
 def test_the_job_requires_the_profiled_build_rather_than_running_after_it():

--- a/ci/tests/test_build_profile_diff_scheduling.py
+++ b/ci/tests/test_build_profile_diff_scheduling.py
@@ -96,8 +96,6 @@ BUILD_FREE_DIFFS = [
     pytest.param(["docs/en/development/continuous-integration.md"], id="docs-only"),
     pytest.param(["tests/queries/0_stateless/0001_x.sql"], id="stateless-test-only"),
     pytest.param([".github/workflows/pull_request.yml"], id="generated-yaml"),
-    pytest.param(["ci/defs/job_configs.py"], id="job-registry"),
-    pytest.param(["ci/defs/defs.py"], id="defs-registry"),
     pytest.param(["ci/jobs/scripts/workflow_hooks/filter_job.py"], id="filter-hook"),
 ]
 
@@ -167,18 +165,21 @@ def test_inherited_carriers_are_not_listed_on_the_job_itself(changed_files):
     assert BPD not in _schedule(changed_files)
 
 
-def test_registry_edits_do_not_schedule_a_run_without_profile_data():
-    """A change to the job registry does not affect the build, so the build stays
-    cache-reusable and uploads no profile for this head. Scheduling the diff job then
-    reproduces the waste this filtering exists to prevent.
+@pytest.mark.parametrize(
+    "changed_files",
+    [
+        pytest.param(["ci/defs/job_configs.py"], id="job-registry"),
+        pytest.param(["ci/defs/defs.py"], id="defs-registry"),
+    ],
+)
+def test_the_job_does_not_track_the_registry_that_declares_it(changed_files):
+    """The registry declares every job, so a job that digests it is affected by every
+    unrelated CI edit.
 
-    Phrased as "these paths do not schedule the job" rather than as a literal copy of
-    the digest list, so adding a genuine consumer input later does not fail this test.
+    This job has something to compare only when the profiled build itself rebuilt, so it
+    must arrive through `requires` rather than through a registry path of its own.
     """
-    for path in ("ci/defs/job_configs.py", "ci/defs/defs.py"):
-        skipped = _schedule([path])
-        assert PROFILED_BUILD in skipped, path
-        assert BPD in skipped, path
+    assert not _job(BPD).is_affected_by(changed_files)
 
 
 def test_the_job_requires_the_profiled_build_rather_than_running_after_it():


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113491


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`CI Tests` is red on master: `test_registry_edits_do_not_schedule_a_run_without_profile_data`
asserts a registry-only diff leaves `Build (arm_release)` skipped, so every PR
whose base carries the test file inherits it.

The assertion is false, and asks the wrong question. `Parser memory check` digests
both registry files and requires `CLICKHOUSE_EXAMPLES`, which the `arm_release`
build provides, so the rescue pass in `_filter_unaffected_jobs` keeps the build
scheduled. But a scheduled build was never the signal either way: the build's own
digest excludes `ci/defs`, so a rescued build can be a cache hit that uploads no
profile, while an edit to the build's own declaration (`timeout`, `runs_on`,
`command`) moves its `config_digest` (`...-de68` -> `...-9243`), a cache miss that
does rebuild and produce a profile. So `ci/defs` paths cannot satisfy
`BUILD_FREE_DIFFS`' contract of not changing the build's output. I drop those two
params, and the function whose second assertion duplicated them.

What they carried is asserted directly instead, over all three registry files
(adding `ci/workflows/pull_request.py`) and claiming nothing about the build: this
job's own digest must not track the registry, and a registry edit must reach the
job only through the build. The registry declares every job, so digesting it makes
a job affected by every unrelated CI edit; and the rescue pass reads `requires`
and `provides` only, so a rescue reaching this job is invisible to a digest
assertion.

Not a weakening: the file asserts three cases more than before. Mutation-checked
against the real workflow - pasting the registry onto this job's digest, removing
its digest, and a rescue reaching it all redden. Adding the registry to the
*build's* digest stays green, correctly: the build rebuilds, so the comparison
exists. The old params called that a regression.

Out of scope: a registry edit moving the build's `config_digest` produces a
profile while this job stays filtered, needing config-digest-aware scheduling.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115749&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115749](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115749+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
