### PR TITLE
Fix flaky 03100_lwu_07_merge_patches_v1 (patch-part merge level)

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_07_merge_patches_v1.reference
+++ b/tests/queries/0_stateless/03100_lwu_07_merge_patches_v1.reference
@@ -19,11 +19,11 @@
 18	1118
 19	19
 all_1_1_0	20
-patch-63f56de952edf6cfcaf3d77635ceee5f-all_3_3_0_2	10
-patch-63f56de952edf6cfcaf3d77635ceee5f-all_5_5_0_4	7
-patch-63f56de952edf6cfcaf3d77635ceee5f-all_7_7_0_6	1
-patch-63f56de952edf6cfcaf3d77635ceee5f-all_9_9_0_8	1
-patch-63f56de952edf6cfcaf3d77635ceee5f-all_11_11_0_10	1
+patch-63f56de952edf6cfcaf3d77635ceee5f-all_3_3_<lvl>_2	10
+patch-63f56de952edf6cfcaf3d77635ceee5f-all_5_5_<lvl>_4	7
+patch-63f56de952edf6cfcaf3d77635ceee5f-all_7_7_<lvl>_6	1
+patch-63f56de952edf6cfcaf3d77635ceee5f-all_9_9_<lvl>_8	1
+patch-63f56de952edf6cfcaf3d77635ceee5f-all_11_11_<lvl>_10	1
 0	1100
 1	1
 2	102
@@ -45,5 +45,5 @@ patch-63f56de952edf6cfcaf3d77635ceee5f-all_11_11_0_10	1
 18	1118
 19	19
 all_1_1_0	20
-patch-63f56de952edf6cfcaf3d77635ceee5f-all_3_11_1_10	13
+patch-63f56de952edf6cfcaf3d77635ceee5f-all_3_11_<lvl>_10	13
 13

--- a/tests/queries/0_stateless/03100_lwu_07_merge_patches_v1.sql
+++ b/tests/queries/0_stateless/03100_lwu_07_merge_patches_v1.sql
@@ -7,7 +7,10 @@ SET enable_lightweight_update = 1;
 
 CREATE TABLE t_lwu_merge_patches_v1 (id UInt64, c1 UInt64)
 ENGINE = MergeTree ORDER BY id
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v1';
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v1',
+         -- the patch parts are listed one by one below, so only the explicit OPTIMIZE FINAL
+         -- (which ignores this limit) may merge them
+         max_bytes_to_merge_at_max_space_in_pool = 1;
 
 INSERT INTO t_lwu_merge_patches_v1 SELECT number, number FROM numbers(20);
 
@@ -18,12 +21,13 @@ UPDATE t_lwu_merge_patches_v1 SET c1 = 13000 WHERE id = 10;
 UPDATE t_lwu_merge_patches_v1 SET c1 = 15000 WHERE id = 15;
 
 SELECT * FROM t_lwu_merge_patches_v1 ORDER BY id SETTINGS apply_patch_parts = 1;
-SELECT name, rows FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_merge_patches_v1' AND active ORDER BY min_block_number;
+-- Mask the merge level in patch part names: a background merge may bump the level before the explicit OPTIMIZE FINAL below, which is irrelevant to what this test checks.
+SELECT replaceRegexpOne(name, '^(patch-[0-9a-f]+-all_[0-9]+_[0-9]+)_[0-9]+(_[0-9]+)$', '\\1_<lvl>\\2'), rows FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_merge_patches_v1' AND active ORDER BY min_block_number;
 
 OPTIMIZE TABLE t_lwu_merge_patches_v1 PARTITION ID 'patch-63f56de952edf6cfcaf3d77635ceee5f-all' FINAL;
 
 SELECT * FROM t_lwu_merge_patches_v1 ORDER BY id SETTINGS apply_patch_parts = 1;
-SELECT name, rows FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_merge_patches_v1' AND active ORDER BY min_block_number;
+SELECT replaceRegexpOne(name, '^(patch-[0-9a-f]+-all_[0-9]+_[0-9]+)_[0-9]+(_[0-9]+)$', '\\1_<lvl>\\2'), rows FROM system.parts WHERE database = currentDatabase() AND table = 't_lwu_merge_patches_v1' AND active ORDER BY min_block_number;
 SELECT count() FROM t_lwu_merge_patches_v1 WHERE c1 != id;
 
 DROP TABLE t_lwu_merge_patches_v1 SYNC;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114236
Related: https://github.com/ClickHouse/ClickHouse/pull/108594
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/114236
Related: https://github.com/ClickHouse/ClickHouse/pull/108594

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03100_lwu_07_merge_patches_v1` prints patch part names from `system.parts` around an explicit
`OPTIMIZE ... PARTITION ID ... FINAL`. The five tiny patch parts the test creates are ordinary
background-merge candidates, so a background merge can collapse them before the `OPTIMIZE` runs.
Since a merged part's level is `max(source levels) + 1`, the `OPTIMIZE` then produces
`..._3_11_2_10` instead of `..._3_11_1_10`, a one-character difference in the printed name, with
every row count unchanged.

This is the same race already fixed twice on this test's v2 twin, `03100_lwu_07_merge_patches`:
#108594 masks the level subfield, #114236 pins `max_bytes_to_merge_at_max_space_in_pool = 1`. The
`_v1` file has neither, because it was cloned from master in c324f831097ec4c (2026-07-26), before
the mask merged (07-29) and before the pin existed (08-10). This applies both hardenings verbatim,
so the two files now differ only in table name, `patch_parts_version` and partition id.

Validation: with a widened window between the first listing and the `OPTIMIZE`, the unmodified test
fails 8/8 with exactly the reported one-character diff and passes 0/8 after the change. Each half
was shown load-bearing separately on the same injected state (pin-only passes, mask-only passes,
neither fails). Crucially, the pin does not make the test vacuous: with it, the five parts survive
the window and `OPTIMIZE FINAL` still collapses them 5 -> 1 into a 13-row part over block range
`_3_11_` (`OPTIMIZE FINAL` ignores this limit by design), and the final `count()` assertion is
unchanged. 50 randomized runs of this test plus 50 of the twin: 100/100 pass.

Also noticed while enumerating the family: `03100_lwu_03_join_v1` is asymmetric with its twin too,
but correctly so: that twin's mask is a partition-hash mask needed only to survive
`patch_parts_version` randomization, which a format-pinned `_v1` clone does not need.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115897&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115897](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115897+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
