### PR TITLE
Sort release branches by version, not lexically

### DIFF
--- a/ci/jobs/auto_release_job.py
+++ b/ci/jobs/auto_release_job.py
@@ -74,8 +74,13 @@ def _fetch_history() -> None:
     )
 
 
+def _branch_version_key(branch: str) -> Tuple[int, ...]:
+    """Numeric `(major, minor, …)` key so release branches order by version, not lexically — otherwise `25.10` sorts before `25.9`."""
+    return tuple(int(part) for part in branch.split("."))
+
+
 def _release_branches() -> List[str]:
-    """Head branches of the open `release`-labeled PRs, oldest first.
+    """Head branches of the open `release`-labeled PRs, version-ascending (oldest first).
 
     A persistent read failure raises rather than returning an empty list: a
     silent empty result would make an autorelease run quietly release nothing
@@ -85,7 +90,9 @@ def _release_branches() -> List[str]:
     )
     if not raw:
         raise RuntimeError("gh pr list failed for release PRs after retries")
-    branches = sorted(pr["headRefName"] for pr in json.loads(raw))
+    branches = sorted(
+        (pr["headRefName"] for pr in json.loads(raw)), key=_branch_version_key
+    )
     print(f"Found release branches {branches}")
     return branches
 

--- a/ci/tests/test_auto_releases.py
+++ b/ci/tests/test_auto_releases.py
@@ -278,3 +278,11 @@ def test_find_release_candidate_errors_without_release_tag(monkeypatch):
     sha, reason, status = m._find_release_candidate("25.8")
     assert sha == "" and "no release tag" in reason
     assert status == m.Result.Status.ERROR
+
+
+def test_release_branches_order_by_version():
+    """Release branches must sort by numeric version, not lexically (`25.9` before `25.10`)."""
+    m = _job_module()
+    assert sorted(
+        ["25.10", "25.9", "26.3", "26.10"], key=m._branch_version_key
+    ) == ["25.9", "25.10", "26.3", "26.10"]


### PR DESCRIPTION
`_release_branches()` sorts the open `release`-labeled PR head branches as plain strings, so once a minor version reaches two digits the ordering is wrong — e.g. `25.10` sorts before `25.9`. It's benign in `auto_release_job.py`'s current per-branch loop (every branch is processed regardless of order), but any newest-first consumer would pick the wrong branch. Sort by a numeric `(major, minor, …)` key via a small `_branch_version_key` helper.

Flagged by the review bot on #113528 (its `_select_patch_dry_run_ref` relies on newest-first order); fixing the ordering at the source here.

Related: https://github.com/ClickHouse/ClickHouse/pull/113528

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115842&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115842](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115842+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
