### PR TITLE
CI: check out the event's own base revision for docs review requests

### DIFF
--- a/.github/workflows/team_review_requests.yml
+++ b/.github/workflows/team_review_requests.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Check out trusted base revision
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Request documentation team reviews
@@ -42,7 +41,6 @@ jobs:
       - name: Check out trusted base revision
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Request documentation team reviews


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/114461
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`request-reviews-fork` fails with `/usr/bin/python3: No module named ci.jobs.scripts.team_review_requests`: 15 failures over 8 days across 12 forks, all with that string (workflow `332641028`).

The harm is lost routing, not the red X. #113429 ("Document chDB ADBC support") is documentation-only, got `can be tested`, and its run died 2 seconds later; it merged with `requested_teams: []` and no `review_requested` event. No affected PR touches `ci/`, so none can fix this.

`pull_request_target` reads the workflow *definition* from the base-branch tip, while `actions/checkout` pinned the *tree* to `base.sha`. That field is the base branch as of the last PR update, so a `labeled` event days later pins a tree well behind the tip that supplied the definition, which then invokes a module the tree lacks. At the ref two failing runs checked out, this workflow file is itself absent while `ci/jobs/scripts/check_ci.py` is present, showing the skew. Dropping `ref:` makes both one revision. `request-reviews-internal` fires on `opened`, where `base.sha` is fresh, so it has not failed yet, but has the same defect and is fixed too.

This keeps the #114461 credential constraint: `repository` stays unset and the revision is still base-branch code, so the robot token never sees fork code. In checkout v6.1.0 (what `@v6` resolves to) the fork guard's unsafe set for this event is exactly `{head.sha, merge_commit_sha}` (`src/unsafe-pr-checkout-helper.ts:32-36`), so this moves from a stale trusted revision to the current one. With no `ref:` checkout takes both from the event (`input-helper.ts:81-82`) and pins the branch ref at that commit (`ref-helper.ts:101`), still an immutable sha. `base.ref` would just invert the skew.

Routing is unchanged: the script reads the event payload and the files API, never the tree, and `request_team_reviews` is add-only. No test is added: a PR cannot exercise its own edit to a `pull_request_target` definition, and `ci/tests/` is removed by #115650.


cc @Blargian @dhtclk

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116210&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116210](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116210+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
