### PR TITLE
Fix compilation of `benchmark_statistics` with `ENABLE_BENCHMARKS=ON`

### DIFF
--- a/src/Storages/benchmarks/benchmark_statistics.cpp
+++ b/src/Storages/benchmarks/benchmark_statistics.cpp
@@ -45,9 +45,9 @@ createBenchmarkUniqCombined64(const String &, const DataTypes & argument_types, 
     const WhichDataType which(argument_types[0]);
     /// Keep precision 12 and the UInt64 hash type in sync with StatisticsUniqV2.
     if (which.isUInt64())
-        return std::make_shared<AggregateFunctionUniqCombined<UInt64, 12, UInt64>>(argument_types, parameters);
+        return std::make_shared<AggregateFunctionUniqCombined<UInt64, ColumnVector<UInt64>, 12, UInt64>>(argument_types, parameters);
     if (which.isFloat64())
-        return std::make_shared<AggregateFunctionUniqCombined<Float64, 12, UInt64>>(argument_types, parameters);
+        return std::make_shared<AggregateFunctionUniqCombined<Float64, ColumnVector<Float64>, 12, UInt64>>(argument_types, parameters);
 
     throw Exception(
         ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116251
Related: https://github.com/ClickHouse/ClickHouse/pull/111221
Related: https://github.com/ClickHouse/ClickHouse/pull/109831
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/116251
Related: https://github.com/ClickHouse/ClickHouse/pull/111221
Related: https://github.com/ClickHouse/ClickHouse/pull/109831

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Building master with `-DENABLE_BENCHMARKS=ON` fails to compile `benchmark_statistics`:

```
src/Storages/benchmarks/benchmark_statistics.cpp:48:71: error: template argument for template type parameter must be a type
   48 |         return std::make_shared<AggregateFunctionUniqCombined<UInt64, 12, UInt64>>(argument_types, parameters);
```

**Root cause.** Two changes landed from branches that never saw each other. #109831
(`ea663038ac44cae`) gave `AggregateFunctionUniqCombined` a `ColumnType` template parameter in
**second** position, so it is now
`template <typename T, typename ColumnType, UInt8 K, typename HashValueType>`. #111221
(`40da35b856499bd`, "Reduce binary size for microbenchmark") then replaced
`registerAggregateFunctions` in this benchmark with a benchmark-local factory that hand-instantiates
the class with the old **3-argument** spelling. The literal `12` therefore binds to the `ColumnType`
position, where a type is required.

**Fix.** Supply the missing argument at the two call sites. `ColumnType` is used in exactly one
place, `Traits::value` doing `assert_cast<const ColumnType &>(column)`, so it must name the column
class the benchmark builds: `makeColumn` creates `ColumnUInt64` / `ColumnFloat64`, which are
`ColumnVector<UInt64>` / `ColumnVector<Float64>`. That is also what the real factory uses
(`AggregateFunctionUniqCombined.h:373`), and it is behaviour-preserving: before #109831 the class
hardcoded `assert_cast<const ColumnVector<T> &>(*columns[0])`, and that commit only hoisted the
hardcoded type into the new parameter.

**Why no build caught it.** `ENABLE_BENCHMARKS` defaults to `OFF` (`CMakeLists.txt:159`) and
`grep -rn ENABLE_BENCHMARKS ci/` returns 0 hits, so no CI job compiles this translation unit.

**Validation.** On the unmodified tree the target fails with exactly the two reported errors at
lines 48 and 50 and no others; with the fix it compiles, links, and the four `UniqV2` benchmark
cases run, covering both the `UInt64` and `Float64` paths. The other eight benchmark targets also
build, so this was the only bit-rotted one.

Note #110093 rewrites this file wholesale, so whichever merges second will conflict; this change is
two lines and trivially re-appliable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116292&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116292](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116292+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.205` (included in `26.9` and later)
<!-- ch-version-info:end -->