### PR TITLE
Pin the query-based parallel replicas in 03303_distributed_explain

### DIFF
--- a/tests/queries/0_stateless/03303_distributed_explain.sql
+++ b/tests/queries/0_stateless/03303_distributed_explain.sql
@@ -22,6 +22,11 @@ INSERT INTO test_parallel_replicas SELECT * FROM numbers(10);
 SET automatic_parallel_replicas_mode = 0;
 SET enable_parallel_replicas=2, max_parallel_replicas=2, cluster_for_parallel_replicas='test_cluster_one_shard_two_replicas', parallel_replicas_for_non_replicated_merge_tree=1, parallel_replicas_local_plan=1;
 
+-- The two explains below assert the exact plan text, which the plan-based implementation of
+-- parallel replicas shapes differently (it ships a plan fragment reading the table instead of a
+-- query over it).
+SET parallel_replicas_plan_based = 0;
+
 explain actions=1, distributed=1 SELECT sum(number) from test_parallel_replicas group by bitAnd(number, 3) settings serialize_query_plan=0;
 
 select '----- pr, serialize_query_plan=1 -----';


### PR DESCRIPTION
The two parallel-replicas explains in `03303_distributed_explain` assert the exact plan text, and the plan-based implementation of parallel replicas shapes it differently: it ships a plan fragment that reads the table (`ReadFromMergeTree`) instead of a query over it (`ReadFromTable`), merges the expressions above the read differently, and names the merging step `MergingAggregated (merge)`.

Pin `parallel_replicas_plan_based = 0` for them, the same way https://github.com/ClickHouse/ClickHouse/pull/116086 did for the other plan-text assertions on parallel replicas. The `remote()` explains earlier in the test are unaffected by the setting.

This is the last of the test-only failures surfaced by https://github.com/ClickHouse/ClickHouse/pull/112351, which turns the setting on by default; the 14 that remain there are gaps in the plan-based implementation itself.

Related: https://github.com/ClickHouse/ClickHouse/pull/112351
Related: https://github.com/ClickHouse/ClickHouse/pull/116086

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116355&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116355](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116355+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
