### PR TITLE
Remove stale no-replicated-database tags from TimeSeries tests

### DIFF
--- a/tests/queries/0_stateless/04131_prometheus_query_parser.sql
+++ b/tests/queries/0_stateless/04131_prometheus_query_parser.sql
@@ -1,7 +1,6 @@
--- Tags: no-fasttest, no-replicated-database
+-- Tags: no-fasttest
 -- ^^ ANTLR4 support is disabled in the fast-test build, and the PromQL
--- grammar requires it. The experimental TimeSeries table engine does not
--- round-trip through DatabaseReplicated and the cleanup query hangs.
+-- grammar requires it.
 --
 -- Exercise Prometheus/PromQL parsing (Parsers/Prometheus/PrometheusQueryParsingUtil.cpp
 -- and the ANTLR visitor) via the prometheusQuery() / prometheusQueryRange() table

--- a/tests/queries/0_stateless/04201_time_series_selector_join_stateful.sql
+++ b/tests/queries/0_stateless/04201_time_series_selector_join_stateful.sql
@@ -1,8 +1,5 @@
--- Tags: no-fasttest, no-replicated-database
+-- Tags: no-fasttest
 -- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
--- Tag no-replicated-database: `DatabaseReplicated::dropTable` does not drop `TimeSeries` inner tables
--- synchronously (unlike for `MaterializedView`), so the deferred inner DROPs are rejected with
--- "It's not initial query. ON CLUSTER is not allowed for Replicated database.".
 
 -- Regression test for the PromQL binary-operator path where ClickHouse query optimization
 -- could push `timeSeriesIdToGroup(id)` ahead of the matching `timeSeriesStoreTags(...)` call,

--- a/tests/queries/0_stateless/04202_prometheus_query_datetime64_nanosecond_modern_timestamp.sql
+++ b/tests/queries/0_stateless/04202_prometheus_query_datetime64_nanosecond_modern_timestamp.sql
@@ -1,7 +1,6 @@
--- Tags: no-fasttest, no-replicated-database
+-- Tags: no-fasttest
 -- ^^ ANTLR4 support is disabled in the fast-test build, and the PromQL
--- grammar requires it. The experimental TimeSeries table engine does not
--- round-trip through DatabaseReplicated.
+-- grammar requires it.
 
 -- Regression test for `timeSeriesTimestampToAST`. With `DateTime64(9)` and a
 -- modern Unix timestamp the raw value (e.g. 1.7e18 for 2024-01-01) exceeds

--- a/tests/queries/0_stateless/04337_prometheus_query_nan_timestamp.sql
+++ b/tests/queries/0_stateless/04337_prometheus_query_nan_timestamp.sql
@@ -1,7 +1,6 @@
--- Tags: no-fasttest, no-replicated-database
+-- Tags: no-fasttest
 -- ^^ ANTLR4 support is disabled in the fast-test build, and the PromQL
--- grammar requires it. The experimental TimeSeries table engine does not
--- round-trip through DatabaseReplicated.
+-- grammar requires it.
 
 -- Regression test: a non-finite Float64 (NaN/inf) argument used as a
 -- timestamp/duration in prometheusQuery / prometheusQueryRange must produce a

--- a/tests/queries/0_stateless/04549_promql_dialect_query_cache.sh
+++ b/tests/queries/0_stateless/04549_promql_dialect_query_cache.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-replicated-database
+# Tags: no-fasttest
 # no-fasttest: the PromQL grammar requires ANTLR4 which is disabled in the fast-test build.
-# no-replicated-database: the experimental TimeSeries table engine does not round-trip through DatabaseReplicated.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04627_timeseries_tf_string_arg_wrappers.sql
+++ b/tests/queries/0_stateless/04627_timeseries_tf_string_arg_wrappers.sql
@@ -1,6 +1,5 @@
--- Tags: no-fasttest, no-replicated-database
--- ^^ PromQL grammar needs ANTLR4 (disabled in fast-test); the experimental TimeSeries engine does
--- not round-trip through DatabaseReplicated.
+-- Tags: no-fasttest
+-- ^^ PromQL grammar needs ANTLR4 (disabled in fast-test).
 --
 -- The `prometheusQuery` / `timeSeriesSelector` table functions read their String arguments via
 -- `evaluateConstantExpressionAsColumn` (no `Field`). This pins the compatibility contract the

--- a/tests/queries/0_stateless/04648_timeseries_samples_codecs.sql
+++ b/tests/queries/0_stateless/04648_timeseries_samples_codecs.sql
@@ -1,5 +1,7 @@
 -- Tags: no-replicated-database
--- Tag no-replicated-database: the experimental TimeSeries table engine does not round-trip through DatabaseReplicated.
+-- Tag no-replicated-database: the DETACH/ATTACH round-trip below hangs in DatabaseReplicated mode
+-- because ATTACH TABLE with a TimeSeries engine goes through the replicated DDL log and requires
+-- replica sync (same as 04146_timeseries_attach_detach.sql).
 
 -- Auto-created `timestamp` and `value` columns of the TimeSeries samples inner table
 -- get compression codecs (DoubleDelta + ZSTD for timestamps, plain ZSTD for values);

--- a/tests/queries/0_stateless/04692_prometheus_query_parse_error_long_input.sh
+++ b/tests/queries/0_stateless/04692_prometheus_query_parse_error_long_input.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-replicated-database
+# Tags: no-fasttest
 # no-fasttest: ANTLR4 support is disabled in the fast-test build, and the PromQL grammar needs it.
-# no-replicated-database: the experimental `TimeSeries` table engine does not round-trip through `DatabaseReplicated`.
 
 # A PromQL query with a long tail of unrecognized characters (e.g. a `FixedString` padded with NUL
 # bytes) must be rejected quickly. The lexer used to recover from each bad byte one at a time and

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, no-replicated-database, no-parallel-replicas
+-- Tags: no-fasttest, no-parallel-replicas
 -- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
 -- Tag no-parallel-replicas: the test asserts on the query plan shape (the number of reads of the samples table).
 

--- a/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.sql
+++ b/tests/queries/0_stateless/04836_time_series_selector_whole_metric_pk_range.sql
@@ -1,7 +1,5 @@
--- Tags: no-fasttest, no-replicated-database, long
+-- Tags: no-fasttest, long
 -- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
--- Tag no-replicated-database: `DatabaseReplicated::dropTable` does not drop `TimeSeries` inner tables
--- synchronously, so the deferred inner DROPs are rejected with "ON CLUSTER is not allowed for Replicated database".
 
 -- `timeSeriesSelector` (and every PromQL selector evaluated through it) filters the samples table with
 -- `id IN <tags subquery>`. With a two-component id layout `Tuple(hash(metric_name), hash(tags))`

--- a/tests/queries/0_stateless/04838_timeseries_tags_column_contains_all_tags.sql
+++ b/tests/queries/0_stateless/04838_timeseries_tags_column_contains_all_tags.sql
@@ -1,7 +1,6 @@
--- Tags: no-fasttest, no-replicated-database
+-- Tags: no-fasttest
 -- ^^ ANTLR4 support is disabled in the fast-test build, and the PromQL
--- grammar requires it. The experimental TimeSeries table engine does not
--- round-trip through DatabaseReplicated.
+-- grammar requires it.
 
 -- The `tags` column of the tags target table contains all the tags, including the metric name
 -- (the `__name__` tag) and the tags with dedicated columns from the `tags_to_columns` setting.

--- a/tests/queries/0_stateless/04897_promql_offset_in_range_selector.sql
+++ b/tests/queries/0_stateless/04897_promql_offset_in_range_selector.sql
@@ -1,7 +1,6 @@
--- Tags: no-fasttest, no-replicated-database
+-- Tags: no-fasttest
 -- ^^ ANTLR4 support is disabled in the fast-test build, and the PromQL
--- grammar requires it. The experimental TimeSeries table engine does not
--- round-trip through DatabaseReplicated.
+-- grammar requires it.
 
 -- Regression test: `offset` inside a range selector (e.g. `rate(m[2m] offset 5m)`)
 -- used to fail with "Illegal type Decimal(18, 0) of argument of function

--- a/tests/queries/0_stateless/05026_time_series_recent_samples_default.sql
+++ b/tests/queries/0_stateless/05026_time_series_recent_samples_default.sql
@@ -1,6 +1,5 @@
--- Tags: no-fasttest, no-replicated-database
+-- Tags: no-fasttest
 -- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
--- Tag no-replicated-database: `DatabaseReplicated` does not drop `TimeSeries` inner tables synchronously; deferred DROPs are rejected.
 
 SET allow_experimental_time_series_table = 1;
 SET session_timezone = 'UTC';


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Dropping a `TimeSeries` table in a `Replicated` database was fixed in https://github.com/ClickHouse/ClickHouse/pull/107604, so the tests tagged `no-replicated-database` only because of that problem can run in the replicated-database suite again. Tests exercising `DETACH`/`ATTACH` keep the tag because `ATTACH TABLE` of a `TimeSeries` table still hangs in `DatabaseReplicated` mode.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115902&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115902](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115902+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.162` (included in `26.9` and later)
<!-- ch-version-info:end -->