### PR TITLE
Fix stateless workers crash with object storage

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -606,7 +606,7 @@ Chunk StorageObjectStorageSource::generate()
                 read_from_format_info.requested_virtual_columns,
                 {
                     .path = path,
-                    .storage_id = storage_snapshot->storage.getStorageID(),
+                    .storage_id = storage_id,
                     .size = object_size,
                     .filename = &filename,
                     /// Report an unknown modification time (e.g. a web object whose HTTP response has no


### PR DESCRIPTION
It is really hard to reproduce test, but the stack trace is quite trivial:

```
system.crash_log, v
2026-08-24 08:36:45, signal 6 (SIGABRT), 597 identical entries since 2026-08-21 23:58

2.  ? @ 0x0000000000082039
3.  raise @ 0x000000000003a83c
4.  abort @ 0x0000000000027134
5.  ? @ 0x0000000000034114
6.  __j1_finite @ 0x000000000003418c
7.  __pthread_mutex_lock @ 0x00000000000836d8
8.0. inlined from src/Common/ThreadFuzzer.cpp:455: pthread_mutex_lock
8.1. inlined from contrib/llvm-project/libcxx/include/__thread/support/pthread.h:95: std::__libcpp_mutex_lock[abi:fqe220101](pthread_mutex_t*)
8.   contrib/llvm-project/libcxx/src/mutex.cpp:30:27: std::mutex::lock() @ 0x000000002170c538
9.0. inlined from contrib/llvm-project/libcxx/include/__mutex/lock_guard.h:32: std::lock_guard<std::mutex>::lock_guard[abi:fqe220101](std::mutex&)
9.   src/Storages/IStorage.cpp:316:10: DB::IStorage::getStorageID() const @ 0x0000000019e0f5e0
10.  src/Storages/ObjectStorage/StorageObjectStorageSource.cpp:609:61: DB::StorageObjectStorageSource::generate() @ 0x00000000172abe34
11.  src/Processors/ISource.cpp:153:18: DB::ISource::tryGenerate() @ 0x000000001b37860c
12.  src/Processors/ISource.cpp:119:26: DB::ISource::work() @ 0x000000001b3781a0
13.0. inlined from src/Processors/Executors/ExecutionThreadContext.cpp:57: DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*)
13.  src/Processors/Executors/ExecutionThreadContext.cpp:127:28: DB::ExecutionThreadContext::executeTask() @ 0x000000001b3996ec
14.  src/Processors/Executors/PipelineExecutor.cpp:387:26: DB::PipelineExecutor::executeStepImpl(unsigned long, DB::WorkloadResources&&, std::atomic<bool>*) @ 0x000000001b38bfa8
15.0. inlined from src/Processors/Executors/PipelineExecutor.cpp:355: DB::PipelineExecutor::executeSingleThread(unsigned long, DB::WorkloadResources&&)
15.1. inlined from src/Processors/Executors/PipelineExecutor.cpp:692: operator()
15.  contrib/llvm-project/libcxx/include/__functional/function.h:443:5: std::__function::__policy_func<void ()>::__call_func[abi:fqe220101]<DB::PipelineExecutor::spawnThreads(std::shared_ptr<DB::IAcquiredSlot>)::$_0>(std::__function::__policy_storage const*) @ 0x000000001b38e128
16.  src/Common/ThreadPool.cpp:1128:12: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false, true>>::ThreadFromThreadPool::worker() @ 0x00000000146ff910
17.  contrib/llvm-project/libcxx/include/__functional/function.h:443:12: std::__function::__policy_func<void ()>::__call_func[abi:fqe220101]<startThreadFromGlobalPool(std::shared_ptr<ThreadFromGlobalPoolState>, std::function<void ()>, unsigned long, unsigned long, bool, bool)::$_0>(std::__function::__policy_storage const*) @ 0x000000001470897c
18.  src/Common/ThreadPool.cpp:1138:12: ThreadPoolImpl<std::thread>::ThreadFromThreadPool::worker() @ 0x00000000146fd72c
19.  contrib/llvm-project/libcxx/include/__thread/thread.h:169: void* std::__thread_proxy[abi:fqe220101]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*) @ 0x0000000014705e1c
20.  ? @ 0x00000000000803c8
21.  ? @ 0x00000000000e9edc

```


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix stateless workers crash with object storage

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116067&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116067](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116067+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.1.1993`, `26.7.6.29`
<!-- ch-version-info:end -->