### PR TITLE
Refuse an insert into a materialized view whose target is a view

### DIFF
--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -1483,6 +1483,17 @@ bool InsertDependenciesBuilder::observePath(const DependencyPath & path)
 
     if (materialized_view && current != init_table_id)
     {
+        /// A view selects from its own source, never from the view that forwards into it, so on a target edge
+        /// the check below is never satisfied and the path is abandoned with no output header. Abandoning is
+        /// right for a dependent view, whose target name now resolves to a view and whose dependency is
+        /// therefore stale, but `createPreSink` requires the header of the view the insert addresses.
+        if (parent == init_table_id && isView(parent) && inner_tables.at(parent) == current)
+            throw Exception(
+                ErrorCodes::NOT_IMPLEMENTED,
+                "Table '{}' is a materialized view, so it cannot be the target of materialized view '{}'. "
+                "Use the target table of '{}' instead.",
+                current, parent, current);
+
         StorageIDMaybeEmpty select_table_id = metadata->getSelectQuery().select_table_id;
         if (select_table_id != parent)
         {

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -1485,8 +1485,8 @@ bool InsertDependenciesBuilder::observePath(const DependencyPath & path)
     {
         /// A view selects from its own source, never from the view that forwards into it, so on a target edge
         /// the check below is never satisfied and the path is abandoned with no output header. Abandoning is
-        /// right for a dependent view, whose target name now resolves to a view and whose dependency is
-        /// therefore stale, but `createPreSink` requires the header of the view the insert addresses.
+        /// right for a view reached as a dependent, which is skipped, but `createPreSink` requires the header
+        /// of the view the insert addresses.
         if (parent == init_table_id && isView(parent) && inner_tables.at(parent) == current)
             throw Exception(
                 ErrorCodes::NOT_IMPLEMENTED,

--- a/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.reference
+++ b/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.reference
@@ -1,0 +1,2 @@
+insert into the source table still succeeds	2
+table target still works	3

--- a/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.sql
+++ b/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.sql
@@ -1,0 +1,27 @@
+CREATE TABLE src (a UInt16) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE tgt (a UInt16) ENGINE = MergeTree ORDER BY tuple();
+
+CREATE MATERIALIZED VIEW v_table_target TO tgt AS SELECT a FROM src;
+CREATE MATERIALIZED VIEW v_view_target TO v_table_target AS SELECT a FROM src;
+
+-- Inserting into a view whose target is another view is refused on both insert routes.
+INSERT INTO v_view_target VALUES (1); -- { serverError NOT_IMPLEMENTED }
+INSERT INTO v_view_target SELECT 1; -- { serverError NOT_IMPLEMENTED }
+
+-- CREATE ... POPULATE reaches the same hop through the population insert, not a user INSERT.
+INSERT INTO src VALUES (2);
+CREATE MATERIALIZED VIEW v_populate TO v_table_target POPULATE AS SELECT a FROM src; -- { serverError NOT_IMPLEMENTED }
+
+-- Reaching the same hop as a dependent view keeps the pre-existing behaviour: the insert addresses
+-- `src`, the hop is skipped, and the rows that would have gone through `v_view_target` are dropped.
+INSERT INTO src VALUES (3);
+SELECT 'insert into the source table still succeeds', count() FROM src ORDER BY ALL;
+
+-- A target that is an ordinary table keeps working, on the direct and the dependent route.
+INSERT INTO v_table_target VALUES (4);
+SELECT 'table target still works', count() FROM tgt;
+
+DROP VIEW v_view_target;
+DROP VIEW v_table_target;
+DROP TABLE tgt;
+DROP TABLE src;

--- a/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.sql
+++ b/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.sql
@@ -28,6 +28,9 @@ SELECT 'insert into the source table still succeeds', count() FROM src ORDER BY 
 INSERT INTO v_table_target VALUES (4);
 SELECT 'table target still works', count() FROM tgt;
 
+-- The population insert throws after the view is created on the database engines that populate
+-- non-atomically, so `v_populate` survives there and not on the others.
+DROP VIEW IF EXISTS v_populate;
 DROP VIEW v_refreshable_target;
 DROP VIEW v_refreshable;
 DROP VIEW v_view_target;

--- a/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.sql
+++ b/tests/queries/0_stateless/04846_materialized_view_target_is_materialized_view.sql
@@ -12,6 +12,13 @@ INSERT INTO v_view_target SELECT 1; -- { serverError NOT_IMPLEMENTED }
 INSERT INTO src VALUES (2);
 CREATE MATERIALIZED VIEW v_populate TO v_table_target POPULATE AS SELECT a FROM src; -- { serverError NOT_IMPLEMENTED }
 
+-- A refreshable view is a materialized view too, so it is refused as a target on the same edge.
+-- It refreshes into a table of its own, so its initial refresh cannot disturb the counts below.
+CREATE TABLE tgt_refreshable (a UInt16) ENGINE = MergeTree ORDER BY tuple();
+CREATE MATERIALIZED VIEW v_refreshable REFRESH EVERY 1 YEAR APPEND TO tgt_refreshable AS SELECT a FROM src;
+CREATE MATERIALIZED VIEW v_refreshable_target TO v_refreshable AS SELECT a FROM src;
+INSERT INTO v_refreshable_target VALUES (5); -- { serverError NOT_IMPLEMENTED }
+
 -- Reaching the same hop as a dependent view keeps the pre-existing behaviour: the insert addresses
 -- `src`, the hop is skipped, and the rows that would have gone through `v_view_target` are dropped.
 INSERT INTO src VALUES (3);
@@ -21,7 +28,10 @@ SELECT 'insert into the source table still succeeds', count() FROM src ORDER BY 
 INSERT INTO v_table_target VALUES (4);
 SELECT 'table target still works', count() FROM tgt;
 
+DROP VIEW v_refreshable_target;
+DROP VIEW v_refreshable;
 DROP VIEW v_view_target;
 DROP VIEW v_table_target;
+DROP TABLE tgt_refreshable;
 DROP TABLE tgt;
 DROP TABLE src;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/114494
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/114494

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a server abort in debug and sanitizer builds when inserting into a materialized view whose `TO` target is another materialized view. Such an insert already failed on released versions, with an uninformative `Code: 1001 STD_EXCEPTION`; it now reports `NOT_IMPLEMENTED` naming the offending view.

### Description

Found by the AST fuzzer. `INSERT` into a materialized view declared `TO <another materialized view>` aborts:

```
std::exception. Code: 1001, type: std::out_of_range, e.what() = unordered_map::at: key not found
DB::InsertDependenciesBuilder::createPreSink(DB::StorageIDMaybeEmpty) const
```

`observePath` rejects a hop whose view does not select from its parent. That check is for a stale dependency left behind by an `ALTER`, and before the pushing-to-views rework it only ran while iterating dependent views. It is now also reached from the target hop, where a view never selects from the view forwarding into it, so it always rejects: the path is abandoned, no output header is recorded, and `createPreSink` calls `output_headers.at(view_id)` on a missing key. Guarding that `.at()` alone is not enough, because the hop has no sink either (`createSinkImpl` reaches `UNREACHABLE()` for a materialized view inner storage).

This refuses the insert with `NOT_IMPLEMENTED`, in the shape `createRetry` already uses for a forwarding path it cannot rebuild.

The refusal is limited to the view the insert addresses, on all three routes that reach the abort: `INSERT ... VALUES`, `INSERT ... SELECT` (via `addInsertToSelectPipeline`) and `CREATE ... POPULATE` (via the population insert). A view reached as a *dependent* still gets the existing stale-dependency skip, which is what `04216_materialized_view_reused_target_name_dependency` asserts; on that route the rows are still dropped silently, so the data-loss half of #114494 is not addressed here.

Validated against a pristine master build: all three routes abort there and return `NOT_IMPLEMENTED` here, an ordinary-table target is byte-identical on both, and the new test fails on master (the server exits 134 on the first insert). `04652_nested_merge_prewhere_type_mismatch`, the fuzzer's own carrier, creates this shape and still passes.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115985&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115985](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115985+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.7.95`, `26.6.6.4`, `26.3.33.72`
<!-- ch-version-info:end -->