### PR TITLE
Fix flaky test `04070_csv_tsv_skip_first_lines_eof`

### DIFF
--- a/tests/queries/0_stateless/04070_csv_tsv_skip_first_lines_eof.sh
+++ b/tests/queries/0_stateless/04070_csv_tsv_skip_first_lines_eof.sh
@@ -2,18 +2,24 @@
 
 # Verify that skip_first_lines doesn't cause an excessive loop when the file has fewer lines than requested.
 # The bug only reproduces with file-based reading (pread), not with inline format() which uses ReadBufferFromMemory.
-# On unfixed builds, the loop iterates skip_first_lines times even after EOF, making the query take unreasonably long.
+# On unfixed builds the loop iterates skip_first_lines times even after EOF, so the number of lines to skip
+# is chosen to be unreachable: a fixed server stops at the end of the file in constant time, while an unfixed
+# one would need centuries. That way the timeout below can be generous, and the test does not depend on how
+# fast the machine is - a tight timeout used to fail spuriously when the server was stalled for a few seconds
+# by an unrelated hiccup, such as contention inside the sanitizer's allocator in the msan build.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+SKIP=1000000000000000000
+
 # CSV
 $CLICKHOUSE_CLIENT -q "INSERT INTO FUNCTION file('${CLICKHOUSE_DATABASE}_04070.csv', 'CSV') SELECT number FROM numbers(2) SETTINGS engine_file_truncate_on_insert = 1"
-timeout 10 $CLICKHOUSE_CLIENT -q "SELECT * FROM file('${CLICKHOUSE_DATABASE}_04070.csv', 'CSV', 'x UInt64') SETTINGS input_format_csv_skip_first_lines = 1000000000"
+timeout 60 $CLICKHOUSE_CLIENT -q "SELECT * FROM file('${CLICKHOUSE_DATABASE}_04070.csv', 'CSV', 'x UInt64') SETTINGS input_format_csv_skip_first_lines = $SKIP"
 echo "CSV: $?"
 
 # TSV
 $CLICKHOUSE_CLIENT -q "INSERT INTO FUNCTION file('${CLICKHOUSE_DATABASE}_04070.tsv', 'TSV') SELECT number FROM numbers(2) SETTINGS engine_file_truncate_on_insert = 1"
-timeout 10 $CLICKHOUSE_CLIENT -q "SELECT * FROM file('${CLICKHOUSE_DATABASE}_04070.tsv', 'TSV', 'x UInt64') SETTINGS input_format_tsv_skip_first_lines = 1000000000"
+timeout 60 $CLICKHOUSE_CLIENT -q "SELECT * FROM file('${CLICKHOUSE_DATABASE}_04070.tsv', 'TSV', 'x UInt64') SETTINGS input_format_tsv_skip_first_lines = $SKIP"
 echo "TSV: $?"


### PR DESCRIPTION
The test `04070_csv_tsv_skip_first_lines_eof` guards against an excessive loop in `skipPrefixBeforeHeader` by putting `timeout 10` around a query that skips `1000000000` lines of a two-line file. Both sides of that bound turned out to be too close to each other:

- With the fix in place the query is instant, but the server can be stalled by something unrelated for seconds. In the reported failure the query took 8.8 s of wall time and only 0.17 s of CPU time, and all nine `Real` profiler samples show the `TCPHandler` thread blocked in `__sanitizer::SizeClassAllocator64::ReturnToAllocator` -> `__sanitizer::Semaphore::Wait` while destroying the pipeline executor - contention inside the msan allocator, not in ClickHouse. That is 88% of the 10 s budget spent on nothing.

- Without the fix the loop is a plain userspace spin: `readImpl` returns early at EOF once the file size is known, so there is not even a syscall per iteration. At the measured ~40 ns per iteration, `1000000000` lines is only tens of seconds - the same order of magnitude as the timeout itself.

So the test could fail on a slow machine, and could also pass on a fast one with the bug present.

Skip `1000000000000000000` lines instead. A fixed server still stops at the end of the file in constant time, while an unfixed one would need centuries, so the timeout can be raised to 60 s and the verdict no longer depends on how fast the machine is.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116161
Related: https://github.com/ClickHouse/ClickHouse/pull/115639

CI report with the failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115639&sha=6d410fc0ff3ed27db04af7aabdf2dc8020438899&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29

### Changelog category (leave one):
- CI Fix or Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116230&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116230](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116230+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.72` (included in `26.9` and later)
<!-- ch-version-info:end -->