### PR TITLE
Stop re-reading join fields on every right row in the hash join build loop

### DIFF
--- a/src/Interpreters/HashJoin/HashJoinMethods.h
+++ b/src/Interpreters/HashJoin/HashJoinMethods.h
@@ -21,14 +21,18 @@ size_t getMinBytesForPrefetchInJoin();
 template <typename HashMap, typename KeyGetter>
 struct Inserter
 {
+    /// `any_take_last_row` is read from the join once, before the loop that calls this. Reading it here
+    /// costs a load per row: the map this writes to lives inside the join object, so the compiler cannot
+    /// prove that the write leaves the flag alone and has to reload it.
     static ALWAYS_INLINE bool
-    insertOne(const HashJoin & join, HashMap & map, KeyGetter & key_getter, UInt32 stored_block_no, size_t i, Arena & pool)
+    insertOne(bool any_take_last_row, HashMap & map, KeyGetter & key_getter, UInt32 stored_block_no, size_t i, Arena & pool)
     {
         auto emplace_result = key_getter.emplaceKey(map, i, pool);
 
-        if (emplace_result.isInserted() || join.anyTakeLastRow())
+        const bool store_row = emplace_result.isInserted() || any_take_last_row;
+        if (store_row)
             new (&emplace_result.getMapped()) typename HashMap::mapped_type(stored_block_no, i);
-        return emplace_result.isInserted() || join.anyTakeLastRow();
+        return store_row;
     }
 
     static ALWAYS_INLINE bool

--- a/src/Interpreters/HashJoin/HashJoinMethods.h
+++ b/src/Interpreters/HashJoin/HashJoinMethods.h
@@ -51,8 +51,12 @@ struct Inserter
         return emplace_result.isInserted();
     }
 
+    /// `asof_type` and `asof_inequality` are read from the join once, before the loop, for the reason
+    /// given above `insertOne`: reading them here would be a load per row, and the type is behind an
+    /// `std::optional` that was dereferenced on every row even though only an insert needs it.
     static ALWAYS_INLINE bool insertAsof(
-        HashJoin & join,
+        TypeIndex asof_type,
+        ASOFJoinInequality asof_inequality,
         HashMap & map,
         KeyGetter & key_getter,
         UInt32 stored_block_no,
@@ -63,9 +67,8 @@ struct Inserter
         auto emplace_result = key_getter.emplaceKey(map, i, pool);
         typename HashMap::mapped_type * time_series_map = &emplace_result.getMapped();
 
-        TypeIndex asof_type = *join.getAsofType();
         if (emplace_result.isInserted())
-            time_series_map = new (time_series_map) typename HashMap::mapped_type(createAsofRowRef(asof_type, join.getAsofInequality()));
+            time_series_map = new (time_series_map) typename HashMap::mapped_type(createAsofRowRef(asof_type, asof_inequality));
         (*time_series_map)->insert(asof_column, stored_block_no, i);
         return emplace_result.isInserted();
     }

--- a/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
+++ b/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
@@ -280,8 +280,15 @@ void HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::insertFromBlockImplTypeCas
     constexpr bool is_asof_join = STRICTNESS == JoinStrictness::Asof;
 
     const IColumn * asof_column [[maybe_unused]] = nullptr;
+    [[maybe_unused]] TypeIndex asof_type{};
+    [[maybe_unused]] ASOFJoinInequality asof_inequality{};
     if constexpr (is_asof_join)
+    {
         asof_column = key_columns.back();
+        /// Hoisted out of the loop below, see `Inserter::insertAsof`.
+        asof_type = *join.getAsofType();
+        asof_inequality = join.getAsofInequality();
+    }
 
     auto key_getter = createKeyGetter<KeyGetter, is_asof_join>(key_columns, key_sizes);
 
@@ -327,7 +334,7 @@ void HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::insertFromBlockImplTypeCas
             continue;
 
         if constexpr (is_asof_join)
-            Inserter<HashMap, KeyGetter>::insertAsof(join, map, key_getter, stored_block_no, ind, pool, *asof_column);
+            Inserter<HashMap, KeyGetter>::insertAsof(asof_type, asof_inequality, map, key_getter, stored_block_no, ind, pool, *asof_column);
         else if constexpr (mapped_one)
             is_inserted |= Inserter<HashMap, KeyGetter>::insertOne(any_take_last_row, map, key_getter, stored_block_no, ind, pool);
         else

--- a/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
+++ b/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
@@ -289,6 +289,8 @@ void HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::insertFromBlockImplTypeCas
     is_inserted = !mapped_one || is_asof_join;
 
     const size_t rows = ScatteredBlock::Selector::size(selector);
+    /// Hoisted out of the loop below, see `Inserter::insertOne`.
+    [[maybe_unused]] const bool any_take_last_row = join.anyTakeLastRow();
 
     /// Software prefetch during the build phase.
     constexpr bool can_prefetch = join_prefetch_supported<KeyGetter, HashMap>;
@@ -327,7 +329,7 @@ void HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::insertFromBlockImplTypeCas
         if constexpr (is_asof_join)
             Inserter<HashMap, KeyGetter>::insertAsof(join, map, key_getter, stored_block_no, ind, pool, *asof_column);
         else if constexpr (mapped_one)
-            is_inserted |= Inserter<HashMap, KeyGetter>::insertOne(join, map, key_getter, stored_block_no, ind, pool);
+            is_inserted |= Inserter<HashMap, KeyGetter>::insertOne(any_take_last_row, map, key_getter, stored_block_no, ind, pool);
         else
             all_values_unique &= Inserter<HashMap, KeyGetter>::insertAll(join, map, key_getter, stored_block_no, ind, pool);
     }

--- a/tests/performance/join_any_build_duplicate_keys.xml
+++ b/tests/performance/join_any_build_duplicate_keys.xml
@@ -1,0 +1,32 @@
+<test>
+    <!--
+        The build side of an `ANY`/`SEMI`/`ANTI` join inserts every right row, but a row whose key is
+        already there stores nothing - the loop is then just a lookup. It used to reload
+        `join_any_take_last_row` from the join object twice per row on top of that, which a right side
+        of repeated keys pays for on every row.
+    -->
+
+    <settings>
+        <max_bytes_ratio_before_external_join>0</max_bytes_ratio_before_external_join>
+        <query_plan_join_swap_table>false</query_plan_join_swap_table>
+        <join_algorithm>hash</join_algorithm>
+        <max_threads>8</max_threads>
+    </settings>
+
+    <create_query>CREATE TABLE join_dup_build (k UInt64, v UInt64) ENGINE = Memory</create_query>
+    <create_query>CREATE TABLE join_dup_probe (k UInt64) ENGINE = Memory</create_query>
+
+    <!-- 64M right rows over 1024 keys: 1024 of them insert, the rest only look the key up. -->
+    <fill_query>INSERT INTO join_dup_build SELECT number % 1024, number FROM numbers_mt(64000000)</fill_query>
+    <fill_query>INSERT INTO join_dup_probe SELECT number % 1024 FROM numbers_mt(1000000)</fill_query>
+
+    <!-- A right column is selected, so these stay on the mapped hash tables. -->
+    <query>SELECT sum(r.v) FROM join_dup_probe AS l ANY LEFT JOIN join_dup_build AS r ON l.k = r.k FORMAT Null</query>
+    <!-- With `join_any_take_last_row` every row stores its reference, so the branch always fires. -->
+    <query>SELECT sum(r.v) FROM join_dup_probe AS l ANY LEFT JOIN join_dup_build AS r ON l.k = r.k SETTINGS join_any_take_last_row = 1 FORMAT Null</query>
+    <!-- `SEMI` with a right column selected also builds a mapped table. -->
+    <query>SELECT sum(r.v) FROM join_dup_probe AS l SEMI LEFT JOIN join_dup_build AS r ON l.k = r.k FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS join_dup_build</drop_query>
+    <drop_query>DROP TABLE IF EXISTS join_dup_probe</drop_query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speeds up building the hash table of an `ANY`, `SEMI` or `ANTI` join when the right-hand side repeats the same join keys many times: the join no longer re-reads the `join_any_take_last_row` setting from memory for every right row.

Related: https://github.com/ClickHouse/ClickHouse/pull/115301

<!-- CI automatic block start :ci_links: -->

---

<img width="1072" height="98" alt="Screenshot 2026-08-21 at 22 07 46" src="https://github.com/user-attachments/assets/274eb649-aa09-495f-af36-d1a8dafefe7e" />

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115820&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115820](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115820+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.86` (included in `26.9` and later)
<!-- ch-version-info:end -->