### PR TITLE
Drop registry files from the `Parser memory check` digest

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1746,12 +1746,14 @@ class JobConfigs:
         command="python3 ./ci/jobs/parser_memory_check.py",
         requires=[ArtifactNames.CLICKHOUSE_EXAMPLES],
         result_name_for_cidb="Tests",
+        # No registry files (ci/defs/*.py, ci/workflows/*.py) in the digest: this
+        # job requires CLICKHOUSE_EXAMPLES, so digesting the registry would make
+        # every registry-only edit rescue Build (arm_release) to produce the
+        # artifact - the waste test_build_profile_diff_scheduling.py pins against.
+        # No other job digests the registry either.
         digest_config=Job.CacheDigestConfig(
             include_paths=[
-                "./ci/defs/defs.py",
-                "./ci/defs/job_configs.py",
                 "./ci/jobs/parser_memory_check.py",
-                "./ci/workflows/pull_request.py",
                 "./utils/parser-memory-profiler/",
             ],
         ),

--- a/ci/tests/test_build_profile_diff_scheduling.py
+++ b/ci/tests/test_build_profile_diff_scheduling.py
@@ -98,6 +98,7 @@ BUILD_FREE_DIFFS = [
     pytest.param([".github/workflows/pull_request.yml"], id="generated-yaml"),
     pytest.param(["ci/defs/job_configs.py"], id="job-registry"),
     pytest.param(["ci/defs/defs.py"], id="defs-registry"),
+    pytest.param(["ci/workflows/pull_request.py"], id="workflow-source"),
     pytest.param(["ci/jobs/scripts/workflow_hooks/filter_job.py"], id="filter-hook"),
 ]
 
@@ -175,7 +176,11 @@ def test_registry_edits_do_not_schedule_a_run_without_profile_data():
     Phrased as "these paths do not schedule the job" rather than as a literal copy of
     the digest list, so adding a genuine consumer input later does not fail this test.
     """
-    for path in ("ci/defs/job_configs.py", "ci/defs/defs.py"):
+    for path in (
+        "ci/defs/job_configs.py",
+        "ci/defs/defs.py",
+        "ci/workflows/pull_request.py",
+    ):
         skipped = _schedule([path])
         assert PROFILED_BUILD in skipped, path
         assert BPD in skipped, path


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/115766
Related: https://github.com/ClickHouse/ClickHouse/pull/115221
Related: https://github.com/ClickHouse/ClickHouse/pull/104631
Related: https://github.com/ClickHouse/ClickHouse/pull/115036

`ci/tests/test_build_profile_diff_scheduling.py::test_registry_edits_do_not_schedule_a_run_without_profile_data` fails on current master, so the `CI Tests` job is red for every pull request that touches `ci/`. The test (added in #115221) asserts that a registry-only edit schedules no build; `Parser memory check` (added to the PR workflow in #104631) digests `ci/defs/defs.py`, `ci/defs/job_configs.py` and `ci/workflows/pull_request.py` while requiring `CLICKHOUSE_EXAMPLES`, so a registry-only edit marks it affected and the rescue pass in `_filter_unaffected_jobs` schedules `Build (arm_release)` just to produce the artifact. Each PR was green on its own — #115221's branch predates #104631's merge, and #104631 could not run the not-yet-existing test — the combination on master is what breaks.

Fix: drop the registry paths from the job's `digest_config`, keeping its own script and `utils/parser-memory-profiler/`. No other job digests the registry, so this also restores the convention. `python3 -m pytest ci/tests/test_build_profile_diff_scheduling.py` passes with the change (37/37; the failing test plus the rest of the module).

First observed in #115036: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115036&sha=1c383b2ae000d256fc2e04e60b4b4b5ddab93b96&name_0=PR&name_1=CI%20Tests

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115783&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115783](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115783+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
