### PR TITLE
Web UI: keep the query selection visible when the editor loses focus

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1300,6 +1300,16 @@
 
         #query-backdrop .q-active { background-color: var(--current-query-background-color); }
 
+        /* Browsers stop painting the text selection as soon as the textarea loses focus, so the
+           range that `Run selected` (or a copy) will act on becomes invisible while the user is
+           reaching for a button. Repaint it ourselves in the backdrop — which is what the user
+           actually sees — with the same colors as the native selection. */
+        #query-backdrop::highlight(query-selection)
+        {
+            color: var(--selection-color);
+            background-color: var(--selection-background-color);
+        }
+
         /* Per-token syntax highlighting classes. The color value here is the raw color
            painted in the backdrop; the visible color the user sees is the difference
            between this and --text-color-active (see the comment on .has-backdrop). */
@@ -16803,6 +16813,57 @@ function updateQueryBackdrop(text, tokens, boundaries) {
     renderQueryBackdrop();
 }
 
+/// Name of the CSS custom highlight that repaints the text selection in the backdrop while the
+/// textarea is not focused (see the `#query-backdrop::highlight(query-selection)` rule).
+const INACTIVE_SELECTION_HIGHLIGHT = 'query-selection';
+
+/// The browser paints the selection inside the textarea only while it has focus: clicking
+/// `Run selected` (or any other control) makes the selected range invisible, although it is still
+/// what the button acts on. Mirror the selection onto the backdrop, whose text is what the user
+/// sees, using the CSS Custom Highlight API. Must be called after every backdrop re-render,
+/// because replacing the backdrop's content invalidates the ranges.
+function highlightInactiveSelection() {
+    if (!window.CSS || !CSS.highlights || typeof Highlight === 'undefined') return;
+
+    const start = query_area.selectionStart;
+    const end = query_area.selectionEnd;
+
+    /// Nothing to paint: no selection, the backdrop is not shown, or the textarea has focus and
+    /// the browser paints the selection itself.
+    if (start === end || queryBackdrop.style.display === 'none' || document.activeElement === query_area) {
+        CSS.highlights.delete(INACTIVE_SELECTION_HIGHLIGHT);
+        return;
+    }
+
+    /// Map the textarea's character offsets onto the backdrop's text nodes. The backdrop holds the
+    /// same characters split across per-token spans (plus a possible trailing space for a final
+    /// newline, which is past the end of any selection).
+    const range = document.createRange();
+    let offset = 0;
+    let has_start = false;
+    let has_end = false;
+    const walker = document.createTreeWalker(queryBackdrop, NodeFilter.SHOW_TEXT);
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const length = node.data.length;
+        if (!has_start && start <= offset + length) {
+            range.setStart(node, start - offset);
+            has_start = true;
+        }
+        if (has_start && end <= offset + length) {
+            range.setEnd(node, end - offset);
+            has_end = true;
+            break;
+        }
+        offset += length;
+    }
+
+    if (has_start && has_end) {
+        CSS.highlights.set(INACTIVE_SELECTION_HIGHLIGHT, new Highlight(range));
+    } else {
+        CSS.highlights.delete(INACTIVE_SELECTION_HIGHLIGHT);
+    }
+}
+
 function renderQueryBackdrop() {
     const text = currentBackdropText;
     const tokens = currentTokens;
@@ -16815,6 +16876,7 @@ function renderQueryBackdrop() {
     if (!text || tokens.length === 0) {
         queryBackdrop.style.display = 'none';
         query_area.classList.remove('has-backdrop');
+        highlightInactiveSelection();
         if (!inRenderBackdrop) updateCompletions();
         return;
     }
@@ -16953,6 +17015,9 @@ function renderQueryBackdrop() {
 
     queryBackdrop.scrollTop = query_area.scrollTop;
     queryBackdrop.scrollLeft = query_area.scrollLeft;
+
+    /// Replacing the backdrop's content dropped the ranges of the selection highlight; recompute.
+    highlightInactiveSelection();
 
     /// Keep autocompletion in sync with the freshly rendered text/cursor (unless this render
     /// was itself triggered by the completion code, which would recurse).

--- a/tests/queries/0_stateless/05042_web_ui_play_inactive_selection.reference
+++ b/tests/queries/0_stateless/05042_web_ui_play_inactive_selection.reference
@@ -1,0 +1,4 @@
+the highlight 'query-selection' is both styled and registered
+color: var(--selection-color);
+background-color: var(--selection-background-color);
+2

--- a/tests/queries/0_stateless/05042_web_ui_play_inactive_selection.sh
+++ b/tests/queries/0_stateless/05042_web_ui_play_inactive_selection.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The Web UI paints the text selection of the query editor itself once the editor loses focus:
+# browsers stop painting it there, which left the range that `Run selected` acts on invisible.
+# The selection is mirrored onto the `#query-backdrop` (the layer the user actually sees) with the
+# CSS Custom Highlight API, so the highlight name in the stylesheet and in the script must agree -
+# renaming one of them silently disables the painting, with nothing failing anywhere.
+
+PLAY_PAGE=$(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/play")
+
+UNINDENTED_PAGE=$(echo "$PLAY_PAGE" | sed -e 's/^[[:space:]]*//')
+
+CSS_NAME=$(echo "$UNINDENTED_PAGE" | sed -n -e 's/^#query-backdrop::highlight(\(.*\))$/\1/p' | head -n 1)
+JS_NAME=$(echo "$UNINDENTED_PAGE" | sed -n -e "s/^const INACTIVE_SELECTION_HIGHLIGHT = '\(.*\)';$/\1/p" | head -n 1)
+
+if [ -n "$CSS_NAME" ] && [ "$CSS_NAME" = "$JS_NAME" ]
+then
+    echo "the highlight '$CSS_NAME' is both styled and registered"
+else
+    echo "the highlight is styled as '$CSS_NAME' but registered as '$JS_NAME'"
+fi
+
+# It must look exactly like the native selection, whichever theme is in use, so it takes its colors
+# from the same two variables - checked inside the highlight's own block, because the very same
+# declarations also appear in the `::selection` rule above it.
+HIGHLIGHT_BLOCK=$(echo "$UNINDENTED_PAGE" | grep -A 4 -F -m1 '#query-backdrop::highlight(' | tr '\n' ' ' | tr -s ' ')
+
+echo "$HIGHLIGHT_BLOCK" | grep -o -F -m1 'color: var(--selection-color);'
+echo "$HIGHLIGHT_BLOCK" | grep -o -F -m1 'background-color: var(--selection-background-color);'
+
+# Every backdrop re-render replaces its content and so invalidates the ranges of the highlight:
+# both the painting path and the path that hides the backdrop have to refresh it.
+echo "$UNINDENTED_PAGE" | grep -c -x -F 'highlightInactiveSelection();'


### PR DESCRIPTION
In the Web UI, the query editor's text is transparent while syntax highlighting is on — what the user sees is the `#query-backdrop` layer behind it. The selection, however, was painted only by the textarea itself, and browsers stop painting a textarea's selection as soon as it loses focus. So the moment the user reached for the `Run selected` button, the range that the button acts on became invisible: the button still worked, but it was no longer possible to see what it would run.

The selection is now mirrored onto the backdrop with the CSS Custom Highlight API, using the same `--selection-color` / `--selection-background-color` as `::selection`, so it looks exactly like the native selection in both themes. The highlight is registered after every backdrop render (replacing the backdrop's content invalidates the ranges) and dropped again as soon as the editor regains focus and the browser paints the selection itself.

Verified in a headless browser: with two statements in the editor, selecting the second one and moving focus to `Run selected` highlights exactly the selected text; refocusing the editor drops the highlight. Also checked selections that start and end in the middle of a token (inside a number with digit-group underlines), a wrapped long line, a selection covering the whole text including a trailing newline, and replacing the text while the editor is unfocused.

The feature needs the CSS Custom Highlight API (Chrome 105+, Safari 17.2+, Firefox 140+). Older browsers behave exactly as before — there is no extra layer or separate code path for them.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Web UI: the query text selection stays visible after the editor loses focus, so it is possible to see what the `Run selected` button will run.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116201&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116201](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116201+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
