### PR TITLE
Allow perf test setup queries to fail on the reference server via `do_not_check_in_pr`

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -985,7 +985,7 @@ class CHServer:
 
     @classmethod
     def run_test(
-        cls, test_file, runs=None, max_queries=0, results_path=f"{temp_dir}/perf_wd/"
+        cls, test_file, runs=None, max_queries=0, pr_number=0, results_path=f"{temp_dir}/perf_wd/"
     ):
         test_name = test_file.split("/")[-1].removesuffix(".xml")
         sw = Utils.Stopwatch()
@@ -999,6 +999,7 @@ class CHServer:
                 --http-port {cls.LEFT_SERVER_HTTP_PORT} {cls.RIGHT_SERVER_HTTP_PORT} \
                 {runs_arg} --max-queries {max_queries} \
                 --profile-seconds 10 \
+                --pr-number {pr_number} \
                 {test_file}",
             verbose=True,
             strip=False,
@@ -1536,6 +1537,7 @@ def main():
                 CHServer.run_test(
                     "./tests/performance/" + test,
                     max_queries=max_queries,
+                    pr_number=info.pr_number,
                     results_path=perf_wd,
                 )
                 cleanup_user_files()

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -541,6 +541,8 @@ function run_tests
                 # Only when the caller explicitly set CHPC_RUNS ("at least N
                 # runs"); otherwise the adaptive run policy decides.
                 ${CHPC_RUNS:+--runs "$CHPC_RUNS"}
+                # Setup queries marked do_not_check_in_pr="$PR_TO_TEST" may fail on the reference server.
+                ${PR_TO_TEST:+--pr-number "$PR_TO_TEST"}
                 --max-queries "$max_queries"
                 --profile-seconds "$profile_seconds"
 
@@ -1022,7 +1024,8 @@ do
         --port "$LEFT_SERVER_PORT" "$RIGHT_SERVER_PORT" \
         --binary left/clickhouse right/clickhouse \
         --http-port "$LEFT_SERVER_HTTP_PORT" "$RIGHT_SERVER_HTTP_PORT" \
-        ${CHPC_RUNS:+--runs "$CHPC_RUNS"} --max-queries 0 --profile-seconds 0 \
+        ${CHPC_RUNS:+--runs "$CHPC_RUNS"} ${PR_TO_TEST:+--pr-number "$PR_TO_TEST"} \
+        --max-queries 0 --profile-seconds 0 \
         --queries-to-run $confirm_indexes \
         > "analyze-confirm/$confirm_test-raw.tsv.tmp" \
         2> "analyze-confirm/$confirm_test-err.log"

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -63,7 +63,7 @@ A `create_query`/`fill_query` normally must succeed on both servers being compar
 <create_query do_not_check_in_pr="12345">CREATE TABLE tab (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS new_setting = 1</create_query>
 ```
 
-When such a query fails on the reference server, the remaining setup queries are skipped there, the whole test runs on the new server only, and its queries are reported under "Backward-incompatible queries" instead of failing the check. The attribute is only allowed on top-level `create_query`/`fill_query` elements, is validated in every run, and is not compatible with `<query type="shell">` in the same test.
+When such a query fails on the reference server, the remaining setup queries are skipped there, the whole test runs on the new server only, and its queries are reported under "Backward-incompatible queries" instead of failing the check. The opt-out applies only in the PR named by the attribute. The attribute is only allowed on top-level `create_query`/`fill_query` elements and is not compatible with `<query type="shell">` in the same test.
 
 ### Shell-script queries
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -55,6 +55,16 @@ Test template:
 
 If your test takes more than 10 minutes, please, add tag `long` to have an opportunity to run all tests and skip long ones.
 
+### Setup queries that cannot run on the reference server
+
+A `create_query`/`fill_query` normally must succeed on both servers being compared. If your PR adds a feature the setup depends on (e.g. a new MergeTree setting), the query cannot work on the reference (master) server yet, and the test would fail the CI check. Opt out of the reference-side check with `check_reference="0"`:
+
+```xml
+<create_query check_reference="0">CREATE TABLE tab (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS new_setting = 1</create_query>
+```
+
+When such a query fails on the reference server, the remaining setup queries are skipped there, the whole test runs on the new server only, and its queries are reported under "Backward-incompatible queries" instead of failing the check. Failures of a setup query on the new server, and failures of setup queries without the attribute, still fail the test. The attribute is not compatible with `<query type="shell">` in the same test, because shell queries must run on every server to be comparable. Remove the attribute in a follow-up PR after the feature reaches master, so the test goes back to comparing both servers.
+
 ### Shell-script queries
 
 In addition to SQL queries sent over the native protocol, a benchmark query can be a shell script, marked with `type="shell"`. This is useful for end-to-end measurements that the native protocol cannot express: HTTP latency, response compression, tool startup time, etc.

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -57,13 +57,13 @@ If your test takes more than 10 minutes, please, add tag `long` to have an oppor
 
 ### Setup queries that cannot run on the reference server
 
-A `create_query`/`fill_query` normally must succeed on both servers being compared. If your PR adds a feature the setup depends on (e.g. a new MergeTree setting), the query cannot work on the reference (master) server yet, and the test would fail the CI check. Opt out of the reference-side check with `check_reference="0"`:
+A `create_query`/`fill_query` normally must succeed on both servers being compared. If your PR adds a feature the setup depends on (e.g. a new MergeTree setting), the query cannot work on the reference (master) server yet, and the test would fail the CI check. Opt out of the reference-side check with `do_not_check_in_pr="<number of your PR>"`:
 
 ```xml
-<create_query check_reference="0">CREATE TABLE tab (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS new_setting = 1</create_query>
+<create_query do_not_check_in_pr="12345">CREATE TABLE tab (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS new_setting = 1</create_query>
 ```
 
-When such a query fails on the reference server, the remaining setup queries are skipped there, the whole test runs on the new server only, and its queries are reported under "Backward-incompatible queries" instead of failing the check. Failures of a setup query on the new server, and failures of setup queries without the attribute, still fail the test. The attribute is not compatible with `<query type="shell">` in the same test, because shell queries must run on every server to be comparable. Remove the attribute in a follow-up PR after the feature reaches master, so the test goes back to comparing both servers.
+When such a query fails on the reference server, the remaining setup queries are skipped there, the whole test runs on the new server only, and its queries are reported under "Backward-incompatible queries" instead of failing the check. The attribute is only allowed on top-level `create_query`/`fill_query` elements, is validated in every run, and is not compatible with `<query type="shell">` in the same test.
 
 ### Shell-script queries
 

--- a/tests/performance/scripts/README.md
+++ b/tests/performance/scripts/README.md
@@ -72,7 +72,7 @@ A query is supposed to run longer than 0.1 second. If your query runs faster, in
 #### Backward-incompatible Queries
 Action required for the cells marked in red.
 
-Shows the queries we are unable to run on an old server -- probably because they contain a new function. You should see this table when you add a new function and a performance test for it. Check that the run time and variance are acceptable (run time between 0.1 and 1 seconds, variance below 10%). If not, they will be highlighted in red.
+Shows the queries we are unable to run on an old server -- probably because they contain a new function. You should see this table when you add a new function and a performance test for it. A test whose `create_query`/`fill_query` marked with `check_reference="0"` fails on the old server also lands here, with all of its queries. Check that the run time and variance are acceptable (run time between 0.1 and 1 seconds, variance below 10%). If not, they will be highlighted in red.
 
 #### Changes in Performance
 Action required for the cells marked in red, and some cheering is appropriate for the cells marked in green.

--- a/tests/performance/scripts/README.md
+++ b/tests/performance/scripts/README.md
@@ -72,7 +72,7 @@ A query is supposed to run longer than 0.1 second. If your query runs faster, in
 #### Backward-incompatible Queries
 Action required for the cells marked in red.
 
-Shows the queries we are unable to run on an old server -- probably because they contain a new function. You should see this table when you add a new function and a performance test for it. A test whose `create_query`/`fill_query` marked with `check_reference="0"` fails on the old server also lands here, with all of its queries. Check that the run time and variance are acceptable (run time between 0.1 and 1 seconds, variance below 10%). If not, they will be highlighted in red.
+Shows the queries we are unable to run on an old server -- probably because they contain a new function. You should see this table when you add a new function and a performance test for it. A test whose `create_query`/`fill_query` is marked with `do_not_check_in_pr="<this PR's number>"` and fails on the old server also lands here, with all of its queries. Check that the run time and variance are acceptable (run time between 0.1 and 1 seconds, variance below 10%). If not, they will be highlighted in red.
 
 #### Changes in Performance
 Action required for the cells marked in red, and some cheering is appropriate for the cells marked in green.

--- a/tests/performance/scripts/README.md
+++ b/tests/performance/scripts/README.md
@@ -72,7 +72,7 @@ A query is supposed to run longer than 0.1 second. If your query runs faster, in
 #### Backward-incompatible Queries
 Action required for the cells marked in red.
 
-Shows the queries we are unable to run on an old server -- probably because they contain a new function. You should see this table when you add a new function and a performance test for it. A test whose `create_query`/`fill_query` is marked with `do_not_check_in_pr="<this PR's number>"` and fails on the old server also lands here, with all of its queries. Check that the run time and variance are acceptable (run time between 0.1 and 1 seconds, variance below 10%). If not, they will be highlighted in red.
+Shows the queries we are unable to run on an old server -- probably because they contain a new function. You should see this table when you add a new function and a performance test for it. A test whose `create_query`/`fill_query` is marked with `do_not_check_in_pr="<this PR's number>"` and fails on the old server also lands here, with all of its queries, in the PR that introduces it. Check that the run time and variance are acceptable (run time between 0.1 and 1 seconds, variance below 10%). If not, they will be highlighted in red.
 
 #### Changes in Performance
 Action required for the cells marked in red, and some cheering is appropriate for the cells marked in green.

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -283,6 +283,14 @@ parser.add_argument(
     "RIGHT, which otherwise diverges across the test and causes background "
     "purges to do asymmetric work during measured queries.",
 )
+parser.add_argument(
+    "--pr-number",
+    type=int,
+    default=0,
+    help="Number of the pull request under test. A setup query marked "
+    'do_not_check_in_pr="<this number>" is allowed to fail on the reference '
+    "server. With the default 0 no failure is tolerated.",
+)
 args = parser.parse_args()
 
 if args.min_runs is not None:
@@ -573,29 +581,39 @@ if has_shell_queries and (args.user != "default" or args.password != "" or args.
         "Remove these options, or run this test without shell-script queries."
     )
 
-# Setup queries (create_query/fill_query) paired with their check_reference flag value.
-# If `check_reference="0"`, the query is not checked on the reference server. Useful for newly added features.
-# findall("./*") + tag filter, not one findall per tag, to keep the document order of the queries.
-create_query_templates = []
-for e in root.findall("./*"):
-    if e.tag not in ("create_query", "fill_query"):
-        continue
-    check_reference = e.get("check_reference", "1")
-    if check_reference not in ("0", "1"):
+# Setup queries, in document order. The do_not_check_in_pr attribute is honoured only on these elements.
+setup_query_elements = [e for e in root.findall("./*") if e.tag in ("create_query", "fill_query")]
+
+for e in root.iter():
+    if "do_not_check_in_pr" in e.attrib and e not in setup_query_elements:
         raise Exception(
-            f'Invalid check_reference="{check_reference}" on <{e.tag}> '
-            'in the test file: must be "0" or "1"'
+            "do_not_check_in_pr is only allowed on top-level <create_query> "
+            f"and <fill_query> elements, but was found on <{e.tag}>"
         )
-    create_query_templates.append((e.text, check_reference == "1"))
 
-# Statements extracted from <query file=...> have no element to carry the attribute.
-create_query_templates += [(template, True) for template in extra_create_queries]
-
-if has_shell_queries and any(not checked for _, checked in create_query_templates):
+if has_shell_queries and any("do_not_check_in_pr" in e.attrib for e in setup_query_elements):
     raise Exception(
-        'check_reference="0" is not compatible with shell queries: a shell '
+        "do_not_check_in_pr is not compatible with shell queries: a shell "
         "performance test must run on every server to be comparable"
     )
+
+# Setup queries paired with a flag. Tolerate query's failure on the reference server
+# only when do_not_check_in_pr matches --pr-number.
+create_query_templates = []
+for e in setup_query_elements:
+    attr = e.get("do_not_check_in_pr")
+    if attr is not None and not re.fullmatch("[1-9][0-9]*", attr):
+        raise Exception(
+            f'Invalid do_not_check_in_pr="{attr}" on <{e.tag}> in the test '
+            "file: must be the number of the pull request that introduces "
+            "the test (a positive integer)"
+        )
+    create_query_templates.append(
+        (e.text, attr is not None and int(attr) == args.pr_number)
+    )
+
+# <query file=...> have no element to carry the attribute. We can add support for it later if needed.
+create_query_templates += [(template, False) for template in extra_create_queries]
 
 # Print report threshold for the test if it is set.
 ignored_relative_change = 0.05
@@ -748,15 +766,15 @@ for conn_index, c in enumerate(all_connections):
 
 reportStageEnd("settings")
 
-# One-line summary per connection whose check_reference="0" setup query failed there (the traceback goes to stderr).
+# One-line summary per connection whose tolerated setup query failed there (the traceback goes to stderr).
 setup_error_on_connection = [None] * len(all_connections)
 
 if not args.use_existing_tables:
     # Run create and fill queries. We will run them simultaneously for both servers, to save time.
     create_queries = []
-    for template, check_reference in create_query_templates:
+    for template, tolerate_on_reference in create_query_templates:
         create_queries += [
-            (q, check_reference) for q in substitute_parameters([template])
+            (q, tolerate_on_reference) for q in substitute_parameters([template])
         ]
 
     # Disallow temporary tables, because the clickhouse_driver reconnects on
@@ -768,17 +786,18 @@ if not args.use_existing_tables:
             sys.exit(1)
 
     def do_create(connection, index, queries):
-        for q, check_reference in queries:
+        for q, tolerate_on_reference in queries:
             try:
                 connection.execute(q)
                 print(f"create\t{index}\t{connection.last_query.elapsed}\t{tsv_escape(q)}")
             except Exception:
                 # Failures on any server other than the reference (connection 0), or of setup queries without the opt-out, stay fatal.
-                if index != 0 or check_reference:
+                if index != 0 or not tolerate_on_reference:
                     raise
 
                 message = (
-                    'setup query failed on the reference server (check_reference="0"), '
+                    "setup query failed on the reference server and is tolerated "
+                    f"by do_not_check_in_pr matching --pr-number {args.pr_number}, "
                     f"running the test on the new server only: {tsv_escape(q)[:200]}"
                 )
                 print(f"{message}\n{traceback.format_exc()}", file=sys.stderr)
@@ -859,9 +878,9 @@ for query_index in queries_to_run:
     # new one. We want to run them on the new server only, so that the PR author
     # can ensure that the test works properly. Remember the errors we had on
     # each server.
-    # A connection whose check_reference="0" setup query failed starts out
-    # already failed for every query, so the partial ("backward-incompatible")
-    # machinery excludes it from the comparison.
+    # A connection whose tolerated (do_not_check_in_pr) setup query failed
+    # starts out already failed for every query, so the partial
+    # ("backward-incompatible") machinery excludes it from the comparison.
     query_error_on_connection = list(setup_error_on_connection)
     for conn_index, c in enumerate(all_connections):
         if query_error_on_connection[conn_index]:

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -748,30 +748,42 @@ for conn_index, c in enumerate(all_connections):
 
 reportStageEnd("settings")
 
+# One-line summary per connection whose check_reference="0" setup query failed there (the traceback goes to stderr).
+setup_error_on_connection = [None] * len(all_connections)
+
 if not args.use_existing_tables:
     # Run create and fill queries. We will run them simultaneously for both servers, to save time.
     create_queries = []
-    create_queries_check_reference = []
     for template, check_reference in create_query_templates:
-        expanded = substitute_parameters([template])
-        create_queries += expanded
-        create_queries_check_reference += [check_reference] * len(expanded)
+        create_queries += [
+            (q, check_reference) for q in substitute_parameters([template])
+        ]
 
     # Disallow temporary tables, because the clickhouse_driver reconnects on
     # errors, and temporary tables are destroyed. We want to be able to continue
     # after some errors.
-    for q in create_queries:
+    for q, _ in create_queries:
         if re.search("create temporary table", q, flags=re.IGNORECASE):
-            print(
-                f"Temporary tables are not allowed in performance tests: '{q}'",
-                file=sys.stderr,
-            )
+            print(f"Temporary tables are not allowed in performance tests: '{q}'", file=sys.stderr)
             sys.exit(1)
 
     def do_create(connection, index, queries):
-        for q in queries:
-            connection.execute(q)
-            print(f"create\t{index}\t{connection.last_query.elapsed}\t{tsv_escape(q)}")
+        for q, check_reference in queries:
+            try:
+                connection.execute(q)
+                print(f"create\t{index}\t{connection.last_query.elapsed}\t{tsv_escape(q)}")
+            except Exception:
+                # Failures on any server other than the reference (connection 0), or of setup queries without the opt-out, stay fatal.
+                if index != 0 or check_reference:
+                    raise
+
+                message = (
+                    'setup query failed on the reference server (check_reference="0"), '
+                    f"running the test on the new server only: {tsv_escape(q)[:200]}"
+                )
+                print(f"{message}\n{traceback.format_exc()}", file=sys.stderr)
+                setup_error_on_connection[index] = message
+                break
 
     threads = [
         SafeThread(target=do_create, args=(connection, index, create_queries))
@@ -847,8 +859,13 @@ for query_index in queries_to_run:
     # new one. We want to run them on the new server only, so that the PR author
     # can ensure that the test works properly. Remember the errors we had on
     # each server.
-    query_error_on_connection = [None] * len(all_connections)
+    # A connection whose check_reference="0" setup query failed starts out
+    # already failed for every query, so the partial ("backward-incompatible")
+    # machinery excludes it from the comparison.
+    query_error_on_connection = list(setup_error_on_connection)
     for conn_index, c in enumerate(all_connections):
+        if query_error_on_connection[conn_index]:
+            continue
         try:
             prewarm_id = f"{query_prefix}.prewarm0"
 
@@ -1139,8 +1156,15 @@ reportStageEnd("run")
 if not args.keep_created_tables and not args.use_existing_tables:
     drop_queries = substitute_parameters(drop_query_templates)
     for conn_index, c in enumerate(all_connections):
+        # Best-effort teardown on a connection whose setup never completed: the objects may not exist there.
+        setup_failed = setup_error_on_connection[conn_index] is not None
         for q in drop_queries:
-            c.execute(q)
+            try:
+                c.execute(q)
+            except Exception:
+                if setup_failed:
+                    continue
+                raise
             print(f"drop\t{conn_index}\t{c.last_query.elapsed}\t{tsv_escape(q)}")
 
     reportStageEnd("drop-2")

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -564,14 +564,37 @@ if not args.long:
 # options, fail closed: reject the test up front rather than benchmark the wrong
 # endpoint. (Done after the `--print-queries` / `--print-settings` early exits so
 # those read-only paths are unaffected.)
-if any(q["kind"] == "shell" for q in test_queries) and (
-    args.user != "default" or args.password != "" or args.secure
-):
+has_shell_queries = any(q["kind"] == "shell" for q in test_queries)
+if has_shell_queries and (args.user != "default" or args.password != "" or args.secure):
     raise Exception(
         'Shell-script queries (<query type="shell">) do not support the '
         "--user / --password / --secure connection options yet: the shell "
         "environment always connects without authentication over plaintext HTTP. "
         "Remove these options, or run this test without shell-script queries."
+    )
+
+# Setup queries (create_query/fill_query) paired with their check_reference flag value.
+# If `check_reference="0"`, the query is not checked on the reference server. Useful for newly added features.
+# findall("./*") + tag filter, not one findall per tag, to keep the document order of the queries.
+create_query_templates = []
+for e in root.findall("./*"):
+    if e.tag not in ("create_query", "fill_query"):
+        continue
+    check_reference = e.get("check_reference", "1")
+    if check_reference not in ("0", "1"):
+        raise Exception(
+            f'Invalid check_reference="{check_reference}" on <{e.tag}> '
+            'in the test file: must be "0" or "1"'
+        )
+    create_query_templates.append((e.text, check_reference == "1"))
+
+# Statements extracted from <query file=...> have no element to carry the attribute.
+create_query_templates += [(template, True) for template in extra_create_queries]
+
+if has_shell_queries and any(not checked for _, checked in create_query_templates):
+    raise Exception(
+        'check_reference="0" is not compatible with shell queries: a shell '
+        "performance test must run on every server to be comparable"
     )
 
 # Print report threshold for the test if it is set.
@@ -726,15 +749,13 @@ for conn_index, c in enumerate(all_connections):
 reportStageEnd("settings")
 
 if not args.use_existing_tables:
-    # Run create and fill queries. We will run them simultaneously for both
-    # servers, to save time. The weird XML search + filter is because we want to
-    # keep the relative order of elements, and etree doesn't support the
-    # appropriate xpath query.
-    create_query_templates = [
-        q.text for q in root.findall("./*") if q.tag in ("create_query", "fill_query")
-    ]
-    create_query_templates += extra_create_queries
-    create_queries = substitute_parameters(create_query_templates)
+    # Run create and fill queries. We will run them simultaneously for both servers, to save time.
+    create_queries = []
+    create_queries_check_reference = []
+    for template, check_reference in create_query_templates:
+        expanded = substitute_parameters([template])
+        create_queries += expanded
+        create_queries_check_reference += [check_reference] * len(expanded)
 
     # Disallow temporary tables, because the clickhouse_driver reconnects on
     # errors, and temporary tables are destroyed. We want to be able to continue


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

When a PR adds a feature together with a performance test whose `create_query`/`fill_query` depends on it, the setup fails on the reference server that predates the feature with an error like `Unknown setting`, and the whole performance comparison check goes red. Measured queries already handled this, setup queries had no equivalent.

Such a query may now be marked `do_not_check_in_pr="<number of the PR>"`. If it fails on the reference server, the test runs on the new server only and its queries are reported under "Backward-incompatible queries" while the check stays green. The comparison resumes by itself once the feature reaches master.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116123&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116123](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116123+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.99` (included in `26.9` and later)
<!-- ch-version-info:end -->