### PR TITLE
Drop the seal normalization assertion from the adaptive aggregation test

### DIFF
--- a/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.reference
+++ b/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.reference
@@ -8,4 +8,3 @@ Nullable(UInt64)
 4873337004925605739
 4873337004925605739
 sealed chunks	1
-normalized	1

--- a/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.sql
+++ b/tests/queries/0_stateless/04676_adaptive_aggregation_replicated_argument.sql
@@ -108,14 +108,5 @@ WHERE current_database = currentDatabase() AND type = 'QueryFinish'
     AND event_date >= yesterday() AND event_time >= now() - 600
     AND log_comment LIKE '04676_seal_%';
 
--- The normalization inside the coalescing additionally needs the buffered batches to disagree at
--- an argument position, and which blocks one producer buffers is not something the settings above
--- pin, so the count is summed over the three arms rather than asserted for each.
-SELECT 'normalized', coalesce(sum(ProfileEvents['AdaptiveAggregationSealNormalizations']), 0) > 0
-FROM system.query_log
-WHERE current_database = currentDatabase() AND type = 'QueryFinish'
-    AND event_date >= yesterday() AND event_time >= now() - 600
-    AND log_comment LIKE '04676_seal_%';
-
 DROP TABLE t_adaptive_repl_left;
 DROP TABLE t_adaptive_repl_right;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/115204
Related: https://github.com/ClickHouse/ClickHouse/pull/115034
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04676_adaptive_aggregation_replicated_argument` asserts that
`AdaptiveAggregationSealNormalizations` is non-zero. That counter fires only when two
staged batches inside one aggregating producer's own buffer disagree at the same
aggregate argument position, which needs the join's per-block lazy-versus-dense decision,
which of the four producers gets which block, one producer buffering two batches before
it crosses the seal target, and those batches actually differing. The seal target is a
compile-time constant and the block distribution is pipeline scheduling, so no setting in
the test reaches any of them. The assertion reports scheduling rather than behaviour, and
it fails on roughly 1 run in 50 of the lanes that put MergeTree metadata in Keeper and
parts on object storage.

Three rounds already tried to pin it; #115204 widened it from per-arm to summed over the
three arms and it still flips. Across the 70 public CI failures of this test in 14 days
the `sealed chunks` line never flipped and this line accounts for all 70, so widening
addressed sample size where the problem is that the sampled event is not the test's to
control. This deletes the assertion. `sealed chunks` stays; the counter is unchanged and
still emitted.

Coverage is preserved, and measured rather than assumed. Reverting the source half of
#115034 and running the trimmed test still fails, with the original
`Bad cast from type DB::ColumnReplicated to DB::ColumnVector<Int128>` abort in
`sealPendingChunks`, through the `04676_seal_uint128` value arm: those six value arms
compare the adaptive result against the `enable_adaptive_aggregator = 0` baseline, so an
unfixed binary aborts on them. `sealed chunks` is still a live oracle: disabling the
frozen path takes it to 0. The trimmed test passes 50/50 on local disk and 50/50 on S3,
randomization on.

No open issue tracks this. Prior rounds on the same assertion: #115034 added it,
#115204 widened it.

<details>
<summary>Validation</summary>

| Arm | Result |
|---|---|
| Trimmed test, fixed binary | `[ OK ]`; output byte-identical to the reference; arms genuinely ran (902400 rows each) |
| Trimmed test, source half of #115034 reverted | **FAIL**: `Bad cast from type DB::ColumnReplicated to DB::ColumnVector<Int128>`, signal 6, in `Aggregator::sealPendingChunks`, on the `04676_seal_uint128` arm |
| `sealed chunks` negative control (frozen path disabled) | `sealed chunks 0`, so the surviving assertion can still fail |
| 50 runs, local disk, randomization on | 50 OK / 0 FAIL |
| 50 runs, S3 (MinIO), randomization on | 50 OK / 0 FAIL |
| Sibling `04654_adaptive_aggregator_profile_events` | `[ OK ]` (asserts a different counter, untouched) |

The mutation arm was asserted single before building (only
`src/Interpreters/AdaptiveAggregation.cpp` modified, `removeSpecialRepresentations`
count 0, distinct Build-ID) and the restore returned the Build-ID to the fix arm's exact
value. Both 50-run arms were proven live: `max_read_buffer_size` took 50 distinct values
across the runs, and the S3 bucket held 5014 objects afterwards. `--long-test-runs-ratio
1.0` was needed because the test is tagged `long`, which otherwise scales 50 runs down
to 5.

`grep -rn SealNormalizations tests/` returns nothing after this change; it previously
returned exactly the one deleted line. The test is master-only, so no backport applies.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115968&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115968](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115968+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
