### PR TITLE
workload: fix MemoryReservation hang when increase races with in-flight decrease

### DIFF
--- a/src/Common/Scheduler/MemoryReservation.cpp
+++ b/src/Common/Scheduler/MemoryReservation.cpp
@@ -44,7 +44,6 @@ MemoryReservation::MemoryReservation(ResourceLink link, const String & id_, Reso
     if (reserved_size > 0)
     {
         // Scheduler may call increaseApproved() immediately after insert, so set state beforehand
-        increase_enqueued = true;
         enqueued_demand = reserved_size;
         demand_increment.add(enqueued_demand);
     }
@@ -123,8 +122,8 @@ void MemoryReservation::syncWithMemoryTracker(const MemoryTracker * memory_track
         // Multiple query threads may call syncWithMemoryTracker concurrently
         // (the MemoryTracker reflects total memory across all threads).
         // By blocking here we ensure at most one increase is in flight at a time.
-        if (increase_enqueued)
-            cv.wait(lock, [this] { return !increase_enqueued || kill_reason || fail_reason; });
+        if (enqueued_demand != 0)
+            cv.wait(lock, [this] { return enqueued_demand == 0 || kill_reason || fail_reason; });
 
         throwIfNeeded();
 
@@ -143,19 +142,17 @@ void MemoryReservation::syncWithMemoryTracker(const MemoryTracker * memory_track
 
         actual_size = new_actual_size;
 
-        if (!fail_reason && actual_size > expected_allocated && !increase_enqueued)
+        if (!fail_reason && actual_size > expected_allocated && enqueued_demand == 0)
         {
             chassert(!removed);
             pending_increase = actual_size - expected_allocated;
-            increase_enqueued = true;
             enqueued_demand = pending_increase;
             demand_increment.add(enqueued_demand);
         }
-        else if (!fail_reason && actual_size < expected_allocated && !decrease_enqueued)
+        else if (!fail_reason && actual_size < expected_allocated && enqueued_decrease == 0)
         {
             chassert(!removed);
             pending_decrease = expected_allocated - actual_size;
-            decrease_enqueued = true;
             enqueued_decrease = pending_decrease;
         }
     }
@@ -222,7 +219,6 @@ void MemoryReservation::increaseApproved(const IncreaseRequest & increase)
     approved_increment.add(increase.size);
     demand_increment.sub(enqueued_demand);
     enqueued_demand = 0;
-    increase_enqueued = false;
     cv.notify_all();
 }
 
@@ -233,20 +229,17 @@ void MemoryReservation::decreaseApproved(const DecreaseRequest & decrease)
     chassert(allocated_size >= decrease.size);
     allocated_size -= decrease.size;
     approved_increment.sub(decrease.size);
-    decrease_enqueued = false;
     enqueued_decrease = 0;
     if (decrease.removing_allocation)
     {
         // The queue cancels any pending increase as part of the removal path
         // (`processActivation` unlinks from `increasing_allocations` without calling
-        // `increaseApproved`). Roll back the demand metric and clear
-        // `increase_enqueued` so threads blocked on the serialization barrier in
-        // `syncWithMemoryTracker` are released and do not wait forever.
-        if (increase_enqueued)
+        // `increaseApproved`). Roll back the demand so threads blocked on the
+        // serialization barrier in `syncWithMemoryTracker` are released.
+        if (enqueued_demand != 0)
         {
             demand_increment.sub(enqueued_demand);
             enqueued_demand = 0;
-            increase_enqueued = false;
         }
         removed = true;
     }
@@ -259,7 +252,7 @@ void MemoryReservation::allocationFailed(const std::exception_ptr & reason)
     metrics.failed++;
     fail_reason = reason;
     removed = true; // failed allocation are auto-removed by the scheduler
-    if (increase_enqueued)
+    if (enqueued_demand != 0)
         demand_increment.sub(enqueued_demand);
     approved_increment.sub(allocated_size);
     allocated_size = 0;

--- a/src/Common/Scheduler/MemoryReservation.cpp
+++ b/src/Common/Scheduler/MemoryReservation.cpp
@@ -142,14 +142,14 @@ void MemoryReservation::syncWithMemoryTracker(const MemoryTracker * memory_track
 
         actual_size = new_actual_size;
 
-        if (!fail_reason && actual_size > expected_allocated && enqueued_demand == 0)
+        if (actual_size > expected_allocated)
         {
             chassert(!removed);
             pending_increase = actual_size - expected_allocated;
             enqueued_demand = pending_increase;
             demand_increment.add(enqueued_demand);
         }
-        else if (!fail_reason && actual_size < expected_allocated && enqueued_decrease == 0)
+        else if (actual_size < expected_allocated && enqueued_decrease == 0)
         {
             chassert(!removed);
             pending_decrease = expected_allocated - actual_size;

--- a/src/Common/Scheduler/MemoryReservation.cpp
+++ b/src/Common/Scheduler/MemoryReservation.cpp
@@ -131,24 +131,32 @@ void MemoryReservation::syncWithMemoryTracker(const MemoryTracker * memory_track
         // Make sure reservation size is always respected
         ResourceCost new_actual_size = std::max(memory_tracker->get(), reserved_size);
 
-        if (new_actual_size == actual_size)
+        // Decreases are approved asynchronously: an increase sized against the current allocated
+        // value would end short by the in-flight decrease, and the wait below would never finish.
+        // Size requests against the value the allocation will hold once the decrease is approved.
+        ResourceCost expected_allocated = allocated_size - enqueued_decrease;
+
+        // An unchanged tracker value alone does not imply there is nothing to do: a shortfall or
+        // excess may remain from an earlier sync, so skip only when fully in sync.
+        if (new_actual_size == actual_size && new_actual_size == expected_allocated)
             return;
 
         actual_size = new_actual_size;
 
-        if (!fail_reason && actual_size > allocated_size && !increase_enqueued)
+        if (!fail_reason && actual_size > expected_allocated && !increase_enqueued)
         {
             chassert(!removed);
-            pending_increase = actual_size - allocated_size;
+            pending_increase = actual_size - expected_allocated;
             increase_enqueued = true;
             enqueued_demand = pending_increase;
             demand_increment.add(enqueued_demand);
         }
-        else if (!fail_reason && actual_size < allocated_size && !decrease_enqueued)
+        else if (!fail_reason && actual_size < expected_allocated && !decrease_enqueued)
         {
             chassert(!removed);
-            pending_decrease = allocated_size - actual_size;
+            pending_decrease = expected_allocated - actual_size;
             decrease_enqueued = true;
+            enqueued_decrease = pending_decrease;
         }
     }
 
@@ -161,11 +169,12 @@ void MemoryReservation::syncWithMemoryTracker(const MemoryTracker * memory_track
     {
         std::unique_lock lock(mutex);
         // Wait on increase to make sure memory is reserved when requested.
-        // Decrease is not waited for — it will be processed asynchronously.
-        if (actual_size > allocated_size)
+        // Decrease is not waited for, but counted as already gone: once approved,
+        // its capacity may be granted to another workload.
+        if (actual_size > allocated_size - enqueued_decrease)
         {
             auto increase_timer = CurrentThread::getProfileEvents().timer(ProfileEvents::MemoryReservationIncreaseMicroseconds);
-            cv.wait(lock, [this] { return kill_reason || fail_reason || actual_size <= allocated_size; });
+            cv.wait(lock, [this] { return kill_reason || fail_reason || actual_size <= allocated_size - enqueued_decrease; });
         }
 
         metrics.apply();
@@ -225,6 +234,7 @@ void MemoryReservation::decreaseApproved(const DecreaseRequest & decrease)
     allocated_size -= decrease.size;
     approved_increment.sub(decrease.size);
     decrease_enqueued = false;
+    enqueued_decrease = 0;
     if (decrease.removing_allocation)
     {
         // The queue cancels any pending increase as part of the removal path

--- a/src/Common/Scheduler/MemoryReservation.h
+++ b/src/Common/Scheduler/MemoryReservation.h
@@ -86,6 +86,7 @@ private:
     ResourceCost allocated_size = 0; // equals ResourceAllocation::allocated, which is private and controlled by the scheduler
     ResourceCost actual_size = 0; // real size of the resource used by the allocation
     ResourceCost enqueued_demand = 0; // amount added to demand_increment when increase was enqueued (for accurate rollback)
+    ResourceCost enqueued_decrease = 0; // size of the in-flight decrease request; nonzero iff decrease_enqueued
 
     /// Helper struct. Holds postponed ProfileEvents increments to be executed from a query thread.
     struct Metrics

--- a/src/Common/Scheduler/MemoryReservation.h
+++ b/src/Common/Scheduler/MemoryReservation.h
@@ -80,13 +80,11 @@ private:
 
     std::exception_ptr kill_reason;
     std::exception_ptr fail_reason;
-    bool increase_enqueued = false;
-    bool decrease_enqueued = false;
     bool removed = false;
     ResourceCost allocated_size = 0; // equals ResourceAllocation::allocated, which is private and controlled by the scheduler
     ResourceCost actual_size = 0; // real size of the resource used by the allocation
-    ResourceCost enqueued_demand = 0; // amount added to demand_increment when increase was enqueued (for accurate rollback)
-    ResourceCost enqueued_decrease = 0; // size of the in-flight decrease request; nonzero iff decrease_enqueued
+    ResourceCost enqueued_demand = 0; // amount added to demand_increment when increase was enqueued
+    ResourceCost enqueued_decrease = 0; // size of the in-flight decrease request
 
     /// Helper struct. Holds postponed ProfileEvents increments to be executed from a query thread.
     struct Metrics

--- a/src/Common/Scheduler/Nodes/tests/gtest_space_shared_scheduler.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_space_shared_scheduler.cpp
@@ -18,6 +18,12 @@ namespace DB::ErrorCodes
     extern const int MEMORY_RESERVATION_KILLED;
 }
 
+namespace CurrentMetrics
+{
+    extern const Metric MemoryReservationApproved;
+    extern const Metric MemoryReservationDemand;
+}
+
 struct SpaceSharedTest : public ResourceTestBase
 {
     SpaceSharedScheduler scheduler;
@@ -213,6 +219,113 @@ TEST(SchedulerSpaceShared, ReservationWithMemoryTracker)
         tracker.adjustWithUntrackedMemory(-4000);
         EXPECT_EQ(tracker.get(), 0);
     }
+}
+
+
+/// Regression test: an increase issued while a decrease is still in flight must be sized against
+/// the post-decrease allocation. It used to be sized against the current allocation, so the
+/// approved total ended short by exactly the in-flight decrease and the sync waited forever.
+TEST(SchedulerSpaceShared, IncreaseWhileDecreaseIsInFlight)
+{
+    SpaceSharedTest t;
+
+    SpaceSharedResourceHolder r(t);
+    r.addLimit("/", 1000000);
+    AllocationQueue * queue = r.addQueue("/queue");
+    r.registerResource();
+
+    ResourceLink link;
+    link.allocation_queue = queue;
+
+    /// Reads the aggregate on the scheduler thread, where it may be safely accessed.
+    auto allocated_of = [&](ISpaceSharedNode * node) -> ResourceCost
+    {
+        std::promise<ResourceCost> p;
+        auto f = p.get_future();
+        t.scheduler.event_queue.enqueue([&] { p.set_value(node->allocated); });
+        return f.get();
+    };
+
+    MemoryTracker tracker;
+    {
+        MemoryReservation res(link, "res", 100);
+        tracker.adjustWithUntrackedMemory(800);
+        res.syncWithMemoryTracker(&tracker);
+        EXPECT_EQ(allocated_of(queue), 800);
+
+        // Hold the scheduler thread so that the following requests stay in flight.
+        std::promise<void> unblock;
+        t.scheduler.event_queue.enqueue([f = unblock.get_future().share()] { f.get(); });
+
+        tracker.adjustWithUntrackedMemory(-500); // 300
+        res.syncWithMemoryTracker(&tracker); // enqueues a decrease of 500 and returns without waiting
+
+        ResourceCost demand = CurrentMetrics::get(CurrentMetrics::MemoryReservationDemand);
+        tracker.adjustWithUntrackedMemory(700); // 1000
+        std::thread grow([&] { res.syncWithMemoryTracker(&tracker); });
+        // Make sure the increase is enqueued while the decrease is still in flight
+        while (CurrentMetrics::get(CurrentMetrics::MemoryReservationDemand) == demand)
+            std::this_thread::yield();
+
+        unblock.set_value();
+        grow.join(); // used to hang forever: 800 - 500 + (1000 - 800) < 1000
+
+        // Both requests approved: the allocation converges to the actual usage
+        while (allocated_of(queue) != 1000)
+            std::this_thread::yield();
+
+        tracker.adjustWithUntrackedMemory(-1000);
+    }
+    EXPECT_EQ(allocated_of(queue), 0);
+}
+
+
+/// The sync must not return while the usage is covered only by capacity that an in-flight decrease
+/// is about to release: once the decrease is approved, that capacity may be granted to another
+/// workload. It used to return without waiting whenever the usage was below the current allocation.
+TEST(SchedulerSpaceShared, SyncWaitsForPostDecreaseCoverage)
+{
+    SpaceSharedTest t;
+
+    SpaceSharedResourceHolder r(t);
+    r.addLimit("/", 1000000);
+    AllocationQueue * queue = r.addQueue("/queue");
+    r.registerResource();
+
+    ResourceLink link;
+    link.allocation_queue = queue;
+
+    MemoryTracker tracker;
+    MemoryReservation res(link, "res", 100);
+    tracker.adjustWithUntrackedMemory(800);
+    res.syncWithMemoryTracker(&tracker); // allocated == 800
+
+    // Hold the scheduler thread so that the following requests stay in flight.
+    std::promise<void> unblock;
+    t.scheduler.event_queue.enqueue([f = unblock.get_future().share()] { f.get(); });
+
+    tracker.adjustWithUntrackedMemory(-500); // 300
+    res.syncWithMemoryTracker(&tracker); // enqueues a decrease of 500 and returns without waiting
+
+    ResourceCost demand = CurrentMetrics::get(CurrentMetrics::MemoryReservationDemand);
+    ResourceCost approved = CurrentMetrics::get(CurrentMetrics::MemoryReservationApproved);
+    tracker.adjustWithUntrackedMemory(300); // 600: covered by the current 800, but not by 800 - 500
+    std::thread grow([&]
+    {
+        res.syncWithMemoryTracker(&tracker);
+        // The compensating increase (+300) must be approved by the time the sync returns;
+        // the decrease (-500) may or may not be. No change at all means the sync did not wait.
+        ResourceCost diff = CurrentMetrics::get(CurrentMetrics::MemoryReservationApproved) - approved;
+        EXPECT_TRUE(diff == 300 || diff == -200) << diff;
+    });
+    // Make sure the increase is enqueued while the decrease is still in flight
+    while (CurrentMetrics::get(CurrentMetrics::MemoryReservationDemand) == demand)
+        std::this_thread::yield();
+
+    unblock.set_value();
+    grow.join();
+
+    tracker.adjustWithUntrackedMemory(-600);
 }
 
 


### PR DESCRIPTION
Decreases are approved asynchronously, so an increase computed while one is in flight used a stale allocated value: drop A->B (decrease A-B enqueued), rise to C before approval enqueues C-A; after both approvals allocated = C - (A-B), and the thread waits on actual <= allocated forever (the unchanged-tracker early return prevented re-issuing the shortfall). Fix: track the in-flight decrease size and size requests against the post-decrease allocated value.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
workload: fix MemoryReservation hang when increase races with in-flight decrease

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116085&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116085](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116085+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.660` (included in `26.9` and later)
<!-- ch-version-info:end -->