### PR TITLE
Await the consumer channel close before deleting RabbitMQ queues on DROP TABLE

### DIFF
--- a/src/Storages/RabbitMQ/RabbitMQConsumer.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQConsumer.cpp
@@ -49,8 +49,31 @@ void RabbitMQConsumer::wakeUp()
 
 void RabbitMQConsumer::closeConnections()
 {
-    if (consumer_channel)
-        consumer_channel->close();
+    if (!consumer_channel)
+        return;
+
+    auto closing = std::make_shared<ChannelCloseState>();
+    close_state = closing;
+
+    consumer_channel->close()
+    .onSuccess([this, closing]()
+    {
+        if (closing->abandoned)
+            return;
+        LOG_TRACE(log, "Consumer channel {} is closed", channel_id);
+        closing->completed = true;
+        event_handler.stopBlockingLoop();
+    })
+    .onError([this, closing](const char * message)
+    {
+        if (closing->abandoned)
+            return;
+        LOG_ERROR(log, "Failed to close consumer channel {}: {}", channel_id, message);
+        /// An error also completes the wait: a channel that could not be closed is not going to
+        /// keep holding the queue, and treating it as outstanding would burn the whole timeout.
+        closing->completed = true;
+        event_handler.stopBlockingLoop();
+    });
 }
 
 void RabbitMQConsumer::subscribe()

--- a/src/Storages/RabbitMQ/RabbitMQConsumer.h
+++ b/src/Storages/RabbitMQ/RabbitMQConsumer.h
@@ -88,10 +88,26 @@ public:
 
     void closeConnections();
 
+    /// True once the broker has answered the channel.close sent by closeConnections(). A consumer
+    /// that never had a channel reports true, as there is nothing to wait for.
+    bool isChannelCloseCompleted() const { return !close_state || close_state->completed; }
+
+    /// Stop expecting that answer, so a callback dispatched later becomes a no-op.
+    void abandonChannelClose() { if (close_state) close_state->abandoned = true; }
+
 private:
     void subscribe();
     bool isChannelUsable();
     void updateCommitInfo(CommitInfo record);
+
+    /// Shared by value into the close() callbacks, mirroring RabbitMQProducer::finish, so that a
+    /// late dispatch after the wait was abandoned cannot touch a destroyed consumer.
+    struct ChannelCloseState
+    {
+        std::atomic<bool> completed = false;
+        std::atomic<bool> abandoned = false;
+    };
+    std::shared_ptr<ChannelCloseState> close_state;
 
     ChannelPtr consumer_channel;
     RabbitMQHandler & event_handler; /// Used concurrently, but is thread safe.

--- a/src/Storages/RabbitMQ/RabbitMQHandler.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQHandler.cpp
@@ -72,6 +72,11 @@ bool RabbitMQHandler::startBlockingLoopWithTimeout(uint64_t timeout_ms)
 
     bool timed_out = false;
 
+    /// uv_timer_start() derives the deadline from the loop's cached time, which is only refreshed
+    /// while the loop runs. Between two blocking waits the loop is idle, so the cached value can be
+    /// arbitrarily far in the past and the timer would then already be overdue when it is armed.
+    uv_update_time(loop);
+
     uv_timer_t timer;
     uv_timer_init(loop, &timer);
     timer.data = &timed_out;

--- a/src/Storages/RabbitMQ/RabbitMQHandler.h
+++ b/src/Storages/RabbitMQ/RabbitMQHandler.h
@@ -23,6 +23,12 @@ namespace Loop
 /// DROP TABLE / INSERT shutdown / server shutdown can block when the broker connection is dead.
 static const uint64_t BLOCKING_LOOP_TIMEOUT_MS = 30000;
 
+/// Timeout for waiting on the consumer channels to close before a dropped table deletes its
+/// queues. Far below BLOCKING_LOOP_TIMEOUT_MS because the wait needs a single channel.close round
+/// trip, while a channel awaiting a reply that never comes queues its close and would make every
+/// DROP TABLE pay the timeout in full. Giving up restores the behaviour of not waiting at all.
+static const uint64_t CONSUMER_CHANNEL_CLOSE_TIMEOUT_MS = 1000;
+
 using ChannelPtr = std::unique_ptr<AMQP::TcpChannel>;
 
 class RabbitMQHandler : public AMQP::LibUvHandler

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -34,6 +34,7 @@
 #include <Common/Exception.h>
 #include <Common/Macros.h>
 #include <Common/RemoteHostFilter.h>
+#include <Common/Stopwatch.h>
 #include <Common/logger_useful.h>
 #include <Common/parseAddress.h>
 
@@ -1063,7 +1064,10 @@ void StorageRabbitMQ::shutdown(bool)
         }
 
         if (drop_table)
+        {
+            waitForConsumerChannelsToClose(consumers_snapshot);
             cleanupRabbitMQ();
+        }
 
         /// It is important to close connection here - before removing consumers, because
         /// it will finish and clean callbacks, which might use those consumers data.
@@ -1091,6 +1095,51 @@ void StorageRabbitMQ::renameInMemory(const StorageID & new_table_id)
     const auto prev_storage_id = getStorageID();
     IStorage::renameInMemory(new_table_id);
     StreamingStorageRegistry::instance().renameTable(prev_storage_id, getStorageID());
+}
+
+
+/// AMQP orders method completion per channel only, so a queue.delete issued on a fresh channel can
+/// be evaluated by the broker while the consumer is still registered on its own channel, and a
+/// classic queue then refuses AMQP::ifunused with PRECONDITION_FAILED. The broker deregisters a
+/// channel's consumers while handling its channel.close, before answering it, so waiting for that
+/// answer establishes the ordering the delete needs.
+void StorageRabbitMQ::waitForConsumerChannelsToClose(
+    const std::vector<std::weak_ptr<RabbitMQConsumer>> & consumers_snapshot) const
+{
+    if (use_user_setup || consumers_snapshot.empty() || !connection->isConnected())
+        return;
+
+    auto outstanding = [&consumers_snapshot]
+    {
+        for (const auto & consumer_weak : consumers_snapshot)
+            if (auto consumer = consumer_weak.lock(); consumer && !consumer->isChannelCloseCompleted())
+                return true;
+        return false;
+    };
+
+    /// Each close that completes stops the loop, so re-enter it while any consumer is outstanding.
+    /// The remaining time is read once per iteration, because computing it from a second reading
+    /// of the clock could underflow past the bound into an effectively unbounded wait.
+    Stopwatch watch;
+    while (outstanding())
+    {
+        const auto elapsed = watch.elapsedMilliseconds();
+        if (elapsed >= CONSUMER_CHANNEL_CLOSE_TIMEOUT_MS)
+            break;
+        if (!connection->getHandler().startBlockingLoopWithTimeout(CONSUMER_CHANNEL_CLOSE_TIMEOUT_MS - elapsed))
+            break;
+    }
+
+    if (outstanding())
+    {
+        for (const auto & consumer_weak : consumers_snapshot)
+            if (auto consumer = consumer_weak.lock())
+                consumer->abandonChannelClose();
+
+        LOG_WARNING(log, "Timed out waiting for consumer channels to close after {} ms. "
+                         "Queue deletion may be refused while the consumers are still registered",
+                    watch.elapsedMilliseconds());
+    }
 }
 
 

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1013,7 +1013,7 @@ void StorageRabbitMQ::scheduleStreamingTasksImpl()
 }
 
 
-void StorageRabbitMQ::shutdown(bool)
+void StorageRabbitMQ::shutdown(bool is_drop)
 {
     /// Needed to make this method idempotent
     if (shutdown_called.exchange(true))
@@ -1063,7 +1063,10 @@ void StorageRabbitMQ::shutdown(bool)
             consumer->closeConnections();
         }
 
-        if (drop_table)
+        /// checkTableCanBeDropped() latches drop_table before the statement it guards can fail, and
+        /// nothing ever clears it, so the flag alone also marks a still-alive table whose TRUNCATE
+        /// or dependency check threw. Deleting the queues needs the shutdown to be a drop as well.
+        if (is_drop && drop_table)
         {
             waitForConsumerChannelsToClose(consumers_snapshot);
             cleanupRabbitMQ();

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.h
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.h
@@ -196,6 +196,7 @@ private:
 
     void initRabbitMQ();
     void cleanupRabbitMQ() const;
+    void waitForConsumerChannelsToClose(const std::vector<std::weak_ptr<RabbitMQConsumer>> & consumers_snapshot) const;
 
     void bindExchange(AMQP::TcpChannel & rabbit_channel);
     void bindQueue(size_t queue_id, AMQP::TcpChannel & rabbit_channel);

--- a/src/Storages/tests/gtest_rabbitmq_handler.cpp
+++ b/src/Storages/tests/gtest_rabbitmq_handler.cpp
@@ -7,6 +7,9 @@
 #include <Storages/RabbitMQ/RabbitMQHandler.h>
 #include <Common/logger_useful.h>
 
+#include <chrono>
+#include <thread>
+
 using namespace DB;
 
 /// Regression test for the dead-connection hang (issue #108496). When RabbitMQ closes the
@@ -49,6 +52,32 @@ TEST(RabbitMQHandler, BlockingLoopReturnsTrueWhenStopped)
     uv_run(loop.getLoop(), UV_RUN_NOWAIT);
 
     EXPECT_TRUE(finished_naturally);
+}
+
+/// The timeout must span the requested interval no matter how long the loop sat idle beforehand.
+/// libuv derives a timer's deadline from a clock the loop caches while it runs, so an idle loop
+/// holds an arbitrarily old value, and a timer armed against it is already overdue and fires on the
+/// first iteration. A wait that returns immediately is indistinguishable from a broker that never
+/// answered, which turns every bounded wait into a no-op.
+TEST(RabbitMQHandler, BlockingLoopHonoursTimeoutAfterIdlePeriod)
+{
+    UVLoop loop;
+    RabbitMQHandler handler(loop.getLoop(), getLogger("RabbitMQHandlerTest"));
+
+    /// One turn so the loop caches a timestamp, then let that cached value age well past the
+    /// timeout used below. Nothing may drive the loop during the wait, as that would refresh it.
+    uv_run(loop.getLoop(), UV_RUN_NOWAIT);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    /// Nothing calls stopBlockingLoop(), so the only way out is the timeout itself.
+    auto started_at = std::chrono::steady_clock::now();
+    bool finished_naturally = handler.startBlockingLoopWithTimeout(/* timeout_ms = */ 500);
+    auto elapsed = std::chrono::steady_clock::now() - started_at;
+
+    EXPECT_FALSE(finished_naturally);
+    /// Only a lower bound is asserted: a loaded machine can overshoot the timeout, but it cannot
+    /// make the wait end early.
+    EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 400);
 }
 
 #endif

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2213,10 +2213,17 @@ def test_rabbitmq_drop_table_waits_for_consumer_channels(rabbitmq_cluster, db, u
 
     assert channel.queue_declare(queue=queue, passive=True)
 
-    # Both patterns are scoped to this table's own logger, so no other test in this module can
-    # satisfy them, and the close they match is this table's own consumer channel.
+    # All three patterns are scoped to this table's own logger, so no other test in this module can
+    # satisfy them, and the close they match is this table's own consumer channel. The bound in the
+    # wait pattern is what distinguishes the awaiting wait from the unrelated 30000ms ones: the
+    # remaining time shrinks across iterations, so any value below the four-digit ceiling matches
+    # while 30000 cannot.
     closed_pattern = f"StorageRabbitMQ ({table}): Consumer channel .* is closed"
     deleted_pattern = f"StorageRabbitMQ ({table}): Successfully deleted queue {queue}"
+    wait_pattern = (
+        f"StorageRabbitMQ ({table}): "
+        r"Started blocking loop with [0-9]\{1,4\}ms timeout"
+    )
 
     def first_timestamp(lines):
         match = re.search(r"\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.\d+", lines)
@@ -2224,6 +2231,7 @@ def test_rabbitmq_drop_table_waits_for_consumer_channels(rabbitmq_cluster, db, u
         return match.group(0)
 
     assert not instance.grep_in_log(closed_pattern), "consumer channel closed before DROP TABLE"
+    assert not instance.grep_in_log(wait_pattern), "consumer channels awaited before DROP TABLE"
 
     instance.query(f"DROP TABLE {table}")
 
@@ -2240,6 +2248,15 @@ def test_rabbitmq_drop_table_waits_for_consumer_channels(rabbitmq_cluster, db, u
     assert closed, "DROP TABLE deleted the queue without awaiting the consumer channel close"
     assert first_timestamp(closed) <= first_timestamp(deleted), (
         f"consumer channel closed after the queue was deleted:\n{closed}\n{deleted}"
+    )
+
+    # The close alone can be ordered first by the reply merely arriving early, so require the wait
+    # itself to have run before the deletion. That edge exists only when the queues are deleted
+    # after awaiting the channels, rather than concurrently with them.
+    waited = instance.grep_in_log(wait_pattern, only_latest=True)
+    assert waited, "DROP TABLE deleted the queue without waiting for the consumer channels"
+    assert first_timestamp(waited) <= first_timestamp(deleted), (
+        f"consumer channels awaited after the queue was deleted:\n{waited}\n{deleted}"
     )
 
     # The queue must be really gone, not merely reported as deleted. Only a 404 means that.

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2268,6 +2268,70 @@ def test_rabbitmq_drop_table_waits_for_consumer_channels(rabbitmq_cluster, db, u
         pytest.fail(f"Queue {queue} still exists after DROP TABLE.")
 
 
+def test_rabbitmq_detach_after_failed_truncate_keeps_queue(rabbitmq_cluster, db, unique):
+    # checkTableCanBeDropped() marks the table before the statement it guards can fail, and nothing
+    # ever unmarks it, so a table whose TRUNCATE threw stays marked while remaining fully alive. A
+    # later DETACH is not a drop, so it must leave the queue and its unconsumed messages alone.
+    table = f"{db}.rabbitmq_detach_keeps_queue"
+    queue = f"{unique}_rabbit_queue_detach_keeps"
+    instance.query(
+        f"""
+        CREATE TABLE {table} (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_exchange_name = '{unique}_detach_keeps',
+                     rabbitmq_format = 'JSONEachRow',
+                     rabbitmq_queue_base = '{queue}'
+        """
+    )
+
+    credentials = pika.PlainCredentials("root", "clickhouse")
+    parameters = pika.ConnectionParameters(
+        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    channel.basic_publish(
+        exchange=f"{unique}_detach_keeps", routing_key="", body=json.dumps({"key": 1, "value": 2})
+    )
+
+    # Reading attaches the consumer, so the shutdown below takes the same path a drop would.
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        if instance.query(f"SELECT * FROM {table} ORDER BY key", ignore_error=True) == "1\t2\n":
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached before reading a message.")
+
+    assert channel.queue_declare(queue=queue, passive=True)
+
+    # RabbitMQ does not implement truncate, so this throws after the table was already marked.
+    error = instance.query_and_get_error(f"TRUNCATE TABLE {table}")
+    assert "NOT_IMPLEMENTED" in error, f"TRUNCATE failed for another reason: {error}"
+
+    # The table is still alive, so the mark it now carries must not turn this into a queue deletion.
+    instance.query(f"DETACH TABLE {table}")
+
+    # Both patterns are scoped to this table's own logger, so no other test can satisfy them. The
+    # refusal line is checked as well, so a delete that was attempted and refused cannot pass for
+    # one that was never attempted.
+    deleted_pattern = f"StorageRabbitMQ ({table}): Successfully deleted queue {queue}"
+    failed_pattern = f"StorageRabbitMQ ({table}): Failed to delete queue {queue}"
+    assert not instance.grep_in_log(deleted_pattern), "DETACH TABLE deleted the queue"
+    assert not instance.grep_in_log(failed_pattern), "DETACH TABLE tried to delete the queue"
+
+    # A passive declare that 404s closes the channel, so ask on a channel nothing else has used.
+    check_channel = connection.channel()
+    assert check_channel.queue_declare(queue=queue, passive=True), (
+        f"Queue {queue} is gone after DETACH TABLE."
+    )
+
+    instance.query(f"ATTACH TABLE {table}")
+    instance.query(f"DROP TABLE {table}")
+
+
 def test_rabbitmq_queue_settings(rabbitmq_cluster, db, unique):
     instance.query(
         f"""

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2172,6 +2172,85 @@ def test_rabbitmq_drop_table_properly(rabbitmq_cluster, db, unique):
         time.sleep(min(0.5, remaining))
 
 
+def test_rabbitmq_drop_table_waits_for_consumer_channels(rabbitmq_cluster, db, unique):
+    # A queue.delete carries AMQP::ifunused, and AMQP orders method completion per channel only,
+    # so the delete is issued on a fresh channel while the consumer may still be registered on
+    # its own one, and a classic queue then refuses it. The broker deregisters a channel's
+    # consumers while handling its channel.close, before answering it, so DROP TABLE must see
+    # that answer before it asks for the deletion.
+    table = f"{db}.rabbitmq_drop_awaits"
+    queue = f"{unique}_rabbit_queue_drop_awaits"
+    instance.query(
+        f"""
+        CREATE TABLE {table} (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_exchange_name = '{unique}_drop_awaits',
+                     rabbitmq_format = 'JSONEachRow',
+                     rabbitmq_queue_base = '{queue}'
+        """
+    )
+
+    credentials = pika.PlainCredentials("root", "clickhouse")
+    parameters = pika.ConnectionParameters(
+        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    channel.basic_publish(
+        exchange=f"{unique}_drop_awaits", routing_key="", body=json.dumps({"key": 1, "value": 2})
+    )
+
+    # Reading attaches the consumer whose channel the deletion has to wait for.
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        if instance.query(f"SELECT * FROM {table} ORDER BY key", ignore_error=True) == "1\t2\n":
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached before reading a message.")
+
+    assert channel.queue_declare(queue=queue, passive=True)
+
+    # Both patterns are scoped to this table's own logger, so no other test in this module can
+    # satisfy them, and the close they match is this table's own consumer channel.
+    closed_pattern = f"StorageRabbitMQ ({table}): Consumer channel .* is closed"
+    deleted_pattern = f"StorageRabbitMQ ({table}): Successfully deleted queue {queue}"
+
+    def first_timestamp(lines):
+        match = re.search(r"\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.\d+", lines)
+        assert match, f"no timestamp in matched log lines: {lines}"
+        return match.group(0)
+
+    assert not instance.grep_in_log(closed_pattern), "consumer channel closed before DROP TABLE"
+
+    instance.query(f"DROP TABLE {table}")
+
+    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        deleted = instance.grep_in_log(deleted_pattern, only_latest=True)
+        if deleted:
+            break
+        time.sleep(0.5)
+    else:
+        pytest.fail(f"Queue {queue} was not deleted within {DEFAULT_TIMEOUT_SEC} seconds.")
+
+    closed = instance.grep_in_log(closed_pattern, only_latest=True)
+    assert closed, "DROP TABLE deleted the queue without awaiting the consumer channel close"
+    assert first_timestamp(closed) <= first_timestamp(deleted), (
+        f"consumer channel closed after the queue was deleted:\n{closed}\n{deleted}"
+    )
+
+    # The queue must be really gone, not merely reported as deleted. Only a 404 means that.
+    try:
+        channel.queue_declare(queue=queue, passive=True)
+    except pika.exceptions.ChannelClosedByBroker as e:
+        assert e.reply_code == 404, f"unexpected channel close: {e}"
+    else:
+        pytest.fail(f"Queue {queue} still exists after DROP TABLE.")
+
+
 def test_rabbitmq_queue_settings(rabbitmq_cluster, db, unique):
     instance.query(
         f"""


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/114269


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a broker-side queue leak when dropping a `RabbitMQ` table. `DROP TABLE` asked the broker to delete the table's queues without waiting for its own consumer channels to close, so the broker could still see a registered consumer and refuse the deletion with `PRECONDITION_FAILED`. The queues are declared durable and are never auto-deleted, so they survived permanently together with any unconsumed messages.

### Description

`StorageRabbitMQ::shutdown()` sent `channel.close` on every consumer channel and then immediately issued `queue.delete` with `AMQP::ifunused` on a separate, freshly created channel. AMQP orders method completion per channel only, so the broker could evaluate the deletion while the consumer was still registered on the other channel. A classic queue then answers exactly what the flag asks for, `PRECONDITION_FAILED - queue '...' in use`, which was logged before giving up. Losing that race depends on broker scheduling, so it is rare.

`shutdown()` now waits, on a dropped table only, for the broker to answer those closes before asking for the deletion. `rabbit_channel` deregisters a channel's consumers while handling its `channel.close`, before answering it, so that answer is the ordering the deletion needs. The deletion is unchanged: still a single `ifunused` attempt, so a queue shared through `rabbitmq_queue_base` still survives.

The cleanup now also requires `shutdown()`'s own drop argument, so a failed `TRUNCATE` latching the internal drop flag no longer costs a later `DETACH` its queues.

The bound is small rather than the 30s used elsewhere: a channel awaiting a reply that never arrives queues its own close, so such a table would otherwise pay the full timeout on every `DROP TABLE`. Expiring restores the previous behaviour.

`startBlockingLoopWithTimeout` also refreshes the loop's cached time before arming its timer: `uv_timer_start` derives the deadline from that value, which libuv only updates while the loop runs, so between two waits the timer can already be overdue and the wait returns at once. The four pre-existing 30s waits could end early the same way.

Two limitations are out of scope. Quorum and stream queues still leak, because the broker does not implement `if-unused` for them at all, so no client-side barrier helps. A table that has already nacked also still leaks, tracked separately as an AMQP-CPP defect.

<details>
<summary>Validation (deterministic forcing, base vs fixed binary)</summary>

The losing interleaving was forced deterministically by suspending the consumer channel's broker-side process until its `channel.close` arrived, then releasing it after 300ms.

| Arm | Base | Fixed |
|---|---|---|
| queue deleted, forced losing interleaving | 6/6 leaked | 6/6 deleted |
| same fixture with no forcing (control) | 3/3 deleted | - |
| ordinary drop, mean wall time over 10 | 0.1015s | 0.0980s |
| queue shared through `rabbitmq_queue_base` | survives | survives |
| shared queue, other table reconnecting during the drop | survives | survives |
| table that has nacked, drop wall time | 0.18s | 1.08s |
| `DETACH TABLE`, added waits | 0s, 0 | 0s, 0 |
| `rabbitmq_num_consumers = 2` | leaked | deleted |

`test_storage_rabbitmq/` was run on both binaries: 58 passed on the fixed one, and the two
failures (`test_rabbitmq_select[1]`, `test_rabbitmq_broker_log_is_collected`) fail identically on
the base binary and are unrelated to this change. The new test fails on the base binary and passes
on the fixed one; it plus `test_rabbitmq_drop_table_properly` ran 50 times each, 100/100 passed.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116050&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116050](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116050+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.258` (included in `26.10` and later)
<!-- ch-version-info:end -->