### PR TITLE
Preserve dictionary identity through `ColumnArray::cut`

### DIFF
--- a/src/Columns/ColumnIndex.cpp
+++ b/src/Columns/ColumnIndex.cpp
@@ -11,6 +11,7 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int LOGICAL_ERROR;
+    extern const int PARAMETER_OUT_OF_BOUND;
 }
 
 
@@ -239,6 +240,16 @@ void ColumnIndex::insertIndexesRange(const IColumn & column, size_t offset, size
             indexes->insertRangeFrom(column, offset, limit);
         else
         {
+            const size_t column_size = column_ptr->size();
+            if (offset > column_size || limit > column_size - offset)
+                throw Exception(
+                    ErrorCodes::PARAMETER_OUT_OF_BOUND,
+                    "Parameters offset = {}, limit = {} are out of bound in ColumnIndex::insertIndexesRange method "
+                    "(column.size() = {})",
+                    offset,
+                    limit,
+                    column_size);
+
             auto copy = [&](auto cur_type)
             {
                 using CurIndexType = decltype(cur_type);

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -205,6 +205,20 @@ void ColumnLowCardinality::doInsertRangeFrom(const IColumn & src, size_t start, 
     if (!low_cardinality_src)
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Expected ColumnLowCardinality, got {}", src.getName());
 
+    if (length == 0)
+        return;
+
+    /// An already shared, structurally compatible source dictionary is immutable. Reuse it when initializing
+    /// an empty column to avoid rebuilding it and keep its indexes unchanged through generic range insertions.
+    /// A private source dictionary can still be mutated in place, while an incompatible dictionary must be
+    /// rebuilt to perform conversions such as nullable promotion.
+    if (
+        empty()
+        && low_cardinality_src->isSharedDictionary()
+        && getDictionary().nestedColumnIsNullable() == low_cardinality_src->getDictionary().nestedColumnIsNullable()
+        && getDictionary().structureEquals(low_cardinality_src->getDictionary()))
+        setSharedDictionary(low_cardinality_src->getDictionaryPtr());
+
     if (&low_cardinality_src->getDictionary() == &getDictionary())
     {
         /// Dictionary is shared with src column. Insert only indexes.

--- a/src/Columns/tests/gtest_column_array.cpp
+++ b/src/Columns/tests/gtest_column_array.cpp
@@ -1,6 +1,10 @@
 #include <Columns/ColumnArray.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
+
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypesNumber.h>
 
 #include <gtest/gtest.h>
 #include <Common/Exception.h>
@@ -40,6 +44,39 @@ TEST(ColumnArray, OffsetsConsistentWithNestedColumn)
     EXPECT_EQ(column->getSize(0), 2);
     EXPECT_EQ(column->getSize(1), 0);
     EXPECT_EQ(column->getSize(2), 1);
+}
+
+TEST(ColumnArray, CutPreservesSharedLowCardinalityDictionary)
+{
+    auto dictionary_keys = ColumnUInt64::create();
+    for (UInt64 value : {0, 10, 20, 30})
+        dictionary_keys->insertValue(value);
+
+    ColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(DataTypeUInt64(), std::move(dictionary_keys));
+
+    auto indexes = ColumnUInt8::create();
+    for (UInt8 index : {UInt8{1}, UInt8{2}, UInt8{3}, UInt8{1}, UInt8{2}})
+        indexes->insertValue(index);
+
+    auto nested = ColumnLowCardinality::create(dictionary, std::move(indexes), /* is_shared = */ true);
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    for (ColumnArray::Offset offset : {2, 2, 5})
+        offsets->insertValue(offset);
+
+    auto column = ColumnArray::create(std::move(nested), std::move(offsets));
+    auto cut_column = column->cut(1, 2);
+    const auto & cut_array = assert_cast<const ColumnArray &>(*cut_column);
+    const auto & cut_nested = assert_cast<const ColumnLowCardinality &>(cut_array.getData());
+
+    ASSERT_TRUE(cut_nested.isSharedDictionary());
+    EXPECT_EQ(cut_nested.getDictionaryPtr().get(), dictionary.get());
+    ASSERT_EQ(cut_array.size(), 2);
+    EXPECT_EQ(cut_array.getSize(0), 0);
+    EXPECT_EQ(cut_array.getSize(1), 3);
+    ASSERT_EQ(cut_nested.size(), 3);
+    EXPECT_EQ(cut_nested.getUInt(0), 30);
+    EXPECT_EQ(cut_nested.getUInt(1), 10);
+    EXPECT_EQ(cut_nested.getUInt(2), 20);
 }
 
 /// Skipped under debug/sanitizers: LOGICAL_ERROR aborts there, so EXPECT_THROW can't catch it.

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -5,6 +5,7 @@
 #include <DataTypes/DataTypeLowCardinality.h>
 
 #include <gtest/gtest.h>
+#include <Common/Exception.h>
 
 using namespace DB;
 
@@ -88,6 +89,29 @@ TEST(ColumnLowCardinality, CloneNullableKeepsZeroValue)
     ASSERT_EQ(value.safeGet<UInt64>(), 1);
     nullable_column->get(2, value);
     ASSERT_EQ(value.safeGet<UInt64>(), 2);
+}
+
+TEST(ColumnLowCardinality, InsertRangeFromChecksBoundsAfterSharingDictionary)
+{
+    auto dictionary_keys = ColumnUInt64::create();
+    for (UInt64 value : {0, 10})
+        dictionary_keys->insertValue(value);
+
+    ColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(DataTypeUInt64(), std::move(dictionary_keys));
+
+    auto source_indexes = ColumnUInt8::create();
+    source_indexes->insertValue(1);
+    auto source = ColumnLowCardinality::create(dictionary, std::move(source_indexes), /* is_shared = */ true);
+
+    auto wide_indexes = ColumnUInt16::create();
+    wide_indexes->insertValue(1);
+    auto wide_column = ColumnLowCardinality::create(dictionary, std::move(wide_indexes), /* is_shared = */ false);
+    auto destination = wide_column->cloneEmpty();
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+
+    ASSERT_EQ(low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt16));
+    EXPECT_THROW(destination->insertRangeFrom(*source, source->size(), 1), Exception);
+    EXPECT_TRUE(destination->empty());
 }
 
 TEST(ColumnLowCardinality, EmptyDictionaryEmptyIndexes)

--- a/tests/performance/group_by_low_cardinality_array_join.xml
+++ b/tests/performance/group_by_low_cardinality_array_join.xml
@@ -1,0 +1,90 @@
+<test>
+    <!--
+        Measure whether `ARRAY JOIN` preserves a shared `LowCardinality` dictionary
+        for downstream single-key aggregation.
+
+        The scalar and array columns contain the same `UInt128` keys in the same
+        row order. Every array has exactly one element, so both measured queries
+        aggregate the same number of rows and differ only by `ARRAY JOIN`.
+
+        The source has 8,190 distinct values, allowing both dictionaries to fit
+        within the default per-part limit. The first read block touches every
+        dictionary position, so later blocks can reuse the complete mapping
+        when dictionary identity is preserved.
+    -->
+
+    <settings>
+        <allow_suspicious_low_cardinality_types>1</allow_suspicious_low_cardinality_types>
+        <merge_tree_use_deserialization_prefixes_cache>1</merge_tree_use_deserialization_prefixes_cache>
+        <max_memory_usage>20G</max_memory_usage>
+    </settings>
+
+    <create_query>DROP TABLE IF EXISTS group_by_low_cardinality_array_join</create_query>
+    <create_query>
+        CREATE TABLE group_by_low_cardinality_array_join
+        (
+            stack_array Array(LowCardinality(UInt128)),
+            stack_flat LowCardinality(UInt128),
+            value UInt64
+        )
+        ENGINE = MergeTree
+        ORDER BY tuple()
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0
+    </create_query>
+
+    <fill_query>
+        INSERT INTO group_by_low_cardinality_array_join
+        WITH
+            if(number &lt; 8190, number, intHash64(number) % 8190) AS stack_number,
+            bitOr(
+                bitShiftLeft(toUInt128(cityHash64(stack_number)), 64),
+                toUInt128(stack_number)) AS stack
+        SELECT
+            [stack] AS stack_array,
+            stack AS stack_flat,
+            toUInt64(1) AS value
+        FROM numbers(25000000)
+        SETTINGS
+            max_threads = 1,
+            max_insert_threads = 1,
+            max_block_size = 25000000,
+            max_insert_block_size = 25000000,
+            min_insert_block_size_rows = 25000000,
+            min_insert_block_size_bytes = 0
+    </fill_query>
+
+    <fill_query>
+        SELECT throwIf(
+            count() != 1 OR countIf(part_type = 'Wide') != 1,
+            'Expected one active Wide part')
+        FROM system.parts
+        WHERE database = currentDatabase()
+          AND table = 'group_by_low_cardinality_array_join'
+          AND active
+    </fill_query>
+
+    <!-- Shared-dictionary control without `ARRAY JOIN`. -->
+    <query>
+        SELECT stack_flat, sum(value)
+        FROM group_by_low_cardinality_array_join
+        GROUP BY stack_flat
+        FORMAT Null
+        SETTINGS
+            max_threads = 1,
+            max_block_size = 65536
+    </query>
+
+    <!-- The production-shaped path whose dictionary identity is currently lost. -->
+    <query>
+        SELECT stack, sum(value)
+        FROM group_by_low_cardinality_array_join
+        ARRAY JOIN stack_array AS stack
+        GROUP BY stack
+        FORMAT Null
+        SETTINGS
+            max_threads = 1,
+            max_block_size = 65536
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS group_by_low_cardinality_array_join</drop_query>
+</test>


### PR DESCRIPTION
This was originally a part of #114993, but it works as a standalone improvement just as well.

It already happens in `ColumnLowCardinality::cut`. Benchmark results:

* ARRAY JOIN: 0.8623s -> 0.7042s (-18.3%)
* Flat control: 0.5579s -> 0.5603s (+0.4%, noise)
* Relative ARRAY JOIN overhead: 54.6% -> 25.7%
* Absolute overhead reduced by 52.8%

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Speed up `Array(LowCardinality(T))` aggregations by preserving dictionary identity.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115961&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115961](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115961+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.187` (included in `26.9` and later)
<!-- ch-version-info:end -->