### PR TITLE
Fix a hang in the `always_read_till_end` drain of sorted merges

### DIFF
--- a/src/Processors/Merges/IMergingTransform.cpp
+++ b/src/Processors/Merges/IMergingTransform.cpp
@@ -217,14 +217,18 @@ IProcessor::Status IMergingTransformBase::prepare()
         {
             for (auto & input : inputs)
             {
-                if (!input.isFinished())
-                {
-                    input.setNeeded();
-                    if (input.hasData())
-                        std::ignore = input.pull();
+                if (input.isFinished())
+                    continue;
 
+                input.setNeeded();
+                if (input.hasData())
+                    std::ignore = input.pull();
+
+                /// `isFinished()` is masked by a buffered chunk, so an input can report
+                /// not-finished here and be finished right after the pull. A finished producer
+                /// emits no further event, so waiting on such an input would never wake up.
+                if (!input.isFinished())
                     return Status::NeedData;
-                }
             }
         }
 

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.reference
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.reference
@@ -127,5 +127,5 @@
 
 	"rows": 1,
 
-	"rows_before_limit_at_least": 44
+	"rows_before_limit_at_least": 33
 }

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.reference
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.reference
@@ -105,3 +105,27 @@
 
 	"rows_before_limit_at_least": 20
 }
+
+-- Assert rows_before_limit for a merge over nested remote streams, exact
+{
+	"meta":
+	[
+		{
+			"name": "id",
+			"type": "Int32"
+		},
+		{
+			"name": "max(val)",
+			"type": "String"
+		}
+	],
+
+	"data":
+	[
+		[0, "40"]
+	],
+
+	"rows": 1,
+
+	"rows_before_limit_at_least": 44
+}

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.sql
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.sql
@@ -42,12 +42,12 @@ FORMAT JSONCompact SETTINGS max_block_size=1, exact_rows_before_limit = 1, distr
 SELECT '';
 SELECT '-- Assert rows_before_limit for a merge over nested remote streams, exact';
 
--- Reading a Distributed table through remote() nests the merges, so the outer merge over the
--- sequence-number reorder gets one input that finishes while a chunk of it is still buffered.
--- max_threads pins the receive fan-out that produces that shape.
+-- max_threads and prefer_localhost_replica are pinned because the shape this asserts needs a
+-- receive fan-out above 1 and a fixed replica topology; the runner randomizes both, and the
+-- topology decides how many legs the rows_before_limit counter sees.
 SELECT DISTINCT id, max(val) FROM remote('127.0.0.{1,2}', currentDatabase(), 03408_dist)
 GROUP BY GROUPING SETS ((), (id)) ORDER BY ALL ASC LIMIT 1
-FORMAT JSONCompact SETTINGS max_block_size=1, exact_rows_before_limit = 1, distributed_group_by_no_merge=2, max_threads=16;
+FORMAT JSONCompact SETTINGS max_block_size=1, exact_rows_before_limit = 1, distributed_group_by_no_merge=2, max_threads=16, prefer_localhost_replica=1;
 
 DROP TABLE 03408_local;
 DROP TABLE 03408_dist;

--- a/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.sql
+++ b/tests/queries/0_stateless/03408_limit_by_rows_before_limit_dist.sql
@@ -39,5 +39,15 @@ SELECT '-- Assert rows_before_limit for distributed without LIMIT BY on initiato
 SELECT id, max(val) FROM 03408_dist GROUP BY id ORDER BY id LIMIT 1 BY id LIMIT 4
 FORMAT JSONCompact SETTINGS max_block_size=1, exact_rows_before_limit = 1, distributed_group_by_no_merge=2;
 
+SELECT '';
+SELECT '-- Assert rows_before_limit for a merge over nested remote streams, exact';
+
+-- Reading a Distributed table through remote() nests the merges, so the outer merge over the
+-- sequence-number reorder gets one input that finishes while a chunk of it is still buffered.
+-- max_threads pins the receive fan-out that produces that shape.
+SELECT DISTINCT id, max(val) FROM remote('127.0.0.{1,2}', currentDatabase(), 03408_dist)
+GROUP BY GROUPING SETS ((), (id)) ORDER BY ALL ASC LIMIT 1
+FORMAT JSONCompact SETTINGS max_block_size=1, exact_rows_before_limit = 1, distributed_group_by_no_merge=2, max_threads=16;
+
 DROP TABLE 03408_local;
 DROP TABLE 03408_dist;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/114723
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a hang in a sorted merge when `exact_rows_before_limit` is enabled. A query with `LIMIT` over sorted remote streams could stop making progress after the merge reached its limit, because the merge waited for an input that had already finished. In debug and sanitizer builds this surfaced as a `Pipeline stuck` logical error instead.

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/114723

`IMergingTransformBase::prepare` reads every source to the end when `always_read_till_end` is set
(from `exact_rows_before_limit`), so `rows_before_limit_at_least` stays exact. That drain returned
`NeedData` unconditionally after touching the first unfinished input.

`InputPort::isFinished()` is masked by a buffered chunk: a producer may push its last chunk and
finish within one `prepare`, and until that chunk is consumed the input reports not-finished. The
drain therefore picked such an input, pulled the chunk (after which the input really is finished)
and then waited on it. Its producer was already `Finished` and emitted no further event, so nothing
rescheduled the merge. It stayed parked in `NeedData` while a later input remained back-pressured:
in a release build the query hangs; in debug and sanitizer builds `finalizeExecution` throws
`Pipeline stuck`.

The fix re-checks the input after the pull and continues to the next one, returning `NeedData` only
while some producer can still deliver. `LimitTransform`, the only other `always_read_till_end`
drain, already does this. When every input turns out finished, control falls through into the
existing completion path.

Reachable on unpatched master via a `Distributed` table read through `remote()`: 17 `Pipeline stuck`
rows across 15 distinct pull requests since 2026-07-22, on `AST fuzzer` and `BuzzHouse` in the
debug, ASan+UBSan, MSan and TSan builds.

Validation: the added case in `03408_limit_by_rows_before_limit_dist` fails on master and passes
with the fix (50/50 randomized runs clean). The drain's purpose is preserved: reported
`rows_before_limit_at_least` is byte-identical before and after across 25 query/`max_threads`
combinations. All 13 `IMergingTransformBase` subclasses share this `prepare`, but 12 hardcode
`always_read_till_end = false`, so only `MergingSortedTransform` reaches the changed loop.

Not addressed here: the exact `rows_before_limit_at_least` count for plan-based parallel replicas,
which #114723 also asks for. That needs the per-replica sort to become unbounded
(`applyParallelReplicas.cpp` carries a `FIXME` for it) and was not re-tested against this change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116051&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116051](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116051+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116051&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116051](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116051+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116051&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116051](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116051+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
