### PR TITLE
Forward declaration of MemorySpillScheduler

### DIFF
--- a/src/Common/MemorySpillScheduler.h
+++ b/src/Common/MemorySpillScheduler.h
@@ -5,25 +5,16 @@
 #include <mutex>
 #include <unordered_map>
 #include <base/types.h>
+#include <Common/ProcessorMemoryStats.h>
 
 namespace DB
 {
 class IProcessor;
-struct ProcessorMemoryStats
-{
-    // The total spillable memory in the processor
-    Int64 spillable_memory_bytes = 0;
-    // To avoid this processor cause OOM, at least `reserved_memory_bytes` should be reserved.
-    // including auxiliary memory to finish the spilling process.
-    Int64 need_reserved_memory_bytes = 0;
-};
 
 // MemorySpillScheduler is bound to one thread group. It's a query-scoped manager to trigger processor spill.
 class MemorySpillScheduler
 {
 public:
-    using Ptr = std::shared_ptr<MemorySpillScheduler>;
-
     explicit MemorySpillScheduler(bool enable_ = false) : enable(enable_) {}
     ~MemorySpillScheduler() = default;
 
@@ -46,4 +37,7 @@ private:
 
     Int64 getHardLimit();
 };
+
+using MemorySpillSchedulerPtr = std::shared_ptr<MemorySpillScheduler>;
+
 }

--- a/src/Common/ProcessorMemoryStats.h
+++ b/src/Common/ProcessorMemoryStats.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <base/types.h>
+
+namespace DB
+{
+struct ProcessorMemoryStats
+{
+    // The total spillable memory in the processor
+    Int64 spillable_memory_bytes = 0;
+    // To avoid this processor cause OOM, at least `reserved_memory_bytes` should be reserved.
+    // including auxiliary memory to finish the spilling process.
+    Int64 need_reserved_memory_bytes = 0;
+};
+}

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -10,7 +10,6 @@
 #include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/Scheduler/ResourceLink.h>
-#include <Common/MemorySpillScheduler.h>
 #include <Common/UntrackedMemoryRegistry.h>
 
 #include <boost/noncopyable.hpp>
@@ -70,6 +69,9 @@ using ThrowIfQueryCanceledPredicate = std::function<void()>;
 class ThreadGroup;
 using ThreadGroupPtr = std::shared_ptr<ThreadGroup>;
 
+class MemorySpillScheduler;
+using MemorySpillSchedulerPtr = std::shared_ptr<MemorySpillScheduler>;
+
 class ThreadGroup
 {
     /// Stores parent ThreadGroup for e.g. async INSERTs/MVs/EXPLAIN ANALYZE (those creates nested ThreadGroup's):
@@ -94,7 +96,7 @@ public:
 
     const Int32 os_threads_nice_value;
 
-    MemorySpillScheduler::Ptr memory_spill_scheduler;
+    MemorySpillSchedulerPtr memory_spill_scheduler;
     ProfileEvents::Counters performance_counters{VariableContext::Process};
     MemoryTracker memory_tracker{VariableContext::Process};
 

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -28,6 +28,7 @@
 #include <Common/logger_useful.h>
 #include <Common/noexcept_scope.h>
 #include <Common/setThreadName.h>
+#include <Common/MemorySpillScheduler.h>
 
 #if defined(OS_LINUX)
 #   include <sys/time.h>

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -8,6 +8,7 @@
 #include <Common/Stopwatch.h>
 #include <Common/CurrentThread.h>
 #include <Common/ThreadStatus.h>
+#include <Common/MemorySpillScheduler.h>
 
 #include <algorithm>
 #include <memory>

--- a/src/Processors/Executors/ExecutionThreadContext.cpp
+++ b/src/Processors/Executors/ExecutionThreadContext.cpp
@@ -4,6 +4,7 @@
 #include <Processors/StepWallClock.h>
 #include <QueryPipeline/ReadProgressCallback.h>
 #include <base/defines.h>
+#include <Common/MemorySpillScheduler.h>
 #include <Common/CurrentThread.h>
 #include <Common/ThreadStatus.h>
 #include <Common/Stopwatch.h>

--- a/src/Processors/Formats/IOutputFormat.h
+++ b/src/Processors/Formats/IOutputFormat.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <Core/Block_fwd.h>
 #include <IO/Progress.h>
 #include <Processors/Chunk.h>

--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Processors/Port.h>
-#include <Common/MemorySpillScheduler.h>
+#include <Common/ProcessorMemoryStats.h>
 #include <Common/Stopwatch.h>
 
 #include <atomic>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115827&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115827](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115827+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1900` (included in `26.8` and later)
<!-- ch-version-info:end -->