### PR TITLE
Web UI: bring back the color highlight of high read speeds

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -2066,6 +2066,24 @@ class QueryProgressElement extends HTMLElement
                     text-align: right;
                 }
 
+                /* The read stats wrap the outstanding numbers - huge row and byte counts, high read
+                   speeds - in <b> (see updateProgress). Paint them in the top tier of the rate
+                   palette of the metrics table, so that an extreme speed reads the same way in both
+                   places, instead of leaving them merely bold.
+
+                   The container paints the whole line through a background-clip: text mask and makes
+                   the text itself transparent to reveal it, so the color has to be given as
+                   -webkit-text-fill-color as well: the inherited transparent fill takes precedence
+                   over the plain color property, so the highlight would have no effect at all.
+                   Stepping out of the mask is also what keeps the highlight readable once the bar has
+                   grown under the stats: this color contrasts with the bar, whereas the progress
+                   color of the old highlight would have blended into it. */
+                #stats b
+                {
+                    color: var(--metric-c6);
+                    -webkit-text-fill-color: var(--metric-c6);
+                }
+
                 /* The elapsed time and the realtime metrics (CPU, memory, disk - shown like
                    clickhouse-client does) share this one element in the left column of the progress
                    area, over the bar. Its glyphs are tinted by the container's text mask (see

--- a/tests/queries/0_stateless/05024_play_ui_read_stats_highlight.reference
+++ b/tests/queries/0_stateless/05024_play_ui_read_stats_highlight.reference
@@ -1,0 +1,2 @@
+1
+#statsb{color:var(--metric-c6);-webkit-text-fill-color:var(--metric-c6);}

--- a/tests/queries/0_stateless/05024_play_ui_read_stats_highlight.sh
+++ b/tests/queries/0_stateless/05024_play_ui_read_stats_highlight.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The read stats of the Web UI progress line wrap the outstanding numbers - huge row and byte counts
+# and high read speeds - in `<b>`, and a CSS rule paints them in a color. That line paints all of its
+# text through a `background-clip: text` mask and makes the text itself transparent to reveal it, and
+# `-webkit-text-fill-color` is inherited, so a rule setting only `color` has no effect at all and the
+# highlight is silently lost. Check that the numbers are wrapped and that both properties are set.
+
+URL="${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}"
+
+PLAY=$(${CLICKHOUSE_CURL} -sS "${URL}/play")
+
+printf '%s' "$PLAY" | grep -cF '<b>${formatted_rps}<\/b>'
+printf '%s' "$PLAY" | tr -d ' \n' | grep -oF '#statsb{color:var(--metric-c6);-webkit-text-fill-color:var(--metric-c6);}' | head -n1


### PR DESCRIPTION
The progress line of the Web UI wraps the outstanding numbers of the read stats - huge row and byte counts and high read speeds - in `<b>`, and a CSS rule used to paint them in a color, so an extreme speed stood out:

```
Read 240.00 G rows, 5.12 TB (1.71 T/sec, 36.57 TB/sec)
```

The rule was lost when the progress line was reworked to paint its text through a `background-clip: text` gradient mask keyed to the `--progress` custom property. Since then the numbers were only bold - the computed color of `#stats b` is `rgba(0, 0, 0, 0)`.

Restore the highlight, painting it in the top tier of the rate palette that the metrics table already uses, so that an extreme speed reads the same way in both places. Two deliberate deviations from the original rule:

- the mask makes the text of the whole line transparent and `-webkit-text-fill-color` is inherited, so the highlight has to set that property as well - a rule setting only `color` is silently ignored;
- the color is no longer the progress color: the read stats now sit over the bar, and the bar is painted in the progress color, so the old highlight would have blended into it at high progress.

Checked in a headless browser in both themes, while the query runs (at 60% and at 99% of the bar) and after it finishes.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Web UI: bring back the color highlight of high read speeds and huge row and byte counts in the progress line.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115830&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115830](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115830+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
