### PR TITLE
Do not extrapolate the adaptive aggregation reserve from an empty sample

### DIFF
--- a/src/Interpreters/AdaptiveAggregationKernels.cpp
+++ b/src/Interpreters/AdaptiveAggregationKernels.cpp
@@ -1136,7 +1136,8 @@ size_t NO_INLINE Aggregator::drainAdaptiveBucketBacklog(
 {
     auto & impl = method.data.impls[bucket_index];
 
-    const size_t reserve_sample_records = total_records / adaptive_reserve_sample_inverse;
+    /// At least one record: the extrapolation below divides by the sample size.
+    const size_t reserve_sample_records = std::max<size_t>(1, total_records / adaptive_reserve_sample_inverse);
     const size_t size_before = impl.size();
     bool reserved = false;
     size_t processed = 0;

--- a/tests/queries/0_stateless/04649_adaptive_aggregator_external.reference
+++ b/tests/queries/0_stateless/04649_adaptive_aggregator_external.reference
@@ -12,5 +12,8 @@ Give-up threads spill through the baseline branch
 1
 Learning-phase spill preserves results
 1
+Sparsely populated buckets under pressure
+1
+1
 Analytic guard under pressure
 30000	449985000	7199940000	120000

--- a/tests/queries/0_stateless/04649_adaptive_aggregator_external.sql
+++ b/tests/queries/0_stateless/04649_adaptive_aggregator_external.sql
@@ -63,6 +63,19 @@ SELECT
     =
     (SELECT count(), sum(c) FROM (SELECT concat(toString(number), repeat('x', number % 40)) AS k, count() AS c FROM numbers_mt(3000000) GROUP BY k SETTINGS enable_adaptive_aggregator = 1, adaptive_aggregator_freeze_threshold = 4000000, group_by_two_level_threshold = 1000, max_bytes_before_external_group_by = 20000000, max_bytes_ratio_before_external_group_by = 0));
 
+-- Few distinct keys spread over many routing buckets leave each bucket holding only a handful
+-- of records, and small blocks mean a bucket's first block often carries none of them. Both
+-- string key layouts are compared, because each pre-sizes its table differently.
+SELECT 'Sparsely populated buckets under pressure';
+SELECT
+    (SELECT count(), sum(cityHash64(k)), sum(c) FROM (SELECT concat('key_', toString(number % 700)) AS k, count() AS c FROM numbers_mt(20000) GROUP BY k SETTINGS enable_adaptive_aggregator = 0))
+    =
+    (SELECT count(), sum(cityHash64(k)), sum(c) FROM (SELECT concat('key_', toString(number % 700)) AS k, count() AS c FROM numbers_mt(20000) GROUP BY k SETTINGS enable_adaptive_aggregator = 1, adaptive_aggregator_freeze_threshold = 8, group_by_two_level_threshold = 1, max_block_size = 64, max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0));
+SELECT
+    (SELECT count(), sum(cityHash64(k)), sum(c) FROM (SELECT concat('key_', toString(number % 700)) AS k, count() AS c FROM numbers_mt(20000) GROUP BY k SETTINGS enable_adaptive_aggregator = 0, enable_packed_string_keys_in_aggregation = 0))
+    =
+    (SELECT count(), sum(cityHash64(k)), sum(c) FROM (SELECT concat('key_', toString(number % 700)) AS k, count() AS c FROM numbers_mt(20000) GROUP BY k SETTINGS enable_adaptive_aggregator = 1, enable_packed_string_keys_in_aggregation = 0, adaptive_aggregator_freeze_threshold = 8, group_by_two_level_threshold = 1, max_block_size = 64, max_bytes_before_external_group_by = 1, max_bytes_ratio_before_external_group_by = 0));
+
 SELECT 'Analytic guard under pressure';
 SELECT count(), sum(g), sum(s), sum(c) FROM (SELECT number % 30000 AS g, sum(number) AS s, count() AS c FROM numbers_mt(120000) GROUP BY g)
 SETTINGS enable_adaptive_aggregator = 1, max_bytes_before_external_group_by = 1;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115480

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Found by `AST fuzzer (arm_asan_ubsan)`, STID `4030-4a54`, on the CI of #115895, whose
Iceberg-only diff is a bystander:

```
src/Interpreters/AdaptiveAggregationKernels.cpp:1153:39: runtime error:
  nan is outside the range of representable values of type 'unsigned long'
```

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115895&sha=650e506ceabf786811ff1ff414781d5639e94b44&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29

Root cause. `drainAdaptiveBucketBacklog` sizes its reserve sample by integer division with no
floor, so a bucket holding 1 to 7 records gets a sample size of 0. The pressure-drain caller
passes the whole unfiltered batch for every bucket, so a chunk's slice for a bucket can be
empty; the guard then admits `processed == 0` because `0 >= 0`, nothing has been inserted yet,
and the insert rate is `0.0 / 0.0`. The division itself is not reported because the sanitizer
build sets `-fno-sanitize=float-divide-by-zero`, so the NaN is produced silently and the
following cast to `size_t` is what aborts.

Measured at the site, immediately before the report:

```
processed=0 total_records=1 reserve_sample_records=0 impl_size=0 size_before=0
```

Two casts read that division: the reserve estimate at `:1153`, and the string-view share at
`:1163`, which only the `StringHashTable` path instantiates. Both sit behind the same guard, and
neutralising the first alone moves the report to the second, so flooring the sample size to one
record fixes both at the definition rather than at either cast.

The reserve is only a pre-sizing hint, so results cannot change: on 13 key shapes (both string
layouts, fixed width, `Nullable`, `LowCardinality`, `FixedString`, tuple, 1/2/257 keys, empty
input, fat states, `DISTINCT`) the result equals the same query with
`enable_adaptive_aggregator = 0`.

Validation. On an `address,undefined` build the added test arm aborts before the fix (exit 134,
the report above) and passes after it, once per string key layout; 50/50 green under CI
randomization. `enable_adaptive_aggregator` is in the 26.8 block of
`SettingsChangesHistory.cpp` and absent from 26.7, so no backport applies.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115909&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115909](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115909+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
