### PR TITLE
Compute the AVX2 rand seeds four at a time

### DIFF
--- a/src/Functions/FunctionsRandom.cpp
+++ b/src/Functions/FunctionsRandom.cpp
@@ -95,6 +95,25 @@ void RandImpl::execute(char * output, size_t size)
 
 using namespace VectorExtension;
 
+/// The Murmur finalizer of intHash64, applied to four values at once.
+inline UInt64x4 intHash64x4(UInt64x4 x)
+{
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdULL;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53ULL;
+    x ^= x >> 33;
+
+    return x;
+}
+
+/// calcSeed for four consecutive entries of random_numbers, starting at `offset`.
+inline UInt64x4 calcSeeds(UInt64 rand_seed, size_t offset, const char * output)
+{
+    const UInt64 additional_seed = reinterpret_cast<intptr_t>(output);
+    return intHash64x4(intHash64x4(unalignedLoad<UInt64x4>(&random_numbers[offset]) + additional_seed) ^ rand_seed);
+}
+
 /* Takes 2 vectors with LinearCongruentialGenerator states and combines them into vector with random values.
  * From every rand-state we use only bits 15...47 to generate random vector.
  */
@@ -129,18 +148,11 @@ void RandImpl::execute(char * output, size_t size)
     UInt64 a = LinearCongruentialGenerator::a;
     constexpr UInt64 c = LinearCongruentialGenerator::c;
 
-    UInt64x4 gens1{};
-    UInt64x4 gens2{};
-    UInt64x4 gens3{};
-    UInt64x4 gens4{};
-
-    for (int i = 0; i < vec_size; ++i)
-    {
-        gens1[i] = calcSeed(rand_seed, random_numbers[i] + reinterpret_cast<intptr_t>(output));
-        gens2[i] = calcSeed(rand_seed, random_numbers[i + vec_size] + reinterpret_cast<intptr_t>(output));
-        gens3[i] = calcSeed(rand_seed, random_numbers[i + 2 * vec_size] + reinterpret_cast<intptr_t>(output));
-        gens4[i] = calcSeed(rand_seed, random_numbers[i + 3 * vec_size] + reinterpret_cast<intptr_t>(output));
-    }
+    /// Same seeds as the scalar formula calcSeed(rand_seed, random_numbers[i] + output), computed four at a time.
+    UInt64x4 gens1 = calcSeeds(rand_seed, 0, output);
+    UInt64x4 gens2 = calcSeeds(rand_seed, vec_size, output);
+    UInt64x4 gens3 = calcSeeds(rand_seed, 2 * vec_size, output);
+    UInt64x4 gens4 = calcSeeds(rand_seed, 3 * vec_size, output);
 
     while ((end - output) + safe_overwrite >= bytes_per_write)
     {


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116133

`RandImpl::execute` derives 16 `LinearCongruentialGenerator` seeds on the AVX2 path, and it does it with 16 scalar `calcSeed` calls written into the four vectors lane by lane. That is a fixed ~80 ns of setup on every call, which for small buffers costs more than the generation loop it is setting up.

This computes the same 16 seeds with vector `intHash64`, four lanes at a time. The formula is untouched, so the generated bytes are bit-identical to before; a standalone harness verifies that byte for byte at sizes 1 to 4096 before timing anything.

Setup drops from ~80 ns to ~8 ns per call. That is invisible at the default block size, where it is amortised over 65536 rows, and worth about 2% when blocks are small.

Measured on a 7950X3D, `-march=x86-64-v3`, against a baseline binary built from the same tree, best of 7:

| query | baseline | patched | |
|---|---:|---:|---:|
| `randomFixedString(10)`, 400M rows, default block size | 0.2664s | 0.2673s | 0.997x |
| `randomFixedString(10)`, 100M rows, `max_block_size=64` | 4.4729s | 4.4196s | 1.012x |
| `generateUUIDv4()`, 100M rows, `max_block_size=64` | 4.4135s | 4.3221s | 1.021x |

The small-block numbers agree with the microbenchmark: 100M rows is 1.5625M calls, times the 56.5 ns per-call saving, gives 88 ms predicted against 91.5 ms measured for `generateUUIDv4`. Block overhead dominates everything else at that block size, which is why a 9x cheaper setup only surfaces as 2%.

Every number above is from a single Zen 4 host. The change is a pure instruction-count reduction with no ISA dependency, so it should hold everywhere, but the `Performance Comparison (amd64)` job on this PR is the authoritative check. That job is also why the changelog category here is Performance Improvement rather than Not for changelog: the category is what makes CI run the x86 performance comparison, and this change needs it.

Found while reviewing the AArch64 counterpart linked above, which notes a small-block regression on its own path. This is the x86 half of the same observation and is independent of it: no new ISA requirement, no runtime dispatch, no change to the generated stream.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reduced the fixed setup cost of random data generation (`rand`, `rand64`, `randomString`, `randomFixedString`, `generateUUIDv4`, `generateUUIDv7`) on x86-64. Noticeable when blocks are small; generated values are unchanged.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116158&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116158](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116158+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.81` (included in `26.9` and later)
<!-- ch-version-info:end -->