### PR TITLE
Re-add streaming-subscription MODIFY PROJECTION rejection test

### DIFF
--- a/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.reference
+++ b/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.reference
@@ -1,0 +1,6 @@
+=== MODIFY PROJECTION is rejected while a streaming query holds a subscription ===
+SUPPORT_IS_DISABLED
+=== a settings-only ALTER is still accepted ===
+ok
+=== the projection settings are unchanged ===
+index_granularity = 1024)

--- a/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.sh
+++ b/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-shared-merge-tree
+# Tags: no-shared-merge-tree, no-old-analyzer
 # no-shared-merge-tree: STREAM reads are only exercised on plain MergeTree here, like the other streaming .sh tests.
+# no-old-analyzer: SELECT ... STREAM throws NOT_IMPLEMENTED, so no subscription is held and the ALTER is accepted.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.sh
+++ b/tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Tags: no-shared-merge-tree
+# no-shared-merge-tree: STREAM reads are only exercised on plain MergeTree here, like the other streaming .sh tests.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+# shellcheck source=./streaming.lib
+. "$CURDIR"/streaming.lib
+
+$STREAMING_CLIENT -q "DROP TABLE IF EXISTS t_streaming_alter_projection"
+$STREAMING_CLIENT -q "CREATE TABLE t_streaming_alter_projection (a String, b UInt64, PROJECTION p (SELECT b ORDER BY b) WITH SETTINGS (index_granularity = 1024)) ENGINE = MergeTree ORDER BY a SETTINGS $STREAMING_TABLE_SETTINGS"
+$STREAMING_CLIENT -q "INSERT INTO t_streaming_alter_projection VALUES ('started', 0)"
+
+read -r fifo pid < <(spawn $STREAMING_CLIENT -q "SELECT a FROM t_streaming_alter_projection STREAM")
+read_until "$fifo" "started" > /dev/null
+
+echo "=== MODIFY PROJECTION is rejected while a streaming query holds a subscription ==="
+# `-- { serverError ... }` is only available in .sql tests, so assert on the error
+# code name the way the other .sh tests do. On any other outcome print the whole
+# error instead of swallowing it, so a failure diff shows what actually happened.
+alter_error=$($STREAMING_CLIENT -q "ALTER TABLE t_streaming_alter_projection MODIFY PROJECTION p (SELECT b ORDER BY b) WITH SETTINGS (index_granularity = 128)" 2>&1 >/dev/null)
+if echo "$alter_error" | grep -qF "SUPPORT_IS_DISABLED"; then
+    echo "SUPPORT_IS_DISABLED"
+else
+    echo "UNEXPECTED: ${alter_error:-the ALTER was accepted}"
+fi
+
+echo "=== a settings-only ALTER is still accepted ==="
+$STREAMING_CLIENT -q "ALTER TABLE t_streaming_alter_projection MODIFY SETTING merge_max_block_size = 8192" 2>&1 && echo "ok"
+
+cleanup "$fifo" "$pid" > /dev/null
+
+echo "=== the projection settings are unchanged ==="
+$STREAMING_CLIENT -q "SELECT extract(create_table_query, 'index_granularity = \d+\)') FROM system.tables WHERE database = currentDatabase() AND name = 't_streaming_alter_projection'"
+
+$STREAMING_CLIENT -q "DROP TABLE IF EXISTS t_streaming_alter_projection"


### PR DESCRIPTION
Fixes #115934

**Implements fix for [issue #115934](https://github.com/ClickHouse/ClickHouse/issues/115934) found during review of [PR #115934](https://github.com/ClickHouse/ClickHouse/pull/115934).**

Requested by @alexey-milovidov.

### What this fixes
What: Re-lands the stateless test deleted by revert PR #115934, substantively unchanged and verified locally. It spawns a `SELECT ... STREAM` that holds a subscription, asserts `ALTER TABLE ... MODIFY PROJECTION ... WITH SETTINGS` is refused with `SUPPORT_IS_DISABLED`, asserts a settings-only `MODIFY SETTING` is still accepted (guard is command-selective, not a blanket ALTER block), and asserts the projection's `index_granularity` is unchanged afterwards.

Why: No source change is needed — `MergeTreeData::checkAlterIsPossible` already lists `AlterCommand::MODIFY_PROJECTION` among the forbidden commands (`src/Storages/MergeTree/MergeTreeData.cpp:5000-5014`). Post-revert that list entry has zero coverage: deleting it keeps every existing test green. The maintainer asked for the reverted change to be resubmitted normally.

Files changed:
- tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.sh (new, mode 100755)
- tests/queries/0_stateless/04235_streaming_queries_alter_projection_rejected.reference (new)

Test: Proves the `MODIFY_PROJECTION` arm of the subscription guard fires. Non-vacuous — the identical statement without a subscription is accepted and rewrites the granularity to 128, so removing `MODIFY_PROJECTION` from the guard breaks both the `SUPPORT_IS_DISABLED` line and the trailing `index_granularity = 1024)` line. ~0.9s runtime; passed 3/3 with `--no-random-settings`, 5/5 with random settings, and under `-j 4` alongside the whole `04235_streaming_queries_*` family. The only failures in a 20x loop were this host's `Invalid time zone: zoneinfo/UTC` randomization, reproducible with a bare `SELECT 1`. Style gates checked: `_streaming_queries_` naming rule (`ci/jobs/check_style.py:213`) and `various_checks.sh` are clean.

### Changelog category (leave one):
- Not For Changelog

### Changelog entry
What: Re-lands the stateless test deleted by revert PR #115934, substantively unchanged and verified locally. It spawns a `SELECT ... STREAM` that holds a subscription, asserts `ALTER TABLE ... MODIFY PROJECTION ... WITH SETTINGS` is refused with `SUPPORT_IS_DISABLED`, asserts a settings-only `MODIFY SETTING` is still accepted (guard is command-selective, not a blanket ALTER block), and asserts the projection's `index_granularity` is unchanged afterwards.

---
_ClickGapAI · Fix for PR #115934_

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115956&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115956](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115956+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1960` (included in `26.8` and later)
<!-- ch-version-info:end -->