### PR TITLE
Verify integration nodes reached the requested state after a compose action

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -167,6 +167,11 @@ INTEGRATION_NODE_EXPECTED_STATUSES = {
 # own budget must not be able to spend that on a description of why it failed.
 CONTAINER_DESCRIBE_TIMEOUT = 5.0
 
+# Request timeout for the inspect that asserts a compose action took effect. Wider than the
+# describe above because this call decides whether a test passes: expiring early would fail
+# a run that a slow-but-working daemon would have completed.
+CONTAINER_STATE_CHECK_TIMEOUT = 30.0
+
 NET_LOCK_PATH = "/tmp/docker_net.lock"
 try:
     os.remove(NET_LOCK_PATH)
@@ -4884,7 +4889,8 @@ class ClickHouseCluster:
             try:
                 # Fetched after the action: a handle caches its state, so a handle taken
                 # earlier would report the status from before the action.
-                state = self.docker_client.containers.get(container).attrs["State"]
+                with self.bounded_docker_requests(CONTAINER_STATE_CHECK_TIMEOUT):
+                    state = self.docker_client.containers.get(container).attrs["State"]
             except Exception as ex:
                 raise Exception(
                     f"Cannot inspect {integration} node {node} after {action}: "

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -154,6 +154,14 @@ CLICKHOUSE_CI_PRE_NULLABLE_TUPLE_VERSION = "25.12"
 
 ZOOKEEPER_CONTAINERS = ("zoo1", "zoo2", "zoo3")
 
+# Container statuses that satisfy each `docker compose` action. `State.Running` is not
+# usable instead: it is also true for the `paused` and `restarting` statuses.
+INTEGRATION_NODE_EXPECTED_STATUSES = {
+    "start": ("running",),
+    "stop": ("exited", "dead", "created"),
+    "kill": ("exited", "dead", "created"),
+}
+
 NET_LOCK_PATH = "/tmp/docker_net.lock"
 try:
     os.remove(NET_LOCK_PATH)
@@ -3283,9 +3291,11 @@ class ClickHouseCluster:
     ) -> None:
         start = time.time()
         err = Exception("")
+        blocking_node = nodes[0] if nodes else None
         while time.time() - start < timeout:
             try:
                 for node in nodes:
+                    blocking_node = node
                     # Use low retries/timeout per attempt since the outer loop
                     # already retries. This avoids kazoo's internal thread join
                     # hanging indefinitely (a known kazoo bug where
@@ -3297,13 +3307,31 @@ class ClickHouseCluster:
                 logging.debug("All instances of ZooKeeper started: %s", nodes)
                 return
             except Exception as ex:
-                logging.debug("Can't connect to ZooKeeper %s: %s", node, ex)
+                logging.debug("Can't connect to ZooKeeper %s: %s", blocking_node, ex)
                 err = ex
                 time.sleep(0.5)
 
         raise Exception(
-            "Cannot wait ZooKeeper container (probably it's a `iptables-nft` issue, you may try to `sudo iptables -P FORWARD ACCEPT`)"
+            f"Cannot connect to ZooKeeper node {blocking_node} "
+            f"({self.describe_container_state(blocking_node)}) "
+            f"after {time.time() - start:.1f}s of {timeout}s. "
+            f"If the container is running and reachable, it may be an `iptables-nft` "
+            f"issue, you may try to `sudo iptables -P FORWARD ACCEPT`"
         ) from err
+
+    def describe_container_state(self, instance_name) -> str:
+        # Diagnostics only: must never raise, or it would mask the failure being reported.
+        container = self.get_instance_docker_id(instance_name)
+        try:
+            state = self.docker_client.containers.get(container).attrs["State"]
+            status = f"status {state['Status']}, exit code {state['ExitCode']}"
+        except Exception as ex:
+            status = f"status unavailable: {ex}"
+        try:
+            ip = self.get_instance_ip(instance_name) or "<empty>"
+        except Exception as ex:
+            ip = f"<unavailable: {ex}>"
+        return f"container {container}, {status}, ip {ip}"
 
     def make_hdfs_api(self, timeout=180):
         self.hdfs_ip = self.get_instance_ip(self.hdfs_host)
@@ -4822,6 +4850,31 @@ class ClickHouseCluster:
             logging.info("Stopping zookeeper node: %s", n)
             subprocess_check_call(self.base_zookeeper_cmd + ["stop", n])
 
+    def check_integration_nodes_state(self, integration: str, nodes: list, action: str):
+        expected = INTEGRATION_NODE_EXPECTED_STATUSES.get(action)
+        if expected is None:
+            return
+
+        for node in nodes:
+            container = self.get_instance_docker_id(node)
+            try:
+                # Fetched after the action: a handle caches its state, so a handle taken
+                # earlier would report the status from before the action.
+                state = self.docker_client.containers.get(container).attrs["State"]
+            except Exception as ex:
+                raise Exception(
+                    f"Cannot inspect {integration} node {node} after {action}: "
+                    f"container {container}: {ex}"
+                ) from ex
+
+            if state["Status"] not in expected:
+                raise Exception(
+                    f"Failed to {action} {integration} node {node}: container {container} "
+                    f"status is {state['Status']}, expected one of {list(expected)} "
+                    f"(exit code {state['ExitCode']}, OOM killed {state['OOMKilled']}). "
+                    f"`docker compose {action}` reported success for {list(nodes)}"
+                )
+
     def process_integration_nodes(self, integration: str, nodes: list, action: str):
         base_cmd = getattr(self, f"base_{integration}_cmd")
         # One `docker compose` invocation for all nodes: concurrent compose commands on
@@ -4829,6 +4882,8 @@ class ClickHouseCluster:
         # action. compose parallelizes the services internally.
         logging.info("%sing %s nodes: %s", action.capitalize(), integration, nodes)
         subprocess_check_call(base_cmd + [action] + list(nodes))
+        # compose can exit 0, and even print `Started`, for a node it did not act on.
+        self.check_integration_nodes_state(integration, nodes, action)
         logging.info("%sed %s nodes: %s", action.capitalize(), integration, nodes)
 
     # Faster than waiting for clean stop

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -162,6 +162,11 @@ INTEGRATION_NODE_EXPECTED_STATUSES = {
     "kill": ("exited", "dead", "created"),
 }
 
+# Request timeout for a describe-only Docker call. The shared client is built with a
+# 600s timeout, which is sized for image pulls; a caller that has already exhausted its
+# own budget must not be able to spend that on a description of why it failed.
+CONTAINER_DESCRIBE_TIMEOUT = 5.0
+
 NET_LOCK_PATH = "/tmp/docker_net.lock"
 try:
     os.remove(NET_LOCK_PATH)
@@ -3319,18 +3324,37 @@ class ClickHouseCluster:
             f"issue, you may try to `sudo iptables -P FORWARD ACCEPT`"
         ) from err
 
+    @contextmanager
+    def bounded_docker_requests(self, timeout: float):
+        # docker-py reads `api.timeout` per request, so lowering it bounds every call made
+        # inside the block. Nothing in this module starts a thread, so no concurrent caller
+        # can observe the lowered value.
+        api = getattr(self.docker_client, "api", None)
+        if api is None:
+            yield
+            return
+        previous = api.timeout
+        api.timeout = timeout
+        try:
+            yield
+        finally:
+            api.timeout = previous
+
     def describe_container_state(self, instance_name) -> str:
-        # Diagnostics only: must never raise, or it would mask the failure being reported.
+        # Diagnostics only: must never raise, or it would mask the failure being reported,
+        # and must stay bounded, or a caller past its own deadline would wait on the
+        # daemon's timeout instead of failing.
         container = self.get_instance_docker_id(instance_name)
-        try:
-            state = self.docker_client.containers.get(container).attrs["State"]
-            status = f"status {state['Status']}, exit code {state['ExitCode']}"
-        except Exception as ex:
-            status = f"status unavailable: {ex}"
-        try:
-            ip = self.get_instance_ip(instance_name) or "<empty>"
-        except Exception as ex:
-            ip = f"<unavailable: {ex}>"
+        with self.bounded_docker_requests(CONTAINER_DESCRIBE_TIMEOUT):
+            try:
+                state = self.docker_client.containers.get(container).attrs["State"]
+                status = f"status {state['Status']}, exit code {state['ExitCode']}"
+            except Exception as ex:
+                status = f"status unavailable: {ex}"
+            try:
+                ip = self.get_instance_ip(instance_name) or "<empty>"
+            except Exception as ex:
+                ip = f"<unavailable: {ex}>"
         return f"container {container}, {status}, ip {ip}"
 
     def make_hdfs_api(self, timeout=180):

--- a/tests/integration/test_cluster_waiters/test_integration_node_state.py
+++ b/tests/integration/test_cluster_waiters/test_integration_node_state.py
@@ -23,6 +23,7 @@ import pytest  # pylint:disable=import-error; for style check
 from helpers import cluster
 from helpers.cluster import (
     CONTAINER_DESCRIBE_TIMEOUT,
+    CONTAINER_STATE_CHECK_TIMEOUT,
     INTEGRATION_NODE_EXPECTED_STATUSES,
     ClickHouseCluster,
 )
@@ -94,6 +95,7 @@ class _Stub:
 
     check_integration_nodes_state = ClickHouseCluster.check_integration_nodes_state
     process_integration_nodes = ClickHouseCluster.process_integration_nodes
+    bounded_docker_requests = ClickHouseCluster.bounded_docker_requests
     get_instance_docker_id = ClickHouseCluster.get_instance_docker_id
 
     def __init__(self, statuses, project="stubproject"):
@@ -193,6 +195,58 @@ def test_only_the_requested_nodes_are_checked():
     with pytest.raises(Exception) as excinfo:
         requested.check_integration_nodes_state("zookeeper", ["zoo1"], "start")
     assert "zoo1" in str(excinfo.value)
+
+
+def test_every_checking_fetch_is_bounded_below_the_shared_client_timeout():
+    """The check runs on the main path, so an unresponsive daemon would hold it for the
+    shared client's timeout once per node, and three of those outlive the per-test timeout
+    that would otherwise report the failure."""
+    assert CONTAINER_STATE_CHECK_TIMEOUT < SHARED_CLIENT_TIMEOUT
+
+    stub = _Stub({"zoo1": "running", "zoo2": "running", "zoo3": "running"})
+    stub.check_integration_nodes_state("zookeeper", ["zoo1", "zoo2", "zoo3"], "start")
+
+    # Per node, not once for the loop: a bound taken outside it would leave every node
+    # after the first waiting on whatever the previous iteration restored.
+    assert stub.docker_client.fetch_timeouts == [CONTAINER_STATE_CHECK_TIMEOUT] * 3
+
+
+def test_the_checking_bound_is_wider_than_the_describing_one():
+    """The two calls are bounded for opposite reasons: this one decides whether a test
+    passes, so expiring early would fail a run a slow daemon would have completed, while
+    describing only shapes the text of a failure that already happened."""
+    assert CONTAINER_STATE_CHECK_TIMEOUT > CONTAINER_DESCRIBE_TIMEOUT
+
+
+def test_the_shared_client_timeout_is_restored_after_checking():
+    """The client is shared with every other caller, so a lowered timeout that outlived the
+    check would silently shorten unrelated calls, including image pulls."""
+    passing = _Stub({"zoo1": "running"})
+    passing.check_integration_nodes_state("zookeeper", ["zoo1"], "start")
+    assert passing.docker_client.api.timeout == SHARED_CLIENT_TIMEOUT
+
+    # Restored on both failing paths: a node in the wrong state, and one that cannot be
+    # inspected at all, which is the path that raises from inside the bound.
+    wrong_state = _Stub({"zoo1": "exited"})
+    with pytest.raises(Exception):
+        wrong_state.check_integration_nodes_state("zookeeper", ["zoo1"], "start")
+    assert wrong_state.docker_client.api.timeout == SHARED_CLIENT_TIMEOUT
+
+    vanished = _Stub({})
+    with pytest.raises(Exception):
+        vanished.check_integration_nodes_state("zookeeper", ["zoo1"], "start")
+    assert vanished.docker_client.api.timeout == SHARED_CLIENT_TIMEOUT
+
+
+def test_a_client_without_a_request_layer_is_checked_anyway():
+    """Negative control on the bound itself: it must not become the thing that breaks the
+    check. A stub client carrying no `api` is still compared against its status."""
+    stub = _Stub({"zoo1": "exited"})
+    del stub.docker_client.api
+
+    with pytest.raises(Exception) as excinfo:
+        stub.check_integration_nodes_state("zookeeper", ["zoo1"], "start")
+    assert "exited" in str(excinfo.value)
 
 
 def test_each_action_accepts_only_the_statuses_declared_for_it():

--- a/tests/integration/test_cluster_waiters/test_integration_node_state.py
+++ b/tests/integration/test_cluster_waiters/test_integration_node_state.py
@@ -1,12 +1,16 @@
-"""Pins the post-condition check ClickHouseCluster runs after a `docker compose` action.
+"""Pins the post-condition check, and the timeout diagnostic, around a ZooKeeper restart.
 
 `docker compose start zoo1 zoo2 zoo3` can exit 0, and even print `Started`, for a node it
 did not act on, so the harness compares the daemon's own view of every requested node
 against the requested state before logging success. Three properties make that comparison
 meaningful: it reads `State.Status` rather than `State.Running`, it reads the status after
-the action, and it checks the nodes it was asked about. None of them is observable from the
-suites that use the seam, because every one of those drives only the success path, so a
-check that silently became a no-op would keep them all green.
+the action, and it checks the nodes it was asked about. When a node is nevertheless left
+behind, the ZooKeeper waiter is what a reporter reads, so it has to name the node that
+blocked, its container state and the elapsed time instead of guessing at a cause.
+
+None of that is observable from the suites that use these seams, because every one of them
+drives only the success path: a check that silently became a no-op, or a diagnostic that
+lost the node it names, would keep them all green.
 
 The methods under test are the shipped ones, bound to a stub, so these assertions track
 helpers/cluster.py rather than a copy of it. No Docker and no cluster is needed.
@@ -44,9 +48,10 @@ class _FakeDocker:
     before an action keeps reporting the state from before it.
     """
 
-    def __init__(self, states, events):
+    def __init__(self, states, events, ips=None):
         self._states = states
         self._events = events
+        self._ips = ips or {}
         # The code under test reaches a fetch as `docker_client.containers.get(...)`.
         self.containers = self
 
@@ -57,7 +62,17 @@ class _FakeDocker:
         self._events.append(("inspect", container))
         if container not in self._states:
             raise RuntimeError(f"stub: no such container: {container}")
-        return types.SimpleNamespace(attrs={"State": self._states[container]})
+        ip = self._ips.get(container, "")
+        # get_instance_ip reads the first network's address, so the shape matters as much
+        # as the value. `None` stands for the empty map docker leaves behind on a container
+        # that is no longer attached to a network, where the lookup itself raises.
+        networks = {} if ip is None else {"stubnet": {"IPAddress": ip}}
+        return types.SimpleNamespace(
+            attrs={
+                "State": self._states[container],
+                "NetworkSettings": {"Networks": networks},
+            }
+        )
 
 
 class _Stub:
@@ -190,3 +205,185 @@ def test_each_action_accepts_only_the_statuses_declared_for_it():
     other = _Stub({"zoo1": "exited"})
     other.check_integration_nodes_state("zookeeper", ["zoo1"], "restart")
     assert other.events == []
+
+
+# --- the ZooKeeper waiter's timeout diagnostic --------------------------------------
+
+# Small enough to spell out in the assertions below, and the clock is faked, so the whole
+# budget elapses within one arm.
+TIMEOUT = 5.0
+
+
+class _FakeClock:
+    """Advances only when the code under test sleeps, so arms are exact and instant.
+
+    Reads are capped, so a loop that neither sleeps nor exits fails here rather than
+    running until pytest's own timeout.
+    """
+
+    _MAX_READS = 100000
+
+    def __init__(self):
+        self.now = 0.0
+        self.reads = 0
+
+    def time(self):
+        self.reads += 1
+        if self.reads > self._MAX_READS:
+            raise AssertionError(
+                f"clock read over {self._MAX_READS} times without advancing: "
+                "the waiter is spinning without sleeping or exiting"
+            )
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+class _WaiterStub:
+    """Carries only the attributes the waiter and its diagnostic touch."""
+
+    wait_zookeeper_nodes_to_start = ClickHouseCluster.wait_zookeeper_nodes_to_start
+    describe_container_state = ClickHouseCluster.describe_container_state
+    get_instance_ip = ClickHouseCluster.get_instance_ip
+    get_instance_docker_id = ClickHouseCluster.get_instance_docker_id
+
+    def __init__(self, statuses, ips=None, unreachable=(), project="stubproject"):
+        # Names containers on no daemon, so nothing here is shared between arms.
+        self.project_name = project
+        self.events = []
+        self._unreachable = set(unreachable)
+        self.docker_client = _FakeDocker(
+            {self.container(name): _state(status) for name, status in statuses.items()},
+            self.events,
+            {self.container(name): ip for name, ip in (ips or {}).items()},
+        )
+
+    def container(self, name):
+        return self.get_instance_docker_id(name)
+
+    def contacted(self):
+        return [name for kind, name in self.events if kind == "kazoo"]
+
+    def get_kazoo_client(self, zoo_instance_name, timeout=30.0, retries=10):
+        # Matches the keywords the waiter passes; a mismatch would fail the bind instead
+        # of the assertion.
+        assert (timeout, retries) == (5.0, 1)
+        self.events.append(("kazoo", zoo_instance_name))
+        if zoo_instance_name in self._unreachable:
+            # What kazoo raises for a container with no address, which is the shape the
+            # reported CI failure took.
+            raise ValueError("bad hostname")
+        return types.SimpleNamespace(get_children=lambda path: [], stop=lambda: None)
+
+
+def _fake_clock(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(cluster, "time", clock)
+    return clock
+
+
+def test_the_timeout_reports_what_a_reporter_has_to_act_on(monkeypatch):
+    """A node compose left behind is unreachable for the whole budget. The message has to
+    carry the node, its container, the state it is in and how long was spent, because the
+    alternative is a reader guessing at host networking."""
+    _fake_clock(monkeypatch)
+    stub = _WaiterStub(
+        {"zoo1": "running", "zoo2": "running", "zoo3": ("exited", 137)},
+        ips={"zoo1": "172.16.0.2", "zoo2": "172.16.0.3", "zoo3": ""},
+        unreachable=["zoo3"],
+    )
+    with pytest.raises(Exception) as excinfo:
+        stub.wait_zookeeper_nodes_to_start(["zoo1", "zoo2", "zoo3"], timeout=TIMEOUT)
+
+    message = str(excinfo.value)
+    for token in (
+        "zoo3",
+        stub.container("zoo3"),
+        "status exited",
+        "exit code 137",
+        # An address the daemon never assigned is the tell that the container is down.
+        "<empty>",
+        f"after {TIMEOUT:.1f}s of {TIMEOUT}s",
+    ):
+        assert token in message, message
+
+
+def test_the_named_node_is_the_one_that_blocked(monkeypatch):
+    """With a healthy node on either side of the failing one, the message must name the
+    middle node: neither the first of the request nor the last one tried."""
+    _fake_clock(monkeypatch)
+    stub = _WaiterStub(
+        {"zoo1": "running", "zoo2": ("exited", 137), "zoo3": "running"},
+        ips={"zoo1": "172.16.0.2", "zoo2": "", "zoo3": "172.16.0.4"},
+        unreachable=["zoo2"],
+    )
+    with pytest.raises(Exception) as excinfo:
+        stub.wait_zookeeper_nodes_to_start(["zoo1", "zoo2", "zoo3"], timeout=TIMEOUT)
+
+    message = str(excinfo.value)
+    assert "zoo2" in message, message
+    assert "zoo1" not in message and "zoo3" not in message, message
+
+
+def test_only_the_requested_nodes_are_waited_for(monkeypatch):
+    """Several suites restart a subset and leave the rest down on purpose, so a node
+    outside the request is neither contacted nor blamed - even when it is the one that is
+    actually unreachable."""
+    _fake_clock(monkeypatch)
+    stub = _WaiterStub(
+        {"zoo1": ("exited", 137), "zoo2": "running", "zoo3": ("exited", 137)},
+        ips={"zoo1": "", "zoo2": "172.16.0.3", "zoo3": ""},
+        unreachable=["zoo1", "zoo3"],
+    )
+    with pytest.raises(Exception) as excinfo:
+        stub.wait_zookeeper_nodes_to_start(["zoo2", "zoo3"], timeout=TIMEOUT)
+
+    message = str(excinfo.value)
+    assert "zoo3" in message, message
+    assert "zoo1" not in message, message
+    assert "zoo1" not in stub.contacted(), stub.contacted()
+
+
+def test_a_vanished_container_is_described_rather_than_masked(monkeypatch):
+    """The diagnostic runs while a failure is already being reported, so a lookup of its
+    own that fails must not become the exception the reader sees. Both fail here."""
+    _fake_clock(monkeypatch)
+    stub = _WaiterStub({}, unreachable=["zoo1"])
+    with pytest.raises(Exception) as excinfo:
+        stub.wait_zookeeper_nodes_to_start(["zoo1"], timeout=TIMEOUT)
+
+    message = str(excinfo.value)
+    assert "Cannot connect to ZooKeeper node zoo1" in message, message
+    assert "status unavailable" in message, message
+    assert "<unavailable:" in message, message
+
+
+def test_a_container_with_no_address_is_described_rather_than_masked(monkeypatch):
+    """The second lookup fails on its own: the container is still there to inspect, but it
+    is attached to no network, so reading its address raises."""
+    _fake_clock(monkeypatch)
+    stub = _WaiterStub(
+        {"zoo1": ("exited", 137)}, ips={"zoo1": None}, unreachable=["zoo1"]
+    )
+    with pytest.raises(Exception) as excinfo:
+        stub.wait_zookeeper_nodes_to_start(["zoo1"], timeout=TIMEOUT)
+
+    message = str(excinfo.value)
+    assert "Cannot connect to ZooKeeper node zoo1" in message, message
+    assert "status exited, exit code 137" in message, message
+    assert "<unavailable:" in message, message
+
+
+def test_reachable_nodes_return_without_spending_the_budget(monkeypatch):
+    """Negative control: without this arm every assertion above is satisfied by a waiter
+    that raises unconditionally."""
+    clock = _fake_clock(monkeypatch)
+    stub = _WaiterStub(
+        {"zoo1": "running", "zoo2": "running", "zoo3": "running"},
+        ips={"zoo1": "172.16.0.2", "zoo2": "172.16.0.3", "zoo3": "172.16.0.4"},
+    )
+    stub.wait_zookeeper_nodes_to_start(["zoo1", "zoo2", "zoo3"], timeout=TIMEOUT)
+
+    assert stub.contacted() == ["zoo1", "zoo2", "zoo3"]
+    assert clock.now == 0.0

--- a/tests/integration/test_cluster_waiters/test_integration_node_state.py
+++ b/tests/integration/test_cluster_waiters/test_integration_node_state.py
@@ -1,0 +1,192 @@
+"""Pins the post-condition check ClickHouseCluster runs after a `docker compose` action.
+
+`docker compose start zoo1 zoo2 zoo3` can exit 0, and even print `Started`, for a node it
+did not act on, so the harness compares the daemon's own view of every requested node
+against the requested state before logging success. Three properties make that comparison
+meaningful: it reads `State.Status` rather than `State.Running`, it reads the status after
+the action, and it checks the nodes it was asked about. None of them is observable from the
+suites that use the seam, because every one of those drives only the success path, so a
+check that silently became a no-op would keep them all green.
+
+The methods under test are the shipped ones, bound to a stub, so these assertions track
+helpers/cluster.py rather than a copy of it. No Docker and no cluster is needed.
+"""
+
+import types
+
+import pytest  # pylint:disable=import-error; for style check
+
+from helpers import cluster
+from helpers.cluster import INTEGRATION_NODE_EXPECTED_STATUSES, ClickHouseCluster
+
+# Statuses whose `State.Running` is true. It covers three of them, so `Running` cannot
+# distinguish a started container from a paused or restarting one.
+RUNNING_STATUSES = ("running", "paused", "restarting")
+
+ALL_STATUSES = ("running", "exited", "paused", "restarting", "dead", "created")
+
+
+def _state(status):
+    """Build a `State` block. `status` is a status, or a (status, exit code) pair."""
+    status, exit_code = status if isinstance(status, tuple) else (status, 0)
+    return {
+        "Status": status,
+        "Running": status in RUNNING_STATUSES,
+        "ExitCode": exit_code,
+        "OOMKilled": False,
+    }
+
+
+class _FakeDocker:
+    """Records every container fetch, so which node was inspected, and when, is observable.
+
+    A fetch returns the status block held at fetch time, as a real handle does: one taken
+    before an action keeps reporting the state from before it.
+    """
+
+    def __init__(self, states, events):
+        self._states = states
+        self._events = events
+        # The code under test reaches a fetch as `docker_client.containers.get(...)`.
+        self.containers = self
+
+    def set(self, container, status):
+        self._states[container] = _state(status)
+
+    def get(self, container):
+        self._events.append(("inspect", container))
+        if container not in self._states:
+            raise RuntimeError(f"stub: no such container: {container}")
+        return types.SimpleNamespace(attrs={"State": self._states[container]})
+
+
+class _Stub:
+    """Carries only the attributes the bound methods touch."""
+
+    check_integration_nodes_state = ClickHouseCluster.check_integration_nodes_state
+    process_integration_nodes = ClickHouseCluster.process_integration_nodes
+    get_instance_docker_id = ClickHouseCluster.get_instance_docker_id
+
+    def __init__(self, statuses, project="stubproject"):
+        # Names a container on no daemon, so nothing here is shared between arms.
+        self.project_name = project
+        self.events = []
+        self.docker_client = _FakeDocker(
+            {self.container(name): _state(status) for name, status in statuses.items()},
+            self.events,
+        )
+        self.base_zookeeper_cmd = ["docker", "compose", "--project-name", project]
+
+    def container(self, name):
+        return self.get_instance_docker_id(name)
+
+    def inspected(self):
+        return [name for kind, name in self.events if kind == "inspect"]
+
+
+def _stub_compose(stub, monkeypatch, becomes):
+    """Replace the compose call with one that records itself and applies `becomes`: the
+    statuses the daemon holds once the action has run. A node absent from `becomes` is one
+    compose reported success for without acting on it."""
+
+    def fake_call(args, **kwargs):
+        stub.events.append(("compose", list(args)))
+        for name, status in becomes.items():
+            stub.docker_client.set(stub.container(name), status)
+        return ""
+
+    monkeypatch.setattr(cluster, "subprocess_check_call", fake_call)
+
+
+def test_start_names_the_node_compose_left_behind():
+    """The failure a reporter has to act on: which node, which container, what state it is
+    in instead, and what compose claimed."""
+    stub = _Stub({"zoo1": "running", "zoo2": "running", "zoo3": ("exited", 7)})
+    with pytest.raises(Exception) as excinfo:
+        stub.check_integration_nodes_state(
+            "zookeeper", ["zoo1", "zoo2", "zoo3"], "start"
+        )
+
+    message = str(excinfo.value)
+    for token in ("zoo3", stub.container("zoo3"), "exited", "running", "exit code 7"):
+        assert token in message, message
+
+
+def test_requested_nodes_in_the_expected_state_pass_silently():
+    """Negative control: the check adds no failure of its own, and inspects exactly the
+    nodes it was given."""
+    stub = _Stub({"zoo1": "running", "zoo2": "running", "zoo3": "running"})
+    stub.check_integration_nodes_state("zookeeper", ["zoo1", "zoo2", "zoo3"], "start")
+    assert stub.inspected() == [stub.container(n) for n in ("zoo1", "zoo2", "zoo3")]
+
+
+@pytest.mark.parametrize("status", ("paused", "restarting"))
+def test_start_rejects_a_status_that_is_running_but_not_started(status):
+    """A container in either status reports `Running` true while nothing in it is
+    reachable, so only the status distinguishes it from a started one."""
+    assert _state(status)["Running"] is True
+    assert status not in INTEGRATION_NODE_EXPECTED_STATUSES["start"]
+
+    stub = _Stub({"zoo1": status})
+    with pytest.raises(Exception) as excinfo:
+        stub.check_integration_nodes_state("zookeeper", ["zoo1"], "start")
+    assert status in str(excinfo.value)
+
+
+def test_status_is_read_after_the_action(monkeypatch):
+    """A node that was down and did start must pass, and a node compose skipped must fail.
+    Both hold only if the status compared is the one the action left behind."""
+    started = _Stub({"zoo1": "exited"})
+    _stub_compose(started, monkeypatch, becomes={"zoo1": "running"})
+    started.process_integration_nodes("zookeeper", ["zoo1"], "start")
+    assert [kind for kind, _ in started.events] == [
+        "compose",
+        "inspect",
+    ], started.events
+
+    skipped = _Stub({"zoo1": "exited"})
+    _stub_compose(skipped, monkeypatch, becomes={})
+    with pytest.raises(Exception) as excinfo:
+        skipped.process_integration_nodes("zookeeper", ["zoo1"], "start")
+    assert "exited" in str(excinfo.value)
+
+
+def test_only_the_requested_nodes_are_checked():
+    """Several suites start a subset and leave the rest down on purpose, so a node outside
+    the request is not this call's business - while the same node inside it is."""
+    statuses = {"zoo1": "exited", "zoo2": "running", "zoo3": "running"}
+
+    subset = _Stub(statuses)
+    subset.check_integration_nodes_state("zookeeper", ["zoo2", "zoo3"], "start")
+    assert subset.inspected() == [subset.container(n) for n in ("zoo2", "zoo3")]
+
+    requested = _Stub(statuses)
+    with pytest.raises(Exception) as excinfo:
+        requested.check_integration_nodes_state("zookeeper", ["zoo1"], "start")
+    assert "zoo1" in str(excinfo.value)
+
+
+def test_each_action_accepts_only_the_statuses_declared_for_it():
+    """The accepted sets are spelled out here rather than read from the table alone, so
+    that widening the table is a change these arms notice."""
+    accepted = {
+        "start": ("running",),
+        "stop": ("exited", "dead", "created"),
+        "kill": ("exited", "dead", "created"),
+    }
+    assert INTEGRATION_NODE_EXPECTED_STATUSES == accepted
+
+    for action, statuses in accepted.items():
+        for status in statuses:
+            passing = _Stub({"zoo1": status})
+            passing.check_integration_nodes_state("zookeeper", ["zoo1"], action)
+        for status in (s for s in ALL_STATUSES if s not in statuses):
+            failing = _Stub({"zoo1": status})
+            with pytest.raises(Exception):
+                failing.check_integration_nodes_state("zookeeper", ["zoo1"], action)
+
+    # An action with no declared post-condition keeps its previous behaviour: it is not
+    # asserted at all, so it does not even inspect.
+    other = _Stub({"zoo1": "exited"})
+    other.check_integration_nodes_state("zookeeper", ["zoo1"], "restart")
+    assert other.events == []

--- a/tests/integration/test_cluster_waiters/test_integration_node_state.py
+++ b/tests/integration/test_cluster_waiters/test_integration_node_state.py
@@ -21,7 +21,14 @@ import types
 import pytest  # pylint:disable=import-error; for style check
 
 from helpers import cluster
-from helpers.cluster import INTEGRATION_NODE_EXPECTED_STATUSES, ClickHouseCluster
+from helpers.cluster import (
+    CONTAINER_DESCRIBE_TIMEOUT,
+    INTEGRATION_NODE_EXPECTED_STATUSES,
+    ClickHouseCluster,
+)
+
+# The timeout the shipped shared client is built with, which is sized for image pulls.
+SHARED_CLIENT_TIMEOUT = 600
 
 # Statuses whose `State.Running` is true. It covers three of them, so `Running` cannot
 # distinguish a started container from a paused or restarting one.
@@ -54,12 +61,19 @@ class _FakeDocker:
         self._ips = ips or {}
         # The code under test reaches a fetch as `docker_client.containers.get(...)`.
         self.containers = self
+        # docker-py reads this attribute per request, so the value held at fetch time is
+        # the one that request would have waited on.
+        self.api = types.SimpleNamespace(timeout=SHARED_CLIENT_TIMEOUT)
+        self.fetch_timeouts = []
 
     def set(self, container, status):
         self._states[container] = _state(status)
 
     def get(self, container):
         self._events.append(("inspect", container))
+        # One arm removes the request layer, so this bookkeeping must not be what fails.
+        api = getattr(self, "api", None)
+        self.fetch_timeouts.append(getattr(api, "timeout", None))
         if container not in self._states:
             raise RuntimeError(f"stub: no such container: {container}")
         ip = self._ips.get(container, "")
@@ -245,6 +259,7 @@ class _WaiterStub:
 
     wait_zookeeper_nodes_to_start = ClickHouseCluster.wait_zookeeper_nodes_to_start
     describe_container_state = ClickHouseCluster.describe_container_state
+    bounded_docker_requests = ClickHouseCluster.bounded_docker_requests
     get_instance_ip = ClickHouseCluster.get_instance_ip
     get_instance_docker_id = ClickHouseCluster.get_instance_docker_id
 
@@ -387,3 +402,43 @@ def test_reachable_nodes_return_without_spending_the_budget(monkeypatch):
 
     assert stub.contacted() == ["zoo1", "zoo2", "zoo3"]
     assert clock.now == 0.0
+
+
+def test_every_describing_fetch_is_bounded_below_the_shared_client_timeout(monkeypatch):
+    """The diagnostic runs after a budget is already spent, so each of its fetches has to
+    carry a timeout of its own: on the shared client's, a wedged daemon would hold the
+    caller for minutes past the deadline it advertises."""
+    assert CONTAINER_DESCRIBE_TIMEOUT < SHARED_CLIENT_TIMEOUT
+
+    _fake_clock(monkeypatch)
+    stub = _WaiterStub(
+        {"zoo1": ("exited", 137)}, ips={"zoo1": ""}, unreachable=["zoo1"]
+    )
+    with pytest.raises(Exception):
+        stub.wait_zookeeper_nodes_to_start(["zoo1"], timeout=TIMEOUT)
+
+    # Both fetches: the state lookup and the address lookup behind it.
+    assert stub.docker_client.fetch_timeouts == [CONTAINER_DESCRIBE_TIMEOUT] * 2
+
+
+def test_the_shared_client_timeout_is_restored_after_describing():
+    """The client is shared with every other caller, so a lowered timeout that outlived the
+    diagnostic would silently shorten unrelated calls, including image pulls."""
+    stub = _WaiterStub({"zoo1": ("exited", 137)}, ips={"zoo1": ""})
+    stub.describe_container_state("zoo1")
+    assert stub.docker_client.api.timeout == SHARED_CLIENT_TIMEOUT
+
+    # Restored on the failing path too, which is the only path this runs on in practice.
+    vanished = _WaiterStub({})
+    vanished.describe_container_state("zoo1")
+    assert vanished.docker_client.api.timeout == SHARED_CLIENT_TIMEOUT
+
+
+def test_a_client_without_a_request_layer_is_described_anyway():
+    """Negative control on the bound itself: it must not become the thing that breaks the
+    diagnostic. A stub client carrying no `api` still gets described."""
+    stub = _WaiterStub({"zoo1": ("exited", 137)}, ips={"zoo1": ""})
+    del stub.docker_client.api
+
+    described = stub.describe_container_state("zoo1")
+    assert "status exited, exit code 137" in described, described


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/104437
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/104437

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_keeper_session_refuse_stale_server::test_session_refused_on_stale_keeper` failed on
[#104437's `Integration tests (amd_tsan, 3/6)`](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104437&sha=7de491bd2afbb6ad6fd8f9efa7f2c5ce41a54ad2&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%203%2F6%29)
with `Cannot wait ZooKeeper container (probably it's a iptables-nft issue)` after a 180 s timeout,
on a host whose network was fine. From the artifacts: zoo3's graceful stop overran
`stop_grace_period: 5s` and it was SIGKILLed, then `docker compose start zoo1 zoo2 zoo3` returned
0 having issued a `/start` call for zoo1 and zoo2 only (dockerd `/start` POST counts: zoo1 2,
zoo2 2, zoo3 1, and zoo3's is fixture startup). `process_integration_nodes` logged
`Started zookeeper nodes: (zoo1, zoo2, zoo3)`, so the failure surfaced 180 s later at an unrelated
frame, blaming the firewall.

Neither the exit code nor the printed output distinguishes success from a silent skip. On compose
2.29.7 (CI's pin) I measured `start` printing both `Starting` and `Started` for a service that
stayed `exited(7)`, returning 0. Only the daemon's state is reliable.

`process_integration_nodes` now inspects each requested node after the compose call and raises if
its `State.Status` is not what the action asked for, naming the node, container, status and exit
code. `State.Running` is not usable here: it is also true for `paused` and `restarting`. The read is
fresh, since a docker-py handle held across the call reports the old value.
`wait_zookeeper_nodes_to_start` reports the blocking node, its resolved IP (empty is the tell),
container status and elapsed time, with `iptables-nft` no longer all it says.

I could not reproduce the compose/dockerd race itself, here or in #109037; the artifacts are the
evidence for the failure, the measurements above for the mechanism this check asserts against.
#109037 made the invocation atomic, fixing a concurrent-compose race; this skip is inside one
invocation. Out of scope: `stop_zookeeper_nodes` bypasses this seam with a serial per-node loop.

Requested by @ bacek; no open issue found for it.

<details><summary>Validation</summary>

All 8 suites using these wrappers pass: `test_keeper_session_refuse_stale_server`,
`test_check_table` (`kill` path), `test_inserts_with_keeper_retries`, `test_read_only_table`,
`test_reload_zookeeper`, `test_remove_stale_moving_parts`,
`test_replicated_user_defined_functions`, `test_replicated_users`. The last four include the
subset-starting callers (`['zoo2','zoo3']`, `['zoo2']`) that a wrongly scoped check would break.
Target test 20/20 on repeat.

Both directions on the real keeper fixture, with the victim not running after a
successful compose `start`: before the change the wait burns its whole budget and blames
`iptables-nft`; after it, the failure is immediate (0.2 s) and names the node. Negative control
with every node genuinely up stays silent.

`test_cluster_waiters/test_integration_node_state.py` adds 13 arms that bind the shipped methods
and run in 0.1 s with no Docker. Seven cover the check: message contents, a negative control,
`paused` and `restarting` rejected for `start`, the read happening after the action in both
directions, subset scoping, the action/status matrix. Six cover the diagnostic, on a faked clock:
message contents, the named node being the one that blocked rather than the first or last, subset
scoping, each of the helper's two lookups failing without masking the reported failure, and a
negative control that returns without spending the budget. None of the 8 suites can see any of
it, since each drives only the success path.

Nine mutants confirm the arms bite: an early-return no-op check reddens all seven of its arms; a
`State.Running` oracle reddens `paused` and `restarting`; a handle cached across the action
reddens freshness; a fixed node set reddens scoping, freshness and the matrix; the old message
reddens five diagnostic arms; dropping the blocking-node tracking reddens three; unguarding
either lookup reddens its own arm; removing the early return reddens the negative control.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116044&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116044](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116044+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
