### PR TITLE
Use PREWHERE for filters pushed down into JOIN sides

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -951,6 +951,13 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             }
         }
 
+        /// The partial filters are inserted two levels below this node (this filter -> join -> new
+        /// filter), so ask for a re-traversal deep enough to reach them. Without it they are never
+        /// merged with the expression below them and stay separate steps, and `optimizePrewhere`
+        /// skips them because it requires the filter directly on top of the read step.
+        if (updated_steps && updated_steps < 3)
+            updated_steps = 3;
+
         if (join)
             join->setDisjunctionsOptimizationApplied(true);
         if (logical_join)

--- a/tests/performance/join_disjunctions_pushdown_prewhere.xml
+++ b/tests/performance/join_disjunctions_pushdown_prewhere.xml
@@ -1,0 +1,44 @@
+<test>
+    <settings>
+        <use_join_disjunctions_push_down>1</use_join_disjunctions_push_down>
+        <optimize_move_to_prewhere>1</optimize_move_to_prewhere>
+    </settings>
+
+    <!-- Wide parts and a high-entropy payload: the win is not reading `payload` for the rows the
+         pushed-down filter rejects, so it only shows if that column is expensive to read.
+         Statistics are off because they reorder PREWHERE conditions and add noise. -->
+    <create_query>
+        CREATE TABLE join_disj_left (k UInt64, sel UInt64, payload String)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = ''
+    </create_query>
+    <create_query>
+        CREATE TABLE join_disj_right (k UInt64, x UInt64, payload String)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0, auto_statistics_types = ''
+    </create_query>
+
+    <fill_query>
+        INSERT INTO join_disj_left
+        SELECT number, number % 1000, arrayStringConcat(arrayMap(i -> hex(sipHash64(number, i)), range(8)), ' ')
+        FROM numbers(3000000)
+    </fill_query>
+    <fill_query>
+        INSERT INTO join_disj_right
+        SELECT number, number % 1000, arrayStringConcat(arrayMap(i -> hex(sipHash64(number, i)), range(8)), ' ')
+        FROM numbers(3000000)
+    </fill_query>
+
+    <!-- Each OR branch contributes one condition per side, so a partial filter is pushed into both
+         sides: `sel IN (1, 2)` and `x IN (1, 2)`. Both keep 0.2% of the rows. -->
+    <query>
+        SELECT sum(length(l.payload)) + sum(length(r.payload))
+        FROM join_disj_left AS l
+        INNER JOIN join_disj_right AS r ON l.k = r.k
+        WHERE (l.sel = 1 AND r.x = 1) OR (l.sel = 2 AND r.x = 2)
+        FORMAT Null
+    </query>
+
+    <drop_query>DROP TABLE join_disj_left</drop_query>
+    <drop_query>DROP TABLE join_disj_right</drop_query>
+</test>

--- a/tests/queries/0_stateless/03610_disjunctions_pushdown_optimization.reference
+++ b/tests/queries/0_stateless/03610_disjunctions_pushdown_optimization.reference
@@ -1,7 +1,7 @@
 --- CASE A: plan (enabled) ---
 Filter column: or(and(in(__table1.k, __set_Int32_UNIQ_ID), equals(__table2.x, 100_UInt8)), and(in(__table1.k, __set_Int32_UNIQ_ID), equals(__table2.x, 200_UInt8))) (removed)
-Filter column: or(in(__table1.k, __set_Int32_UNIQ_ID), in(__table1.k, __set_Int32_UNIQ_ID)) (removed)
-Filter column: or(equals(__table2.x, 100_UInt8), equals(__table2.x, 200_UInt8)) (removed)
+Prewhere filter column: or(in(__table1.k, __set_Int32_UNIQ_ID), in(__table1.k, __set_Int32_UNIQ_ID)) (removed)
+Prewhere filter column: or(equals(__table2.x, 100_UInt8), equals(__table2.x, 200_UInt8)) (removed)
 --- CASE A: plan (disabled) ---
 Filter column: or(and(in(__table1.k, __set_Int32_UNIQ_ID), equals(__table2.x, 100_UInt8)), and(in(__table1.k, __set_Int32_UNIQ_ID), equals(__table2.x, 200_UInt8))) (removed)
 --- CASE A: result (enabled) ---


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

When a `JOIN` has OR-connected conditions in `WHERE`, ClickHouse extracts the parts that apply to a single side and pushes them down as pre-join filters, so each side reads less data:

```sql
SELECT t1.k, t1.a, t2.x
FROM tp1 AS t1 JOIN tp2 AS t2 ON t1.k = t2.k
WHERE (t1.k IN (1, 2) AND t2.x = 100) OR (t1.k IN (3, 4) AND t2.x = 200)
```

Those pushed-down filters were never moved to `PREWHERE`, even with `optimize_move_to_prewhere` enabled. They ran as ordinary filters after all the requested columns of the row had been read, instead of being evaluated during reading so that non-matching rows skip the remaining columns. The wider the table, the more this costs.

Both filters now reach `PREWHERE`. Query results are unaffected; only the plan changes, which is why one existing test reference is updated.


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Filters pushed into the sides of a `JOIN` from OR-connected `WHERE` conditions are now moved to `PREWHERE`, so they are evaluated while reading instead of after it.

Note: 

1. This claims a performance win I have not measured. I only verified the plan and that results are unchanged. 
2. A perf run would be confounded right now by the `PREWHERE` ordering bug in (#114998 still open), so if a reviewer asks for numbers, that fix needs to be in the picture first.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115772&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115772](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115772+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
