### PR TITLE
Keep the prefetched read pool out of the memory budget in 04104

### DIFF
--- a/tests/queries/0_stateless/04104_lightweight_update_v2_eager_patch_discard.sql
+++ b/tests/queries/0_stateless/04104_lightweight_update_v2_eager_patch_discard.sql
@@ -45,6 +45,16 @@ INSERT INTO t_v2_eager_discard SELECT number FROM numbers(800000,   200000);
 SET lightweight_delete_mode = 'lightweight_update_force';
 SET max_threads = 1;
 
+-- The budget below measures the patch reader's own memory. On object storage the prefetched
+-- read pool charges its read buffers to the same query - they are bounded by
+-- `filesystem_prefetch_max_memory_usage`, which the test randomizer draws from 32/64/128 MiB -
+-- and that has nothing to do with what this test asserts. On an `amd_msan, s3 storage` run with
+-- a randomized `allow_prefetched_read_pool_for_remote_filesystem = 1` the first query peaked at
+-- 62.05 MiB against the 61.04 MiB budget, and the failure reproduced 6 times out of 6 with the
+-- same settings while passing without randomization. Pin the setting off, as the randomizer
+-- itself already does for debug builds.
+SET allow_prefetched_read_pool_for_remote_filesystem = 0;
+
 DELETE FROM t_v2_eager_discard WHERE (a % 2) = 0;
 
 -- Tight budget. Enough patch metadata and one working block per patch fit comfortably;


### PR DESCRIPTION
`04104_lightweight_update_v2_eager_patch_discard` asserts that the v2 patch reader does not pin patch blocks, using `max_memory_usage = '64M'` as the assertion. On object storage the prefetched read pool charges its read buffers to the same query — they are bounded by `filesystem_prefetch_max_memory_usage`, which the test randomizer draws from 32/64/128 MiB — so the budget stops measuring what the test is about.

On an `amd_msan, s3 storage` run with a randomized `allow_prefetched_read_pool_for_remote_filesystem = 1` the first query peaked at 62.05 MiB against the 61.04 MiB budget and failed with `MEMORY_LIMIT_EXCEEDED` in `AsynchronousBoundedReadBuffer::prefetch` under `MergeTreePrefetchedReadPool::createPrefetchedTask`. The harness re-ran it 6 times with the same randomized settings and it failed 6 times, then 3 times without randomization and it passed 3 times, pointing at that single setting.

This pins the setting off for this test, as the randomizer itself already does for debug builds.

CI report: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=49527&sha=7a3e4a5ebe58d31d04f67118b0412099eba1ad3a&name_0=PR&name_1=Stateless%20tests%20(amd_msan%2C%20meta%20in%20keeper%2C%20s3%20storage%2C%20parallel%2C%203%2F3)

Related: https://github.com/ClickHouse/ClickHouse/pull/96886

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115924&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115924](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115924+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1918` (included in `26.8` and later)
<!-- ch-version-info:end -->