### PR TITLE
Fix wrong results from the query condition cache after a part name is reused

### DIFF
--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -30,10 +30,10 @@ QueryConditionCache::Key QueryConditionCache::makeKey(const UUID & table_id, con
     return hash.get128();
 }
 
-String QueryConditionCache::makeFilePartName(const String & path, std::string_view version_token)
+String QueryConditionCache::makeVersionedPartName(const String & name, std::string_view version_token)
 {
-    /// NUL cannot occur in a file path or in a version token, so it is an unambiguous separator.
-    String part_name = path;
+    /// NUL cannot occur in a name or in a version token, so it is an unambiguous separator.
+    String part_name = name;
     part_name.push_back('\0');
     part_name.append(version_token);
     return part_name;

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -77,14 +77,15 @@ public:
     static Key makeKey(const UUID & table_id, const String & part_name, UInt64 condition_hash);
 
     /// Compose the `part_name` component of a cache key for a file-backed table (e.g. `File`, `S3`,
-    /// object storage). Uses the full path (not just the base name) so files that share a name in
-    /// different directories do not collide, and folds in a content-version token so an in-place
-    /// rewrite of the file yields a different key rather than a stale hit. The token is the ETag for
-    /// remote objects, or a local identity (modification time + inode + size) for local files. For
-    /// immutable files (e.g. data-lake data files) the path alone is a stable identity and the token
-    /// may be left empty. The path and the token are separated by a NUL byte, which cannot occur in
-    /// either, so the mapping is unambiguous.
-    static String makeFilePartName(const String & path, std::string_view version_token);
+    /// object storage) or for a `MergeTree` part, by joining the name with a content-version token.
+    /// The name should be unique within the table - the full path rather than the base name, so files
+    /// that share a name in different directories do not collide - but a name alone is not a stable
+    /// identity: a file can be rewritten in place, and a part's block number can be recycled when the
+    /// table is re-created. The token changes with the content, so such a lookup misses rather than
+    /// taking a stale hit. It is the ETag for remote objects, a local identity (modification time +
+    /// inode + size) for local files, and the total checksum for a `MergeTree` part. The name and the
+    /// token are separated by a NUL byte, which cannot occur in either, so the mapping is unambiguous.
+    static String makeVersionedPartName(const String & name, std::string_view version_token);
 
     QueryConditionCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3662,11 +3662,15 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
             for (const auto & remaining_ranges : remaining)
             {
                 const auto & data_part = remaining_ranges.data_part;
-                String part_name = data_part->isProjectionPart() ? fmt::format("{}:{}", data_part->getParentPartName(), data_part->name)
-                                                                 : data_part->name;
+                const auto query_condition_cache_key = data_part->makeQueryConditionCacheKey(
+                    data_part->isProjectionPart() ? fmt::format("{}:{}", data_part->getParentPartName(), data_part->name)
+                                                  : data_part->name);
+                if (!query_condition_cache_key)
+                    continue;
+
                 query_condition_cache->write(
                     data_part->storage.getStorageID().uuid,
-                    part_name,
+                    *query_condition_cache_key,
                     profiled_condition_hash,
                     output->result_name,
                     remaining_ranges.ranges,

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -19,6 +19,7 @@
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
+#include <Interpreters/Cache/QueryConditionCache.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/MergeTreeTransaction.h>
@@ -2143,6 +2144,34 @@ void IMergeTreeDataPart::loadPartitionAndMinMaxIndex()
         throw Exception(ErrorCodes::CORRUPTED_DATA, "While loading part {}: "
             "calculated partition ID: {} differs from partition ID in part name: {}",
             getDataPartStorage().getFullPath(), calculated_partition_id, info.getPartitionId());
+}
+
+const String & IMergeTreeDataPart::queryConditionCacheToken() const
+{
+    std::call_once(query_condition_cache_token_initialized, [this]
+    {
+        /// `checksums` is not changed after the part is loaded, so the token is computed once. It is
+        /// empty only for a part whose `checksums.txt` is at format version 1, which `read` does not
+        /// parse; every other path either parses the file or recomputes it.
+        if (!checksums.empty())
+            query_condition_cache_token = checksums.getTotalChecksumHex();
+    });
+
+    return query_condition_cache_token;
+}
+
+bool IMergeTreeDataPart::hasQueryConditionCacheKey() const
+{
+    return !queryConditionCacheToken().empty();
+}
+
+std::optional<String> IMergeTreeDataPart::makeQueryConditionCacheKey(const String & name) const
+{
+    const String & token = queryConditionCacheToken();
+    if (token.empty())
+        return std::nullopt;
+
+    return QueryConditionCache::makeVersionedPartName(name, token);
 }
 
 void IMergeTreeDataPart::loadChecksums(bool require)

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2165,13 +2165,13 @@ bool IMergeTreeDataPart::hasQueryConditionCacheKey() const
     return !queryConditionCacheToken().empty();
 }
 
-std::optional<String> IMergeTreeDataPart::makeQueryConditionCacheKey(const String & name) const
+std::optional<String> IMergeTreeDataPart::makeQueryConditionCacheKey(const String & part_name) const
 {
     const String & token = queryConditionCacheToken();
     if (token.empty())
         return std::nullopt;
 
-    return QueryConditionCache::makeVersionedPartName(name, token);
+    return QueryConditionCache::makeVersionedPartName(part_name, token);
 }
 
 void IMergeTreeDataPart::loadChecksums(bool require)

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -509,10 +509,10 @@ public:
     UInt64 getMarksCount() const;
     IndexSize getIndexSizeFromFile() const;
 
-    /// Compose the Query Condition Cache key (`part_name`) for this part under `name` - the caller
-    /// spells `name`, since projection parts are keyed as `<parent part>:<projection>` - or nullopt
-    /// when the part has no content-version token and so must not be cached.
-    std::optional<String> makeQueryConditionCacheKey(const String & name) const;
+    /// Compose the Query Condition Cache key from `part_name` - which the caller spells, since
+    /// projection parts are keyed as `<parent part>:<projection>` - or nullopt when the part has no
+    /// content-version token and so must not be cached.
+    std::optional<String> makeQueryConditionCacheKey(const String & part_name) const;
     bool hasQueryConditionCacheKey() const;
 
     UInt64 getBytesOnDisk() const { return bytes_on_disk; }

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -509,6 +509,12 @@ public:
     UInt64 getMarksCount() const;
     IndexSize getIndexSizeFromFile() const;
 
+    /// Compose the Query Condition Cache key (`part_name`) for this part under `name` - the caller
+    /// spells `name`, since projection parts are keyed as `<parent part>:<projection>` - or nullopt
+    /// when the part has no content-version token and so must not be cached.
+    std::optional<String> makeQueryConditionCacheKey(const String & name) const;
+    bool hasQueryConditionCacheKey() const;
+
     UInt64 getBytesOnDisk() const { return bytes_on_disk; }
     UInt64 getBytesUncompressedOnDisk() const { return bytes_uncompressed_on_disk; }
     void setBytesOnDisk(UInt64 bytes_on_disk_) { bytes_on_disk = bytes_on_disk_; }
@@ -858,6 +864,12 @@ protected:
 private:
     String mutable_name;
     mutable std::atomic<MergeTreeDataPartState> state{MergeTreeDataPartState::Temporary};
+
+    /// Lazily computed content-version token, see `makeQueryConditionCacheKey`. Empty when the part
+    /// has no reliable identity.
+    const String & queryConditionCacheToken() const;
+    mutable std::once_flag query_condition_cache_token_initialized;
+    mutable String query_condition_cache_token;
 
     /// Schema-derived metadata shared with all other parts of the table that store the same
     /// columns: the column list, the name-to-position map (in compact parts order of columns

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1665,19 +1665,25 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
 
             const auto & data_part = part_with_ranges.data_part;
             auto storage_id = data_part->storage.getStorageID();
+            const auto query_condition_cache_key = data_part->makeQueryConditionCacheKey(data_part->name);
+            if (!query_condition_cache_key)
+            {
+                ++it;
+                continue;
+            }
             /// Row-level entries are sound under any profile; skip-index entries only under the
             /// matching profile. Merge the two verdicts: a mark must be read iff both say so.
             /// This is one logical cache consultation, so it must emit at most one
             /// QueryConditionCacheHits/Misses event regardless of how many keys are probed: count
             /// the hit/miss ourselves and suppress the per-read events on every lookup.
-            auto row_level_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, condition_hash, /*increment_profile_events=*/false);
-            auto skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, profiled_condition_hash, /*increment_profile_events=*/false);
+            auto row_level_marks_opt = query_condition_cache->read(storage_id.uuid, *query_condition_cache_key, condition_hash, /*increment_profile_events=*/false);
+            auto skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, *query_condition_cache_key, profiled_condition_hash, /*increment_profile_events=*/false);
             std::optional<QueryConditionCache::MatchingMarks> topk_reuse_predicate_only_row_level_marks_opt;
             std::optional<QueryConditionCache::MatchingMarks> topk_reuse_predicate_only_skip_index_marks_opt;
             if (also_probe_topk_reuse_predicate_only_hash)
             {
-                topk_reuse_predicate_only_row_level_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, topk_reuse_predicate_only_hash, /*increment_profile_events=*/false);
-                topk_reuse_predicate_only_skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, topk_reuse_predicate_only_profiled_hash, /*increment_profile_events=*/false);
+                topk_reuse_predicate_only_row_level_marks_opt = query_condition_cache->read(storage_id.uuid, *query_condition_cache_key, topk_reuse_predicate_only_hash, /*increment_profile_events=*/false);
+                topk_reuse_predicate_only_skip_index_marks_opt = query_condition_cache->read(storage_id.uuid, *query_condition_cache_key, topk_reuse_predicate_only_profiled_hash, /*increment_profile_events=*/false);
             }
             if (!row_level_marks_opt && !skip_index_marks_opt
                 && !topk_reuse_predicate_only_row_level_marks_opt && !topk_reuse_predicate_only_skip_index_marks_opt)

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -292,21 +292,26 @@ MergeTreeSelectProcessor::readCurrentTask(MergeTreeReadTask & current_task, IMer
             /// apply_mutations_on_fly = 0 query.
             if (!current_task.appliesMutationsBeforePrewhere())
             {
-                String part_name
-                    = data_part_info->isProjectionPart() ? fmt::format("{}:{}", data_part_info->getParentPartName(), data_part_info->getPartName()) : data_part_info->getPartName();
-                chunk.getChunkInfos().add(std::make_shared<MarkRangesInfo>(
-                    /// QueryConditionCache is a coordinator feature; concrete part present here.
-                    data_part_info->getDataPart()->storage.getStorageID().uuid,
-                    part_name,
-                    data_part_info->getIndexGranularity().getMarksCount(),
-                    data_part_info->getIndexGranularity().hasFinalMark(),
-                    res.read_mark_ranges));
+                /// Leaving the marks unattached makes the downstream FilterTransform write nothing.
+                const auto query_condition_cache_key = data_part_info->getDataPart()->makeQueryConditionCacheKey(
+                    data_part_info->isProjectionPart() ? fmt::format("{}:{}", data_part_info->getParentPartName(), data_part_info->getPartName()) : data_part_info->getPartName());
+                if (query_condition_cache_key)
+                {
+                    chunk.getChunkInfos().add(std::make_shared<MarkRangesInfo>(
+                        /// QueryConditionCache is a coordinator feature; concrete part present here.
+                        data_part_info->getDataPart()->storage.getStorageID().uuid,
+                        *query_condition_cache_key,
+                        data_part_info->getIndexGranularity().getMarksCount(),
+                        data_part_info->getIndexGranularity().hasFinalMark(),
+                        res.read_mark_ranges));
+                }
             }
 
             /// Some rows survived PREWHERE, but individual granules within this batch may
             /// still have been fully filtered out. Record those granules immediately so that
             /// future queries can skip them without waiting for an entire batch to be zero.
             if (prewhere_info && !res.unmatched_mark_ranges.empty()
+                && data_part_info->getDataPart()->hasQueryConditionCacheKey()
                 && !current_task.readersChainCanSkipMarksBeforePrewhere()
                 && !current_task.appliesMutationsBeforePrewhere()
                 && !row_level_filter)
@@ -327,7 +332,9 @@ MergeTreeSelectProcessor::readCurrentTask(MergeTreeReadTask & current_task, IMer
     /// security filter is also prepended before PREWHERE (getPrewhereActions), yet this write keys only
     /// on the query PREWHERE hash, so a mark hidden by a row policy would be wrongly attributed to the
     /// PREWHERE predicate and read by a later query without that policy.
+    const auto & concrete_part = current_task.getInfo().data_part_info->getDataPart();
     if (reader_settings.use_query_condition_cache && prewhere_info
+        && concrete_part && concrete_part->hasQueryConditionCacheKey()
         && !current_task.readersChainCanSkipMarksBeforePrewhere()
         && !current_task.appliesMutationsBeforePrewhere()
         && !row_level_filter)
@@ -432,13 +439,17 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
                             auto query_condition_cache = Context::getGlobalContextInstance()->getQueryConditionCache();
                             const auto & data_part_info = task->getInfo().data_part_info;
 
-                            String part_name = data_part_info->isProjectionPart()
-                                ? fmt::format("{}:{}", data_part_info->getParentPartName(), data_part_info->getPartName())
-                                : data_part_info->getPartName();
+                            const auto query_condition_cache_key = data_part_info->getDataPart()->makeQueryConditionCacheKey(
+                                data_part_info->isProjectionPart()
+                                    ? fmt::format("{}:{}", data_part_info->getParentPartName(), data_part_info->getPartName())
+                                    : data_part_info->getPartName());
+                            if (!query_condition_cache_key)
+                                break;
+
                             query_condition_cache->write(
                                 /// QueryConditionCache is a coordinator feature; concrete part present here.
                                 data_part_info->getDataPart()->storage.getStorageID().uuid,
-                                part_name,
+                                *query_condition_cache_key,
                                 output->getHash(),
                                 prewhere_info->prewhere_actions.getNames()[0],
                                 task->getPrewhereUnmatchedMarks(),

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -140,7 +140,7 @@ namespace
         const auto & metadata = object_info.getObjectMetadata();
         if (!metadata || metadata->etag.empty())
             return std::nullopt;
-        return QueryConditionCache::makeFilePartName(identifier, metadata->etag);
+        return QueryConditionCache::makeVersionedPartName(identifier, metadata->etag);
     }
 
     std::optional<Map> tryGetHeadersFromReadBuffer(const ReadBuffer * read_buffer)

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1818,7 +1818,7 @@ Chunk StorageFileSource::generate()
 
             if (query_condition_cache)
             {
-                const String cache_file_key = QueryConditionCache::makeFilePartName(current_path, *current_file_cache_version);
+                const String cache_file_key = QueryConditionCache::makeVersionedPartName(current_path, *current_file_cache_version);
                 auto matching_marks = query_condition_cache->read(
                     storage->getStorageID().uuid, cache_file_key, *format_filter_info->condition_hash);
                 if (matching_marks.has_value())
@@ -2070,7 +2070,7 @@ Chunk StorageFileSource::generate()
                     {
                         if (auto query_condition_cache = getContext()->getQueryConditionCache())
                         {
-                            const String cache_file_key = QueryConditionCache::makeFilePartName(current_path, *current_file_cache_version);
+                            const String cache_file_key = QueryConditionCache::makeVersionedPartName(current_path, *current_file_cache_version);
                             query_condition_cache->write(
                                 storage->getStorageID().uuid,
                                 cache_file_key,

--- a/tests/queries/0_stateless/03460_query_condition_cache_with_projections.reference
+++ b/tests/queries/0_stateless/03460_query_condition_cache_with_projections.reference
@@ -18,7 +18,7 @@ select j from t where j > 3 and i = 20 order by j settings max_threads = 1, use_
 7
 8
 9
-select part_name from system.query_condition_cache order by part_name;
+select splitByChar(char(0), part_name)[1] from system.query_condition_cache order by part_name;
 all_1_1_0:p
 all_2_2_0:p
 select j from t where j > 3 and i = 20 order by j settings max_threads = 1, use_query_condition_cache = 1, query_condition_cache_store_conditions_as_plaintext = 1;

--- a/tests/queries/0_stateless/03460_query_condition_cache_with_projections.sql
+++ b/tests/queries/0_stateless/03460_query_condition_cache_with_projections.sql
@@ -26,7 +26,7 @@ system clear query condition cache;
 
 select j from t where j > 3 and i = 20 order by j settings max_threads = 1, use_query_condition_cache = 1, query_condition_cache_store_conditions_as_plaintext = 1;
 
-select part_name from system.query_condition_cache order by part_name;
+select splitByChar(char(0), part_name)[1] from system.query_condition_cache order by part_name;
 
 select j from t where j > 3 and i = 20 order by j settings max_threads = 1, use_query_condition_cache = 1, query_condition_cache_store_conditions_as_plaintext = 1;
 

--- a/tests/queries/0_stateless/04498_query_condition_cache_local_files.sh
+++ b/tests/queries/0_stateless/04498_query_condition_cache_local_files.sh
@@ -19,7 +19,7 @@
 # rows regardless of the cache.
 #
 # The file version token (sub-second mtime + inode + size) is folded into the cache
-# key via `QueryConditionCache::makeFilePartName`, and it is trusted only after the
+# key via `QueryConditionCache::makeVersionedPartName`, and it is trusted only after the
 # file has settled: filesystem timestamps are coarser than the wall clock, so a
 # rewrite that lands in the same timestamp tick as the previous write could otherwise
 # produce an identical token and reuse a stale entry. The table therefore points at

--- a/tests/queries/0_stateless/05042_query_condition_cache_part_name_reuse.reference
+++ b/tests/queries/0_stateless/05042_query_condition_cache_part_name_reuse.reference
@@ -1,0 +1,12 @@
+one freshly inserted part
+1
+incarnation 1, nothing matches
+0
+an entry was written
+1
+one freshly inserted part
+1
+incarnation 2, the row must be visible
+1
+2	yes
+1

--- a/tests/queries/0_stateless/05042_query_condition_cache_part_name_reuse.sql
+++ b/tests/queries/0_stateless/05042_query_condition_cache_part_name_reuse.sql
@@ -1,0 +1,51 @@
+-- Tags: no-parallel
+-- Tag no-parallel: Messes with internal cache
+
+-- Block numbers restart for a re-created table, so a `DROP` + `CREATE` that reuses the table UUID
+-- produces a new part carrying a name an earlier part already used. The query condition cache must
+-- not serve the earlier part's verdict for the new one, or rows silently go missing.
+
+SET enable_analyzer = 1; -- the cache is only consulted with the analyzer
+SET use_query_condition_cache = 1;
+SET use_statistics_for_part_pruning = 0; -- randomized auto_statistics_types could prune the part first
+SET database_replicated_allow_explicit_uuid = 1; -- pinning the UUID is the point of the test
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+DROP TABLE IF EXISTS t_part_name_reuse SYNC;
+
+CREATE TABLE t_part_name_reuse UUID '8f1e0d2c-3b4a-4596-8778-69aabbccddee' (a Int64, s String)
+ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_part_name_reuse VALUES (1, 'no');
+
+SELECT 'one freshly inserted part';
+SELECT count() FROM system.parts
+WHERE database = currentDatabase() AND table = 't_part_name_reuse' AND active
+    AND level = 0 AND min_block_number = max_block_number;
+
+-- Primes the cache: nothing matches, so the granule is recorded as skippable for this predicate.
+SELECT 'incarnation 1, nothing matches';
+SELECT count() FROM t_part_name_reuse WHERE s = 'yes';
+SELECT a, s FROM t_part_name_reuse WHERE s = 'yes';
+
+SELECT 'an entry was written';
+SELECT count() > 0 FROM system.query_condition_cache;
+
+DROP TABLE t_part_name_reuse SYNC;
+
+CREATE TABLE t_part_name_reuse UUID '8f1e0d2c-3b4a-4596-8778-69aabbccddee' (a Int64, s String)
+ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_part_name_reuse VALUES (2, 'yes');
+
+-- Same shape as above, so this part carries the same name as the one the cache holds an entry for.
+SELECT 'one freshly inserted part';
+SELECT count() FROM system.parts
+WHERE database = currentDatabase() AND table = 't_part_name_reuse' AND active
+    AND level = 0 AND min_block_number = max_block_number;
+
+SELECT 'incarnation 2, the row must be visible';
+SELECT count() FROM t_part_name_reuse WHERE s = 'yes';
+SELECT a, s FROM t_part_name_reuse WHERE s = 'yes';
+SELECT count() FROM t_part_name_reuse WHERE s = 'yes' SETTINGS use_query_condition_cache = 0;
+
+DROP TABLE t_part_name_reuse SYNC;


### PR DESCRIPTION
`QueryConditionCache` keys entries on `(table UUID, part name, condition hash)`, which assumes a part name permanently identifies one set of rows. Block numbers restart for a freshly created table, so a `DROP` + `CREATE` that reuses the table UUID produces a new part carrying a name an earlier part already used. The earlier part's entry is then served for the new one, skipping granules that hold matching rows.

The fix folds a content-version token (the part's total checksum) into the `part_name` component of the key, so a name that comes to denote different data yields a different key and the lookup misses instead of taking a stale hit. 

#109310 already did exactly this for object storage and `File` via `makeFilePartName`, which is generalised here to `makeVersionedPartName`; MergeTree parts were not covered by it. A part with no checksums has no reliable identity and is not cached at all rather than keyed on a weaker token.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results from the query condition cache. After a table was re-created with the same UUID, a new part could reuse an earlier part's name and inherit its stale cache entry, causing granules that hold matching rows to be skipped.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116203&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116203](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116203+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
