### PR TITLE
Fix build in the 26.6 backport of #111803

### DIFF
--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3697,7 +3697,7 @@ TEST(PostingListCursorTest, TextIndexHeaderWriteInitialVersionOmitsCodec)
     EXPECT_EQ(sparse_index_data.version, MergeTreeTextIndexSerializationVersion::V0_Initial);
     EXPECT_EQ(sparse_index_data.codec_type, IPostingListCodec::Type::None);
     EXPECT_EQ(sparse_index_data.sparse_index.size(), 1u);
-    EXPECT_EQ(sparse_index_data.sparse_index.getToken(0), "gamma");
+    EXPECT_EQ(assert_cast<const ColumnString &>(*sparse_index_data.sparse_index.tokens).getDataAt(0), "gamma");
     EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 13u);
 
     ReadBufferFromString in_with_positions(out_with_positions.str());


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/115793
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the build of the 26.6 backport #115793, targeted at its head branch so it can be merged directly.

`DictionarySparseIndex::getToken` does not exist on 26.6. It was added by 5513d5358562ff427a3696731778a74fb82b94ed ("Decompose tokens in sparse index of text index into chars and bit-packed offsets", 2026-07-05), which is not an ancestor of 26.6. Only the new gtest from the backport references it, so the `src/` half of #115793 is fine and the single `-Werror` failure is:

```
src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp:3700:46:
    error: no member named 'getToken' in 'DB::DictionarySparseIndex'
```

The fix reads the token through the tokens column instead. This is behavior-preserving here: on master `getToken` returns `assert_cast<const ColumnString &>(**tokens_column).getDataAt(idx)` for the `ColumnPtr` arm, and the bit-packed arm only exists with the commit above. On 26.6 `deserializeHeader` builds the tokens column through `deserializeTokensRaw`, which returns a `ColumnString`, so the `ColumnPtr` arm is the only reachable one. The same idiom is already used twice in this file, for `alpha` and `beta`, and both lines predate the backport. The assertion still covers the token round-trip through the V0_Initial header.

Verified by compiling the failing translation unit with the command recorded in `compile_commands.json` (clang++-21, `-Werror`): before the patch it fails with the exact CI error at 3700:46, after it there are 0 errors and 0 warnings.

No second missing symbol is hiding behind the first error. All three failing builds report exactly one `error:` and one `FAILED:` target, and the ninja run kept going past it to `[16660/16696]`, so the other six touched `src/` files compiled.
