### PR TITLE
Raise the randomizer floors for the compress block sizes and merge_max_block_size

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1586,8 +1586,8 @@ class SettingsRandomizer:
         "merge_tree_coarse_index_granularity": lambda: random.randint(2, 32),
         "optimize_distinct_in_order": lambda: random.randint(0, 1),
         "max_bytes_before_remerge_sort": lambda: random.randint(1, 3000000000),
-        "min_compress_block_size": lambda: random.randint(1, 1048576 * 3),
-        "max_compress_block_size": lambda: random.randint(1, 1048576 * 3),
+        "min_compress_block_size": lambda: random.randint(8000, 1048576 * 3),
+        "max_compress_block_size": lambda: random.randint(8000, 1048576 * 3),
         "merge_tree_compact_parts_min_granules_to_multibuffer_read": lambda: random.randint(
             1, 128
         ),
@@ -1840,7 +1840,7 @@ class MergeTreeSettingsRandomizer:
             0.25, 0.25, 1, 10 * 1024 * 1024 * 1024
         ),
         "index_granularity_bytes": lambda: random.randint(1024, 30 * 1024 * 1024),
-        "merge_max_block_size": lambda: random.randint(1, 8192 * 3),
+        "merge_max_block_size": lambda: random.randint(100, 8192 * 3),
         "merge_use_batch_sorting_queue": lambda: random.randint(0, 1),
         "index_granularity": lambda: random.randint(1, 65536),
         "min_bytes_for_wide_part": threshold_generator(0.3, 0.3, 0, 1024 * 1024 * 1024),


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/116233
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/116233


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested by @ PedroTadim in https://github.com/ClickHouse/ClickHouse/pull/116233#issuecomment-5410037661.

`tests/clickhouse-test` draws `min_compress_block_size` and `max_compress_block_size` from
`randint(1, 1048576 * 3)` and `merge_max_block_size` from `randint(1, 8192 * 3)`, so it can inject a
tiny column compression or merge sizing value into any test that never asked for one. A draw of 21
made `02973_backup_of_in_memory_compressed.sh` trip the hung check on a
`Stress test (arm_asan_ubsan, s3)` job. Over 500,000 draws per setting, 0.25% land below 8000 for the
two compress sizes and 0.42% below 100 for `merge_max_block_size`, and each hit costs a full CI leg.

Neither new floor is invented. 8000 is already the floor for `marks_compress_block_size` and
`primary_key_compress_block_size` at `:1849-1850` and for `max_block_size` and
`max_joined_block_size_rows` at `:1520-1521`, so afterwards every `*compress_block_size` entry here is
floored at 8000. 100 is what the suite's own per-test clamps already use: 12 of the 13
`-- Random settings limits:` lines naming `merge_max_block_size` use `(100, None)`.

It costs no coverage. An explicit `SET`, `SETTINGS` clause or table-level setting still beats the
injected value, and low values are already pinned deterministically below the new floors by 12, 15 and
14 stateless tests respectively, down to 0 and 1 in each case.

Random low values do find real defects, so in fairness to the other side: of the three such fixes in
history, only `1161b8a7e87cbdf` came from a low random draw (a per-block log storm at
`max_compress_block_size=128`), and its regression test pins 128 explicitly, so that coverage
survives. `a937442ebe033b8` is about the extreme upper end, and #113585 is about
`merge_max_block_size_bytes`, which is not randomized.

No test file: nothing outside `tests/clickhouse-test` asserts on the randomizer classes, and
`ci/tests/` is being removed. Validation is behavioural, with a negative control per line.

`temporary_files_buffer_size` is deliberately untouched: it draws from
`randint(800 * 1024, 1200 * 1024)` and is `NonZeroUInt64`, so the randomizer cannot set it low.

<details><summary>Validation</summary>

Oracle: the real draw path through `runpy.run_path` on the file itself, 500,000 draws per setting,
seed pinned.

| setting | floor | before: min / below floor | after: min / below floor | range top, unedited |
|---|---|---|---|---|
| `min_compress_block_size` | 8000 | 7 / 1250 of 500000 | 8006 / **0** | 3145728 |
| `max_compress_block_size` | 8000 | 7 / 1284 of 500000 | 8006 / **0** | 3145728 |
| `merge_max_block_size` | 100 | 1 / 2111 of 500000 | 100 / **0** | 24576 |

Negative control, one floor reverted at a time: reverting `min_compress_block_size` gives min 3 and
497 low draws while the other two stay clean; reverting `max_compress_block_size` gives min 5 and 534;
reverting `merge_max_block_size` gives min 1 and 781. So each of the three lines is independently
load bearing and the oracle is not blind.

Clamp composition, executed against the real `TestCase.apply_random_settings_limits`: the 12 existing
`merge_max_block_size=(100, None)` clamps become redundant but harmless, since draws of 100, 101, 250
and 24576 pass through unchanged; the same clamp still lifts 1, 21 and 99 to 100, so the mechanism is
live; the one stricter clamp, `(8192, None)` in
`03174_split_parts_ranges_into_intersecting_and_non_intersecting_final_and_read-in-order_bug.sql`,
still lifts 100, 500 and 8191 to 8192. With no clamp registered a draw of 3 passes through as 3.
There are no upper bound clamps on any of the three settings.

3000 rounds through both `get_random_settings` functions emit all three settings every round with no
value below the floor; with the `merge_max_block_size` floor reverted the same arm reports min 17.

`black` is not run: `--check` already reports that this file would be reformatted on master, so
running it would bury a three line change.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116347&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116347](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116347+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
