### PR TITLE
Apply disableProtocols tlsv1_3 instead of silently ignoring it

### DIFF
--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -100,7 +100,8 @@ namespace Net
             PROTO_SSLV3 = 0x02,
             PROTO_TLSV1 = 0x04,
             PROTO_TLSV1_1 = 0x08,
-            PROTO_TLSV1_2 = 0x10
+            PROTO_TLSV1_2 = 0x10,
+            PROTO_TLSV1_3 = 0x20
         };
 
         struct NetSSL_API CAPaths

--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -93,7 +93,7 @@ namespace Net
     ///            <requireTLSv1>true|false</requireTLSv1>
     ///            <requireTLSv1_1>true|false</requireTLSv1_1>
     ///            <requireTLSv1_2>true|false</requireTLSv1_2>
-    ///            <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_2</disableProtocols>
+    ///            <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_2,tlsv1_3</disableProtocols>
     ///            <dhParamsFile>dh.pem</dhParamsFile>
     ///            <ecdhCurve>prime256v1</ecdhCurve>
     ///          </server|client>
@@ -143,7 +143,7 @@ namespace Net
     ///    - requireTLSv1_1 (boolean): Require a TLSv1.1 connection.
     ///    - requireTLSv1_2 (boolean): Require a TLSv1.2 connection.
     ///    - disableProtocols (string): A comma-separated list of protocols that should be
-    ///      disabled. Valid protocol names are sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2.
+    ///      disabled. Valid protocol names are sslv2, sslv3, tlsv1, tlsv1_1, tlsv1_2, tlsv1_3.
     ///    - dhParamsFile (string): Specifies a file containing Diffie-Hellman parameters.
     ///      If not specified or empty, the default parameters are used.
     ///    - ecdhCurve (string): Specifies the name of the curve to use for ECDH, based

--- a/base/poco/NetSSL_OpenSSL/src/Context.cpp
+++ b/base/poco/NetSSL_OpenSSL/src/Context.cpp
@@ -458,6 +458,12 @@ void Context::disableProtocols(int protocols)
 		SSL_CTX_set_options(_pSSLContext, SSL_OP_NO_TLSv1_2);
 #endif
 	}
+	if (protocols & PROTO_TLSV1_3)
+	{
+#if defined(SSL_OP_NO_TLSv1_3)
+		SSL_CTX_set_options(_pSSLContext, SSL_OP_NO_TLSv1_3);
+#endif
+	}
 }
 
 

--- a/base/poco/NetSSL_OpenSSL/src/SSLManager.cpp
+++ b/base/poco/NetSSL_OpenSSL/src/SSLManager.cpp
@@ -314,6 +314,8 @@ void SSLManager::initDefaultContext(bool server)
 			disabledProtocols |= Context::PROTO_TLSV1_1;
 		else if (*it == "tlsv1_2")
 			disabledProtocols |= Context::PROTO_TLSV1_2;
+		else if (*it == "tlsv1_3")
+			disabledProtocols |= Context::PROTO_TLSV1_3;
 	}
 	if (server)
 		_ptrDefaultServerContext->disableProtocols(disabledProtocols);

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -174,6 +174,8 @@ auto getSslContextProvider(const Poco::Util::AbstractConfiguration & config, std
             disabled_protocols |= Poco::Net::Context::PROTO_TLSV1_1;
         else if (token == "tlsv1_2")
             disabled_protocols |= Poco::Net::Context::PROTO_TLSV1_2;
+        else if (token == "tlsv1_3")
+            disabled_protocols |= Poco::Net::Context::PROTO_TLSV1_3;
     }
 
     auto prefer_server_cypher = config.getBool(config_prefix + "preferServerCiphers", false);

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -320,6 +320,8 @@ PostgreSQLHandler::PostgreSQLHandler(
                 disabled_protocols |= Poco::Net::Context::PROTO_TLSV1_1;
             else if (token == "tlsv1_2")
                 disabled_protocols |= Poco::Net::Context::PROTO_TLSV1_2;
+            else if (token == "tlsv1_3")
+                disabled_protocols |= Poco::Net::Context::PROTO_TLSV1_3;
         }
 
         extended_verification = config.getBool(prefix + Poco::Net::SSLManager::CFG_EXTENDED_VERIFICATION, false);

--- a/src/Server/TLSHandler.cpp
+++ b/src/Server/TLSHandler.cpp
@@ -90,6 +90,8 @@ DB::TLSHandler::TLSHandler(
             disabled_protocols |= Context::PROTO_TLSV1_1;
         else if (token == "tlsv1_2")
             disabled_protocols |= Context::PROTO_TLSV1_2;
+        else if (token == "tlsv1_3")
+            disabled_protocols |= Context::PROTO_TLSV1_3;
     }
 
     extended_verification = config.getBool(prefix + SSLManager::CFG_EXTENDED_VERIFICATION, false);

--- a/tests/integration/test_composable_protocols/configs/config.xml
+++ b/tests/integration/test_composable_protocols/configs/config.xml
@@ -9,7 +9,7 @@
             <verificationMode>none</verificationMode>
             <loadDefaultCAFile>true</loadDefaultCAFile>
             <cacheSessions>true</cacheSessions>
-            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <disableProtocols>sslv2,sslv3,tlsv1_3</disableProtocols>
             <preferServerCiphers>true</preferServerCiphers>
         </server>
     </openSSL>
@@ -78,6 +78,16 @@
             <certificateFile>/etc/clickhouse-server/config.d/server.crt</certificateFile>
             <privateKeyFile>/etc/clickhouse-server/config.d/server.key</privateKeyFile>
         </https_tls1_3>
+        <https_no_tls1_3>
+            <type>tls</type>
+            <impl>http</impl>
+            <host>0.0.0.0</host>
+            <port>8447</port>
+            <description>https protocol with TLSv1_3 disabled</description>
+            <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_3</disableProtocols>
+            <certificateFile>/etc/clickhouse-server/config.d/server.crt</certificateFile>
+            <privateKeyFile>/etc/clickhouse-server/config.d/server.key</privateKeyFile>
+        </https_no_tls1_3>
         <http_proxy>
             <type>proxy1</type>
             <impl>http</impl>

--- a/tests/integration/test_composable_protocols/test.py
+++ b/tests/integration/test_composable_protocols/test.py
@@ -147,6 +147,26 @@ def test_connections():
         == "1\n"
     )
 
+    assert (
+        execute_query_https(
+            server.ip_address, 8447, "SELECT 1", version=ssl.TLSVersion.TLSv1_2
+        )
+        == "1\n"
+    )
+    assert execute_query_https_unsupported(
+        server.ip_address, 8447, "SELECT 1", version=ssl.TLSVersion.TLSv1_3
+    )
+
+    assert (
+        execute_query_https(
+            server.ip_address, 8443, "SELECT 1", version=ssl.TLSVersion.TLSv1_2
+        )
+        == "1\n"
+    )
+    assert execute_query_https_unsupported(
+        server.ip_address, 8443, "SELECT 1", version=ssl.TLSVersion.TLSv1_3
+    )
+
 
 # tests when using PROXYv1 with enabled auth_use_forwarded_address that forwarded address is used for authentication and query's source address
 def test_proxy_1():


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/79876   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Listing `tlsv1_3` in `<openSSL><server><disableProtocols>` (or the `client` equivalent) now actually disables TLS 1.3. Previously the token was dropped with no error or log line and the server kept negotiating TLS 1.3, so an operator who disabled it believed TLS 1.3 was off while it was not. Closes #79876.


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/79876

The token `tlsv1_3` matched no branch in any `disableProtocols` parser, so no bit was set, `Context::disableProtocols` never called `SSL_OP_NO_TLSv1_3`, and the version-flexible `TLS_server_method()` context kept offering TLS 1.3. Nothing was logged, so the config looked accepted. `requireTLSv1_2` is no workaround (it also selects a version-flexible context), nor is `cipherList` (TLS 1.3 suites go through `SSL_CTX_set_ciphersuites`, which Poco never calls).

Three layers were missing it: `enum Protocols` stopped at `PROTO_TLSV1_2`, `Context::disableProtocols` had no `SSL_OP_NO_TLSv1_3` block, and **four** parsers matched five token names with no `else`. All four now accept `tlsv1_3`:

- `base/poco/NetSSL_OpenSSL/src/SSLManager.cpp` (default `openSSL.server`/`client` contexts)
- `src/Server/TLSHandler.cpp` (composable protocols)
- `src/Coordination/KeeperServer.cpp` (Keeper internal raft TLS)
- `src/Server/PostgreSQLHandler.cpp`

The `base/poco/` changes adopt the fix upstream `pocoproject/poco` already carries and the vendored copy (1.9.3) predates, so a future resync stays conflict-free. The two `.cpp` hunks are byte-identical to upstream; the header hunks differ only in indentation, since the vendored headers use spaces.

Validated with `disableProtocols=sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_3`: before, `openssl s_client -tls1_3` negotiated `TLS_AES_256_GCM_SHA384`; after, the handshake returns `tlsv1 alert protocol version` while TLS 1.2 still serves queries. Both separators, whitespace and token order behave as for the existing names.

New arms in `test_composable_protocols` cover the `SSLManager` and `TLSHandler` parsers, each paired with a TLS 1.2 control; both fail on unpatched master. The Keeper and PostgreSQL parsers are checked by reading only: no existing test asserts a version rejection at either, and arming them needs a hand-rolled version-pinned client plus edits to `test_keeper_internal_secure`, which #116053 is changing.

No in-tree config or test names `tlsv1_3`, so nothing changes meaning; a config listing all six tokens will accept nothing, which is what it asks for. `tests/casa_del_dolor/properties.py` deliberately keeps its five-token list: it emits a random subset, and all six would leave no usable protocol.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116170&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116170](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116170+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.95` (included in `26.9` and later)
<!-- ch-version-info:end -->