### PR TITLE
Make the unversioned-leaf gtest fixture independent of which functions are versioned

### DIFF
--- a/src/DataTypes/tests/gtest_aggregate_function_version_race.cpp
+++ b/src/DataTypes/tests/gtest_aggregate_function_version_race.cpp
@@ -31,6 +31,16 @@ DataTypePtr makeVersionedAggType()
     return type;
 }
 
+/// `count` state is a single counter and its `serialize` ignores the version parameter, so there is
+/// no second representation a version could select between: `isVersioned` is the base class's false.
+DataTypePtr makeUnversionedAggType()
+{
+    auto type = DataTypeFactory::instance().get("AggregateFunction(count, UInt64)");
+    /// Guard the test's own premise: if this ever becomes versioned, the setup is invalid.
+    EXPECT_FALSE(typeid_cast<const DataTypeAggregateFunction &>(*type).isVersioned());
+    return type;
+}
+
 const DataTypeAggregateFunction & asAgg(const DataTypePtr & type)
 {
     const auto * agg = typeid_cast<const DataTypeAggregateFunction *>(type.get());
@@ -121,16 +131,15 @@ GTEST_TEST(DataTypeAggregateFunctionVersion, PreservesCustomNameOfNonAggregateTy
     ASSERT_EQ(point->getName(), "Point");
 }
 
-/// A wrapper whose only aggregate child is UNVERSIONED (uniq) must be left untouched:
-/// no leaf is replaced, so the outer Nested/Array/Tuple must NOT be rebuilt (that would drop the
-/// Nested custom name and rewrite the Native type name / ATTACH encoding from Nested(...) to
-/// plain Array(Tuple(...))).
+/// A wrapper whose only aggregate child is UNVERSIONED must be left untouched:
+/// no leaf is replaced, so the outer `Nested`/`Array`/`Tuple` must NOT be rebuilt (that would drop
+/// the `Nested` custom name and rewrite the Native type name / ATTACH encoding from `Nested(...)` to
+/// plain `Array(Tuple(...))`).
 GTEST_TEST(DataTypeAggregateFunctionVersion, UnversionedLeafPreservesNestedCustomName)
 {
     tryRegisterAggregateFunctions();
 
-    /// uniq is not versioned, so no leaf is ever replaced under this Nested wrapper.
-    DataTypePtr nested = DataTypeFactory::instance().get("Nested(s AggregateFunction(uniq, UInt64))");
+    DataTypePtr nested = createNested({makeUnversionedAggType()}, {"s"});
     const String name_before = nested->getName();
     ASSERT_TRUE(name_before.starts_with("Nested("));
     const IDataType * nested_ptr_before = nested.get();


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`DataTypeAggregateFunctionVersion.UnversionedLeafPreservesNestedCustomName` asserts that
`setVersionToAggregateFunctions` returns its input object unchanged when no aggregate leaf under the
wrapper is versioned. It is the only guard for that no-rebuild direction: both SQL siblings
(`04612_*`, `04658_*`) use the versioned `sumMap`, so they cover only the rebuild direction.

The test picked `uniq` as its unversioned leaf and recorded that premise only in a comment. An
in-flight change makes `uniq` versioned, so the premise is now false: with `isVersioned` true and no
explicit version on the type, none of the early returns in `setVersionToAggregateFunctionsImpl`
fires, the leaf is rebuilt with an explicit version 0 (same version, new object), and the rebuild
propagates up through `Tuple` and `Array`. The custom name is faithfully reconstructed, so only the
object identity assertion fails: an opaque pointer mismatch with no hint that the fixture rather
than the traversal is at fault.

This re-points the fixture at `count`, which is unversioned by construction of its own
serialization: its state is a single counter and its `serialize` ignores the version parameter, so
there is no second representation a version could select between. It also asserts that premise,
mirroring the existing `makeVersionedAggType` helper that guards the opposite one, so a future
versioning change fails with "the chosen function is no longer unversioned" rather than a pointer
comparison. The identity assertion is unchanged: relaxing it would retire the only coverage of the
no-rebuild path.

Test-only, one file. Validated by mutating `uniq` to be versioned (old fixture fails at the identity
assertion with the reported operands, new fixture passes), on clean master, and with two mutants
showing the premise guard and the identity assertion each still fail independently.

Also noticed: the `Map` wrapper has no unversioned-leaf arm. Same `nullptr`-propagation contract
already covered through `Array`/`Tuple`, no user-reachable consequence, so not raised here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116314&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116314](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116314+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
