### PR TITLE
Bound the AST fuzzer liveness probes and teardown diagnostics

### DIFF
--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -106,7 +106,7 @@ function filter_exists_and_template
 
 function stop_server
 {
-    clickhouse-client --query "select elapsed, query from system.processes" ||:
+    timeout --signal TERM --kill-after=10 20 clickhouse-client --query "select elapsed, query from system.processes" ||:
     clickhouse stop
 
     # Debug.
@@ -149,7 +149,7 @@ function fuzz
     # A dead server is detected early, so the deadline only affects hung servers.
     for _ in {1..120}
     do
-        if clickhouse-client --receive_timeout=5 --query "select 1" || ! kill -0 $server_bg_pid
+        if clickhouse-client --handshake_timeout_ms=30000 --receive_timeout=5 --query "select 1" || ! kill -0 $server_bg_pid
         then
             break
         fi
@@ -204,7 +204,7 @@ function fuzz
         # to freeze, and the fuzzer will fail. In debug build, it can take a lot of time.
         for _ in {1..180}
         do
-            if clickhouse-client --receive_timeout=5 --query "select 1"
+            if clickhouse-client --handshake_timeout_ms=30000 --receive_timeout=5 --query "select 1"
             then
                 break
             fi
@@ -337,7 +337,7 @@ function fuzz
         # Make sure the server is still accepting queries before restarting: a fuzzer that
         # exited with code 0 against a dead server would otherwise restart-loop until the budget
         # runs out and hide the failure.
-        if ! clickhouse-client --receive_timeout=5 --query "SELECT 'fuzzer restart liveness check'"; then
+        if ! clickhouse-client --handshake_timeout_ms=30000 --receive_timeout=5 --query "SELECT 'fuzzer restart liveness check'"; then
             echo "Server is not responding, not restarting the fuzzer"
             break
         fi
@@ -359,15 +359,17 @@ function fuzz
     # returns "Connection refused"/EOF instead -- so count repeated timeouts and
     # only declare a hang once they persist, otherwise a single transient timeout
     # turns a clean (exit 143) run into a bogus "server died" FAIL.
-    # BEGIN: server-liveness probe loop (exercised verbatim by
-    # ci/tests/test_fuzzer_liveness_loop.py)
+    # BEGIN: server-liveness probe loop
     server_died=0
     timeouts=0
     timeouts_max=12
 
     for _ in {1..100}
     do
-        if clickhouse-client --receive_timeout=5 --query "SELECT 1" 2> err
+        # --receive_timeout governs the socket only once the handshake has completed; until
+        # then both directions run on handshake_timeout_ms, whose client-side default is 300s.
+        # A probe needs both bounds to be held to the budget it asks for.
+        if clickhouse-client --handshake_timeout_ms=30000 --receive_timeout=5 --query "SELECT 1" 2> err
         then
             server_died=0
             break
@@ -380,7 +382,7 @@ function fuzz
                 # diagnostic and runs under `set -e`; if the same overload rejects
                 # it, do not abort the script (that would skip the status.tsv
                 # write below and surface as a missing-status job ERROR).
-                clickhouse-client --query "SHOW PROCESSLIST" ||:
+                timeout --signal TERM --kill-after=10 20 clickhouse-client --query "SHOW PROCESSLIST" ||:
                 timeouts=0
                 sleep 1
             elif grep -F 'MEMORY_LIMIT_EXCEEDED' err


### PR DESCRIPTION
---8<--- PR BODY BELOW (first line above is the intended title) ---8<---
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111892
Related: https://github.com/ClickHouse/ClickHouse/pull/112927
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not user-facing: bounds the AST fuzzer job's own liveness probes and teardown diagnostics.

### Description

In `AST fuzzer (amd_debug, targeted)` on #111394 the post-fuzz liveness probe loop
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111394&sha=e069a23a79ab83c83dae2c6b2c89bd7036fd85d2&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29))
took 66 minutes to reach a verdict it budgets 5 seconds per attempt for: 5m27s per probe, twelve
times.

Root cause: `--receive_timeout` is inert until the handshake completes. `Connection.cpp:319-320`
puts both socket timeouts on `handshake_timeout` before `sendHello` and
only swaps them at `:407-408`, and the client CLI's handshake fallback is 300000 ms
(`ConnectionParameters.cpp:177`) even though the setting's own default is 10000. So a server that
accepts TCP but never finishes the handshake never reaches the 5 second bound. Against a listener
that accepts and never replies, `--receive_timeout=5` alone blocks 300 s (322 s over TLS, the
fuzzer's port, where the message reads "writing to socket" and misattributes to `send_timeout`);
`--handshake_timeout_ms=30000` bounds it at 30 s, and 5000 and 12000 confirm the bound tracks the
value passed.

Four probes therefore get one extra token, and the two best-effort diagnostics get a hard command
deadline, `--kill-after` included because a bare `timeout` waits indefinitely for a child ignoring
SIGTERM (12 s for a 3 s budget). No loop bound, branch or verdict changes: I ran the loop's five
outcomes against the patched and unpatched text and got identical results.

30000 rather than 10000 because the merged `7ec04d1132644a7` documents a healthy server needing
over 10 s to send Hello on a loaded lane, and each retry restarts the handshake. My worst healthy
handshake under 65 concurrent queries was 0.148 s.

This does not fix whatever wedged the server, and would not have turned that run green: it
genuinely failed 12 consecutive probes. It removes about 54 minutes of wasted runner time per
occurrence, and brings three over-cap scenarios to 188 min inside the 5 hour cap.

Related: #111892 (same file, memory-stuck angle), #112927 (same remedy, stress harness).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115915&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115915](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115915+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
