### PR TITLE
Make per-key duplicate-key bookkeeping cheaper when parsing JSON objects

### DIFF
--- a/src/Formats/JSONExtractTree.cpp
+++ b/src/Formats/JSONExtractTree.cpp
@@ -2040,6 +2040,37 @@ private:
 
         if (element.isObject() && (skip_typed_path_check || !typed_path_nodes.contains(current_path) || (format_settings.json.type_json_allow_duplicated_key_with_literal_and_nested_object && hasTypedPathWithPrefix(current_path + "."))))
         {
+            /// An object with no repeated key cannot observe the two passes below: visited_keys can
+            /// never report a repeat, key_element_types[key].size() > 1 requires a repeated key so
+            /// skip_typed is always false, and every duplicate error/skip branch is unreachable.
+            /// The probe must finish before the first recursive call: a duplicate has to be rejected
+            /// before any value is inserted, because a dynamic path created for an earlier key is not
+            /// removed when the row is later abandoned.
+            bool has_duplicated_key = false;
+            {
+                std::unordered_set<std::string_view> probed_keys;
+                for (const auto & key_value : element.getObject())
+                {
+                    if (!probed_keys.insert(key_value.first).second)
+                    {
+                        has_duplicated_key = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!has_duplicated_key)
+            {
+                for (auto [key, value] : element.getObject())
+                {
+                    String path = buildChildPath(current_path, key, insert_settings, is_root);
+                    if (!traverseAndInsert(column_object, value, path, insert_settings, format_settings, paths_and_values_for_shared_data, current_size, error, false))
+                        return false;
+                }
+
+                return true;
+            }
+
             /// First pass: collect the set of distinct element types (LITERAL/OBJECT) per key.
             /// This lets us detect all duplicates upfront so we can:
             ///  - throw errors immediately for invalid duplicates (before any data is inserted),

--- a/src/Formats/JSONExtractTree.cpp
+++ b/src/Formats/JSONExtractTree.cpp
@@ -58,6 +58,7 @@
 #include <IO/WriteHelpers.h>
 #include <IO/parseDateTimeBestEffort.h>
 
+#include <bit>
 #include <limits>
 
 namespace DB
@@ -2040,57 +2041,26 @@ private:
 
         if (element.isObject() && (skip_typed_path_check || !typed_path_nodes.contains(current_path) || (format_settings.json.type_json_allow_duplicated_key_with_literal_and_nested_object && hasTypedPathWithPrefix(current_path + "."))))
         {
-            /// An object with no repeated key cannot observe the two passes below: visited_keys can
-            /// never report a repeat, key_element_types[key].size() > 1 requires a repeated key so
-            /// skip_typed is always false, and every duplicate error/skip branch is unreachable.
-            /// The probe must finish before the first recursive call: a duplicate has to be rejected
-            /// before any value is inserted, because a dynamic path created for an earlier key is not
-            /// removed when the row is later abandoned.
-            bool has_duplicated_key = false;
-            {
-                std::unordered_set<std::string_view> probed_keys;
-                for (const auto & key_value : element.getObject())
-                {
-                    if (!probed_keys.insert(key_value.first).second)
-                    {
-                        has_duplicated_key = true;
-                        break;
-                    }
-                }
-            }
-
-            if (!has_duplicated_key)
-            {
-                for (auto [key, value] : element.getObject())
-                {
-                    String path = buildChildPath(current_path, key, insert_settings, is_root);
-                    if (!traverseAndInsert(column_object, value, path, insert_settings, format_settings, paths_and_values_for_shared_data, current_size, error, false))
-                        return false;
-                }
-
-                return true;
-            }
-
             /// First pass: collect the set of distinct element types (LITERAL/OBJECT) per key.
             /// This lets us detect all duplicates upfront so we can:
             ///  - throw errors immediately for invalid duplicates (before any data is inserted),
             ///  - handle both orderings of literal+object duplicates in the main loop
             ///    (e.g. {"a":42,"a":{"b":42}} and {"a":{"b":42},"a":42} are both valid).
-            std::unordered_map<std::string_view, std::unordered_set<JSONElementType>> key_element_types;
+            std::unordered_map<std::string_view, KeyTypes> key_element_types;
             for (auto [key, value] : element.getObject())
             {
                 auto value_element_type = getJSONElementType(value);
                 auto & types = key_element_types[key];
 
-                if (types.empty())
+                if (types.acceptedEmpty())
                 {
                     /// First occurrence of this key — just record its type.
-                    types.insert(value_element_type);
+                    types.accept(value_element_type);
                     continue;
                 }
 
                 /// Duplicate key detected. Decide whether to allow or reject.
-                if (types.contains(value_element_type))
+                if (types.accepted(value_element_type))
                 {
                     /// Same-type duplicate (e.g. two literals or two objects for the same key).
                     /// This is never allowed by type_json_allow_duplicated_key_with_literal_and_nested_object
@@ -2108,7 +2078,7 @@ private:
                 if (format_settings.json.type_json_allow_duplicated_key_with_literal_and_nested_object)
                 {
                     /// Setting enabled — record the second type so the main loop processes both.
-                    types.insert(value_element_type);
+                    types.accept(value_element_type);
                 }
                 else
                 {
@@ -2129,13 +2099,12 @@ private:
             /// Second pass: process each key-value pair in original order.
             /// All invalid duplicates have already been rejected in the first pass,
             /// so here we only need to skip already-processed (key, type) combinations.
-            std::unordered_map<std::string_view, std::unordered_set<JSONElementType>> visited_keys;
             for (auto [key, value] : element.getObject())
             {
                 String path = buildChildPath(current_path, key, insert_settings, is_root);
                 auto value_element_type = getJSONElementType(value);
-                auto it = visited_keys.find(key);
-                if (it != visited_keys.end())
+                auto & types = key_element_types[key];
+                if (!types.emittedEmpty())
                 {
                     /// We have seen this key before. Skip if:
                     ///  - we already processed a value with this element type for this key
@@ -2143,13 +2112,13 @@ private:
                     ///  - the first pass rejected this type for this key (different-type duplicate
                     ///    that was skipped because type_json_allow_duplicated_key_with_literal_and_nested_object
                     ///    is disabled but type_json_skip_duplicated_paths is enabled).
-                    if (it->second.contains(value_element_type) || !key_element_types[key].contains(value_element_type))
+                    if (types.emitted(value_element_type) || !types.accepted(value_element_type))
                         continue;
-                    it->second.insert(value_element_type);
+                    types.emit(value_element_type);
                 }
                 else
                 {
-                    visited_keys[key].insert(value_element_type);
+                    types.emit(value_element_type);
                 }
 
                 /// When a key has both literal and object values (key_element_types has 2 types),
@@ -2158,7 +2127,7 @@ private:
                 /// inserted into the typed path. Instead, pass skip_typed_path_check=true so the
                 /// recursive call enters object traversal and sends the object's children to
                 /// dynamic/shared data. The literal value will fill the typed path via normal recursion.
-                bool skip_typed = key_element_types[key].size() > 1
+                bool skip_typed = types.acceptedMoreThanOne()
                     && value_element_type == JSONElementType::OBJECT
                     && typed_path_nodes.contains(path)
                     && !canParseObjectValue(typed_paths_types.at(path));
@@ -2551,6 +2520,28 @@ private:
     {
         LITERAL = 0,
         OBJECT = 1,
+    };
+
+    /// Per-key state of the two object traversal passes, one entry per key of the object being
+    /// traversed. `accepted` is the set of element types the first pass admitted for the key,
+    /// `emitted` the set the second pass has already sent down the recursion. Both sets range over
+    /// JSONElementType, which has two enumerators, so each is a two-bit mask.
+    struct KeyTypes
+    {
+        static unsigned bit(JSONElementType type) { return 1U << static_cast<unsigned>(type); }
+
+        bool acceptedEmpty() const { return accepted_mask == 0; }
+        bool accepted(JSONElementType type) const { return accepted_mask & bit(type); }
+        bool acceptedMoreThanOne() const { return std::popcount(accepted_mask) > 1; }
+        void accept(JSONElementType type) { accepted_mask |= bit(type); }
+
+        bool emittedEmpty() const { return emitted_mask == 0; }
+        bool emitted(JSONElementType type) const { return emitted_mask & bit(type); }
+        void emit(JSONElementType type) { emitted_mask |= bit(type); }
+
+    private:
+        unsigned accepted_mask = 0;
+        unsigned emitted_mask = 0;
     };
 
     JSONElementType getJSONElementType(const typename JSONParser::Element & element) const


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/113731
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved the performance of parsing JSON objects into a `JSON` column. The per-key duplicate-key bookkeeping now keeps its two type sets as bit masks in a single map entry instead of two maps of nested sets. The gain grows with the number of keys per object, and applies whether or not the object contains a repeated key.

### Description

Related: #113731

Since `ObjectJSONNode::traverseAndInsert` was split into two passes, duplicate-key bookkeeping costs two `getJSONElementType()` calls, two `unordered_map` nodes and two nested `unordered_set` allocations per traversed key, where the single-pass version paid one of each. The cost scales with key count, not byte size. The split carries backport labels, so release branches inherit it.

`JSONElementType` has two enumerators, so a set of them is two bits. Both per-key sets now live in one map entry as bit masks: the types the first pass accepted, and those the second already emitted. That removes the nested-set allocations and the separate `visited_keys` map, and the second pass goes from up to four hash lookups per key to one.

Measured on x86_64 release builds with `UserTimeMicroseconds`, paired interleaved, 7 runs per side, across the patch releases bracketing the split (v26.6.2.160, v26.6.3.62). The regression: **1.4772** at 1000 keys per object against **1.0398** at 10 keys per object at equal byte volume, so it tracks key count rather than a general slowdown, and **1.3277** on `json_type_parsing` query 3. Against master: **0.6604** on query 3, **0.5589** at 1000 keys, **0.5676** with the duplicated key last.

Pre-scanning each object to skip the bookkeeping entirely was rejected: faster still without a repeated key, but it charges the scan to objects that have one, measuring 1.13 to 1.14 there. Duplicated literal-and-object keys are accepted by default, so that is not a rare shape.

Behaviour is unchanged, so no new test is added. A differential matrix of 60 duplicated-key cases (both orderings, three-way duplicates, typed paths, shared data, escaped dots, both settings crossed) is byte-identical to master in results and error text, while diverging from a pre-split binary. Breaking either mask changes 5, 9 or 11 of the existing duplicated-key tests' queries.

Root cause analysis by egor-click, who proposed the pre-scan variant.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115888&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115888](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115888+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
