### PR TITLE
Fix bad projection names

### DIFF
--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -94,6 +94,11 @@ IndexDescription IndexDescription::getIndexFromAST(
     if (index_definition->name.empty())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Skip index must have name in definition.");
 
+    /// Without escaping the name becomes a part of the index file name as is, see `getIndexFileName`.
+    if (!escape_filenames && index_definition->name.contains('/'))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "Skip index name ({}) cannot contain '/' with `escape_index_filenames` disabled", index_definition->name);
+
     auto index_type = index_definition->getType();
     if (!index_type)
         throw Exception(ErrorCodes::INCORRECT_QUERY, "TYPE is required for index");

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -18,6 +18,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int INCORRECT_QUERY;
+    extern const int BAD_ARGUMENTS;
 }
 
 bool indexFileExistsInChecksums(
@@ -51,6 +52,14 @@ String getIndexFileName(const String & index_name, bool escape_filename)
 {
     if (escape_filename)
         return escapeForFileName(String(SKIP_INDEX_FILE_PREFIX) + index_name);
+
+    /// Here the name becomes a part of the file name as is, so a '/' in it would turn into a path
+    /// separator. `getIndexFromAST` rejects such names, but `escape_index_filenames` can also be
+    /// switched off by `ALTER TABLE ... MODIFY SETTING` after the index was created.
+    if (index_name.contains('/'))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "Skip index name ({}) cannot contain '/' with `escape_index_filenames` disabled", index_name);
+
     return String(SKIP_INDEX_FILE_PREFIX) + index_name;
 }
 

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -255,6 +255,11 @@ ProjectionDescription ProjectionDescription::getProjectionFromAST(
     if (projection_definition->name.empty())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Projection must have name in definition.");
 
+    /// The name is used unescaped as a directory name (`getDirectoryName`) inside a part directory,
+    /// so a '/' in it would address files outside of the part and outside of the data directory.
+    if (projection_definition->name.contains('/'))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Projection name ({}) cannot contain '/'", projection_definition->name);
+
     ProjectionDescription result;
     result.definition_ast = projection_definition->clone();
     result.name = projection_definition->name;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject invalid names of projections and indexes

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115824&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115824](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115824+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.20` (included in `26.9` and later)
- Backported to: `26.8.1.1992`, `26.7.6.26`, `26.6.4.52`, `26.3.31.6`
<!-- ch-version-info:end -->