### PR TITLE
Fix DeltaLake trivial count and total_rows over tables with deletion vectors

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -66,6 +66,19 @@ namespace DB::FailPoints
 namespace DeltaLake
 {
 
+namespace
+{
+
+/// A file's `numRecords` statistic counts rows that a deletion vector still logically removes,
+/// so it is not a row count for such a file. delta-kernel states this alongside the statistic
+/// itself (`kernel/src/scan/state.rs`) and names `has_vector` as the flag to consult.
+bool hasDeletionVector(ffi::SharedDvInfo * dv_info_ptr)
+{
+    return dv_info_ptr && ffi::dv_info_has_vector(dv_info_ptr);
+}
+
+}
+
 class TableSnapshot::Iterator final : public DB::IObjectIterator
 {
 private:
@@ -551,6 +564,9 @@ public:
         if (transform.tag == ffi::OptionalValue<ffi::SharedExpression *>::Tag::Some)
             transform_handle.emplace(transform.some._0);
 
+        /// Read before `dv_info_handle` is moved into `data_files` below.
+        const bool has_deletion_vector = hasDeletionVector(dv_info_handle.get());
+
         auto * context = static_cast<TableSnapshot::Iterator *>(engine_context);
         if (context->shutdown)
         {
@@ -608,7 +624,7 @@ public:
 
         context->total_data_files += 1;
         context->total_bytes += size;
-        if (stats && context->total_rows.has_value())
+        if (stats && !has_deletion_vector && context->total_rows.has_value())
             context->total_rows.value() += stats->num_records;
         else
             context->total_rows = std::nullopt;
@@ -777,7 +793,7 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
             auto * visitor = static_cast<StatsVisitor *>(engine_context);
             visitor->total_data_files += 1;
             visitor->total_bytes += static_cast<size_t>(size);
-            if (stats && visitor->total_rows.has_value())
+            if (stats && !hasDeletionVector(dv_info_handle.get()) && visitor->total_rows.has_value())
                 visitor->total_rows.value() += stats->num_records;
             else
                 visitor->total_rows = std::nullopt;

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4824,6 +4824,99 @@ deltaLake{suffix}({cluster}
     # (not 3 because third deleted row is inside a different partition and represents a single row inside it)
     assert node.contains_in_log("Row indexes size 2 for file")
 
+    # A bare `count()` is eligible for the trivial-count optimization, which answers from the
+    # `numRecords` statistics of the surviving files: 4 here, because the deletion vector removes
+    # 2 more rows that those statistics still include. The assertions above use `ORDER BY all`,
+    # which resolves to `count()` and so makes `applyTrivialCountIfPossible` see the aggregate
+    # twice and decline, which is why they never exercised this path.
+    trivial_count_step = "ReadFromPreparedSource (Optimized trivial count)"
+
+    count_query_id = f"test_dv_count_{table_name}"
+    assert 2 == int(
+        node.query(
+            f"SELECT count() FROM {delta_function}", query_id=count_query_id
+        ).strip()
+    )
+    assert trivial_count_step not in node.query(
+        f"EXPLAIN SELECT count() FROM {delta_function}"
+    )
+    # That count went through the metadata-only stats scan, one of the two places the row counts
+    # are accumulated.
+    node.query("SYSTEM FLUSH LOGS")
+    assert 1 == int(
+        node.query(
+            f"SELECT count() FROM system.text_log WHERE query_id = '{count_query_id}' "
+            "AND message LIKE '%Updated statistics for snapshot version%'"
+        )
+    )
+
+    # Pinning a version before the DELETE keeps the pre-deletion count: that snapshot carries no
+    # deletion vector, so the optimization still applies there.
+    assert 5 == int(
+        node.query(
+            f"SELECT count() FROM {delta_function} SETTINGS delta_lake_snapshot_version = 1"
+        ).strip()
+    )
+
+    if on_cluster:
+        return
+
+    # An engine table keeps one metadata object across queries, which is what reaches the second
+    # accumulation site: the scan callback publishes the statistics a later `count()` then reads,
+    # whereas a table function rebuilds its metadata per query and only ever reaches the
+    # metadata-only stats scan.
+    engine_table = table_name + "_engine"
+    node.query(f"DROP TABLE IF EXISTS {engine_table}")
+    node.query(
+        f"CREATE TABLE {engine_table} ENGINE=DeltaLake(s3, filename = '{table_name}/', "
+        f"format=Parquet, url = 'http://minio1:9001/{bucket}/')"
+    )
+    scan_query_id = f"test_dv_scan_{table_name}"
+    node.query(f"SELECT * FROM {engine_table} FORMAT Null", query_id=scan_query_id)
+    node.query("SYSTEM FLUSH LOGS")
+    assert 1 == int(
+        node.query(
+            f"SELECT count() FROM system.text_log WHERE query_id = '{scan_query_id}' "
+            "AND message LIKE '%Updated statistics from data files iterator for snapshot version%'"
+        )
+    )
+
+    assert 2 == int(node.query(f"SELECT count() FROM {engine_table}").strip())
+    assert trivial_count_step not in node.query(
+        f"EXPLAIN SELECT count() FROM {engine_table}"
+    )
+    # `system.tables.total_rows` reads the same seam, so it reports NULL rather than an
+    # over-count. `IcebergMetadata::totalRows` behaves the same way under delete files.
+    assert 1 == int(
+        node.query(
+            f"SELECT total_rows IS NULL FROM system.tables WHERE name = '{engine_table}'"
+        ).strip()
+    )
+    # total_bytes is the size of the data files, which a deletion vector does not change.
+    assert 0 < int(
+        node.query(
+            f"SELECT total_bytes FROM system.tables WHERE name = '{engine_table}'"
+        ).strip()
+    )
+
+    # Positive control: a table with no deletion vector keeps the optimization, so the arms
+    # above distinguish "declined for this file" from "disabled for every Delta table".
+    plain_table = randomize_table_name("test_dv_plain")
+    write_delta_from_df(
+        spark, generate_data(spark, 0, 5), f"/{plain_table}", mode="overwrite"
+    )
+    upload_directory(minio_client, bucket, f"/{plain_table}", "")
+    create_delta_table(node, "s3", plain_table, started_cluster)
+    assert 5 == int(node.query(f"SELECT count() FROM {plain_table}").strip())
+    assert trivial_count_step in node.query(
+        f"EXPLAIN SELECT count() FROM {plain_table}"
+    )
+    assert 5 == int(
+        node.query(
+            f"SELECT total_rows FROM system.tables WHERE name = '{plain_table}'"
+        ).strip()
+    )
+
 
 @pytest.mark.parametrize("cluster", [False, True])
 def test_partition_columns_jumbled(started_cluster, cluster):

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4850,21 +4850,49 @@ deltaLake{suffix}({cluster}
         )
     )
 
-    # Pinning a version before the DELETE keeps the pre-deletion count: that snapshot carries no
-    # deletion vector, so the optimization still applies there.
+    # Version 1 is the overwrite that precedes the DELETE, so that snapshot carries no deletion
+    # vector and the optimization still applies to it. This is the positive control for the pinned
+    # path: without it, the assertions below would also hold if the optimization had been disabled
+    # for every Delta table rather than declined for the files that carry a vector.
     assert 5 == int(
         node.query(
             f"SELECT count() FROM {delta_function} SETTINGS delta_lake_snapshot_version = 1"
         ).strip()
     )
+    assert trivial_count_step in node.query(
+        f"EXPLAIN SELECT count() FROM {delta_function} SETTINGS delta_lake_snapshot_version = 1"
+    )
+
+    # A commit after the DELETE, so the version that carries the vector becomes an older snapshot
+    # and the counts below cannot be served by whatever the latest version happens to be.
+    df_appended = spark.createDataFrame(data=[(3, "z", "z")], schema=schema)
+    df_appended.write.format("delta").partitionBy("a").mode("append").save(path)
+    upload_directory(minio_client, bucket, path, "")
+
+    # The vector stays on the surviving file across later commits, so the newest version is
+    # over-counted too: 3 rows survive, while the statistics of its files still add up to 5.
+    assert 3 == int(node.query(f"SELECT count() FROM {delta_function}").strip())
+    assert trivial_count_step not in node.query(
+        f"EXPLAIN SELECT count() FROM {delta_function}"
+    )
+    # Version 2 is the DELETE itself. Reading it counts 2, the number of rows that version has,
+    # rather than the 4 its file statistics record.
+    assert 2 == int(
+        node.query(
+            f"SELECT count() FROM {delta_function} SETTINGS delta_lake_snapshot_version = 2"
+        ).strip()
+    )
+    assert trivial_count_step not in node.query(
+        f"EXPLAIN SELECT count() FROM {delta_function} SETTINGS delta_lake_snapshot_version = 2"
+    )
 
     if on_cluster:
         return
 
-    # An engine table keeps one metadata object across queries, which is what reaches the second
-    # accumulation site: the scan callback publishes the statistics a later `count()` then reads,
-    # whereas a table function rebuilds its metadata per query and only ever reaches the
-    # metadata-only stats scan.
+    # Scanning a table before counting it makes the scan callback publish the statistics, which is
+    # the other place the row counts are accumulated: `getSnapshotStats` caches, and the callback
+    # only fills an empty cache, so whichever query runs first decides which of the two sites is
+    # exercised.
     engine_table = table_name + "_engine"
     node.query(f"DROP TABLE IF EXISTS {engine_table}")
     node.query(
@@ -4881,7 +4909,7 @@ deltaLake{suffix}({cluster}
         )
     )
 
-    assert 2 == int(node.query(f"SELECT count() FROM {engine_table}").strip())
+    assert 3 == int(node.query(f"SELECT count() FROM {engine_table}").strip())
     assert trivial_count_step not in node.query(
         f"EXPLAIN SELECT count() FROM {engine_table}"
     )
@@ -4914,6 +4942,37 @@ deltaLake{suffix}({cluster}
     assert 5 == int(
         node.query(
             f"SELECT total_rows FROM system.tables WHERE name = '{plain_table}'"
+        ).strip()
+    )
+
+    # The control above counts before it scans, so its row count comes from the metadata-only stats
+    # scan. Reading the same data through a table that is scanned first covers the other site in
+    # the direction where it must still report a number, which the deletion-vector assertions above
+    # cannot check: they only require it to report nothing.
+    plain_scanned = plain_table + "_scanned"
+    node.query(f"DROP TABLE IF EXISTS {plain_scanned}")
+    node.query(
+        f"CREATE TABLE {plain_scanned} ENGINE=DeltaLake(s3, filename = '{plain_table}/', "
+        f"format=Parquet, url = 'http://minio1:9001/{bucket}/')"
+    )
+    plain_scan_query_id = f"test_dv_plain_scan_{table_name}"
+    node.query(
+        f"SELECT * FROM {plain_scanned} FORMAT Null", query_id=plain_scan_query_id
+    )
+    node.query("SYSTEM FLUSH LOGS")
+    assert 1 == int(
+        node.query(
+            f"SELECT count() FROM system.text_log WHERE query_id = '{plain_scan_query_id}' "
+            "AND message LIKE '%Updated statistics from data files iterator for snapshot version%'"
+        )
+    )
+    assert 5 == int(node.query(f"SELECT count() FROM {plain_scanned}").strip())
+    assert trivial_count_step in node.query(
+        f"EXPLAIN SELECT count() FROM {plain_scanned}"
+    )
+    assert 5 == int(
+        node.query(
+            f"SELECT total_rows FROM system.tables WHERE name = '{plain_scanned}'"
         ).strip()
     )
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114933   (auto-closes the issue when this PR is merged into the default branch)
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/114933

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SELECT count()` and `system.tables.total_rows` returning too many rows for a Delta Lake table whose deletes are stored as deletion vectors: the count came from the `numRecords` file statistics, which still include the removed rows. Closes #114933.

### Description

`SELECT count()` over a Delta table with `delta.enableDeletionVectors = true` counted the deleted rows: the trivial-count optimization answers from the `numRecords` statistics in `_delta_log` and never consulted the file's deletion vector. Any query that scans returned the correct answer, so `count()` disagreed with every other answer the same table gave. `system.tables.total_rows` over a `DeltaLake` engine table over-counted identically, through the same `IStorage::totalRows` seam.

`TableSnapshot` accumulates `total_rows` at two places, and both summed `stats->num_records` while holding the file's `dv_info` handle and ignoring it. delta-kernel documents that statistic as stale under a deletion vector in the same doc comment that names `DvInfo::has_vector` as the flag to consult (`kernel/src/scan/state.rs`).

Both sites now drop `total_rows` when a file carries a deletion vector, so `count()` becomes an ordinary scan, which already applies the vector correctly, and `total_rows` reports NULL rather than a wrong number. That is what `IcebergMetadata::totalRows` already does under delete files. `total_bytes` is unchanged: a deletion vector does not change data-file size. Subtracting the vector's `cardinality` would be exact, but that field is not reachable without reading the deletion-vector file, the very read this shortcut avoids.

The `delta_lake_snapshot_version` disagreement the issue also reports has the same cause and is fixed too, since `getTotalRows` is version-agnostic. On the test fixture, whose vector removes 2 rows, pinning the version that carries the vector returned 4 before and returns 2 now, matching Spark's `VERSION AS OF`. A version pinned before the delete keeps the optimization.

Extends `test_deletion_vector`, whose existing assertions use `ORDER BY all`, which makes the planner see the `count()` aggregate twice and decline the optimization, so they never reached this path. New arms cover a bare `count()`, both accumulation sites, `total_rows`, a pinned read of the version carrying the vector, and two controls that the optimization is still applied where no vector is present.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115872&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115872](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115872+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
