### PR TITLE
Hide aws_external_id in DataLakeCatalog SHOW CREATE DATABASE

### DIFF
--- a/src/Databases/DataLake/DataLakeConstants.h
+++ b/src/Databases/DataLake/DataLakeConstants.h
@@ -27,6 +27,7 @@ static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
     /// AWS credentials
     {"aws_access_key_id", DEFAULT_MASKING_RULE},
     {"aws_secret_access_key", DEFAULT_MASKING_RULE},
+    {"aws_external_id", DEFAULT_MASKING_RULE},
     /// Legacy storage_* aliases (declared in DataLakeStorageSettings.h, originally for the Glue catalog)
     {"storage_catalog_credential", DEFAULT_MASKING_RULE},
     {"storage_auth_header", DEFAULT_MASKING_RULE},

--- a/tests/queries/0_stateless/05030_datalake_catalog_hide_aws_external_id.reference
+++ b/tests/queries/0_stateless/05030_datalake_catalog_hide_aws_external_id.reference
@@ -1,0 +1,13 @@
+--- default: aws_external_id hidden, role identifiers visible
+aws_external_id = '[HIDDEN]'
+aws_access_key_id = '[HIDDEN]'
+aws_secret_access_key = '[HIDDEN]'
+aws_role_arn = 'arn:aws:iam::1:role/r'
+aws_role_session_name = 'sess'
+OK: no secret in formatted query
+--- show_secrets: aws_external_id visible
+aws_external_id = 'SECRET_THAT_MUST_NOT_LEAK'
+aws_access_key_id = 'SECRET_THAT_MUST_NOT_LEAK'
+aws_secret_access_key = 'SECRET_THAT_MUST_NOT_LEAK'
+aws_role_arn = 'arn:aws:iam::1:role/r'
+aws_role_session_name = 'sess'

--- a/tests/queries/0_stateless/05030_datalake_catalog_hide_aws_external_id.sh
+++ b/tests/queries/0_stateless/05030_datalake_catalog_hide_aws_external_id.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Regression test: aws_external_id is the shared secret of the AWS AssumeRole triple, so it must be
+# redacted as [HIDDEN] when a DataLakeCatalog CREATE query is formatted (system.databases.engine_full,
+# SHOW CREATE DATABASE), while aws_role_arn and aws_role_session_name are non-secret identifiers that
+# stay visible. Uses clickhouse-format so it needs no live catalog and is safe to run in parallel.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+SECRET="SECRET_THAT_MUST_NOT_LEAK"
+
+query="CREATE DATABASE d ENGINE = DataLakeCatalog('http://example.invalid/catalog') SETTINGS
+catalog_type = 'glue',
+region = 'us-east-1',
+aws_access_key_id = '${SECRET}',
+aws_secret_access_key = '${SECRET}',
+aws_external_id = '${SECRET}',
+aws_role_arn = 'arn:aws:iam::1:role/r',
+aws_role_session_name = 'sess'"
+
+show_settings() {
+    local formatted="$1"
+    for setting in \
+        aws_external_id \
+        aws_access_key_id \
+        aws_secret_access_key \
+        aws_role_arn \
+        aws_role_session_name
+    do
+        echo "$formatted" | grep -oE "(^|[, ])${setting} = '[^']*'" | sed -E "s/^[, ]//"
+    done
+}
+
+# Arm A: at the default the secret is redacted; arms C (non-secret identifiers stay visible) and
+# D (sibling AWS keys still redacted) are asserted by the same output.
+echo "--- default: aws_external_id hidden, role identifiers visible"
+formatted=$(echo "$query" | $CLICKHOUSE_FORMAT --oneline)
+show_settings "$formatted"
+if echo "$formatted" | grep -q "$SECRET"; then
+    echo "FAIL: secret leaked in formatted query"
+else
+    echo "OK: no secret in formatted query"
+fi
+
+# Arm B: an authorized caller can still retrieve the value, so the fix redacts rather than destroys.
+echo "--- show_secrets: aws_external_id visible"
+formatted=$(echo "$query" | $CLICKHOUSE_FORMAT --oneline --show_secrets)
+show_settings "$formatted"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114999
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Mask the `aws_external_id` setting of the `DataLakeCatalog` database engine in `SHOW CREATE DATABASE` and `system.databases.engine_full`. It was previously printed in plaintext, unlike the other AWS credential settings. Closes: #114999

### Description

`aws_external_id` was missing from `DataLake::SETTINGS_TO_HIDE`, so any user able to run
`SHOW CREATE DATABASE` or read `system.databases` saw it verbatim at the default
`format_display_secrets_in_show_and_select = 0` and without the `displaySecretsInShowAndSelect`
privilege. Every other credential setting of the engine was already masked.

Root cause: `ASTSetQuery::formatImpl` consults that map to decide whether to print a masking rule
instead of the value; the key was absent, so the fallthrough printed the secret. This adds the
missing entry. Both surfaces share one seam (`StorageSystemDatabases` builds `engine_full` with the
same formatter `SHOW CREATE DATABASE` uses), and the map also backs `ASTSetQuery::hasSecretParts`,
so log masking is covered too. The stored metadata and replicated-DDL propagation format with
secrets shown, so the database still authenticates after a restart.

The codebase already classifies the value as a secret: `external_id` is a member of `s3_secret_keys`
in `src/Parsers/FunctionSecretArgumentsFinder.h`, whose comment calls it the shared secret of the
assume-role triple while `role_arn` and `role_session_name` are non-secret identifiers that stay
visible. So the identical value was masked in the inline `s3()` form and leaked only here.
`aws_role_arn` and `aws_role_session_name` are therefore left visible, and the new test pins them
visible so a future over-masking change fails.

Validation: new stateless test `05030_datalake_catalog_hide_aws_external_id.sh` asserts `[HIDDEN]`
at the default and the true value still retrievable with `clickhouse-format --show_secrets`, so the
fix redacts rather than destroys. It fails on master and passes here; 50 randomized runs of it and
of the neighbouring `04401` pass. Both real surfaces were checked directly in both directions.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115791&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115791](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115791+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.137` (included in `26.9` and later)
- Backported to: `26.8.1.2022`, `26.7.6.33`, `26.6.4.35`, `26.3.26.3`
<!-- ch-version-info:end -->