### PR TITLE
Scope the memory limit in 04501/04500 to the query it asserts on

### DIFF
--- a/tests/queries/0_stateless/04500_group_by_limit_pushdown_no_order_by.sql
+++ b/tests/queries/0_stateless/04500_group_by_limit_pushdown_no_order_by.sql
@@ -305,9 +305,9 @@ WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND log_comm
 -- LowCardinality keys cannot prune the hash table, but the heap still runs in
 -- skip-only mode and the synthesized sort discards evicted stragglers; the
 -- query must stay within the memory limit and external aggregation must not
--- be force-disabled (~660MB working set without spilling).
-SET max_memory_usage = 300000000;
-SET max_bytes_before_external_group_by = 50000000;
+-- be force-disabled (~660MB working set without spilling).  The limits are
+-- per-query, not session `SET`s: the verification query below reads
+-- `system.query_log`, whose cost tracks the whole suite's log volume.
 
 SELECT 'LowCardinality key under a memory limit (skip-only heap + spill)';
 SELECT count() FROM
@@ -316,7 +316,7 @@ SELECT count() FROM
     FROM (SELECT toLowCardinality(toString(number % 3000000)) AS k FROM numbers(9000000))
     GROUP BY k
     LIMIT 5
-) SETTINGS log_comment = '04500_lowcard_spill';
+) SETTINGS log_comment = '04500_lowcard_spill', max_memory_usage = 300000000, max_bytes_before_external_group_by = 50000000;
 
 SYSTEM FLUSH LOGS query_log;
 

--- a/tests/queries/0_stateless/04501_group_by_limit_pushdown_heap_stress.sql
+++ b/tests/queries/0_stateless/04501_group_by_limit_pushdown_heap_stress.sql
@@ -347,9 +347,9 @@ WHERE current_database = currentDatabase()
 -- new key and evicts an older one, so without reuse the arena grows by one
 -- state per distinct key seen (20M here) even though the hash table stays
 -- bounded, defeating the optimization's memory contract for non-`count`
--- aggregates and failing the memory limit below.
-
-SET max_memory_usage = 100000000;
+-- aggregates and failing the memory limit below.  The limit is per-query, not a
+-- session `SET`: the verification query below reads `system.query_log`, whose
+-- cost tracks the whole suite's log volume rather than anything under test.
 
 SELECT 'arena slot reuse under eviction';
 SELECT k, sum(v) FROM
@@ -359,7 +359,7 @@ SELECT k, sum(v) FROM
 GROUP BY k
 ORDER BY k ASC
 LIMIT 10
-SETTINGS log_comment = '04501_state_arena_reuse';
+SETTINGS log_comment = '04501_state_arena_reuse', max_memory_usage = 100000000;
 
 SYSTEM FLUSH LOGS query_log;
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/96630
-->

Related: #96630

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04501_group_by_limit_pushdown_heap_stress` failed on an unrelated PR
([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116099&sha=00b55ddae2f972753ab8a05e83386c11b43be9f7&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29)):

```
Code: 241. Query memory limit exceeded: would use 95.61 MiB, maximum: 95.37 MiB:
(while reading column ProfileEvents.key_AggregationTopKKeysEvicted)
(while reading from part .../202608_1_261_7 in table system.query_log ...)
```

The statement that died is the test's own liveness oracle, not the code under test.

Root cause: `95.37 MiB` is the test's own `SET max_memory_usage = 100000000`
(`100000000 / 1048576 = 95.3674...`), session-scoped with no later reset. The limit is there
deliberately - it *is* the arena-slot-reuse assertion - but it also reached the next statement,
which reads the `ProfileEvents` map out of `system.query_log`. That table is
`ORDER BY (event_date, event_time)`, so the `log_comment` filter cannot prune granules and the
subcolumn is materialized over every concurrently-running test's rows, so the oracle's cost
tracks suite-wide log volume. CI's own diagnosis rerun: `Runs: 6, Failed: 0`.

The fix moves each limit into the `SETTINGS` clause of the query it asserts on. The assertion
is unchanged: same value, same query (verified by observing
`Settings['max_memory_usage'] = '100000000'` on it before and after). The oracle is kept - it is
an anti-vacuity guard, and deleting it would make the test guard nothing.

`04500_group_by_limit_pushdown_no_order_by` has the same defect from the same PR (its oracle
inherited `max_memory_usage = 300000000` and `max_bytes_before_external_group_by = 50000000`)
and is fixed here too. Five stateless tests have a session memory limit followed by a
`query_log` read; taking 04501's cap as 1.0x, the other three sit at 4.3x, 10.7x and 107x with
no matching Code 241 history over 90 days, so they are left alone.

Validation: forcing the condition (inflated `query_log`, limit lowered between the assertion's
1.24 MiB need and the oracle's 9.21 MiB) reproduces the reported error before the change and
passes after it; both tests are 50/50 green under randomized settings; `.reference` files are
unchanged.

<details>
<summary>Measured cost separation (why the limit leak matters)</summary>

Peak memory, same binary, `max_threads = 1`:

| query | peak |
|---|---|
| arena-reuse query (the assertion) | 1.24 MiB |
| oracle, 30-row `query_log` | 0.49 MiB |
| oracle, 655k-row `query_log` | 17.18 MiB |
| oracle, 5.24M-row `query_log` | 31.85 MiB |
| oracle, 5.64M rows, diverse `ProfileEvents` maps | 9.21 MiB |

The assertion's need is constant; the oracle's is not - it tracks the log, and the last row
shows map shape matters too, not just row count. Only the oracle was ever meant to run without
a limit.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116226&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116226](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116226+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
