### PR TITLE
Retry the job-script image pull so a transient cannot kill the job

### DIFF
--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -430,8 +430,12 @@ def main():
 
     args = parse_args()
 
-    deb_image = DockerImage.get_docker_image(DEB_IMAGE).pull_image()
-    rpm_image = DockerImage.get_docker_image(RPM_IMAGE).pull_image()
+    deb_image = DockerImage.get_docker_image(DEB_IMAGE).pull_image(
+        timeout_s=120, retries=2
+    )
+    rpm_image = DockerImage.get_docker_image(RPM_IMAGE).pull_image(
+        timeout_s=120, retries=2
+    )
 
     Shell.check(f"chmod +x {Utils.cwd()}/ci/tmp/clickhouse", verbose=True, strict=True)
 

--- a/ci/jobs/scripts/docker_image.py
+++ b/ci/jobs/scripts/docker_image.py
@@ -2,7 +2,9 @@ import json
 import os
 from typing import Optional
 
-from ci.praktika.utils import Shell, Utils
+from ci.praktika.docker import Docker
+from ci.praktika.info import Info
+from ci.praktika.utils import Utils
 
 DOCKER_TAG = os.getenv("DOCKER_TAG", "latest")
 
@@ -21,10 +23,18 @@ class DockerImage:
     def __repr__(self):
         return f"DockerImage({self.name}:{self.version})"
 
+    def _warn_pull_retried(self, matched, attempt, attempts):
+        # A job script holds no frame-local env, so Info() is the route here (as in
+        # scripts/server_cleanup.py); _add_report_message dumps immediately.
+        Info().add_workflow_warning(
+            f"Job image pull failed with [{matched}] and was retried "
+            f"({attempt}/{attempts}): {self}"
+        )
+
     def pull_image(self):
         try:
             print(f"Pulling image {self} - start")
-            Shell.check(f"docker pull {self}", strict=True)
+            Docker.pull_image(str(self), strict=True, on_retry=self._warn_pull_retried)
             print(f"Pulling image {self} - done")
         except Exception as ex:
             print(f"Got exception pulling docker: {ex}")

--- a/ci/jobs/scripts/docker_image.py
+++ b/ci/jobs/scripts/docker_image.py
@@ -31,10 +31,19 @@ class DockerImage:
             f"({attempt}/{attempts}): {self}"
         )
 
-    def pull_image(self):
+    def pull_image(self, *, timeout_s=None, retries=None):
+        # An omitted knob must fall through to Docker.pull_image's own default,
+        # so it is left out of the call rather than passed as None.
+        budget = {}
+        if timeout_s is not None:
+            budget["timeout_s"] = timeout_s
+        if retries is not None:
+            budget["retries"] = retries
         try:
             print(f"Pulling image {self} - start")
-            Docker.pull_image(str(self), strict=True, on_retry=self._warn_pull_retried)
+            Docker.pull_image(
+                str(self), strict=True, on_retry=self._warn_pull_retried, **budget
+            )
             print(f"Pulling image {self} - done")
         except Exception as ex:
             print(f"Got exception pulling docker: {ex}")

--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -195,6 +195,10 @@ class Docker:
         that pays the retries out of its own job timeout passes a budget that
         fits inside it.
         """
+        # Below these floors the budget silently widens: `timeout 0` runs unbounded,
+        # and Shell.run raises `retries` to 2 whenever `retry_errors` is set.
+        assert timeout_s >= 1, f"timeout_s must be >= 1, got [{timeout_s}]"
+        assert retries >= 2, f"retries must be >= 2, got [{retries}]"
         return Shell.run(
             f"timeout --verbose {timeout_s} docker pull {image}",
             strict=strict,

--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -5,6 +5,24 @@ from typing import Dict, List
 from .settings import Settings
 from .utils import Shell, Utils
 
+# Matched against the pull's stderr. Transport-class phrases only: must never match a
+# permanent failure (`manifest unknown`, `pull access denied`, `no matching manifest`).
+_IMAGE_PULL_RETRY_ERRORS = [
+    "connection reset by peer",
+    "connection refused",
+    "TLS handshake timeout",
+    "i/o timeout",
+    "unexpected EOF",
+    # A nameserver answered badly (SERVFAIL), so the name can resolve next attempt.
+    # Its NXDOMAIN sibling `no such host` is permanent and is deliberately absent.
+    "server misbehaving",
+    # What `timeout --verbose` writes when it kills a stalled attempt. Plain `timeout`
+    # writes nothing, so without this entry a stall is not retried.
+    "sending signal TERM to command",
+]
+_IMAGE_PULL_TIMEOUT_S = 300  # per attempt, matching prefetch-integration-test-images
+_IMAGE_PULL_RETRIES = 3
+
 
 class Docker:
     class Platforms:
@@ -155,6 +173,23 @@ class Docker:
             else:
                 dockers.append(dockers.pop(i))
         return dockers
+
+    @classmethod
+    def pull_image(cls, image, *, strict=False, on_retry=None, verbose=True):
+        """Pull `image`, retrying only transport-class failures.
+
+        `strict` raises on a failed pull; `on_retry(matched, attempt, attempts)`
+        is called once per actual retry, so a caller with a report surface can
+        make the retry visible. Returns the pull's exit code.
+        """
+        return Shell.run(
+            f"timeout --verbose {_IMAGE_PULL_TIMEOUT_S} docker pull {image}",
+            strict=strict,
+            retries=_IMAGE_PULL_RETRIES,
+            retry_errors=_IMAGE_PULL_RETRY_ERRORS,
+            verbose=verbose,
+            on_retry=on_retry,
+        )
 
     @classmethod
     def login(cls, user_name, user_password):

--- a/ci/praktika/docker.py
+++ b/ci/praktika/docker.py
@@ -175,17 +175,30 @@ class Docker:
         return dockers
 
     @classmethod
-    def pull_image(cls, image, *, strict=False, on_retry=None, verbose=True):
+    def pull_image(
+        cls,
+        image,
+        *,
+        strict=False,
+        on_retry=None,
+        verbose=True,
+        timeout_s=_IMAGE_PULL_TIMEOUT_S,
+        retries=_IMAGE_PULL_RETRIES,
+    ):
         """Pull `image`, retrying only transport-class failures.
 
         `strict` raises on a failed pull; `on_retry(matched, attempt, attempts)`
         is called once per actual retry, so a caller with a report surface can
         make the retry visible. Returns the pull's exit code.
+
+        `timeout_s` bounds one attempt and `retries` caps their number; a caller
+        that pays the retries out of its own job timeout passes a budget that
+        fits inside it.
         """
         return Shell.run(
-            f"timeout --verbose {_IMAGE_PULL_TIMEOUT_S} docker pull {image}",
+            f"timeout --verbose {timeout_s} docker pull {image}",
             strict=strict,
-            retries=_IMAGE_PULL_RETRIES,
+            retries=retries,
             retry_errors=_IMAGE_PULL_RETRY_ERRORS,
             verbose=verbose,
             on_retry=on_retry,

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -13,6 +13,12 @@ from ._environment import _Environment
 from .artifact import Artifact
 from .cidb import CIDB
 from .digest import Digest
+from .docker import (  # noqa: F401  - re-exported: the pull policy moved to docker.py
+    _IMAGE_PULL_RETRIES,
+    _IMAGE_PULL_RETRY_ERRORS,
+    _IMAGE_PULL_TIMEOUT_S,
+    Docker,
+)
 from .event import EventFeed
 from .gh import GH
 from .gh_auth import GHAuth
@@ -27,24 +33,6 @@ from .s3 import S3
 from .settings import Settings
 from .usage import ComputeUsage, StorageUsage
 from .utils import Shell, TeePopen, Utils
-
-# Matched against the pull's stderr. Transport-class phrases only: must never match a
-# permanent failure (`manifest unknown`, `pull access denied`, `no matching manifest`).
-_IMAGE_PULL_RETRY_ERRORS = [
-    "connection reset by peer",
-    "connection refused",
-    "TLS handshake timeout",
-    "i/o timeout",
-    "unexpected EOF",
-    # A nameserver answered badly (SERVFAIL), so the name can resolve next attempt.
-    # Its NXDOMAIN sibling `no such host` is permanent and is deliberately absent.
-    "server misbehaving",
-    # What `timeout --verbose` writes when it kills a stalled attempt. Plain `timeout`
-    # writes nothing, so without this entry a stall is not retried.
-    "sending signal TERM to command",
-]
-_IMAGE_PULL_TIMEOUT_S = 300  # per attempt, matching prefetch-integration-test-images
-_IMAGE_PULL_RETRIES = 3
 
 
 class Runner:
@@ -500,13 +488,7 @@ class Runner:
                         f"({attempt}/{attempts}): {docker}"
                     )
 
-                Shell.run(
-                    f"timeout --verbose {_IMAGE_PULL_TIMEOUT_S} docker pull {docker}",
-                    retries=_IMAGE_PULL_RETRIES,
-                    retry_errors=_IMAGE_PULL_RETRY_ERRORS,
-                    verbose=True,
-                    on_retry=_warn_pull_retried,
-                )
+                Docker.pull_image(docker, on_retry=_warn_pull_retried)
 
         # Sample whole-VM CPU/RAM usage in the background for the duration of the
         # job (see HostMetricsCollector). Runs on the host, so metrics cover the


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/113611
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description
One transient registry or resolver error aborts a whole AST fuzzer / Stress / Upgrade / Install /
libFuzzer job with 0 tests run: `DockerImage.pull_image()` issued a bare `docker pull` under
`strict=True`, with no retries and no per-attempt timeout. Seen on 7 PRs over 4 days and 3 job
families, as `check_status = error` with no test row.

#113611 already added this policy for the implicit pull `docker run` performs, and its allowlist
already classifies today's `connection refused` as retryable. It was just unreachable from
`pull_image()`, which #113611 scoped out.

So the policy moves into `Docker.pull_image()` in `ci/praktika/docker.py`, which already owns
Docker retry classification, and both callers route through it: `Runner._run` unchanged
(non-strict, same allowlist object, same `on_retry`), and `DockerImage.pull_image` with
`strict=True` plus its own `on_retry` so a retry reaches the report page. No new constants and no
new allowlist entries, so a permanent failure (`manifest unknown`, `pull access denied`) is still
tried once. The bare pulls in `release_job.py` and `artifactory.py` are untouched.

The timeout and retry count are parameters, since the runner pulls outside its job's timeout while
a job script pulls inside it. Four callers keep the defaults, 300s x 3. `Install packages` passes
120s x 2: its job timeout is 900s, so the default budget for its two pulls could never fit there,
and its images are the smallest of the five at 0.03 and 0.08 GiB against 2.02 GiB.

Validated locally: on master the production DNS failure burns 1 attempt and aborts, with this
change 3, and a permanent failure still burns 1. `ci/tests/test_job_image_pull_retry.py` passes
unchanged; no test is added because #115650 deletes that file. Arm matrix in a comment below.

@maxknv you approved #113611 but closed #108975 ("retries can make the problem worse"). That one
retried a 23-image *concurrent* batch; all 5 sites here are sequential single-image pulls.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116022&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116022](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116022+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1965` (included in `26.8` and later)
<!-- ch-version-info:end -->