### PR TITLE
Make 03822_named_collection_drop_dependency_check restart-safe in CI

### DIFF
--- a/tests/queries/0_stateless/03822_named_collection_drop_dependency_check.sh
+++ b/tests/queries/0_stateless/03822_named_collection_drop_dependency_check.sh
@@ -5,6 +5,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# A killed client must stop the test: continuing would reach a drop of a named collection whose
+# dependent table has not been removed yet, leaving that table unloadable at the next start.
+set -e
+
 ORDINARY_DB="${CLICKHOUSE_DATABASE}_ordinary"
 # A table whose collection this test drops out from under it cannot be attached again, so it lives
 # in a Memory database: that metadata is never written, so no restart can replay it.
@@ -15,9 +19,12 @@ NC_NAME="test_nc_dep_${CLICKHOUSE_DATABASE}"
 # interrupted run outlives the collection it references.
 # ignore_drop_queries_probability = 0: the stress runner sets it to 0.2, which makes a DROP a no-op
 # (for URL, a TRUNCATE that throws).
+# ast_fuzzer_runs = 0: a fuzzed DROP TABLE can become UNDROP TABLE for the same target, which
+# reattaches the table after this block has dropped the collection it references.
 $CLICKHOUSE_CLIENT -m -q "
 SET check_named_collection_dependencies = false;
 SET ignore_drop_queries_probability = 0;
+SET ast_fuzzer_runs = 0;
 DROP TABLE IF EXISTS test_nc_dep_table;
 DROP TABLE IF EXISTS test_nc_dep_table_renamed;
 DROP TABLE IF EXISTS test_nc_dep_table2;
@@ -86,6 +93,7 @@ $CLICKHOUSE_CLIENT -m -q "DROP NAMED COLLECTION ${NC_NAME2}; -- { serverError NA
 
 # Clean up
 $CLICKHOUSE_CLIENT -m -q "
+SET ast_fuzzer_runs = 0;
 DROP TABLE test_nc_dep_table_renamed SETTINGS ignore_drop_queries_probability = 0;
 DROP TABLE test_nc_dep_table2 SETTINGS ignore_drop_queries_probability = 0;
 DROP NAMED COLLECTION ${NC_NAME};
@@ -116,11 +124,12 @@ $CLICKHOUSE_CLIENT -q "RENAME TABLE ${ORDINARY_DB}.test_nc_dep_ordinary TO ${ORD
 $CLICKHOUSE_CLIENT -m -q "DROP NAMED COLLECTION ${NC_NAME}; -- { serverError NAMED_COLLECTION_IS_USED }"
 
 # Drop the Atomic table, should still fail because Ordinary table uses the collection
-$CLICKHOUSE_CLIENT -q "DROP TABLE test_nc_dep_atomic SETTINGS ignore_drop_queries_probability = 0;"
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_nc_dep_atomic SETTINGS ignore_drop_queries_probability = 0, ast_fuzzer_runs = 0;"
 $CLICKHOUSE_CLIENT -m -q "DROP NAMED COLLECTION ${NC_NAME}; -- { serverError NAMED_COLLECTION_IS_USED }"
 
 # Drop the Ordinary table, now drop should succeed
 $CLICKHOUSE_CLIENT -m -q "
+SET ast_fuzzer_runs = 0;
 DROP TABLE ${ORDINARY_DB}.test_nc_dep_ordinary_renamed SETTINGS ignore_drop_queries_probability = 0;
 DROP NAMED COLLECTION ${NC_NAME};
 DROP DATABASE ${ORDINARY_DB};

--- a/tests/queries/0_stateless/03822_named_collection_drop_dependency_check.sh
+++ b/tests/queries/0_stateless/03822_named_collection_drop_dependency_check.sh
@@ -6,18 +6,35 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 ORDINARY_DB="${CLICKHOUSE_DATABASE}_ordinary"
+# A table whose collection this test drops out from under it cannot be attached again, so it lives
+# in a Memory database: that metadata is never written, so no restart can replay it.
+MEMORY_DB="${CLICKHOUSE_DATABASE}_memory"
 NC_NAME="test_nc_dep_${CLICKHOUSE_DATABASE}"
 
-# Setup: clean up any leftover state
+# Setup: clean up any leftover state. Tables go before the collection, otherwise a table left by an
+# interrupted run outlives the collection it references.
+# ignore_drop_queries_probability = 0: the stress runner sets it to 0.2, which makes a DROP a no-op
+# (for URL, a TRUNCATE that throws).
 $CLICKHOUSE_CLIENT -m -q "
 SET check_named_collection_dependencies = false;
+SET ignore_drop_queries_probability = 0;
+DROP TABLE IF EXISTS test_nc_dep_table;
+DROP TABLE IF EXISTS test_nc_dep_table_renamed;
+DROP TABLE IF EXISTS test_nc_dep_table2;
+DROP TABLE IF EXISTS test_nc_dep_atomic;
+DROP DATABASE IF EXISTS ${MEMORY_DB};
+DROP DATABASE IF EXISTS ${ORDINARY_DB};
 DROP NAMED COLLECTION IF EXISTS ${NC_NAME};
 "
 
-# Create named collection and table that uses it
+# Create named collection and table that uses it.
+# ast_fuzzer_runs = 0: the stress profile enables the server-side AST fuzzer, which clones a
+# CREATE TABLE under a `__fuzz_N` name that inherits the collection reference this test drops.
 $CLICKHOUSE_CLIENT -m -q "
+SET ast_fuzzer_runs = 0;
+CREATE DATABASE ${MEMORY_DB} ENGINE = Memory;
 CREATE NAMED COLLECTION ${NC_NAME} AS url = 'http://localhost:8123', format = 'CSV';
-CREATE TABLE test_nc_dep_table (x UInt32) ENGINE = URL(${NC_NAME});
+CREATE TABLE ${MEMORY_DB}.test_nc_dep_table (x UInt32) ENGINE = URL(${NC_NAME});
 "
 
 # Should fail because table uses the named collection (check_named_collection_dependencies is true by default)
@@ -27,11 +44,12 @@ $CLICKHOUSE_CLIENT -m -q "DROP NAMED COLLECTION ${NC_NAME}; -- { serverError NAM
 $CLICKHOUSE_CLIENT -m -q "
 SET check_named_collection_dependencies = false;
 DROP NAMED COLLECTION ${NC_NAME};
-DROP TABLE test_nc_dep_table;
+DROP DATABASE ${MEMORY_DB};
 "
 
 # Test normal behavior again with the setting enabled
 $CLICKHOUSE_CLIENT -m -q "
+SET ast_fuzzer_runs = 0;
 CREATE NAMED COLLECTION ${NC_NAME} AS url = 'http://localhost:8123', format = 'CSV';
 CREATE TABLE test_nc_dep_table (x UInt32) ENGINE = URL(${NC_NAME});
 "
@@ -50,6 +68,7 @@ SET check_named_collection_dependencies = false;
 DROP NAMED COLLECTION IF EXISTS ${NC_NAME2};
 "
 $CLICKHOUSE_CLIENT -m -q "
+SET ast_fuzzer_runs = 0;
 CREATE NAMED COLLECTION ${NC_NAME2} AS url = 'http://localhost:8123', format = 'JSON';
 CREATE TABLE test_nc_dep_table2 (x UInt32) ENGINE = URL(${NC_NAME2});
 "
@@ -67,8 +86,8 @@ $CLICKHOUSE_CLIENT -m -q "DROP NAMED COLLECTION ${NC_NAME2}; -- { serverError NA
 
 # Clean up
 $CLICKHOUSE_CLIENT -m -q "
-DROP TABLE test_nc_dep_table_renamed;
-DROP TABLE test_nc_dep_table2;
+DROP TABLE test_nc_dep_table_renamed SETTINGS ignore_drop_queries_probability = 0;
+DROP TABLE test_nc_dep_table2 SETTINGS ignore_drop_queries_probability = 0;
 DROP NAMED COLLECTION ${NC_NAME};
 DROP NAMED COLLECTION ${NC_NAME2};
 "
@@ -83,6 +102,7 @@ CREATE DATABASE ${ORDINARY_DB} ENGINE = Ordinary;
 "
 
 $CLICKHOUSE_CLIENT -m -q "
+SET ast_fuzzer_runs = 0;
 CREATE NAMED COLLECTION ${NC_NAME} AS url = 'http://localhost:8123', format = 'CSV';
 CREATE TABLE test_nc_dep_atomic (x UInt32) ENGINE = URL(${NC_NAME});
 CREATE TABLE ${ORDINARY_DB}.test_nc_dep_ordinary (x UInt32) ENGINE = URL(${NC_NAME});
@@ -96,12 +116,12 @@ $CLICKHOUSE_CLIENT -q "RENAME TABLE ${ORDINARY_DB}.test_nc_dep_ordinary TO ${ORD
 $CLICKHOUSE_CLIENT -m -q "DROP NAMED COLLECTION ${NC_NAME}; -- { serverError NAMED_COLLECTION_IS_USED }"
 
 # Drop the Atomic table, should still fail because Ordinary table uses the collection
-$CLICKHOUSE_CLIENT -q "DROP TABLE test_nc_dep_atomic;"
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_nc_dep_atomic SETTINGS ignore_drop_queries_probability = 0;"
 $CLICKHOUSE_CLIENT -m -q "DROP NAMED COLLECTION ${NC_NAME}; -- { serverError NAMED_COLLECTION_IS_USED }"
 
 # Drop the Ordinary table, now drop should succeed
 $CLICKHOUSE_CLIENT -m -q "
-DROP TABLE ${ORDINARY_DB}.test_nc_dep_ordinary_renamed;
+DROP TABLE ${ORDINARY_DB}.test_nc_dep_ordinary_renamed SETTINGS ignore_drop_queries_probability = 0;
 DROP NAMED COLLECTION ${NC_NAME};
 DROP DATABASE ${ORDINARY_DB};
 "


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115326
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/115326

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The test deliberately holds a `URL` table whose named collection was dropped, because that is what it
asserts. CI randomizers turn that window into persisted metadata the next start cannot load:

```
Code: 722 -> Code: 695. Load job 'load table <db>.test_nc_dep_table__fuzz_0' failed:
Code: 669. There is no named collection `test_nc_dep_<db>`. (NAMED_COLLECTION_DOESNT_EXIST)
```

It surfaces as `Stress test (*)` / `Cannot start clickhouse-server`, never as a 03822 failure. Three
randomizers reach it: the AST fuzzer clones a `CREATE TABLE` under a `__fuzz_N` name inheriting the
collection reference the test drops, and nothing server-side drops a fuzzed clone;
`ignore_drop_queries_probability = 0.2` can make a cleanup `DROP` a no-op; the query killer can SIGTERM
the client mid-block.

Restart safety by construction:

- the table inside the guard-disabled window moves into a `Memory` database, whose table metadata is
  never written, so no restart can replay it. `DROP DATABASE` removes it, and the drop injector excludes
  that form. The second table stays Atomic, keeping `RENAME`/`EXCHANGE` unchanged;
- `ast_fuzzer_runs = 0` on the four `CREATE TABLE ... ENGINE = URL(...)` blocks;
- `ignore_drop_queries_probability = 0` on the drops the test depends on;
- setup cleanup removes leftover tables and databases before the collection.

All ten `serverError NAMED_COLLECTION_IS_USED` assertions still fire individually, and each pinned item
is load-bearing: omitting any one reproduces the dead boot. 50 sequential and 50 parallel runs pass and
the server boots after. 1 occurrence in 90 days on public CI after #115326 landed
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106199&sha=f0a0ec7cd0f2f369183e27065462dacbc8100183&name_0=PR&name_1=Stress%20test%20%28arm_msan%29));
the other four were `04320`/`04327`, predating it, hence one file.

Ordering: #112805 also edits this file, adding `SET check_named_collection_dependencies = true` to the
same assertions. The changes are orthogonal but overlap in one hunk, so whichever merges second needs a
one-line resolution. Not fixed: the fuzzer has no clone cleanup, so a clone can outlive its table.


<details>
<summary>Restart evidence and per-item ablations (the test itself has no restart oracle)</summary>

Ordinary green CI does not prove this works: all ten assertions only check
`NAMED_COLLECTION_IS_USED`, and the test passes with the safeguards reverted. The oracle is the
restart, so it was measured out of band, with `--async_load_databases=false` (the sync branch is what
turns a failed table load into a dead boot).

A whole-script run then a restart is vacuous, because the script recreates the collection at its
"test normal behavior again" step. The run has to stop at the unsafe prefix, which is where the random
query killer lands: setup, create, the guard-on assertion, the guard-off `DROP NAMED COLLECTION`, stop
before the statement removing the first table, restart.

| arm | result |
|---|---|
| first table in the Atomic test database (pre-fix) | boot dies, `Code: 722` -> `695` -> `669 NAMED_COLLECTION_DOESNT_EXIST` |
| first table in a `Memory` database (this PR) | boots |
| control: collection recreated, same metadata | boots, so the persisted definition was always correct |

Per-item ablation: omit exactly one safeguard, keep the rest, full run then prefix then restart. Oracle
is persistent-database `URL` tables whose collection is absent, cross-checked against on-disk orphans.

| omitted | orphan pairs | boot |
|---|---|---|
| nothing | 0 | OK |
| `Memory` database | 1 | dies |
| `ast_fuzzer_runs = 0` | 2 | dies |
| `ignore_drop_queries_probability = 0` | 1 | dies |
| extended setup cleanup | 0 | OK unless a leftover is seeded, then `Code: 82` plus a `669` cascade |

The last row is a recovery mechanism, so with everything else present there is nothing to recover;
seeding the state an interrupted run leaves separates it. Arming, separately: on the unmodified test
with `ast_fuzzer_runs=5 ast_fuzzer_any_query=1` the fuzzer logs 14 clone `CREATE`s of the corpus table
and the run fails naming five `__fuzz_N` dependents; after the fix, 0 while 274 fuzzer lines fire.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115990&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115990](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115990+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
