### PR TITLE
Inline the per-row emplace of a `GROUP BY` without aggregate functions

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1370,23 +1370,6 @@ void NO_INLINE Aggregator::executeImplBatchNoAggregates(
     if constexpr (top_k && has_typed_key)
         typed_key_data = state.getKeyData();
 
-    auto emplace = [&](size_t row)
-    {
-        // For some methods we simply don't have a set counterpart, so a map method is used.
-        // Thus we have to set a `mapped` even though nothing reads it. Only the row that creates the
-        // cell has to: for a key that is already there the cell holds the same sentinel, and writing it
-        // again is a store into a random place of the table on every row.
-        if constexpr (State::has_mapped)
-        {
-            auto emplace_result = state.emplaceKey(method.data, row, *aggregates_pool);
-            if (emplace_result.isInserted())
-                emplace_result.setMapped(place);
-            return emplace_result;
-        }
-        else
-            return state.emplaceKey(method.data, row, *aggregates_pool);
-    };
-
     auto heap_push = [&]([[maybe_unused]] size_t row, [[maybe_unused]] const auto & emplace_result)
     {
         if constexpr (top_k)
@@ -1401,9 +1384,31 @@ void NO_INLINE Aggregator::executeImplBatchNoAggregates(
         }
     };
 
+    /// Returns nothing and is force-inlined on purpose: a variant of this that returned the emplace
+    /// result was compiled into an out-of-line call per row for the string methods, and the call is
+    /// what the loop's speed is made of - it costs more than the work it wraps.
+    auto process_row = [&](size_t row) ALWAYS_INLINE
+    {
+        // For some methods we simply don't have a set counterpart, so a map method is used.
+        // Thus we have to set a `mapped` even though nothing reads it. Only the row that creates the
+        // cell has to: for a key that is already there the cell holds the same sentinel, and writing it
+        // again is a store into a random place of the table on every row.
+        if constexpr (State::has_mapped)
+        {
+            auto emplace_result = state.emplaceKey(method.data, row, *aggregates_pool);
+            if (emplace_result.isInserted())
+                emplace_result.setMapped(place);
+            heap_push(row, emplace_result);
+        }
+        else
+        {
+            heap_push(row, state.emplaceKey(method.data, row, *aggregates_pool));
+        }
+    };
+
     if (all_keys_are_const)
     {
-        heap_push(0, emplace(0));
+        process_row(0);
         return;
     }
 
@@ -1442,7 +1447,7 @@ void NO_INLINE Aggregator::executeImplBatchNoAggregates(
             }
         }
 
-        heap_push(i, emplace(i));
+        process_row(i);
 
         if constexpr (top_k)
         {

--- a/tests/performance/group_by_no_aggregates_string_keys.xml
+++ b/tests/performance/group_by_no_aggregates_string_keys.xml
@@ -1,0 +1,15 @@
+<test>
+    <!--
+        `GROUP BY` without aggregate functions over a short, low-cardinality string key. Single string
+        keys have no set counterpart, so they run on the map methods `key_packed_string` (default) and
+        `key_string` (`enable_packed_string_keys_in_aggregation = 0`), and all the per-row work is the
+        emplace of `executeImplBatchNoAggregates`.
+        The queries are the ones from https://github.com/ClickHouse/ClickHouse/issues/115804.
+    -->
+
+    <query>SELECT length(URL) > 1000 ? 'LONG' : 'SHORT' as x FROM hits_100m_single GROUP BY x FORMAT Null</query>
+    <query>SELECT transform(number, [2, 4, 6], ['google', 'yandex', 'yahoo'], 'other') as x FROM numbers(100000000) GROUP BY x FORMAT Null</query>
+
+    <query>SELECT length(URL) > 1000 ? 'LONG' : 'SHORT' as x FROM hits_100m_single GROUP BY x SETTINGS enable_packed_string_keys_in_aggregation = 0 FORMAT Null</query>
+    <query>SELECT transform(number, [2, 4, 6], ['google', 'yandex', 'yahoo'], 'other') as x FROM numbers(100000000) GROUP BY x SETTINGS enable_packed_string_keys_in_aggregation = 0 FORMAT Null</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up `GROUP BY` without aggregates by inlining some functions.

Closes: #115804

---

<img width="1062" height="160" alt="Screenshot 2026-08-25 at 20 34 47" src="https://github.com/user-attachments/assets/2a0a81c8-e4ac-43e1-8dd2-c88baa6fc058" />

<img width="1037" height="148" alt="Screenshot 2026-08-25 at 20 34 33" src="https://github.com/user-attachments/assets/b1192f17-120a-4b1f-bf43-c044a680c631" />


<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116267&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116267](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116267+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.124` (included in `26.9` and later)
- Backported to: `26.8.2.3`
<!-- ch-version-info:end -->