### PR TITLE
Reject invalid subrequests in ZooKeeper multi requests

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -1115,9 +1115,71 @@ size_t ZooKeeperErrorResponse::sizeImpl() const
     return Coordination::size(error);
 }
 
+ZooKeeperRequestPtr ZooKeeperRequest::cloneForMulti(const ACLs &) const
+{
+    throw Exception::fromMessage(Error::ZBADARGUMENTS, "Illegal command as part of multi ZooKeeper request");
+}
+
+ZooKeeperRequestPtr ZooKeeperCreateRequest::cloneForMulti(const ACLs & default_acls) const
+{
+    auto result = std::make_shared<ZooKeeperCreateRequest>(*this);
+    if (result->acls.empty())
+        result->acls = default_acls;
+    return result;
+}
+
+std::optional<ZooKeeperMultiRequest::OperationType> ZooKeeperMultiRequest::getOperationType(OpNum op_num)
+{
+    switch (op_num)
+    {
+        case OpNum::Create:
+        case OpNum::Create2:
+        case OpNum::CreateContainer:
+        case OpNum::CreateTTL:
+        case OpNum::CreateIfNotExists:
+        case OpNum::Remove:
+        case OpNum::TryRemove:
+        case OpNum::RemoveRecursive:
+        case OpNum::Set:
+        case OpNum::Check:
+        case OpNum::CheckNotExists:
+        case OpNum::CheckStat:
+            return OperationType::Write;
+
+        case OpNum::Get:
+        case OpNum::Exists:
+        case OpNum::SimpleList:
+        case OpNum::List:
+        case OpNum::FilteredList:
+        case OpNum::FilteredListWithStatsAndData:
+        case OpNum::ListRecursive:
+            return OperationType::Read;
+
+        case OpNum::Close:
+        case OpNum::Error:
+        case OpNum::GetACL:
+        case OpNum::SetACL:
+        case OpNum::Sync:
+        case OpNum::Heartbeat:
+        case OpNum::Multi:
+        case OpNum::Reconfig:
+        case OpNum::CheckWatch:
+        case OpNum::RemoveWatch:
+        case OpNum::MultiRead:
+        case OpNum::Auth:
+        case OpNum::SetWatch:
+        case OpNum::SetWatch2:
+        case OpNum::AddWatch:
+        case OpNum::SessionID:
+            return std::nullopt;
+    }
+}
+
 void ZooKeeperMultiRequest::checkOperationType(OperationType type)
 {
-    chassert(!operation_type.has_value() || *operation_type == type);
+    if (operation_type.has_value() && *operation_type != type)
+        throw Exception::fromMessage(Error::ZBADARGUMENTS, "Cannot mix read and write commands in a multi ZooKeeper request");
+
     operation_type = type;
 }
 
@@ -1136,64 +1198,18 @@ ZooKeeperMultiRequest::ZooKeeperMultiRequest(std::span<const Coordination::Reque
     /// Note that deep copy is required to avoid modifying path in presence of chroot prefix.
     requests.reserve(generic_requests.size());
 
-    using enum OperationType;
     for (const auto & generic_request : generic_requests)
     {
-        if (const auto * concrete_request_create = dynamic_cast<const ZooKeeperCreateRequest *>(generic_request.get()))
-        {
-            checkOperationType(Write);
-            auto create = std::make_shared<ZooKeeperCreateRequest>(*concrete_request_create);
-            if (create->acls.empty())
-                create->acls = default_acls;
-            requests.push_back(create);
-        }
-        else if (const auto * concrete_request_remove = dynamic_cast<const ZooKeeperRemoveRequest *>(generic_request.get()))
-        {
-            checkOperationType(Write);
-            requests.push_back(std::make_shared<ZooKeeperRemoveRequest>(*concrete_request_remove));
-        }
-        else if (const auto * concrete_request_remove_recursive = dynamic_cast<const ZooKeeperRemoveRecursiveRequest *>(generic_request.get()))
-        {
-            checkOperationType(Write);
-            requests.push_back(std::make_shared<ZooKeeperRemoveRecursiveRequest>(*concrete_request_remove_recursive));
-        }
-        else if (const auto * concrete_request_set = dynamic_cast<const ZooKeeperSetRequest *>(generic_request.get()))
-        {
-            checkOperationType(Write);
-            requests.push_back(std::make_shared<ZooKeeperSetRequest>(*concrete_request_set));
-        }
-        else if (const auto * concrete_request_check = dynamic_cast<const ZooKeeperCheckRequest *>(generic_request.get()))
-        {
-            checkOperationType(Write);
-            requests.push_back(std::make_shared<ZooKeeperCheckRequest>(*concrete_request_check));
-        }
-        else if (const auto * concrete_request_get = dynamic_cast<const ZooKeeperGetRequest *>(generic_request.get()))
-        {
-            checkOperationType(Read);
-            requests.push_back(std::make_shared<ZooKeeperGetRequest>(*concrete_request_get));
-        }
-        else if (const auto * concrete_request_exists = dynamic_cast<const ZooKeeperExistsRequest *>(generic_request.get()))
-        {
-            checkOperationType(Read);
-            requests.push_back(std::make_shared<ZooKeeperExistsRequest>(*concrete_request_exists));
-        }
-        else if (const auto * concrete_request_simple_list = dynamic_cast<const ZooKeeperSimpleListRequest *>(generic_request.get()))
-        {
-            checkOperationType(Read);
-            requests.push_back(std::make_shared<ZooKeeperSimpleListRequest>(*concrete_request_simple_list));
-        }
-        else if (const auto * concrete_request_list_recursive = dynamic_cast<const ZooKeeperListRecursiveRequest *>(generic_request.get()))
-        {
-            checkOperationType(Read);
-            requests.push_back(std::make_shared<ZooKeeperListRecursiveRequest>(*concrete_request_list_recursive));
-        }
-        else if (const auto * concrete_request_list = dynamic_cast<const ZooKeeperListRequest *>(generic_request.get()))
-        {
-            checkOperationType(Read);
-            requests.push_back(std::make_shared<ZooKeeperListRequest>(*concrete_request_list));
-        }
-        else
+        const auto * zk_request = dynamic_cast<const ZooKeeperRequest *>(generic_request.get());
+        if (!zk_request)
             throw Exception::fromMessage(Error::ZBADARGUMENTS, "Illegal command as part of multi ZooKeeper request");
+
+        const auto type = getOperationType(zk_request->getOpNum());
+        if (!type)
+            throw Exception::fromMessage(Error::ZBADARGUMENTS, "Illegal command as part of multi ZooKeeper request");
+
+        checkOperationType(*type);
+        requests.push_back(zk_request->cloneForMulti(default_acls));
     }
 }
 
@@ -1286,6 +1302,13 @@ void ZooKeeperMultiRequest::readImpl(ReadBuffer & in, RequestValidator request_v
 
         ZooKeeperRequestPtr request = ZooKeeperRequestFactory::instance().get(op_num);
         request->readImpl(in);
+
+        const auto type = getOperationType(request->getOpNum());
+        if (!type)
+            throw Exception::fromMessage(Error::ZBADARGUMENTS, "Illegal command as part of multi ZooKeeper request");
+
+        checkOperationType(*type);
+
         if (request_validator)
             request_validator(*request);
         requests.push_back(request);

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -94,6 +94,7 @@ struct ZooKeeperRequest : virtual Request
 
     virtual ZooKeeperResponsePtr makeResponse() const = 0;
     virtual bool isReadRequest() const = 0;
+    virtual std::shared_ptr<ZooKeeperRequest> cloneForMulti(const ACLs & default_acls) const;
 
     virtual void createLogElements(LogElements & elems) const;
 };
@@ -267,6 +268,7 @@ struct ZooKeeperCreateRequest final : public CreateRequest, ZooKeeperRequest
 
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return false; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs & default_acls) const override;
 
     size_t bytesSize() const override { return CreateRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 
@@ -336,6 +338,10 @@ struct ZooKeeperRemoveRequest final : RemoveRequest, ZooKeeperRequest
 
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return false; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperRemoveRequest>(*this);
+    }
 
     size_t bytesSize() const override { return RemoveRequest::bytesSize() + sizeof(xid); }
 
@@ -371,6 +377,10 @@ struct ZooKeeperRemoveRecursiveRequest final : RemoveRecursiveRequest, ZooKeeper
 
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return false; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperRemoveRecursiveRequest>(*this);
+    }
 
     size_t bytesSize() const override { return RemoveRecursiveRequest::bytesSize() + sizeof(xid); }
 };
@@ -398,6 +408,10 @@ struct ZooKeeperExistsRequest final : ExistsRequest, ZooKeeperRequest
 
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return true; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperExistsRequest>(*this);
+    }
 
     size_t bytesSize() const override { return ExistsRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 };
@@ -427,6 +441,10 @@ struct ZooKeeperGetRequest final : GetRequest, ZooKeeperRequest
 
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return true; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperGetRequest>(*this);
+    }
 
     size_t bytesSize() const override { return GetRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 };
@@ -455,6 +473,10 @@ struct ZooKeeperSetRequest final : SetRequest, ZooKeeperRequest
     std::string toStringImpl(bool short_format) const override;
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return false; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperSetRequest>(*this);
+    }
 
     size_t bytesSize() const override { return SetRequest::bytesSize() + sizeof(xid); }
 
@@ -485,6 +507,10 @@ struct ZooKeeperListRequest : ListRequest, ZooKeeperRequest
     std::string toStringImpl(bool short_format) const override;
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return true; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperListRequest>(*this);
+    }
 
     size_t bytesSize() const override { return ListRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 };
@@ -494,6 +520,10 @@ struct ZooKeeperSimpleListRequest final : ZooKeeperListRequest
 {
     OpNum getOpNum() const override { return OpNum::SimpleList; }
     ZooKeeperResponsePtr makeResponse() const override;
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperSimpleListRequest>(*this);
+    }
 };
 
 struct ZooKeeperListResponse : ListResponse, ZooKeeperResponse
@@ -539,6 +569,10 @@ struct ZooKeeperCheckRequest : CheckRequest, ZooKeeperRequest
 
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return true; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperCheckRequest>(*this);
+    }
 
     size_t bytesSize() const override { return CheckRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 
@@ -772,6 +806,7 @@ struct ZooKeeperMultiRequest final : MultiRequest<ZooKeeperRequestPtr>, ZooKeepe
 
     std::optional<OperationType> operation_type;
 private:
+    static std::optional<OperationType> getOperationType(OpNum op_num);
     void checkOperationType(OperationType type);
     size_t computeSizeImpl() const;
 
@@ -866,6 +901,10 @@ struct ZooKeeperListRecursiveRequest final : ListRecursiveRequest, ZooKeeperRequ
 
     ZooKeeperResponsePtr makeResponse() const override;
     bool isReadRequest() const override { return true; }
+    ZooKeeperRequestPtr cloneForMulti(const ACLs &) const override
+    {
+        return std::make_shared<ZooKeeperListRecursiveRequest>(*this);
+    }
 
     size_t bytesSize() const override { return ListRecursiveRequest::bytesSize() + sizeof(xid); }
 };

--- a/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
@@ -4,6 +4,7 @@
 #include <Common/ZooKeeper/Types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
+#include <Common/ZooKeeper/ZooKeeperIO.h>
 
 #include <gtest/gtest.h>
 
@@ -104,4 +105,19 @@ TEST(ZooKeeperTest, Create2ResponseWireRoundTrip)
     EXPECT_EQ(decoded.path_created, original.path_created);
     EXPECT_EQ(decoded.zstat, original.zstat);
     EXPECT_EQ(decoded.zstat.dataLength, 13);
+}
+
+TEST(ZooKeeperTest, MultiRequestRejectsCloseSubrequest)
+{
+    WriteBufferFromOwnString out;
+    Coordination::write(OpNum::Close, out);
+    Coordination::write(false, out);
+    Coordination::write(-1, out);
+    Coordination::write(OpNum::Error, out);
+    Coordination::write(true, out);
+    Coordination::write(-1, out);
+
+    auto request = ZooKeeperRequestFactory::instance().get(OpNum::Multi);
+    ReadBufferFromString in(out.str());
+    EXPECT_THROW(request->readImpl(in), Coordination::Exception);
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject unsupported and mixed read/write operations in ZooKeeper multi requests.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115768&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115768](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115768+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.200` (included in `26.9` and later)
- Backported to: `26.8.1.2020`, `26.7.6.19`, `26.6.4.32`, `26.3.25.2`
<!-- ch-version-info:end -->