### PR TITLE
Fix hang in ThreadPool.GlobalFull1/GlobalFull2 unit tests

### DIFF
--- a/src/Common/tests/gtest_thread_pool_global_full.cpp
+++ b/src/Common/tests/gtest_thread_pool_global_full.cpp
@@ -18,22 +18,31 @@ namespace CurrentMetrics
 /// There was a bug: if local ThreadPool cannot allocate even a single thread,
 ///  the job will be scheduled but never get executed.
 
+namespace
+{
+
+/// Fault injection is process-global, so it has to be switched off on every path out of the
+/// scope, including an exception or a fatal assertion: while it is on, no thread pool anywhere
+/// in this binary can start a thread.
+struct AlwaysFailToAllocateThread
+{
+    AlwaysFailToAllocateThread() { CannotAllocateThreadFaultInjector::setFaultProbability(1.0); }
+    ~AlwaysFailToAllocateThread() { CannotAllocateThreadFaultInjector::setFaultProbability(0.0); }
+};
+
+}
+
 
 TEST(ThreadPool, GlobalFull1)
 {
-    GlobalThreadPool & global_pool = GlobalThreadPool::instance();
-
     static constexpr size_t capacity = 5;
-
-    global_pool.setMaxThreads(capacity);
-    global_pool.setMaxFreeThreads(1);
-    global_pool.setQueueSize(capacity);
-    global_pool.wait();
 
     std::atomic<size_t> counter = 0;
     static constexpr size_t num_jobs = capacity + 1;
 
-    auto func = [&] { ++counter; while (counter != num_jobs) {} };
+    /// The counter only ever grows, and an unexpectedly admitted job pushes it past the target,
+    /// so the predicate has to be an inequality for the spin to terminate at all.
+    auto func = [&] { ++counter; while (counter < num_jobs) {} };
 
     ThreadPool pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, num_jobs);
 
@@ -42,57 +51,42 @@ TEST(ThreadPool, GlobalFull1)
 
     for (size_t i = capacity; i < num_jobs; ++i)
     {
+        AlwaysFailToAllocateThread always_fail;
         EXPECT_THROW(pool.scheduleOrThrowOnError(func), DB::Exception);
         ++counter;
     }
 
     pool.wait();
     EXPECT_EQ(counter, num_jobs);
-
-    global_pool.setMaxThreads(10000);
-    global_pool.setMaxFreeThreads(1000);
-    global_pool.setQueueSize(10000);
 }
 
 
 TEST(ThreadPool, GlobalFull2)
 {
-    GlobalThreadPool & global_pool = GlobalThreadPool::instance();
-
     static constexpr size_t capacity = 5;
 
-    global_pool.setMaxThreads(capacity);
-    global_pool.setMaxFreeThreads(1);
-    global_pool.setQueueSize(capacity);
-
-    /// ThreadFromGlobalPool from local thread pools from previous test case have exited
-    ///  but their threads from global_pool may not have finished (they still have to exit).
-    /// If we will not wait here, we can get "Cannot schedule a task exception" earlier than we expect in this test.
-    global_pool.wait();
-
     std::atomic<size_t> counter = 0;
-    auto func = [&] { ++counter; while (counter != capacity + 1) {} };
+    auto func = [&] { ++counter; while (counter < capacity + 1) {} };
 
     ThreadPool pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, capacity, 0, capacity);
     for (size_t i = 0; i < capacity; ++i)
         pool.scheduleOrThrowOnError(func);
 
     ThreadPool another_pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 1);
-    EXPECT_THROW(another_pool.scheduleOrThrowOnError(func), DB::Exception);
+    {
+        AlwaysFailToAllocateThread always_fail;
+        EXPECT_THROW(another_pool.scheduleOrThrowOnError(func), DB::Exception);
+    }
 
     ++counter;
 
     pool.wait();
 
-    global_pool.wait();
-
+    /// Injection has to be off by this point, otherwise these jobs are rejected too and the
+    /// pool never gets to demonstrate that it recovers.
     for (size_t i = 0; i < capacity; ++i)
         another_pool.scheduleOrThrowOnError([&] { ++counter; });
 
     another_pool.wait();
     EXPECT_EQ(counter, capacity * 2 + 1);
-
-    global_pool.setMaxThreads(10000);
-    global_pool.setMaxFreeThreads(1000);
-    global_pool.setQueueSize(10000);
 }

--- a/src/Common/tests/gtest_thread_pool_global_full.cpp
+++ b/src/Common/tests/gtest_thread_pool_global_full.cpp
@@ -14,6 +14,11 @@ namespace CurrentMetrics
     extern const Metric LocalThreadScheduled;
 }
 
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_SCHEDULE_TASK;
+}
+
 /// Test what happens if local ThreadPool cannot create a ThreadFromGlobalPool.
 /// There was a bug: if local ThreadPool cannot allocate even a single thread,
 ///  the job will be scheduled but never get executed.
@@ -29,6 +34,25 @@ struct AlwaysFailToAllocateThread
     AlwaysFailToAllocateThread() { CannotAllocateThreadFaultInjector::setFaultProbability(1.0); }
     ~AlwaysFailToAllocateThread() { CannotAllocateThreadFaultInjector::setFaultProbability(0.0); }
 };
+
+/// A pool refuses a job either because it could not start a thread or because its queue would
+/// not admit it. Both refusals carry `CANNOT_SCHEDULE_TASK`, so the reason string is the only
+/// thing that distinguishes them, and only the first one is what these tests are about.
+void expectFailureToStartThread(ThreadPool & pool, ThreadPool::Job job)
+{
+    bool threw = false;
+    try
+    {
+        pool.scheduleOrThrowOnError(std::move(job));
+    }
+    catch (const DB::Exception & e)
+    {
+        threw = true;
+        EXPECT_EQ(e.code(), DB::ErrorCodes::CANNOT_SCHEDULE_TASK);
+        EXPECT_TRUE(e.message().contains("failed to start the thread")) << e.message();
+    }
+    EXPECT_TRUE(threw);
+}
 
 }
 
@@ -52,7 +76,7 @@ TEST(ThreadPool, GlobalFull1)
     for (size_t i = capacity; i < num_jobs; ++i)
     {
         AlwaysFailToAllocateThread always_fail;
-        EXPECT_THROW(pool.scheduleOrThrowOnError(func), DB::Exception);
+        expectFailureToStartThread(pool, func);
         ++counter;
     }
 
@@ -75,7 +99,7 @@ TEST(ThreadPool, GlobalFull2)
     ThreadPool another_pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, 1);
     {
         AlwaysFailToAllocateThread always_fail;
-        EXPECT_THROW(another_pool.scheduleOrThrowOnError(func), DB::Exception);
+        expectFailureToStartThread(another_pool, func);
     }
 
     ++counter;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110171
Related: https://github.com/ClickHouse/ClickHouse/pull/107996

CI report with the failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110171&sha=c29439904ffe645d443e3c90a49a420c0007562e&name_0=PR&name_1=Unit%20tests%20%28tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`ThreadPool.GlobalFull1` can hang the whole `unit_tests_dbms` binary, so CI's gdb watchdog kills the job
at 45 minutes and all ~28000 tests in it are lost. 66 occurrences in 30 days, in `Unit tests (tsan)`
and `Unit tests (msan)`.

Root cause: both tests reshaped the shared `GlobalThreadPool` and then waited for it to be completely
empty (`global_pool.wait`, predicate `scheduled_jobs == 0`), which assumes the test owns the whole pool.
It does not. Any earlier suite that resolves a function expression against the shared gtest context
lazily constructs `ExternalUserDefinedExecutableFunctionsLoader`, whose constructor calls
`enablePeriodicUpdates(true)` and parks a process-lifetime `ThreadFromGlobalPool` job there. That job
never completes, so the predicate can never become true.

The change stops the tests depending on global-pool state at all. Every
`setMaxThreads`/`setMaxFreeThreads`/`setQueueSize`/`wait` call on the global pool is deleted, and the
thread-creation failure the tests are about comes from `CannotAllocateThreadFaultInjector`, in the same
RAII shape `gtest_async_loader.cpp` already uses. Injection is on only around each asserted
`scheduleOrThrowOnError`, and off before `GlobalFull2` checks the pool recovers. Both counter
assertions are unchanged.

A pool raises `CANNOT_SCHEDULE_TASK` for a failed thread start and for a rejected queue admission
alike, so the original `EXPECT_THROW(..., DB::Exception)` would have accepted either and no longer
pinned the path these tests exist for. Both assertion sites now go through a helper that also
requires the reason `failed to start the thread`. One trade-off: the injector
short-circuits before the queue-admission check, so these tests no longer cover that path. Their
stated purpose, a local pool that cannot create a `ThreadFromGlobalPool`, is pinned more tightly.

<details>
<summary>Validation matrix</summary>

Validation needed the contaminant built deliberately, since neither original carrier still reproduces
it. Reproducer: a scratch-only gtest in a suite that sorts before `ThreadPool`, calling
`tryRegisterFunctions` then `getExternalUserDefinedExecutableFunctionsLoader`. It asserts it armed:
`global_pool.active()` `0 -> 1`, `ExternalLoader` threads `0 -> 1`.

| # | tree | contaminant | expected | observed |
|---|---|---|---|---|
| 1 | master | present | hang | RC=124, stuck at `[ RUN ] ThreadPool.GlobalFull1` |
| 2 | master | absent | pass | RC=0 (same binary as arm 1) |
| 3 | fix | present | pass | RC=0 |
| 4 | fix | absent | pass | RC=0 |

| mutation | expected | observed |
|---|---|---|
| never enable injection | the throw assertion fails in both tests | both FAILED, "it throws nothing" |
| scope expires before the assertion | the throw assertion fails | both FAILED |
| injection left on across `GlobalFull2` recovery | only `GlobalFull2` fails | `GlobalFull1` OK, `GlobalFull2` FAILED with `fault injected` |
| bare enable, no RAII restore | later tests cannot schedule | `HugeQueueSizeInConstructor`, `LIFOStartsManyBlockingJobs`, `ThreadRemoval` all FAILED with `fault injected`; shipped form passes all four |
| refusal forced down the queue-side path | only the reason check fails | FAILED on the reason, message `Cannot schedule a task: fault injected`; the code check stayed satisfied |
| expected error code perturbed | only the code check fails | both FAILED, `439` vs `49` |

Regression: `GlobalFull*` x50 -> 100 OK / 0 FAILED; `ThreadPool.*` -> 13/13; `ThreadPool*` +
`AsyncLoader*` + `ThreadFuzzer*` + `ThreadGroupSwitcher*` + `Common*` + `Exception*` -> 79 OK / 0 FAILED.

</details>

This supersedes #107996, which blamed the spin predicate overshooting its target; the backtraces park
in `global_pool.wait`, before the spin loop is reached. Its `!=` -> `<` change is kept for a different
reason: the counter only grows, so an inequality is what lets the spin terminate.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116296&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116296](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116296+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.142` (included in `26.9` and later)
<!-- ch-version-info:end -->