### PR TITLE
Cascades: run a `PARTITION BY` window on each node

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/Cascades/ARCHITECTURE.md
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/ARCHITECTURE.md
@@ -452,6 +452,10 @@ The lists below use class names; `getName` log names may omit the `Implementatio
   `ANY`/`RightAny` joins are not replication-safe: with duplicate build-side keys the
   kept row depends on the parallel build order, so nodes could produce different rows
 - `TopNImplementation` — bounded sort at one node, or per node for the top-N partial
+- `WindowImplementation` — a window on a single node, or on each node for a `PARTITION BY`
+  window: the input is required hashed by the partition keys and sorted on each node, so
+  the enforcers add the keyed shuffle and the per-node sort, and each node holds its
+  partitions completely
 - `DefaultImplementation` — wraps otherwise-unhandled steps at `{1 node}`; operators
   with dedicated rules above are excluded
 - `DistributionPassthrough` — propagates distribution through stateless per-row steps
@@ -598,18 +602,15 @@ branch-and-bound pruning as the primary bound.
    `dphyp,greedy`, unsupported cases fall through to the next algorithm. Cascades still
    receives a single fixed order; feeding the top k orders into the memo (the hybrid TOP-K
    of Gretscher & Dittrich, PVLDB 2025) is future work.
-11. **Window function distribution**: `WindowStep` currently goes through
-   `DefaultImplementation` at `{1 node}`. Needs a `WindowImplementation` rule
-   that sets distribution by PARTITION BY key.
-12. **CTE / common subplan sharing**: Detect `CommonSubplanReferenceStep` and
+11. **CTE / common subplan sharing**: Detect `CommonSubplanReferenceStep` and
    map to existing groups instead of cloning.
-13. **Dependent group-by key elimination**: Remove redundant GROUP BY columns using
+12. **Dependent group-by key elimination**: Remove redundant GROUP BY columns using
    functional dependencies from MergeTree keys.
-14. **Width through same-type value-changing functions**: a deterministic `String` ->
+13. **Width through same-type value-changing functions**: a deterministic `String` ->
    `String` function (`substring`, `hex`) keeps the source column's average width even
    though the bytes change; width preservation needs a value-pass-through rule separate
    from the NDV rule.
-15. **Reads from remote shards**: a read from a `Distributed` table (or the `remote`/
+14. **Reads from remote shards**: a read from a `Distributed` table (or the `remote`/
    `cluster` table functions) with genuinely remote shards is rejected up front
    (`checkStepSupportedByCascades`); localhost shards are inlined and planned normally.
    Supporting it as a coordinator-pinned single-task source is future work.

--- a/src/Processors/QueryPlan/Optimizations/Cascades/ARCHITECTURE.md
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/ARCHITECTURE.md
@@ -124,7 +124,17 @@ Each physical expression has **properties** describing what it produces:
   - `{4 nodes, by custkey}` — data hash-partitioned by `custkey` across 4 nodes
   - `{4 nodes, replicated}` — full copy on every node
 
-- **Sorting**: Whether the output is sorted and by which columns.
+- **Sorting**: Whether the output is sorted and by which columns. The sorting describes
+  each stream on its own; with one stream per node it is the node's total order.
+
+- **Stream layout**: How one node's streams relate to each other. `Unknown` — several
+  streams with no relation (reads, joins, exchange receive sides). `Single` — one stream
+  per node (a plain full sort, a sorted gather). `Disjoint` on a column set — rows equal
+  on those columns share a stream (a sort partitioned by the columns), so an operator
+  that works per group, such as a `PARTITION BY` window, can run on every stream at once.
+  One stream keeps every group whole, so `Single` satisfies every requirement; `Disjoint`
+  on a subset of the required columns satisfies a `Disjoint` requirement (a coarser split
+  never tears a required group apart).
 
 A parent step **requires** specific properties from its child. For example, a
 `ShuffleHashJoin` on `custkey` requires both inputs to be distributed `{4 nodes, by custkey}`.
@@ -453,9 +463,10 @@ The lists below use class names; `getName` log names may omit the `Implementatio
   kept row depends on the parallel build order, so nodes could produce different rows
 - `TopNImplementation` — bounded sort at one node, or per node for the top-N partial
 - `WindowImplementation` — a window on a single node, or on each node for a `PARTITION BY`
-  window: the input is required hashed by the partition keys and sorted on each node, so
-  the enforcers add the keyed shuffle and the per-node sort, and each node holds its
-  partitions completely
+  window: the input is required hashed by the partition keys, sorted on each node, and
+  with streams disjoint on the partition keys, so the enforcers add the keyed shuffle and
+  a per-node sort partitioned by the keys, and every node runs the window on several
+  streams at once with each partition whole in one stream
 - `DefaultImplementation` — wraps otherwise-unhandled steps at `{1 node}`; operators
   with dedicated rules above are excluded
 - `DistributionPassthrough` — propagates distribution through stateless per-row steps
@@ -468,7 +479,10 @@ The lists below use class names; `getName` log names may omit the `Implementatio
   `ShuffleExchange`, `ScatterExchange` (keyed, or column-less round-robin for a
   multi-node requirement with no partitioning constraint). Produces both regular
   and sorted-merge gather variants.
-- `SortingEnforcer` — adds `SortingStep` with required sort description.
+- `SortingEnforcer` — adds `SortingStep` with the required sort description. It also
+  closes stream-layout gaps: for a `Disjoint` requirement whose columns cover a prefix of
+  the sort it builds the sort partitioned by those columns (streams stay split per
+  partition), otherwise a plain sort whose single merged stream satisfies every layout.
 
 **Key files**: `Rules/*.cpp`, `DagNameTranslation.h/cpp`
 

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
@@ -13,6 +13,7 @@
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/SortingStep.h>
+#include <Processors/QueryPlan/WindowStep.h>
 #include <Processors/QueryPlan/BroadcastExchangeStep.h>
 #include <Processors/QueryPlan/LogicalExchangeStep.h>
 #include <Processors/QueryPlan/GatherExchangeStep.h>
@@ -212,6 +213,21 @@ Cost ReplicatedReadStrategy::estimateOperatorCost(const CostInputs & inputs) con
     return fullReadCost(inputs);
 }
 
+/// Per-row window work, 1/N per node when the data is split across N nodes. A window
+/// emits one output row per input row and writes every row with the columns it appends.
+static Cost windowCost(const CostInputs & inputs)
+{
+    Cost cost;
+    cost.work = inputs.output_stats.estimated_row_count
+        * (1.0 + inputs.output_stats.estimated_bytes_per_row) / inputs.parallelism;
+    return cost;
+}
+
+Cost WindowStrategy::estimateOperatorCost(const CostInputs & inputs) const
+{
+    return windowCost(inputs);
+}
+
 static Cost mergingAggregatedCost(const CostInputs & inputs)
 {
     Cost cost;
@@ -315,6 +331,13 @@ Cost estimateOperatorCost(const CostInputs & inputs, const IImplementationStrate
 
     if (typeid_cast<const MergingAggregatedStep *>(step))
         return mergingAggregatedCost(inputs);
+
+    if (typeid_cast<const WindowStep *>(step))
+    {
+        if (const auto * window_strategy = dynamic_cast<const IWindowStrategy *>(strategy))
+            return window_strategy->estimateOperatorCost(inputs);
+        return windowCost(inputs);
+    }
 
     if (dynamic_cast<const BroadcastExchangeStep *>(step))
         return broadcastExchangeCost(inputs);

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
@@ -290,8 +290,11 @@ static Cost sortCost(const CostInputs & inputs, const SortingStep & sorting_step
         : rows;
     Cost cost;
     cost.work += rows * std::max(1.0, std::log2(sorted_rows)) / inputs.parallelism;
-    /// N-way merge is single-threaded and sees only the rows the sort emits.
-    cost.sequential += inputs.config.merge_sequential_cost_per_row * inputs.output_stats.estimated_row_count / inputs.parallelism;
+    /// N-way merge is single-threaded and sees only the rows the sort emits. A partitioned
+    /// sort keeps its per-partition streams instead of merging them into one, so it pays no
+    /// merge.
+    if (!sorting_step.hasPartitions())
+        cost.sequential += inputs.config.merge_sequential_cost_per_row * inputs.output_stats.estimated_row_count / inputs.parallelism;
     return cost;
 }
 

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
@@ -272,8 +272,17 @@ static Cost exchangeCost(const CostInputs & inputs, const IQueryPlanStep & step)
     /// sends or receives them sequentially, so their transfer stays undivided and each row
     /// pays the funnel cost. Without it a gather of a large input looks as cheap as a
     /// shuffle, so the optimizer distributes work (e.g. a sort) that should stay local.
+    /// A sorted gather under a limit funnels only the consumed rows: the receiver pulls
+    /// merged rows until the limit is satisfied and cancels the senders. The network term
+    /// above keeps the shipped rows - the senders push eagerly until the cancel arrives.
     if (dynamic_cast<const GatherExchangeStep *>(&step) || dynamic_cast<const ScatterExchangeStep *>(&step))
-        cost.sequential += inputs.config.funnel_sequential_cost_per_row * rows;
+    {
+        Float64 funnel_rows = rows;
+        if (const auto * sorted_gather = dynamic_cast<const GatherExchangeStep *>(&step);
+            sorted_gather && sorted_gather->getMaintainSortDescription())
+            funnel_rows = std::min(funnel_rows, inputs.output_stats.estimated_row_count);
+        cost.sequential += inputs.config.funnel_sequential_cost_per_row * funnel_rows;
+    }
     if (const auto * gather = dynamic_cast<const GatherExchangeStep *>(&step);
         gather && gather->getMaintainSortDescription())
     {

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
@@ -274,6 +274,15 @@ static Cost exchangeCost(const CostInputs & inputs, const IQueryPlanStep & step)
     /// shuffle, so the optimizer distributes work (e.g. a sort) that should stay local.
     if (dynamic_cast<const GatherExchangeStep *>(&step) || dynamic_cast<const ScatterExchangeStep *>(&step))
         cost.sequential += inputs.config.funnel_sequential_cost_per_row * rows;
+    /// A sorted gather's sender merges its streams into one before shipping
+    /// (`GatherSendStep`), so a source with several streams per node pays the same per-row
+    /// merge a full sort's final phase pays; a single-stream source ships as is. The senders
+    /// merge concurrently, so each one sees its node's share of the rows.
+    if (const auto * gather = dynamic_cast<const GatherExchangeStep *>(&step))
+        if (gather->getMaintainSortDescription() && inputs.first_input_properties
+            && inputs.first_input_properties->stream_layout != StreamLayout::Single)
+            cost.sequential += inputs.config.merge_sequential_cost_per_row * rows
+                / std::max(1.0, Float64(inputs.first_input_properties->distribution.node_count));
     return cost;
 }
 
@@ -417,6 +426,9 @@ ExpressionCost CostEstimator::estimateCost(GroupExpressionPtr expression)
         .parallelism = parallelism,
         .node_count = distribution_node_count,
         .exchange_rows_override = exchange_rows_override,
+        .first_input_properties = selected_inputs.empty() || !selected_inputs[0].expression
+            ? nullptr
+            : &selected_inputs[0].expression->properties,
         .config = memo.getContext().cost_config,
     };
     inputs.input_stats.reserve(expression->inputs.size());

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Cost.cpp
@@ -274,15 +274,25 @@ static Cost exchangeCost(const CostInputs & inputs, const IQueryPlanStep & step)
     /// shuffle, so the optimizer distributes work (e.g. a sort) that should stay local.
     if (dynamic_cast<const GatherExchangeStep *>(&step) || dynamic_cast<const ScatterExchangeStep *>(&step))
         cost.sequential += inputs.config.funnel_sequential_cost_per_row * rows;
-    /// A sorted gather's sender merges its streams into one before shipping
-    /// (`GatherSendStep`), so a source with several streams per node pays the same per-row
-    /// merge a full sort's final phase pays; a single-stream source ships as is. The senders
-    /// merge concurrently, so each one sees its node's share of the rows.
-    if (const auto * gather = dynamic_cast<const GatherExchangeStep *>(&step))
-        if (gather->getMaintainSortDescription() && inputs.first_input_properties
+    if (const auto * gather = dynamic_cast<const GatherExchangeStep *>(&step);
+        gather && gather->getMaintainSortDescription())
+    {
+        /// The receiver of a sorted gather merges the sorted bucket streams into one
+        /// (`GatherReceiveStep`): a serial per-row merge on one node, like a full sort's
+        /// final phase; without this charge a sorted gather would cost the same as an
+        /// unordered one. The merge advances only while the consumer pulls, so a limit
+        /// above stops it at the trimmed output rows - the group statistics, not the
+        /// shipped `rows`.
+        if (gather->getSourceBucketCount() > 1)
+            cost.sequential += inputs.config.merge_sequential_cost_per_row * inputs.output_stats.estimated_row_count;
+        /// The sender also merges when its node has several streams (`GatherSendStep`);
+        /// a single-stream source ships as is. The senders merge concurrently, so each
+        /// one sees its node's share of the rows.
+        if (inputs.first_input_properties
             && inputs.first_input_properties->stream_layout != StreamLayout::Single)
             cost.sequential += inputs.config.merge_sequential_cost_per_row * rows
                 / std::max(1.0, Float64(inputs.first_input_properties->distribution.node_count));
+    }
     return cost;
 }
 

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Cost.h
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Cost.h
@@ -123,6 +123,8 @@ using GroupId = size_t;
 class IQueryPlanStep;
 struct IImplementationStrategy;
 
+struct ExpressionProperties;
+
 /// Everything the local (single-operator) cost functions may read. Deliberately holds no memo
 /// access, so operator costing stays a pure function of statistics and configuration.
 struct CostInputs
@@ -141,6 +143,10 @@ struct CostInputs
     /// statistics say (a partial top-N emits up to L rows per node). Resolved by the caller
     /// from the selected child; overrides the trimmed output row count.
     std::optional<Float64> exchange_rows_override;
+    /// Properties of the first input's selected implementation, null when none is resolved.
+    /// A sorted gather reads the stream layout from it: a sender with several streams per
+    /// node merges them before shipping, which costs like a sort's final merge.
+    const ExpressionProperties * first_input_properties = nullptr;
     const CostConfig & config;
 };
 

--- a/src/Processors/QueryPlan/Optimizations/Cascades/ImplementationStrategy.h
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/ImplementationStrategy.h
@@ -29,6 +29,10 @@ struct IReadStrategy : IImplementationStrategy
 {
     virtual Cost estimateOperatorCost(const CostInputs & inputs) const = 0;
 };
+struct IWindowStrategy : IImplementationStrategy
+{
+    virtual Cost estimateOperatorCost(const CostInputs & inputs) const = 0;
+};
 
 /// --- Join strategies ---
 
@@ -67,6 +71,16 @@ struct ShuffleAggregationStrategy final : IAggregationStrategy
 struct PartialAggregationStrategy final : IAggregationStrategy
 {
     String getName() const override { return "PartialAggregation"; }
+    Cost estimateOperatorCost(const CostInputs & inputs) const override;
+};
+
+/// --- Window strategy ---
+
+/// One strategy for both the single-node and the per-node window; the cost formula
+/// divides the work by the node count, which is what tells them apart.
+struct WindowStrategy final : IWindowStrategy
+{
+    String getName() const override { return "Window"; }
     Cost estimateOperatorCost(const CostInputs & inputs) const override;
 };
 

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Optimizer.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Optimizer.cpp
@@ -13,7 +13,6 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/SortingStep.h>
-#include <Processors/QueryPlan/WindowStep.h>
 #include <DataTypes/IDataType.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/Context_fwd.h>
@@ -26,6 +25,7 @@
 #include <Common/typeid_cast.h>
 #include <IO/WriteBufferFromString.h>
 #include <fmt/format.h>
+#include <algorithm>
 #include <exception>
 #include <memory>
 #include <optional>
@@ -48,63 +48,29 @@ namespace QueryPlanOptimizations
     bool keyTypeBreaksHashSharding(const IDataType & type);
 }
 
-/// The sorting enforcer builds plain full sorts, and the executor merges their output into
-/// one stream per node. A sort that directly feeds a `PARTITION BY` window can carry the
-/// partition keys instead, like the sorts the planner builds for windows: the executor then
-/// splits the streams by a hash of the keys, each partition stays within one stream, the
-/// window computes its partitions in parallel, and `applyStreamDisjointness` passes the
-/// disjointness to the operators above (an aggregation on the partition keys skips its
-/// merge phase). Keys whose hash disagrees with `compareAt` (floats, `JSON`, `Dynamic`)
-/// are left alone - the split would tear one partition apart.
-static void addPartitionsToWindowSorts(QueryPlan & query_plan)
+/// The partition keys of a partitioned sort as stream-disjointness columns, or empty when
+/// the split cannot be reproduced safely: the keys must be a prefix of the sort (so a
+/// rebuilt sort can split by them), be columns of the sort's input, and hash in agreement
+/// with `compareAt` (floats, `JSON`, `Dynamic` hash `-0.` and `0.` differently while they
+/// compare equal, so a hash split would tear one group apart).
+static DistributionColumns streamSplitColumns(const SortingStep & sorting_step)
 {
-    std::vector<QueryPlan::Node *> stack = {query_plan.getRootNode()};
-    while (!stack.empty())
+    const auto & partition_by = sorting_step.getPartitionByDescription();
+    const auto & sort_description = sorting_step.getSortDescription();
+    if (sort_description.size() < partition_by.size()
+        || !std::equal(partition_by.begin(), partition_by.end(), sort_description.begin()))
+        return {};
+
+    const auto & input_header = sorting_step.getInputHeaders().front();
+    DistributionColumns columns;
+    for (const auto & partition_column : partition_by)
     {
-        QueryPlan::Node * node = stack.back();
-        stack.pop_back();
-        for (auto * child : node->children)
-            stack.push_back(child);
-
-        if (node->children.size() != 1)
-            continue;
-        const auto * window_step = typeid_cast<const WindowStep *>(node->step.get());
-        if (!window_step)
-            continue;
-        const auto & partition_by = window_step->getWindowDescription().partition_by;
-        if (partition_by.empty())
-            continue;
-
-        auto * sorting_step = typeid_cast<SortingStep *>(node->children[0]->step.get());
-        if (!sorting_step || sorting_step->getType() != SortingStep::Type::Full
-            || sorting_step->getLimit() != 0 || sorting_step->hasPartitions())
-            continue;
-
-        /// Only the sort made for this window: the partition keys are its prefix.
-        const auto & sort_description = sorting_step->getSortDescription();
-        if (sort_description.size() < partition_by.size()
-            || !std::equal(partition_by.begin(), partition_by.end(), sort_description.begin()))
-            continue;
-
-        const auto & input_header = sorting_step->getInputHeaders().front();
-        bool keys_split_partitions = false;
-        for (const auto & partition_column : partition_by)
-        {
-            if (!input_header->has(partition_column.column_name)
-                || QueryPlanOptimizations::keyTypeBreaksHashSharding(*input_header->getByName(partition_column.column_name).type))
-            {
-                keys_split_partitions = true;
-                break;
-            }
-        }
-        if (keys_split_partitions)
-            continue;
-
-        auto partitioned_sort = std::make_unique<SortingStep>(
-            input_header, sort_description, partition_by, /*limit_=*/0, sorting_step->getSettings());
-        partitioned_sort->setStepDescription(*sorting_step);
-        node->children[0]->step = std::move(partitioned_sort);
+        if (!input_header->has(partition_column.column_name)
+            || QueryPlanOptimizations::keyTypeBreaksHashSharding(*input_header->getByName(partition_column.column_name).type))
+            return {};
+        columns.push_back(NameSet{partition_column.column_name});
     }
+    return columns;
 }
 
 static String dumpQueryPlanShort(const QueryPlan & query_plan)
@@ -231,6 +197,17 @@ std::pair<GroupId, ExpressionProperties> CascadesOptimizer::addGroup(QueryPlan::
         auto [child_group_id, _] = addGroup(*node.children.front());
         ExpressionProperties stripped_props;
         stripped_props.sorting = sorting_step->getSortDescription();
+        /// The stream layout the sort produced is part of the requirement: a plain sort
+        /// merges each node's streams into one, a partitioned sort (the planner builds them
+        /// for windows) keeps streams disjoint on the partition keys. A partitioned sort
+        /// whose keys cannot split safely demands one stream, which keeps every group whole.
+        DistributionColumns disjoint_columns;
+        if (sorting_step->hasPartitions())
+            disjoint_columns = streamSplitColumns(*sorting_step);
+        if (!disjoint_columns.empty())
+            stripped_props.setDisjointStreams(std::move(disjoint_columns));
+        else
+            stripped_props.stream_layout = StreamLayout::Single;
         return {child_group_id, stripped_props};
     }
 
@@ -396,8 +373,6 @@ void CascadesOptimizer::optimize()
 
     /// Update the original plan in-place because there might be references to the root node of the original plan
     query_plan.replaceNodeWithPlan(query_plan.getRootNode(), std::move(*best_plan));
-
-    addPartitionsToWindowSorts(query_plan);
 
     LOG_TRACE(log, "Optimization took {} ms", optimizer_timer.elapsedMilliseconds());
 }

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Optimizer.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Optimizer.cpp
@@ -127,6 +127,7 @@ CascadesOptimizer::CascadesOptimizer(QueryPlan & query_plan_, const QueryPlanOpt
     addRule(createReplicatedSubplanImplementation());
     addRule(createTopNImplementation());
     addRule(createTwoStageTopN());
+    addRule(createWindowImplementation());
     addEnforcerRule(createDistributionEnforcer());
     addEnforcerRule(createSortingEnforcer());
 }

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Optimizer.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Optimizer.cpp
@@ -13,6 +13,8 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/SortingStep.h>
+#include <Processors/QueryPlan/WindowStep.h>
+#include <DataTypes/IDataType.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/Context_fwd.h>
 #include <QueryPipeline/DistributedPlanExecutor.h>
@@ -39,6 +41,70 @@ namespace ErrorCodes
     extern const int INVALID_SETTING_VALUE;
     extern const int LOGICAL_ERROR;
     extern const int SUPPORT_IS_DISABLED;
+}
+
+namespace QueryPlanOptimizations
+{
+    bool keyTypeBreaksHashSharding(const IDataType & type);
+}
+
+/// The sorting enforcer builds plain full sorts, and the executor merges their output into
+/// one stream per node. A sort that directly feeds a `PARTITION BY` window can carry the
+/// partition keys instead, like the sorts the planner builds for windows: the executor then
+/// splits the streams by a hash of the keys, each partition stays within one stream, the
+/// window computes its partitions in parallel, and `applyStreamDisjointness` passes the
+/// disjointness to the operators above (an aggregation on the partition keys skips its
+/// merge phase). Keys whose hash disagrees with `compareAt` (floats, `JSON`, `Dynamic`)
+/// are left alone - the split would tear one partition apart.
+static void addPartitionsToWindowSorts(QueryPlan & query_plan)
+{
+    std::vector<QueryPlan::Node *> stack = {query_plan.getRootNode()};
+    while (!stack.empty())
+    {
+        QueryPlan::Node * node = stack.back();
+        stack.pop_back();
+        for (auto * child : node->children)
+            stack.push_back(child);
+
+        if (node->children.size() != 1)
+            continue;
+        const auto * window_step = typeid_cast<const WindowStep *>(node->step.get());
+        if (!window_step)
+            continue;
+        const auto & partition_by = window_step->getWindowDescription().partition_by;
+        if (partition_by.empty())
+            continue;
+
+        auto * sorting_step = typeid_cast<SortingStep *>(node->children[0]->step.get());
+        if (!sorting_step || sorting_step->getType() != SortingStep::Type::Full
+            || sorting_step->getLimit() != 0 || sorting_step->hasPartitions())
+            continue;
+
+        /// Only the sort made for this window: the partition keys are its prefix.
+        const auto & sort_description = sorting_step->getSortDescription();
+        if (sort_description.size() < partition_by.size()
+            || !std::equal(partition_by.begin(), partition_by.end(), sort_description.begin()))
+            continue;
+
+        const auto & input_header = sorting_step->getInputHeaders().front();
+        bool keys_split_partitions = false;
+        for (const auto & partition_column : partition_by)
+        {
+            if (!input_header->has(partition_column.column_name)
+                || QueryPlanOptimizations::keyTypeBreaksHashSharding(*input_header->getByName(partition_column.column_name).type))
+            {
+                keys_split_partitions = true;
+                break;
+            }
+        }
+        if (keys_split_partitions)
+            continue;
+
+        auto partitioned_sort = std::make_unique<SortingStep>(
+            input_header, sort_description, partition_by, /*limit_=*/0, sorting_step->getSettings());
+        partitioned_sort->setStepDescription(*sorting_step);
+        node->children[0]->step = std::move(partitioned_sort);
+    }
 }
 
 static String dumpQueryPlanShort(const QueryPlan & query_plan)
@@ -330,6 +396,8 @@ void CascadesOptimizer::optimize()
 
     /// Update the original plan in-place because there might be references to the root node of the original plan
     query_plan.replaceNodeWithPlan(query_plan.getRootNode(), std::move(*best_plan));
+
+    addPartitionsToWindowSorts(query_plan);
 
     LOG_TRACE(log, "Optimization took {} ms", optimizer_timer.elapsedMilliseconds());
 }

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Properties.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Properties.cpp
@@ -3,6 +3,7 @@
 #include <IO/Operators.h>
 #include <fmt/ranges.h>
 #include <algorithm>
+#include <numeric>
 
 namespace DB
 {
@@ -12,18 +13,26 @@ void ExpressionProperties::setDisjointStreams(DistributionColumns columns)
     chassert(!columns.empty());
     /// Order the sets by their full sorted name lists: comparing only one name per set would
     /// leave sets that share it in an unspecified order, and the same disjointness written
-    /// in a different set order would then compare and hash unequal.
-    auto sorted_names = [](const NameSet & column_set)
+    /// in a different set order would then compare and hash unequal. The sort permutes
+    /// indexes over precomputed keys; sorting the sets directly would let the comparator
+    /// read a set that `std::sort` has moved out.
+    std::vector<Names> sort_keys(columns.size());
+    for (size_t i = 0; i < columns.size(); ++i)
     {
-        chassert(!column_set.empty());
-        Names names(column_set.begin(), column_set.end());
-        std::sort(names.begin(), names.end());
-        return names;
-    };
-    std::sort(columns.begin(), columns.end(),
-        [&](const NameSet & left, const NameSet & right) { return sorted_names(left) < sorted_names(right); });
+        chassert(!columns[i].empty());
+        sort_keys[i].assign(columns[i].begin(), columns[i].end());
+        std::sort(sort_keys[i].begin(), sort_keys[i].end());
+    }
+    std::vector<size_t> order(columns.size());
+    std::iota(order.begin(), order.end(), 0);
+    std::sort(order.begin(), order.end(),
+        [&](size_t left, size_t right) { return sort_keys[left] < sort_keys[right]; });
+
     stream_layout = StreamLayout::Disjoint;
-    stream_disjoint_columns = std::move(columns);
+    stream_disjoint_columns.clear();
+    stream_disjoint_columns.reserve(columns.size());
+    for (size_t i : order)
+        stream_disjoint_columns.push_back(std::move(columns[i]));
 }
 
 bool ExpressionProperties::isStreamLayoutSatisfiedBy(const ExpressionProperties & required, const ExpressionProperties & existing)

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Properties.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Properties.cpp
@@ -2,9 +2,64 @@
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
 #include <fmt/ranges.h>
+#include <algorithm>
 
 namespace DB
 {
+
+void ExpressionProperties::setDisjointStreams(DistributionColumns columns)
+{
+    chassert(!columns.empty());
+    /// Order the sets by their full sorted name lists: comparing only one name per set would
+    /// leave sets that share it in an unspecified order, and the same disjointness written
+    /// in a different set order would then compare and hash unequal.
+    auto sorted_names = [](const NameSet & column_set)
+    {
+        chassert(!column_set.empty());
+        Names names(column_set.begin(), column_set.end());
+        std::sort(names.begin(), names.end());
+        return names;
+    };
+    std::sort(columns.begin(), columns.end(),
+        [&](const NameSet & left, const NameSet & right) { return sorted_names(left) < sorted_names(right); });
+    stream_layout = StreamLayout::Disjoint;
+    stream_disjoint_columns = std::move(columns);
+}
+
+bool ExpressionProperties::isStreamLayoutSatisfiedBy(const ExpressionProperties & required, const ExpressionProperties & existing)
+{
+    if (required.stream_layout == StreamLayout::Unknown)
+        return true;
+    /// One stream trivially keeps every group of equal rows whole.
+    if (existing.stream_layout == StreamLayout::Single)
+        return true;
+    if (required.stream_layout == StreamLayout::Single || existing.stream_layout != StreamLayout::Disjoint)
+        return false;
+
+    /// Streams disjoint on the existing columns satisfy a disjointness requirement when every
+    /// existing column set matches one of the required sets: rows equal on the required
+    /// columns are then equal on the existing ones, so they share a stream.
+    for (const auto & existing_column : existing.stream_disjoint_columns)
+    {
+        bool found = false;
+        for (const auto & required_column : required.stream_disjoint_columns)
+        {
+            for (const auto & name : existing_column)
+            {
+                if (required_column.contains(name))
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (found)
+                break;
+        }
+        if (!found)
+            return false;
+    }
+    return true;
+}
 
 bool ExpressionProperties::isSortingSatisfiedBy(const SortDescription & required, const SortDescription & existing)
 {
@@ -64,7 +119,8 @@ bool ExpressionProperties::isDistributionSatisfiedBy(const DistributionDescripti
 bool ExpressionProperties::isSatisfiedBy(const ExpressionProperties & existing_properties) const
 {
     return isSortingSatisfiedBy(sorting, existing_properties.sorting) &&
-        isDistributionSatisfiedBy(distribution, existing_properties.distribution);
+        isDistributionSatisfiedBy(distribution, existing_properties.distribution) &&
+        isStreamLayoutSatisfiedBy(*this, existing_properties);
 }
 
 void  ExpressionProperties::dump(WriteBuffer & out) const
@@ -73,6 +129,10 @@ void  ExpressionProperties::dump(WriteBuffer & out) const
     out << dumpSortDescription(sorting);
     out << "], {";
     out << fmt::format("{} nodes, {}, {}", distribution.node_count, distribution.is_replicated ? "replicated" : "not replicated", fmt::join(distribution.columns, ","));
+    if (stream_layout == StreamLayout::Single)
+        out << ", single stream";
+    else if (stream_layout == StreamLayout::Disjoint)
+        out << fmt::format(", streams disjoint on {}", fmt::join(stream_disjoint_columns, ","));
     out << "}}";
 }
 

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Properties.h
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Properties.h
@@ -29,10 +29,25 @@ struct DistributionDescription
     String dump() const;
 };
 
+/// How one node's streams relate to each other. `sorting` always describes each single
+/// stream; the layout says what crossing a stream boundary means.
+enum class StreamLayout : uint8_t
+{
+    Unknown,    /// several streams with no relation (reads, joins, exchange receive sides)
+    Single,     /// one stream per node
+    Disjoint,   /// streams disjoint on `stream_disjoint_columns`: rows equal on them share a stream
+};
+
 struct ExpressionProperties
 {
     SortDescription sorting;
     DistributionDescription distribution;
+    StreamLayout stream_layout = StreamLayout::Unknown;
+    DistributionColumns stream_disjoint_columns;    /// Nonempty exactly for `Disjoint`; set via `setDisjointStreams`
+
+    /// Marks the streams disjoint on the columns (must be nonempty sets). Orders the column
+    /// sets canonically, so equal layouts compare and hash equal (disjointness has no key order).
+    void setDisjointStreams(DistributionColumns columns);
 
     bool operator==(const ExpressionProperties & other) const = default;
 
@@ -40,6 +55,7 @@ struct ExpressionProperties
 
     static bool isSortingSatisfiedBy(const SortDescription & required, const SortDescription & existing);
     static bool isDistributionSatisfiedBy(const DistributionDescription & required, const DistributionDescription & existing);
+    static bool isStreamLayoutSatisfiedBy(const ExpressionProperties & required, const ExpressionProperties & existing);
 
     void dump(WriteBuffer & out) const;
     String dump() const;
@@ -61,6 +77,15 @@ struct ExpressionPropertiesHash
         }
         for (const auto & type_name : props.distribution.hash_type_names)
             boost::hash_combine(h, type_name);
+        boost::hash_combine(h, static_cast<UInt8>(props.stream_layout));
+        for (const auto & col_set : props.stream_disjoint_columns)
+        {
+            /// Equal sets must hash equally regardless of insertion order.
+            size_t set_hash = 0;
+            for (const auto & name : col_set)
+                set_hash += std::hash<String>()(name);
+            boost::hash_combine(h, set_hash);
+        }
         /// Hash exactly the fields SortColumnDescription::operator== compares, so the hash is
         /// consistent with equality (`ORDER BY k ASC` and k DESC must hash differently).
         for (const auto & col : props.sorting)

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rule.h
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rule.h
@@ -56,6 +56,7 @@ OptimizationRulePtr createReplicatedReadImplementation();
 OptimizationRulePtr createReplicatedSubplanImplementation();
 OptimizationRulePtr createTopNImplementation();
 OptimizationRulePtr createTwoStageTopN();
+OptimizationRulePtr createWindowImplementation();
 OptimizationRulePtr createDefaultImplementation();
 OptimizationRulePtr createDistributionPassthrough();
 OptimizationRulePtr createDistributionEnforcer();

--- a/src/Processors/QueryPlan/Optimizations/Cascades/RuleUtils.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/RuleUtils.cpp
@@ -12,7 +12,10 @@ namespace DB
 bool isTopNSort(const IQueryPlanStep & step)
 {
     const auto * sorting_step = typeid_cast<const SortingStep *>(&step);
-    return sorting_step != nullptr && sorting_step->getType() == SortingStep::Type::Full && sorting_step->getLimit() > 0;
+    /// A partitioned bounded sort keeps one stream per hash partition instead of merging to
+    /// a global top-N, so the top-N rules (which promise one sorted stream) must not take it.
+    return sorting_step != nullptr && sorting_step->getType() == SortingStep::Type::Full
+        && sorting_step->getLimit() > 0 && !sorting_step->hasPartitions();
 }
 
 bool isDistributionPassthroughStep(const IQueryPlanStep & step)

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DefaultImplementation.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DefaultImplementation.cpp
@@ -10,6 +10,7 @@
 #include <Processors/QueryPlan/JoinStepLogical.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/SortingStep.h>
+#include <Processors/QueryPlan/WindowStep.h>
 #include <Common/typeid_cast.h>
 #include <memory>
 
@@ -34,6 +35,7 @@ public:
         /// Steps with specialized implementation rules.
         if (typeid_cast<const AggregatingStep *>(step) != nullptr
             || typeid_cast<const JoinStepLogical *>(step) != nullptr
+            || typeid_cast<const WindowStep *>(step) != nullptr
             || typeid_cast<const ReadFromMergeTree *>(step) != nullptr)
             return false;
         /// A top-N sort is handled by `TopNImplementation`; any other sort left in the memo

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DistributionEnforcer.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DistributionEnforcer.cpp
@@ -75,7 +75,11 @@ public:
     void addKeyedShuffle();
 
 private:
-    void addEnforcer(QueryPlanStepPtr step, ExpressionProperties input_required, SortDescription output_sorting = {});
+    void addEnforcer(
+        QueryPlanStepPtr step,
+        ExpressionProperties input_required,
+        SortDescription output_sorting = {},
+        StreamLayout output_layout = StreamLayout::Unknown);
     /// Input requirement matching the source expression's own distribution: the exchange
     /// consumes the stream where it already is.
     ExpressionProperties inputAtSourceDistribution() const;
@@ -101,11 +105,13 @@ ExpressionProperties DistributionEnforcer::EnforcerEnumerator::inputAtSourceDist
     return input_required;
 }
 
-void DistributionEnforcer::EnforcerEnumerator::addEnforcer(QueryPlanStepPtr step, ExpressionProperties input_required, SortDescription output_sorting)
+void DistributionEnforcer::EnforcerEnumerator::addEnforcer(
+    QueryPlanStepPtr step, ExpressionProperties input_required, SortDescription output_sorting, StreamLayout output_layout)
 {
     ExpressionProperties output_properties;
     output_properties.distribution = required_properties.distribution;
     output_properties.sorting = std::move(output_sorting);
+    output_properties.stream_layout = output_layout;
     auto enforcer_expr = makeEnforcerExpression(
         expression, std::move(step), std::move(input_required), std::move(output_properties), EnforcedProperty::Distribution);
 
@@ -120,9 +126,12 @@ void DistributionEnforcer::EnforcerEnumerator::addBroadcast()
     ExpressionProperties input_required;
     input_required.distribution.node_count = 1;
 
+    /// Each receiving node gets one stream from the single source.
     addEnforcer(
         std::make_unique<BroadcastExchangeStep>(input_header, required_properties.distribution.node_count),
-        std::move(input_required));
+        std::move(input_required),
+        /*output_sorting=*/{},
+        StreamLayout::Single);
 }
 
 /// Column-less scatter: rows go round-robin, any node may get any row. Like the
@@ -133,9 +142,12 @@ void DistributionEnforcer::EnforcerEnumerator::addRoundRobinScatter()
     ExpressionProperties input_required;
     input_required.distribution.node_count = 1;
 
+    /// Each receiving node gets one stream from the single source.
     addEnforcer(
         std::make_unique<ScatterExchangeStep>(input_header, Names{}, required_properties.distribution.node_count),
-        std::move(input_required));
+        std::move(input_required),
+        /*output_sorting=*/{},
+        StreamLayout::Single);
 }
 
 /// Regular gather: N nodes -> 1 node, sorting NOT preserved.
@@ -154,13 +166,15 @@ void DistributionEnforcer::EnforcerEnumerator::addSortedGather()
     ExpressionProperties input_required = inputAtSourceDistribution();
     input_required.sorting = expression->properties.sorting;
 
+    /// The sorted merge combines the sources into one stream.
     addEnforcer(
         std::make_unique<GatherExchangeStep>(
             input_header,
             expression->properties.distribution.node_count,
             expression->properties.sorting),
         std::move(input_required),
-        expression->properties.sorting);
+        expression->properties.sorting,
+        StreamLayout::Single);
 }
 
 /// Keyed shuffle: repartition by the required columns, as a 1->N scatter when the source
@@ -214,8 +228,9 @@ void DistributionEnforcer::EnforcerEnumerator::addKeyedShuffle()
             hash_cast_types.push_back(type_factory.get(type_name));
     }
 
+    const bool is_scatter = expression->properties.distribution.node_count == 1;
     QueryPlanStepPtr exchange_step =
-        (expression->properties.distribution.node_count == 1)
+        is_scatter
         ? QueryPlanStepPtr(std::make_unique<ScatterExchangeStep>(
             input_header,
             std::move(shuffle_columns),
@@ -228,8 +243,13 @@ void DistributionEnforcer::EnforcerEnumerator::addKeyedShuffle()
             required_properties.distribution.node_count,
             std::move(hash_cast_types)));
 
-    /// Shuffle/scatter destroys sorting.
-    addEnforcer(std::move(exchange_step), inputAtSourceDistribution());
+    /// Shuffle/scatter destroys sorting. A scatter gives each receiving node one stream from
+    /// the single source; a shuffle gives it one unrelated stream per sending node.
+    addEnforcer(
+        std::move(exchange_step),
+        inputAtSourceDistribution(),
+        /*output_sorting=*/{},
+        is_scatter ? StreamLayout::Single : StreamLayout::Unknown);
 }
 
 std::vector<GroupExpressionPtr> DistributionEnforcer::applyImpl(GroupExpressionPtr expression, const ExpressionProperties & required_properties, Memo & memo) const

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DistributionPassthrough.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DistributionPassthrough.cpp
@@ -104,14 +104,14 @@ protected:
 
             if (can_translate)
             {
-                auto create_sorted_variant = [&](const DistributionDescription & dist)
+                auto create_sorted_variant = [&](const DistributionDescription & input_dist, const DistributionDescription & output_dist)
                 {
                     auto sorted_impl = std::make_shared<GroupExpression>(*expression);
 
                     chassert(sorted_impl->inputs.size() == 1);
                     auto & sorted_input_props = sorted_impl->inputs[0].required_properties;
 
-                    sorted_input_props.distribution = dist;
+                    sorted_input_props.distribution = input_dist;
                     sorted_input_props.sorting = input_sorting;
                     /// Translation renames columns, so the canonical set order must be rebuilt.
                     if (input_layout == StreamLayout::Disjoint)
@@ -124,7 +124,7 @@ protected:
                         sorted_input_props.stream_disjoint_columns.clear();
                     }
 
-                    sorted_impl->properties.distribution = dist;
+                    sorted_impl->properties.distribution = output_dist;
                     sorted_impl->properties.sorting = required_properties.sorting;
                     sorted_impl->properties.stream_layout = required_properties.stream_layout;
                     sorted_impl->properties.stream_disjoint_columns = required_properties.stream_disjoint_columns;
@@ -136,10 +136,23 @@ protected:
                 {
                     DistributionDescription dist;
                     dist.node_count = candidate;
-                    create_sorted_variant(dist);
+                    create_sorted_variant(dist, dist);
                 }
 
-                create_sorted_variant({});
+                create_sorted_variant({}, {});
+
+                /// A sorted variant at the full required distribution, with its columns
+                /// translated through the step like in `tryCreateAtDistribution`. Without it
+                /// a sort below this step could never serve a consumer that requires
+                /// distribution by specific columns (e.g. a per-node window): the shuffle and
+                /// the sort would always land above this step, even when the input can
+                /// deliver both below it.
+                if (!required_properties.distribution.columns.empty())
+                {
+                    DistributionDescription translated = required_properties.distribution;
+                    if (!dag || translateDistributionColumns(*dag, translated.columns))
+                        create_sorted_variant(translated, required_properties.distribution);
+                }
             }
         }
 

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DistributionPassthrough.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/DistributionPassthrough.cpp
@@ -89,6 +89,19 @@ protected:
             SortDescription input_sorting = required_properties.sorting;
             bool can_translate = !dag || translateSortDescription(*dag, input_sorting);
 
+            /// The step keeps rows within their stream, so a required stream layout is also
+            /// delegated: the input delivers it and the output claims it. Disjoint columns
+            /// that do not map through the DAG degrade to a `Single` demand, which delivers
+            /// every layout.
+            StreamLayout input_layout = required_properties.stream_layout;
+            DistributionColumns input_disjoint_columns = required_properties.stream_disjoint_columns;
+            if (input_layout == StreamLayout::Disjoint
+                && dag && !translateDistributionColumns(*dag, input_disjoint_columns))
+            {
+                input_layout = StreamLayout::Single;
+                input_disjoint_columns.clear();
+            }
+
             if (can_translate)
             {
                 auto create_sorted_variant = [&](const DistributionDescription & dist)
@@ -100,9 +113,21 @@ protected:
 
                     sorted_input_props.distribution = dist;
                     sorted_input_props.sorting = input_sorting;
+                    /// Translation renames columns, so the canonical set order must be rebuilt.
+                    if (input_layout == StreamLayout::Disjoint)
+                    {
+                        sorted_input_props.setDisjointStreams(input_disjoint_columns);
+                    }
+                    else
+                    {
+                        sorted_input_props.stream_layout = input_layout;
+                        sorted_input_props.stream_disjoint_columns.clear();
+                    }
 
                     sorted_impl->properties.distribution = dist;
                     sorted_impl->properties.sorting = required_properties.sorting;
+                    sorted_impl->properties.stream_layout = required_properties.stream_layout;
+                    sorted_impl->properties.stream_disjoint_columns = required_properties.stream_disjoint_columns;
 
                     addPhysicalToMemo(sorted_impl, required_properties, memo, result);
                 };

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/SortingEnforcer.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/SortingEnforcer.cpp
@@ -41,7 +41,14 @@ protected:
 
 bool SortingEnforcer::checkPattern(GroupExpressionPtr expression, const ExpressionProperties & required_properties, const Memo & /*memo*/) const
 {
-    return !ExpressionProperties::isSortingSatisfiedBy(required_properties.sorting, expression->properties.sorting);
+    /// Without a required sort description there is nothing this enforcer can build.
+    if (required_properties.sorting.empty())
+        return false;
+    /// The stream layout is also this enforcer's axis: a layout gap can exist alone (e.g.
+    /// streams disjoint on more columns than required), and the sort it builds closes both
+    /// gaps at once.
+    return !ExpressionProperties::isSortingSatisfiedBy(required_properties.sorting, expression->properties.sorting)
+        || !ExpressionProperties::isStreamLayoutSatisfiedBy(required_properties, expression->properties);
 }
 
 std::vector<GroupExpressionPtr> SortingEnforcer::applyImpl(GroupExpressionPtr expression, const ExpressionProperties & required_properties, Memo & memo) const
@@ -55,17 +62,60 @@ std::vector<GroupExpressionPtr> SortingEnforcer::applyImpl(GroupExpressionPtr ex
     const SortingStep::Settings & sort_settings = *captured_settings;
     const auto & input_header = expression->getQueryPlanStep()->getOutputHeader();
 
+    /// A disjointness requirement is met by splitting the streams by the required columns
+    /// before sorting. The columns must form a prefix of the sort, so that every partition
+    /// lands whole in one stream and each stream stays sorted. When they do not, the plain
+    /// sort below still satisfies the requirement: one stream keeps every group whole.
+    SortDescription partition_by;
+    if (required_properties.stream_layout == StreamLayout::Disjoint)
+    {
+        for (const auto & sort_column : sort_desc)
+        {
+            if (partition_by.size() == required_properties.stream_disjoint_columns.size())
+                break;
+            bool is_disjoint_column = false;
+            for (const auto & column_set : required_properties.stream_disjoint_columns)
+            {
+                if (column_set.contains(sort_column.column_name))
+                {
+                    is_disjoint_column = true;
+                    break;
+                }
+            }
+            if (!is_disjoint_column)
+                break;
+            partition_by.push_back(sort_column);
+        }
+        if (partition_by.size() != required_properties.stream_disjoint_columns.size())
+            partition_by.clear();
+    }
+
     /// Create a full SortingStep expression whose input requires the same distribution
-    /// as the source expression but with sorting relaxed to empty.  Any row limit is owned
+    /// as the source expression but with sorting and layout relaxed.  Any row limit is owned
     /// by a separate Limit/top-N operator, not by the sorting property.
     ExpressionProperties input_required = expression->properties;
     input_required.sorting = {};
+    input_required.stream_layout = StreamLayout::Unknown;
+    input_required.stream_disjoint_columns.clear();
 
+    /// The sort makes the stream layout itself: one merged stream, or streams split by the
+    /// partition columns.
     ExpressionProperties output_properties = expression->properties;
     output_properties.sorting = sort_desc;
+    if (partition_by.empty())
+    {
+        output_properties.stream_layout = StreamLayout::Single;
+        output_properties.stream_disjoint_columns.clear();
+    }
+    else
+        output_properties.setDisjointStreams(required_properties.stream_disjoint_columns);
+
+    auto sorting_step = partition_by.empty()
+        ? std::make_unique<SortingStep>(input_header, sort_desc, /*limit=*/0, sort_settings)
+        : std::make_unique<SortingStep>(input_header, sort_desc, partition_by, /*limit=*/0, sort_settings);
     auto sort_expr = makeEnforcerExpression(
         expression,
-        std::make_unique<SortingStep>(input_header, sort_desc, /*limit=*/0, sort_settings),
+        std::move(sorting_step),
         input_required,
         std::move(output_properties),
         EnforcedProperty::Sorting);

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/TopNImplementation.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/TopNImplementation.cpp
@@ -55,6 +55,7 @@ std::vector<GroupExpressionPtr> TopNImplementation::applyImpl(GroupExpressionPtr
         impl->properties = ExpressionProperties{};
         impl->properties.distribution.node_count = node_count;
         impl->properties.sorting = sort_desc;                  /// output is sorted
+        impl->properties.stream_layout = StreamLayout::Single; /// the bounded sort merges each node's streams
 
         addPhysicalToMemo(impl, required_properties, memo, result);
     };

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/WindowImplementation.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/WindowImplementation.cpp
@@ -108,7 +108,14 @@ std::vector<GroupExpressionPtr> WindowImplementation::applyImpl(GroupExpressionP
     for (size_t candidate_node_count : getCandidateNodeCounts(memo.getContext().cluster_node_count))
     {
         auto distributed = std::make_shared<GroupExpression>(*expression);
-        auto new_step = window_step->clone();
+        /// The fan-out re-parallelizes one node's pipeline after the last window; here the
+        /// parallelism comes from the nodes, and the fan-out would only destroy the
+        /// output order.
+        auto new_step = std::make_unique<WindowStep>(
+            window_step->getInputHeaders().at(0),
+            window_step->getWindowDescription(),
+            window_step->getWindowFunctions(),
+            /*streams_fan_out_=*/false);
         new_step->setStepDescription(fmt::format("Partitioned {}", window_step->getStepDescription()), 200);
         distributed->plan_step = std::move(new_step);
         distributed->strategy = strategySingleton<WindowStrategy>();
@@ -120,10 +127,10 @@ std::vector<GroupExpressionPtr> WindowImplementation::applyImpl(GroupExpressionP
         distributed->inputs[0].required_properties = input_required;
 
         distributed->properties = ExpressionProperties{};
-        /// The window moves no rows, so the output keeps the input distribution.
+        /// The window moves no rows, so the output keeps the input distribution; without the
+        /// fan-out it also keeps the input order.
         distributed->properties.distribution = input_required.distribution;
-        if (!window_step->hasStreamsFanOut())
-            distributed->properties.sorting = input_required.sorting;
+        distributed->properties.sorting = input_required.sorting;
 
         addPhysicalToMemo(distributed, required_properties, memo, result);
     }

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/WindowImplementation.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/WindowImplementation.cpp
@@ -92,11 +92,16 @@ std::vector<GroupExpressionPtr> WindowImplementation::applyImpl(GroupExpressionP
         auto single_node = std::make_shared<GroupExpression>(*expression);
         single_node->strategy = strategySingleton<WindowStrategy>();
         single_node->properties = ExpressionProperties{};    /// node_count=1 (default)
-        /// `WindowTransform` emits rows in input order, so the sorting required from the
-        /// input also holds for the output. With `streams_fan_out` the output is split into
-        /// several streams and only each stream keeps the order, so no sorting is promised.
+        /// `WindowTransform` emits rows in input order and within their stream, so the
+        /// sorting and the stream layout required from the input also hold for the output.
+        /// With `streams_fan_out` the output is split into fresh streams, so neither is
+        /// promised.
         if (!window_step->hasStreamsFanOut())
+        {
             single_node->properties.sorting = single_node->inputs[0].required_properties.sorting;
+            single_node->properties.stream_layout = single_node->inputs[0].required_properties.stream_layout;
+            single_node->properties.stream_disjoint_columns = single_node->inputs[0].required_properties.stream_disjoint_columns;
+        }
 
         addPhysicalToMemo(single_node, required_properties, memo, result);
     }
@@ -124,13 +129,19 @@ std::vector<GroupExpressionPtr> WindowImplementation::applyImpl(GroupExpressionP
         input_required.distribution.node_count = candidate_node_count;
         input_required.distribution.columns = partition_columns;
         input_required.sorting = window_step->getWindowDescription().full_sort_description;
+        /// Streams disjoint on the partition keys let each node run the window on several
+        /// streams at once: every partition lands whole in one stream.
+        input_required.setDisjointStreams(partition_columns);
         distributed->inputs[0].required_properties = input_required;
 
         distributed->properties = ExpressionProperties{};
-        /// The window moves no rows, so the output keeps the input distribution; without the
-        /// fan-out it also keeps the input order.
+        /// The window moves no rows and keeps them within their stream, so the output keeps
+        /// the input distribution and stream layout; without the fan-out it also keeps the
+        /// input order.
         distributed->properties.distribution = input_required.distribution;
         distributed->properties.sorting = input_required.sorting;
+        distributed->properties.stream_layout = input_required.stream_layout;
+        distributed->properties.stream_disjoint_columns = input_required.stream_disjoint_columns;
 
         addPhysicalToMemo(distributed, required_properties, memo, result);
     }

--- a/src/Processors/QueryPlan/Optimizations/Cascades/Rules/WindowImplementation.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/Rules/WindowImplementation.cpp
@@ -1,0 +1,136 @@
+#include <Processors/QueryPlan/Optimizations/Cascades/Rule.h>
+#include <Processors/QueryPlan/Optimizations/Cascades/RuleUtils.h>
+#include <Processors/QueryPlan/Optimizations/Cascades/Group.h>
+#include <Processors/QueryPlan/Optimizations/Cascades/GroupExpression.h>
+#include <Processors/QueryPlan/Optimizations/Cascades/ImplementationStrategy.h>
+#include <Processors/QueryPlan/Optimizations/Cascades/Memo.h>
+#include <Processors/QueryPlan/Optimizations/Cascades/Properties.h>
+#include <Processors/QueryPlan/WindowStep.h>
+#include <DataTypes/IDataType.h>
+#include <Common/Exception.h>
+#include <Common/typeid_cast.h>
+#include <fmt/format.h>
+#include <memory>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+namespace QueryPlanOptimizations
+{
+    bool keyTypeBreaksHashSharding(const IDataType & type);
+}
+
+/// Implements a window on a single node (always available) and, for a window with
+/// `PARTITION BY`, on each node: the input requirement asks for rows with equal partition
+/// keys on one node and for the window's sort order on each node; the enforcers add the
+/// keyed shuffle and the per-node sort, so each node computes its partitions on its own.
+class WindowImplementation : public IOptimizationRule
+{
+public:
+    String getName() const override { return "Window"; }
+
+    bool checkPattern(GroupExpressionPtr expression, const ExpressionProperties & /*required_properties*/, const Memo & /*memo*/) const override
+    {
+        return typeid_cast<const WindowStep *>(expression->getQueryPlanStep()) != nullptr;
+    }
+
+    Promise getPromise() const override { return 5000; }
+    bool isTransformation() const override { return false; }
+
+protected:
+    std::vector<GroupExpressionPtr> applyImpl(GroupExpressionPtr expression, const ExpressionProperties & required_properties, Memo & memo) const override;
+};
+
+/// The partition keys as distribution columns, or empty when the window cannot run per
+/// node: without `PARTITION BY` all rows form one partition, and only a single node keeps
+/// them together (empty distribution columns mean "any distribution"); a partition key
+/// that is not a column of the input header cannot be hashed by name; and a key whose
+/// hash disagrees with `compareAt` (floats, `JSON`, `Dynamic`: `-0.` and `0.` compare as
+/// one partition but hash differently) would split one logical partition across nodes
+/// and produce wrong window values.
+static DistributionColumns partitionKeyColumns(const WindowStep & window_step)
+{
+    const auto & partition_by = window_step.getWindowDescription().partition_by;
+    if (partition_by.empty())
+        return {};
+
+    const auto & input_header = window_step.getInputHeaders().at(0);
+    DistributionColumns columns;
+    for (const auto & partition_column : partition_by)
+    {
+        if (!input_header->has(partition_column.column_name))
+            return {};
+        if (QueryPlanOptimizations::keyTypeBreaksHashSharding(*input_header->getByName(partition_column.column_name).type))
+            return {};
+        columns.push_back(NameSet{partition_column.column_name});
+    }
+    return columns;
+}
+
+std::vector<GroupExpressionPtr> WindowImplementation::applyImpl(GroupExpressionPtr expression, const ExpressionProperties & required_properties, Memo & memo) const
+{
+    const auto * window_step = typeid_cast<const WindowStep *>(expression->getQueryPlanStep());
+    if (!window_step)
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "WindowImplementation::applyImpl called for non-WindowStep expression '{}'",
+            expression->getDescription());
+    if (expression->inputs.size() != 1)
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "WindowImplementation::applyImpl: expected 1 input, got {} for expression '{}'",
+            expression->inputs.size(), expression->getDescription());
+
+    std::vector<GroupExpressionPtr> result;
+
+    /// Single-node implementation - always available, and the only one when the window
+    /// cannot be distributed.
+    {
+        auto single_node = std::make_shared<GroupExpression>(*expression);
+        single_node->strategy = strategySingleton<WindowStrategy>();
+        single_node->properties = ExpressionProperties{};    /// node_count=1 (default)
+        /// `WindowTransform` emits rows in input order, so the sorting required from the
+        /// input also holds for the output. With `streams_fan_out` the output is split into
+        /// several streams and only each stream keeps the order, so no sorting is promised.
+        if (!window_step->hasStreamsFanOut())
+            single_node->properties.sorting = single_node->inputs[0].required_properties.sorting;
+
+        addPhysicalToMemo(single_node, required_properties, memo, result);
+    }
+
+    const DistributionColumns partition_columns = partitionKeyColumns(*window_step);
+    if (partition_columns.empty())
+        return result;
+
+    for (size_t candidate_node_count : getCandidateNodeCounts(memo.getContext().cluster_node_count))
+    {
+        auto distributed = std::make_shared<GroupExpression>(*expression);
+        auto new_step = window_step->clone();
+        new_step->setStepDescription(fmt::format("Partitioned {}", window_step->getStepDescription()), 200);
+        distributed->plan_step = std::move(new_step);
+        distributed->strategy = strategySingleton<WindowStrategy>();
+
+        ExpressionProperties input_required;
+        input_required.distribution.node_count = candidate_node_count;
+        input_required.distribution.columns = partition_columns;
+        input_required.sorting = window_step->getWindowDescription().full_sort_description;
+        distributed->inputs[0].required_properties = input_required;
+
+        distributed->properties = ExpressionProperties{};
+        /// The window moves no rows, so the output keeps the input distribution.
+        distributed->properties.distribution = input_required.distribution;
+        if (!window_step->hasStreamsFanOut())
+            distributed->properties.sorting = input_required.sorting;
+
+        addPhysicalToMemo(distributed, required_properties, memo, result);
+    }
+
+    return result;
+}
+
+OptimizationRulePtr createWindowImplementation() { return std::make_shared<WindowImplementation>(); }
+
+}

--- a/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_best_implementation.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_best_implementation.cpp
@@ -236,6 +236,35 @@ TEST(CascadesBestImplementation, SortingSatisfactionSelectsImplementation)
     EXPECT_EQ(for_k_ts.expression, nullptr);
 }
 
+/// A partitioned sort satisfies a disjoint-streams requirement at a strictly lower cost than
+/// the plain sort (it pays no merge), so the cost comparison alone picks the plan that keeps
+/// the streams split; a plain sort with its merge cost never suppresses it.
+TEST(CascadesBestImplementation, CheaperDisjointWinsDisjointRequirement)
+{
+    Group group(0);
+    CostConfig cost_config;
+
+    auto single_props = propsAt(4, sortByColumns({"k"}));
+    single_props.stream_layout = StreamLayout::Single;
+    auto single_sort = costedExpr(single_props, 50);
+
+    auto disjoint_props = propsAt(4, sortByColumns({"k"}));
+    disjoint_props.setDisjointStreams({NameSet{"k"}});
+    auto disjoint_sort = costedExpr(disjoint_props, 45);
+
+    group.updateBestImplementation(single_sort, cost_config);
+    group.updateBestImplementation(disjoint_sort, cost_config);
+
+    auto disjoint_required = propsAt(4, sortByColumns({"k"}));
+    disjoint_required.setDisjointStreams({NameSet{"k"}});
+    EXPECT_EQ(group.getBestImplementation(disjoint_required, cost_config).expression, disjoint_sort);
+
+    /// The requirement for one stream is served only by the single-stream sort.
+    auto single_required = propsAt(4, sortByColumns({"k"}));
+    single_required.stream_layout = StreamLayout::Single;
+    EXPECT_EQ(group.getBestImplementation(single_required, cost_config).expression, single_sort);
+}
+
 /// Implementations of different distribution shapes do not satisfy each other's requirements.
 TEST(CascadesBestImplementation, DistributionShapeIsolation)
 {

--- a/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
@@ -191,10 +191,9 @@ TEST(CascadesTopNSort, PartitionedBoundedSortIsNotTopN)
     EXPECT_FALSE(isTopNSort(partitioned_bounded));
 }
 
-/// A sorted gather's sender merges its streams into one before shipping, so a source with
-/// several streams per node (disjoint layout) pays the per-row merge, while a single-stream
-/// source ships as is.
-TEST(CascadesSortedGatherCost, SendSideMergePricedByInputStreamLayout)
+/// A sorted gather pays the receiver's merge of the bucket streams into one, and a sender
+/// with several streams per node (disjoint layout) also pays its own merge before shipping.
+TEST(CascadesSortedGatherCost, SendAndReceiveMergesPriced)
 {
     constexpr Float64 rows = 10000;
     constexpr size_t node_count = 4;
@@ -219,22 +218,30 @@ TEST(CascadesSortedGatherCost, SendSideMergePricedByInputStreamLayout)
         return std::pair{group_id, source};
     };
 
-    auto gather_cost_over = [&](StreamLayout layout)
+    auto gather_cost_over = [&](StreamLayout layout, bool sorted)
     {
         auto [group_id, source] = make_source(layout);
+        std::optional<SortDescription> maintain_sort;
+        if (sorted)
+            maintain_sort = makeSortDescription();
         auto gather = std::make_shared<GroupExpression>(
-            std::make_unique<GatherExchangeStep>(header, node_count, makeSortDescription()));
+            std::make_unique<GatherExchangeStep>(header, node_count, std::move(maintain_sort)));
         gather->properties.distribution.node_count = 1;
-        gather->properties.sorting = makeSortDescription();
+        if (sorted)
+            gather->properties.sorting = makeSortDescription();
         gather->inputs.push_back({group_id, source->properties});
         auto gather_group_id = memo.addGroup(gather);
         memo.getGroup(gather_group_id)->statistics = makeStats(rows, 10);
         return estimator.estimateCost(gather).cost.sequential;
     };
 
-    const Float64 over_single = gather_cost_over(StreamLayout::Single);
-    const Float64 over_disjoint = gather_cost_over(StreamLayout::Disjoint);
+    const Float64 unordered = gather_cost_over(StreamLayout::Single, /*sorted=*/false);
+    const Float64 over_single = gather_cost_over(StreamLayout::Single, /*sorted=*/true);
+    const Float64 over_disjoint = gather_cost_over(StreamLayout::Disjoint, /*sorted=*/true);
 
     const auto & config = memo.getContext().cost_config;
+    /// The receiver merges the sorted bucket streams into one: a full per-row merge.
+    EXPECT_DOUBLE_EQ(over_single - unordered, config.merge_sequential_cost_per_row * rows);
+    /// A sender with several streams per node merges its node's share before shipping.
     EXPECT_DOUBLE_EQ(over_disjoint - over_single, config.merge_sequential_cost_per_row * rows / node_count);
 }

--- a/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
@@ -9,6 +9,7 @@
 #include <Processors/QueryPlan/Optimizations/Cascades/GroupExpression.h>
 #include <Processors/QueryPlan/Optimizations/Cascades/ImplementationStrategy.h>
 #include <Processors/QueryPlan/Optimizations/Cascades/Memo.h>
+#include <Processors/QueryPlan/Optimizations/Cascades/RuleUtils.h>
 #include <Processors/QueryPlan/SortingStep.h>
 
 using namespace DB;
@@ -174,4 +175,18 @@ TEST(CascadesUnbuildableExpression, UnsatisfiableInputMarksCostUnbuildable)
     buildable->group_id = group_id;
 
     EXPECT_TRUE(estimator.estimateCost(buildable).buildable);
+}
+
+/// A bounded partitioned sort keeps one stream per hash partition instead of merging to a
+/// global top-N, so the top-N rules (which promise one sorted stream) must not take it.
+TEST(CascadesTopNSort, PartitionedBoundedSortIsNotTopN)
+{
+    auto header = makeHeader();
+
+    SortingStep plain_bounded(header, makeSortDescription(), /*limit_=*/10, SortingStep::Settings(65000));
+    EXPECT_TRUE(isTopNSort(plain_bounded));
+
+    SortingStep partitioned_bounded(
+        header, makeSortDescription(), /*partition_by_description_=*/makeSortDescription(), /*limit_=*/10, SortingStep::Settings(65000));
+    EXPECT_FALSE(isTopNSort(partitioned_bounded));
 }

--- a/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
@@ -190,3 +190,51 @@ TEST(CascadesTopNSort, PartitionedBoundedSortIsNotTopN)
         header, makeSortDescription(), /*partition_by_description_=*/makeSortDescription(), /*limit_=*/10, SortingStep::Settings(65000));
     EXPECT_FALSE(isTopNSort(partitioned_bounded));
 }
+
+/// A sorted gather's sender merges its streams into one before shipping, so a source with
+/// several streams per node (disjoint layout) pays the per-row merge, while a single-stream
+/// source ships as is.
+TEST(CascadesSortedGatherCost, SendSideMergePricedByInputStreamLayout)
+{
+    constexpr Float64 rows = 10000;
+    constexpr size_t node_count = 4;
+
+    Memo memo(getLogger("gtest_cascades_partial_topn_cost"));
+    CostEstimator estimator(memo);
+    auto header = makeHeader();
+
+    auto make_source = [&](StreamLayout layout)
+    {
+        auto source = std::make_shared<GroupExpression>(QueryPlanStepPtr{});
+        source->properties.distribution.node_count = node_count;
+        source->properties.sorting = makeSortDescription();
+        if (layout == StreamLayout::Disjoint)
+            source->properties.setDisjointStreams({NameSet{"x"}});
+        else
+            source->properties.stream_layout = layout;
+        source->cost = ExpressionCost{};
+        auto group_id = memo.addGroup(source);
+        memo.getGroup(group_id)->statistics = makeStats(rows, 10);
+        memo.getGroup(group_id)->updateBestImplementation(source, memo.getContext().cost_config);
+        return std::pair{group_id, source};
+    };
+
+    auto gather_cost_over = [&](StreamLayout layout)
+    {
+        auto [group_id, source] = make_source(layout);
+        auto gather = std::make_shared<GroupExpression>(
+            std::make_unique<GatherExchangeStep>(header, node_count, makeSortDescription()));
+        gather->properties.distribution.node_count = 1;
+        gather->properties.sorting = makeSortDescription();
+        gather->inputs.push_back({group_id, source->properties});
+        auto gather_group_id = memo.addGroup(gather);
+        memo.getGroup(gather_group_id)->statistics = makeStats(rows, 10);
+        return estimator.estimateCost(gather).cost.sequential;
+    };
+
+    const Float64 over_single = gather_cost_over(StreamLayout::Single);
+    const Float64 over_disjoint = gather_cost_over(StreamLayout::Disjoint);
+
+    const auto & config = memo.getContext().cost_config;
+    EXPECT_DOUBLE_EQ(over_disjoint - over_single, config.merge_sequential_cost_per_row * rows / node_count);
+}

--- a/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_partial_topn_cost.cpp
@@ -99,8 +99,15 @@ TEST(CascadesPartialTopNCost, GatherPricedOnPhysicalRowsOfSelectedChild)
     const auto gather_cost = estimator.estimateCost(gather);
     const Float64 physical_rows = limit * node_count;
     EXPECT_DOUBLE_EQ(gather_cost.cost.network, physical_rows * bytes_per_row);
-    /// The gather funnel is priced on the same physical rows.
-    EXPECT_GE(gather_cost.cost.sequential, physical_rows);
+    /// The limit above stops the receiver after the trimmed L rows, so the funnel and the
+    /// receive merge are priced on L; the sender merge sees its node's share of the
+    /// shipped rows.
+    const auto & config = memo.getContext().cost_config;
+    EXPECT_DOUBLE_EQ(gather_cost.cost.sequential,
+        config.exchange_fixed_overhead
+        + config.funnel_sequential_cost_per_row * limit
+        + config.merge_sequential_cost_per_row * limit
+        + config.merge_sequential_cost_per_row * physical_rows / node_count);
 }
 
 TEST(CascadesPartialTopNCost, PhysicalRowsClampedByInput)

--- a/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_properties.cpp
+++ b/src/Processors/QueryPlan/Optimizations/Cascades/tests/gtest_cascades_properties.cpp
@@ -32,6 +32,20 @@ ExpressionProperties sorted(SortDescription sorting)
     return properties;
 }
 
+ExpressionProperties singleStream()
+{
+    ExpressionProperties properties;
+    properties.stream_layout = StreamLayout::Single;
+    return properties;
+}
+
+ExpressionProperties disjointStreams(DistributionColumns columns)
+{
+    ExpressionProperties properties;
+    properties.setDisjointStreams(std::move(columns));
+    return properties;
+}
+
 ExpressionProperties distributed(size_t node_count, bool is_replicated, DistributionColumns columns = {}, Names hash_type_names = {})
 {
     ExpressionProperties properties;
@@ -145,4 +159,82 @@ TEST(CascadesProperties, DistributionSatisfaction)
     const auto required_a = distributed(4, false, {NameSet{"a"}}).distribution;
     const auto existing_equiv = distributed(4, false, {NameSet{"a", "b"}}).distribution;
     EXPECT_TRUE(ExpressionProperties::isDistributionSatisfiedBy(required_a, existing_equiv));
+}
+
+TEST(CascadesProperties, StreamLayoutSatisfaction)
+{
+    const auto unknown = ExpressionProperties{};
+    const auto single = singleStream();
+    const auto by_a = disjointStreams({NameSet{"a"}});
+    const auto by_ab = disjointStreams({NameSet{"a"}, NameSet{"b"}});
+
+    /// An unknown requirement accepts every layout.
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(unknown, unknown));
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(unknown, single));
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(unknown, by_a));
+
+    /// One stream keeps every group whole, so Single satisfies everything.
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(single, single));
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_a, single));
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_ab, single));
+
+    /// Unknown and Disjoint do not satisfy a Single requirement.
+    EXPECT_FALSE(ExpressionProperties::isStreamLayoutSatisfiedBy(single, unknown));
+    EXPECT_FALSE(ExpressionProperties::isStreamLayoutSatisfiedBy(single, by_a));
+
+    /// Streams disjoint on a subset of the required columns keep the required groups whole;
+    /// a superset splits them.
+    EXPECT_FALSE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_a, unknown));
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_a, by_a));
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_ab, by_a));
+    EXPECT_FALSE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_a, by_ab));
+
+    /// Different columns do not satisfy each other.
+    const auto by_c = disjointStreams({NameSet{"c"}});
+    EXPECT_FALSE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_a, by_c));
+
+    /// An equivalent name in the existing set matches the required set.
+    const auto by_a_equiv = disjointStreams({NameSet{"x", "a"}});
+    EXPECT_TRUE(ExpressionProperties::isStreamLayoutSatisfiedBy(by_a, by_a_equiv));
+}
+
+/// `setDisjointStreams` orders the column sets canonically, so the same disjointness
+/// written in a different key order stays one goal for the memo bookkeeping.
+TEST(CascadesProperties, StreamLayoutHashAndEquality)
+{
+    const auto ab = disjointStreams({NameSet{"a"}, NameSet{"b"}});
+    const auto ba = disjointStreams({NameSet{"b"}, NameSet{"a"}});
+    EXPECT_EQ(ab, ba);
+    EXPECT_EQ(hashOf(ab), hashOf(ba));
+
+    /// Sets that share their smallest name still get one canonical order.
+    const auto shared_min = disjointStreams({NameSet{"a", "b"}, NameSet{"a", "c"}});
+    const auto shared_min_swapped = disjointStreams({NameSet{"a", "c"}, NameSet{"a", "b"}});
+    EXPECT_EQ(shared_min, shared_min_swapped);
+    EXPECT_EQ(hashOf(shared_min), hashOf(shared_min_swapped));
+
+    EXPECT_NE(disjointStreams({NameSet{"a"}}), disjointStreams({NameSet{"b"}}));
+    EXPECT_NE(hashOf(disjointStreams({NameSet{"a"}})), hashOf(disjointStreams({NameSet{"b"}})));
+
+    EXPECT_NE(ExpressionProperties{}, singleStream());
+    EXPECT_NE(hashOf(ExpressionProperties{}), hashOf(singleStream()));
+    EXPECT_NE(singleStream(), disjointStreams({NameSet{"a"}}));
+}
+
+/// The layout takes part in full-properties satisfaction alongside sorting and distribution.
+TEST(CascadesProperties, StreamLayoutInIsSatisfiedBy)
+{
+    auto required = sorted(sortBy({sortColumn("k")}));
+    required.setDisjointStreams({NameSet{"k"}});
+
+    auto existing_plain = sorted(sortBy({sortColumn("k")}));
+    EXPECT_FALSE(required.isSatisfiedBy(existing_plain));
+
+    auto existing_single = existing_plain;
+    existing_single.stream_layout = StreamLayout::Single;
+    EXPECT_TRUE(required.isSatisfiedBy(existing_single));
+
+    auto existing_disjoint = sorted(sortBy({sortColumn("k")}));
+    existing_disjoint.setDisjointStreams({NameSet{"k"}});
+    EXPECT_TRUE(required.isSatisfiedBy(existing_disjoint));
 }

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -836,11 +836,18 @@ QueryPlanStepPtr SortingStep::clone() const
     /// Reconstructing another type as Full would silently drop its ordered-input contract.
     if (type != Type::Full)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Clone of SortingStep is implemented only for Full sorting");
-    if (!partition_by_description.empty())
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Clone of partitioned sorting is not implemented for SortingStep");
+    /// The merge-join scattered sort carries extra state (`scatter_partitions`, the skip
+    /// flag) this reconstruction would drop.
+    if (!partition_by_description.empty() && (is_sorting_for_merge_join || scatter_partitions > 0 || skip_scatter_by_partition))
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Clone of a partitioned sorting with scatter state is not implemented for SortingStep");
 
-    auto cloned = std::make_unique<SortingStep>(
-        input_headers.front(), result_description, limit, sort_settings, is_sorting_for_merge_join);
+    std::unique_ptr<SortingStep> cloned;
+    if (partition_by_description.empty())
+        cloned = std::make_unique<SortingStep>(
+            input_headers.front(), result_description, limit, sort_settings, is_sorting_for_merge_join);
+    else
+        cloned = std::make_unique<SortingStep>(
+            input_headers.front(), result_description, partition_by_description, limit, sort_settings);
     cloned->always_read_till_end = always_read_till_end;
     cloned->is_partial_top_n = is_partial_top_n;
     cloned->use_buffering = use_buffering;

--- a/tests/queries/0_stateless/03836_tpch_join_order_plans.reference
+++ b/tests/queries/0_stateless/03836_tpch_join_order_plans.reference
@@ -307,20 +307,18 @@ Expression ((Project names + Projection))
                 ReadFromMergeTree (ParallelRead default.lineitem)
 -- Q15
 Expression (Project names)
-  GatherExchange
-    Expression ((Before ORDER BY + (Projection + )))
-      Sorting
-        JoinLogical (Broadcast HashJoin )
-          Expression (Change column names to column identifiers)
-            ReadFromMergeTree (ParallelRead default.supplier)
-          BroadcastExchange
-            GatherExchange
-              Filter ((WHERE + (Change column names to column identifiers + (Convert VIEW subquery result to VIEW table structure + (Project names + (Projection + (Change column names to column identifiers + (Project names + Projection))))))))
-                Aggregating
-                  Expression (Before GROUP BY)
-                    Expression ((WHERE + Change column names to column identifiers))
-                      ShuffleExchange
-                        ReadFromMergeTree (ParallelRead default.lineitem)
+  Expression ((Before ORDER BY + (Projection + )))
+    Sorting
+      JoinLogical (Local HashJoin )
+        Expression (Change column names to column identifiers)
+          ReadFromMergeTree (default.supplier)
+        GatherExchange
+          Filter ((WHERE + (Change column names to column identifiers + (Convert VIEW subquery result to VIEW table structure + (Project names + (Projection + (Change column names to column identifiers + (Project names + Projection))))))))
+            Aggregating
+              Expression (Before GROUP BY)
+                Expression ((WHERE + Change column names to column identifiers))
+                  ShuffleExchange
+                    ReadFromMergeTree (ParallelRead default.lineitem)
 -- Q16
 DelayedCreatingSets
   Expression (Project names)

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.reference
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.reference
@@ -40,3 +40,53 @@ Expression (Project names)
               ReadFromMergeTree (ParallelRead default.t_win)
 -- 7. the window sort keeps per-partition streams: the aggregation above skips merging
 1
+-- 8. stacked windows: each partitioned window runs per node with its own sort
+GatherExchange
+  Expression ((Project names + Projection))
+    Window (Partitioned Window step for window \'PARTITION BY __table1.k\')
+      Sorting
+        Expression ((Before WINDOW + (Change column names to column identifiers + (Project names + Projection))))
+          ShuffleExchange
+            Window (Partitioned Window step for window \'PARTITION BY __table2.k, __table2.v\')
+              Sorting
+                Expression ((Before WINDOW + Change column names to column identifiers))
+                  ShuffleExchange
+                    ReadFromMergeTree (ParallelRead default.t_win)
+-- 9. stacked window results match the single-node plan
+100000	4999950000	499995000000
+100000	4999950000	499995000000
+-- 10. a single-node window over a partitioned sort keeps the ORDER BY above it
+Expression (Project names)
+  GatherExchange
+    Expression ((Before ORDER BY + Projection))
+      Sorting
+        ScatterExchange
+          Window (Window step for window \'PARTITION BY modulo(__table1.k, 3_UInt8) ORDER BY __table1.v ASC\')
+            GatherExchange
+              Sorting
+                Expression ((Before WINDOW + Change column names to column identifiers))
+                  ReadFromMergeTree (ParallelRead default.t_ord)
+0	0	0
+3	3	3
+6	6	9
+0	8	17
+3	11	28
+6	14	42
+0	16	58
+3	19	77
+6	22	99
+1	1	1
+4	4	5
+7	7	12
+1	9	21
+4	12	33
+7	15	48
+1	17	65
+4	20	85
+7	23	108
+2	2	2
+5	5	7
+2	10	17
+5	13	30
+2	18	48
+5	21	69

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.reference
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.reference
@@ -29,3 +29,12 @@ GatherExchange
 -- 5. negative and positive zero form one partition, as in the single-node plan
 100000
 100000
+-- 6. the window output order is reused: no new sort for a matching ORDER BY
+Expression (Project names)
+  GatherExchange
+    Expression ((Before ORDER BY + Projection))
+      Window (Partitioned Window step for window \'PARTITION BY __table1.k ORDER BY __table1.v ASC\')
+        Sorting
+          Expression ((Before WINDOW + Change column names to column identifiers))
+            ShuffleExchange
+              ReadFromMergeTree (ParallelRead default.t_win)

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.reference
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.reference
@@ -38,3 +38,5 @@ Expression (Project names)
           Expression ((Before WINDOW + Change column names to column identifiers))
             ShuffleExchange
               ReadFromMergeTree (ParallelRead default.t_win)
+-- 7. the window sort keeps per-partition streams: the aggregation above skips merging
+1

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.reference
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.reference
@@ -1,0 +1,31 @@
+-- 1. PARTITION BY window runs per node: shuffle by the partition key, sort and window on each node
+GatherExchange
+  Expression ((Project names + Projection))
+    Window (Partitioned Window step for window \'PARTITION BY __table1.k ORDER BY __table1.v ASC\')
+      Sorting
+        Expression ((Before WINDOW + Change column names to column identifiers))
+          ShuffleExchange
+            ReadFromMergeTree (ParallelRead default.t_win)
+-- 2. results match the single-node plan
+100000	4999950000	169172475000
+100000	4999950000	169172475000
+-- 3. a window without PARTITION BY stays on a single node
+GatherExchange
+  Expression ((Project names + Projection))
+    ScatterExchange
+      Window (Window step for window \'\')
+        GatherExchange
+          Expression ((Before WINDOW + Change column names to column identifiers))
+            ReadFromMergeTree (ParallelRead default.t_win)
+-- 4. a float partition key keeps the window on a single node
+GatherExchange
+  Expression ((Project names + Projection))
+    ScatterExchange
+      Window (Window step for window \'PARTITION BY __table1.k\')
+        GatherExchange
+          Expression ((Before WINDOW + Change column names to column identifiers))
+            Sorting
+              ReadFromMergeTree (ParallelRead default.t_wfloat)
+-- 5. negative and positive zero form one partition, as in the single-node plan
+100000
+100000

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.reference
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.reference
@@ -2,8 +2,8 @@
 GatherExchange
   Expression ((Project names + Projection))
     Window (Partitioned Window step for window \'PARTITION BY __table1.k ORDER BY __table1.v ASC\')
-      Sorting
-        Expression ((Before WINDOW + Change column names to column identifiers))
+      Expression ((Before WINDOW + Change column names to column identifiers))
+        Sorting
           ShuffleExchange
             ReadFromMergeTree (ParallelRead default.t_win)
 -- 2. results match the single-node plan
@@ -34,8 +34,8 @@ Expression (Project names)
   GatherExchange
     Expression ((Before ORDER BY + Projection))
       Window (Partitioned Window step for window \'PARTITION BY __table1.k ORDER BY __table1.v ASC\')
-        Sorting
-          Expression ((Before WINDOW + Change column names to column identifiers))
+        Expression ((Before WINDOW + Change column names to column identifiers))
+          Sorting
             ShuffleExchange
               ReadFromMergeTree (ParallelRead default.t_win)
 -- 7. the window sort keeps per-partition streams: the aggregation above skips merging
@@ -44,12 +44,12 @@ Expression (Project names)
 GatherExchange
   Expression ((Project names + Projection))
     Window (Partitioned Window step for window \'PARTITION BY __table1.k\')
-      Sorting
-        Expression ((Before WINDOW + (Change column names to column identifiers + (Project names + Projection))))
+      Expression ((Before WINDOW + (Change column names to column identifiers + (Project names + Projection))))
+        Sorting
           ShuffleExchange
             Window (Partitioned Window step for window \'PARTITION BY __table2.k, __table2.v\')
-              Sorting
-                Expression ((Before WINDOW + Change column names to column identifiers))
+              Expression ((Before WINDOW + Change column names to column identifiers))
+                Sorting
                   ShuffleExchange
                     ReadFromMergeTree (ParallelRead default.t_win)
 -- 9. stacked window results match the single-node plan
@@ -90,3 +90,17 @@ Expression (Project names)
 5	13	30
 2	18	48
 5	21	69
+-- 11. same-key stacked windows through an expression share one shuffle and sort
+GatherExchange
+  Expression ((Project names + Projection))
+    Window (Partitioned Window step for window \'PARTITION BY __table1.k\')
+      Expression ((Before WINDOW + (Change column names to column identifiers + (Project names + Projection))) [lifted up part])
+        Expression ((Before WINDOW + (Change column names to column identifiers + (Project names + Projection))))
+          Window (Partitioned Window step for window \'PARTITION BY __table2.k\')
+            Expression ((Before WINDOW + Change column names to column identifiers))
+              Sorting
+                ShuffleExchange
+                  ReadFromMergeTree (ParallelRead default.t_win)
+-- 12. same-key stacked window results match the single-node plan
+100000	50050000	49999500000000
+100000	50050000	49999500000000

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.sql
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.sql
@@ -1,0 +1,62 @@
+-- Tags: no-darwin, no-old-analyzer
+-- no-darwin: distributed execution uses the streaming exchange, which is implemented only on Linux.
+-- no-old-analyzer: distributed Cascades planning requires the analyzer.
+
+-- A window with PARTITION BY runs on each node: the input is shuffled so that rows with
+-- equal partition keys are on one node, then each node sorts its part and computes its
+-- windows on its own. A window without PARTITION BY stays on a single node.
+
+SET enable_analyzer = 1;
+SET explain_query_plan_default = 'legacy';
+SET make_distributed_plan = 1;
+SET enable_cascades_optimizer = 1;
+SET enable_parallel_replicas = 0;
+SET automatic_parallel_replicas_mode = 0;
+SET enable_join_runtime_filters = 0;
+SET max_rows_to_group_by = 0;
+SET query_plan_optimize_join_order_randomize = 0;
+SET param__internal_cascades_cluster_node_count = 4;
+-- A high work weight makes the sort and window work decide the plan: splitting that work
+-- across nodes saves far more than the extra exchange costs.
+SET param__internal_cascades_cost_config = '{"work_weight":1000,"network_weight":0.01,"sequential_weight":1}';
+
+DROP TABLE IF EXISTS t_win;
+
+CREATE TABLE t_win (k UInt64, v UInt64) ENGINE = MergeTree() ORDER BY k
+  SETTINGS auto_statistics_types = '';
+-- a merge between planning and the worker read would invalidate the planned part names
+SYSTEM STOP MERGES t_win;
+INSERT INTO t_win SELECT number % 1000, number FROM numbers(100000);
+
+SELECT '-- 1. PARTITION BY window runs per node: shuffle by the partition key, sort and window on each node';
+EXPLAIN SELECT k, v, sum(v) OVER (PARTITION BY k ORDER BY v) FROM t_win;
+
+SELECT '-- 2. results match the single-node plan';
+SELECT count(), sum(v), sum(s) FROM (
+    SELECT k, v, sum(v) OVER (PARTITION BY k ORDER BY v) AS s FROM t_win
+);
+SELECT count(), sum(v), sum(s) FROM (
+    SELECT k, v, sum(v) OVER (PARTITION BY k ORDER BY v) AS s FROM t_win
+) SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
+
+SELECT '-- 3. a window without PARTITION BY stays on a single node';
+EXPLAIN SELECT k, v, sum(v) OVER () FROM t_win;
+
+-- A float partition key hashes `-0.` and `0.` differently while they compare as one
+-- partition, so a per-node window would split that partition across nodes.
+DROP TABLE IF EXISTS t_wfloat;
+CREATE TABLE t_wfloat (k Float64, v UInt64) ENGINE = MergeTree() ORDER BY v
+  SETTINGS auto_statistics_types = '';
+SYSTEM STOP MERGES t_wfloat;
+INSERT INTO t_wfloat SELECT if(number % 2 = 0, 0., -0.), number FROM numbers(100000);
+
+SELECT '-- 4. a float partition key keeps the window on a single node';
+EXPLAIN SELECT k, sum(v) OVER (PARTITION BY k) FROM t_wfloat;
+
+SELECT '-- 5. negative and positive zero form one partition, as in the single-node plan';
+SELECT DISTINCT c FROM (SELECT count() OVER (PARTITION BY k) AS c FROM t_wfloat) ORDER BY c;
+SELECT DISTINCT c FROM (SELECT count() OVER (PARTITION BY k) AS c FROM t_wfloat) ORDER BY c
+SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
+
+DROP TABLE t_win;
+DROP TABLE t_wfloat;

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.sql
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.sql
@@ -15,6 +15,9 @@ SET automatic_parallel_replicas_mode = 0;
 SET enable_join_runtime_filters = 0;
 SET max_rows_to_group_by = 0;
 SET query_plan_optimize_join_order_randomize = 0;
+-- The window fan-out decides whether the window promises its output order, and with it the
+-- plan shape around the window, so the randomized default would flip the EXPLAIN results.
+SET query_plan_enable_multithreading_after_window_functions = 1;
 SET param__internal_cascades_cluster_node_count = 4;
 -- A high work weight makes the sort and window work decide the plan: splitting that work
 -- across nodes saves far more than the extra exchange costs.
@@ -73,6 +76,41 @@ SELECT countIf(explain LIKE '%Skip merging: 1%') > 0 FROM (
     EXPLAIN actions = 1 SELECT k, sum(s) FROM (SELECT k, sum(v) OVER (PARTITION BY k) AS s FROM t_win) GROUP BY k
     SETTINGS make_distributed_plan = 1, enable_cascades_optimizer = 1, distributed_plan_force_shuffle_aggregation = 1
 ) SETTINGS make_distributed_plan = 0, enable_cascades_optimizer = 0;
+
+-- The inner window keeps streams disjoint on `(k, v)`, which splits the outer window's
+-- `k` partitions, so a new sort (partitioned by `k`) is placed between the windows.
+SELECT '-- 8. stacked windows: each partitioned window runs per node with its own sort';
+EXPLAIN SELECT k, s1, sum(s1) OVER (PARTITION BY k) AS s2
+FROM (SELECT k, v, sum(v) OVER (PARTITION BY k, v) AS s1 FROM t_win);
+
+SELECT '-- 9. stacked window results match the single-node plan';
+SELECT count(), sum(s1), sum(s2) FROM (
+    SELECT k, s1, sum(s1) OVER (PARTITION BY k) AS s2
+    FROM (SELECT k, v, sum(v) OVER (PARTITION BY k, v) AS s1 FROM t_win)
+);
+SELECT count(), sum(s1), sum(s2) FROM (
+    SELECT k, s1, sum(s1) OVER (PARTITION BY k) AS s2
+    FROM (SELECT k, v, sum(v) OVER (PARTITION BY k, v) AS s1 FROM t_win)
+) SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
+
+-- The sort below the window splits the streams by the partition key, so the window output
+-- is only sorted within each stream. A matching ORDER BY above needs one more sort that
+-- merges the streams; without it the rows would come out in hash order. The window must
+-- not fan out, or it would promise no order at all and hide the gap; the network-heavy
+-- cost config keeps the window on a single node.
+SELECT '-- 10. a single-node window over a partitioned sort keeps the ORDER BY above it';
+DROP TABLE IF EXISTS t_ord;
+CREATE TABLE t_ord (k UInt64, v UInt64) ENGINE = MergeTree() ORDER BY v
+  SETTINGS auto_statistics_types = '';
+SYSTEM STOP MERGES t_ord;
+INSERT INTO t_ord SELECT number % 8, number FROM numbers(24);
+EXPLAIN SELECT k, v, sum(v) OVER (PARTITION BY k % 3 ORDER BY v) AS s FROM t_ord ORDER BY k % 3, v
+SETTINGS query_plan_enable_multithreading_after_window_functions = 0, max_threads = 4,
+    param__internal_cascades_cost_config = '{"work_weight":1,"network_weight":1000,"sequential_weight":1}';
+SELECT k, v, sum(v) OVER (PARTITION BY k % 3 ORDER BY v) AS s FROM t_ord ORDER BY k % 3, v
+SETTINGS query_plan_enable_multithreading_after_window_functions = 0, max_threads = 4,
+    param__internal_cascades_cost_config = '{"work_weight":1,"network_weight":1000,"sequential_weight":1}';
+DROP TABLE t_ord;
 
 DROP TABLE t_win;
 DROP TABLE t_wfloat;

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.sql
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.sql
@@ -112,5 +112,22 @@ SETTINGS query_plan_enable_multithreading_after_window_functions = 0, max_thread
     param__internal_cascades_cost_config = '{"work_weight":1,"network_weight":1000,"sequential_weight":1}';
 DROP TABLE t_ord;
 
+-- The inner window's shuffle and sort already give the distribution and order the outer
+-- window needs, and the expression between them keeps rows in place, so the plan has no
+-- second shuffle or sort between the windows.
+SELECT '-- 11. same-key stacked windows through an expression share one shuffle and sort';
+EXPLAIN SELECT k, t, sum(s1) OVER (PARTITION BY k) AS s2
+FROM (SELECT k, sum(v) OVER (PARTITION BY k) AS s1, k + 1 AS t FROM t_win);
+
+SELECT '-- 12. same-key stacked window results match the single-node plan';
+SELECT count(), sum(t), sum(s2) FROM (
+    SELECT k, t, sum(s1) OVER (PARTITION BY k) AS s2
+    FROM (SELECT k, sum(v) OVER (PARTITION BY k) AS s1, k + 1 AS t FROM t_win)
+);
+SELECT count(), sum(t), sum(s2) FROM (
+    SELECT k, t, sum(s1) OVER (PARTITION BY k) AS s2
+    FROM (SELECT k, sum(v) OVER (PARTITION BY k) AS s1, k + 1 AS t FROM t_win)
+) SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
+
 DROP TABLE t_win;
 DROP TABLE t_wfloat;

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.sql
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.sql
@@ -63,5 +63,16 @@ SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
 SELECT '-- 6. the window output order is reused: no new sort for a matching ORDER BY';
 EXPLAIN SELECT k, v, sum(v) OVER (PARTITION BY k ORDER BY v) AS s FROM t_win ORDER BY k, v;
 
+-- The sort below the window carries the partition keys, so each node's streams stay
+-- disjoint on `k`; the aggregation on `k` above the window then aggregates each stream
+-- on its own, without the merge phase.
+-- The outer query reads the plan text through `viewExplain`, which distributed Cascades
+-- planning rejects, so the outer level turns it off.
+SELECT '-- 7. the window sort keeps per-partition streams: the aggregation above skips merging';
+SELECT countIf(explain LIKE '%Skip merging: 1%') > 0 FROM (
+    EXPLAIN actions = 1 SELECT k, sum(s) FROM (SELECT k, sum(v) OVER (PARTITION BY k) AS s FROM t_win) GROUP BY k
+    SETTINGS make_distributed_plan = 1, enable_cascades_optimizer = 1, distributed_plan_force_shuffle_aggregation = 1
+) SETTINGS make_distributed_plan = 0, enable_cascades_optimizer = 0;
+
 DROP TABLE t_win;
 DROP TABLE t_wfloat;

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.sql
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.sql
@@ -58,5 +58,10 @@ SELECT DISTINCT c FROM (SELECT count() OVER (PARTITION BY k) AS c FROM t_wfloat)
 SELECT DISTINCT c FROM (SELECT count() OVER (PARTITION BY k) AS c FROM t_wfloat) ORDER BY c
 SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
 
+-- The per-node window runs without the stream fan-out, so its output keeps the sort order
+-- and a matching ORDER BY above needs no new sort, only the order-keeping gather.
+SELECT '-- 6. the window output order is reused: no new sort for a matching ORDER BY';
+EXPLAIN SELECT k, v, sum(v) OVER (PARTITION BY k ORDER BY v) AS s FROM t_win ORDER BY k, v;
+
 DROP TABLE t_win;
 DROP TABLE t_wfloat;

--- a/tests/queries/0_stateless/05025_cascades_window_distribution.sql
+++ b/tests/queries/0_stateless/05025_cascades_window_distribution.sql
@@ -56,7 +56,7 @@ EXPLAIN SELECT k, sum(v) OVER (PARTITION BY k) FROM t_wfloat;
 SELECT '-- 5. negative and positive zero form one partition, as in the single-node plan';
 SELECT DISTINCT c FROM (SELECT count() OVER (PARTITION BY k) AS c FROM t_wfloat) ORDER BY c;
 SELECT DISTINCT c FROM (SELECT count() OVER (PARTITION BY k) AS c FROM t_wfloat) ORDER BY c
-SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0;
+SETTINGS enable_cascades_optimizer = 0, make_distributed_plan = 0, max_threads = 1;
 
 -- The per-node window runs without the stream fan-out, so its output keeps the sort order
 -- and a matching ORDER BY above needs no new sort, only the order-keeping gather.


### PR DESCRIPTION
The experimental distributed Cascades optimizer executed every window function on a single node: the whole input was gathered, sorted there, and processed by one `WindowTransform`.

### Distributed window rule

The new `WindowImplementation` rule gives a window with `PARTITION BY` a distributed alternative: the input is required hashed by all partition keys, sorted on each node by the window's combined sort order, and with streams disjoint on the partition keys. The existing enforcers insert the keyed shuffle and the per-node partitioned sort, so every partition lands whole on one node and each node computes its windows independently:

```
GatherExchange
  Window                  (on each node)
    Sorting               (partitioned by the keys, on each node)
      ShuffleExchange     (hash by the partition keys)
        <input>
```

The single-node alternative stays in the search space and the cost model decides. The plan shape, hashing, and type guards match the rule-based `make_distributed_plan` window optimization, but the rule applies to a window over any input and the choice is cost-based. A window stays on a single node when it has no `PARTITION BY`, when a partition key is not a plain input column, or when a key's hash disagrees with `compareAt` (floats, `JSON`, `Dynamic`): `-0.` and `0.` compare as one partition but hash differently, so hashing such a key would produce wrong window values.

### New physical property: stream layout

`ExpressionProperties` gains a `stream_layout` next to sorting and distribution; `sorting` describes each stream, the layout says how one node's streams relate: `Unknown` (no relation), `Single` (one stream per node), or `Disjoint` on a column set (rows equal on those columns share a stream - a sort partitioned by those columns). `Single` satisfies every requirement; `Disjoint` on a subset of the required columns satisfies a `Disjoint` requirement. `SortingEnforcer` builds a partitioned sort for a `Disjoint` requirement and a plain sort otherwise.

The property is what makes the per-node window correct and fast: the window runs on all partition streams of a node at once with no fan-out after it, its output keeps the order and the disjoint layout (a matching `ORDER BY` above needs only the order-keeping gather, and a `GROUP BY` on the partition keys skips the merge phase), and a consumer that needs one globally ordered stream requires `Single`, which a partitioned sort does not satisfy, so a new sort is placed above the window. It replaces the plan-rewrite peephole that approximated the same effect.

Follow-up PRs will let the window reuse input already hashed by a subset of its partition keys, with a statistics-based safety check.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The experimental distributed Cascades optimizer (`enable_cascades_optimizer`) now executes window functions with `PARTITION BY` on all nodes of the cluster: the input is shuffled by the partition keys and each node sorts and computes its partitions independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116108&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116108](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116108+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
