### PR TITLE
Speed up to_utc_timestamp and from_utc_timestamp on DateTime64

### DIFF
--- a/src/Functions/UTCTimestampTransform.cpp
+++ b/src/Functions/UTCTimestampTransform.cpp
@@ -154,7 +154,7 @@ namespace
                     /// shifting the underlying value by `offset * scale_multiplier`. That product fits
                     /// Int64 (|offset| < 2^18, scale_multiplier <= 10^9); only the shift can overflow.
                     Int64 offset_scaled = time_zone_offset * scale_multiplier;
-                    Int64 res;
+                    Int64 res = 0;
                     if (to_utc ? common::subOverflow(date_time_val.value, offset_scaled, res)
                                : common::addOverflow(date_time_val.value, offset_scaled, res))
                     {

--- a/src/Functions/UTCTimestampTransform.cpp
+++ b/src/Functions/UTCTimestampTransform.cpp
@@ -1,3 +1,4 @@
+#include <base/arithmeticOverflow.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnsDateTime.h>
 #include <Columns/ColumnString.h>
@@ -143,27 +144,25 @@ namespace
                 {
                     DateTime64 date_time_val = date_time_col.getElement(i);
                     Int64 seconds = date_time_val.value / scale_multiplier;
-                    Int64 micros = date_time_val.value % scale_multiplier;
-                    /// Floor the split so `micros` stays non-negative and timezoneOffset() sees the
-                    /// floor second, not the next one (wrong offset at a DST/offset boundary otherwise).
-                    if (micros < 0)
-                    {
+                    /// Truncating division rounds toward zero, so a negative sub-second remainder
+                    /// lands on the next second up. Floor it, otherwise timezoneOffset() reads the
+                    /// wrong side of a DST/offset boundary.
+                    if (date_time_val.value % scale_multiplier < 0)
                         seconds -= 1;
-                        micros += scale_multiplier;
-                    }
                     auto time_zone_offset = time_zone.timezoneOffset(seconds);
-                    /// Compute in Int128 (the offset add and scale multiply overflow Int64 near the
-                    /// boundary), then clamp to the representable range.
-                    Int128 time_val = seconds;
-                    if (to_utc)
-                        time_val -= time_zone_offset;
-                    else
-                        time_val += time_zone_offset;
-                    Int128 wide_val = time_val * scale_multiplier + micros;
-                    static constexpr Int128 min_val = std::numeric_limits<Int64>::min();
-                    static constexpr Int128 max_val = std::numeric_limits<Int64>::max();
-                    wide_val = wide_val < min_val ? min_val : (wide_val > max_val ? max_val : wide_val);
-                    result_data[i] = DateTime64(static_cast<Int64>(wide_val));
+                    /// Shifting the floored seconds by the offset and reassembling is the same as
+                    /// shifting the underlying value by `offset * scale_multiplier`. That product fits
+                    /// Int64 (|offset| < 2^18, scale_multiplier <= 10^9); only the shift can overflow.
+                    Int64 offset_scaled = time_zone_offset * scale_multiplier;
+                    Int64 res;
+                    if (to_utc ? common::subOverflow(date_time_val.value, offset_scaled, res)
+                               : common::addOverflow(date_time_val.value, offset_scaled, res))
+                    {
+                        /// The sign of the applied shift tells which end the true value ran past.
+                        const bool shift_is_negative = to_utc ? (offset_scaled > 0) : (offset_scaled < 0);
+                        res = shift_is_negative ? std::numeric_limits<Int64>::min() : std::numeric_limits<Int64>::max();
+                    }
+                    result_data[i] = DateTime64(res);
                 }
                 return result_column;
             }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115802   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Speed up `toUTCTimestamp`/`to_utc_timestamp` and `fromUTCTimestamp`/`from_utc_timestamp` on `DateTime64` arguments, restoring the throughput they had before the overflow fix in #109738. Results are unchanged. Closes #115802.


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/115802

My #109738 fixed a signed-overflow and a wrong-offset-at-a-boundary bug on the `DateTime64` path of these functions, but it did the arithmetic and the clamp in `Int128`, once per row. `Int128` here is `wide::integer<128, signed>`, a software big-integer, so `operator*` sign-normalizes through branches before a native multiply and reassembles a two-`UInt64` struct. Each row gained that call plus two 128-bit compares and selects where it previously had one `imul` and one `add`. The `DateTime` branch was untouched and did not regress.

The wide arithmetic is redundant. The floored split guarantees `seconds * scale_multiplier + micros == value` exactly, so shifting the seconds by the offset and reassembling equals shifting the underlying value by `offset * scale_multiplier`; the `Int128` multiply only re-derived its own input. This PR shifts the underlying value directly with a saturating `Int64` add/sub (`common::addOverflow`/`subOverflow`: one `add`/`sub` plus a flag test).

`offset * scale_multiplier` cannot overflow `Int64`: scanning `timeZoneOffset` over all 597 shipped time zones (4.18M samples, including out-of-LUT extremes) gives `max|offset| = 130800`, and `scale_multiplier <= 10^9`, so the product stays 70000x below the `Int64` limit. Both semantics from #109738 are kept: the split still floors, and the result is still saturated.

Measured on the queries from `tests/performance/utc_timestamp_transform.xml` (10M rows, `max_threads=1`, optimized build, arms differing by exactly this hunk): `0.102s -> 0.062s`, against `0.061s` before #109738. The `DateTime` queries are the control and stay at `0.033s` throughout. That is x86_64, so the ratio is smaller than the ARM 2.7x in the issue, but the fix returns to the pre-#109738 cost rather than narrowing the gap.

Results are bit-identical to master over 12.9M `(value, scale, timezone, direction)` cases plus 112K cases built on the 1,056 real offset-transition seconds. `03891_utc_timestamp_datetime64_overflow` passes byte-identical, and still reddens if the saturation is dropped, its direction flipped, or the floor correction removed.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115838&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115838](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115838+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1944` (included in `26.8` and later)
<!-- ch-version-info:end -->