### PR TITLE
Retry the previous-release clone in the upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -35,7 +35,20 @@ fi
 echo $previous_release_tag
 
 echo "Clone previous release repository"
-git clone https://github.com/ClickHouse/ClickHouse.git --no-tags --progress --branch=$previous_release_tag --no-recurse-submodules --depth=1 previous_release_repository
+
+function clone_previous_release_repository()
+{
+    # A killed clone leaves a `.git`-only directory that every later attempt rejects.
+    rm -rf previous_release_repository
+    # git has no default low-speed bound, so a stalled-but-open connection never ends.
+    git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=120 clone https://github.com/ClickHouse/ClickHouse.git --no-tags --progress --branch=$previous_release_tag --no-recurse-submodules --depth=1 previous_release_repository
+}
+
+if ! run_with_retry 3 clone_previous_release_repository; then
+    echo -e "Failed to clone previous release tests$FAIL" >> /test_output/test_results.tsv
+    echo -e 'failure\tFailed to clone previous release tests' > /test_output/check_status.tsv
+    exit 1
+fi
 
 echo "Download clickhouse-server from the previous release"
 mkdir previous_release_package_folder
@@ -58,6 +71,7 @@ fi
 # Check if we cloned previous release repository successfully
 if ! [ "$(ls -A previous_release_repository/tests/queries)" ]
 then
+    echo -e "Failed to clone previous release tests$FAIL" >> /test_output/test_results.tsv
     echo -e 'failure\tFailed to clone previous release tests' > /test_output/check_status.tsv
     exit 1
 elif ! [ "$(ls -A previous_release_package_folder/clickhouse-common-static_*.deb && ls -A previous_release_package_folder/clickhouse-server_*.deb)" ]


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113783
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Upgrade check` aborts in its prologue when the `git clone` of the previous-release
repository hits a transient network failure, so the upgrade path is never exercised
and the check reports two rows that name no cause: `Unknown job error` (`Cannot parse
test_results.tsv`) and `Check failed with exit code 128`.

The clone at `tests/docker_scripts/upgrade_runner.sh:38` is bare and unretried under
`set -e`, so a nonzero exit kills the script before any `test_results.tsv` row is
written. On PR #115906 head `bc40ad72`
([job](https://github.com/ClickHouse/ClickHouse/actions/runs/32569392224/job/97041362854),
[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115906&sha=bc40ad7247234cc224a0de5990407e62be8e73c0&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29))
the transfer stalled at 56% for 10 min 12 s, then died `fatal: early EOF`. Not caused
by that PR: a concurrent run of the same commit passed with a 15 s clone
([job](https://github.com/ClickHouse/ClickHouse/actions/runs/32569398667/job/97041210983)).
CIDB shows 4 occurrences across 4 unrelated PRs in 30 days and none on master.

The clone now goes through `run_with_retry`, the wrapper `stress_tests.lib` already
defines and nothing called, and on exhaustion the job writes a named `Failed to clone
previous release tests` row instead of dying resultless. Two details: each attempt
removes the destination first, because a killed clone leaves a `.git`-only directory
that makes every later attempt fail with `already exists and is not an empty
directory`; and each carries `http.lowSpeedLimit=1000`/`lowSpeedTime=120`, because git has no
default low-speed bound, so an unbounded stall can outlast the job (measured: git had
not given up after 5 minutes). The same reporting gap in the adjacent clone-validity
guard is fixed too; its condition and `exit 1` are unchanged.

Validated with a stalling proxy that reproduces the CI stanza, and a harness running
the real block against a stub `git`. Details in the thread.

Left out on purpose: no test under `ci/tests`, since #115650 removes that directory
(say the word and I will add one wherever you prefer); and the
`get_previous_release_tag` gap in the same prologue, which #112974 covers.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115935&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115935](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115935+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1936` (included in `26.8` and later)
<!-- ch-version-info:end -->