### PR TITLE
Fix early short-circuit fallback for IN subqueries

### DIFF
--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -284,7 +284,16 @@ bool hasFunctionNotSuitableForEarlyShortCircuit(const QueryTreeNodePtr & node, b
                 arguments.reserve(argument_nodes.size());
 
                 for (const auto & argument : argument_nodes)
+                {
+                    /// IN-family functions keep their set subquery as a QueryNode/UnionNode
+                    /// argument. Such nodes have no expression result type, and the speculative
+                    /// early-fold check must fall back instead of trying to inspect one.
+                    if (argument->getNodeType() == QueryTreeNodeType::QUERY
+                        || argument->getNodeType() == QueryTreeNodeType::UNION)
+                        return true;
+
                     arguments.push_back({argument->getResultType(), argument->as<ConstantNode>() != nullptr});
+                }
 
                 if (!function_base->isSuitableForShortCircuitArgumentsExecution(arguments)
                     && !isComparisonOfEarlyShortCircuitScalar(*function))
@@ -1163,6 +1172,7 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
             type_inference_analyzer.subquery_counter = subquery_counter;
 
             bool type_inference_succeeded = false;
+            bool post_resolution_is_safe = false;
             ProjectionNames type_inference_projection_names;
             try
             {
@@ -1174,6 +1184,13 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
                     false /*ignore_alias*/,
                     allow_niladic_functions);
                 type_inference_succeeded = !type_inference_analyzer.early_short_circuit_type_inference_failed;
+
+                /// Post-resolution safety is also speculative: an unfamiliar non-expression
+                /// argument must decline the optimization, never make the original query fail.
+                if (type_inference_succeeded)
+                    post_resolution_is_safe = !hasFunctionNode(node_for_type_inference, "arrayJoin")
+                        && !hasUnsafeEarlyShortCircuitScalarUsage(node_for_type_inference)
+                        && !hasFunctionNotSuitableForEarlyShortCircuit(node_for_type_inference);
             }
             catch (...)
             {
@@ -1182,10 +1199,6 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
                 /// cannot provide it, so fall back to the regular path which evaluates the scalar.
                 type_inference_succeeded = false;
             }
-
-            const bool post_resolution_is_safe = !hasFunctionNode(node_for_type_inference, "arrayJoin")
-                && !hasUnsafeEarlyShortCircuitScalarUsage(node_for_type_inference)
-                && !hasFunctionNotSuitableForEarlyShortCircuit(node_for_type_inference);
             if (type_inference_succeeded && (is_strict_safe_logical_tree || post_resolution_is_safe))
             {
                 auto result_type = node_for_type_inference->getResultType();

--- a/tests/queries/0_stateless/03562_short_circuit_for_and_or.reference
+++ b/tests/queries/0_stateless/03562_short_circuit_for_and_or.reference
@@ -29,6 +29,11 @@ Test aggregate and arrayJoin branches are not erased
 0
 1
 1
+Test IN subqueries in discarded logical branches fall back to normal analysis
+1
+0
+1
+1
 Test JOIN ON scalar subqueries remain planner-safe
 1	1
 Test EXISTS falls back when its runtime value is unknown

--- a/tests/queries/0_stateless/03562_short_circuit_for_and_or.sql
+++ b/tests/queries/0_stateless/03562_short_circuit_for_and_or.sql
@@ -50,6 +50,12 @@ SELECT 1 OR count() FROM numbers(10);
 SELECT 0 AND count() FROM numbers(10);
 SELECT 1 OR arrayJoin([1, 2]);
 
+SELECT 'Test IN subqueries in discarded logical branches fall back to normal analysis';
+SELECT 1 OR (1 IN (SELECT count() FROM test_03562));
+SELECT 0 AND (1 IN (SELECT count() FROM test_03562));
+SELECT 1 OR (1 NOT IN (SELECT count() FROM test_03562));
+SELECT 1 OR (1 GLOBAL IN (SELECT count() FROM test_03562));
+
 SELECT 'Test JOIN ON scalar subqueries remain planner-safe';
 SELECT *
 FROM values('l UInt8', 1) AS l


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/115835
Related: https://github.com/ClickHouse/ClickHouse/pull/83505

With `enable_function_early_short_circuit = 1`, a valid query with `IN`/`NOT IN`/`GLOBAL IN` over a subquery in a decided `AND`/`OR` branch failed with `UNSUPPORTED_METHOD`: the speculative safety check called `getResultType` on the set subquery (a `QueryNode`/`UnionNode`), which has no expression result type.

The check now treats `QueryNode`/`UnionNode` arguments as unsupported and declines the optimization, and the post-resolution safety evaluation moved inside the existing speculative try/catch, so unexpected argument shapes fall back to ordinary analysis instead of failing the query.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix `UNSUPPORTED_METHOD` error for queries using `IN`/`NOT IN`/`GLOBAL IN` with a subquery inside `AND`/`OR` when `enable_function_early_short_circuit` is enabled.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116037&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116037](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116037+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
