### PR TITLE
Normalize ColumnSparce before the insert deduplication hash

### DIFF
--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -405,8 +405,6 @@ public:
     /// rebuilds the same one.
     /// ColumnSparse is the exception: sparseness is chosen by the storage, and a merge flips it under
     /// an unchanged query, so insert deduplication removes it before hashing.
-    /// ColumnReplicated needs no override: replication is chosen by the query plan, which a retry
-    /// repeats, and the row-wise default keeps the hash independent of the nested/indexes layout.
     /// Default implementation calls updateHashWithValue for each element.
     virtual void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const;
 

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -403,6 +403,7 @@ public:
     /// the same in-memory representation. It does NOT guarantee the same hash for logically
     /// equivalent data stored differently in memory (e.g. different dynamic/shared path layout
     /// in ColumnObject, or different variant layout in ColumnDynamic).
+    /// ColumnSparse needs no override: insert deduplication removes sparse representation before hashing.
     /// Default implementation calls updateHashWithValue for each element.
     virtual void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const;
 

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -399,11 +399,14 @@ public:
     virtual void updateHashWithValue(size_t n, SipHash & hash) const = 0;
 
     /// Update state of hash function with values in range [begin, end).
-    /// Used for deduplication: the hash must be the same for the same INSERT data producing
-    /// the same in-memory representation. It does NOT guarantee the same hash for logically
-    /// equivalent data stored differently in memory (e.g. different dynamic/shared path layout
-    /// in ColumnObject, or different variant layout in ColumnDynamic).
-    /// ColumnSparse needs no override: insert deduplication removes sparse representation before hashing.
+    /// Used for deduplication, which works per query: only a retry of the same query has to land on
+    /// the same hash. So the hash may depend on the in-memory representation (e.g. the dynamic/shared
+    /// path layout in ColumnObject, or the variant layout in ColumnDynamic) as long as the same query
+    /// rebuilds the same one.
+    /// ColumnSparse is the exception: sparseness is chosen by the storage, and a merge flips it under
+    /// an unchanged query, so insert deduplication removes it before hashing.
+    /// ColumnReplicated needs no override: replication is chosen by the query plan, which a retry
+    /// repeats, and the row-wise default keeps the hash independent of the nested/indexes layout.
     /// Default implementation calls updateHashWithValue for each element.
     virtual void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const;
 

--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -416,11 +416,8 @@ void DeduplicationInfo::calculateDataHashes() const
 
     chassert(original_block && original_block->rows() == getRows());
 
-    /// Column-major, with the whole batch of tokens in flight: a sparse column hashes row-wise
-    /// while the same data materialized hashes column-wise, so a merge flipping the source part's
-    /// serialization would otherwise move the block id of a query whose result never changed.
-    /// Hashing one column at a time keeps a single materialized column alive, hashing all the
-    /// tokens against it keeps the materialization at one per column instead of one per token.
+    /// The hash must not depend on the column's sparse/dense representation, so remove sparse before hashing.
+    /// Column-major so only one column is materialized at a time, instead of a dense copy of the whole block.
     std::vector<SipHash> hashes(pending.size());
     for (const auto & col : original_block->getColumns())
     {

--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -12,6 +12,7 @@
 #include <QueryPipeline/QueryPipeline.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Columns/IColumn.h>
+#include <Columns/ColumnSparse.h>
 #include <Core/Settings.h>
 #include <Core/Block.h>
 #include <IO/WriteHelpers.h>
@@ -418,8 +419,14 @@ UInt128 DeduplicationInfo::calculateDataHashColumnWise(size_t offset, const Bloc
     SipHash hash;
     size_t begin = getTokenBegin(offset);
     size_t end = getTokenEnd(offset);
+    /// ColumnSparse hashes row-wise while the same data materialized hashes column-wise, so a merge flipping
+    /// the source part to sparse serialization would move the block id of an otherwise unchanged query.
+    /// A replicated column hashes row-wise whatever it wraps, so its nested representation cannot move the stream.
     for (const auto & col : cols)
-        col->updateHashWithValueRange(begin, end, hash);
+    {
+        auto full = (!col->isReplicated() && recursiveHasSparse(col)) ? recursiveRemoveSparse(col) : col;
+        full->updateHashWithValueRange(begin, end, hash);
+    }
 
     tokens[offset].data_hash_batch = hash.get128();
     return tokens[offset].data_hash_batch.value();

--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -400,35 +400,48 @@ DeduplicationInfo::FilterResult DeduplicationInfo::filterImpl(const std::set<siz
 }
 
 
-UInt128 DeduplicationInfo::calculateDataHashColumnWise(size_t offset, const Block & block) const
+void DeduplicationInfo::calculateDataHashes() const
 {
-    chassert(offset < offsets.size());
+    std::vector<size_t> pending;
+    for (size_t offset = 0; offset < tokens.size(); ++offset)
+        if (tokens[offset].by_user.empty() && !tokens[offset].data_hash_batch.has_value())
+            pending.push_back(offset);
 
-    if (tokens[offset].data_hash_batch.has_value())
-        return tokens[offset].data_hash_batch.value();
+    if (pending.empty())
+        return;
 
-    /// Cache miss: an actual column-wise hash pass over the token's rows. Counting these makes the
-    /// prewarm optimization observable: pre-warming keeps this at O(tokens); the per-partition
+    /// Counted per token, not per pass: pre-warming keeps this at O(tokens); the per-partition
     /// cold-clone path drives it to O(partitions*tokens) for tokens that span several partitions.
-    ProfileEvents::increment(ProfileEvents::DuplicationDataHashComputations);
+    ProfileEvents::increment(ProfileEvents::DuplicationDataHashComputations, pending.size());
 
-    chassert(block.rows() == getRows());
+    chassert(original_block && original_block->rows() == getRows());
 
-    auto cols = block.getColumns();
-
-    SipHash hash;
-    size_t begin = getTokenBegin(offset);
-    size_t end = getTokenEnd(offset);
-    /// ColumnSparse hashes row-wise while the same data materialized hashes column-wise, so a merge flipping
-    /// the source part to sparse serialization would move the block id of an otherwise unchanged query.
-    /// A replicated column hashes row-wise whatever it wraps, so its nested representation cannot move the stream.
-    for (const auto & col : cols)
+    /// Column-major, with the whole batch of tokens in flight: a sparse column hashes row-wise
+    /// while the same data materialized hashes column-wise, so a merge flipping the source part's
+    /// serialization would otherwise move the block id of a query whose result never changed.
+    /// Hashing one column at a time keeps a single materialized column alive, hashing all the
+    /// tokens against it keeps the materialization at one per column instead of one per token.
+    std::vector<SipHash> hashes(pending.size());
+    for (const auto & col : original_block->getColumns())
     {
-        auto full = (!col->isReplicated() && recursiveHasSparse(col)) ? recursiveRemoveSparse(col) : col;
-        full->updateHashWithValueRange(begin, end, hash);
+        auto dense = recursiveRemoveSparse(col);
+        for (size_t i = 0; i < pending.size(); ++i)
+            dense->updateHashWithValueRange(getTokenBegin(pending[i]), getTokenEnd(pending[i]), hashes[i]);
     }
 
-    tokens[offset].data_hash_batch = hash.get128();
+    for (size_t i = 0; i < pending.size(); ++i)
+        tokens[pending[i]].data_hash_batch = hashes[i].get128();
+}
+
+
+UInt128 DeduplicationInfo::getDataHash(size_t offset) const
+{
+    chassert(offset < offsets.size());
+    chassert(tokens[offset].by_user.empty());
+
+    if (!tokens[offset].data_hash_batch.has_value())
+        calculateDataHashes();
+
     return tokens[offset].data_hash_batch.value();
 }
 
@@ -447,7 +460,7 @@ DeduplicationHash DeduplicationInfo::getBlockUnifiedHash(size_t offset, const st
     }
     else
     {
-        auto data_hash = calculateDataHashColumnWise(offset, *original_block);
+        auto data_hash = getDataHash(offset);
         extension = fmt::format("{}_{}", data_hash.items[0], data_hash.items[1]);
     }
 
@@ -533,14 +546,7 @@ void DeduplicationInfo::cacheDataHashes() const
     if (disabled)
         return;
 
-    for (size_t offset = 0; offset < offsets.size(); ++offset)
-    {
-        if (!tokens[offset].by_user.empty() || tokens[offset].data_hash_batch.has_value())
-            continue;
-
-        chassert(original_block);
-        calculateDataHashColumnWise(offset, *original_block);
-    }
+    calculateDataHashes();
 }
 
 
@@ -581,12 +587,7 @@ void DeduplicationInfo::prewarmDataHashes() const
     if (!original_block || !original_block->rows())
         return;
 
-    for (size_t i = 0; i < tokens.size(); ++i)
-    {
-        if (!tokens[i].by_user.empty())
-            continue;
-        calculateDataHashColumnWise(i, *original_block);
-    }
+    calculateDataHashes();
 }
 
 
@@ -877,7 +878,6 @@ void DeduplicationInfo::updateOriginalBlock(const Chunk & chunk, SharedHeader he
     /// is called (e.g. in the sink), avoiding redundant recomputation during squashing.
     /// The columns are COW-shared with the chunk, so this does not increase memory usage.
     original_block = std::make_shared<Block>(header->cloneWithColumns(chunk.getColumns()));
-
 }
 
 

--- a/src/Interpreters/InsertDeduplication.h
+++ b/src/Interpreters/InsertDeduplication.h
@@ -152,8 +152,12 @@ public:
 private:
     explicit DeduplicationInfo(bool async_insert_);
 
-    /// Column-major hash: for each column, hash the row range. Used by the unified path.
-    UInt128 calculateDataHashColumnWise(size_t offset, const Block & block) const;
+    /// Column-major hash of every token that still needs one, in a single pass over the columns.
+    void calculateDataHashes() const;
+
+    /// The token's column-major data hash, computing the batch on first demand. Used by the
+    /// unified path for the tokens which carry no user token.
+    UInt128 getDataHash(size_t offset) const;
     DeduplicationHash getBlockUnifiedHash(size_t offset, const std::string & partition_) const;
 
 

--- a/tests/queries/0_stateless/04692_insert_dedup_sparse_serialization.reference
+++ b/tests/queries/0_stateless/04692_insert_dedup_sparse_serialization.reference
@@ -1,0 +1,6 @@
+retry before the merge	1
+source is sparse	Sparse
+tuple element is sparse	1
+selected row unchanged	1	x	(1,'y')
+retry after the merge	1
+sparse rows stored sparse	1

--- a/tests/queries/0_stateless/04692_insert_dedup_sparse_serialization.sql
+++ b/tests/queries/0_stateless/04692_insert_dedup_sparse_serialization.sql
@@ -1,0 +1,44 @@
+-- A merge can flip a source column to sparse serialization. That column then reaches the sink as
+-- ColumnSparse, which used to hash row-wise while the same data materialized hashes column-wise, so
+-- a retried INSERT ... SELECT stopped deduplicating even though its result never changed.
+
+SET deduplicate_insert_select = 'enable_even_for_bad_queries';
+
+DROP TABLE IF EXISTS t_dedup_sparse_src;
+DROP TABLE IF EXISTS t_dedup_sparse_dst;
+
+-- `s` is sparse at the top level, `t.s` is sparse nested in a Tuple. Both are String, because
+-- fixed-width types hash identically row-wise and column-wise and would pass even unfixed.
+CREATE TABLE t_dedup_sparse_src (id UInt64, s String, t Tuple(k UInt64, s String))
+ENGINE = MergeTree ORDER BY id SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+CREATE TABLE t_dedup_sparse_dst (id UInt64, s String, t Tuple(k UInt64, s String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS non_replicated_deduplication_window = 100, ratio_of_defaults_for_sparse_serialization = 0.9;
+
+INSERT INTO t_dedup_sparse_src VALUES (1, 'x', (1, 'y'));
+
+INSERT INTO t_dedup_sparse_dst SELECT * FROM t_dedup_sparse_src WHERE id = 1;
+INSERT INTO t_dedup_sparse_dst SELECT * FROM t_dedup_sparse_src WHERE id = 1;
+SELECT 'retry before the merge', count() FROM t_dedup_sparse_dst;
+
+-- Unrelated rows holding default values, every one of them filtered out by WHERE id = 1. The
+-- merged part stores both String columns sparse.
+INSERT INTO t_dedup_sparse_src SELECT number + 2, '', (0, '') FROM numbers(20);
+OPTIMIZE TABLE t_dedup_sparse_src FINAL;
+
+SELECT 'source is sparse', serialization_kind FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_dedup_sparse_src' AND column = 's' AND active;
+SELECT 'tuple element is sparse', dumpColumnStructure(t) LIKE '%Sparse%'
+FROM t_dedup_sparse_src LIMIT 1;
+SELECT 'selected row unchanged', * FROM t_dedup_sparse_src WHERE id = 1;
+
+INSERT INTO t_dedup_sparse_dst SELECT * FROM t_dedup_sparse_src WHERE id = 1;
+SELECT 'retry after the merge', count() FROM t_dedup_sparse_dst;
+
+-- The hash normalizes a copy, so sparse data still reaches disk sparse.
+INSERT INTO t_dedup_sparse_dst SELECT * FROM t_dedup_sparse_src WHERE id = 2;
+SELECT 'sparse rows stored sparse', countIf(serialization_kind = 'Sparse') FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_dedup_sparse_dst' AND column = 's' AND active;
+
+DROP TABLE t_dedup_sparse_dst;
+DROP TABLE t_dedup_sparse_src;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Related: https://github.com/ClickHouse/ClickHouse/issues/116151


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed missed insert deduplication when a block reaches the sink with sparse column representation, for example `INSERT ... SELECT` from a part with sparse serialization. Such an insert did not deduplicate against the same data inserted seconds ago from unmerged parts.


<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116287&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116287](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116287+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.412` (included in `26.9` and later)
<!-- ch-version-info:end -->