### PR TITLE
Read statistics files with format version `V3` instead of rejecting them

### DIFF
--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -525,15 +525,12 @@ std::shared_ptr<ColumnStatistics> ColumnStatistics::deserialize(ReadBuffer & buf
     readIntBinary(version_raw, buf);
     auto version = static_cast<StatisticsFileVersion>(version_raw);
 
-    /// `V3` was briefly written by reverted PR #102356 and is permanently reserved. Refuse to read it
-    /// rather than silently misinterpret a `V3` payload as `V4`.
-    if (version == StatisticsFileVersion::V3)
-        throw Exception(
-            ErrorCodes::ILLEGAL_STATISTICS,
-            "Statistics file version V3 is reserved and is never produced by any released build. "
-            "Please run `ALTER TABLE [db.]table MATERIALIZE STATISTICS ALL` to regenerate the statistics.");
-
-    if (version != StatisticsFileVersion::V1 && version != StatisticsFileVersion::V2 && version != StatisticsFileVersion::V4)
+    /// `V3` was written only by builds of `master` between PR #102356 and its revert; no stable
+    /// release produced it. It is still read here: parts written by such a build are otherwise
+    /// unreadable, and `ALTER TABLE ... MATERIALIZE STATISTICS` cannot rewrite them on a readonly
+    /// disk. See the `V3` note in `Statistics.h` for the two differences from `V4`.
+    if (version != StatisticsFileVersion::V1 && version != StatisticsFileVersion::V2
+        && version != StatisticsFileVersion::V3 && version != StatisticsFileVersion::V4)
         throw Exception(
             ErrorCodes::ILLEGAL_STATISTICS,
             "Tried to read statistics file with unsupported format version {}. "
@@ -547,22 +544,27 @@ std::shared_ptr<ColumnStatistics> ColumnStatistics::deserialize(ReadBuffer & buf
     ColumnStatisticsDescription stats_desc;
     stats_desc.data_type = data_type;
 
-    if (version == StatisticsFileVersion::V4)
+    if (version == StatisticsFileVersion::V3 || version == StatisticsFileVersion::V4)
     {
         /// V4 layout: stored_type_name, then per-stat size prefix. Return nullptr if the stored
         /// column type differs from the current type — statistics built on a different type are
         /// stale (e.g. a MODIFY COLUMN mutation is in progress) and must not be used.
-        String stored_type_name;
-        readStringBinary(stored_type_name, buf);
-        if (stored_type_name != data_type->getName())
+        /// V3 is the same layout without `stored_type_name`, so it has no such guard, exactly like
+        /// V1 / V2.
+        if (version == StatisticsFileVersion::V4)
         {
-            LOG_TRACE(
-                getLogger("ColumnStatistics"),
-                "Skipping statistics: stored type {} does not match current column type {}. "
-                "Statistics will be ignored until rematerialized after the MODIFY COLUMN mutation completes.",
-                stored_type_name,
-                data_type->getName());
-            return nullptr;
+            String stored_type_name;
+            readStringBinary(stored_type_name, buf);
+            if (stored_type_name != data_type->getName())
+            {
+                LOG_TRACE(
+                    getLogger("ColumnStatistics"),
+                    "Skipping statistics: stored type {} does not match current column type {}. "
+                    "Statistics will be ignored until rematerialized after the MODIFY COLUMN mutation completes.",
+                    stored_type_name,
+                    data_type->getName());
+                return nullptr;
+            }
         }
 
         UInt64 rows_value = 0;
@@ -580,6 +582,15 @@ std::shared_ptr<ColumnStatistics> ColumnStatistics::deserialize(ReadBuffer & buf
             readIntBinary(stat_size, buf);
 
             auto type = static_cast<StatisticsType>(i);
+
+            /// This bit was the reverted `NullCount` statistic in `V3` and is `Basic` today, so a
+            /// `V3` payload here is not a `Basic` payload. The size prefix lets us skip it.
+            if (version == StatisticsFileVersion::V3 && type == StatisticsType::Basic)
+            {
+                buf.ignore(stat_size);
+                continue;
+            }
+
             if (auto stat_ptr = factory.tryCreateSingle(type, data_type))
             {
                 /// Track bytes consumed so we can detect a per-stat parser drift and either pad the

--- a/src/Storages/Statistics/Statistics.h
+++ b/src/Storages/Statistics/Statistics.h
@@ -19,8 +19,11 @@ enum class StatisticsFileVersion : UInt16
     V0 = 0,
     V1 = 1, /// modified the format of uniq, https://github.com/ClickHouse/ClickHouse/pull/90311
     V2 = 2, /// minmax statistics now serialize Field type and use Field instead of Float64
-    V3 = 3, /// reserved — never use this value. PR #102356 briefly wrote V3 before being reverted.
-            /// The deserializer rejects V3 to avoid attempting to read incompatible reverted-format files.
+    V3 = 3, /// reserved — never write this value again. PR #102356 added the `NullCount` statistic and
+            /// wrote V3; it was reverted, so only builds of `master` between the two commits produced
+            /// such files (no stable release did). V3 is still readable: its layout is V4 without the
+            /// `stored_type_name` field, and the only conflict is bit 4 of `stat_types_mask`, which
+            /// meant the reverted `NullCount` in V3 and means `Basic` now — the deserializer skips it.
     V4 = 4, /// per-statistic size prefix added (`stat_size: UInt64` precedes each stat payload),
             /// so unknown statistics types can be skipped on deserialize.
             /// Also stores the column type name (`stored_type_name: String`) immediately after

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -20,6 +20,9 @@
 #include <Interpreters/convertFieldToType.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+#include <Core/Field.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Storages/Statistics/Statistics.h>
 #include <Storages/Statistics/StatisticsBasic.h>
@@ -780,3 +783,67 @@ TEST(Statistics, BasicDefaultCountArray)
     EXPECT_DOUBLE_EQ(*eq_empty, 2.0);
 }
 
+
+/// Statistics files with version `V3` were produced by builds of `master` between PR #102356 (which
+/// added a `NullCount` statistic) and its revert. They must stay readable: a part written by such a
+/// build is otherwise unqueryable, and on a readonly disk it cannot be rewritten by
+/// `ALTER TABLE ... MATERIALIZE STATISTICS`. The layout is `V4` without `stored_type_name`, and bit 4
+/// of the type mask -- the reverted `NullCount` -- must be skipped rather than parsed as `Basic`.
+TEST(Statistics, DeserializeV3SkipsRevertedNullCount)
+{
+    auto data_type = std::make_shared<DataTypeInt32>();
+
+    auto lengthPrefixed = [](WriteBuffer & out, const String & stat_payload)
+    {
+        writeIntBinary(static_cast<UInt64>(stat_payload.size()), out);
+        out.write(stat_payload.data(), stat_payload.size());
+    };
+
+    String minmax_payload;
+    {
+        WriteBufferFromString buf(minmax_payload);
+        writeIntBinary(static_cast<UInt64>(100), buf); /// row_count
+        writeStringBinary(data_type->getName(), buf);
+        writeFieldBinary(Field(Int64(-5)), buf);
+        writeFieldBinary(Field(Int64(42)), buf);
+        buf.finalize();
+    }
+
+    /// `StatisticsNullCount::serialize` wrote a single `UInt64`.
+    String null_count_payload;
+    {
+        WriteBufferFromString buf(null_count_payload);
+        writeIntBinary(static_cast<UInt64>(7), buf);
+        buf.finalize();
+    }
+
+    String file;
+    {
+        WriteBufferFromString buf(file);
+        writeIntBinary(static_cast<UInt16>(3), buf); /// StatisticsFileVersion::V3
+        /// bit 3 = `MinMax`, bit 4 = the reverted `NullCount`, which is today's `Basic` slot
+        writeIntBinary(static_cast<UInt64>((1ULL << 3) | (1ULL << 4)), buf);
+        writeIntBinary(static_cast<UInt64>(100), buf); /// rows
+        lengthPrefixed(buf, minmax_payload);
+        lengthPrefixed(buf, null_count_payload);
+        buf.finalize();
+    }
+
+    ReadBufferFromString rb(file);
+    auto restored = ColumnStatistics::deserialize(rb, data_type);
+
+    ASSERT_TRUE(restored != nullptr);
+    EXPECT_EQ(restored->getNumRows(), 100u);
+
+    /// `MinMax` was read...
+    ASSERT_TRUE(restored->hasMinMax());
+    auto estimate = restored->getEstimate();
+    ASSERT_TRUE(estimate.estimated_min.has_value());
+    ASSERT_TRUE(estimate.estimated_max.has_value());
+    EXPECT_EQ(*estimate.estimated_min, Field(Int64(-5)));
+    EXPECT_EQ(*estimate.estimated_max, Field(Int64(42)));
+
+    /// ...and the reverted `NullCount` payload was skipped, not misread as a `Basic` payload.
+    EXPECT_FALSE(restored->getStats().contains(StatisticsType::Basic));
+    EXPECT_FALSE(restored->hasNullCount());
+}


### PR DESCRIPTION
`ColumnStatistics::deserialize` threw `ILLEGAL_STATISTICS` for any statistics file written with format version `V3`, which made every part carrying one unreadable:

```
Code: 708. DB::Exception: Statistics file version V3 is reserved and is never produced
by any released build. Please run `ALTER TABLE [db.]table MATERIALIZE STATISTICS ALL`
to regenerate the statistics: (while loading statistics for column by from file
statistics_by.stats in packed file statistics.packed of part all_1_36_3).
(ILLEGAL_STATISTICS) (version 26.8.1.1)
```

`V3` was written only by builds of `master` between the `NullCount` statistic being added and that change being reverted; no stable release produced it. But a part written by one of those builds is still a part, and the remedy the message suggests does not always exist — on a readonly disk `ALTER TABLE ... MATERIALIZE STATISTICS` cannot rewrite the part, so the table stays unreadable forever. This is how it was hit: a `ReplacingMergeTree` over a readonly `s3_plain_rewritable` disk.

The failure is also not confined to the optimization that wants the statistics. It propagates out of `MergeTreeData::getConditionSelectivityEstimator`, out of `IMergeTreeDataPart::getEstimates` during statistics part pruning (which calls it outside its `try`), and out of `system.parts_columns` — so the whole query fails, not just the estimate.

`V3` is in fact readable. Its layout is `V4` without the `stored_type_name` field, and the payloads of every statistic that outlived the revert (`MinMax`, `Uniq`, `TDigest`, `CountMinSketch`) are byte-identical between the two versions. The one real incompatibility is bit 4 of `stat_types_mask`: it selected the reverted `NullCount` in `V3` and selects `Basic` today. Because `V3` already length-prefixes each statistic, that bit is skipped instead of being misparsed as a `Basic` payload.

`V3` is still never written — only read.

A unit test builds a `V3` file by hand, with `MinMax` plus a `NullCount` payload in bit 4, and checks that the min/max come back and that the `NullCount` bytes are skipped.

Until this is available, such a table can be read with `SET use_statistics = 0, use_statistics_for_part_pruning = 0` (`system.parts_columns` will still throw, as that call site honours no setting).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Statistics files with format version `V3` are now read instead of rejected with `ILLEGAL_STATISTICS`. Such files were produced only by builds of `master` from a narrow window, but parts containing them were completely unreadable, and on a readonly disk `ALTER TABLE ... MATERIALIZE STATISTICS` cannot regenerate them.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116030&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116030](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116030+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
