### PR TITLE
Fix flaky test_default_session_user config-reload tests racing with the background config reloader

### DIFF
--- a/tests/integration/test_default_session_user/configs/config_reloader.xml
+++ b/tests/integration/test_default_session_user/configs/config_reloader.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <clickhouse>
-  <!-- 3.600.000ms = 1 hour to basically prevent automatic reloads happening.
-       A listener's restart decision compares the incoming config against the one recorded
-       by the previous reload, so a background reload landing between a test's config edit
-       and its explicit `SYSTEM RELOAD CONFIG` consumes the difference, and the explicit
-       reload then observes an unchanged config. -->
+  <!-- 3.600.000ms = 1 hour to basically prevent automatic reloads happening, so that
+       `SYSTEM RELOAD CONFIG` is the only reloader in this module's tests. -->
   <config_reload_interval_ms>3600000</config_reload_interval_ms>
 </clickhouse>

--- a/tests/integration/test_default_session_user/configs/config_reloader.xml
+++ b/tests/integration/test_default_session_user/configs/config_reloader.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clickhouse>
+  <!-- 3.600.000ms = 1 hour to basically prevent automatic reloads happening.
+       A listener's restart decision compares the incoming config against the one recorded
+       by the previous reload, so a background reload landing between a test's config edit
+       and its explicit `SYSTEM RELOAD CONFIG` consumes the difference, and the explicit
+       reload then observes an unchanged config. -->
+  <config_reload_interval_ms>3600000</config_reload_interval_ms>
+</clickhouse>

--- a/tests/integration/test_default_session_user/test.py
+++ b/tests/integration/test_default_session_user/test.py
@@ -28,12 +28,12 @@ import clickhouse_grpc_pb2_grpc
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
-    main_configs=["configs/config.xml", "configs/cluster.xml"],
+    main_configs=["configs/config.xml", "configs/cluster.xml", "configs/config_reloader.xml"],
     user_configs=["configs/users.xml"],
 )
 node2 = cluster.add_instance(
     "node2",
-    main_configs=["configs/config.xml", "configs/cluster.xml"],
+    main_configs=["configs/config.xml", "configs/cluster.xml", "configs/config_reloader.xml"],
     user_configs=["configs/users.xml"],
 )
 # A node with an empty global `default_session_user`: connections without a user name are
@@ -41,7 +41,7 @@ node2 = cluster.add_instance(
 # reject mode can only be enabled globally, which needs a separate node.
 node_reject = cluster.add_instance(
     "node_reject",
-    main_configs=["configs/config_reject.xml"],
+    main_configs=["configs/config_reject.xml", "configs/config_reloader.xml"],
     user_configs=["configs/users.xml"],
 )
 

--- a/tests/integration/test_default_session_user/test.py
+++ b/tests/integration/test_default_session_user/test.py
@@ -54,6 +54,14 @@ def started_cluster():
         # port that the readiness check uses.
         node1.wait_until_port_is_ready(9110, timeout=10)
         node_reject.wait_until_port_is_ready(9110, timeout=10)
+        # `SYSTEM RELOAD CONFIG` is the only reloader every test below relies on.
+        for node in (node1, node2, node_reject):
+            assert (
+                node.query(
+                    "SELECT value FROM system.server_settings WHERE name = 'config_reload_interval_ms'"
+                ).strip()
+                == "3600000"
+            )
         yield cluster
     finally:
         cluster.shutdown()


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110179
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_default_session_user/test.py::test_config_reload_prometheus_handlers_switch_to_fixed_user`
failed twice on master today on `Integration tests (amd_msan, 1/8)`, and is clean on every other check
variant that ran it (master, 30 days: 60 OK, 2 FAIL). No related open issue. The test landed with #110179.
[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0251a33d384a6a0e40ec2926fd7836d2364513f2&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%201%2F8%29)

**Root cause.** A listener's restart decision in `updateServers` compares the incoming config against
the config recorded by the *previous* reload. `SYSTEM RELOAD CONFIG` is not the only reloader: the
background `ConfigReloader` polls every `config_reload_interval_ms` (default 2000 ms) and detects
change by config-file mtime, which `replace_in_config`'s `sed -i` bumps. A poller tick landing between
a test's edit and its explicit reload consumes the difference, so the test's own reload compares an
edited config against an edited config and logs nothing. In the failing run a poller reload started
352 ms *before* the test's own reload and emitted the three `will reload` lines with no query id; the
test's `SYSTEM RELOAD CONFIG` then logged no listener lines at all.

**Change.** Pin `config_reload_interval_ms` to one hour for the module's three instances, so
`SYSTEM RELOAD CONFIG` is the only reloader and the one-edit-set-to-one-reload assumption these tests
already make actually holds. This follows the existing idiom in `test_zookeeper_connection_log` and
`test_shard_names`. Test-only: no assertion changed, no test removed, no server default altered.

This also repairs three `assert not contains_in_log` sites that were passing *vacuously*: a negative
assertion is satisfied whenever the poller already consumed the edit, so it failed silently open. No
polling scheme could fix those; only removing the competing reloader can.

**Validation.** Forcing the race (50 ms poller, 1 s gap between the two edits) reproduces the exact CI
assertion 20/20, with the line absent from the whole server log. With the fix under the same forcing,
20/20 pass and the line appears with the reload query's own query id. Full module 29/29 green.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116109&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116109](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116109+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.40` (included in `26.9` and later)
- Backported to: `26.8.3.20`
<!-- ch-version-info:end -->