### PR TITLE
Docs: clarify that path-less chDB sessions are temporary and document connection/path rules

### DIFF
--- a/docs/chdb/api/python.mdx
+++ b/docs/chdb/api/python.mdx
@@ -29,7 +29,7 @@ chdb.query(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                                     |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for a temporary database                                                                                                                                                                                               |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for an in-memory database                                                                                                                                                                                               |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                        |
 
 **Returns**
@@ -94,7 +94,7 @@ chdb.sql(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                              |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for a temporary database                                                                                                                                                                                         |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for an in-memory database                                                                                                                                                                                         |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                 |
 
 **Returns**
@@ -232,8 +232,7 @@ The following Session Functions are available:
 Create a connection to chDB background server.
 
 This function establishes a [Connection](#chdb-state-sqlitelike-connection) to the chDB (ClickHouse) database engine.
-Only one open connection is allowed per process.
-Multiple calls with the same connection string will return the same connection object.
+Each call returns an independent connection, and any number of connections to the same database path may be open at the same time.
 
 ```python
 chdb.connect(connection_string: str = ':memory:') → Connection
@@ -702,8 +701,7 @@ id,name
 Create a [Connection](#chdb-state-sqlitelike-connection) to the chDB background server.
 
 This function establishes a connection to the chDB (ClickHouse) database engine.
-Only one open connection is allowed per process. Multiple calls with the same
-connection string will return the same connection object.
+Each call returns an independent connection, and any number of connections to the same database path may be open at the same time.
 
 **Syntax**
 
@@ -1743,7 +1741,7 @@ chdb.dbapi.connect(*args, **kwargs)
 
 | Parameter  | Type  | Default  | Description                                     |
 |------------|-------|----------|-------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. None for a temporary, non-persistent database |
+| `path`     | str   | `None`   | Database file path. None for an in-memory database |
 
 **Raises**
 
@@ -1824,7 +1822,7 @@ class chdb.dbapi.connections.Connection(path=None)
 
 | Parameter  | Type  | Default  | Description                                                                                                        |
 |------------|-------|----------|--------------------------------------------------------------------------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. If None, uses a temporary, non-persistent database. Can be a file path like 'database.db' or None for ':memory:' |
+| `path`     | str   | `None`   | Database file path. If None (the default), uses an in-memory database (`':memory:'`). Pass a file path like 'database.db' to persist to disk. |
 
 **Variables**
 

--- a/docs/chdb/api/python.mdx
+++ b/docs/chdb/api/python.mdx
@@ -29,7 +29,7 @@ chdb.query(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                                     |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to in-memory database.<br/>Can be a file path or `":memory:"` for in-memory database                                                                                                                                                                                               |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for a temporary database                                                                                                                                                                                               |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                        |
 
 **Returns**
@@ -94,7 +94,7 @@ chdb.sql(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                              |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to in-memory database.<br/>Can be a file path or `":memory:"` for in-memory database                                                                                                                                                                                         |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for a temporary database                                                                                                                                                                                         |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                 |
 
 **Returns**
@@ -288,10 +288,9 @@ For a complete parameter list, see `clickhouse local --help --verbose`
 |----------------|---------------------------------|
 | `RuntimeError` | If connection to database fails |
 
-<Warning>
-Only one connection per process is supported.
-Creating a new connection will close any existing connection.
-</Warning>
+<Note>
+A process runs one embedded engine bound to one database path. Multiple connections to the same path can coexist and run queries concurrently; opening a *different* path while any connection is open raises — close the open ones first.
+</Note>
 
 **Examples**
 
@@ -373,12 +372,13 @@ Some special args handling:
 - “mode=ro” would be “–readonly=1” for clickhouse (read-only mode)
 </Info>
 
-<Warning>
+<Note>
 **Important**
 
-- There can be only one session at a time. If you want to create a new session, you need to close the existing one.
-- Creating a new session will close the existing one.
-</Warning>
+- Multiple sessions can coexist, each with its own connection and database context, as long as they share the same database path.
+- Sessions are thread-safe; for best performance, use a separate session per thread.
+- To use a different database path, close the open session(s) first.
+</Note>
 
 ---
 
@@ -763,12 +763,9 @@ For a complete parameter list, see `clickhouse local --help --verbose`
 |----------------|---------------------------------|
 | `RuntimeError` | If connection to database fails |
 
-<Warning>
-**Warning**
-
-Only one connection per process is supported.
-Creating a new connection will close any existing connection.
-</Warning>
+<Note>
+A process runs one embedded engine bound to one database path. Multiple connections to the same path can coexist and run queries concurrently; opening a *different* path while any connection is open raises — close the open ones first.
+</Note>
 
 **Examples**
 
@@ -1747,7 +1744,7 @@ chdb.dbapi.connect(*args, **kwargs)
 
 | Parameter  | Type  | Default  | Description                                     |
 |------------|-------|----------|-------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. None for in-memory database |
+| `path`     | str   | `None`   | Database file path. None for a temporary, non-persistent database |
 
 **Raises**
 
@@ -1828,7 +1825,7 @@ class chdb.dbapi.connections.Connection(path=None)
 
 | Parameter  | Type  | Default  | Description                                                                                                        |
 |------------|-------|----------|--------------------------------------------------------------------------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. If None, uses in-memory database. Can be a file path like 'database.db' or None for ':memory:' |
+| `path`     | str   | `None`   | Database file path. If None, uses a temporary, non-persistent database. Can be a file path like 'database.db' or None for ':memory:' |
 
 **Variables**
 

--- a/docs/chdb/api/python.mdx
+++ b/docs/chdb/api/python.mdx
@@ -29,7 +29,7 @@ chdb.query(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                                     |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database (the `":memory:"` sentinel).<br/>Pass a file path to persist to disk                                                                                                                                                                                               |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database (equivalent to `":memory:"`).<br/>Pass a file path to persist to disk                                                                                                                                                                                               |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                        |
 
 **Returns**
@@ -94,7 +94,7 @@ chdb.sql(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                              |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database (the `":memory:"` sentinel).<br/>Pass a file path to persist to disk                                                                                                                                                                                         |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database (equivalent to `":memory:"`).<br/>Pass a file path to persist to disk                                                                                                                                                                                         |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                 |
 
 **Returns**
@@ -288,7 +288,7 @@ For a complete parameter list, see `clickhouse local --help --verbose`
 | `RuntimeError` | If connection to database fails |
 
 <Note>
-A process runs one embedded engine bound to one database path. Multiple connections to the same path can coexist and run queries concurrently; opening a *different* path while any connection is open raises — close the open ones first.
+A process runs one embedded engine bound to one database path. Multiple connections to the same path can coexist and run queries concurrently. Opening a *different* path while any connection is open raises a `RuntimeError`; close the open ones first.
 </Note>
 
 **Examples**
@@ -336,7 +336,7 @@ provides error information from the underlying ClickHouse engine.
 Bases: `object`
 
 Session will keep the state of query.
-If path is None, the session uses the shared temporary (`:memory:`) database for the process, so all path-less sessions see each other's tables; its temporary directory is removed only when the last such session or connection closes.
+If path is None, the session uses the process-wide temporary (`:memory:`) database, so all path-less sessions see each other's tables; its temporary directory is removed only when the last such session or connection closes.
 You can also pass in a path to create a database at that path where will keep your data.
 
 You can also use a connection string to pass in the path and other parameters.
@@ -760,7 +760,7 @@ For a complete parameter list, see `clickhouse local --help --verbose`
 | `RuntimeError` | If connection to database fails |
 
 <Note>
-A process runs one embedded engine bound to one database path. Multiple connections to the same path can coexist and run queries concurrently; opening a *different* path while any connection is open raises — close the open ones first.
+A process runs one embedded engine bound to one database path. Multiple connections to the same path can coexist and run queries concurrently. Opening a *different* path while any connection is open raises a `RuntimeError`; close the open ones first.
 </Note>
 
 **Examples**
@@ -1740,7 +1740,7 @@ chdb.dbapi.connect(*args, **kwargs)
 
 | Parameter  | Type  | Default  | Description                                     |
 |------------|-------|----------|-------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. None for a temporary (non-persistent) database |
+| `path`     | str   | `None`   | Database file path. None for a temporary, non-persistent database |
 
 **Raises**
 
@@ -1821,7 +1821,7 @@ class chdb.dbapi.connections.Connection(path=None)
 
 | Parameter  | Type  | Default  | Description                                                                                                        |
 |------------|-------|----------|--------------------------------------------------------------------------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. If None (the default), uses a temporary (non-persistent) database (`':memory:'`). Pass a file path like 'database.db' to persist to disk. |
+| `path`     | str   | `None`   | Database file path. If None (the default), uses a temporary, non-persistent database (equivalent to `':memory:'`). Pass a file path like 'database.db' to persist to disk. |
 
 **Variables**
 

--- a/docs/chdb/api/python.mdx
+++ b/docs/chdb/api/python.mdx
@@ -336,8 +336,7 @@ provides error information from the underlying ClickHouse engine.
 Bases: `object`
 
 Session will keep the state of query.
-If path is None, it will create a temporary directory and use it as the database path
-and the temporary directory will be removed when the session is closed.
+If path is None, the session uses the shared in-memory (`:memory:`) database for the process, so all path-less sessions see each other's tables; its temporary directory is removed only when the last such session or connection closes.
 You can also pass in a path to create a database at that path where will keep your data.
 
 You can also use a connection string to pass in the path and other parameters.

--- a/docs/chdb/api/python.mdx
+++ b/docs/chdb/api/python.mdx
@@ -14,7 +14,7 @@ doc_type: 'reference'
 Execute SQL query using chDB engine.
 
 This is the main query function that executes SQL statements using the embedded
-ClickHouse engine. Supports various output formats and can work with in-memory
+ClickHouse engine. Supports various output formats and can work with temporary
 or file-based databases.
 
 **Syntax**
@@ -29,7 +29,7 @@ chdb.query(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                                     |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for an in-memory database                                                                                                                                                                                               |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database (the `":memory:"` sentinel).<br/>Pass a file path to persist to disk                                                                                                                                                                                               |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                        |
 
 **Returns**
@@ -79,7 +79,7 @@ Returns the query result in the specified format:
 Execute SQL query using chDB engine.
 
 This is the main query function that executes SQL statements using the embedded
-ClickHouse engine. Supports various output formats and can work with in-memory
+ClickHouse engine. Supports various output formats and can work with temporary
 or file-based databases.
 
 **Syntax**
@@ -94,7 +94,7 @@ chdb.sql(sql, output_format='CSV', path='', udf_path='')
 |-----------------|-------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `sql`           | str   | *required* | SQL query string to execute                                                                                                                                                                                                                                                                              |
 | `output_format` | str   | `"CSV"`    | Output format for results. Supported formats:<br/>• `"CSV"` - Comma-separated values<br/>• `"JSON"` - JSON format<br/>• `"Arrow"` - Apache Arrow format<br/>• `"Parquet"` - Parquet format<br/>• `"DataFrame"` - Pandas DataFrame<br/>• `"ArrowTable"` - PyArrow Table<br/>• `"Debug"` - Enable verbose logging |
-| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database.<br/>Can be a file path, or `":memory:"` for an in-memory database                                                                                                                                                                                         |
+| `path`          | str   | `""`       | Database file path. Defaults to a temporary, non-persistent database (the `":memory:"` sentinel).<br/>Pass a file path to persist to disk                                                                                                                                                                                         |
 | `udf_path`      | str   | `""`       | Path to legacy subprocess-based UDF directory. Not needed for native Python UDFs ([`@func`](#func-decorator) / [`create_function`](#create-function))                                                                                                                                                                                                                                                                 |
 
 **Returns**
@@ -248,7 +248,7 @@ chdb.connect(connection_string: str = ':memory:') → Connection
 
 | Format                    | Description                  |
 |---------------------------|------------------------------|
-| `":memory:"`              | In-memory database (default) |
+| `":memory:"`              | Temporary database (default) |
 | `"test.db"`               | Relative path database file  |
 | `"file:test.db"`          | Same as relative path        |
 | `"/path/to/test.db"`      | Absolute path database file  |
@@ -259,7 +259,7 @@ chdb.connect(connection_string: str = ':memory:') → Connection
 | Format                                             | Description               |
 |----------------------------------------------------|---------------------------|
 | `"file:test.db?param1=value1&param2=value2"`       | Relative path with params |
-| `"file::memory:?verbose&log-level=test"`           | In-memory with params     |
+| `"file::memory:?verbose&log-level=test"`           | Temporary with params     |
 | `"///path/to/test.db?param1=value1&param2=value2"` | Absolute path with params |
 
 **Query parameter handling**
@@ -294,7 +294,7 @@ A process runs one embedded engine bound to one database path. Multiple connecti
 **Examples**
 
 ```pycon
->>> # In-memory database
+>>> # Temporary database
 >>> conn = connect()
 >>> conn = connect(":memory:")
 >>>
@@ -336,7 +336,7 @@ provides error information from the underlying ClickHouse engine.
 Bases: `object`
 
 Session will keep the state of query.
-If path is None, the session uses the shared in-memory (`:memory:`) database for the process, so all path-less sessions see each other's tables; its temporary directory is removed only when the last such session or connection closes.
+If path is None, the session uses the shared temporary (`:memory:`) database for the process, so all path-less sessions see each other's tables; its temporary directory is removed only when the last such session or connection closes.
 You can also pass in a path to create a database at that path where will keep your data.
 
 You can also use a connection string to pass in the path and other parameters.
@@ -349,13 +349,13 @@ class chdb.session.Session(path=None)
 
 | Connection String                                  | Description                          |
 |----------------------------------------------------|--------------------------------------|
-| `":memory:"`                                       | In-memory database                   |
+| `":memory:"`                                       | Temporary database                   |
 | `"test.db"`                                        | Relative path                        |
 | `"file:test.db"`                                   | Same as above                        |
 | `"/path/to/test.db"`                               | Absolute path                        |
 | `"file:/path/to/test.db"`                          | Same as above                        |
 | `"file:test.db?param1=value1&param2=value2"`       | Relative path with query params      |
-| `"file::memory:?verbose&log-level=test"`           | In-memory database with query params |
+| `"file::memory:?verbose&log-level=test"`           | Temporary database with query params |
 | `"///path/to/test.db?param1=value1&param2=value2"` | Absolute path with query params      |
 
 <Info>
@@ -720,7 +720,7 @@ Supported connection string formats:
 
 | Format                    | Description                  |
 |---------------------------|------------------------------|
-| `":memory:"`              | In-memory database (default) |
+| `":memory:"`              | Temporary database (default) |
 | `"test.db"`               | Relative path database file  |
 | `"file:test.db"`          | Same as relative path        |
 | `"/path/to/test.db"`      | Absolute path database file  |
@@ -731,7 +731,7 @@ Supported connection string formats:
 | Format                                             | Description               |
 |----------------------------------------------------|---------------------------|
 | `"file:test.db?param1=value1&param2=value2"`       | Relative path with params |
-| `"file::memory:?verbose&log-level=test"`           | In-memory with params     |
+| `"file::memory:?verbose&log-level=test"`           | Temporary with params     |
 | `"///path/to/test.db?param1=value1&param2=value2"` | Absolute path with params |
 
 **Query parameter handling**
@@ -766,7 +766,7 @@ A process runs one embedded engine bound to one database path. Multiple connecti
 **Examples**
 
 ```pycon
->>> # In-memory database
+>>> # Temporary database
 >>> conn = connect()
 >>> conn = connect(":memory:")
 >>>
@@ -1740,7 +1740,7 @@ chdb.dbapi.connect(*args, **kwargs)
 
 | Parameter  | Type  | Default  | Description                                     |
 |------------|-------|----------|-------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. None for an in-memory database |
+| `path`     | str   | `None`   | Database file path. None for a temporary (non-persistent) database |
 
 **Raises**
 
@@ -1808,7 +1808,7 @@ Bases: `object`
 DB-API 2.0 compliant connection to chDB database.
 
 This class provides a standard DB-API interface for connecting to and interacting
-with chDB databases. It supports both in-memory and file-based databases.
+with chDB databases. It supports both temporary and file-based databases.
 
 The connection manages the underlying chDB engine and provides methods for
 executing queries, managing transactions (no-op for ClickHouse), and creating cursors.
@@ -1821,7 +1821,7 @@ class chdb.dbapi.connections.Connection(path=None)
 
 | Parameter  | Type  | Default  | Description                                                                                                        |
 |------------|-------|----------|--------------------------------------------------------------------------------------------------------------------|
-| `path`     | str   | `None`   | Database file path. If None (the default), uses an in-memory database (`':memory:'`). Pass a file path like 'database.db' to persist to disk. |
+| `path`     | str   | `None`   | Database file path. If None (the default), uses a temporary (non-persistent) database (`':memory:'`). Pass a file path like 'database.db' to persist to disk. |
 
 **Variables**
 
@@ -1833,7 +1833,7 @@ class chdb.dbapi.connections.Connection(path=None)
 **Examples**
 
 ```pycon
->>> # In-memory database
+>>> # Temporary database
 >>> conn = Connection()
 >>> cursor = conn.cursor()
 >>> cursor.execute("SELECT 1")
@@ -3228,7 +3228,7 @@ Connection Management:
 ```python
 import chdb.dbapi as dbapi
 
-# In-memory database (default)
+# Temporary database (default)
 conn1 = dbapi.connect()
 
 # Persistent database file

--- a/docs/chdb/api/python.mdx
+++ b/docs/chdb/api/python.mdx
@@ -375,8 +375,7 @@ Some special args handling:
 <Note>
 **Important**
 
-- Multiple sessions can coexist, each with its own connection and database context, as long as they share the same database path.
-- Sessions are thread-safe; for best performance, use a separate session per thread.
+- Multiple sessions can coexist, as long as they share the same database path.
 - To use a different database path, close the open session(s) first.
 </Note>
 

--- a/docs/chdb/getting-started.mdx
+++ b/docs/chdb/getting-started.mdx
@@ -215,8 +215,8 @@ sess = chs.Session("gettingStarted.chdb")
 chDB runs a single embedded engine per process, so the database directory (its path) follows a few rules:
 
 - **One process per path**: a chDB data directory can be opened by only one operating system process at a time. A second process that opens the same path fails until the first one closes.
-- **One path per process**: while any connection is open you cannot open another connection for a *different* path — close the existing connection(s) first. Any number of connections to the *same* path may be open at the same time.
-- **Concurrency**: connections to the same path can run queries concurrently.
+- **One path per process**: while a session or connection is open, opening another one for a *different* path fails — close the open one(s) first. Multiple sessions or connections on the *same* path can coexist.
+- **Concurrency**: sessions or connections on the same path can run queries concurrently.
 </Note>
 
 Next, we'll create a database:

--- a/docs/chdb/getting-started.mdx
+++ b/docs/chdb/getting-started.mdx
@@ -205,11 +205,19 @@ from chdb import session as chs
 
 Next, we'll initialize a session.
 If we want the session to be persisted to disk, we need to provide a directory name.
-If we leave it blank, the database will be in-memory and lost as soon as we kill the Python process.
+If we leave it blank, the session is temporary: chDB stores its data in a temporary directory on disk that is removed when the session is closed, so it is lost as soon as we kill the Python process.
 
 ```python
 sess = chs.Session("gettingStarted.chdb")
 ```
+
+<Note>
+chDB runs a single embedded engine per process, so the database directory (its path) follows a few rules:
+
+- **One process per path**: a chDB data directory can be opened by only one operating system process at a time. A second process that opens the same path fails until the first one closes.
+- **One path per process**: while any connection is open you cannot open another connection for a *different* path — close the existing connection(s) first. Any number of connections to the *same* path may be open at the same time.
+- **Concurrency**: connections to the same path can run queries concurrently; for best performance, use a separate connection per thread.
+</Note>
 
 Next, we'll create a database:
 

--- a/docs/chdb/getting-started.mdx
+++ b/docs/chdb/getting-started.mdx
@@ -215,8 +215,9 @@ sess = chs.Session("gettingStarted.chdb")
 chDB runs a single embedded engine per process, so the database directory (its path) follows a few rules:
 
 - **One process per path**: a chDB data directory can be opened by only one operating system process at a time. A second process that opens the same path fails until the first one closes.
-- **One path per process**: while a session or connection is open, opening another one for a *different* path fails — close the open one(s) first. Multiple sessions or connections on the *same* path can coexist.
+- **One path per process**: while a session or connection is open, opening another one for a *different* path fails; first close the open one(s) to avoid the error. Multiple sessions or connections on the *same* path can coexist.
 - **Concurrency**: sessions or connections on the same path can run queries concurrently.
+- **Path-less sessions are shared**: with no path, sessions use the process-wide `:memory:` database (so blank sessions see each other's tables), and its temporary directory is removed only when the last one closes.
 </Note>
 
 Next, we'll create a database:

--- a/docs/chdb/getting-started.mdx
+++ b/docs/chdb/getting-started.mdx
@@ -205,7 +205,7 @@ from chdb import session as chs
 
 Next, we'll initialize a session.
 If we want the session to be persisted to disk, we need to provide a directory name.
-If we leave it blank, the session is temporary: chDB stores its data in a temporary directory on disk that is removed when the session is closed, so it is lost as soon as we kill the Python process.
+If we leave it blank, the session is temporary: chDB keeps its data in a temporary directory on disk and deletes it when the session is closed, so the data does not persist.
 
 ```python
 sess = chs.Session("gettingStarted.chdb")
@@ -216,7 +216,7 @@ chDB runs a single embedded engine per process, so the database directory (its p
 
 - **One process per path**: a chDB data directory can be opened by only one operating system process at a time. A second process that opens the same path fails until the first one closes.
 - **One path per process**: while any connection is open you cannot open another connection for a *different* path — close the existing connection(s) first. Any number of connections to the *same* path may be open at the same time.
-- **Concurrency**: connections to the same path can run queries concurrently; for best performance, use a separate connection per thread.
+- **Concurrency**: connections to the same path can run queries concurrently.
 </Note>
 
 Next, we'll create a database:

--- a/docs/chdb/install/python.mdx
+++ b/docs/chdb/install/python.mdx
@@ -54,7 +54,7 @@ For better resource management and performance:
 ```python
 import chdb
 
-# Create connection (in-memory by default)
+# Create connection (":memory:" is a temporary, non-persistent database)
 conn = chdb.connect(":memory:")
 # Or use file-based: conn = chdb.connect("mydata.db")
 


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

Corrects the "path-less chDB = in-memory" claim and the stale single-connection/session contract across the chDB Python docs.

**`docs/chdb/getting-started.mdx`**
- A path-less session is not kept in RAM. Without a path, chDB runs in *temporary mode*: it creates a temporary working directory on disk, uses it as the ClickHouse data path, and deletes it when the session closes. The data is ephemeral (not persisted), but disk-backed (the default table engine is `MergeTree`, and large sorts/aggregations spill to that directory). Reworded from *in-memory* to *temporary*.
- Added a `<Note>` documenting the connection/path rules: one process per path (directory lock), one path per process (opening a *different* path while one is open raises), and multiple sessions/connections on the *same* path can coexist and run queries concurrently.

**`docs/chdb/install/python.mdx`**
- Clarified that `":memory:"` is a temporary, non-persistent database (not RAM-only).

**`docs/chdb/api/python.mdx`**
- Replaced the stale `<Warning>` blocks on `chdb.connect`, `chdb.state.connect`, and `chdb.session.Session` that claimed "only one connection/session per process; a new one closes the existing one." The engine is now a ref-counted per-process singleton: multiple connections/sessions on the same path coexist and run concurrently, and only a *different* path raises. This aligns the reference with the current docstrings (`chdb/session/state.py`, `chdb/state/sqlitelike.py`) and `docs/troubleshooting.rst`.
- Changed "Defaults to in-memory database" to "temporary, non-persistent database" for the `path` parameters of `chdb.query`, `chdb.sql`, and `chdb.dbapi.connect`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116008&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116008](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116008+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1985` (included in `26.8` and later)
<!-- ch-version-info:end -->