### PR TITLE
Make test_server_overload deterministic under the metrics-reset window

### DIFF
--- a/tests/integration/test_server_overload/configs/min_cpu_busy_time.xml
+++ b/tests/integration/test_server_overload/configs/min_cpu_busy_time.xml
@@ -1,3 +1,4 @@
 <clickhouse>
-    <os_cpu_busy_time_threshold>300000</os_cpu_busy_time_threshold>
+    <!-- The wait/busy ratio, not a busy-time budget, decides overload here. -->
+    <os_cpu_busy_time_threshold>0</os_cpu_busy_time_threshold>
 </clickhouse>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113529


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_server_overload::test_overload` still fails intermittently with #113529 merged
([run](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112972&sha=62c3d740b368ad7fe5555d333afd791b069f1572&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29)).
That PR removed the Bernoulli lottery; a sampling one remained.

`checkCPUOverload` reads `getCPUOverload(os_cpu_busy_time_threshold)` with `reset=false`
(`ProfileEvents.cpp:1972`), which returns 0 at `:2039` while busy time accrued since the last reset is
below the threshold; on 0 the ratio, the ramp and the draw are never evaluated. The only resetting caller
is `AsynchronousMetrics.cpp:2734`, so every window opens at zero busy time and its first
`threshold / busy_rate` cannot throw - ~0.43 s on the failing runner. The probe loop samples that grid at
~0.99 s (a fresh `clickhouse-client` per probe, not the 0.3 s sleep), drifting only ~9 ms per iteration,
so a run starting inside that window stays there.

Setting the fixture's `os_cpu_busy_time_threshold` to `0` makes the measured ratio decide, not the
probe's arrival time. `0` is not a tuned constant: it degenerates to the liveness precondition the ratio
needs (no zero denominator, no ratio from an idle window). What excludes an unloaded server is
`min_os_cpu_wait_time_ratio_to_throw`, not this budget - on an idle node at threshold `0` the ratios
reaching the ramp are 0.137-0.470, all probability 0. Both `probability ... 1.` assertions from #113529
are kept, and the test now throws on probe 1.

Validated both directions: with the fix `test_overload` passes 10/10 debug, 10/10 asan+ubsan and 50/50,
`test_drop_connections` 10/10; with `checkCPUOverload` returning early, the ramp forced to 0, or the
threshold unreachably high it fails 3/3 each with CI's assertion.

Left alone: node2's `early_drop.xml` keeps `300000` - it shares the blind window but is green, and its
config also carries the drop-connection ratios. `helpers/min_cpu_busy_time.xml` holds `300000` too, but
nothing references it. The product default `1'000'000` is unchanged - two `getCPUOverload` consumers
sharing one `prev_*` pair gives any server a short blind window each period, a product question rather
than a test fix.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115905&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115905](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115905+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1931` (included in `26.8` and later)
<!-- ch-version-info:end -->