### PR TITLE
Add test: `Dynamic` operand gate in `mergeFilterIntoJoinCondition` has zero test coverage

### DIFF
--- a/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.reference
+++ b/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.reference
@@ -1,0 +1,6 @@
+-- `Dynamic` key is rejected with allow_dynamic_type_in_join_keys = 0
+cross		1
+1	1
+2	2
+-- `Dynamic` key is merged with allow_dynamic_type_in_join_keys = 1
+inner	CAST(a AS Dynamic) = d	0

--- a/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.reference
+++ b/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.reference
@@ -4,5 +4,3 @@ cross		1
 2	2
 -- `Dynamic` key is merged with allow_dynamic_type_in_join_keys = 1
 inner	CAST(a AS Dynamic) = d	0
-2
-0

--- a/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.reference
+++ b/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.reference
@@ -4,3 +4,5 @@ cross		1
 2	2
 -- `Dynamic` key is merged with allow_dynamic_type_in_join_keys = 1
 inner	CAST(a AS Dynamic) = d	0
+2
+0

--- a/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.sql
+++ b/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.sql
@@ -1,3 +1,5 @@
+-- Tags: no-random-merge-tree-settings
+
 -- A `WHERE` equality on a `Dynamic` column is not merged into the JOIN condition
 -- unless `allow_dynamic_type_in_join_keys` is enabled.
 
@@ -8,9 +10,9 @@ SET enable_parallel_replicas = 0;
 SET query_plan_merge_filter_into_join_condition = 1;
 SET query_plan_join_swap_table = 'false';
 SET enable_join_runtime_filters = 0;
+-- CI randomizes this to 0, which leaves `ON 1` reported as `inner` instead of `cross`.
+SET query_plan_optimize_join_order_limit = 10;
 
-DROP TABLE IF EXISTS t_int;
-DROP TABLE IF EXISTS t_dyn;
 CREATE TABLE t_int (a Int32) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE t_dyn (d Dynamic) ENGINE = MergeTree ORDER BY tuple();
 
@@ -39,6 +41,13 @@ FROM (
     EXPLAIN SELECT * FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
     SETTINGS allow_dynamic_type_in_join_keys = 1
 );
+
+-- Merging a `Dynamic` key drops the matches: comparing a `Dynamic` against
+-- another type is what the setting's default of false exists to prevent.
+SELECT count() FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
+SETTINGS allow_dynamic_type_in_join_keys = 0;
+SELECT count() FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
+SETTINGS allow_dynamic_type_in_join_keys = 1;
 
 DROP TABLE t_int;
 DROP TABLE t_dyn;

--- a/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.sql
+++ b/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.sql
@@ -1,0 +1,44 @@
+-- A `WHERE` equality on a `Dynamic` column is not merged into the JOIN condition
+-- unless `allow_dynamic_type_in_join_keys` is enabled.
+
+DROP TABLE IF EXISTS t_int;
+DROP TABLE IF EXISTS t_dyn;
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+SET query_plan_merge_filter_into_join_condition = 1;
+SET query_plan_join_swap_table = 'false';
+SET enable_join_runtime_filters = 0;
+
+DROP TABLE IF EXISTS t_int;
+DROP TABLE IF EXISTS t_dyn;
+CREATE TABLE t_int (a Int32) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_dyn (d Dynamic) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_int VALUES (1), (2), (3);
+INSERT INTO t_dyn VALUES (1), (2), (5);
+
+SELECT '-- `Dynamic` key is rejected with allow_dynamic_type_in_join_keys = 0';
+SELECT
+    extract(arrayStringConcat(groupArray(explain), '\n'), 'Type: (\\w+)') AS join_kind,
+    extract(arrayStringConcat(groupArray(explain), '\n'), 'Join conditions: ([^\n]*)') AS join_conditions,
+    countIf(explain LIKE '%Filter column:%') AS filters_above_join
+FROM (
+    EXPLAIN SELECT * FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
+    SETTINGS allow_dynamic_type_in_join_keys = 0
+);
+
+SELECT a, toString(d) FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
+ORDER BY ALL SETTINGS allow_dynamic_type_in_join_keys = 0;
+
+SELECT '-- `Dynamic` key is merged with allow_dynamic_type_in_join_keys = 1';
+SELECT
+    extract(arrayStringConcat(groupArray(explain), '\n'), 'Type: (\\w+)') AS join_kind,
+    extract(arrayStringConcat(groupArray(explain), '\n'), 'Join conditions: ([^\n]*)') AS join_conditions,
+    countIf(explain LIKE '%Filter column:%') AS filters_above_join
+FROM (
+    EXPLAIN SELECT * FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
+    SETTINGS allow_dynamic_type_in_join_keys = 1
+);
+
+DROP TABLE t_int;
+DROP TABLE t_dyn;

--- a/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.sql
+++ b/tests/queries/0_stateless/04665_merge_filter_into_join_dynamic_key.sql
@@ -42,12 +42,5 @@ FROM (
     SETTINGS allow_dynamic_type_in_join_keys = 1
 );
 
--- Merging a `Dynamic` key drops the matches: comparing a `Dynamic` against
--- another type is what the setting's default of false exists to prevent.
-SELECT count() FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
-SETTINGS allow_dynamic_type_in_join_keys = 0;
-SELECT count() FROM (SELECT * FROM t_int INNER JOIN t_dyn ON 1) WHERE a = d
-SETTINGS allow_dynamic_type_in_join_keys = 1;
-
 DROP TABLE t_int;
 DROP TABLE t_dyn;


### PR DESCRIPTION
_Test-only PR. Review: are the gaps real, is the test right._

Adds test coverage for 1 untested code path, found during automated review of [PR #112630](https://github.com/ClickHouse/ClickHouse/pull/112630).
That PR: (1) Relaxes the type gate in `extractActionsForJoinCondition` (`mergeFilterIntoJoinCondition.cpp`): a `WHERE` equality is now merged into the JOIN condition when operands merely share a common supertype (`tryGetLeastSupertype`) instead of requiring `equals` types, and adds a new gate rejecting …

**1. `Dynamic` operand gate in `mergeFilterIntoJoinCondition` has zero test coverage**
  `src/Processors/QueryPlan/Optimizations/mergeFilterIntoJoinCondition.cpp:189`, `src/Processors/QueryPlan/Optimizations/mergeFilterIntoJoinCondition.cpp:314`
  **Risk:** `tryMergeFilterIntoJoinCondition` reads `join_step->getJoinSettings().allow_dynamic_type_in_join_keys` (line 314) and passes it into `extractActionsForJoinCondition`, where line 187 rejects any equality conjunct with a `Dynamic` operand. No test in either tree constructs such a conjunct, so lines …
  **Unique vs PR tests:** The PR's `04654_merge_filter_into_join_condition_common_supertype.sql` covers the other new gate (common supertype: `Int32`/`Nullable(Int32)` merged, `Int32`/`UInt64` rejected), the `Join`-engine early-out and a correlated subquery, but never constructs a `Dynamic` operand — so lines 189-190 stay …

cc @m-selmi (author of #112630), @novikd (merged/approved #112630) — could you take a look, and add the `can be tested` label if this looks good?

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116334&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116334](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116334+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.159` (included in `26.9` and later)
<!-- ch-version-info:end -->