### PR TITLE
Do not request CountMinSketch when the build does not have it

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1916,6 +1916,15 @@ class MergeTreeSettingsRandomizer:
                 value = random.randint(100 * 1024, 30 * 1024 * 1024)
             else:
                 value = generator()
+
+            # `countmin` is unavailable when ClickHouse is built without DataSketches.
+            if setting == "auto_statistics_types" and "use_datasketches" not in args.build_flags:
+                value = ",".join(
+                    statistic_type
+                    for statistic_type in value.split(",")
+                    if statistic_type != "countmin"
+                )
+
             if type(value) == str and value == "":
                 continue
 


### PR DESCRIPTION
I have a pretty minimal set of flags in `cmake` that does not include `USE_DATASKETCHES`, which often results in tests failing with this error:

```
Code: 80. DB::Exception: Received from localhost:9000. DB::Exception: Unknown statistic type 'CountMinSketch'. (INCORRECT_QUERY)
```

This change makes `clickhouse-test` check for support to avoid the failure.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Do not request CountMinSketch in tests when the build does not have it.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115975&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115975](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115975+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1966` (included in `26.8` and later)
<!-- ch-version-info:end -->