### PR TITLE
Do not dereference the global context in the crash handler

### DIFF
--- a/src/Common/SignalHandlers.cpp
+++ b/src/Common/SignalHandlers.cpp
@@ -747,7 +747,9 @@ try
 
     if (daemon)
          daemon->flushTextLogs();
-    Context::getGlobalContextInstance()->handleCrash();
+    /// These handlers are installed before the global context is created, so it can still be absent during startup.
+    if (auto global_context = Context::getGlobalContextInstance())
+        global_context->handleCrash();
 
     /// Send crash report to developers (if configured)
     if (daemon)

--- a/src/Core/ServerUUID.cpp
+++ b/src/Core/ServerUUID.cpp
@@ -28,6 +28,11 @@ UUID ServerUUID::get()
     return server_uuid;
 }
 
+UUID ServerUUID::tryGet()
+{
+    return server_uuid;
+}
+
 void ServerUUID::load(const fs::path & server_uuid_file, Poco::Logger * log)
 {
     server_uuid = loadServerUUID(server_uuid_file, log);

--- a/src/Core/ServerUUID.h
+++ b/src/Core/ServerUUID.h
@@ -18,6 +18,10 @@ public:
     /// Returns persistent UUID of current clickhouse-server or clickhouse-keeper instance.
     static UUID get();
 
+    /// The UUID is loaded after the global context is created, so a caller that runs before that
+    /// point, or that treats the UUID as optional, cannot use get(). Nil means "not loaded yet".
+    static UUID tryGet();
+
     /// Loads server UUID from file or creates new one. Should be called on daemon startup.
     static void load(const fs::path & server_uuid_file, Poco::Logger * log);
 

--- a/src/Core/ServerUUID.h
+++ b/src/Core/ServerUUID.h
@@ -18,8 +18,8 @@ public:
     /// Returns persistent UUID of current clickhouse-server or clickhouse-keeper instance.
     static UUID get();
 
-    /// The UUID is loaded after the global context is created, so a caller that runs before that
-    /// point, or that treats the UUID as optional, cannot use get(). Nil means "not loaded yet".
+    /// Nil until load() runs. Unlike get(), never throws and never reads the global context, so it
+    /// is usable before either exists.
     static UUID tryGet();
 
     /// Loads server UUID from file or creates new one. Should be called on daemon startup.

--- a/src/Daemon/CrashWriter.cpp
+++ b/src/Daemon/CrashWriter.cpp
@@ -118,7 +118,7 @@ void CrashWriter::sendError(Type type, int sig_or_error, std::string_view error_
             writeJSONString(build_id_hex, json, settings);
         #endif
 
-        UUID server_uuid = ServerUUID::get();
+        UUID server_uuid = ServerUUID::tryGet();
         if (server_uuid != UUIDHelpers::Nil)
         {
             std::string server_uuid_str = toString(server_uuid);

--- a/tests/integration/test_send_crash_reports/fake_sentry_server.py
+++ b/tests/integration/test_send_crash_reports/fake_sentry_server.py
@@ -1,11 +1,16 @@
 import http.server
 
 RESULT_PATH = "/result.txt"
+PAYLOAD_PATH = "/payload.json"
 
 
 class SentryHandler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
-        self.__read_and_decode_post_data()
+        decoded = self.__read_and_decode_post_data()
+        # Written before RESULT_PATH: a reader that polls RESULT_PATH for "OK" is then
+        # guaranteed to see a complete payload.
+        with open(PAYLOAD_PATH, "wb") as f:
+            f.write(decoded)
         with open(RESULT_PATH, "w") as f:
             f.write("OK")
         self.send_response(200)
@@ -28,6 +33,8 @@ class SentryHandler(http.server.BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
+    with open(PAYLOAD_PATH, "w") as f:
+        f.write("")
     with open(RESULT_PATH, "w") as f:
         f.write("INITIAL_STATE")
     httpd = http.server.HTTPServer(

--- a/tests/integration/test_send_crash_reports/test.py
+++ b/tests/integration/test_send_crash_reports/test.py
@@ -3,6 +3,7 @@
 # pylint: disable=line-too-long
 # pylint: disable=bare-except
 
+import json
 import os
 import time
 
@@ -45,6 +46,10 @@ def test_send_segfault(started_node):
     ):
         pytest.skip("doesn't fit in timeouts for stacktrace generation")
 
+    # The report carries the UUID only once ServerUUID::load() has run, so read it from the
+    # live server to compare against.
+    uuid_before_crash = started_node.query("SELECT serverUUID()").strip()
+
     started_node.copy_file_to_container(
         os.path.join(SCRIPT_DIR, "fake_sentry_server.py"), "/fake_sentry_server.py"
     )
@@ -72,3 +77,11 @@ def test_send_segfault(started_node):
             assert False, "Unexpected state: " + result
 
     assert result == "OK", "Crash report not sent"
+
+    payload = json.loads(
+        started_node.exec_in_container(
+            ["cat", fake_sentry_server.PAYLOAD_PATH], user="root"
+        )
+    )
+    assert "server_uuid" in payload, "Crash report has no server_uuid: " + repr(payload)
+    assert payload["server_uuid"] == uuid_before_crash

--- a/tests/queries/0_stateless/05042_crash_handler_without_global_context.reference
+++ b/tests/queries/0_stateless/05042_crash_handler_without_global_context.reference
@@ -1,0 +1,3 @@
+crash handler ran
+no signal death
+no null dereference

--- a/tests/queries/0_stateless/05042_crash_handler_without_global_context.sh
+++ b/tests/queries/0_stateless/05042_crash_handler_without_global_context.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# The deadly signal handlers and the signal listener are installed before the global context
+# exists, so the crash handler has to tolerate a global context that is not there yet.
+#
+# `--logger.log` is opened while the configuration is being processed, which is still before the
+# global context is created, and opening a FIFO for writing blocks until a reader appears. That
+# parks the process in exactly that window with the listener already running, so a signal
+# delivered there runs the crash handler in the state under test. The signal also interrupts the
+# blocked open, so the process reports a file error and exits on its own afterwards.
+#
+# `SIGTSTP` is the signal to use: the handler treats it as non-crashing and returns, so the manner
+# of the exit is the oracle. A fault signal would end the process even when the handler works,
+# leaving nothing to distinguish.
+#
+# Unique names keep this parallel-safe.
+fifo="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_05042_logger.fifo"
+err="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_05042_stderr.txt"
+work="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_05042_work"
+rm -rf "$fifo" "$err" "$work"
+mkfifo "$fifo"
+mkdir -p "$work"
+
+cleanup() {
+    [ -n "${local_pid:-}" ] && kill -9 "$local_pid" 2>/dev/null
+    wait 2>/dev/null
+    rm -rf "$fifo" "$err" "$work"
+}
+trap cleanup EXIT
+
+# Nothing reads the FIFO, so this parks in its open.
+$CLICKHOUSE_LOCAL --path="$work" --logger.log="$fifo" --logger.level=trace \
+    --query "SELECT 1" >/dev/null 2>"$err" &
+local_pid=$!
+
+# Both checks are mandatory. Signalling before the handlers are installed would use the default
+# disposition and only stop the process, and signalling after the global context has been created
+# would exercise the state that already worked - either way nothing under test runs and the test
+# would pass without measuring anything.
+#
+# The process announces the log destination on stderr immediately before opening it, so that line
+# means it has reached the open. `wait_for_partner` is the kernel state for a process blocked
+# opening a FIFO, and confirms it is parked there rather than elsewhere in startup; it needs symbol
+# names in /proc, so sleeping is the fallback when it stays unavailable while the line is already
+# out. A signal that still lands outside the window is caught by the oracles below.
+parked=0
+announced=0
+for i in {1..600}; do
+    kill -0 "$local_pid" 2>/dev/null || break
+    grep -q "Logging trace to $fifo" "$err" 2>/dev/null && announced=1
+    if [ "$(cat "/proc/$local_pid/wchan" 2>/dev/null)" = "wait_for_partner" ]; then
+        parked=1
+        break
+    fi
+    [ "$announced" = 1 ] && [ "$i" -gt 20 ] && { parked=1; break; }
+    sleep 0.1
+done
+[ "$parked" = 1 ] || { echo "failed to park the process before the global context is created"; exit 1; }
+
+# The working directory is populated right after the global context is created, so an empty one
+# confirms the process has not passed that point.
+[ -z "$(ls -A "$work" 2>/dev/null)" ] || { echo "the global context already exists"; exit 1; }
+
+kill -TSTP "$local_pid"
+
+wait "$local_pid"
+rc=$?
+local_pid=""
+
+# The crash handler prints its first line before it reaches the global context, so this says the
+# handler ran rather than merely that the signal was delivered.
+grep -q 'Received signal' "$err" \
+    && echo "crash handler ran" \
+    || echo "crash handler did not run"
+
+# Reaching the absent global context ends the process: a sanitizer build reports the null
+# dereference and aborts, and every other build reaches a mutex at a wild address and takes a
+# second signal inside the handler, which also costs the ~300s the faulting thread spends waiting
+# for a report that can no longer come.
+#
+# `clickhouse-local` exits with a ClickHouse error code that the shell truncates to its low byte,
+# which can land in the same numeric range as a signal status, so name the signal statuses instead
+# of testing a range.
+case "$rc" in
+    134) echo "died from signal 6" ;;
+    139) echo "died from signal 11" ;;
+    *) echo "no signal death" ;;
+esac
+
+# The report has to be absent rather than merely unseen, so check for it directly. It is what a
+# sanitizer build prints, and it is the only build that can print it.
+grep -q 'member call on null pointer' "$err" \
+    && echo "null global context dereferenced" \
+    || echo "no null dereference"

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
@@ -1,4 +1,8 @@
-crash handler ran
-crash report attempted
-crash report completed
-no null dereference
+keeper: crash handler ran
+keeper: crash report attempted
+keeper: crash report completed
+keeper: no null dereference
+server: crash handler ran
+server: crash report attempted
+server: crash report completed
+server: no null dereference

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
@@ -1,3 +1,4 @@
+keeper exited
 crash handler ran
 crash report attempted
 no null dereference

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
@@ -1,0 +1,3 @@
+crash handler ran
+crash report attempted
+no null dereference

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.reference
@@ -1,4 +1,4 @@
-keeper exited
 crash handler ran
 crash report attempted
+crash report completed
 no null dereference

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: starts a second server process, which the fast test image does not carry.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# A daemon runs the crash-report half of the crash handler, which clickhouse-local never reaches
+# because it has no daemon, so covering it needs a daemon parked before its global context exists.
+#
+# Keeper reads its persistent UUID from <path>/uuid while the global context is still absent, and
+# reading a FIFO blocks until a writer appears, so a FIFO there parks the process in that window
+# with the signal listener already running.
+#
+# The crash report is only built when an endpoint is configured, and the writer connects before it
+# asks for the server UUID, so the endpoint has to accept the connection or the report is abandoned
+# before the part under test runs.
+#
+# Unique names and ports keep this parallel-safe.
+work="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_05043"
+err="$work/stderr.txt"
+log="$work/keeper.log"
+rm -rf "$work"
+mkdir -p "$work/data"
+
+# Ports derived from the database name, which is unique per test run.
+port_hash=$(( $(echo "$CLICKHOUSE_DATABASE" | cksum | cut -d' ' -f1) % 20000 ))
+keeper_port=$(( 25000 + port_hash ))
+raft_port=$(( 45000 + port_hash ))
+sink_port=$(( 25001 + port_hash ))
+
+cleanup() {
+    [ -n "${keeper_pid:-}" ] && kill -9 "$keeper_pid" 2>/dev/null
+    [ -n "${sink_pid:-}" ] && kill -9 "$sink_pid" 2>/dev/null
+    wait 2>/dev/null
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+# Accepts the report and answers it. Answering matters for the run time as much as accepting: the
+# writer waits for a response before it finishes, so a listener that only drains costs a read
+# timeout, about a minute, on every run.
+python3 -c "
+import socket, threading
+srv = socket.socket()
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(('127.0.0.1', $sink_port))
+srv.listen(4)
+def serve(c):
+    try:
+        c.settimeout(10)
+        while b'\r\n\r\n' not in c.recv(65536):
+            pass
+        c.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n')
+    except OSError:
+        pass
+    finally:
+        c.close()
+while True:
+    c, _ = srv.accept()
+    threading.Thread(target=serve, args=(c,), daemon=True).start()
+" >/dev/null 2>&1 &
+sink_pid=$!
+
+for _ in {1..50}; do
+    (exec 3<>"/dev/tcp/127.0.0.1/$sink_port") 2>/dev/null && break
+    sleep 0.1
+done
+
+cat > "$work/config.xml" <<EOF
+<clickhouse>
+    <logger><level>trace</level><log>$log</log><console>0</console></logger>
+    <send_crash_reports>
+        <enabled>true</enabled>
+        <endpoint>http://127.0.0.1:$sink_port/</endpoint>
+    </send_crash_reports>
+    <keeper_server>
+        <tcp_port>$keeper_port</tcp_port>
+        <server_id>1</server_id>
+        <path>$work/data</path>
+        <log_storage_path>$work/data/log</log_storage_path>
+        <snapshot_storage_path>$work/data/snapshots</snapshot_storage_path>
+        <coordination_settings><session_timeout_ms>30000</session_timeout_ms></coordination_settings>
+        <raft_configuration>
+            <server><id>1</id><hostname>127.0.0.1</hostname><port>$raft_port</port></server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>
+EOF
+
+# Nothing writes to the FIFO, so reading the UUID parks here.
+mkfifo "$work/data/uuid"
+
+# The shell reports an abnormal exit of a background job on its own stderr, naming a signal the
+# process is expected to take here, and the manner of the exit is not what this test reads. A
+# subshell keeps the job, and that report, out of this one.
+( $CLICKHOUSE_BINARY keeper --config-file="$work/config.xml" >/dev/null 2>"$err" & echo $! > "$work/pid" ) 2>/dev/null
+keeper_pid=$(cat "$work/pid")
+
+# Both checks are mandatory. Signalling before the listener is running would use the default
+# disposition, and signalling after the global context exists would exercise the state that already
+# worked, so either way nothing under test would run and the test would pass without measuring.
+#
+# `wait_for_partner` is the kernel state of a process blocked opening a FIFO. It needs symbol names
+# in /proc, so a log line the process writes on the way there is the fallback.
+parked=0
+announced=0
+for i in {1..600}; do
+    kill -0 "$keeper_pid" 2>/dev/null || break
+    grep -q 'Initializing DateLUT' "$log" 2>/dev/null && { parked=0; break; }
+    grep -q 'Starting ClickHouse Keeper' "$log" 2>/dev/null && announced=1
+    if [ "$(cat "/proc/$keeper_pid/wchan" 2>/dev/null)" = "wait_for_partner" ]; then
+        parked=1
+        break
+    fi
+    [ "$announced" = 1 ] && [ "$i" -gt 30 ] && { parked=1; break; }
+    sleep 0.1
+done
+[ "$parked" = 1 ] || { echo "failed to park the process before the global context is created"; exit 1; }
+
+# DateLUT is initialized right after the global context is created, so its absence confirms the
+# process has not passed that point.
+grep -q 'Initializing DateLUT' "$log" && { echo "the global context already exists"; exit 1; }
+
+kill -SEGV "$keeper_pid"
+
+for _ in {1..600}; do
+    kill -0 "$keeper_pid" 2>/dev/null || break
+    sleep 0.1
+done
+kill -9 "$keeper_pid" 2>/dev/null
+# Started in a subshell, so it is not a child of this shell and cannot be waited for; the loop above
+# already established it is gone.
+keeper_pid=""
+
+# Says the handler ran, rather than merely that the signal was delivered.
+grep -qh 'Received signal' "$err" "$log" \
+    && echo "crash handler ran" \
+    || echo "crash handler did not run"
+
+# Says the handler got as far as the crash report, so the next check measures the report path
+# instead of silently never reaching it. A sanitizer build stops at the report it is about to
+# print, before the logger flushes this line, so the report itself counts as having got here.
+{ grep -qhE 'Sending crash report$' "$err" "$log" || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
+    && echo "crash report attempted" \
+    || echo "crash report not attempted"
+
+# Has to be absent rather than merely unseen, so check for it directly. Only a sanitizer build can
+# print it; on every other build the same access reads a wild address instead.
+grep -qh 'member call on null pointer' "$err" \
+    && echo "null global context dereferenced" \
+    || echo "no null dereference"

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
@@ -1,23 +1,30 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest
-# Tag no-fasttest: starts a second server process, which the fast test image does not carry.
+# Tag no-fasttest: starts further server processes, which the fast test image does not carry.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-# The keeper mode is a build option, and this test drives a keeper.
+# The keeper mode is a build option, and one of the two arms below drives a keeper.
 if ! $CLICKHOUSE_BINARY help 2>&1 | grep -qF 'clickhouse keeper [args]'; then
     echo "@@SKIP@@: the binary has no keeper mode"
     exit 0
 fi
 
 # A daemon runs the crash-report half of the crash handler, which clickhouse-local never reaches
-# because it has no daemon, so covering it needs a daemon parked before its global context exists.
+# because it has no daemon, so covering it needs a daemon parked before the report is complete.
 #
-# Keeper reads its persistent UUID from <path>/uuid while the global context is still absent, and
-# reading a FIFO blocks until a writer appears, so a FIFO there parks the process in that window
-# with the signal listener already running.
+# The report names the server UUID, which is read from <path>/uuid during startup, and reading a
+# FIFO blocks until a writer appears, so a FIFO there parks the process at that read with the signal
+# listener already running. Both arms below use that same park, and they differ only in which daemon
+# they park, because the two daemons read the UUID on opposite sides of creating the global context:
+#
+#   keeper  reads it BEFORE  creating the context, so the context is absent   (arm 1)
+#   server  reads it AFTER   creating the context, so the context exists but the UUID is unset (arm 2)
+#
+# Those are the two states in which the report is built without a UUID to name, and they are
+# reachable from different daemons, so neither arm can stand in for the other.
 #
 # The crash report is only built when an endpoint is configured, and the writer connects before it
 # asks for the server UUID, so the endpoint has to accept the connection or the report is abandoned
@@ -25,14 +32,16 @@ fi
 #
 # Unique names keep this parallel-safe.
 work="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_05043"
-err="$work/stderr.txt"
-log="$work/keeper.log"
 rm -rf "$work"
-mkdir -p "$work/data"
+mkdir -p "$work"
+
+pids="$work/pids"
+: > "$pids"
 
 cleanup() {
-    [ -n "${keeper_pid:-}" ] && kill -9 "$keeper_pid" 2>/dev/null
-    [ -n "${sink_pid:-}" ] && kill -9 "$sink_pid" 2>/dev/null
+    while read -r p; do
+        [ -n "$p" ] && kill -9 "$p" 2>/dev/null
+    done < "$pids"
     wait 2>/dev/null
     rm -rf "$work"
 }
@@ -55,16 +64,21 @@ trap cleanup EXIT
 # ends in a digit followed by two CRLF pairs of its own, which matches the same bytes before any body
 # byte exists.
 #
+# Each arm gets its own listener under its own directory, so one arm's markers cannot answer for the
+# other's.
+#
 # This is killed at the end of the run, and a shell reports the death of its own background job on
 # its own stderr, which the runner reads as a failure, so a subshell keeps the job out of this one.
-( python3 -c "
+start_sink() {
+    local dir="$1"
+    ( python3 -c "
 import os, socket, threading
 srv = socket.socket()
 srv.bind(('127.0.0.1', 0))
 srv.listen(4)
-with open('$work/sink_port.tmp', 'w') as f:
+with open('$dir/sink_port.tmp', 'w') as f:
     f.write(str(srv.getsockname()[1]))
-os.rename('$work/sink_port.tmp', '$work/sink_port')
+os.rename('$dir/sink_port.tmp', '$dir/sink_port')
 def serve(c):
     try:
         # Outlasts a slow symbolization pass, so a read cannot decide the outcome instead.
@@ -77,12 +91,12 @@ def serve(c):
             data += chunk
             if b'\r\n\r\n' not in data:
                 continue
-            if not os.path.exists('$work/request_started'):
-                open('$work/request_started', 'w').close()
+            if not os.path.exists('$dir/request_started'):
+                open('$dir/request_started', 'w').close()
             # A chunk boundary can fall anywhere, so this reads the accumulated body, not the last
             # read. The payload is a few KB.
             if data.split(b'\r\n\r\n', 1)[1].endswith(b'0\r\n\r\n'):
-                open('$work/report_complete', 'w').close()
+                open('$dir/report_complete', 'w').close()
                 break
         c.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n')
     except OSError:
@@ -92,29 +106,82 @@ def serve(c):
 while True:
     c, _ = srv.accept()
     threading.Thread(target=serve, args=(c,), daemon=True).start()
-" >/dev/null 2>&1 & echo $! > "$work/sink_pid" ) 2>/dev/null
-sink_pid=$(cat "$work/sink_pid")
+" >/dev/null 2>&1 & echo $! >> "$pids" ) 2>/dev/null
 
-for _ in {1..300}; do
-    [ -f "$work/sink_port" ] && break
-    sleep 0.1
-done
-[ -f "$work/sink_port" ] || { echo "sink did not start"; exit 1; }
-sink_port=$(cat "$work/sink_port")
+    local i
+    for i in {1..300}; do
+        [ -f "$dir/sink_port" ] && return 0
+        sleep 0.1
+    done
+    echo "sink did not start"
+    exit 1
+}
+
+# Waits for the report, then reads the four things this test is about off the run. The wait leaves on
+# the marker when the report arrives, however slow symbolization was, and on the exit when the
+# handler faults instead and stops waiting for a report it can no longer send. Its count only has to
+# exceed that wait, so it decides no outcome; the checks below do.
+report_checks() {
+    local dir="$1" label="$2" pid="$3" err="$4" log="$5"
+    local i
+    for i in {1..4000}; do
+        [ -f "$dir/report_complete" ] && break
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.1
+    done
+    kill -9 "$pid" 2>/dev/null
+
+    # Says the handler ran, rather than merely that the signal was delivered.
+    grep -qh 'Received signal' "$err" "$log" \
+        && echo "$label: crash handler ran" \
+        || echo "$label: crash handler did not run"
+
+    # Says the handler got as far as opening the connection, so the next check measures the report
+    # path instead of silently never reaching it. A sanitizer build stops inside the report it is
+    # about to print, so the report it prints counts as having got here.
+    { [ -f "$dir/request_started" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
+        && echo "$label: crash report attempted" \
+        || echo "$label: crash report not attempted"
+
+    # Says the report was written in full. The part under test sits between the connection above and
+    # the finalize that terminates the body, so a report abandoned in between never gets here. A
+    # sanitizer build stops there and prints the null dereference instead, which is its equivalent
+    # evidence.
+    { [ -f "$dir/report_complete" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
+        && echo "$label: crash report completed" \
+        || echo "$label: crash report not completed"
+
+    # Has to be absent rather than merely unseen, so check for it directly. Only a sanitizer build
+    # can print it; on every other build the same access reads a wild address instead.
+    grep -qh 'member call on null pointer' "$err" \
+        && echo "$label: null global context dereferenced" \
+        || echo "$label: no null dereference"
+}
+
+##########################################################################################
+# Arm 1: keeper. The UUID is read before the global context is created, so the context is absent.
+##########################################################################################
+
+kdir="$work/keeper"
+mkdir -p "$kdir/data"
+kerr="$kdir/stderr.txt"
+klog="$kdir/keeper.log"
+start_sink "$kdir"
+ksink_port=$(cat "$kdir/sink_port")
 
 # No tcp_port: the test never connects to the keeper, and omitting it is supported.
-cat > "$work/config.xml" <<EOF
+cat > "$kdir/config.xml" <<EOF
 <clickhouse>
-    <logger><level>trace</level><log>$log</log><console>0</console></logger>
+    <logger><level>trace</level><log>$klog</log><console>0</console></logger>
     <send_crash_reports>
         <enabled>true</enabled>
-        <endpoint>http://127.0.0.1:$sink_port/</endpoint>
+        <endpoint>http://127.0.0.1:$ksink_port/</endpoint>
     </send_crash_reports>
     <keeper_server>
         <server_id>1</server_id>
-        <path>$work/data</path>
-        <log_storage_path>$work/data/log</log_storage_path>
-        <snapshot_storage_path>$work/data/snapshots</snapshot_storage_path>
+        <path>$kdir/data</path>
+        <log_storage_path>$kdir/data/log</log_storage_path>
+        <snapshot_storage_path>$kdir/data/snapshots</snapshot_storage_path>
         <coordination_settings><session_timeout_ms>30000</session_timeout_ms></coordination_settings>
         <raft_configuration>
             <server><id>1</id><hostname>127.0.0.1</hostname><port>0</port></server>
@@ -124,13 +191,14 @@ cat > "$work/config.xml" <<EOF
 EOF
 
 # Nothing writes to the FIFO, so reading the UUID parks here.
-mkfifo "$work/data/uuid"
+mkfifo "$kdir/data/uuid"
 
 # The shell reports an abnormal exit of a background job on its own stderr, naming a signal the
 # process is expected to take here, and the manner of the exit is not what this test reads. A
 # subshell keeps the job, and that report, out of this one.
-( $CLICKHOUSE_BINARY keeper --config-file="$work/config.xml" >/dev/null 2>"$err" & echo $! > "$work/pid" ) 2>/dev/null
-keeper_pid=$(cat "$work/pid")
+( $CLICKHOUSE_BINARY keeper --config-file="$kdir/config.xml" >/dev/null 2>"$kerr" & echo $! > "$kdir/pid" ) 2>/dev/null
+keeper_pid=$(cat "$kdir/pid")
+echo "$keeper_pid" >> "$pids"
 
 # Both checks are mandatory. Signalling before the listener is running would use the default
 # disposition, and signalling after the global context exists would exercise the state that already
@@ -142,8 +210,8 @@ parked=0
 announced=0
 for i in {1..600}; do
     kill -0 "$keeper_pid" 2>/dev/null || break
-    grep -q 'Initializing DateLUT' "$log" 2>/dev/null && { parked=0; break; }
-    grep -q 'Starting ClickHouse Keeper' "$log" 2>/dev/null && announced=1
+    grep -q 'Initializing DateLUT' "$klog" 2>/dev/null && { parked=0; break; }
+    grep -q 'Starting ClickHouse Keeper' "$klog" 2>/dev/null && announced=1
     if [ "$(cat "/proc/$keeper_pid/wchan" 2>/dev/null)" = "wait_for_partner" ]; then
         parked=1
         break
@@ -151,48 +219,82 @@ for i in {1..600}; do
     [ "$announced" = 1 ] && [ "$i" -gt 30 ] && { parked=1; break; }
     sleep 0.1
 done
-[ "$parked" = 1 ] || { echo "failed to park the process before the global context is created"; exit 1; }
+[ "$parked" = 1 ] || { echo "keeper: failed to park the process before the global context is created"; exit 1; }
 
 # DateLUT is initialized right after the global context is created, so its absence confirms the
 # process has not passed that point.
-grep -q 'Initializing DateLUT' "$log" && { echo "the global context already exists"; exit 1; }
+grep -q 'Initializing DateLUT' "$klog" && { echo "keeper: the global context already exists"; exit 1; }
 
 kill -SEGV "$keeper_pid"
+report_checks "$kdir" "keeper" "$keeper_pid" "$kerr" "$klog"
 
-# Leaves on the marker when the report arrives, however slow symbolization was, and on the exit when
-# the handler faults instead and stops waiting for a report it can no longer send. The count only has
-# to exceed that wait, so it decides neither outcome; the checks below do.
-for _ in {1..4000}; do
-    [ -f "$work/report_complete" ] && break
-    kill -0 "$keeper_pid" 2>/dev/null || break
+##########################################################################################
+# Arm 2: server. The UUID is read after the global context is created, so the context exists while
+# the UUID is still unset. That is a state the keeper never has, and the arm above cannot reach it.
+##########################################################################################
+
+sdir="$work/server"
+mkdir -p "$sdir/data"
+serr="$sdir/stderr.txt"
+slog="$sdir/server.log"
+start_sink "$sdir"
+ssink_port=$(cat "$sdir/sink_port")
+
+# No ports: the test never connects to the server, and it parks long before it opens a listener.
+cat > "$sdir/config.xml" <<EOF
+<clickhouse>
+    <logger><level>trace</level><log>$slog</log><console>0</console></logger>
+    <path>$sdir/data</path>
+    <tmp_path>$sdir/data/tmp</tmp_path>
+    <user_files_path>$sdir/data/user_files</user_files_path>
+    <send_crash_reports>
+        <enabled>true</enabled>
+        <endpoint>http://127.0.0.1:$ssink_port/</endpoint>
+    </send_crash_reports>
+    <users><default><profile>default</profile><quota>default</quota>
+        <networks><ip>::/0</ip></networks></default></users>
+    <profiles><default></default></profiles>
+    <quotas><default></default></quotas>
+</clickhouse>
+EOF
+
+mkfifo "$sdir/data/uuid"
+
+# A server not attached to a terminal forks a watchdog and keeps running as its child, and the
+# watchdog forwards only the termination signals, not this one, so the signal below has to reach the
+# process that parked. Disabling the fork is what makes the started process that process.
+( CLICKHOUSE_WATCHDOG_ENABLE=0 $CLICKHOUSE_BINARY server --config-file="$sdir/config.xml" >/dev/null 2>"$serr" & echo $! > "$sdir/pid" ) 2>/dev/null
+server_pid=$(cat "$sdir/pid")
+echo "$server_pid" >> "$pids"
+
+# The state this arm exists for is bounded on both sides, so both bounds are checked, and the status
+# file carries both bounds on its own. It is written after the global context is created and
+# immediately before the UUID is read, so its presence says the context exists; and it is written by
+# the thread that then blocks on the FIFO, which nothing ever writes to, so the process can never
+# reach the load that would end the state. Signalling outside those bounds would measure one of the
+# states the other arm or the integration test already covers.
+#
+# The file itself is the witness rather than the line the same code logs, because logging is
+# asynchronous, so that line can still be queued at the moment the process is already parked, while
+# the file is written synchronously before the read. Waiting on the line instead loses the race
+# occasionally and reports a state the process has in fact already left.
+parked=0
+seen=0
+for i in {1..600}; do
+    kill -0 "$server_pid" 2>/dev/null || break
+    [ -s "$sdir/data/status" ] && seen=1
+    if [ "$seen" = 1 ] && [ "$(cat "/proc/$server_pid/wchan" 2>/dev/null)" = "wait_for_partner" ]; then
+        parked=1
+        break
+    fi
+    # `wait_for_partner` needs symbol names in /proc, so the file alone decides when it has none.
+    [ "$seen" = 1 ] && [ "$i" -gt 30 ] && { parked=1; break; }
     sleep 0.1
 done
-kill -9 "$keeper_pid" 2>/dev/null
-# Started in a subshell, so it is not a child of this shell and cannot be waited for; the loop above
-# already established whether it is gone.
-keeper_pid=""
+[ "$parked" = 1 ] || { echo "server: failed to park the process before the server UUID is read"; exit 1; }
 
-# Says the handler ran, rather than merely that the signal was delivered.
-grep -qh 'Received signal' "$err" "$log" \
-    && echo "crash handler ran" \
-    || echo "crash handler did not run"
+[ -s "$sdir/data/status" ] || { echo "server: the global context does not exist yet"; exit 1; }
+grep -q 'Initializing DateLUT' "$slog" && { echo "server: the server UUID is already loaded"; exit 1; }
 
-# Says the handler got as far as opening the connection, so the next check measures the report path
-# instead of silently never reaching it. A sanitizer build stops inside the report it is about to
-# print, so the report it prints counts as having got here.
-{ [ -f "$work/request_started" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
-    && echo "crash report attempted" \
-    || echo "crash report not attempted"
-
-# Says the report was written in full. The part under test sits between the connection above and the
-# finalize that terminates the body, so a report abandoned in between never gets here. A sanitizer
-# build stops there and prints the null dereference instead, which is its equivalent evidence.
-{ [ -f "$work/report_complete" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
-    && echo "crash report completed" \
-    || echo "crash report not completed"
-
-# Has to be absent rather than merely unseen, so check for it directly. Only a sanitizer build can
-# print it; on every other build the same access reads a wild address instead.
-grep -qh 'member call on null pointer' "$err" \
-    && echo "null global context dereferenced" \
-    || echo "no null dereference"
+kill -SEGV "$server_pid"
+report_checks "$sdir" "server" "$server_pid" "$serr" "$slog"

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
@@ -46,8 +46,18 @@ trap cleanup EXIT
 # cannot lose a race for a predetermined number. The port file is published by rename, so reading it
 # never yields a partial number, and its presence means the socket is already accepting.
 #
-# The marker records that a request arrived here, which is what the report check downstream reads.
-python3 -c "
+# The two markers separate "the connection was opened" from "the whole report arrived". The report
+# is sent with chunked transfer encoding, whose body ends with a zero-length chunk that is written
+# only when the writer finalizes, downstream of everything the body is built from, so that chunk
+# means the report was written in full rather than abandoned part way through.
+#
+# The terminator is matched against the body rather than the whole request because the header block
+# ends in a digit followed by two CRLF pairs of its own, which matches the same bytes before any body
+# byte exists.
+#
+# This is killed at the end of the run, and a shell reports the death of its own background job on
+# its own stderr, which the runner reads as a failure, so a subshell keeps the job out of this one.
+( python3 -c "
 import os, socket, threading
 srv = socket.socket()
 srv.bind(('127.0.0.1', 0))
@@ -57,12 +67,23 @@ with open('$work/sink_port.tmp', 'w') as f:
 os.rename('$work/sink_port.tmp', '$work/sink_port')
 def serve(c):
     try:
-        c.settimeout(10)
+        # Outlasts a slow symbolization pass, so a read cannot decide the outcome instead.
+        c.settimeout(300)
+        data = b''
         while True:
             chunk = c.recv(65536)
-            if not chunk or b'\r\n\r\n' in chunk:
+            if not chunk:
                 break
-        open('$work/report_received', 'w').close()
+            data += chunk
+            if b'\r\n\r\n' not in data:
+                continue
+            if not os.path.exists('$work/request_started'):
+                open('$work/request_started', 'w').close()
+            # A chunk boundary can fall anywhere, so this reads the accumulated body, not the last
+            # read. The payload is a few KB.
+            if data.split(b'\r\n\r\n', 1)[1].endswith(b'0\r\n\r\n'):
+                open('$work/report_complete', 'w').close()
+                break
         c.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n')
     except OSError:
         pass
@@ -71,8 +92,8 @@ def serve(c):
 while True:
     c, _ = srv.accept()
     threading.Thread(target=serve, args=(c,), daemon=True).start()
-" >/dev/null 2>&1 &
-sink_pid=$!
+" >/dev/null 2>&1 & echo $! > "$work/sink_pid" ) 2>/dev/null
+sink_pid=$(cat "$work/sink_pid")
 
 for _ in {1..300}; do
     [ -f "$work/sink_port" ] && break
@@ -138,13 +159,12 @@ grep -q 'Initializing DateLUT' "$log" && { echo "the global context already exis
 
 kill -SEGV "$keeper_pid"
 
-# A handler that reaches the absent global context faults a second time and spends about 300s
-# waiting for a report that can no longer come, while a handler that tolerates it is gone in about a
-# second, so this deadline separates the two by an order of magnitude on either side. Termination is
-# the one part of the outcome every build reports, sanitizer or not.
-exited=0
-for _ in {1..300}; do
-    kill -0 "$keeper_pid" 2>/dev/null || { exited=1; break; }
+# Leaves on the marker when the report arrives, however slow symbolization was, and on the exit when
+# the handler faults instead and stops waiting for a report it can no longer send. The count only has
+# to exceed that wait, so it decides neither outcome; the checks below do.
+for _ in {1..4000}; do
+    [ -f "$work/report_complete" ] && break
+    kill -0 "$keeper_pid" 2>/dev/null || break
     sleep 0.1
 done
 kill -9 "$keeper_pid" 2>/dev/null
@@ -152,21 +172,24 @@ kill -9 "$keeper_pid" 2>/dev/null
 # already established whether it is gone.
 keeper_pid=""
 
-[ "$exited" = 1 ] \
-    && echo "keeper exited" \
-    || echo "keeper did not exit"
-
 # Says the handler ran, rather than merely that the signal was delivered.
 grep -qh 'Received signal' "$err" "$log" \
     && echo "crash handler ran" \
     || echo "crash handler did not run"
 
-# Says the handler got as far as the crash report, so the next check measures the report path
+# Says the handler got as far as opening the connection, so the next check measures the report path
 # instead of silently never reaching it. A sanitizer build stops inside the report it is about to
 # print, so the report it prints counts as having got here.
-{ [ -f "$work/report_received" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
+{ [ -f "$work/request_started" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
     && echo "crash report attempted" \
     || echo "crash report not attempted"
+
+# Says the report was written in full. The part under test sits between the connection above and the
+# finalize that terminates the body, so a report abandoned in between never gets here. A sanitizer
+# build stops there and prints the null dereference instead, which is its equivalent evidence.
+{ [ -f "$work/report_complete" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
+    && echo "crash report completed" \
+    || echo "crash report not completed"
 
 # Has to be absent rather than merely unseen, so check for it directly. Only a sanitizer build can
 # print it; on every other build the same access reads a wild address instead.

--- a/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
+++ b/tests/queries/0_stateless/05043_crash_report_without_global_context.sh
@@ -6,6 +6,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# The keeper mode is a build option, and this test drives a keeper.
+if ! $CLICKHOUSE_BINARY help 2>&1 | grep -qF 'clickhouse keeper [args]'; then
+    echo "@@SKIP@@: the binary has no keeper mode"
+    exit 0
+fi
+
 # A daemon runs the crash-report half of the crash handler, which clickhouse-local never reaches
 # because it has no daemon, so covering it needs a daemon parked before its global context exists.
 #
@@ -17,18 +23,12 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # asks for the server UUID, so the endpoint has to accept the connection or the report is abandoned
 # before the part under test runs.
 #
-# Unique names and ports keep this parallel-safe.
+# Unique names keep this parallel-safe.
 work="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_05043"
 err="$work/stderr.txt"
 log="$work/keeper.log"
 rm -rf "$work"
 mkdir -p "$work/data"
-
-# Ports derived from the database name, which is unique per test run.
-port_hash=$(( $(echo "$CLICKHOUSE_DATABASE" | cksum | cut -d' ' -f1) % 20000 ))
-keeper_port=$(( 25000 + port_hash ))
-raft_port=$(( 45000 + port_hash ))
-sink_port=$(( 25001 + port_hash ))
 
 cleanup() {
     [ -n "${keeper_pid:-}" ] && kill -9 "$keeper_pid" 2>/dev/null
@@ -41,17 +41,28 @@ trap cleanup EXIT
 # Accepts the report and answers it. Answering matters for the run time as much as accepting: the
 # writer waits for a response before it finishes, so a listener that only drains costs a read
 # timeout, about a minute, on every run.
+#
+# The kernel picks the port and the listener publishes it once it is accepting, so a parallel copy
+# cannot lose a race for a predetermined number. The port file is published by rename, so reading it
+# never yields a partial number, and its presence means the socket is already accepting.
+#
+# The marker records that a request arrived here, which is what the report check downstream reads.
 python3 -c "
-import socket, threading
+import os, socket, threading
 srv = socket.socket()
-srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-srv.bind(('127.0.0.1', $sink_port))
+srv.bind(('127.0.0.1', 0))
 srv.listen(4)
+with open('$work/sink_port.tmp', 'w') as f:
+    f.write(str(srv.getsockname()[1]))
+os.rename('$work/sink_port.tmp', '$work/sink_port')
 def serve(c):
     try:
         c.settimeout(10)
-        while b'\r\n\r\n' not in c.recv(65536):
-            pass
+        while True:
+            chunk = c.recv(65536)
+            if not chunk or b'\r\n\r\n' in chunk:
+                break
+        open('$work/report_received', 'w').close()
         c.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n')
     except OSError:
         pass
@@ -63,11 +74,14 @@ while True:
 " >/dev/null 2>&1 &
 sink_pid=$!
 
-for _ in {1..50}; do
-    (exec 3<>"/dev/tcp/127.0.0.1/$sink_port") 2>/dev/null && break
+for _ in {1..300}; do
+    [ -f "$work/sink_port" ] && break
     sleep 0.1
 done
+[ -f "$work/sink_port" ] || { echo "sink did not start"; exit 1; }
+sink_port=$(cat "$work/sink_port")
 
+# No tcp_port: the test never connects to the keeper, and omitting it is supported.
 cat > "$work/config.xml" <<EOF
 <clickhouse>
     <logger><level>trace</level><log>$log</log><console>0</console></logger>
@@ -76,14 +90,13 @@ cat > "$work/config.xml" <<EOF
         <endpoint>http://127.0.0.1:$sink_port/</endpoint>
     </send_crash_reports>
     <keeper_server>
-        <tcp_port>$keeper_port</tcp_port>
         <server_id>1</server_id>
         <path>$work/data</path>
         <log_storage_path>$work/data/log</log_storage_path>
         <snapshot_storage_path>$work/data/snapshots</snapshot_storage_path>
         <coordination_settings><session_timeout_ms>30000</session_timeout_ms></coordination_settings>
         <raft_configuration>
-            <server><id>1</id><hostname>127.0.0.1</hostname><port>$raft_port</port></server>
+            <server><id>1</id><hostname>127.0.0.1</hostname><port>0</port></server>
         </raft_configuration>
     </keeper_server>
 </clickhouse>
@@ -125,14 +138,23 @@ grep -q 'Initializing DateLUT' "$log" && { echo "the global context already exis
 
 kill -SEGV "$keeper_pid"
 
-for _ in {1..600}; do
-    kill -0 "$keeper_pid" 2>/dev/null || break
+# A handler that reaches the absent global context faults a second time and spends about 300s
+# waiting for a report that can no longer come, while a handler that tolerates it is gone in about a
+# second, so this deadline separates the two by an order of magnitude on either side. Termination is
+# the one part of the outcome every build reports, sanitizer or not.
+exited=0
+for _ in {1..300}; do
+    kill -0 "$keeper_pid" 2>/dev/null || { exited=1; break; }
     sleep 0.1
 done
 kill -9 "$keeper_pid" 2>/dev/null
 # Started in a subshell, so it is not a child of this shell and cannot be waited for; the loop above
-# already established it is gone.
+# already established whether it is gone.
 keeper_pid=""
+
+[ "$exited" = 1 ] \
+    && echo "keeper exited" \
+    || echo "keeper did not exit"
 
 # Says the handler ran, rather than merely that the signal was delivered.
 grep -qh 'Received signal' "$err" "$log" \
@@ -140,9 +162,9 @@ grep -qh 'Received signal' "$err" "$log" \
     || echo "crash handler did not run"
 
 # Says the handler got as far as the crash report, so the next check measures the report path
-# instead of silently never reaching it. A sanitizer build stops at the report it is about to
-# print, before the logger flushes this line, so the report itself counts as having got here.
-{ grep -qhE 'Sending crash report$' "$err" "$log" || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
+# instead of silently never reaching it. A sanitizer build stops inside the report it is about to
+# print, so the report it prints counts as having got here.
+{ [ -f "$work/report_received" ] || grep -qh 'ServerUUID.cpp.*member call on null pointer' "$err"; } \
     && echo "crash report attempted" \
     || echo "crash report not attempted"
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110105


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a crash inside the crash handler itself when a fatal signal arrives during startup of `clickhouse-server`, `clickhouse-keeper` or `clickhouse-local`. The handler dereferenced the global context, which does not exist yet at that point, so right after logging the stack trace it took a second fault, hung for about five minutes, and never sent the configured crash report.


### Description

The deadly signal handlers and the signal listener are installed before the global context is created (`BaseDaemon.cpp:473`/`:492` before `Server.cpp:1549` and `Keeper.cpp:433`, and the same order in `clickhouse-local`), so a fatal signal arriving in between reaches the crash handler with no global context.

Two places on that path used it unconditionally. `SignalHandlers.cpp:750` called `Context::handleCrash()`, whose first action takes a lock on a non-static member, so a null `this` is a mutex operation on a wild address instead of the no-op that function's own `!shared` check gives. On a daemon the report path then reached `ServerUUID::get()` from `CrashWriter.cpp:121`, which asks the context for the application type.

The tree already guards this path at the point of use in `ProxyConfigurationResolverProvider.cpp:152` and `DateLUT.cpp:183`; these two were the omissions. The first now tests the pointer the same way. The second uses a non-throwing accessor that reads the stored value and needs no context, which suits a report that already omits the UUID when unset, and also covers the span where the context exists but the UUID is not loaded. `ServerUUID::get()` is unchanged, keeping its initialization-order assertion for its 22 other callers.

Each window gets a test that parks a process in it using only documented options, and fails without its fix.

Reported for `SignalHandlers.cpp:750` by [`Stateless tests (arm_asan_ubsan, targeted)`](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110105&sha=5dcd02d276b8469269e74edad26655a85fce317e&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20targeted%29). What delivered the signal there is not established: that test ran in 1.47 s so the harness timeout path was not involved, and the job's logs show no crash. This rests on the ordering above, not on that run. The context pointer and the stored UUID are both read here without synchronization; both pre-date this change, which takes the UUID read from two to one, and neither is addressed.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116245&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116245](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116245+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1537` (included in `26.9` and later)
<!-- ch-version-info:end -->