### PR TITLE
Fix flaky test 00818_inner_join_bug_3567

### DIFF
--- a/tests/queries/0_stateless/00818_inner_join_bug_3567.sql
+++ b/tests/queries/0_stateless/00818_inner_join_bug_3567.sql
@@ -10,10 +10,15 @@ CREATE TABLE table2(c String, a String, d Date) ENGINE MergeTree order by c;
 INSERT INTO table1 VALUES ('a', '2018-01-01') ('b', '2018-01-01') ('c', '2018-01-01');
 INSERT INTO table2 VALUES ('D', 'd', '2018-01-01') ('B', 'b', '2018-01-01') ('C', 'c', '2018-01-01');
 
-SELECT * FROM table1 t1 FORMAT PrettyCompact;
-SELECT *, c as a, d as b FROM table2 FORMAT PrettyCompact;
-SELECT * FROM table1 t1 ALL LEFT JOIN (SELECT *, c, d as b FROM table2) t2 USING (a, b) ORDER BY d, t1.a FORMAT PrettyCompact;
-SELECT * FROM table1 t1 ALL INNER JOIN (SELECT *, c, d as b FROM table2) t2 USING (a, b) ORDER BY d, t1.a FORMAT PrettyCompact;
+-- The test only cares about the column names in the result header, but `PrettyCompact` starts a new
+-- table for every chunk it receives, and consecutive chunks are glued together only if they arrive
+-- within `output_format_pretty_squash_consecutive_ms`. The `ALL LEFT JOIN` below emits its single
+-- non-joined row in a chunk of its own, so on a loaded machine the result is printed as two tables.
+-- `MonoBlock` squashes everything into one table regardless of chunking and timing.
+SELECT * FROM table1 t1 FORMAT PrettyCompactMonoBlock;
+SELECT *, c as a, d as b FROM table2 FORMAT PrettyCompactMonoBlock;
+SELECT * FROM table1 t1 ALL LEFT JOIN (SELECT *, c, d as b FROM table2) t2 USING (a, b) ORDER BY d, t1.a FORMAT PrettyCompactMonoBlock;
+SELECT * FROM table1 t1 ALL INNER JOIN (SELECT *, c, d as b FROM table2) t2 USING (a, b) ORDER BY d, t1.a FORMAT PrettyCompactMonoBlock;
 
 DROP TABLE table1;
 DROP TABLE table2;


### PR DESCRIPTION
`PrettyCompact` starts a new table for every chunk it receives, and glues consecutive chunks together only while they keep arriving within `output_format_pretty_squash_consecutive_ms` (50 ms by default).

The `ALL LEFT JOIN` in `00818_inner_join_bug_3567` emits its single non-joined row in a chunk of its own, so whenever the next chunk is more than 50 ms behind — which happens on a loaded runner, most often under TSan — the result is printed as two tables:

```
    ┌─a─┬──────────b─┬─c─┬──────────d─┬─c─┐
 1. │ a │ 2018-01-01 │   │ 1970-01-01 │   │
+   └───┴────────────┴───┴────────────┴───┘
+   ┌─a─┬──────────b─┬─c─┬──────────d─┬─c─┐
 2. │ b │ 2018-01-01 │ B │ 2018-01-01 │ B │
 3. │ c │ 2018-01-01 │ C │ 2018-01-01 │ C │
    └───┴────────────┴───┴────────────┴───┘
```

All 27 recorded failures of this test in the last 180 days have exactly this signature.

The test only uses a `Pretty` format to show the column names of the join result, so it switches to `PrettyCompactMonoBlock`, which squashes everything into a single table regardless of chunking and timing. The reference file is unchanged.

Verified with the randomized settings of the failed run and `output_format_pretty_squash_consecutive_ms = 0` (the worst case): 15/15 runs of the old test differ from the reference, 15/15 runs of the new one match it.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=55e5ac561cf3d55abf07459ee46425f4f15b5a45&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115865&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115865](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115865+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1894` (included in `26.8` and later)
<!-- ch-version-info:end -->