### PR TITLE
Add test: No test for arity/type guards of PromQL `clamp`/`clamp_min`/`clamp_max`/`round`

### DIFF
--- a/tests/queries/0_stateless/04926_promql_clamp_round_argument_errors.reference
+++ b/tests/queries/0_stateless/04926_promql_clamp_round_argument_errors.reference
@@ -1,0 +1,6 @@
+-- wrong number of arguments
+-- first argument must be an instant vector
+-- bounds must be scalars
+-- valid calls still work
+[('host','h1')]	1970-01-01 00:01:50.000	2
+[('host','h1')]	1970-01-01 00:01:50.000	3

--- a/tests/queries/0_stateless/04926_promql_clamp_round_argument_errors.sql
+++ b/tests/queries/0_stateless/04926_promql_clamp_round_argument_errors.sql
@@ -1,0 +1,38 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+
+-- Argument validation of the PromQL functions clamp/clamp_min/clamp_max/round.
+
+DROP TABLE IF EXISTS prometheus;
+
+SET session_timezone = 'UTC';
+SET allow_experimental_time_series_table = 1;
+
+CREATE TABLE prometheus ENGINE = TimeSeries;
+
+INSERT INTO prometheus (metric_name, tags, time_series) VALUES
+    ('m', map('host', 'h1'), [(toDateTime64(100, 3), 1.5), (toDateTime64(110, 3), 2.5)]);
+
+SELECT '-- wrong number of arguments';
+SELECT * FROM prometheusQuery('prometheus', 'clamp(m, 0)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'clamp(m, 0, 1, 2)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'clamp_min(m)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'clamp_max(m, 0, 1)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'round(m, 1, 2)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+
+SELECT '-- first argument must be an instant vector';
+SELECT * FROM prometheusQuery('prometheus', 'clamp(1, 0, 2)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'clamp_min(1, 0)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'round(1)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+
+SELECT '-- bounds must be scalars';
+SELECT * FROM prometheusQuery('prometheus', 'clamp(m, m, 2)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'clamp(m, 0, m)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'clamp_max(m, m)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('prometheus', 'round(m, m)', 110); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+
+SELECT '-- valid calls still work';
+SELECT * FROM prometheusQuery('prometheus', 'clamp(m, 0, 2)', 110) ORDER BY tags;
+SELECT * FROM prometheusQuery('prometheus', 'round(m)', 110) ORDER BY tags;
+
+DROP TABLE prometheus;


### PR DESCRIPTION
_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #111870](https://github.com/ClickHouse/ClickHouse/pull/111870).
That PR: (1) Adds PromQL `clamp`, `clamp_min`, `clamp_max` (new `applyClampFunction`, mapped to `greatest`/`least` with explicit NaN/NULL/`max < min` guards) and `round` (new `applyRoundFunction`, `floor(x*inv + 0.5)/inv`), wires both into `applyFunction`, and extends `applyFunctionScalar` so `scalar()` of …

**1. No test for arity/type guards of PromQL `clamp`/`clamp_min`/`clamp_max`/`round`**
  `src/Storages/TimeSeries/PrometheusQueryToSQL/applyClampFunction.cpp:35`, `src/Storages/TimeSeries/PrometheusQueryToSQL/applyClampFunction.cpp:42`
  **Risk:** `applyClampFunction` calls `checkArgumentTypes` and then immediately indexes `arguments[min_index]` / `arguments[max_index]` (`applyClampFunction.cpp:81-82`) with `max_index == 2` for `clamp`; the arity guard at `applyClampFunction.cpp:33` is the only thing standing between a malformed user query …
  **Unique vs PR tests:** The PR's `test_clamp` / `test_round` in test_evaluation.py only issue well-formed calls; no case passes a wrong number of arguments or a wrong argument type to any of the four new functions. The suite already has exactly this kind of case for `label_replace`/`label_join` …
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: PromQL parsing needs ANTLR4, which is disabled in the fast-test build (same tag as 04811_promql_topk_bottomk_limitk.sql).
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/6d865006-8cef-44e7-874b-4cc7c5479690)

cc @valerypetrov (author of #111870), @nikitamikhaylov (merged/approved #111870) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115787&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115787](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115787+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1945` (included in `26.8` and later)
<!-- ch-version-info:end -->