### PR TITLE
Guard the text index rewrite above a JOIN by column provenance

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -19,6 +19,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Processors/QueryPlan/FilterStep.h>
+#include <Processors/QueryPlan/IQueryPlanStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
@@ -125,6 +126,31 @@ const ActionsDAG::Node * replaceNodes(ActionsDAG & dag, const ActionsDAG::Node *
     }
 
     return node;
+}
+
+/// Whether `step` (e.g. a JOIN) passes `column_names` through unchanged, just reordering/dropping rows.
+bool isColumnPreservingStep(const IQueryPlanStep & step, const NameSet & column_names)
+{
+    if (!step.hasOutputHeader())
+        return false;
+
+    const auto & output_header = *step.getOutputHeader();
+
+    for (const auto & column_name : column_names)
+    {
+        if (!output_header.has(column_name))
+            return false;
+
+        bool found_in_inputs = std::ranges::any_of(step.getInputHeaders(), [&](const auto & input_header)
+        {
+            return input_header->has(column_name);
+        });
+
+        if (!found_in_inputs)
+            return false;
+    }
+
+    return true;
 }
 
 String optimizationInfoToString(const IndexReadColumns & added_columns, const Names & removed_columns)
@@ -954,21 +980,43 @@ void processAndOptimizeTextIndexFunctions(const Stack & stack, QueryPlan::Nodes 
     if (stack.size() < 2)
         return;
 
-    QueryPlan::Node * filter_node = (stack.rbegin() + 1)->node;
-    auto * filter_step = typeid_cast<FilterStep *>(filter_node->step.get());
+    /// Column names used by isColumnPreservingStep to bound how far up the walk below may climb.
+    NameSet text_index_column_names;
+    for (const auto & [index_name, info] : text_index_read_infos)
+    {
+        auto & text_index_condition = typeid_cast<MergeTreeIndexConditionText &>(*info.index->condition_template->generateUnsubstituted());
+        for (const auto & column : text_index_condition.getHeader())
+            text_index_column_names.insert(column.name);
+    }
 
-    if (!filter_step)
-        return;
+    /// Reach a FilterStep past a JOIN (e.g. an OR-combined WHERE not pushed below it); only the step
+    /// adjacent to the scan may get the virtual-column direct-read substitution.
+    bool allow_direct_read = direct_read_from_text_index && !optimized && !already_has_direct_read;
 
-    ActionsDAG & filter_dag = filter_step->getExpression();
-    const auto * result_filter_node = processAndOptimizeTextIndexDAG(*read_from_merge_tree_step, filter_dag, text_index_read_infos, filter_step->getFilterColumnName(), direct_read_from_text_index && !optimized && !already_has_direct_read);
+    for (auto it = stack.rbegin() + 1; it != stack.rend(); ++it)
+    {
+        QueryPlan::Node * node = it->node;
+        auto * filter_step = typeid_cast<FilterStep *>(node->step.get());
 
-    if (!result_filter_node)
-        return;
+        if (!filter_step)
+        {
+            if (isColumnPreservingStep(*node->step, text_index_column_names))
+                continue;
+            break;
+        }
 
-    bool removes_filter_column = filter_step->removesFilterColumn();
-    auto new_filter_column_name = result_filter_node->result_name;
-    filter_node->step = std::make_unique<FilterStep>(read_from_merge_tree_step->getOutputHeader(), filter_dag.clone(), new_filter_column_name, removes_filter_column);
+        ActionsDAG & filter_dag = filter_step->getExpression();
+        const auto * result_filter_node = processAndOptimizeTextIndexDAG(
+            *read_from_merge_tree_step, filter_dag, text_index_read_infos, filter_step->getFilterColumnName(), allow_direct_read);
+        allow_direct_read = false;
+
+        if (!result_filter_node)
+            continue;
+
+        bool removes_filter_column = filter_step->removesFilterColumn();
+        auto new_filter_column_name = result_filter_node->result_name;
+        node->step = std::make_unique<FilterStep>(filter_step->getInputHeaders().front(), filter_dag.clone(), new_filter_column_name, removes_filter_column);
+    }
 }
 
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -52,9 +52,9 @@ using NodesReplacementMap = absl::flat_hash_map<const ActionsDAG::Node *, const 
 
 struct TextIndexReadInfo
 {
-    const MergeTreeIndexWithCondition * index;
-    bool is_materialized;
-    bool is_fully_materialized;
+    const MergeTreeIndexWithCondition * index = nullptr;
+    bool is_materialized = false;
+    bool is_fully_materialized = false;
     /// False for an index granule analysis did not select: it has no read tasks, so it can only supply the
     /// tokenizer for the row-level rewrite (createReadTasksForTextIndex rejects an unanalyzed index).
     bool can_direct_read = true;

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -18,8 +18,11 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/IQueryPlanStep.h>
+#include <Processors/QueryPlan/JoinStep.h>
+#include <Processors/QueryPlan/JoinStepLogical.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
@@ -128,29 +131,56 @@ const ActionsDAG::Node * replaceNodes(ActionsDAG & dag, const ActionsDAG::Node *
     return node;
 }
 
-/// Whether `step` (e.g. a JOIN) passes `column_names` through unchanged, just reordering/dropping rows.
-bool isColumnPreservingStep(const IQueryPlanStep & step, const NameSet & column_names)
+const ActionsDAG::Node * removeAliases(const ActionsDAG::Node * node)
 {
-    if (!step.hasOutputHeader())
-        return false;
+    while (node->type == ActionsDAG::ActionType::ALIAS)
+        node = node->children.front();
+    return node;
+}
 
-    const auto & output_header = *step.getOutputHeader();
+/// Names that still denote the scan's indexed columns after `dag` renames them. An output reading an input
+/// of a tracked name keeps referring to the scan's column; anything computed (`lower(s) AS s`) does not.
+NameSet trackColumnsThroughDAG(const ActionsDAG & dag, const NameSet & tracked)
+{
+    NameSet result;
 
-    for (const auto & column_name : column_names)
+    for (const auto * output : dag.getOutputs())
     {
-        if (!output_header.has(column_name))
-            return false;
-
-        bool found_in_inputs = std::ranges::any_of(step.getInputHeaders(), [&](const auto & input_header)
-        {
-            return input_header->has(column_name);
-        });
-
-        if (!found_in_inputs)
-            return false;
+        const auto * node = removeAliases(output);
+        if (node->type == ActionsDAG::ActionType::INPUT && tracked.contains(node->result_name))
+            result.insert(output->result_name);
     }
 
-    return true;
+    return result;
+}
+
+/// Whether the haystack of `function_node` reads only columns in `tracked`. Above a JOIN, a same-named
+/// column of the other side must not be matched against this table's index.
+bool isHaystackTracked(const ActionsDAG::Node & function_node, const NameSet & tracked)
+{
+    if (function_node.children.empty())
+        return false;
+
+    bool found_input = false;
+    std::vector<const ActionsDAG::Node *> to_visit{function_node.children[0]};
+
+    while (!to_visit.empty())
+    {
+        const auto * node = removeAliases(to_visit.back());
+        to_visit.pop_back();
+
+        if (node->type == ActionsDAG::ActionType::INPUT)
+        {
+            if (!tracked.contains(node->result_name))
+                return false;
+            found_input = true;
+        }
+
+        for (const auto * child : node->children)
+            to_visit.push_back(child);
+    }
+
+    return found_input;
 }
 
 String optimizationInfoToString(const IndexReadColumns & added_columns, const Names & removed_columns)
@@ -355,10 +385,11 @@ ASTPtr convertNodeToAST(const ActionsDAG::Node & node, const std::unordered_map<
 class TextIndexDAGReplacer
 {
 public:
-    TextIndexDAGReplacer(ActionsDAG & actions_dag_, const TextIndexReadInfos & text_index_read_infos_, bool direct_read_from_text_index_)
+    TextIndexDAGReplacer(ActionsDAG & actions_dag_, const TextIndexReadInfos & text_index_read_infos_, bool direct_read_from_text_index_, NameSet tracked_columns_ = {})
         : actions_dag(actions_dag_)
         , text_index_read_infos(text_index_read_infos_)
         , direct_read_from_text_index(direct_read_from_text_index_)
+        , tracked_columns(std::move(tracked_columns_))
     {
     }
 
@@ -454,6 +485,9 @@ private:
     ActionsDAG & actions_dag;
     TextIndexReadInfos text_index_read_infos;
     bool direct_read_from_text_index = false;
+    /// Names denoting this scan's indexed columns in `actions_dag`. Empty means no restriction (the DAG
+    /// belongs to the scan itself, so every column is its own).
+    NameSet tracked_columns;
 
     struct SelectedCondition
     {
@@ -511,8 +545,9 @@ private:
             if (!search_query)
                 continue;
 
-            /// For None mode, the condition is still needed for preprocessing (tokenizer/preprocessor injection).
-            if (search_query->getDirectReadMode() == TextIndexDirectReadMode::None)
+            /// Also skip replaceToVirtualColumn (registers/reserves the virtual column) when this replacer isn't
+            /// allowed to use direct read: the same predicate may be analyzed again elsewhere for injection only.
+            if (search_query->getDirectReadMode() == TextIndexDirectReadMode::None || !direct_read_from_text_index)
             {
                 selected_conditions.emplace_back(search_query, index_name, String{}, &info);
                 used_index_columns.insert(index_header.begin()->name);
@@ -550,6 +585,9 @@ private:
 
         /// Early exit if there is nothing to process.
         if (!need_transform_function && !direct_read_from_text_index)
+            return replacement;
+
+        if (!tracked_columns.empty() && !isHaystackTracked(function_node, tracked_columns))
             return replacement;
 
         auto selected_conditions = selectConditions(function_node, context);
@@ -859,9 +897,10 @@ static const ActionsDAG::Node * processAndOptimizeTextIndexDAG(
     ActionsDAG & filter_dag,
     const TextIndexReadInfos & text_index_read_infos,
     const String & filter_column_name,
-    bool direct_read_from_text_index)
+    bool direct_read_from_text_index,
+    const NameSet & tracked_columns = {})
 {
-    TextIndexDAGReplacer replacer(filter_dag, text_index_read_infos, direct_read_from_text_index);
+    TextIndexDAGReplacer replacer(filter_dag, text_index_read_infos, direct_read_from_text_index, tracked_columns);
     auto result = replacer.replace(read_from_merge_tree_step.getContext(), filter_column_name);
 
     /// Even when no virtual columns are added (added_columns is empty),
@@ -980,14 +1019,17 @@ void processAndOptimizeTextIndexFunctions(const Stack & stack, QueryPlan::Nodes 
     if (stack.size() < 2)
         return;
 
-    /// Column names used by isColumnPreservingStep to bound how far up the walk below may climb.
-    NameSet text_index_column_names;
-    for (const auto & [index_name, info] : text_index_read_infos)
-    {
-        auto & text_index_condition = typeid_cast<MergeTreeIndexConditionText &>(*info.index->condition_template->generateUnsubstituted());
-        for (const auto & column : text_index_condition.getHeader())
-            text_index_column_names.insert(column.name);
-    }
+    /// Names that still read this scan's own columns at the level currently reached by the walk below. It is
+    /// re-mapped through every step crossed, so a step that renames a column (the planner's `__tableN.`
+    /// rename) keeps it tracked while one that recomputes it drops it. Seeded from the scan's columns rather
+    /// than the index header, because an expression index's header holds the expression (`lower(s)`) while
+    /// the DAG inputs a haystack reads are always base columns.
+    if (!read_from_merge_tree_step->hasOutputHeader())
+        return;
+
+    NameSet tracked_columns;
+    for (const auto & column : *read_from_merge_tree_step->getOutputHeader())
+        tracked_columns.insert(column.name);
 
     /// Reach a FilterStep past a JOIN (e.g. an OR-combined WHERE not pushed below it); only the step
     /// adjacent to the scan may get the virtual-column direct-read substitution.
@@ -995,27 +1037,53 @@ void processAndOptimizeTextIndexFunctions(const Stack & stack, QueryPlan::Nodes 
 
     for (auto it = stack.rbegin() + 1; it != stack.rend(); ++it)
     {
+        if (tracked_columns.empty())
+            break;
+
         QueryPlan::Node * node = it->node;
         auto * filter_step = typeid_cast<FilterStep *>(node->step.get());
 
         if (!filter_step)
         {
-            if (isColumnPreservingStep(*node->step, text_index_column_names))
-                continue;
-            break;
+            if (const auto * expression_step = typeid_cast<const ExpressionStep *>(node->step.get()))
+            {
+                tracked_columns = trackColumnsThroughDAG(expression_step->getExpression(), tracked_columns);
+            }
+            /// A JOIN only drops, reorders and duplicates rows, so a name it still outputs is unchanged.
+            else if (typeid_cast<const JoinStep *>(node->step.get()) || typeid_cast<const JoinStepLogical *>(node->step.get()))
+            {
+                if (!node->step->hasOutputHeader())
+                    break;
+
+                const auto & output_header = *node->step->getOutputHeader();
+                std::erase_if(tracked_columns, [&](const auto & name) { return !output_header.has(name); });
+            }
+            else
+            {
+                break;
+            }
+
+            /// Direct read substitutes a per-granule column of this scan, so it is valid only for a filter
+            /// adjacent to it; crossing any other step (the `__tableN.` rename, a JOIN) invalidates it.
+            allow_direct_read = false;
+            continue;
         }
 
+        bool is_adjacent_to_scan = (it == stack.rbegin() + 1);
         ActionsDAG & filter_dag = filter_step->getExpression();
         const auto * result_filter_node = processAndOptimizeTextIndexDAG(
-            *read_from_merge_tree_step, filter_dag, text_index_read_infos, filter_step->getFilterColumnName(), allow_direct_read);
+            *read_from_merge_tree_step, filter_dag, text_index_read_infos, filter_step->getFilterColumnName(), allow_direct_read, tracked_columns);
         allow_direct_read = false;
+        tracked_columns = trackColumnsThroughDAG(filter_dag, tracked_columns);
 
         if (!result_filter_node)
             continue;
 
         bool removes_filter_column = filter_step->removesFilterColumn();
         auto new_filter_column_name = result_filter_node->result_name;
-        node->step = std::make_unique<FilterStep>(filter_step->getInputHeaders().front(), filter_dag.clone(), new_filter_column_name, removes_filter_column);
+        /// Only the adjacent filter can have had its input header widened by a direct-read virtual column.
+        const auto & new_input_header = is_adjacent_to_scan ? read_from_merge_tree_step->getOutputHeader() : filter_step->getInputHeaders().front();
+        node->step = std::make_unique<FilterStep>(new_input_header, filter_dag.clone(), new_filter_column_name, removes_filter_column);
     }
 }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -35,6 +35,7 @@
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/StorageInMemoryMetadata.h>
 #include <base/defines.h>
+#include <optional>
 
 namespace DB::ErrorCodes
 {
@@ -159,6 +160,28 @@ NameSet trackColumnsThroughDAG(const ActionsDAG & dag, const NameSet & tracked)
     }
 
     return result;
+}
+
+/// Narrows `tracked` to the names that still read the scan's columns above `step`. Returns nullopt when the
+/// walk must stop, because the step's rows no longer correspond to the scan's.
+std::optional<NameSet> trackColumnsThroughStep(const IQueryPlanStep & step, const NameSet & tracked)
+{
+    if (const auto * expression_step = typeid_cast<const ExpressionStep *>(&step))
+        return trackColumnsThroughDAG(expression_step->getExpression(), tracked);
+
+    /// A JOIN only drops, reorders and duplicates rows, so a name it still outputs is unchanged.
+    if (typeid_cast<const JoinStep *>(&step) || typeid_cast<const JoinStepLogical *>(&step))
+    {
+        if (!step.hasOutputHeader())
+            return {};
+
+        const auto & output_header = *step.getOutputHeader();
+        NameSet result = tracked;
+        std::erase_if(result, [&](const auto & name) { return !output_header.has(name); });
+        return result;
+    }
+
+    return {};
 }
 
 /// Whether the haystack of `function_node` reads only columns in `tracked`. Above a JOIN, a same-named
@@ -1021,6 +1044,42 @@ static const ActionsDAG::Node * processAndOptimizeTextIndexDAG(
     return result.filter_node;
 }
 
+/// Rewrites the text-search functions of one FilterStep and replaces the step when the DAG changed. Advances
+/// `tracked_columns` past this filter, whether or not anything was rewritten.
+static void processAndOptimizeTextIndexFunctionsInFilter(
+    ReadFromMergeTree & read_from_merge_tree_step,
+    QueryPlan::Node & node,
+    const TextIndexReadInfos & analyzed_index_infos,
+    OwnedTextIndexConditions & owned_conditions,
+    bool direct_read_from_text_index,
+    bool is_adjacent_to_scan,
+    NameSet & tracked_columns)
+{
+    auto & filter_step = typeid_cast<FilterStep &>(*node.step);
+    ActionsDAG & filter_dag = filter_step.getExpression();
+    const String & filter_column_name = filter_step.getFilterColumnName();
+
+    /// Synthesized conditions describe this filter's own predicate, so they are built per filter.
+    TextIndexReadInfos index_infos = analyzed_index_infos;
+    collectTextIndexInjectInfos(
+        read_from_merge_tree_step, &filter_dag.findInOutputs(filter_column_name), index_infos, owned_conditions);
+
+    const auto * result_filter_node = index_infos.empty()
+        ? nullptr
+        : processAndOptimizeTextIndexDAG(
+            read_from_merge_tree_step, filter_dag, index_infos, filter_column_name, direct_read_from_text_index, tracked_columns);
+
+    tracked_columns = trackColumnsThroughDAG(filter_dag, tracked_columns);
+
+    if (!result_filter_node)
+        return;
+
+    /// Only a filter adjacent to the scan can have had its input header widened by a direct-read column.
+    const auto & input_header = is_adjacent_to_scan ? read_from_merge_tree_step.getOutputHeader() : filter_step.getInputHeaders().front();
+    node.step = std::make_unique<FilterStep>(
+        input_header, filter_dag.clone(), result_filter_node->result_name, filter_step.removesFilterColumn());
+}
+
 static bool processAndOptimizeTextIndexFunctionsInPrewhere(
     ReadFromMergeTree & read_from_merge_tree_step,
     const PrewhereInfoPtr & prewhere_info,
@@ -1118,24 +1177,11 @@ void processAndOptimizeTextIndexFunctions(const Stack & stack, QueryPlan::Nodes 
 
         if (!filter_step)
         {
-            if (const auto * expression_step = typeid_cast<const ExpressionStep *>(node->step.get()))
-            {
-                tracked_columns = trackColumnsThroughDAG(expression_step->getExpression(), tracked_columns);
-            }
-            /// A JOIN only drops, reorders and duplicates rows, so a name it still outputs is unchanged.
-            else if (typeid_cast<const JoinStep *>(node->step.get()) || typeid_cast<const JoinStepLogical *>(node->step.get()))
-            {
-                if (!node->step->hasOutputHeader())
-                    break;
-
-                const auto & output_header = *node->step->getOutputHeader();
-                std::erase_if(tracked_columns, [&](const auto & name) { return !output_header.has(name); });
-            }
-            else
-            {
+            auto tracked_columns_above = trackColumnsThroughStep(*node->step, tracked_columns);
+            if (!tracked_columns_above)
                 break;
-            }
 
+            tracked_columns = std::move(*tracked_columns_above);
             /// Direct read substitutes a per-granule column of this scan, so it is valid only for a filter
             /// adjacent to it; crossing any other step (the `__tableN.` rename, a JOIN) invalidates it.
             allow_direct_read = false;
@@ -1143,29 +1189,9 @@ void processAndOptimizeTextIndexFunctions(const Stack & stack, QueryPlan::Nodes 
         }
 
         bool is_adjacent_to_scan = (it == stack.rbegin() + 1);
-        ActionsDAG & filter_dag = filter_step->getExpression();
-
-        /// Built per filter: the synthesized conditions describe this filter's own predicate.
-        TextIndexReadInfos filter_index_infos = text_index_read_infos;
-        collectTextIndexInjectInfos(
-            *read_from_merge_tree_step, &filter_dag.findInOutputs(filter_step->getFilterColumnName()), filter_index_infos, owned_conditions);
-
-        if (filter_index_infos.empty())
-            continue;
-
-        const auto * result_filter_node = processAndOptimizeTextIndexDAG(
-            *read_from_merge_tree_step, filter_dag, filter_index_infos, filter_step->getFilterColumnName(), allow_direct_read, tracked_columns);
+        processAndOptimizeTextIndexFunctionsInFilter(
+            *read_from_merge_tree_step, *node, text_index_read_infos, owned_conditions, allow_direct_read, is_adjacent_to_scan, tracked_columns);
         allow_direct_read = false;
-        tracked_columns = trackColumnsThroughDAG(filter_dag, tracked_columns);
-
-        if (!result_filter_node)
-            continue;
-
-        bool removes_filter_column = filter_step->removesFilterColumn();
-        auto new_filter_column_name = result_filter_node->result_name;
-        /// Only the adjacent filter can have had its input header widened by a direct-read virtual column.
-        const auto & new_input_header = is_adjacent_to_scan ? read_from_merge_tree_step->getOutputHeader() : filter_step->getInputHeaders().front();
-        node->step = std::make_unique<FilterStep>(new_input_header, filter_dag.clone(), new_filter_column_name, removes_filter_column);
     }
 }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -33,6 +33,7 @@
 #include <Storages/MergeTree/MergeTreeIndexTextPostprocessor.h>
 #include <Storages/MergeTree/MergeTreeIndexTextPreprocessor.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
+#include <Storages/StorageInMemoryMetadata.h>
 #include <base/defines.h>
 
 namespace DB::ErrorCodes
@@ -53,7 +54,13 @@ struct TextIndexReadInfo
     const MergeTreeIndexWithCondition * index;
     bool is_materialized;
     bool is_fully_materialized;
+    /// False for an index granule analysis did not select: it has no read tasks, so it can only supply the
+    /// tokenizer for the row-level rewrite (createReadTasksForTextIndex rejects an unanalyzed index).
+    bool can_direct_read = true;
 };
+
+/// Keeps conditions synthesized by collectTextIndexInjectInfos alive while TextIndexReadInfos points at them.
+using OwnedTextIndexConditions = std::vector<std::shared_ptr<MergeTreeIndexWithCondition>>;
 
 using TextIndexReadInfos = absl::flat_hash_map<String, TextIndexReadInfo>;
 
@@ -276,7 +283,69 @@ void collectTextIndexReadInfos(const ReadFromMergeTree * read_from_merge_tree_st
         {
             .index = &index,
             .is_materialized = num_materialized_parts > 0,
-            .is_fully_materialized = num_materialized_parts == unique_parts.size()
+            .is_fully_materialized = num_materialized_parts == unique_parts.size(),
+            .can_direct_read = true,
+        };
+    }
+}
+
+/// Whether `metadata_snapshot` defines any text index, regardless of what granule analysis selected.
+bool hasTextIndex(const ReadFromMergeTree & read_from_merge_tree_step)
+{
+    auto metadata_snapshot = read_from_merge_tree_step.getStorageMetadata();
+    auto settings = read_from_merge_tree_step.getMergeTreeData().getSettings();
+
+    return std::ranges::any_of(metadata_snapshot->getSecondaryIndices(), [&](const auto & index_description)
+    {
+        return MergeTreeIndexFactory::instance().get(metadata_snapshot, index_description, *settings)->isTextIndex();
+    });
+}
+
+/// Adds the text indexes granule analysis did not select. It only selects an index the predicate reaching the
+/// scan constrains, but a predicate above the scan needs the tokenizer of its index all the same -- otherwise
+/// it falls back to `splitByNonAlpha` and answers a different question than the index does.
+void collectTextIndexInjectInfos(
+    const ReadFromMergeTree & read_from_merge_tree_step,
+    const ActionsDAG::Node * predicate,
+    TextIndexReadInfos & text_index_read_infos,
+    OwnedTextIndexConditions & owned_conditions)
+{
+    if (!predicate)
+        return;
+
+    auto metadata_snapshot = read_from_merge_tree_step.getStorageMetadata();
+    auto context = read_from_merge_tree_step.getContext();
+    auto settings = read_from_merge_tree_step.getMergeTreeData().getSettings();
+
+    for (const auto & index_description : metadata_snapshot->getSecondaryIndices())
+    {
+        if (text_index_read_infos.contains(index_description.name))
+            continue;
+
+        auto index_helper = MergeTreeIndexFactory::instance().get(metadata_snapshot, index_description, *settings);
+        if (!index_helper->isTextIndex())
+            continue;
+
+        ConditionTemplate<MergeTreeIndexConditionPtr>::Factory factory =
+            [index_helper, context](const ActionsDAG *, const ActionsDAG::Node * node) -> MergeTreeIndexConditionPtr
+            {
+                return node ? index_helper->createIndexCondition(node, context) : nullptr;
+            };
+
+        auto dag = std::make_shared<ActionsDAGWithInversionPushDown>(predicate, context, /*boolean_context=*/ true);
+        auto condition_template = std::make_shared<ConditionTemplate<MergeTreeIndexConditionPtr>>(
+            std::move(dag), std::move(factory), metadata_snapshot, context, /*skip_folding=*/ true);
+
+        if (!condition_template->generateUnsubstituted())
+            continue;
+
+        owned_conditions.push_back(std::make_shared<MergeTreeIndexWithCondition>(std::move(index_helper), std::move(condition_template)));
+        text_index_read_infos[index_description.name] =
+        {
+            .index = owned_conditions.back().get(),
+            .is_materialized = false,
+            .is_fully_materialized = false,
+            .can_direct_read = false,
         };
     }
 }
@@ -547,7 +616,7 @@ private:
 
             /// Also skip replaceToVirtualColumn (registers/reserves the virtual column) when this replacer isn't
             /// allowed to use direct read: the same predicate may be analyzed again elsewhere for injection only.
-            if (search_query->getDirectReadMode() == TextIndexDirectReadMode::None || !direct_read_from_text_index)
+            if (search_query->getDirectReadMode() == TextIndexDirectReadMode::None || !direct_read_from_text_index || !info.can_direct_read)
             {
                 selected_conditions.emplace_back(search_query, index_name, String{}, &info);
                 used_index_columns.insert(index_header.begin()->name);
@@ -990,10 +1059,14 @@ void processAndOptimizeTextIndexFunctions(const Stack & stack, QueryPlan::Nodes 
     if (!read_from_merge_tree_step)
         return;
 
+    if (!hasTextIndex(*read_from_merge_tree_step))
+        return;
+
+    /// Conditions granule analysis selected. Only these can be read directly; the walk below adds the
+    /// remaining text indexes per filter, for the tokenizer rewrite alone.
     TextIndexReadInfos text_index_read_infos;
     collectTextIndexReadInfos(read_from_merge_tree_step, text_index_read_infos);
-    if (text_index_read_infos.empty())
-        return;
+    OwnedTextIndexConditions owned_conditions;
 
     /// This step can be visited by the pass more than once, because a Merge child plan is optimized
     /// again after ReadFromMerge pushes a filter down into it (StorageMerge), and because the same
@@ -1071,8 +1144,17 @@ void processAndOptimizeTextIndexFunctions(const Stack & stack, QueryPlan::Nodes 
 
         bool is_adjacent_to_scan = (it == stack.rbegin() + 1);
         ActionsDAG & filter_dag = filter_step->getExpression();
+
+        /// Built per filter: the synthesized conditions describe this filter's own predicate.
+        TextIndexReadInfos filter_index_infos = text_index_read_infos;
+        collectTextIndexInjectInfos(
+            *read_from_merge_tree_step, &filter_dag.findInOutputs(filter_step->getFilterColumnName()), filter_index_infos, owned_conditions);
+
+        if (filter_index_infos.empty())
+            continue;
+
         const auto * result_filter_node = processAndOptimizeTextIndexDAG(
-            *read_from_merge_tree_step, filter_dag, text_index_read_infos, filter_step->getFilterColumnName(), allow_direct_read, tracked_columns);
+            *read_from_merge_tree_step, filter_dag, filter_index_infos, filter_step->getFilterColumnName(), allow_direct_read, tracked_columns);
         allow_direct_read = false;
         tracked_columns = trackColumnsThroughDAG(filter_dag, tracked_columns);
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -3,10 +3,25 @@
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Common/OptimizedRegularExpression.h>
+#include <Common/StringUtils.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 namespace DB
 {
+
+/// A JOIN disambiguates column names above it as `__table1.name`, `__table2.name`, ...; strip that.
+inline String stripJoinTableQualifier(const String & name)
+{
+    static constexpr std::string_view prefix = "__table";
+    if (!name.starts_with(prefix))
+        return name;
+
+    size_t pos = prefix.size();
+    while (pos < name.size() && isNumericASCII(name[pos]))
+        ++pos;
+
+    return pos > prefix.size() && pos < name.size() && name[pos] == '.' ? name.substr(pos + 1) : name;
+}
 
 class TextIndexTokensCache;
 using TextIndexTokensCachePtr = std::shared_ptr<TextIndexTokensCache>;
@@ -189,7 +204,11 @@ private:
 
     bool tryPrepareSetForTextSearch(const RPNBuilderTreeNode & lhs, const RPNBuilderTreeNode & rhs, const String & function_name, RPNElement & out) const;
 
-    bool hasIndexForColumn(const String & column_name) const { return header.has(column_name) || column_name == normalized_index_column_name; }
+    bool hasIndexForColumn(const String & column_name) const
+    {
+        String unqualified = stripJoinTableQualifier(column_name);
+        return header.has(unqualified) || unqualified == normalized_index_column_name;
+    }
 
     /// Returns true if all tokens must be read for text index analysis
     /// and we cannot exit analysis earlier if some of the tokens are missing in granule.

--- a/tests/queries/0_stateless/02346_text_index_bug115999.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.reference
@@ -1,0 +1,9 @@
+default settings
+1
+2
+use_skip_indexes = 0
+1
+2
+query_plan_direct_read_from_text_index = 0
+1
+2

--- a/tests/queries/0_stateless/02346_text_index_bug115999.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.reference
@@ -4,6 +4,17 @@ default settings
 query_plan_direct_read_from_text_index = 0
 1
 2
+OR with a column of the scanned table
+1
+3
+AND with the other side, no OR
+1
+explicit tokenizer argument
+1
+3
+has, not a text-search function
+1
+3
 same column name on the other join side
 without a JOIN
 1

--- a/tests/queries/0_stateless/02346_text_index_bug115999.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.reference
@@ -1,9 +1,11 @@
 default settings
 1
 2
-use_skip_indexes = 0
-1
-2
 query_plan_direct_read_from_text_index = 0
 1
 2
+same column name on the other join side
+without a JOIN
+1
+2
+3

--- a/tests/queries/0_stateless/02346_text_index_bug115999.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.reference
@@ -4,6 +4,17 @@ default settings
 query_plan_direct_read_from_text_index = 0
 1
 2
+nothing pushed below the JOIN
+1
+3
+use_join_disjunctions_push_down = 0
+1
+2
+use_skip_indexes = 0
+1
+2
+one index constrained below the JOIN, the other above
+2
 OR with a column of the scanned table
 1
 3

--- a/tests/queries/0_stateless/02346_text_index_bug115999.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.sql
@@ -54,6 +54,42 @@ WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'ta
 ORDER BY a.record_id
 SETTINGS query_plan_direct_read_from_text_index = 0;
 
+-- The tokenizer must not depend on what reached the table. Nothing of this predicate does, and with
+-- `use_join_disjunctions_push_down = 0` nothing of the one above does either.
+SELECT 'nothing pushed below the JOIN';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) OR b.category = 'nonexistent'
+ORDER BY a.record_id;
+
+SELECT 'use_join_disjunctions_push_down = 0';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'target')
+   OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
+ORDER BY a.record_id
+SETTINGS use_join_disjunctions_push_down = 0;
+
+SELECT 'use_skip_indexes = 0';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'target')
+   OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
+ORDER BY a.record_id
+SETTINGS use_skip_indexes = 0;
+
+-- Only one of the two indexes is constrained by what reaches the table; the other must still be applied.
+SELECT 'one index constrained below the JOIN, the other above';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE hasAnyTokens(a.plain_text, ['fallback'])
+  AND (hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']) OR b.category = 'target')
+ORDER BY a.record_id;
+
 SELECT 'OR with a column of the scanned table';
 
 SELECT a.record_id

--- a/tests/queries/0_stateless/02346_text_index_bug115999.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.sql
@@ -54,6 +54,35 @@ WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'ta
 ORDER BY a.record_id
 SETTINGS query_plan_direct_read_from_text_index = 0;
 
+SELECT 'OR with a column of the scanned table';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) OR a.group_id = 999
+ORDER BY a.record_id;
+
+SELECT 'AND with the other side, no OR';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'target'
+ORDER BY a.record_id;
+
+-- The explicit-tokenizer form and `has` never depended on the injection; they pin that it stays that way.
+SELECT 'explicit tokenizer argument';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE hasAnyTokens(a.shingle_tokens, ['alpha beta gamma'], 'array') OR a.group_id = 999
+ORDER BY a.record_id;
+
+SELECT 'has, not a text-search function';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE has(a.shingle_tokens, 'alpha beta gamma') OR a.group_id = 999
+ORDER BY a.record_id;
+
 -- An unindexed column of the other join side that happens to share the indexed column's name must not be
 -- tokenized with this index's tokenizer. Both queries must agree (and return nothing).
 SELECT 'same column name on the other join side';

--- a/tests/queries/0_stateless/02346_text_index_bug115999.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.sql
@@ -44,15 +44,7 @@ WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'ta
    OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
 ORDER BY a.record_id;
 
-SELECT 'use_skip_indexes = 0';
-
-SELECT a.record_id
-FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
-WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'target')
-   OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
-ORDER BY a.record_id
-SETTINGS use_skip_indexes = 0;
-
+-- Row-level evaluation must agree, i.e. the fix must not depend on the direct read from the index.
 SELECT 'query_plan_direct_read_from_text_index = 0';
 
 SELECT a.record_id
@@ -61,6 +53,36 @@ WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'ta
    OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
 ORDER BY a.record_id
 SETTINGS query_plan_direct_read_from_text_index = 0;
+
+-- An unindexed column of the other join side that happens to share the indexed column's name must not be
+-- tokenized with this index's tokenizer. Both queries must agree (and return nothing).
+SELECT 'same column name on the other join side';
+
+CREATE TABLE t_115999_c (id UInt64, shingle_tokens Array(String)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_115999_c VALUES (1, ['alpha beta gamma']);
+
+SELECT c.id
+FROM t_115999_a AS a INNER JOIN t_115999_c AS c ON a.record_id = c.id
+WHERE hasAnyTokens(a.shingle_tokens, ['alpha beta gamma'])
+  AND (hasAnyTokens(c.shingle_tokens, ['alpha beta gamma']) OR a.record_id = 999)
+ORDER BY c.id;
+
+SELECT c.id
+FROM t_115999_a AS a INNER JOIN t_115999_c AS c ON a.record_id = c.id
+WHERE hasAnyTokens(a.shingle_tokens, ['alpha beta gamma'])
+  AND (hasAnyTokens(c.shingle_tokens, ['alpha beta gamma']) OR a.record_id = 999)
+ORDER BY c.id
+SETTINGS use_skip_indexes = 0;
+
+DROP TABLE t_115999_c;
+
+SELECT 'without a JOIN';
+
+SELECT record_id
+FROM t_115999_a
+WHERE hasAnyTokens(shingle_tokens, ['alpha beta gamma'])
+   OR hasAnyTokens(shingle_tokens, ['delta epsilon zeta'])
+ORDER BY record_id;
 
 DROP TABLE t_115999_a;
 DROP TABLE t_115999_b;

--- a/tests/queries/0_stateless/02346_text_index_bug115999.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug115999.sql
@@ -1,0 +1,66 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/115999
+-- A text-search predicate OR-combined with a condition on the other side of a JOIN cannot be pushed
+-- below the JOIN, so it stays in a WHERE filter above it; the index's tokenizer must still reach it there.
+
+SET enable_full_text_index = 1;
+
+CREATE TABLE t_115999_a
+(
+    record_id UInt64,
+    group_id UInt64,
+    plain_text String,
+    shingle_tokens Array(String),
+    INDEX idx_plain_text plain_text TYPE text(tokenizer = splitByNonAlpha),
+    INDEX idx_shingle_tokens shingle_tokens TYPE text(tokenizer = array)
+)
+ENGINE = MergeTree
+ORDER BY record_id;
+
+CREATE TABLE t_115999_b
+(
+    group_id UInt64,
+    category String
+)
+ENGINE = MergeTree
+ORDER BY group_id;
+
+INSERT INTO t_115999_a VALUES
+    (1, 1, 'alpha beta gamma', ['alpha beta gamma']),
+    (2, 2, 'fallback', ['delta epsilon zeta']),
+    (3, 3, 'alpha beta gamma', ['alpha beta gamma']),
+    (4, 4, 'unrelated', ['unrelated example value']);
+
+INSERT INTO t_115999_b VALUES
+    (1, 'target'),
+    (2, 'other'),
+    (3, 'other'),
+    (4, 'target');
+
+SELECT 'default settings';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'target')
+   OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
+ORDER BY a.record_id;
+
+SELECT 'use_skip_indexes = 0';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'target')
+   OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
+ORDER BY a.record_id
+SETTINGS use_skip_indexes = 0;
+
+SELECT 'query_plan_direct_read_from_text_index = 0';
+
+SELECT a.record_id
+FROM t_115999_a AS a INNER JOIN t_115999_b AS b ON a.group_id = b.group_id
+WHERE (hasAnyTokens(a.shingle_tokens, ['alpha beta gamma']) AND b.category = 'target')
+   OR (hasAnyTokens(a.plain_text, ['fallback']) OR hasAnyTokens(a.shingle_tokens, ['delta epsilon zeta']))
+ORDER BY a.record_id
+SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE t_115999_a;
+DROP TABLE t_115999_b;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/115999
Related: https://github.com/ClickHouse/ClickHouse/issues/108808
Related: https://github.com/ClickHouse/ClickHouse/pull/113154

When combining an `OR` with a condition on the other table it is evaluated after the `JOIN` and silently fell back to `splitByNonAlpha`. With `tokenizer = array` the index keeps `alpha beta gamma` as one token while `splitByNonAlpha` splits it into three, so matching rows disappeared.

The tokenizer now also reaches predicates evaluated after a `JOIN`, but only where the value is read straight from the indexed table. 

Reading the index directly stays restricted to predicates evaluated on the table itself: it yields a per-granule answer, meaningless once a `JOIN` has reordered or duplicated rows. Previously it could reach past the `JOIN` and fail the query with an exception.

When nothing can be evaluated before the `JOIN`, the index is never consulted for that table (`force_data_skipping_indices` reports `INDEX_NOT_USED`) and no tokenizer is available to supply.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `hasAnyTokens`, `hasAllTokens` and `hasPhrase` on a column with a non-default `text` index tokenizer silently returning wrong results when the predicate could not be pushed below a `JOIN`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116197&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116197](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116197+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
