### PR TITLE
Evaluate `_sample_factor` as 1 in on-the-fly mutation expressions

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1318,6 +1318,37 @@ void ActionsDAG::substitute(const std::unordered_map<const Node *, ColumnWithTyp
     }
 }
 
+void ActionsDAG::substituteInputForConsumersOnly(const std::string & input_name, const ColumnWithTypeAndName & replacement)
+{
+    auto it = std::ranges::find_if(inputs, [&](const Node * node) { return node->result_name == input_name; });
+    if (it == inputs.end())
+        return;
+
+    const Node * input = *it;
+
+    if (!replacement.column || !isColumnConst(*replacement.column))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Replacement for input {} must be a constant column", input_name);
+    if (!replacement.type->equals(*input->result_type))
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Replacement for input {} has type {} but the input has type {}",
+            input_name,
+            replacement.type->getName(),
+            input->result_type->getName());
+
+    const auto & constant = addColumn(
+        typeid_cast<const ColumnConst *>(replacement.column.get())->getPtr(), replacement.type, replacement.name);
+
+    for (auto & node : nodes)
+    {
+        for (auto & child : node.children)
+        {
+            if (child == input)
+                child = &constant;
+        }
+    }
+}
+
 static ColumnWithTypeAndName executeActionForPartialResult(
     const ActionsDAG::Node * node,
     ColumnsWithTypeAndName arguments,

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -316,9 +316,9 @@ public:
     /// Replace each node listed in `substitutions` (a node of this DAG) with a constant COLUMN node.
     void substitute(const std::unordered_map<const Node *, ColumnWithTypeAndName> & substitutions);
 
-    /// Rewire consumers of the input named `input_name` to a constant, leaving the input node and the
-    /// outputs untouched: expressions computed here see `replacement`, while a passthrough output of
-    /// the same name keeps the value supplied for the input.
+    /// Rewire consumers of the input named `input_name` to a constant. The input node and the output
+    /// list are unchanged, so an output that IS that input keeps the value supplied for it; an output
+    /// computed FROM it, including an alias, is a consumer and sees `replacement`.
     void substituteInputForConsumersOnly(const std::string & input_name, const ColumnWithTypeAndName & replacement);
 
     /// Clone the DAG, retaining only the subgraph computable from the specified available input columns.

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -316,6 +316,11 @@ public:
     /// Replace each node listed in `substitutions` (a node of this DAG) with a constant COLUMN node.
     void substitute(const std::unordered_map<const Node *, ColumnWithTypeAndName> & substitutions);
 
+    /// Rewire consumers of the input named `input_name` to a constant, leaving the input node and the
+    /// outputs untouched: expressions computed here see `replacement`, while a passthrough output of
+    /// the same name keeps the value supplied for the input.
+    void substituteInputForConsumersOnly(const std::string & input_name, const ColumnWithTypeAndName & replacement);
+
     /// Clone the DAG, retaining only the subgraph computable from the specified available input columns.
     /// Special handling for logical AND: non-computable children are replaced with constant true.
     /// Useful for evaluating boolean filters in projection indices when some input columns are missing.

--- a/src/Storages/MergeTree/AlterConversions.cpp
+++ b/src/Storages/MergeTree/AlterConversions.cpp
@@ -11,6 +11,8 @@
 #include <Parsers/ASTLiteral.h>
 #include <Common/ProfileEvents.h>
 #include <Core/Settings.h>
+#include <Columns/ColumnConst.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <ranges>
 
 namespace ProfileEvents
@@ -384,9 +386,22 @@ PrewhereExprSteps AlterConversions::getMutationSteps(
         }
     }
 
+    /// A mutation expression is evaluated with the sample factor its background materialization sees,
+    /// which is 1 (`createMergeTreeSequentialSource`), never the reading query's factor. Only the
+    /// expression's dependency is rebound; the column the step forwards to the query is unaffected.
+    const bool bind_sample_factor = metadata_snapshot->isVirtualColumn("_sample_factor");
+
     PrewhereExprSteps steps;
     for (auto & actions : actions_chain)
     {
+        if (bind_sample_factor)
+        {
+            DataTypePtr type = std::make_shared<DataTypeFloat64>();
+            auto column = type->createColumnConst(1, Field(1.0));
+            actions.dag.substituteInputForConsumersOnly(
+                "_sample_factor", ColumnWithTypeAndName{column->getPtr(), type, "_sample_factor"});
+        }
+
         /// For mutations before ALTER MODIFY we should not apply conversions
         /// because correctness of ALTER MODIFY may depend on the result of mutation.
         bool perform_alter_conversions = !version_of_alter_mutation || actions.mutation_version > version_of_alter_mutation;

--- a/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.reference
+++ b/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.reference
@@ -1,12 +1,24 @@
+pending	1
 preview sampled	1	2
 preview plain	1	1
 preview sampled no outer sf	1
 preview off	0
 materialized sampled	1	2
 materialized plain	1	1
+pending	1
 delete preview sampled	100
 delete preview plain	100
 delete materialized sampled	100
 delete materialized plain	100
+pending	1
+delete inverse preview sampled	90
+delete inverse preview plain	90
+delete inverse materialized sampled	90
+delete inverse materialized plain	90
+pending	1
 shadow preview sampled	126	42
 shadow materialized sampled	126	42
+pending	1
+shadow mat preview sampled	5	15
+shadow mat preview plain	5	15
+shadow mat materialized sampled	5	15

--- a/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.reference
+++ b/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.reference
@@ -1,0 +1,12 @@
+preview sampled	1	2
+preview plain	1	1
+preview sampled no outer sf	1
+preview off	0
+materialized sampled	1	2
+materialized plain	1	1
+delete preview sampled	100
+delete preview plain	100
+delete materialized sampled	100
+delete materialized plain	100
+shadow preview sampled	126	42
+shadow materialized sampled	126	42

--- a/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.sql
+++ b/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.sql
@@ -1,0 +1,67 @@
+DROP TABLE IF EXISTS t_ofsf;
+CREATE TABLE t_ofsf (c0 UInt32, u Float64 DEFAULT 0) ENGINE = MergeTree ORDER BY c0 SAMPLE BY c0;
+INSERT INTO t_ofsf SELECT number, 0 FROM numbers(100);
+
+SYSTEM STOP MERGES t_ofsf;
+SET mutations_sync = 0;
+ALTER TABLE t_ofsf UPDATE u = _sample_factor WHERE 1;
+
+-- The pair is the oracle: the previewed `u` must be what the background mutation persists (1),
+-- while the query's own `_sample_factor` must still be the query's factor (2).
+SELECT 'preview sampled', any(u), any(_sample_factor) FROM t_ofsf SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
+SELECT 'preview plain', any(u), any(_sample_factor) FROM t_ofsf SETTINGS apply_mutations_on_fly = 1;
+-- The outer query does not name the virtual at all.
+SELECT 'preview sampled no outer sf', any(u) FROM t_ofsf SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
+-- Preview off: the mutation is not applied, so the column keeps its stored value.
+SELECT 'preview off', any(u) FROM t_ofsf SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 0;
+
+SYSTEM START MERGES t_ofsf;
+SET mutations_sync = 2;
+ALTER TABLE t_ofsf DELETE WHERE 0;
+
+SELECT 'materialized sampled', any(u), any(_sample_factor) FROM t_ofsf SAMPLE 0.5;
+SELECT 'materialized plain', any(u), any(_sample_factor) FROM t_ofsf;
+
+DROP TABLE t_ofsf;
+
+-- Row-count carrier: with the query's factor the predicate is true for every row and the preview
+-- drops the whole table.
+DROP TABLE IF EXISTS t_ofsf_del;
+CREATE TABLE t_ofsf_del (c0 UInt32) ENGINE = MergeTree ORDER BY c0 SAMPLE BY c0;
+INSERT INTO t_ofsf_del SELECT number FROM numbers(100);
+
+SYSTEM STOP MERGES t_ofsf_del;
+SET mutations_sync = 0;
+ALTER TABLE t_ofsf_del DELETE WHERE _sample_factor > 1;
+
+SELECT 'delete preview sampled', count() FROM t_ofsf_del SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
+SELECT 'delete preview plain', count() FROM t_ofsf_del SETTINGS apply_mutations_on_fly = 1;
+
+SYSTEM START MERGES t_ofsf_del;
+SET mutations_sync = 2;
+ALTER TABLE t_ofsf_del DELETE WHERE 0;
+
+SELECT 'delete materialized sampled', count() FROM t_ofsf_del SAMPLE 0.5;
+SELECT 'delete materialized plain', count() FROM t_ofsf_del;
+
+DROP TABLE t_ofsf_del;
+
+-- A physical column shadows the virtual, so the mutation must read the stored value.
+DROP TABLE IF EXISTS t_ofsf_shadow;
+CREATE TABLE t_ofsf_shadow (c0 UInt32, _sample_factor Float64, d Float64 DEFAULT _sample_factor * 3, u Float64 DEFAULT 0)
+ENGINE = MergeTree ORDER BY c0 SAMPLE BY c0;
+INSERT INTO t_ofsf_shadow (c0, _sample_factor) SELECT number, 42 FROM numbers(100);
+
+SYSTEM STOP MERGES t_ofsf_shadow;
+SET mutations_sync = 0;
+ALTER TABLE t_ofsf_shadow UPDATE u = d WHERE 1;
+
+SELECT 'shadow preview sampled', any(u), any(_sample_factor) FROM t_ofsf_shadow SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
+
+SYSTEM START MERGES t_ofsf_shadow;
+SET mutations_sync = 2;
+ALTER TABLE t_ofsf_shadow DELETE WHERE 0;
+
+SELECT 'shadow materialized sampled', any(u), any(_sample_factor) FROM t_ofsf_shadow SAMPLE 0.5;
+
+DROP TABLE t_ofsf_shadow;

--- a/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.sql
+++ b/tests/queries/0_stateless/05029_on_fly_mutation_sample_factor.sql
@@ -6,6 +6,11 @@ SYSTEM STOP MERGES t_ofsf;
 SET mutations_sync = 0;
 ALTER TABLE t_ofsf UPDATE u = _sample_factor WHERE 1;
 
+-- Every preview expectation below equals its materialized counterpart, so the arms only exercise the
+-- on-the-fly path while the mutation is unfinished.
+SELECT 'pending', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_ofsf' AND NOT is_done;
+
 -- The pair is the oracle: the previewed `u` must be what the background mutation persists (1),
 -- while the query's own `_sample_factor` must still be the query's factor (2).
 SELECT 'preview sampled', any(u), any(_sample_factor) FROM t_ofsf SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
@@ -34,6 +39,9 @@ SYSTEM STOP MERGES t_ofsf_del;
 SET mutations_sync = 0;
 ALTER TABLE t_ofsf_del DELETE WHERE _sample_factor > 1;
 
+SELECT 'pending', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_ofsf_del' AND NOT is_done;
+
 SELECT 'delete preview sampled', count() FROM t_ofsf_del SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
 SELECT 'delete preview plain', count() FROM t_ofsf_del SETTINGS apply_mutations_on_fly = 1;
 
@@ -46,7 +54,34 @@ SELECT 'delete materialized plain', count() FROM t_ofsf_del;
 
 DROP TABLE t_ofsf_del;
 
--- A physical column shadows the virtual, so the mutation must read the stored value.
+-- Inverse row-count carrier: 90 rows survive only when the filter runs with the factor the background
+-- mutation sees. Either the query's factor reaching the predicate or the filter not running at all
+-- leaves all 100.
+DROP TABLE IF EXISTS t_ofsf_del_inv;
+CREATE TABLE t_ofsf_del_inv (c0 UInt32) ENGINE = MergeTree ORDER BY c0 SAMPLE BY c0;
+INSERT INTO t_ofsf_del_inv SELECT number FROM numbers(100);
+
+SYSTEM STOP MERGES t_ofsf_del_inv;
+SET mutations_sync = 0;
+ALTER TABLE t_ofsf_del_inv DELETE WHERE _sample_factor = 1 AND c0 < 10;
+
+SELECT 'pending', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_ofsf_del_inv' AND NOT is_done;
+
+SELECT 'delete inverse preview sampled', count() FROM t_ofsf_del_inv SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
+SELECT 'delete inverse preview plain', count() FROM t_ofsf_del_inv SETTINGS apply_mutations_on_fly = 1;
+
+SYSTEM START MERGES t_ofsf_del_inv;
+SET mutations_sync = 2;
+ALTER TABLE t_ofsf_del_inv DELETE WHERE 0;
+
+SELECT 'delete inverse materialized sampled', count() FROM t_ofsf_del_inv SAMPLE 0.5;
+SELECT 'delete inverse materialized plain', count() FROM t_ofsf_del_inv;
+
+DROP TABLE t_ofsf_del_inv;
+
+-- A stored column over a shadowed physical _sample_factor keeps its inserted value under a pending
+-- mutation.
 DROP TABLE IF EXISTS t_ofsf_shadow;
 CREATE TABLE t_ofsf_shadow (c0 UInt32, _sample_factor Float64, d Float64 DEFAULT _sample_factor * 3, u Float64 DEFAULT 0)
 ENGINE = MergeTree ORDER BY c0 SAMPLE BY c0;
@@ -55,6 +90,9 @@ INSERT INTO t_ofsf_shadow (c0, _sample_factor) SELECT number, 42 FROM numbers(10
 SYSTEM STOP MERGES t_ofsf_shadow;
 SET mutations_sync = 0;
 ALTER TABLE t_ofsf_shadow UPDATE u = d WHERE 1;
+
+SELECT 'pending', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_ofsf_shadow' AND NOT is_done;
 
 SELECT 'shadow preview sampled', any(u), any(_sample_factor) FROM t_ofsf_shadow SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
 
@@ -65,3 +103,28 @@ ALTER TABLE t_ofsf_shadow DELETE WHERE 0;
 SELECT 'shadow materialized sampled', any(u), any(_sample_factor) FROM t_ofsf_shadow SAMPLE 0.5;
 
 DROP TABLE t_ofsf_shadow;
+
+-- A MATERIALIZED column recomputed by the mutation resolves its dependency to the shadowing physical
+-- column, so `d` is 15 from the updated stored 5 and never 3 from a sampling factor.
+DROP TABLE IF EXISTS t_ofsf_shadow_mat;
+CREATE TABLE t_ofsf_shadow_mat (c0 UInt32, _sample_factor Float64, d Float64 MATERIALIZED _sample_factor * 3)
+ENGINE = MergeTree ORDER BY c0 SAMPLE BY c0;
+INSERT INTO t_ofsf_shadow_mat (c0, _sample_factor) SELECT number, 42 FROM numbers(100);
+
+SYSTEM STOP MERGES t_ofsf_shadow_mat;
+SET mutations_sync = 0;
+ALTER TABLE t_ofsf_shadow_mat UPDATE _sample_factor = 5 WHERE 1;
+
+SELECT 'pending', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_ofsf_shadow_mat' AND NOT is_done;
+
+SELECT 'shadow mat preview sampled', any(_sample_factor), any(d) FROM t_ofsf_shadow_mat SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;
+SELECT 'shadow mat preview plain', any(_sample_factor), any(d) FROM t_ofsf_shadow_mat SETTINGS apply_mutations_on_fly = 1;
+
+SYSTEM START MERGES t_ofsf_shadow_mat;
+SET mutations_sync = 2;
+ALTER TABLE t_ofsf_shadow_mat DELETE WHERE 0;
+
+SELECT 'shadow mat materialized sampled', any(_sample_factor), any(d) FROM t_ofsf_shadow_mat SAMPLE 0.5;
+
+DROP TABLE t_ofsf_shadow_mat;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115837   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/109813
-->

Closes: #115837
Related: #109813

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the on-the-fly preview of a pending mutation whose expression references `_sample_factor`. With `apply_mutations_on_fly = 1` and a `SAMPLE` clause, the expression was evaluated with the reading query's sample factor instead of the value the background materialization persists, so previewed rows disagreed with the eventual materialized result, and a pending `ALTER TABLE t DELETE WHERE _sample_factor > 1` could make a `SAMPLE` read return no rows at all. The query's own `_sample_factor` column is unchanged.

### Description

The preview disagreed with the materialized result, driven by a read-side clause:

```sql
CREATE TABLE t (c0 UInt32, u Float64 DEFAULT 0) ENGINE = MergeTree ORDER BY c0 SAMPLE BY c0;
INSERT INTO t SELECT number, 0 FROM numbers(100);
SYSTEM STOP MERGES t;
SET mutations_sync = 0;
ALTER TABLE t UPDATE u = _sample_factor WHERE 1;
SELECT any(u) FROM t SAMPLE 0.5 SETTINGS apply_mutations_on_fly = 1;  -- was 2
```

After materialization that row reads `u = 1`. The `DELETE` shape in the changelog entry is worse: the predicate held for every row, so a `SAMPLE` read returned 0 of 100 rows.

Root cause: `ReadFromMergeTree::initializePipeline` publishes the query's factor into `shared_virtual_fields`, and `MergeTreeReadPoolBase::buildReadTaskInfo` copies that map into the read task after building the pending-mutation steps. One map serves two consumers that need different values in the same query: the query's own `_sample_factor` keeps the query's factor, while the mutation expression must see what its background materialization sees (`1`, seeded in `createMergeTreeSequentialSource`).

The fix rebinds `_sample_factor` to `1` for the mutation step's expression dependencies only, via a new `ActionsDAG::substituteInputForConsumersOnly` that rewires an input's consumer edges but leaves the input node and outputs alone, so the passthrough column forwarded to the query is unaffected. An `isVirtualColumn` guard stops a physical column of that name being folded; it is defence in depth, as no mutation can reference one today (`NOT_FOUND_COLUMN_IN_BLOCK`).

This is the read-path counterpart of #109813, which fixed the background arm; the divergence is pre-existing rather than introduced there, as the reporter confirmed. `_table` and `_database` are out of scope: their background arm fails outright, so no eventual value exists to match.

The test's oracle pairs two assertions in one row: previewed `u` is `1` while the query's own `_sample_factor` is still `2`. 4 of its 24 assertions redden without the fix.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115906&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115906](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115906+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1927` (included in `26.8` and later)
<!-- ch-version-info:end -->