### PR TITLE
Do not let a stateless test take the harness's bash xtrace descriptor

### DIFF
--- a/tests/queries/0_stateless/05024_local_listener_survives_handler_exception.sh
+++ b/tests/queries/0_stateless/05024_local_listener_survives_handler_exception.sh
@@ -63,17 +63,19 @@ for _ in {1..600}; do
     sleep 0.1
 done
 read -r tcp_port http_port < "$ports_file"
-# Both steps below are mandatory: skipping either leaves the final query answering from a listener
-# that was never poked, which passes without testing anything.
+# Both steps below are mandatory: skipping either leaves the final query answering from a listener that
+# was never poked, which passes without testing anything.
 [ -n "$tcp_port" ] && [ -n "$http_port" ] || { echo "failed to read listener ports"; exit 1; }
 
-# The method matters: `GET` and `POST` are recognized as a wrong-port mistake and answered politely,
-# while any other verb is rejected as an unexpected packet, which is the case this test needs.
-exec 3<>"/dev/tcp/127.0.0.1/${tcp_port}" || { echo "failed to connect to the native port"; exit 1; }
-printf 'HEAD / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n' >&3
-head -c 20 <&3 >/dev/null 2>&1
-exec 3<&- 2>/dev/null
-exec 3>&- 2>/dev/null
+# `GET` and `POST` are answered as a wrong-port mistake, so the unexpected packet needs another verb.
+# The server closes the connection in response, which makes writes to the socket raise SIGPIPE. Bash
+# picks the descriptor, because a number chosen here can be one the shell already uses for itself.
+trap '' PIPE
+exec {sock}<>"/dev/tcp/127.0.0.1/${tcp_port}" || { echo "failed to connect to the native port"; exit 1; }
+{ printf 'HEAD / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n' >&${sock}; } 2>/dev/null
+head -c 20 <&${sock} >/dev/null 2>&1
+exec {sock}<&- 2>/dev/null
+exec {sock}>&- 2>/dev/null
 
 # The listener cannot answer this if the failed connection took the process down.
 ${CLICKHOUSE_CURL} -sS --max-time 60 "http://127.0.0.1:${http_port}/?query=SELECT%20%27listener%20still%20serving%27"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115715
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/115715

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`05024_local_listener_survives_handler_exception` exits `141` on `Fast test (arm_darwin)`. It landed with
#115715 and reddened four unrelated PRs in one 2h20m window; `Fast test` gates every PR. Two of those runs:
[report 1](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115389&sha=5708ea120fce05854010b4f3df00fb94bf7f9c24&name_0=PR&name_1=Fast%20test%20%28arm_darwin%29),
[report 2](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114734&sha=eaf0f7325ecfdb32c8502e747ee74b8e6e89cc9e&name_0=PR&name_1=Fast%20test%20%28arm_darwin%29).

`141` is `128 + 13`, death by `SIGPIPE`, from a descriptor collision with the harness itself.
`shell_config.sh` opens the bash xtrace log on **fd 3** and sets `BASH_XTRACEFD=3`. The test then did
`exec 3<>/dev/tcp/...`, closing that log and rebinding fd 3 to the native port, so bash wrote every xtrace
record into the socket. The test sends `HEAD` precisely so the server rejects it as an unexpected packet and
closes the connection, and the tracer's next write lands on a closed socket. That also explains the
bashlogs ending mid-script: the line that stole the descriptor is the last thing the trace could record, so
the truncation points at the hijack, not at where execution stopped.

The fix lets bash allocate the descriptor (`exec {sock}<>...`, as
`04306_insert_stream_timeout_flush_http_input.sh` already does) and ignores `SIGPIPE` around a poke whose
whole point is that the peer goes away. `|| true` does not work here: the signal kills the shell before the
`||` list is evaluated.

Every traced run hijacks the descriptor on Linux too; only whether the peer closes early enough to be
fatal is racy, hence macOS. And because the tracer shared the socket, the packet the server received was
xtrace text wrapped around the intended `HEAD`, so this is a descriptor fix, not signal tolerance. Only
this test collides, so the harness is unchanged.

Validation: 60/60 `141` before and 60/60 clean after on the isolated mechanism, 10/10 to 10/10 against a
real `clickhouse-local` native port, 150/150 green across randomized and `Fast test`-shaped runs. The fixed
test still fails against a pre-#115715 binary, so it is not disarmed.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115917&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115917](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115917+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1922` (included in `26.8` and later)
<!-- ch-version-info:end -->