### PR TITLE
Do not strand processors queued for removal in `ExecutingGraph`

### DIFF
--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -304,23 +304,11 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemo
     return result;
 }
 
-std::shared_ptr<ExecutingGraph::PendingRemovalGroup> ExecutingGraph::findGroupReadyForRemoval()
-{
-    for (const auto & [_, group] : removed_processors)
-        if (group->not_finished.load() == 0)
-            return group;
-
-    return nullptr;
-}
-
 ExecutingGraph::RemoveGroupResult ExecutingGraph::removeReadyGroups(Processors & delayed_destruction)
 {
-    RemoveGroupResult result;
-
     std::unique_lock lock(nodes_mutex);
 
-    /// Retire everything that is removable right now: a group is only looked at again when some node
-    /// is prepared, so leaving a ready group behind may keep its processors in the pipeline forever.
+    RemoveGroupResult result;
     while (auto group = findGroupReadyForRemoval())
     {
         auto group_result = removePendingGroup(*group, delayed_destruction);
@@ -329,6 +317,15 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removeReadyGroups(Processors &
     }
 
     return result;
+}
+
+std::shared_ptr<ExecutingGraph::PendingRemovalGroup> ExecutingGraph::findGroupReadyForRemoval()
+{
+    for (const auto & [_, group] : removed_processors)
+        if (group->not_finished.load() == 0)
+            return group;
+
+    return nullptr;
 }
 
 void ExecutingGraph::accountFinishedProcessorInGroup(const ProcessorPtr & processor)
@@ -548,10 +545,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
 
                 if (update_status != UpdateNodeStatus::Done)
                 {
-                    /// `updatePipeline` has already queued its removals, but this thread is leaving the graph
-                    /// for good and nobody is going to prepare a node again, so the queue would never be
-                    /// looked at. Retire what is already removable, otherwise those processors stay in the
-                    /// pipeline until the whole query is destroyed.
+                    /// updatePipeline has already queued its removals, but this thread is leaving the graph forever.
                     removeReadyGroups(delayed_destruction);
                     return update_status;
                 }

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -313,6 +313,24 @@ std::shared_ptr<ExecutingGraph::PendingRemovalGroup> ExecutingGraph::findGroupRe
     return nullptr;
 }
 
+ExecutingGraph::RemoveGroupResult ExecutingGraph::removeReadyGroups(Processors & delayed_destruction)
+{
+    RemoveGroupResult result;
+
+    std::unique_lock lock(nodes_mutex);
+
+    /// Retire everything that is removable right now: a group is only looked at again when some node
+    /// is prepared, so leaving a ready group behind may keep its processors in the pipeline forever.
+    while (auto group = findGroupReadyForRemoval())
+    {
+        auto group_result = removePendingGroup(*group, delayed_destruction);
+        result.removed_nodes.insert_range(group_result.removed_nodes);
+        result.removed_edges.insert_range(group_result.removed_edges);
+    }
+
+    return result;
+}
+
 void ExecutingGraph::accountFinishedProcessorInGroup(const ProcessorPtr & processor)
 {
     auto group_it = removed_processors.find(processor);
@@ -529,7 +547,14 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                 }();
 
                 if (update_status != UpdateNodeStatus::Done)
+                {
+                    /// `updatePipeline` has already queued its removals, but this thread is leaving the graph
+                    /// for good and nobody is going to prepare a node again, so the queue would never be
+                    /// looked at. Retire what is already removable, otherwise those processors stay in the
+                    /// pipeline until the whole query is destroyed.
+                    removeReadyGroups(delayed_destruction);
                     return update_status;
+                }
 
                 /// Add itself back to be prepared again.
                 updated_processors.push_front(current);
@@ -542,15 +567,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
             {
                 read_lock.unlock();
 
-                RemoveGroupResult remove_result = [&]() -> RemoveGroupResult
-                {
-                    std::unique_lock lock(nodes_mutex);
-
-                    if (auto group = findGroupReadyForRemoval())
-                        return removePendingGroup(*group, delayed_destruction);
-
-                    return {};
-                }();
+                RemoveGroupResult remove_result = removeReadyGroups(delayed_destruction);
 
                 if (!remove_result.removed_edges.empty())
                 {

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -201,11 +201,9 @@ private:
         std::unordered_set<const void *> removed_edges;
     };
     RemoveGroupResult removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction);
+    RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
     std::shared_ptr<PendingRemovalGroup> findGroupReadyForRemoval();
     void accountFinishedProcessorInGroup(const ProcessorPtr & processor);
-
-    /// Retire every pending group whose processors have all finished. Must be called without `nodes_mutex` held.
-    RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
 
     /// Monotonic counter for assigning Node::processors_id.
     uint64_t next_node_id = 0;

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -204,6 +204,9 @@ private:
     std::shared_ptr<PendingRemovalGroup> findGroupReadyForRemoval();
     void accountFinishedProcessorInGroup(const ProcessorPtr & processor);
 
+    /// Retire every pending group whose processors have all finished. Must be called without `nodes_mutex` held.
+    RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
+
     /// Monotonic counter for assigning Node::processors_id.
     uint64_t next_node_id = 0;
 

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -12,6 +12,9 @@
 #include <Common/assert_cast.h>
 #include <DataTypes/DataTypesNumber.h>
 
+#include <functional>
+#include <utility>
+
 using namespace DB;
 
 namespace
@@ -60,6 +63,9 @@ public:
 
     String getName() const override { return "DynamicSourceCoordinator"; }
 
+    /// Called once, from `prepare`, right before the cycle that retires the current source.
+    void setBeforeRetireHook(std::function<void()> hook) { before_retire_hook = std::move(hook); }
+
     Status prepare() override
     {
         auto & output = outputs.front();
@@ -69,7 +75,12 @@ public:
 
         auto & input = inputs.back();
         if (input.isFinished())
+        {
+            if (before_retire_hook)
+                std::exchange(before_retire_hook, {})();
+
             return Status::UpdatePipeline;
+        }
 
         if (!output.canPush())
             return Status::PortFull;
@@ -129,6 +140,7 @@ private:
     const SharedHeader header;
     ProcessorPtr current_source;
     std::vector<std::weak_ptr<IProcessor>> source_history;
+    std::function<void()> before_retire_hook;
 };
 
 class FinishingSource final : public IProcessor
@@ -559,4 +571,36 @@ TEST(Processors, UpdatePipelineDeferredRemovalOfUnfinishedProcessors)
     }
 
     EXPECT_EQ(coordinator->getInputs().size(), 1u);
+}
+
+TEST(Processors, UpdatePipelineRemovalIsNotStrandedByCancellation)
+{
+    auto header = makeHeader();
+
+    auto coordinator = std::make_shared<DynamicSourceCoordinator>(header);
+    Pipe pipe(coordinator);
+
+    QueryPipeline pipeline(std::move(pipe));
+    {
+        PullingPipelineExecutor executor(pipeline);
+
+        /// Cancel from inside `prepare`, so that the `updatePipeline` retiring the first source is
+        /// the very one that observes the cancellation.
+        coordinator->setBeforeRetireHook([&] { executor.cancel(); });
+
+        Chunk chunk;
+        ASSERT_TRUE(executor.pull(chunk));
+        ASSERT_EQ(chunk.getNumRows(), 1u);
+
+        /// Drains whatever is left after the cancellation.
+        while (executor.pull(chunk))
+        {
+        }
+    }
+
+    ASSERT_EQ(coordinator->totalSourcesCreated(), 2u);
+
+    /// A source scheduled for removal must leave the pipeline even when the query is cancelled in
+    /// the middle of the update, otherwise it stays around until the whole pipeline is destroyed.
+    EXPECT_TRUE(coordinator->getSourceWeak(0).expired());
 }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115625

Processor removal in `ExecutingGraph` recently became deferred: `updatePipeline` only records `update.to_remove` into a pending group, and `updateNode` retires that group once every processor in it reports `Finished`.

Two paths leave a recorded group behind, so its processors stay in the pipeline until the whole query is destroyed:

- `updatePipeline` records the group and then returns `Cancelled`, which makes `updateNode` return before it reaches the code that retires groups;
- the retiring code handles a single group per prepared node, so a backlog can outlive the last `updateNode` call.

This change retires every group that is ready instead of just one, and also retires them on the way out when `updatePipeline` does not return `Done`.

This is what `Processors.UpdatePipelineMultipleCoordinatorsMultithreaded` caught on master — it cancels the executor while 16 coordinators are cycling, so one of them gets its removal stranded and an extra source is still alive at the end of the test:

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b16561cc816cf56cadd0c35ed9ad48964ad7758d&name_0=MasterCI&name_1=Unit%20tests%20%28amd_llvm_coverage%29

```
src/Processors/tests/gtest_update_pipeline.cpp:504
Expected: (alive) <= (1u), actual: 2 vs 1
```

The existing test only reproduces this rarely, so a deterministic one is added: `Processors.UpdatePipelineRemovalIsNotStrandedByCancellation` cancels the pipeline from inside `prepare`, so the `updatePipeline` that retires the source is exactly the one that observes the cancellation. It fails before this change and passes after it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115800&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115800](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115800+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
