### PR TITLE
Make h3kRing and its siblings observe cancellation while expanding a block

### DIFF
--- a/src/Functions/h3HexRing.cpp
+++ b/src/Functions/h3HexRing.cpp
@@ -8,6 +8,7 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
+#include <Functions/CancellationBudget.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Common/typeid_cast.h>
@@ -128,7 +129,13 @@ public:
         /// Allocate based on total size of arrays for all rows
         dst_data.getData().resize(current_offset);
 
-        /// Fill the array for each row with known size
+        /// Fill the array for each row with known size. The whole block is expanded inside this one call and
+        /// the size of each row's result is driven by `k` rather than by the input size, so the executor's
+        /// between-blocks cancellation check cannot bound it. The sizing loop above is `6 * k` arithmetic plus a
+        /// cell validation, which is not worth a checkpoint.
+        const std::function<void()> check_cancellation = makeCancellationCheck(name);
+        CancellationBudget budget(check_cancellation);
+
         auto* ptr = dst_data.getData().data();
         current_offset = 0;
         for (size_t row = 0; row < input_rows_count; ++row)
@@ -138,6 +145,8 @@ public:
             const auto size = dst_offsets[row] - current_offset;
             if (size == 0)
                 continue;
+
+            budget.charge(size * sizeof(H3Index));
 
             H3Error err = gridRingUnsafe(origin_hindex, k, ptr + current_offset);
 

--- a/src/Functions/h3Line.cpp
+++ b/src/Functions/h3Line.cpp
@@ -6,6 +6,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <Functions/CancellationBudget.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Common/typeid_cast.h>
@@ -94,6 +95,13 @@ public:
         auto & dst_data = *dst_data_column;
         auto & dst_offsets = dst_offsets_column->getData();
 
+        /// The whole block is expanded inside this one call and the length of each row's line is driven by the
+        /// arguments rather than by the input size, so the executor's between-blocks cancellation check cannot
+        /// bound it. Both loops carry a checkpoint: `gridPathCellsSize` walks the grid, so the sizing pass below
+        /// is expensive on its own rather than being mere arithmetic.
+        const std::function<void()> check_cancellation = makeCancellationCheck(name);
+        CancellationBudget budget(check_cancellation);
+
         /// First calculate array sizes for all rows and save them in Offsets
         UInt64 current_offset = 0;
         for (size_t row = 0; row < input_rows_count; ++row)
@@ -116,6 +124,8 @@ public:
                     "Line cannot be computed between start H3 index {} and end H3 index {}, error: {}",
                     start, end, err);
 
+            budget.charge(static_cast<size_t>(size) * sizeof(H3Index));
+
             current_offset += size;
             dst_offsets[row] = current_offset;
         }
@@ -135,6 +145,7 @@ public:
             {
                 continue;
             }
+            budget.charge(size * sizeof(H3Index));
             gridPathCells(start, end, ptr + current_offset);
             current_offset += size;
         }

--- a/src/Functions/h3ToChildren.cpp
+++ b/src/Functions/h3ToChildren.cpp
@@ -6,6 +6,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <Functions/CancellationBudget.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Common/typeid_cast.h>
@@ -99,6 +100,12 @@ public:
         auto & dst_offsets = dst_offsets_column->getData();
         auto current_offset = 0;
 
+        /// The whole block is expanded inside this one call and the size of each row's result is driven by the
+        /// arguments rather than by the input size, so the executor's between-blocks cancellation check cannot
+        /// bound it: a cancelled query would keep a thread busy until the last row was done.
+        const std::function<void()> check_cancellation = makeCancellationCheck(name);
+        CancellationBudget budget(check_cancellation);
+
         for (size_t row = 0; row < input_rows_count; ++row)
         {
             const UInt64 parent_hindex = data_hindex[row];
@@ -124,6 +131,8 @@ public:
                     ErrorCodes::TOO_LARGE_ARRAY_SIZE,
                     "The result of function {} (array of {} elements) will be too large with resolution argument = {}",
                     getName(), vec_size, toString(child_resolution));
+
+            budget.charge(vec_size * sizeof(H3Index));
 
             VectorWithMemoryTracking<H3Index> hindex_vec;
             hindex_vec.resize(vec_size);

--- a/src/Functions/h3kRing.cpp
+++ b/src/Functions/h3kRing.cpp
@@ -7,6 +7,7 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
+#include <Functions/CancellationBudget.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/IFunction.h>
 #include <Common/typeid_cast.h>
@@ -101,6 +102,12 @@ public:
         auto & dst_offsets = dst_offsets_column->getData();
         auto current_offset = 0;
 
+        /// The whole block is expanded inside this one call and the size of each row's result is driven by the
+        /// arguments rather than by the input size, so the executor's between-blocks cancellation check cannot
+        /// bound it: a cancelled query would keep a thread busy until the last row was done.
+        const std::function<void()> check_cancellation = makeCancellationCheck(name);
+        CancellationBudget budget(check_cancellation);
+
         for (size_t row = 0; row < input_rows_count; ++row)
         {
             const H3Index origin_hindex = data_hindex[row];
@@ -125,6 +132,8 @@ public:
             int64_t disk_size = 0;
             maxGridDiskSize(k, &disk_size);
             const auto vec_size = static_cast<size_t>(disk_size);
+            budget.charge(vec_size * sizeof(H3Index));
+
             VectorWithMemoryTracking<H3Index> hindex_vec;
             hindex_vec.resize(vec_size);
             gridDisk(origin_hindex, k, hindex_vec.data());

--- a/tests/queries/0_stateless/05029_h3_kring_cancellation.reference
+++ b/tests/queries/0_stateless/05029_h3_kring_cancellation.reference
@@ -1,0 +1,2 @@
+stopped at the deadline
+122	30301	1

--- a/tests/queries/0_stateless/05029_h3_kring_cancellation.sh
+++ b/tests/queries/0_stateless/05029_h3_kring_cancellation.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: the H3 library is not built in fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `h3kRing` expands a whole block of rows inside one `IFunction::executeImpl` call, so the executor's
+# between-blocks cancellation check could not bound it and `max_execution_time` was ignored until the last
+# row was done. The cost of a row is `maxGridDiskSize(k)` regardless of how many cells actually exist at the
+# cell's resolution, so a coarse cell with a large `k` burns minutes per block while producing almost
+# nothing: the query below returns 122 cells per row and does not run out of memory, it just runs.
+#
+# The oracle is the outer `timeout`, not a measured elapsed time. With the deadline observed this stops in
+# about a second; without it the same query took 250 s on a release build and 993 s under MSan in CI.
+
+if timeout 60 ${CLICKHOUSE_CLIENT} --max_execution_time 1 --max_block_size 65409 --max_rows_to_read 0 \
+        --max_memory_usage 0 --query "
+            SELECT sum(length(h3kRing(materialize(579205133326352383), toUInt16(1023)))) FROM numbers(65409)
+        " 2>&1 | grep -q -F 'TIMEOUT_EXCEEDED'
+then
+    echo 'stopped at the deadline'
+else
+    echo 'still running after 60 seconds'
+fi
+
+# The checkpoint must not change what the function returns. 579205133326352383 is a resolution 0 cell, so
+# every disk larger than the grid is the whole grid; 644325529233966508 is resolution 15, where the disk is
+# the full 3 * k * (k + 1) + 1 cells.
+
+${CLICKHOUSE_CLIENT} --query "
+    SELECT
+        length(h3kRing(materialize(579205133326352383), toUInt16(1023))),
+        length(h3kRing(materialize(644325529233966508), toUInt16(100))),
+        arraySort(h3kRing(materialize(579205133326352383), toUInt16(1))) = arraySort(h3kRing(579205133326352383, toUInt16(1)))
+"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/112203
Related: https://github.com/ClickHouse/ClickHouse/pull/113924
Related: https://github.com/ClickHouse/ClickHouse/pull/112273
Related: https://github.com/ClickHouse/ClickHouse/pull/115773

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `h3kRing`, `h3HexRing`, `h3Line` and `h3ToChildren` ignoring `max_execution_time` and `KILL QUERY` while expanding a block of rows.


### Description

`Stress test (amd_msan)` on master failed the hung check with a single query that had been
cancelled 993 s earlier, against its own `max_execution_time = 10`:

```
SELECT sum(length(h3kRing(materialize(579205133326352383), toUInt16(1023)))) FROM numbers(150000)
```

[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d3d7dc9bb6b2dfe932910da82715bcbe7d0d6806&name_0=MasterCI&name_1=Stress%20test%20%28amd_msan%29),
`is_cancelled: 1`, `peak_memory_usage: 127 MB`, the working thread inside `FunctionH3KRing::executeImpl`.
The `arm_asan_ubsan` master run 1 h earlier hung on the same shape.

These four functions expand every row of a block inside one `IFunction::executeImpl` call, and the
executor evaluates `max_execution_time` and `KILL QUERY` only between blocks, so nothing observes the
query's `QueryStatus` until the whole block is done. The per-row caps these functions already have
bound one row, not the sum over the block, and the size of a row's result is driven by the arguments
rather than by the number of rows read.

`h3kRing` is the worst of the four, and it is the reason this shows up as a hang rather than as an
error. A row costs `maxGridDiskSize(k)` regardless of how many cells exist at the cell's resolution,
and on a coarse cell `gridDiskDistancesUnsafe` fails on the pentagons, after which h3 clears that
whole buffer and walks the grid recursively. `579205133326352383` is a resolution 0 cell, where the
whole grid is 122 cells, so at `k = 1023` each row allocates and zeroes 25 MB to produce 122 cells:
the query never comes near a memory limit, it just runs. The other three produce what they cost, so
they are additionally bounded by `max_memory_usage`.

Measured on a release build, the query the fuzzer produced, one block:

```
SELECT sum(length(h3kRing(materialize(579205133326352383), toUInt16(1023))))
FROM numbers(65409)
SETTINGS max_block_size = 65409, max_execution_time = 1
```

| | elapsed |
|---|---|
| before | 250088 ms |
| after | 1004 ms |

### Implementation

The checkpoint uses `makeCancellationCheck` and `CancellationBudget`, which are already on master and
used by `countSubstrings`, `replaceString`, `countMatches` and `isProbablePrime`, so this adds no new
constant and no new mechanism. Work is charged in the bytes a row expands into rather than in rows, so
the check fires once per row while `k` is large and about every sixteen thousand rows while it is 1.

`h3Line` charges in both of its loops: `gridPathCellsSize` walks the grid rather than being arithmetic,
so its sizing pass is expensive on its own. `h3HexRing`'s sizing loop is `6 * k` arithmetic plus a cell
validation and is left alone.

This is a narrower version of #113924, which was closed. The objection there was the four hand-written
`items_between_cancellation_checks = 10'000` constants; the shared helper that removes them landed on
master in #113369 and has been used by merged work since (#114032). If the preferred answer is still a
single generic check before `IFunction::executeImpl`, note that it cannot bound these four, because the
whole block is inside one such call.

### Testing

`05029_h3_kring_cancellation.sh` runs the reported shape under `max_execution_time = 1` inside an outer
`timeout 60`, so the oracle is the outer timeout rather than a measured elapsed time, and asserts the
results are unchanged. It takes 1.7 s fixed and cannot finish unfixed. All 59 existing `h3` tests pass
against the patched binary with no hung queries.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115893&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115893](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115893+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1908` (included in `26.8` and later)
<!-- ch-version-info:end -->