### PR TITLE
Do not read a subcolumn that a wide part's column type does not have

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -114,6 +114,31 @@ bool IMergeTreeReader::isSystemColumnInvalidated(size_t pos) const
     return data_part_info_for_read->isSystemColumnInvalidated(columns_to_read[pos].getNameInStorage());
 }
 
+bool IMergeTreeReader::isSubcolumnMissingInPart(size_t pos) const
+{
+    const auto & column_to_read = columns_to_read[pos];
+    if (!column_to_read.isSubcolumn())
+        return false;
+
+    /// The part's own columns list, not the Nested-collected view: a member of a Nested group is a
+    /// column in its own right, and asking the synthesized group type about it reports every member
+    /// the part lacks as a missing subcolumn, including one that is only awaiting offsets sharing.
+    auto storage_column_from_part = data_part_info_for_read->getColumnsDescription().tryGetColumn(
+        GetColumnsOptions::AllPhysical, column_to_read.getNameInStorage());
+    if (!storage_column_from_part)
+        return false;
+
+    /// The `Quantize` codec's custom serialization exposes companion `quantized`/`pq_codebook` subcolumns that
+    /// the part's plain columns list cannot represent - they round-trip to the bare type name and are lost, so
+    /// the subcolumn would be treated as missing and recomputed/defaulted after a reload. Decide presence from
+    /// the requested column's storage type in that case. Restricted to that specific serialization so it does
+    /// not change presence decisions for ordinary subcolumns (e.g. of sparse columns).
+    const auto * custom = column_to_read.getTypeInStorage()->getCustomSerialization();
+    const bool is_quantize = custom && typeid(*custom) == typeid(SerializationQuantizedVector);
+    const auto & type_for_subcolumn = is_quantize ? column_to_read.getTypeInStorage() : storage_column_from_part->type;
+    return !type_for_subcolumn->hasSubcolumn(column_to_read.getSubcolumnName());
+}
+
 void IMergeTreeReader::fillVirtualColumns(Columns & columns, size_t rows) const
 {
     chassert(columns.size() == getColumns().size());

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -191,6 +191,11 @@ protected:
     /// Returns true if the column at position @pos in columns_to_read is a system column that was invalidated.
     bool isSystemColumnInvalidated(size_t pos) const;
 
+    /// Returns true if the column at position @pos in columns_to_read is a subcolumn that the part's own
+    /// column type does not have. Such a subcolumn must not be read from the part: its streams belong to a
+    /// different shape of the parent, so it is derived from the converted parent by evaluateMissingDefaults.
+    bool isSubcolumnMissingInPart(size_t pos) const;
+
 private:
     friend class MergeTreeReaderIndex;
     friend class MergeTreeReaderTextIndex;

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -4,7 +4,6 @@
 #include <Storages/MergeTree/DeserializationPrefixesCache.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <DataTypes/Serializations/getSubcolumnsDeserializationOrder.h>
-#include <DataTypes/Serializations/SerializationQuantizedVector.h>
 #include <DataTypes/NestedUtils.h>
 #include <Interpreters/Context.h>
 #include <ranges>
@@ -84,23 +83,8 @@ void MergeTreeReaderCompact::fillColumnPositions()
         if (position.has_value() && (isColumnDroppedByPendingMutation(i) || isSystemColumnInvalidated(i)))
             position.reset();
 
-        if (position.has_value() && column_to_read.isSubcolumn())
-        {
-            auto name_in_storage = column_to_read.getNameInStorage();
-            auto subcolumn_name = column_to_read.getSubcolumnName();
-            auto storage_column_from_part = part_columns.getColumn(GetColumnsOptions::All, name_in_storage);
-
-            /// The `Quantize` codec's custom serialization exposes companion `quantized`/`pq_codebook` subcolumns that
-            /// the part's plain columns list cannot represent - they round-trip to the bare type name and are lost, so
-            /// the subcolumn would be treated as missing and recomputed/defaulted after a reload. Decide presence from
-            /// the requested column's storage type in that case. Restricted to that specific serialization so it does
-            /// not change presence decisions for ordinary subcolumns (e.g. of sparse columns).
-            const auto * custom = column_to_read.getTypeInStorage()->getCustomSerialization();
-            const bool is_quantize = custom && typeid(*custom) == typeid(SerializationQuantizedVector);
-            const auto & type_for_subcolumn = is_quantize ? column_to_read.getTypeInStorage() : storage_column_from_part.type;
-            if (!type_for_subcolumn->hasSubcolumn(subcolumn_name))
-                position.reset();
-        }
+        if (position.has_value() && isSubcolumnMissingInPart(i))
+            position.reset();
 
         column_positions[i] = std::move(position);
 

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -63,10 +63,17 @@ MergeTreeReaderWide::MergeTreeReaderWide(
 {
     try
     {
+        /// Must be decided before any stream name is resolved: for a subcolumn absent from the part's
+        /// type, `getStreamNameForColumn` resolves an existing stream of the parent, so a check made
+        /// after resolution cannot tell the two apart.
+        columns_skipped_from_part.resize(columns_to_read.size());
+        for (size_t i = 0; i < columns_to_read.size(); ++i)
+            columns_skipped_from_part[i]
+                = isColumnDroppedByPendingMutation(i) || isSystemColumnInvalidated(i) || isSubcolumnMissingInPart(i);
+
         for (size_t i = 0; i < columns_to_read.size(); ++i)
         {
-            /// Column was dropped by a pending mutation or invalidated. Don't read stale data;
-            if (!isColumnDroppedByPendingMutation(i) && !isSystemColumnInvalidated(i))
+            if (!columns_skipped_from_part[i])
                 addStreams(columns_to_read[i], serializations[i]);
         }
     }
@@ -127,7 +134,7 @@ void MergeTreeReaderWide::prefetchForAllColumns(
     /// so if reading can be asynchronous, it will also be performed in parallel for all columns.
     for (size_t pos = 0; pos < num_columns; ++pos)
     {
-        if (isColumnDroppedByPendingMutation(pos) || isSystemColumnInvalidated(pos))
+        if (columns_skipped_from_part[pos])
             continue;
 
         try
@@ -169,7 +176,7 @@ size_t MergeTreeReaderWide::readRows(
 
         for (size_t pos = 0; pos < num_columns; ++pos)
         {
-            if (isColumnDroppedByPendingMutation(pos) || isSystemColumnInvalidated(pos))
+            if (columns_skipped_from_part[pos])
             {
                 res_columns[pos] = nullptr;
                 continue;
@@ -513,7 +520,7 @@ void MergeTreeReaderWide::deserializePrefixForAllColumnsImpl(size_t num_columns,
         DeserializeBinaryBulkStateMap deserialize_state_map;
         for (size_t pos = 0; pos < num_columns; ++pos)
         {
-            if (isColumnDroppedByPendingMutation(pos) || isSystemColumnInvalidated(pos))
+            if (columns_skipped_from_part[pos])
                 continue;
 
             try
@@ -708,6 +715,9 @@ std::unordered_map<String, std::vector<String>> MergeTreeReaderWide::getAllColum
     std::unordered_map<String, std::vector<String>> column_to_streams;
     for (size_t i = 0; i < columns_to_read.size(); ++i)
     {
+        if (columns_skipped_from_part[i])
+            continue;
+
         const auto & name_and_type = columns_to_read[i];
         const auto & serialization = serializations[i];
 

--- a/src/Storages/MergeTree/MergeTreeReaderWide.h
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.h
@@ -107,6 +107,11 @@ private:
     using StreamCallbackGetter = std::function<ISerialization::StreamCallback(const NameAndTypePair &)>;
     void deserializePrefixForAllColumnsImpl(size_t num_columns, size_t from_mark, StreamCallbackGetter prefixes_prefetch_callback_getter);
 
+    /// Positions in `columns_to_read` that must not be read from this part. Computed in the constructor
+    /// before any stream is created, so that no loop opens, prefixes or enumerates a stream that the
+    /// read loop then skips.
+    std::vector<bool> columns_skipped_from_part;
+
     std::unordered_map<String, ISerialization::SubstreamsCache> caches;
     std::unordered_map<String, ISerialization::SubstreamsDeserializeStatesCache> deserialize_states_caches;
     DeserializationPrefixesCache * deserialization_prefixes_cache;

--- a/tests/queries/0_stateless/05030_wide_part_subcolumn_missing_in_part.reference
+++ b/tests/queries/0_stateless/05030_wide_part_subcolumn_missing_in_part.reference
@@ -1,0 +1,15 @@
+Wide
+1
+String	LowCardinality(String)
+1	1
+2	2
+3
+1
+1	1	a
+2	2	bb
+Compact
+1	1
+2	2
+6000000
+1
+1

--- a/tests/queries/0_stateless/05030_wide_part_subcolumn_missing_in_part.sql
+++ b/tests/queries/0_stateless/05030_wide_part_subcolumn_missing_in_part.sql
@@ -1,13 +1,13 @@
 -- Tags: no-random-merge-tree-settings
 -- Random settings limits: min_bytes_for_wide_part=(0, 0)
 
--- A pending `MODIFY COLUMN y String` makes the metadata snapshot report `String`, so `length(y)`
--- is rewritten to the `y.size` subcolumn, while the part on disk still holds
--- `LowCardinality(String)`, whose type has no `size` subcolumn. Reading it anyway resolves the
--- request to an unrelated stream of the parent and yields a column of the wrong class.
+-- A pending `MODIFY COLUMN y String` makes the metadata snapshot report `String`, so `y.size` is a
+-- valid request, while the part on disk still holds `LowCardinality(String)`, whose type has no
+-- `size` subcolumn. Reading it anyway resolves the request to an unrelated stream of the parent and
+-- yields a column of the wrong class.
 
--- The subcolumn request is what reaches the reader, so the rewrite must stay on.
-SET optimize_functions_to_subcolumns = 1;
+-- The subcolumn is requested explicitly: `length(y)` reaches the same request, but only through a
+-- rewrite the old analyzer does not perform.
 
 DROP TABLE IF EXISTS t_wide;
 
@@ -22,17 +22,17 @@ SYSTEM STOP MERGES t_wide;
 ALTER TABLE t_wide MODIFY COLUMN y String SETTINGS mutations_sync = 0, alter_sync = 0;
 
 -- The subcolumn request is what arms this: without it the parent is read directly.
-SELECT count() > 0 FROM (EXPLAIN actions = 1 SELECT x, length(y) FROM t_wide ORDER BY x) WHERE explain ILIKE '%y.size%';
+SELECT count() > 0 FROM (EXPLAIN actions = 1 SELECT x, y.size FROM t_wide ORDER BY x) WHERE explain ILIKE '%y.size%';
 
 -- On disk the column is still LowCardinality while the snapshot says String.
 SELECT
     (SELECT type FROM system.columns WHERE database = currentDatabase() AND table = 't_wide' AND name = 'y'),
     (SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_wide' AND active AND column = 'y');
 
-SELECT x, length(y) FROM t_wide ORDER BY x;
-SELECT sum(length(y)) FROM t_wide;
-SELECT count() FROM t_wide WHERE length(y) = 2;
-SELECT x, length(y), y FROM t_wide ORDER BY x;
+SELECT x, y.size FROM t_wide ORDER BY x;
+SELECT sum(y.size) FROM t_wide;
+SELECT count() FROM t_wide WHERE y.size = 2;
+SELECT x, y.size, y FROM t_wide ORDER BY x;
 
 -- Compact parts already refused the read; they must keep returning the same values.
 DROP TABLE IF EXISTS t_compact;
@@ -47,7 +47,7 @@ SELECT part_type FROM system.parts WHERE database = currentDatabase() AND table 
 SYSTEM STOP MERGES t_compact;
 ALTER TABLE t_compact MODIFY COLUMN y String SETTINGS mutations_sync = 0, alter_sync = 0;
 
-SELECT x, length(y) FROM t_compact ORDER BY x;
+SELECT x, y.size FROM t_compact ORDER BY x;
 
 -- A subcolumn the part's type does have must still be read from its own stream, not derived from
 -- the parent: reading only the sizes of long strings must not pull in the data stream.
@@ -60,7 +60,7 @@ INSERT INTO t_sizes SELECT number, repeat('z', 2000) FROM numbers(3000);
 
 -- ast_fuzzer_runs = 0: a fuzzed re-execution inherits log_comment and is logged too, so the
 -- stress-test profile would otherwise add rows measuring a different query.
-SELECT sum(length(y)) FROM t_sizes SETTINGS log_comment = '05030_sizes_only', ast_fuzzer_runs = 0;
+SELECT sum(y.size) FROM t_sizes SETTINGS log_comment = '05030_sizes_only', ast_fuzzer_runs = 0;
 SELECT sum(cityHash64(y)) > 0 FROM t_sizes SETTINGS log_comment = '05030_full_data', ast_fuzzer_runs = 0;
 
 SYSTEM FLUSH LOGS query_log;

--- a/tests/queries/0_stateless/05030_wide_part_subcolumn_missing_in_part.sql
+++ b/tests/queries/0_stateless/05030_wide_part_subcolumn_missing_in_part.sql
@@ -1,0 +1,79 @@
+-- Tags: no-random-merge-tree-settings
+-- Random settings limits: min_bytes_for_wide_part=(0, 0)
+
+-- A pending `MODIFY COLUMN y String` makes the metadata snapshot report `String`, so `length(y)`
+-- is rewritten to the `y.size` subcolumn, while the part on disk still holds
+-- `LowCardinality(String)`, whose type has no `size` subcolumn. Reading it anyway resolves the
+-- request to an unrelated stream of the parent and yields a column of the wrong class.
+
+-- The subcolumn request is what reaches the reader, so the rewrite must stay on.
+SET optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_wide;
+
+CREATE TABLE t_wide (x UInt32, y LowCardinality(String)) ENGINE = MergeTree ORDER BY x
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, string_serialization_version = 'with_size_stream';
+
+INSERT INTO t_wide VALUES (1, 'a'), (2, 'bb');
+
+SELECT part_type FROM system.parts WHERE database = currentDatabase() AND table = 't_wide' AND active;
+
+SYSTEM STOP MERGES t_wide;
+ALTER TABLE t_wide MODIFY COLUMN y String SETTINGS mutations_sync = 0, alter_sync = 0;
+
+-- The subcolumn request is what arms this: without it the parent is read directly.
+SELECT count() > 0 FROM (EXPLAIN actions = 1 SELECT x, length(y) FROM t_wide ORDER BY x) WHERE explain ILIKE '%y.size%';
+
+-- On disk the column is still LowCardinality while the snapshot says String.
+SELECT
+    (SELECT type FROM system.columns WHERE database = currentDatabase() AND table = 't_wide' AND name = 'y'),
+    (SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_wide' AND active AND column = 'y');
+
+SELECT x, length(y) FROM t_wide ORDER BY x;
+SELECT sum(length(y)) FROM t_wide;
+SELECT count() FROM t_wide WHERE length(y) = 2;
+SELECT x, length(y), y FROM t_wide ORDER BY x;
+
+-- Compact parts already refused the read; they must keep returning the same values.
+DROP TABLE IF EXISTS t_compact;
+
+CREATE TABLE t_compact (x UInt32, y LowCardinality(String)) ENGINE = MergeTree ORDER BY x
+SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000, string_serialization_version = 'with_size_stream';
+
+INSERT INTO t_compact VALUES (1, 'a'), (2, 'bb');
+
+SELECT part_type FROM system.parts WHERE database = currentDatabase() AND table = 't_compact' AND active;
+
+SYSTEM STOP MERGES t_compact;
+ALTER TABLE t_compact MODIFY COLUMN y String SETTINGS mutations_sync = 0, alter_sync = 0;
+
+SELECT x, length(y) FROM t_compact ORDER BY x;
+
+-- A subcolumn the part's type does have must still be read from its own stream, not derived from
+-- the parent: reading only the sizes of long strings must not pull in the data stream.
+DROP TABLE IF EXISTS t_sizes;
+
+CREATE TABLE t_sizes (x UInt32, y String) ENGINE = MergeTree ORDER BY x
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, string_serialization_version = 'with_size_stream';
+
+INSERT INTO t_sizes SELECT number, repeat('z', 2000) FROM numbers(3000);
+
+-- ast_fuzzer_runs = 0: a fuzzed re-execution inherits log_comment and is logged too, so the
+-- stress-test profile would otherwise add rows measuring a different query.
+SELECT sum(length(y)) FROM t_sizes SETTINGS log_comment = '05030_sizes_only', ast_fuzzer_runs = 0;
+SELECT sum(cityHash64(y)) > 0 FROM t_sizes SETTINGS log_comment = '05030_full_data', ast_fuzzer_runs = 0;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- Reading the sizes alone must stay an order of magnitude cheaper than reading the string data.
+SELECT
+    (SELECT argMax(ProfileEvents['CompressedReadBufferBytes'], event_time_microseconds)
+     FROM system.query_log
+     WHERE current_database = currentDatabase() AND log_comment = '05030_sizes_only' AND type = 'QueryFinish') * 10
+    < (SELECT argMax(ProfileEvents['CompressedReadBufferBytes'], event_time_microseconds)
+       FROM system.query_log
+       WHERE current_database = currentDatabase() AND log_comment = '05030_full_data' AND type = 'QueryFinish');
+
+DROP TABLE t_sizes;
+DROP TABLE t_compact;
+DROP TABLE t_wide;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115705
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a logical error `Bad cast from type DB::ColumnVector<unsigned long> to DB::ColumnLowCardinality` when reading a subcolumn from a wide part whose column type does not have that subcolumn, which can happen while an `ALTER TABLE ... MODIFY COLUMN` is not yet materialized. For example `SELECT length(y)` over a part where `y` is still `LowCardinality(String)` while the table metadata already says `String`.


### Description

Related: #115705 (this fixes one of the two unrelated CI failures reported there; no related open issue found).

`SELECT length(y)` is answered from the `y.size` subcolumn, and that rewrite is keyed on the metadata snapshot type. With a pending `MODIFY COLUMN y String` the snapshot says `String`, so `y.size` is requested, while the part on disk still holds `LowCardinality(String)` - a type that has no `size` subcolumn.

`MergeTreeReaderCompact` already refuses such a read and lets the existing missing-subcolumn path derive the value from the converted parent. `MergeTreeReaderWide` did not. It fell back to the requested type's default serialization, which is single-stream, and parsed the dictionary indexes stream as string lengths into a `ColumnVector<UInt64>`. The substreams cache is shared per storage column, so the full `y` read adopted that column, and the alter-conversion `CAST` to `LowCardinality(String)` class-cast it and threw. Debug and sanitizer builds abort.

This ports the presence check into `IMergeTreeReader` and has both readers use it, so they cannot drift again. In the wide reader it is decided once in the constructor, before any stream name is resolved: for an absent subcolumn `getStreamNameForColumn` resolves an existing stream of the parent, so a check made after resolution cannot tell the two apart. All five per-column loops consult that one decision, including the prefix loop.

Read-path only: on-disk data is unaffected and there is no format or setting change.

A new stateless test reproduces the logical error deterministically before the fix and returns the correct lengths after it, and a control asserts via profile events that a subcolumn the part genuinely has is still read from its own size stream rather than derived from the parent. Existing `subcolumn`, `nested`, `lowcardinality`, `alter_modify` and `quantize` tests were compared against a pre-fix build; every remaining failure fails identically on both.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115964&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115964](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115964+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
