### PR TITLE
Fix a data race on the lazily calculated column and index sizes in MergeTree

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1579,7 +1579,10 @@ protected:
 
     void resetColumnSizes()
     {
+        std::lock_guard sizes_lock(columns_and_secondary_indices_sizes_mutex);
         column_sizes.clear();
+        secondary_index_sizes.clear();
+        primary_index_size = {};
         are_columns_and_secondary_indices_sizes_calculated = false;
     }
 

--- a/tests/queries/0_stateless/05038_drop_table_vs_data_skipping_indices_race.sh
+++ b/tests/queries/0_stateless/05038_drop_table_vs_data_skipping_indices_race.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tags: race
+
+set -e
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# The Map column matters: without a column that has dynamic subcolumns the size calculation keeps
+# the parts lock for its whole duration and the interleaving below cannot happen.
+for i in $(seq 1 30); do
+    echo "CREATE TABLE t_$i (x UInt64, m Map(String, String), INDEX idx x TYPE minmax GRANULARITY 1) ENGINE = MergeTree ORDER BY x;
+          INSERT INTO t_$i SELECT number, map('k', toString(number)) FROM numbers(50);
+          DROP TABLE t_$i;"
+done | $CLICKHOUSE_CLIENT &
+
+for _ in $(seq 1 60); do
+    echo "SELECT * FROM system.data_skipping_indices WHERE database = '${CLICKHOUSE_DATABASE}' FORMAT Null;"
+done | $CLICKHOUSE_CLIENT 2>/dev/null &
+
+wait


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112691
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a data race between `DROP TABLE` and reads of `system.columns` or `system.data_skipping_indices` on a MergeTree table that has a column with dynamic subcolumns, such as `Map` or `JSON`. Under a sanitizer build this was reported by ThreadSanitizer and aborted the server.


### Description

`MergeTreeData` keeps the lazily calculated column and index sizes in four members guarded by `columns_and_secondary_indices_sizes_mutex`. Every reader and every other writer takes that mutex. `resetColumnSizes()`, called from `dropAllData()`, did not.

The exclusive parts lock that `dropAllData()` holds does not serialize this, because the reader gives its parts lock up: `calculateColumnAndSecondaryIndexSizesLazily` calls `parts_lock.unlock()` when the table has a column with dynamic subcolumns, and its comment states the result stays correct "since it is guarded by the `columns_and_secondary_indices_sizes_mutex`". That is the invariant the unlocked write broke: a `DROP TABLE` could clear the maps and flip the calculated flag while a reader was inside the calculation.

The fix takes the mutex in `resetColumnSizes()`, and makes the reset exhaustive: it cleared `column_sizes` only, while flipping the flag guarding `secondary_index_sizes` and `primary_index_size` too.

Lock ordering was the risk, since the documented order is `parts_lock -> sizes_lock`. This adds no new edge: `parts_lock(exclusive) -> sizes_lock` already exists at five call sites, and no `sizes_lock -> parts_lock` path exists, so no cycle can close.

Found on master by `Stress test (amd_tsan)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f377c044bbe3be01e614a629e1fcc21bb678bbce&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

Reproduced on a ThreadSanitizer build and verified both ways: without the fix ThreadSanitizer reports the race between `getSecondaryIndexSizes()` and `dropAllData()` and aborts the server; with it the report is gone and the drop waits for the mutex, then completes. A `Map` column is required: without one the reader keeps the parts lock.

The new test drives both sides concurrently in the shape of `00838_system_tables_drop_table_race.sh`. Like that one it is a regression test rather than a reliable reproducer, since the background drop worker skips a table while a reader still holds a pointer to it; the proof above is what demonstrates the fix. It ran 50 times with randomized settings, and the `system.data_skipping_indices` tests showed no regressions.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116054&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116054](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116054+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
