### PR TITLE
PromQL: reject vector matching with scalar operands

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.cpp
@@ -1,5 +1,6 @@
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applySimpleBinaryOperator.h>
 
+#include <Common/Exception.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
@@ -12,11 +13,31 @@
 #include <algorithm>
 
 
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_EXECUTE_PROMQL_QUERY;
+}
+
+
 namespace DB::PrometheusQueryToSQL
 {
 
 namespace
 {
+    void checkVectorMatching(
+        const PrometheusQueryTree::BinaryOperator * operator_node,
+        const SQLQueryPiece & left_argument,
+        const SQLQueryPiece & right_argument)
+    {
+        if (!operator_node->labels.empty()
+            && ((left_argument.type != ResultType::INSTANT_VECTOR) || (right_argument.type != ResultType::INSTANT_VECTOR)))
+        {
+            throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                            "Binary operator '{}' with vector matching expects two arguments of type {}, got {} and {}",
+                            operator_node->operator_name, ResultType::INSTANT_VECTOR, left_argument.type, right_argument.type);
+        }
+    }
+
     /// Applies a simple binary operator to operands if at least one of them is scalar.
     /// Other operand can be either scalar or instant vector.
     SQLQueryPiece applyOperatorToScalarsOrVectorAndScalar(
@@ -378,6 +399,8 @@ SQLQueryPiece applySimpleBinaryOperator(
     bool drop_metric_name,
     bool allow_grouping_modifier_copy_metric_name)
 {
+    checkVectorMatching(operator_node, left_argument, right_argument);
+
     if ((left_argument.type == ResultType::SCALAR) || (right_argument.type == ResultType::SCALAR))
     {
         /// At least one operand is scalar.

--- a/tests/queries/0_stateless/04131_prometheus_query_parser.reference
+++ b/tests/queries/0_stateless/04131_prometheus_query_parser.reference
@@ -53,6 +53,8 @@ nan
 0
 0
 0
+0
+0
 --- prometheusQueryRange with various steps ---
 0
 0

--- a/tests/queries/0_stateless/04131_prometheus_query_parser.sql
+++ b/tests/queries/0_stateless/04131_prometheus_query_parser.sql
@@ -87,6 +87,8 @@ SELECT count() FROM prometheusQuery('ts', 'up * on (job) up', 1000);
 SELECT count() FROM prometheusQuery('ts', 'up * ignoring (instance) up', 1000);
 SELECT count() FROM prometheusQuery('ts', 'up * on (job) group_left() up', 1000);
 SELECT count() FROM prometheusQuery('ts', 'up * ignoring (instance) group_right() up', 1000);
+SELECT count() FROM prometheusQuery('ts', 'up + 1', 1000);
+SELECT count() FROM prometheusQuery('ts', 'up + on () 1', 1000);
 
 SELECT '--- prometheusQueryRange with various steps ---';
 SELECT count() FROM prometheusQueryRange('ts', 'up', 1000, 2000, 60);
@@ -99,5 +101,7 @@ SELECT * FROM prometheusQuery('ts', 'rate(up[abc])', 1000); -- { serverError CAN
 SELECT * FROM prometheusQuery('ts', '1 +', 1000); -- { serverError CANNOT_PARSE_PROMQL_QUERY }
 SELECT * FROM prometheusQuery('ts', 'up{job=}', 1000); -- { serverError CANNOT_PARSE_PROMQL_QUERY }
 SELECT * FROM prometheusQuery('ts', 'up{job="unclosed}', 1000); -- { serverError CANNOT_PARSE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('ts', 'up + on (job) 1', 1000); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
+SELECT * FROM prometheusQuery('ts', 'up == ignoring (instance) 1', 1000); -- { serverError CANNOT_EXECUTE_PROMQL_QUERY }
 
 DROP TABLE ts;


### PR DESCRIPTION
### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
**Reject PromQL vector matching modifiers when one operand is a scalar.**

### Summary

PromQL rejects `on(...)` and `ignoring(...)` when one binary operator operand is a scalar.

ClickHouse currently accepts queries such as:

`up + on(job) 1`

and evaluates them like `up + 1`, silently dropping the requested matching labels.

This change rejects non-empty vector matching labels when either operand is a scalar. Empty `on()` and `ignoring()` clauses remain valid.

### Why it matters

PromQL-compatible clients expect invalid vector matching expressions to fail instead of returning a plausible result with different semantics.

### Tests

- Add regression coverage for scalar math and comparison expressions with vector matching labels.
- Keep coverage for valid scalar expressions and empty matching clauses.
- Syntax-check the changed C++ translation unit with the existing compile command.
- Run `git diff --check`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115828&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115828](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115828+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
