### PR TITLE
Fix a segfault of showCertificate when TLS certificates are provisioned by ACME

### DIFF
--- a/src/Common/Crypto/X509Certificate.cpp
+++ b/src/Common/Crypto/X509Certificate.cpp
@@ -19,6 +19,9 @@ extern const int BAD_ARGUMENTS;
 X509Certificate::X509Certificate(X509 * cert_)
     : certificate(cert_)
 {
+    /// Every accessor dereferences the certificate, so a null pointer here turns into a segfault later.
+    if (!certificate)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot create a certificate from a null pointer");
 }
 
 X509Certificate::operator X509 *() const

--- a/src/Functions/FunctionShowCertificate.cpp
+++ b/src/Functions/FunctionShowCertificate.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <Columns/ColumnMap.h>
@@ -17,6 +18,7 @@
 #if USE_SSL
     #include <Poco/Net/SSLManager.h>
     #include <Common/Crypto/X509Certificate.h>
+    #include <Server/CertificateReloader.h>
 #endif
 
 namespace DB
@@ -29,6 +31,27 @@ namespace ErrorCodes
 
 namespace
 {
+
+#if USE_SSL
+/// The certificate that the server currently serves to clients.
+/// It is not always the certificate of the default SSL context: when certificates are provisioned
+/// dynamically (the `<acme>` configuration), that context has no certificate at all, and only
+/// `CertificateReloader` knows the certificate in use.
+std::optional<X509Certificate> getServerCertificate()
+{
+    auto served_certificate = CertificateReloader::instance().getCertificate(Poco::Net::SSLManager::CFG_SERVER_PREFIX);
+    if (served_certificate)
+        return served_certificate;
+
+    X509 * context_certificate = SSL_CTX_get0_certificate(Poco::Net::SSLManager::instance().defaultServerContext()->sslContext());
+    if (!context_certificate)
+        return {};
+
+    /// `SSL_CTX_get0_certificate` does not transfer the ownership, and `X509` is reference counted.
+    X509_up_ref(context_certificate);
+    return X509Certificate(context_certificate);
+}
+#endif
 
 // showCertificate()
 class FunctionShowCertificate final : public IFunction
@@ -71,15 +94,11 @@ public:
         if (input_rows_count)
         {
 #if USE_SSL
-            std::unique_ptr<X509Certificate> x509_cert;
+            std::optional<X509Certificate> x509_cert;
             if (!certificate.empty())
-                x509_cert = std::make_unique<X509Certificate>(certificate);
-
-            if (!x509_cert)
-            {
-                const auto * server_context_cert = SSL_CTX_get0_certificate(Poco::Net::SSLManager::instance().defaultServerContext()->sslContext());
-                x509_cert = std::make_unique<X509Certificate>(X509_dup(server_context_cert));
-            }
+                x509_cert.emplace(certificate);
+            else
+                x509_cert = getServerCertificate();
 
             if (x509_cert)
             {
@@ -143,6 +162,7 @@ REGISTER_FUNCTION(ShowCertificate)
 {
     FunctionDocumentation::Description description = R"(
 Shows information about the current server's Secure Sockets Layer (SSL) certificate if it has been configured.
+An empty map is returned if the server has no certificate, for example, when the certificate is provisioned with ACME and has not been issued yet.
 See [Configuring TLS](/concepts/features/security/tls/configuring-tls) for more information on how to configure ClickHouse to use OpenSSL certificates to validate connections.
     )";
     FunctionDocumentation::Syntax syntax = "showCertificate()";

--- a/src/Server/CertificateReloader.cpp
+++ b/src/Server/CertificateReloader.cpp
@@ -273,6 +273,25 @@ bool CertificateReloader::registerAdditionalContext(SSL_CTX * ctx, const std::st
 }
 
 
+std::optional<X509Certificate> CertificateReloader::getCertificate(const std::string & prefix) const
+{
+    std::lock_guard lock{data_mutex};
+
+    auto it = data_index.find(prefix);
+    if (it == data_index.end())
+        return {};
+
+    auto current = it->second->data.get();
+    if (!current || current->certs_chain.empty())
+        return {};
+
+    /// `X509` is reference counted and immutable, so the certificate can be shared with the caller.
+    X509 * leaf_certificate = static_cast<X509 *>(current->certs_chain.front());
+    X509_up_ref(leaf_certificate);
+    return X509Certificate(leaf_certificate);
+}
+
+
 CertificateReloader::Data::Data(std::string cert_path, std::string key_path, std::string pass_phrase)
     : certs_chain(X509Certificate::fromFile(cert_path)), key(KeyPair::fromFile(key_path, pass_phrase))
 {

--- a/src/Server/CertificateReloader.h
+++ b/src/Server/CertificateReloader.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <filesystem>
 #include <list>
+#include <optional>
 #include <unordered_map>
 #include <mutex>
 
@@ -95,6 +96,11 @@ public:
 
     /// A callback for OpenSSL
     int setCertificate(SSL * ssl, const MultiData * pdata);
+
+    /// The leaf certificate that is currently served for `prefix` connections, if there is one.
+    /// It is not necessarily the certificate of the corresponding `SSL_CTX`: certificates are installed
+    /// per connection, and with `<acme>` the context itself never gets a certificate at all.
+    std::optional<X509Certificate> getCertificate(const std::string & prefix) const;
 
 private:
     CertificateReloader() = default;

--- a/tests/integration/test_acme_tls/configs/config_no_certificate.xml
+++ b/tests/integration/test_acme_tls/configs/config_no_certificate.xml
@@ -1,0 +1,11 @@
+<clickhouse>
+    <acme>
+        <email>test@clickhouse.com</email>
+        <terms_of_service_agreed>true</terms_of_service_agreed>
+        <domains>
+            <domain>never-issued.integration-tests.clickhouse.com</domain>
+        </domains>
+        <!-- Nothing is listening on this address, so the certificate is never issued. -->
+        <directory_url>https://127.0.0.1:14000/dir</directory_url>
+    </acme>
+</clickhouse>

--- a/tests/integration/test_acme_tls/test_no_certificate.py
+++ b/tests/integration/test_acme_tls/test_no_certificate.py
@@ -1,0 +1,32 @@
+import logging
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().addHandler(logging.StreamHandler())
+
+no_certificate_cluster = ClickHouseCluster(__file__)
+node = no_certificate_cluster.add_instance(
+    "node_no_certificate",
+    main_configs=["configs/config_no_certificate.xml"],
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_no_certificate_cluster():
+    try:
+        no_certificate_cluster.start()
+        yield no_certificate_cluster
+    finally:
+        no_certificate_cluster.shutdown()
+
+
+def test_show_certificate_without_certificate(started_no_certificate_cluster):
+    # The certificate is provisioned by ACME, and the ACME server is unreachable, so the server
+    # runs with an SSL context that has no certificate at all. `showCertificate` used to
+    # dereference a null pointer in this case.
+    assert node.query("SELECT showCertificate()") == "{}\n"
+    assert node.query("SELECT 1") == "1\n"

--- a/tests/integration/test_acme_tls/test_single_node.py
+++ b/tests/integration/test_acme_tls/test_single_node.py
@@ -66,3 +66,23 @@ def test_acme_authorization(started_single_replica_cluster):
         return
 
     raise Exception("Failed to get expected certificate issuer")
+
+
+def test_show_certificate(started_single_replica_cluster):
+    # Let Pebble know where to find our server
+    requests.post(
+        'http://10.5.11.3:8055/add-a',
+        json={'host': 'single.integration-tests.clickhouse.com', 'addresses': ['10.5.11.11']}
+    )
+
+    # With ACME the SSL context of the server never receives a certificate, so `showCertificate`
+    # has to report the certificate held by the certificate reloader.
+    certificate = ""
+    for _ in range(120):
+        certificate = node.query("SELECT showCertificate()")
+        if "CN=Pebble Intermediate CA" in certificate:
+            return
+
+        time.sleep(1)
+
+    raise Exception(f"showCertificate() did not report the ACME certificate: {certificate}")


### PR DESCRIPTION
`showCertificate` took the server certificate from the default `SSL_CTX`. When certificates are provisioned dynamically with the `<acme>` configuration, that context never receives a certificate: `SSL_CTX_get0_certificate` returns a null pointer, `X509_dup` of it returns a null pointer as well, and the result was wrapped into an `X509Certificate` whose every accessor dereferences it. Any user - including a read-only one - could crash the server with `SELECT showCertificate()`:

```
<Fatal> BaseDaemon: Address: NULL pointer. Access: <not available>. Address not mapped to object.
<Fatal> BaseDaemon: 2. DB::(anonymous namespace)::FunctionShowCertificate::executeImpl(...) const @ 0x000000000ee52f05
<Fatal> BaseDaemon: 3. DB::IExecutableFunction::executeWithoutLowCardinalityColumns(...) const @ 0x0000000016b11df8
...
<Fatal> BaseDaemon: 5. DB::QueryAnalyzer::resolveFunction(...) @ 0x0000000018196eec
```

It is reproducible without an ACME server, because it is enough that the certificate is not there:

```
$ cat acme.xml
<clickhouse>
    <acme>
        <email>test@clickhouse.com</email>
        <terms_of_service_agreed>true</terms_of_service_agreed>
        <domains><domain>example.com</domain></domains>
        <directory_url>https://127.0.0.1:14000/dir</directory_url>
    </acme>
</clickhouse>

$ clickhouse local --config-file=acme.xml --query "SELECT showCertificate()"
Segmentation fault
```

The null check existed in the original implementation and was lost when `Poco::Crypto` was replaced with our own `X509Certificate` wrapper; it became reachable when ACME support was added.

The certificate is now taken from `CertificateReloader` - the component that owns the certificate actually served to clients. Besides ACME, this also makes the function report the certificate in use after a reload, instead of the one loaded into the SSL context at startup. When there is no certificate at all, an empty map is returned, as it was before ACME.

Additionally, `X509Certificate` no longer accepts a null pointer silently: constructing it from `nullptr` throws instead of producing an object that segfaults on the first use.

Related: https://github.com/ClickHouse/ClickHouse/pull/78591
Related: https://github.com/ClickHouse/ClickHouse/pull/66315

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a crash of the `showCertificate` function on a server that obtains its TLS certificate with ACME (Let's Encrypt). The function now reports the certificate that is actually served, also after a certificate reload.


### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115976&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115976](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115976+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1943` (included in `26.8` and later)
- Backported to: `26.7.6.45`, `26.6.4.33`, `26.3.24.3`
<!-- ch-version-info:end -->