### PR TITLE
Docs: document scheduled upgrades for Managed Postgres

### DIFF
--- a/docs/products/managed-postgres/faq.mdx
+++ b/docs/products/managed-postgres/faq.mdx
@@ -105,7 +105,7 @@ Enhanced RBAC features with console integration are planned for this year.
 
 ### How are PostgreSQL version upgrades handled? {#version-upgrades}
 
-Both minor and major version upgrades are performed via failover and typically result in only a few seconds of downtime. You can configure a maintenance window to control when upgrades are applied. For complete details, see the [Upgrades](/products/managed-postgres/upgrades) documentation.
+Both minor and major version upgrades are performed via failover and typically result in only a few seconds of downtime. You can configure [scheduled upgrades](/products/managed-postgres/upgrades#scheduled-upgrades) to control the days and the two-hour UTC window in which upgrades are applied. For complete details, see the [Upgrades](/products/managed-postgres/upgrades) documentation.
 
 ## Migration {#migration}
 

--- a/docs/products/managed-postgres/pricing.mdx
+++ b/docs/products/managed-postgres/pricing.mdx
@@ -66,6 +66,7 @@ The table below summarizes the features, capabilities, and limits included in ea
       <li><a href="/products/managed-postgres/scaling">Up to 96 vCPUs and 768 GB RAM</a></li>
       <li><a href="/products/managed-postgres/scaling">Storage autoscale</a></li>
       <li><a href="/products/managed-postgres/read-replicas">Read replicas</a></li>
+      <li><a href="/products/managed-postgres/upgrades#scheduled-upgrades">Scheduled upgrades</a></li>
       <li><a href="/products/managed-postgres/security">Private networking</a></li>
       <li><a href="/products/managed-postgres/backup-and-restore">Backups with retention of 7 days</a></li>
       <li><a href="/products/managed-postgres/monitoring/query-insights">Query Insights</a> with 7 day retention</li>
@@ -82,7 +83,7 @@ The table below summarizes the features, capabilities, and limits included in ea
       <li>Named Lead Support Engineer</li>
       <li><a href="/products/managed-postgres/extensions">Custom extensions</a> (*pending approval)</li>
       <li><a href="/products/managed-postgres/migrations/clickpipes">Consultative migrations guides</a></li>
-      <li><a href="/products/managed-postgres/upgrades">Scheduled upgrades</a></li>
+      <li><a href="/products/managed-postgres/upgrades#days-of-the-week">Day-of-week selection for scheduled upgrades</a></li>
     </ul>
   </div>
 </div>

--- a/docs/products/managed-postgres/scaling.mdx
+++ b/docs/products/managed-postgres/scaling.mdx
@@ -139,7 +139,7 @@ ClickHouse Managed Postgres monitors disk usage and scales storage automatically
 
 - **85% disk usage**: You receive a [notification](/products/managed-postgres/monitoring/notifications) through the cloud console and email.
 - **90% disk usage**: Autoscaling starts. Storage is increased to the next larger size available for your instance family. CPU and memory stay the same unless the current instance size doesn't support a larger disk, in which case the instance size is increased as well. [Read replicas](/products/managed-postgres/read-replicas) are scaled alongside the primary.
-- **95% disk usage**: The cutover skips any configured maintenance window and happens as soon as the new server is ready.
+- **95% disk usage**: The cutover happens as soon as the new server is ready, bypassing any wait.
 
 If your instance is already at the largest available configuration, autoscaling can't go further. Free up disk space or contact [support](https://clickhouse.com/support/program).
 
@@ -147,7 +147,7 @@ If your instance is already at the largest available configuration, autoscaling 
 
 Storage isn't resized in place. Autoscaling follows the same [scaling process](#scaling-process) as a manual instance type change: a replacement server with more storage is provisioned, restored from the latest backup, catches up on WAL, and a controlled cutover promotes it to the new primary. Instances with [high availability](/products/managed-postgres/high-availability) get replacement standbys at the new size as part of the same operation.
 
-The cutover is the only step with downtime, typically under a minute. If a [maintenance window](/products/managed-postgres/upgrades#maintenance-windows) is configured, the cutover waits for it unless disk usage reaches 95%. During the cutover, open connections are dropped and in-flight transactions are rolled back. Your connection string doesn't change: DNS is updated to point at the new primary, and applications with standard reconnect logic recover automatically.
+The cutover is the only step with downtime, typically under a minute. A configured [scheduled upgrade window](/products/managed-postgres/upgrades#scheduled-upgrades) doesn't delay it: the window applies to platform maintenance, not to scaling. During the cutover, open connections are dropped and in-flight transactions are rolled back. Your connection string doesn't change: DNS is updated to point at the new primary, and applications with standard reconnect logic recover automatically.
 
 ### Read-only mode {#autoscaling-read-only}
 

--- a/docs/products/managed-postgres/scaling.mdx
+++ b/docs/products/managed-postgres/scaling.mdx
@@ -168,7 +168,7 @@ An instance with 1024 GB of storage runs a write-heavy workload:
 
 1. At 870 GB used (85%), you receive the storage notification.
 2. At 922 GB used (90%), autoscaling starts. A replacement server with 2048 GB of storage is provisioned and restored from the latest backup while your instance keeps serving traffic.
-3. Once the replacement has caught up, the cutover runs, within your maintenance window if one is configured. Connections drop for under a minute, your application reconnects to the same hostname, and usage is back around 45%.
+3. Once the replacement has caught up, the cutover runs. Connections drop for under a minute, your application reconnects to the same hostname, and usage is back around 45%.
 4. If free space drops below 2% (about 20 GB) before the cutover completes, the instance goes read-only. Writes resume automatically once the cutover to the larger disk finishes.
 
 ## Additional resources {#resources}

--- a/docs/products/managed-postgres/settings.mdx
+++ b/docs/products/managed-postgres/settings.mdx
@@ -36,3 +36,9 @@ To modify a parameter, select the **Edit parameters** button. Select the paramet
 All changes made to the configuration parameters are typically persisted to the instance within one minute. Some parameters require a database restart to take effect. These changes will be applied after the next restart, which you can trigger manually from the **Service actions** toolbar.
 
 Refer to the official [documentation](https://www.postgresql.org/docs/current/runtime-config.html) on the configuration parameters. The list of parameters available to set will be extended soon. In the meantime, contact [support](https://clickhouse.com/support/program) to request a parameter not currently supported.
+
+## Scheduled upgrades {#scheduled-upgrades}
+
+The **Configuration** section also lets you control when platform maintenance — minor PostgreSQL version upgrades, managed service feature updates, and operating system patches — is applied to your instance. Select **Configure schedule** in the **Scheduled upgrades** subsection to pick a two-hour UTC window and, optionally, the days of the week on which upgrades may be applied.
+
+For the available windows and what a schedule does and doesn't cover, see [scheduled upgrades](/products/managed-postgres/upgrades#scheduled-upgrades).

--- a/docs/products/managed-postgres/upgrades.mdx
+++ b/docs/products/managed-postgres/upgrades.mdx
@@ -3,7 +3,7 @@ slug: /cloud/managed-postgres/upgrades
 sidebarTitle: 'Upgrades'
 title: 'Upgrades'
 description: 'How PostgreSQL version upgrades work in ClickHouse Managed Postgres'
-keywords: ['managed postgres upgrades', 'postgres version', 'minor upgrade', 'major upgrade', 'maintenance window']
+keywords: ['managed postgres upgrades', 'postgres version', 'minor upgrade', 'major upgrade', 'maintenance window', 'scheduled upgrades']
 doc_type: 'guide'
 ---
 
@@ -25,12 +25,95 @@ These are performed via failover and typically result in only a brief disconnect
 
 For instances with [standbys](/products/managed-postgres/high-availability) enabled, the upgrade is applied to the standby first, followed by a failover to minimize downtime.
 
-## Maintenance windows {#maintenance-windows}
+## Scheduled upgrades {#scheduled-upgrades}
 
-Default maintenance window is 14:00 to 16:00 UTC on Sunday.
-Expected downtime is less than 1 minute within the window.
+By default, maintenance is applied to your instance whenever a new release is ready.
+With **scheduled upgrades** you choose a two-hour UTC window, and optionally the days of
+the week, during which that maintenance may be applied, so the brief failover lands at
+the time that's least disruptive to your workload. Expected downtime is less than
+1 minute within the window.
 
-For Enterprise Tier organizations, ClickHouse Managed Postgres supports maintenance windows so that upgrades and other maintenance operations can be scheduled at a time that's least disruptive to your workload. UI and API support for configuring maintenance windows is coming soon. In the meantime, contact [support](https://clickhouse.com/support/program) to set up a maintenance window for your instance.
+Scheduled upgrades are enabled per organization. If you don't see the **Scheduled
+upgrades** section described below, contact [support](https://clickhouse.com/support/program)
+to have it enabled for your organization.
+
+### Configure a schedule {#configure-a-schedule}
+
+<Steps>
+<Step title="Open the instance settings" id="open-settings">
+Select your instance, then select **Settings** from the left menu and scroll to the
+**Configuration** section.
+</Step>
+<Step title="Open the scheduled upgrades flyout" id="open-flyout">
+In the **Scheduled upgrades** subsection, select **Configure schedule**. If a schedule
+is already set, the current schedule is shown and the button reads **Edit schedule**.
+</Step>
+<Step title="Pick a time period" id="pick-time-period">
+Select one of the twelve two-hour UTC windows from the **Time period (UTC)** list. A time
+period is required.
+</Step>
+<Step title="Optionally restrict the days" id="pick-days">
+Select one or more days under **Day(s) of the week**. Leave every day unselected to allow
+upgrades on any day within the time period.
+</Step>
+<Step title="Save" id="save">
+Select **Save**. The schedule takes effect immediately and is shown in the
+**Scheduled upgrades** subsection, for example
+`Scheduled upgrades: Sat, Sun at 12:00 a.m. - 2:00 a.m. UTC`.
+</Step>
+</Steps>
+
+You need the `control-plane:postgres-service:manage` permission on the instance to change
+its schedule. The controls are also disabled while an instance is stopped or is still
+being provisioned.
+
+### Time periods {#time-periods}
+
+Windows are two hours long and are always expressed in UTC — there's no local-timezone
+selection. The available windows are:
+
+| First half of the day (UTC) | Second half of the day (UTC) |
+|-----------------------------|------------------------------|
+| 12:00 a.m. - 2:00 a.m.      | 12:00 p.m. - 2:00 p.m.       |
+| 2:00 a.m. - 4:00 a.m.       | 2:00 p.m. - 4:00 p.m.        |
+| 4:00 a.m. - 6:00 a.m.       | 4:00 p.m. - 6:00 p.m.        |
+| 6:00 a.m. - 8:00 a.m.       | 6:00 p.m. - 8:00 p.m.        |
+| 8:00 a.m. - 10:00 a.m.      | 8:00 p.m. - 10:00 p.m.       |
+| 10:00 a.m. - 12:00 p.m.     | 10:00 p.m. - 12:00 a.m.      |
+
+Custom start times, custom window lengths, and more than one window per instance aren't
+supported.
+
+### Days of the week {#days-of-the-week}
+
+Restricting the days is optional:
+
+- **No days selected** — upgrades may be applied on any day, inside the chosen time period.
+- **One or more days selected** — upgrades are only applied on those days, inside the
+  chosen time period. Selecting all seven days is equivalent to selecting none.
+
+### What a schedule applies to {#schedule-scope}
+
+A schedule governs **platform maintenance** only — the minor version upgrades, managed
+service feature updates, and operating system patches described in
+[Maintenance updates](#maintenance-updates).
+
+Changes that you initiate yourself aren't deferred to the window and are applied as soon
+as you make them. This includes [scaling](/products/managed-postgres/scaling) an instance,
+resizing storage, and changing [configuration parameters](/products/managed-postgres/settings).
+
+<Note>
+Scheduled upgrades are best effort. Maintenance may be applied outside your window when it's
+required for the health of your instance — for example when disk usage reaches 95% — or for
+critical security patches and vulnerability fixes. You'll be notified of such exceptions as
+necessary.
+</Note>
+
+### Read replicas {#read-replicas}
+
+[Read replicas](/products/managed-postgres/read-replicas) follow the schedule of their
+primary instance and don't have a schedule of their own, so the **Scheduled upgrades**
+section isn't shown for them.
 
 ## Major version upgrades {#major-version-upgrades}
 

--- a/docs/products/managed-postgres/upgrades.mdx
+++ b/docs/products/managed-postgres/upgrades.mdx
@@ -8,6 +8,7 @@ doc_type: 'guide'
 ---
 
 import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
+import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanFeatureBadge/EnterprisePlanFeatureBadge.jsx";
 
 <BetaBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} galaxyEvent="docs.managed-postgres.upgrades-beta" />
 
@@ -27,15 +28,13 @@ For instances with [standbys](/products/managed-postgres/high-availability) enab
 
 ## Scheduled upgrades {#scheduled-upgrades}
 
+<EnterprisePlanFeatureBadge feature="Scheduled upgrades" linking_verb_are="true" support={true}/>
+
 By default, maintenance is applied to your instance whenever a new release is ready.
 With **scheduled upgrades** you choose a two-hour UTC window, and optionally the days of
 the week, during which that maintenance may be applied, so the brief failover lands at
 the time that's least disruptive to your workload. Expected downtime is less than
 1 minute within the window.
-
-Scheduled upgrades are enabled per organization. If you don't see the **Scheduled
-upgrades** section described below, contact [support](https://clickhouse.com/support/program)
-to have it enabled for your organization.
 
 ### Configure a schedule {#configure-a-schedule}
 

--- a/docs/products/managed-postgres/upgrades.mdx
+++ b/docs/products/managed-postgres/upgrades.mdx
@@ -9,6 +9,7 @@ doc_type: 'guide'
 
 import { BetaBadge } from "/snippets/components/BetaBadge/BetaBadge.jsx";
 import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanFeatureBadge/EnterprisePlanFeatureBadge.jsx";
+import { ScalePlanFeatureBadge } from "/snippets/components/ScalePlanFeatureBadge/ScalePlanFeatureBadge.jsx";
 
 <BetaBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} galaxyEvent="docs.managed-postgres.upgrades-beta" />
 
@@ -28,13 +29,16 @@ For instances with [standbys](/products/managed-postgres/high-availability) enab
 
 ## Scheduled upgrades {#scheduled-upgrades}
 
-<EnterprisePlanFeatureBadge feature="Scheduled upgrades" linking_verb_are="true" support={true}/>
+<ScalePlanFeatureBadge feature="Scheduled upgrades" linking_verb_are="true"/>
 
 By default, maintenance is applied to your instance whenever a new release is ready.
-With **scheduled upgrades** you choose a two-hour UTC window, and optionally the days of
-the week, during which that maintenance may be applied, so the brief failover lands at
-the time that's least disruptive to your workload. Expected downtime is less than
-1 minute within the window.
+With **scheduled upgrades** you choose a two-hour UTC window during which that
+maintenance may be applied, so the brief failover lands at the time that's least
+disruptive to your workload. Expected downtime is less than 1 minute within the window.
+
+On the Enterprise plan you can also restrict upgrades to specific
+[days of the week](#days-of-the-week). On the Scale plan you choose the time period only,
+and upgrades may be applied on any day within it.
 
 ### Configure a schedule {#configure-a-schedule}
 
@@ -52,8 +56,8 @@ Select one of the twelve two-hour UTC windows from the **Time period (UTC)** lis
 period is required.
 </Step>
 <Step title="Optionally restrict the days" id="pick-days">
-Select one or more days under **Day(s) of the week**. Leave every day unselected to allow
-upgrades on any day within the time period.
+On the Enterprise plan, select one or more days under **Day(s) of the week**. Leave every
+day unselected to allow upgrades on any day within the time period.
 </Step>
 <Step title="Save" id="save">
 Select **Save**. The schedule takes effect immediately and is shown in the
@@ -84,6 +88,8 @@ Custom start times, custom window lengths, and more than one window per instance
 supported.
 
 ### Days of the week {#days-of-the-week}
+
+<EnterprisePlanFeatureBadge feature="Restricting upgrades to specific days of the week"/>
 
 Restricting the days is optional:
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

Documents **scheduled upgrades** for ClickHouse Managed Postgres.

[docs/products/managed-postgres/upgrades.mdx](https://github.com/ClickHouse/ClickHouse/blob/master/docs/products/managed-postgres/upgrades.mdx) previously said that maintenance windows were Enterprise-only and that "UI and API support for configuring maintenance windows is coming soon. In the meantime, contact support". That placeholder is replaced with the actual feature:

- How to configure a schedule from **Settings → Configuration → Scheduled upgrades**.
- The twelve two-hour UTC windows, and the note that custom start times, custom durations and multiple windows aren't supported.
- The optional day-of-week restriction, including that no days selected (or all seven) means any day within the window.
- Plan availability: choosing a time period is a **Scale** plan feature; restricting upgrades to specific **days of the week** is Enterprise only. Rendered with the existing `ScalePlanFeatureBadge` on the section and `EnterprisePlanFeatureBadge` on the days subsection.
- What a schedule applies to: platform maintenance only. Customer-initiated changes — scaling, storage resize, parameter changes — are applied immediately and are **not** deferred to the window.
- Best-effort caveats: maintenance may land outside the window when required for instance health (for example at 95% disk usage) or for critical security patches.
- Read replicas follow their primary's schedule.

Supporting changes:

- `settings.mdx` — pointer to the new section, since the control lives in the **Configuration** section that page documents.
- `scaling.mdx` — corrects two now-inaccurate claims that the autoscaling cutover waits for a configured maintenance window.
- `faq.mdx` — links the upgrades FAQ answer at the new section.
- `pricing.mdx` — **Scheduled upgrades** moves to the Scale column, and the Enterprise column gains **Day-of-week selection for scheduled upgrades**, so the pricing page matches the badges.

Only English sources are edited; localized pages are generated by the translation workflow.

Previewed locally with `mint dev`.

#### Open items for reviewers

- The previous text stated a default maintenance window of *14:00–16:00 UTC on Sunday*. That conflicts with the console, where an unconfigured instance shows "upgrades will be applied when a new Postgres release is ready", so the claim is dropped here. Please confirm whether a platform-side default window actually exists.
- No screenshots yet. The **Configure a schedule** steps are the natural place for them.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116079&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116079](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116079+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.77` (included in `26.9` and later)
<!-- ch-version-info:end -->