### PR TITLE
Enable the 64-byte filter counting path on AArch64

### DIFF
--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -28,6 +28,12 @@ static UInt64 toBits64(const Int8 * bytes64)
 
     return ~res;
 }
+#elif defined(__aarch64__) && defined(__ARM_NEON)
+/// bytes64MaskToBits64Mask returns the same mask as the branch above: bit i is set iff byte i is non-zero.
+static UInt64 toBits64(const Int8 * bytes64)
+{
+    return bytes64MaskToBits64Mask(reinterpret_cast<const UInt8 *>(bytes64));
+}
 #endif
 
 size_t countBytesInFilter(const UInt8 * filt, size_t start, size_t end)
@@ -44,7 +50,7 @@ size_t countBytesInFilter(const UInt8 * filt, size_t start, size_t end)
 
     const Int8 * end_pos = pos + (end - start);
 
-#if defined(__SSE2__)
+#if defined(__SSE2__) || (defined(__aarch64__) && defined(__ARM_NEON))
     const Int8 * end_pos64 = pos + (end - start) / 64 * 64;
 
     for (; pos < end_pos64; pos += 64)
@@ -77,7 +83,7 @@ size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * nu
     const Int8 * pos2 = reinterpret_cast<const Int8 *>(null_map) + start;
     const Int8 * end_pos = pos + (end - start);
 
-#if defined(__SSE2__)
+#if defined(__SSE2__) || (defined(__aarch64__) && defined(__ARM_NEON))
     const Int8 * end_pos64 = pos + (end - start) / 64 * 64;
 
     for (; pos < end_pos64; pos += 64, pos2 += 64)

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -40,10 +40,7 @@ size_t countBytesInFilter(const UInt8 * filt, size_t start, size_t end)
 {
     size_t count = 0;
 
-    /** NOTE: In theory, `filt` should only contain zeros and ones.
-      * But, just in case, here the condition > 0 (to signed bytes) is used.
-      * It would be better to use != 0, then this does not allow SSE2.
-      */
+    /// `filt` is not restricted to zeros and ones, so every non-zero byte counts as one row.
 
     const Int8 * pos = reinterpret_cast<const Int8 *>(filt);
     pos += start;
@@ -74,10 +71,7 @@ size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * nu
 {
     size_t count = 0;
 
-    /** NOTE: In theory, `filt` should only contain zeros and ones.
-      * But, just in case, here the condition > 0 (to signed bytes) is used.
-      * It would be better to use != 0, then this does not allow SSE2.
-      */
+    /// `filt` is not restricted to zeros and ones, so every non-zero byte counts as one row.
 
     const Int8 * pos = reinterpret_cast<const Int8 *>(filt.data()) + start;
     const Int8 * pos2 = reinterpret_cast<const Int8 *>(null_map) + start;
@@ -93,7 +87,7 @@ size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * nu
 #endif
 
     for (; pos < end_pos; ++pos, ++pos2)
-        count += (*pos & ~*pos2) != 0;
+        count += (*pos != 0) && (*pos2 == 0);
 
     return count;
 }

--- a/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.reference
+++ b/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.reference
@@ -1,35 +1,3 @@
--- countBytesInFilter, one block length per row
-0
-0
-21
-21
-22
-42
-43
-43
-85
-85
-86
--- countBytesInFilter reached with the output column optimised away
-21
-21
-22
-43
-64
--- countBytesInFilterWithNull
-17
-17
-18
-35
-35
-69
--- all-zero, all-one and a single set byte in the second block
-0
-128
-1
--- a filter spanning many blocks must agree with the sum of its parts
-1
--- non-binary UInt8 condition, block-size independent
 50
 50
 50

--- a/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.reference
+++ b/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.reference
@@ -1,0 +1,31 @@
+-- countBytesInFilter, one block length per row
+0
+0
+21
+21
+22
+42
+43
+43
+85
+85
+86
+-- countBytesInFilter reached with the output column optimised away
+21
+21
+22
+43
+64
+-- countBytesInFilterWithNull
+17
+17
+18
+35
+35
+69
+-- all-zero, all-one and a single set byte in the second block
+0
+128
+1
+-- a filter spanning many blocks must agree with the sum of its parts
+1

--- a/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.reference
+++ b/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.reference
@@ -29,3 +29,9 @@
 1
 -- a filter spanning many blocks must agree with the sum of its parts
 1
+-- non-binary UInt8 condition, block-size independent
+50
+50
+50
+31
+64

--- a/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.sql
+++ b/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.sql
@@ -42,3 +42,13 @@ SELECT count() FROM numbers(128) WHERE number = 100  SETTINGS max_block_size = 1
 SELECT '-- a filter spanning many blocks must agree with the sum of its parts';
 SELECT countIf(number % 7 = 3) = (SELECT count() FROM numbers(100000) WHERE number % 7 = 3)
 FROM numbers(100000) SETTINGS max_block_size = 100000;
+
+-- An -If condition column is forwarded as a raw UInt8, so a byte outside 0/1 reaches these loops.
+-- Each condition byte below keeps a set bit outside the null byte, so `filter & ~null` stays
+-- non-zero on a NULL row while `filter != 0 && null == 0` is false: the two disagree there.
+SELECT '-- non-binary UInt8 condition, block-size independent';
+SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(2)) FROM numbers(100) SETTINGS max_block_size = 63;
+SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(2)) FROM numbers(100) SETTINGS max_block_size = 64;
+SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(2)) FROM numbers(100) SETTINGS max_block_size = 100;
+SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(255)) FROM numbers(63) SETTINGS max_block_size = 63;
+SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(128)) FROM numbers(129) SETTINGS max_block_size = 129;

--- a/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.sql
+++ b/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.sql
@@ -1,0 +1,44 @@
+-- A filter is counted 64 bytes at a time with a byte-at-a-time tail, so a count must not
+-- depend on whether the block length is a multiple of 64. Partial selectivity is required:
+-- an all-pass filter cannot tell a correct block mask from a broken one.
+-- max_block_size pins the filter length so each query lands on a chosen boundary.
+
+SELECT '-- countBytesInFilter, one block length per row';
+SELECT countIf(number % 3 = 1) FROM numbers(0)   SETTINGS max_block_size = 1;
+SELECT countIf(number % 3 = 1) FROM numbers(1)   SETTINGS max_block_size = 1;
+SELECT countIf(number % 3 = 1) FROM numbers(63)  SETTINGS max_block_size = 63;
+SELECT countIf(number % 3 = 1) FROM numbers(64)  SETTINGS max_block_size = 64;
+SELECT countIf(number % 3 = 1) FROM numbers(65)  SETTINGS max_block_size = 65;
+SELECT countIf(number % 3 = 1) FROM numbers(127) SETTINGS max_block_size = 127;
+SELECT countIf(number % 3 = 1) FROM numbers(128) SETTINGS max_block_size = 128;
+SELECT countIf(number % 3 = 1) FROM numbers(129) SETTINGS max_block_size = 129;
+SELECT countIf(number % 3 = 1) FROM numbers(255) SETTINGS max_block_size = 255;
+SELECT countIf(number % 3 = 1) FROM numbers(256) SETTINGS max_block_size = 256;
+SELECT countIf(number % 3 = 1) FROM numbers(257) SETTINGS max_block_size = 257;
+
+SELECT '-- countBytesInFilter reached with the output column optimised away';
+SELECT count() FROM numbers(63)  WHERE number % 3 = 1 SETTINGS max_block_size = 63;
+SELECT count() FROM numbers(64)  WHERE number % 3 = 1 SETTINGS max_block_size = 64;
+SELECT count() FROM numbers(65)  WHERE number % 3 = 1 SETTINGS max_block_size = 65;
+SELECT count() FROM numbers(128) WHERE number % 3 = 1 SETTINGS max_block_size = 128;
+SELECT count() FROM numbers(193) WHERE number % 3 = 1 SETTINGS max_block_size = 193;
+
+-- countIfOrNull is the shape that reaches countBytesInFilterWithNull: it needs a null map
+-- forwarded together with a filter argument. A plain countIf over a Nullable column folds the
+-- null map into its own filter and never calls it.
+SELECT '-- countBytesInFilterWithNull';
+SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(63)  SETTINGS max_block_size = 63;
+SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(64)  SETTINGS max_block_size = 64;
+SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(65)  SETTINGS max_block_size = 65;
+SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(128) SETTINGS max_block_size = 128;
+SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(129) SETTINGS max_block_size = 129;
+SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(257) SETTINGS max_block_size = 257;
+
+SELECT '-- all-zero, all-one and a single set byte in the second block';
+SELECT count() FROM numbers(128) WHERE number > 1000 SETTINGS max_block_size = 128;
+SELECT count() FROM numbers(128) WHERE number < 1000 SETTINGS max_block_size = 128;
+SELECT count() FROM numbers(128) WHERE number = 100  SETTINGS max_block_size = 128;
+
+SELECT '-- a filter spanning many blocks must agree with the sum of its parts';
+SELECT countIf(number % 7 = 3) = (SELECT count() FROM numbers(100000) WHERE number % 7 = 3)
+FROM numbers(100000) SETTINGS max_block_size = 100000;

--- a/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.sql
+++ b/tests/queries/0_stateless/04946_count_bytes_in_filter_block_boundary.sql
@@ -1,52 +1,6 @@
--- A filter is counted 64 bytes at a time with a byte-at-a-time tail, so a count must not
--- depend on whether the block length is a multiple of 64. Partial selectivity is required:
--- an all-pass filter cannot tell a correct block mask from a broken one.
--- max_block_size pins the filter length so each query lands on a chosen boundary.
+-- countIfOrNull with a condition that is a UInt8 value other than 0 or 1 must return the same
+-- count whatever the block size is. max_block_size pins the block length.
 
-SELECT '-- countBytesInFilter, one block length per row';
-SELECT countIf(number % 3 = 1) FROM numbers(0)   SETTINGS max_block_size = 1;
-SELECT countIf(number % 3 = 1) FROM numbers(1)   SETTINGS max_block_size = 1;
-SELECT countIf(number % 3 = 1) FROM numbers(63)  SETTINGS max_block_size = 63;
-SELECT countIf(number % 3 = 1) FROM numbers(64)  SETTINGS max_block_size = 64;
-SELECT countIf(number % 3 = 1) FROM numbers(65)  SETTINGS max_block_size = 65;
-SELECT countIf(number % 3 = 1) FROM numbers(127) SETTINGS max_block_size = 127;
-SELECT countIf(number % 3 = 1) FROM numbers(128) SETTINGS max_block_size = 128;
-SELECT countIf(number % 3 = 1) FROM numbers(129) SETTINGS max_block_size = 129;
-SELECT countIf(number % 3 = 1) FROM numbers(255) SETTINGS max_block_size = 255;
-SELECT countIf(number % 3 = 1) FROM numbers(256) SETTINGS max_block_size = 256;
-SELECT countIf(number % 3 = 1) FROM numbers(257) SETTINGS max_block_size = 257;
-
-SELECT '-- countBytesInFilter reached with the output column optimised away';
-SELECT count() FROM numbers(63)  WHERE number % 3 = 1 SETTINGS max_block_size = 63;
-SELECT count() FROM numbers(64)  WHERE number % 3 = 1 SETTINGS max_block_size = 64;
-SELECT count() FROM numbers(65)  WHERE number % 3 = 1 SETTINGS max_block_size = 65;
-SELECT count() FROM numbers(128) WHERE number % 3 = 1 SETTINGS max_block_size = 128;
-SELECT count() FROM numbers(193) WHERE number % 3 = 1 SETTINGS max_block_size = 193;
-
--- countIfOrNull is the shape that reaches countBytesInFilterWithNull: it needs a null map
--- forwarded together with a filter argument. A plain countIf over a Nullable column folds the
--- null map into its own filter and never calls it.
-SELECT '-- countBytesInFilterWithNull';
-SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(63)  SETTINGS max_block_size = 63;
-SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(64)  SETTINGS max_block_size = 64;
-SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(65)  SETTINGS max_block_size = 65;
-SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(128) SETTINGS max_block_size = 128;
-SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(129) SETTINGS max_block_size = 129;
-SELECT countIfOrNull(if(number % 5 = 0, NULL, number), number % 3 = 1) FROM numbers(257) SETTINGS max_block_size = 257;
-
-SELECT '-- all-zero, all-one and a single set byte in the second block';
-SELECT count() FROM numbers(128) WHERE number > 1000 SETTINGS max_block_size = 128;
-SELECT count() FROM numbers(128) WHERE number < 1000 SETTINGS max_block_size = 128;
-SELECT count() FROM numbers(128) WHERE number = 100  SETTINGS max_block_size = 128;
-
-SELECT '-- a filter spanning many blocks must agree with the sum of its parts';
-SELECT countIf(number % 7 = 3) = (SELECT count() FROM numbers(100000) WHERE number % 7 = 3)
-FROM numbers(100000) SETTINGS max_block_size = 100000;
-
--- An -If condition column is forwarded as a raw UInt8, so a byte outside 0/1 reaches these loops.
--- Each condition byte below keeps a set bit outside the null byte, so `filter & ~null` stays
--- non-zero on a NULL row while `filter != 0 && null == 0` is false: the two disagree there.
-SELECT '-- non-binary UInt8 condition, block-size independent';
 SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(2)) FROM numbers(100) SETTINGS max_block_size = 63;
 SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(2)) FROM numbers(100) SETTINGS max_block_size = 64;
 SELECT countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(2)) FROM numbers(100) SETTINGS max_block_size = 100;


### PR DESCRIPTION
Enable the 64-byte filter counting path on AArch64

<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/116073
-->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `countIfOrNull` over a `Nullable` argument returning a count that depended on the block size when the condition was a `UInt8` value other than 0 or 1. Also sped up filter row counting on AArch64: `countBytesInFilter` and `countBytesInFilterWithNull` reduce a filter 64 bytes at a time using a bitmask and `popcount`, but that loop was gated on `__SSE2__`, so AArch64 builds counted one byte per iteration. Closes #116073.


### Description

Both wide loops in `src/Columns/ColumnsCommon.cpp`, and the private `toBits64` they call, sat behind
a bare `#if defined(__SSE2__)`: an x86-64 baseline feature, not runtime dispatch, so x86 always
compiled the fast path and AArch64 never did. The guards now also admit
`defined(__aarch64__) && defined(__ARM_NEON)`, with an `#elif` arm defining `toBits64` via
`bytes64MaskToBits64Mask` from this module's header, which already has a NEON tier. NEON is
unconditional at the AArch64 baseline, and this file already calls that helper in
`filterArraysImplGeneric` and `filterArraysImplInPlace`. On x86 the guard is inert.

One correctness fix rides along, and it does change x86. An `-If` condition column is forwarded as
a raw `UInt8`, so bytes outside 0/1 reach these loops, and `countBytesInFilterWithNull`'s scalar
tail counted `(*pos & ~*pos2) != 0` while its wide loop counts `filter != 0 && null == 0`. These
differ on a NULL row whose condition byte keeps a set bit outside the null byte: of the 65536
(filter, null) pairs the tail disagrees on 58720, always over-counting, never where the wide loop
errs. `countIfOrNull(if(number % 2 = 0, NULL, 1), toUInt8(2))` over 100 rows returns 68 or 100
today depending on where the 64-byte boundary falls, against a true 50. The tail now uses the wide
loop's predicate, removing the block-size dependence everywhere. This is the correction
`031132038b1e89e` applied to the `> 0` comparisons here; `countBytesInFilter`'s tail already used
`!= 0`.

AArch64 mask equivalence for 0/1 filters was checked exhaustively under `qemu-aarch64-static`
against the pre-change build: 0 mismatches, mutation-controlled. The new test covers the non-binary
`UInt8` condition, pinning block lengths via `max_block_size`; all five of its cases fail without the
tail fix (100/68/68/63/65 against 50/50/50/31/64).

The ARM `Performance Comparison` at `8088404f` measures it: `rewrite_sumIf` 575 ms to 374 ms on
`arm_release` (1.54x) against 227/227 ms on the `amd_release` control. 27 arm queries were flagged
faster, 0 slower; on amd, 0 either way.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116173&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116173](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116173+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


