### PR TITLE
Pin ast_fuzzer_runs = 0 in 04870_distinct_merge_over_distributed

### DIFF
--- a/tests/queries/0_stateless/04870_distinct_merge_over_distributed.sql
+++ b/tests/queries/0_stateless/04870_distinct_merge_over_distributed.sql
@@ -10,6 +10,13 @@
 -- hash-dedups the whole stream and returns the right count even when the order is corrupt.
 -- The runner randomizes the setting, so it is pinned here.
 
+-- The stress profile sets `ast_fuzzer_runs = 5` and `ast_fuzzer_any_query = true`, so the
+-- server-side AST fuzzer re-runs mutated copies of every statement here, `CREATE` included. It can
+-- retype the `Merge` parent's column and substitute the retyped clone into a `SELECT`, and a `Merge`
+-- parent whose column type differs from its child's breaks the sort order the arms below assume.
+-- Pinning the baseline to 0 keeps the fixture at the types it declares.
+SET ast_fuzzer_runs = 0;
+
 DROP TABLE IF EXISTS t_distinct;
 DROP TABLE IF EXISTS dist_distinct;
 DROP TABLE IF EXISTS merge_distinct;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113242
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #115455
Related: #113242
Related: #114677

`Stress test (*)` jobs abort with `Logical error: 'Equal values are not contiguous within the
range assumed to be sorted'` at `DistinctSortedStreamTransform.cpp:184`: 87 times across 78
unrelated pull requests since `04870` was merged on 2026-08-17, against 5 in the 20 days before,
and it is still firing today.

The engine defect is old and is not what I change here. The stress profile sets
`ast_fuzzer_runs = 5` and `ast_fuzzer_any_query = true`
(`tests/docker_scripts/stress_tests.lib`), so the server-side AST fuzzer re-runs mutated copies of
every statement of every stateless test, `CREATE` included. In `04870` it retypes the fixture's
`Merge` parent and substitutes the clone into a `SELECT`, and a `Merge` parent whose column type
differs from its child's is the precondition for the assertion. My test is the amplifier, and this
PR removes only that. The defect itself is #113242, still open.

The change is one statement, `SET ast_fuzzer_runs = 0;`, pinning the setting to its own declared
default. It weakens nothing: all seven arms still run and still assert, and the `.reference` file
is unchanged. Nine stateless tests already pin it, several for this same reason. It is file-level
rather than per-query because the chain needs both a fuzzed `CREATE`, to mint the clone, and a
fuzzed `SELECT`, to substitute it in. `-- Tags: no-stress` is not an option, `clickhouse-test`
rejects it.

Validation, one debug binary differing only in the test file: with the fuzzer armed the unpinned
test fails 6 of 30 runs and the pinned test passes 30 of 30. I also reproduced the abort on a
hand-built mistyped fixture, with a stack matching CI. 50 randomized runs, and 50 with the fuzzer
armed, pass.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115839&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115839](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115839+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
