### PR TITLE
Pin the suggestion limit in 01676_clickhouse_client_autocomplete

### DIFF
--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -131,9 +131,10 @@ client_compwords_positive = [
     "uniqCombined64ForEach",
     # system.keywords
     "CHANGEABLE_IN_READONLY",
-    # NOTE: The words below live in contexts the client truncates to
-    # suggestion_limit rows ordered by word, so tables held by concurrent tests can
-    # outrank them at the default bound. The argv passes an explicit larger limit.
+    # The words below come from contexts the client truncates to suggestion_limit rows
+    # ordered by word, so concurrent tests' tables can outrank them at the default bound.
+    # The bound itself is not asserted here: crowding system.completions past it would
+    # perturb every other test on the lane.
     # system.databases
     # NOTE: Do not use "system" here because the prefix "sys" (3 chars) is too
     # short and matches many completions, causing timeouts under TSan.

--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -133,8 +133,6 @@ client_compwords_positive = [
     "CHANGEABLE_IN_READONLY",
     # The words below come from contexts the client truncates to suggestion_limit rows
     # ordered by word, so concurrent tests' tables can outrank them at the default bound.
-    # The bound itself is not asserted here: crowding system.completions past it would
-    # perturb every other test on the lane.
     # system.databases
     # NOTE: Do not use "system" here because the prefix "sys" (3 chars) is too
     # short and matches many completions, causing timeouts under TSan.
@@ -160,6 +158,17 @@ local_compwords_positive = [
     "SimpleAggregateFunction",
 ]
 
+# With the window truncated to one row per context, a word that only exists as a column name
+# cannot be offered, while a word from an unlimited context still is.
+client_compwords_truncated_absent = [
+    # system.columns
+    "primary_key_bytes_in_memory_allocated",
+]
+client_compwords_truncated_present = [
+    # system.functions
+    "concatAssumeInjective",
+]
+
 
 if __name__ == "__main__":
     print("# clickhouse-client")
@@ -173,6 +182,21 @@ if __name__ == "__main__":
             test_completion, [args[0], args, comp_word], COMPLETION_TIMEOUT_SECONDS
         )
         for comp_word in client_compwords_positive
+    ]
+
+    print("# clickhouse-client, suggestion limit 1")
+    truncated_args = shlex.split(clickhouse_client)
+    truncated_args.append("--wait_for_suggestions_to_load")
+    truncated_args.append("--highlight=0")
+    truncated_args.append("--suggestion_limit=1")
+    [
+        run_with_timeout(
+            test_completion,
+            [truncated_args[0], truncated_args, comp_word],
+            COMPLETION_TIMEOUT_SECONDS,
+        )
+        for comp_word in client_compwords_truncated_absent
+        + client_compwords_truncated_present
     ]
 
     print("# clickhouse-local")

--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -131,7 +131,9 @@ client_compwords_positive = [
     "uniqCombined64ForEach",
     # system.keywords
     "CHANGEABLE_IN_READONLY",
-    # FIXME: one may add separate case for suggestion_limit
+    # NOTE: The words below live in contexts the client truncates to
+    # suggestion_limit rows ordered by word, so tables held by concurrent tests can
+    # outrank them at the default bound. The argv passes an explicit larger limit.
     # system.databases
     # NOTE: Do not use "system" here because the prefix "sys" (3 chars) is too
     # short and matches many completions, causing timeouts under TSan.
@@ -164,6 +166,7 @@ if __name__ == "__main__":
     args = shlex.split(clickhouse_client)
     args.append("--wait_for_suggestions_to_load")
     args.append("--highlight=0")
+    args.append("--suggestion_limit=1000000")
     [
         run_with_timeout(
             test_completion, [args[0], args, comp_word], COMPLETION_TIMEOUT_SECONDS

--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.python
@@ -185,10 +185,14 @@ if __name__ == "__main__":
     ]
 
     print("# clickhouse-client, suggestion limit 1")
-    truncated_args = shlex.split(clickhouse_client)
-    truncated_args.append("--wait_for_suggestions_to_load")
-    truncated_args.append("--highlight=0")
-    truncated_args.append("--suggestion_limit=1")
+    # Derived from the argv above by replacing the pinned bound, so removing that pin breaks this
+    # run rather than silently leaving it to pass at the default.
+    high_limit_arg = "--suggestion_limit=1000000"
+    if high_limit_arg not in args:
+        raise AssertionError(f"expected {high_limit_arg} in the client argv")
+    truncated_args = [
+        "--suggestion_limit=1" if arg == high_limit_arg else arg for arg in args
+    ]
     [
         run_with_timeout(
             test_completion,

--- a/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.reference
+++ b/tests/queries/0_stateless/01676_clickhouse_client_autocomplete.reference
@@ -14,6 +14,9 @@ CHANGEABLE_IN_READONLY: OK
 information_schema: OK
 aggregate_function_combinators: OK
 primary_key_bytes_in_memory_allocated: OK
+# clickhouse-client, suggestion limit 1
+primary_key_bytes_in_memory_allocated: FAIL
+concatAssumeInjective: OK
 # clickhouse-local
 concatAssumeInjective: OK
 ReplacingMergeTree: OK


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115921
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/115921

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115921&sha=edfa4c1e598cbec7029e892e23f0af556589871a&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

`01676_clickhouse_client_autocomplete` fails on parallel lanes with
`+primary_key_bytes_in_memory_allocated: FAIL`.

**Root cause.** The client fetches the `database`, `table`, `column` and
`dictionary` completion contexts through a per-context window cut at
`--suggestion_limit` (default 10000), ordered by word
(`src/Client/Suggest.cpp:120-131`). On a parallel lane the other workers hold
their own tables, so `system.completions` carries their column names too, the
`column` context exceeds the bound, and truncation being alphabetical the asserted
word falls outside it. Every failure is on a `parallel`/`targeted` lane, none on
sequential master.

**Change**, test-only. Pass a larger `--suggestion_limit` on the
`clickhouse-client` argv so the windowed contexts cannot be truncated by
concurrent tests. Coverage is unchanged: the test still asserts a real
`system.columns` word rather than one from an unlimited context, and
`clickhouse-local`'s argv is untouched (all its words are unlimited-context).
A second short client run at `--suggestion_limit=1` cuts the window to one row
per context, so a column-only word cannot be offered while an unlimited-context
word still is; hence the expected `primary_key_bytes_in_memory_allocated: FAIL`
reference line. Its argv is derived from the pinned one, so the pin cannot be
dropped silently. Neither run crowds the server-wide `system.completions`, which
would inject into its neighbours the crowding this test exists to survive.

**Validation.** On a server crowded to 13176 `column` words (target at rank
12849), one binary and only the test file varying, the unmodified test fails on
`primary_key_bytes_in_memory_allocated` while every other keyword passes, and
passes with the limit pinned; `system.query_log` shows `rn <= 10000` before and
`rn <= 1000000` after. Removing either bound reddens the test, while the positive
word stays `OK`. 50 of 50 randomized runs pass.

`no-parallel` was not added: it would hide the same crowd-out on every other
parallel lane. Disclosed, not fixed: a user with over 10000 columns is truncated
likewise.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116229&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116229](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116229+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
