### PR TITLE
Treat a NULL array element as NULL in hasAll, hasAny and hasSubstr

### DIFF
--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -649,38 +649,23 @@ bool sliceHas(const NumericArraySlice<T> & /*first*/, const GenericArraySlice & 
 }
 
 template <ArraySearchType search_type, typename FirstArraySlice, typename SecondArraySlice>
-bool sliceHas(const FirstArraySlice & first, NullableSlice<SecondArraySlice> & second)
+bool sliceHas(const FirstArraySlice & first, const NullableSlice<SecondArraySlice> & second)
 {
-    auto impl = sliceHasImpl<
-        search_type,
-        FirstArraySlice,
-        SecondArraySlice,
-        sliceEqualElements<FirstArraySlice, SecondArraySlice>,
-        insliceEqualElements<SecondArraySlice>>;
+    auto impl = sliceHasImpl<search_type, FirstArraySlice, SecondArraySlice, sliceEqualElements, insliceEqualElements>;
     return impl(first, second, nullptr, second.null_map);
 }
 
 template <ArraySearchType search_type, typename FirstArraySlice, typename SecondArraySlice>
-bool sliceHas(const NullableSlice<FirstArraySlice> & first, SecondArraySlice & second)
+bool sliceHas(const NullableSlice<FirstArraySlice> & first, const SecondArraySlice & second)
 {
-    auto impl = sliceHasImpl<
-        search_type,
-        FirstArraySlice,
-        SecondArraySlice,
-        sliceEqualElements<FirstArraySlice, SecondArraySlice>,
-        insliceEqualElements<SecondArraySlice>>;
+    auto impl = sliceHasImpl<search_type, FirstArraySlice, SecondArraySlice, sliceEqualElements, insliceEqualElements>;
     return impl(first, second, first.null_map, nullptr);
 }
 
 template <ArraySearchType search_type, typename FirstArraySlice, typename SecondArraySlice>
-bool sliceHas(const NullableSlice<FirstArraySlice> & first, NullableSlice<SecondArraySlice> & second)
+bool sliceHas(const NullableSlice<FirstArraySlice> & first, const NullableSlice<SecondArraySlice> & second)
 {
-    auto impl = sliceHasImpl<
-        search_type,
-        FirstArraySlice,
-        SecondArraySlice,
-        sliceEqualElements<FirstArraySlice, SecondArraySlice>,
-        insliceEqualElements<SecondArraySlice>>;
+    auto impl = sliceHasImpl<search_type, FirstArraySlice, SecondArraySlice, sliceEqualElements, insliceEqualElements>;
     return impl(first, second, first.null_map, second.null_map);
 }
 

--- a/tests/queries/0_stateless/05042_array_membership_null_map.reference
+++ b/tests/queries/0_stateless/05042_array_membership_null_map.reference
@@ -2,12 +2,21 @@
 0	0	0	0	0	0
 -- false negative: NULL needle over a non-zero hidden value --
 1	1	1	1	1	1
--- two arrays that print identically must still answer differently --
+-- two arrays a user cannot tell apart must answer identically --
 1	0	0	0	0
 -- all eight integer widths --
 0	0	0	0	0	0	0	0
--- an array long enough to use the vectorised loop, not only the remainder --
+-- a long haystack with a one-element needle, which is the remainder path --
 40	0	0	0	1
+-- needles long enough to enter the vectorised loop, on every width --
+Int8	0	0	0	1	1	1
+Int16	0	0	0	1	1	1
+Int32	0	0	0	1	1	1
+Int64	0	0	0	1	1	1
+UInt8	0	0	0	1	1	1
+UInt16	0	0	0	1	1	1
+UInt32	0	0	0	1	1	1
+UInt64	0	0	0	1	1	1
 -- String and Tuple elements --
 0	0	0	0	0	1
 0	0	0	1

--- a/tests/queries/0_stateless/05042_array_membership_null_map.reference
+++ b/tests/queries/0_stateless/05042_array_membership_null_map.reference
@@ -1,0 +1,26 @@
+-- false positive: needle equals the value hidden under the NULL --
+0	0	0	0	0	0
+-- false negative: NULL needle over a non-zero hidden value --
+1	1	1	1	1	1
+-- two arrays that print identically must still answer differently --
+1	0	0	0	0
+-- all eight integer widths --
+0	0	0	0	0	0	0	0
+-- an array long enough to use the vectorised loop, not only the remainder --
+40	0	0	0	1
+-- String and Tuple elements --
+0	0	0	0	0	1
+0	0	0	1
+-- constant, materialized haystack, and materialized needle --
+0	0	0
+-- every startsWith and endsWith name --
+0	0	0	0	0	0	0	0
+-- on a real column rather than a literal --
+1	0	0	0	1
+2	1	1	1	0
+-- controls: no NULL present, non-nullable haystack, needle absent --
+1	1	0	0
+-- controls: NULL matches NULL, and a NULL needle over a haystack without NULL --
+1	1	1	0	0
+-- controls: prefix and suffix still work --
+1	0	1	0

--- a/tests/queries/0_stateless/05042_array_membership_null_map.sql
+++ b/tests/queries/0_stateless/05042_array_membership_null_map.sql
@@ -41,56 +41,59 @@ SELECT '-- needles long enough to enter the vectorised loop, on every width --';
 -- The haystack is 1..24, every value genuinely present, plus one NULL hiding 100. So a
 -- needle containing 100 can only fail because the NULL is respected, and the arms whose
 -- needles hold none of it must keep matching.
-WITH arrayMap(x -> nullIf(x, toInt8(100)), arrayMap(i -> toInt8(if(i = 24, 100, i + 1)), range(25))) AS h
+-- The payload arms put that NULL at index 0, inside the first vector iteration, so they
+-- exercise the haystack null map's masking rather than the scalar tail that follows it,
+-- while needle_null_16 puts a NULL in the needle and exercises the needle-side mask.
+WITH arrayMap(x -> nullIf(x, toInt8(100)), arrayMap(i -> toInt8(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'Int8' AS width, has(h, toInt8(100)) AS has,
        hasAll(h, arrayMap(i -> toInt8(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toInt8(if(i = 0, 100, i)), range(22))) AS payload_22,
        hasAll(h, arrayMap(i -> toInt8(i + 1), range(16))) AS present_16,
        hasAll(h, arrayMap(i -> toInt8(i + 1), range(22))) AS present_22,
        hasAll(h, arrayMap(x -> nullIf(x, toInt8(99)), arrayConcat([toInt8(99)], arrayMap(i -> toInt8(i + 1), range(15))))) AS needle_null_16;
-WITH arrayMap(x -> nullIf(x, toInt16(100)), arrayMap(i -> toInt16(if(i = 24, 100, i + 1)), range(25))) AS h
+WITH arrayMap(x -> nullIf(x, toInt16(100)), arrayMap(i -> toInt16(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'Int16' AS width, has(h, toInt16(100)) AS has,
        hasAll(h, arrayMap(i -> toInt16(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toInt16(if(i = 0, 100, i)), range(22))) AS payload_22,
        hasAll(h, arrayMap(i -> toInt16(i + 1), range(16))) AS present_16,
        hasAll(h, arrayMap(i -> toInt16(i + 1), range(22))) AS present_22,
        hasAll(h, arrayMap(x -> nullIf(x, toInt16(99)), arrayConcat([toInt16(99)], arrayMap(i -> toInt16(i + 1), range(15))))) AS needle_null_16;
-WITH arrayMap(x -> nullIf(x, toInt32(100)), arrayMap(i -> toInt32(if(i = 24, 100, i + 1)), range(25))) AS h
+WITH arrayMap(x -> nullIf(x, toInt32(100)), arrayMap(i -> toInt32(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'Int32' AS width, has(h, toInt32(100)) AS has,
        hasAll(h, arrayMap(i -> toInt32(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toInt32(if(i = 0, 100, i)), range(22))) AS payload_22,
        hasAll(h, arrayMap(i -> toInt32(i + 1), range(16))) AS present_16,
        hasAll(h, arrayMap(i -> toInt32(i + 1), range(22))) AS present_22,
        hasAll(h, arrayMap(x -> nullIf(x, toInt32(99)), arrayConcat([toInt32(99)], arrayMap(i -> toInt32(i + 1), range(15))))) AS needle_null_16;
-WITH arrayMap(x -> nullIf(x, toInt64(100)), arrayMap(i -> toInt64(if(i = 24, 100, i + 1)), range(25))) AS h
+WITH arrayMap(x -> nullIf(x, toInt64(100)), arrayMap(i -> toInt64(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'Int64' AS width, has(h, toInt64(100)) AS has,
        hasAll(h, arrayMap(i -> toInt64(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toInt64(if(i = 0, 100, i)), range(22))) AS payload_22,
        hasAll(h, arrayMap(i -> toInt64(i + 1), range(16))) AS present_16,
        hasAll(h, arrayMap(i -> toInt64(i + 1), range(22))) AS present_22,
        hasAll(h, arrayMap(x -> nullIf(x, toInt64(99)), arrayConcat([toInt64(99)], arrayMap(i -> toInt64(i + 1), range(15))))) AS needle_null_16;
-WITH arrayMap(x -> nullIf(x, toUInt8(100)), arrayMap(i -> toUInt8(if(i = 24, 100, i + 1)), range(25))) AS h
+WITH arrayMap(x -> nullIf(x, toUInt8(100)), arrayMap(i -> toUInt8(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'UInt8' AS width, has(h, toUInt8(100)) AS has,
        hasAll(h, arrayMap(i -> toUInt8(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toUInt8(if(i = 0, 100, i)), range(22))) AS payload_22,
        hasAll(h, arrayMap(i -> toUInt8(i + 1), range(16))) AS present_16,
        hasAll(h, arrayMap(i -> toUInt8(i + 1), range(22))) AS present_22,
        hasAll(h, arrayMap(x -> nullIf(x, toUInt8(99)), arrayConcat([toUInt8(99)], arrayMap(i -> toUInt8(i + 1), range(15))))) AS needle_null_16;
-WITH arrayMap(x -> nullIf(x, toUInt16(100)), arrayMap(i -> toUInt16(if(i = 24, 100, i + 1)), range(25))) AS h
+WITH arrayMap(x -> nullIf(x, toUInt16(100)), arrayMap(i -> toUInt16(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'UInt16' AS width, has(h, toUInt16(100)) AS has,
        hasAll(h, arrayMap(i -> toUInt16(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toUInt16(if(i = 0, 100, i)), range(22))) AS payload_22,
        hasAll(h, arrayMap(i -> toUInt16(i + 1), range(16))) AS present_16,
        hasAll(h, arrayMap(i -> toUInt16(i + 1), range(22))) AS present_22,
        hasAll(h, arrayMap(x -> nullIf(x, toUInt16(99)), arrayConcat([toUInt16(99)], arrayMap(i -> toUInt16(i + 1), range(15))))) AS needle_null_16;
-WITH arrayMap(x -> nullIf(x, toUInt32(100)), arrayMap(i -> toUInt32(if(i = 24, 100, i + 1)), range(25))) AS h
+WITH arrayMap(x -> nullIf(x, toUInt32(100)), arrayMap(i -> toUInt32(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'UInt32' AS width, has(h, toUInt32(100)) AS has,
        hasAll(h, arrayMap(i -> toUInt32(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toUInt32(if(i = 0, 100, i)), range(22))) AS payload_22,
        hasAll(h, arrayMap(i -> toUInt32(i + 1), range(16))) AS present_16,
        hasAll(h, arrayMap(i -> toUInt32(i + 1), range(22))) AS present_22,
        hasAll(h, arrayMap(x -> nullIf(x, toUInt32(99)), arrayConcat([toUInt32(99)], arrayMap(i -> toUInt32(i + 1), range(15))))) AS needle_null_16;
-WITH arrayMap(x -> nullIf(x, toUInt64(100)), arrayMap(i -> toUInt64(if(i = 24, 100, i + 1)), range(25))) AS h
+WITH arrayMap(x -> nullIf(x, toUInt64(100)), arrayMap(i -> toUInt64(if(i = 0, 100, i)), range(25))) AS h
 SELECT 'UInt64' AS width, has(h, toUInt64(100)) AS has,
        hasAll(h, arrayMap(i -> toUInt64(if(i = 0, 100, i)), range(16))) AS payload_16,
        hasAll(h, arrayMap(i -> toUInt64(if(i = 0, 100, i)), range(22))) AS payload_22,

--- a/tests/queries/0_stateless/05042_array_membership_null_map.sql
+++ b/tests/queries/0_stateless/05042_array_membership_null_map.sql
@@ -1,0 +1,71 @@
+-- A NULL array element must be treated as NULL by hasAll, hasAny, hasSubstr, startsWith and
+-- endsWith, never as the value physically stored beneath it. Every arm prints the answer of
+-- has() next to it, because has() is already correct and makes the expected answer self-evident.
+
+SELECT '-- false positive: needle equals the value hidden under the NULL --';
+-- h is [NULL] with 42 stored underneath. Nothing here contains 42.
+WITH arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]) AS h
+SELECT has(h, 42) AS has, hasAll(h, [42]), hasAny(h, [42]), hasSubstr(h, [42]),
+       startsWith(h, [42]), endsWith(h, [42]);
+
+SELECT '-- false negative: NULL needle over a non-zero hidden value --';
+WITH arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]) AS h
+SELECT has(h, NULL) AS has, hasAll(h, [NULL]), hasAny(h, [NULL]), hasSubstr(h, [NULL]),
+       startsWith(h, [NULL]), endsWith(h, [NULL]);
+
+SELECT '-- two arrays that print identically must still answer differently --';
+WITH arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42), 5]) AS a,
+     arrayMap(x -> nullIf(x, toInt32(99)), [toInt32(99), 5]) AS b
+SELECT toString(a) = toString(b) AS printed_alike, hasAll(a, [42]), hasAll(b, [42]),
+       hasAll(a, [99]), hasAll(b, [99]);
+
+SELECT '-- all eight integer widths --';
+SELECT hasAll(arrayMap(x -> nullIf(x, toInt8(42)), [toInt8(42)]), [toInt8(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toInt16(42)), [toInt16(42)]), [toInt16(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]), [toInt32(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toInt64(42)), [toInt64(42)]), [toInt64(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toUInt8(42)), [toUInt8(42)]), [toUInt8(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toUInt16(42)), [toUInt16(42)]), [toUInt16(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toUInt32(42)), [toUInt32(42)]), [toUInt32(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toUInt64(42)), [toUInt64(42)]), [toUInt64(42)]);
+
+SELECT '-- an array long enough to use the vectorised loop, not only the remainder --';
+WITH arrayMap(x -> nullIf(x, toInt32(42)), arrayMap(i -> if(i = 20, toInt32(42), toInt32(i)), range(40))) AS h
+SELECT length(h), has(h, 42) AS has, hasAll(h, [42]), hasAny(h, [42]), hasAll(h, [NULL]);
+
+SELECT '-- String and Tuple elements --';
+WITH arrayMap(x -> nullIf(x, 'zz'), ['zz']) AS h
+SELECT has(h, 'zz') AS has, hasAll(h, ['zz']), hasAny(h, ['zz']), hasSubstr(h, ['zz']),
+       startsWith(h, ['zz']), hasAll(h, [NULL]);
+WITH arrayMap(x -> nullIf(x, (toInt32(1), 'a')), [(toInt32(1), 'a')]) AS h
+SELECT has(h, (1, 'a')) AS has, hasAll(h, [(1, 'a')]), hasAny(h, [(1, 'a')]), hasAll(h, [NULL]);
+
+SELECT '-- constant, materialized haystack, and materialized needle --';
+SELECT hasAll(arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]), [toInt32(42)]),
+       hasAll(materialize(arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)])), [toInt32(42)]),
+       hasAll(arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]), materialize([toInt32(42)]));
+
+SELECT '-- every startsWith and endsWith name --';
+WITH arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]) AS h
+SELECT startsWith(h, [42]), startsWithCaseInsensitive(h, [42]), startsWithUTF8(h, [42]),
+       startsWithCaseInsensitiveUTF8(h, [42]), endsWith(h, [42]), endsWithCaseInsensitive(h, [42]),
+       endsWithUTF8(h, [42]), endsWithCaseInsensitiveUTF8(h, [42]);
+
+SELECT '-- on a real column rather than a literal --';
+DROP TABLE IF EXISTS t_null_map;
+CREATE TABLE t_null_map (id UInt32, v Array(Nullable(Int32))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_null_map SELECT 1, arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42), 5]);
+INSERT INTO t_null_map SELECT 2, [toInt32(42), 5];
+SELECT id, has(v, 42) AS has, hasAll(v, [42]), hasAny(v, [42]), hasAll(v, [NULL])
+FROM t_null_map ORDER BY id;
+DROP TABLE t_null_map;
+
+SELECT '-- controls: no NULL present, non-nullable haystack, needle absent --';
+SELECT hasAll([1, 2, 3], [2]), hasAll(materialize([1, 2, 3]), [2]), hasAll([1, 2, 3], [0]),
+       hasAll(arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]), [777]);
+SELECT '-- controls: NULL matches NULL, and a NULL needle over a haystack without NULL --';
+SELECT hasAll([1, NULL], [NULL]), hasSubstr([1, NULL], [NULL]), startsWith([NULL, 2], [NULL]),
+       hasAll(materialize([1, 2, 3]), [NULL]), hasAny(materialize([1, 2, 3]), [NULL]);
+SELECT '-- controls: prefix and suffix still work --';
+SELECT startsWith([1, 2, 3], [1, 2]), startsWith([1, 2, 3], [2, 3]),
+       endsWith([1, 2, 3], [2, 3]), endsWith([1, 2, 3], [1, 2]);

--- a/tests/queries/0_stateless/05042_array_membership_null_map.sql
+++ b/tests/queries/0_stateless/05042_array_membership_null_map.sql
@@ -13,7 +13,7 @@ WITH arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42)]) AS h
 SELECT has(h, NULL) AS has, hasAll(h, [NULL]), hasAny(h, [NULL]), hasSubstr(h, [NULL]),
        startsWith(h, [NULL]), endsWith(h, [NULL]);
 
-SELECT '-- two arrays that print identically must still answer differently --';
+SELECT '-- two arrays a user cannot tell apart must answer identically --';
 WITH arrayMap(x -> nullIf(x, toInt32(42)), [toInt32(42), 5]) AS a,
      arrayMap(x -> nullIf(x, toInt32(99)), [toInt32(99), 5]) AS b
 SELECT toString(a) = toString(b) AS printed_alike, hasAll(a, [42]), hasAll(b, [42]),
@@ -29,9 +29,74 @@ SELECT hasAll(arrayMap(x -> nullIf(x, toInt8(42)), [toInt8(42)]), [toInt8(42)]),
        hasAll(arrayMap(x -> nullIf(x, toUInt32(42)), [toUInt32(42)]), [toUInt32(42)]),
        hasAll(arrayMap(x -> nullIf(x, toUInt64(42)), [toUInt64(42)]), [toUInt64(42)]);
 
-SELECT '-- an array long enough to use the vectorised loop, not only the remainder --';
+SELECT '-- a long haystack with a one-element needle, which is the remainder path --';
 WITH arrayMap(x -> nullIf(x, toInt32(42)), arrayMap(i -> if(i = 20, toInt32(42), toInt32(i)), range(40))) AS h
 SELECT length(h), has(h, 42) AS has, hasAll(h, [42]), hasAny(h, [42]), hasAll(h, [NULL]);
+
+SELECT '-- needles long enough to enter the vectorised loop, on every width --';
+-- hasAll admits its vector loop only when BOTH sizes exceed a per-width threshold (3 for
+-- 64-bit, 7 for 32-bit, 15 for 16- and 8-bit), and it is the NEEDLE size that is compared
+-- against it. A 16-element needle clears all four, and 22 also leaves a remainder on all
+-- four, so the vector loop and the hand-off to the remainder loop are both covered.
+-- The haystack is 1..24, every value genuinely present, plus one NULL hiding 100. So a
+-- needle containing 100 can only fail because the NULL is respected, and the arms whose
+-- needles hold none of it must keep matching.
+WITH arrayMap(x -> nullIf(x, toInt8(100)), arrayMap(i -> toInt8(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'Int8' AS width, has(h, toInt8(100)) AS has,
+       hasAll(h, arrayMap(i -> toInt8(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toInt8(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toInt8(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toInt8(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toInt8(99)), arrayConcat([toInt8(99)], arrayMap(i -> toInt8(i + 1), range(15))))) AS needle_null_16;
+WITH arrayMap(x -> nullIf(x, toInt16(100)), arrayMap(i -> toInt16(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'Int16' AS width, has(h, toInt16(100)) AS has,
+       hasAll(h, arrayMap(i -> toInt16(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toInt16(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toInt16(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toInt16(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toInt16(99)), arrayConcat([toInt16(99)], arrayMap(i -> toInt16(i + 1), range(15))))) AS needle_null_16;
+WITH arrayMap(x -> nullIf(x, toInt32(100)), arrayMap(i -> toInt32(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'Int32' AS width, has(h, toInt32(100)) AS has,
+       hasAll(h, arrayMap(i -> toInt32(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toInt32(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toInt32(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toInt32(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toInt32(99)), arrayConcat([toInt32(99)], arrayMap(i -> toInt32(i + 1), range(15))))) AS needle_null_16;
+WITH arrayMap(x -> nullIf(x, toInt64(100)), arrayMap(i -> toInt64(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'Int64' AS width, has(h, toInt64(100)) AS has,
+       hasAll(h, arrayMap(i -> toInt64(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toInt64(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toInt64(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toInt64(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toInt64(99)), arrayConcat([toInt64(99)], arrayMap(i -> toInt64(i + 1), range(15))))) AS needle_null_16;
+WITH arrayMap(x -> nullIf(x, toUInt8(100)), arrayMap(i -> toUInt8(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'UInt8' AS width, has(h, toUInt8(100)) AS has,
+       hasAll(h, arrayMap(i -> toUInt8(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toUInt8(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toUInt8(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toUInt8(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toUInt8(99)), arrayConcat([toUInt8(99)], arrayMap(i -> toUInt8(i + 1), range(15))))) AS needle_null_16;
+WITH arrayMap(x -> nullIf(x, toUInt16(100)), arrayMap(i -> toUInt16(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'UInt16' AS width, has(h, toUInt16(100)) AS has,
+       hasAll(h, arrayMap(i -> toUInt16(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toUInt16(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toUInt16(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toUInt16(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toUInt16(99)), arrayConcat([toUInt16(99)], arrayMap(i -> toUInt16(i + 1), range(15))))) AS needle_null_16;
+WITH arrayMap(x -> nullIf(x, toUInt32(100)), arrayMap(i -> toUInt32(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'UInt32' AS width, has(h, toUInt32(100)) AS has,
+       hasAll(h, arrayMap(i -> toUInt32(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toUInt32(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toUInt32(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toUInt32(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toUInt32(99)), arrayConcat([toUInt32(99)], arrayMap(i -> toUInt32(i + 1), range(15))))) AS needle_null_16;
+WITH arrayMap(x -> nullIf(x, toUInt64(100)), arrayMap(i -> toUInt64(if(i = 24, 100, i + 1)), range(25))) AS h
+SELECT 'UInt64' AS width, has(h, toUInt64(100)) AS has,
+       hasAll(h, arrayMap(i -> toUInt64(if(i = 0, 100, i)), range(16))) AS payload_16,
+       hasAll(h, arrayMap(i -> toUInt64(if(i = 0, 100, i)), range(22))) AS payload_22,
+       hasAll(h, arrayMap(i -> toUInt64(i + 1), range(16))) AS present_16,
+       hasAll(h, arrayMap(i -> toUInt64(i + 1), range(22))) AS present_22,
+       hasAll(h, arrayMap(x -> nullIf(x, toUInt64(99)), arrayConcat([toUInt64(99)], arrayMap(i -> toUInt64(i + 1), range(15))))) AS needle_null_16;
 
 SELECT '-- String and Tuple elements --';
 WITH arrayMap(x -> nullIf(x, 'zz'), ['zz']) AS h

--- a/tests/queries/0_stateless/05043_array_membership_null_map_text_index.reference
+++ b/tests/queries/0_stateless/05043_array_membership_null_map_text_index.reference
@@ -1,0 +1,20 @@
+-- has(), which is the expected answer for every arm below --
+1	0
+2	1
+-- hasAll and hasAny without the index --
+1	0	0
+2	1	1
+-- matching ids, index off --
+2
+2
+-- matching ids, index on, reading through the index --
+2
+2
+-- matching ids, index on, pruning only --
+2
+2
+-- control: a needle that is genuinely present in both rows --
+1
+2
+1
+2

--- a/tests/queries/0_stateless/05043_array_membership_null_map_text_index.reference
+++ b/tests/queries/0_stateless/05043_array_membership_null_map_text_index.reference
@@ -11,12 +11,15 @@
 2
 2
 1
+1	1
 -- matching ids, index on, pruning only --
 2
 2
 1	0
+1	0	1
 -- plan-shape negative control, index off --
 0	0	0
+0	0	0	0
 -- control: a needle that is genuinely present in both rows --
 1
 2

--- a/tests/queries/0_stateless/05043_array_membership_null_map_text_index.reference
+++ b/tests/queries/0_stateless/05043_array_membership_null_map_text_index.reference
@@ -10,9 +10,13 @@
 -- matching ids, index on, reading through the index --
 2
 2
+1
 -- matching ids, index on, pruning only --
 2
 2
+1	0
+-- plan-shape negative control, index off --
+0	0	0
 -- control: a needle that is genuinely present in both rows --
 1
 2

--- a/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
+++ b/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
@@ -3,6 +3,10 @@
 -- ordinary array path on an array whose NULL element hides a value equal to the needle.
 
 SET enable_full_text_index = 1;
+-- The query condition cache is keyed on the bare condition hash as well as on one salted with
+-- the skip-index profile, so the index-off arms below would prime entries the indexed arms then
+-- reuse, letting an index that declines still report a pruned mark count.
+SET use_query_condition_cache = 0;
 
 DROP TABLE IF EXISTS t_null_map_text;
 

--- a/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
+++ b/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
@@ -41,6 +41,13 @@ SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_dir
 SELECT countIf(explain ILIKE '%__text_index%') > 0 AS reads_through_index
 FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz'])
       SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1);
+-- hasAny reaches the index through a different RPN element and evaluator than hasAll, so it
+-- needs its own plan proof. The mode token pins which element: the condition reads Any only
+-- for the one-query hasAny element, and All for the per-element fallback and for hasAll.
+SELECT countIf(explain ILIKE '%__text_index_idx_hasAny%') > 0 AS reads_through_index,
+       countIf(explain ILIKE '%mode: Any%') > 0 AS any_tokens_element
+FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz'])
+      SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1);
 
 SELECT '-- matching ids, index on, pruning only --';
 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz']) ORDER BY id
@@ -51,6 +58,11 @@ SELECT countIf(explain ILIKE '%Granules: 1/2%') > 0 AS prunes_a_granule,
        countIf(explain ILIKE '%__text_index%') > 0 AS reads_through_index
 FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz'])
       SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, query_plan_direct_read_from_text_index = 0);
+SELECT countIf(explain ILIKE '%Granules: 1/2%') > 0 AS prunes_a_granule,
+       countIf(explain ILIKE '%__text_index%') > 0 AS reads_through_index,
+       countIf(explain ILIKE '%mode: Any%') > 0 AS any_tokens_element
+FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz'])
+      SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, query_plan_direct_read_from_text_index = 0);
 
 -- Negative control for both probes above: with the index off neither token may appear, so a
 -- token that happens to match something unrelated in the plan text cannot read as a pass.
@@ -59,6 +71,12 @@ SELECT countIf(explain ILIKE '%Name: idx%') > 0 AS index_used,
        countIf(explain ILIKE '%__text_index%') > 0 AS reads_through_index,
        countIf(explain ILIKE '%Granules: 1/2%') > 0 AS prunes_a_granule
 FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz'])
+      SETTINGS use_skip_indexes = 0);
+SELECT countIf(explain ILIKE '%Name: idx%') > 0 AS index_used,
+       countIf(explain ILIKE '%__text_index_idx_hasAny%') > 0 AS reads_through_index,
+       countIf(explain ILIKE '%Granules: 1/2%') > 0 AS prunes_a_granule,
+       countIf(explain ILIKE '%mode: Any%') > 0 AS any_tokens_element
+FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz'])
       SETTINGS use_skip_indexes = 0);
 
 SELECT '-- control: a needle that is genuinely present in both rows --';

--- a/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
+++ b/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
@@ -1,0 +1,49 @@
+-- Tags: no-parallel-replicas
+-- A text index answers hasAll and hasAny with its own evaluator, so it must agree with the
+-- ordinary array path on an array whose NULL element hides a value equal to the needle.
+
+SET allow_experimental_full_text_index = 1;
+
+DROP TABLE IF EXISTS t_null_map_text;
+
+CREATE TABLE t_null_map_text
+(
+    id UInt32,
+    arr Array(Nullable(String)),
+    INDEX idx arr TYPE text(tokenizer = array) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
+
+-- id 1 stores 'zz' underneath a NULL, so it does not contain 'zz'. id 2 really contains it.
+INSERT INTO t_null_map_text SELECT 1, arrayMap(x -> nullIf(x, 'zz'), ['a', 'zz', 'c']);
+INSERT INTO t_null_map_text SELECT 2, ['a', 'zz', 'c'];
+
+SELECT '-- has(), which is the expected answer for every arm below --';
+SELECT id, has(arr, 'zz') FROM t_null_map_text ORDER BY id;
+
+SELECT '-- hasAll and hasAny without the index --';
+SELECT id, hasAll(arr, ['zz']), hasAny(arr, ['zz'])
+FROM t_null_map_text ORDER BY id SETTINGS use_skip_indexes = 0;
+
+SELECT '-- matching ids, index off --';
+SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz']) ORDER BY id SETTINGS use_skip_indexes = 0;
+SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz']) ORDER BY id SETTINGS use_skip_indexes = 0;
+
+SELECT '-- matching ids, index on, reading through the index --';
+SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz']) ORDER BY id
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz']) ORDER BY id
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+
+SELECT '-- matching ids, index on, pruning only --';
+SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz']) ORDER BY id
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0;
+SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz']) ORDER BY id
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0;
+
+SELECT '-- control: a needle that is genuinely present in both rows --';
+SELECT id FROM t_null_map_text WHERE hasAll(arr, ['a']) ORDER BY id SETTINGS use_skip_indexes = 0;
+SELECT id FROM t_null_map_text WHERE hasAll(arr, ['a']) ORDER BY id
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+
+DROP TABLE t_null_map_text;

--- a/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
+++ b/tests/queries/0_stateless/05043_array_membership_null_map_text_index.sql
@@ -2,7 +2,7 @@
 -- A text index answers hasAll and hasAny with its own evaluator, so it must agree with the
 -- ordinary array path on an array whose NULL element hides a value equal to the needle.
 
-SET allow_experimental_full_text_index = 1;
+SET enable_full_text_index = 1;
 
 DROP TABLE IF EXISTS t_null_map_text;
 
@@ -29,21 +29,41 @@ SELECT '-- matching ids, index off --';
 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz']) ORDER BY id SETTINGS use_skip_indexes = 0;
 SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz']) ORDER BY id SETTINGS use_skip_indexes = 0;
 
+-- query_plan_direct_read_from_text_index selects which of the two modes below runs, and the
+-- test runner randomizes it, so both arms pin it explicitly. Each mode is also asserted on
+-- the plan rather than on results alone: post-fix every path returns the same row, so a
+-- result-only check would still pass if index evaluation silently declined.
 SELECT '-- matching ids, index on, reading through the index --';
 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz']) ORDER BY id
-SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1;
 SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz']) ORDER BY id
-SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1;
+SELECT countIf(explain ILIKE '%__text_index%') > 0 AS reads_through_index
+FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz'])
+      SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1);
 
 SELECT '-- matching ids, index on, pruning only --';
 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz']) ORDER BY id
-SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0;
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, query_plan_direct_read_from_text_index = 0;
 SELECT id FROM t_null_map_text WHERE hasAny(arr, ['zz']) ORDER BY id
-SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0;
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, query_plan_direct_read_from_text_index = 0;
+SELECT countIf(explain ILIKE '%Granules: 1/2%') > 0 AS prunes_a_granule,
+       countIf(explain ILIKE '%__text_index%') > 0 AS reads_through_index
+FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz'])
+      SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, query_plan_direct_read_from_text_index = 0);
+
+-- Negative control for both probes above: with the index off neither token may appear, so a
+-- token that happens to match something unrelated in the plan text cannot read as a pass.
+SELECT '-- plan-shape negative control, index off --';
+SELECT countIf(explain ILIKE '%Name: idx%') > 0 AS index_used,
+       countIf(explain ILIKE '%__text_index%') > 0 AS reads_through_index,
+       countIf(explain ILIKE '%Granules: 1/2%') > 0 AS prunes_a_granule
+FROM (EXPLAIN indexes = 1 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['zz'])
+      SETTINGS use_skip_indexes = 0);
 
 SELECT '-- control: a needle that is genuinely present in both rows --';
 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['a']) ORDER BY id SETTINGS use_skip_indexes = 0;
 SELECT id FROM t_null_map_text WHERE hasAll(arr, ['a']) ORDER BY id
-SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1;
 
 DROP TABLE t_null_map_text;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/68310   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `hasAll`, `hasAny`, `hasSubstr`, `startsWith` and `endsWith` returning wrong results on `Array(Nullable(T))`. A `NULL` element was compared as whatever value was physically stored beneath it, so these functions disagreed with `has` on identical input: `hasAll([1, 2, NULL, 4], [0])` returned `1` while `has([1, 2, NULL, 4], 0)` returned `0`. Closes #68310.

### Description

Reported in #68310; reproduces on 26.7.5.10, 26.3.21.7 and 25.8.32.4. Only the needle equal to the hidden value matches, so two arrays a user cannot tell apart answer differently, and a `NULL` needle is wrong the other way:

```sql
SELECT hasAll(arrayMap(x -> nullIf(x, 42), [42, 5]), [42]);   -- 1, should be 0
SELECT hasAll(arrayMap(x -> nullIf(x, 42), [42, 5]), [NULL]); -- 0, should be 1
```

**Root cause.** `arrayAllAny`, the only caller of the `sliceHas` overload set, passes rvalues because `NullableArraySource::getWhole()` returns by value. The three null-map-carrying overloads took non-const lvalue references, which cannot bind an rvalue, so they left the candidate set; `NullableSlice` derives from the plain slice, so derived-to-base made the plain overload viable and it won, passing `nullptr, nullptr`. Both null maps were always null and every downstream null-map branch unreachable.

**Change.** Those overloads now take their nullable arguments by `const &`. Their bodies had never been instantiated and did not compile, because they passed slice types to comparators expecting element types; they now pass the comparators as contextual overload sets, as the plain generic overload already did. The already-correct null-map branches start being fed. Non-nullable input still picks the plain overload.

**Validation.** Fails without the change, passes with it, and answers #68310's reproducer correctly. No `.reference` file changed: all 48 `NULL`-carrying arms in the existing membership tests are unaffected, including the documented `hasAll([1, Null], [Null])`. 65 array-membership tests pass, the new tests pass 100/100 under randomized settings, and the vectorised kernels' dead null-map paths are covered per width under ASAN+UBSAN. `05043` pins a second symptom: a text index answers these functions with its own already-correct evaluator, so results used to depend on whether an index existed.

Not fixed here, different cause: on arrays `startsWithCaseInsensitive`, `startsWithUTF8` and `startsWithCaseInsensitiveUTF8` test a suffix, since only `NameStartsWith` picks the prefix branch.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116239&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116239](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116239+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.233` (included in `26.10` and later)
<!-- ch-version-info:end -->