### PR TITLE
Fix LOGICAL_ERROR on a lightweight update or delete over a reversed sorting key

### DIFF
--- a/src/Storages/MergeTree/PatchParts/PatchPartsUtils.cpp
+++ b/src/Storages/MergeTree/PatchParts/PatchPartsUtils.cpp
@@ -12,6 +12,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTOrderByElement.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/KeyDescription.h>
@@ -176,8 +177,28 @@ StorageMetadataPtr getPatchPartMetadataV2(ColumnsDescription patch_part_desc, co
             order_by_expression->arguments->children.push_back(child->clone());
     }
 
-    order_by_expression->arguments->children.push_back(make_intrusive<ASTIdentifier>(BlockNumberColumn::name));
-    order_by_expression->arguments->children.push_back(make_intrusive<ASTIdentifier>(BlockOffsetColumn::name));
+    /// KeyDescription requires either all children of a key expression list to be wrapped
+    /// in ASTStorageOrderByElement, or none of them, so the trailing columns must repeat
+    /// the shape of the inherited list. They are always ascending.
+    const bool wrap_in_order_by_element = sorting_key_expr_list && !sorting_key_expr_list->children.empty()
+        && sorting_key_expr_list->children.front()->as<ASTStorageOrderByElement>();
+
+    auto add_key_column = [&](const String & column_name)
+    {
+        ASTPtr column_ast = make_intrusive<ASTIdentifier>(column_name);
+
+        if (wrap_in_order_by_element)
+        {
+            auto element = make_intrusive<ASTStorageOrderByElement>();
+            element->children.push_back(std::move(column_ast));
+            column_ast = std::move(element);
+        }
+
+        order_by_expression->arguments->children.push_back(std::move(column_ast));
+    };
+
+    add_key_column(BlockNumberColumn::name);
+    add_key_column(BlockOffsetColumn::name);
 
     addCodecsForPatchSystemColumns(patch_part_desc);
 

--- a/tests/queries/0_stateless/04702_lwu_reverse_sorting_key.reference
+++ b/tests/queries/0_stateless/04702_lwu_reverse_sorting_key.reference
@@ -1,0 +1,56 @@
+-- single reversed key column
+1	v1
+3	v3
+5	v5
+1	v1
+3	x
+5	v5
+-- mixed directions in a multi-column key
+1	1	1	v1
+0	3	3	v3
+2	5	5	v5
+1	1	1	v1
+0	3	3	x
+2	5	5	v5
+-- all-ascending key
+1	v1
+3	v3
+5	v5
+-- reversed key with a non-identifier column
+1	1	v1
+3	3	v3
+5	5	v5
+1	1	v1
+3	3	x
+5	5	v5
+-- empty sorting key
+1	v1
+3	v3
+5	v5
+-- reversed key with ReplacingMergeTree
+1	1	v1
+3	3	v3
+5	5	v5
+1	1	v1
+3	3	x
+5	5	v5
+-- two patches on a reversed key, then applied on merge
+0	a0	b0
+1	p1	b1
+2	a2	b2
+3	a3	p2
+4	a4	b4
+5	a5	b5
+0	a0	b0
+1	p1	b1
+2	a2	b2
+3	a3	p2
+4	a4	b4
+5	a5	b5
+-- reversed key with v1 patch parts
+1	v1
+3	v3
+5	v5
+1	v1
+3	x
+5	v5

--- a/tests/queries/0_stateless/04702_lwu_reverse_sorting_key.sql
+++ b/tests/queries/0_stateless/04702_lwu_reverse_sorting_key.sql
@@ -14,7 +14,7 @@ DROP TABLE IF EXISTS t_lwu_rev_v1 SYNC;
 SELECT '-- single reversed key column';
 
 CREATE TABLE t_lwu_rev (c0 UInt64, c1 String) ENGINE = MergeTree ORDER BY c0 DESC
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v2';
 
 INSERT INTO t_lwu_rev SELECT number, 'v' || toString(number) FROM numbers(6);
 
@@ -28,7 +28,7 @@ SELECT '-- mixed directions in a multi-column key';
 
 CREATE TABLE t_lwu_rev_multi (c0 UInt64, c1 UInt64, c2 UInt64, c3 String)
 ENGINE = MergeTree ORDER BY (c0 DESC, c1, c2)
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v2';
 
 INSERT INTO t_lwu_rev_multi SELECT number % 3, number, number, 'v' || toString(number) FROM numbers(6);
 
@@ -41,7 +41,7 @@ SELECT c0, c1, c2, c3 FROM t_lwu_rev_multi ORDER BY c1;
 SELECT '-- all-ascending key';
 
 CREATE TABLE t_lwu_asc (c0 UInt64, c1 String) ENGINE = MergeTree ORDER BY (c0, c1)
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v2';
 
 INSERT INTO t_lwu_asc SELECT number, 'v' || toString(number) FROM numbers(6);
 
@@ -52,7 +52,7 @@ SELECT '-- reversed key with a non-identifier column';
 
 CREATE TABLE t_lwu_rev_expr (c0 UInt64, c1 UInt64, c2 String)
 ENGINE = MergeTree ORDER BY (c0 DESC, c1 + 1)
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v2';
 
 INSERT INTO t_lwu_rev_expr SELECT number, number, 'v' || toString(number) FROM numbers(6);
 
@@ -65,7 +65,7 @@ SELECT c0, c1, c2 FROM t_lwu_rev_expr ORDER BY c0;
 SELECT '-- empty sorting key';
 
 CREATE TABLE t_lwu_empty (c0 UInt64, c1 String) ENGINE = MergeTree ORDER BY ()
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v2';
 
 INSERT INTO t_lwu_empty SELECT number, 'v' || toString(number) FROM numbers(6);
 
@@ -76,7 +76,7 @@ SELECT '-- reversed key with ReplacingMergeTree';
 
 CREATE TABLE t_lwu_rev_replacing (c0 UInt64, c1 UInt64, c2 String)
 ENGINE = ReplacingMergeTree(c1) ORDER BY c0 DESC
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v2';
 
 INSERT INTO t_lwu_rev_replacing SELECT number, number, 'v' || toString(number) FROM numbers(6);
 
@@ -89,7 +89,7 @@ SELECT c0, c1, c2 FROM t_lwu_rev_replacing ORDER BY c0;
 SELECT '-- two patches on a reversed key, then applied on merge';
 
 CREATE TABLE t_lwu_rev_merge (c0 UInt64, c1 String, c2 String) ENGINE = MergeTree ORDER BY c0 DESC
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, apply_patches_on_merge = 1;
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, apply_patches_on_merge = 1, patch_parts_version = 'v2';
 
 INSERT INTO t_lwu_rev_merge SELECT number, 'a' || toString(number), 'b' || toString(number) FROM numbers(6);
 

--- a/tests/queries/0_stateless/04702_lwu_reverse_sorting_key.sql
+++ b/tests/queries/0_stateless/04702_lwu_reverse_sorting_key.sql
@@ -1,0 +1,123 @@
+SET enable_lightweight_update = 1;
+SET lightweight_delete_mode = 'lightweight_update_force';
+SET apply_patch_parts = 1;
+
+DROP TABLE IF EXISTS t_lwu_rev SYNC;
+DROP TABLE IF EXISTS t_lwu_rev_multi SYNC;
+DROP TABLE IF EXISTS t_lwu_asc SYNC;
+DROP TABLE IF EXISTS t_lwu_rev_expr SYNC;
+DROP TABLE IF EXISTS t_lwu_empty SYNC;
+DROP TABLE IF EXISTS t_lwu_rev_replacing SYNC;
+DROP TABLE IF EXISTS t_lwu_rev_merge SYNC;
+DROP TABLE IF EXISTS t_lwu_rev_v1 SYNC;
+
+SELECT '-- single reversed key column';
+
+CREATE TABLE t_lwu_rev (c0 UInt64, c1 String) ENGINE = MergeTree ORDER BY c0 DESC
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_rev SELECT number, 'v' || toString(number) FROM numbers(6);
+
+DELETE FROM t_lwu_rev WHERE c0 % 2 = 0;
+SELECT c0, c1 FROM t_lwu_rev ORDER BY c0;
+
+UPDATE t_lwu_rev SET c1 = 'x' WHERE c0 = 3;
+SELECT c0, c1 FROM t_lwu_rev ORDER BY c0;
+
+SELECT '-- mixed directions in a multi-column key';
+
+CREATE TABLE t_lwu_rev_multi (c0 UInt64, c1 UInt64, c2 UInt64, c3 String)
+ENGINE = MergeTree ORDER BY (c0 DESC, c1, c2)
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_rev_multi SELECT number % 3, number, number, 'v' || toString(number) FROM numbers(6);
+
+DELETE FROM t_lwu_rev_multi WHERE c1 % 2 = 0;
+SELECT c0, c1, c2, c3 FROM t_lwu_rev_multi ORDER BY c1;
+
+UPDATE t_lwu_rev_multi SET c3 = 'x' WHERE c1 = 3;
+SELECT c0, c1, c2, c3 FROM t_lwu_rev_multi ORDER BY c1;
+
+SELECT '-- all-ascending key';
+
+CREATE TABLE t_lwu_asc (c0 UInt64, c1 String) ENGINE = MergeTree ORDER BY (c0, c1)
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_asc SELECT number, 'v' || toString(number) FROM numbers(6);
+
+DELETE FROM t_lwu_asc WHERE c0 % 2 = 0;
+SELECT c0, c1 FROM t_lwu_asc ORDER BY c0;
+
+SELECT '-- reversed key with a non-identifier column';
+
+CREATE TABLE t_lwu_rev_expr (c0 UInt64, c1 UInt64, c2 String)
+ENGINE = MergeTree ORDER BY (c0 DESC, c1 + 1)
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_rev_expr SELECT number, number, 'v' || toString(number) FROM numbers(6);
+
+DELETE FROM t_lwu_rev_expr WHERE c0 % 2 = 0;
+SELECT c0, c1, c2 FROM t_lwu_rev_expr ORDER BY c0;
+
+UPDATE t_lwu_rev_expr SET c2 = 'x' WHERE c0 = 3;
+SELECT c0, c1, c2 FROM t_lwu_rev_expr ORDER BY c0;
+
+SELECT '-- empty sorting key';
+
+CREATE TABLE t_lwu_empty (c0 UInt64, c1 String) ENGINE = MergeTree ORDER BY ()
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_empty SELECT number, 'v' || toString(number) FROM numbers(6);
+
+DELETE FROM t_lwu_empty WHERE c0 % 2 = 0;
+SELECT c0, c1 FROM t_lwu_empty ORDER BY c0;
+
+SELECT '-- reversed key with ReplacingMergeTree';
+
+CREATE TABLE t_lwu_rev_replacing (c0 UInt64, c1 UInt64, c2 String)
+ENGINE = ReplacingMergeTree(c1) ORDER BY c0 DESC
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_rev_replacing SELECT number, number, 'v' || toString(number) FROM numbers(6);
+
+DELETE FROM t_lwu_rev_replacing WHERE c0 % 2 = 0;
+SELECT c0, c1, c2 FROM t_lwu_rev_replacing ORDER BY c0;
+
+UPDATE t_lwu_rev_replacing SET c2 = 'x' WHERE c0 = 3;
+SELECT c0, c1, c2 FROM t_lwu_rev_replacing ORDER BY c0;
+
+SELECT '-- two patches on a reversed key, then applied on merge';
+
+CREATE TABLE t_lwu_rev_merge (c0 UInt64, c1 String, c2 String) ENGINE = MergeTree ORDER BY c0 DESC
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, apply_patches_on_merge = 1;
+
+INSERT INTO t_lwu_rev_merge SELECT number, 'a' || toString(number), 'b' || toString(number) FROM numbers(6);
+
+UPDATE t_lwu_rev_merge SET c1 = 'p1' WHERE c0 = 1;
+UPDATE t_lwu_rev_merge SET c2 = 'p2' WHERE c0 = 3;
+SELECT c0, c1, c2 FROM t_lwu_rev_merge ORDER BY c0;
+
+OPTIMIZE TABLE t_lwu_rev_merge FINAL SETTINGS optimize_throw_if_noop = 1;
+SELECT c0, c1, c2 FROM t_lwu_rev_merge ORDER BY c0;
+
+SELECT '-- reversed key with v1 patch parts';
+
+CREATE TABLE t_lwu_rev_v1 (c0 UInt64, c1 String) ENGINE = MergeTree ORDER BY c0 DESC
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v1';
+
+INSERT INTO t_lwu_rev_v1 SELECT number, 'v' || toString(number) FROM numbers(6);
+
+DELETE FROM t_lwu_rev_v1 WHERE c0 % 2 = 0;
+SELECT c0, c1 FROM t_lwu_rev_v1 ORDER BY c0;
+
+UPDATE t_lwu_rev_v1 SET c1 = 'x' WHERE c0 = 3;
+SELECT c0, c1 FROM t_lwu_rev_v1 ORDER BY c0;
+
+DROP TABLE t_lwu_rev SYNC;
+DROP TABLE t_lwu_rev_multi SYNC;
+DROP TABLE t_lwu_asc SYNC;
+DROP TABLE t_lwu_rev_expr SYNC;
+DROP TABLE t_lwu_empty SYNC;
+DROP TABLE t_lwu_rev_replacing SYNC;
+DROP TABLE t_lwu_rev_merge SYNC;
+DROP TABLE t_lwu_rev_v1 SYNC;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/103182


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes an unreleased defect from #103182 (`master` only): `DELETE` and `UPDATE` on a `MergeTree` table whose sorting key has a descending column, with `enable_block_number_column` and `enable_block_offset_column` enabled, raised `The size of reverse_flags (N) does not match the size of KeyDescription M`. No stable release is affected, so no changelog entry and no backport are owed.

### Description

`DELETE FROM t WHERE ...` and `UPDATE t SET ...` failed with an internal error instead of executing, for any table combining a reversed sorting key (`ORDER BY c0 DESC`) with `enable_block_number_column = 1, enable_block_offset_column = 1`. Found by BuzzHouse on unrelated PRs (`DELETE FROM d18.t278 WHERE (NULL)`; [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115867&sha=37ea12a03c9459bceb92b5022ca2d1b38dfc01fe&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29)). Ordinary DML, no experimental setting, and `patch_parts_version` defaults to `v2`, so this is the default path on `master`. `v2` patch parts arrived in #103182, which is in no release branch.

Root cause: `KeyDescription` requires a key expression list to be either entirely wrapped in `ASTStorageOrderByElement` or not wrapped at all (the contract is stated at `ParserCreateQuery.cpp:567-569`). `getPatchPartMetadataV2` built the patch part's sorting key by mixing both shapes: it appended the table key children returned by `getOriginalExpressionList()`, which re-wraps every child when the key has a reversed column, and then appended bare identifiers for `_block_number` and `_block_offset`. `buildKeyColumns` records a direction flag only for wrapped children, so `reverse_flags` ended up two entries short and the consistency check in `getKeyFromAST` threw.

The fix appends those two trailing columns in the shape inherited from the list, so `getKeyFromAST` always receives a uniform list and the flags line up positionally. `KeyDescription.cpp` is untouched and its check stays armed. For a table with no reversed column the emitted AST is unchanged.

Validated with a deterministic reproducer in both directions, and by confirming the formatted key text and the patch partition ids stay byte-identical across the change. Ascending-key patch parts, the only shape a pre-fix binary can write, were exchanged both ways between the two binaries and merged, which exercises the equality check on the persisted `sorting_key_desc`. A descending key has no pre-fix counterpart: writing such a patch is the statement that failed.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115900&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115900](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115900+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
