### PR TITLE
Refuse a second praktika run against a temp directory already in use

### DIFF
--- a/ci/praktika/__main__.py
+++ b/ci/praktika/__main__.py
@@ -1,9 +1,11 @@
 import argparse
 import datetime
+import fcntl
 import os
 import shlex
 import sys
 import textwrap
+from pathlib import Path
 
 from .html_prepare import Html
 from .settings import Settings
@@ -342,6 +344,21 @@ def main():
                 only=args.only,
             )
     elif args.command == "run":
+        # At most one run at a time may write into a given temp directory: job.log,
+        # environment.json and result_<job>.json are shared per directory. Workflow
+        # discovery below already writes environment.json, so the lock precedes it.
+        temp_dir = Path(Settings.TEMP_DIR).resolve()
+        os.makedirs(temp_dir, exist_ok=True)
+        lock_file = open(temp_dir / ".praktika.lock", "a")
+        try:
+            fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            # Only contention; any other OSError must surface with its own errno.
+            Utils.exit_with_error(
+                f"Another praktika run is using [{temp_dir}]. "
+                "Wait for it to finish, or run from a separate checkout."
+            )
+
         from .mangle import _get_workflows
         from .runner import Runner
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/116044
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

On PR #116044 the `Code Review` job posted its full review, then went red anyway: praktika
reported `Job killed or terminated, no Result provided`, the step exited 1 with
`TypeError: 'NoneType' object is not iterable`, and 82% of its own `job.log` was NUL.

The job's review agent runs with `-s workspace-write` and elected to verify the PR by running
a nested `python3 -m ci.praktika run "integration" ...` inside the live job's own checkout.
praktika's state files are per-directory (`Settings.TEMP_DIR`, i.e. `./ci/tmp`), so the nested
run wrote over the outer job's files. It opens `RUN_LOG` in `"w"` mode, truncating `job.log`
while the outer writer still held a large offset, and the kernel zero-filled the hole - that
is the NUL log. It also rewrote `environment.json` with its own `JOB_NAME` and an empty
`JOB_KV_DATA`, and `_Environment.get()` re-reads that file on every call, so the clobber was
permanent: the outer job wrote its real result under the wrong filename,
`result_code_review.json` stayed `PENDING`, and praktika truthfully reported no result. That
not-ok result opened the Slack-feed branch, where the erased `commit_authors` raised the
`TypeError`.

This takes the temp directory as a non-blocking `flock` at the top of the `run` branch, held
for the invocation, so a second run against the same directory refuses at once while a run in
any other checkout is unaffected. It sits before workflow discovery, which already writes
`environment.json`. Only `BlockingIOError` is contention; any other `OSError` propagates,
mirroring `StatusFile.cpp`.

A/B harness: without the change the outer log ends 96.8% NUL, with it 0% and byte-identical.
Refusal is independent of `--ci`, covers `pre_hooks`, and survives `SIGKILL`. Blast radius is
bounded: each job step already runs `rm -rf ./ci/tmp` before `praktika run` and `flock` is
per-inode, so a leaked lock cannot block the next job, and the empty lock file changes no
digest.

<details>
<summary>Validation matrix and deliberate omissions</summary>

| arm | result |
|---|---|
| A/B log corruption, 507000-byte offset (real log 510578) | before **96.8% NUL** (490748/507040) / after **0%**, prefix md5 intact |
| nested run reached `open(RUN_LOG, "w")` (arming assertion) | yes before / no after |
| the 3 shared files under refusal | all md5-identical |
| absent `environment.json` stays absent | yes; unlocked control does create it |
| fresh checkout, temp dir absent | proceeds, no `FileNotFoundError` |
| same arm with `--ci` | refuses, files identical |
| unrelated `setsid` sibling holder | refuses |
| `pre_hooks` shape (child of the holder) | nested refuses, outer proceeds |
| different temp directory while first holds | proceeds; same-dir control refuses |
| holder `SIGKILL`ed | next run acquires |
| pre-existing content in the lock file | survives (mode `"a"`) |
| contention vs bad descriptor | `BlockingIOError` 11 vs plain `OSError` 9, uncaught |
| docker bind mount, host holds | `BUSY` 11; holder killed: `ACQUIRED` |
| temp-dir spellings (relative, absolute, trailing `/`, `..`, symlink) | one lock identity |
| leaked holder + the job step's `rm -rf ./ci/tmp` | next job acquires (fresh inode) |
| job digest with and without the empty lock file | md5 identical |

Two adjacent changes are deliberately not made. The unguarded
`for commit_author in commit_authors` is left alone: with the clobber prevented, an absent
`commit_authors` means malformed state and should keep failing loudly. The conditional store
in `native_jobs.py` is not the cause - `_Environment` seeds that key unconditionally on both
the Config-job and no-Config-job paths, and the real job log shows it present and empty.

No automated test is added: a `ci/tests/` arm would be removed with that directory.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116121&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116121](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116121+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
