### PR TITLE
Docs: Make SQL console database permissions easier to find

### DIFF
--- a/docs/products/cloud/features/sql-console-features/clickstack.mdx
+++ b/docs/products/cloud/features/sql-console-features/clickstack.mdx
@@ -15,7 +15,7 @@ As a managed offering, Managed ClickStack delivers the open-source project with 
 
 The ClickStack UI (HyperDX) is a purpose-built frontend for exploring and visualizing observability data, supporting both Lucene-style and SQL queries, interactive dashboards, alerting, trace exploration, and more, all optimized for ClickHouse as the backend.
 
-Managed ClickStack can be launched with a single click and connected to your data, fully integrated into the ClickHouse Cloud authentication system for seamless, secure access to your observability insights.
+Managed ClickStack can be launched with a single click and connected to your data, fully integrated into the ClickHouse Cloud authentication system for seamless, secure access to your observability insights. To customize a user's permissions on the underlying ClickHouse data, see [SQL console users and roles](/products/cloud/guides/security/cloud-access-management/manage-database-users#sql-console-users-and-roles).
 
 ## Deployment {#main-concepts}
 

--- a/docs/products/cloud/guides/security/cloud-access-management/manage-sql-console-role-assignments.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-sql-console-role-assignments.mdx
@@ -16,6 +16,8 @@ This setting is deprecated and has been replaced with a new setting on the role 
 > This guide shows you how to configure SQL console role assignments, which
 determine console-wide access permissions and the features that a user can
 access within Cloud console.
+>
+> To customize database permissions for an individual SQL console user, see [SQL console users and roles](/products/cloud/guides/security/cloud-access-management/manage-database-users#sql-console-users-and-roles).
 
 <Steps>
 <Step title="Access service settings" id="access-service-settings">

--- a/docs/products/cloud/guides/security/cloud-access-management/manage-sql-console-role-assignments.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-sql-console-role-assignments.mdx
@@ -13,11 +13,7 @@ import { Image } from "/snippets/components/Image.jsx";
 This setting is deprecated and has been replaced with a new setting on the role creation screen in organizations that have migrated to custom roles. For more information, see [Manage cloud users](/products/cloud/guides/security/cloud-access-management/manage-cloud-users).
 </Warning>
 
-> This guide shows you how to configure SQL console role assignments, which
-determine console-wide access permissions and the features that a user can
-access within Cloud console.
->
-> To customize database permissions for an individual SQL console user, see [SQL console users and roles](/products/cloud/guides/security/cloud-access-management/manage-database-users#sql-console-users-and-roles).
+This guide shows you how to configure SQL console role assignments, which determine console-wide access permissions and the features that a user can access within Cloud console. To customize database permissions for an individual SQL console user, see [SQL console users and roles](/products/cloud/guides/security/cloud-access-management/manage-database-users#sql-console-users-and-roles).
 
 <Steps>
 <Step title="Access service settings" id="access-service-settings">

--- a/docs/products/cloud/reference/security/console-roles.mdx
+++ b/docs/products/cloud/reference/security/console-roles.mdx
@@ -34,6 +34,7 @@ Service permissions must be explicitly granted by an admin to users with roles o
 
 ## SQL console roles {#sql-console-roles}
 Refer to [Manage SQL console role assignments](/products/cloud/guides/security/cloud-access-management/manage-sql-console-role-assignments) for instructions on assigning SQL console roles.
+To customize database permissions for an individual SQL console user, see [SQL console users and roles](/products/cloud/guides/security/cloud-access-management/manage-database-users#sql-console-users-and-roles).
 
 | Role                  | Description                                                                                    |
 |-----------------------|------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Makes the existing SQL console user-role guidance easier to find from the places where users naturally look for permission information: console roles, legacy SQL console role assignments, and Managed ClickStack.

The broader Cloud access-management IA and canonical database-user guidance are already on `master`, so this follow-up is limited to three contextual cross-links.

Related: https://github.com/ClickHouse/ClickHouse/pull/112461

Related: https://github.com/ClickHouse/ClickHouse/pull/112488

Linear: https://linear.app/clickhouse/issue/DOC-859/make-console-roles-docs-easier-to-find

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make SQL console database-permission guidance easier to find from related ClickHouse Cloud and Managed ClickStack pages.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116185&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116185](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116185+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
