### PR TITLE
Do not buffer the serialized step when computing the hash-table-stats cache key

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/SipHashingWriteBuffer.h
+++ b/src/Processors/QueryPlan/Optimizations/SipHashingWriteBuffer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <IO/BufferWithOwnMemory.h>
+#include <IO/WriteBuffer.h>
+#include <Common/SipHash.h>
+
+namespace DB
+{
+
+/// Feeds everything written to it into a `SipHash` over a fixed-size window and discards the bytes,
+/// so a stream that is only ever hash input never has to be held in memory to be hashed.
+///
+/// `SipHash::update` carries state, including any sub-word remainder, across calls, so hashing a
+/// stream in consecutive chunks gives the same 64-bit value as hashing one contiguous buffer holding
+/// all of it: the window size is not observable in the result.
+class SipHashingWriteBuffer final : public BufferWithOwnMemory<WriteBuffer>
+{
+public:
+    /// Any size is correct: `WriteBuffer` callers either loop over `available()` or check it before
+    /// writing into the buffer directly.
+    static constexpr size_t window_bytes = 32768;
+
+    explicit SipHashingWriteBuffer(SipHash & hash_) : BufferWithOwnMemory<WriteBuffer>(window_bytes), hash(hash_) { }
+
+    /// This buffer may be destroyed with a stream still half-written: nothing reads the discarded
+    /// bytes, so abandoning one costs nothing and callers need not finalize. `~WriteBuffer` asserts
+    /// against being left neither finalized nor canceled, so cancel here.
+    ~SipHashingWriteBuffer() override { cancel(); }
+
+private:
+    void nextImpl() override { hash.update(working_buffer.begin(), offset()); }
+
+    SipHash & hash;
+};
+
+}

--- a/src/Processors/QueryPlan/Optimizations/calculateHashTableCacheKeys.cpp
+++ b/src/Processors/QueryPlan/Optimizations/calculateHashTableCacheKeys.cpp
@@ -11,6 +11,7 @@
 #include <Interpreters/TableJoin.h>
 #include <Processors/QueryPlan/AggregatingStep.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
+#include <Processors/QueryPlan/Optimizations/SipHashingWriteBuffer.h>
 #include <Common/typeid_cast.h>
 #include <Processors/QueryPlan/ITransformingStep.h>
 #include <Processors/QueryPlan/JoinStepLogical.h>
@@ -95,7 +96,11 @@ UInt64 calculateHashFromStep(const ITransformingStep & transform)
         && sameByteLayout(*transform.getOutputHeader(), *transform.getInputHeaders().front()))
         return 0;
 
-    WriteBufferFromOwnString wbuf;
+    /// This serialized form is only ever hash input - nothing reads the bytes back - so it is
+    /// hashed as it is produced rather than accumulated. A step can carry a whole constant-folded
+    /// literal here, which `serializeConstant` writes out in full.
+    SipHash hash;
+    SipHashingWriteBuffer wbuf(hash);
     SerializedSetsRegistry registry;
     registry.for_cache_key = true;
     /// The bytes are hashed in-process by the same binary that wrote them and never reach another
@@ -110,8 +115,7 @@ UInt64 calculateHashFromStep(const ITransformingStep & transform)
     if (transform.isSerializable())
         transform.serialize(ctx);
 
-    SipHash hash;
-    hash.update(wbuf.str());
+    wbuf.finalize();
     return hash.get64();
 }
 

--- a/src/Processors/QueryPlan/tests/gtest_siphashing_write_buffer_key_identity.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_siphashing_write_buffer_key_identity.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include <IO/WriteBufferFromString.h>
+#include <Processors/QueryPlan/Optimizations/SipHashingWriteBuffer.h>
+#include <Common/SipHash.h>
+
+using namespace DB;
+
+namespace
+{
+
+/// The value `calculateHashFromStep` produced before it streamed: accumulate the whole stream, then
+/// hash the contiguous result in one call.
+UInt64 bufferedKey(const std::vector<std::string> & writes)
+{
+    WriteBufferFromOwnString out;
+    for (const auto & w : writes)
+        out.write(w.data(), w.size());
+
+    SipHash hash;
+    hash.update(out.str());
+    return hash.get64();
+}
+
+/// The value it produces now: hash each chunk as it is written, keeping no copy of the stream.
+UInt64 streamedKey(const std::vector<std::string> & writes)
+{
+    SipHash hash;
+    SipHashingWriteBuffer out(hash);
+    for (const auto & w : writes)
+        out.write(w.data(), w.size());
+    out.finalize();
+    return hash.get64();
+}
+
+/// Writes that between them cross the sink's flush boundary at every alignment: sub-word chunks
+/// (which exercise `SipHash::update`'s carried remainder), chunks straddling one window, and a
+/// single write many windows long.
+std::vector<std::vector<std::string>> streamShapes()
+{
+    const size_t w = SipHashingWriteBuffer::window_bytes;
+    return {
+        {},
+        {""},
+        {"a"},
+        {"a", "b", "c"},
+        {std::string(7, 'x')},
+        {std::string(8, 'x')},
+        {std::string(9, 'x')},
+        {std::string(1, 'a'), std::string(w - 1, 'b')},
+        {std::string(w - 1, 'a'), std::string(1, 'b')},
+        {std::string(w, 'a')},
+        {std::string(w, 'a'), std::string(1, 'b')},
+        {std::string(w + 1, 'a')},
+        {std::string(3, 'a'), std::string(w, 'b'), std::string(5, 'c')},
+        {std::string(4 * w + 3, 'a')},
+    };
+}
+
+}
+
+/// The property the whole change rests on: streaming the key must not change its value. If this
+/// fails, every cached hash-table-statistics entry and every parallel-replicas node match silently
+/// stops agreeing with the plan that produced it.
+TEST(SipHashingWriteBuffer, KeyIsIdenticalToBufferedHash)
+{
+    for (const auto & writes : streamShapes())
+        ASSERT_EQ(streamedKey(writes), bufferedKey(writes)) << "stream shape with " << writes.size() << " write(s)";
+}
+
+/// Negative control for the test above. Perturbing the stream by a single byte in one shape must
+/// change the key, otherwise `KeyIsIdenticalToBufferedHash` would pass for a sink that hashes
+/// nothing at all.
+TEST(SipHashingWriteBuffer, KeyDiffersWhenStreamIsPerturbed)
+{
+    const std::vector<std::string> writes{std::string(SipHashingWriteBuffer::window_bytes + 1, 'a')};
+
+    auto perturbed = writes;
+    perturbed.front().back() = 'b';
+
+    ASSERT_NE(streamedKey(writes), streamedKey(perturbed));
+    ASSERT_NE(streamedKey(writes), streamedKey({}));
+}
+
+/// Destroying the sink with a stream still half-written must not trip `~WriteBuffer`'s "neither
+/// finalized nor canceled" assertion, since callers are free to abandon a key half-computed.
+TEST(SipHashingWriteBuffer, DestroyedWithoutFinalizeAfterPartialWrite)
+{
+    SipHash hash;
+    {
+        SipHashingWriteBuffer out(hash);
+        const std::string chunk(SipHashingWriteBuffer::window_bytes + 17, 'x');
+        out.write(chunk.data(), chunk.size());
+    }
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/113736
Related: https://github.com/ClickHouse/ClickHouse/pull/113333
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reduced memory usage and query-plan optimization time for keyed aggregations over large constant-folded literals. The aggregation hash-table-statistics cache key is now hashed as it is serialized instead of being accumulated in memory first, so a plan carrying a large literal no longer holds a copy of it during optimization. For an 80 MB literal, peak memory drops by about 250 MB and optimization time by about 2.5x. The computed key is unchanged.


### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/113736

`calculateHashFromStep` buffered a step's whole serialized form, then hashed it in a second pass. That stream is hash input only, and `serializeConstant` writes a constant-folded literal out in full, so a large literal was copied just to be hashed and dropped. This hashes the stream as it is produced, through a small `WriteBuffer` feeding a `SipHash` over a 32 KiB window.

**The key value is bit-identical to before**, since `SipHash::update` carries state across calls including any sub-word remainder. That matters because a collision is harmless for only one of the three consumers: `considerEnablingParallelReplicas` uses these hashes as a node matcher across two plan builds, transplanting cached dataflow statistics on a match. Truncating the key would make different constants compare equal there.

Measured with `clickhouse local` on a `GROUP BY` over an 80 MB `repeat()` literal, 3 runs:

| 80 MB literal | `QueryPlanOptimizeMicroseconds` | peak RSS |
|---|---|---|
| before | 176 / 179 / 175 ms | 668 / 671 / 668 MB |
| after | 68 / 70 / 73 ms | 407 / 419 / 419 MB |
| setting off (floor) | 43 / 39 / 40 ms | 407 / 413 / 407 MB |

Peak memory now sits at the floor. Same at 800 MB: 3460 to 1817 MB, floor 1817 MB.

The O(N) term remains: `serializeBinary` still walks every byte, and each aggregation node serializes its own subtree. Removing it means giving up exact key identity, which given the matcher above is the code owner's call.

A gtest asserts the streamed key equals the previously buffered key across window-boundary alignments, and fails under two deliberate perturbations of the sink. 12 real cache keys spanning constants, Array, Tuple, Nullable, LowCardinality and Decimal are unchanged.

Reported by @ egor-click.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115847&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115847](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115847+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.35` (included in `26.9` and later)
<!-- ch-version-info:end -->