### PR TITLE
Revert "Revert "Allow Unfinished Processor Removal in Query Runtime""

### DIFF
--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -183,7 +183,7 @@ std::unordered_set<const void *> ExecutingGraph::removeAffectedEdges(Node & node
     return removed_edge_ids;
 }
 
-ExecutingGraph::UpdatePipelineResult ExecutingGraph::updatePipeline(boost::container::devector<Node *> & stack, Node & cur_node, Processors & delayed_destruction)
+ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container::devector<Node *> & stack, Node & cur_node)
 {
     IProcessor::PipelineUpdate update;
 
@@ -194,10 +194,9 @@ ExecutingGraph::UpdatePipelineResult ExecutingGraph::updatePipeline(boost::conta
     catch (...)
     {
         cur_node.exception = std::current_exception();
-        return {UpdateNodeStatus::Exception, {}, {}};
+        return UpdateNodeStatus::Exception;
     }
 
-    UpdatePipelineResult result{UpdateNodeStatus::Done, {}, {}};
     IProcessor::CancelReason cancel_reason_if_cancelled = IProcessor::CancelReason::NotCancelled;
     {
         std::lock_guard guard(processors_mutex);
@@ -216,12 +215,21 @@ ExecutingGraph::UpdatePipelineResult ExecutingGraph::updatePipeline(boost::conta
             addNode(new_proc);
         }
 
-        /// Remove deleted processors from pipeline
-        for (const auto & removed_proc : update.to_remove)
+        /// Record removed processors in pending removal queue
+        if (!update.to_remove.empty())
         {
-            auto [removed_node, removed_edges] = removeNode(removed_proc);
-            result.removed_nodes.insert(removed_node);
-            result.removed_edges.insert_range(removed_edges);
+            size_t not_finished = 0;
+            for (const auto & removed_proc : update.to_remove)
+                if (const auto * node = processors_map.at(removed_proc.get()))
+                    if (node->last_processor_status != IProcessor::Status::Finished)
+                        ++not_finished;
+
+            auto group = std::make_shared<PendingRemovalGroup>();
+            group->not_finished = not_finished;
+            group->processors = std::move(update.to_remove);
+
+            for (const auto & removed_proc : group->processors)
+                removed_processors.emplace(removed_proc, group);
         }
 
         /// Propagate cancellation to newly added processors.
@@ -234,30 +242,12 @@ ExecutingGraph::UpdatePipelineResult ExecutingGraph::updatePipeline(boost::conta
         }
     }
 
-    /// Processors that was removed from the pipeline can hold the last strong reference to data.
-    /// It is too expensive to destroy them under the nodes mutex.
-    delayed_destruction.splice(delayed_destruction.end(), update.to_remove);
-
     /// Updated edges for every node.
     std::vector<std::pair<Node *, NewEdges>> added_edges;
     for (auto & node : nodes)
     {
-        std::optional<NewEdges> edges;
-
-        if (!result.removed_nodes.empty())
-        {
-            if (auto removed_edges = removeAffectedEdges(node, result.removed_nodes); !removed_edges.empty())
-            {
-                result.removed_edges.insert_range(removed_edges);
-                edges.emplace();
-            }
-        }
-
         if (auto new_edges = addEdges(node); !new_edges.empty())
-            edges = std::move(new_edges);
-
-        if (edges.has_value())
-            added_edges.emplace_back(&node, std::move(edges.value()));
+            added_edges.emplace_back(&node, std::move(new_edges));
     }
 
     /// Record updated ports for each newly added edge for each processor and schedule it for prepare if something changed.
@@ -281,9 +271,55 @@ ExecutingGraph::UpdatePipelineResult ExecutingGraph::updatePipeline(boost::conta
 
     /// If PartialResult was requested requested - continue normally
     if (cancel_reason_if_cancelled != IProcessor::CancelReason::NotCancelled && cancel_reason_if_cancelled != IProcessor::CancelReason::PartialResult)
-        result.status = UpdateNodeStatus::Cancelled;
+        return UpdateNodeStatus::Cancelled;
+
+    return UpdateNodeStatus::Done;
+}
+
+ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction)
+{
+    RemoveGroupResult result;
+
+    {
+        std::lock_guard guard(processors_mutex);
+
+        for (const auto & removed_proc : group.processors)
+        {
+            auto [removed_node, removed_edges] = removeNode(removed_proc);
+            result.removed_nodes.insert(removed_node);
+            result.removed_edges.insert_range(removed_edges);
+        }
+    }
+
+    for (const auto & removed_proc : group.processors)
+        removed_processors.erase(removed_proc);
+
+    for (auto & node : nodes)
+        result.removed_edges.insert_range(removeAffectedEdges(node, result.removed_nodes));
+
+    /// Removed processors can hold the last strong reference to data.
+    /// It is too expensive to destroy them under the nodes mutex.
+    delayed_destruction.splice(delayed_destruction.end(), group.processors);
 
     return result;
+}
+
+std::shared_ptr<ExecutingGraph::PendingRemovalGroup> ExecutingGraph::findGroupReadyForRemoval()
+{
+    for (const auto & [_, group] : removed_processors)
+        if (group->not_finished.load() == 0)
+            return group;
+
+    return nullptr;
+}
+
+void ExecutingGraph::accountFinishedProcessorInGroup(const ProcessorPtr & processor)
+{
+    auto group_it = removed_processors.find(processor);
+    if (group_it == removed_processors.end())
+        return;
+
+    group_it->second->not_finished.fetch_sub(1);
 }
 
 void ExecutingGraph::initializeExecution(Queue & queue, Queue & async_queue)
@@ -312,13 +348,10 @@ void ExecutingGraph::initializeExecution(Queue & queue, Queue & async_queue)
 
 ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Queue & queue, Queue & async_queue)
 {
+    Processors delayed_destruction;
     boost::container::devector<Edge *> updated_edges;
     boost::container::devector<Node *> updated_processors;
     updated_processors.push_back(start_node);
-
-    /// Processors removed via updatePipeline accumulate here and die at function exit,
-    /// after all graph mutexes have been released.
-    Processors delayed_destruction;
 
     std::shared_lock read_lock(nodes_mutex);
 
@@ -433,6 +466,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                     case IProcessor::Status::Finished:
                     {
                         node.status = ExecutingGraph::ExecStatus::Finished;
+                        accountFinishedProcessorInGroup(*node.processor_iter);
                         break;
                     }
                     case IProcessor::Status::Ready:
@@ -488,29 +522,45 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                 // We do not need to upgrade lock atomically, so we can safely release shared_lock and acquire unique_lock
                 read_lock.unlock();
 
-                UpdatePipelineResult update_result = [&]()
+                UpdateNodeStatus update_status = [&]()
                 {
                     std::unique_lock lock(nodes_mutex);
-                    return updatePipeline(updated_processors, node, delayed_destruction);
+                    return updatePipeline(updated_processors, node);
                 }();
 
-                if (update_result.status != UpdateNodeStatus::Done)
-                    return update_result.status;
-
-                /// updatePipeline may have removed locally recorded edges.
-                if (!update_result.removed_edges.empty())
-                {
-                    auto removed_range = std::ranges::remove_if(updated_edges, [&](const void * edge) { return update_result.removed_edges.contains(edge); });
-                    updated_edges.erase(removed_range.begin(), removed_range.end());
-                }
+                if (update_status != UpdateNodeStatus::Done)
+                    return update_status;
 
                 /// Add itself back to be prepared again.
                 updated_processors.push_front(current);
 
-                /// updatePipeline may have removed locally recorded processors.
-                if (!update_result.removed_nodes.empty())
+                read_lock.lock();
+            }
+
+            /// The peek under the shared lock is only a hint.
+            if (!removed_processors.empty() && findGroupReadyForRemoval())
+            {
+                read_lock.unlock();
+
+                RemoveGroupResult remove_result = [&]() -> RemoveGroupResult
                 {
-                    auto removed_range = std::ranges::remove_if(updated_processors, [&](const Node * node_ptr) { return update_result.removed_nodes.contains(node_ptr); });
+                    std::unique_lock lock(nodes_mutex);
+
+                    if (auto group = findGroupReadyForRemoval())
+                        return removePendingGroup(*group, delayed_destruction);
+
+                    return {};
+                }();
+
+                if (!remove_result.removed_edges.empty())
+                {
+                    auto removed_range = std::ranges::remove_if(updated_edges, [&](const void * edge) { return remove_result.removed_edges.contains(edge); });
+                    updated_edges.erase(removed_range.begin(), removed_range.end());
+                }
+
+                if (!remove_result.removed_nodes.empty())
+                {
+                    auto removed_range = std::ranges::remove_if(updated_processors, [&](const Node * node_ptr) { return remove_result.removed_nodes.contains(node_ptr); });
                     updated_processors.erase(removed_range.begin(), removed_range.end());
                 }
 

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -304,23 +304,11 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemo
     return result;
 }
 
-std::shared_ptr<ExecutingGraph::PendingRemovalGroup> ExecutingGraph::findGroupReadyForRemoval()
-{
-    for (const auto & [_, group] : removed_processors)
-        if (group->not_finished.load() == 0)
-            return group;
-
-    return nullptr;
-}
-
 ExecutingGraph::RemoveGroupResult ExecutingGraph::removeReadyGroups(Processors & delayed_destruction)
 {
-    RemoveGroupResult result;
-
     std::unique_lock lock(nodes_mutex);
 
-    /// Retire everything that is removable right now: a group is only looked at again when some node
-    /// is prepared, so leaving a ready group behind may keep its processors in the pipeline forever.
+    RemoveGroupResult result;
     while (auto group = findGroupReadyForRemoval())
     {
         auto group_result = removePendingGroup(*group, delayed_destruction);
@@ -329,6 +317,15 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removeReadyGroups(Processors &
     }
 
     return result;
+}
+
+std::shared_ptr<ExecutingGraph::PendingRemovalGroup> ExecutingGraph::findGroupReadyForRemoval()
+{
+    for (const auto & [_, group] : removed_processors)
+        if (group->not_finished.load() == 0)
+            return group;
+
+    return nullptr;
 }
 
 void ExecutingGraph::accountFinishedProcessorInGroup(const ProcessorPtr & processor)
@@ -548,10 +545,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
 
                 if (update_status != UpdateNodeStatus::Done)
                 {
-                    /// `updatePipeline` has already queued its removals, but this thread is leaving the graph
-                    /// for good and nobody is going to prepare a node again, so the queue would never be
-                    /// looked at. Retire what is already removable, otherwise those processors stay in the
-                    /// pipeline until the whole query is destroyed.
+                    /// updatePipeline has already queued its removals, but this thread is leaving the graph forever.
                     removeReadyGroups(delayed_destruction);
                     return update_status;
                 }

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -313,6 +313,24 @@ std::shared_ptr<ExecutingGraph::PendingRemovalGroup> ExecutingGraph::findGroupRe
     return nullptr;
 }
 
+ExecutingGraph::RemoveGroupResult ExecutingGraph::removeReadyGroups(Processors & delayed_destruction)
+{
+    RemoveGroupResult result;
+
+    std::unique_lock lock(nodes_mutex);
+
+    /// Retire everything that is removable right now: a group is only looked at again when some node
+    /// is prepared, so leaving a ready group behind may keep its processors in the pipeline forever.
+    while (auto group = findGroupReadyForRemoval())
+    {
+        auto group_result = removePendingGroup(*group, delayed_destruction);
+        result.removed_nodes.insert_range(group_result.removed_nodes);
+        result.removed_edges.insert_range(group_result.removed_edges);
+    }
+
+    return result;
+}
+
 void ExecutingGraph::accountFinishedProcessorInGroup(const ProcessorPtr & processor)
 {
     auto group_it = removed_processors.find(processor);
@@ -529,7 +547,14 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                 }();
 
                 if (update_status != UpdateNodeStatus::Done)
+                {
+                    /// `updatePipeline` has already queued its removals, but this thread is leaving the graph
+                    /// for good and nobody is going to prepare a node again, so the queue would never be
+                    /// looked at. Retire what is already removable, otherwise those processors stay in the
+                    /// pipeline until the whole query is destroyed.
+                    removeReadyGroups(delayed_destruction);
                     return update_status;
+                }
 
                 /// Add itself back to be prepared again.
                 updated_processors.push_front(current);
@@ -542,15 +567,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
             {
                 read_lock.unlock();
 
-                RemoveGroupResult remove_result = [&]() -> RemoveGroupResult
-                {
-                    std::unique_lock lock(nodes_mutex);
-
-                    if (auto group = findGroupReadyForRemoval())
-                        return removePendingGroup(*group, delayed_destruction);
-
-                    return {};
-                }();
+                RemoveGroupResult remove_result = removeReadyGroups(delayed_destruction);
 
                 if (!remove_result.removed_edges.empty())
                 {

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -4,6 +4,7 @@
 #include <Processors/IProcessor.h>
 #include <Common/SharedMutex.h>
 #include <Common/AllocatorWithMemoryTracking.h>
+#include <atomic>
 #include <list>
 #include <mutex>
 #include <queue>
@@ -181,17 +182,27 @@ private:
 
     /// Update graph after processor `node` returned UpdatePipeline status.
     /// All new nodes and nodes with updated ports are pushed into stack.
-    struct UpdatePipelineResult
-    {
-        UpdateNodeStatus status;
-        std::unordered_set<const Node *> removed_nodes;
-        std::unordered_set<const void *> removed_edges;
-    };
-    UpdatePipelineResult updatePipeline(boost::container::devector<Node *> & stack, Node & node, Processors & delayed_destruction);
+    UpdateNodeStatus updatePipeline(boost::container::devector<Node *> & stack, Node & node);
 
     /// Shared with QueryPipeline.
     std::shared_ptr<Processors> processors;
     std::mutex processors_mutex;
+
+    struct PendingRemovalGroup
+    {
+        Processors processors;
+        std::atomic<size_t> not_finished = 0;
+    };
+    std::unordered_map<ProcessorPtr, std::shared_ptr<PendingRemovalGroup>> removed_processors;
+
+    struct RemoveGroupResult
+    {
+        std::unordered_set<const Node *> removed_nodes;
+        std::unordered_set<const void *> removed_edges;
+    };
+    RemoveGroupResult removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction);
+    std::shared_ptr<PendingRemovalGroup> findGroupReadyForRemoval();
+    void accountFinishedProcessorInGroup(const ProcessorPtr & processor);
 
     /// Monotonic counter for assigning Node::processors_id.
     uint64_t next_node_id = 0;

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -201,11 +201,9 @@ private:
         std::unordered_set<const void *> removed_edges;
     };
     RemoveGroupResult removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction);
+    RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
     std::shared_ptr<PendingRemovalGroup> findGroupReadyForRemoval();
     void accountFinishedProcessorInGroup(const ProcessorPtr & processor);
-
-    /// Retire every pending group whose processors have all finished. Must be called without `nodes_mutex` held.
-    RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
 
     /// Monotonic counter for assigning Node::processors_id.
     uint64_t next_node_id = 0;

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -204,6 +204,9 @@ private:
     std::shared_ptr<PendingRemovalGroup> findGroupReadyForRemoval();
     void accountFinishedProcessorInGroup(const ProcessorPtr & processor);
 
+    /// Retire every pending group whose processors have all finished. Must be called without `nodes_mutex` held.
+    RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
+
     /// Monotonic counter for assigning Node::processors_id.
     uint64_t next_node_id = 0;
 

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -12,6 +12,9 @@
 #include <Common/assert_cast.h>
 #include <DataTypes/DataTypesNumber.h>
 
+#include <functional>
+#include <utility>
+
 using namespace DB;
 
 namespace
@@ -60,6 +63,9 @@ public:
 
     String getName() const override { return "DynamicSourceCoordinator"; }
 
+    /// Called once, from `prepare`, right before the cycle that retires the current source.
+    void setBeforeRetireHook(std::function<void()> hook) { before_retire_hook = std::move(hook); }
+
     Status prepare() override
     {
         auto & output = outputs.front();
@@ -69,7 +75,12 @@ public:
 
         auto & input = inputs.back();
         if (input.isFinished())
+        {
+            if (before_retire_hook)
+                std::exchange(before_retire_hook, {})();
+
             return Status::UpdatePipeline;
+        }
 
         if (!output.canPush())
             return Status::PortFull;
@@ -129,6 +140,7 @@ private:
     const SharedHeader header;
     ProcessorPtr current_source;
     std::vector<std::weak_ptr<IProcessor>> source_history;
+    std::function<void()> before_retire_hook;
 };
 
 class FinishingSource final : public IProcessor
@@ -559,4 +571,36 @@ TEST(Processors, UpdatePipelineDeferredRemovalOfUnfinishedProcessors)
     }
 
     EXPECT_EQ(coordinator->getInputs().size(), 1u);
+}
+
+TEST(Processors, UpdatePipelineRemovalIsNotStrandedByCancellation)
+{
+    auto header = makeHeader();
+
+    auto coordinator = std::make_shared<DynamicSourceCoordinator>(header);
+    Pipe pipe(coordinator);
+
+    QueryPipeline pipeline(std::move(pipe));
+    {
+        PullingPipelineExecutor executor(pipeline);
+
+        /// Cancel from inside `prepare`, so that the `updatePipeline` retiring the first source is
+        /// the very one that observes the cancellation.
+        coordinator->setBeforeRetireHook([&] { executor.cancel(); });
+
+        Chunk chunk;
+        ASSERT_TRUE(executor.pull(chunk));
+        ASSERT_EQ(chunk.getNumRows(), 1u);
+
+        /// Drains whatever is left after the cancellation.
+        while (executor.pull(chunk))
+        {
+        }
+    }
+
+    ASSERT_EQ(coordinator->totalSourcesCreated(), 2u);
+
+    /// A source scheduled for removal must leave the pipeline even when the query is cancelled in
+    /// the middle of the update, otherwise it stays around until the whole pipeline is destroyed.
+    EXPECT_TRUE(coordinator->getSourceWeak(0).expired());
 }

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -208,6 +208,167 @@ private:
     bool source_added = false;
 };
 
+/// Processor with deferred finish: after its input or output closes it still needs one work() call before it reports Finished
+class DeferredFinishTransform final : public IProcessor
+{
+public:
+    explicit DeferredFinishTransform(SharedHeader header_)
+        : IProcessor({Block(*header_)}, {Block(*header_)})
+    {
+    }
+
+    String getName() const override { return "DeferredFinishTransform"; }
+
+    Status prepare() override
+    {
+        auto & input = inputs.front();
+        auto & output = outputs.front();
+
+        if (!draining)
+        {
+            if (output.isFinished() || input.isFinished())
+            {
+                draining = true;
+                return Status::Ready;
+            }
+
+            if (!output.canPush())
+                return Status::PortFull;
+
+            if (!input.hasData())
+            {
+                input.setNeeded();
+                return Status::NeedData;
+            }
+
+            output.push(input.pull(/*set_not_needed=*/true));
+            return Status::PortFull;
+        }
+
+        if (!drained)
+            return Status::Ready;
+
+        input.close();
+        output.finish();
+        return Status::Finished;
+    }
+
+    void work() override { drained = true; }
+
+private:
+    bool draining = false;
+    bool drained = false;
+};
+
+/// Closes its input and finishes its output on the first prepare.
+class EarlyClosingTransform final : public IProcessor
+{
+public:
+    explicit EarlyClosingTransform(SharedHeader header_)
+        : IProcessor({Block(*header_)}, {Block(*header_)})
+    {
+    }
+
+    String getName() const override { return "EarlyClosingTransform"; }
+
+    Status prepare() override
+    {
+        inputs.front().close();
+        outputs.front().finish();
+        return Status::Finished;
+    }
+};
+
+/// Cycles source -> deferred-finish (-> early closer for the first batch) sub-pipelines, retiring each batch via to_remove.
+class BatchCyclingCoordinator final : public IProcessor
+{
+public:
+    BatchCyclingCoordinator(SharedHeader header_, size_t total_batches_)
+        : IProcessor({}, {Block(*header_)})
+        , header(std::move(header_))
+        , total_batches(total_batches_)
+    {
+    }
+
+    String getName() const override { return "BatchCyclingCoordinator"; }
+
+    Status prepare() override
+    {
+        auto & output = outputs.front();
+
+        if (output.isFinished())
+            return Status::Finished;
+
+        if (inputs.empty() || inputs.back().isFinished())
+            return Status::UpdatePipeline;
+
+        if (!output.canPush())
+            return Status::PortFull;
+
+        auto & input = inputs.back();
+        if (!input.hasData())
+        {
+            input.setNeeded();
+            return Status::NeedData;
+        }
+
+        output.push(input.pull(/*set_not_needed=*/true));
+        return Status::PortFull;
+    }
+
+    PipelineUpdate updatePipeline() override
+    {
+        PipelineUpdate update;
+
+        if (!inputs.empty())
+        {
+            disconnect(inputs.back().getOutputPort(), inputs.back());
+            update.to_remove = std::move(current_batch);
+        }
+        else
+        {
+            inputs.emplace_back(*header, this);
+        }
+
+        if (batches_started == total_batches)
+        {
+            outputs.front().finish();
+            return update;
+        }
+
+        auto source = std::make_shared<SingleValueSource>(header, static_cast<UInt8>(batches_started));
+        auto laggard = std::make_shared<DeferredFinishTransform>(header);
+        connect(source->getOutputs().front(), laggard->getInputs().front());
+        current_batch = {source, laggard};
+
+        if (batches_started == 0)
+        {
+            auto closer = std::make_shared<EarlyClosingTransform>(header);
+            connect(laggard->getOutputs().front(), closer->getInputs().front());
+            current_batch.push_back(closer);
+        }
+
+        connect(current_batch.back()->getOutputs().front(), inputs.back());
+        inputs.back().reopen();
+        inputs.back().setNeeded();
+
+        update.to_add = current_batch;
+        batch_history.append_range(current_batch);
+        ++batches_started;
+
+        return update;
+    }
+
+    const std::vector<std::weak_ptr<IProcessor>> & batchHistory() const { return batch_history; }
+
+private:
+    const SharedHeader header;
+    const size_t total_batches;
+    size_t batches_started = 0;
+    Processors current_batch;
+    std::vector<std::weak_ptr<IProcessor>> batch_history;
+};
+
 }
 
 TEST(Processors, PortDisconnect)
@@ -369,4 +530,33 @@ TEST(Processors, UpdatePipelineFanInRemovalNoUseAfterFree)
     }
 
     SUCCEED();
+}
+
+TEST(Processors, UpdatePipelineDeferredRemovalOfUnfinishedProcessors)
+{
+    auto header = makeHeader();
+
+    auto coordinator = std::make_shared<BatchCyclingCoordinator>(header, /*total_batches=*/5);
+    Pipe pipe(coordinator);
+
+    QueryPipeline pipeline(std::move(pipe));
+    {
+        PullingPipelineExecutor executor(pipeline);
+
+        std::vector<UInt8> values;
+        Chunk chunk;
+        while (executor.pull(chunk))
+        {
+            ASSERT_EQ(chunk.getNumRows(), 1u);
+            const auto & col = assert_cast<const ColumnUInt8 &>(*chunk.getColumns().front());
+            values.push_back(col.getElement(0));
+        }
+
+        EXPECT_EQ(values, (std::vector<UInt8>{1, 2, 3, 4}));
+
+        for (const auto & weak : coordinator->batchHistory())
+            EXPECT_TRUE(weak.expired());
+    }
+
+    EXPECT_EQ(coordinator->getInputs().size(), 1u);
 }


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#115809
Must include https://github.com/ClickHouse/ClickHouse/pull/115800

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115810&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115810](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115810+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1890` (included in `26.8` and later)
<!-- ch-version-info:end -->