### PR TITLE
Fix performance regression in text serialization of JSON and Dynamic columns

### DIFF
--- a/src/DataTypes/DataTypesCache.cpp
+++ b/src/DataTypes/DataTypesCache.cpp
@@ -129,7 +129,13 @@ SerializationPtr DataTypesCache::getSerialization(const String & type_name)
     if (const auto * elem = getSimpleDataTypesCache().findByName(type_name))
         return elem->serialization;
 
-    return getCacheElement(type_name).serialization;
+    const auto & element = getCacheElement(type_name);
+    if (element.serialization)
+        return element.serialization;
+
+    /// The default serialization of this type is non-poolable (see getCacheElement),
+    /// so it must be rebuilt fresh for every use.
+    return element.type->getDefaultSerialization();
 }
 
 SerializationPtr DataTypesCache::getSerialization(const String & type_name, const DataTypePtr & type)
@@ -138,7 +144,13 @@ SerializationPtr DataTypesCache::getSerialization(const String & type_name, cons
     if (const auto * elem = getSimpleDataTypesCache().findByName(type_name))
         return elem->serialization;
 
-    return getCacheElement(type_name, &type).serialization;
+    const auto & element = getCacheElement(type_name, &type);
+    if (element.serialization)
+        return element.serialization;
+
+    /// The default serialization of this type is non-poolable (see getCacheElement),
+    /// so it must be rebuilt fresh for every use.
+    return element.type->getDefaultSerialization();
 }
 
 void DataTypesCache::clearIfQueryContextChanged()
@@ -183,7 +195,18 @@ const DataTypesCache::Element & DataTypesCache::getCacheElement(const String & t
         cache.clear();
 
     auto type = known_type ? *known_type : DataTypeFactory::instance().get(type_name);
-    it = cache.emplace(type_name, Element{type, type->getDefaultSerialization()}).first;
+    auto serialization = type->getDefaultSerialization();
+
+    /// A serialization with `supportsPooling() == false` must not be shared across uses:
+    /// it keeps mutable per-use state (e.g. SerializationJSON accumulates caches inside its
+    /// extraction tree; the property propagates through wrapper serializations of composite
+    /// types). The type itself is an immutable value object and is safe to cache, so cache
+    /// only the type and leave the serialization null; getSerialization rebuilds a fresh
+    /// serialization on every lookup for such types.
+    if (!serialization->supportsPooling())
+        serialization = nullptr;
+
+    it = cache.emplace(type_name, Element{type, std::move(serialization)}).first;
     return it->second;
 }
 

--- a/src/DataTypes/DataTypesCache.cpp
+++ b/src/DataTypes/DataTypesCache.cpp
@@ -125,6 +125,15 @@ SerializationPtr DataTypesCache::getSerialization(const String & type_name)
     return getCacheElement(type_name).serialization;
 }
 
+SerializationPtr DataTypesCache::getSerialization(const String & type_name, const DataTypePtr & type)
+{
+    /// Check the thread-local cache of simple types first.
+    if (const auto * elem = getSimpleDataTypesCache().findByName(type_name))
+        return elem->serialization;
+
+    return getCacheElement(type_name, &type).serialization;
+}
+
 void DataTypesCache::clearIfQueryContextChanged()
 {
     ContextPtr current_query_context = CurrentThread::tryGetQueryContext();
@@ -142,7 +151,7 @@ void DataTypesCache::clearIfQueryContextChanged()
     query_context = current_query_context;
 }
 
-const DataTypesCache::Element & DataTypesCache::getCacheElement(const String & type_name)
+const DataTypesCache::Element & DataTypesCache::getCacheElement(const String & type_name, const DataTypePtr * known_type)
 {
     clearIfQueryContextChanged();
 
@@ -154,7 +163,7 @@ const DataTypesCache::Element & DataTypesCache::getCacheElement(const String & t
     if (cache.size() >= MAX_ELEMENTS)
         cache.clear();
 
-    auto type = DataTypeFactory::instance().get(type_name);
+    auto type = known_type ? *known_type : DataTypeFactory::instance().get(type_name);
     it = cache.emplace(type_name, Element{type, type->getDefaultSerialization()}).first;
     return it->second;
 }

--- a/src/DataTypes/DataTypesCache.cpp
+++ b/src/DataTypes/DataTypesCache.cpp
@@ -1,5 +1,6 @@
 #include <DataTypes/DataTypesCache.h>
 #include <DataTypes/DataTypeFactory.h>
+#include <Common/CurrentThread.h>
 
 namespace DB
 {
@@ -124,8 +125,27 @@ SerializationPtr DataTypesCache::getSerialization(const String & type_name)
     return getCacheElement(type_name).serialization;
 }
 
+void DataTypesCache::clearIfQueryContextChanged()
+{
+    ContextPtr current_query_context = CurrentThread::tryGetQueryContext();
+
+    /// Owner-based identity comparison. It does not lock the weak_ptr, and since we hold
+    /// the weak_ptr (keeping the control block alive), an expired context cannot be
+    /// confused with a new one allocated at the same address.
+    if (!query_context.owner_before(current_query_context) && !current_query_context.owner_before(query_context))
+        return;
+
+    /// The thread is now serving a different query. Cached types/serializations may depend
+    /// on the previous query's context (e.g. `session_timezone` captured by DateTime types),
+    /// so they must not be reused.
+    cache.clear();
+    query_context = current_query_context;
+}
+
 const DataTypesCache::Element & DataTypesCache::getCacheElement(const String & type_name)
 {
+    clearIfQueryContextChanged();
+
     auto it = cache.find(type_name);
     if (it != cache.end())
         return it->second;

--- a/src/DataTypes/DataTypesCache.cpp
+++ b/src/DataTypes/DataTypesCache.cpp
@@ -1,9 +1,16 @@
 #include <DataTypes/DataTypesCache.h>
 #include <DataTypes/DataTypeFactory.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
 #include <Common/CurrentThread.h>
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsTimezone session_timezone;
+}
 
 namespace ErrorCodes
 {
@@ -141,14 +148,26 @@ void DataTypesCache::clearIfQueryContextChanged()
     /// Owner-based identity comparison. It does not lock the weak_ptr, and since we hold
     /// the weak_ptr (keeping the control block alive), an expired context cannot be
     /// confused with a new one allocated at the same address.
-    if (!query_context.owner_before(current_query_context) && !current_query_context.owner_before(query_context))
+    bool same_query_context = !query_context.owner_before(current_query_context) && !current_query_context.owner_before(query_context);
+
+    /// Context identity is not enough: clickhouse-client keeps one long-lived client context
+    /// (attached to the client thread by a single query scope) for the whole session and
+    /// mutates `session_timezone` in place between queries (see `ClientBase::onTimezoneUpdate`),
+    /// so also track the value of the setting the cached types may have captured.
+    const String * current_session_timezone
+        = current_query_context ? &current_query_context->getSettingsRef()[Setting::session_timezone].value : nullptr;
+    bool same_session_timezone
+        = current_session_timezone ? *current_session_timezone == session_timezone : session_timezone.empty();
+
+    if (same_query_context && same_session_timezone)
         return;
 
-    /// The thread is now serving a different query. Cached types/serializations may depend
-    /// on the previous query's context (e.g. `session_timezone` captured by DateTime types),
-    /// so they must not be reused.
+    /// The thread is now serving a different query, or `session_timezone` changed in place
+    /// on the same context. Cached types/serializations may depend on the previous query's
+    /// context (e.g. `session_timezone` captured by DateTime types), so they must not be reused.
     cache.clear();
     query_context = current_query_context;
+    session_timezone = current_session_timezone ? *current_session_timezone : String();
 }
 
 const DataTypesCache::Element & DataTypesCache::getCacheElement(const String & type_name, const DataTypePtr * known_type)

--- a/src/DataTypes/DataTypesCache.h
+++ b/src/DataTypes/DataTypesCache.h
@@ -2,6 +2,7 @@
 
 #include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypesBinaryEncoding.h>
+#include <Interpreters/Context_fwd.h>
 
 #include <array>
 #include <unordered_map>
@@ -61,6 +62,17 @@ const SimpleDataTypesCache & getSimpleDataTypesCache();
 /// Thread-local cache for data type lookups by name.
 /// Checks the thread-local SimpleDataTypesCache first; only caches
 /// non-simple types (e.g. DateTime64(9), Variant types) in its own map.
+///
+/// The cache is scoped to a single query: a type name does not uniquely identify
+/// a type/serialization across queries, because construction depends on the current
+/// query context. For example, `DateTime` without an explicit timezone captures
+/// the query's `session_timezone` setting at construction (see TimezoneMixin and
+/// `DateLUT::instance`), and `JSON` serializations are built against the current
+/// query context and hold mutable per-use state that must not be shared between
+/// queries (see the comment in SerializationJSON::create). Since the cache lives
+/// in a long-lived thread, it must be cleared whenever the thread starts serving
+/// a different query; otherwise a stale entry produces wrong results (e.g. DateTime
+/// values rendered in another query's timezone).
 class DataTypesCache
 {
 public:
@@ -78,7 +90,16 @@ private:
 
     const Element & getCacheElement(const String & type_name);
 
+    /// Clear the cache if the thread is now attached to a different query context
+    /// than the one the cache was populated under.
+    void clearIfQueryContextChanged();
+
     std::unordered_map<String, Element> cache;
+
+    /// The query context the cached entries were created under (null for threads
+    /// not attached to any query). Holding a weak_ptr keeps the control block alive,
+    /// which makes the owner-based identity comparison immune to address reuse.
+    ContextWeakPtr query_context;
 };
 
 /// Return instance of a thread local cache.

--- a/src/DataTypes/DataTypesCache.h
+++ b/src/DataTypes/DataTypesCache.h
@@ -79,8 +79,17 @@ public:
     DataTypePtr getType(const String & type_name);
     SerializationPtr getSerialization(const String & type_name);
 
+    /// Same as getSerialization(type_name), but on a cache miss reuses the already
+    /// constructed `type` instead of parsing `type_name` through DataTypeFactory.
+    /// `type_name` must be equal to `type->getName()`.
+    SerializationPtr getSerialization(const String & type_name, const DataTypePtr & type);
+
 private:
-    static constexpr size_t MAX_ELEMENTS = 16;
+    /// Sized to cover a full set of Dynamic variants (up to 255) plus types from the
+    /// shared variant, so that interleaved values of many distinct non-simple types
+    /// (e.g. a Dynamic(max_types=N) column with N > 16 complex variants) do not
+    /// constantly clear and rebuild the cache. Matches ColumnDynamic::SERIALIZATION_CACHE_MAX_SIZE.
+    static constexpr size_t MAX_ELEMENTS = 256;
 
     struct Element
     {
@@ -88,7 +97,8 @@ private:
         SerializationPtr serialization;
     };
 
-    const Element & getCacheElement(const String & type_name);
+    /// If `known_type` is provided, it is used on a cache miss instead of a DataTypeFactory lookup.
+    const Element & getCacheElement(const String & type_name, const DataTypePtr * known_type = nullptr);
 
     /// Clear the cache if the thread is now attached to a different query context
     /// than the one the cache was populated under.

--- a/src/DataTypes/DataTypesCache.h
+++ b/src/DataTypes/DataTypesCache.h
@@ -71,8 +71,10 @@ const SimpleDataTypesCache & getSimpleDataTypesCache();
 /// query context and hold mutable per-use state that must not be shared between
 /// queries (see the comment in SerializationJSON::create). Since the cache lives
 /// in a long-lived thread, it must be cleared whenever the thread starts serving
-/// a different query; otherwise a stale entry produces wrong results (e.g. DateTime
-/// values rendered in another query's timezone).
+/// a different query, and also when `session_timezone` is mutated in place on the
+/// same context (clickhouse-client does this between queries of one session);
+/// otherwise a stale entry produces wrong results (e.g. DateTime values rendered
+/// in another query's timezone).
 class DataTypesCache
 {
 public:
@@ -101,7 +103,8 @@ private:
     const Element & getCacheElement(const String & type_name, const DataTypePtr * known_type = nullptr);
 
     /// Clear the cache if the thread is now attached to a different query context
-    /// than the one the cache was populated under.
+    /// than the one the cache was populated under, or if `session_timezone` was
+    /// changed in place on the same context.
     void clearIfQueryContextChanged();
 
     std::unordered_map<String, Element> cache;
@@ -110,6 +113,12 @@ private:
     /// not attached to any query). Holding a weak_ptr keeps the control block alive,
     /// which makes the owner-based identity comparison immune to address reuse.
     ContextWeakPtr query_context;
+
+    /// The value of `session_timezone` the cached entries were created under. Tracked
+    /// in addition to the context identity because clickhouse-client keeps one
+    /// long-lived client context for the whole session and mutates the setting
+    /// in place between queries (see `ClientBase::onTimezoneUpdate`).
+    String session_timezone;
 };
 
 /// Return instance of a thread local cache.

--- a/src/DataTypes/DataTypesCache.h
+++ b/src/DataTypes/DataTypesCache.h
@@ -67,14 +67,19 @@ const SimpleDataTypesCache & getSimpleDataTypesCache();
 /// a type/serialization across queries, because construction depends on the current
 /// query context. For example, `DateTime` without an explicit timezone captures
 /// the query's `session_timezone` setting at construction (see TimezoneMixin and
-/// `DateLUT::instance`), and `JSON` serializations are built against the current
-/// query context and hold mutable per-use state that must not be shared between
-/// queries (see the comment in SerializationJSON::create). Since the cache lives
-/// in a long-lived thread, it must be cleared whenever the thread starts serving
-/// a different query, and also when `session_timezone` is mutated in place on the
-/// same context (clickhouse-client does this between queries of one session);
-/// otherwise a stale entry produces wrong results (e.g. DateTime values rendered
-/// in another query's timezone).
+/// `DateLUT::instance`). Since the cache lives in a long-lived thread, it must be
+/// cleared whenever the thread starts serving a different query, and also when
+/// `session_timezone` is mutated in place on the same context (clickhouse-client
+/// does this between queries of one session); otherwise a stale entry produces
+/// wrong results (e.g. DateTime values rendered in another query's timezone).
+///
+/// Serializations with `supportsPooling() == false` (e.g. SerializationJSON, which
+/// holds mutable per-use state, see the comment in SerializationJSON::create) are
+/// never cached at all, not even within one query: for them only the type is cached
+/// and a fresh serialization is built on every lookup. Note that query-scoped
+/// invalidation alone would not be enough for them anyway: clickhouse-client keeps
+/// one client context attached to the client thread for the whole session, so
+/// consecutive client queries can share one "query scope".
 class DataTypesCache
 {
 public:
@@ -96,6 +101,9 @@ private:
     struct Element
     {
         DataTypePtr type;
+        /// Null if the default serialization of `type` has `supportsPooling() == false`:
+        /// such serializations keep mutable per-use state and must be rebuilt for every use
+        /// instead of being served from the cache.
         SerializationPtr serialization;
     };
 

--- a/src/DataTypes/Serializations/SerializationDynamic.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamic.cpp
@@ -971,7 +971,8 @@ static void serializeTextImpl(
         ReadBufferFromMemory buf(value);
         auto variant_type = decodeDataType(buf);
         auto tmp_variant_column = variant_type->createColumn();
-        auto variant_serialization = getDataTypesCache().getSerialization(variant_type->getName());
+        /// Pass the decoded type so a cache miss doesn't parse the name through DataTypeFactory again.
+        auto variant_serialization = getDataTypesCache().getSerialization(variant_type->getName(), variant_type);
         variant_serialization->deserializeBinary(*tmp_variant_column, buf, FormatSettings{});
         nested_serialize(*variant_serialization, *tmp_variant_column, 0, ostr);
         return;
@@ -980,8 +981,10 @@ static void serializeTextImpl(
     /// Otherwise use the serialization of the exact variant this row holds. Getting the serialization of the whole
     /// Variant type instead would build serializations and names of all the variants and go through the globally
     /// locked serialization pool for every value.
+    const auto & variant_info = dynamic_column.getVariantInfo();
+    const auto & variant_types = assert_cast<const DataTypeVariant &>(*variant_info.variant_type).getVariants();
     nested_serialize(
-        *getDataTypesCache().getSerialization(dynamic_column.getVariantInfo().variant_names[global_discr]),
+        *getDataTypesCache().getSerialization(variant_info.variant_names[global_discr], variant_types[global_discr]),
         variant_column.getVariantByGlobalDiscriminator(global_discr),
         variant_column.offsetAt(row_num),
         ostr);

--- a/src/DataTypes/Serializations/SerializationDynamic.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamic.cpp
@@ -1,5 +1,6 @@
 #include <Common/SipHash.h>
 #include <DataTypes/Serializations/SerializationDynamic.h>
+#include <DataTypes/Serializations/SerializationNullable.h>
 #include <DataTypes/Serializations/SerializationVariant.h>
 #include <DataTypes/Serializations/SerializationDynamicHelpers.h>
 #include <DataTypes/FieldToDataType.h>
@@ -945,31 +946,45 @@ static void deserializeTextImpl(
     dynamic_column.insertValueIntoSharedVariant(*tmp_variant_column, variant_type, variant_type_name, 0);
 }
 
-template <typename NestedSerialize>
+template <typename NestedSerialize, typename SerializeNull>
 static void serializeTextImpl(
     const IColumn & column,
     size_t row_num,
     WriteBuffer & ostr,
-    NestedSerialize nested_serialize)
+    NestedSerialize nested_serialize,
+    SerializeNull serialize_null)
 {
     const auto & dynamic_column = assert_cast<const ColumnDynamic &>(column);
     const auto & variant_column = dynamic_column.getVariantColumn();
+    auto global_discr = variant_column.globalDiscriminatorAt(row_num);
+
+    if (global_discr == ColumnVariant::NULL_DISCRIMINATOR)
+    {
+        serialize_null(ostr);
+        return;
+    }
+
     /// Check if this row has value in shared variant. In this case we should first deserialize it from binary format.
-    if (variant_column.globalDiscriminatorAt(row_num) == dynamic_column.getSharedVariantDiscriminator())
+    if (global_discr == dynamic_column.getSharedVariantDiscriminator())
     {
         auto value = dynamic_column.getSharedVariant().getDataAt(variant_column.offsetAt(row_num));
         ReadBufferFromMemory buf(value);
         auto variant_type = decodeDataType(buf);
         auto tmp_variant_column = variant_type->createColumn();
-        auto variant_serialization = variant_type->getDefaultSerialization();
+        auto variant_serialization = getDataTypesCache().getSerialization(variant_type->getName());
         variant_serialization->deserializeBinary(*tmp_variant_column, buf, FormatSettings{});
         nested_serialize(*variant_serialization, *tmp_variant_column, 0, ostr);
+        return;
     }
-    /// Otherwise just use serialization for Variant.
-    else
-    {
-        nested_serialize(*dynamic_column.getVariantInfo().variant_type->getDefaultSerialization(), variant_column, row_num, ostr);
-    }
+
+    /// Otherwise use the serialization of the exact variant this row holds. Getting the serialization of the whole
+    /// Variant type instead would build serializations and names of all the variants and go through the globally
+    /// locked serialization pool for every value.
+    nested_serialize(
+        *getDataTypesCache().getSerialization(dynamic_column.getVariantInfo().variant_names[global_discr]),
+        variant_column.getVariantByGlobalDiscriminator(global_discr),
+        variant_column.offsetAt(row_num),
+        ostr);
 }
 
 SerializationPtr SerializationDynamic::create(size_t max_dynamic_types_, const SerializationInfoSettings & serialization_info_settings_)
@@ -984,7 +999,12 @@ void SerializationDynamic::serializeTextCSV(const IColumn & column, size_t row_n
         serialization.serializeTextCSV(col, row, buf, settings);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [&settings](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullCSV(buf, settings);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 void SerializationDynamic::deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
@@ -1022,7 +1042,12 @@ void SerializationDynamic::serializeTextEscaped(const IColumn & column, size_t r
         serialization.serializeTextEscaped(col, row, buf, settings);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [&settings](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullEscaped(buf, settings);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 void SerializationDynamic::deserializeTextEscaped(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
@@ -1060,7 +1085,12 @@ void SerializationDynamic::serializeTextQuoted(const IColumn & column, size_t ro
         serialization.serializeTextQuoted(col, row, buf, settings);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullQuoted(buf);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 void SerializationDynamic::deserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
@@ -1098,7 +1128,12 @@ void SerializationDynamic::serializeTextJSON(const IColumn & column, size_t row_
         serialization.serializeTextJSON(col, row, buf, settings);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullJSON(buf);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 void SerializationDynamic::serializeTextJSONPretty(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings, size_t indent) const
@@ -1108,7 +1143,12 @@ void SerializationDynamic::serializeTextJSONPretty(const IColumn & column, size_
         serialization.serializeTextJSONPretty(col, row, buf, settings, indent);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullJSON(buf);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 void SerializationDynamic::deserializeTextJSON(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
@@ -1146,7 +1186,12 @@ void SerializationDynamic::serializeTextRaw(const IColumn & column, size_t row_n
         serialization.serializeTextRaw(col, row, buf, settings);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [&settings](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullRaw(buf, settings);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 void SerializationDynamic::deserializeTextRaw(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
@@ -1184,7 +1229,12 @@ void SerializationDynamic::serializeText(const IColumn & column, size_t row_num,
         serialization.serializeText(col, row, buf, settings);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [&settings](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullText(buf, settings);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 void SerializationDynamic::deserializeWholeText(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
@@ -1222,7 +1272,12 @@ void SerializationDynamic::serializeTextXML(const IColumn & column, size_t row_n
         serialization.serializeTextXML(col, row, buf, settings);
     };
 
-    serializeTextImpl(column, row_num, ostr, nested_serialize);
+    auto serialize_null = [](WriteBuffer & buf)
+    {
+        SerializationNullable::serializeNullXML(buf);
+    };
+
+    serializeTextImpl(column, row_num, ostr, nested_serialize, serialize_null);
 }
 
 SerializationPtr SerializationDynamic::createSerializationForType(const DataTypePtr & type) const

--- a/src/DataTypes/tests/gtest_data_types_cache.cpp
+++ b/src/DataTypes/tests/gtest_data_types_cache.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <Common/QueryScope.h>
+#include <Common/ThreadStatus.h>
+#include <Common/assert_cast.h>
+#include <Common/tests/gtest_global_context.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypesCache.h>
+#include <Interpreters/Context.h>
+
+using namespace DB;
+
+namespace
+{
+
+ContextMutablePtr makeQueryContext(const String & query_id, const String & session_timezone)
+{
+    auto query_context = Context::createCopy(getContext().context);
+    query_context->makeQueryContext();
+    query_context->setCurrentQueryId(query_id);
+    query_context->setSetting("session_timezone", session_timezone);
+    return query_context;
+}
+
+/// `DateTime` without an explicit timezone captures the current query's `session_timezone`
+/// at construction (see TimezoneMixin and DateLUT::instance), so the timezone of the returned
+/// type shows which query context the cached entry was built under.
+String cachedDateTimeTimezone()
+{
+    auto type = getDataTypesCache().getType("DateTime");
+    return assert_cast<const DataTypeDateTime &>(*type).getTimeZone().getTimeZone();
+}
+
+}
+
+TEST(DataTypesCache, ReusesEntriesWithinOneQuery)
+{
+    ThreadStatus thread_status;
+
+    auto query_context = makeQueryContext("data_types_cache_test_same_query", "UTC");
+    auto query_scope = QueryScope::create(query_context);
+
+    auto first = getDataTypesCache().getType("DateTime64(3)");
+    auto second = getDataTypesCache().getType("DateTime64(3)");
+    ASSERT_EQ(first.get(), second.get());
+}
+
+TEST(DataTypesCache, InvalidatedOnQueryContextChange)
+{
+    ThreadStatus thread_status;
+
+    /// A long-lived thread serves one query, caching a context-dependent type...
+    {
+        auto query_context = makeQueryContext("data_types_cache_test_query_1", "Asia/Tokyo");
+        auto query_scope = QueryScope::create(query_context);
+
+        ASSERT_EQ(cachedDateTimeTimezone(), "Asia/Tokyo");
+        /// The second lookup is served from the cache and must see the same context.
+        ASSERT_EQ(cachedDateTimeTimezone(), "Asia/Tokyo");
+    }
+
+    /// ...and is then reused by another query with a different `session_timezone`.
+    /// Without query-scoped invalidation, the thread-local cache would return the
+    /// `DateTime` type constructed under the previous query's timezone.
+    {
+        auto query_context = makeQueryContext("data_types_cache_test_query_2", "Europe/Amsterdam");
+        auto query_scope = QueryScope::create(query_context);
+
+        ASSERT_EQ(cachedDateTimeTimezone(), "Europe/Amsterdam");
+    }
+}

--- a/src/DataTypes/tests/gtest_data_types_cache.cpp
+++ b/src/DataTypes/tests/gtest_data_types_cache.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <Common/CurrentThread.h>
 #include <Common/DateLUTImpl.h>
 #include <Common/QueryScope.h>
 #include <Common/ThreadStatus.h>
@@ -23,6 +24,18 @@ ContextMutablePtr makeQueryContext(const String & query_id, const String & sessi
     return query_context;
 }
 
+/// The gtest binary's main thread already has a `MainThreadStatus` attached, and
+/// `ThreadStatus`'s constructor asserts no `ThreadStatus` is already current on this
+/// thread. Reset `current_thread` before constructing a local `ThreadStatus` and restore
+/// it afterward, matching the `FileCacheTest` fixture pattern in gtest_filecache.cpp.
+/// Declare this before the `ThreadStatus` it guards so construction/destruction order
+/// (reverse of declaration) resets first and restores last.
+struct ResetCurrentThreadGuard
+{
+    ResetCurrentThreadGuard() { current_thread = nullptr; }
+    ~ResetCurrentThreadGuard() { current_thread = MainThreadStatus::get(); }
+};
+
 /// `DateTime` without an explicit timezone captures the current query's `session_timezone`
 /// at construction (see TimezoneMixin and DateLUT::instance), so the timezone of the returned
 /// type shows which query context the cached entry was built under.
@@ -36,6 +49,7 @@ String cachedDateTimeTimezone()
 
 TEST(DataTypesCache, ReusesEntriesWithinOneQuery)
 {
+    ResetCurrentThreadGuard reset_current_thread;
     ThreadStatus thread_status;
 
     auto query_context = makeQueryContext("data_types_cache_test_same_query", "UTC");
@@ -48,6 +62,7 @@ TEST(DataTypesCache, ReusesEntriesWithinOneQuery)
 
 TEST(DataTypesCache, InvalidatedOnQueryContextChange)
 {
+    ResetCurrentThreadGuard reset_current_thread;
     ThreadStatus thread_status;
 
     /// A long-lived thread serves one query, caching a context-dependent type...
@@ -73,6 +88,7 @@ TEST(DataTypesCache, InvalidatedOnQueryContextChange)
 
 TEST(DataTypesCache, DoesNotPoolNonPoolableSerializations)
 {
+    ResetCurrentThreadGuard reset_current_thread;
     ThreadStatus thread_status;
 
     auto query_context = makeQueryContext("data_types_cache_test_non_poolable", "UTC");
@@ -94,6 +110,7 @@ TEST(DataTypesCache, DoesNotPoolNonPoolableSerializations)
 
 TEST(DataTypesCache, InvalidatedOnSessionTimezoneChangeWithinOneContext)
 {
+    ResetCurrentThreadGuard reset_current_thread;
     ThreadStatus thread_status;
 
     /// clickhouse-client keeps one long-lived client context attached to the client thread

--- a/src/DataTypes/tests/gtest_data_types_cache.cpp
+++ b/src/DataTypes/tests/gtest_data_types_cache.cpp
@@ -71,6 +71,27 @@ TEST(DataTypesCache, InvalidatedOnQueryContextChange)
     }
 }
 
+TEST(DataTypesCache, DoesNotPoolNonPoolableSerializations)
+{
+    ThreadStatus thread_status;
+
+    auto query_context = makeQueryContext("data_types_cache_test_non_poolable", "UTC");
+    auto query_scope = QueryScope::create(query_context);
+
+    /// The JSON type itself is an immutable value object and is safe to cache...
+    auto first_type = getDataTypesCache().getType("JSON");
+    auto second_type = getDataTypesCache().getType("JSON");
+    ASSERT_EQ(first_type.get(), second_type.get());
+
+    /// ...but SerializationJSON holds mutable per-use state (`supportsPooling() == false`,
+    /// see the comment in SerializationJSON::create), so even within one query the cache
+    /// must build a fresh serialization on every lookup instead of pooling one instance.
+    auto first_serialization = getDataTypesCache().getSerialization("JSON");
+    auto second_serialization = getDataTypesCache().getSerialization("JSON");
+    ASSERT_FALSE(first_serialization->supportsPooling());
+    ASSERT_NE(first_serialization.get(), second_serialization.get());
+}
+
 TEST(DataTypesCache, InvalidatedOnSessionTimezoneChangeWithinOneContext)
 {
     ThreadStatus thread_status;

--- a/src/DataTypes/tests/gtest_data_types_cache.cpp
+++ b/src/DataTypes/tests/gtest_data_types_cache.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <Common/DateLUTImpl.h>
 #include <Common/QueryScope.h>
 #include <Common/ThreadStatus.h>
 #include <Common/assert_cast.h>
@@ -68,4 +69,23 @@ TEST(DataTypesCache, InvalidatedOnQueryContextChange)
 
         ASSERT_EQ(cachedDateTimeTimezone(), "Europe/Amsterdam");
     }
+}
+
+TEST(DataTypesCache, InvalidatedOnSessionTimezoneChangeWithinOneContext)
+{
+    ThreadStatus thread_status;
+
+    /// clickhouse-client keeps one long-lived client context attached to the client thread
+    /// by a single query scope for the whole session, and mutates `session_timezone` on it
+    /// in place between queries (see `ClientBase::onTimezoneUpdate`). The context identity
+    /// never changes here, so the cache must track the setting value itself.
+    auto client_context = makeQueryContext("data_types_cache_test_client_session", "Asia/Tokyo");
+    auto query_scope = QueryScope::create(client_context);
+
+    ASSERT_EQ(cachedDateTimeTimezone(), "Asia/Tokyo");
+
+    /// The next query of the same client session changes the setting on the same context.
+    client_context->setSetting("session_timezone", String("Europe/Amsterdam"));
+
+    ASSERT_EQ(cachedDateTimeTimezone(), "Europe/Amsterdam");
 }

--- a/tests/performance/json_to_string.xml
+++ b/tests/performance/json_to_string.xml
@@ -1,0 +1,33 @@
+<test>
+    <create_query>
+        CREATE TABLE json_to_string (id UInt64, payload JSON) ENGINE = MergeTree ORDER BY id
+    </create_query>
+    <create_query>
+        CREATE TABLE json_to_string_shared_data (id UInt64, payload JSON(max_dynamic_paths=0)) ENGINE = MergeTree ORDER BY id
+    </create_query>
+
+    <fill_query>
+        INSERT INTO json_to_string
+        SELECT
+            number,
+            CAST((
+                number,
+                ['info', 'warn', 'error', 'debug'][(number % 4) + 1],
+                map('user', randomPrintableASCII(8), 'session', randomPrintableASCII(12)),
+                [randomPrintableASCII(5), randomPrintableASCII(6)],
+                CAST((randomPrintableASCII(6), rand64() / 1000000.0) AS Tuple(country String, lat Float64)),
+                (number % 2) = 0
+            ) AS Tuple(user_id UInt64, event String, props Map(String, String),
+                       tags Array(String), geo Tuple(country String, lat Float64), active Bool))::JSON
+        FROM numbers(500000)
+    </fill_query>
+    <fill_query>INSERT INTO json_to_string_shared_data SELECT * FROM json_to_string</fill_query>
+    <fill_query>OPTIMIZE TABLE json_to_string FINAL</fill_query>
+    <fill_query>OPTIMIZE TABLE json_to_string_shared_data FINAL</fill_query>
+
+    <query>SELECT sum(length(toString(payload))) FROM json_to_string</query>
+    <query>SELECT sum(length(toString(payload))) FROM json_to_string_shared_data</query>
+
+    <drop_query>DROP TABLE IF EXISTS json_to_string</drop_query>
+    <drop_query>DROP TABLE IF EXISTS json_to_string_shared_data</drop_query>
+</test>


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/115796
Related: https://github.com/ClickHouse/ClickHouse/pull/96563

`SerializationDynamic::serializeTextImpl` got the serialization of the whole `Variant` type for
every value, which builds the serializations and names of all the variants and goes through the
globally locked `SerializationObjectPool`. `SerializationJSON` calls it once per JSON path per row.

Resolve the exact variant by its global discriminator and take its serialization from the
thread-local `DataTypesCache`, like the row-level binary serializer already does.

`toString` over a 1M-row `JSON` table, 200k rows, `max_threads = 4`:

| | master | this PR | 26.2 |
| --- | --- | --- | --- |
| `JSON`, 10 dynamic paths | 6.4 s | 0.26 s | 1.0 s |
| `JSON(max_dynamic_paths=0)` | 8.2 s | 1.79 s | 2.4 s |

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix performance regression introduced in 26.4 when writing `JSON` and `Dynamic` columns in text formats.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115852&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115852](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115852+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.13`, `26.7.7.8`, `26.6.5.25`
<!-- ch-version-info:end -->