### PR TITLE
Bound the symbolization of the jemalloc profiles in log collection

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -54,6 +54,9 @@ class ClickHouseProc:
     # Per-table wall-clock cap for dump_system_tables (seconds). One stuck dump
     # must not exhaust the job's 9000s budget and get the whole job SIGKILLed.
     DUMP_SYSTEM_TABLE_TIMEOUT = 600
+    # Total wall-clock cap for symbolizing the jemalloc profiles of a job (seconds),
+    # for the same reason.
+    JEMALLOC_SYMBOLIZATION_BUDGET = 1200
 
     def __init__(
         self,
@@ -944,16 +947,42 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             file_with_max_third_number = max(files_in_group, key=lambda x: x[0])[1]
             latest_profiles[pid] = file_with_max_third_number
 
+        # Symbolizing a heap profile is unbounded work: it scales with the number of distinct
+        # addresses in the profile, and on a coverage build a single jeprof run has taken over an
+        # hour, timing the whole job out here, long after every test had finished (the sibling
+        # shard of the same build symbolized six profiles in 13 minutes). The flamegraphs are an
+        # artifact of the job, not its result, so give them up rather than the job.
+        deadline = time.time() + cls.JEMALLOC_SYMBOLIZATION_BUDGET
+
         chbinary = Shell.get_output("readlink -f $(which clickhouse)")
         for pid, profile in latest_profiles.items():
-            Shell.check(
-                f"jeprof {chbinary} {temp_dir}/jemalloc_profiles/{profile} --text > {temp_dir}/jemalloc_profiles/jemalloc.{pid}.txt 2>/dev/null",
+            budget = int(deadline - time.time())
+            if budget <= 0:
+                print(f"WARNING: Out of time to symbolize the profile of process {pid}")
+                continue
+
+            text_report = f"{temp_dir}/jemalloc_profiles/jemalloc.{pid}.txt"
+            if not Shell.check(
+                f"timeout --verbose --signal=TERM --kill-after=60 {budget} jeprof {chbinary} {temp_dir}/jemalloc_profiles/{profile} --text > {text_report} 2>/dev/null",
                 verbose=True,
-            )
-            Shell.check(
-                f"jeprof {chbinary} {temp_dir}/jemalloc_profiles/{profile} --collapsed 2>/dev/null | flamegraph.pl --color mem --width 2560 > {temp_dir}/jemalloc_profiles/jemalloc.{pid}.svg",
+            ):
+                print(f"WARNING: Failed to symbolize {profile}, dropping {text_report}")
+                Path(text_report).unlink(missing_ok=True)
+
+            budget = int(deadline - time.time())
+            if budget <= 0:
+                print(f"WARNING: Out of time to build the flamegraph of process {pid}")
+                continue
+
+            flamegraph = f"{temp_dir}/jemalloc_profiles/jemalloc.{pid}.svg"
+            # The whole pipeline is under the timeout: killing jeprof alone would leave
+            # flamegraph.pl to write a truncated graph out of what it had received.
+            if not Shell.check(
+                f"timeout --verbose --signal=TERM --kill-after=60 {budget} bash -c 'jeprof {chbinary} {temp_dir}/jemalloc_profiles/{profile} --collapsed 2>/dev/null | flamegraph.pl --color mem --width 2560 > {flamegraph}'",
                 verbose=True,
-            )
+            ):
+                print(f"WARNING: Failed to symbolize {profile}, dropping {flamegraph}")
+                Path(flamegraph).unlink(missing_ok=True)
 
         Shell.check(
             f"cd {temp_dir} && tar -czf jemalloc.tar.zst --files-from <(find . -type d -name jemalloc_profiles)",


### PR DESCRIPTION
The `Collect logs` step of a stateless test job runs `jeprof` over the last jemalloc heap profile of every server process, once for the text report and once for the flamegraph, with no time limit. Symbolization is unbounded work — it scales with the number of distinct addresses in the profile — and on a coverage build it can run for hours. In [this job](https://s3.amazonaws.com/clickhouse-test-reports/PRs/114043/e6e8b719df702fecbd2459a6d123a9934daf00e7/stateless_tests_amd_llvm_coverage_old_analyzer_s3_storage_dbreplicated_wasmedge_sequential_2_2/job.log) all 491 tests passed and the fatal-error checks were clean, and then:

```
[00:13:39] Collect logs
[00:13:39] Run command: [jeprof .../clickhouse .../clickhouse.jemalloc.559.2.m2.heap --text > ...]
[01:15:01] Run command: [jeprof .../clickhouse .../clickhouse.jemalloc.559.2.m2.heap --collapsed | flamegraph.pl ... > ...]
[02:04:39] WARNING: Job timed out: [...], timeout [9000], exit code [-15]
[02:04:42] ERROR: Run failed with exit code [-15]
```

The first `jeprof` took 61 minutes and the second was still running when the job was killed, so a green job was reported as an `ERROR`. For comparison, the sibling shard `1/2` of the same coverage build symbolized six profiles in 13.5 minutes (1.5–3.7 minutes each) and passed. The same ~9070 s timeout signature also hit https://github.com/ClickHouse/ClickHouse/pull/101273 on 2026-08-19.

The flamegraphs are an artifact of the job, not its result, so give them up rather than the job: the profiles are now symbolized under a total wall-clock budget, following the `DUMP_SYSTEM_TABLE_TIMEOUT` precedent in the same class, and a report that does not finish in time is dropped instead of being left truncated. The raw `.heap` files are archived as before, so a profile that could not be symbolized in CI still can be symbolized locally.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114043&sha=e6e8b719df702fecbd2459a6d123a9934daf00e7&name_0=PR
Related: https://github.com/ClickHouse/ClickHouse/pull/114043

### Changelog category (leave one):
- CI Fix or Improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115977&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115977](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115977+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1950` (included in `26.8` and later)
<!-- ch-version-info:end -->