### PR TITLE
Require forward progress when counting rows in Avro

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -1286,19 +1286,6 @@ bool AvroRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & ex
     return false;
 }
 
-size_t AvroRowInputFormat::countRows(size_t max_block_size)
-{
-    size_t num_rows = 0;
-    while (file_reader_ptr->hasMore() && num_rows < max_block_size)
-    {
-        file_reader_ptr->decr();
-        file_reader_ptr->decoder().drain();
-        ++num_rows;
-    }
-
-    return num_rows;
-}
-
 static uint32_t readConfluentSchemaId(ReadBuffer & in)
 {
     uint8_t magic = 0;

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.h
@@ -179,9 +179,8 @@ private:
     bool readRow(MutableColumns & columns, RowReadExtension & ext) override;
     void readPrefix() override;
 
-    bool supportsCountRows() const override { return true; }
-    size_t countRows(size_t max_block_size) override;
-
+    /// No count shortcut: the row count comes from the block header, so counting without decoding
+    /// the payload cannot tell a declared count from the rows actually present.
     std::unique_ptr<avro::DataFileReaderBase> file_reader_ptr;
     std::unique_ptr<AvroDeserializer> deserializer_ptr;
     FormatSettings format_settings;

--- a/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.reference
+++ b/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.reference
@@ -1,0 +1,20 @@
+--- a corrupted block header is rejected instead of counted
+optimize_count_from_files = 1
+1
+1
+optimize_count_from_files = 0
+1
+1
+--- valid input still counts every row, including rows that occupy no payload bytes
+optimize_count_from_files = 1
+5000
+1000
+200000
+optimize_count_from_files = 0
+5000
+1000
+200000
+--- reading valid input is unchanged, at several block sizes
+5000	16876015480804349662
+5000	16876015480804349662
+5000	16876015480804349662

--- a/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.reference
+++ b/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.reference
@@ -2,7 +2,14 @@
 optimize_count_from_files = 1
 1
 1
+1
 optimize_count_from_files = 0
+1
+1
+1
+--- a negative declared count is rejected at the header, not at the payload
+1
+1
 1
 1
 --- valid input still counts every row, including rows that occupy no payload bytes

--- a/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.sh
+++ b/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: the Avro format is not available in the fast test build.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# max_execution_time is a safety belt so a regression fails fast instead of hanging the suite. The
+# assertion is always the error code or the row count, never the elapsed time.
+BOUND="SETTINGS max_execution_time = 30"
+
+DIR="$CLICKHOUSE_TMP/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rm -rf "$DIR"
+mkdir -p "$DIR"
+
+# Append an Avro block header (zigzag object count, zigzag byte count) plus the file's own sync
+# marker, so the appended block is well-framed and only its declared count is wrong.
+avro_append_block() {
+    python3 -c "
+import sys
+src, dst, count = sys.argv[1], sys.argv[2], int(sys.argv[3])
+def zigzag(n):
+    n = ((n << 1) ^ (n >> 63)) if n < 0 else (n << 1)
+    n &= (1 << 64) - 1
+    out = bytearray()
+    while True:
+        b = n & 0x7f
+        n >>= 7
+        out.append(b | 0x80 if n else b)
+        if not n:
+            break
+    return bytes(out)
+data = open(src, 'rb').read()
+open(dst, 'wb').write(data + zigzag(count) + zigzag(0) + data[-16:])
+" "$1" "$2" "$3"
+}
+
+$CLICKHOUSE_LOCAL -q "
+    SELECT number AS n, toString(number) AS s FROM numbers(5000)
+    INTO OUTFILE '$DIR/ok.avro' TRUNCATE FORMAT Avro
+    SETTINGS output_format_avro_codec = 'null'"
+# An all-NULL column encodes to zero payload bytes, so this file legitimately declares 1000 rows in
+# a few hundred bytes. It is the counter-example to bounding the declared count by the input size.
+$CLICKHOUSE_LOCAL -q "
+    SELECT NULL AS a FROM numbers(1000)
+    INTO OUTFILE '$DIR/nullrows.avro' TRUNCATE FORMAT Avro
+    SETTINGS output_format_avro_codec = 'null'"
+# Same for a compressed file: 200000 rows of one repeated value compress to under a kilobyte.
+$CLICKHOUSE_LOCAL -q "
+    SELECT 1 AS a FROM numbers(200000)
+    INTO OUTFILE '$DIR/deflate.avro' TRUNCATE FORMAT Avro
+    SETTINGS output_format_avro_codec = 'deflate'"
+
+# A negative declared object count: hasMore() tests != 0 and decr() only decrements.
+avro_append_block "$DIR/ok.avro" "$DIR/negative.avro" -5
+# A huge positive declared count: the loop terminates, but every row it reports past the payload is
+# invented, so the count came back as a successful wrong answer.
+avro_append_block "$DIR/ok.avro" "$DIR/huge.avro" 1000000000
+
+echo '--- a corrupted block header is rejected instead of counted'
+for setting in 1 0; do
+    echo "optimize_count_from_files = $setting"
+    $CLICKHOUSE_LOCAL -q "
+        SELECT count() FROM file('$DIR/negative.avro', Avro)
+        $BOUND, optimize_count_from_files = $setting" 2>&1 | grep -c -F 'EOF reached'
+    $CLICKHOUSE_LOCAL -q "
+        SELECT count() FROM file('$DIR/huge.avro', Avro)
+        $BOUND, optimize_count_from_files = $setting" 2>&1 | grep -c -F 'EOF reached'
+done
+
+echo '--- valid input still counts every row, including rows that occupy no payload bytes'
+for setting in 1 0; do
+    echo "optimize_count_from_files = $setting"
+    for f in ok.avro nullrows.avro deflate.avro; do
+        $CLICKHOUSE_LOCAL -q "SELECT count() FROM file('$DIR/$f', Avro) $BOUND, optimize_count_from_files = $setting"
+    done
+done
+
+echo '--- reading valid input is unchanged, at several block sizes'
+for size in 1 13 65505; do
+    $CLICKHOUSE_LOCAL -q "
+        SELECT count(), sum(cityHash64(n, s))
+        FROM file('$DIR/ok.avro', Avro)
+        $BOUND, max_block_size = $size"
+done
+
+rm -rf "$DIR"

--- a/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.sh
+++ b/tests/queries/0_stateless/04947_avro_count_from_files_forward_progress.sh
@@ -16,10 +16,11 @@ mkdir -p "$DIR"
 
 # Append an Avro block header (zigzag object count, zigzag byte count) plus the file's own sync
 # marker, so the appended block is well-framed and only its declared count is wrong.
+# The byte count defaults to zero, which is what an empty appended payload declares.
 avro_append_block() {
     python3 -c "
 import sys
-src, dst, count = sys.argv[1], sys.argv[2], int(sys.argv[3])
+src, dst, count, bytes_declared = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
 def zigzag(n):
     n = ((n << 1) ^ (n >> 63)) if n < 0 else (n << 1)
     n &= (1 << 64) - 1
@@ -32,8 +33,8 @@ def zigzag(n):
             break
     return bytes(out)
 data = open(src, 'rb').read()
-open(dst, 'wb').write(data + zigzag(count) + zigzag(0) + data[-16:])
-" "$1" "$2" "$3"
+open(dst, 'wb').write(data + zigzag(count) + zigzag(bytes_declared) + data[-16:])
+" "$1" "$2" "$3" "${4-0}"
 }
 
 $CLICKHOUSE_LOCAL -q "
@@ -52,21 +53,38 @@ $CLICKHOUSE_LOCAL -q "
     INTO OUTFILE '$DIR/deflate.avro' TRUNCATE FORMAT Avro
     SETTINGS output_format_avro_codec = 'deflate'"
 
-# A negative declared object count: hasMore() tests != 0 and decr() only decrements.
-avro_append_block "$DIR/ok.avro" "$DIR/negative.avro" -5
-# A huge positive declared count: the loop terminates, but every row it reports past the payload is
-# invented, so the count came back as a successful wrong answer.
-avro_append_block "$DIR/ok.avro" "$DIR/huge.avro" 1000000000
+# A negative declared object count. Never reaches zero by decrementing, so the count call used to
+# spin here until the query deadline.
+avro_append_block "$DIR/ok.avro" "$DIR/negative.avro" -5 0
+# A negative declared byte count. Widens into an unbounded payload limit when cast unsigned.
+avro_append_block "$DIR/ok.avro" "$DIR/negbytes.avro" 10 -1
+# A positive declared count larger than the payload holds. The count must not be answered from the
+# header alone, or every row reported past the payload is invented and returned as a success.
+avro_append_block "$DIR/ok.avro" "$DIR/huge.avro" 1000000000 0
 
+# Assert on the error class, not on one message: a corrupted header is rejected either by the Avro
+# library at the block header or by the read path when the payload runs out.
 echo '--- a corrupted block header is rejected instead of counted'
 for setting in 1 0; do
     echo "optimize_count_from_files = $setting"
+    for f in negative.avro negbytes.avro huge.avro; do
+        $CLICKHOUSE_LOCAL -q "
+            SELECT count() FROM file('$DIR/$f', Avro)
+            $BOUND, optimize_count_from_files = $setting" 2>&1 | grep -c -F 'AVRO_EXCEPTION'
+    done
+done
+
+# A block whose declared count is corrupted is also a block that runs out of input, so the broad
+# assertion above cannot tell the header check from payload exhaustion. Name the header diagnostic
+# for both counts, which keeps these pinned to the header check itself.
+echo '--- a negative declared count is rejected at the header, not at the payload'
+for setting in 1 0; do
     $CLICKHOUSE_LOCAL -q "
         SELECT count() FROM file('$DIR/negative.avro', Avro)
-        $BOUND, optimize_count_from_files = $setting" 2>&1 | grep -c -F 'EOF reached'
+        $BOUND, optimize_count_from_files = $setting" 2>&1 | grep -c -F 'object count in block header'
     $CLICKHOUSE_LOCAL -q "
-        SELECT count() FROM file('$DIR/huge.avro', Avro)
-        $BOUND, optimize_count_from_files = $setting" 2>&1 | grep -c -F 'EOF reached'
+        SELECT count() FROM file('$DIR/negbytes.avro', Avro)
+        $BOUND, optimize_count_from_files = $setting" 2>&1 | grep -c -F 'byte count in block header'
 done
 
 echo '--- valid input still counts every row, including rows that occupy no payload bytes'


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/115437
Related: https://github.com/ClickHouse/ClickHouse/pull/115884
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/115437
Related: https://github.com/ClickHouse/ClickHouse/pull/115884

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `SELECT count()` never terminating, or returning an invented row count, on an `Avro` file with a corrupted block header. The `optimize_count_from_files` fast path took the row count from the header without reading the payload, so a negative declared count looped forever and an inflated one reported rows the file does not hold.

### Description

Split out of #115884 at @ PedroTadim's request. Reported in #115437.

`IRowInputFormat::read()` re-enters `countRows()` until it returns 0, and `AvroRowInputFormat::countRows` took the count straight from the block header: `hasMore()` tests the declared count against zero while `decr()` only decrements, so a negative count never reaches it, and an inflated count reports rows that are not there. A header declaring 10^9 rows returned `1000005000` rows from a 34KB file **as a successful answer**, so nothing alerted the user.

Two changes:

- `contrib/avro` is bumped to pick up ClickHouse/avro#33, which rejects a block header declaring a negative object or byte count and hardens `hasMore()` to test `> 0`. This is the layer that owns the header, so it also covers the Iceberg manifest deserializer, and it fixes the negative-count hang on a record whose fields encode to zero payload bytes, which no ClickHouse side change reached.
- `supportsCountRows()` stays false, so count queries take the read path. A non-negative but inflated count is indistinguishable from a real one at the header, and the library has no accessor for the block extent, so nothing on this side can bound it.

Cost on valid files, medians of 9 interleaved runs on 30M rows snappy, debug build, two binaries differing only in the shortcut: 1.49s with it, 2.44s without. The row-count cache still applies, because `StorageFile` populates it on the ordinary read path too.

Still not terminating: a record whose fields all encode to zero payload bytes, with a *positive* corrupted count. The payload is legitimately empty, so neither the header nor the reader can tell that count is wrong.

<details><summary>Refuted alternatives and validation</summary>

Bounding the declared count by the remaining input size is refuted by measurement: valid Avro holds 1000 rows in 139 bytes with an all-NULL column, and 200000 rows in 810 bytes with deflate. Both are test arms here, so the design cannot be reintroduced silently.

A central guard in `IRowInputFormat::read()` is refuted too: `Npy` and `RawBLOB` legitimately return rows consuming zero bytes.

`supportsCountRows()` has exactly one caller, `IRowInputFormat.cpp`, so removing the override has no other reachable consumer. `AvroConfluentRowInputFormat` is a separate `IRowInputFormat` subclass that never declared it and is unaffected.

`04947_avro_count_from_files_forward_progress.sh` asserts error codes on a bounded run, never elapsed time. The same file on three binaries: this tree passes; without the submodule bump 12 lines differ, including all four header diagnostics; with the bump and the shortcut restored 2 lines differ, the inflated count still answering `1000005000`.

</details>
