### PR TITLE
Mark 04411_memory_profiler_sample_probability as no-llvm-coverage

### DIFF
--- a/tests/queries/0_stateless/04411_memory_profiler_sample_probability_sql_settings.sh
+++ b/tests/queries/0_stateless/04411_memory_profiler_sample_probability_sql_settings.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-flaky-check
+# Tags: no-fasttest, no-flaky-check, no-llvm-coverage
+# no-llvm-coverage: coverage instrumentation slows the server enough that the global
+# `trace_log` drain exceeds the 180s deadline in `SYSTEM FLUSH LOGS`, so the sampled
+# rows are not yet visible when the assertion runs. Runs in `excluded_from_llvm` instead.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/114204
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/114204

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`04411_memory_profiler_sample_probability_sql_settings` runs a query with
`memory_profiler_sample_probability = 1`, then `SYSTEM FLUSH LOGS trace_log`, then asserts
that a `MemorySample` row is visible. The flush deadline is a hardcoded
`timeout_seconds = 180` in `SystemLogQueue::waitFlush` (`src/Common/SystemLogBase.cpp:191`),
and the index it waits for is a server-global queue position, so it drains the trace rows of
every concurrently running parallel test. Under LLVM coverage instrumentation the server is
slow enough to cross 180 s, and the flush throws:

```
Code: 159. DB::Exception: Timeout exceeded (180 s) while flushing system log
'DB::SystemLogQueue<DB::TraceLogElement>'. (TIMEOUT_EXCEEDED)
(in query: SYSTEM FLUSH LOGS trace_log)
```

That is not only stderr noise: the following `SELECT count() > 0 ... 'MemorySample'` then
prints `0`, so the lane reports a false negative.

Over 30 days of coverage-lane runs that PASSED, this test has p50 9.8 s and **p95 185.5 s**
(max 202.3 s) against p50 5.1 s / p95 11.1 s in every other lane, and **2310 of 37668** are
already over 180 s. Two crossed it on the flush: `amd_llvm_coverage, 3/3` on 2026-08-20
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115623&sha=9b52646c82721f24b7dfb1ddc58d949beef5a7d0&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%203%2F3%29))
and `amd_llvm_coverage, ParallelReplicas, s3 storage, parallel` on 2026-07-23.

`no-llvm-coverage` is the standing remedy for this mechanism: 36 stateless tests carry it, and
this test's direct sibling `02818_memory_profiler_sample_min_max_allocation_size` was tagged
for the same reason in `36decd61` ("Mark tests that timed out under LLVM coverage as
`no-llvm-coverage`"). 04411 was created two months later, which is why it was missed.

Coverage is relocated, not lost: the inverse filter in `tests/clickhouse-test` makes
`Stateless tests (amd_binary_excluded_from_llvm)` run exactly the tagged complement, where
02818 and `01473_event_time_microseconds` pass ~4370 times per 14 days while 04411 is
currently skipped. The test keeps running unchanged in every non-coverage lane. One residual,
shared with all 36 tagged tests: the per-test coverage job also passes `--llvm-coverage`, so
this test's per-test attribution is dropped too.

<details>
<summary>Tag/flag matrix (local runner, Build-ID verified server)</summary>

| tag | runner flag | result |
|---|---|---|
| present | `--llvm-coverage` | `[ SKIPPED ] 0.00 sec` |
| present | `--excluded-from-llvm` | `[ OK ] 5.54 sec` |
| removed | `--llvm-coverage` | `[ OK ] 1.14 sec` |
| removed | `--excluded-from-llvm` | `[ SKIPPED ] 0.00 sec` |
| present | none | `[ OK ] 1.04 sec` |

With the tag removed both verdicts invert, so the probe measures the tag rather than an
unrelated skip reason.

Prior art on the identical intervention: #103219 tagged `01473_event_time_microseconds`
(merged 2026-08-04); its coverage-lane failures over 120 days are 5 before that instant and
0 after. 02818 has none in the last 120 days either; its last ones are from the day it was
tagged.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116242&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116242](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116242+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.66` (included in `26.9` and later)
<!-- ch-version-info:end -->