### PR TITLE
Fix flaky test `04614_join_runtime_filter_shared_fixed_hash_table_key_cast`

### DIFF
--- a/tests/queries/0_stateless/04614_join_runtime_filter_shared_fixed_hash_table_key_cast.sql
+++ b/tests/queries/0_stateless/04614_join_runtime_filter_shared_fixed_hash_table_key_cast.sql
@@ -22,19 +22,24 @@ SET enable_parallel_replicas = 0; -- The descriptors are not serialized with the
 
 SET join_algorithm = 'hash', max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0;
 SET enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 1;
+-- The join order optimizer may put the small table on the probe side (for example when
+-- `query_plan_optimize_join_order_randomize` is on and `query_plan_join_swap_table` is `false`, so the
+-- sides cannot be swapped back). The estimated probe size is then below the default threshold and no
+-- runtime filter is created at all, which is not what this test is about.
+SET join_runtime_filter_min_probe_rows = 0;
 
 
 -- Nullable probe + non-Nullable build: the common type Nullable(Int32) forces a cast on the build key.
 SELECT '-- nullable probe, plain build';
 SELECT count() FROM t_probe_nullable p INNER JOIN t_build_i32 b ON p.k = b.k
-    SETTINGS log_comment = '04613_publish_nullable_probe';
+    SETTINGS log_comment = '04614_publish_nullable_probe';
 SELECT count() FROM t_probe_nullable p INNER JOIN t_build_i32 b ON p.k = b.k
     SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
 
 -- Wider probe type: the common type Int32 forces a cast on the UInt8 build key.
 SELECT '-- wider probe, narrow build';
 SELECT count() FROM t_probe_i32 p INNER JOIN t_build_u8 b ON p.k = b.k
-    SETTINGS log_comment = '04613_publish_width_cast';
+    SETTINGS log_comment = '04614_publish_width_cast';
 SELECT count() FROM t_probe_i32 p INNER JOIN t_build_u8 b ON p.k = b.k
     SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
 
@@ -47,7 +52,7 @@ WHERE event_date >= yesterday() AND event_time >= now() - 600
       AND message LIKE '%Published shared fixed-hash-table runtime filter%'
       AND query_id IN (
           SELECT query_id FROM system.query_log
-          WHERE log_comment LIKE '04613_publish_%' AND current_database = currentDatabase()
+          WHERE log_comment LIKE '04614_publish_%' AND current_database = currentDatabase()
                 AND type = 'QueryFinish' AND event_date >= yesterday());
 
 DROP TABLE t_build_i32;


### PR DESCRIPTION
The stateless test `04614_join_runtime_filter_shared_fixed_hash_table_key_cast` is flaky under randomized settings. It asserts that two queries publish a shared fixed-hash-table JOIN runtime filter, but the assertion can observe `0` instead of `2`.

Root cause: with `query_plan_optimize_join_order_randomize` enabled, the join order optimizer works from random cardinalities and can put the small table on the probe side; with `query_plan_join_swap_table` pinned to `false`, the sides cannot be swapped back. The estimated probe size then falls below `join_runtime_filter_min_probe_rows`, so no runtime filter is created at all - which is not what the test is about. Neither setting reproduces the failure alone; all three are needed, which is why it shows up only occasionally.

The fix sets `join_runtime_filter_min_probe_rows = 0` in the test, so the filter is always created regardless of the chosen plan shape. Verified locally across the whole `query_plan_join_swap_table` x `query_plan_optimize_join_order_randomize` matrix, including the exact settings from the failed run, plus 20 runs with fully randomized settings.

Also fixes a leftover `04613_` prefix in the `log_comment` values, which no longer matches the test's own number.

The test has failed the same way on five unrelated pull requests in the last 30 days (#115961, #115487, #110997, #114187, #106734).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115961&sha=1a3475209c5db937dae51192124325b1a22a17b3&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29
Related: https://github.com/ClickHouse/ClickHouse/pull/115961

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115983&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115983](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115983+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
