### PR TITLE
Fix optimize_functions_to_subcolumns rewriting onto the wrong subcolumn

### DIFF
--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -9,8 +9,11 @@
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeQBit.h>
 #include <DataTypes/DataTypeObject.h>
-#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/NestedUtils.h>
+#include <DataTypes/Serializations/SerializationArray.h>
+#include <DataTypes/Serializations/SerializationMap.h>
+#include <DataTypes/Serializations/SerializationNullable.h>
+#include <DataTypes/Serializations/SerializationString.h>
 
 #include <Storages/IStorage.h>
 
@@ -169,41 +172,42 @@ bool sourceHasColumnCaseInsensitive(const QueryTreeNodePtr & column_source, cons
 /// Sometimes we cannot optimize function to subcolumn because there is no such subcolumn in the table.
 /// For example, for column "a Array(Tuple(b UInt32))" function length(a.b) cannot be replaced to
 /// a.b.size0, because there is no such subcolumn, even though a.b has type Array(UInt32)
-bool canOptimizeToSubcolumn(QueryTreeNodePtr column_source, const String & subcolumn_name, bool is_regular_subcolumn = true)
+bool canOptimizeToSubcolumn(QueryTreeNodePtr column_source, const String & subcolumn_name)
 {
     auto storage_snapshot = getStorageSnapshotForColumnSource(column_source);
     if (!storage_snapshot)
         return {};
 
-    auto get_options = GetColumnsOptions(GetColumnsOptions::All);
-    if (is_regular_subcolumn)
-        get_options = get_options.withRegularSubcolumns();
-    else
-        get_options = get_options.withSubcolumns();
+    auto get_options = GetColumnsOptions(GetColumnsOptions::All).withRegularSubcolumns();
     return storage_snapshot->tryGetColumn(get_options, subcolumn_name).has_value();
 }
 
-/// True when the subcolumn is itself Nullable in storage, which the transformers below cannot
-/// handle because they hardcode a non-Nullable result type.
-bool subcolumnIsNullableInStorage(const QueryTreeNodePtr & column_source, const String & subcolumn_name)
+using SubcolumnPredicate = bool (*)(const ISerialization::SubstreamPath &);
+
+/// A rewrite means one specific subcolumn of the column - its array sizes, its null map, its Map
+/// keys - and hardcodes the type that subcolumn has. Two independent things can make
+/// `<column>.<name>` not be it, and neither check catches the other's case:
+///
+///  * subcolumn names are flat, so a Tuple element or a JSON path can claim the name with the same
+///    type: ``Tuple(`a.size` UInt64, `a` String)`` resolves `c.a.size` to the element, and
+///    declaration order decides the winner. Only the substreams path tells them apart.
+///  * an enclosing Nullable wraps the subcolumn without changing which substream it is:
+///    `Nullable(JSON(`a` Array(Int64)))` resolves `c.a.size0` to `Nullable(UInt64)`, while `length`
+///    must give 0 for a NULL row, not NULL. Reachable because `Array` and `Map` cannot be inside
+///    `Nullable`, so `c.a` is exposed as a bare `Array` while its own subcolumns are wrapped.
+bool canOptimizeToExpectedSubcolumn(
+    const QueryTreeNodePtr & column_source, const NameAndTypePair & subcolumn, SubcolumnPredicate is_expected_subcolumn)
 {
     auto storage_snapshot = getStorageSnapshotForColumnSource(column_source);
     if (!storage_snapshot)
         return false;
 
-    auto actual = storage_snapshot->tryGetColumn(
-        GetColumnsOptions(GetColumnsOptions::All).withRegularSubcolumns(), subcolumn_name);
-    return actual && actual->type->isNullable();
-}
+    auto resolved = storage_snapshot->tryGetColumn(GetColumnsOptions(GetColumnsOptions::All).withSubcolumns(), subcolumn.name);
+    if (!resolved || !resolved->isSubcolumn() || !resolved->type->equals(*subcolumn.type))
+        return false;
 
-/// For Nullable(T) where T has its own "null" subcolumn (e.g. Nullable(JSON)),
-/// col.null refers to the nested type's subcolumn rather than the Nullable null-map,
-/// so optimizations that rewrite isNull/isNotNull/count to use .null do not apply.
-bool nestedTypeHasNullSubcolumn(const DataTypePtr & type)
-{
-    if (const auto * nullable_type = typeid_cast<const DataTypeNullable *>(type.get()))
-        return nullable_type->getNestedType()->hasSubcolumn("null");
-    return false;
+    auto info = resolved->getTypeInStorage()->tryGetSubcolumnInfo(resolved->getSubcolumnName());
+    return info && is_expected_subcolumn(info->substreams_path);
 }
 
 void optimizeFunctionStringLength(QueryTreeNodePtr & node, FunctionNode &, ColumnContext & ctx)
@@ -212,7 +216,8 @@ void optimizeFunctionStringLength(QueryTreeNodePtr & node, FunctionNode &, Colum
     /// `argument` is String.
 
     NameAndTypePair column{ctx.column.name + ".size", std::make_shared<DataTypeUInt64>()};
-    if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
+    if (sourceHasColumn(ctx.column_source, column.name)
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationString::isStringSizesSubcolumn))
         return;
     node = std::make_shared<ColumnNode>(column, ctx.column_source);
 }
@@ -225,7 +230,8 @@ void optimizeFunctionStringEmpty(QueryTreeNodePtr &, FunctionNode & function_nod
     /// `argument` is String.
 
     NameAndTypePair column{ctx.column.name + ".size", std::make_shared<DataTypeUInt64>()};
-    if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
+    if (sourceHasColumn(ctx.column_source, column.name)
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationString::isStringSizesSubcolumn))
         return;
     auto & function_arguments_nodes = function_node.getArguments().getNodes();
 
@@ -243,7 +249,8 @@ void optimizeFunctionLength(QueryTreeNodePtr & node, FunctionNode &, ColumnConte
     /// `argument` may be Array or Map.
 
     NameAndTypePair column{ctx.column.name + ".size0", std::make_shared<DataTypeUInt64>()};
-    if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
+    if (sourceHasColumn(ctx.column_source, column.name)
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationArray::isArraySizesSubcolumn))
         return;
 
     node = std::make_shared<ColumnNode>(column, ctx.column_source);
@@ -257,13 +264,8 @@ void optimizeFunctionEmpty(QueryTreeNodePtr &, FunctionNode & function_node, Col
     /// `argument` may be Array or Map.
 
     NameAndTypePair column{ctx.column.name + ".size0", std::make_shared<DataTypeUInt64>()};
-    if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
-        return;
-
-    /// If the .size0 subcolumn is actually Nullable (e.g. when the column type is Nullable(Array(...))),
-    /// skip the optimization. The hardcoded UInt64 type would mismatch the actual Nullable(UInt64),
-    /// causing a type mismatch exception at runtime in ExpressionActions::execute.
-    if (subcolumnIsNullableInStorage(ctx.column_source, column.name))
+    if (sourceHasColumn(ctx.column_source, column.name)
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationArray::isArraySizesSubcolumn))
         return;
 
     auto & function_arguments_nodes = function_node.getArguments().getNodes();
@@ -305,9 +307,8 @@ void optimizeFunctionArrayElementForMap(QueryTreeNodePtr & node, FunctionNode & 
 
     /// The resulting subcolumn has the map's value type, e.g. `m.key_foo : V` for `Map(K, V)`.
     NameAndTypePair column{ctx.column.name + "." + subcolumn_name, data_type_map.getValueType()};
-    /// Use is_regular_subcolumn=false because key subcolumns are not declared as regular subcolumns
-    /// of the table schema — they are dynamic subcolumns.
-    if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name, false))
+    if (sourceHasColumn(ctx.column_source, column.name)
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isKeyValueSubcolumn))
         return;
 
     node = std::make_shared<ColumnNode>(column, ctx.column_source);
@@ -496,7 +497,8 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
             auto key_type = std::make_shared<DataTypeArray>(data_type_map.getKeyType());
 
             NameAndTypePair column{ctx.column.name + ".keys", key_type};
-            if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
+            if (sourceHasColumn(ctx.column_source, column.name)
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isKeysSubcolumn))
                 return;
             node = std::make_shared<ColumnNode>(column, ctx.column_source);
         },
@@ -510,7 +512,8 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
             auto value_type = std::make_shared<DataTypeArray>(data_type_map.getValueType());
 
             NameAndTypePair column{ctx.column.name + ".values", value_type};
-            if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
+            if (sourceHasColumn(ctx.column_source, column.name)
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isValuesSubcolumn))
                 return;
             node = std::make_shared<ColumnNode>(column, ctx.column_source);
         },
@@ -523,7 +526,8 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
             const auto & data_type_map = assert_cast<const DataTypeMap &>(*ctx.column.type);
 
             NameAndTypePair column{ctx.column.name + ".keys", std::make_shared<DataTypeArray>(data_type_map.getKeyType())};
-            if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
+            if (sourceHasColumn(ctx.column_source, column.name)
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isKeysSubcolumn))
                 return;
             auto & function_arguments_nodes = function_node.getArguments().getNodes();
 
@@ -539,17 +543,8 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
         {
             /// Replace `count(nullable_argument)` with `sum(not(nullable_argument.null))`
             NameAndTypePair column{ctx.column.name + ".null", std::make_shared<DataTypeUInt8>()};
-            if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
-                return;
-
-            if (nestedTypeHasNullSubcolumn(ctx.column.type))
-                return;
-
-            /// When the column is inside a Nullable(Tuple(...)), the .null subcolumn/nullmap
-            /// in storage is Nullable(UInt8), not UInt8, because the type system wraps all
-            /// subcolumns of a Nullable(Tuple(...)) with the outer nullability. Using it with
-            /// a hardcoded UInt8 type causes a type mismatch at runtime. Skip the optimization.
-            if (subcolumnIsNullableInStorage(ctx.column_source, column.name))
+            if (sourceHasColumn(ctx.column_source, column.name)
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationNullable::isNullMapSubcolumn))
                 return;
 
             auto & function_arguments_nodes = function_node.getArguments().getNodes();
@@ -571,16 +566,8 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
         {
             /// Replace `isNull(nullable_argument)` with `nullable_argument.null`
             NameAndTypePair column{ctx.column.name + ".null", std::make_shared<DataTypeUInt8>()};
-            if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
-                return;
-
-            if (nestedTypeHasNullSubcolumn(ctx.column.type))
-                return;
-
-            /// For nested Nullable types (e.g. Nullable(Tuple(... Nullable(T) ...))),
-            /// the .null subcolumn in storage is Nullable(UInt8), not UInt8.
-            /// Using it with a hardcoded UInt8 type causes a type mismatch at runtime.
-            if (subcolumnIsNullableInStorage(ctx.column_source, column.name))
+            if (sourceHasColumn(ctx.column_source, column.name)
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationNullable::isNullMapSubcolumn))
                 return;
 
             node = std::make_shared<ColumnNode>(column, ctx.column_source);
@@ -592,14 +579,8 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
         {
             /// Replace `isNotNull(nullable_argument)` with `not(nullable_argument.null)`
             NameAndTypePair column{ctx.column.name + ".null", std::make_shared<DataTypeUInt8>()};
-            if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
-                return;
-
-            if (nestedTypeHasNullSubcolumn(ctx.column.type))
-                return;
-
-            /// Same guard as isNull above: nested Nullable .null subcolumn may itself be Nullable.
-            if (subcolumnIsNullableInStorage(ctx.column_source, column.name))
+            if (sourceHasColumn(ctx.column_source, column.name)
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationNullable::isNullMapSubcolumn))
                 return;
 
             auto & function_arguments_nodes = function_node.getArguments().getNodes();

--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -14,6 +14,8 @@
 #include <DataTypes/Serializations/SerializationMap.h>
 #include <DataTypes/Serializations/SerializationNullable.h>
 #include <DataTypes/Serializations/SerializationString.h>
+#include <DataTypes/Serializations/SerializationTuple.h>
+#include <DataTypes/Serializations/SerializationVariant.h>
 
 #include <Storages/IStorage.h>
 
@@ -169,24 +171,10 @@ bool sourceHasColumnCaseInsensitive(const QueryTreeNodePtr & column_source, cons
     return false;
 }
 
-/// Sometimes we cannot optimize function to subcolumn because there is no such subcolumn in the table.
-/// For example, for column "a Array(Tuple(b UInt32))" function length(a.b) cannot be replaced to
-/// a.b.size0, because there is no such subcolumn, even though a.b has type Array(UInt32)
-bool canOptimizeToSubcolumn(QueryTreeNodePtr column_source, const String & subcolumn_name)
-{
-    auto storage_snapshot = getStorageSnapshotForColumnSource(column_source);
-    if (!storage_snapshot)
-        return {};
-
-    auto get_options = GetColumnsOptions(GetColumnsOptions::All).withRegularSubcolumns();
-    return storage_snapshot->tryGetColumn(get_options, subcolumn_name).has_value();
-}
-
-using SubcolumnPredicate = bool (*)(const ISerialization::SubstreamPath &);
+using SubcolumnPredicate = std::function<bool(const ISerialization::SubstreamPath &)>;
 
 /// A rewrite means one specific subcolumn of the column - its array sizes, its null map, its Map
-/// keys - and hardcodes the type that subcolumn has. Two independent things can make
-/// `<column>.<name>` not be it, and neither check catches the other's case:
+/// keys, one Tuple element. Two independent things can make `<column>.<name>` not be it:
 ///
 ///  * subcolumn names are flat, so a Tuple element or a JSON path can claim the name with the same
 ///    type: ``Tuple(`a.size` UInt64, `a` String)`` resolves `c.a.size` to the element, and
@@ -195,15 +183,24 @@ using SubcolumnPredicate = bool (*)(const ISerialization::SubstreamPath &);
 ///    `Nullable(JSON(`a` Array(Int64)))` resolves `c.a.size0` to `Nullable(UInt64)`, while `length`
 ///    must give 0 for a NULL row, not NULL. Reachable because `Array` and `Map` cannot be inside
 ///    `Nullable`, so `c.a` is exposed as a bare `Array` while its own subcolumns are wrapped.
+///
+/// `expected_type` is passed only by the rewrites that hardcode it. The element rewrites take it
+/// from the type definition, where an enclosing Nullable legitimately wraps it in storage.
 bool canOptimizeToExpectedSubcolumn(
-    const QueryTreeNodePtr & column_source, const NameAndTypePair & subcolumn, SubcolumnPredicate is_expected_subcolumn)
+    const QueryTreeNodePtr & column_source,
+    const String & subcolumn_name,
+    const SubcolumnPredicate & is_expected_subcolumn,
+    const DataTypePtr & expected_type = nullptr)
 {
     auto storage_snapshot = getStorageSnapshotForColumnSource(column_source);
     if (!storage_snapshot)
         return false;
 
-    auto resolved = storage_snapshot->tryGetColumn(GetColumnsOptions(GetColumnsOptions::All).withSubcolumns(), subcolumn.name);
-    if (!resolved || !resolved->isSubcolumn() || !resolved->type->equals(*subcolumn.type))
+    auto resolved = storage_snapshot->tryGetColumn(GetColumnsOptions(GetColumnsOptions::All).withSubcolumns(), subcolumn_name);
+    if (!resolved || !resolved->isSubcolumn())
+        return false;
+
+    if (expected_type && !resolved->type->equals(*expected_type))
         return false;
 
     auto info = resolved->getTypeInStorage()->tryGetSubcolumnInfo(resolved->getSubcolumnName());
@@ -217,7 +214,7 @@ void optimizeFunctionStringLength(QueryTreeNodePtr & node, FunctionNode &, Colum
 
     NameAndTypePair column{ctx.column.name + ".size", std::make_shared<DataTypeUInt64>()};
     if (sourceHasColumn(ctx.column_source, column.name)
-        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationString::isStringSizesSubcolumn))
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationString::isStringSizesSubcolumn, column.type))
         return;
     node = std::make_shared<ColumnNode>(column, ctx.column_source);
 }
@@ -231,7 +228,7 @@ void optimizeFunctionStringEmpty(QueryTreeNodePtr &, FunctionNode & function_nod
 
     NameAndTypePair column{ctx.column.name + ".size", std::make_shared<DataTypeUInt64>()};
     if (sourceHasColumn(ctx.column_source, column.name)
-        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationString::isStringSizesSubcolumn))
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationString::isStringSizesSubcolumn, column.type))
         return;
     auto & function_arguments_nodes = function_node.getArguments().getNodes();
 
@@ -250,7 +247,7 @@ void optimizeFunctionLength(QueryTreeNodePtr & node, FunctionNode &, ColumnConte
 
     NameAndTypePair column{ctx.column.name + ".size0", std::make_shared<DataTypeUInt64>()};
     if (sourceHasColumn(ctx.column_source, column.name)
-        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationArray::isArraySizesSubcolumn))
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationArray::isArraySizesSubcolumn, column.type))
         return;
 
     node = std::make_shared<ColumnNode>(column, ctx.column_source);
@@ -265,7 +262,7 @@ void optimizeFunctionEmpty(QueryTreeNodePtr &, FunctionNode & function_node, Col
 
     NameAndTypePair column{ctx.column.name + ".size0", std::make_shared<DataTypeUInt64>()};
     if (sourceHasColumn(ctx.column_source, column.name)
-        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationArray::isArraySizesSubcolumn))
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationArray::isArraySizesSubcolumn, column.type))
         return;
 
     auto & function_arguments_nodes = function_node.getArguments().getNodes();
@@ -308,7 +305,7 @@ void optimizeFunctionArrayElementForMap(QueryTreeNodePtr & node, FunctionNode & 
     /// The resulting subcolumn has the map's value type, e.g. `m.key_foo : V` for `Map(K, V)`.
     NameAndTypePair column{ctx.column.name + "." + subcolumn_name, data_type_map.getValueType()};
     if (sourceHasColumn(ctx.column_source, column.name)
-        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isKeyValueSubcolumn))
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationMap::isKeyValueSubcolumn, column.type))
         return;
 
     node = std::make_shared<ColumnNode>(column, ctx.column_source);
@@ -433,7 +430,15 @@ void optimizeTupleOrVariantElement(QueryTreeNodePtr & node, FunctionNode & funct
             || sourceHasColumnCaseInsensitive(ctx.column_source, column.name))
             return;
 
-    if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
+    /// ``Tuple(`t.a` UInt64, t Tuple(a UInt64))`` resolves `c.t.a` to the sibling, not to `t`.`a`.
+    SubcolumnPredicate is_expected_subcolumn;
+    if constexpr (std::is_same_v<DataType, DataTypeVariant>)
+        is_expected_subcolumn = [&](const auto & path) { return SerializationVariant::isElementSubcolumn(path, subcolumn->name); };
+    else
+        is_expected_subcolumn = [&](const auto & path) { return SerializationTuple::isElementSubcolumn(path, subcolumn->name); };
+
+    if (sourceHasColumn(ctx.column_source, column.name)
+        || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, is_expected_subcolumn))
         return;
     node = std::make_shared<ColumnNode>(column, ctx.column_source);
 }
@@ -498,7 +503,7 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
 
             NameAndTypePair column{ctx.column.name + ".keys", key_type};
             if (sourceHasColumn(ctx.column_source, column.name)
-                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isKeysSubcolumn))
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationMap::isKeysSubcolumn, column.type))
                 return;
             node = std::make_shared<ColumnNode>(column, ctx.column_source);
         },
@@ -513,7 +518,7 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
 
             NameAndTypePair column{ctx.column.name + ".values", value_type};
             if (sourceHasColumn(ctx.column_source, column.name)
-                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isValuesSubcolumn))
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationMap::isValuesSubcolumn, column.type))
                 return;
             node = std::make_shared<ColumnNode>(column, ctx.column_source);
         },
@@ -527,7 +532,7 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
 
             NameAndTypePair column{ctx.column.name + ".keys", std::make_shared<DataTypeArray>(data_type_map.getKeyType())};
             if (sourceHasColumn(ctx.column_source, column.name)
-                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationMap::isKeysSubcolumn))
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationMap::isKeysSubcolumn, column.type))
                 return;
             auto & function_arguments_nodes = function_node.getArguments().getNodes();
 
@@ -544,7 +549,7 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
             /// Replace `count(nullable_argument)` with `sum(not(nullable_argument.null))`
             NameAndTypePair column{ctx.column.name + ".null", std::make_shared<DataTypeUInt8>()};
             if (sourceHasColumn(ctx.column_source, column.name)
-                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationNullable::isNullMapSubcolumn))
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationNullable::isNullMapSubcolumn, column.type))
                 return;
 
             auto & function_arguments_nodes = function_node.getArguments().getNodes();
@@ -567,7 +572,7 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
             /// Replace `isNull(nullable_argument)` with `nullable_argument.null`
             NameAndTypePair column{ctx.column.name + ".null", std::make_shared<DataTypeUInt8>()};
             if (sourceHasColumn(ctx.column_source, column.name)
-                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationNullable::isNullMapSubcolumn))
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationNullable::isNullMapSubcolumn, column.type))
                 return;
 
             node = std::make_shared<ColumnNode>(column, ctx.column_source);
@@ -580,7 +585,7 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
             /// Replace `isNotNull(nullable_argument)` with `not(nullable_argument.null)`
             NameAndTypePair column{ctx.column.name + ".null", std::make_shared<DataTypeUInt8>()};
             if (sourceHasColumn(ctx.column_source, column.name)
-                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column, SerializationNullable::isNullMapSubcolumn))
+                || !canOptimizeToExpectedSubcolumn(ctx.column_source, column.name, SerializationNullable::isNullMapSubcolumn, column.type))
                 return;
 
             auto & function_arguments_nodes = function_node.getArguments().getNodes();

--- a/src/DataTypes/DataTypeArray.cpp
+++ b/src/DataTypes/DataTypeArray.cpp
@@ -84,7 +84,7 @@ void DataTypeArray::forEachChild(const ChildCallback & callback) const
     nested->forEachChild(callback);
 }
 
-std::unique_ptr<ISerialization::SubstreamData> DataTypeArray::getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
+std::unique_ptr<IDataType::SubcolumnInfo> DataTypeArray::getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
 {
     auto nested_type = assert_cast<const DataTypeArray &>(*data.type).nested;
     const auto & array_serialization = assert_cast<const SerializationArray &>(*removeNamedSerialization(data.serialization));
@@ -92,16 +92,20 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeArray::getDynamicSubcolum
     nested_data->type = nested_type;
     nested_data->column = data.column ? assert_cast<const ColumnArray &>(*data.column).getDataPtr() : nullptr;
 
-    auto nested_subcolumn_data = getSubcolumnData(subcolumn_name, *nested_data, initial_array_level + 1, throw_if_null);
-    if (!nested_subcolumn_data)
+    auto nested_subcolumn_info = getSubcolumnInfo(subcolumn_name, *nested_data, initial_array_level + 1, throw_if_null);
+    if (!nested_subcolumn_info)
         return nullptr;
 
     auto creator = SerializationArray::SubcolumnCreator(data.column ? assert_cast<const ColumnArray &>(*data.column).getOffsetsPtr() : nullptr);
-    auto res = std::make_unique<ISerialization::SubstreamData>();
-    res->serialization = creator.create(nested_subcolumn_data->serialization, nested_subcolumn_data->type);
-    res->type = creator.create(nested_subcolumn_data->type);
+    auto res = std::make_unique<SubcolumnInfo>();
+    res->data.serialization = creator.create(nested_subcolumn_info->data.serialization, nested_subcolumn_info->data.type);
+    res->data.type = creator.create(nested_subcolumn_info->data.type);
     if (data.column)
-        res->column = creator.create(nested_subcolumn_data->column);
+        res->data.column = creator.create(nested_subcolumn_info->data.column);
+
+    /// Reached through the array elements, exactly as the static enumeration would reach it.
+    res->substreams_path.emplace_back(ISerialization::Substream::ArrayElements);
+    res->substreams_path.insert(res->substreams_path.end(), nested_subcolumn_info->substreams_path.begin(), nested_subcolumn_info->substreams_path.end());
 
     return res;
 }

--- a/src/DataTypes/DataTypeArray.h
+++ b/src/DataTypes/DataTypeArray.h
@@ -60,7 +60,7 @@ public:
     /// If nested column has dynamic subcolumns, Array of this type should also be able to read these dynamic subcolumns.
     bool hasDynamicSubcolumnsData() const override { return nested->hasDynamicSubcolumnsData(); }
     bool hasDynamicStructure() const override { return nested->hasDynamicStructure(); }
-    std::unique_ptr<SubstreamData> getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
+    std::unique_ptr<SubcolumnInfo> getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
 
     bool isValueUnambiguouslyRepresentedInContiguousMemoryRegion() const override
     {

--- a/src/DataTypes/DataTypeDynamic.cpp
+++ b/src/DataTypes/DataTypeDynamic.cpp
@@ -887,7 +887,7 @@ std::pair<std::string_view, std::string_view> splitSubcolumnName(std::string_vie
 
 }
 
-std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
+std::unique_ptr<IDataType::SubcolumnInfo> DataTypeDynamic::getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
 {
     auto [type_subcolumn_name, subcolumn_nested_name] = splitSubcolumnName(subcolumn_name);
     /// Check if requested subcolumn is a valid data type.
@@ -901,8 +901,9 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
 
     const auto & dynamic_serialization = assert_cast<const SerializationDynamic &>(*removeNamedSerialization(data.serialization));
     auto subcolumn_serialization = dynamic_serialization.createSerializationForType(subcolumn_type);
-    std::unique_ptr<SubstreamData> res = std::make_unique<SubstreamData>(subcolumn_serialization);
-    res->type = subcolumn_type;
+    auto res = std::make_unique<SubcolumnInfo>();
+    res->data = SubstreamData(subcolumn_serialization);
+    res->data.type = subcolumn_type;
     std::optional<ColumnVariant::Discriminator> discriminator;
     ColumnPtr null_map_for_variant_from_shared_variant;
     if (data.column)
@@ -918,7 +919,7 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
         if (it != variant_info.variant_name_to_discriminator.end())
         {
             discriminator = it->second;
-            res->column = variant_column.getVariantPtrByGlobalDiscriminator(*discriminator);
+            res->data.column = variant_column.getVariantPtrByGlobalDiscriminator(*discriminator);
         }
         /// Otherwise if there is data in shared variant try to find requested type there.
         else if (!shared_variant.empty())
@@ -955,7 +956,7 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
                 }
             }
 
-            res->column = std::move(subcolumn);
+            res->data.column = std::move(subcolumn);
             null_map_for_variant_from_shared_variant = std::move(null_map_column);
         }
     }
@@ -971,24 +972,34 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Dynamic type doesn't have subcolumn '{}'", subcolumn_name);
             return nullptr;
         }
-        res->type = std::make_shared<DataTypeUInt8>();
+        res->data.type = std::make_shared<DataTypeUInt8>();
     }
-    else if (!subcolumn_nested_name.empty())
+
+    /// The variant the subcolumn resolved to, which is what a read of it traverses.
+    res->substreams_path.emplace_back(ISerialization::Substream::DynamicData);
+    res->substreams_path.emplace_back(is_null_map_subcolumn ? ISerialization::Substream::VariantElementNullMap : ISerialization::Substream::VariantElement);
+    res->substreams_path.back().variant_element_name = subcolumn_type->getName();
+
+    if (!is_null_map_subcolumn && !subcolumn_nested_name.empty())
     {
-        res = getSubcolumnData(subcolumn_nested_name, *res, initial_array_level, throw_if_null);
-        if (!res)
+        auto nested_info = getSubcolumnInfo(subcolumn_nested_name, res->data, initial_array_level, throw_if_null);
+        if (!nested_info)
         {
             if (throw_if_null)
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR,
-                    "Expected getSubcolumnData() to throw for subcolumn '{}' in throw_if_null mode",
+                    "Expected getSubcolumnInfo() to throw for subcolumn '{}' in throw_if_null mode",
                     subcolumn_name);
             return nullptr;
         }
+
+        res->data = std::move(nested_info->data);
+        res->substreams_path.insert(
+            res->substreams_path.end(), nested_info->substreams_path.begin(), nested_info->substreams_path.end());
     }
 
-    res->serialization = SerializationDynamicElement::create(
-        res->serialization,
+    res->data.serialization = SerializationDynamicElement::create(
+        res->data.serialization,
         dynamic_serialization.createSerializationForType(ColumnDynamic::getSharedVariantDataType()),
         subcolumn_type->getName(),
         String(subcolumn_nested_name),
@@ -996,7 +1007,7 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
     /// Make resulting subcolumn Nullable only if type subcolumn can be inside Nullable or can be LowCardinality(Nullable()).
     bool make_subcolumn_nullable = canExtractedSubcolumnsBeInsideNullableOrLowCardinalityNullable(subcolumn_type);
     if (!is_null_map_subcolumn && make_subcolumn_nullable)
-        res->type = makeNullableOrLowCardinalityNullableSafe(res->type);
+        res->data.type = makeNullableOrLowCardinalityNullableSafe(res->data.type);
 
     if (data.column)
     {
@@ -1022,7 +1033,7 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
                     make_subcolumn_nullable,
                     nullptr,
                     variant_column.getNumVariants());
-            res->column = creator->create(res->column);
+            res->data.column = creator->create(res->data.column);
         }
         /// Check if requested type was extracted from shared variant. In this case we should use
         /// VariantSubcolumnCreator to create full subcolumn from variant according to created null map.
@@ -1030,13 +1041,13 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
         {
             if (is_null_map_subcolumn)
             {
-                res->column = null_map_for_variant_from_shared_variant;
+                res->data.column = null_map_for_variant_from_shared_variant;
             }
             else
             {
                 SerializationVariantElement::VariantSubcolumnCreator creator(
                     null_map_for_variant_from_shared_variant, "", 0, 0, make_subcolumn_nullable, null_map_for_variant_from_shared_variant);
-                res->column = creator.create(res->column);
+                res->data.column = creator.create(res->data.column);
             }
         }
         /// Provided Dynamic column doesn't have subcolumn of this type, just create column filled with default values.
@@ -1045,13 +1056,13 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeDynamic::getDynamicSubcolumnDa
             /// Fill null map with 1 when there is no such Dynamic subcolumn.
             auto column = ColumnUInt8::create();
             assert_cast<ColumnUInt8 &>(*column).getData().resize_fill(data.column->size(), 1);
-            res->column = std::move(column);
+            res->data.column = std::move(column);
         }
         else
         {
-            auto column = res->type->createColumn();
+            auto column = res->data.type->createColumn();
             column->insertManyDefaults(data.column->size());
-            res->column = std::move(column);
+            res->data.column = std::move(column);
         }
     }
 

--- a/src/DataTypes/DataTypeDynamic.h
+++ b/src/DataTypes/DataTypeDynamic.h
@@ -42,7 +42,7 @@ public:
 
     bool hasDynamicSubcolumnsData() const override { return true; }
     bool hasDynamicStructure() const override { return true; }
-    std::unique_ptr<SubstreamData> getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
+    std::unique_ptr<SubcolumnInfo> getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
 
     size_t getMaxDynamicTypes() const { return max_dynamic_types; }
 

--- a/src/DataTypes/DataTypeMap.cpp
+++ b/src/DataTypes/DataTypeMap.cpp
@@ -184,7 +184,7 @@ void DataTypeMap::forEachChild(const DB::IDataType::ChildCallback & callback) co
 /// creating a `SerializationMapKeyValue` that knows how to read only the relevant bucket,
 /// and optionally pre-extracting the values from an existing column.
 /// The subcolumn name must start with "key_" followed by the text-serialized key value.
-std::unique_ptr<IDataType::SubstreamData> DataTypeMap::getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t /*initial_array_level*/, bool throw_if_null) const
+std::unique_ptr<IDataType::SubcolumnInfo> DataTypeMap::getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t /*initial_array_level*/, bool throw_if_null) const
 {
     /// Only subcolumns of the form "key_<serialized_key>" are supported.
     if (!subcolumn_name.starts_with(KEY_SUBCOLUMN_PREFIX))
@@ -218,8 +218,11 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeMap::getDynamicSubcolumnData(s
         map_serialization.getMapSerializationVersion(),
         key_column->getPtr(),
         nested);
-    std::unique_ptr<SubstreamData> res = std::make_unique<SubstreamData>(key_value_serialization);
-    res->type = value_type;
+    auto res = std::make_unique<SubcolumnInfo>();
+    res->data = SubstreamData(key_value_serialization).withType(value_type);
+
+    res->substreams_path.emplace_back(ISerialization::Substream::MapKeyValue);
+    res->substreams_path.back().name_of_substream = subcolumn_name;
 
     /// If a column is available, pre-extract the values for the requested key.
     if (data.column)
@@ -227,7 +230,7 @@ std::unique_ptr<IDataType::SubstreamData> DataTypeMap::getDynamicSubcolumnData(s
         const auto & column_map = assert_cast<const ColumnMap &>(*data.column);
         auto value_column = value_type->createColumn();
         extractKeyValueFromMap(*column_map.getNestedColumnPtr(), *key_column->getPtr(), *value_column, 0, data.column->size());
-        res->column = std::move(value_column);
+        res->data.column = std::move(value_column);
     }
 
     return res;

--- a/src/DataTypes/DataTypeMap.h
+++ b/src/DataTypes/DataTypeMap.h
@@ -66,7 +66,7 @@ public:
 
     bool hasDynamicSubcolumnsData() const override { return true; }
     bool hasDynamicStructure() const override { return key_type->hasDynamicStructure() || value_type->hasDynamicStructure(); }
-    std::unique_ptr<SubstreamData> getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
+    std::unique_ptr<SubcolumnInfo> getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
 private:
     void assertKeyType() const;
 };

--- a/src/DataTypes/DataTypeNullable.cpp
+++ b/src/DataTypes/DataTypeNullable.cpp
@@ -109,7 +109,7 @@ void DataTypeNullable::forEachChild(const ChildCallback & callback) const
 }
 
 
-std::unique_ptr<ISerialization::SubstreamData> DataTypeNullable::getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
+std::unique_ptr<IDataType::SubcolumnInfo> DataTypeNullable::getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
 {
     auto nested_type = assert_cast<const DataTypeNullable &>(*data.type).nested_data_type;
     const auto & nullable_serialization = assert_cast<const SerializationNullable &>(*removeNamedSerialization(data.serialization));
@@ -117,16 +117,21 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeNullable::getDynamicSubco
     nested_data.type = nested_type;
     nested_data.column = data.column ? assert_cast<const ColumnNullable &>(*data.column).getNestedColumnPtr() : nullptr;
 
-    auto nested_subcolumn_data = DB::IDataType::getSubcolumnData(subcolumn_name, nested_data, initial_array_level, throw_if_null);
-    if (!nested_subcolumn_data)
+    auto nested_subcolumn_info = DB::IDataType::getSubcolumnInfo(subcolumn_name, nested_data, initial_array_level, throw_if_null);
+    if (!nested_subcolumn_info)
         return nullptr;
 
     auto creator = NullableSubcolumnCreator(data.column ? assert_cast<const ColumnNullable &>(*data.column).getNullMapColumnPtr() : nullptr);
-    auto res = std::make_unique<ISerialization::SubstreamData>();
-    res->serialization = creator.create(nested_subcolumn_data->serialization, nested_subcolumn_data->type);
-    res->type = creator.create(nested_subcolumn_data->type);
+    auto res = std::make_unique<SubcolumnInfo>();
+    res->data.serialization = creator.create(nested_subcolumn_info->data.serialization, nested_subcolumn_info->data.type);
+    res->data.type = creator.create(nested_subcolumn_info->data.type);
     if (data.column)
-        res->column = creator.create(nested_subcolumn_data->column);
+        res->data.column = creator.create(nested_subcolumn_info->data.column);
+
+    /// Reached through the nullable elements, exactly as the static enumeration would reach it.
+    res->substreams_path.emplace_back(ISerialization::Substream::NullableElements);
+    res->substreams_path.insert(
+        res->substreams_path.end(), nested_subcolumn_info->substreams_path.begin(), nested_subcolumn_info->substreams_path.end());
 
     return res;
 }

--- a/src/DataTypes/DataTypeNullable.h
+++ b/src/DataTypes/DataTypeNullable.h
@@ -46,8 +46,8 @@ public:
     MutableColumnConstPtr createColumnConst(size_t size, const Field & field) const override;
     bool hasDynamicSubcolumnsData() const override { return nested_data_type->hasDynamicSubcolumns(); }
     bool hasDynamicStructure() const override { return nested_data_type->hasDynamicStructure(); }
-    std::unique_ptr<SubstreamData>
-    getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
+    std::unique_ptr<SubcolumnInfo>
+    getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
     bool supportsSparseSerialization() const override { return nested_data_type->supportsSparseSerialization(); }
     bool canBeInsideSparseColumns() const override { return nested_data_type->canBeInsideSparseColumns(); }
 

--- a/src/DataTypes/DataTypeObject.cpp
+++ b/src/DataTypes/DataTypeObject.cpp
@@ -563,7 +563,7 @@ std::pair<DataTypePtr, SerializationPtr> buildSubObjectTypeAndSerialization(
 
 }
 
-std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
+std::unique_ptr<IDataType::SubcolumnInfo> DataTypeObject::getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const
 {
     /// Check if it's a special subcolumn used for distinct paths calculation.
     if (subcolumn_name == SPECIAL_SUBCOLUMN_NAME_FOR_DISTINCT_PATHS_CALCULATION)
@@ -573,13 +573,14 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
         for (const auto & [path, _] : typed_paths)
             typed_path_names.push_back(path);
 
-        std::unique_ptr<SubstreamData> res = std::make_unique<SubstreamData>(SerializationObjectDistinctPaths::create(typed_path_names));
-        res->type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
+        auto res = std::make_unique<SubcolumnInfo>();
+        res->data = SubstreamData(SerializationObjectDistinctPaths::create(typed_path_names));
+        res->data.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
         /// If column was provided, we should create a column for the requested subcolumn.
         if (data.column)
         {
             const auto & object_column = assert_cast<const ColumnObject &>(*data.column);
-            auto result_column = res->type->createColumn();
+            auto result_column = res->data.type->createColumn();
             if (!object_column.empty())
             {
                 auto & result_array_column = assert_cast<ColumnArray &>(*result_column);
@@ -593,9 +594,11 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
                 result_array_column.getOffsets().push_back(result_paths_column.size());
                 result_array_column.insertManyDefaults(object_column.size() - 1);
             }
-            res->column = std::move(result_column);
+            res->data.column = std::move(result_column);
         }
 
+        res->substreams_path.emplace_back(ISerialization::Substream::ObjectDistinctPaths);
+        res->substreams_path.back().name_of_substream = subcolumn_name;
         return res;
     }
 
@@ -614,15 +617,18 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
             prefix, typed_paths, typed_paths_serializations, schema_format, paths_to_skip, path_regexps_to_skip,
             max_dynamic_paths, max_dynamic_types, getDynamicType(), dynamic_path_serialization);
 
-        std::unique_ptr<SubstreamData> res = std::make_unique<SubstreamData>(sub_object_serialization);
-        res->type = sub_object_type;
+        auto res = std::make_unique<SubcolumnInfo>();
+        res->data = SubstreamData(sub_object_serialization);
+        res->data.type = sub_object_type;
 
         if (data.column)
         {
             const auto & object_column = assert_cast<const ColumnObject &>(*data.column);
-            res->column = extractSubObjectColumn(object_column, prefix, sub_object_type);
+            res->data.column = extractSubObjectColumn(object_column, prefix, sub_object_type);
         }
 
+        res->substreams_path.emplace_back(ISerialization::Substream::ObjectSubObject);
+        res->substreams_path.back().name_of_substream = subcolumn_name;
         return res;
     }
 
@@ -638,14 +644,17 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
         /// For typed paths, return literal value only (typed paths are always considered present).
         if (auto it = typed_paths.find(combined_path); it != typed_paths.end())
         {
-            auto res = std::make_unique<SubstreamData>(typed_paths_serializations.at(combined_path));
-            res->type = it->second;
+            auto res = std::make_unique<SubcolumnInfo>();
+            res->data = SubstreamData(typed_paths_serializations.at(combined_path));
+            res->data.type = it->second;
             if (data.column)
             {
                 const auto & object_column = assert_cast<const ColumnObject &>(*data.column);
-                res->column = object_column.getTypedPaths().at(combined_path);
+                res->data.column = object_column.getTypedPaths().at(combined_path);
             }
-            res->serialization = SerializationObjectTypedPath::create(res->serialization, combined_path);
+            res->data.serialization = SerializationObjectTypedPath::create(res->data.serialization, combined_path);
+            res->substreams_path.emplace_back(ISerialization::Substream::ObjectCombinedPath);
+            res->substreams_path.back().name_of_substream = subcolumn_name;
             return res;
         }
 
@@ -658,25 +667,28 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
 
         auto literal_serialization = SerializationObjectDynamicPath::create(dynamic_path_serialization, combined_path, /*path_subcolumn=*/"", dynamic_result_type, dynamic_path_serialization, dynamic_result_type);
 
-        auto res = std::make_unique<SubstreamData>(SerializationObjectCombinedPath::create(
+        auto res = std::make_unique<SubcolumnInfo>();
+        res->data = SubstreamData(SerializationObjectCombinedPath::create(
             literal_serialization, sub_object_serialization, dynamic_result_type, sub_object_type));
-        res->type = dynamic_result_type;
+        res->data.type = dynamic_result_type;
 
         if (data.column)
         {
             const auto & object_column = assert_cast<const ColumnObject &>(*data.column);
-            res->column = extractCombinedColumn(object_column, combined_path, prefix, sub_object_type, dynamic_result_type, max_dynamic_types);
+            res->data.column = extractCombinedColumn(object_column, combined_path, prefix, sub_object_type, dynamic_result_type, max_dynamic_types);
         }
 
+        res->substreams_path.emplace_back(ISerialization::Substream::ObjectCombinedPath);
+        res->substreams_path.back().name_of_substream = subcolumn_name;
         return res;
     }
 
-    /// If the subcolumn starts with a type hint (.:`Type`), it means this getDynamicSubcolumnData
-    /// was reached from IDataType::getSubcolumnData after a typed path prefix match in enumerateStreams.
+    /// If the subcolumn starts with a type hint (.:`Type`), it means this getDynamicSubcolumnInfo
+    /// was reached from IDataType::getSubcolumnInfo after a typed path prefix match in enumerateStreams.
     /// E.g. for json.a.:`Array(JSON)`.x where a is a typed Array(JSON) path, enumerateStreams found "a"
     /// as a static subcolumn, then tried to resolve the remaining ":`Array(JSON)`.x" via the typed path's
     /// type chain, which eventually called this method. We return nullptr here so that the resolution falls
-    /// through to the outer DataTypeObject::getDynamicSubcolumnData with the full subcolumn name, where
+    /// through to the outer DataTypeObject::getDynamicSubcolumnInfo with the full subcolumn name, where
     /// the type hint can be properly detected and stripped. That prefix-match probe always passes
     /// throw_if_null=false; in throw_if_null mode there is no outer attempt to fall through to, so the
     /// name is unresolvable.
@@ -691,7 +703,7 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
     auto split = splitPathAndDynamicTypeSubcolumn(subcolumn_name, getTypeOfNestedObjects()->getName());
     const auto & path = split.path;
     String path_subcolumn;
-    std::unique_ptr<SubstreamData> res;
+    std::unique_ptr<SubcolumnInfo> res;
     if (auto it = typed_paths.find(path); it != typed_paths.end())
     {
         /// If there is a type hint subcolumn and it matches the typed path's type
@@ -701,34 +713,45 @@ std::unique_ptr<ISerialization::SubstreamData> DataTypeObject::getDynamicSubcolu
         else
             path_subcolumn = split.fullSubcolumn();
 
-        res = std::make_unique<SubstreamData>(typed_paths_serializations.at(path));
-        res->type = it->second;
+        res = std::make_unique<SubcolumnInfo>();
+        res->data = SubstreamData(typed_paths_serializations.at(path));
+        res->data.type = it->second;
     }
     else
     {
         path_subcolumn = split.fullSubcolumn();
-        res = std::make_unique<SubstreamData>(dynamic_path_serialization);
-        res->type = std::make_shared<DataTypeDynamic>(max_dynamic_types);
+        res = std::make_unique<SubcolumnInfo>();
+        res->data = SubstreamData(dynamic_path_serialization);
+        res->data.type = std::make_shared<DataTypeDynamic>(max_dynamic_types);
     }
 
     if (data.column)
     {
         const auto & object_column = assert_cast<const ColumnObject &>(*data.column);
-        res->column = extractLiteralColumn(object_column, path, max_dynamic_types);
+        res->data.column = extractLiteralColumn(object_column, path, max_dynamic_types);
     }
+
+    /// The same element the static enumeration emits for a typed path, so that both resolutions of
+    /// one name agree on the identity.
+    res->substreams_path.emplace_back(typed_paths.contains(path) ? ISerialization::Substream::ObjectTypedPath : ISerialization::Substream::ObjectDynamicPath);
+    res->substreams_path.back().object_path_name = path;
 
     /// Get subcolumn for Dynamic type if needed.
     if (!path_subcolumn.empty())
     {
-        res = DB::IDataType::getSubcolumnData(path_subcolumn, *res, initial_array_level, throw_if_null);
-        if (!res)
+        auto nested_info = DB::IDataType::getSubcolumnInfo(path_subcolumn, res->data, initial_array_level, throw_if_null);
+        if (!nested_info)
             return nullptr;
+
+        res->data = std::move(nested_info->data);
+        res->substreams_path.insert(
+            res->substreams_path.end(), nested_info->substreams_path.begin(), nested_info->substreams_path.end());
     }
 
     if (typed_paths.contains(path))
-        res->serialization = SerializationObjectTypedPath::create(res->serialization, path);
+        res->data.serialization = SerializationObjectTypedPath::create(res->data.serialization, path);
     else
-        res->serialization = SerializationObjectDynamicPath::create(res->serialization, path, path_subcolumn, getDynamicType(), dynamic_path_serialization, res->type);
+        res->data.serialization = SerializationObjectDynamicPath::create(res->data.serialization, path, path_subcolumn, getDynamicType(), dynamic_path_serialization, res->data.type);
 
     return res;
 }

--- a/src/DataTypes/DataTypeObject.h
+++ b/src/DataTypes/DataTypeObject.h
@@ -64,7 +64,7 @@ public:
 
     bool hasDynamicSubcolumnsData() const override { return true; }
     bool hasDynamicStructure() const override { return true; }
-    std::unique_ptr<SubstreamData> getDynamicSubcolumnData(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
+    std::unique_ptr<SubcolumnInfo> getDynamicSubcolumnInfo(std::string_view subcolumn_name, const SubstreamData & data, size_t initial_array_level, bool throw_if_null) const override;
 
     SerializationPtr doGetSerialization(const SerializationInfoSettings & settings) const override;
 

--- a/src/DataTypes/IDataType.cpp
+++ b/src/DataTypes/IDataType.cpp
@@ -151,13 +151,29 @@ void IDataType::forEachSubcolumn(
     data.serialization->enumerateStreams(settings, callback_with_data, data);
 }
 
-std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
+namespace
+{
+
+/// `nested` is the result of resolving the rest of the name dynamically; its path continues ours.
+std::unique_ptr<IDataType::SubcolumnInfo> makeSubcolumnInfo(const ISerialization::SubstreamPath & path, size_t prefix_len, const IDataType::SubcolumnInfo * nested)
+{
+    auto result = std::make_unique<IDataType::SubcolumnInfo>();
+    result->data = ISerialization::createFromPath(path, prefix_len);
+    result->substreams_path.assign(path.begin(), path.begin() + prefix_len);
+    if (nested)
+        result->substreams_path.insert(result->substreams_path.end(), nested->substreams_path.begin(), nested->substreams_path.end());
+    return result;
+}
+
+}
+
+std::unique_ptr<IDataType::SubcolumnInfo> IDataType::getSubcolumnInfo(
     std::string_view subcolumn_name,
     const SubstreamData & data,
     size_t initial_array_level,
     bool throw_if_null)
 {
-    std::unique_ptr<IDataType::SubstreamData> res;
+    std::unique_ptr<IDataType::SubcolumnInfo> res;
     /// Track whether res was set by an exact name match, so that exact matches
     /// always take priority over prefix (dynamic subcolumn) matches.
     /// This matters when e.g. JSON has typed paths "a" (Array(JSON)) and "a.b" (Int64):
@@ -180,7 +196,7 @@ std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
                 /// Exact matches always take priority over prefix matches regardless of iteration order.
                 if (name == subcolumn_name && !res_from_exact_match)
                 {
-                    res = std::make_unique<SubstreamData>(ISerialization::createFromPath(subpath, prefix_len));
+                    res = makeSubcolumnInfo(subpath, prefix_len, nullptr);
                     res_from_exact_match = true;
                 }
                 /// Check if this subcolumn is a prefix of requested subcolumn and it can create dynamic subcolumns.
@@ -188,24 +204,24 @@ std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
                 else if (!res_from_exact_match && subcolumn_name.starts_with(name + ".") && subpath[i].data.type && subpath[i].data.type->hasDynamicSubcolumnsData())
                 {
                     auto dynamic_subcolumn_name = subcolumn_name.substr(name.size() + 1);
-                    auto dynamic_subcolumn_data = subpath[i].data.type->getDynamicSubcolumnData(
+                    auto dynamic_subcolumn_info = subpath[i].data.type->getDynamicSubcolumnInfo(
                         dynamic_subcolumn_name,
                         subpath[i].data,
                         initial_array_level + ISerialization::getArrayLevel(subpath, prefix_len),
                         false);
-                    if (dynamic_subcolumn_data)
+                    if (dynamic_subcolumn_info)
                     {
                         /// Create requested subcolumn using dynamic subcolumn data.
                         auto tmp_subpath = subpath;
                         if (tmp_subpath[i].creator)
                         {
-                            dynamic_subcolumn_data->type = tmp_subpath[i].creator->create(dynamic_subcolumn_data->type);
-                            dynamic_subcolumn_data->column = tmp_subpath[i].creator->create(dynamic_subcolumn_data->column);
-                            dynamic_subcolumn_data->serialization = tmp_subpath[i].creator->create(dynamic_subcolumn_data->serialization, dynamic_subcolumn_data->type);
+                            dynamic_subcolumn_info->data.type = tmp_subpath[i].creator->create(dynamic_subcolumn_info->data.type);
+                            dynamic_subcolumn_info->data.column = tmp_subpath[i].creator->create(dynamic_subcolumn_info->data.column);
+                            dynamic_subcolumn_info->data.serialization = tmp_subpath[i].creator->create(dynamic_subcolumn_info->data.serialization, dynamic_subcolumn_info->data.type);
                         }
 
-                        tmp_subpath[i].data = *dynamic_subcolumn_data;
-                        res = std::make_unique<SubstreamData>(ISerialization::createFromPath(tmp_subpath, prefix_len));
+                        tmp_subpath[i].data = dynamic_subcolumn_info->data;
+                        res = makeSubcolumnInfo(tmp_subpath, prefix_len, dynamic_subcolumn_info.get());
                     }
                 }
             }
@@ -222,7 +238,7 @@ std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
     data.serialization->enumerateStreams(settings, callback_with_data, data);
 
     if (!res && data.type->hasDynamicSubcolumnsData())
-        return data.type->getDynamicSubcolumnData(subcolumn_name, data, settings.array_level, throw_if_null);
+        res = data.type->getDynamicSubcolumnInfo(subcolumn_name, data, settings.array_level, throw_if_null);
 
     if (!res && throw_if_null)
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "There is no subcolumn {} in type {}", subcolumn_name, data.type->getName());
@@ -230,14 +246,14 @@ std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
     return res;
 }
 
-std::unique_ptr<IDataType::SubstreamData> IDataType::getDynamicSubcolumnData(
+std::unique_ptr<IDataType::SubcolumnInfo> IDataType::getDynamicSubcolumnInfo(
     std::string_view /*subcolumn_name*/,
     const SubstreamData & /*data*/,
     size_t /*initial_array_level*/,
     bool throw_if_null) const
 {
     if (throw_if_null)
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method getDynamicSubcolumnData is not implemented for type {}", getName());
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method getDynamicSubcolumnInfo is not implemented for type {}", getName());
     return nullptr;
 }
 
@@ -264,14 +280,23 @@ bool IDataType::hasDynamicSubcolumns() const
 DataTypePtr IDataType::tryGetSubcolumnType(std::string_view subcolumn_name) const
 {
     auto data = SubstreamData(getDefaultSerialization()).withType(getPtr());
-    auto subcolumn_data = getSubcolumnData(subcolumn_name, data, {}, false);
-    return subcolumn_data ? subcolumn_data->type : nullptr;
+    auto subcolumn_data = getSubcolumnInfo(subcolumn_name, data, {}, false);
+    return subcolumn_data ? subcolumn_data->data.type : nullptr;
 }
 
 DataTypePtr IDataType::getSubcolumnType(std::string_view subcolumn_name) const
 {
     auto data = SubstreamData(getDefaultSerialization()).withType(getPtr());
-    return getSubcolumnData(subcolumn_name, data, {}, true)->type;
+    return getSubcolumnInfo(subcolumn_name, data, {}, true)->data.type;
+}
+
+std::optional<IDataType::SubcolumnInfo> IDataType::tryGetSubcolumnInfo(std::string_view subcolumn_name) const
+{
+    auto data = SubstreamData(getDefaultSerialization()).withType(getPtr());
+    auto info = getSubcolumnInfo(subcolumn_name, data, {}, false);
+    if (!info)
+        return {};
+    return std::move(*info);
 }
 
 ColumnPtr IDataType::tryGetSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column) const
@@ -285,8 +310,8 @@ ColumnPtr IDataType::tryGetSubcolumn(std::string_view subcolumn_name, const Colu
     }
 
     auto data = SubstreamData(getSerialization(*getSerializationInfo(*column))).withType(getPtr()).withColumn(column);
-    auto subcolumn_data = getSubcolumnData(subcolumn_name, data, {}, false);
-    return subcolumn_data ? subcolumn_data->column : nullptr;
+    auto subcolumn_data = getSubcolumnInfo(subcolumn_name, data, {}, false);
+    return subcolumn_data ? subcolumn_data->data.column : nullptr;
 }
 
 ColumnPtr IDataType::getSubcolumn(std::string_view subcolumn_name, const ColumnPtr & column) const
@@ -295,13 +320,13 @@ ColumnPtr IDataType::getSubcolumn(std::string_view subcolumn_name, const ColumnP
         return ColumnConst::create(getSubcolumn(subcolumn_name, column_const->getDataColumnPtr()), column_const->size());
 
     auto data = SubstreamData(getSerialization(*getSerializationInfo(*column))).withType(getPtr()).withColumn(column);
-    return getSubcolumnData(subcolumn_name, data, {}, true)->column;
+    return getSubcolumnInfo(subcolumn_name, data, {}, true)->data.column;
 }
 
 SerializationPtr IDataType::getSubcolumnSerialization(std::string_view subcolumn_name, const SerializationPtr & serialization) const
 {
     auto data = SubstreamData(serialization).withType(getPtr());
-    return getSubcolumnData(subcolumn_name, data, {}, true)->serialization;
+    return getSubcolumnInfo(subcolumn_name, data, {}, true)->data.serialization;
 }
 
 Names IDataType::getSubcolumnNames() const

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -7,6 +7,7 @@
 #include <DataTypes/Serializations/ISerialization.h>
 
 #include <memory>
+#include <optional>
 
 #include <boost/noncopyable.hpp>
 #include <fmt/format.h>
@@ -106,6 +107,18 @@ public:
 
     using SubstreamData = ISerialization::SubstreamData;
     using SubstreamPath = ISerialization::SubstreamPath;
+
+    /// A resolved subcolumn: everything needed to read it, plus the path saying which substream it is.
+    /// The name alone does not, because subcolumn names are flat and several substreams can claim one -
+    /// ``Tuple(`a.size` UInt64, `a` String)`` exposes `a.size` twice. Subcolumns resolved from the data
+    /// rather than from the static enumeration get a synthesized path that identifies them the same way.
+    struct SubcolumnInfo
+    {
+        SubstreamData data;
+        SubstreamPath substreams_path;
+    };
+
+    std::optional<SubcolumnInfo> tryGetSubcolumnInfo(std::string_view subcolumn_name) const;
 
     using SubcolumnCallback = std::function<void(
         const SubstreamPath &,
@@ -327,7 +340,7 @@ public:
 
     /// Checks if column has dynamic subcolumns.
     virtual bool hasDynamicSubcolumns() const;
-    /// Checks if column can create dynamic subcolumns data and getDynamicSubcolumnData can be called.
+    /// Checks if column can create dynamic subcolumns data and getDynamicSubcolumnInfo can be called.
     virtual bool hasDynamicSubcolumnsData() const { return false; }
 
     /// Checks if this type or any nested type has dynamic internal structure (like JSON or Dynamic).
@@ -353,13 +366,13 @@ public:
     const ISerialization * getCustomSerialization() const { return custom_serialization.get(); }
 
 protected:
-    static std::unique_ptr<SubstreamData> getSubcolumnData(
+    static std::unique_ptr<SubcolumnInfo> getSubcolumnInfo(
         std::string_view subcolumn_name,
         const SubstreamData & data,
         size_t initial_array_level,
         bool throw_if_null);
 
-    virtual std::unique_ptr<SubstreamData> getDynamicSubcolumnData(
+    virtual std::unique_ptr<SubcolumnInfo> getDynamicSubcolumnInfo(
         std::string_view subcolumn_name,
         const SubstreamData & data,
         size_t initial_array_level,

--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -176,6 +176,10 @@ const std::set<SubstreamType> ISerialization::Substream::named_types
     NamedVariantDiscriminators,
     QuantizedCodes,
     ProductQuantizationCodebook,
+    MapKeyValue,
+    ObjectDistinctPaths,
+    ObjectSubObject,
+    ObjectCombinedPath,
 };
 
 String ISerialization::Substream::toString() const

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -282,6 +282,11 @@ public:
             ObjectSharedDataCopyValues,
             ObjectStructure,
 
+            MapKeyValue,
+            ObjectDistinctPaths,
+            ObjectSubObject,
+            ObjectCombinedPath,
+
             Bucket,
             MapBucketsInfo,
             MapBucketIndexes,

--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -46,6 +46,11 @@ SerializationPtr SerializationArray::create(const SerializationPtr & nested_)
     return ISerialization::pooled(getHash(nested_), [&] { return new SerializationArray(nested_); });
 }
 
+bool SerializationArray::isArraySizesSubcolumn(const SubstreamPath & path)
+{
+    return !path.empty() && path.back().type == Substream::ArraySizes;
+}
+
 static constexpr size_t MAX_ARRAY_SIZE = 1ULL << 30;
 static constexpr size_t MAX_ARRAYS_SIZE = 1ULL << 40;
 

--- a/src/DataTypes/Serializations/SerializationArray.h
+++ b/src/DataTypes/Serializations/SerializationArray.h
@@ -17,6 +17,10 @@ public:
     static SerializationPtr create(const SerializationPtr & nested_);
     bool supportsPooling() const override { return nested->supportsPooling(); }
 
+    /// Whether a resolved subcolumn is really the array sizes, which its name alone cannot tell.
+    /// `Map` sizes are the same substream, so this covers them too.
+    static bool isArraySizesSubcolumn(const SubstreamPath & path);
+
     void serializeBinary(const Field & field, WriteBuffer & ostr, const FormatSettings & settings) const override;
     void deserializeBinary(Field & field, ReadBuffer & istr, const FormatSettings & settings) const override;
     void serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;

--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -161,6 +161,35 @@ SerializationPtr SerializationMap::create(
     return ISerialization::pooled(getHash(nested_serialization_, serialization_version_), [&] { return new SerializationMap(key_serialization_, value_serialization_, nested_serialization_, serialization_version_); });
 }
 
+namespace
+{
+
+bool isMapNestedTupleElementSubcolumn(const ISerialization::SubstreamPath & path, std::string_view element_name)
+{
+    using Substream = ISerialization::Substream;
+    return path.size() >= 2
+        && path[path.size() - 2].type == Substream::ArrayElements
+        && path.back().type == Substream::TupleElement
+        && path.back().name_of_substream == element_name;
+}
+
+}
+
+bool SerializationMap::isKeysSubcolumn(const SubstreamPath & path)
+{
+    return isMapNestedTupleElementSubcolumn(path, "keys");
+}
+
+bool SerializationMap::isValuesSubcolumn(const SubstreamPath & path)
+{
+    return isMapNestedTupleElementSubcolumn(path, "values");
+}
+
+bool SerializationMap::isKeyValueSubcolumn(const SubstreamPath & path)
+{
+    return !path.empty() && path.back().type == Substream::MapKeyValue;
+}
+
 template <typename KeyWriter, typename ValueWriter>
 void SerializationMap::serializeTextImpl(
     const IColumn & column,

--- a/src/DataTypes/Serializations/SerializationMap.h
+++ b/src/DataTypes/Serializations/SerializationMap.h
@@ -44,6 +44,15 @@ public:
 
     bool supportsPooling() const override { return nested_serialization->supportsPooling(); }
 
+    /// Whether a resolved subcolumn is really the `.keys` / `.values` array, which its name alone
+    /// cannot tell. A `Map` exposes them through its nested `Array(Tuple(keys, values))`, so the last
+    /// path element alone is not enough either.
+    static bool isKeysSubcolumn(const SubstreamPath & path);
+    static bool isValuesSubcolumn(const SubstreamPath & path);
+
+    /// Whether a resolved subcolumn is really the value stored under one key (`m.key_<key>`).
+    static bool isKeyValueSubcolumn(const SubstreamPath & path);
+
     void serializeBinary(const Field & field, WriteBuffer & ostr, const FormatSettings & settings) const override;
     void deserializeBinary(Field & field, ReadBuffer & istr, const FormatSettings & settings) const override;
     void serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;

--- a/src/DataTypes/Serializations/SerializationNullable.cpp
+++ b/src/DataTypes/Serializations/SerializationNullable.cpp
@@ -1007,4 +1007,9 @@ SerializationPtr SerializationNullable::create(const SerializationPtr & nested_,
     return ISerialization::pooled(getHash(nested_, use_default_null_map_), [&] { return new SerializationNullable(nested_, use_default_null_map_); });
 }
 
+bool SerializationNullable::isNullMapSubcolumn(const SubstreamPath & path)
+{
+    return !path.empty() && (path.back().type == Substream::NullMap || path.back().type == Substream::SparseNullMap);
+}
+
 }

--- a/src/DataTypes/Serializations/SerializationNullable.h
+++ b/src/DataTypes/Serializations/SerializationNullable.h
@@ -24,6 +24,9 @@ public:
     static UInt128 getHash(const SerializationPtr & nested_, bool use_default_null_map_);
     static SerializationPtr create(const SerializationPtr & nested_, bool use_default_null_map_ = false);
 
+    /// Whether a resolved subcolumn is really the null map, which its name alone cannot tell.
+    static bool isNullMapSubcolumn(const SubstreamPath & path);
+
     bool supportsPooling() const override { return nested->supportsPooling(); }
 
     const SerializationPtr & getNested() const { return nested; }

--- a/src/DataTypes/Serializations/SerializationObjectCombinedPath.h
+++ b/src/DataTypes/Serializations/SerializationObjectCombinedPath.h
@@ -11,7 +11,7 @@ namespace DB
 /// For example, if we have type JSON and data {"a" : {"b" : {"c" : 42, "d" : "Hello"}}, "c" : [1, 2, 3]}
 /// this class will be responsible for reading combined path 'a' and will return a Dynamic column
 /// that contains the literal value at path 'a' (if present) or the sub-object at path 'a' (if not empty).
-/// This class is never used for typed paths - the typed-path check is done in `getDynamicSubcolumnData`.
+/// This class is never used for typed paths - the typed-path check is done in `getDynamicSubcolumnInfo`.
 class SerializationObjectCombinedPath final : public SimpleTextSerialization
 {
 private:

--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -45,6 +45,11 @@ SerializationPtr SerializationString::create(MergeTreeStringSerializationVersion
     return ISerialization::pooled(getHash(version_), [=] { return new SerializationString(version_); });
 }
 
+bool SerializationString::isStringSizesSubcolumn(const SubstreamPath & path)
+{
+    return !path.empty() && (path.back().type == Substream::StringSizes || path.back().type == Substream::InlinedStringSizes);
+}
+
 void SerializationString::serializeBinary(const Field & field, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     const String & s = field.safeGet<String>();

--- a/src/DataTypes/Serializations/SerializationString.h
+++ b/src/DataTypes/Serializations/SerializationString.h
@@ -36,6 +36,10 @@ public:
     static UInt128 getHash(MergeTreeStringSerializationVersion version_);
     static SerializationPtr create(MergeTreeStringSerializationVersion version_ = MergeTreeStringSerializationVersion::SINGLE_STREAM);
 
+    /// Whether a resolved subcolumn is really the string lengths, which its name alone cannot tell.
+    /// Covers both the stored size stream and the virtual one computed from the data.
+    static bool isStringSizesSubcolumn(const SubstreamPath & path);
+
     void serializeBinary(const Field & field, WriteBuffer & ostr, const FormatSettings & settings) const override;
     void deserializeBinary(Field & field, ReadBuffer & istr, const FormatSettings & settings) const override;
     void serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const override;

--- a/src/DataTypes/Serializations/SerializationTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationTuple.cpp
@@ -173,6 +173,11 @@ SerializationPtr SerializationTuple::create(ElementSerializations elems_, bool h
     return ISerialization::pooled(hash, [e = std::move(elems_), has_explicit_names_]() mutable { return new SerializationTuple(std::move(e), has_explicit_names_); });
 }
 
+bool SerializationTuple::isElementSubcolumn(const SubstreamPath & path, const String & element_name)
+{
+    return !path.empty() && path.back().type == Substream::TupleElement && path.back().name_of_substream == element_name;
+}
+
 void SerializationTuple::deserializeBinary(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
 {
     addElementSafe<void>(elems.size(), column, [&]

--- a/src/DataTypes/Serializations/SerializationTuple.h
+++ b/src/DataTypes/Serializations/SerializationTuple.h
@@ -21,6 +21,10 @@ private:
 public:
     static UInt128 getHash(const ElementSerializations & elems_, bool has_explicit_names_);
     static SerializationPtr create(ElementSerializations elems_, bool has_explicit_names_);
+
+    /// Whether a resolved subcolumn is really this element, which its name alone cannot tell: a
+    /// sibling element can flatten to the same name. `QBit` elements are the same substream.
+    static bool isElementSubcolumn(const SubstreamPath & path, const String & element_name);
     size_t allocatedBytes() const override;
     bool supportsPooling() const override;
 

--- a/src/DataTypes/Serializations/SerializationVariant.cpp
+++ b/src/DataTypes/Serializations/SerializationVariant.cpp
@@ -103,6 +103,11 @@ SerializationPtr SerializationVariant::create(const DataTypes & variant_types_, 
     return ISerialization::pooled(getHash(variant_serializations_, variant_name_), [&] { return new SerializationVariant(variant_types_, variant_serializations_, variant_names_, variant_name_); });
 }
 
+bool SerializationVariant::isElementSubcolumn(const SubstreamPath & path, const String & element_name)
+{
+    return !path.empty() && path.back().type == Substream::VariantElement && path.back().variant_element_name == element_name;
+}
+
 SerializationVariant::SerializationVariant(
     const DataTypes & variant_types_,
     const VariantSerializations & variant_serializations_,

--- a/src/DataTypes/Serializations/SerializationVariant.h
+++ b/src/DataTypes/Serializations/SerializationVariant.h
@@ -79,6 +79,10 @@ private:
 public:
     static UInt128 getHash(const VariantSerializations & variant_serializations_, const String & variant_name_);
     static SerializationPtr create(const DataTypes & variant_types_, const VariantSerializations & variant_serializations_, const Names & variant_names_, const String & variant_name_);
+
+    /// Whether a resolved subcolumn is really this variant, which its name alone cannot tell: a
+    /// sibling element can flatten to the same name.
+    static bool isElementSubcolumn(const SubstreamPath & path, const String & element_name);
     size_t allocatedBytes() const override;
     bool supportsPooling() const override;
 

--- a/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.reference
+++ b/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.reference
@@ -1,0 +1,54 @@
+string size
+3	0	1
+0	1	0
+3	0	1
+0	1	0
+array size
+2	0	1
+0	1	0
+2	0	1
+0	1	0
+null map
+0	1
+1	0
+0	1
+1	0
+1
+1
+map keys
+['k']	0
+['k']	0
+map values
+[1]
+[1]
+map element
+1
+1
+nullable json
+2	0	1	1
+0	1	0	0
+2	0	1	1
+0	1	0	0
+nullable tuple
+2	0	1	['k']
+0	1	0	[]
+2	0	1	['k']
+0	1	0	[]
+json size path
+2	0	1	1
+2	0	1	1
+still optimized
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1

--- a/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.reference
+++ b/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.reference
@@ -37,7 +37,18 @@ nullable tuple
 json size path
 2	0	1	1
 2	0	1	1
+tuple element
+1
+1
+tuple element, nested declared first
+1
+1
+variant element
+7
+7
 still optimized
+1
+1
 1
 1
 1

--- a/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.sql
+++ b/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.sql
@@ -1,0 +1,125 @@
+-- A rewrite to a subcolumn must land on the subcolumn it means. Subcolumn names are flat, so a
+-- Tuple element or a JSON path can claim the name of an automatic subcolumn with the same type,
+-- and an enclosing Nullable can wrap the automatic subcolumn. Every query below must give the same
+-- answer with the optimization on and off.
+
+SET enable_analyzer = 1;
+
+-- A Tuple element named `<sibling>.<automatic name>` claims the sibling's automatic subcolumn.
+-- Memory, because the Map cases collide on file names in MergeTree.
+
+DROP TABLE IF EXISTS t_shadowed_string_size;
+CREATE TABLE t_shadowed_string_size (c Tuple(`a.size` UInt64, `a` String)) ENGINE = Memory;
+INSERT INTO t_shadowed_string_size VALUES ((99, 'abc')), ((0, ''));
+
+SELECT 'string size';
+SELECT length(c.a), empty(c.a), notEmpty(c.a) FROM t_shadowed_string_size SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT length(c.a), empty(c.a), notEmpty(c.a) FROM t_shadowed_string_size SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_shadowed_array_size;
+CREATE TABLE t_shadowed_array_size (c Tuple(`a.size0` UInt64, `a` Array(UInt64))) ENGINE = Memory;
+INSERT INTO t_shadowed_array_size VALUES ((99, [10, 20])), ((7, []));
+
+SELECT 'array size';
+SELECT length(c.a), empty(c.a), notEmpty(c.a) FROM t_shadowed_array_size SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT length(c.a), empty(c.a), notEmpty(c.a) FROM t_shadowed_array_size SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_shadowed_null_map;
+CREATE TABLE t_shadowed_null_map (c Tuple(`a.null` UInt8, `a` Nullable(UInt64))) ENGINE = Memory;
+INSERT INTO t_shadowed_null_map VALUES ((1, 5)), ((1, NULL));
+
+SELECT 'null map';
+SELECT isNull(c.a), isNotNull(c.a) FROM t_shadowed_null_map SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT isNull(c.a), isNotNull(c.a) FROM t_shadowed_null_map SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT count(c.a) FROM t_shadowed_null_map SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT count(c.a) FROM t_shadowed_null_map SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_shadowed_map_keys;
+CREATE TABLE t_shadowed_map_keys (c Tuple(`a.keys` Array(String), `a` Map(String, UInt64))) ENGINE = Memory;
+INSERT INTO t_shadowed_map_keys VALUES ((['x', 'y'], {'k': 1}));
+
+SELECT 'map keys';
+SELECT mapKeys(c.a), mapContains(c.a, 'x') FROM t_shadowed_map_keys SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT mapKeys(c.a), mapContains(c.a, 'x') FROM t_shadowed_map_keys SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_shadowed_map_values;
+CREATE TABLE t_shadowed_map_values (c Tuple(`a.values` Array(UInt64), `a` Map(String, UInt64))) ENGINE = Memory;
+INSERT INTO t_shadowed_map_values VALUES (([7, 8], {'k': 1}));
+
+SELECT 'map values';
+SELECT mapValues(c.a) FROM t_shadowed_map_values SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT mapValues(c.a) FROM t_shadowed_map_values SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_shadowed_map_key;
+CREATE TABLE t_shadowed_map_key (c Tuple(`a.key_foo` UInt64, `a` Map(String, UInt64))) ENGINE = Memory;
+INSERT INTO t_shadowed_map_key VALUES ((99, {'foo': 1}));
+
+SELECT 'map element';
+SELECT c.a['foo'] FROM t_shadowed_map_key SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT c.a['foo'] FROM t_shadowed_map_key SETTINGS optimize_functions_to_subcolumns = 1;
+
+-- The automatic subcolumn is the one resolved, but an enclosing Nullable wraps it. `Array` and `Map`
+-- cannot be inside `Nullable`, so `c.a` is exposed as a bare `Array` while `c.a.size0` is
+-- `Nullable(UInt64)`, and `length` must give 0 for a NULL row, not NULL.
+
+DROP TABLE IF EXISTS t_nullable_json;
+CREATE TABLE t_nullable_json (c Nullable(JSON(`a` Array(Int64), `m` Map(String, Int64)))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nullable_json VALUES ('{"a":[1,2],"m":{"k":1}}'), (NULL);
+
+SELECT 'nullable json';
+SELECT length(c.a), empty(c.a), notEmpty(c.a), length(c.m) FROM t_nullable_json SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT length(c.a), empty(c.a), notEmpty(c.a), length(c.m) FROM t_nullable_json SETTINGS optimize_functions_to_subcolumns = 1;
+
+SET enable_nullable_tuple_type = 1;
+DROP TABLE IF EXISTS t_nullable_tuple;
+CREATE TABLE t_nullable_tuple (c Nullable(Tuple(arr Array(Int64), m Map(String, Int64)))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nullable_tuple VALUES (([1, 2], {'k': 1})), (NULL);
+
+SELECT 'nullable tuple';
+SELECT length(c.arr), empty(c.arr), length(c.m), mapKeys(c.m) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT length(c.arr), empty(c.arr), length(c.m), mapKeys(c.m) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 1;
+
+-- A JSON path can be named like an automatic subcolumn too. What `arr.size0` resolves to is decided
+-- by the resolution order, but the rewrite must agree with the unoptimized query either way.
+
+DROP TABLE IF EXISTS t_json_size_path;
+CREATE TABLE t_json_size_path (arr Array(JSON), nested Array(Array(JSON)), m Map(String, JSON)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_json_size_path VALUES ([('{"size0":7}'), ('{"size0":8}')], [[('{"size0":7}')]], {'k': '{"size0":9}'});
+
+SELECT 'json size path';
+SELECT length(arr), empty(arr), length(nested), length(m) FROM t_json_size_path SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT length(arr), empty(arr), length(nested), length(m) FROM t_json_size_path SETTINGS optimize_functions_to_subcolumns = 1;
+
+-- The guard must not reject the ordinary case: every rewrite still fires when nothing claims the name.
+
+DROP TABLE IF EXISTS t_plain;
+CREATE TABLE t_plain (s String, arr Array(UInt64), m Map(String, UInt64), n Nullable(UInt64))
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_plain VALUES ('abc', [1, 2], {'k': 1}, 5);
+
+SELECT 'still optimized';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT length(s) FROM t_plain) WHERE explain LIKE '%s.size%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT empty(s) FROM t_plain) WHERE explain LIKE '%s.size%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT notEmpty(s) FROM t_plain) WHERE explain LIKE '%s.size%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT length(arr) FROM t_plain) WHERE explain LIKE '%arr.size0%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT empty(arr) FROM t_plain) WHERE explain LIKE '%arr.size0%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT notEmpty(arr) FROM t_plain) WHERE explain LIKE '%arr.size0%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT length(m) FROM t_plain) WHERE explain LIKE '%m.size0%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT mapKeys(m) FROM t_plain) WHERE explain LIKE '%m.keys%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT mapValues(m) FROM t_plain) WHERE explain LIKE '%m.values%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT mapContains(m, 'k') FROM t_plain) WHERE explain LIKE '%m.keys%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT m['k'] FROM t_plain) WHERE explain LIKE '%m.key_k%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT isNull(n) FROM t_plain) WHERE explain LIKE '%n.null%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT isNotNull(n) FROM t_plain) WHERE explain LIKE '%n.null%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT count(n) FROM t_plain) WHERE explain LIKE '%n.null%';
+
+DROP TABLE t_shadowed_string_size;
+DROP TABLE t_shadowed_array_size;
+DROP TABLE t_shadowed_null_map;
+DROP TABLE t_shadowed_map_keys;
+DROP TABLE t_shadowed_map_values;
+DROP TABLE t_shadowed_map_key;
+DROP TABLE t_nullable_json;
+DROP TABLE t_nullable_tuple;
+DROP TABLE t_json_size_path;
+DROP TABLE t_plain;

--- a/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.sql
+++ b/tests/queries/0_stateless/04935_optimize_functions_to_subcolumns_name_collision.sql
@@ -90,12 +90,42 @@ SELECT 'json size path';
 SELECT length(arr), empty(arr), length(nested), length(m) FROM t_json_size_path SETTINGS optimize_functions_to_subcolumns = 0;
 SELECT length(arr), empty(arr), length(nested), length(m) FROM t_json_size_path SETTINGS optimize_functions_to_subcolumns = 1;
 
+-- A sibling element can flatten to the same name as a nested one, and declaration order decides
+-- which one a read returns. Only the case where the sibling is declared first is wrong.
+
+DROP TABLE IF EXISTS t_shadowed_tuple_element;
+CREATE TABLE t_shadowed_tuple_element (c Tuple(`t.a` UInt64, t Tuple(a UInt64))) ENGINE = Memory;
+INSERT INTO t_shadowed_tuple_element VALUES ((99, (1)));
+
+SELECT 'tuple element';
+SELECT tupleElement(c.t, 'a') FROM t_shadowed_tuple_element SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT tupleElement(c.t, 'a') FROM t_shadowed_tuple_element SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_nested_tuple_element;
+CREATE TABLE t_nested_tuple_element (c Tuple(t Tuple(a UInt64), `t.a` UInt64)) ENGINE = Memory;
+INSERT INTO t_nested_tuple_element VALUES (((1), 99));
+
+SELECT 'tuple element, nested declared first';
+SELECT tupleElement(c.t, 'a') FROM t_nested_tuple_element SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT tupleElement(c.t, 'a') FROM t_nested_tuple_element SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_shadowed_variant_element;
+CREATE TABLE t_shadowed_variant_element (c Tuple(`t.Int64` UInt64, t Variant(Int64, String))) ENGINE = Memory;
+INSERT INTO t_shadowed_variant_element VALUES ((99, 7::Int64));
+
+SELECT 'variant element';
+SELECT variantElement(c.t, 'Int64') FROM t_shadowed_variant_element SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT variantElement(c.t, 'Int64') FROM t_shadowed_variant_element SETTINGS optimize_functions_to_subcolumns = 1;
+
 -- The guard must not reject the ordinary case: every rewrite still fires when nothing claims the name.
+-- The setting is randomized in CI, and these queries read it from the session.
 
 DROP TABLE IF EXISTS t_plain;
-CREATE TABLE t_plain (s String, arr Array(UInt64), m Map(String, UInt64), n Nullable(UInt64))
+CREATE TABLE t_plain (s String, arr Array(UInt64), m Map(String, UInt64), n Nullable(UInt64), t Tuple(x UInt64), v Variant(Int64, String))
 ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO t_plain VALUES ('abc', [1, 2], {'k': 1}, 5);
+INSERT INTO t_plain VALUES ('abc', [1, 2], {'k': 1}, 5, (1), 7::Int64);
+
+SET optimize_functions_to_subcolumns = 1;
 
 SELECT 'still optimized';
 SELECT count() FROM (EXPLAIN QUERY TREE SELECT length(s) FROM t_plain) WHERE explain LIKE '%s.size%';
@@ -112,6 +142,8 @@ SELECT count() FROM (EXPLAIN QUERY TREE SELECT m['k'] FROM t_plain) WHERE explai
 SELECT count() FROM (EXPLAIN QUERY TREE SELECT isNull(n) FROM t_plain) WHERE explain LIKE '%n.null%';
 SELECT count() FROM (EXPLAIN QUERY TREE SELECT isNotNull(n) FROM t_plain) WHERE explain LIKE '%n.null%';
 SELECT count() FROM (EXPLAIN QUERY TREE SELECT count(n) FROM t_plain) WHERE explain LIKE '%n.null%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT tupleElement(t, 'x') FROM t_plain) WHERE explain LIKE '%t.x%';
+SELECT count() FROM (EXPLAIN QUERY TREE SELECT variantElement(v, 'Int64') FROM t_plain) WHERE explain LIKE '%v.Int64%';
 
 DROP TABLE t_shadowed_string_size;
 DROP TABLE t_shadowed_array_size;
@@ -122,4 +154,7 @@ DROP TABLE t_shadowed_map_key;
 DROP TABLE t_nullable_json;
 DROP TABLE t_nullable_tuple;
 DROP TABLE t_json_size_path;
+DROP TABLE t_shadowed_tuple_element;
+DROP TABLE t_nested_tuple_element;
+DROP TABLE t_shadowed_variant_element;
 DROP TABLE t_plain;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115632
Related: https://github.com/ClickHouse/ClickHouse/issues/115394

`optimize_functions_to_subcolumns` rewrites a function to a subcolumn of its argument
(`length(arr)` to `arr.size0`, `isNull(n)` to `n.null`, `mapKeys(m)` to `m.keys`, ...) and
hardcodes the type that subcolumn has. It only checked that a subcolumn with that name exists,
which is wrong in two independent ways, both giving wrong results.

A `Tuple` element or a `JSON` path can claim the name with the same type, and declaration order
decides which one a read returns:

```sql
CREATE TABLE t (c Tuple(`a.size` UInt64, `a` String)) ENGINE = Memory;
INSERT INTO t VALUES ((99, 'abc'));

SELECT length(c.a) FROM t SETTINGS optimize_functions_to_subcolumns = 0;  -- 3   correct
SELECT length(c.a) FROM t SETTINGS optimize_functions_to_subcolumns = 1;  -- 99  wrong
```

The same shape affects `empty`, `notEmpty`, `isNull`, `isNotNull`, `count`, `mapKeys`,
`mapValues`, `mapContains` and `m['key']`.

An enclosing `Nullable` wraps the subcolumn without changing which substream it is - `c.a` is a
bare `Array` while `c.a.size0` is `Nullable(UInt64)`, because `Array` cannot be inside `Nullable`.
Only `length` lacked the guard the other rewrites already had:

```sql
CREATE TABLE t (c Nullable(JSON(`a` Array(Int64)))) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES ('{"a":[1,2]}'), (NULL);

SELECT length(c.a) FROM t SETTINGS optimize_functions_to_subcolumns = 0;  -- 2, 0   correct
SELECT length(c.a) FROM t SETTINGS optimize_functions_to_subcolumns = 1;  -- 2, \N  wrong
```

To tell these apart, subcolumn resolution now reports the substreams path identifying the
resolved subcolumn, not just its data (`getSubcolumnData` becomes `getSubcolumnInfo`).
Subcolumns resolved from the data get a synthesized path too, so all of them are identifiable
the same way. The optimizer asks the serialization owning the substream whether the resolved
subcolumn is the one the rewrite means, and additionally requires the exact type; neither check
catches the other's case. Subsumes `subcolumnIsNullableInStorage` and `nestedTypeHasNullSubcolumn`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results from `optimize_functions_to_subcolumns`. A `Tuple` element or a `JSON` path named like an automatic subcolumn claimed it, so for example `length(c.a)` on ``Tuple(`a.size` UInt64, `a` String)`` returned the element instead of the length; `empty`, `notEmpty`, `isNull`, `isNotNull`, `count`, `mapKeys`, `mapValues`, `mapContains` and `m['key']` were affected the same way. Separately, `length` on an `Array` or `Map` inside a `Nullable` (for example ``Nullable(JSON(`a` Array(Int64)))``) returned NULL instead of 0 for a NULL row.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115777&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115777](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115777+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1084` (included in `26.9` and later)
<!-- ch-version-info:end -->