### PR TITLE
Order test_precedence_kills_lower_priority from the server

### DIFF
--- a/tests/integration/test_scheduler_memory/test.py
+++ b/tests/integration/test_scheduler_memory/test.py
@@ -242,10 +242,12 @@ def test_precedence_kills_lower_priority():
 
     def run_production_query():
         try:
-            # A production query that reserves most of the memory
+            # Reserves most of the memory and holds it. `sleepEachRow(1)` with
+            # `max_block_size=1` ticks the pipeline once per row, and the kill is
+            # delivered between processor executions, so it is observable.
             node.query(
-                "select sleep(3) from numbers(1) "
-                "settings workload='production', reserve_memory='45Mi'",
+                "select sleepEachRow(1) from numbers(60) "
+                "settings max_block_size=1, workload='production', reserve_memory='45Mi'",
                 query_id="test_production_precedence",
             )
             results["production"] = "success"
@@ -255,7 +257,17 @@ def test_precedence_kills_lower_priority():
 
     def run_vip_query():
         try:
-            time.sleep(0.3)  # Let production query start first
+            # Presence in system.processes means the reservation was already admitted:
+            # ProcessList::insert constructs MemoryReservation before publishing the
+            # query, and that constructor throws instead of returning when the
+            # allocation is not admitted. Only then is evicting production correct.
+            while (
+                node.query(
+                    "select count() from system.processes where query_id = 'test_production_precedence'"
+                ).strip()
+                == "0"
+            ):
+                time.sleep(0.1)
             # A VIP query with higher precedence that needs memory
             node.query(
                 "select count(*) from numbers(1000000) settings workload='vip', reserve_memory='20Mi'",

--- a/tests/integration/test_scheduler_memory/test.py
+++ b/tests/integration/test_scheduler_memory/test.py
@@ -267,6 +267,10 @@ def test_precedence_kills_lower_priority():
                 ).strip()
                 == "0"
             ):
+                # A settled result means production will never appear here: it was
+                # either refused admission or already finished.
+                if results["production"] is not None:
+                    return
                 time.sleep(0.1)
             # A VIP query with higher precedence that needs memory
             node.query(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113489
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Found on #113489, check `Integration tests (amd_tsan, 3/6)`:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113489&sha=3e604187ae632c52bf33863cefd5369aa01342fb&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%203%2F6%29

The test asserts that a higher-precedence `vip` query evicts a running lower-precedence
`production` query, and ordered the two with a client-side `time.sleep(0.3)` in the VIP
thread.

That ordering is not preserved. The server saw VIP **6us before** production despite the
300ms head start, and VIP finished 2.2ms before production reached the Planner:

```
17:21:02.640196 {test_vip_precedence}        executeQuery: ... workload='vip'
17:21:02.640202 {test_production_precedence} executeQuery: ... workload='production'
17:21:02.654174 {test_vip_precedence}        TCPHandler: Processed in 0.016 sec.
17:21:02.656336 {test_production_precedence} Planner: Query to stage Complete
```

The queries never overlapped, so there was nothing to evict; both succeeding was correct for
what ran. `node.query()` spawns a fresh `clickhouse-client` per query, so the delay before
the server accepts one is spawn + connect + handshake -- unbounded under a sanitizer and
uncorrelated between threads. A fixed client-side sleep cannot order two server-side
admissions.

The scheduler is fine: eviction fired correctly 8s earlier in the same run
(`MEMORY_RESERVATION_KILLED ... Evicting the largest allocation`), and
`gtest_workload_resource_manager` covers it. Test-only change.

The sleep is replaced with a server-observable barrier: VIP waits until production is visible
in `system.processes`, which already proves its reservation was admitted. Production holds
that reservation with `sleepEachRow(1) from numbers(60)` at `max_block_size=1`, which keeps
the window open past VIP's own spawn latency and ticks the pipeline so the kill, delivered
between processor executions, is observable. Both mechanisms are already used elsewhere in
this file. The assertion is unchanged; no `no-parallel` tag, no widened timeout.

Validated by injecting the observed inversion (1s delay before production, VIP sleep
removed): the old test fails with the exact CI message, the new one passes on that state.
Mutating `PrecedenceAllocation::selectAllocationToKill` to never evict makes the new test
fail, so the barrier is not vacuous. 30/30 sequential, 10/10 with 68 workers, 10/10 on TSan,
whole module green.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115911&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115911](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115911+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1924` (included in `26.8` and later)
<!-- ch-version-info:end -->