### PR TITLE
Install the test configs for real in the CFI classification guard

### DIFF
--- a/ci/tests/test_cfi_not_a_sanitizer_build.py
+++ b/ci/tests/test_cfi_not_a_sanitizer_build.py
@@ -25,6 +25,7 @@ See ClickHouse/ClickHouse#115122.
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -119,18 +120,22 @@ def test_named_checks_distinguish_between_sanitizers(name):
 
 
 def symbolization_is_disabled_by_installer(tmp_path, flags):
-    """Run the installer's own classification block against a stub `clickhouse`.
+    """Install the test configs for a build whose `CXX_FLAGS` row is `flags`.
 
-    Executes `is_sanitizer_build` together with the `if` that consumes it, so both
-    the classification and its wiring to the symlink are covered, and reports
-    whether `trace_log_no_symbolize.xml` was installed. The function shells out to
-    a bare `clickhouse local --query`, so a stub earlier on PATH answers it.
+    Reports whether the server reads `trace_log_no_symbolize.xml`, so the link
+    must also resolve to the installer's own copy: a dangling link is not an
+    installed config. A stub `clickhouse` earlier on PATH answers the installer's
+    `system.build_options` probes; the environment is an allow-list so an
+    exported `USE_*` cannot steer the run.
     """
     stub = tmp_path / "clickhouse"
     stub.write_text(
         "#!/usr/bin/env python3\n"
         "import sys\n"
         "flags = {!r}\n"
+        "if '--query' not in sys.argv:\n"
+        "    print('ClickHouse local version 99.1.1.1.')\n"
+        "    raise SystemExit(0)\n"
         "query = sys.argv[sys.argv.index('--query') + 1]\n"
         'start = query.index("\'") + 1\n'
         "pattern = query[start : query.index(\"'\", start)].strip('%')\n"
@@ -138,25 +143,20 @@ def symbolization_is_disabled_by_installer(tmp_path, flags):
     )
     stub.chmod(0o755)
 
-    dest = tmp_path / "dest"
-    (dest / "config.d").mkdir(parents=True)
-    script = (
-        "set -e\n"
-        "block=$(sed -n '/^function is_sanitizer_build()/,/^fi$/p' \"$1\")\n"
-        'test -n "$block"\n'
-        'eval "$block"\n'
-    )
-    env = dict(
-        os.environ,
-        PATH="{}:{}".format(tmp_path, os.environ["PATH"]),
-        SRC_PATH=os.path.dirname(INSTALLER),
-        DEST_SERVER_PATH=str(dest),
-    )
+    dest = tmp_path / "server"
     run = subprocess.run(
-        ["bash", "-c", script, "bash", INSTALLER], env=env, capture_output=True
+        ["bash", INSTALLER, str(dest), str(tmp_path / "client")],
+        env={"PATH": "{}:{}".format(tmp_path, os.environ["PATH"])},
+        capture_output=True,
     )
     assert run.returncode == 0, run.stderr.decode()
-    return (dest / "config.d" / "trace_log_no_symbolize.xml").is_symlink()
+    link = dest / "config.d" / "trace_log_no_symbolize.xml"
+    return (
+        link.is_symlink()
+        and link.exists()
+        and link.resolve()
+        == (Path(INSTALLER).parent / "config.d" / link.name).resolve()
+    )
 
 
 @pytest.mark.parametrize("profile", sorted(NON_SANITIZER_FLAGS))


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/115591
Related: https://github.com/ClickHouse/ClickHouse/pull/113107
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`ci/tests/test_cfi_not_a_sanitizer_build.py` did not run `tests/config/install.sh`: it `eval`ed a
fragment cut out with `sed -n '/^function is_sanitizer_build()/,/^fi$/p'`. That range ends at the
first bare `^fi$` after the anchor, which on master closes
`if is_sanitizer_build; then ln -sf ... trace_log_no_symbolize.xml ...`, so the wiring was captured
only by luck of layout.

Inserting any bare `fi` between the function and that `if` truncates the range, so the fragment loses
the `ln -sf` and all five `test_installer_disables_symbolization_under_a_sanitizer` parameters fail
on a correct tree. #113107 does exactly that. The four
`test_installer_keeps_symbolization_without_a_sanitizer` parameters share the helper and go
*vacuously* green there, since "nothing installed" is their expected answer.

The guard now runs the real installer with a stub `clickhouse` earlier on `PATH`, into the test's
`tmp_path`, and asserts the resulting symlink. No `sed`, no `eval`, so rearranging that region cannot
affect it. Same nine parameters, one function, 21 lines replaced. `tests/config/install.sh` is not
modified: the shell predicate is correct and is the subject under test. The link must resolve to the
installer's own copy, not merely exist: `ln -sf` succeeds against an absent source, and a dangling
link leaves the server reading nothing.

Validated with the #113107 installer (5 failed before, 22 passed after) and with a bare `fi`
injected before the consuming `if` (22 passed). Six mutations of a scratch `install.sh` confirm the
oracle still discriminates: the bare `-fsanitize=` revert reds only `amd_cfi`; deleting the wiring,
ignoring the build flags either way, pointing the symlink elsewhere, and leaving it dangling each
red the expected arms. 20 runs, 20 identical passes. `pytest ci/tests/` failure ids are unchanged.

One limit: `assert run.returncode == 0` catches less than it looks, since the installer's probes sit
in command substitutions, so a stub refusing every call still exits 0. Such a break surfaces through
the symlink assertion instead.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115825&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115825](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115825+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
