### PR TITLE
Vectorize the plain Float64 variance accumulator on aarch64

### DIFF
--- a/src/AggregateFunctions/Moments.h
+++ b/src/AggregateFunctions/Moments.h
@@ -118,6 +118,7 @@ struct VarMoments
     {
         static constexpr size_t lanes = neonLanes<T>;
         static constexpr size_t vectors = unroll_count / lanes;
+        static_assert(vectors * lanes == unroll_count);
 
         using Vector = T __attribute__((ext_vector_type(lanes)));
         using SourceVector = Value __attribute__((ext_vector_type(lanes)));

--- a/src/AggregateFunctions/Moments.h
+++ b/src/AggregateFunctions/Moments.h
@@ -37,6 +37,18 @@ inline T ALWAYS_INLINE maskFloatingPoint(T x, bool keep)
     return x;
 }
 
+#if defined(__aarch64__)
+/// Lanes of a 128-bit NEON vector holding accumulator elements.
+template <typename T>
+static constexpr size_t neonLanes = 16 / sizeof(T);
+
+/// Equal source and accumulator width is required because a narrower source would need a
+/// widening convert per lane, which costs more than the vectorization saves.
+template <typename T, typename Value>
+static constexpr bool neonPlainAccumulable
+    = std::is_same_v<T, Float64> && std::is_arithmetic_v<Value> && sizeof(Value) == sizeof(T);
+#endif
+
 
 /**
     Calculating univariate central moments
@@ -96,6 +108,45 @@ struct VarMoments
     })
     )
 
+#if defined(__aarch64__)
+    /// The vectors span exactly unroll_count rows, so lane (v, j) accumulates the same rows as
+    /// scalar partial v * lanes + j and the reduction below visits them in the same order.
+    /// That equality is required, not incidental: FP addition is not associative, so any other
+    /// grouping would return different low-order digits than the scalar kernel.
+    template <typename Value>
+    void NO_INLINE addManyNeon(const Value * __restrict ptr, size_t row_begin, size_t row_end)
+    {
+        static constexpr size_t lanes = neonLanes<T>;
+        static constexpr size_t vectors = unroll_count / lanes;
+
+        using Vector = T __attribute__((ext_vector_type(lanes)));
+        using SourceVector = Value __attribute__((ext_vector_type(lanes)));
+
+        Vector partials[_level][vectors]{};
+        size_t i = row_begin;
+        for (; i + unroll_count <= row_end; i += unroll_count)
+        {
+            for (size_t v = 0; v < vectors; ++v)
+            {
+                SourceVector raw;
+                std::memcpy(&raw, ptr + i + v * lanes, sizeof(raw));
+                Vector x = __builtin_convertvector(raw, Vector);
+                partials[0][v] += x;
+                partials[1][v] += x * x;
+                if constexpr (_level >= 3) partials[2][v] += x * x * x;
+                if constexpr (_level >= 4) partials[3][v] += x * x * x * x;
+            }
+        }
+        m[0] += static_cast<T>(i - row_begin);
+        for (size_t k = 1; k <= _level; ++k)
+            for (size_t v = 0; v < vectors; ++v)
+                for (size_t j = 0; j < lanes; ++j)
+                    m[k] += partials[k - 1][v][j];
+        for (; i < row_end; ++i)
+            add(static_cast<T>(ptr[i]));
+    }
+#endif
+
     template <typename Value>
     void addMany(const Value * __restrict ptr, size_t row_begin, size_t row_end)
     {
@@ -103,6 +154,14 @@ struct VarMoments
         if (isArchSupported(TargetArch::x86_64_v4))
         {
             addManyImpl_x86_64_v4(ptr, row_begin, row_end);
+            return;
+        }
+#endif
+
+#if defined(__aarch64__)
+        if constexpr (neonPlainAccumulable<T, Value>)
+        {
+            addManyNeon(ptr, row_begin, row_end);
             return;
         }
 #endif

--- a/tests/performance/statistics_simple_if.xml
+++ b/tests/performance/statistics_simple_if.xml
@@ -13,10 +13,6 @@
     <query>SELECT kurtSamp(number) FROM numbers(100000000)</query>
     <query>SELECT corr(number, number + 1) FROM numbers(100000000)</query>
 
-    <query>SELECT skewSamp(number) FROM numbers(100000000)</query>
-    <query>SELECT varSamp(toFloat64(number)) FROM numbers(100000000)</query>
-    <query>SELECT varSamp(toInt64(number)) FROM numbers(100000000)</query>
-
     <!-- ~20% NULL values, random so the branch predictor doesn't do all the work -->
     <create_query>CREATE TABLE nullfloat64_stats (x Nullable(Float64)) ENGINE = Memory</create_query>
     <fill_query>INSERT INTO nullfloat64_stats
@@ -26,5 +22,10 @@
     </fill_query>
     <query>SELECT varSamp(x) FROM nullfloat64_stats</query>
     <query>SELECT varSampIf(x, rand32() % 2 = 0) FROM nullfloat64_stats</query>
+
+    <!-- Plain (non-If) moments over numbers(): level 3, and the Float64 and Int64 source paths -->
+    <query>SELECT skewSamp(number) FROM numbers(100000000)</query>
+    <query>SELECT varSamp(toFloat64(number)) FROM numbers(100000000)</query>
+    <query>SELECT varSamp(toInt64(number)) FROM numbers(100000000)</query>
     <drop_query>DROP TABLE IF EXISTS nullfloat64_stats</drop_query>
 </test>

--- a/tests/performance/statistics_simple_if.xml
+++ b/tests/performance/statistics_simple_if.xml
@@ -13,6 +13,10 @@
     <query>SELECT kurtSamp(number) FROM numbers(100000000)</query>
     <query>SELECT corr(number, number + 1) FROM numbers(100000000)</query>
 
+    <query>SELECT skewSamp(number) FROM numbers(100000000)</query>
+    <query>SELECT varSamp(toFloat64(number)) FROM numbers(100000000)</query>
+    <query>SELECT varSamp(toInt64(number)) FROM numbers(100000000)</query>
+
     <!-- ~20% NULL values, random so the branch predictor doesn't do all the work -->
     <create_query>CREATE TABLE nullfloat64_stats (x Nullable(Float64)) ENGINE = Memory</create_query>
     <fill_query>INSERT INTO nullfloat64_stats

--- a/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.reference
+++ b/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.reference
@@ -21,6 +21,7 @@ covarSamp f64 approx	1	1	1
 corr int exact	1	1	1	1
 corr f64 approx	1	1	1
 int64 exact	1	1	1
+grouping f64 exact	1	1	1	1	1
 f32 approx	1	1
 nan-safety If	1	1	1
 inf-safety If	1

--- a/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.reference
+++ b/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.reference
@@ -20,6 +20,7 @@ covarSamp int exact	1	1	1	1
 covarSamp f64 approx	1	1	1
 corr int exact	1	1	1	1
 corr f64 approx	1	1	1
+int64 exact	1	1	1
 f32 approx	1	1
 nan-safety If	1	1	1
 inf-safety If	1

--- a/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.sql
+++ b/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.sql
@@ -297,6 +297,16 @@ FROM
         (SELECT kurtSampMerge(s) FROM (SELECT kurtSampState(v) AS s FROM (SELECT number, toInt64(cityHash64(number, 1) % 199) - 99 AS v FROM numbers(70000)) GROUP BY cityHash64(number, 99) % 97)) AS r2
 );
 
+-- The batch kernels split the rows into a fixed number of partial accumulators, and which rows land
+-- in which partial must not change: floating point addition is not associative, so a different split
+-- returns different low-order digits. The plain kernel is compared against the -If kernel under a
+-- condition true for every row, which sums the same rows in the same order through separate code.
+-- Both aggregates share one SELECT over one source, so both always see the same blocks. Unlike the
+-- exact blocks above, these values leave the sums inexact, which is what lets the comparison see a
+-- changed split at all.
+SELECT 'grouping f64 exact', varSamp(v) = varSampIf(v, c), skewSamp(v) = skewSampIf(v, c), kurtSamp(v) = kurtSampIf(v, c), varSamp(u) = varSampIf(u, c), countIf(c) = 70000
+FROM (SELECT toFloat64(cityHash64(number, 1) % 1000000) / 3 AS v, toUInt64(cityHash64(number, 5)) AS u, number >= 0 AS c FROM numbers(70000));
+
 SELECT 'f32 approx', abs(d0 - r0) <= 1e-3 * greatest(abs(d0), abs(r0), 1e-30), abs(d1 - r1) <= 1e-3 * greatest(abs(d1), abs(r1), 1e-30)
 FROM
 (

--- a/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.sql
+++ b/tests/queries/0_stateless/04546_statistics_simple_batch_single_place.sql
@@ -282,6 +282,21 @@ FROM
         (SELECT corrIfMerge(s) FROM (SELECT corrIfState(vn, w, c) AS s FROM (SELECT number, toFloat64(cityHash64(number, 1) % 1000) / 8 AS v, toFloat64(toInt64(cityHash64(number, 2) % 1000) - 500) / 4 AS w, cityHash64(number, 42) % 2 = 0 AS c, if(cityHash64(number, 7) % 4 = 0, NULL, v) AS vn FROM numbers(70000)) GROUP BY cityHash64(number, 99) % 97)) AS r2
 );
 
+-- A source as wide as the accumulator takes a different arm of the batch kernels than the 4-byte
+-- sources above, and a signed source that spans zero exercises the signed conversion. Values are
+-- kept under 100 so that the sum of 4th powers stays exact, see `kurtPop int exact` above.
+SELECT 'int64 exact', d0 = r0, d1 = r1, d2 = r2
+FROM
+(
+    SELECT
+        (SELECT varSamp(v) FROM (SELECT toInt64(cityHash64(number, 1) % 199) - 99 AS v FROM numbers(70000))) AS d0,
+        (SELECT varSampMerge(s) FROM (SELECT varSampState(v) AS s FROM (SELECT number, toInt64(cityHash64(number, 1) % 199) - 99 AS v FROM numbers(70000)) GROUP BY cityHash64(number, 99) % 97)) AS r0,
+        (SELECT skewSamp(v) FROM (SELECT toInt64(cityHash64(number, 1) % 199) - 99 AS v FROM numbers(70000))) AS d1,
+        (SELECT skewSampMerge(s) FROM (SELECT skewSampState(v) AS s FROM (SELECT number, toInt64(cityHash64(number, 1) % 199) - 99 AS v FROM numbers(70000)) GROUP BY cityHash64(number, 99) % 97)) AS r1,
+        (SELECT kurtSamp(v) FROM (SELECT toInt64(cityHash64(number, 1) % 199) - 99 AS v FROM numbers(70000))) AS d2,
+        (SELECT kurtSampMerge(s) FROM (SELECT kurtSampState(v) AS s FROM (SELECT number, toInt64(cityHash64(number, 1) % 199) - 99 AS v FROM numbers(70000)) GROUP BY cityHash64(number, 99) % 97)) AS r2
+);
+
 SELECT 'f32 approx', abs(d0 - r0) <= 1e-3 * greatest(abs(d0), abs(r0), 1e-30), abs(d1 - r1) <= 1e-3 * greatest(abs(d1), abs(r1), 1e-30)
 FROM
 (


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/116084
Related: https://github.com/ClickHouse/ClickHouse/pull/110461


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Vectorized the batch accumulation loop of `varSamp`, `varPop`, `stddevSamp`, `stddevPop`, `skewSamp`, `skewPop`, `kurtSamp` and `kurtPop` on AArch64, for `Int64`, `UInt64` and `Float64` columns. The loop previously compiled to scalar code there because the vectorized batch kernels in `VarMoments` are only cloned for x86-64-v4. Query results are unchanged. A block that mixes infinities of both signs with a NaN can serialize a different NaN payload inside an intermediate aggregate state, visible only by reinterpreting those state bytes.


### Description

Reported in #116084. The timings there are the reporter's; I measured codegen instead, having no AArch64 hardware. The real number must come from ARM `Performance Comparison`.

**Scope limits.** Source and accumulator width must match, so only `Int64`, `UInt64` and `Float64` reach the kernel; narrower types, `Int128`, Decimal, `Float32` and `Nullable` are unchanged.

**Root cause, narrower than the report.** `VarMoments`' batch kernels are wrapped in `MULTITARGET_FUNCTION_X86_V4`, and `USE_MULTITARGET_CODE` requires `__x86_64__` (`TargetSpecific.h:110`), so AArch64 gets only the default clone. Cross-compiled with the project's pins, plain `Float64` levels 2/3/4 emit **0** vector operations, while every conditional and `Float32` kernel already auto-vectorizes; the plain loop is declined on **cost**, not semantics.

**Results are bit-identical.** Lane `(v, j)` accumulates the same rows as scalar partial `v * lanes + j`, in the same order. FP addition is not associative, so that equality is required rather than incidental: the reporter's fixed 4-vector width regroups the rows and shifts level-4 digits. One difference does not reach a result: the two reductions order their `fadd` operands differently and AArch64 returns operand 1's payload when both are quiet NaNs, so a block mixing infinities of both signs with a NaN serializes a different payload in `m[1]`/`m[3]`. Every such block also makes `m[2]` a NaN, `getSample` clamps that to zero, and the finalizer then emits a fresh canonical NaN without reading those words, so no result differs. That payload already differs between x86 and AArch64 in master. No `SettingsChangesHistory.cpp` entry.

#116084 stays open: it scopes three stacked patches, and its `-If` and `corr` rows are untouched. `04546` gained an exact block for the 8-byte integer sources, plus the plain kernel against the untouched `-If` kernel under an all-true condition, the only block that can see a changed grouping; it was mutation-tested against the real AArch64 kernels.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116254&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116254](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116254+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
