### PR TITLE
Fix a heap-use-after-free on pipeline edges queued in a concurrent executor frame

### DIFF
--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -249,9 +249,8 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
                 if (removed_processors.contains(removed_proc) || !distinct_removed.insert(removed_proc.get()).second)
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
-                        "Processor {} is listed more than once for removal. Graph: {}",
-                        removed_proc->getName(),
-                        dump(false));
+                        "Processor {} is listed more than once for removal",
+                        removed_proc->getName());
 
                 if (const auto * node = processors_map.at(removed_proc.get()))
                     if (node->last_processor_status != IProcessor::Status::Finished)

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -43,6 +43,15 @@ String describeProcessor(const IProcessor * processor)
     return fmt::format("{} at {}", processor->getUniqID(), static_cast<const void *>(processor));
 }
 
+/// Stands in for the removed peer of a retired edge. Portless and always `Finished`, so it has
+/// nothing to connect to and nothing to do.
+class RetiredEdgeTarget final : public IProcessor
+{
+public:
+    String getName() const override { return "RetiredEdgeTarget"; }
+    Status prepare() override { return Status::Finished; }
+};
+
 }
 
 ExecutingGraph::ExecutingGraph(std::shared_ptr<Processors> processors_, bool profile_processors_)
@@ -151,32 +160,44 @@ ExecutingGraph::NewEdges ExecutingGraph::addEdges(Node & node)
     return result;
 }
 
-void ExecutingGraph::collectAffectedEdges(
-    const Node & node, const std::unordered_set<const Node *> & removed_nodes, std::unordered_set<const void *> & removed_edge_ids)
+void ExecutingGraph::retireAffectedEdges(const std::unordered_set<const Node *> & removed_nodes)
 {
-    auto collect = [&](const Edges & edges)
+    /// Allocate before anything moves, so that a throw here leaves the graph as it was.
+    if (!retired_edge_target)
     {
-        for (const auto & edge : edges)
-            if (removed_nodes.contains(edge.to))
-                removed_edge_ids.insert(edge.update_info.id);
+        retired_edge_target_processors.push_back(std::make_shared<RetiredEdgeTarget>());
+        auto target = std::make_unique<Node>(std::prev(retired_edge_target_processors.end()), 0);
+        target->status = ExecStatus::Finished;
+        target->last_processor_status = IProcessor::Status::Finished;
+        retired_edge_target = std::move(target);
+    }
+
+    auto retire = [&](Edges & edges, bool retire_every_edge)
+    {
+        for (auto it = edges.begin(); it != edges.end();)
+        {
+            auto next = std::next(it);
+
+            if (retire_every_edge || removed_nodes.contains(it->to))
+            {
+                it->to = retired_edge_target.get();
+                /// The list belongs to the node owning the edge, which may itself be going away,
+                /// and a retired edge is never visited again to drain what was pushed to it.
+                it->update_info.update_list = nullptr;
+                retired_edges.splice(retired_edges.end(), edges, it);
+            }
+
+            it = next;
+        }
     };
 
-    collect(node.back_edges);
-    collect(node.direct_edges);
-}
-
-void ExecutingGraph::eraseAffectedEdges(
-    Node & node, const std::unordered_set<const Node *> & removed_nodes, const std::unordered_set<const void *> & removed_edge_ids)
-{
-    auto is_removed = [&](const Edge & edge) { return removed_nodes.contains(edge.to); };
-    const size_t erased = std::erase_if(node.back_edges, is_removed) + std::erase_if(node.direct_edges, is_removed);
-
-    /// We need to remove cached updates for removed edges. This updates now contain stale pointers.
-    if (erased != 0)
+    for (auto & node : nodes)
     {
-        auto is_stale = [&](void * id) { return removed_edge_ids.contains(id); };
-        std::erase_if(node.post_updated_input_ports, is_stale);
-        std::erase_if(node.post_updated_output_ports, is_stale);
+        /// A removed node's own edges are queued elsewhere just the same, and the lists holding
+        /// them die with the node, so all of them are retired and not just the ones pointing back.
+        const bool owner_is_removed = removed_nodes.contains(&node);
+        retire(node.back_edges, owner_is_removed);
+        retire(node.direct_edges, owner_is_removed);
     }
 }
 
@@ -289,49 +310,12 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
     return UpdateNodeStatus::Done;
 }
 
-ExecutingGraph::EdgeWorkListGuard::EdgeWorkListGuard(ExecutingGraph & graph_, EdgeWorkList & work_list_)
-    : graph(graph_), work_list(work_list_)
-{
-    std::lock_guard guard(graph.active_edge_work_lists_mutex);
-    next = graph.active_edge_work_lists;
-    if (next)
-        next->prev = this;
-    graph.active_edge_work_lists = this;
-}
-
-ExecutingGraph::EdgeWorkListGuard::~EdgeWorkListGuard()
-{
-    std::lock_guard guard(graph.active_edge_work_lists_mutex);
-    if (prev)
-        prev->next = next;
-    else
-        graph.active_edge_work_lists = next;
-    if (next)
-        next->prev = prev;
-}
-
-void ExecutingGraph::scrubRemovedEdges(const std::unordered_set<const void *> & removed_edge_ids)
-{
-    if (removed_edge_ids.empty())
-        return;
-
-    std::lock_guard guard(active_edge_work_lists_mutex);
-
-    for (auto * entry = active_edge_work_lists; entry; entry = entry->next)
-    {
-        auto stale = std::ranges::remove_if(entry->work_list, [&](const void * edge) { return removed_edge_ids.contains(edge); });
-        entry->work_list.erase(stale.begin(), stale.end());
-    }
-}
-
 ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction)
 {
     RemoveGroupResult result;
 
-    /// Identify everything that is about to go away while it is all still alive, so that the
-    /// destruction below runs after the work lists have been cleaned. Doing it the other way
-    /// round would leave a window in which an edge is freed but still published: the set
-    /// insertions here allocate, and an allocation may throw.
+    /// Look every node up before anything changes, so that a malformed removal throws with the
+    /// graph untouched.
     std::vector<Node *> nodes_to_erase;
     nodes_to_erase.reserve(group.processors.size());
 
@@ -341,35 +325,20 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemo
         for (const auto & removed_proc : group.processors)
         {
             auto * removed_node = findNodeToRemove(removed_proc);
-
             result.removed_nodes.insert(removed_node);
             nodes_to_erase.push_back(removed_node);
-            result.removed_edges.insert_range(
-                removed_node->direct_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
-            result.removed_edges.insert_range(
-                removed_node->back_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
         }
     }
 
-    for (const auto & node : nodes)
-        collectAffectedEdges(node, result.removed_nodes, result.removed_edges);
+    /// Must precede the erase below: it is what keeps the edges of these nodes alive.
+    retireAffectedEdges(result.removed_nodes);
 
-    /// These edges may still be queued in a concurrent `updateNode` frame, which is parked at a
-    /// gap in `nodes_mutex` and cannot resume before this exclusive section ends. Dropping them
-    /// from every published work list before anything is destroyed is what keeps those frames
-    /// from dereferencing freed memory.
-    scrubRemovedEdges(result.removed_edges);
-
-    /// Nothing below may allocate into `result`: the edges are gone once this starts.
     {
         std::lock_guard guard(processors_mutex);
 
         for (auto * removed_node : nodes_to_erase)
             eraseNode(removed_node);
     }
-
-    for (auto & node : nodes)
-        eraseAffectedEdges(node, result.removed_nodes, result.removed_edges);
 
     for (const auto & removed_proc : group.processors)
         removed_processors.erase(removed_proc);
@@ -390,7 +359,6 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removeReadyGroups(Processors &
     {
         auto group_result = removePendingGroup(*group, delayed_destruction);
         result.removed_nodes.insert_range(group_result.removed_nodes);
-        result.removed_edges.insert_range(group_result.removed_edges);
     }
 
     return result;
@@ -473,7 +441,7 @@ void ExecutingGraph::initializeExecution(Queue & queue, Queue & async_queue)
 ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Queue & queue, Queue & async_queue)
 {
     Processors delayed_destruction;
-    EdgeWorkList updated_edges;
+    boost::container::devector<Edge *> updated_edges;
     boost::container::devector<Node *> updated_processors;
     updated_processors.push_back(start_node);
 
@@ -643,10 +611,6 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
 
             if (need_update_pipeline)
             {
-                /// Constructed before the lock is dropped and destroyed after it is retaken, so the
-                /// queued edges are never unpublished while this frame holds no lock.
-                EdgeWorkListGuard edge_work_list_guard(*this, updated_edges);
-
                 // We do not need to upgrade lock atomically, so we can safely release shared_lock and acquire unique_lock
                 read_lock.unlock();
 
@@ -672,10 +636,6 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
             /// The peek under the shared lock is only a hint.
             if (!removed_processors.empty() && findGroupReadyForRemoval())
             {
-                /// Publication also covers this frame's own removals: `removeReadyGroups` below
-                /// scrubs every published list, including this one.
-                EdgeWorkListGuard edge_work_list_guard(*this, updated_edges);
-
                 read_lock.unlock();
 
                 RemoveGroupResult remove_result = removeReadyGroups(delayed_destruction);

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -215,16 +215,17 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
         /// Record removed processors in pending removal queue
         if (!update.to_remove.empty())
         {
-            /// `to_remove` is a set (`IProcessor::PipelineUpdate`). `not_finished` counts every
-            /// entry while `removed_processors` and the graph hold one of each, so a repeated
-            /// unfinished processor would leave a counter that can never reach zero.
+            /// A processor may be pending removal at most once across the whole graph, whether it
+            /// repeats within this list or was queued by an earlier call: `not_finished` counts
+            /// every entry, while `removed_processors` and the graph hold one of each, so a second
+            /// entry leaves a counter that can never reach zero.
             std::unordered_set<const IProcessor *> distinct_removed;
             distinct_removed.reserve(update.to_remove.size());
 
             size_t not_finished = 0;
             for (const auto & removed_proc : update.to_remove)
             {
-                if (!distinct_removed.insert(removed_proc.get()).second)
+                if (removed_processors.contains(removed_proc) || !distinct_removed.insert(removed_proc.get()).second)
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
                         "Processor {} is listed more than once for removal. Graph: {}",

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -71,7 +71,7 @@ ExecutingGraph::Node & ExecutingGraph::addNode(Processors::iterator processor_it
     return new_node;
 }
 
-std::pair<const ExecutingGraph::Node *, std::unordered_set<const void *>> ExecutingGraph::removeNode(ProcessorPtr processor)
+ExecutingGraph::Node * ExecutingGraph::findNodeToRemove(const ProcessorPtr & processor)
 {
     auto node_it = processors_map.find(processor.get());
     if (node_it == processors_map.end())
@@ -84,15 +84,14 @@ std::pair<const ExecutingGraph::Node *, std::unordered_set<const void *>> Execut
     if (node->last_processor_status.value() != IProcessor::Status::Finished)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}. Graph: {}", processor->getName(), dump(false));
 
-    std::unordered_set<const void *> removed_edges;
-    removed_edges.insert_range(node->direct_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
-    removed_edges.insert_range(node->back_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
+    return node;
+}
 
-    processors_map.erase(node_it);
+void ExecutingGraph::eraseNode(Node * node)
+{
+    processors_map.erase(node->processor());
     processors->erase(node->processor_iter);
     nodes.erase(node->self_iter);
-
-    return {node, std::move(removed_edges)};
 }
 
 ExecutingGraph::Node & ExecutingGraph::addNode(ProcessorPtr processor)
@@ -152,41 +151,33 @@ ExecutingGraph::NewEdges ExecutingGraph::addEdges(Node & node)
     return result;
 }
 
-std::unordered_set<const void *> ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<const Node *> & removed_nodes)
+void ExecutingGraph::collectAffectedEdges(
+    const Node & node, const std::unordered_set<const Node *> & removed_nodes, std::unordered_set<const void *> & removed_edge_ids)
 {
-    std::unordered_set<const void *> removed_edge_ids;
-
-    for (auto it = node.back_edges.begin(); it != node.back_edges.end();)
+    auto collect = [&](const Edges & edges)
     {
-        if (removed_nodes.contains(it->to))
-        {
-            removed_edge_ids.insert(it->update_info.id);
-            it = node.back_edges.erase(it);
-        }
-        else
-            it = std::next(it);
-    }
+        for (const auto & edge : edges)
+            if (removed_nodes.contains(edge.to))
+                removed_edge_ids.insert(edge.update_info.id);
+    };
 
-    for (auto it = node.direct_edges.begin(); it != node.direct_edges.end();)
-    {
-        if (removed_nodes.contains(it->to))
-        {
-            removed_edge_ids.insert(it->update_info.id);
-            it = node.direct_edges.erase(it);
-        }
-        else
-            it = std::next(it);
-    }
+    collect(node.back_edges);
+    collect(node.direct_edges);
+}
+
+void ExecutingGraph::eraseAffectedEdges(
+    Node & node, const std::unordered_set<const Node *> & removed_nodes, const std::unordered_set<const void *> & removed_edge_ids)
+{
+    auto is_removed = [&](const Edge & edge) { return removed_nodes.contains(edge.to); };
+    const size_t erased = std::erase_if(node.back_edges, is_removed) + std::erase_if(node.direct_edges, is_removed);
 
     /// We need to remove cached updates for removed edges. This updates now contain stale pointers.
-    if (!removed_edge_ids.empty())
+    if (erased != 0)
     {
         auto is_stale = [&](void * id) { return removed_edge_ids.contains(id); };
         std::erase_if(node.post_updated_input_ports, is_stale);
         std::erase_if(node.post_updated_output_ports, is_stale);
     }
-
-    return removed_edge_ids;
 }
 
 ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container::devector<Node *> & stack, Node & cur_node)
@@ -321,28 +312,50 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemo
 {
     RemoveGroupResult result;
 
+    /// Identify everything that is about to go away while it is all still alive, so that the
+    /// destruction below runs after the work lists have been cleaned. Doing it the other way
+    /// round would leave a window in which an edge is freed but still published: the set
+    /// insertions here allocate, and an allocation may throw.
+    std::vector<Node *> nodes_to_erase;
+    nodes_to_erase.reserve(group.processors.size());
+
     {
         std::lock_guard guard(processors_mutex);
 
         for (const auto & removed_proc : group.processors)
         {
-            auto [removed_node, removed_edges] = removeNode(removed_proc);
+            auto * removed_node = findNodeToRemove(removed_proc);
+            nodes_to_erase.push_back(removed_node);
             result.removed_nodes.insert(removed_node);
-            result.removed_edges.insert_range(removed_edges);
+            result.removed_edges.insert_range(
+                removed_node->direct_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
+            result.removed_edges.insert_range(
+                removed_node->back_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
         }
     }
 
-    for (const auto & removed_proc : group.processors)
-        removed_processors.erase(removed_proc);
+    for (const auto & node : nodes)
+        collectAffectedEdges(node, result.removed_nodes, result.removed_edges);
+
+    /// These edges may still be queued in a concurrent `updateNode` frame, which is parked at a
+    /// gap in `nodes_mutex` and cannot resume before this exclusive section ends. Dropping them
+    /// from every published work list before anything is destroyed is what keeps those frames
+    /// from dereferencing freed memory.
+    scrubRemovedEdges(result.removed_edges);
+
+    /// Nothing below may allocate into `result`: the edges are gone once this starts.
+    {
+        std::lock_guard guard(processors_mutex);
+
+        for (auto * removed_node : nodes_to_erase)
+            eraseNode(removed_node);
+    }
 
     for (auto & node : nodes)
-        result.removed_edges.insert_range(removeAffectedEdges(node, result.removed_nodes));
+        eraseAffectedEdges(node, result.removed_nodes, result.removed_edges);
 
-    /// The edges just freed may still be queued in a concurrent `updateNode` frame, which is
-    /// parked at a gap in `nodes_mutex` and cannot resume before this exclusive section ends.
-    /// Dropping them here, while no new edge can be allocated, keeps every published work list
-    /// free of dangling pointers without ever comparing a reused address.
-    scrubRemovedEdges(result.removed_edges);
+    for (const auto & removed_proc : group.processors)
+        removed_processors.erase(removed_proc);
 
     /// Removed processors can hold the last strong reference to data.
     /// It is too expensive to destroy them under the nodes mutex.
@@ -446,11 +459,6 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
     EdgeWorkList updated_edges;
     boost::container::devector<Node *> updated_processors;
     updated_processors.push_back(start_node);
-
-    /// Queued edges outlive the gaps this frame makes in `nodes_mutex`, so they must be visible to
-    /// whoever frees them. A `Node *` needs no such publication: a node cannot be removed before it
-    /// is `Finished`, and a `Finished` node is never queued.
-    EdgeWorkListGuard edge_work_list_guard(*this, updated_edges);
 
     std::shared_lock read_lock(nodes_mutex);
 
@@ -618,6 +626,10 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
 
             if (need_update_pipeline)
             {
+                /// Constructed before the lock is dropped and destroyed after it is retaken, so the
+                /// queued edges are never unpublished while this frame holds no lock.
+                EdgeWorkListGuard edge_work_list_guard(*this, updated_edges);
+
                 // We do not need to upgrade lock atomically, so we can safely release shared_lock and acquire unique_lock
                 read_lock.unlock();
 
@@ -643,6 +655,10 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
             /// The peek under the shared lock is only a hint.
             if (!removed_processors.empty() && findGroupReadyForRemoval())
             {
+                /// Publication also covers this frame's own removals: `removeReadyGroups` below
+                /// scrubs every published list, including this one.
+                EdgeWorkListGuard edge_work_list_guard(*this, updated_edges);
+
                 read_lock.unlock();
 
                 RemoveGroupResult remove_result = removeReadyGroups(delayed_destruction);

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -282,6 +282,41 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
     return UpdateNodeStatus::Done;
 }
 
+ExecutingGraph::EdgeWorkListGuard::EdgeWorkListGuard(ExecutingGraph & graph_, EdgeWorkList & work_list_)
+    : graph(graph_), work_list(work_list_)
+{
+    std::lock_guard guard(graph.active_edge_work_lists_mutex);
+    next = graph.active_edge_work_lists;
+    if (next)
+        next->prev = this;
+    graph.active_edge_work_lists = this;
+}
+
+ExecutingGraph::EdgeWorkListGuard::~EdgeWorkListGuard()
+{
+    std::lock_guard guard(graph.active_edge_work_lists_mutex);
+    if (prev)
+        prev->next = next;
+    else
+        graph.active_edge_work_lists = next;
+    if (next)
+        next->prev = prev;
+}
+
+void ExecutingGraph::scrubRemovedEdges(const std::unordered_set<const void *> & removed_edge_ids)
+{
+    if (removed_edge_ids.empty())
+        return;
+
+    std::lock_guard guard(active_edge_work_lists_mutex);
+
+    for (auto * entry = active_edge_work_lists; entry; entry = entry->next)
+    {
+        auto stale = std::ranges::remove_if(entry->work_list, [&](const void * edge) { return removed_edge_ids.contains(edge); });
+        entry->work_list.erase(stale.begin(), stale.end());
+    }
+}
+
 ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction)
 {
     RemoveGroupResult result;
@@ -302,6 +337,12 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemo
 
     for (auto & node : nodes)
         result.removed_edges.insert_range(removeAffectedEdges(node, result.removed_nodes));
+
+    /// The edges just freed may still be queued in a concurrent `updateNode` frame, which is
+    /// parked at a gap in `nodes_mutex` and cannot resume before this exclusive section ends.
+    /// Dropping them here, while no new edge can be allocated, keeps every published work list
+    /// free of dangling pointers without ever comparing a reused address.
+    scrubRemovedEdges(result.removed_edges);
 
     /// Removed processors can hold the last strong reference to data.
     /// It is too expensive to destroy them under the nodes mutex.
@@ -402,9 +443,14 @@ void ExecutingGraph::initializeExecution(Queue & queue, Queue & async_queue)
 ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Queue & queue, Queue & async_queue)
 {
     Processors delayed_destruction;
-    boost::container::devector<Edge *> updated_edges;
+    EdgeWorkList updated_edges;
     boost::container::devector<Node *> updated_processors;
     updated_processors.push_back(start_node);
+
+    /// Queued edges outlive the gaps this frame makes in `nodes_mutex`, so they must be visible to
+    /// whoever frees them. A `Node *` needs no such publication: a node cannot be removed before it
+    /// is `Finished`, and a `Finished` node is never queued.
+    EdgeWorkListGuard edge_work_list_guard(*this, updated_edges);
 
     std::shared_lock read_lock(nodes_mutex);
 
@@ -600,12 +646,6 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                 read_lock.unlock();
 
                 RemoveGroupResult remove_result = removeReadyGroups(delayed_destruction);
-
-                if (!remove_result.removed_edges.empty())
-                {
-                    auto removed_range = std::ranges::remove_if(updated_edges, [&](const void * edge) { return remove_result.removed_edges.contains(edge); });
-                    updated_edges.erase(removed_range.begin(), removed_range.end());
-                }
 
                 if (!remove_result.removed_nodes.empty())
                 {

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -215,11 +215,26 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
         /// Record removed processors in pending removal queue
         if (!update.to_remove.empty())
         {
+            /// `to_remove` is a set (`IProcessor::PipelineUpdate`). `not_finished` counts every
+            /// entry while `removed_processors` and the graph hold one of each, so a repeated
+            /// unfinished processor would leave a counter that can never reach zero.
+            std::unordered_set<const IProcessor *> distinct_removed;
+            distinct_removed.reserve(update.to_remove.size());
+
             size_t not_finished = 0;
             for (const auto & removed_proc : update.to_remove)
+            {
+                if (!distinct_removed.insert(removed_proc.get()).second)
+                    throw Exception(
+                        ErrorCodes::LOGICAL_ERROR,
+                        "Processor {} is listed more than once for removal. Graph: {}",
+                        removed_proc->getName(),
+                        dump(false));
+
                 if (const auto * node = processors_map.at(removed_proc.get()))
                     if (node->last_processor_status != IProcessor::Status::Finished)
                         ++not_finished;
+            }
 
             auto group = std::make_shared<PendingRemovalGroup>();
             group->not_finished = not_finished;
@@ -326,16 +341,7 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemo
         {
             auto * removed_node = findNodeToRemove(removed_proc);
 
-            /// `to_remove` is a set (`IProcessor::PipelineUpdate`), and every node collected here is
-            /// erased exactly once below. A repeated processor has to be rejected while the whole
-            /// group is still alive, because the erase loop cannot detect it any more.
-            if (!result.removed_nodes.insert(removed_node).second)
-                throw Exception(
-                    ErrorCodes::LOGICAL_ERROR,
-                    "Processor {} is listed more than once for removal. Graph: {}",
-                    removed_proc->getName(),
-                    dump(false));
-
+            result.removed_nodes.insert(removed_node);
             nodes_to_erase.push_back(removed_node);
             result.removed_edges.insert_range(
                 removed_node->direct_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -325,8 +325,18 @@ ExecutingGraph::RemoveGroupResult ExecutingGraph::removePendingGroup(PendingRemo
         for (const auto & removed_proc : group.processors)
         {
             auto * removed_node = findNodeToRemove(removed_proc);
+
+            /// `to_remove` is a set (`IProcessor::PipelineUpdate`), and every node collected here is
+            /// erased exactly once below. A repeated processor has to be rejected while the whole
+            /// group is still alive, because the erase loop cannot detect it any more.
+            if (!result.removed_nodes.insert(removed_node).second)
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Processor {} is listed more than once for removal. Graph: {}",
+                    removed_proc->getName(),
+                    dump(false));
+
             nodes_to_erase.push_back(removed_node);
-            result.removed_nodes.insert(removed_node);
             result.removed_edges.insert_range(
                 removed_node->direct_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
             result.removed_edges.insert_range(

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -53,6 +53,9 @@ public:
     /// Use std::list because new ports can be added to processor during execution.
     using Edges = std::list<Edge>;
 
+    /// Pending edge updates of a single `updateNode` frame.
+    using EdgeWorkList = boost::container::devector<Edge *>;
+
     /// Status for processor.
     /// Can be owning or not. Owning means that executor who set this status can change node's data and nobody else can.
     enum class ExecStatus : uint8_t
@@ -203,6 +206,38 @@ private:
     };
     RemoveGroupResult removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction);
     RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
+
+    /// Publishes one `updateNode` frame's pending edge updates for as long as that frame runs.
+    /// A frame holds raw `Edge *` across gaps in `nodes_mutex`, so another frame can free those
+    /// edges in the meantime; being published lets the freeing frame drop the entries.
+    class EdgeWorkListGuard
+    {
+    public:
+        EdgeWorkListGuard(ExecutingGraph & graph_, EdgeWorkList & work_list_);
+        ~EdgeWorkListGuard();
+
+        EdgeWorkListGuard(const EdgeWorkListGuard &) = delete;
+        EdgeWorkListGuard & operator=(const EdgeWorkListGuard &) = delete;
+
+    private:
+        friend class ExecutingGraph;
+
+        ExecutingGraph & graph;
+        EdgeWorkList & work_list;
+        EdgeWorkListGuard * prev = nullptr;
+        EdgeWorkListGuard * next = nullptr;
+    };
+
+    /// Intrusive list of the published work lists, newest first. Intrusive so that entering
+    /// `updateNode` does not allocate.
+    EdgeWorkListGuard * active_edge_work_lists = nullptr;
+    std::mutex active_edge_work_lists_mutex;
+
+    /// Drop the given edges from every published work list. Callers must hold `nodes_mutex`
+    /// exclusively, which is what makes the in-place mutation of another frame's work list safe:
+    /// every other access to a work list happens under `nodes_mutex` too.
+    /// Lock order is `nodes_mutex` then `active_edge_work_lists_mutex`, never the reverse.
+    void scrubRemovedEdges(const std::unordered_set<const void *> & removed_edge_ids);
     std::shared_ptr<PendingRemovalGroup> findGroupReadyForRemoval();
     void accountFinishedProcessorInGroup(const ProcessorPtr & processor);
 

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -171,7 +171,7 @@ private:
     /// Changes nothing, so a throw here leaves the graph as it was.
     Node * findNodeToRemove(const ProcessorPtr & processor);
 
-    /// Destroy a node found by findNodeToRemove, together with the edges it owns.
+    /// Destroy a node found by `findNodeToRemove`, together with the edges it owns.
     void eraseNode(Node * node);
 
     /// Add single edge to edges list. Check processor is known.
@@ -185,13 +185,6 @@ private:
         bool empty() const { return back.empty() && direct.empty(); }
     };
     NewEdges addEdges(Node & node);
-
-    /// Edges of `node` that point at one of `removed_nodes`, split the same way as node removal:
-    /// collectAffectedEdges only reads, eraseAffectedEdges is what destroys them.
-    static void collectAffectedEdges(
-        const Node & node, const std::unordered_set<const Node *> & removed_nodes, std::unordered_set<const void *> & removed_edge_ids);
-    static void eraseAffectedEdges(
-        Node & node, const std::unordered_set<const Node *> & removed_nodes, const std::unordered_set<const void *> & removed_edge_ids);
 
     /// Update graph after processor `node` returned UpdatePipeline status.
     /// All new nodes and nodes with updated ports are pushed into stack.

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -53,9 +53,6 @@ public:
     /// Use std::list because new ports can be added to processor during execution.
     using Edges = std::list<Edge>;
 
-    /// Pending edge updates of a single `updateNode` frame.
-    using EdgeWorkList = boost::container::devector<Edge *>;
-
     /// Status for processor.
     /// Can be owning or not. Owning means that executor who set this status can change node's data and nobody else can.
     enum class ExecStatus : uint8_t
@@ -214,43 +211,24 @@ private:
     struct RemoveGroupResult
     {
         std::unordered_set<const Node *> removed_nodes;
-        std::unordered_set<const void *> removed_edges;
     };
     RemoveGroupResult removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction);
     RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
 
-    /// Publishes one `updateNode` frame's pending edge updates while that frame holds no
-    /// `nodes_mutex`, which is the only time another frame can free those edges; being published
-    /// is what lets the freeing frame drop the entries. Only edges need this: a node cannot be
-    /// removed before it is `Finished`, and a `Finished` node is never queued.
-    class EdgeWorkListGuard
-    {
-    public:
-        EdgeWorkListGuard(ExecutingGraph & graph_, EdgeWorkList & work_list_);
-        ~EdgeWorkListGuard();
+    /// An edge of a removed processor is moved here instead of being destroyed, and lives until the
+    /// graph does: a `updateNode` frame may hold it queued across a gap it makes in `nodes_mutex`,
+    /// and that pointer has to stay valid.
+    Edges retired_edges;
 
-        EdgeWorkListGuard(const EdgeWorkListGuard &) = delete;
-        EdgeWorkListGuard & operator=(const EdgeWorkListGuard &) = delete;
+    /// Permanently `Finished` node every retired edge is pointed at. `updateNode` skips a
+    /// `Finished` node without reaching its processor, so a retired edge cannot reach the removed
+    /// processor. It is in neither `nodes` nor the pipeline's processors, so nothing prepares it and
+    /// nothing reports it. Its processor needs a list of its own because `Node` holds an iterator.
+    Processors retired_edge_target_processors;
+    std::unique_ptr<Node> retired_edge_target;
 
-    private:
-        friend class ExecutingGraph;
-
-        ExecutingGraph & graph;
-        EdgeWorkList & work_list;
-        EdgeWorkListGuard * prev = nullptr;
-        EdgeWorkListGuard * next = nullptr;
-    };
-
-    /// Intrusive list of the published work lists, newest first. Intrusive so that entering
-    /// `updateNode` does not allocate.
-    EdgeWorkListGuard * active_edge_work_lists = nullptr;
-    std::mutex active_edge_work_lists_mutex;
-
-    /// Drop the given edges from every published work list. Callers must hold `nodes_mutex`
-    /// exclusively, which is what makes the in-place mutation of another frame's work list safe:
-    /// every other access to a work list happens under `nodes_mutex` too.
-    /// Lock order is `nodes_mutex` then `active_edge_work_lists_mutex`, never the reverse.
-    void scrubRemovedEdges(const std::unordered_set<const void *> & removed_edge_ids);
+    /// Callers must hold `nodes_mutex` exclusively.
+    void retireAffectedEdges(const std::unordered_set<const Node *> & removed_nodes);
     std::shared_ptr<PendingRemovalGroup> findGroupReadyForRemoval();
     void accountFinishedProcessorInGroup(const ProcessorPtr & processor);
 

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -169,7 +169,13 @@ private:
     /// register it in the processors map. Does not create edges — that is done separately by addEdges.
     Node & addNode(ProcessorPtr processor);
     Node & addNode(Processors::iterator processor_iter);
-    std::pair<const Node *, std::unordered_set<const void *>> removeNode(ProcessorPtr processor);
+
+    /// Look up the node of a processor that is about to be removed, and check it may be removed.
+    /// Changes nothing, so a throw here leaves the graph as it was.
+    Node * findNodeToRemove(const ProcessorPtr & processor);
+
+    /// Destroy a node found by findNodeToRemove, together with the edges it owns.
+    void eraseNode(Node * node);
 
     /// Add single edge to edges list. Check processor is known.
     Edge & addEdge(Edges & edges, Edge edge, const IProcessor * from, const IProcessor * to);
@@ -182,7 +188,13 @@ private:
         bool empty() const { return back.empty() && direct.empty(); }
     };
     NewEdges addEdges(Node & node);
-    std::unordered_set<const void *> removeAffectedEdges(Node & node, const std::unordered_set<const Node *> & removed_nodes);
+
+    /// Edges of `node` that point at one of `removed_nodes`, split the same way as node removal:
+    /// collectAffectedEdges only reads, eraseAffectedEdges is what destroys them.
+    static void collectAffectedEdges(
+        const Node & node, const std::unordered_set<const Node *> & removed_nodes, std::unordered_set<const void *> & removed_edge_ids);
+    static void eraseAffectedEdges(
+        Node & node, const std::unordered_set<const Node *> & removed_nodes, const std::unordered_set<const void *> & removed_edge_ids);
 
     /// Update graph after processor `node` returned UpdatePipeline status.
     /// All new nodes and nodes with updated ports are pushed into stack.
@@ -207,9 +219,10 @@ private:
     RemoveGroupResult removePendingGroup(PendingRemovalGroup & group, Processors & delayed_destruction);
     RemoveGroupResult removeReadyGroups(Processors & delayed_destruction);
 
-    /// Publishes one `updateNode` frame's pending edge updates for as long as that frame runs.
-    /// A frame holds raw `Edge *` across gaps in `nodes_mutex`, so another frame can free those
-    /// edges in the meantime; being published lets the freeing frame drop the entries.
+    /// Publishes one `updateNode` frame's pending edge updates while that frame holds no
+    /// `nodes_mutex`, which is the only time another frame can free those edges; being published
+    /// is what lets the freeing frame drop the entries. Only edges need this: a node cannot be
+    /// removed before it is `Finished`, and a `Finished` node is never queued.
     class EdgeWorkListGuard
     {
     public:

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -451,12 +451,14 @@ public:
             return update;
         }
 
+        Processors next_batch;
+
         size_t slot = 0;
         for (auto & input : inputs)
         {
             const bool early_close = (slot % 2) == 1;
             auto source = std::make_shared<SingleValueSource>(header, static_cast<UInt8>(slot++));
-            current_batch.push_back(source);
+            next_batch.push_back(source);
 
             ProcessorPtr tail = source;
             for (size_t depth = 0; depth < 6; ++depth)
@@ -464,7 +466,7 @@ public:
                 auto laggard = std::make_shared<DeferredFinishTransform>(header);
                 connect(tail->getOutputs().front(), laggard->getInputs().front());
                 tail = laggard;
-                current_batch.push_back(std::move(laggard));
+                next_batch.push_back(std::move(laggard));
             }
 
             if (early_close)
@@ -472,7 +474,7 @@ public:
                 auto closer = std::make_shared<EarlyClosingTransform>(header);
                 connect(tail->getOutputs().front(), closer->getInputs().front());
                 tail = closer;
-                current_batch.push_back(std::move(closer));
+                next_batch.push_back(std::move(closer));
             }
 
             connect(tail->getOutputs().front(), input);
@@ -480,7 +482,8 @@ public:
             input.setNeeded();
         }
 
-        update.to_add = current_batch;
+        update.to_add = next_batch;
+        current_batch = std::move(next_batch);
         ++batches_started;
 
         return update;

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -547,7 +547,7 @@ private:
 /// Retires a whole fan-in of upstreams at once, so that a single `prepare` queues an edge per
 /// input slot. Every one of those edges points at a processor of the batch being retired, which
 /// widens the window in which a queued edge can be freed. Each chain ends in a processor that
-/// needs one more work() call before it reports Finished, so the batch is still unfinished when
+/// needs one more `work` call before it reports `Finished`, so the batch is still unfinished when
 /// it is queued for removal and is therefore retired by a later, arbitrary frame.
 class WideFanInCyclingCoordinator final : public IProcessor
 {

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -367,6 +367,96 @@ private:
     Processors current_batch;
 };
 
+/// Retires a batch holding a still-unfinished transform, then lists that same transform again on
+/// the next call, so the repetition spans two `to_remove` lists instead of appearing within one.
+class RepeatingRemovalAcrossCallsCoordinator final : public IProcessor
+{
+public:
+    explicit RepeatingRemovalAcrossCallsCoordinator(SharedHeader header_)
+        : IProcessor({}, {Block(*header_)})
+        , header(std::move(header_))
+    {
+    }
+
+    String getName() const override { return "RepeatingRemovalAcrossCallsCoordinator"; }
+
+    Status prepare() override
+    {
+        auto & output = outputs.front();
+
+        if (output.isFinished())
+            return Status::Finished;
+
+        /// The input was disconnected by the retiring call, so it must not be inspected before
+        /// the follow-up call has run.
+        if (!retired.empty())
+            return Status::UpdatePipeline;
+
+        if (inputs.empty() || inputs.back().isFinished())
+            return Status::UpdatePipeline;
+
+        if (!output.canPush())
+            return Status::PortFull;
+
+        auto & input = inputs.back();
+        if (!input.hasData())
+        {
+            input.setNeeded();
+            return Status::NeedData;
+        }
+
+        output.push(input.pull(/*set_not_needed=*/true));
+        return Status::PortFull;
+    }
+
+    PipelineUpdate updatePipeline() override
+    {
+        PipelineUpdate update;
+
+        if (!retired.empty())
+        {
+            /// Follow-up call: re-list the transform that is still pending removal from the group
+            /// the previous call queued.
+            update.to_remove.push_back(retired.back());
+            retired.clear();
+            outputs.front().finish();
+            return update;
+        }
+
+        if (!inputs.empty())
+        {
+            disconnect(inputs.back().getOutputPort(), inputs.back());
+            /// The closer finished this processor's input while the transform behind it still owes
+            /// a work call, so the batch is unfinished when it is queued for removal and its group
+            /// stays pending.
+            retired = current_batch;
+            update.to_remove = std::move(current_batch);
+            return update;
+        }
+
+        inputs.emplace_back(*header, this);
+
+        auto source = std::make_shared<SingleValueSource>(header, 0);
+        auto laggard = std::make_shared<DeferredFinishTransform>(header);
+        auto closer = std::make_shared<EarlyClosingTransform>(header);
+        connect(source->getOutputs().front(), laggard->getInputs().front());
+        connect(laggard->getOutputs().front(), closer->getInputs().front());
+        current_batch = {source, closer, laggard};
+
+        connect(closer->getOutputs().front(), inputs.back());
+        inputs.back().reopen();
+        inputs.back().setNeeded();
+
+        update.to_add = current_batch;
+        return update;
+    }
+
+private:
+    const SharedHeader header;
+    Processors current_batch;
+    Processors retired;
+};
+
 /// Cycles source -> deferred-finish (-> early closer for the first batch) sub-pipelines, retiring each batch via to_remove.
 class BatchCyclingCoordinator final : public IProcessor
 {
@@ -767,10 +857,11 @@ TEST(Processors, UpdatePipelineDeferredRemovalOfUnfinishedProcessors)
 
 namespace
 {
+template <typename Coordinator>
 void runRepeatedRemoval()
 {
     auto header = makeHeader();
-    auto coordinator = std::make_shared<RepeatingRemovalCoordinator>(header);
+    auto coordinator = std::make_shared<Coordinator>(header);
     Pipe pipe(coordinator);
     QueryPipeline pipeline(std::move(pipe));
     PullingPipelineExecutor executor(pipeline);
@@ -788,7 +879,13 @@ void runRepeatedRemoval()
 TEST(ProcessorsDeathTest, UpdatePipelineRepeatedRemovalIsRejected)
 {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-    EXPECT_DEATH(runRepeatedRemoval(), "listed more than once for removal");
+    EXPECT_DEATH(runRepeatedRemoval<RepeatingRemovalCoordinator>(), "listed more than once for removal");
+}
+
+TEST(ProcessorsDeathTest, UpdatePipelineRepeatedRemovalAcrossCallsIsRejected)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_DEATH(runRepeatedRemoval<RepeatingRemovalAcrossCallsCoordinator>(), "listed more than once for removal");
 }
 
 #else
@@ -797,7 +894,21 @@ TEST(Processors, UpdatePipelineRepeatedRemovalIsRejected)
 {
     try
     {
-        runRepeatedRemoval();
+        runRepeatedRemoval<RepeatingRemovalCoordinator>();
+        ASSERT_TRUE(false) << "Should have thrown.";
+    }
+    catch (Exception & e)
+    {
+        ASSERT_TRUE(e.displayText().find("listed more than once for removal") != std::string::npos)
+            << "Expected 'listed more than once for removal', got: " << e.displayText();
+    }
+}
+
+TEST(Processors, UpdatePipelineRepeatedRemovalAcrossCallsIsRejected)
+{
+    try
+    {
+        runRepeatedRemoval<RepeatingRemovalAcrossCallsCoordinator>();
         ASSERT_TRUE(false) << "Should have thrown.";
     }
     catch (Exception & e)

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -291,6 +291,82 @@ public:
     }
 };
 
+/// Lists the batch it retires twice, so `to_remove` violates the set contract while the batch is
+/// still unfinished.
+class RepeatingRemovalCoordinator final : public IProcessor
+{
+public:
+    explicit RepeatingRemovalCoordinator(SharedHeader header_)
+        : IProcessor({}, {Block(*header_)})
+        , header(std::move(header_))
+    {
+    }
+
+    String getName() const override { return "RepeatingRemovalCoordinator"; }
+
+    Status prepare() override
+    {
+        auto & output = outputs.front();
+
+        if (output.isFinished())
+            return Status::Finished;
+
+        if (inputs.empty() || inputs.back().isFinished())
+            return Status::UpdatePipeline;
+
+        if (!output.canPush())
+            return Status::PortFull;
+
+        auto & input = inputs.back();
+        if (!input.hasData())
+        {
+            input.setNeeded();
+            return Status::NeedData;
+        }
+
+        output.push(input.pull(/*set_not_needed=*/true));
+        return Status::PortFull;
+    }
+
+    PipelineUpdate updatePipeline() override
+    {
+        PipelineUpdate update;
+
+        if (!inputs.empty())
+        {
+            disconnect(inputs.back().getOutputPort(), inputs.back());
+            /// The repeated entry is the one that is still unfinished at this point.
+            update.to_remove = current_batch;
+            update.to_remove.push_back(current_batch.back());
+            current_batch.clear();
+            outputs.front().finish();
+            return update;
+        }
+
+        inputs.emplace_back(*header, this);
+
+        /// The closer finishes this processor's input while the transform behind it still owes a
+        /// work call, so the batch is unfinished when it is queued for removal.
+        auto source = std::make_shared<SingleValueSource>(header, 0);
+        auto laggard = std::make_shared<DeferredFinishTransform>(header);
+        auto closer = std::make_shared<EarlyClosingTransform>(header);
+        connect(source->getOutputs().front(), laggard->getInputs().front());
+        connect(laggard->getOutputs().front(), closer->getInputs().front());
+        current_batch = {source, closer, laggard};
+
+        connect(closer->getOutputs().front(), inputs.back());
+        inputs.back().reopen();
+        inputs.back().setNeeded();
+
+        update.to_add = current_batch;
+        return update;
+    }
+
+private:
+    const SharedHeader header;
+    Processors current_batch;
+};
+
 /// Cycles source -> deferred-finish (-> early closer for the first batch) sub-pipelines, retiring each batch via to_remove.
 class BatchCyclingCoordinator final : public IProcessor
 {
@@ -688,6 +764,50 @@ TEST(Processors, UpdatePipelineDeferredRemovalOfUnfinishedProcessors)
 
     EXPECT_EQ(coordinator->getInputs().size(), 1u);
 }
+
+namespace
+{
+void runRepeatedRemoval()
+{
+    auto header = makeHeader();
+    auto coordinator = std::make_shared<RepeatingRemovalCoordinator>(header);
+    Pipe pipe(coordinator);
+    QueryPipeline pipeline(std::move(pipe));
+    PullingPipelineExecutor executor(pipeline);
+
+    Chunk chunk;
+    while (executor.pull(chunk))
+    {
+    }
+}
+}
+
+#ifdef DEBUG_OR_SANITIZER_BUILD
+
+/// A LOGICAL_ERROR aborts here, hence a death test.
+TEST(ProcessorsDeathTest, UpdatePipelineRepeatedRemovalIsRejected)
+{
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_DEATH(runRepeatedRemoval(), "listed more than once for removal");
+}
+
+#else
+
+TEST(Processors, UpdatePipelineRepeatedRemovalIsRejected)
+{
+    try
+    {
+        runRepeatedRemoval();
+        ASSERT_TRUE(false) << "Should have thrown.";
+    }
+    catch (Exception & e)
+    {
+        ASSERT_TRUE(e.displayText().find("listed more than once for removal") != std::string::npos)
+            << "Expected 'listed more than once for removal', got: " << e.displayText();
+    }
+}
+
+#endif
 
 /// `updateNode` keeps pending edge updates in a work list that outlives the gaps it makes in
 /// `nodes_mutex`, so a concurrent frame can retire a processor and free edges that are still

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -650,7 +650,7 @@ TEST(Processors, UpdatePipelineFanInRemovalNoUseAfterFree)
         PullingPipelineExecutor executor(pipeline);
 
         Chunk chunk;
-        /// Drain to completion. The point is that execution finishes without an ASAN report;
+        /// Drain to completion. The point is that execution finishes without an ASan report;
         /// the exact number/content of chunks is not what we assert here.
         while (executor.pull(chunk))
         {
@@ -724,7 +724,7 @@ TEST(Processors, UpdatePipelineConcurrentRemovalDoesNotFreeQueuedEdges)
         }
     }
 
-    /// The assertion is the ASAN report; this only distinguishes "clean because the pipeline ran"
+    /// The assertion is the ASan report; this only distinguishes "clean because the pipeline ran"
     /// from "clean because nothing executed".
     EXPECT_GT(pulled, 0u);
 }

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -481,13 +481,10 @@ public:
         }
 
         update.to_add = current_batch;
-        batch_history.append_range(current_batch);
         ++batches_started;
 
         return update;
     }
-
-    const std::vector<std::weak_ptr<IProcessor>> & batchHistory() const { return batch_history; }
 
 private:
     const SharedHeader header;
@@ -495,7 +492,6 @@ private:
     const size_t total_batches;
     size_t batches_started = 0;
     Processors current_batch;
-    std::vector<std::weak_ptr<IProcessor>> batch_history;
 };
 
 }
@@ -702,14 +698,8 @@ TEST(Processors, UpdatePipelineConcurrentRemovalDoesNotFreeQueuedEdges)
     auto header = makeHeader();
 
     Pipes pipes;
-    std::vector<std::shared_ptr<WideFanInCyclingCoordinator>> coordinators;
-    coordinators.reserve(num_streams);
     for (size_t i = 0; i < num_streams; ++i)
-    {
-        auto coordinator = std::make_shared<WideFanInCyclingCoordinator>(header, fan_in, total_batches);
-        coordinators.push_back(coordinator);
-        pipes.emplace_back(std::move(coordinator));
-    }
+        pipes.emplace_back(std::make_shared<WideFanInCyclingCoordinator>(header, fan_in, total_batches));
 
     auto united = Pipe::unitePipes(std::move(pipes));
     united.resize(1, /*strict=*/false, /*min_outstreams_per_resize_after_split=*/0);
@@ -731,12 +721,9 @@ TEST(Processors, UpdatePipelineConcurrentRemovalDoesNotFreeQueuedEdges)
         }
     }
 
+    /// The assertion is the ASAN report; this only distinguishes "clean because the pipeline ran"
+    /// from "clean because nothing executed".
     EXPECT_GT(pulled, 0u);
-
-    /// Retired batches are gone, i.e. removals were carried out rather than stranded.
-    for (const auto & coordinator : coordinators)
-        for (const auto & weak : coordinator->batchHistory())
-            EXPECT_TRUE(weak.expired());
 }
 
 TEST(Processors, UpdatePipelineRemovalIsNotStrandedByCancellation)

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -381,6 +381,123 @@ private:
     std::vector<std::weak_ptr<IProcessor>> batch_history;
 };
 
+/// Retires a whole fan-in of upstreams at once, so that a single `prepare` queues an edge per
+/// input slot. Every one of those edges points at a processor of the batch being retired, which
+/// widens the window in which a queued edge can be freed. Each chain ends in a processor that
+/// needs one more work() call before it reports Finished, so the batch is still unfinished when
+/// it is queued for removal and is therefore retired by a later, arbitrary frame.
+class WideFanInCyclingCoordinator final : public IProcessor
+{
+public:
+    WideFanInCyclingCoordinator(SharedHeader header_, size_t fan_in_, size_t total_batches_)
+        : IProcessor({}, {Block(*header_)})
+        , header(std::move(header_))
+        , fan_in(fan_in_)
+        , total_batches(total_batches_)
+    {
+    }
+
+    String getName() const override { return "WideFanInCyclingCoordinator"; }
+
+    Status prepare() override
+    {
+        auto & output = outputs.front();
+
+        if (output.isFinished())
+            return Status::Finished;
+
+        if (inputs.empty() || std::ranges::all_of(inputs, [](const auto & input) { return input.isFinished(); }))
+            return Status::UpdatePipeline;
+
+        if (!output.canPush())
+            return Status::PortFull;
+
+        for (auto & input : inputs)
+        {
+            if (input.hasData())
+            {
+                output.push(input.pull(/*set_not_needed=*/true));
+                return Status::PortFull;
+            }
+        }
+
+        for (auto & input : inputs)
+            if (!input.isFinished())
+                input.setNeeded();
+
+        return Status::NeedData;
+    }
+
+    PipelineUpdate updatePipeline() override
+    {
+        PipelineUpdate update;
+
+        if (inputs.empty())
+        {
+            for (size_t i = 0; i < fan_in; ++i)
+                inputs.emplace_back(*header, this);
+        }
+        else
+        {
+            for (auto & input : inputs)
+                disconnect(input.getOutputPort(), input);
+
+            update.to_remove = std::move(current_batch);
+        }
+
+        if (batches_started == total_batches)
+        {
+            outputs.front().finish();
+            return update;
+        }
+
+        size_t slot = 0;
+        for (auto & input : inputs)
+        {
+            const bool early_close = (slot % 2) == 1;
+            auto source = std::make_shared<SingleValueSource>(header, static_cast<UInt8>(slot++));
+            current_batch.push_back(source);
+
+            ProcessorPtr tail = source;
+            for (size_t depth = 0; depth < 6; ++depth)
+            {
+                auto laggard = std::make_shared<DeferredFinishTransform>(header);
+                connect(tail->getOutputs().front(), laggard->getInputs().front());
+                tail = laggard;
+                current_batch.push_back(std::move(laggard));
+            }
+
+            if (early_close)
+            {
+                auto closer = std::make_shared<EarlyClosingTransform>(header);
+                connect(tail->getOutputs().front(), closer->getInputs().front());
+                tail = closer;
+                current_batch.push_back(std::move(closer));
+            }
+
+            connect(tail->getOutputs().front(), input);
+            input.reopen();
+            input.setNeeded();
+        }
+
+        update.to_add = current_batch;
+        batch_history.append_range(current_batch);
+        ++batches_started;
+
+        return update;
+    }
+
+    const std::vector<std::weak_ptr<IProcessor>> & batchHistory() const { return batch_history; }
+
+private:
+    const SharedHeader header;
+    const size_t fan_in;
+    const size_t total_batches;
+    size_t batches_started = 0;
+    Processors current_batch;
+    std::vector<std::weak_ptr<IProcessor>> batch_history;
+};
+
 }
 
 TEST(Processors, PortDisconnect)
@@ -571,6 +688,55 @@ TEST(Processors, UpdatePipelineDeferredRemovalOfUnfinishedProcessors)
     }
 
     EXPECT_EQ(coordinator->getInputs().size(), 1u);
+}
+
+/// `updateNode` keeps pending edge updates in a work list that outlives the gaps it makes in
+/// `nodes_mutex`, so a concurrent frame can retire a processor and free edges that are still
+/// queued elsewhere. Runs many coordinators over many threads, each retiring a wide fan-in of
+/// unfinished upstreams, so that removals land in frames other than the one holding the edges.
+TEST(Processors, UpdatePipelineConcurrentRemovalDoesNotFreeQueuedEdges)
+{
+    constexpr size_t num_streams = 4;
+    constexpr size_t fan_in = 16;
+    constexpr size_t total_batches = 40;
+    auto header = makeHeader();
+
+    Pipes pipes;
+    std::vector<std::shared_ptr<WideFanInCyclingCoordinator>> coordinators;
+    coordinators.reserve(num_streams);
+    for (size_t i = 0; i < num_streams; ++i)
+    {
+        auto coordinator = std::make_shared<WideFanInCyclingCoordinator>(header, fan_in, total_batches);
+        coordinators.push_back(coordinator);
+        pipes.emplace_back(std::move(coordinator));
+    }
+
+    auto united = Pipe::unitePipes(std::move(pipes));
+    united.resize(1, /*strict=*/false, /*min_outstreams_per_resize_after_split=*/0);
+
+    QueryPipeline pipeline(std::move(united));
+    pipeline.setNumThreads(16);
+
+    size_t pulled = 0;
+    {
+        PullingAsyncPipelineExecutor executor(pipeline);
+
+        Chunk chunk;
+        while (executor.pull(chunk))
+        {
+            if (!chunk)
+                continue;
+            ASSERT_EQ(chunk.getNumRows(), 1u);
+            ++pulled;
+        }
+    }
+
+    EXPECT_GT(pulled, 0u);
+
+    /// Retired batches are gone, i.e. removals were carried out rather than stranded.
+    for (const auto & coordinator : coordinators)
+        for (const auto & weak : coordinator->batchHistory())
+            EXPECT_TRUE(weak.expired());
 }
 
 TEST(Processors, UpdatePipelineRemovalIsNotStrandedByCancellation)

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -415,8 +415,7 @@ public:
 
         if (!retired.empty())
         {
-            /// Follow-up call: re-list the transform that is still pending removal from the group
-            /// the previous call queued.
+            /// Re-lists a processor whose group is still pending from the previous call.
             update.to_remove.push_back(retired.back());
             retired.clear();
             outputs.front().finish();
@@ -426,9 +425,7 @@ public:
         if (!inputs.empty())
         {
             disconnect(inputs.back().getOutputPort(), inputs.back());
-            /// The closer finished this processor's input while the transform behind it still owes
-            /// a work call, so the batch is unfinished when it is queued for removal and its group
-            /// stays pending.
+            /// The laggard still owes a work call here, so the group stays pending.
             retired = current_batch;
             update.to_remove = std::move(current_batch);
             return update;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a heap-use-after-free in the query pipeline executor. When a processor removed itself from a running pipeline, graph edges could be freed while pointers to them were still queued for processing in another executor thread.


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/111017

`ExecutingGraph::updateNode` keeps pending edge updates in a work list local to its own frame, filled under only a shared lock on `nodes_mutex`, so several frames hold private lists at once. When one frame takes the lock exclusively and retires a processor group, destroying the node frees its edges, but the existing cleanup reached only the removing frame's own list. A frame parked at either gap `updateNode` makes in `nodes_mutex` then resumes and dereferences a freed `Edge`.

Rather than tracking those lists, this keeps the edges. An edge of a removed processor is pointed at a single permanently `Finished` node and moved to a list that lives as long as the graph, so a queued pointer stays valid; `updateNode` skips a finished node without reaching its processor, so it cannot reach the removed one either. No frame has to be tracked.

The cost is that retired edges are not freed before the graph is. `MergeTreeCommitOrderSequentialSource`, the one production path that removes processors, retires 26 edges of 64 bytes per removal, so a subscribed stream grows by about 1.6 KB per snapshot replacement without bound. That needs `enable_streaming_queries`, which is experimental and off by default. The live graph does not grow: `nodes` peaked at 103 to 129 entries.

CI reported this at `auto & node = *edge->to;` eight times over 120 days on eight unrelated pull requests, always `arm_asan_ubsan`, in buckets `STID 2837-40ba` and `STID 1003-358c`. Three are cross-thread.

Replacing the retention with a plain erase reproduces the use-after-free at the same statement. The pre-existing `Processors.UpdatePipelineFanInRemovalNoUseAfterFree` catches that in 40 of 40 runs over four CPU pinnings, single-threaded: one frame fills its work list, frees edges further down the same loop, then pops a stale one. Master scrubbed the list at that point; this change drops the scrub and retains instead. The new concurrent test covers the cross-frame case and catches the same mutant in 1 of 20 runs alone. With the retention, 30 of 30 clean, and 30 of 30 for the whole `Processors` suite.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113332&sha=c982642a8a1f3cf5619ba4faf7b9cd3af78f188c&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%29

The rate has since risen sharply, and the failure now reaches `master`. In `STID 2837-40ba` over the last 60 days, the 5 hits before #115584 landed on 2026-08-22 are all `AST fuzzer (arm_asan_ubsan)`; the 8 hits after it span 6 jobs — `Stress test (amd_tsan)`, `Stress test (amd_asan_ubsan)`, `Stress test (arm_asan_ubsan)`, `Stateless tests (amd_asan_ubsan, distributed plan)`, `Stateless tests (arm_asan_ubsan, targeted)` and `AST fuzzer (arm_asan_ubsan)`. #115584 defers removal into `removeReadyGroups`, which any frame may call at either gap `updateNode` makes in `nodes_mutex`, so the window a parked frame can be caught in got much wider, and plain stateless runs now hit it too.

The `master` occurrence is a `heap-use-after-free` at the same `auto & node = *edge->to;`, cross-thread: `T462` frees the edges in `removeReadyGroups` -> `removePendingGroup` -> `removeNode` -> `~Node` while `T552` pops one of them. That is the freeing path this change removes, since `retireAffectedEdges` retires every edge of a removed node before `eraseNode` runs.

Report on `master`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9593cfadad22b8112fd28a6fbabece49cade9890&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116103&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116103](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116103+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
