### PR TITLE
Fix LOGICAL_ERROR on ALTER RENAME COLUMN combined with another command in one statement

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1267,7 +1267,14 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context,
             /// For implicit indices, check the index name rather than column_names because
             /// for ALIAS columns, column_names contains the underlying expression columns.
             if (index.isImplicitlyCreated() && index.name == IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + column_name)
+            {
                 index.definition_ast = createImplicitMinMaxIndexAST(rename_to);
+                index.name = IMPLICITLY_ADDED_MINMAX_INDEX_PREFIX + rename_to;
+                /// For an ALIAS column the index covers the columns its expression expands to,
+                /// which the column's own name never appears in, so a rename does not affect them.
+                if (!metadata.columns.hasAlias(rename_to))
+                    index.column_names = {rename_to};
+            }
             else
                 rename_visitor.visit(index.definition_ast);
         }

--- a/tests/queries/0_stateless/03748_default_minmax_indices_alter.reference
+++ b/tests/queries/0_stateless/03748_default_minmax_indices_alter.reference
@@ -48,3 +48,41 @@ SELECT * FROM system.data_skipping_indices WHERE database = current_database() A
 default	t_implicit	auto_minmax_index_a	minmax	minmax()	a	Implicit	1	0	0	0
 default	t_implicit	auto_minmax_index_s2	minmax	minmax()	s2	Implicit	1	0	0	0
 DROP TABLE t_implicit;
+DROP TABLE IF EXISTS t_rename;
+CREATE TABLE t_rename (c0 Int32, c2 Int32) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN c2 TO c13), (MODIFY SETTING fsync_part_directory = 1);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+auto_minmax_index_c0	c0
+auto_minmax_index_c13	c13
+DROP TABLE t_rename;
+CREATE TABLE t_rename (c0 Int32, s String, d Date) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_string_columns = 1, add_minmax_index_for_temporal_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN s TO s2), (MODIFY SETTING fsync_part_directory = 1);
+ALTER TABLE t_rename (RENAME COLUMN d TO d2), (MODIFY SETTING fsync_part_directory = 0);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+auto_minmax_index_d2	d2
+auto_minmax_index_s2	s2
+DROP TABLE t_rename;
+CREATE TABLE t_rename (value Int32, al Int32 ALIAS value > 0) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN al TO al2), (MODIFY SETTING fsync_part_directory = 1);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+auto_minmax_index_al2	value > 0
+auto_minmax_index_value	value
+DROP TABLE t_rename;
+CREATE TABLE t_rename (c0 Int32, c2 Int32) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN c2 TO c13), (DROP COLUMN c13);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+auto_minmax_index_c0	c0
+DROP TABLE t_rename;
+CREATE TABLE t_rename (c0 Int32, c2 Int32) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN c2 TO c13), (ADD COLUMN c2 Int32);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+auto_minmax_index_c0	c0
+auto_minmax_index_c13	c13
+auto_minmax_index_c2	c2
+DROP TABLE t_rename;
+CREATE TABLE t_rename (a Int32, al Int32 ALIAS a + 1) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (MODIFY COLUMN a String), (RENAME COLUMN al TO al2), (MODIFY COLUMN a Int32);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+auto_minmax_index_a	a
+auto_minmax_index_al2	a + 1
+DROP TABLE t_rename;

--- a/tests/queries/0_stateless/03748_default_minmax_indices_alter.sql
+++ b/tests/queries/0_stateless/03748_default_minmax_indices_alter.sql
@@ -36,3 +36,36 @@ SHOW CREATE TABLE t_implicit;
 SELECT * FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_implicit';
 
 DROP TABLE t_implicit;
+
+DROP TABLE IF EXISTS t_rename;
+
+CREATE TABLE t_rename (c0 Int32, c2 Int32) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN c2 TO c13), (MODIFY SETTING fsync_part_directory = 1);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+DROP TABLE t_rename;
+
+CREATE TABLE t_rename (c0 Int32, s String, d Date) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_string_columns = 1, add_minmax_index_for_temporal_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN s TO s2), (MODIFY SETTING fsync_part_directory = 1);
+ALTER TABLE t_rename (RENAME COLUMN d TO d2), (MODIFY SETTING fsync_part_directory = 0);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+DROP TABLE t_rename;
+
+CREATE TABLE t_rename (value Int32, al Int32 ALIAS value > 0) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN al TO al2), (MODIFY SETTING fsync_part_directory = 1);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+DROP TABLE t_rename;
+
+CREATE TABLE t_rename (c0 Int32, c2 Int32) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN c2 TO c13), (DROP COLUMN c13);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+DROP TABLE t_rename;
+
+CREATE TABLE t_rename (c0 Int32, c2 Int32) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (RENAME COLUMN c2 TO c13), (ADD COLUMN c2 Int32);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+DROP TABLE t_rename;
+
+CREATE TABLE t_rename (a Int32, al Int32 ALIAS a + 1) ENGINE = MergeTree ORDER BY tuple() SETTINGS add_minmax_index_for_numeric_columns = 1;
+ALTER TABLE t_rename (MODIFY COLUMN a String), (RENAME COLUMN al TO al2), (MODIFY COLUMN a Int32);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = current_database() AND table = 't_rename' ORDER BY name;
+DROP TABLE t_rename;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/114054
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `LOGICAL_ERROR: Index with name auto_minmax_index_<column> already exists` when a single `ALTER TABLE` statement combined `RENAME COLUMN` with another command, such as `MODIFY SETTING`, on a table with implicit minmax indices (`add_minmax_index_for_numeric_columns` and friends). Renaming a plain column also no longer leaves a following `DROP COLUMN` failing with `UNKNOWN_IDENTIFIER`, nor a following `ADD COLUMN` without its implicit index.


### Description

`ALTER TABLE t (RENAME COLUMN a TO b), (MODIFY SETTING fsync_part_directory = 1)` raised a `LOGICAL_ERROR` on any table with an implicit minmax index for `a`: an exception in release builds, an abort under debug and sanitizers. No related open issue; surfaced by `BuzzHouse (arm_asan_ubsan)`, STID 3219-3899 ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114054&sha=052eff9243e13d2a88492f793dba153e14f8c119&name_0=PR&name_1=BuzzHouse%20%28arm_asan_ubsan%29)).

Root cause: an implicit index's `name` and `column_names` are derived from its `definition_ast`, but the `RENAME COLUMN` branch of `AlterCommands::apply` replaced only the AST, and both are re-derived only at the end of the statement. Commands apply in order against one accumulating metadata copy, so a later command read the stale record: the `MODIFY SETTING` refresh missed its name-keyed drop and created a second index on its `column_names`-keyed add. Both re-derived to one name, which `checkProperties` rejects.

The fix assigns those two fields where they go stale. `name` is `auto_minmax_index_` plus the new column name by construction. `column_names` is skipped for ALIAS columns, whose index covers what the expression expands to and is unaffected by the rename.

Two further symptoms are fixed for plain columns: `(RENAME a TO b), (DROP COLUMN b)` returned `UNKNOWN_IDENTIFIER` naming an index that no longer existed, and `(RENAME a TO b), (ADD COLUMN a)` left `a` without one.

Pre-existing defects here are unchanged and pinned at baseline, since each needs a cached key repaired on an index this branch does not own: an EXPLICIT minmax index on the renamed column, or an ALIAS column whose expression names its own output, leave a following `ADD COLUMN` of that name unindexed until a reload; and mixing `MODIFY SETTING` with another command can resurrect an index dropped earlier, or drop one a later ALIAS index shadows.

Regression arms were added to `03748_default_minmax_indices_alter`, and validated with 44 base-versus-fix probes covering every intra-statement reader, all column kinds, ten type wrappers and replication.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116063&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116063](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116063+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
