### PR TITLE
Add IcebergLocal performance tests

### DIFF
--- a/ci/jobs/collect_clickhouse_profiles.py
+++ b/ci/jobs/collect_clickhouse_profiles.py
@@ -23,7 +23,10 @@ import time
 import xml.etree.ElementTree as ET
 
 from ci.defs.defs import ToolSet
-from ci.jobs.scripts.dataset_download import download_and_extract_datasets
+from ci.jobs.scripts.dataset_download import (
+    download_and_extract_datasets,
+    iceberg_database_ddl_commands,
+)
 from ci.jobs.scripts.server_cleanup import kill_leftover_server_processes
 from ci.praktika.result import Result
 from ci.praktika.utils import MetaClasses, Shell, Utils
@@ -216,6 +219,7 @@ def download_datasets():
         "hits1": "https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_v1.tar",
         "values": "https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar",
         "tpch10": "https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch.tar",
+        "tpch_ice10": "https://clickhouse-datasets.s3.amazonaws.com/h-ice/10/tpch_ice_sf10.tar",
     }
     errors = download_and_extract_datasets(dataset_paths.values(), PERF_DB_PATH)
     for error in errors:
@@ -517,6 +521,10 @@ def configure_datasets(server_dir, port=9000):
         f'for f in {repo_path}/tests/performance/user_files/*; do [ -e "$f" ] || continue; '
         f'ln -sf "$(readlink -f "$f")" {server_dir}/db/user_files/; done'
     )
+    # Attach the Iceberg datasets as databases, so the Iceberg performance tests exercise their read paths here instead of failing on a missing database.
+    for command in iceberg_database_ddl_commands(server_dir):
+        if not Shell.check(command, verbose=True):
+            return False
     return True
 
 

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -18,7 +18,11 @@ import yaml
 from ci.defs.defs import S3_REPORT_BUCKET_HTTP_ENDPOINT
 from ci.jobs.scripts import log_export
 from ci.jobs.scripts.cidb_cluster import CIDBCluster
-from ci.jobs.scripts.dataset_download import download_and_extract_datasets
+from ci.jobs.scripts.dataset_download import (
+    ICEBERG_DATASETS,
+    download_and_extract_datasets,
+    iceberg_database_ddl_commands,
+)
 from ci.praktika._environment import _Environment
 from ci.praktika.info import Info
 from ci.praktika.result import Result
@@ -1723,6 +1727,9 @@ def rebuild_table(port, source, destination):
 
 POPULATE_DONE_MARKER = "test._populate_done"
 
+# Derived, not hand-maintained: adding a dataset to ICEBERG_DATASETS is enough to protect it from the between-tests user_files wipe.
+PERSISTENT_USER_FILES = {directory for directory, _ in ICEBERG_DATASETS.values()}
+
 
 def populate_data(port):
     # Rebuild the hits datasets on one server, sequentially. The three inserts
@@ -1987,6 +1994,7 @@ def main():
                 "hits1": "https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_v1.tar",
                 "values": "https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar",
                 "tpch10": "https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch_sf10.tar",
+                "tpch_ice10": "https://clickhouse-datasets.s3.amazonaws.com/h-ice/10/tpch_ice_sf10.tar",
                 "tpcds1": "https://clickhouse-datasets.s3.amazonaws.com/ds/scale_1/tpcds.tar",
             }
             stop_watch = Utils.Stopwatch()
@@ -2046,6 +2054,9 @@ def main():
             # Same: the CI Logs cluster must be in the config of both servers.
             create_log_export_configs,
         ]
+        # Attach the Iceberg datasets as databases, so tests read tpch_ice10.<table> with no create_query of their own.
+        commands += iceberg_database_ddl_commands(perf_left)
+        commands += iceberg_database_ddl_commands(perf_right)
         results.append(Result.from_commands_run(name="Configure", command=commands))
         res = results[-1].is_ok()
 
@@ -2140,6 +2151,9 @@ def main():
                 if not user_files.is_dir():
                     continue
                 for entry in user_files.iterdir():
+                    # Dataset directories must outlive the tests; they are real directories, so the is_symlink() check below does not cover them.
+                    if entry.name in PERSISTENT_USER_FILES:
+                        continue
                     if entry.is_symlink():
                         continue
                     if entry.is_dir():

--- a/ci/jobs/scripts/dataset_download.py
+++ b/ci/jobs/scripts/dataset_download.py
@@ -3,6 +3,41 @@ from concurrent.futures import ThreadPoolExecutor
 
 from ci.praktika.utils import Shell
 
+# Iceberg datasets unpacked into user_files as <database> -> (directory, tables); every job that downloads a tarball must also attach the database via iceberg_database_ddl_commands, or the tests querying it fail.
+ICEBERG_DATASETS = {
+    "tpch_ice10": (
+        "tpch_ice_sf10",
+        (
+            "nation",
+            "region",
+            "supplier",
+            "part",
+            "customer",
+            "partsupp",
+            "orders",
+            "lineitem",
+        ),
+    ),
+}
+
+
+def iceberg_database_ddl_commands(server_path):
+    """Attach the Iceberg datasets as databases on one server ({server_path}/db); must run after the server's db directory is materialized, because IcebergLocal stores an absolute path that differs per server."""
+    user_files = f"{server_path}/db/user_files"
+    metadata = f"{server_path}/db/metadata"
+    commands = []
+    for database, (directory, tables) in ICEBERG_DATASETS.items():
+        commands.append(f"mkdir -p {metadata}/{database}")
+        commands.append(
+            f'echo "ATTACH DATABASE {database} ENGINE=Ordinary" > {metadata}/{database}.sql'
+        )
+        for table in tables:
+            commands.append(
+                f"echo \"ATTACH TABLE {table} ENGINE = IcebergLocal('{user_files}/{directory}/{table}/')\""
+                f" > {metadata}/{database}/{table}.sql"
+            )
+    return commands
+
 
 def download_and_extract_datasets(dataset_urls, target_dir, retries=5):
     """Download dataset tarballs in parallel and extract them into target_dir.

--- a/tests/performance/iceberg_suite_read.xml
+++ b/tests/performance/iceberg_suite_read.xml
@@ -1,0 +1,83 @@
+<test profile_all_queries="1" run_all_queries="1">
+    <settings>
+        <iceberg_metadata_log_level>none</iceberg_metadata_log_level>
+    </settings>
+
+    <!-- READ suite over the shared tpch_ice10 dataset (60M-row lineitem, 84 monthly partitions): the read-path aspects the TPC-H scans can't isolate - metadata cost, pruning, PREWHERE, push-down, parallelism, table resolution. -->
+
+    <substitutions>
+        <substitution>
+            <name>database</name>
+            <values>
+                <value>tpch_ice10</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <!-- point_lookup_warm: single-day predicate prunes to one data file via partition + per-file min/max, metadata from cache. -->
+    <query>SELECT count(), sum(l_extendedprice) FROM {database}.lineitem WHERE l_shipdate = toDate('1994-06-15')</query>
+
+    <!-- point_lookup_cold: same lookup with the metadata cache off, so the diff vs warm is the metadata.json parse + manifest Avro decode. -->
+    <query>SELECT count(), sum(l_extendedprice) FROM {database}.lineitem WHERE l_shipdate = toDate('1994-06-15') SETTINGS use_iceberg_metadata_files_cache = 0</query>
+
+    <!-- manifest_metadata_decode: metadata-only manifest walk via system.iceberg_files with the cache off, isolating manifest Avro decode without touching a data file. -->
+    <query>SELECT count(), sum(record_count), sum(file_size_in_bytes) FROM system.iceberg_files WHERE database = '{database}' AND table = 'lineitem' AND content = 0 SETTINGS use_iceberg_metadata_files_cache = 0</query>
+
+    <!-- partition_prune_month: filter aligned with the month partition transform; signal IcebergPartitionPrunedFiles ~ 83. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1995-01-01') AND l_shipdate &lt; toDate('1995-02-01') SETTINGS use_iceberg_partition_pruning = 1</query>
+
+    <!-- minmax_prune_edge: last shipping day lives in the last file only, the rest skipped via per-file min/max; signal IcebergMinMaxIndexPrunedFiles ~ 83. -->
+    <query>SELECT count() FROM {database}.lineitem WHERE l_shipdate = toDate('1998-12-01')</query>
+
+    <!-- minmax_secondary_column: filter the non-partition l_receiptdate with partition pruning off, so only per-file min/max stats can skip files. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_receiptdate = toDate('1994-06-15') SETTINGS use_iceberg_partition_pruning = 0</query>
+
+    <!-- prune_negative_control: predicate spans every file's range, nothing prunes, so the walk over all manifest entries is paid every run. -->
+    <query>SELECT count(), min(l_shipdate) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1990-01-01')</query>
+
+    <!-- trivial_count: no predicate, answerable from snapshot-level row counts without touching a data file. -->
+    <query>SELECT count() FROM {database}.lineitem</query>
+
+    <!-- time_travel baseline + iceberg_timestamp_ms as-of a far-future timestamp; the diff isolates timestamp-to-snapshot resolution from the scan. -->
+    <query>SELECT count(), sum(l_extendedprice) FROM {database}.lineitem</query>
+    <query>SELECT count(), sum(l_extendedprice) FROM {database}.lineitem SETTINGS iceberg_timestamp_ms = 32503680000000</query>
+
+    <!-- join_fact_dim_mergetree: Iceberg fact joined with the MergeTree dimension holding the same data (right side ~6 months of orders); the cross-engine join path. -->
+    <query>SELECT count() FROM {database}.lineitem AS l INNER JOIN tpch10.orders AS o ON l.l_orderkey = o.o_orderkey WHERE o.o_orderdate &lt; toDate('1992-06-01')</query>
+
+    <!-- join_fact_dim_iceberg: same join with both sides on Iceberg, so the diff vs the MergeTree variant isolates the data-lake read path. -->
+    <query>SELECT count() FROM {database}.lineitem AS l INNER JOIN {database}.orders AS o ON l.l_orderkey = o.o_orderkey WHERE o.o_orderdate &lt; toDate('1992-06-01')</query>
+
+    <!-- columns_narrow: full scan decoding 2 of 16 columns; Parquet column pruning on the revenue expression. -->
+    <query>SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem</query>
+
+    <!-- columns_wide: same full scan forced to decode every column; the diff vs narrow is the column-count scaling of the Parquet decode. -->
+    <query>SELECT count() FROM {database}.lineitem WHERE NOT ignore(*)</query>
+
+    <!-- pushdown_off: selective l_orderkey range with every in-file filter layer off, so the whole table is decoded and filtered in the engine (matches cluster in a few row groups). -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_orderkey BETWEEN 10000000 AND 10100000 SETTINGS input_format_parquet_filter_push_down = 0, input_format_parquet_page_filter_push_down = 0</query>
+
+    <!-- pushdown_rowgroup: row-group min/max statistics only. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_orderkey BETWEEN 10000000 AND 10100000 SETTINGS input_format_parquet_filter_push_down = 1, input_format_parquet_page_filter_push_down = 0</query>
+
+    <!-- pushdown_page: row-group plus page-level pruning, the finest granularity. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_orderkey BETWEEN 10000000 AND 10100000 SETTINGS input_format_parquet_filter_push_down = 1, input_format_parquet_page_filter_push_down = 1</query>
+
+    <!-- prewhere_off: a ~4%-selective filter with PREWHERE off, so both columns are fully decoded before filtering. -->
+    <query>SELECT sum(l_extendedprice), count() FROM {database}.lineitem WHERE l_quantity &lt; 2 SETTINGS optimize_move_to_prewhere = 0</query>
+
+    <!-- prewhere_on: same query with the filter in PREWHERE on the object-storage read path, so l_extendedprice is decoded only for surviving rows. -->
+    <query>SELECT sum(l_extendedprice), count() FROM {database}.lineitem WHERE l_quantity &lt; 2 SETTINGS optimize_move_to_prewhere = 1</query>
+
+    <!-- threads_1: one year (12 files) of the revenue scan on a single thread; baseline of the parallelism pair. -->
+    <query>SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1994-01-01') AND l_shipdate &lt; toDate('1995-01-01') SETTINGS max_threads = 1</query>
+
+    <!-- threads_16: same scan on 16 threads; the ratio vs threads_1 is the file-level parallelization efficiency of the Iceberg source. -->
+    <query>SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1994-01-01') AND l_shipdate &lt; toDate('1995-01-01') SETTINGS max_threads = 16</query>
+
+    <!-- table_function_resolution: the point lookup via the icebergLocal table function, paying table resolution + schema inference each run; the absolute path comes from system.server_settings since the function doesn't resolve relative paths against user_files. -->
+    <query>SELECT count(), sum(l_extendedprice) FROM icebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/tpch_ice_sf10/lineitem/') WHERE l_shipdate = toDate('1994-06-15')</query>
+
+    <!-- limit_early_exit: reader startup and cancellation - open only the first data file and stop after the first thousand wide rows. -->
+    <query>SELECT * FROM {database}.lineitem LIMIT 1000</query>
+</test>

--- a/tests/performance/iceberg_suite_read.xml
+++ b/tests/performance/iceberg_suite_read.xml
@@ -1,4 +1,4 @@
-<test profile_all_queries="1" run_all_queries="1">
+<test>
     <settings>
         <iceberg_metadata_log_level>none</iceberg_metadata_log_level>
     </settings>

--- a/tests/performance/iceberg_suite_read.xml
+++ b/tests/performance/iceberg_suite_read.xml
@@ -24,7 +24,7 @@
     <query>SELECT count(), sum(record_count), sum(file_size_in_bytes) FROM system.iceberg_files WHERE database = '{database}' AND table = 'lineitem' AND content = 0 SETTINGS use_iceberg_metadata_files_cache = 0</query>
 
     <!-- partition_prune_month: filter aligned with the month partition transform; signal IcebergPartitionPrunedFiles ~ 83. -->
-    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1995-01-01') AND l_shipdate &lt; toDate('1995-02-01') SETTINGS use_iceberg_partition_pruning = 1</query>
+    <query><![CDATA[SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_shipdate >= toDate('1995-01-01') AND l_shipdate < toDate('1995-02-01') SETTINGS use_iceberg_partition_pruning = 1]]></query>
 
     <!-- minmax_prune_edge: last shipping day lives in the last file only, the rest skipped via per-file min/max; signal IcebergMinMaxIndexPrunedFiles ~ 83. -->
     <query>SELECT count() FROM {database}.lineitem WHERE l_shipdate = toDate('1998-12-01')</query>
@@ -33,7 +33,7 @@
     <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_receiptdate = toDate('1994-06-15') SETTINGS use_iceberg_partition_pruning = 0</query>
 
     <!-- prune_negative_control: predicate spans every file's range, nothing prunes, so the walk over all manifest entries is paid every run. -->
-    <query>SELECT count(), min(l_shipdate) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1990-01-01')</query>
+    <query>SELECT count(), min(l_shipdate) FROM {database}.lineitem WHERE l_shipdate >= toDate('1990-01-01')</query>
 
     <!-- trivial_count: no predicate, answerable from snapshot-level row counts without touching a data file. -->
     <query>SELECT count() FROM {database}.lineitem</query>
@@ -43,10 +43,10 @@
     <query>SELECT count(), sum(l_extendedprice) FROM {database}.lineitem SETTINGS iceberg_timestamp_ms = 32503680000000</query>
 
     <!-- join_fact_dim_mergetree: Iceberg fact joined with the MergeTree dimension holding the same data (right side ~6 months of orders); the cross-engine join path. -->
-    <query>SELECT count() FROM {database}.lineitem AS l INNER JOIN tpch10.orders AS o ON l.l_orderkey = o.o_orderkey WHERE o.o_orderdate &lt; toDate('1992-06-01')</query>
+    <query><![CDATA[SELECT count() FROM {database}.lineitem AS l INNER JOIN tpch10.orders AS o ON l.l_orderkey = o.o_orderkey WHERE o.o_orderdate < toDate('1992-06-01')]]></query>
 
     <!-- join_fact_dim_iceberg: same join with both sides on Iceberg, so the diff vs the MergeTree variant isolates the data-lake read path. -->
-    <query>SELECT count() FROM {database}.lineitem AS l INNER JOIN {database}.orders AS o ON l.l_orderkey = o.o_orderkey WHERE o.o_orderdate &lt; toDate('1992-06-01')</query>
+    <query><![CDATA[SELECT count() FROM {database}.lineitem AS l INNER JOIN {database}.orders AS o ON l.l_orderkey = o.o_orderkey WHERE o.o_orderdate < toDate('1992-06-01')]]></query>
 
     <!-- columns_narrow: full scan decoding 2 of 16 columns; Parquet column pruning on the revenue expression. -->
     <query>SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem</query>
@@ -64,16 +64,16 @@
     <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem WHERE l_orderkey BETWEEN 10000000 AND 10100000 SETTINGS input_format_parquet_filter_push_down = 1, input_format_parquet_page_filter_push_down = 1</query>
 
     <!-- prewhere_off: a ~4%-selective filter with PREWHERE off, so both columns are fully decoded before filtering. -->
-    <query>SELECT sum(l_extendedprice), count() FROM {database}.lineitem WHERE l_quantity &lt; 2 SETTINGS optimize_move_to_prewhere = 0</query>
+    <query><![CDATA[SELECT sum(l_extendedprice), count() FROM {database}.lineitem WHERE l_quantity < 2 SETTINGS optimize_move_to_prewhere = 0]]></query>
 
     <!-- prewhere_on: same query with the filter in PREWHERE on the object-storage read path, so l_extendedprice is decoded only for surviving rows. -->
-    <query>SELECT sum(l_extendedprice), count() FROM {database}.lineitem WHERE l_quantity &lt; 2 SETTINGS optimize_move_to_prewhere = 1</query>
+    <query><![CDATA[SELECT sum(l_extendedprice), count() FROM {database}.lineitem WHERE l_quantity < 2 SETTINGS optimize_move_to_prewhere = 1]]></query>
 
     <!-- threads_1: one year (12 files) of the revenue scan on a single thread; baseline of the parallelism pair. -->
-    <query>SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1994-01-01') AND l_shipdate &lt; toDate('1995-01-01') SETTINGS max_threads = 1</query>
+    <query><![CDATA[SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem WHERE l_shipdate >= toDate('1994-01-01') AND l_shipdate < toDate('1995-01-01') SETTINGS max_threads = 1]]></query>
 
     <!-- threads_16: same scan on 16 threads; the ratio vs threads_1 is the file-level parallelization efficiency of the Iceberg source. -->
-    <query>SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem WHERE l_shipdate &gt;= toDate('1994-01-01') AND l_shipdate &lt; toDate('1995-01-01') SETTINGS max_threads = 16</query>
+    <query><![CDATA[SELECT sum(l_extendedprice * (1 - l_discount)) FROM {database}.lineitem WHERE l_shipdate >= toDate('1994-01-01') AND l_shipdate < toDate('1995-01-01') SETTINGS max_threads = 16]]></query>
 
     <!-- table_function_resolution: the point lookup via the icebergLocal table function, paying table resolution + schema inference each run; the absolute path comes from system.server_settings since the function doesn't resolve relative paths against user_files. -->
     <query>SELECT count(), sum(l_extendedprice) FROM icebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/tpch_ice_sf10/lineitem/') WHERE l_shipdate = toDate('1994-06-15')</query>

--- a/tests/performance/iceberg_suite_rw_features.xml
+++ b/tests/performance/iceberg_suite_rw_features.xml
@@ -1,0 +1,89 @@
+<test profile_all_queries="1" run_all_queries="1">
+    <settings>
+        <allow_insert_into_iceberg>1</allow_insert_into_iceberg>
+        <mutations_sync>2</mutations_sync>
+        <iceberg_metadata_log_level>none</iceberg_metadata_log_level>
+        <iceberg_delete_data_on_drop>1</iceberg_delete_data_on_drop>
+    </settings>
+
+    <!-- RW-FEATURES suite: per-feature IcebergLocal tables built once in <create_query>, each measuring a stable read or idempotent mutation not covered by iceberg_suite_write.xml. -->
+
+    <substitutions>
+        <substitution>
+            <name>database</name>
+            <values>
+                <value>iceberg_suite_rw_features</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>CREATE DATABASE IF NOT EXISTS {database}</create_query>
+
+    <!-- add_column: read across an ADD COLUMN boundary, pre-add data files resolve l_note as NULL; expect countIf(l_note IS NULL) ~ 100000 of 200000. -->
+    <create_query>DROP TABLE IF EXISTS {database}.evo_add</create_query>
+    <create_query>CREATE TABLE {database}.evo_add (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/evo_add_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.evo_add SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>ALTER TABLE {database}.evo_add ADD COLUMN l_note Nullable(String)</create_query>
+    <create_query>INSERT INTO {database}.evo_add SELECT l_orderkey, l_quantity, l_comment FROM tpch10.lineitem LIMIT 100000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>SELECT count(), countIf(l_note IS NULL) FROM {database}.evo_add</query>
+
+    <!-- drop_column: read after a metadata-only DROP COLUMN; the dropped field is skipped when decoding pre-drop data files. -->
+    <create_query>DROP TABLE IF EXISTS {database}.evo_drop</create_query>
+    <create_query>CREATE TABLE {database}.evo_drop (l_orderkey Int32, l_quantity Float64, l_comment String) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/evo_drop_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.evo_drop SELECT l_orderkey, l_quantity, l_comment FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>ALTER TABLE {database}.evo_drop DROP COLUMN l_comment</create_query>
+    <query>SELECT count(), sum(l_quantity) FROM {database}.evo_drop</query>
+
+    <!-- rename_column: read the renamed column under its new name qty; field-id-stable resolution over files written as l_quantity. -->
+    <create_query>DROP TABLE IF EXISTS {database}.evo_rename</create_query>
+    <create_query>CREATE TABLE {database}.evo_rename (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/evo_rename_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.evo_rename SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>ALTER TABLE {database}.evo_rename RENAME COLUMN l_quantity TO qty</create_query>
+    <query>SELECT count(), sum(qty) FROM {database}.evo_rename</query>
+
+    <!-- partition_identity_prune: equality on the identity-partitioned l_returnflag keeps one partition and prunes the rest. -->
+    <create_query>DROP TABLE IF EXISTS {database}.part_identity</create_query>
+    <create_query>CREATE TABLE {database}.part_identity (l_orderkey Int32, l_returnflag String, l_extendedprice Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/part_identity_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet') PARTITION BY (l_returnflag)</create_query>
+    <create_query>INSERT INTO {database}.part_identity SELECT l_orderkey, l_returnflag, l_extendedprice FROM tpch10.lineitem LIMIT 200000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>SELECT count(), sum(l_extendedprice) FROM {database}.part_identity WHERE l_returnflag = 'R'</query>
+
+    <!-- partition_bucket_prune: equality on l_orderkey lets icebergBucket(16, l_orderkey) prune to a single bucket of 16. -->
+    <create_query>DROP TABLE IF EXISTS {database}.part_bucket</create_query>
+    <create_query>CREATE TABLE {database}.part_bucket (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/part_bucket_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet') PARTITION BY (icebergBucket(16, l_orderkey))</create_query>
+    <create_query>INSERT INTO {database}.part_bucket SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 200000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>SELECT count(), sum(l_quantity) FROM {database}.part_bucket WHERE l_orderkey = 12345678</query>
+
+    <!-- update_partition_key_move: ALTER UPDATE rewriting the partition column for 1-in-5 rows, forcing a cross-partition row move no other mutation scenario triggers. -->
+    <create_query>DROP TABLE IF EXISTS {database}.upd_part</create_query>
+    <create_query>CREATE TABLE {database}.upd_part (l_orderkey Int32, l_returnflag String, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/upd_part_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet') PARTITION BY (l_returnflag)</create_query>
+    <create_query>INSERT INTO {database}.upd_part SELECT l_orderkey, l_returnflag, l_quantity FROM tpch10.lineitem LIMIT 200000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>ALTER TABLE {database}.upd_part UPDATE l_returnflag = 'X' WHERE l_orderkey % 5 = 0</query>
+
+    <!-- sort_order_minmax_read: ORDER BY write into 50K-row files yields tight per-file min/max; the one-month range read prunes on stats produced by ClickHouse's own write. -->
+    <create_query>DROP TABLE IF EXISTS {database}.sorted_li</create_query>
+    <create_query>CREATE TABLE {database}.sorted_li (l_orderkey Int32, l_shipdate Date, l_extendedprice Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/sorted_li_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet') ORDER BY (l_shipdate, l_orderkey)</create_query>
+    <create_query>INSERT INTO {database}.sorted_li SELECT l_orderkey, l_shipdate, l_extendedprice FROM tpch10.lineitem LIMIT 500000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 50000</create_query>
+    <query>SELECT count(), sum(l_extendedprice) FROM {database}.sorted_li WHERE l_shipdate BETWEEN toDate('1994-06-01') AND toDate('1994-06-30')</query>
+
+    <!-- nested_types_write_read: round-trips Array/Map/Tuple through Iceberg Parquet; reads back length(tags), props['k'] and rec.1. -->
+    <create_query>DROP TABLE IF EXISTS {database}.nested_t</create_query>
+    <create_query>CREATE TABLE {database}.nested_t (id Int64, tags Array(String), props Map(String, Int64), rec Tuple(a Int64, b String)) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/nested_t_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.nested_t SELECT number, [toString(number), 'x'], map('k', number), (number, toString(number)) FROM numbers(200000) SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>SELECT count(), sum(length(tags)), sum(props['k']), sum(rec.1) FROM {database}.nested_t</query>
+
+    <!-- many_small_data_files: full scan over ~200 tiny data files (iceberg_insert_max_rows_in_data_file = 1000); per-file open and scan-planning overhead. -->
+    <create_query>DROP TABLE IF EXISTS {database}.small_files</create_query>
+    <create_query>CREATE TABLE {database}.small_files (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/small_files_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.small_files SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 200000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 1000</create_query>
+    <query>SELECT count(), sum(l_quantity) FROM {database}.small_files</query>
+
+    <drop_query>DROP TABLE IF EXISTS {database}.evo_add</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.evo_drop</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.evo_rename</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.part_identity</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.part_bucket</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.upd_part</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.sorted_li</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.nested_t</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.small_files</drop_query>
+</test>

--- a/tests/performance/iceberg_suite_rw_features.xml
+++ b/tests/performance/iceberg_suite_rw_features.xml
@@ -1,12 +1,11 @@
-<test profile_all_queries="1" run_all_queries="1">
+<test>
     <settings>
         <allow_insert_into_iceberg>1</allow_insert_into_iceberg>
-        <mutations_sync>2</mutations_sync>
         <iceberg_metadata_log_level>none</iceberg_metadata_log_level>
         <iceberg_delete_data_on_drop>1</iceberg_delete_data_on_drop>
     </settings>
 
-    <!-- RW-FEATURES suite: per-feature IcebergLocal tables built once in <create_query>, each measuring a stable read or idempotent mutation not covered by iceberg_suite_write.xml. -->
+    <!-- RW-FEATURES suite: per-feature IcebergLocal tables built once in <create_query>; each query depends only on its own table's setup and runs, so CI may sample and shuffle them freely; iceberg_suite_write.xml keeps only the append-only write paths. -->
 
     <substitutions>
         <substitution>
@@ -77,6 +76,81 @@
     <create_query>INSERT INTO {database}.small_files SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 200000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 1000</create_query>
     <query>SELECT count(), sum(l_quantity) FROM {database}.small_files</query>
 
+    <!-- update_every_file: min/max stats cannot refute the modulo predicate, so every run scans all three data files and rewrites the matches; 30K rows keeps a single run under the report's 2 s budget. -->
+    <create_query>DROP TABLE IF EXISTS {database}.upd_files</create_query>
+    <create_query>CREATE TABLE {database}.upd_files (l_orderkey Int32, l_partkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/upd_files_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.upd_files SELECT l_orderkey, l_partkey, l_quantity FROM tpch10.lineitem LIMIT 30000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <query>ALTER TABLE {database}.upd_files UPDATE l_quantity = l_quantity + 1 WHERE l_partkey % 10 = 0</query>
+
+    <!-- modify_column: metadata-only schema commit; the prewarm run does the real Int32 -> Int64 promotion, later runs re-commit the same type. -->
+    <create_query>DROP TABLE IF EXISTS {database}.evo_promote</create_query>
+    <create_query>CREATE TABLE {database}.evo_promote (l_orderkey Int32, l_suppkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/evo_promote_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.evo_promote SELECT l_orderkey, l_suppkey, l_quantity FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>ALTER TABLE {database}.evo_promote MODIFY COLUMN l_suppkey Int64</query>
+
+    <!-- read_after_type_promotion: the promotion happens at setup, so every run reads still-Int32 data files under the Int64 schema. -->
+    <create_query>DROP TABLE IF EXISTS {database}.evo_promoted</create_query>
+    <create_query>CREATE TABLE {database}.evo_promoted (l_orderkey Int32, l_suppkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/evo_promoted_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.evo_promoted SELECT l_orderkey, l_suppkey, l_quantity FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>ALTER TABLE {database}.evo_promoted MODIFY COLUMN l_suppkey Int64</create_query>
+    <query>SELECT count(), sum(l_suppkey) FROM {database}.evo_promoted</query>
+
+    <!-- delete_position_deletes: the prewarm run writes the real position deletes, later runs scan under merge-on-read, match nothing and commit nothing; 50K rows keeps a single run under the report's 2 s budget. -->
+    <create_query>DROP TABLE IF EXISTS {database}.del_pos</create_query>
+    <create_query>CREATE TABLE {database}.del_pos (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/del_pos_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.del_pos SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 50000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>ALTER TABLE {database}.del_pos DELETE WHERE l_orderkey % 7 = 0</query>
+
+    <!-- mor_read_position_deletes_roaring: position deletes are written at setup, so every run is a full roaring-bitmap merge-on-read scan over fixed state. -->
+    <create_query>DROP TABLE IF EXISTS {database}.del_read</create_query>
+    <create_query>CREATE TABLE {database}.del_read (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/del_read_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.del_read SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>ALTER TABLE {database}.del_read DELETE WHERE l_orderkey % 7 = 0</create_query>
+    <query>SELECT count(), sum(l_quantity) FROM {database}.del_read SETTINGS use_roaring_bitmap_iceberg_positional_deletes = 1</query>
+
+    <!-- optimize_manifests: ten setup commits produce ten manifests; the prewarm run consolidates them, later runs measure the early-returning threshold check. -->
+    <create_query>DROP TABLE IF EXISTS {database}.many_manifests</create_query>
+    <create_query>CREATE TABLE {database}.many_manifests (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/many_manifests_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 0, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 10000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 20000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 30000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 40000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 50000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 60000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 70000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 80000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.many_manifests SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 90000, 10000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>
+        OPTIMIZE TABLE {database}.many_manifests MANIFEST
+        SETTINGS allow_experimental_iceberg_compaction = 1, iceberg_manifest_min_count_to_compact = 8
+    </query>
+
+    <!-- deep_history_scan: cache-off full scan over a fixed twenty-commit history built at setup, measuring manifest read planning. -->
+    <create_query>DROP TABLE IF EXISTS {database}.deep_history</create_query>
+    <create_query>CREATE TABLE {database}.deep_history (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/deep_history_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 0, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 5000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 10000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 15000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 20000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 25000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 30000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 35000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 40000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 45000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 50000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 55000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 60000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 65000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 70000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 75000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 80000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 85000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 90000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 95000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
+    <query>SELECT count(), sum(l_quantity) FROM {database}.deep_history SETTINGS use_iceberg_metadata_files_cache = 0</query>
+
     <drop_query>DROP TABLE IF EXISTS {database}.evo_add</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.evo_drop</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.evo_rename</drop_query>
@@ -86,4 +160,11 @@
     <drop_query>DROP TABLE IF EXISTS {database}.sorted_li</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.nested_t</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.small_files</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.upd_files</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.evo_promote</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.evo_promoted</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.del_pos</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.del_read</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.many_manifests</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.deep_history</drop_query>
 </test>

--- a/tests/performance/iceberg_suite_rw_features.xml
+++ b/tests/performance/iceberg_suite_rw_features.xml
@@ -108,6 +108,9 @@
     <create_query>ALTER TABLE {database}.del_read DELETE WHERE l_orderkey % 7 = 0</create_query>
     <query>SELECT count(), sum(l_quantity) FROM {database}.del_read SETTINGS use_roaring_bitmap_iceberg_positional_deletes = 1</query>
 
+    <!-- mor_read_position_deletes_streaming: the same fixed delete state scanned through IcebergStreamingPositionDeleteTransform (the default path), which merges sorted delete-file positions against each data file instead of materializing a bitmap; pairs with the roaring query above to isolate the two MoR implementations. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.del_read SETTINGS use_roaring_bitmap_iceberg_positional_deletes = 0</query>
+
     <!-- optimize_manifests: ten setup commits produce ten manifests; the prewarm run consolidates them, later runs measure the early-returning threshold check. -->
     <create_query>DROP TABLE IF EXISTS {database}.many_manifests</create_query>
     <create_query>CREATE TABLE {database}.many_manifests (l_orderkey Int32, l_quantity Float64) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/many_manifests_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')</create_query>

--- a/tests/performance/iceberg_suite_rw_features.xml
+++ b/tests/performance/iceberg_suite_rw_features.xml
@@ -151,6 +151,31 @@
     <create_query>INSERT INTO {database}.deep_history SELECT l_orderkey, l_quantity FROM tpch10.lineitem LIMIT 95000, 5000 SETTINGS max_threads = 1, max_insert_threads = 1</create_query>
     <query>SELECT count(), sum(l_quantity) FROM {database}.deep_history SETTINGS use_iceberg_metadata_files_cache = 0</query>
 
+    <!-- manifest_grid: twelve single-partition commits of five data files each - many manifests, many entries per manifest. -->
+    <create_query>DROP TABLE IF EXISTS {database}.manifest_grid</create_query>
+    <create_query>CREATE TABLE {database}.manifest_grid (l_orderkey Int32, l_quantity Float64, l_month Int32) ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/manifest_grid_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet') PARTITION BY (l_month)</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199401 AS l_month FROM tpch10.lineitem LIMIT 0, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199402 AS l_month FROM tpch10.lineitem LIMIT 50000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199403 AS l_month FROM tpch10.lineitem LIMIT 100000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199404 AS l_month FROM tpch10.lineitem LIMIT 150000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199405 AS l_month FROM tpch10.lineitem LIMIT 200000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199406 AS l_month FROM tpch10.lineitem LIMIT 250000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199407 AS l_month FROM tpch10.lineitem LIMIT 300000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199408 AS l_month FROM tpch10.lineitem LIMIT 350000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199409 AS l_month FROM tpch10.lineitem LIMIT 400000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199410 AS l_month FROM tpch10.lineitem LIMIT 450000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199411 AS l_month FROM tpch10.lineitem LIMIT 500000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+    <create_query>INSERT INTO {database}.manifest_grid SELECT l_orderkey, l_quantity, 199412 AS l_month FROM tpch10.lineitem LIMIT 550000, 50000 SETTINGS max_threads = 1, max_insert_threads = 1, iceberg_insert_max_rows_in_data_file = 10000</create_query>
+
+    <!-- manifest_list_prune: partition-only filter with cache off; all twelve manifests are decoded today, and whole-manifest skipping via the manifest-list partition summary will show here once implemented. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.manifest_grid WHERE l_month = 199406 SETTINGS use_iceberg_metadata_files_cache = 0</query>
+
+    <!-- manifest_decode_serial: cache-off full scan decoding the twelve manifests one at a time. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.manifest_grid SETTINGS use_iceberg_metadata_files_cache = 0, iceberg_manifest_decode_concurrency = 1</query>
+
+    <!-- manifest_decode_parallel: the same scan with concurrent manifest decoding; the pair isolates the parallel decode path. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.manifest_grid SETTINGS use_iceberg_metadata_files_cache = 0, iceberg_manifest_decode_concurrency = 8</query>
+
     <drop_query>DROP TABLE IF EXISTS {database}.evo_add</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.evo_drop</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.evo_rename</drop_query>
@@ -167,4 +192,5 @@
     <drop_query>DROP TABLE IF EXISTS {database}.del_read</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.many_manifests</drop_query>
     <drop_query>DROP TABLE IF EXISTS {database}.deep_history</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.manifest_grid</drop_query>
 </test>

--- a/tests/performance/iceberg_suite_tpch.xml
+++ b/tests/performance/iceberg_suite_tpch.xml
@@ -1,0 +1,45 @@
+<!-- https://clickhouse.com/docs/getting-started/example-datasets/tpch -->
+<!-- Scale factor: 10 -->
+<test profile_all_queries="1" run_all_queries="1">
+    <settings file="../benchmarks/tpc-h/settings.json"/>
+    <settings>
+        <max_bytes_ratio_before_external_join>0</max_bytes_ratio_before_external_join>
+        <iceberg_metadata_log_level>none</iceberg_metadata_log_level>
+    </settings>
+
+    <!-- The 22 queries of tpch.xml, unchanged, over the CI-attached `tpch_ice10` Iceberg dataset; nothing is built or dropped here, and `iceberg_delete_data_on_drop` must stay off because the dataset is shared. -->
+    <substitutions>
+        <substitution>
+            <name>database</name>
+            <values>
+                <value>tpch_ice10</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <!-- The query files use unqualified table names, as in tpch.xml, so the session has to point at the dataset's database. -->
+    <fill_query>USE {database}</fill_query>
+
+    <!-- Q1 -->  <query file="../benchmarks/tpc-h/queries/query_01.sql"/>
+    <!-- Q2 -->  <query file="../benchmarks/tpc-h/queries/query_02.sql"/>
+    <!-- Q3 -->  <query file="../benchmarks/tpc-h/queries/query_03.sql"/>
+    <!-- Q4 -->  <query file="../benchmarks/tpc-h/queries/query_04.sql"/>
+    <!-- Q5 -->  <query file="../benchmarks/tpc-h/queries/query_05.sql"/>
+    <!-- Q6 -->  <query file="../benchmarks/tpc-h/queries/query_06.sql"/>
+    <!-- Q7 -->  <query file="../benchmarks/tpc-h/queries/query_07.sql"/>
+    <!-- Q8 -->  <query file="../benchmarks/tpc-h/queries/query_08.sql"/>
+    <!-- Q9 -->  <query file="../benchmarks/tpc-h/queries/query_09.sql"/>
+    <!-- Q10 --> <query file="../benchmarks/tpc-h/queries/query_10.sql"/>
+    <!-- Q11 --> <query file="../benchmarks/tpc-h/queries/query_11_sf10.sql"/>
+    <!-- Q12 --> <query file="../benchmarks/tpc-h/queries/query_12.sql"/>
+    <!-- Q13 --> <query file="../benchmarks/tpc-h/queries/query_13.sql"/>
+    <!-- Q14 --> <query file="../benchmarks/tpc-h/queries/query_14.sql"/>
+    <!-- Q15 --> <query file="../benchmarks/tpc-h/queries/query_15.sql"/>
+    <!-- Q16 --> <query file="../benchmarks/tpc-h/queries/query_16.sql"/>
+    <!-- Q17 --> <query file="../benchmarks/tpc-h/queries/query_17.sql"/>
+    <!-- Q18 --> <query file="../benchmarks/tpc-h/queries/query_18.sql"/>
+    <!-- Q19 --> <query file="../benchmarks/tpc-h/queries/query_19.sql"/>
+    <!-- Q20 --> <query file="../benchmarks/tpc-h/queries/query_20.sql"/>
+    <!-- Q21 --> <query file="../benchmarks/tpc-h/queries/query_21.sql"/>
+    <!-- Q22 --> <query file="../benchmarks/tpc-h/queries/query_22.sql"/>
+</test>

--- a/tests/performance/iceberg_suite_tpch.xml
+++ b/tests/performance/iceberg_suite_tpch.xml
@@ -1,6 +1,6 @@
 <!-- https://clickhouse.com/docs/getting-started/example-datasets/tpch -->
 <!-- Scale factor: 10 -->
-<test profile_all_queries="1" run_all_queries="1">
+<test>
     <settings file="../benchmarks/tpc-h/settings.json"/>
     <settings>
         <max_bytes_ratio_before_external_join>0</max_bytes_ratio_before_external_join>

--- a/tests/performance/iceberg_suite_write.xml
+++ b/tests/performance/iceberg_suite_write.xml
@@ -1,0 +1,79 @@
+<!-- https://clickhouse.com/docs/getting-started/example-datasets/tpch -->
+<!-- Scale factor: 10 -->
+<test profile_all_queries="1" run_all_queries="1">
+    <settings>
+        <allow_insert_into_iceberg>1</allow_insert_into_iceberg>
+        <mutations_sync>2</mutations_sync>
+        <iceberg_metadata_log_level>none</iceberg_metadata_log_level>
+        <iceberg_delete_data_on_drop>1</iceberg_delete_data_on_drop>
+    </settings>
+
+    <!-- WRITE suite: one lineitem-shaped IcebergLocal table fed from tpch10; run_all_queries runs the stages in file order as a deterministic pipeline both servers walk in lockstep, keeping the comparison of modifying queries fair. -->
+
+    <substitutions>
+        <substitution>
+            <name>database</name>
+            <values>
+                <value>iceberg_suite_write</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>CREATE DATABASE IF NOT EXISTS {database}</create_query>
+    <create_query>DROP TABLE IF EXISTS {database}.lineitem</create_query>
+
+    <!-- Measures are Float64 and fixed text is String because Iceberg::getIcebergType maps neither Decimal nor FixedString. -->
+    <create_query>
+        CREATE TABLE {database}.lineitem
+        (
+            l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
+            l_quantity Float64, l_extendedprice Float64, l_discount Float64, l_tax Float64,
+            l_returnflag String, l_linestatus String,
+            l_shipdate Date, l_commitdate Date, l_receiptdate Date,
+            l_shipinstruct String, l_shipmode String, l_comment String
+        )
+        ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/iceberg_suite_write_lineitem_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')
+    </create_query>
+
+    <!-- insert_large: a 100K-row lineitem SF10 prefix as one ordered stream/block/commit (max_threads=1 pins the row set), so per-run cost is dominated by Parquet encoding not metadata. -->
+    <query>
+        INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100000
+        SETTINGS max_threads = 1, max_insert_threads = 1,
+                 min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0
+    </query>
+
+    <!-- insert_small_commits: 10 tiny commits/run (payload comparable to per-commit metadata) that deepen the shared snapshot history by 10 each run; lives in an external .sql so perf.py times the batch as one profiled unit with {database} substitution and the test's settings. -->
+    <query file="write_small_commits.sql"/>
+
+    <!-- optimize_table: runs while the history is still append-only (compaction's tryGetAppendUpdate throws on the UPDATE stages' overwrite snapshots); with no position deletes nothing is rewritten, so it measures the planning pass over every manifest of every snapshot. -->
+    <query>OPTIMIZE TABLE {database}.lineitem SETTINGS allow_experimental_iceberg_compaction = 1</query>
+
+    <!-- update_no_match: mutation planning over every data file, predicate pruned by column stats so nothing is scanned/rewritten and state stays stable; zero-match mutations commit no snapshot. -->
+    <query>ALTER TABLE {database}.lineitem UPDATE l_quantity = l_quantity + 1 WHERE l_partkey &lt; 0</query>
+
+    <!-- update_every_file: l_partkey % 10 hits every data file so the mutation scans all and rewrites matches; later runs pay the full history replay over prior overwrite snapshots - the steady state measured. -->
+    <query>ALTER TABLE {database}.lineitem UPDATE l_quantity = l_quantity + 1 WHERE l_partkey % 10 = 0</query>
+
+    <!-- modify_column: pure metadata schema commit (no snapshot); first run does the real Int32 -> Int64 promotion, later runs re-commit the same type via the identical read-generate-write path. -->
+    <query>ALTER TABLE {database}.lineitem MODIFY COLUMN l_suppkey Int64</query>
+
+    <!-- read_after_type_promotion: read casts the still-Int32 pre-promotion files after modify_column set the schema to Int64. -->
+    <query>SELECT count(), sum(l_suppkey) FROM {database}.lineitem</query>
+
+    <!-- delete_position_deletes: row-level DELETE writing Iceberg position delete files; placed after optimize_table, whose compaction needs an append-only history. -->
+    <query>ALTER TABLE {database}.lineitem DELETE WHERE l_orderkey % 7 = 0</query>
+
+    <!-- mor_read_position_deletes_roaring: full scan applying the position deletes above via the roaring-bitmap merge-on-read path. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem SETTINGS use_roaring_bitmap_iceberg_positional_deletes = 1</query>
+
+    <!-- optimize_manifests: tolerates the mutation snapshots; first run consolidates the accumulated manifests, later runs measure the manifest-list read + the early-returning threshold check. -->
+    <query>
+        OPTIMIZE TABLE {database}.lineitem MANIFEST
+        SETTINGS allow_experimental_iceberg_compaction = 1, iceberg_manifest_min_count_to_compact = 8
+    </query>
+
+    <!-- deep_history_scan: cache-off full scan over the pipeline's accumulated snapshot history, measuring manifest-list/manifest read planning. -->
+    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem SETTINGS use_iceberg_metadata_files_cache = 0</query>
+
+    <drop_query>DROP TABLE IF EXISTS {database}.lineitem</drop_query>
+</test>

--- a/tests/performance/iceberg_suite_write.xml
+++ b/tests/performance/iceberg_suite_write.xml
@@ -1,14 +1,13 @@
 <!-- https://clickhouse.com/docs/getting-started/example-datasets/tpch -->
 <!-- Scale factor: 10 -->
-<test profile_all_queries="1" run_all_queries="1">
+<test>
     <settings>
         <allow_insert_into_iceberg>1</allow_insert_into_iceberg>
-        <mutations_sync>2</mutations_sync>
         <iceberg_metadata_log_level>none</iceberg_metadata_log_level>
         <iceberg_delete_data_on_drop>1</iceberg_delete_data_on_drop>
     </settings>
 
-    <!-- WRITE suite: one lineitem-shaped IcebergLocal table fed from tpch10; run_all_queries runs the stages in file order as a deterministic pipeline both servers walk in lockstep, keeping the comparison of modifying queries fair. -->
+    <!-- WRITE suite: append-only IcebergLocal write paths; each query depends only on setup and its own runs, so CI may sample and shuffle them freely; mutations that rewrite data or change schema live in iceberg_suite_rw_features.xml. -->
 
     <substitutions>
         <substitution>
@@ -20,11 +19,12 @@
     </substitutions>
 
     <create_query>CREATE DATABASE IF NOT EXISTS {database}</create_query>
-    <create_query>DROP TABLE IF EXISTS {database}.lineitem</create_query>
 
-    <!-- Measures are Float64 and fixed text is String because Iceberg::getIcebergType maps neither Decimal nor FixedString. -->
+
+    <!-- wr_large: insert_large target; the baseline fill makes every measured run append to a non-empty table. -->
+    <create_query>DROP TABLE IF EXISTS {database}.wr_large</create_query>
     <create_query>
-        CREATE TABLE {database}.lineitem
+        CREATE TABLE {database}.wr_large
         (
             l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
             l_quantity Float64, l_extendedprice Float64, l_discount Float64, l_tax Float64,
@@ -32,48 +32,69 @@
             l_shipdate Date, l_commitdate Date, l_receiptdate Date,
             l_shipinstruct String, l_shipmode String, l_comment String
         )
-        ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/iceberg_suite_write_lineitem_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')
+        ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/iceberg_suite_write_wr_large_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')
     </create_query>
+    <create_query>INSERT INTO {database}.wr_large SELECT * FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
 
-    <!-- insert_large: a 100K-row lineitem SF10 prefix as one ordered stream/block/commit (max_threads=1 pins the row set), so per-run cost is dominated by Parquet encoding not metadata. -->
+    <!-- insert_large: 200K rows as one block/commit, so Parquet encoding dominates the per-run cost. -->
     <query>
-        INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100000
+        INSERT INTO {database}.wr_large SELECT * FROM tpch10.lineitem LIMIT 200000
         SETTINGS max_threads = 1, max_insert_threads = 1,
-                 min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0
+                 min_insert_block_size_rows = 200000, min_insert_block_size_bytes = 0
     </query>
 
-    <!-- insert_small_commits: 10 tiny commits/run (payload comparable to per-commit metadata) that deepen the shared snapshot history by 10 each run; lives in an external .sql so perf.py times the batch as one profiled unit with {database} substitution and the test's settings. -->
+
+    <!-- wr_small: write_small_commits.sql target; baseline fill for the same reason. -->
+    <create_query>DROP TABLE IF EXISTS {database}.wr_small</create_query>
+    <create_query>
+        CREATE TABLE {database}.wr_small
+        (
+            l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
+            l_quantity Float64, l_extendedprice Float64, l_discount Float64, l_tax Float64,
+            l_returnflag String, l_linestatus String,
+            l_shipdate Date, l_commitdate Date, l_receiptdate Date,
+            l_shipinstruct String, l_shipmode String, l_comment String
+        )
+        ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/iceberg_suite_write_wr_small_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')
+    </create_query>
+    <create_query>INSERT INTO {database}.wr_small SELECT * FROM tpch10.lineitem LIMIT 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+
+    <!-- insert_small_commits: 5 tiny commits per run to pressure metadata updates -->
     <query file="write_small_commits.sql"/>
 
-    <!-- optimize_table: runs while the history is still append-only (compaction's tryGetAppendUpdate throws on the UPDATE stages' overwrite snapshots); with no position deletes nothing is rewritten, so it measures the planning pass over every manifest of every snapshot. -->
-    <query>OPTIMIZE TABLE {database}.lineitem SETTINGS allow_experimental_iceberg_compaction = 1</query>
 
-    <!-- update_no_match: mutation planning over every data file, predicate pruned by column stats so nothing is scanned/rewritten and state stays stable; zero-match mutations commit no snapshot. -->
-    <query>ALTER TABLE {database}.lineitem UPDATE l_quantity = l_quantity + 1 WHERE l_partkey &lt; 0</query>
+    <!-- wr_planned: fixed ten-snapshot append-only history shared by the two planning-only queries below, which commit nothing and so never change it. -->
+    <create_query>DROP TABLE IF EXISTS {database}.wr_planned</create_query>
+    <create_query>
+        CREATE TABLE {database}.wr_planned
+        (
+            l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
+            l_quantity Float64, l_extendedprice Float64, l_discount Float64, l_tax Float64,
+            l_returnflag String, l_linestatus String,
+            l_shipdate Date, l_commitdate Date, l_receiptdate Date,
+            l_shipinstruct String, l_shipmode String, l_comment String
+        )
+        ENGINE = IcebergLocal((SELECT value FROM system.server_settings WHERE name = 'user_files_path') || '/iceberg_suite_write_wr_planned_' || toString(toUnixTimestamp64Micro(now64(6))) || '/', 'Parquet')
+    </create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 0, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 100000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 200000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 300000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 400000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 500000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 600000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 700000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 800000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
+    <create_query>INSERT INTO {database}.wr_planned SELECT * FROM tpch10.lineitem LIMIT 900000, 100000 SETTINGS max_threads = 1, max_insert_threads = 1, min_insert_block_size_rows = 100000, min_insert_block_size_bytes = 0</create_query>
 
-    <!-- update_every_file: l_partkey % 10 hits every data file so the mutation scans all and rewrites matches; later runs pay the full history replay over prior overwrite snapshots - the steady state measured. -->
-    <query>ALTER TABLE {database}.lineitem UPDATE l_quantity = l_quantity + 1 WHERE l_partkey % 10 = 0</query>
+    <!-- optimize_table: with an append-only history and no position deletes nothing is rewritten, so every run measures the planning pass over the fixed ten snapshots. -->
+    <query>OPTIMIZE TABLE {database}.wr_planned SETTINGS allow_experimental_iceberg_compaction = 1</query>
 
-    <!-- modify_column: pure metadata schema commit (no snapshot); first run does the real Int32 -> Int64 promotion, later runs re-commit the same type via the identical read-generate-write path. -->
-    <query>ALTER TABLE {database}.lineitem MODIFY COLUMN l_suppkey Int64</query>
+    <!-- update_no_match: mutation planning only - per-file stats refute the predicate, so nothing is scanned or rewritten and no snapshot is committed. -->
+    <query>ALTER TABLE {database}.wr_planned UPDATE l_quantity = l_quantity + 1 WHERE l_partkey &lt; 0</query>
 
-    <!-- read_after_type_promotion: read casts the still-Int32 pre-promotion files after modify_column set the schema to Int64. -->
-    <query>SELECT count(), sum(l_suppkey) FROM {database}.lineitem</query>
 
-    <!-- delete_position_deletes: row-level DELETE writing Iceberg position delete files; placed after optimize_table, whose compaction needs an append-only history. -->
-    <query>ALTER TABLE {database}.lineitem DELETE WHERE l_orderkey % 7 = 0</query>
-
-    <!-- mor_read_position_deletes_roaring: full scan applying the position deletes above via the roaring-bitmap merge-on-read path. -->
-    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem SETTINGS use_roaring_bitmap_iceberg_positional_deletes = 1</query>
-
-    <!-- optimize_manifests: tolerates the mutation snapshots; first run consolidates the accumulated manifests, later runs measure the manifest-list read + the early-returning threshold check. -->
-    <query>
-        OPTIMIZE TABLE {database}.lineitem MANIFEST
-        SETTINGS allow_experimental_iceberg_compaction = 1, iceberg_manifest_min_count_to_compact = 8
-    </query>
-
-    <!-- deep_history_scan: cache-off full scan over the pipeline's accumulated snapshot history, measuring manifest-list/manifest read planning. -->
-    <query>SELECT count(), sum(l_quantity) FROM {database}.lineitem SETTINGS use_iceberg_metadata_files_cache = 0</query>
-
-    <drop_query>DROP TABLE IF EXISTS {database}.lineitem</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.wr_large</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.wr_small</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {database}.wr_planned</drop_query>
 </test>

--- a/tests/performance/iceberg_suite_write.xml
+++ b/tests/performance/iceberg_suite_write.xml
@@ -91,7 +91,7 @@
     <query>OPTIMIZE TABLE {database}.wr_planned SETTINGS allow_experimental_iceberg_compaction = 1</query>
 
     <!-- update_no_match: mutation planning only - per-file stats refute the predicate, so nothing is scanned or rewritten and no snapshot is committed. -->
-    <query>ALTER TABLE {database}.wr_planned UPDATE l_quantity = l_quantity + 1 WHERE l_partkey &lt; 0</query>
+    <query><![CDATA[ALTER TABLE {database}.wr_planned UPDATE l_quantity = l_quantity + 1 WHERE l_partkey < 0]]></query>
 
 
     <drop_query>DROP TABLE IF EXISTS {database}.wr_large</drop_query>

--- a/tests/performance/write_small_commits.sql
+++ b/tests/performance/write_small_commits.sql
@@ -1,0 +1,10 @@
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;

--- a/tests/performance/write_small_commits.sql
+++ b/tests/performance/write_small_commits.sql
@@ -1,10 +1,5 @@
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
-INSERT INTO {database}.lineitem SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.wr_small SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.wr_small SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.wr_small SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.wr_small SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;
+INSERT INTO {database}.wr_small SELECT * FROM tpch10.lineitem LIMIT 100 SETTINGS max_threads = 1, max_insert_threads = 1;


### PR DESCRIPTION
Performance tests for `IcebergLocal`: 
- using new dataset `tpch_ice10` (traditional tpch sf10 pre-stored in Iceberg format)
- iceberg_suite_tpch.xml - regular tpch suite against it
- iceberg_suite_write.xml - long and short independent writes
- iceberg_suite_read.xml - reusing pre-loaded `tpch_ice10` dataset to benchmark read features
- iceberg_suite_rw_features.xml - creates independent tables to validate various rw features

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `IcebergLocal` performance tests covering read, insert and mutation paths.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116065&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116065](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116065+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
