### PR TITLE
PromQL: speed up duplicate series zero scan

### DIFF
--- a/src/Functions/TimeSeries/timeSeriesThrowDuplicateSeriesIf.cpp
+++ b/src/Functions/TimeSeries/timeSeriesThrowDuplicateSeriesIf.cpp
@@ -1,5 +1,6 @@
 #include <Functions/FunctionFactory.h>
 
+#include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionHelpers.h>
@@ -156,6 +157,9 @@ private:
         }
 
         const auto & in_data = in->getData();
+        if (memoryIsZero(in_data.data(), 0, in_data.size() * sizeof(in_data[0])))
+            return static_cast<size_t>(-1); /// Not found.
+
         for (size_t i = 0; i != in->size(); ++i)
         {
             if (in_data[i] != 0)

--- a/tests/performance/promql_duplicate_series_if.xml
+++ b/tests/performance/promql_duplicate_series_if.xml
@@ -1,0 +1,22 @@
+<test>
+    <query>
+        SELECT timeSeriesThrowDuplicateSeriesIf(materialize(toUInt8(0)), toUInt64(0))
+        FROM numbers(1000000)
+        SETTINGS max_threads = 1, max_block_size = 500000
+        FORMAT Null
+    </query>
+
+    <query>
+        SELECT timeSeriesThrowDuplicateSeriesIf(materialize(toUInt8(0)), toUInt64(0))
+        FROM numbers(10000000)
+        SETTINGS max_threads = 1, max_block_size = 500000
+        FORMAT Null
+    </query>
+
+    <query>
+        SELECT timeSeriesThrowDuplicateSeriesIf(materialize(CAST('-0.0', 'Float64')), toUInt64(0))
+        FROM numbers(10000000)
+        SETTINGS max_threads = 1, max_block_size = 500000
+        FORMAT Null
+    </query>
+</test>

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.reference
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.reference
@@ -34,6 +34,18 @@ timeSeriesReplaceTag (2):
 timeSeriesThrowDuplicateSeriesIf:
 0
 
+timeSeriesThrowDuplicateSeriesIf vectorized all-zero:
+0
+0
+0
+0
+
+timeSeriesThrowDuplicateSeriesIf negative zero:
+0
+0
+
+timeSeriesThrowDuplicateSeriesIf vectorized nonzero:
+
 timeSeriesRemoveTag vectorized dense groups:
 [('instance','0')]
 [('instance','1')]

--- a/tests/queries/0_stateless/03779_time_series_tags_functions.sql
+++ b/tests/queries/0_stateless/03779_time_series_tags_functions.sql
@@ -275,6 +275,37 @@ FROM
 );  -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
 
 SELECT '';
+SELECT 'timeSeriesThrowDuplicateSeriesIf vectorized all-zero:';
+
+SELECT timeSeriesThrowDuplicateSeriesIf(materialize(toUInt8(0)), group)
+FROM
+(
+    SELECT timeSeriesTagsToGroup([('__name__', 'up')]) AS group
+    FROM numbers(4)
+);
+
+SELECT '';
+SELECT 'timeSeriesThrowDuplicateSeriesIf negative zero:';
+
+SELECT timeSeriesThrowDuplicateSeriesIf(materialize(CAST('-0.0', 'Float64')), group)
+FROM
+(
+    SELECT timeSeriesTagsToGroup([('__name__', 'up')]) AS group
+    FROM numbers(2)
+);
+
+SELECT '';
+SELECT 'timeSeriesThrowDuplicateSeriesIf vectorized nonzero:';
+
+SELECT timeSeriesThrowDuplicateSeriesIf(number = 2, group)
+FROM
+(
+    SELECT number,
+           timeSeriesTagsToGroup([('__name__', 'up'), ('instance', toString(number))]) AS group
+    FROM numbers(4)
+);  -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+
+SELECT '';
 SELECT 'timeSeriesRemoveTag vectorized dense groups:';
 
 SELECT timeSeriesGroupToTags(new_group)


### PR DESCRIPTION
### TL;DR

Use `memoryIsZero` to return early for all-zero PromQL condition vectors. Keep the existing scalar fallback for other values. The local 10M-row microbenchmark is up to 26.8x faster.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up duplicate-series checks for all-zero PromQL condition vectors.

### Summary

PromQL duplicate-series detection calls `timeSeriesThrowDuplicateSeriesIf` with a condition column. The function used to scan the whole column value by value even when every value was zero.

This change uses `memoryIsZero` as an all-zero check. If the bytes are all zero, the function returns immediately. Otherwise, it keeps the existing scalar scan. This preserves the behavior for non-zero values and special floating-point values such as `-0.0`.

### Benchmark

Local arm64 macOS. 10M preallocated values. Median of 7 runs. The old path is the existing scalar scan.

| Input | Old path | New path | Speedup |
| --- | ---: | ---: | ---: |
| UInt8, all zero | 7.393 ms | 0.275 ms | 26.8x |
| Float64, all zero | 3.442 ms | 2.246 ms | 1.53x |
| Float64, `-0.0` | 3.676 ms | 3.440 ms | 1.07x |

The `-0.0` case does not take the early return because its sign bit is set. It still uses the scalar fallback and returns the same result.

### Tests

- Add all-zero vector coverage to `03779_time_series_tags_functions`.
- Add `-0.0` fallback coverage.
- Add non-zero vector error coverage.
- Add a performance fixture for 1M and 10M rows.
- Compile the changed C++ translation unit.
- Run `git diff --check`.




<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1946` (included in `26.8` and later)
<!-- ch-version-info:end -->