### PR TITLE
Docs: improve Cloud release schedule readability

### DIFF
--- a/docs/snippets/components/ReleaseSchedule/ReleaseSchedule.jsx
+++ b/docs/snippets/components/ReleaseSchedule/ReleaseSchedule.jsx
@@ -13,6 +13,11 @@
  */
 
 const ReleaseSchedule = ({ releases = [] }) => {
+  const groupStartStyle = {
+    borderLeft: "1px solid rgba(128, 128, 128, 0.35)",
+    paddingLeft: 16,
+  };
+
   const StatusIndicator = ({ status }) => {
     const color =
       status === "green" ? "#22c55e" :
@@ -31,40 +36,38 @@ const ReleaseSchedule = ({ releases = [] }) => {
   };
 
   const DateCell = ({ date, note, status }) => (
-    <span>
-      <StatusIndicator status={status} />
-      {date}
-      {note && <Tooltip tip={note}><Icon icon="circle-info" size={12} /></Tooltip>}
-    </span>
-  );
-
-  const ChannelSchedule = ({ startDate, endDate, note, status }) => (
-    <span style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-      <span>
-        <strong>Start:</strong>{" "}
-        <DateCell date={startDate} note={note} status={status} />
-      </span>
-      <span>
-        <strong>End:</strong>{" "}
-        <DateCell date={endDate} status={status} />
-      </span>
+    <span style={{ whiteSpace: "nowrap" }}>
+      {status && <StatusIndicator status={status} />}
+      {note ? <Tooltip tip={note}>{date}</Tooltip> : date}
     </span>
   );
 
   return (
     <table>
+      <colgroup />
+      <colgroup span={2} />
+      <colgroup span={2} />
+      <colgroup span={2} />
       <thead>
         <tr>
-          <th>Version</th>
-          <th>
+          <th rowSpan={2} scope="col">Version</th>
+          <th colSpan={2} scope="colgroup" style={groupStartStyle}>
             <a href="/docs/manage/updates#fast-release-channel-early-upgrades">Fast Channel</a>
           </th>
-          <th>
+          <th colSpan={2} scope="colgroup" style={groupStartStyle}>
             <a href="/docs/manage/updates#regular-release-channel">Regular Channel</a>
           </th>
-          <th>
+          <th colSpan={2} scope="colgroup" style={groupStartStyle}>
             <a href="/docs/manage/updates#slow-release-channel-deferred-upgrades">Slow Channel</a>
           </th>
+        </tr>
+        <tr>
+          <th scope="col" style={groupStartStyle}>Start</th>
+          <th scope="col">End</th>
+          <th scope="col" style={groupStartStyle}>Start</th>
+          <th scope="col">End</th>
+          <th scope="col" style={groupStartStyle}>Start</th>
+          <th scope="col">End</th>
         </tr>
       </thead>
       <tbody>
@@ -80,7 +83,7 @@ const ReleaseSchedule = ({ releases = [] }) => {
 
           return (
             <tr key={idx}>
-              <td>
+              <th scope="row">
                 {release.changelog_link ? (
                   <a href={release.changelog_link} target="_blank" rel="noopener noreferrer">
                     {release.version}
@@ -88,37 +91,19 @@ const ReleaseSchedule = ({ releases = [] }) => {
                 ) : (
                   release.version
                 )}
-              </td>
+              </th>
               {isCompleted ? (
-                <td colSpan={3} style={{ textAlign: "center" }}>
+                <td colSpan={6} style={{ textAlign: "center" }}>
                   <DateCell date="Completed" status="green" />
                 </td>
               ) : (
                 <>
-                  <td>
-                    <ChannelSchedule
-                      startDate={release.fast_start_date}
-                      endDate={release.fast_end_date}
-                      note={release.fast_delay_note}
-                      status={release.fast_progress}
-                    />
-                  </td>
-                  <td>
-                    <ChannelSchedule
-                      startDate={release.regular_start_date}
-                      endDate={release.regular_end_date}
-                      note={release.regular_delay_note}
-                      status={release.regular_progress}
-                    />
-                  </td>
-                  <td>
-                    <ChannelSchedule
-                      startDate={release.slow_start_date}
-                      endDate={release.slow_end_date}
-                      note={release.slow_delay_note}
-                      status={release.slow_progress}
-                    />
-                  </td>
+                  <td style={groupStartStyle}><DateCell date={release.fast_start_date} note={release.fast_delay_note} status={release.fast_progress} /></td>
+                  <td><DateCell date={release.fast_end_date} status={release.fast_progress} /></td>
+                  <td style={groupStartStyle}><DateCell date={release.regular_start_date} note={release.regular_delay_note} status={release.regular_progress} /></td>
+                  <td><DateCell date={release.regular_end_date} status={release.regular_progress} /></td>
+                  <td style={groupStartStyle}><DateCell date={release.slow_start_date} note={release.slow_delay_note} status={release.slow_progress} /></td>
+                  <td><DateCell date={release.slow_end_date} status={release.slow_progress} /></td>
                 </>
               )}
             </tr>

--- a/docs/snippets/components/ReleaseSchedule/ReleaseSchedule.jsx
+++ b/docs/snippets/components/ReleaseSchedule/ReleaseSchedule.jsx
@@ -38,12 +38,7 @@ const ReleaseSchedule = ({ releases = [] }) => {
   const DateCell = ({ date, note, status }) => (
     <span style={{ whiteSpace: "nowrap" }}>
       {status && <StatusIndicator status={status} />}
-      {date}
-      {note && (
-        <span style={{ display: "inline-flex", marginLeft: 4, verticalAlign: "middle" }}>
-          <Tooltip tip={note}><span><Icon icon="circle-info" size={12} /></span></Tooltip>
-        </span>
-      )}
+      {note ? <Tooltip tip={note}>{date}</Tooltip> : date}
     </span>
   );
 

--- a/docs/snippets/components/ReleaseSchedule/ReleaseSchedule.jsx
+++ b/docs/snippets/components/ReleaseSchedule/ReleaseSchedule.jsx
@@ -38,7 +38,12 @@ const ReleaseSchedule = ({ releases = [] }) => {
   const DateCell = ({ date, note, status }) => (
     <span style={{ whiteSpace: "nowrap" }}>
       {status && <StatusIndicator status={status} />}
-      {note ? <Tooltip tip={note}>{date}</Tooltip> : date}
+      {date}
+      {note && (
+        <span style={{ display: "inline-flex", marginLeft: 4, verticalAlign: "middle" }}>
+          <Tooltip tip={note}><span><Icon icon="circle-info" size={12} /></span></Tooltip>
+        </span>
+      )}
     </span>
   );
 


### PR DESCRIPTION
The Cloud release schedule became difficult to scan after its Start and End dates were stacked inside each channel cell to avoid horizontal overflow. This restores a comparison-table layout with grouped Fast, Regular, and Slow channel headers, separate Start and End columns, and subtle separators between the channel groups.

Annotated dates remain interactive tooltip triggers without separate information icons. The table also uses semantic column groups and version row headers so its relationships are available to assistive technology.

Design references:

- [W3C WAI: Tables with irregular headers](https://www.w3.org/WAI/tutorials/tables/irregular/) for two-tier headers, column groups, and `scope` associations

Linear: https://linear.app/clickhouse/issue/DOC-1005/improve-readability-of-the-cloud-release-schedule-table

Related: https://github.com/ClickHouse/ClickHouse/pull/111904


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116198&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116198](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116198+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
