### PR TITLE
Fix(PromQL): Regex matcher anchoring for alternation

### DIFF
--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -477,6 +477,16 @@ namespace
             expression,
             static_cast<re2::Regexp::ParseFlags>(options.ParseFlags()),
             &status);
+
+        if (!parsed && status.code() == re2::kRegexpBadUTF8)
+        {
+            options.set_encoding(re2::RE2::Options::EncodingLatin1);
+            parsed = re2::Regexp::Parse(
+                expression,
+                static_cast<re2::Regexp::ParseFlags>(options.ParseFlags()),
+                &status);
+        }
+
         if (!parsed)
             throw Exception(ErrorCodes::CANNOT_COMPILE_REGEXP, "Cannot compile PromQL regular expression '{}': {}", expression, status.Text());
 

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -3,6 +3,7 @@
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
+#include <Common/re2.h>
 #include <Columns/IColumn.h>
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypeLowCardinality.h>
@@ -44,6 +45,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int CANNOT_COMPILE_REGEXP;
     extern const int LOGICAL_ERROR;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
@@ -207,6 +209,284 @@ namespace
         return makeASTFunction("arrayElement", make_intrusive<ASTIdentifier>(TimeSeriesColumnNames::Tags), make_intrusive<ASTLiteral>(tag_name));
     }
 
+    bool hasMultilineFlag(std::string_view expression)
+    {
+        bool in_character_class = false;
+        bool character_class_at_start = false;
+        bool in_quoted_literal = false;
+
+        for (size_t i = 0; i < expression.size(); ++i)
+        {
+            const char c = expression[i];
+
+            if (in_quoted_literal)
+            {
+                if (c == '\\' && i + 1 < expression.size() && expression[i + 1] == 'E')
+                {
+                    in_quoted_literal = false;
+                    ++i;
+                }
+                continue;
+            }
+
+            if (in_character_class)
+            {
+                if (c == '\\' && i + 1 < expression.size())
+                {
+                    character_class_at_start = false;
+                    ++i;
+                    continue;
+                }
+
+                if (c == '[' && i + 1 < expression.size()
+                    && (expression[i + 1] == ':' || expression[i + 1] == '.' || expression[i + 1] == '='))
+                {
+                    const char delimiter = expression[i + 1];
+                    i += 2;
+                    while (i + 1 < expression.size()
+                        && !(expression[i] == delimiter && expression[i + 1] == ']'))
+                        ++i;
+                    if (i + 1 < expression.size())
+                        ++i;
+                    character_class_at_start = false;
+                    continue;
+                }
+
+                if (c == ']' && !character_class_at_start)
+                    in_character_class = false;
+
+                if (character_class_at_start && c == '^')
+                    continue;
+
+                character_class_at_start = false;
+                continue;
+            }
+
+            if (c == '\\')
+            {
+                if (i + 1 < expression.size() && expression[i + 1] == 'Q')
+                {
+                    in_quoted_literal = true;
+                    ++i;
+                }
+                else if (i + 1 < expression.size())
+                    ++i;
+                continue;
+            }
+
+            if (c == '[')
+            {
+                in_character_class = true;
+                character_class_at_start = true;
+                continue;
+            }
+
+            if (c != '(' || i + 2 >= expression.size() || expression[i + 1] != '?')
+                continue;
+
+            size_t flag_pos = i + 2;
+            while (flag_pos < expression.size())
+            {
+                const char flag = expression[flag_pos];
+                if (flag == 'm')
+                    return true;
+                if (flag != 'i' && flag != 's' && flag != 'U')
+                    break;
+                ++flag_pos;
+            }
+        }
+
+        return false;
+    }
+
+    bool hasUnterminatedQuotedLiteral(std::string_view expression)
+    {
+        bool in_quoted_literal = false;
+        for (size_t i = 0; i < expression.size();)
+        {
+            if (expression[i] != '\\')
+            {
+                ++i;
+                continue;
+            }
+
+            if (in_quoted_literal)
+            {
+                if (i + 1 < expression.size() && expression[i + 1] == 'E')
+                {
+                    in_quoted_literal = false;
+                    i += 2;
+                }
+                else
+                    ++i;
+            }
+            else if (i + 1 < expression.size() && expression[i + 1] == 'Q')
+            {
+                in_quoted_literal = true;
+                i += 2;
+            }
+            else if (i + 1 < expression.size())
+                i += 2;
+            else
+                ++i;
+        }
+
+        return in_quoted_literal;
+    }
+
+    bool hasEscapedTrailingDollar(std::string_view expression)
+    {
+        if (!expression.ends_with('$'))
+            return false;
+
+        size_t trailing_backslashes = 0;
+        for (size_t pos = expression.size() - 1; pos > 0 && expression[pos - 1] == '\\'; --pos)
+            ++trailing_backslashes;
+
+        return trailing_backslashes % 2 != 0;
+    }
+
+    bool hasMandatoryLeadingBeginText(re2::Regexp * expression)
+    {
+        while (true)
+        {
+            switch (expression->op())
+            {
+                case re2::kRegexpBeginText:
+                    return true;
+                case re2::kRegexpCapture:
+                case re2::kRegexpConcat:
+                    if (expression->nsub() == 0)
+                        return false;
+                    expression = expression->sub()[0];
+                    break;
+                case re2::kRegexpPlus:
+                    expression = expression->sub()[0];
+                    break;
+                case re2::kRegexpRepeat:
+                    if (expression->min() == 0)
+                        return false;
+                    expression = expression->sub()[0];
+                    break;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    bool hasTopLevelAlternation(std::string_view expression)
+    {
+        size_t parentheses_depth = 0;
+        bool in_character_class = false;
+        bool character_class_at_start = false;
+        bool in_quoted_literal = false;
+
+        for (size_t i = 0; i < expression.size(); ++i)
+        {
+            const char c = expression[i];
+
+            if (in_quoted_literal)
+            {
+                if (c == '\\' && i + 1 < expression.size() && expression[i + 1] == 'E')
+                {
+                    in_quoted_literal = false;
+                    ++i;
+                }
+                continue;
+            }
+
+            if (in_character_class)
+            {
+                if (c == '\\' && i + 1 < expression.size())
+                {
+                    character_class_at_start = false;
+                    ++i;
+                    continue;
+                }
+
+                if (c == '[' && i + 1 < expression.size()
+                    && (expression[i + 1] == ':' || expression[i + 1] == '.' || expression[i + 1] == '='))
+                {
+                    const char delimiter = expression[i + 1];
+                    i += 2;
+                    while (i + 1 < expression.size()
+                        && !(expression[i] == delimiter && expression[i + 1] == ']'))
+                        ++i;
+                    if (i + 1 < expression.size())
+                        ++i;
+                    character_class_at_start = false;
+                    continue;
+                }
+
+                if (c == ']' && !character_class_at_start)
+                {
+                    in_character_class = false;
+                    continue;
+                }
+
+                if (character_class_at_start && c == '^')
+                    continue;
+
+                character_class_at_start = false;
+                continue;
+            }
+
+            if (c == '\\')
+            {
+                if (i + 1 < expression.size() && expression[i + 1] == 'Q')
+                {
+                    in_quoted_literal = true;
+                    ++i;
+                }
+                else if (i + 1 < expression.size())
+                    ++i;
+                continue;
+            }
+
+            if (c == '[')
+            {
+                in_character_class = true;
+                character_class_at_start = true;
+            }
+            else if (c == '(')
+                ++parentheses_depth;
+            else if (c == ')')
+            {
+                if (parentheses_depth > 0)
+                    --parentheses_depth;
+            }
+            else if (c == '|' && parentheses_depth == 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    struct ParsedPromQLRegexp
+    {
+        bool has_top_level_alternation;
+        bool has_mandatory_leading_begin_text;
+    };
+
+    ParsedPromQLRegexp parsePromQLRegexp(std::string_view expression)
+    {
+        re2::RE2::Options options;
+        options.set_dot_nl(true);
+        re2::RegexpStatus status;
+        auto * parsed = re2::Regexp::Parse(
+            expression,
+            static_cast<re2::Regexp::ParseFlags>(options.ParseFlags()),
+            &status);
+        if (!parsed)
+            throw Exception(ErrorCodes::CANNOT_COMPILE_REGEXP, "Cannot compile PromQL regular expression '{}': {}", expression, status.Text());
+
+        const ParsedPromQLRegexp result{
+            .has_top_level_alternation = hasTopLevelAlternation(expression),
+            .has_mandatory_leading_begin_text = hasMandatoryLeadingBeginText(parsed)};
+        parsed->Decref();
+        return result;
+    }
+
     ASTPtr matcherToAST(const PrometheusQueryTree::Matcher & matcher, const std::unordered_map<String, String> & column_name_by_tag_name)
     {
         std::string_view function_name;
@@ -225,10 +505,26 @@ namespace
         String value = matcher.label_value;
         if (add_anchors)
         {
-            if (!value.starts_with('^'))
-                value = '^' + value;
-            if (!value.ends_with('$'))
-                value += '$';
+            const auto parsed_regexp = parsePromQLRegexp(value);
+            const bool has_unterminated_quoted_literal = hasUnterminatedQuotedLiteral(value);
+            const bool needs_grouped_anchors
+                = parsed_regexp.has_top_level_alternation
+                || hasMultilineFlag(value)
+                || hasEscapedTrailingDollar(value)
+                || has_unterminated_quoted_literal;
+
+            if (has_unterminated_quoted_literal)
+                value += "\\E";
+
+            if (needs_grouped_anchors)
+                value = "^(?:" + value + ")$";
+            else
+            {
+                if (!value.starts_with('^') || !parsed_regexp.has_mandatory_leading_begin_text)
+                    value = '^' + value;
+                if (!value.ends_with('$'))
+                    value += '$';
+            }
         }
         ASTPtr res = makeASTFunction(function_name, tagNameToAST(matcher.label_name, column_name_by_tag_name), make_intrusive<ASTLiteral>(value));
         if (add_not)

--- a/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.reference
+++ b/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.reference
@@ -10,6 +10,12 @@ explicit anchors
 2
 dot matches newline
 1
+byte regex matcher
+1
+5
+2
+3
+4
 multiline anchors match the whole label
 0
 5
@@ -23,7 +29,7 @@ literal escapes keep the whole-value anchor
 5
 0
 5
-quoted literal with a backslash before \E
+quoted literal with a backslash before \\E
 1
 4
 quoted literal punctuation keeps alternation anchored
@@ -46,13 +52,14 @@ quantified leading anchor keeps whole-value matching
 3
 4
 5
-metric regex with a character class keeps the plain form
-1
-metric regex with a leading class terminator keeps the plain form
-1
-metric regex with a POSIX class keeps the plain form
-1
+metric regex with a character class
+0
+metric regex with a leading class terminator
+0
+metric regex with a POSIX class
+0
 deeply nested matcher regex stays safe
 1
-simple metric regex keeps the plain form
-1
+metric regex matcher
+5
+0

--- a/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.reference
+++ b/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.reference
@@ -1,0 +1,58 @@
+positive regex matcher
+1
+2
+negative regex matcher
+3
+4
+5
+explicit anchors
+1
+2
+dot matches newline
+1
+multiline anchors match the whole label
+0
+5
+quoted literal keeps a following multiline flag visible
+0
+5
+literal escapes keep the whole-value anchor
+0
+5
+0
+5
+0
+5
+quoted literal with a backslash before \E
+1
+4
+quoted literal punctuation keeps alternation anchored
+1
+4
+POSIX character class punctuation keeps alternation anchored
+1
+4
+common-prefix alternation stays whole-value anchored
+1
+2
+3
+4
+5
+invalid trailing escape keeps the regexp error
+invalid regex syntax keeps the regexp error
+quantified leading anchor keeps whole-value matching
+2
+1
+3
+4
+5
+metric regex with a character class keeps the plain form
+1
+metric regex with a leading class terminator keeps the plain form
+1
+metric regex with a POSIX class keeps the plain form
+1
+deeply nested matcher regex stays safe
+1
+simple metric regex keeps the plain form
+1

--- a/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.reference
+++ b/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.reference
@@ -58,6 +58,8 @@ metric regex with a leading class terminator
 0
 metric regex with a POSIX class
 0
+simple metric regex keeps the tags primary-key optimization
+1
 deeply nested matcher regex stays safe
 1
 metric regex matcher

--- a/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.sql
+++ b/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.sql
@@ -9,11 +9,11 @@ DROP TABLE IF EXISTS ts;
 CREATE TABLE ts ENGINE = TimeSeries;
 
 INSERT INTO ts (metric_name, tags, time_series) VALUES
-    ('test_metric', map('job', 'foo', 'text', concat('foo', char(10), 'bar'), 'dollar', 'foo$bar', 'quoted', concat('foo', char(92), 'bar'), 'quoted_multiline', concat('[', char(10), 'rest')), [(toDateTime64(100, 3), 1.)]),
-    ('test_metric', map('job', 'bar'),    [(toDateTime64(100, 3), 2.)]),
-    ('test_metric', map('job', 'foobar'), [(toDateTime64(100, 3), 3.)]),
-    ('test_metric', map('job', 'xxbar'),  [(toDateTime64(100, 3), 4.)]),
-    ('test_metric', map('job', 'xfooy'),  [(toDateTime64(100, 3), 5.)]);
+    ('test_metric', map('job', 'foo', 'text', concat('foo', char(10), 'bar'), 'dollar', 'foo$bar', 'quoted', concat('foo', char(92), 'bar'), 'quoted_multiline', concat('[', char(10), 'rest'), 'byte', char(255)), [(toDateTime64(100, 3), 1.)]),
+    ('test_metric', map('job', 'bar', 'byte', concat(char(255), 'suffix')),    [(toDateTime64(100, 3), 2.)]),
+    ('test_metric', map('job', 'foobar', 'byte', concat('prefix', char(255))), [(toDateTime64(100, 3), 3.)]),
+    ('test_metric', map('job', 'xxbar', 'byte', char(254)),  [(toDateTime64(100, 3), 4.)]),
+    ('test_metric', map('job', 'xfooy', 'byte', char(255)), [(toDateTime64(100, 3), 5.)]);
 
 SELECT 'positive regex matcher';
 SELECT value FROM timeSeriesSelector(ts, '{job=~"foo|bar"}', 0, 1000) ORDER BY value;
@@ -26,6 +26,10 @@ SELECT value FROM timeSeriesSelector(ts, '{job=~"^foo|bar$"}', 0, 1000) ORDER BY
 
 SELECT 'dot matches newline';
 SELECT value FROM timeSeriesSelector(ts, '{text=~"foo.bar"}', 0, 1000) ORDER BY value;
+
+SELECT 'byte regex matcher';
+SELECT value FROM timeSeriesSelector(ts, '{byte=~"\\xFF"}', 0, 1000) ORDER BY value;
+SELECT value FROM timeSeriesSelector(ts, '{byte!~"\\xFF"}', 0, 1000) ORDER BY value;
 
 SELECT 'multiline anchors match the whole label';
 SELECT count() FROM timeSeriesSelector(ts, '{text=~"(?m)^foo$"}', 0, 1000);
@@ -72,20 +76,14 @@ SELECT 'quantified leading anchor keeps whole-value matching';
 SELECT value FROM timeSeriesSelector(ts, '{job=~"^?bar"}', 0, 1000) ORDER BY value;
 SELECT value FROM timeSeriesSelector(ts, '{job!~"^?bar"}', 0, 1000) ORDER BY value;
 
-SELECT 'metric regex with a character class keeps the plain form';
-SELECT plan LIKE '%^http_[0-9]+$%' AND NOT plan LIKE '%^(?:http_[0-9]+)$%' AS has_plain_metric_regex_with_class
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
-      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"http_[0-9]+"}', 0, 1000)));
+SELECT 'metric regex with a character class';
+SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"http_[0-9]+"}', 0, 1000);
 
-SELECT 'metric regex with a leading class terminator keeps the plain form';
-SELECT plan LIKE '%^foo[](?m)]$%' AND NOT plan LIKE '%^(?:foo[](?m)])$%' AS has_plain_metric_regex_with_leading_class_terminator
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
-      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[](?m)]"}', 0, 1000)));
+SELECT 'metric regex with a leading class terminator';
+SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[](?m)]"}', 0, 1000);
 
-SELECT 'metric regex with a POSIX class keeps the plain form';
-SELECT plan LIKE '%^foo[[:alpha:](?m)]$%' AND NOT plan LIKE '%^(?:foo[[:alpha:](?m)])$%' AS has_plain_metric_regex_with_posix_class
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
-      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[[:alpha:](?m)]"}', 0, 1000)));
+SELECT 'metric regex with a POSIX class';
+SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[[:alpha:](?m)]"}', 0, 1000);
 
 SELECT 'deeply nested matcher regex stays safe';
 SELECT count() FROM timeSeriesSelector(
@@ -93,9 +91,8 @@ SELECT count() FROM timeSeriesSelector(
     concat('{job=~"', repeat('(', 10000), 'foo', repeat(')', 10000), '"}'),
     0, 1000);
 
-SELECT 'simple metric regex keeps the plain form';
-SELECT plan LIKE '%^test_metric$%' AND NOT plan LIKE '%^(?:test_metric)$%' AS has_plain_metric_regex
-FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
-      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"test_metric"}', 0, 1000)));
+SELECT 'metric regex matcher';
+SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"test_metric"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{__name__!~"test_metric"}', 0, 1000);
 
 DROP TABLE ts;

--- a/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.sql
+++ b/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.sql
@@ -85,6 +85,15 @@ SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[](?m)]"}', 0, 1000);
 SELECT 'metric regex with a POSIX class';
 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[[:alpha:](?m)]"}', 0, 1000);
 
+SELECT 'simple metric regex keeps the tags primary-key optimization';
+-- EXPLAIN of timeSeriesSelector only shows the samples-side read. Inspect the tags table directly,
+-- where the plain anchored regex and its primary-key condition are visible.
+SELECT plan LIKE '%Filter column: match(metric_name, \'^test_metric$\')%'
+    AND plan LIKE '%Condition: (metric_name in [\'test_metric\', \'test_metric\'])%'
+    AND NOT plan LIKE '%^(?:test_metric)$%' AS has_plain_metric_regex
+FROM (SELECT arrayStringConcat(groupArray(explain), '\\n') AS plan
+      FROM (EXPLAIN indexes = 1 SELECT metric_name FROM timeSeriesTags(ts) WHERE match(metric_name, '^test_metric$')));
+
 SELECT 'deeply nested matcher regex stays safe';
 SELECT count() FROM timeSeriesSelector(
     ts,

--- a/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.sql
+++ b/tests/queries/0_stateless/05024_promql_regex_matcher_anchoring.sql
@@ -1,0 +1,101 @@
+-- Tags: no-fasttest, no-replicated-database
+-- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+-- Tag no-replicated-database: `DatabaseReplicated::dropTable` does not drop `TimeSeries` inner tables synchronously.
+
+SET allow_experimental_time_series_table = 1;
+SET session_timezone = 'UTC';
+
+DROP TABLE IF EXISTS ts;
+CREATE TABLE ts ENGINE = TimeSeries;
+
+INSERT INTO ts (metric_name, tags, time_series) VALUES
+    ('test_metric', map('job', 'foo', 'text', concat('foo', char(10), 'bar'), 'dollar', 'foo$bar', 'quoted', concat('foo', char(92), 'bar'), 'quoted_multiline', concat('[', char(10), 'rest')), [(toDateTime64(100, 3), 1.)]),
+    ('test_metric', map('job', 'bar'),    [(toDateTime64(100, 3), 2.)]),
+    ('test_metric', map('job', 'foobar'), [(toDateTime64(100, 3), 3.)]),
+    ('test_metric', map('job', 'xxbar'),  [(toDateTime64(100, 3), 4.)]),
+    ('test_metric', map('job', 'xfooy'),  [(toDateTime64(100, 3), 5.)]);
+
+SELECT 'positive regex matcher';
+SELECT value FROM timeSeriesSelector(ts, '{job=~"foo|bar"}', 0, 1000) ORDER BY value;
+
+SELECT 'negative regex matcher';
+SELECT value FROM timeSeriesSelector(ts, '{job!~"foo|bar",__name__=~".+"}', 0, 1000) ORDER BY value;
+
+SELECT 'explicit anchors';
+SELECT value FROM timeSeriesSelector(ts, '{job=~"^foo|bar$"}', 0, 1000) ORDER BY value;
+
+SELECT 'dot matches newline';
+SELECT value FROM timeSeriesSelector(ts, '{text=~"foo.bar"}', 0, 1000) ORDER BY value;
+
+SELECT 'multiline anchors match the whole label';
+SELECT count() FROM timeSeriesSelector(ts, '{text=~"(?m)^foo$"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{text!~"(?m)^foo$"}', 0, 1000);
+
+SELECT 'quoted literal keeps a following multiline flag visible';
+SELECT count() FROM timeSeriesSelector(ts, '{quoted_multiline=~"\\\\Q[\\\\E(?m)$"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{quoted_multiline!~"\\\\Q[\\\\E(?m)$"}', 0, 1000);
+
+SELECT 'literal escapes keep the whole-value anchor';
+SELECT count() FROM timeSeriesSelector(ts, '{dollar=~"foo\\\\$"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{dollar!~"foo\\\\$"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{dollar=~"\\\\Qfoo$"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{dollar!~"\\\\Qfoo$"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{dollar=~"\\\\Qfoo"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{dollar!~"\\\\Qfoo"}', 0, 1000);
+SELECT 'quoted literal with a backslash before \\E';
+SELECT count() FROM timeSeriesSelector(ts, '{quoted=~"\\\\Qfoo\\\\\\\\Ebar$"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{quoted!~"\\\\Qfoo\\\\\\\\Ebar$"}', 0, 1000);
+
+SELECT 'quoted literal punctuation keeps alternation anchored';
+SELECT count() FROM timeSeriesSelector(ts, '{job=~"\\\\Q(\\\\Efoo|bar"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{job!~"\\\\Q(\\\\Efoo|bar"}', 0, 1000);
+
+SELECT 'POSIX character class punctuation keeps alternation anchored';
+SELECT count() FROM timeSeriesSelector(ts, '{job=~"[[:alpha:](]foo|bar"}', 0, 1000);
+SELECT count() FROM timeSeriesSelector(ts, '{job!~"[[:alpha:](]foo|bar"}', 0, 1000);
+
+SELECT 'common-prefix alternation stays whole-value anchored';
+SELECT value FROM timeSeriesSelector(ts, '{job=~"foo|fooz"}', 0, 1000) ORDER BY value;
+SELECT value FROM timeSeriesSelector(ts, '{job!~"foo|fooz"}', 0, 1000) ORDER BY value;
+
+SELECT 'invalid trailing escape keeps the regexp error';
+SELECT count() FROM timeSeriesSelector(ts, '{dollar=~"foo\\\\"}', 0, 1000); -- { serverError CANNOT_COMPILE_REGEXP }
+SELECT count() FROM timeSeriesSelector(ts, '{dollar!~"foo\\\\"}', 0, 1000); -- { serverError CANNOT_COMPILE_REGEXP }
+
+SELECT 'invalid regex syntax keeps the regexp error';
+SELECT count() FROM timeSeriesSelector(ts, '{job=~"*bar"}', 0, 1000); -- { serverError CANNOT_COMPILE_REGEXP }
+SELECT count() FROM timeSeriesSelector(ts, '{job!~"*bar"}', 0, 1000); -- { serverError CANNOT_COMPILE_REGEXP }
+SELECT count() FROM timeSeriesSelector(ts, '{job=~"foo|)("}', 0, 1000); -- { serverError CANNOT_COMPILE_REGEXP }
+SELECT count() FROM timeSeriesSelector(ts, '{job!~"foo|)("}', 0, 1000); -- { serverError CANNOT_COMPILE_REGEXP }
+
+SELECT 'quantified leading anchor keeps whole-value matching';
+SELECT value FROM timeSeriesSelector(ts, '{job=~"^?bar"}', 0, 1000) ORDER BY value;
+SELECT value FROM timeSeriesSelector(ts, '{job!~"^?bar"}', 0, 1000) ORDER BY value;
+
+SELECT 'metric regex with a character class keeps the plain form';
+SELECT plan LIKE '%^http_[0-9]+$%' AND NOT plan LIKE '%^(?:http_[0-9]+)$%' AS has_plain_metric_regex_with_class
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
+      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"http_[0-9]+"}', 0, 1000)));
+
+SELECT 'metric regex with a leading class terminator keeps the plain form';
+SELECT plan LIKE '%^foo[](?m)]$%' AND NOT plan LIKE '%^(?:foo[](?m)])$%' AS has_plain_metric_regex_with_leading_class_terminator
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
+      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[](?m)]"}', 0, 1000)));
+
+SELECT 'metric regex with a POSIX class keeps the plain form';
+SELECT plan LIKE '%^foo[[:alpha:](?m)]$%' AND NOT plan LIKE '%^(?:foo[[:alpha:](?m)])$%' AS has_plain_metric_regex_with_posix_class
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
+      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"foo[[:alpha:](?m)]"}', 0, 1000)));
+
+SELECT 'deeply nested matcher regex stays safe';
+SELECT count() FROM timeSeriesSelector(
+    ts,
+    concat('{job=~"', repeat('(', 10000), 'foo', repeat(')', 10000), '"}'),
+    0, 1000);
+
+SELECT 'simple metric regex keeps the plain form';
+SELECT plan LIKE '%^test_metric$%' AND NOT plan LIKE '%^(?:test_metric)$%' AS has_plain_metric_regex
+FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
+      FROM (EXPLAIN actions = 1 SELECT count() FROM timeSeriesSelector(ts, '{__name__=~"test_metric"}', 0, 1000)));
+
+DROP TABLE ts;


### PR DESCRIPTION
### TL;DR

- Fix PromQL regex matchers so they match the full label value.
- Validate the original regex before adding whole-value anchors.
- Keep simple metric-name regexes eligible for primary-key pruning.

### Changelog category (leave one):
- **Bug Fix (user-visible misbehavior in an official stable release)**

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
**Fix anchoring of PromQL regex label matchers.**

### Summary

PromQL regex matchers must match the complete label value. The old rewrite added anchors directly to the user pattern. For example:

```text
foo|bar -> ^foo|bar$
```

This could match `foobar` and `xxbar` unexpectedly.

This change:

- Parses the original expression with the bundled RE2 parser before rewriting it.
- Wraps patterns when needed for top-level alternation, multiline flags, escaped terminal `$`, and unterminated `\Q` literals.
- Keeps the plain `^...$` form for simple patterns so metric-name fixed-prefix extraction still works.
- Falls back to RE2 Latin1 parsing for valid non-UTF-8 byte patterns.
- Keeps the same behavior for both `=~` and `!~`.
- Preserves the normal `CANNOT_COMPILE_REGEXP` error for invalid patterns.

### Why this matters

- Regex selectors could return series that Prometheus would not return.
- This could produce incorrect dashboard and alert results.
- Adding anchors must not repair or change an invalid user expression.
- Simple metric-name matchers should continue to use the metric-name primary key.

### Prometheus reference

Prometheus parses the user regexp first and then applies whole-value matching with dot-matching-newlines enabled. See the [Prometheus `NewFastRegexMatcher` implementation](https://github.com/prometheus/prometheus/blob/main/model/labels/regexp.go#L2299-L2310).

### Tests

- Added stateless coverage for positive and negative matchers.
- Covered alternation, explicit and multiline anchors, dot matching newlines, quoted literals, escaped dollars, POSIX classes, and quantified leading anchors.
- Covered invalid trailing escapes, invalid repetition, unmatched parentheses, and raw byte values.
- Added a focused `EXPLAIN` regression for the plain metric-name regex and its primary-key condition.
- Covered deeply nested expressions.
- Ran `git diff --check` and a local smoke run against the updated reference.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116009&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116009](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116009+org%3AClickHouse+type%3Apr&type=pullrequests)
<!-- CI automatic block end :ci_links: -->
