### PR TITLE
Ignore a column absent from the table when materializing TTL

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -514,7 +514,7 @@ static void splitAndModifyMutationCommands(
         {
             if (!mutated_columns.contains(column.name))
             {
-                if (!metadata_snapshot->columns.has(column.name) && !metadata_snapshot->virtuals.has(column.name) && !ignored_columns.contains(column.name))
+                if (!metadata_snapshot->columns.has(column.name) && !metadata_snapshot->virtuals.has(column.name))
                 {
                     /// We cannot add the column because there's no such column in table.
                     /// It's okay if the column was dropped. It may also absent in dropped_columns

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -538,6 +538,11 @@ static void splitAndModifyMutationCommands(
                                         "in table {} with metadata version {}",
                                         part->name, part_metadata_version, column.name,
                                         part->storage.getStorageID().getNameForLogs(), table_metadata_version);
+
+                    LOG_WARNING(log, "Ignoring column {} from part {} because there is no such column in table {}. "
+                                     "Assuming the column was dropped", column.name, part->name,
+                                part->storage.getStorageID().getNameForLogs());
+                    continue;
                 }
 
                 for_interpreter.emplace_back(

--- a/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.reference
+++ b/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.reference
@@ -1,0 +1,20 @@
+compact
+part_type	Compact
+h_has_files_before	1
+h_in_part_not_in_metadata	1
+unfinished_mutations	0
+unknown_identifier_failures	0
+rows_sum_digest	100	5050	3316964675657091280
+h_has_files_after	0
+wide
+part_type	Wide
+h_has_files_before	1
+h_in_part_not_in_metadata	1
+unfinished_mutations	0
+unknown_identifier_failures	0
+rows_sum_digest	100	5050	3316964675657091280
+h_has_files_after	0
+column still in metadata
+unfinished_mutations	0
+b_type	Int64
+rows_sum	100	4950

--- a/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.reference
+++ b/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.reference
@@ -14,6 +14,14 @@ unfinished_mutations	0
 unknown_identifier_failures	0
 rows_sum_digest	100	5050	3316964675657091280
 h_has_files_after	0
+materialize ttl only drop parts
+ttl_part_type	Compact
+ttl_rows_survive	100
+ttl_h_in_part_not_in_metadata	1
+ttl_unfinished_mutations	0
+ttl_unknown_identifier_failures	0
+ttl_rows_digest	100	10902439880810631721
+ttl_h_has_files_after	0
 column still in metadata
 unfinished_mutations	0
 b_type	Int64

--- a/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.sh
+++ b/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.sh
@@ -99,6 +99,54 @@ echo 'wide'
 run_dropped_column_case t_dropped_column_wide \
     'min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0'
 
+# MATERIALIZE TTL with ttl_only_drop_parts = 1 reaches the same state through a different
+# command. The TTL must not expire here, so the rows survive and the mutation is the only
+# thing that can move the assertions below.
+echo 'materialize ttl only drop parts'
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_ttl_dropped_column SYNC"
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_ttl_dropped_column (a UInt8, b Int16, h String, ts DateTime)
+    ENGINE = MergeTree ORDER BY a PARTITION BY a % 2
+    TTL ts + INTERVAL 30 YEAR
+    SETTINGS ttl_only_drop_parts = 1,
+             min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000"
+${CLICKHOUSE_CLIENT} -q "
+    INSERT INTO t_ttl_dropped_column
+    SELECT number, number, toString(number), now() FROM numbers(100)"
+
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'ttl_part_type', arrayStringConcat(arraySort(groupUniqArray(part_type)), ',')
+    FROM system.parts WHERE database = currentDatabase() AND table = 't_ttl_dropped_column' AND active"
+${CLICKHOUSE_CLIENT} -q "SELECT 'ttl_rows_survive', count() FROM t_ttl_dropped_column"
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_ttl_dropped_column DETACH PARTITION 0"
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_ttl_dropped_column DROP COLUMN h"
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_ttl_dropped_column ATTACH PARTITION 0"
+
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'ttl_h_in_part_not_in_metadata',
+           (SELECT count() FROM system.parts_columns
+            WHERE database = currentDatabase() AND table = 't_ttl_dropped_column' AND active AND column = 'h') > 0
+       AND (SELECT count() FROM system.columns
+            WHERE database = currentDatabase() AND table = 't_ttl_dropped_column' AND name = 'h') = 0"
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_ttl_dropped_column MATERIALIZE TTL SETTINGS alter_sync = 0"
+wait_for_mutations t_ttl_dropped_column
+
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'ttl_unfinished_mutations', count() FROM system.mutations
+    WHERE database = currentDatabase() AND table = 't_ttl_dropped_column' AND NOT is_done"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'ttl_unknown_identifier_failures', count() FROM system.mutations
+    WHERE database = currentDatabase() AND table = 't_ttl_dropped_column'
+      AND latest_fail_error_code_name = 'UNKNOWN_IDENTIFIER'"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'ttl_rows_digest', count(), sum(cityHash64(a, b)) FROM t_ttl_dropped_column"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'ttl_h_has_files_after', count() FROM system.parts_columns
+    WHERE database = currentDatabase() AND table = 't_ttl_dropped_column' AND active AND column = 'h'"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_dropped_column SYNC"
+
 # A column still present in the table metadata must keep being rewritten. This fails if
 # the skip is over-broad and silently turns legitimate reads into no-ops.
 echo 'column still in metadata'

--- a/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.sh
+++ b/tests/queries/0_stateless/04880_mutation_dropped_column_compact_part.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Tags: no-shared-merge-tree
+# Tag no-shared-merge-tree: the metadata-version branch that decides this case is only
+# reachable on engines without a metadata version, and the runner rewrites bare MergeTree.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Waits until the table has no unfinished mutation, or until it has failed.
+# A synchronous ALTER cannot be used as the oracle: StorageMergeTree::waitForMutation
+# returns as soon as a mutation reports any latest_fail_reason, so it can come back
+# before the mutation has been applied to every part.
+wait_for_mutations() {
+    local table=$1
+    local i
+    for i in {1..300}; do
+        if [ "$(${CLICKHOUSE_CLIENT} -q "
+                SELECT count() FROM system.mutations
+                WHERE database = currentDatabase() AND table = '${table}' AND NOT is_done")" = "0" ]; then
+            return 0
+        fi
+        if [ "$(${CLICKHOUSE_CLIENT} -q "
+                SELECT count() FROM system.mutations
+                WHERE database = currentDatabase() AND table = '${table}'
+                  AND NOT is_done AND latest_fail_reason != ''")" != "0" ]; then
+            return 0
+        fi
+        sleep 0.3
+    done
+}
+
+# $1 = table name, $2 = extra CREATE settings selecting the part type
+run_dropped_column_case() {
+    local table=$1
+    local part_settings=$2
+
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${table} SYNC"
+    ${CLICKHOUSE_CLIENT} -q "
+        CREATE TABLE ${table} (a UInt8, b Int16, c Float32, d String, h String)
+        ENGINE = MergeTree ORDER BY a PARTITION BY a % 2
+        SETTINGS ${part_settings}"
+
+    ${CLICKHOUSE_CLIENT} -q "
+        INSERT INTO ${table}
+        SELECT number, number, number, toString(number), toString(number) FROM numbers(100)"
+
+    # Preconditions. Without both of these the mutation never reaches the code under
+    # test and every assertion below would pass vacuously.
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT 'part_type', arrayStringConcat(arraySort(groupUniqArray(part_type)), ',')
+        FROM system.parts WHERE database = currentDatabase() AND table = '${table}' AND active"
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT 'h_has_files_before', count() > 0 FROM system.parts_columns
+        WHERE database = currentDatabase() AND table = '${table}' AND active AND column = 'h'"
+
+    # Detaching the partition lets h be dropped from the table while a part that still
+    # holds h's files stays on disk. Re-attaching it yields a part whose column set is a
+    # strict superset of the table's.
+    ${CLICKHOUSE_CLIENT} -q "ALTER TABLE ${table} DETACH PARTITION 0"
+    ${CLICKHOUSE_CLIENT} -q "ALTER TABLE ${table} DROP COLUMN h"
+    ${CLICKHOUSE_CLIENT} -q "ALTER TABLE ${table} ATTACH PARTITION 0"
+
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT 'h_in_part_not_in_metadata',
+               (SELECT count() FROM system.parts_columns
+                WHERE database = currentDatabase() AND table = '${table}' AND active AND column = 'h') > 0
+           AND (SELECT count() FROM system.columns
+                WHERE database = currentDatabase() AND table = '${table}' AND name = 'h') = 0"
+
+    ${CLICKHOUSE_CLIENT} -q "ALTER TABLE ${table} UPDATE b = b + 1 WHERE 1 SETTINGS alter_sync = 0"
+    wait_for_mutations "${table}"
+
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT 'unfinished_mutations', count() FROM system.mutations
+        WHERE database = currentDatabase() AND table = '${table}' AND NOT is_done"
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT 'unknown_identifier_failures', count() FROM system.mutations
+        WHERE database = currentDatabase() AND table = '${table}'
+          AND latest_fail_error_code_name = 'UNKNOWN_IDENTIFIER'"
+
+    # The read of h was skipped, the rest of the row was not: every row survives and b
+    # was incremented exactly once in both partitions.
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT 'rows_sum_digest', count(), sum(b), sum(cityHash64(a, c, d)) FROM ${table}"
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT 'h_has_files_after', count() FROM system.parts_columns
+        WHERE database = currentDatabase() AND table = '${table}' AND active AND column = 'h'"
+
+    ${CLICKHOUSE_CLIENT} -q "DROP TABLE ${table} SYNC"
+}
+
+echo 'compact'
+run_dropped_column_case t_dropped_column_compact \
+    'min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000'
+
+# Wide parts already behaved this way; cover them against a regression.
+echo 'wide'
+run_dropped_column_case t_dropped_column_wide \
+    'min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0'
+
+# A column still present in the table metadata must keep being rewritten. This fails if
+# the skip is over-broad and silently turns legitimate reads into no-ops.
+echo 'column still in metadata'
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_present_column SYNC"
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t_present_column (a UInt8, b Int16) ENGINE = MergeTree ORDER BY a PARTITION BY a % 2
+    SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000"
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_present_column SELECT number, number FROM numbers(100)"
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_present_column MODIFY COLUMN b Int64 SETTINGS alter_sync = 0"
+wait_for_mutations t_present_column
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'unfinished_mutations', count() FROM system.mutations
+    WHERE database = currentDatabase() AND table = 't_present_column' AND NOT is_done"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'b_type', arrayStringConcat(arraySort(groupUniqArray(type)), ',')
+    FROM system.parts_columns
+    WHERE database = currentDatabase() AND table = 't_present_column' AND active AND column = 'b'"
+${CLICKHOUSE_CLIENT} -q "SELECT 'rows_sum', count(), sum(b) FROM t_present_column"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_present_column SYNC"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/115416
Related: https://github.com/ClickHouse/ClickHouse/pull/119354
Related: https://github.com/ClickHouse/ClickHouse/issues/102153
Related: https://github.com/ClickHouse/ClickHouse/issues/116646


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `ALTER TABLE ... MATERIALIZE TTL` failing with `UNKNOWN_IDENTIFIER` and being retried forever on a table with `ttl_only_drop_parts = 1` when a part still holds a column that the table dropped while that part's partition was detached. Mutating such a partition after cloning it into another table with `ATTACH PARTITION FROM` no longer fails with a logical error either.


### Description

#119354 merged the same skip for the general case and closed #115416, leaving only the `MATERIALIZE TTL` fast path it does not reach.

With only a rows TTL and `ttl_only_drop_parts = 1`, `MATERIALIZE TTL` marked every column it does not rewrite as ignored, and an ignored column skipped the check for columns absent from the table. A partition detached before `DROP COLUMN` and re-attached after it still carries that column, so the split emitted a `READ_COLUMN` whose identifier no longer resolved, and the mutation was retried for as long as the part existed:

```
Code: 341 ... mutation 'mutation_4.txt' with part '1_3_3_0' reason:
'Code: 47 ... Unknown expression identifier `c`. Maybe you meant: ['p'] ... (UNKNOWN_IDENTIFIER)'
```

Dropping that term makes the fast path take the same decision as every other mutation command, which exposed a second case, reported in review (#102153) and folded in here: `ATTACH`/`REPLACE PARTITION FROM` and `MOVE PARTITION TO TABLE` stamp the destination's metadata version on a part that keeps the source's columns, so a partition cloned out of a table that had dropped the column arrives at the table's own version with a column in no schema at all, which took the logical error in the split and aborted a debug or sanitizer build. Every mutation on this path now treats an equal metadata version like a smaller one; the throw is kept only for a part AHEAD of the table, where the column is real data (#96008, reverted by #97301) and the queue already postpones the mutation.

The test has three arms, `MergeTree`, `ReplicatedMergeTree` and a cloned partition, and drops `no-shared-merge-tree`: every arm now takes the version comparison, not the branch that asks whether the storage is replicated. On debug builds master fails all three with `UNKNOWN_IDENTIFIER`, this branch without the one-line change passes the first two and aborts on the third, and with it all three pass.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115962&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115962](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115962+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1602` (included in `26.9` and later)
<!-- ch-version-info:end -->