### PR TITLE
Fix two bugs in the JSON object size limit

### DIFF
--- a/src/Formats/JSONUtils.cpp
+++ b/src/Formats/JSONUtils.cpp
@@ -50,7 +50,9 @@ namespace JSONUtils
 
         while (loadAtPosition(in, memory, pos) && need_more_data)
         {
-            if (max_row_size && balance > 0)
+            /// Not restricted to the inside of an object: input that never opens a bracket must be bounded too,
+            /// otherwise it is buffered until EOF.
+            if (max_row_size)
             {
                 const auto current_object_size = memory.size() + static_cast<size_t>(pos - in.position()) - object_start_bytes;
                 if (current_object_size > max_row_size)

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -1288,6 +1288,10 @@ ReturnType readJSONStringInto(Vector & s, ReadBuffer & buf, const FormatSettings
         return error("Cannot parse JSON string: expected opening quote", ErrorCodes::CANNOT_PARSE_QUOTED_STRING);
     ++buf.position();
 
+    /// `s` is an append target already holding previous values (for a column, all previous rows of the block),
+    /// so the size of the current value is the growth of `s`.
+    const size_t initial_size = s.size();
+
     while (!buf.eof())
     {
         char * next_pos = find_first_symbols<'\\', '"'>(buf.position(), buf.buffer().end());
@@ -1295,8 +1299,12 @@ ReturnType readJSONStringInto(Vector & s, ReadBuffer & buf, const FormatSettings
         appendToStringOrVector(s, buf, next_pos);
         buf.position() = next_pos;
 
-        if (s.size() > DEFAULT_MAX_STRING_SIZE)
-            throw Exception(ErrorCodes::TOO_LARGE_STRING_SIZE, "JSON string is too large, maximum size is {} bytes", DEFAULT_MAX_STRING_SIZE);
+        if (s.size() - initial_size > DEFAULT_MAX_STRING_SIZE)
+        {
+            if constexpr (throw_exception)
+                throw Exception(ErrorCodes::TOO_LARGE_STRING_SIZE, "JSON string is too large, maximum size is {} bytes", DEFAULT_MAX_STRING_SIZE);
+            return ReturnType(false);
+        }
 
         if (!buf.hasPendingData())
             continue;
@@ -1341,6 +1349,9 @@ ReturnType readJSONObjectOrArrayPossiblyInvalid(Vector & s, ReadBuffer & buf)
     if (buf.eof() || *buf.position() != opening_bracket)
         return error("JSON object/array should start with corresponding opening bracket", ErrorCodes::INCORRECT_DATA);
 
+    /// See the comment about `initial_size` in readJSONStringInto.
+    const size_t initial_size = s.size();
+
     s.push_back(*buf.position());
     ++buf.position();
 
@@ -1353,8 +1364,12 @@ ReturnType readJSONObjectOrArrayPossiblyInvalid(Vector & s, ReadBuffer & buf)
         appendToStringOrVector(s, buf, next_pos);
         buf.position() = next_pos;
 
-        if (s.size() > DEFAULT_MAX_STRING_SIZE)
-            throw Exception(ErrorCodes::TOO_LARGE_STRING_SIZE, "JSON string is too large, maximum size is {} bytes", DEFAULT_MAX_STRING_SIZE);
+        if (s.size() - initial_size > DEFAULT_MAX_STRING_SIZE)
+        {
+            if constexpr (throw_exception)
+                throw Exception(ErrorCodes::TOO_LARGE_STRING_SIZE, "JSON string is too large, maximum size is {} bytes", DEFAULT_MAX_STRING_SIZE);
+            return ReturnType(false);
+        }
 
         if (!buf.hasPendingData())
             continue;

--- a/tests/queries/0_stateless/04926_json_segmentation_no_opening_bracket_size_limit.reference
+++ b/tests/queries/0_stateless/04926_json_segmentation_no_opening_bracket_size_limit.reference
@@ -1,0 +1,6 @@
+--- garbage without an opening bracket is rejected ---
+1
+--- JSONEachRow data fed to JSONCompactEachRow is rejected ---
+1
+--- many small objects still parse ---
+5000	5000000

--- a/tests/queries/0_stateless/04926_json_segmentation_no_opening_bracket_size_limit.sh
+++ b/tests/queries/0_stateless/04926_json_segmentation_no_opening_bracket_size_limit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+SETTINGS="--input_format_parallel_parsing=1 --max_parsing_threads=2 --min_chunk_bytes_for_parallel_parsing=1048576 --input_format_json_max_object_size=1048576 --max_memory_usage=0"
+
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_segmentation (a String) ENGINE = Memory"
+
+echo "--- garbage without an opening bracket is rejected ---"
+python3 -c "import sys; sys.stdout.buffer.write(b'x' * (20 * 1024 * 1024))" 2>/dev/null \
+    | ${CLICKHOUSE_CLIENT} $SETTINGS -q "INSERT INTO t_json_segmentation FORMAT JSONEachRow" 2>&1 \
+    | grep -c "input_format_json_max_object_size"
+
+echo "--- JSONEachRow data fed to JSONCompactEachRow is rejected ---"
+python3 -c "
+import sys
+for _ in range(20):
+    sys.stdout.buffer.write(b'{\"a\":\"' + b'y' * (1024 * 1024) + b'\"}\n')
+" 2>/dev/null \
+    | ${CLICKHOUSE_CLIENT} $SETTINGS -q "INSERT INTO t_json_segmentation FORMAT JSONCompactEachRow" 2>&1 \
+    | grep -c "input_format_json_max_object_size"
+
+echo "--- many small objects still parse ---"
+python3 -c "
+import sys
+for _ in range(5000):
+    sys.stdout.buffer.write(b'{\"a\":\"' + b'y' * 1000 + b'\"}\n')
+" 2>/dev/null \
+    | ${CLICKHOUSE_CLIENT} $SETTINGS -q "INSERT INTO t_json_segmentation FORMAT JSONEachRow"
+${CLICKHOUSE_CLIENT} -q "SELECT count(), sum(length(a)) FROM t_json_segmentation"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_json_segmentation"

--- a/tests/queries/0_stateless/04927_json_string_size_limit_per_value.reference
+++ b/tests/queries/0_stateless/04927_json_string_size_limit_per_value.reference
@@ -1,0 +1,4 @@
+--- string values summing to more than 1 GiB in a single block ---
+9	1132462080
+--- objects read as strings summing to more than 1 GiB in a single block ---
+9	1132462152

--- a/tests/queries/0_stateless/04927_json_string_size_limit_per_value.sh
+++ b/tests/queries/0_stateless/04927_json_string_size_limit_per_value.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tags: long, no-debug, no-asan, no-tsan, no-msan
+# The 1 GiB limit on a single JSON value is hardcoded, so the test needs more than 1 GiB of data to check it.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+SETTINGS="--input_format_parallel_parsing=0 --max_memory_usage=0"
+
+echo "--- string values summing to more than 1 GiB in a single block ---"
+python3 -c "
+import sys
+for _ in range(9):
+    sys.stdout.buffer.write(b'{\"a\":\"' + b'y' * (120 * 1024 * 1024) + b'\"}\n')
+" 2>/dev/null \
+    | ${CLICKHOUSE_LOCAL} $SETTINGS \
+        --input-format=JSONEachRow --structure="a String" -q "SELECT count(), sum(length(a)) FROM table"
+
+echo "--- objects read as strings summing to more than 1 GiB in a single block ---"
+python3 -c "
+import sys
+for _ in range(9):
+    sys.stdout.buffer.write(b'{\"a\":{\"b\":\"' + b'y' * (120 * 1024 * 1024) + b'\"}}\n')
+" 2>/dev/null \
+    | ${CLICKHOUSE_LOCAL} $SETTINGS \
+        --input-format=JSONEachRow --structure="a String" -q "SELECT count(), sum(length(a)) FROM table"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/114985
Closes: https://github.com/ClickHouse/ClickHouse/issues/114986
Related: https://github.com/ClickHouse/ClickHouse/pull/107669

Two follow-ups to #107669.

`fileSegmentationEngineJSONEachRowImpl` gated the size check on `balance > 0`,
so bytes accumulated before any opening bracket were unbounded. `object_start_bytes`
already anchors the measurement to the last completed object, so the gate is
not needed.

`readJSONStringInto` and `readJSONObjectOrArrayPossiblyInvalid` compared
`s.size()` against the 1 GiB limit, but `s` is an append target holding all
previous rows of the block, so valid data was rejected depending on
`max_block_size`. The limit now applies to the growth of `s`, and the check
honours the `ReturnType = bool` contract instead of throwing.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115795&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115795](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115795+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
