### PR TITLE
Write the GROUP BY placeholder only when the hash table cell is created

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1222,9 +1222,15 @@ void NO_INLINE Aggregator::executeImplBatchNoAggregates(
     auto emplace = [&](size_t row)
     {
         // For some methods we simply don't have a set counterpart, so a map method is used.
-        // Thus we have to set a `mapped` even though it will be unused.
+        // Thus we have to set a `mapped` even though nothing reads it. Only the row that creates the
+        // cell has to: for a key that is already there the cell holds the same sentinel, and writing it
+        // again is a store into a random place of the table on every row.
         if constexpr (State::has_mapped)
-            state.emplaceKey(method.data, row, *aggregates_pool).setMapped(place);
+        {
+            auto emplace_result = state.emplaceKey(method.data, row, *aggregates_pool);
+            if (emplace_result.isInserted())
+                emplace_result.setMapped(place);
+        }
         else
             state.emplaceKey(method.data, row, *aggregates_pool);
     };

--- a/tests/performance/group_by_no_aggregates_mapped_keys.xml
+++ b/tests/performance/group_by_no_aggregates_mapped_keys.xml
@@ -1,0 +1,23 @@
+<test>
+    <!--
+        `GROUP BY` with no aggregate functions keeps a hash table whose mapped value is a sentinel that
+        nothing reads. Keys that have a set counterpart use a `HashSet` and hold no value at all, but a
+        `String` or `LowCardinality` key still uses a mapped table, and every row - not only the row that
+        creates the cell - used to write the sentinel into it.
+    -->
+
+    <settings>
+        <max_threads>8</max_threads>
+    </settings>
+
+    <create_query>CREATE TABLE group_by_sentinel (s String, lc LowCardinality(String)) ENGINE = Memory</create_query>
+
+    <!-- 100M rows: 1M distinct strings, and 50k distinct LowCardinality values. -->
+    <fill_query>INSERT INTO group_by_sentinel SELECT concat('key_', toString(rand64() % 1000000)), concat('v', toString(rand64() % 50000)) FROM numbers_mt(100000000)</fill_query>
+
+    <query>SELECT lc FROM group_by_sentinel GROUP BY lc FORMAT Null</query>
+    <query>SELECT lc FROM group_by_sentinel GROUP BY lc SETTINGS max_threads = 32 FORMAT Null</query>
+    <query>SELECT s FROM group_by_sentinel GROUP BY s FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS group_by_sentinel</drop_query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speeds up `GROUP BY` without aggregate functions over `String`, `FixedString` and `LowCardinality` keys: the query no longer rewrites an unused placeholder into the hash table for every row, only for the rows that add a new key.

Related: https://github.com/ClickHouse/ClickHouse/pull/108862

---

<img width="1146" height="34" alt="Screenshot 2026-08-22 at 01 03 07" src="https://github.com/user-attachments/assets/59e4e8f1-ff71-4445-b599-42eddc03917c" />

---

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115834&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115834](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115834+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1941` (included in `26.8` and later)
<!-- ch-version-info:end -->