### PR TITLE
TEST: demonstrate sccache low-hit-rate warning in CI report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.25)
+# TEST RIG (do not merge): force build jobs to run and recompile to exercise the sccache hit-rate warning.
 
 # Some CMakeLists.txt in contrib/ are not being good citizens and change cmake cache variables
 # globally. This policy prevents such *cache* variable assignments from altering *normal* variables

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -115,9 +115,15 @@ def warn_on_low_sccache_hit_rate(info):
     stats = Shell.get_output("sccache --show-stats --stats-format json")
     if not stats:
         return
-    counts = json.loads(stats)["stats"]
-    hits = sum(counts.get("cache_hits", {}).get("counts", {}).values())
-    misses = sum(counts.get("cache_misses", {}).get("counts", {}).values())
+    # Best-effort observability: an unexpected stats blob (unparseable, or a
+    # future sccache renaming these fields) must never fail an already-green build.
+    try:
+        counts = json.loads(stats)["stats"]
+        hits = sum(counts["cache_hits"]["counts"].values())
+        misses = sum(counts["cache_misses"]["counts"].values())
+    except (json.JSONDecodeError, KeyError, AttributeError, TypeError) as e:
+        print(f"WARNING: could not parse sccache stats, skipping hit-rate check: {e}")
+        return
     total = hits + misses
     if total == 0:
         return

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import shutil
 
@@ -107,6 +108,24 @@ def run_shell(name, command, **kwargs):
     print(f"\n>>>> {name}\n")
     Shell.check(command, **kwargs)
     print(f"\n<<<< {name}\n")
+
+
+def warn_on_low_sccache_hit_rate(info):
+    """Post a non-blocking workflow warning when the sccache hit rate is below 40% (issue #46502)."""
+    stats = Shell.get_output("sccache --show-stats --stats-format json")
+    if not stats:
+        return
+    counts = json.loads(stats)["stats"]
+    hits = sum(counts.get("cache_hits", {}).get("counts", {}).values())
+    misses = sum(counts.get("cache_misses", {}).get("counts", {}).values())
+    total = hits + misses
+    if total == 0:
+        return
+    hit_rate = 100 * hits / total
+    if hit_rate < 40:
+        info.add_workflow_warning(
+            f"Low sccache hit rate {hit_rate:.1f}% ({hits}/{total} compilations cached) - the compiler cache may be degraded or stale"
+        )
 
 
 def setup_build_caches_env(info):
@@ -459,6 +478,8 @@ def main():
                 results.append(retry_cmake)
 
         run_shell("sccache stats", "sccache --show-stats")
+        if not cache_warmup:
+            warn_on_low_sccache_hit_rate(info)
         if build_type in (BuildTypes.AMD_TIDY, BuildTypes.ARM_TIDY):
             run_shell("clang-tidy-cache stats", "clang-tidy-cache.py --show-stats")
             clang_tidy_cache_log = "./ci/tmp/clang-tidy-cache.log"

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -128,7 +128,7 @@ def warn_on_low_sccache_hit_rate(info):
     if total == 0:
         return
     hit_rate = 100 * hits / total
-    if hit_rate < 40:
+    if hit_rate < 101:  # TEST RIG (do not merge): forces the warning to always fire; real threshold is 40
         info.add_workflow_warning(
             f"Low sccache hit rate {hit_rate:.1f}% ({hits}/{total} compilations cached) - the compiler cache may be degraded or stale"
         )


### PR DESCRIPTION
**TEST PR — do not merge.** Follow-up to https://github.com/ClickHouse/ClickHouse/pull/115823 to demonstrate the sccache hit-rate warning rendering in the CI report.

It temporarily raises the hit-rate threshold to 101% so the non-blocking warning always fires on a real build, and adds a comment to `CMakeLists.txt` to schedule the build jobs and force recompilation. The warning should appear on the workflow report page (notification panel) and as the green, non-blocking `CI Infrastructure Messages` commit status.

Related: https://github.com/ClickHouse/ClickHouse/pull/115823
Related: https://github.com/ClickHouse/ClickHouse/issues/46502

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115826&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115826](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115826+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
