### PR TITLE
Docs: Embed YouTube video in MCP documentation

### DIFF
--- a/docs/clickstack/mcp.mdx
+++ b/docs/clickstack/mcp.mdx
@@ -13,8 +13,9 @@ ClickStack includes a built-in [Model Context Protocol (MCP)](https://modelconte
 
 This allows you to use tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Cursor](https://www.cursor.com/), or any MCP-compatible client to investigate incidents, build dashboards, and manage your observability setup without leaving your development environment.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/FaL5iOgNogg?si=dUbsRQe4wYuZ78zt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-
+<Frame>
+<iframe src="https://www.youtube.com/embed/FaL5iOgNogg?si=dUbsRQe4wYuZ78zt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</Frame>
 ## Availability {#availability}
 
 The MCP server is available in the following ClickStack deployment types:

--- a/docs/clickstack/mcp.mdx
+++ b/docs/clickstack/mcp.mdx
@@ -13,6 +13,8 @@ ClickStack includes a built-in [Model Context Protocol (MCP)](https://modelconte
 
 This allows you to use tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Cursor](https://www.cursor.com/), or any MCP-compatible client to investigate incidents, build dashboards, and manage your observability setup without leaving your development environment.
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/FaL5iOgNogg?si=dUbsRQe4wYuZ78zt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## Availability {#availability}
 
 The MCP server is available in the following ClickStack deployment types:


### PR DESCRIPTION
Added an embedded YouTube video to the MCP documentation.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116102&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116102](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116102+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.28` (included in `26.9` and later)
<!-- ch-version-info:end -->