### PR TITLE
Wait for distributed plan stages without holding an execution thread

### DIFF
--- a/src/Processors/Sources/ReadFromDistributedPlanSource.cpp
+++ b/src/Processors/Sources/ReadFromDistributedPlanSource.cpp
@@ -43,7 +43,7 @@ std::optional<Chunk> ReadFromDistributedPlanSource::tryGenerate()
         {
             started = true;
             distributed_query_executor = createDistributedQueryExecutor(
-                unique_query_id, distributed_query_plan, task_to_host_map, CurrentThread::tryGetQueryContext(), cancellation);
+                unique_query_id, distributed_query_plan, task_to_host_map, CurrentThread::tryGetQueryContext(), cancellation, stage_wakeup);
             distributed_query_executor->start();
         }
 
@@ -92,13 +92,15 @@ IProcessor::Status ReadFromDistributedPlanSource::prepare()
 #if defined(OS_LINUX) || defined(OS_DARWIN)
 std::tuple<int, uint32_t, Int64> ReadFromDistributedPlanSource::scheduleForEvent()
 {
-    stage_poll_timer.setRelative(stage_poll_interval_us);
-    return {stage_poll_timer.getDescriptor(), EPOLLIN | EPOLLERR, -1};
+    /// Wake on the executor's notification, and fall back to the interval so a state change that
+    /// does not notify still gets noticed.
+    return {stage_wakeup->fd(), EPOLLIN | EPOLLERR, stage_poll_interval_ms};
 }
 
 void ReadFromDistributedPlanSource::onAsyncJobReady()
 {
-    stage_poll_timer.drain();
+    /// Drains nothing when the interval fired instead of a notification; the fd is non-blocking.
+    stage_wakeup->drain();
     waiting_for_stages = false;
 }
 #endif
@@ -109,6 +111,8 @@ void ReadFromDistributedPlanSource::onCancel() noexcept
     /// under the lock. Without active cleanup, cancellation is only seen on the next tryGenerate,
     /// which may never come once the pipeline is cancelled.
     cancellation->cancel();
+    /// Wake a parked source so it observes the cancellation now instead of at the next interval.
+    notifyStageWakeup(stage_wakeup);
     try
     {
         /// Wake exchange waiters before taking the lock: the lock holder itself may be blocked

--- a/src/Processors/Sources/ReadFromDistributedPlanSource.cpp
+++ b/src/Processors/Sources/ReadFromDistributedPlanSource.cpp
@@ -6,6 +6,10 @@
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+#include <Common/Epoll.h>
+#endif
+
 namespace DB
 {
 
@@ -43,7 +47,13 @@ std::optional<Chunk> ReadFromDistributedPlanSource::tryGenerate()
             distributed_query_executor->start();
         }
 
-        if (distributed_query_executor->execute())
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+        /// `prepare` waits for the stages in the async queue, so do not block an execution thread here.
+        const UInt64 stage_poll_timeout_ms = 0;
+#else
+        const UInt64 stage_poll_timeout_ms = 100;
+#endif
+        if (distributed_query_executor->execute(stage_poll_timeout_ms))
         {
             cleanupLocked();
             return std::nullopt;
@@ -58,8 +68,40 @@ std::optional<Chunk> ReadFromDistributedPlanSource::tryGenerate()
         throw;
     }
 
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+    waiting_for_stages = true;
+#endif
+
     return Chunk();
 }
+
+IProcessor::Status ReadFromDistributedPlanSource::prepare()
+{
+    auto status = ISource::prepare();
+
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+    /// `Ready` means `work` would be called next, but the stages are still running and there is
+    /// nothing for it to do until the poll interval elapses. Give the execution thread back.
+    if (status == Status::Ready && waiting_for_stages)
+        return Status::Async;
+#endif
+
+    return status;
+}
+
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+std::tuple<int, uint32_t, Int64> ReadFromDistributedPlanSource::scheduleForEvent()
+{
+    stage_poll_timer.setRelative(stage_poll_interval_us);
+    return {stage_poll_timer.getDescriptor(), EPOLLIN | EPOLLERR, -1};
+}
+
+void ReadFromDistributedPlanSource::onAsyncJobReady()
+{
+    stage_poll_timer.drain();
+    waiting_for_stages = false;
+}
+#endif
 
 void ReadFromDistributedPlanSource::onCancel() noexcept
 {

--- a/src/Processors/Sources/ReadFromDistributedPlanSource.h
+++ b/src/Processors/Sources/ReadFromDistributedPlanSource.h
@@ -7,10 +7,6 @@
 #include <Core/Types_fwd.h>
 #include <QueryPipeline/DistributedPlanExecutor.h>
 
-#if defined(OS_LINUX) || defined(OS_DARWIN)
-#include <Common/TimerDescriptor.h>
-#endif
-
 namespace DB
 {
 
@@ -66,6 +62,10 @@ private:
     /// from a failure and report the latter.
     DistributedQueryCancellationPtr cancellation = std::make_shared<DistributedQueryCancellation>();
 
+    /// The executor notifies this every time a task reaches a terminal state, and `onCancel` notifies
+    /// it too, so a parked source wakes as soon as `execute` can make progress.
+    StageWakeupPtr stage_wakeup = std::make_shared<WakeupFd>();
+
 #if defined(OS_LINUX) || defined(OS_DARWIN)
     /// This source only dispatches the plan's stages and waits for them; the query result arrives
     /// through a second source of the same pipeline. On a streaming exchange nothing runs until
@@ -73,10 +73,12 @@ private:
     /// not ask its input for data, so the whole plan is blocked on it. Waiting inside `work` would
     /// hold an execution thread, and a pipeline that has only one of them would never reach the
     /// result source. So park in the executor's async queue instead and let it re-dispatch us.
-    static constexpr UInt64 stage_poll_interval_us = 100'000;
-    TimerDescriptor stage_poll_timer;
+    ///
+    /// The park ends on `stage_wakeup`, and this interval is only a backstop for a state change that
+    /// does not notify it.
+    static constexpr Int64 stage_poll_interval_ms = 100;
     /// True while the last `tryGenerate` left the stages running, i.e. there is nothing to do until
-    /// the timer fires. Reset in `onAsyncJobReady`, right before the async re-dispatch calls `work`.
+    /// the wake-up arrives. Reset in `onAsyncJobReady`, right before the re-dispatch calls `work`.
     bool waiting_for_stages = false;
 #endif
 };

--- a/src/Processors/Sources/ReadFromDistributedPlanSource.h
+++ b/src/Processors/Sources/ReadFromDistributedPlanSource.h
@@ -7,6 +7,10 @@
 #include <Core/Types_fwd.h>
 #include <QueryPipeline/DistributedPlanExecutor.h>
 
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+#include <Common/TimerDescriptor.h>
+#endif
+
 namespace DB
 {
 
@@ -32,6 +36,13 @@ public:
 
     String getName() const override { return "ReadFromDistributedPlanSource"; }
 
+    Status prepare() override;
+
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+    std::tuple<int, uint32_t, Int64> scheduleForEvent() override;
+    void onAsyncJobReady() override;
+#endif
+
 private:
     std::optional<Chunk> tryGenerate() override;
     void onCancel() noexcept override;
@@ -54,6 +65,20 @@ private:
     /// also records a failing task's exception here, so `tryGenerate` can tell a plain cancellation
     /// from a failure and report the latter.
     DistributedQueryCancellationPtr cancellation = std::make_shared<DistributedQueryCancellation>();
+
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+    /// This source only dispatches the plan's stages and waits for them; the query result arrives
+    /// through a second source of the same pipeline. On a streaming exchange nothing runs until
+    /// that second source connects to the `main` task's sink, and a sink without a connection does
+    /// not ask its input for data, so the whole plan is blocked on it. Waiting inside `work` would
+    /// hold an execution thread, and a pipeline that has only one of them would never reach the
+    /// result source. So park in the executor's async queue instead and let it re-dispatch us.
+    static constexpr UInt64 stage_poll_interval_us = 100'000;
+    TimerDescriptor stage_poll_timer;
+    /// True while the last `tryGenerate` left the stages running, i.e. there is nothing to do until
+    /// the timer fires. Reset in `onAsyncJobReady`, right before the async re-dispatch calls `work`.
+    bool waiting_for_stages = false;
+#endif
 };
 
 }

--- a/src/QueryPipeline/DistributedPlanExecutor.cpp
+++ b/src/QueryPipeline/DistributedPlanExecutor.cpp
@@ -943,8 +943,8 @@ static void executeTask(const UUID & unique_query_id, const DistributedQueryTask
 class DistributedQueryPlanExecutorLocal final : public DistributedQueryPlanExecutor
 {
 public:
-    DistributedQueryPlanExecutorLocal(const UUID & unique_query_id_, const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_)
-        : DistributedQueryPlanExecutor(unique_query_id_, distributed_query_plan_, makeContextForLocalExecution(context_), std::move(cancellation_))
+    DistributedQueryPlanExecutorLocal(const UUID & unique_query_id_, const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_, StageWakeupPtr stage_wakeup_)
+        : DistributedQueryPlanExecutor(unique_query_id_, distributed_query_plan_, makeContextForLocalExecution(context_), std::move(cancellation_), std::move(stage_wakeup_))
     {
     }
 
@@ -983,7 +983,7 @@ protected:
         std::promise<void> task_promise;
         std::future<void> future = task_promise.get_future();
 
-        threads.emplace_back([promise = std::move(task_promise), query_id = unique_query_id, task_description, ctx = context, cancellation = this->cancellation]() mutable
+        threads.emplace_back([promise = std::move(task_promise), query_id = unique_query_id, task_description, ctx = context, cancellation = this->cancellation, stage_wakeup = this->stage_wakeup]() mutable
         {
             ThreadStatus thread_status;
             /// The task attaches its own query context and thread group inside executeTask (matching
@@ -998,6 +998,10 @@ protected:
             {
                 promise.set_exception(std::current_exception());
             }
+
+            /// The task future this promise belongs to is what `waitForStage` looks at, so tell the
+            /// waiter that its answer may have changed.
+            notifyStageWakeup(stage_wakeup);
         });
 
         return future;
@@ -1287,10 +1291,11 @@ public:
         const DistributedQueryPlan & distributed_query_plan_,
         TaskToHostMapPtr task_to_host_map_,
         ContextPtr context_,
-        DistributedQueryCancellationPtr cancellation_)
-        : DistributedQueryPlanExecutor(unique_query_id_, distributed_query_plan_, std::move(context_), std::move(cancellation_))
+        DistributedQueryCancellationPtr cancellation_,
+        StageWakeupPtr stage_wakeup_)
+        : DistributedQueryPlanExecutor(unique_query_id_, distributed_query_plan_, std::move(context_), std::move(cancellation_), std::move(stage_wakeup_))
         , task_to_host_map(std::move(task_to_host_map_))
-        , running_tasks(8, context, cancellation, logger)
+        , running_tasks(8, context, cancellation, stage_wakeup, logger)
     {
         /// A null map belongs to an in-process plan, which createDistributedQueryExecutor routes to
         /// the local executor instead.
@@ -1329,11 +1334,12 @@ protected:
     class TaskTracker
     {
     public:
-        TaskTracker(Int64 max_in_flight_requests_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_, LoggerPtr logger_)
+        TaskTracker(Int64 max_in_flight_requests_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_, StageWakeupPtr stage_wakeup_, LoggerPtr logger_)
             : context(std::move(context_))
             , query_status(context->getProcessListElement())
             , max_in_flight_requests(max_in_flight_requests_)
             , cancellation(std::move(cancellation_))
+            , stage_wakeup(std::move(stage_wakeup_))
             , thread_pool(CurrentMetrics::TaskTrackerThreads, CurrentMetrics::TaskTrackerThreadsActive, CurrentMetrics::TaskTrackerThreadsScheduled,
                 max_in_flight_requests, max_in_flight_requests, 2 * max_in_flight_requests)
             , logger(std::move(logger_))
@@ -1593,6 +1599,8 @@ protected:
             {
                 stage->promise_signaled = true;
                 stage->promise.set_value();
+                /// `waitForStage` waits on this promise, so tell the waiter its answer changed.
+                notifyStageWakeup(stage_wakeup);
             }
 
             stage_tasks[stage_name].erase(task_name); // TODO: really need to erase?
@@ -1706,6 +1714,7 @@ protected:
         DequeWithMemoryTracking<StageInfoPtr> stages_to_check TSA_GUARDED_BY(lock);
         UnorderedMapWithMemoryTracking<String, std::shared_future<void>> stage_results TSA_GUARDED_BY(lock);
         DistributedQueryCancellationPtr cancellation;
+        StageWakeupPtr stage_wakeup;
         ThreadPool thread_pool;
         LoggerPtr logger;
     };
@@ -1848,12 +1857,27 @@ void DistributedQueryCancellation::throwIfCancelled() const
 }
 
 
-DistributedQueryPlanExecutor::DistributedQueryPlanExecutor(const UUID & unique_query_id_, const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_)
+void notifyStageWakeup(const StageWakeupPtr & stage_wakeup) noexcept
+{
+    if (!stage_wakeup)
+        return;
+    try
+    {
+        stage_wakeup->notify();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
+DistributedQueryPlanExecutor::DistributedQueryPlanExecutor(const UUID & unique_query_id_, const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_, StageWakeupPtr stage_wakeup_)
     : unique_query_id(unique_query_id_)
     , distributed_query_plan(distributed_query_plan_)
     , context(std::move(context_))
     , query_status(context->getProcessListElement())
     , cancellation(std::move(cancellation_))
+    , stage_wakeup(std::move(stage_wakeup_))
     , logger(getLogger("DistributedQueryPlanExecutor"))
 {
 }
@@ -1970,7 +1994,8 @@ std::unique_ptr<DistributedQueryPlanExecutor> createDistributedQueryExecutor(
     const DistributedQueryPlan & distributed_query_plan,
     TaskToHostMapPtr task_to_host_map,
     ContextPtr context,
-    DistributedQueryCancellationPtr cancellation)
+    DistributedQueryCancellationPtr cancellation,
+    StageWakeupPtr stage_wakeup)
 {
     /// A null map means the plan was built for in-process execution, so it carries no worker hosts.
     /// Deriving the branch from the map instead of re-reading `distributed_plan_execute_locally` keeps
@@ -1979,10 +2004,10 @@ std::unique_ptr<DistributedQueryPlanExecutor> createDistributedQueryExecutor(
     if (!task_to_host_map)
     {
         ProfileEvents::increment(ProfileEvents::DistributedPlanLocalExecution);
-        executor = std::make_unique<DistributedQueryPlanExecutorLocal>(unique_query_id, distributed_query_plan, context, cancellation);
+        executor = std::make_unique<DistributedQueryPlanExecutorLocal>(unique_query_id, distributed_query_plan, context, cancellation, stage_wakeup);
     }
     else
-        executor = std::make_unique<DistributedQueryPlanExecutorRemote>(unique_query_id, distributed_query_plan, task_to_host_map, context, cancellation);
+        executor = std::make_unique<DistributedQueryPlanExecutorRemote>(unique_query_id, distributed_query_plan, task_to_host_map, context, cancellation, stage_wakeup);
 
     return executor;
 }

--- a/src/QueryPipeline/DistributedPlanExecutor.cpp
+++ b/src/QueryPipeline/DistributedPlanExecutor.cpp
@@ -1949,13 +1949,13 @@ void DistributedQueryPlanExecutor::start()
         running_stages.push_back(stage_name);
 }
 
-bool DistributedQueryPlanExecutor::execute()
+bool DistributedQueryPlanExecutor::execute(UInt64 poll_timeout_ms)
 {
     if (running_stages.empty())
         return true;
 
     auto & stage_name = running_stages.front();
-    bool stage_finished = waitForStage(stage_name, 100);
+    bool stage_finished = waitForStage(stage_name, poll_timeout_ms);
     if (stage_finished)
     {
         LOG_DEBUG(logger, "Stage '{}' finished", stage_name);

--- a/src/QueryPipeline/DistributedPlanExecutor.h
+++ b/src/QueryPipeline/DistributedPlanExecutor.h
@@ -19,6 +19,7 @@
 #include <Common/SettingsChanges.h>
 #include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/UnorderedSetWithMemoryTracking.h>
+#include <Common/WakeupFd.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <Core/ProtocolDefines.h>
 
@@ -111,6 +112,15 @@ private:
 
 using DistributedQueryCancellationPtr = std::shared_ptr<DistributedQueryCancellation>;
 
+/// Notified whenever a task reaches a terminal state, so a caller that waits for stages without
+/// holding an execution thread wakes as soon as `execute` can make progress, instead of at the end
+/// of a poll interval.
+using StageWakeupPtr = std::shared_ptr<WakeupFd>;
+
+/// Never throws: a lost wake-up only costs the waiter its poll interval, while the callers are task
+/// threads and a `noexcept` cancellation path, where an escaping exception would end the process.
+void notifyStageWakeup(const StageWakeupPtr & stage_wakeup) noexcept;
+
 /// Implements distributed query plan execution logic by executing stages according to dependencies between them.
 class DistributedQueryPlanExecutor
 {
@@ -129,7 +139,7 @@ private:
     void startStageWithDependencies(const String & stage_name, UnorderedSetWithMemoryTracking<String> & executed_stages);
 
 protected:
-    DistributedQueryPlanExecutor(const UUID & unique_query_id_, const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_);
+    DistributedQueryPlanExecutor(const UUID & unique_query_id_, const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_, DistributedQueryCancellationPtr cancellation_, StageWakeupPtr stage_wakeup_);
 
     virtual void startStage(const String & stage_name, const DistributedQueryStage & stage) = 0;
     virtual bool waitForStage(const String & stage_name, std::optional<UInt64> timeout_ms) = 0;
@@ -141,6 +151,7 @@ protected:
     ContextPtr context;
     QueryStatusPtr query_status;
     DistributedQueryCancellationPtr cancellation;
+    StageWakeupPtr stage_wakeup;
     DequeWithMemoryTracking<String> running_stages;
     LoggerPtr logger;
 };
@@ -150,7 +161,8 @@ std::unique_ptr<DistributedQueryPlanExecutor> createDistributedQueryExecutor(
     const DistributedQueryPlan & distributed_query_plan,
     TaskToHostMapPtr task_to_host_map,
     ContextPtr context,
-    DistributedQueryCancellationPtr cancellation);
+    DistributedQueryCancellationPtr cancellation,
+    StageWakeupPtr stage_wakeup);
 
 /// Wake every in-memory exchange waiter of the query; the waiters rethrow `failure` (or a
 /// generic cancellation error when it is null) instead of treating the stream as complete.

--- a/src/QueryPipeline/DistributedPlanExecutor.h
+++ b/src/QueryPipeline/DistributedPlanExecutor.h
@@ -118,7 +118,10 @@ public:
     virtual ~DistributedQueryPlanExecutor() = default;
 
     void start();
-    bool execute(); /// Returns true if the execution is finished, false if it is still in progress and should be called again later.
+    /// Returns true if the execution is finished, false if it is still in progress and should be called again later.
+    /// `poll_timeout_ms` is how long to wait for the current stage before giving up and returning; pass 0 to only
+    /// look at the current state, so the caller can wait somewhere it does not hold an execution thread.
+    bool execute(UInt64 poll_timeout_ms);
 
     virtual void cleanup() = 0;
 

--- a/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
+++ b/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
@@ -561,7 +561,7 @@ try
     try
     {
         executor->start();
-        while (!executor->execute());
+        while (!executor->execute(/*poll_timeout_ms=*/ 100));
         executor->cleanup();
     }
     catch (...)

--- a/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
+++ b/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
@@ -556,7 +556,8 @@ try
     auto cancellation = std::make_shared<DistributedQueryCancellation>();
 
     /// Just execute the distributed query plan without checking the result
-    auto executor = createDistributedQueryExecutor(query_uuid, distributed_query_plan, nullptr, query_context, cancellation);
+    auto executor = createDistributedQueryExecutor(
+        query_uuid, distributed_query_plan, nullptr, query_context, cancellation, std::make_shared<WakeupFd>());
 
     try
     {


### PR DESCRIPTION
A distributed plan could make no progress at all until `max_execution_time` fired, whenever its initiator pipeline ended up with a single execution thread.

`ReadFromDistributedPlanSource` dispatches the plan's stages and waits for them; the query result arrives through a second source of the same pipeline, which reads the `final_result` exchange. With a streaming exchange nothing runs until that second source connects, because `StreamingExchangeSink` has no socket until its consumer shows up and therefore never asks its input for data — every worker task builds its pipeline and then sits idle.

The driver used to wait inside `work`, which keeps an execution thread busy and leaves the source immediately runnable again, so a single-threaded pipeline kept re-running the driver and never reached the result source. This is not a corner case: on a loaded server concurrency control hands a query only its guaranteed master slot, i.e. exactly one execution thread. Now the source parks itself in the executor's async queue between polls, so the thread is free while the stages run.

This is what made `04891_distributed_plan_limit_early_stop` flaky on master (the test times out because the query never starts, not because the `LIMIT` early stop is broken). CI report of a failing run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=30024ffcc4bbaa402c58248515477da98cd18621&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

In that run all 14 worker tasks built their pipelines and then did nothing for 25 s, no exchange source ever connected, and the initiator's only pipeline worker thread spent 25 of 25 profiler samples inside `ReadFromDistributedPlanSource::tryGenerate` → `waitForStage`.

Reproduced locally with a single-CPU-slot server (`concurrent_threads_soft_limit_num = 1`) plus a background query holding the slot, running the query of `04891_distributed_plan_limit_early_stop` with its own `max_threads = 2`, 8 runs each:

```
before: 17.01 15.97 16.97 16.97 16.97 17.97 17.10 16.97
after:   4.28  4.26  4.26  4.26  5.26  4.26  4.27  4.26
```

With `max_threads = 1` the same setup gives 19.5-25.6 s before and 4.3-5.6 s after. All 45 `distributed_plan` stateless tests were run locally against the patched build; the only ones that did not pass are the `s3` test `04824_parquet_lazy_materialization_distributed_plan`, which needs a fixture the ad-hoc local server does not have.

No new test: `04891_distributed_plan_limit_early_stop` already covers this — it is the test the bug was breaking, and it only passes reliably with the fix.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116017&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116017](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116017+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
