### PR TITLE
Fix a very slow BACKUP of Memory and KeeperMap tables

### DIFF
--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -90,7 +90,7 @@ namespace Setting
     extern const SettingsUInt64 keeper_max_retries;
     extern const SettingsUInt64 keeper_retry_initial_backoff_ms;
     extern const SettingsUInt64 keeper_retry_max_backoff_ms;
-    extern const SettingsUInt64 max_compress_block_size;
+    extern const SettingsNonZeroUInt64 temporary_files_buffer_size;
 }
 
 namespace FailPoints
@@ -1297,8 +1297,7 @@ void StorageKeeperMap::backupData(BackupEntriesCollector & backup_entries_collec
         }
 
         TemporaryDataOnDiskSettings tmp_data_settings;
-        auto max_compress_block_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::max_compress_block_size];
-        tmp_data_settings.buffer_size = max_compress_block_size ? max_compress_block_size : DBMS_DEFAULT_BUFFER_SIZE;
+        tmp_data_settings.buffer_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::temporary_files_buffer_size];
 
         auto tmp_data = std::make_shared<TemporaryDataOnDiskScope>(backup_entries_collector.getContext()->getTempDataOnDisk(), tmp_data_settings);
 

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -53,7 +53,7 @@ namespace DB
 {
 namespace Setting
 {
-    extern const SettingsUInt64 max_compress_block_size;
+    extern const SettingsNonZeroUInt64 temporary_files_buffer_size;
 }
 
 namespace MemorySetting
@@ -608,8 +608,7 @@ void StorageMemory::backupData(BackupEntriesCollector & backup_entries_collector
     }
 
     TemporaryDataOnDiskSettings tmp_data_settings;
-    auto max_compress_block_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::max_compress_block_size];
-    tmp_data_settings.buffer_size = max_compress_block_size ? max_compress_block_size : DBMS_DEFAULT_BUFFER_SIZE;
+    tmp_data_settings.buffer_size = backup_entries_collector.getContext()->getSettingsRef()[Setting::temporary_files_buffer_size];
     auto tmp_data = std::make_shared<TemporaryDataOnDiskScope>(backup_entries_collector.getContext()->getTempDataOnDisk(), tmp_data_settings);
     const auto & read_settings = backup_entries_collector.getReadSettings();
 

--- a/tests/queries/0_stateless/03760_backup_keepermap_memory.sql
+++ b/tests/queries/0_stateless/03760_backup_keepermap_memory.sql
@@ -1,3 +1,4 @@
+-- This setting does not reach the backup temporary file buffer, which is sized by a NonZeroUInt64 setting.
 SET max_compress_block_size = 0;
 
 CREATE TABLE 03760_backup_memory (c0 Int) ENGINE = Memory;

--- a/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.reference
+++ b/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.reference
@@ -1,0 +1,2 @@
+1
+1000000	Hello, world	Hello, world

--- a/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.reference
+++ b/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.reference
@@ -1,2 +1,3 @@
-1
+1	1
+1	0
 1000000	Hello, world	Hello, world

--- a/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.sh
+++ b/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.sh
@@ -17,11 +17,18 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #
 # The two arms differ only in WHICH setting is made tiny, so together they say which setting
 # reaches the buffer: only the temporary_files_buffer_size arm may expand.
+#
+# Expansion is a per-frame property, so the second arm shows it on a small table. It has its
+# own, because temporary_files_buffer_size does reach the buffer here and a large fixture there
+# would cost one write and one filesystem-cache reservation per 21 bytes.
 
 $CLICKHOUSE_CLIENT -m -q "
 DROP TABLE IF EXISTS test;
+DROP TABLE IF EXISTS test_small;
 CREATE TABLE test (x String) ENGINE = Memory SETTINGS compress = 1;
+CREATE TABLE test_small (x String) ENGINE = Memory SETTINGS compress = 1;
 INSERT INTO test SELECT 'Hello, world' FROM numbers(1000000);
+INSERT INTO test_small SELECT 'Hello, world' FROM numbers(10000);
 "
 
 function check_backup()
@@ -44,7 +51,7 @@ check_backup mcbs
 
 $CLICKHOUSE_CLIENT -m -q "
 SET temporary_files_buffer_size = 21;
-BACKUP TABLE test TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}_tfbs.zip');
+BACKUP TABLE test_small TO File('${CLICKHOUSE_TEST_UNIQUE_NAME}_tfbs.zip');
 " --format Null
 check_backup tfbs
 
@@ -56,4 +63,5 @@ RESTORE TABLE test FROM File('${CLICKHOUSE_TEST_UNIQUE_NAME}_mcbs.zip');
 $CLICKHOUSE_CLIENT -m -q "
 SELECT count(), min(x), max(x) FROM test;
 DROP TABLE test;
+DROP TABLE test_small;
 "

--- a/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.sh
+++ b/tests/queries/0_stateless/04801_backup_memory_table_temp_buffer_size.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, memory-engine
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The temporary file that BACKUP of a Memory table streams through is sized by
+# temporary_files_buffer_size. max_compress_block_size must not reach it: it is a column
+# compression setting, it has no lower bound, and a small value makes every compressed frame
+# its own write, so the compressed stream grows larger than the data it encodes.
+#
+# Oracle is the byte ratio, not wall clock: compression must never expand. The uncompressed
+# figure is fixed by the data, so the assertion is independent of machine speed, sanitizer,
+# disk backend and of temporary_files_buffer_size itself.
+
+backup_name="File('${CLICKHOUSE_TEST_UNIQUE_NAME}.zip')"
+
+$CLICKHOUSE_CLIENT -m -q "
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (x String) ENGINE = Memory SETTINGS compress = 1;
+INSERT INTO test SELECT 'Hello, world' FROM numbers(1000000);
+"
+
+$CLICKHOUSE_CLIENT -m -q "
+SET max_compress_block_size = 21;
+BACKUP TABLE test TO $backup_name;
+" --format Null
+
+$CLICKHOUSE_CLIENT -m -q "
+SELECT ProfileEvents['ExternalProcessingCompressedBytesTotal']
+           <= ProfileEvents['ExternalProcessingUncompressedBytesTotal'] AS compression_did_not_expand
+FROM system.backups WHERE name LIKE '%${CLICKHOUSE_TEST_UNIQUE_NAME}%' AND status = 'BACKUP_CREATED';
+"
+
+$CLICKHOUSE_CLIENT -m -q "
+TRUNCATE TABLE test;
+RESTORE TABLE test FROM $backup_name;
+" --format Null
+
+$CLICKHOUSE_CLIENT -m -q "
+SELECT count(), min(x), max(x) FROM test;
+DROP TABLE test;
+"

--- a/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.reference
+++ b/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.reference
@@ -1,3 +1,3 @@
 1	1
 1	0
-50000	Hello, world	Hello, world
+2000	Hello, world	Hello, world

--- a/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.reference
+++ b/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.reference
@@ -1,3 +1,3 @@
 1	1
 1	0
-2000	Hello, world	Hello, world
+200	Hello, world	Hello, world

--- a/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.reference
+++ b/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.reference
@@ -1,0 +1,3 @@
+1	1
+1	0
+50000	Hello, world	Hello, world

--- a/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
+++ b/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
@@ -10,14 +10,15 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # is separate from the Memory one - a post-collecting task writing binary strings from Keeper
 # instead of a native block stream - so it needs its own arm.
 #
-# Expansion is a per-frame property, so a small table shows it. Row count also sets the number
-# of single-key Keeper writes, which dominate this test's runtime.
+# Expansion is a per-frame property, so a small table shows it. Every phase here costs one
+# Keeper round trip per row - insert, backup, restore, drop - so the row count alone sets the
+# runtime, and the ratio the oracle reads is the same at any of them.
 
 $CLICKHOUSE_CLIENT -m -q "
 DROP TABLE IF EXISTS test SYNC;
 CREATE TABLE test (key UInt64, value String)
 ENGINE = KeeperMap('/' || currentDatabase() || '/test04802') PRIMARY KEY(key);
-INSERT INTO test SELECT number, 'Hello, world' FROM numbers(2000);
+INSERT INTO test SELECT number, 'Hello, world' FROM numbers(200);
 "
 
 function check_backup()

--- a/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
+++ b/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
@@ -10,9 +10,9 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # is separate from the Memory one - a post-collecting task writing binary strings from Keeper
 # instead of a native block stream - so it needs its own arm.
 #
-# Expansion is a per-frame property, so a small table shows it. Every phase here costs one
-# Keeper round trip per row - insert, backup, restore, drop - so the row count alone sets the
-# runtime, and the ratio the oracle reads is the same at any of them.
+# Expansion is a per-frame property, so a small table shows it. Row count is what this test
+# costs: it is one Keeper node per row, and dropping the table walks all of them, so keep it
+# only as large as the ratio needs, which is any size at all.
 
 $CLICKHOUSE_CLIENT -m -q "
 DROP TABLE IF EXISTS test SYNC;

--- a/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
+++ b/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
@@ -9,12 +9,15 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # through is sized by temporary_files_buffer_size, never by max_compress_block_size. That path
 # is separate from the Memory one - a post-collecting task writing binary strings from Keeper
 # instead of a native block stream - so it needs its own arm.
+#
+# Expansion is a per-frame property, so a small table shows it. Row count also sets the number
+# of single-key Keeper writes, which dominate this test's runtime.
 
 $CLICKHOUSE_CLIENT -m -q "
 DROP TABLE IF EXISTS test SYNC;
 CREATE TABLE test (key UInt64, value String)
 ENGINE = KeeperMap('/' || currentDatabase() || '/test04802') PRIMARY KEY(key);
-INSERT INTO test SELECT number, 'Hello, world' FROM numbers(50000);
+INSERT INTO test SELECT number, 'Hello, world' FROM numbers(2000);
 "
 
 function check_backup()

--- a/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
+++ b/tests/queries/0_stateless/04802_backup_keepermap_temp_buffer_size.sh
@@ -1,27 +1,20 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, memory-engine
+# Tags: no-ordinary-database, no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# The temporary file that BACKUP of a Memory table streams through is sized by
-# temporary_files_buffer_size, never by max_compress_block_size: the latter is a column
-# compression setting, it has no lower bound, and a small value makes every compressed frame
-# its own write, so the compressed stream grows larger than the data it encodes.
-#
-# Oracle is the byte ratio, not wall clock: compression must never expand. The uncompressed
-# figure is fixed by the data, so the assertion is independent of machine speed, sanitizer
-# and disk backend. The accounted column fails if the byte accounting itself goes away, so
-# the ratio cannot be satisfied by two absent counters.
-#
-# The two arms differ only in WHICH setting is made tiny, so together they say which setting
-# reaches the buffer: only the temporary_files_buffer_size arm may expand.
+# Same property as 04801, for the KeeperMap backup path: the temporary file it streams rows
+# through is sized by temporary_files_buffer_size, never by max_compress_block_size. That path
+# is separate from the Memory one - a post-collecting task writing binary strings from Keeper
+# instead of a native block stream - so it needs its own arm.
 
 $CLICKHOUSE_CLIENT -m -q "
-DROP TABLE IF EXISTS test;
-CREATE TABLE test (x String) ENGINE = Memory SETTINGS compress = 1;
-INSERT INTO test SELECT 'Hello, world' FROM numbers(1000000);
+DROP TABLE IF EXISTS test SYNC;
+CREATE TABLE test (key UInt64, value String)
+ENGINE = KeeperMap('/' || currentDatabase() || '/test04802') PRIMARY KEY(key);
+INSERT INTO test SELECT number, 'Hello, world' FROM numbers(50000);
 "
 
 function check_backup()
@@ -54,6 +47,6 @@ RESTORE TABLE test FROM File('${CLICKHOUSE_TEST_UNIQUE_NAME}_mcbs.zip');
 " --format Null
 
 $CLICKHOUSE_CLIENT -m -q "
-SELECT count(), min(x), max(x) FROM test;
-DROP TABLE test;
+SELECT count(), min(value), max(value) FROM test;
+DROP TABLE test SYNC;
 "


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/99280
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/99280

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `BACKUP` of a `Memory` or `KeeperMap` table becoming extremely slow when `max_compress_block_size` is set to a small value. The temporary file the backup streams through is now sized by `temporary_files_buffer_size`.

### Description

`BACKUP` of a `Memory` or `KeeperMap` table streams the table through a temporary file. Both call sites sized that file's buffer from `max_compress_block_size`, a column compression setting with no lower bound. `TemporaryDataOnDiskSettings::buffer_size` sizes both the `CompressedWriteBuffer` block and the file write buffer, so a small value makes every compressed frame its own `write()` and its own filesystem cache reservation, and the compressed stream ends up larger than the data it encodes.

Out of scope: entry generation polls no cancellation point, which is why the query outlived `max_execution_time`.

Found by `Stress test (arm_asan_ubsan, s3)` on #99280: https://github.com/ClickHouse/ClickHouse/actions/runs/32538093915/job/96964404475. `tests/clickhouse-test` randomizes `max_compress_block_size` over `1..3Mi`; that run drew 21, and the hung processlist shows a 26 MB stream taking 1240396 writes plus 243 s of `FilesystemCacheReserveMicroseconds`, still running at 562 s with `max_execution_time = 60`. It reads as a deadlock because all five entries share one `IBackupEntriesLazyBatch`, whose mutex is held for the whole serialization, so the peers pile up behind it.

The coupling came from refactoring. Before `01f1174080b2bf0` the setting sized only the `CompressedWriteBuffer`; that commit moved it into `buffer_size`, which also sizes the file. `bb15c0a4d4b96a5` later guarded zero, but not small values.

Both call sites now read `temporary_files_buffer_size`, which is what the field is for and what every other writer of it uses. Its default equals the old one, so defaults are unchanged, and it is `NonZeroUInt64`, so the zero guard is redundant.

Measured on a debug build with `max_compress_block_size = 21`: compressed bytes drop from 29715827 to 52078 against 13000672 uncompressed. There is one test per engine asserting that ratio rather than a wall clock, so both are independent of machine speed, sanitizer and disk backend. Each also varies `temporary_files_buffer_size` instead, pinning down which setting reaches the buffer. Both fail without the change, and 50 randomized runs of each are green.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116233&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116233](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116233+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.144` (included in `26.9` and later)
<!-- ch-version-info:end -->