### PR TITLE
Add test: Streaming-subscription ALTER guard untested; PR adds `MODIFY_PROJECTION` to it

### DIFF
--- a/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.reference
+++ b/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.reference
@@ -1,0 +1,6 @@
+=== MODIFY PROJECTION is rejected while a streaming query holds a subscription ===
+SUPPORT_IS_DISABLED
+=== a settings-only ALTER is still accepted ===
+ok
+=== the projection settings are unchanged ===
+index_granularity = 1024)

--- a/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.sh
+++ b/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Tags: no-shared-merge-tree
+# no-shared-merge-tree: STREAM reads are only exercised on plain MergeTree here, like the other streaming .sh tests.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+# shellcheck source=./streaming.lib
+. "$CURDIR"/streaming.lib
+
+$STREAMING_CLIENT -q "DROP TABLE IF EXISTS t_streaming_alter_projection"
+$STREAMING_CLIENT -q "CREATE TABLE t_streaming_alter_projection (a String, b UInt64, PROJECTION p (SELECT b ORDER BY b) WITH SETTINGS (index_granularity = 1024)) ENGINE = MergeTree ORDER BY a SETTINGS $STREAMING_TABLE_SETTINGS"
+$STREAMING_CLIENT -q "INSERT INTO t_streaming_alter_projection VALUES ('started', 0)"
+
+read -r fifo pid < <(spawn $STREAMING_CLIENT -q "SELECT a FROM t_streaming_alter_projection STREAM")
+read_until "$fifo" "started" > /dev/null
+
+echo "=== MODIFY PROJECTION is rejected while a streaming query holds a subscription ==="
+$STREAMING_CLIENT -q "ALTER TABLE t_streaming_alter_projection MODIFY PROJECTION p (SELECT b ORDER BY b) WITH SETTINGS (index_granularity = 128)" 2>&1 | grep -oF "SUPPORT_IS_DISABLED" | head -n 1
+
+echo "=== a settings-only ALTER is still accepted ==="
+$STREAMING_CLIENT -q "ALTER TABLE t_streaming_alter_projection MODIFY SETTING merge_max_block_size = 8192"
+echo "ok"
+
+cleanup "$fifo" "$pid" > /dev/null
+
+echo "=== the projection settings are unchanged ==="
+$STREAMING_CLIENT -q "SELECT extract(create_table_query, 'index_granularity = \d+\)') FROM system.tables WHERE database = currentDatabase() AND name = 't_streaming_alter_projection'"
+
+$STREAMING_CLIENT -q "DROP TABLE t_streaming_alter_projection"


### PR DESCRIPTION
_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #113343](https://github.com/ClickHouse/ClickHouse/pull/113343).
That PR: (1) Adds `ALTER TABLE ... MODIFY PROJECTION [IF EXISTS] <name> (<query>) WITH SETTINGS (...)`: new `Keyword::MODIFY_PROJECTION`, new `ASTAlterCommand::MODIFY_PROJECTION` + parser/format/readJSON support, new `AlterCommand::MODIFY_PROJECTION` whose `apply` re-validates the restated declaration, …

**1. Streaming-subscription ALTER guard untested; PR adds `MODIFY_PROJECTION` to it**
  `src/Storages/MergeTree/MergeTreeData.cpp:5007`, `src/Storages/MergeTree/MergeTreeData.cpp:5014`
  **Risk:** `MergeTreeData::checkAlterIsPossible` short-circuits on `subscription_manager.hasSome()` and rejects any command in `forbidden_commands`; this PR adds `AlterCommand::MODIFY_PROJECTION` at `MergeTreeData.cpp:5007`. Risk: if the list or the guard regresses, a schema-changing ALTER lands under an in- …
  **Unique vs PR tests:** The PR's three tests all run `MODIFY PROJECTION` on a quiescent table (metadata change, per-part granularity via `system.projection_parts`, merge rebuild, error cases, replication). None of them, and no other test in either tree, runs any ALTER while a streaming subscription is held — the …

cc @diegomestre2 (author of #113343), @Michicosun (merged/approved #113343) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115887&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115887](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115887+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1906` (included in `26.8` and later)
<!-- ch-version-info:end -->