### PR TITLE
Add a test for a correlated subquery over a Bool grouping key

### DIFF
--- a/tests/queries/0_stateless/05030_correlated_subquery_bool_group_by_use_nulls.reference
+++ b/tests/queries/0_stateless/05030_correlated_subquery_bool_group_by_use_nulls.reference
@@ -1,0 +1,22 @@
+true
+\N
+true
+\N
+true
+
+\N
+true	1
+\N	1
+true
+\N
+true
+\N
+true
+
+\N
+true	1
+\N	1
+true	false	true	false
+true	\N	true	\N
+\N	\N	\N	\N
+Nullable(Bool)

--- a/tests/queries/0_stateless/05030_correlated_subquery_bool_group_by_use_nulls.sql
+++ b/tests/queries/0_stateless/05030_correlated_subquery_bool_group_by_use_nulls.sql
@@ -4,6 +4,7 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/91119
 
 SET group_by_use_nulls = 1;
+SET enable_analyzer = 1;
 
 SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH ROLLUP ORDER BY c0;
 SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH CUBE ORDER BY c0;

--- a/tests/queries/0_stateless/05030_correlated_subquery_bool_group_by_use_nulls.sql
+++ b/tests/queries/0_stateless/05030_correlated_subquery_bool_group_by_use_nulls.sql
@@ -1,0 +1,31 @@
+-- A correlated scalar subquery reading a `Bool` grouping key that `ROLLUP`, `CUBE` or `GROUPING SETS`
+-- turn into `Nullable(Bool)` because of `group_by_use_nulls`.
+-- It used to throw `Bad cast from type DB::ColumnNullable to DB::ColumnVector<char8_t>`.
+-- https://github.com/ClickHouse/ClickHouse/issues/91119
+
+SET group_by_use_nulls = 1;
+
+SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH ROLLUP ORDER BY c0;
+SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH CUBE ORDER BY c0;
+SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH TOTALS ORDER BY c0;
+SELECT (SELECT c0), count() FROM (SELECT 1::Bool) t0(c0) GROUP BY GROUPING SETS ((c0), ()) ORDER BY c0;
+
+-- The same, but without rewriting the correlated subquery into a plain column reference,
+-- so that the query goes through the decorrelation of the query plan.
+
+SET correlated_subqueries_substitute_equivalent_expressions = 0;
+
+SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH ROLLUP ORDER BY c0;
+SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH CUBE ORDER BY c0;
+SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH TOTALS ORDER BY c0;
+SELECT (SELECT c0), count() FROM (SELECT 1::Bool) t0(c0) GROUP BY GROUPING SETS ((c0), ()) ORDER BY c0;
+
+-- More than one grouping key, and a `Nullable(Bool)` source column.
+
+SELECT c0, c1, (SELECT c0), (SELECT c1)
+FROM (SELECT true AS c0, CAST(false, 'Nullable(Bool)') AS c1)
+GROUP BY c0, c1 WITH ROLLUP ORDER BY c0, c1;
+
+-- The result of the correlated subquery is `Nullable` as well.
+
+SELECT DISTINCT toTypeName(x) FROM (SELECT (SELECT c0) AS x FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH ROLLUP);


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/91119

A correlated scalar subquery that reads a `Bool` grouping key, which `ROLLUP`/`CUBE`/`GROUPING SETS` turn into `Nullable(Bool)` under `group_by_use_nulls`, used to throw `Bad cast from type DB::ColumnNullable to DB::ColumnVector<char8_t>`:

```sql
SELECT (SELECT c0) FROM (SELECT 1::Bool) t0(c0) GROUP BY c0 WITH ROLLUP SETTINGS group_by_use_nulls = 1;
```

It does not reproduce anymore, so this adds a test to keep it from coming back. The test also covers `CUBE`, `TOTALS`, `GROUPING SETS`, a second `Nullable(Bool)` grouping key, and the same queries with `correlated_subqueries_substitute_equivalent_expressions = 0`, so that the query goes through the query plan decorrelation from the original stack trace instead of being rewritten into a plain column reference.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115945&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115945](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115945+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
