### PR TITLE
docker: disable SBOM for PRs and downgrade version that does not OOMs private builds

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -207,7 +207,7 @@ jobs:
               docker buildx build \
                 --platform=linux/amd64,linux/arm64 \
                 --provenance=true \
-                --sbom=true \
+                --attest=type=sbom,generator=docker/buildkit-syft-scanner:1.11 \
                 --target=production \
                 ${PUSH_FLAG:-$OUTPUT_FLAG} \
                 --label="build-url=${GITHUB_RUN_URL}" \

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -235,7 +235,7 @@ def gen_tags(version_str: str, tag_type: str) -> List[str]:
 
 
 # `docker buildx build` resolves base/SBOM-scanner images such as
-# `docker/buildkit-syft-scanner` (pulled by `--sbom=true`) from docker.io, which
+# `docker/buildkit-syft-scanner` (pulled for the SBOM attestation) from docker.io, which
 # intermittently returns transient HTTP errors while resolving and while pushing
 # image layers, and the build itself hits `apt-get` package mirrors that occasionally
 # refuse connections. Retry the buildx commands only on genuine
@@ -451,9 +451,11 @@ def buildx_args(
     # Attestations survive only in pushed manifests (the local docker exporter
     # drops them), while the SBOM scan of a multi-GB image OOMs smaller runners,
     # so generate them only for pushed images.
+    # The scanner is pinned because the floating stable-1 tag can silently move
+    # to a version whose scan of a multi-GB image exceeds the runner's memory.
     if attest:
         args.append("--provenance=true")
-        args.append("--sbom=true")
+        args.append("--attest=type=sbom,generator=docker/buildkit-syft-scanner:1.11")
     if direct_urls:
         args.append(f"--build-arg=DIRECT_DOWNLOAD_URLS='{' '.join(direct_urls)}'")
     elif urls:

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -440,15 +440,20 @@ def buildx_args(
     version: str,
     sha: str,
     action_url: str,
+    attest: bool,
 ) -> List[str]:
     args = [
-        "--provenance=true",
-        "--sbom=true",
         f"--platform=linux/{arch}",
         f"--label=build-url={action_url}",
         f"--label=com.clickhouse.build.githash={sha}",
         f"--label=com.clickhouse.build.version={version}",
     ]
+    # Attestations survive only in pushed manifests (the local docker exporter
+    # drops them), while the SBOM scan of a multi-GB image OOMs smaller runners,
+    # so generate them only for pushed images.
+    if attest:
+        args.append("--provenance=true")
+        args.append("--sbom=true")
     if direct_urls:
         args.append(f"--build-arg=DIRECT_DOWNLOAD_URLS='{' '.join(direct_urls)}'")
     elif urls:
@@ -522,6 +527,7 @@ def build_and_push_image(
                 version=version,
                 action_url=run_url,
                 sha=sha,
+                attest=push,
             )
         )
         if not push:

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -633,7 +633,9 @@ def main():
                         f"docker buildx build"
                         f" --platform=linux/amd64,linux/arm64"
                         f" --provenance=true"
-                        f" --sbom=true"
+                        # Pinned scanner: the floating stable-1 tag can move to a
+                        # version whose scan exceeds the runner's memory.
+                        f" --attest=type=sbom,generator=docker/buildkit-syft-scanner:1.11"
                         f" --output=type=registry"
                         f"{target_arg}"
                         f" --label=com.clickhouse.build.version={label_version}"

--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -103,7 +103,7 @@ class Docker:
                     ",force-compression=true"
                 )
 
-            command = f"docker buildx build {tags_substr} {from_tag}{build_args} --platform {','.join(platforms)} --provenance=mode=max --sbom=true {config.path}{push_out}"
+            command = f"docker buildx build {tags_substr} {from_tag}{build_args} --platform {','.join(platforms)} --provenance=mode=max --attest=type=sbom,generator=docker/buildkit-syft-scanner:1.11 {config.path}{push_out}"
 
             return Result.from_commands_run(
                 name=name,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115761&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115761](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115761+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.349` (included in `26.9` and later)
<!-- ch-version-info:end -->