### PR TITLE
Make test_good_intent_size not depend on Kafka batch timing

### DIFF
--- a/tests/integration/test_storage_kafka/test_intent_sizes.py
+++ b/tests/integration/test_storage_kafka/test_intent_sizes.py
@@ -117,12 +117,17 @@ def test_good_intent_size(kafka_cluster):
         # Do an extra check to make sure wait_for_log_line in `check_intent_size` didn't caught the wrong line
         assert instance.wait_for_log_line(f"Saving intent of 1 for topic-partition \\[{topic_name}:0\\] at offset {INVALID_KAFKA_OFFSET}", repetitions=2)
 
-        # Check that intent size is correct with multiple messages
+        # Check that intent size is correct with multiple messages.
+        # Both records must already be in the topic when the batching cycle starts,
+        # otherwise the cycle's flush window can expire between them and each is
+        # consumed alone.
+        instance.query("SYSTEM STOP test.kafka")
         k.kafka_produce(
             kafka_cluster,
             topic_name,
             ["message_4", "message_5"]
         )
+        instance.query("SYSTEM START test.kafka")
 
         consumed_messages = instance.query_with_retry("SELECT * FROM test.dst", retry_count = 30, sleep_time = 1, check_callback=lambda x: len(TSV(x)) == 3)
         logging.debug(f"Consumed messages: {consumed_messages}")


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`test_storage_kafka/test_intent_sizes.py::test_good_intent_size` produces `message_4` and
`message_5` and then waits for `Saving intent of 2 ... at offset 3`, i.e. it assumes both records
land in one consuming cycle. Nothing guarantees that. `kafka_produce` flushes per message, so the
two records reach the broker at different times, while the batch ends on the first of three
conditions in `StorageKafka2.cpp:1224-1225`, one of which is a deadline of
`kafka_flush_interval_ms` measured from a `Stopwatch` constructed per cycle at
`StorageKafka2.cpp:1390`, before any message is seen. A cycle that opens before the records exist
burns its window on stalled polls and closes at one row, so the engine logs `intent of 1` at
offset 3 and then `intent of 1` at offset 4.

`Saving intent of 2` is then never printed at all, so the test burns its full 30 s
`wait_for_log_line` budget and fails. The failure reads like a too-tight wait, but no wait budget
can help. Nor can a wider window: because the `Stopwatch` starts before the first poll, every
finite `kafka_flush_interval_ms` still has a phase in which the produce lands too late, so
widening only shrinks that phase. That was already the mitigation in 7dcb1c10eed3eed (500 to
3000 ms, by the test's author, for this same check).

This stops the stream across the produce instead, so the next cycle's first poll already sees both
records and a 2-row batch is guaranteed:

```
SYSTEM STOP test.kafka  ->  produce message_4 + message_5  ->  SYSTEM START test.kafka
```

`STOP` rather than `PAUSE` because only `STOP` also cancels the in-flight cycle, and an
already-open window is the hazard. The aborted cycle commits nothing (its `OffsetGuard` rolls back
to committed offsets), so `at offset 3` and the final data assertion are unchanged. No assertion
is relaxed. The same STOP/produce/START shape is already used by `test_system_stop.py` against
this engine.

<details>
<summary>Validation</summary>

Forcing the losing interleaving deterministically (the two records produced one cycle period
apart, matching the reported failure):

- old test: FAILS, server log shows `Saving intent of 1 ... at offset 3` and `... at offset 4`,
  `grep -c "Saving intent of 2"` = 0
- old test without forcing: PASSES (control)
- patched test, same forcing: PASSES, `Saving intent of 2 ... at offset 3` present
- patched test with the awaited line changed to `intent of 3`: FAILS, so the assertion still
  discriminates

50/50 passes of the patched test (12 serial, 38 under `pytest -n 3`, the configuration the failure
was seen in), and `test_intent_sizes.py` plus the whole `test_system_stop.py` suite together:
35/35.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115771&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115771](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115771+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1892` (included in `26.8` and later)
<!-- ch-version-info:end -->