### PR TITLE
Do not reject a distributed plan whose sort column passes through a step unchanged

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
+++ b/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
@@ -835,11 +835,15 @@ void tryReplaceScatterGatherWithShuffle(QueryPlan::Node * node)
     node->children = std::move(node->children[0]->children);
 }
 
-/// True if `column_name` is produced by `dag` as the unchanged input column of the same name (only
-/// possibly aliased). Such a column keeps its value, so a merge by it stays sort-preserving.
+/// True if `column_name` reaches the step's output with its value unchanged. Two shapes qualify: `dag`
+/// does not mention the column at all, in which case `ActionsDAG::updateHeader` copies the input column
+/// straight into the output header, or `dag` outputs the input column of the same name, only possibly
+/// aliased. Such a column keeps its value, so a merge by it stays sort-preserving.
 static bool isSortColumnPreserved(const ActionsDAG & dag, const String & column_name)
 {
-    const auto * node = &dag.findInOutputs(column_name);
+    const auto * node = dag.tryFindInOutputs(column_name);
+    if (!node)
+        return true;
     while (node->type == ActionsDAG::ActionType::ALIAS)
         node = node->children.front();
     return node->type == ActionsDAG::ActionType::INPUT && node->result_name == column_name;

--- a/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
+++ b/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
@@ -1033,11 +1033,6 @@ void optimizeExchanges(QueryPlan::Node & root, const QueryPlanOptimizationSettin
                     if (dag && dagContainsNonDeterministicFunction(*dag))
                         can_move_gather_up = false;
 
-                    /// A stateful function's output depends on the rows that precede it in the same
-                    /// stream, so below the gather it would see one bucket instead of the whole input.
-                    if (can_move_gather_up && dag && dag->hasStatefulFunctions())
-                        can_move_gather_up = false;
-
                     /// Moving the sorted GatherExchange above the step is only valid if every sort column
                     /// survives the step unchanged - otherwise GatherReceive would merge by a sort
                     /// description that no longer matches the data. Expression/Filter may recompute or

--- a/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
+++ b/src/Processors/QueryPlan/Optimizations/makeDistributed.cpp
@@ -835,10 +835,9 @@ void tryReplaceScatterGatherWithShuffle(QueryPlan::Node * node)
     node->children = std::move(node->children[0]->children);
 }
 
-/// True if `column_name` reaches the step's output with its value unchanged. Two shapes qualify: `dag`
-/// does not mention the column at all, in which case `ActionsDAG::updateHeader` copies the input column
-/// straight into the output header, or `dag` outputs the input column of the same name, only possibly
-/// aliased. Such a column keeps its value, so a merge by it stays sort-preserving.
+/// True if `column_name` reaches the step's output with its value unchanged, so a merge by it stays
+/// sort-preserving. A column the `dag` does not mention is preserved: the step forwards it untouched.
+/// A column the `dag` does mention is preserved only if it is the input column of the same name.
 static bool isSortColumnPreserved(const ActionsDAG & dag, const String & column_name)
 {
     const auto * node = dag.tryFindInOutputs(column_name);
@@ -1032,6 +1031,11 @@ void optimizeExchanges(QueryPlan::Node & root, const QueryPlanOptimizationSettin
                     /// depend on the whole block stream; below a gather they would run per shard and
                     /// produce different values. Keep such a step above the gather.
                     if (dag && dagContainsNonDeterministicFunction(*dag))
+                        can_move_gather_up = false;
+
+                    /// A stateful function's output depends on the rows that precede it in the same
+                    /// stream, so below the gather it would see one bucket instead of the whole input.
+                    if (can_move_gather_up && dag && dag->hasStatefulFunctions())
                         can_move_gather_up = false;
 
                     /// Moving the sorted GatherExchange above the step is only valid if every sort column

--- a/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.reference
+++ b/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.reference
@@ -6,4 +6,5 @@ Array key	8000
 empty input	0
 inner sorted gather moved up	1
 rewrite off keeps the gather below	1
-window values match local	1
+window values distributed	1636374373430204823
+window values local	1636374373430204823

--- a/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.reference
+++ b/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.reference
@@ -1,0 +1,9 @@
+query runs	8000
+Nullable key	8000
+LowCardinality key	8000
+LowCardinality(Nullable) key	8000
+Array key	8000
+empty input	0
+inner sorted gather moved up	1
+rewrite off keeps the gather below	1
+window values match local	1

--- a/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
+++ b/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
@@ -124,9 +124,9 @@ SELECT 'rewrite off keeps the gather below', count() > 0 FROM
 WHERE explain ILIKE '%GatherExchange (sorted by (a ASC, v ASC))%'
 SETTINGS make_distributed_plan = 0;
 
--- The distributed result for the branch-reaching shape, and the same query planned locally. Plan
--- optimization is whole-statement, so the local reference needs its own statement: a `SETTINGS` clause
--- on a FROM-subquery does not exempt that subquery's subtree from being distributed.
+-- The distributed result for the branch-reaching shape, and the same query planned locally. The local
+-- reference needs its own statement: optimization is whole-statement, so a FROM-subquery `SETTINGS` does
+-- not exempt its subtree. Measured equal for both candidate answers: regression coverage, not a witness.
 SELECT 'window values distributed', sum(cityHash64(a, v, s, r)) FROM
 (
     SELECT a, v, s, uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))

--- a/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
+++ b/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
@@ -1,0 +1,144 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- A sorted `GatherExchange` under a step whose `ActionsDAG` does not mention a sort column at all.
+-- `ActionsDAG::updateHeader` copies such a column from the input header into the output header without
+-- giving it a node in `outputs`, so the move-up check found it in the header and then failed to look it
+-- up in the DAG. Before the fix every query below was rejected during plan optimization with
+-- `Unknown identifier`.
+--
+-- The shape needs two ingredients at once: a column-keyed inner window supplies the sorted gather, and
+-- an outer window keyed by a constant supplies the step above it whose DAG holds only that constant, so
+-- every other header column is a pass-through. Either alone does not reach the branch.
+
+DROP TABLE IF EXISTS t_passthrough_sort;
+
+-- The wrapped columns cover the sort column's type matrix: the header carries the column whatever its
+-- type, so all of these reach the same branch.
+CREATE TABLE t_passthrough_sort
+(
+    a UInt32,
+    a_nullable Nullable(UInt32),
+    a_low_cardinality LowCardinality(String),
+    a_low_cardinality_nullable LowCardinality(Nullable(String)),
+    a_array Array(UInt32),
+    v UInt32
+)
+ENGINE = MergeTree ORDER BY (a, v) SETTINGS index_granularity = 256, allow_nullable_key = 1;
+
+-- Two parts so the fragment below the gather reads with more than one stream.
+INSERT INTO t_passthrough_sort SELECT number % 10, if(number % 13 = 0, NULL, number % 10),
+    toString(number % 7), if(number % 11 = 0, NULL, toString(number % 7)), [number % 3], number
+FROM numbers(4000);
+INSERT INTO t_passthrough_sort SELECT number % 10, if(number % 13 = 0, NULL, number % 10),
+    toString(number % 7), if(number % 11 = 0, NULL, toString(number % 7)), [number % 3], number + 10000000
+FROM numbers(4000);
+
+-- max_rows_to_group_by must be 0, otherwise make_distributed_plan declines plans with an aggregation.
+SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
+    distributed_plan_max_rows_to_broadcast = 0, enable_join_runtime_filters = 0,
+    distributed_plan_default_shuffle_join_bucket_count = 2, distributed_plan_default_reader_bucket_count = 2,
+    distributed_plan_optimize_exchanges = 1, max_threads = 4, max_rows_to_group_by = 0,
+    optimize_read_in_order = 0, optimize_sorting_by_input_stream_properties = 1;
+
+-- The outer window argument is a non-trivial expression on purpose: a plain aggregate is pushed below
+-- the gather and does not build the failing shape.
+SELECT 'query runs', count() FROM
+(
+    SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
+);
+
+-- The same shape with the sort column wrapped. Each of these was rejected before the fix too.
+SELECT 'Nullable key', count() FROM
+(
+    SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a_nullable, v, sum(v) OVER (PARTITION BY a_nullable ORDER BY v) AS s FROM t_passthrough_sort)
+);
+
+SELECT 'LowCardinality key', count() FROM
+(
+    SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a_low_cardinality, v, sum(v) OVER (PARTITION BY a_low_cardinality ORDER BY v) AS s
+        FROM t_passthrough_sort)
+);
+
+SELECT 'LowCardinality(Nullable) key', count() FROM
+(
+    SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a_low_cardinality_nullable, v,
+        sum(v) OVER (PARTITION BY a_low_cardinality_nullable ORDER BY v) AS s FROM t_passthrough_sort)
+);
+
+SELECT 'Array key', count() FROM
+(
+    SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a_array, v, sum(v) OVER (PARTITION BY a_array ORDER BY v) AS s FROM t_passthrough_sort)
+);
+
+-- An empty input still builds the plan, so the branch is reached with no rows to merge.
+SELECT 'empty input', count() FROM
+(
+    SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort
+        WHERE v > 999999999)
+);
+
+-- The move-up witness. A `GatherExchange` is present in this plan whether or not it moved
+-- (`tryMakeDistributedSorting` creates it unconditionally), so its mere presence proves nothing. What
+-- the fix controls is the swap: once the gather moves above the pass-through step it is replaced by a
+-- keyed shuffle, and the `(a ASC, v ASC)` sorted gather disappears. Answering "not preserved" instead
+-- would keep that gather in place, so this arm distinguishes the two candidate answers.
+-- `make_distributed_plan` is repeated inside because the outer `SETTINGS` propagates into the subquery
+-- and the outer query must stay local.
+SELECT 'inner sorted gather moved up', count() = 0 FROM
+(
+    EXPLAIN SELECT count() FROM
+    (
+        SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+            OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+        FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
+    ) SETTINGS make_distributed_plan = 1
+)
+WHERE explain ILIKE '%GatherExchange (sorted by (a ASC, v ASC))%'
+SETTINGS make_distributed_plan = 0;
+
+-- Control for the arm above: with the exchange rewrite off no move-up may happen, so the sorted
+-- gather must still be there. Without this the arm could pass for a planner that stopped distributing.
+SELECT 'rewrite off keeps the gather below', count() > 0 FROM
+(
+    EXPLAIN SELECT count() FROM
+    (
+        SELECT uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+            OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+        FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
+    ) SETTINGS make_distributed_plan = 1, distributed_plan_optimize_exchanges = 0
+)
+WHERE explain ILIKE '%GatherExchange (sorted by (a ASC, v ASC))%'
+SETTINGS make_distributed_plan = 0;
+
+-- The move-up is only correct if the pass-through column reaches the step's output unchanged. If it did
+-- not, `GatherReceive` would merge by a sort description that no longer matches the data and the inner
+-- window would be computed over the wrong row sequence, so its values would diverge from the
+-- non-distributed plan. Comparing every window value against the local plan is what checks that.
+SELECT 'window values match local', d.h = l.h FROM
+(
+    SELECT sum(cityHash64(a, v, s)) AS h FROM
+    (
+        SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort
+    )
+) AS d,
+(
+    SELECT sum(cityHash64(a, v, s)) AS h FROM
+    (
+        SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort
+    ) SETTINGS make_distributed_plan = 0
+) AS l;
+
+DROP TABLE t_passthrough_sort;

--- a/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
+++ b/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
@@ -27,6 +27,7 @@ CREATE TABLE t_passthrough_sort
 ENGINE = MergeTree ORDER BY (a, v) SETTINGS index_granularity = 256, allow_nullable_key = 1;
 
 -- Two parts so the fragment below the gather reads with more than one stream.
+SYSTEM STOP MERGES t_passthrough_sort;
 INSERT INTO t_passthrough_sort SELECT number % 10, if(number % 13 = 0, NULL, number % 10),
     toString(number % 7), if(number % 11 = 0, NULL, toString(number % 7)), [number % 3], number
 FROM numbers(4000);
@@ -126,18 +127,23 @@ SETTINGS make_distributed_plan = 0;
 -- The move-up is only correct if the pass-through column reaches the step's output unchanged. If it did
 -- not, `GatherReceive` would merge by a sort description that no longer matches the data and the inner
 -- window would be computed over the wrong row sequence, so its values would diverge from the
--- non-distributed plan. Comparing every window value against the local plan is what checks that.
+-- non-distributed plan. Both sides run the shape that reaches the branch, so the outer constant-keyed
+-- window is kept and every inner window value stays live in the hash.
 SELECT 'window values match local', d.h = l.h FROM
 (
-    SELECT sum(cityHash64(a, v, s)) AS h FROM
+    SELECT sum(cityHash64(a, v, s, r)) AS h FROM
     (
-        SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort
+        SELECT a, v, s, uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+            OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+        FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
     )
 ) AS d,
 (
-    SELECT sum(cityHash64(a, v, s)) AS h FROM
+    SELECT sum(cityHash64(a, v, s, r)) AS h FROM
     (
-        SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort
+        SELECT a, v, s, uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+            OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+        FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
     ) SETTINGS make_distributed_plan = 0
 ) AS l;
 

--- a/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
+++ b/tests/queries/0_stateless/05026_distributed_plan_passthrough_sort_column.sql
@@ -124,27 +124,21 @@ SELECT 'rewrite off keeps the gather below', count() > 0 FROM
 WHERE explain ILIKE '%GatherExchange (sorted by (a ASC, v ASC))%'
 SETTINGS make_distributed_plan = 0;
 
--- The move-up is only correct if the pass-through column reaches the step's output unchanged. If it did
--- not, `GatherReceive` would merge by a sort description that no longer matches the data and the inner
--- window would be computed over the wrong row sequence, so its values would diverge from the
--- non-distributed plan. Both sides run the shape that reaches the branch, so the outer constant-keyed
--- window is kept and every inner window value stays live in the hash.
-SELECT 'window values match local', d.h = l.h FROM
+-- The distributed result for the branch-reaching shape, and the same query planned locally. Plan
+-- optimization is whole-statement, so the local reference needs its own statement: a `SETTINGS` clause
+-- on a FROM-subquery does not exempt that subquery's subtree from being distributed.
+SELECT 'window values distributed', sum(cityHash64(a, v, s, r)) FROM
 (
-    SELECT sum(cityHash64(a, v, s, r)) AS h FROM
-    (
-        SELECT a, v, s, uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
-            OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
-        FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
-    )
-) AS d,
+    SELECT a, v, s, uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
+);
+
+SELECT 'window values local', sum(cityHash64(a, v, s, r)) FROM
 (
-    SELECT sum(cityHash64(a, v, s, r)) AS h FROM
-    (
-        SELECT a, v, s, uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
-            OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
-        FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
-    ) SETTINGS make_distributed_plan = 0
-) AS l;
+    SELECT a, v, s, uniq(modulo(s, finalizeAggregation(initializeAggregation('anyState', toNullable(-1)))))
+        OVER (PARTITION BY 'c' ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS r
+    FROM (SELECT a, v, sum(v) OVER (PARTITION BY a ORDER BY v) AS s FROM t_passthrough_sort)
+) SETTINGS make_distributed_plan = 0;
 
 DROP TABLE t_passthrough_sort;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115737   (auto-closes the issue when this PR is merged into the default branch)
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/115737

Requested by @ PedroTadim in https://github.com/ClickHouse/ClickHouse/issues/115737#issuecomment-5368109515. Reported by @ XuJia0210.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Unknown identifier` raised during query plan optimization under `make_distributed_plan = 1` when a window query's sort column passes through an `Expression` step that does not mention it. Closes #115737.

### Description

Under `make_distributed_plan = 1` and `distributed_plan_optimize_exchanges = 1`, a valid query was rejected while `optimizeExchanges` moved a sorted `GatherExchange` above an `Expression` step:

```
Code: 47. DB::Exception: Unknown identifier: '__table3.a'. (UNKNOWN_IDENTIFIER)
```

Root cause. `ActionsDAG::updateHeader` builds a step's output header from the evaluated DAG outputs plus every input-header column that matched no DAG input, copied through unchanged. Such a pass-through column is in the header while having no node in `dag.outputs`. The move-up check tested `expression_header->has(...)` first, which passes, and the short-circuit `||` then called `isSortColumnPreserved`, whose `findInOutputs` scans only `outputs` and throws instead of answering.

The change uses the existing `tryFindInOutputs` and answers "preserved" when the DAG does not mention the column. That is the correct answer, not the convenient one: `ExpressionActions` forwards an unconsumed input column's `ColumnPtr` verbatim, and both step types are `ISimpleTransform`s that cannot reorder rows, so a merge keyed by such a column stays valid. `Optimizations/Cascades/DagNameTranslation` already answers the same question the same way for the same machinery, via its `TranslatedName::Passthrough` case.

Reaching the branch needs a column-keyed inner window to build the sorted gather and an outer window keyed by a constant to put an all-pass-through step above it; the new test builds exactly that. It asserts the move-up positionally: "no longer throws" would also pass for the fail-closed answer, and a `GatherExchange` is present whether or not it moved.

Only the `Expression` carrier is reachable today, so the test covers that one. For a focused `Filter` the analyzer's `__tableN` renaming makes the preceding `expression_header->has(...)` test fail, so the `||` short-circuits before the lookup, and a `Filter` arm would pass on unpatched master.

Validation: 43 `distributed_plan` and 119 `window` tests give identical results on the patched and unpatched binary apart from the new test; 50 randomized runs of the new test pass.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115890&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115890](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115890+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1932` (included in `26.8` and later)
<!-- ch-version-info:end -->