### PR TITLE
Use `sipHash128` instead of `MD5` to derive attach UUIDs in test 04401 (fails in FIPS builds)

### DIFF
--- a/tests/queries/0_stateless/04401_url_engine_s3_dispatch_engine_grant.sh
+++ b/tests/queries/0_stateless/04401_url_engine_s3_dispatch_engine_grant.sh
@@ -24,8 +24,9 @@ S3_URL="s3://my-bucket/my-key.csv"
 
 # Attaching a full definition into an Atomic database (the default) requires an explicit UUID. Each
 # one is derived from the test's unique name plus a per-table suffix: two tables may never share a
-# UUID, and concurrent copies of this test must not collide with each other.
-attach_uuid() { ${CLICKHOUSE_CLIENT} -q "SELECT reinterpretAsUUID(MD5('${CLICKHOUSE_TEST_UNIQUE_NAME}_$1'))"; }
+# UUID, and concurrent copies of this test must not collide with each other. `sipHash128` rather
+# than `MD5`: `MD5` throws `SUPPORT_IS_DISABLED` in OpenSSL FIPS builds.
+attach_uuid() { ${CLICKHOUSE_CLIENT} -q "SELECT reinterpretAsUUID(sipHash128('${CLICKHOUSE_TEST_UNIQUE_NAME}_$1'))"; }
 
 # The denial assertions match the privilege sentence, not just the engine name: the client echoes the
 # failing query back, and that echo contains both the engine name and the word "grant" (it is in this


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `sipHash128` instead of `MD5` to derive attach UUIDs in the stateless test `04401_url_engine_s3_dispatch_engine_grant`.

The test's `attach_uuid` helper derives deterministic table UUIDs via `SELECT reinterpretAsUUID(MD5(...))`. In OpenSSL FIPS builds `MD5` throws `SUPPORT_IS_DISABLED` ("Function MD5 is not available in FIPS mode"), so the helper returns an empty string and every `ATTACH TABLE ... UUID ''` fails with `CANNOT_PARSE_UUID` — the test fails deterministically in the FIPS stateless job (which only runs in the private repository's CI, so upstream CI never exercises this path; observed as a `CH Inc sync` failure, e.g. on #115286). `sipHash128` also returns `FixedString(16)` and is available in FIPS builds.

Related: https://github.com/ClickHouse/ClickHouse/pull/115914
Related: https://github.com/ClickHouse/ClickHouse/pull/115286

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116023&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116023](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116023+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.41` (included in `26.9` and later)
<!-- ch-version-info:end -->