### PR TITLE
Iceberg: inherit missing optional manifest-entry fields from the manifest list

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Common/AvroForIcebergDeserializer.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Common/AvroForIcebergDeserializer.cpp
@@ -142,32 +142,29 @@ ParsedManifestFileEntryPtr AvroForIcebergDeserializer::createParsedManifestFileE
             manifest_file_path,
             has_snapshot_id_column ? "null" : "absent");
 
+    /// `sequence_number` is optional on a v2 manifest entry for the same reason as `snapshot_id`, so a
+    /// missing column is left unresolved rather than substituted with 0. A literal 0 reads as an assigned
+    /// value, which skips inheritance in ManifestFileIterator and makes an ADDED data file look older than
+    /// it is; a manifest rewrite would then persist that 0 as the entry's explicit data sequence number.
     std::optional<Int64> sequence_number;
-
     if (format_version > 1)
     {
-        if (!hasPath(f_sequence_number))
-        {
-            sequence_number = 0;
-        }
-        else
+        const bool has_sequence_number_column = hasPath(f_sequence_number);
+        if (has_sequence_number_column)
         {
             const auto sequence_number_value = getValueFromRowByName(row_index, f_sequence_number);
-            if (sequence_number_value.isNull())
-            {
-                if (status == ManifestEntryStatus::EXISTING)
-                {
-                    throw Exception(
-                        ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
-                        "Cannot read Iceberg table: manifest file '{}' has entry with status 'EXISTING' without sequence number",
-                        manifest_file_path);
-                }
-            }
-            else
-            {
+            if (!sequence_number_value.isNull())
                 sequence_number = sequence_number_value.safeGet<Int64>();
-            }
         }
+        /// The spec inherits data and file sequence numbers only for ADDED entries; EXISTING and DELETED
+        /// must carry them explicitly (https://iceberg.apache.org/spec/#sequence-number-inheritance).
+        if (!sequence_number.has_value() && status == ManifestEntryStatus::EXISTING)
+            throw Exception(
+                ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+                "Cannot read Iceberg table: manifest file '{}' has an EXISTING entry without a data "
+                "sequence number (the sequence_number column is {})",
+                manifest_file_path,
+                has_sequence_number_column ? "null" : "absent");
     }
 
     /// `file_sequence_number` can differ from the data `sequence_number` and, like it, is inherited from the

--- a/src/Storages/ObjectStorage/DataLakes/Common/AvroForIcebergDeserializer.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Common/AvroForIcebergDeserializer.cpp
@@ -118,23 +118,29 @@ ParsedManifestFileEntryPtr AvroForIcebergDeserializer::createParsedManifestFileE
         content_type = FileContentType(getValueFromRowByName(row_index, c_data_file_content, TypeIndex::Int32).safeGet<UInt64>());
     const auto status = ManifestEntryStatus(getValueFromRowByName(row_index, f_status, TypeIndex::Int32).safeGet<UInt64>());
 
-    const auto snapshot_id_value = getValueFromRowByName(row_index, f_snapshot_id);
+    /// Iceberg v2 makes `snapshot_id` optional on the manifest entry: a missing Avro column
+    /// or a null value is inherited from the manifest list (`added_snapshot_id`). Not gated
+    /// on `format_version > 1` because the version comes from the Avro `format-version` key
+    /// or, failing that, from the presence of `sequence_number` -- a writer omitting both
+    /// would be misclassified as v1 and rejected here.
     std::optional<Int64> snapshot_id;
-
-    if (snapshot_id_value.isNull())
+    const bool has_snapshot_id_column = hasPath(f_snapshot_id);
+    if (has_snapshot_id_column)
     {
-        if (status == ManifestEntryStatus::EXISTING)
-        {
-            throw Exception(
-                ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
-                "Cannot read Iceberg table: manifest file '{}' has entry with status 'EXISTING' without snapshot id",
-                manifest_file_path);
-        }
+        const auto snapshot_id_value = getValueFromRowByName(row_index, f_snapshot_id);
+        if (!snapshot_id_value.isNull())
+            snapshot_id = snapshot_id_value.safeGet<Int64>();
     }
-    else
-    {
-        snapshot_id = snapshot_id_value.safeGet<Int64>();
-    }
+    /// EXISTING entries must carry an explicit snapshot id: Compaction.cpp restores their
+    /// lineage from `parsed_snapshot_id` and would otherwise substitute this manifest's
+    /// `added_snapshot_id`, which is not the snapshot that originally added the file.
+    if (!snapshot_id.has_value() && status == ManifestEntryStatus::EXISTING)
+        throw Exception(
+            ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+            "Cannot read Iceberg table: manifest file '{}' has an EXISTING entry without a snapshot id "
+            "(the snapshot_id column is {})",
+            manifest_file_path,
+            has_snapshot_id_column ? "null" : "absent");
 
     std::optional<Int64> sequence_number;
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1084,6 +1084,58 @@ def test_select_manifest_without_sequence_number(started_cluster, rewrite_manife
     assert num_rows == int(node.query(f"SELECT count() FROM {table_ref} WHERE symbol = 'kek'"))
 
 
+@pytest.mark.parametrize("rewrite_manifest_list", [False, True])
+def test_select_manifest_without_snapshot_id(started_cluster, rewrite_manifest_list):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_manifest_without_snapshot_id_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(root_namespace)
+    create_table(catalog, root_namespace, table_name)
+
+    num_rows = 10
+    table = catalog.load_table(f"{root_namespace}.{table_name}")
+    table.append(pa.Table.from_pylist([generate_record() for _ in range(num_rows)]))
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+    table_ref = f"{CATALOG_NAME}.`{root_namespace}.{table_name}`"
+
+    assert num_rows == int(node.query(f"SELECT count() FROM (SELECT * FROM {table_ref})"))
+
+    snapshot = catalog.load_table(f"{root_namespace}.{table_name}").current_snapshot()
+    manifests = snapshot.manifests(table.io)
+    assert len(manifests) > 0
+
+    for manifest in manifests:
+        _rewrite_s3_avro_without_fields(
+            started_cluster.minio_client,
+            manifest.manifest_path,
+            ["snapshot_id", "sequence_number", "file_sequence_number"],
+            {"data_file": ["content"]},
+        )
+
+    if rewrite_manifest_list:
+        _rewrite_s3_avro_without_fields(
+            started_cluster.minio_client,
+            snapshot.manifest_list,
+            ["sequence_number", "min_sequence_number", "content"],
+        )
+
+    node.query("SYSTEM DROP ICEBERG METADATA CACHE")
+
+    assert num_rows == int(node.query(f"SELECT count() FROM (SELECT * FROM {table_ref})"))
+    assert num_rows == int(node.query(f"SELECT count() FROM {table_ref} WHERE symbol = 'kek'"))
+    inherited_snapshot_id = node.query(
+        f"SELECT DISTINCT snapshot_id FROM system.iceberg_files "
+        f"WHERE database = '{CATALOG_NAME}' AND table = '{root_namespace}.{table_name}' "
+        "SETTINGS show_data_lake_catalogs_in_system_tables = 1"
+    ).strip()
+    assert str(snapshot.snapshot_id) == inherited_snapshot_id
+
+
 def test_create(started_cluster):
     node = started_cluster.instances["node1"]
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1128,12 +1128,20 @@ def test_select_manifest_without_snapshot_id(started_cluster, rewrite_manifest_l
 
     assert num_rows == int(node.query(f"SELECT count() FROM (SELECT * FROM {table_ref})"))
     assert num_rows == int(node.query(f"SELECT count() FROM {table_ref} WHERE symbol = 'kek'"))
-    inherited_snapshot_id = node.query(
-        f"SELECT DISTINCT snapshot_id FROM system.iceberg_files "
-        f"WHERE database = '{CATALOG_NAME}' AND table = '{root_namespace}.{table_name}' "
+    files_of_table = (
+        f"FROM system.iceberg_files WHERE database = '{CATALOG_NAME}' "
+        f"AND table = '{root_namespace}.{table_name}' "
         "SETTINGS show_data_lake_catalogs_in_system_tables = 1"
+    )
+    assert str(snapshot.snapshot_id) == node.query(
+        f"SELECT DISTINCT snapshot_id {files_of_table}"
     ).strip()
-    assert str(snapshot.snapshot_id) == inherited_snapshot_id
+    # The data sequence number is inherited from the manifest list, which this run may have
+    # stripped of its own sequence number; then there is nothing to inherit and 0 is correct.
+    expected_sequence_number = 0 if rewrite_manifest_list else snapshot.sequence_number
+    assert str(expected_sequence_number) == node.query(
+        f"SELECT DISTINCT sequence_number {files_of_table}"
+    ).strip()
 
 
 def test_create(started_cluster):


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/114480
Related: https://github.com/ClickHouse/ClickHouse/pull/112431


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

You can now read Iceberg v2 tables whose manifests omit the optional `snapshot_id` column, such
as tables managed by BigQuery; reading one previously failed with `Cannot find column
snapshot_id`. A manifest that omits `sequence_number` is also no longer read as sequence number
0. Both values are inherited from the manifest list, as the Iceberg spec requires.


---

Iceberg v2 makes [`snapshot_id`, `sequence_number` and `file_sequence_number`
optional](https://iceberg.apache.org/spec/#manifest-entry-fields) on the manifest entry and
inherits them from the manifest list when null, and an optional column may be omitted from the
Avro schema. BigQuery writes manifest entries as `[status, data_file]`, so all three are absent.

`snapshot_id` — `getValueFromRowByName` rejected the file before any scan. Now left unresolved
when the column is absent so `ManifestFileIterator` inherits `added_snapshot_id`.

`sequence_number` — #112431 made such a manifest readable by storing 0, but 0 reads as an
assigned value and skips inheritance, so an ADDED data file looks older than it is, which
changes which delete files apply, and a manifest rewrite persists that 0 as the entry's explicit
data sequence number. Now left unresolved as well. Measured on a manifest stripped of the column
whose manifest list still carries sequence number 1: `system.iceberg_files` reported 0 before
and 1 after.

`file_sequence_number` already had this shape and is unchanged, so the three fields the issue
lists now behave consistently.

`EXISTING` entries still require an explicit `snapshot_id` and data `sequence_number`, now with
messages that separate an absent column from a null value. For the data sequence number that is
what the spec says — inheritance applies "only if the entry status is 1 (added)"
([manifest entry fields](https://iceberg.apache.org/spec/#manifest-entry-fields)). The spec puts
`file_sequence_number` under the same rule, but it is not enforced here because nothing in the
read path consumes it; the place that does is `Compaction.cpp`, and that is left for a follow-up.
For `snapshot_id` the check is stricter than the spec, which does not restrict its inheritance by
status. The reason to keep it is `Compaction.cpp`, which restores an EXISTING entry's lineage from
these fields and would otherwise substitute the rewritten manifest's own values.

Not a regression: reproduces on 26.5 through master.

One behavior change beyond the reported case: a v2 manifest that omits `sequence_number` while
carrying `EXISTING` entries used to read with those files at sequence number 0, and is now
rejected. An `EXISTING` entry must carry "the original values that were either inherited or
provided at the commit time"
([sequence number inheritance](https://iceberg.apache.org/spec/#sequence-number-inheritance)),
which the rewriting manifest's own number is not, so there is nothing correct to inherit. It
does turn a silently wrong read into an error, which is worth calling out.

On the BigLake table I inspected the manifest carries `format-version: 2`, so version detection
does not fall back to the `sequence_number` heuristic, and every export I ran wrote a standalone
snapshot listing all current files as `ADDED`, with no delete files and `sequence-number: 0`
throughout. Neither the rejected `EXISTING` path nor the substituted 0 was observable for this
writer; the `sequence_number` defect is latent and came from reading the sibling path.

Out of scope: once the manifest parses, a BigQuery table that has had row-level DML fails in the
Parquet reader on a `_CHANGE_TYPE` column with field_id 2147483346 that the schema never
assigned. That rejection is deliberate and predates #113465 — an unmapped id outside the reserved
range is what the check exists to catch — so the fix belongs on the BigQuery side, which I am
pursuing. Append-only tables read end to end.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116040&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116040](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116040+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.207` (included in `26.9` and later)
- Backported to: `26.8.1.2021`, `26.7.6.27`
<!-- ch-version-info:end -->