### PR TITLE
Fix init.d delegation to systemd for RPM packages

### DIFF
--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -139,7 +139,9 @@ bash -ex /packages/server_test.sh
 # RPM installs the unit under /usr/lib/systemd/system. The init script must
 # delegate to it instead of starting a second, daemonized server.
 /etc/init.d/clickhouse-server start
-/etc/init.d/clickhouse-server status""",
+/etc/init.d/clickhouse-server status
+systemctl stop clickhouse-server
+! /etc/init.d/clickhouse-server status""",
         "Install keeper rpm": r"""#!/bin/bash -ex
 yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-keeper*rpm
 bash -ex /packages/keeper_test.sh""",

--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -134,6 +134,7 @@ def test_install_rpm(image: DockerImage) -> List[Result]:
     tests = {
         "Install server rpm": r"""#!/bin/bash -ex
 yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-{server,client,common}*rpm
+systemctl is-enabled clickhouse-server
 echo CLICKHOUSE_WATCHDOG_ENABLE=0 > /etc/default/clickhouse-server
 bash -ex /packages/server_test.sh
 # RPM installs the unit under /usr/lib/systemd/system. The init script must

--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -135,7 +135,11 @@ def test_install_rpm(image: DockerImage) -> List[Result]:
         "Install server rpm": r"""#!/bin/bash -ex
 yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-{server,client,common}*rpm
 echo CLICKHOUSE_WATCHDOG_ENABLE=0 > /etc/default/clickhouse-server
-bash -ex /packages/server_test.sh""",
+bash -ex /packages/server_test.sh
+# RPM installs the unit under /usr/lib/systemd/system. The init script must
+# delegate to it instead of starting a second, daemonized server.
+/etc/init.d/clickhouse-server start
+/etc/init.d/clickhouse-server status""",
         "Install keeper rpm": r"""#!/bin/bash -ex
 yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-keeper*rpm
 bash -ex /packages/keeper_test.sh""",

--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -145,6 +145,7 @@ systemctl stop clickhouse-server
 ! /etc/init.d/clickhouse-server status""",
         "Install keeper rpm": r"""#!/bin/bash -ex
 yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-keeper*rpm
+systemctl is-enabled clickhouse-keeper
 bash -ex /packages/keeper_test.sh""",
     }
     return test_install(image, tests)

--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -142,6 +142,10 @@ bash -ex /packages/server_test.sh
 /etc/init.d/clickhouse-server start
 /etc/init.d/clickhouse-server status
 systemctl stop clickhouse-server
+# A stale pid file distinguishes systemctl status from the legacy status command,
+# which exits successfully after reading a stale pid.
+mkdir -p /run/clickhouse-server
+echo "$(( $(cat /proc/sys/kernel/pid_max) + 1 ))" > /run/clickhouse-server/clickhouse-server.pid
 ! /etc/init.d/clickhouse-server status""",
         "Install keeper rpm": r"""#!/bin/bash -ex
 yum localinstall --disablerepo=* --allowerasing -y /packages/clickhouse-keeper*rpm

--- a/packages/clickhouse-keeper.postinstall
+++ b/packages/clickhouse-keeper.postinstall
@@ -28,7 +28,10 @@ if [ "$1" = configure ] || [ -n "$not_deb_os" ]; then
             "${KEEPER_USER}"
     fi
 
-    if [ -x "/bin/systemctl" ] && [ -f /lib/systemd/system/clickhouse-keeper.service ] && [ -d /run/systemd/system ]; then
+    if [ -x "/bin/systemctl" ] && [ -d /run/systemd/system ] &&
+        { [ -f /etc/systemd/system/$PROGRAM.service ] ||
+          [ -f /lib/systemd/system/$PROGRAM.service ] ||
+          [ -f /usr/lib/systemd/system/$PROGRAM.service ]; }; then
         # if old rc.d service present - remove it
         if [ -x "/etc/init.d/clickhouse-keeper" ] && [ -x "/usr/sbin/update-rc.d" ]; then
             /usr/sbin/update-rc.d clickhouse-keeper remove

--- a/packages/clickhouse-server.init
+++ b/packages/clickhouse-server.init
@@ -99,6 +99,15 @@ forcestop()
 }
 
 
+systemd_service_exists()
+{
+    [ -x "/bin/systemctl" ] && [ -d /run/systemd/system ] &&
+        { [ -f /etc/systemd/system/$PROGRAM.service ] ||
+          [ -f /lib/systemd/system/$PROGRAM.service ] ||
+          [ -f /usr/lib/systemd/system/$PROGRAM.service ]; }
+}
+
+
 service_or_func()
 {
     if [ -n "${SYSTEMCTL_SKIP_REDIRECT+x}" ]; then
@@ -106,11 +115,9 @@ service_or_func()
         return
     fi
 
-    if [ -x "/bin/systemctl" ] && [ -d /run/systemd/system ]; then
-        if [ -f /etc/systemd/system/clickhouse-server.service ] || [ -f /lib/systemd/system/clickhouse-server.service ]; then
-            systemctl $1 $PROGRAM
-            return
-        fi
+    if systemd_service_exists; then
+        systemctl $1 $PROGRAM
+        return
     fi
 
     $1
@@ -126,7 +133,7 @@ forcerestart()
 use_cron()
 {
     # 1. running systemd
-    if [ -x "/bin/systemctl" ] && [ -f /etc/systemd/system/clickhouse-server.service ] && [ -d /run/systemd/system ]; then
+    if systemd_service_exists; then
         return 1
     fi
     # 2. checking whether the config is existed
@@ -226,8 +233,8 @@ status()
 # Running commands without need of locking
 case "$1" in
 status)
-    status
-    exit 0
+    service_or_func status
+    exit $?
     ;;
 esac
 

--- a/packages/clickhouse-server.postinstall
+++ b/packages/clickhouse-server.postinstall
@@ -29,7 +29,10 @@ if [ "$1" = configure ] || [ -n "$not_deb_os" ]; then
 
     ${CLICKHOUSE_GENERIC_PROGRAM} install --user "${CLICKHOUSE_USER}" --group "${CLICKHOUSE_GROUP}" --pid-path "${CLICKHOUSE_PIDDIR}" --config-path "${CLICKHOUSE_CONFDIR}" --binary-path "${CLICKHOUSE_BINDIR}" --log-path "${CLICKHOUSE_LOGDIR}" --data-path "${CLICKHOUSE_DATADIR}"
 
-    if [ -x "/bin/systemctl" ] && [ -f /lib/systemd/system/clickhouse-server.service ] && [ -d /run/systemd/system ]; then
+    if [ -x "/bin/systemctl" ] && [ -d /run/systemd/system ] &&
+        { [ -f /etc/systemd/system/$PROGRAM.service ] ||
+          [ -f /lib/systemd/system/$PROGRAM.service ] ||
+          [ -f /usr/lib/systemd/system/$PROGRAM.service ]; }; then
         # if old rc.d service present - remove it
         if [ -x "/etc/init.d/clickhouse-server" ] && [ -x "/usr/sbin/update-rc.d" ]; then
             /usr/sbin/update-rc.d clickhouse-server remove


### PR DESCRIPTION
RPM distributions install the packaged service under `/usr/lib/systemd/system`, while the SysV compatibility script only recognized units under `/etc/systemd/system` and `/lib/systemd/system`. Calling `service clickhouse-server start` could therefore bypass systemd and launch a separate daemonized server. With the systemd unit configured to restart, both managers could then repeatedly compete for the same data-directory lock.

Use one helper for systemd detection, including `/usr/lib/systemd/system`, and route `status` through the same delegation path as start, stop, and restart. The existing `SYSTEMCTL_SKIP_REDIRECT` escape hatch still provides direct SysV behavior where explicitly requested.

The RPM installation check now exercises both init.d start and status after systemd has started the service, covering the package layout that exposed the issue without adding another container.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `clickhouse-server` SysV compatibility script on RPM distributions to delegate start and status operations to systemd, preventing a second server instance from being launched for the same data directory.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115978&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115978](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115978+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
