### PR TITLE
Apply target row policies to Alias tables

### DIFF
--- a/src/Access/EnabledRowPolicies.cpp
+++ b/src/Access/EnabledRowPolicies.cpp
@@ -3,6 +3,8 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
 
+#include <utility>
+
 
 namespace DB
 {
@@ -54,7 +56,11 @@ RowPolicyFilterPtr EnabledRowPolicies::getFilter(const String & database, const 
 
 RowPolicyFilterPtr EnabledRowPolicies::getFilter(const String & database, const String & table_name, RowPolicyFilterType filter_type, RowPolicyFilterPtr combine_with_filter) const
 {
-    RowPolicyFilterPtr filter = getFilter(database, table_name, filter_type);
+    return combineRowPolicyFilters(getFilter(database, table_name, filter_type), std::move(combine_with_filter));
+}
+
+RowPolicyFilterPtr combineRowPolicyFilters(RowPolicyFilterPtr filter, RowPolicyFilterPtr combine_with_filter)
+{
     if (filter && combine_with_filter)
     {
         auto new_filter = std::make_shared<RowPolicyFilter>(*filter);

--- a/src/Access/EnabledRowPolicies.h
+++ b/src/Access/EnabledRowPolicies.h
@@ -28,6 +28,9 @@ struct RowPolicyFilter
 
 using RowPolicyFilterPtr = std::shared_ptr<const RowPolicyFilter>;
 
+/// Combines two prepared row policy filters with a logical AND and retains their contributing policies.
+RowPolicyFilterPtr combineRowPolicyFilters(RowPolicyFilterPtr filter, RowPolicyFilterPtr combine_with_filter);
+
 
 /// Provides fast access to row policies' conditions for a specific user and tables.
 class EnabledRowPolicies

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -22,6 +22,7 @@
 
 #include <Access/Common/AccessFlags.h>
 #include <Access/ContextAccess.h>
+#include <Access/EnabledRowPolicies.h>
 
 #include <AggregateFunctions/AggregateFunctionCount.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -786,6 +787,15 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     if (storage)
     {
         row_policy_filter = context->getRowPolicyFilter(table_id.getDatabaseName(), table_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+
+        if (const auto * alias = storage->as<StorageAlias>())
+        {
+            const auto target_storage_id = alias->getTargetTable()->getStorageID();
+            auto target_row_policy_filter = context->getRowPolicyFilter(
+                target_storage_id.getDatabaseName(), target_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+            row_policy_filter = combineRowPolicyFilters(std::move(row_policy_filter), std::move(target_row_policy_filter));
+        }
+
         if (row_policy_filter && context->hasQueryContext())
         {
             for (const auto & row_policy : row_policy_filter->policies)

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -23,6 +23,7 @@
 
 #include <Access/Common/AccessFlags.h>
 #include <Access/ContextAccess.h>
+#include <Access/EnabledRowPolicies.h>
 
 #include <Storages/ColumnsDescription.h>
 #include <Storages/IStorage.h>
@@ -522,6 +523,15 @@ RowPolicyFilterPtr getEffectiveRowPolicyFilter(const StoragePtr & storage, const
         return nullptr;
     auto row_policy_filter = query_context->getRowPolicyFilter(
         storage_id.getDatabaseName(), storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+
+    if (const auto * alias = storage->as<StorageAlias>())
+    {
+        const auto target_storage_id = alias->getTargetTable()->getStorageID();
+        auto target_row_policy_filter = query_context->getRowPolicyFilter(
+            target_storage_id.getDatabaseName(), target_storage_id.getTableName(), RowPolicyFilterType::SELECT_FILTER);
+        row_policy_filter = combineRowPolicyFilters(std::move(row_policy_filter), std::move(target_row_policy_filter));
+    }
+
     if (!row_policy_filter || row_policy_filter->isAlwaysTrue())
         return nullptr;
     return row_policy_filter;

--- a/src/Processors/QueryPlan/Optimizations/optimizeTrivialCountFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTrivialCountFromTextIndex.cpp
@@ -242,6 +242,10 @@ bool guardsHold(const ReadFromMergeTree & reading)
         if (!useful.index->isTextIndex())
             return false;
 
+    /// The effective row policy may belong to a wrapper such as `Alias`.
+    if (reading.getRowLevelFilter())
+        return false;
+
     /// Row policy filters rows the cardinality ignores; without a database name it can't be resolved, so fail closed.
     auto storage_id = reading.getStorageID();
     if (!storage_id.hasDatabase())

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1,6 +1,7 @@
 #include <functional>
 #include <iterator>
 #include <Access/ContextAccess.h>
+#include <Access/EnabledRowPolicies.h>
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/ColumnNode.h>
 #include <Analyzer/FunctionNode.h>
@@ -987,6 +988,18 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
                 database_name,
                 table_name,
                 RowPolicyFilterType::SELECT_FILTER);
+            /// `Merge` reads matched tables directly, so include the target policy when a matched table is an `Alias`.
+            if (const auto * alias = storage->as<StorageAlias>())
+            {
+                const auto target_storage_id = alias->getTargetTable()->getStorageID();
+                auto target_row_policy_filter = modified_context->getRowPolicyFilter(
+                    target_storage_id.getDatabaseName(),
+                    target_storage_id.getTableName(),
+                    RowPolicyFilterType::SELECT_FILTER);
+                row_policy_filter_ptr = combineRowPolicyFilters(
+                    std::move(row_policy_filter_ptr), std::move(target_row_policy_filter));
+            }
+
             if (row_policy_filter_ptr && !row_policy_filter_ptr->isAlwaysTrue())
             {
                 row_policy_data_opt = RowPolicyData(row_policy_filter_ptr, storage, modified_context);

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
@@ -2,6 +2,10 @@ Target policy with the old analyzer
 [1,2]
 Target policy with the analyzer
 [1,2]
+Target policy through Merge with the old analyzer
+[1,2]
+Target policy through Merge with the analyzer
+[1,2]
 Combined policies with the old analyzer
 [1]
 Combined policies with the analyzer

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
@@ -1,20 +1,20 @@
 Target policy with the old analyzer
 [1,2]
-Target policy with the new analyzer
+Target policy with the analyzer
 [1,2]
 Combined policies with the old analyzer
 [1]
-Combined policies with the new analyzer
+Combined policies with the analyzer
 [1]
 Combined policies and trivial count disabled with the old analyzer
 1
 Combined policies and trivial count enabled with the old analyzer
 1
-Combined policies and trivial count disabled with the new analyzer
+Combined policies and trivial count disabled with the analyzer
 1
-Combined policies and trivial count enabled with the new analyzer
+Combined policies and trivial count enabled with the analyzer
 1
 Alias policy with the old analyzer
 [1,3]
-Alias policy with the new analyzer
+Alias policy with the analyzer
 [1,3]

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
@@ -1,0 +1,20 @@
+Target policy with the old analyzer
+[1,2]
+Target policy with the new analyzer
+[1,2]
+Combined policies with the old analyzer
+[1]
+Combined policies with the new analyzer
+[1]
+Combined policies and trivial count disabled with the old analyzer
+1
+Combined policies and trivial count enabled with the old analyzer
+1
+Combined policies and trivial count disabled with the new analyzer
+1
+Combined policies and trivial count enabled with the new analyzer
+1
+Alias policy with the old analyzer
+[1,3]
+Alias policy with the new analyzer
+[1,3]

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
@@ -22,3 +22,9 @@ Alias policy with the old analyzer
 [1,3]
 Alias policy with the analyzer
 [1,3]
+Alias policy and text-index count optimization disabled
+2
+Alias policy and text-index count optimization enabled
+2
+Alias policy disables text-index count optimization
+0

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.reference
@@ -26,5 +26,3 @@ Alias policy and text-index count optimization disabled
 2
 Alias policy and text-index count optimization enabled
 2
-Alias policy disables text-index count optimization
-0

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
@@ -85,11 +85,6 @@ SELECT count() FROM test_alias WHERE hasToken(text, 'alpha')
 SELECT 'Alias policy and text-index count optimization enabled';
 SELECT count() FROM test_alias WHERE hasToken(text, 'alpha') SETTINGS enable_analyzer = 1;
 
-SELECT 'Alias policy disables text-index count optimization';
-SELECT count(explain)
-FROM (EXPLAIN SELECT count() FROM test_alias WHERE hasToken(text, 'alpha') SETTINGS enable_analyzer = 1)
-WHERE explain LIKE '%ReadFromTextIndexCount%';
-
 DROP ROW POLICY alias_policy ON test_alias;
 DROP TABLE test_merge;
 DROP TABLE test_alias;

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
@@ -5,9 +5,27 @@ DROP TABLE IF EXISTS test_alias;
 DROP TABLE IF EXISTS test_table;
 
 SET allow_experimental_alias_table_engine = 1;
+SET enable_full_text_index = 1;
+SET use_skip_indexes = 1;
+SET query_plan_direct_read_from_text_index = 1;
+SET query_plan_optimize_count_from_text_index = 1;
+SET optimize_trivial_count_query = 1;
+SET make_distributed_plan = 0;
+SET serialize_query_plan = 0;
+SET allow_experimental_parallel_reading_from_replicas = 0;
 
-CREATE TABLE test_table (id UInt32, tenant_id UInt32, active UInt8) ENGINE = MergeTree ORDER BY id;
-INSERT INTO test_table VALUES (1, 1, 1), (2, 1, 0), (3, 2, 1), (4, 2, 0);
+CREATE TABLE test_table
+(
+    id UInt32,
+    tenant_id UInt32,
+    active UInt8,
+    text String,
+    INDEX text_idx text TYPE text(tokenizer = splitByNonAlpha)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS materialize_skip_indexes_on_insert = 1;
+INSERT INTO test_table VALUES (1, 1, 1, 'alpha'), (2, 1, 0, 'alpha'), (3, 2, 1, 'alpha'), (4, 2, 0, 'alpha');
 
 CREATE TABLE test_alias ENGINE = Alias('test_table');
 CREATE TABLE test_merge (id UInt32, tenant_id UInt32, active UInt8)
@@ -58,6 +76,19 @@ SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
 
 SELECT 'Alias policy with the analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
+
+-- The text-index count optimization must not discard a policy defined only on the `Alias`.
+SELECT 'Alias policy and text-index count optimization disabled';
+SELECT count() FROM test_alias WHERE hasToken(text, 'alpha')
+    SETTINGS enable_analyzer = 1, query_plan_optimize_count_from_text_index = 0;
+
+SELECT 'Alias policy and text-index count optimization enabled';
+SELECT count() FROM test_alias WHERE hasToken(text, 'alpha') SETTINGS enable_analyzer = 1;
+
+SELECT 'Alias policy disables text-index count optimization';
+SELECT count(explain)
+FROM (EXPLAIN SELECT count() FROM test_alias WHERE hasToken(text, 'alpha') SETTINGS enable_analyzer = 1)
+WHERE explain LIKE '%ReadFromTextIndexCount%';
 
 DROP ROW POLICY alias_policy ON test_alias;
 DROP TABLE test_merge;

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
@@ -1,0 +1,54 @@
+DROP ROW POLICY IF EXISTS target_policy ON test_table;
+DROP ROW POLICY IF EXISTS alias_policy ON test_alias;
+DROP TABLE IF EXISTS test_alias;
+DROP TABLE IF EXISTS test_table;
+
+SET allow_experimental_alias_table_engine = 1;
+
+CREATE TABLE test_table (id UInt32, tenant_id UInt32, active UInt8) ENGINE = MergeTree ORDER BY id;
+INSERT INTO test_table VALUES (1, 1, 1), (2, 1, 0), (3, 2, 1), (4, 2, 0);
+
+CREATE TABLE test_alias ENGINE = Alias('test_table');
+
+CREATE ROW POLICY target_policy ON test_table FOR SELECT USING tenant_id = 1 TO CURRENT_USER;
+
+-- A policy on the target table is also applied when reading through `Alias`.
+SELECT 'Target policy with the old analyzer';
+SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
+
+SELECT 'Target policy with the new analyzer';
+SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
+
+CREATE ROW POLICY alias_policy ON test_alias FOR SELECT USING active = 1 TO CURRENT_USER;
+
+-- Policies on the `Alias` and its target are combined with a logical AND.
+SELECT 'Combined policies with the old analyzer';
+SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
+
+SELECT 'Combined policies with the new analyzer';
+SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
+
+-- A non-trivial combined policy disables the trivial count optimization.
+SELECT 'Combined policies and trivial count disabled with the old analyzer';
+SELECT count() FROM test_alias SETTINGS enable_analyzer = 0, optimize_trivial_count_query = 0;
+
+SELECT 'Combined policies and trivial count enabled with the old analyzer';
+SELECT count() FROM test_alias SETTINGS enable_analyzer = 0, optimize_trivial_count_query = 1;
+
+SELECT 'Combined policies and trivial count disabled with the new analyzer';
+SELECT count() FROM test_alias SETTINGS enable_analyzer = 1, optimize_trivial_count_query = 0;
+
+SELECT 'Combined policies and trivial count enabled with the new analyzer';
+SELECT count() FROM test_alias SETTINGS enable_analyzer = 1, optimize_trivial_count_query = 1;
+
+DROP ROW POLICY target_policy ON test_table;
+
+SELECT 'Alias policy with the old analyzer';
+SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
+
+SELECT 'Alias policy with the new analyzer';
+SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
+
+DROP ROW POLICY alias_policy ON test_alias;
+DROP TABLE test_alias;
+DROP TABLE test_table;

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
@@ -16,7 +16,7 @@ CREATE ROW POLICY target_policy ON test_table FOR SELECT USING tenant_id = 1 TO 
 SELECT 'Target policy with the old analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
 
-SELECT 'Target policy with the new analyzer';
+SELECT 'Target policy with the analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
 
 CREATE ROW POLICY alias_policy ON test_alias FOR SELECT USING active = 1 TO CURRENT_USER;
@@ -25,7 +25,7 @@ CREATE ROW POLICY alias_policy ON test_alias FOR SELECT USING active = 1 TO CURR
 SELECT 'Combined policies with the old analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
 
-SELECT 'Combined policies with the new analyzer';
+SELECT 'Combined policies with the analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
 
 -- A non-trivial combined policy disables the trivial count optimization.
@@ -35,10 +35,10 @@ SELECT count() FROM test_alias SETTINGS enable_analyzer = 0, optimize_trivial_co
 SELECT 'Combined policies and trivial count enabled with the old analyzer';
 SELECT count() FROM test_alias SETTINGS enable_analyzer = 0, optimize_trivial_count_query = 1;
 
-SELECT 'Combined policies and trivial count disabled with the new analyzer';
+SELECT 'Combined policies and trivial count disabled with the analyzer';
 SELECT count() FROM test_alias SETTINGS enable_analyzer = 1, optimize_trivial_count_query = 0;
 
-SELECT 'Combined policies and trivial count enabled with the new analyzer';
+SELECT 'Combined policies and trivial count enabled with the analyzer';
 SELECT count() FROM test_alias SETTINGS enable_analyzer = 1, optimize_trivial_count_query = 1;
 
 DROP ROW POLICY target_policy ON test_table;
@@ -46,7 +46,7 @@ DROP ROW POLICY target_policy ON test_table;
 SELECT 'Alias policy with the old analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
 
-SELECT 'Alias policy with the new analyzer';
+SELECT 'Alias policy with the analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
 
 DROP ROW POLICY alias_policy ON test_alias;

--- a/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
+++ b/tests/queries/0_stateless/03636_storage_alias_row_policy.sql
@@ -1,5 +1,6 @@
 DROP ROW POLICY IF EXISTS target_policy ON test_table;
 DROP ROW POLICY IF EXISTS alias_policy ON test_alias;
+DROP TABLE IF EXISTS test_merge;
 DROP TABLE IF EXISTS test_alias;
 DROP TABLE IF EXISTS test_table;
 
@@ -9,6 +10,8 @@ CREATE TABLE test_table (id UInt32, tenant_id UInt32, active UInt8) ENGINE = Mer
 INSERT INTO test_table VALUES (1, 1, 1), (2, 1, 0), (3, 2, 1), (4, 2, 0);
 
 CREATE TABLE test_alias ENGINE = Alias('test_table');
+CREATE TABLE test_merge (id UInt32, tenant_id UInt32, active UInt8)
+    ENGINE = Merge(currentDatabase(), '^test_alias$');
 
 CREATE ROW POLICY target_policy ON test_table FOR SELECT USING tenant_id = 1 TO CURRENT_USER;
 
@@ -18,6 +21,13 @@ SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 0;
 
 SELECT 'Target policy with the analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
+
+-- A target policy is also applied when `Merge` reads through `Alias`.
+SELECT 'Target policy through Merge with the old analyzer';
+SELECT arraySort(groupArray(id)) FROM test_merge SETTINGS enable_analyzer = 0;
+
+SELECT 'Target policy through Merge with the analyzer';
+SELECT arraySort(groupArray(id)) FROM test_merge SETTINGS enable_analyzer = 1;
 
 CREATE ROW POLICY alias_policy ON test_alias FOR SELECT USING active = 1 TO CURRENT_USER;
 
@@ -50,5 +60,6 @@ SELECT 'Alias policy with the analyzer';
 SELECT arraySort(groupArray(id)) FROM test_alias SETTINGS enable_analyzer = 1;
 
 DROP ROW POLICY alias_policy ON test_alias;
+DROP TABLE test_merge;
 DROP TABLE test_alias;
 DROP TABLE test_table;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
`Alias` delegates reads to its target table, but row policies were previously resolved only for the `Alias` table itself. As a result, policies defined on the target table could be skipped, including for queries eligible for trivial-count optimization.

Resolve row policies for combine both the `Alias` and its target.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `Alias` tables ignoring row policies defined on its target tables. `Alias` now combine the row policies of both the Alias and its target.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116290&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116290](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116290+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
