### PR TITLE
Docs: clarify that use_skip_indexes_if_final stale-result risk requires exact mode to be disabled

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1893,7 +1893,7 @@ Possible values:
     DECLARE(Bool, use_skip_indexes_if_final, true, R"(
 Controls whether skipping indexes are used when executing a query with the FINAL modifier.
 
-Skip indexes may exclude rows (granules) containing the latest data, which could lead to incorrect results from a query with the FINAL modifier. When this setting is enabled, skipping indexes are applied even with the FINAL modifier, potentially improving performance. Correct results still depend on setting use_skip_indexes_if_final_exact_mode, which is enabled by default and scans the additional parts that overlap the ranges returned by the skip index. The risk of missing recent updates applies only if that setting is disabled.
+Skip indexes may exclude rows (granules) containing the latest data, which could lead to incorrect results from a query with the `FINAL` modifier. When this setting is enabled, skipping indexes are applied even with the `FINAL` modifier, potentially improving performance. Correct results still depend on setting `use_skip_indexes_if_final_exact_mode`, which is enabled by default and scans the additional parts that overlap the ranges returned by the skip index. The risk of missing recent updates applies only if that setting is disabled.
 
 Possible values:
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1893,7 +1893,7 @@ Possible values:
     DECLARE(Bool, use_skip_indexes_if_final, true, R"(
 Controls whether skipping indexes are used when executing a query with the FINAL modifier.
 
-Skip indexes may exclude rows (granules) containing the latest data, which could lead to incorrect results from a query with the FINAL modifier. When this setting is enabled, skipping indexes are applied even with the FINAL modifier, potentially improving performance but with the risk of missing recent updates. This setting should be enabled in sync with the setting use_skip_indexes_if_final_exact_mode (default is enabled).
+Skip indexes may exclude rows (granules) containing the latest data, which could lead to incorrect results from a query with the FINAL modifier. When this setting is enabled, skipping indexes are applied even with the FINAL modifier, potentially improving performance. Correct results still depend on setting use_skip_indexes_if_final_exact_mode, which is enabled by default and scans the additional parts that overlap the ranges returned by the skip index. The risk of missing recent updates applies only if that setting is disabled.
 
 Possible values:
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

The `use_skip_indexes_if_final` description states the stale-result risk as if it were an unconditional consequence of enabling the setting, and mentions `use_skip_indexes_if_final_exact_mode` only in a trailing clause whose `(default is enabled)` is easy to read as referring back to `use_skip_indexes_if_final` itself.

Both settings default to `true` (`src/Core/Settings.cpp`, and `SettingsChangesHistory.cpp` records the `0 -> 1` flip for both in 25.6). With the shipped defaults there is no stale-result risk: `use_skip_indexes_if_final_exact_mode` runs the `PrimaryKeyExpand` step (`findPKRangesForFinalAfterSkipIndex`, `src/Processors/QueryPlan/PartsSplitter.cpp`), which adds back granules in the other parts that overlap the primary key ranges the skip index selected. The "risk of missing recent updates" applies only when that setting is turned off, which is exactly what the existing sibling description says ("This setting should be disabled only if approximate results based on looking up the skip index are okay for an application").

Reworded so the conditionality and the default are explicit. Documentation only, no behavior change.

Before:
> Skip indexes may exclude rows (granules) containing the latest data, which could lead to incorrect results from a query with the FINAL modifier. When this setting is enabled, skipping indexes are applied even with the FINAL modifier, potentially improving performance but with the risk of missing recent updates. This setting should be enabled in sync with the setting use_skip_indexes_if_final_exact_mode (default is enabled).

After:
> Skip indexes may exclude rows (granules) containing the latest data, which could lead to incorrect results from a query with the FINAL modifier. When this setting is enabled, skipping indexes are applied even with the FINAL modifier, potentially improving performance. Correct results still depend on setting use_skip_indexes_if_final_exact_mode, which is enabled by default and scans the additional parts that overlap the ranges returned by the skip index. The risk of missing recent updates applies only if that setting is disabled.

The rendered page (https://clickhouse.com/docs/reference/settings/session-settings/use-skip-indexes) is inside `AUTOGENERATED` markers, so per `docs/reference/AGENTS.md` only the `DECLARE` doc string is edited here; the nightly docs autogeneration job regenerates the `.mdx`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115846&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115846](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115846+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.18` (included in `26.9` and later)
<!-- ch-version-info:end -->