### PR TITLE
Enable the analyzer in the streaming-queries test client

### DIFF
--- a/tests/queries/0_stateless/04545_streaming_queries_row_policy_multi_partition.sh
+++ b/tests/queries/0_stateless/04545_streaming_queries_row_policy_multi_partition.sh
@@ -6,26 +6,30 @@ set -e
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
+# shellcheck source=./streaming.lib
+. "$CURDIR"/streaming.lib
 
-$CLICKHOUSE_CLIENT -q "DROP ROW POLICY IF EXISTS rp_04545 ON t_streaming_rp"
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_streaming_rp"
+$STREAMING_CLIENT -q "DROP ROW POLICY IF EXISTS rp_04545 ON t_streaming_rp"
+$STREAMING_CLIENT -q "DROP TABLE IF EXISTS t_streaming_rp"
 
-$CLICKHOUSE_CLIENT -q "
+$STREAMING_CLIENT -q "
     CREATE TABLE t_streaming_rp (a UInt32, b UInt32)
     ENGINE = MergeTree PARTITION BY a ORDER BY a
-    SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1"
+    SETTINGS $STREAMING_TABLE_SETTINGS"
 
-$CLICKHOUSE_CLIENT -q "INSERT INTO t_streaming_rp SELECT number, 9000 FROM numbers(10)"
-$CLICKHOUSE_CLIENT -q "INSERT INTO t_streaming_rp SELECT number % 10, number % 5000 FROM numbers(10000)"
+$STREAMING_CLIENT -q "INSERT INTO t_streaming_rp SELECT number, 9000 FROM numbers(10)"
+$STREAMING_CLIENT -q "INSERT INTO t_streaming_rp SELECT number % 10, number % 5000 FROM numbers(10000)"
 
-$CLICKHOUSE_CLIENT -q "CREATE ROW POLICY rp_04545 ON t_streaming_rp FOR SELECT USING b < 5000 TO ALL"
+$STREAMING_CLIENT -q "CREATE ROW POLICY rp_04545 ON t_streaming_rp FOR SELECT USING b < 5000 TO ALL"
 
 for _ in {1..30}; do
-    $CLICKHOUSE_CLIENT --enable_analyzer=1 --enable_streaming_queries=1 --query_plan_remove_unused_columns=1 --max_threads=4 --max_threads_min_free_memory_per_thread=0 --max_execution_time=20 \
-        -q "SELECT throwIf(max(b) >= 5000 OR count() = 0) FROM (SELECT b FROM t_streaming_rp STREAM LIMIT 400) FORMAT Null"
+    $STREAMING_CLIENT -q "
+        SELECT throwIf(max(b) >= 5000 OR count() = 0) FROM (SELECT b FROM t_streaming_rp STREAM LIMIT 400)
+        SETTINGS query_plan_remove_unused_columns = 1, max_threads = 4, max_threads_min_free_memory_per_thread = 0, max_execution_time = 20
+        FORMAT Null"
 done
 
 echo "ok"
 
-$CLICKHOUSE_CLIENT -q "DROP ROW POLICY rp_04545 ON t_streaming_rp"
-$CLICKHOUSE_CLIENT -q "DROP TABLE t_streaming_rp"
+$STREAMING_CLIENT -q "DROP ROW POLICY rp_04545 ON t_streaming_rp"
+$STREAMING_CLIENT -q "DROP TABLE t_streaming_rp"

--- a/tests/queries/0_stateless/04545_streaming_queries_row_policy_multi_partition.sh
+++ b/tests/queries/0_stateless/04545_streaming_queries_row_policy_multi_partition.sh
@@ -21,7 +21,7 @@ $CLICKHOUSE_CLIENT -q "INSERT INTO t_streaming_rp SELECT number % 10, number % 5
 $CLICKHOUSE_CLIENT -q "CREATE ROW POLICY rp_04545 ON t_streaming_rp FOR SELECT USING b < 5000 TO ALL"
 
 for _ in {1..30}; do
-    $CLICKHOUSE_CLIENT --enable_streaming_queries=1 --query_plan_remove_unused_columns=1 --max_threads=4 --max_threads_min_free_memory_per_thread=0 --max_execution_time=20 \
+    $CLICKHOUSE_CLIENT --enable_analyzer=1 --enable_streaming_queries=1 --query_plan_remove_unused_columns=1 --max_threads=4 --max_threads_min_free_memory_per_thread=0 --max_execution_time=20 \
         -q "SELECT throwIf(max(b) >= 5000 OR count() = 0) FROM (SELECT b FROM t_streaming_rp STREAM LIMIT 400) FORMAT Null"
 done
 

--- a/tests/queries/0_stateless/streaming.lib
+++ b/tests/queries/0_stateless/streaming.lib
@@ -9,7 +9,8 @@ STREAMING_TABLE_SETTINGS="\
     part_minmax_index_columns = 'with_block_number_offset'"
 
 # Default client invocation for streaming-queries tests.
-STREAMING_CLIENT="$CLICKHOUSE_CLIENT --enable_streaming_queries=1 --use_skip_indexes_on_data_read=0"
+# Streaming queries require the analyzer, which some CI configurations disable in the default profile.
+STREAMING_CLIENT="$CLICKHOUSE_CLIENT --enable_analyzer=1 --enable_streaming_queries=1 --use_skip_indexes_on_data_read=0"
 
 spawn()
 {

--- a/tests/queries/0_stateless/streaming.lib
+++ b/tests/queries/0_stateless/streaming.lib
@@ -9,7 +9,6 @@ STREAMING_TABLE_SETTINGS="\
     part_minmax_index_columns = 'with_block_number_offset'"
 
 # Default client invocation for streaming-queries tests.
-# Streaming queries require the analyzer, which some CI configurations disable in the default profile.
 STREAMING_CLIENT="$CLICKHOUSE_CLIENT --enable_analyzer=1 --enable_streaming_queries=1 --use_skip_indexes_on_data_read=0"
 
 spawn()


### PR DESCRIPTION
Enable the analyzer in the streaming-queries test client

Related: https://github.com/ClickHouse/ClickHouse/pull/113737

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`04235_streaming_queries_alter_projection_rejected` fails deterministically on master on
`Stateless tests (amd_llvm_coverage, old analyzer, s3 storage, DBReplicated, WasmEdge, parallel, 2/3)`:
9 master commits and 17 unrelated pull-request branches in three days, 3 of 3 reruns each. It has
never passed on that job; every other job is green. Report for the first occurrence:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9f73b426899380fb82c5acb883d0ad33a443e8cf&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29

Root cause: `streaming.lib`'s `STREAMING_CLIENT` did not enable the analyzer, and streaming queries
are only implemented there (`InterpreterSelectQuery.cpp` raises `NOT_IMPLEMENTED`). The job's
`old analyzer` option installs `users.d/analyzer.xml`, which turns the analyzer off through the
default profile, so the `SELECT ... STREAM` the test spawns exits immediately (all 26 failing runs
log `Streaming queries are not supported with the old analyzer. (NOT_IMPLEMENTED)`), no subscription
is registered, and the guard in `MergeTreeData::checkAlterIsPossible` is correctly skipped. That
explains both halves of the diff: the missing `SUPPORT_IS_DISABLED` and `index_granularity` becoming
128. The guard is correct and unchanged.

The setting is a precondition of the fixture, like the `enable_streaming_queries=1` already on that
line, so it is pinned in `streaming.lib`; nine `.sql` siblings pin `enable_analyzer = 1` in their
bodies for the same reason. `04545_streaming_queries_row_policy_multi_partition` built its own client
invocation instead of sourcing the library, so it inherited none of those defaults. It now sources
`streaming.lib` and uses `$STREAMING_CLIENT` and `$STREAMING_TABLE_SETTINGS` like the other ten, with
its query-level settings moved to a `SETTINGS` clause, so all eleven shell streaming tests share one
pin. A `no-old-analyzer` tag was rejected, it would remove the job's only `streaming.lib` coverage.

Validated on a server carrying `users.d/analyzer.xml`: both tests fail before the change and pass
after, on the same build; with the guard also removed, `04235` still fails, so the assertion is not
vacuous. `04545` passes there 10 of 10 and in 4 concurrent copies, all 26 streaming tests pass, and
removing the library pin makes it fail with `NOT_IMPLEMENTED` again.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115957&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115957](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115957+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.87` (included in `26.9` and later)
<!-- ch-version-info:end -->