### PR TITLE
Allow DESCRIBE FILESYSTEM CACHE on the introspection port

### DIFF
--- a/src/Parsers/ASTDescribeCacheQuery.h
+++ b/src/Parsers/ASTDescribeCacheQuery.h
@@ -14,6 +14,8 @@ public:
     String getID(char) const override;
     ASTPtr clone() const override;
 
+    QueryKind getQueryKind() const override { return QueryKind::Describe; }
+
 protected:
     void formatQueryImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };

--- a/tests/integration/test_introspection_port/test.py
+++ b/tests/integration/test_introspection_port/test.py
@@ -60,13 +60,22 @@ def test_introspection_port(started_cluster):
     introspection_client().query("SHOW PROCESSLIST")
 
     # Reaches the interpreter and fails on its argument instead of being refused.
+    describe_cache_query_id = "introspection_test_describe_filesystem_cache"
     assert "There is no cache by name" in introspection_client().query_and_get_error(
-        "DESCRIBE FILESYSTEM CACHE 'nonexistent'"
+        "DESCRIBE FILESYSTEM CACHE 'nonexistent'", query_id=describe_cache_query_id
     )
     # Impersonating another user is not a diagnostic query, so it stays refused.
     # On a regular port the same statement reports UNKNOWN_USER instead.
     assert "QUERY_IS_PROHIBITED" in introspection_client().query_and_get_error(
         "EXECUTE AS foo"
+    )
+    # It is admitted as a DESCRIBE, not as some other kind that the port also accepts.
+    node.query("SYSTEM FLUSH LOGS query_log")
+    assert_eq_with_retry(
+        node,
+        "SELECT DISTINCT query_kind FROM system.query_log"
+        f" WHERE query_id = '{describe_cache_query_id}'",
+        "Describe",
     )
 
     node.query("SYSTEM STOP LISTEN CUSTOM 'introspection_native'")

--- a/tests/integration/test_introspection_port/test.py
+++ b/tests/integration/test_introspection_port/test.py
@@ -59,6 +59,16 @@ def test_introspection_port(started_cluster):
     assert introspection_client().query("EXISTS TABLE system.one") == "1\n"
     introspection_client().query("SHOW PROCESSLIST")
 
+    # Reaches the interpreter and fails on its argument instead of being refused.
+    assert "There is no cache by name" in introspection_client().query_and_get_error(
+        "DESCRIBE FILESYSTEM CACHE 'nonexistent'"
+    )
+    # Impersonating another user is not a diagnostic query, so it stays refused.
+    # On a regular port the same statement reports UNKNOWN_USER instead.
+    assert "QUERY_IS_PROHIBITED" in introspection_client().query_and_get_error(
+        "EXECUTE AS foo"
+    )
+
     node.query("SYSTEM STOP LISTEN CUSTOM 'introspection_native'")
     assert introspection_client().query("SELECT 1") == "1\n"
 

--- a/tests/integration/test_introspection_port/test.py
+++ b/tests/integration/test_introspection_port/test.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from helpers.client import Client
@@ -60,7 +62,8 @@ def test_introspection_port(started_cluster):
     introspection_client().query("SHOW PROCESSLIST")
 
     # Reaches the interpreter and fails on its argument instead of being refused.
-    describe_cache_query_id = "introspection_test_describe_filesystem_cache"
+    # A fresh id per run keeps the kind assertion below scoped to this execution.
+    describe_cache_query_id = f"introspection_test_describe_cache_{uuid.uuid4()}"
     assert "There is no cache by name" in introspection_client().query_and_get_error(
         "DESCRIBE FILESYSTEM CACHE 'nonexistent'", query_id=describe_cache_query_id
     )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115806   (auto-closes the issue when this PR is merged into the default branch)
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/115806


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

On an introspection port, `DESCRIBE FILESYSTEM CACHE 'x'` was rejected with `QUERY_IS_PROHIBITED` even though the refusal message and the introspection-port documentation both list `DESCRIBE` as accepted.

`ASTDescribeCacheQuery` had no `getQueryKind` override, so it inherited `IAST::getQueryKind`'s `QueryKind::None`. `isAllowedOnIntrospectionPort` switches on the kind and `None` falls into `default: return false`, so the statement was refused before it was ever interpreted. The fix adds the missing override, returning `QueryKind::Describe` to match `DESCRIBE TABLE`. No documentation change is needed: this makes the existing page true.

Deliberately not a blanket sweep. I enumerated every class deriving from `ASTQueryWithOutput`, resolving kinds through base classes and template parameters: exactly two are `None`, and they need opposite decisions. This one is read-only and is fixed here; `ASTExecuteAsQuery` impersonates another user and must stay refused, so making `None` permissive at the allow-list would have been an access-control regression. The test asserts both directions.

The kind is not a free label, so I read every call site. Two see a change, and neither is gated by the port: the statement now reports `query_kind = Describe` instead of `None` in `system.query_log` and `system.processes`, and `isReadOnlyQuery` (which gates `ast_fuzzer_runs`) now admits it, so it becomes fuzzable. Every remaining call site keys on `Select` or `Insert`, or treats `None` and `Describe` identically.

Validated on a bare server with an introspection listener: before the fix the statement returns `Code: 392`; after, it returns rows for a configured cache, byte-identical to a regular port, and `Code: 36 BAD_ARGUMENTS` for an unknown name. Ten mutating statements and `EXECUTE AS` stay refused.

Not for changelog because the refusal cannot happen in a released version: the port landed in #110838 after 26.7 branched. The two effects above do reach released versions. Happy to switch to Bug Fix if you would rather announce them.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115894&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115894](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115894+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
