### PR TITLE
Validate the Keeper path when converting a table with ATTACH AS REPLICATED

### DIFF
--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -32,6 +32,7 @@
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/StorageTableProxy.h>
+#include <Storages/TableZnodeInfo.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/PoolId.h>
 #include <Common/escapeForFileName.h>
@@ -141,6 +142,22 @@ static void checkReplicaPathExists(ASTCreateQuery & create_query, ContextPtr loc
         );
 }
 
+void DatabaseOrdinary::checkReplicaPathIsSafe(const ASTCreateQuery & create_query, ContextPtr local_context)
+{
+    /// A conversion mints a path the table never had, from the server's template and the table's own
+    /// name, so it is a fresh definition and is judged like a CREATE. Re-deriving the path of an
+    /// already replicated table is the opposite case and must keep loading whatever it expands to.
+    const auto & server_settings = local_context->getServerSettings();
+    TableZnodeInfo::resolve(
+        server_settings[ServerSetting::default_replica_path],
+        server_settings[ServerSetting::default_replica_name],
+        StorageID(create_query.getDatabase(), create_query.getTable(), create_query.uuid),
+        create_query,
+        LoadingStrictnessLevel::CREATE,
+        local_context,
+        /*validate_substitutions=*/true);
+}
+
 void DatabaseOrdinary::setMergeTreeEngine(ASTCreateQuery & create_query, ContextPtr local_context, bool replicated)
 {
     auto * storage = create_query.storage;
@@ -232,6 +249,7 @@ void DatabaseOrdinary::convertMergeTreeToReplicatedIfNeeded(ASTPtr ast, const Qu
 
     LOG_INFO(log, "Found {} flag for table {}. Will try to change it's engine in metadata to replicated.", CONVERT_TO_REPLICATED_FLAG_NAME, backQuote(qualified_name.getFullName()));
 
+    checkReplicaPathIsSafe(create_query, getContext());
     checkReplicaPathExists(create_query, getContext());
     setMergeTreeEngine(create_query, getContext(), /*replicated*/ true);
 

--- a/src/Databases/DatabaseOrdinary.cpp
+++ b/src/Databases/DatabaseOrdinary.cpp
@@ -144,16 +144,16 @@ static void checkReplicaPathExists(ASTCreateQuery & create_query, ContextPtr loc
 
 void DatabaseOrdinary::checkReplicaPathIsSafe(const ASTCreateQuery & create_query, ContextPtr local_context)
 {
-    /// A conversion mints a path the table never had, from the server's template and the table's own
-    /// name, so it is a fresh definition and is judged like a CREATE. Re-deriving the path of an
-    /// already replicated table is the opposite case and must keep loading whatever it expands to.
+    /// A conversion mints a path the table never had, so the substituted name is validated as strictly
+    /// as a CREATE validates it -- but one level below CREATE, because the requirement that a path start
+    /// with '/' applies to a genuinely new table, not to a template this server has long been expanding.
     const auto & server_settings = local_context->getServerSettings();
     TableZnodeInfo::resolve(
         server_settings[ServerSetting::default_replica_path],
         server_settings[ServerSetting::default_replica_name],
         StorageID(create_query.getDatabase(), create_query.getTable(), create_query.uuid),
         create_query,
-        LoadingStrictnessLevel::CREATE,
+        LoadingStrictnessLevel::SECONDARY_CREATE,
         local_context,
         /*validate_substitutions=*/true);
 }

--- a/src/Databases/DatabaseOrdinary.h
+++ b/src/Databases/DatabaseOrdinary.h
@@ -88,6 +88,10 @@ public:
 
     static void setMergeTreeEngine(ASTCreateQuery & create_query, ContextPtr context, bool replicated);
 
+    /// Rejects a conversion to a replicated engine whose Keeper path would not be a safe one.
+    /// Contacts nothing and mutates nothing, so a caller can run it before its own side effects.
+    static void checkReplicaPathIsSafe(const ASTCreateQuery & create_query, ContextPtr context);
+
 protected:
     /// Erase pending async load/startup task references for a table. Must hold `mutex`.
     /// Shared by detachTableUnlocked and the Atomic rename detach path (issue #91777).

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -3645,6 +3645,11 @@ void InterpreterCreateQuery::convertMergeTreeTableIfPossible(ASTCreateQuery & cr
     else if (!to_replicated)
        throw Exception(ErrorCodes::INCORRECT_QUERY, "Can not attach table as not replicated, table is already not replicated");
 
+    /// Must precede every side effect below: neither the transaction metadata removal nor the
+    /// metadata rewrite can be rolled back. The other direction takes no Keeper path at all.
+    if (to_replicated)
+        DatabaseOrdinary::checkReplicaPathIsSafe(create, getContext());
+
     /// Ensure the old detached table instance is destroyed before we remove
     /// transaction metadata files. Otherwise the old table's parts still hold
     /// in-memory version metadata referencing those files, and the debug

--- a/src/Storages/TableZnodeInfo.h
+++ b/src/Storages/TableZnodeInfo.h
@@ -58,7 +58,9 @@ struct TableZnodeInfo
     /// `validate_substitutions` rejects a {database}/{table} value that would not stay a single safe
     /// ZooKeeper path component. It must be requested only for a freshly supplied definition: enabling
     /// it while merely re-deriving the path of an existing table (a short ATTACH, a Replicated-database
-    /// recovery replay, a RESTORE) would break that table.
+    /// recovery replay, a RESTORE) would break that table. Converting a MergeTree table to a
+    /// replicated engine counts as fresh: the path is minted from the server's template at
+    /// conversion time rather than read back from the table's own metadata.
     static TableZnodeInfo resolve(
         const String & requested_path, const String & requested_replica_name,
         const StorageID & table_id, const ASTCreateQuery & query, LoadingStrictnessLevel mode,

--- a/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters_name_path.xml
+++ b/tests/integration/test_modify_engine_on_restart/configs/config.d/clusters_name_path.xml
@@ -1,0 +1,23 @@
+<clickhouse>
+<remote_servers>
+    <cluster>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>ch1</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </cluster>
+</remote_servers>
+
+<macros>
+        <shard>01</shard>
+</macros>
+
+<!-- A name-based template, the form the engine's own documentation recommends. Unlike the
+     {uuid}-based default it splices the table's own name into the path, so a name is only safe
+     while it stays a single path component. -->
+<default_replica_path>/clickhouse/tables/{database}/{table}</default_replica_path>
+
+</clickhouse>

--- a/tests/integration/test_modify_engine_on_restart/test_unsafe_name.py
+++ b/tests/integration/test_modify_engine_on_restart/test_unsafe_name.py
@@ -44,6 +44,19 @@ def victim_total_replicas():
     ).strip()
 
 
+def active_part_paths(table):
+    """Absolute in-container paths of the table's active parts, each with a trailing '/'.
+
+    `system.parts` rather than a directory listing: a MergeTree table's data directory always holds
+    a top-level `detached` directory too, and Outdated parts keep their own, so enumerating
+    directories counts more than the parts.
+    """
+    return q(
+        "SELECT path FROM system.parts"
+        f" WHERE database = '{database_name}' AND table = '{table}' AND active"
+    ).split()
+
+
 def count_txn_version_files(table):
     path = get_table_path(ch1, table, database_name)
     return int(
@@ -54,7 +67,7 @@ def count_txn_version_files(table):
 
 
 def plant_txn_version_files(table):
-    """Write a valid non-transactional `txn_version.txt` onto every part of `table`.
+    """Write a valid non-transactional `txn_version.txt` onto every active part of `table`.
 
     Transactions are off by default, so parts carry no such file and a bare count of them cannot
     tell whether the conversion removed anything. The content is the form `VersionInfo` itself
@@ -69,15 +82,10 @@ def plant_txn_version_files(table):
         f"removal_tid: (0, 0, {nil})\\n"
         "removal_csn: 0"
     )
-    path = get_table_path(ch1, table, database_name)
-    ch1.exec_in_container(
-        [
-            "bash",
-            "-c",
-            f"for d in $(find {path} -mindepth 1 -maxdepth 1 -type d); do "
-            f'printf "{content}" > "$d/txn_version.txt"; done',
-        ]
-    )
+    for part_path in active_part_paths(table):
+        ch1.exec_in_container(
+            ["bash", "-c", f'printf "{content}" > "{part_path}txn_version.txt"']
+        )
 
 
 def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
@@ -96,11 +104,20 @@ def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
     )
     assert victim_total_replicas() == "1"
 
-    q(f"CREATE TABLE `{GHOST}` ( A Int64 ) ENGINE = MergeTree ORDER BY A")
+    # Merges are pinned off so the set of active parts, and therefore the planted file count, is the
+    # same before the conversion and after the re-attach below.
+    q(
+        f"CREATE TABLE `{GHOST}` ( A Int64 ) ENGINE = MergeTree ORDER BY A"
+        " SETTINGS max_bytes_to_merge_at_max_space_in_pool = 1"
+    )
     q(f"INSERT INTO `{GHOST}` VALUES (7)")
     q(f"INSERT INTO `{GHOST}` VALUES (8)")
+    planted = len(active_part_paths(GHOST))
+    # Arming assertion: with no part to plant onto, the file count reads 0 in every arm and T1c
+    # discriminates nothing.
+    assert planted > 0
     plant_txn_version_files(GHOST)
-    assert count_txn_version_files(GHOST) == 2
+    assert count_txn_version_files(GHOST) == planted
     q(f"DETACH TABLE `{GHOST}`")
 
     # T1: the conversion must be refused. Without the check it succeeds and the table takes a path
@@ -119,10 +136,10 @@ def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
         == "MergeTree"
     )
 
-    # T1c: it also ran before the transaction metadata was removed. A part whose `txn_version.txt`
-    # is gone is misread as a rolled-back transaction and discarded, so losing these files loses
-    # rows. This is the row that pins the rejection ahead of `clearTransactionMetadata`.
-    assert count_txn_version_files(GHOST) == 2
+    # T1c: it also ran before the table's transaction metadata was removed. That removal is
+    # irreversible, so the file count is what pins the check ahead of `clearTransactionMetadata`; the
+    # row count below is a plain no-regression line.
+    assert count_txn_version_files(GHOST) == planted
     assert q(f"SELECT count() FROM `{GHOST}`").strip() == "2"
 
     # T1d: the victim is untouched, and still accepts a metadata ALTER. A planted ghost replica
@@ -150,6 +167,24 @@ def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
     )
     assert q("SELECT count() FROM safe_name").strip() == "2"
 
+    # T4 (control): the reverse direction mints no Keeper path, so an unsafe name must not block it.
+    # The table has to be replicated already AND unsafely named, which conversion cannot produce, so
+    # it is created directly with an explicit path outside the victim's subtree.
+    q(
+        f"CREATE TABLE `{GHOST}2` ( A Int64 )"
+        f" ENGINE = ReplicatedMergeTree('/clickhouse/unrelated/{database_name}', 'node1') ORDER BY A"
+    )
+    q(f"INSERT INTO `{GHOST}2` VALUES (1), (2)")
+    q(f"DETACH TABLE `{GHOST}2`")
+    q(f"ATTACH TABLE `{GHOST}2` AS NOT REPLICATED")
+    assert (
+        q(
+            f"SELECT engine FROM system.tables WHERE database = '{database_name}' AND name = '{GHOST}2'"
+        ).strip()
+        == "MergeTree"
+    )
+    assert q(f"SELECT count() FROM `{GHOST}2`").strip() == "2"
+
     ch1.query(f"DROP DATABASE IF EXISTS {database_name} SYNC")
 
 
@@ -160,6 +195,9 @@ def test_convert_flag_rejects_unsafe_name(started_cluster):
     q(f"CREATE TABLE `{GHOST}` ( A Int64 ) ENGINE = MergeTree ORDER BY A")
     q(f"INSERT INTO `{GHOST}` VALUES (1), (2)")
     set_convert_flags(ch1, database_name, [GHOST])
+    # Read while the server is up: every helper here answers from a query, and between the stop and
+    # the recovery start below there is provably no server to answer one.
+    table_data_path = get_table_path(ch1, GHOST, database_name)
 
     # T2: the flag-file route refuses the same conversion, and because it runs during startup the
     # server does not come up. That is the behaviour the sibling `checkReplicaPathExists` already
@@ -168,11 +206,7 @@ def test_convert_flag_rejects_unsafe_name(started_cluster):
     ch1.start_clickhouse(start_wait_sec=120, expected_to_fail=True)
 
     ch1.exec_in_container(
-        [
-            "bash",
-            "-c",
-            f"rm {get_table_path(ch1, GHOST, database_name)}convert_to_replicated",
-        ]
+        ["bash", "-c", f"rm {table_data_path}convert_to_replicated"]
     )
     ch1.start_clickhouse()
 

--- a/tests/integration/test_modify_engine_on_restart/test_unsafe_name.py
+++ b/tests/integration/test_modify_engine_on_restart/test_unsafe_name.py
@@ -113,20 +113,20 @@ def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
     q(f"INSERT INTO `{GHOST}` VALUES (7)")
     q(f"INSERT INTO `{GHOST}` VALUES (8)")
     planted = len(active_part_paths(GHOST))
-    # Arming assertion: with no part to plant onto, the file count reads 0 in every arm and T1c
-    # discriminates nothing.
+    # Arming assertion: with no part to plant onto, the file count reads 0 in every arm and the
+    # transaction-metadata assertion below discriminates nothing.
     assert planted > 0
     plant_txn_version_files(GHOST)
     assert count_txn_version_files(GHOST) == planted
     q(f"DETACH TABLE `{GHOST}`")
 
-    # T1: the conversion must be refused. Without the check it succeeds and the table takes a path
+    # The conversion must be refused. Without the check it succeeds and the table takes a path
     # under the victim's own subtree.
     assert "BAD_ARGUMENTS" in ch1.query_and_get_error(
         f"ATTACH TABLE `{GHOST}` AS REPLICATED", database=database_name
     )
 
-    # T1b: the rejection ran before the metadata rewrite, so a plain ATTACH brings the table back as
+    # The rejection ran before the metadata rewrite, so a plain ATTACH brings the table back as
     # the MergeTree it always was. A rejection sited after the rewrite reports ReplicatedMergeTree.
     q(f"ATTACH TABLE `{GHOST}`")
     assert (
@@ -136,13 +136,13 @@ def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
         == "MergeTree"
     )
 
-    # T1c: it also ran before the table's transaction metadata was removed. That removal is
+    # It also ran before the table's transaction metadata was removed. That removal is
     # irreversible, so the file count is what pins the check ahead of `clearTransactionMetadata`; the
     # row count below is a plain no-regression line.
     assert count_txn_version_files(GHOST) == planted
     assert q(f"SELECT count() FROM `{GHOST}`").strip() == "2"
 
-    # T1d: the victim is untouched, and still accepts a metadata ALTER. A planted ghost replica
+    # The victim is untouched, and still accepts a metadata ALTER. A planted ghost replica
     # leaves this failing with a Keeper error over the ghost's missing log_pointer.
     assert victim_total_replicas() == "1"
     assert (
@@ -153,7 +153,7 @@ def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
     )
     q(f"ALTER TABLE `{VICTIM}` ADD COLUMN B UInt64 SETTINGS alter_sync = 2")
 
-    # T3 (control): a path-safe name converts fine under the very same configuration, so the
+    # Control: a path-safe name converts fine under the very same configuration, so the
     # rejection above is about the name and not about the config or the conversion route.
     q("CREATE TABLE safe_name ( A Int64 ) ENGINE = MergeTree ORDER BY A")
     q("INSERT INTO safe_name VALUES (1), (2)")
@@ -167,7 +167,7 @@ def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
     )
     assert q("SELECT count() FROM safe_name").strip() == "2"
 
-    # T4 (control): the reverse direction mints no Keeper path, so an unsafe name must not block it.
+    # Control: the reverse direction mints no Keeper path, so an unsafe name must not block it.
     # The table has to be replicated already AND unsafely named, which conversion cannot produce, so
     # it is created directly with an explicit path outside the victim's subtree.
     q(
@@ -199,7 +199,7 @@ def test_convert_flag_rejects_unsafe_name(started_cluster):
     # the recovery start below there is provably no server to answer one.
     table_data_path = get_table_path(ch1, GHOST, database_name)
 
-    # T2: the flag-file route refuses the same conversion, and because it runs during startup the
+    # The flag-file route refuses the same conversion, and because it runs during startup the
     # server does not come up. That is the behaviour the sibling `checkReplicaPathExists` already
     # has on this route (see test_zk_path_exists.py), and the recovery is the same: delete the flag.
     ch1.stop_clickhouse()

--- a/tests/integration/test_modify_engine_on_restart/test_unsafe_name.py
+++ b/tests/integration/test_modify_engine_on_restart/test_unsafe_name.py
@@ -1,0 +1,188 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from test_modify_engine_on_restart.common import get_table_path, set_convert_flags
+
+cluster = ClickHouseCluster(__file__)
+ch1 = cluster.add_instance(
+    "ch1",
+    main_configs=[
+        "configs/config.d/clusters_name_path.xml",
+        "configs/config.d/distributed_ddl.xml",
+    ],
+    with_zookeeper=True,
+    macros={"replica": "node1"},
+    stay_alive=True,
+)
+
+database_name = "modify_engine_unsafe_name"
+
+# A name-based `default_replica_path` splices the table's own name into the Keeper path, so a name
+# carrying '/' resolves inside another table's subtree. `victim` is the co-tenant that gets damaged;
+# the ghost's name is exactly the replica path underneath it.
+VICTIM = "victim"
+GHOST = "victim/replicas/ghost"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def q(query):
+    return ch1.query(database=database_name, sql=query)
+
+
+def victim_total_replicas():
+    return q(
+        f"SELECT total_replicas FROM system.replicas WHERE database = '{database_name}' AND table = '{VICTIM}'"
+    ).strip()
+
+
+def count_txn_version_files(table):
+    path = get_table_path(ch1, table, database_name)
+    return int(
+        ch1.exec_in_container(
+            ["bash", "-c", f"find {path} -name txn_version.txt | wc -l"]
+        ).strip()
+    )
+
+
+def plant_txn_version_files(table):
+    """Write a valid non-transactional `txn_version.txt` onto every part of `table`.
+
+    Transactions are off by default, so parts carry no such file and a bare count of them cannot
+    tell whether the conversion removed anything. The content is the form `VersionInfo` itself
+    emits, so a surviving file still loads.
+    """
+    nil = "00000000-0000-0000-0000-000000000000"
+    content = (
+        "version: 1\\n"
+        "storing_version: 1\\n"
+        f"creation_tid: (1, 1, {nil})\\n"
+        "creation_csn: 1\\n"
+        f"removal_tid: (0, 0, {nil})\\n"
+        "removal_csn: 0"
+    )
+    path = get_table_path(ch1, table, database_name)
+    ch1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"for d in $(find {path} -mindepth 1 -maxdepth 1 -type d); do "
+            f'printf "{content}" > "$d/txn_version.txt"; done',
+        ]
+    )
+
+
+def test_attach_as_replicated_rejects_unsafe_name(started_cluster):
+    ch1.query(f"DROP DATABASE IF EXISTS {database_name} SYNC")
+    ch1.query(f"CREATE DATABASE {database_name}")
+
+    q(f"CREATE TABLE `{VICTIM}` ( A Int64 ) ENGINE = ReplicatedMergeTree ORDER BY A")
+    q(f"INSERT INTO `{VICTIM}` VALUES (1)")
+    # The whole scenario needs the path to be derived from the name, so assert that rather than
+    # assuming the config took effect.
+    assert (
+        q(
+            f"SELECT zookeeper_path FROM system.replicas WHERE database = '{database_name}' AND table = '{VICTIM}'"
+        ).strip()
+        == f"/clickhouse/tables/{database_name}/{VICTIM}"
+    )
+    assert victim_total_replicas() == "1"
+
+    q(f"CREATE TABLE `{GHOST}` ( A Int64 ) ENGINE = MergeTree ORDER BY A")
+    q(f"INSERT INTO `{GHOST}` VALUES (7)")
+    q(f"INSERT INTO `{GHOST}` VALUES (8)")
+    plant_txn_version_files(GHOST)
+    assert count_txn_version_files(GHOST) == 2
+    q(f"DETACH TABLE `{GHOST}`")
+
+    # T1: the conversion must be refused. Without the check it succeeds and the table takes a path
+    # under the victim's own subtree.
+    assert "BAD_ARGUMENTS" in ch1.query_and_get_error(
+        f"ATTACH TABLE `{GHOST}` AS REPLICATED", database=database_name
+    )
+
+    # T1b: the rejection ran before the metadata rewrite, so a plain ATTACH brings the table back as
+    # the MergeTree it always was. A rejection sited after the rewrite reports ReplicatedMergeTree.
+    q(f"ATTACH TABLE `{GHOST}`")
+    assert (
+        q(
+            f"SELECT engine FROM system.tables WHERE database = '{database_name}' AND name = '{GHOST}'"
+        ).strip()
+        == "MergeTree"
+    )
+
+    # T1c: it also ran before the transaction metadata was removed. A part whose `txn_version.txt`
+    # is gone is misread as a rolled-back transaction and discarded, so losing these files loses
+    # rows. This is the row that pins the rejection ahead of `clearTransactionMetadata`.
+    assert count_txn_version_files(GHOST) == 2
+    assert q(f"SELECT count() FROM `{GHOST}`").strip() == "2"
+
+    # T1d: the victim is untouched, and still accepts a metadata ALTER. A planted ghost replica
+    # leaves this failing with a Keeper error over the ghost's missing log_pointer.
+    assert victim_total_replicas() == "1"
+    assert (
+        q(
+            f"SELECT groupArray(name) FROM system.zookeeper WHERE path = '/clickhouse/tables/{database_name}/{VICTIM}/replicas'"
+        ).strip()
+        == "['node1']"
+    )
+    q(f"ALTER TABLE `{VICTIM}` ADD COLUMN B UInt64 SETTINGS alter_sync = 2")
+
+    # T3 (control): a path-safe name converts fine under the very same configuration, so the
+    # rejection above is about the name and not about the config or the conversion route.
+    q("CREATE TABLE safe_name ( A Int64 ) ENGINE = MergeTree ORDER BY A")
+    q("INSERT INTO safe_name VALUES (1), (2)")
+    q("DETACH TABLE safe_name")
+    q("ATTACH TABLE safe_name AS REPLICATED")
+    assert (
+        q(
+            f"SELECT engine FROM system.tables WHERE database = '{database_name}' AND name = 'safe_name'"
+        ).strip()
+        == "ReplicatedMergeTree"
+    )
+    assert q("SELECT count() FROM safe_name").strip() == "2"
+
+    ch1.query(f"DROP DATABASE IF EXISTS {database_name} SYNC")
+
+
+def test_convert_flag_rejects_unsafe_name(started_cluster):
+    ch1.query(f"DROP DATABASE IF EXISTS {database_name} SYNC")
+    ch1.query(f"CREATE DATABASE {database_name}")
+
+    q(f"CREATE TABLE `{GHOST}` ( A Int64 ) ENGINE = MergeTree ORDER BY A")
+    q(f"INSERT INTO `{GHOST}` VALUES (1), (2)")
+    set_convert_flags(ch1, database_name, [GHOST])
+
+    # T2: the flag-file route refuses the same conversion, and because it runs during startup the
+    # server does not come up. That is the behaviour the sibling `checkReplicaPathExists` already
+    # has on this route (see test_zk_path_exists.py), and the recovery is the same: delete the flag.
+    ch1.stop_clickhouse()
+    ch1.start_clickhouse(start_wait_sec=120, expected_to_fail=True)
+
+    ch1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"rm {get_table_path(ch1, GHOST, database_name)}convert_to_replicated",
+        ]
+    )
+    ch1.start_clickhouse()
+
+    # The table is intact: still a MergeTree, still holding its rows.
+    assert (
+        q(
+            f"SELECT engine FROM system.tables WHERE database = '{database_name}' AND name = '{GHOST}'"
+        ).strip()
+        == "MergeTree"
+    )
+    assert q(f"SELECT count() FROM `{GHOST}`").strip() == "2"
+
+    ch1.query(f"DROP DATABASE IF EXISTS {database_name} SYNC")

--- a/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.reference
+++ b/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.reference
@@ -1,0 +1,8 @@
+C1	ReplicatedMergeTree	2
+C4	1
+C3	MergeTree
+C2_armed	1
+C2 ATTACHED
+C2_count	1
+C5 RESTARTED
+C5_count	1

--- a/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.reference
+++ b/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.reference
@@ -2,7 +2,7 @@ safe_name_converts	ReplicatedMergeTree	2
 definition_not_rewritten	1
 as_not_replicated_allows_unsafe_name	MergeTree
 stored_macro_armed	1
-short_attach ATTACHED
+short_attach OK
 short_attach_count	1
-restart_replica RESTARTED
+restart_replica OK
 restart_replica_count	1

--- a/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.reference
+++ b/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.reference
@@ -1,8 +1,8 @@
-C1	ReplicatedMergeTree	2
-C4	1
-C3	MergeTree
-C2_armed	1
-C2 ATTACHED
-C2_count	1
-C5 RESTARTED
-C5_count	1
+safe_name_converts	ReplicatedMergeTree	2
+definition_not_rewritten	1
+as_not_replicated_allows_unsafe_name	MergeTree
+stored_macro_armed	1
+short_attach ATTACHED
+short_attach_count	1
+restart_replica RESTARTED
+restart_replica_count	1

--- a/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
+++ b/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
@@ -12,28 +12,28 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # that setting, and the rows here pin the exemptions the rejection must not disturb.
 CLIENT="${CLICKHOUSE_CLIENT} --server_logs_file=/dev/null"
 
-# C1: converting a table with a path-safe name still works. Guards the check against rejecting the
+# Converting a table with a path-safe name still works. Guards the check against rejecting the
 # ordinary case: the shipped {uuid} template resolves through the same code path.
 ${CLIENT} -q "CREATE TABLE c1 (c0 Int) ENGINE = MergeTree ORDER BY c0"
 ${CLIENT} -q "INSERT INTO c1 VALUES (1), (2)"
 ${CLIENT} -q "DETACH TABLE c1"
 ${CLIENT} -q "ATTACH TABLE c1 AS REPLICATED"
-${CLIENT} -q "SELECT 'C1', engine, (SELECT count() FROM c1) FROM system.tables WHERE database = currentDatabase() AND name = 'c1'"
+${CLIENT} -q "SELECT 'safe_name_converts', engine, (SELECT count() FROM c1) FROM system.tables WHERE database = currentDatabase() AND name = 'c1'"
 
-# C4: the check only reads the definition, it must not rewrite the engine arguments. The stored
+# The check only reads the definition, it must not rewrite the engine arguments. The stored
 # template stays unexpanded, which is what keeps a metadata file copyable between replicas.
-${CLIENT} -q "SELECT 'C4', create_table_query LIKE '%{uuid}%' FROM system.tables WHERE database = currentDatabase() AND name = 'c1'"
+${CLIENT} -q "SELECT 'definition_not_rewritten', create_table_query LIKE '%{uuid}%' FROM system.tables WHERE database = currentDatabase() AND name = 'c1'"
 ${CLIENT} -q "DROP TABLE c1"
 
-# C3: the opposite direction strips the path arguments instead of minting one, so an unsafe name is
+# The opposite direction strips the path arguments instead of minting one, so an unsafe name is
 # irrelevant to it. The path is given explicitly here, so the CREATE itself is legal.
 ${CLIENT} -q "CREATE TABLE \`c3/unsafe\` (c0 Int) ENGINE = ReplicatedMergeTree('/clickhouse/04853/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/c3', 'r1') ORDER BY c0"
 ${CLIENT} -q "DETACH TABLE \`c3/unsafe\`"
 ${CLIENT} -q "ATTACH TABLE \`c3/unsafe\` AS NOT REPLICATED"
-${CLIENT} -q "SELECT 'C3', engine FROM system.tables WHERE database = currentDatabase() AND name = 'c3/unsafe'"
+${CLIENT} -q "SELECT 'as_not_replicated_allows_unsafe_name', engine FROM system.tables WHERE database = currentDatabase() AND name = 'c3/unsafe'"
 ${CLIENT} -q "DROP TABLE \`c3/unsafe\`"
 
-# C2/C5: a table whose STORED path re-expands to a path-unsafe value keeps loading, both through a
+# A table whose STORED path re-expands to a path-unsafe value keeps loading, both through a
 # short ATTACH and through SYSTEM RESTART REPLICA. Two arming details:
 #  * only a CONFIGURED macro survives into metadata unexpanded; a direct {database} is unfolded at
 #    CREATE, leaving nothing to re-substitute.
@@ -44,13 +44,13 @@ ${CLIENT} -q "DROP DATABASE IF EXISTS \`${LEGACY_DB}/d\` SYNC"
 ${CLIENT} -q "DROP DATABASE IF EXISTS \`${LEGACY_DB}\` SYNC"
 ${CLIENT} -q "CREATE DATABASE \`${LEGACY_DB}\`"
 ${CLIENT} -q "CREATE TABLE \`${LEGACY_DB}\`.t (c0 Int) ENGINE = ReplicatedMergeTree('{default_path_test}04853legacy', 'r2') ORDER BY c0"
-${CLIENT} -q "SELECT 'C2_armed', create_table_query LIKE '%{default_path_test}%' FROM system.tables WHERE database = '${LEGACY_DB}' AND name = 't'"
+${CLIENT} -q "SELECT 'stored_macro_armed', create_table_query LIKE '%{default_path_test}%' FROM system.tables WHERE database = '${LEGACY_DB}' AND name = 't'"
 ${CLIENT} -q "RENAME DATABASE \`${LEGACY_DB}\` TO \`${LEGACY_DB}/d\`"
 ${CLIENT} -q "DETACH TABLE \`${LEGACY_DB}/d\`.t"
-${CLIENT} -q "ATTACH TABLE \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'C2 REJECTED' || echo 'C2 ATTACHED'
-${CLIENT} -q "SELECT 'C2_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
-${CLIENT} -q "SYSTEM RESTART REPLICA \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'C5 REJECTED' || echo 'C5 RESTARTED'
-${CLIENT} -q "SELECT 'C5_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
+${CLIENT} -q "ATTACH TABLE \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'short_attach REJECTED' || echo 'short_attach ATTACHED'
+${CLIENT} -q "SELECT 'short_attach_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
+${CLIENT} -q "SYSTEM RESTART REPLICA \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'restart_replica REJECTED' || echo 'restart_replica RESTARTED'
+${CLIENT} -q "SELECT 'restart_replica_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
 # Re-resolve the path under the original name before dropping: the stored path re-expands {database},
 # so under the new name the table points at a different znode tree than the CREATE made, and dropping
 # it there would leave the original tree behind.

--- a/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
+++ b/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
@@ -12,8 +12,6 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # that setting, and the rows here pin the exemptions the rejection must not disturb.
 CLIENT="${CLICKHOUSE_CLIENT} --server_logs_file=/dev/null"
 
-ZK="/clickhouse/04853/${CLICKHOUSE_DATABASE}"
-
 # C1: converting a table with a path-safe name still works. Guards the check against rejecting the
 # ordinary case: the shipped {uuid} template resolves through the same code path.
 ${CLIENT} -q "CREATE TABLE c1 (c0 Int) ENGINE = MergeTree ORDER BY c0"
@@ -29,7 +27,7 @@ ${CLIENT} -q "DROP TABLE c1"
 
 # C3: the opposite direction strips the path arguments instead of minting one, so an unsafe name is
 # irrelevant to it. The path is given explicitly here, so the CREATE itself is legal.
-${CLIENT} -q "CREATE TABLE \`c3/unsafe\` (c0 Int) ENGINE = ReplicatedMergeTree('${ZK}/c3', 'r1') ORDER BY c0"
+${CLIENT} -q "CREATE TABLE \`c3/unsafe\` (c0 Int) ENGINE = ReplicatedMergeTree('/clickhouse/04853/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/c3', 'r1') ORDER BY c0"
 ${CLIENT} -q "DETACH TABLE \`c3/unsafe\`"
 ${CLIENT} -q "ATTACH TABLE \`c3/unsafe\` AS NOT REPLICATED"
 ${CLIENT} -q "SELECT 'C3', engine FROM system.tables WHERE database = currentDatabase() AND name = 'c3/unsafe'"

--- a/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
+++ b/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
@@ -39,6 +39,20 @@ ${CLIENT} -q "DROP TABLE \`c3/unsafe\`"
 #    CREATE, leaving nothing to re-substitute.
 #  * the DATABASE is renamed rather than the table, because RenamingRestrictions refuses to rename
 #    a table whose path carries an implicit macro.
+# Report the exemption from the client's exit status, not from a grep for one error code: the table
+# is registered in the catalog before `startup()` runs on both routes, so a failure there leaves the
+# table present and the count assertions below cannot see it.
+run_exempt() {
+    local label=$1 query=$2 out rc
+    out=$(${CLIENT} -q "$query" 2>&1)
+    rc=$?
+    if [ "$rc" = "0" ]; then
+        echo "$label OK"
+    else
+        echo "$label FAILED rc=$rc: $out"
+    fi
+}
+
 LEGACY_DB="${CLICKHOUSE_DATABASE}_legacy"
 ${CLIENT} -q "DROP DATABASE IF EXISTS \`${LEGACY_DB}/d\` SYNC"
 ${CLIENT} -q "DROP DATABASE IF EXISTS \`${LEGACY_DB}\` SYNC"
@@ -47,9 +61,9 @@ ${CLIENT} -q "CREATE TABLE \`${LEGACY_DB}\`.t (c0 Int) ENGINE = ReplicatedMergeT
 ${CLIENT} -q "SELECT 'stored_macro_armed', create_table_query LIKE '%{default_path_test}%' FROM system.tables WHERE database = '${LEGACY_DB}' AND name = 't'"
 ${CLIENT} -q "RENAME DATABASE \`${LEGACY_DB}\` TO \`${LEGACY_DB}/d\`"
 ${CLIENT} -q "DETACH TABLE \`${LEGACY_DB}/d\`.t"
-${CLIENT} -q "ATTACH TABLE \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'short_attach REJECTED' || echo 'short_attach ATTACHED'
+run_exempt short_attach "ATTACH TABLE \`${LEGACY_DB}/d\`.t"
 ${CLIENT} -q "SELECT 'short_attach_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
-${CLIENT} -q "SYSTEM RESTART REPLICA \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'restart_replica REJECTED' || echo 'restart_replica RESTARTED'
+run_exempt restart_replica "SYSTEM RESTART REPLICA \`${LEGACY_DB}/d\`.t"
 ${CLIENT} -q "SELECT 'restart_replica_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
 # Re-resolve the path under the original name before dropping: the stored path re-expands {database},
 # so under the new name the table points at a different znode tree than the CREATE made, and dropping

--- a/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
+++ b/tests/queries/0_stateless/04853_attach_as_replicated_keeper_path_macro.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-replicated-database, no-ordinary-database, no-shared-merge-tree
+# Rows needing a per-copy unique database name, which a .sql file cannot interpolate.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# The rejection this test guards fires only on a name-based `default_replica_path`, which the test
+# config does not set (it is {uuid}-based, and a {uuid} is never path-unsafe). So the treatment row
+# lives in tests/integration/test_modify_engine_on_restart/test_unsafe_name.py, which configures
+# that setting, and the rows here pin the exemptions the rejection must not disturb.
+CLIENT="${CLICKHOUSE_CLIENT} --server_logs_file=/dev/null"
+
+ZK="/clickhouse/04853/${CLICKHOUSE_DATABASE}"
+
+# C1: converting a table with a path-safe name still works. Guards the check against rejecting the
+# ordinary case: the shipped {uuid} template resolves through the same code path.
+${CLIENT} -q "CREATE TABLE c1 (c0 Int) ENGINE = MergeTree ORDER BY c0"
+${CLIENT} -q "INSERT INTO c1 VALUES (1), (2)"
+${CLIENT} -q "DETACH TABLE c1"
+${CLIENT} -q "ATTACH TABLE c1 AS REPLICATED"
+${CLIENT} -q "SELECT 'C1', engine, (SELECT count() FROM c1) FROM system.tables WHERE database = currentDatabase() AND name = 'c1'"
+
+# C4: the check only reads the definition, it must not rewrite the engine arguments. The stored
+# template stays unexpanded, which is what keeps a metadata file copyable between replicas.
+${CLIENT} -q "SELECT 'C4', create_table_query LIKE '%{uuid}%' FROM system.tables WHERE database = currentDatabase() AND name = 'c1'"
+${CLIENT} -q "DROP TABLE c1"
+
+# C3: the opposite direction strips the path arguments instead of minting one, so an unsafe name is
+# irrelevant to it. The path is given explicitly here, so the CREATE itself is legal.
+${CLIENT} -q "CREATE TABLE \`c3/unsafe\` (c0 Int) ENGINE = ReplicatedMergeTree('${ZK}/c3', 'r1') ORDER BY c0"
+${CLIENT} -q "DETACH TABLE \`c3/unsafe\`"
+${CLIENT} -q "ATTACH TABLE \`c3/unsafe\` AS NOT REPLICATED"
+${CLIENT} -q "SELECT 'C3', engine FROM system.tables WHERE database = currentDatabase() AND name = 'c3/unsafe'"
+${CLIENT} -q "DROP TABLE \`c3/unsafe\`"
+
+# C2/C5: a table whose STORED path re-expands to a path-unsafe value keeps loading, both through a
+# short ATTACH and through SYSTEM RESTART REPLICA. Two arming details:
+#  * only a CONFIGURED macro survives into metadata unexpanded; a direct {database} is unfolded at
+#    CREATE, leaving nothing to re-substitute.
+#  * the DATABASE is renamed rather than the table, because RenamingRestrictions refuses to rename
+#    a table whose path carries an implicit macro.
+LEGACY_DB="${CLICKHOUSE_DATABASE}_legacy"
+${CLIENT} -q "DROP DATABASE IF EXISTS \`${LEGACY_DB}/d\` SYNC"
+${CLIENT} -q "DROP DATABASE IF EXISTS \`${LEGACY_DB}\` SYNC"
+${CLIENT} -q "CREATE DATABASE \`${LEGACY_DB}\`"
+${CLIENT} -q "CREATE TABLE \`${LEGACY_DB}\`.t (c0 Int) ENGINE = ReplicatedMergeTree('{default_path_test}04853legacy', 'r2') ORDER BY c0"
+${CLIENT} -q "SELECT 'C2_armed', create_table_query LIKE '%{default_path_test}%' FROM system.tables WHERE database = '${LEGACY_DB}' AND name = 't'"
+${CLIENT} -q "RENAME DATABASE \`${LEGACY_DB}\` TO \`${LEGACY_DB}/d\`"
+${CLIENT} -q "DETACH TABLE \`${LEGACY_DB}/d\`.t"
+${CLIENT} -q "ATTACH TABLE \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'C2 REJECTED' || echo 'C2 ATTACHED'
+${CLIENT} -q "SELECT 'C2_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
+${CLIENT} -q "SYSTEM RESTART REPLICA \`${LEGACY_DB}/d\`.t" 2>&1 | grep -q -F 'BAD_ARGUMENTS' && echo 'C5 REJECTED' || echo 'C5 RESTARTED'
+${CLIENT} -q "SELECT 'C5_count', count() FROM system.tables WHERE database = '${LEGACY_DB}/d' AND name = 't'"
+# Re-resolve the path under the original name before dropping: the stored path re-expands {database},
+# so under the new name the table points at a different znode tree than the CREATE made, and dropping
+# it there would leave the original tree behind.
+${CLIENT} -q "RENAME DATABASE \`${LEGACY_DB}/d\` TO \`${LEGACY_DB}\`"
+${CLIENT} -q "DETACH TABLE \`${LEGACY_DB}\`.t"
+${CLIENT} -q "ATTACH TABLE \`${LEGACY_DB}\`.t"
+${CLIENT} -q "DROP DATABASE \`${LEGACY_DB}\` SYNC"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/115967
Related: https://github.com/ClickHouse/ClickHouse/pull/114006
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/115967
Related: https://github.com/ClickHouse/ClickHouse/pull/114006

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `ATTACH TABLE ... AS REPLICATED` and the `convert_to_replicated` flag file accepting a conversion whose ZooKeeper path is not a safe path. On a server whose `default_replica_path` substitutes `{database}` or `{table}`, a name containing `/` used to resolve to a path inside another table's subtree, letting the converted table register a replica under a table it has no privileges on. Such a conversion is now rejected with `BAD_ARGUMENTS`, the same way an equivalent `CREATE` already was. Closes #115967.

### Description

A plain `MergeTree` table has no ZooKeeper path, so `ATTACH TABLE t AS REPLICATED` mints one from `default_replica_path` and the table's own name, then marks the definition `attach_short_syntax`, which turns off the path validation added in #114006. That exemption is correct for a genuine short `ATTACH`, which re-derives an existing path, but a conversion is the opposite case: a brand new path.

So on a name-based template (recommended by the engine's own docs, unlike the immune `{uuid}` default) a table named `` `victim/replicas/ghost` `` resolves under `victim`'s subtree. Converting it and running `SYSTEM RESTORE REPLICA` registers a second replica of `victim`, which then fails `ALTER ... SETTINGS alter_sync = 2` with `KEEPER_EXCEPTION` while still serving reads. Both statements fall under `GRANT ALL ON <database>.*`, so no privilege on the affected table is needed, and only an admin can clear it.

I validate the prospective path in a new side-effect-free helper next to `checkReplicaPathExists`, reusing `TableZnodeInfo::resolve` with validation on, so no new validation logic is added. It is called from both conversion routes. Not covered: a coordinated refreshable materialized view expands the same template unvalidated (`RefreshTask.cpp:194`), but that route needs database-wide DDL rights, so it is not a privilege boundary. Placement matters: in the interpreter it runs before the transaction metadata removal and the metadata rewrite, neither of which can be rolled back, so a rejection leaves the table as it was. On the flag file route it rejects at startup, matching the neighbouring check there and recoverable by deleting the flag.

Validated on a local server with a name-based template: the conversion is accepted before this change and rejected after it, and the affected table stays at one replica. New stateless test `04853` pins the exemptions that must survive; the rejection needs the new `test_unsafe_name.py`, since the stateless config is immune.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115991&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/115991](https://github.com/search?q=head%3Async-upstream%2Fpr%2F115991+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.93` (included in `26.9` and later)
- Backported to: `26.8.10.8`, `26.7.14.8`, `26.3.33.129`
<!-- ch-version-info:end -->