### PR TITLE
Allow multiple hosts in clickhouse keeper-client

### DIFF
--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -3,6 +3,7 @@
 #include <Client/ClientBase.h>
 #include <Client/ReplxxLineReader.h>
 #include <Parsers/TokenIterator.h>
+#include <fmt/format.h>
 #include <Poco/Util/HelpFormatter.h>
 #include <Poco/Util/OptionCallback.h>
 #include <Common/Config/ConfigProcessor.h>
@@ -30,6 +31,9 @@ namespace
 {
 
 char WORD_BREAK_CHARACTERS[] = " \t\v\f\a\b\r\n";
+static constexpr const char * DEFAULT_HOST = "localhost";
+static constexpr const char * DEFAULT_PORT = "9181";
+
 
 /// Unescape a bare (unquoted) path that may contain backslash escaping
 /// and inline quoted segments, mirroring what parseKeeperArg accepts:
@@ -488,9 +492,9 @@ void KeeperClient::initialize(Poco::Util::Application & /* self */)
         config().setString("identity", env_identity);
 
     if (!hosts.empty() && hosts.back().empty())
-        hosts.back() = "localhost";
+        hosts.back() = DEFAULT_HOST;
     if (!ports.empty() && ports.back().empty())
-        ports.back() = "9181";
+        ports.back() = DEFAULT_PORT;
 }
 
 bool KeeperClient::processQueryText(const String & text, bool is_interactive)
@@ -708,17 +712,19 @@ void KeeperClient::connectToKeeper()
     zkutil::ZooKeeperArgs new_zk_args;
 
     const bool secure_config = config().has("secure");
+
+    auto add_host = [&](const String & host, const String & port) {
+        if (secure_config)
+            new_zk_args.hosts.push_back("secure://" + host + ":" + port);
+        else
+            new_zk_args.hosts.push_back(host + ":" + port);
+    };
     if (!hosts.empty() && !ports.empty())
     {
         chassert(hosts.size() == ports.size());
         for (size_t i = 0; i < hosts.size(); ++i)
         {
-            if (secure_config)
-            {
-                new_zk_args.hosts.push_back("secure://" + hosts[i] + ":" + ports[i]);
-                continue;
-            }
-            new_zk_args.hosts.push_back(hosts[i] + ":" + ports[i]);
+            add_host(hosts[i], ports[i]);
         }
     }
     else if (!keys.empty())
@@ -742,11 +748,7 @@ void KeeperClient::connectToKeeper()
     }
     else
     {
-        const String default_option = "localhost:9181";
-        if (secure_config)
-            new_zk_args.hosts.push_back("secure://" + default_option);
-        else
-            new_zk_args.hosts.push_back(default_option);
+        add_host(DEFAULT_HOST, DEFAULT_PORT);
     }
 
     new_zk_args.availability_zones.resize(new_zk_args.hosts.size());

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -1,18 +1,19 @@
 #include <KeeperClient.h>
-#include <Client/ReplxxLineReader.h>
-#include <Client/ClientBase.h>
-#include <Common/VersionNumber.h>
-#include <Common/Config/ConfigProcessor.h>
 #include <Client/ClientApplicationBase.h>
+#include <Client/ClientBase.h>
+#include <Client/ReplxxLineReader.h>
+#include <Parsers/TokenIterator.h>
+#include <Poco/Util/HelpFormatter.h>
+#include <Poco/Util/OptionCallback.h>
+#include <Common/Config/ConfigProcessor.h>
+#include <Common/ErrnoException.h>
 #include <Common/EventNotifier.h>
+#include <Common/VersionNumber.h>
 #include <Common/ZooKeeper/IKeeper.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/ZooKeeperArgs.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/filesystemHelpers.h>
-#include <Common/ZooKeeper/ZooKeeper.h>
-#include <Common/ErrnoException.h>
-#include <Parsers/TokenIterator.h>
-#include <Poco/Util/HelpFormatter.h>
 
 #if USE_SSL
 #include <Poco/Net/Context.h>
@@ -307,14 +308,16 @@ void KeeperClient::defineOptions(Poco::Util::OptionSet & options)
             .binding("help"));
 
     options.addOption(
-        Poco::Util::Option("host", "h", "server hostname. default `localhost`")
+        Poco::Util::Option("host", "h", "server hostname. default `localhost`. When repeated, `--host` and `--port` must alternate")
             .argument("<host>")
-            .binding("host"));
+            .repeatable(true)
+            .callback(Poco::Util::OptionCallback<KeeperClient>(this, &KeeperClient::handleHostOption)));
 
     options.addOption(
-        Poco::Util::Option("port", "p", "server port. default `9181`")
+        Poco::Util::Option("port", "p", "server port. default `9181`. When repeated, `--host` and `--port` must alternate")
             .argument("<port>")
-            .binding("port"));
+            .repeatable(true)
+            .callback(Poco::Util::OptionCallback<KeeperClient>(this, &KeeperClient::handlePortOption)));
 
     options.addOption(
         Poco::Util::Option("password", "", "password to connect to keeper server")
@@ -397,6 +400,44 @@ void KeeperClient::defineOptions(Poco::Util::OptionSet & options)
             .binding("accept-invalid-certificate"));
 }
 
+void KeeperClient::handleHostOption(const std::string & /* name */, const std::string & value)
+{
+    if (value.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "`--host` option cannot be empty");
+
+    if (!hosts.empty() && !hosts.back().empty() && !ports.empty() && ports.back().empty())
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "`--host` option must be followed by the `--port` option if you want to specify another pair");
+
+    if (!hosts.empty() && hosts.back().empty() && !ports.empty() && !ports.back().empty())
+    {
+        hosts.back() = value;
+        return;
+    }
+
+    hosts.push_back(value);
+    ports.push_back("");
+}
+
+void KeeperClient::handlePortOption(const std::string & /* name */, const std::string & value)
+{
+    if (value.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "`--port` option cannot be empty");
+
+    if (!hosts.empty() && hosts.back().empty() && !ports.empty() && !ports.back().empty())
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "`--port` option must be followed by the `--host` option if you want to specify another pair");
+
+    if (!hosts.empty() && !hosts.back().empty() && !ports.empty() && ports.back().empty())
+    {
+        ports.back() = value;
+        return;
+    }
+
+    hosts.push_back("");
+    ports.push_back(value);
+}
+
 void KeeperClient::initialize(Poco::Util::Application & /* self */)
 {
     suggest.setCompletionsCallback(
@@ -445,6 +486,11 @@ void KeeperClient::initialize(Poco::Util::Application & /* self */)
     const char * env_identity = getenv("CLICKHOUSE_KEEPER_IDENTITY"); // NOLINT(concurrency-mt-unsafe)
     if (env_identity && !config().has("identity"))
         config().setString("identity", env_identity);
+
+    if (!hosts.empty() && hosts.back().empty())
+        hosts.back() = "localhost";
+    if (!ports.empty() && ports.back().empty())
+        ports.back() = "9181";
 }
 
 bool KeeperClient::processQueryText(const String & text, bool is_interactive)
@@ -661,7 +707,21 @@ void KeeperClient::connectToKeeper()
 
     zkutil::ZooKeeperArgs new_zk_args;
 
-    if (!config().has("host") && !config().has("port") && !keys.empty())
+    const bool secure_config = config().has("secure");
+    if (!hosts.empty() && !ports.empty())
+    {
+        chassert(hosts.size() == ports.size());
+        for (size_t i = 0; i < hosts.size(); ++i)
+        {
+            if (secure_config)
+            {
+                new_zk_args.hosts.push_back("secure://" + hosts[i] + ":" + ports[i]);
+                continue;
+            }
+            new_zk_args.hosts.push_back(hosts[i] + ":" + ports[i]);
+        }
+    }
+    else if (!keys.empty())
     {
         LOG_INFO(getLogger("KeeperClient"), "Found keeper node in the config.xml, will use it for connection");
 
@@ -674,7 +734,7 @@ void KeeperClient::connectToKeeper()
             String host = clickhouse_config.configuration->getString(prefix + ".host");
             String port = clickhouse_config.configuration->getString(prefix + ".port");
 
-            if (clickhouse_config.configuration->has(prefix + ".secure") || config().has("secure"))
+            if (clickhouse_config.configuration->has(prefix + ".secure") || secure_config)
                 host = "secure://" + host;
 
             new_zk_args.hosts.push_back(host + ":" + port);
@@ -682,13 +742,11 @@ void KeeperClient::connectToKeeper()
     }
     else
     {
-        String host = config().getString("host", "localhost");
-        String port = config().getString("port", "9181");
-
-        if (config().has("secure"))
-            host = "secure://" + host;
-
-        new_zk_args.hosts.push_back(host + ":" + port);
+        const String default_option = "localhost:9181";
+        if (secure_config)
+            new_zk_args.hosts.push_back("secure://" + default_option);
+        else
+            new_zk_args.hosts.push_back(default_option);
     }
 
     new_zk_args.availability_zones.resize(new_zk_args.hosts.size());

--- a/programs/keeper-client/KeeperClient.cpp
+++ b/programs/keeper-client/KeeperClient.cpp
@@ -31,8 +31,8 @@ namespace
 {
 
 char WORD_BREAK_CHARACTERS[] = " \t\v\f\a\b\r\n";
-static constexpr const char * DEFAULT_HOST = "localhost";
-static constexpr const char * DEFAULT_PORT = "9181";
+constexpr const char * DEFAULT_HOST = "localhost";
+constexpr const char * DEFAULT_PORT = "9181";
 
 
 /// Unescape a bare (unquoted) path that may contain backslash escaping
@@ -713,12 +713,14 @@ void KeeperClient::connectToKeeper()
 
     const bool secure_config = config().has("secure");
 
-    auto add_host = [&](const String & host, const String & port) {
+    auto add_host = [&](const String & host, const String & port)
+    {
         if (secure_config)
             new_zk_args.hosts.push_back("secure://" + host + ":" + port);
         else
             new_zk_args.hosts.push_back(host + ":" + port);
     };
+
     if (!hosts.empty() && !ports.empty())
     {
         chassert(hosts.size() == ports.size());

--- a/programs/keeper-client/KeeperClient.h
+++ b/programs/keeper-client/KeeperClient.h
@@ -5,6 +5,7 @@
 #include <Common/ZooKeeper/KeeperClientCLI/KeeperClient.h>
 
 #include <iostream>
+#include <vector>
 
 namespace DB
 {
@@ -33,7 +34,12 @@ protected:
 
     std::vector<String> getCompletions(const String & prefix) const;
 
+    void handleHostOption(const std::string & name, const std::string & value);
+    void handlePortOption(const std::string & name, const std::string & value);
+
     zkutil::ZooKeeperArgs zk_args;
+    std::vector<String> hosts;
+    std::vector<String> ports;
 
     String history_file;
     UInt32 history_max_entries = 0; /// Maximum number of entries in the history file.

--- a/tests/integration/test_keeper_client_config/test.py
+++ b/tests/integration/test_keeper_client_config/test.py
@@ -197,3 +197,27 @@ def test_cli_identity_overrides_env(started_cluster):
         environment={"CLICKHOUSE_KEEPER_IDENTITY": "wrong:wrong"},
     )
     assert "protected_data" in data
+
+def test_multiple_cli_hosts(started_cluster):
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"clickhouse keeper-client -h 127.0.0.1 -p 1 -h node1 -p 9181 --password {KEEPER_PASSWORD} --connection-timeout 1 -q \"ls '/keeper'\"",
+        ],
+        privileged=True,
+    )
+    assert "api_version" in data
+
+
+def test_multiple_cli_hosts_requires_port_between_hosts(started_cluster):
+    data = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "clickhouse keeper-client -h node1 -h node2 -q \"ls '/keeper'\" 2>&1",
+        ],
+        privileged=True,
+        nothrow=True,
+    )
+    assert "`--host` option must be followed by the `--port` option" in data


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow multiple hosts in clickhouse keeper-client

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116332&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116332](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116332+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
