### PR TITLE
Apply openSSL cipherList when the value is on its own line

### DIFF
--- a/base/poco/NetSSL_OpenSSL/src/Context.cpp
+++ b/base/poco/NetSSL_OpenSSL/src/Context.cpp
@@ -18,6 +18,7 @@
 #include "Poco/Net/Utility.h"
 #include "Poco/File.h"
 #include "Poco/Path.h"
+#include "Poco/String.h"
 #include "Poco/DirectoryIterator.h"
 #include "Poco/RegularExpression.h"
 #include "Poco/Timestamp.h"
@@ -316,7 +317,33 @@ void Context::init(const Params& params)
 		else
 			SSL_CTX_set_verify(_pSSLContext, params.verificationMode, &SSLManager::verifyClientCallback);
 
-		SSL_CTX_set_cipher_list(_pSSLContext, params.cipherList.c_str());
+		// Only ':', ' ', ';' and ',' separate items in an OpenSSL cipher list, so a newline or
+		// tab is a lexing error rather than padding, and it makes the whole list unusable.
+		std::string cipherList = Poco::trim(params.cipherList);
+
+		// The reason code below only describes this call if the queue is empty on entry: the
+		// default-CA probing above leaves errors queued for candidate paths it discards, and
+		// ERR_peek_error() returns the oldest entry.
+		ERR_clear_error();
+		if (SSL_CTX_set_cipher_list(_pSSLContext, cipherList.c_str()) != 1)
+		{
+			unsigned long err = ERR_peek_error();
+
+			// Manually unwrap ERR_GET_REASON(err) due to ossl_unused
+			// https://github.com/openssl/openssl/issues/16776
+			bool noCipherMatch = (err & ERR_SYSTEM_FLAG) == 0 && (err & ERR_REASON_MASK) == SSL_R_NO_CIPHER_MATCH;
+
+			// A list that lexes but selects no TLS 1.2 or older cipher is legitimate - a
+			// TLS 1.3 only deployment reaches this - so only an unlexable list is an error.
+			if (noCipherMatch)
+				ERR_clear_error();
+			else
+			{
+				std::string msg = Utility::getLastError();
+				throw SSLContextException(std::string("Cannot set cipher list ") + cipherList, msg);
+			}
+		}
+
 		SSL_CTX_set_verify_depth(_pSSLContext, params.verificationDepth);
 		SSL_CTX_set_mode(_pSSLContext, SSL_MODE_AUTO_RETRY);
 		SSL_CTX_set_session_cache_mode(_pSSLContext, SSL_SESS_CACHE_OFF);

--- a/base/poco/NetSSL_OpenSSL/src/Context.cpp
+++ b/base/poco/NetSSL_OpenSSL/src/Context.cpp
@@ -318,7 +318,7 @@ void Context::init(const Params& params)
 			SSL_CTX_set_verify(_pSSLContext, params.verificationMode, &SSLManager::verifyClientCallback);
 
 		// Only ':', ' ', ';' and ',' separate items in an OpenSSL cipher list, so a newline or
-		// tab is a lexing error rather than padding, and it makes the whole list unusable.
+		// tab is a lexing error rather than padding.
 		std::string cipherList = Poco::trim(params.cipherList);
 
 		// The reason code below only describes this call if the queue is empty on entry: the

--- a/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher_padded.yml
+++ b/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher_padded.yml
@@ -1,0 +1,21 @@
+openSSL:
+  server:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    privateKeyFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.key'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'none'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    # The value sits on its own line, as an XML/YAML auto-formatter writes it.
+    cipherList: "\n            ECDHE-RSA-AES256-GCM-SHA384\n        "
+  client:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'relaxed'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    cipherList: "\n            ECDHE-RSA-AES256-GCM-SHA384\n        "

--- a/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher_tls13_only.yml
+++ b/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher_tls13_only.yml
@@ -1,0 +1,23 @@
+openSSL:
+  server:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    privateKeyFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.key'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'none'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    # Lexes, but names only a TLS 1.3 suite, so it selects no TLS 1.2 or older
+    # cipher. SSL_CTX_set_cipher_list reports failure for this, and it must be
+    # tolerated rather than rejected.
+    cipherList: 'TLS_AES_256_GCM_SHA384'
+  client:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'relaxed'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    cipherList: 'TLS_AES_256_GCM_SHA384'

--- a/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher_unlexable.yml
+++ b/tests/integration/test_keeper_internal_secure/configs/ssl_conf_cipher_unlexable.yml
@@ -1,0 +1,21 @@
+openSSL:
+  server:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    privateKeyFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.key'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'none'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    # A newline BETWEEN two ciphers, which trimming the ends cannot remove.
+    cipherList: "ECDHE-RSA-AES256-GCM-SHA384:\n            ECDHE-RSA-AES128-GCM-SHA256"
+  client:
+    certificateFile: '/etc/clickhouse-server/config.d/WithoutPassPhrase.crt'
+    caConfig: '/etc/clickhouse-server/config.d/rootCA.pem'
+    loadDefaultCAFile: true
+    verificationMode: 'relaxed'
+    cacheSessions: true
+    disableProtocols: 'sslv2,sslv3'
+    preferServerCiphers: true
+    cipherList: 'ECDHE-RSA-AES256-GCM-SHA384'

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -266,14 +266,18 @@ def check_cipher_list_is_enforced(ssl_conf_file, allowed_cipher, excluded_cipher
     start_all_clickhouse()
     wait_for_raft_ssl_listener(nodes[0], log_anchors[nodes[0].name])
 
-    # The configured value keeps its surrounding whitespace all the way to OpenSSL,
-    # so this arm only means something if it is still padded here.
-    configured = nodes[0].query(
-        "SELECT value FROM system.server_settings "
+    # The configured value keeps its surrounding whitespace all the way to OpenSSL, so this
+    # arm only means something if it is still padded here. The bytes are compared as hex
+    # because a newline is rendered as a two-character escape sequence in TSV output, and
+    # because the client appends a record separator of its own.
+    configured_hex = nodes[0].query(
+        "SELECT hex(value) FROM system.server_settings "
         "WHERE name = 'openSSL.server.cipherList'"
     )
-    assert configured != configured.strip(), (
-        f"fixture is not armed: cipherList reached the server already trimmed: {configured!r}"
+    configured_hex = configured_hex.strip()
+    assert configured_hex.startswith("0A") and configured_hex.endswith("20"), (
+        "fixture is not armed: cipherList reached the server without the surrounding "
+        f"whitespace this arm needs: {configured_hex}"
     )
 
     assert offer_single_cipher(nodes[0], allowed_cipher)

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -14,6 +14,7 @@ RAFT_PEER_VERIFICATION_DISABLED_LOG = (
     r"Keeper Raft peer certificate verification is disabled because "
     r"`openSSL\.client\.verificationMode` is set to `none`"
 )
+CIPHER_LIST_REJECTED_LOG = r"Cannot set cipher list"
 
 cluster = ClickHouseCluster(__file__)
 nodes = [
@@ -239,6 +240,66 @@ def check_peer_verification_failure(ssl_conf_file):
         ku.wait_until_connected(cluster, nodes[0], timeout=5)
 
 
+def offer_single_cipher(node, cipher):
+    """Hand the Raft port exactly one TLS 1.2 cipher and report whether it was accepted.
+
+    Reads the negotiated cipher rather than the exit status, because s_client also
+    reports a verification failure for the self-signed peer certificate.
+    """
+    result = node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"openssl s_client -connect 127.0.0.1:9234 -tls1_2 -cipher {cipher} "
+            f"</dev/null 2>&1 || true",
+        ]
+    )
+    return f"Cipher is {cipher}" in result
+
+
+def check_cipher_list_is_enforced(ssl_conf_file, allowed_cipher, excluded_cipher):
+    stop_all_clickhouse()
+    for node in nodes:
+        setupSsl(node, "WithoutPassPhrase", None, ssl_conf_file)
+
+    log_anchors = get_log_anchors()
+    start_all_clickhouse()
+    wait_for_raft_ssl_listener(nodes[0], log_anchors[nodes[0].name])
+
+    # The configured value keeps its surrounding whitespace all the way to OpenSSL,
+    # so this arm only means something if it is still padded here.
+    configured = nodes[0].query(
+        "SELECT value FROM system.server_settings "
+        "WHERE name = 'openSSL.server.cipherList'"
+    )
+    assert configured != configured.strip(), (
+        f"fixture is not armed: cipherList reached the server already trimmed: {configured!r}"
+    )
+
+    assert offer_single_cipher(nodes[0], allowed_cipher)
+    assert not offer_single_cipher(nodes[0], excluded_cipher)
+
+    run_test()
+
+
+def check_rejected_cipher_list(ssl_conf_file):
+    stop_all_clickhouse()
+    for node in nodes:
+        setupSsl(node, "WithoutPassPhrase", None, ssl_conf_file)
+
+    log_anchors = get_log_anchors()
+    nodes[0].start_clickhouse(expected_to_fail=True)
+
+    nodes[0].wait_for_log_line(
+        CIPHER_LIST_REJECTED_LOG, look_behind_lines=f"+{log_anchors[nodes[0].name]}"
+    )
+
+    # The listener is never brought up, so the Keeper port stays closed.
+    assert not nodes[0].contains_in_log(
+        RAFT_SSL_LISTENER_LOG, from_host=True, filename="clickhouse-server.log"
+    )
+
+
 def test_secure_raft_works(started_cluster):
     check_valid_configuration("WithoutPassPhrase", None)
 
@@ -269,4 +330,26 @@ def test_secure_raft_works_with_password(started_cluster):
 def test_secure_raft_works_with_cipher_list(started_cluster):
     check_valid_configuration(
         "WithoutPassPhrase", None, ssl_conf_file="configs/ssl_conf_cipher.yml"
+    )
+
+
+def test_secure_raft_works_with_padded_cipher_list(started_cluster):
+    check_cipher_list_is_enforced(
+        ssl_conf_file="configs/ssl_conf_cipher_padded.yml",
+        allowed_cipher="ECDHE-RSA-AES256-GCM-SHA384",
+        excluded_cipher="AES128-SHA",
+    )
+
+
+def test_secure_raft_works_with_tls13_only_cipher_list(started_cluster):
+    check_valid_configuration(
+        "WithoutPassPhrase",
+        None,
+        ssl_conf_file="configs/ssl_conf_cipher_tls13_only.yml",
+    )
+
+
+def test_secure_raft_rejects_unlexable_cipher_list(started_cluster):
+    check_rejected_cipher_list(
+        ssl_conf_file="configs/ssl_conf_cipher_unlexable.yml",
     )


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/115808
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `openSSL` `cipherList` being silently ignored when its value is written on its own line, as an XML or YAML auto-formatter produces. The configured value is now trimmed before it reaches OpenSSL, and a cipher list OpenSSL cannot parse is reported instead of discarded, so the server no longer keeps OpenSSL's built-in default cipher list while appearing to honour the configured restriction. Closes #115808.


### Description

Writing the documented option across three lines silently disables it:

```xml
<cipherList>
    ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256
</cipherList>
```

**Root cause.** Config values keep their surrounding whitespace, and in an OpenSSL cipher list only `:`, ` `, `;` and `,` separate items, so a leading newline is a lexing error, not padding: `ssl_cipher_process_rulestr` scans no token, raises `SSL_R_INVALID_COMMAND` and rejects the **whole** list. `Context::init` discarded the return value, so the `SSL_CTX` silently kept OpenSSL's built-in default list, and excluded ciphers still negotiate. Measured over TLS 1.2, one cipher offered at a time: `AES128-SHA` (non-PFS CBC) is **negotiated** with the value on its own line, refused with the same value inline.

**The change.** One site, where the configured list crosses into OpenSSL: trim a local copy, then check the return code. A test pins each half: trimming alone leaves a wrapped list (`A:\n B`) silently unrestricted; checking alone leaves the reporter's config failing rather than working. `SSL_CTX_set_cipher_list` has exactly one non-`contrib` call site and every `Context` constructor funnels through `init`, so all four config readers and the `openSSL.client` direction are covered, as is the `cypherList` back-compat alias wherever a reader honours it.

**Deliberate behaviour change:** an unparsable cipher list now fails closed and loudly instead of being dropped. A list that parses but selects no TLS 1.2 or older cipher is tolerated, since a TLS 1.3 only deployment reaches that. No setting default changes, so no `SettingsChangesHistory.cpp` entry.

**Tests.** Three arms in the existing `test_keeper_internal_secure`: the padded value, asserting an excluded cipher is refused rather than just that the server starts; a wrapped list, which must be rejected; a TLS 1.3 only list, which must keep working. Both new positive arms fail without the fix.

<details><summary>Reason codes behind the return-code check (contrib OpenSSL 3.5.7)</summary>

| cipherList | rc | reason | new behaviour |
|---|---|---|---|
| valid inline list | 1 | - | applied |
| value on its own line, or leading tab | 0 | `INVALID_COMMAND` | rejected |
| interior newline (wrapped list) | 0 | `INVALID_COMMAND` | rejected |
| leading space | 1 | - | applied (a space is already a separator) |
| `TLS_AES_256_GCM_SHA384`, or empty | 0 | `NO_CIPHER_MATCH` | tolerated |
| unknown cipher name | 0 | `NO_CIPHER_MATCH` | tolerated (not distinguishable) |

An unknown cipher *name* shares its reason code with a TLS 1.3 only list, so typos are not
caught. The guarantee is narrower: a list OpenSSL cannot parse is never silently discarded.

Every cipher string present in the tree, including both `ServerSettings` defaults and Poco's
`VAL_CIPHER_LIST`, still returns 1, so no in-tree configuration changes behaviour.

The four config readers covered through `init` are `SSLManager` (both the `openSSL.server` and
`openSSL.client` prefixes), `TLSHandler`, `PostgreSQLHandler` and `KeeperServer`. Of those,
`SSLManager`, `TLSHandler` and `PostgreSQLHandler` additionally honour the `cypherList`
back-compat spelling; `KeeperServer` reads only `cipherList`, which is pre-existing and
unchanged here. `SSL_set_cipher_list` and `SSL_CTX_set_ciphersuites` have no non-`contrib`
callers at all. `ecdhCurve` and `dhParamsFile` already throw on bad input and are left alone,
as are the two unchecked `SSL_CTX_set_tmp_*` calls, which take objects validated immediately
above them.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116053&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116053](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116053+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
