### PR TITLE
Parse known custom settings correctly

### DIFF
--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -745,21 +745,8 @@ void BaseSettings<TTraits>::read(ReadBuffer & in, SettingsWriteFormat format)
         bool is_important = (flags & Flags::IMPORTANT);
         bool is_custom = (flags & Flags::CUSTOM);
 
-        if (is_custom && Traits::allow_custom_settings)
+        if (is_custom && Traits::allow_custom_settings && index == static_cast<size_t>(-1))
         {
-            /// Honor the wire `CUSTOM` flag even when `name` collides with a built-in setting, rather
-            /// than coercing the value into that setting's typed slot. Query parameters are transported
-            /// through this `Settings` serialization, and a parameter whose name matches a built-in
-            /// setting (e.g. `--param_page` now that `page` is a real `Double` setting) must round-trip
-            /// as a string-valued custom field — otherwise a non-numeric value like `foo` would throw
-            /// while being parsed as the setting's type. A correctly-formed real settings packet never
-            /// flags a built-in setting as custom, so only such parameters take this branch.
-            ///
-            /// Store under the original wire name (`read_name`), not the alias-resolved `name`: a query
-            /// parameter whose name is a setting *alias* (e.g. `enable_analyzer`, an alias of
-            /// `allow_experimental_analyzer`) must round-trip under the user's chosen name so that
-            /// `SELECT {enable_analyzer:String}` can find it. `read_name` equals `name` for any
-            /// non-alias custom field, so this is exact for genuine custom settings.
             getCustomSetting(read_name).parseFromString(BaseSettingsHelpers::readString(in));
         }
         else if (index != static_cast<size_t>(-1))

--- a/src/Core/tests/gtest_settings.cpp
+++ b/src/Core/tests/gtest_settings.cpp
@@ -184,6 +184,33 @@ GTEST_TEST(QueryParameters, DuplicateNameOnTheWireLastOccurrenceWins)
     ASSERT_EQ(parameters.at("x"), "2");
 }
 
+GTEST_TEST(Settings, KnownSettingFlaggedCustomOnTheWireIsReadIntoItsTypedField)
+{
+    /// A client older than a setting has no typed field for it, so it holds the setting as a custom
+    /// field and sends it with the CUSTOM flag. The receiver knows the setting, so it must end up in
+    /// the typed field and be seen as changed.
+    Settings sent;
+    sent.setCustom("log_comment", Field(String("hello")));
+    sent.setCustom("max_block_size", Field(UInt64(1234)));
+    sent.setCustom("custom_unknown_here", Field(String("kept")));
+
+    WriteBufferFromOwnString out;
+    sent.write(out, SettingsWriteFormat::STRINGS_WITH_FLAGS);
+
+    Settings settings;
+    ReadBufferFromString in(out.str());
+    settings.read(in, SettingsWriteFormat::STRINGS_WITH_FLAGS);
+
+    ASSERT_TRUE(settings.isChanged("log_comment"));
+    ASSERT_EQ(settings.get("log_comment"), Field(String("hello")));
+    ASSERT_TRUE(settings.isChanged("max_block_size"));
+    ASSERT_EQ(settings.get("max_block_size"), Field(UInt64(1234)));
+
+    /// A name that is not a setting here stays a custom setting.
+    ASSERT_TRUE(settings.isChanged("custom_unknown_here"));
+    ASSERT_EQ(settings.get("custom_unknown_here"), Field(String("kept")));
+}
+
 GTEST_TEST(SettingFieldTimespan, ValueAlwaysFitsInt64Microseconds)
 {
     constexpr Int64 max_ms = std::numeric_limits<Int64>::max() / 1000;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2702,9 +2702,13 @@ void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
     client_info.connection_parallel_replicas_protocol_version = client_parallel_replicas_protocol_version;
     client_info.is_from_introspection_port = is_from_introspection_port;
 
-    state->run_query_in_background = passed_settings[Setting::run_query_in_background].changed
-        ? passed_settings[Setting::run_query_in_background].value
-        : session->sessionOrGlobalContext()->getSettingsRef()[Setting::run_query_in_background].value;
+    {
+        auto tmp_context = Context::createCopy(session->sessionOrGlobalContext());
+        SettingsChanges settings_changes_copy = passed_settings.changes();
+        tmp_context->clampToSettingsConstraints(settings_changes_copy, SettingSource::QUERY);
+        tmp_context->applySettingsChanges(settings_changes_copy);
+        state->run_query_in_background = tmp_context->getSettingsRef()[Setting::run_query_in_background];
+    }
 
     state->query_context = state->run_query_in_background
         ? session->makeDetachedQueryContext(client_info)

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2702,13 +2702,9 @@ void TCPHandler::processQuery(std::shared_ptr<QueryState> & state)
     client_info.connection_parallel_replicas_protocol_version = client_parallel_replicas_protocol_version;
     client_info.is_from_introspection_port = is_from_introspection_port;
 
-    {
-        auto tmp_context = Context::createCopy(session->sessionOrGlobalContext());
-        SettingsChanges settings_changes_copy = passed_settings.changes();
-        tmp_context->clampToSettingsConstraints(settings_changes_copy, SettingSource::QUERY);
-        tmp_context->applySettingsChanges(settings_changes_copy);
-        state->run_query_in_background = tmp_context->getSettingsRef()[Setting::run_query_in_background];
-    }
+    state->run_query_in_background = passed_settings[Setting::run_query_in_background].changed
+        ? passed_settings[Setting::run_query_in_background].value
+        : session->sessionOrGlobalContext()->getSettingsRef()[Setting::run_query_in_background].value;
 
     state->query_context = state->run_query_in_background
         ? session->makeDetachedQueryContext(client_info)


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/2066
<!-- End of fixes issue link part, do not remove -->

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A setting that a client does not know about is sent over the native protocol as a custom setting. The server now reads such a setting into the setting it names, instead of keeping it as a custom setting of the same name. Previously, it was reported as unchanged, at its default value, in the settings received with the query.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116317&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116317](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116317+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.78`
<!-- ch-version-info:end -->