### PR TITLE
Update dbt docs: dictionaries, clone, new s3 args,  query correlation, delete+insert updates, update refreshable parameters

### DIFF
--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations.mdx
@@ -163,11 +163,27 @@ keys used to populate the parameters of the S3 table function:
 | aws_access_key_id     | The S3 access key id.                                                                                                                                                                        |
 | aws_secret_access_key | The S3 secret key.                                                                                                                                                                           |
 | role_arn              | The ARN of the IAM role created for secure S3 access. See this [documentation](/products/cloud/guides/data-sources/accessing-s3-data-securely) for more information.     |
+| external_id           | The external ID to pass along with `role_arn` when assuming the IAM role. Requires `role_arn` to be set. Available since dbt-clickhouse 1.10.2.                                              |
 | compression           | The compression method used with the S3 objects.  If not provided ClickHouse will attempt to determine compression based on the file name.                                                   |
 
-See
-the [S3 test file](https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/clickhouse/test_clickhouse_s3.py)
-for examples of how to use this macro.
+#### Example {#s3source-example}
+
+Define the shared configuration in `dbt_project.yml` (the dictionary name must end in `s3`):
+
+```yaml
+vars:
+  taxi_s3:
+    bucket: 'datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi'
+    fmt: 'TabSeparatedWithNames'
+```
+
+Then call the macro in a model. Any of the arguments above can also be passed directly in the call, taking precedence over the dictionary values:
+
+```sql
+select * from {{ clickhouse_s3source('taxi_s3', path='/trips_4.gz') }}
+```
+
+See the [S3 test file](https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/clickhouse/test_clickhouse_s3.py) for more examples.
 
 ### Cross database macro support {#cross-database-macro-support}
 

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/index.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/index.mdx
@@ -182,10 +182,7 @@ Some operations may take longer than expected due to specific ClickHouse queries
 
 ### Correlating dbt runs with ClickHouse queries {#query-id-tracking}
 
-For server-side detail, starting with dbt-clickhouse 1.10.1, every query executed by the adapter is assigned a unique query ID (a UUID4), which is forwarded to ClickHouse. This makes it possible to correlate a dbt model run with the queries it executed on the server:
-
-- The query ID is returned in the `adapter_response` of each dbt result, so it's available in dbt artifacts such as [`run_results.json`](https://docs.getdbt.com/reference/artifacts/run-results-json).
-- On the ClickHouse side, you can look up the same ID in the [`system.query_log`](/reference/system-tables/query_log) table to inspect the timing and resource usage of the queries behind a model.
+For server-side detail, starting with dbt-clickhouse 1.10.1, every statement executed by the adapter is assigned its own query ID (a UUID4), which is forwarded to ClickHouse. The ID of a model's main statement is returned in the `adapter_response` of its dbt result, so it's available in dbt artifacts such as [`run_results.json`](https://docs.getdbt.com/reference/artifacts/run-results-json). You can look it up in the [`system.query_log`](/reference/system-tables/query_log) table to inspect that statement's timing and resource usage:
 
 ```sql
 SELECT query_id, query, query_duration_ms, read_rows, memory_usage
@@ -194,7 +191,9 @@ WHERE query_id = '<query_id from run_results.json>'
   AND type = 'QueryFinish'
 ```
 
-This also enables observability tools that consume dbt artifacts (for example, Elementary) to link dbt model runs to entries in `system.query_log` automatically.
+Note that a materialization usually runs several statements per model (DDL, inserts, etc.), each with its own query ID; the one in `run_results.json` identifies only the model's main statement. To find every statement behind a run, filter `system.query_log` by the [dbt query comment](https://docs.getdbt.com/reference/project-configs/query-comment) embedded in each query's text instead.
+
+The query ID also enables observability tools that consume dbt artifacts (for example, Elementary) to link dbt model runs to entries in `system.query_log` automatically.
 
 ## Limitations {#limitations}
 

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/index.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/index.mdx
@@ -49,6 +49,7 @@ List of supported features:
 - [x] Ephemeral materialization
 - [x] Distributed table materialization (experimental)
 - [x] Distributed incremental materialization (experimental)
+- [x] Dictionary materialization (experimental)
 - [x] Contracts
 - [x] ClickHouse-specific column configurations (Codec, TTL...)
 - [x] ClickHouse-specific table settings (indexes, projections...)
@@ -70,8 +71,6 @@ dbt provides 5 types of materialization. All of them are supported by `dbt-click
 * **materialized view**: The model is built as a materialized view in the database. At ClickHouse this is built as a [materialized view](/reference/statements/create/view#materialized-view).
 
 Additional syntax and clauses define how these models should be updated if their underlying data changes. dbt generally recommends starting with the view materialization until performance becomes a concern. The table materialization provides a query time performance improvement by capturing the results of the model's query as a table at the expense of increased storage. The incremental approach builds on this further to allow subsequent updates to the underlying data to be captured in the target table.
-
-The[ current adapter](https://github.com/silentsokolov/dbt-clickhouse) for ClickHouse supports also support **dictionary**, **distributed table** and **distributed incremental** materializations. The adapter also supports dbt [snapshots](https://docs.getdbt.com/docs/building-a-dbt-project/snapshots#check-strategy) and [seeds](https://docs.getdbt.com/docs/building-a-dbt-project/seeds).
 
 The following are [experimental features](/reference/settings/beta-and-experimental-features) in `dbt-clickhouse`:
 
@@ -144,7 +143,7 @@ Your CD step can be as simple as running `dbt build` against your production Cli
 
 One common strategy is to use [Slim CI](https://docs.getdbt.com/best-practices/best-practice-workflows#run-only-modified-models-to-test-changes-slim-ci) jobs, where only the modified models (and their up- and downstream dependencies) are re-deployed. This approach uses artifacts from your production runs (i.e., the [dbt manifest](https://docs.getdbt.com/reference/artifacts/manifest-json)) to reduce the run time of your project and ensure there is no schema drift across environments.
 
-To keep your development environments in sync and avoid running your models against stale deployments, you can use [clone](https://docs.getdbt.com/reference/commands/clone) or even [defer](https://docs.getdbt.com/reference/node-selection/defer).
+To keep your development environments in sync and avoid running your models against stale deployments, you can use [clone](https://docs.getdbt.com/reference/commands/clone) or even [defer](https://docs.getdbt.com/reference/node-selection/defer). On ClickHouse, `dbt clone` copies MergeTree tables using a zero-copy `CLONE` statement — see [Cloning models with dbt clone](#dbt-clone) below for details.
 
 We recommend using a dedicated ClickHouse cluster or service for the testing environment (i.e., a staging environment) to avoid impacting the operation of your production environment. To ensure the testing environment is representative, it's important that you use a subset of your production data, as well as run dbt in a way that prevents schema drift between environments.
 
@@ -154,6 +153,17 @@ We recommend using a dedicated ClickHouse cluster or service for the testing env
 Using a dedicated environment for CI testing also allows you to perform manual testing without impacting your production environment. For example, you may want to point a BI tool to this environment for testing.
 
 For deployment (i.e., the CD step), we recommend using the artifacts from your production deployments to only update the models that have changed. This requires setting up object storage (e.g., S3) as intermediate storage for your dbt artifacts. Once that is set up, you can run a command like `dbt build --select state:modified+ --state path/to/last/deploy/state.json` to selectively rebuild the minimum amount of models needed based on what changed since the last run in production.
+
+#### Cloning models with `dbt clone` {#dbt-clone}
+
+Starting with dbt-clickhouse 1.10.1, the [`dbt clone`](https://docs.getdbt.com/reference/commands/clone) command uses ClickHouse's zero-copy `CREATE OR REPLACE TABLE ... CLONE AS ...` statement to clone models materialized as tables that use a MergeTree-family engine. This creates a copy of the table without duplicating the underlying data parts, making it a fast and cheap way to sync environments — for example, when setting up a development or [Slim CI](https://docs.getdbt.com/best-practices/best-practice-workflows#run-only-modified-models-to-test-changes-slim-ci) environment from production state.
+
+Models that can't be cloned this way fall back to dbt's default behavior of creating a view pointing to the source relation:
+
+- Tables using non-MergeTree engines
+- Distributed materializations
+
+For materialized view models, only the target table is cloned; the materialized view itself is created on top of the cloned table.
 
 ## Troubleshooting common issues {#troubleshooting-common-issues}
 
@@ -169,6 +179,22 @@ If you encounter issues connecting to ClickHouse from dbt, make sure the followi
 ### Understanding long-running operations {#understanding-long-running-operations}
 
 Some operations may take longer than expected due to specific ClickHouse queries. To gain more insight into which queries are taking longer, increase the [log level](https://docs.getdbt.com/reference/global-configs/logs#log-level) to `debug` — this will print the time used by each query. For example, this can be achieved by appending `--log-level debug` to dbt commands.
+
+### Correlating dbt runs with ClickHouse queries {#query-id-tracking}
+
+For server-side detail, starting with dbt-clickhouse 1.10.1, every query executed by the adapter is assigned a unique query ID (a UUID4), which is forwarded to ClickHouse. This makes it possible to correlate a dbt model run with the queries it executed on the server:
+
+- The query ID is returned in the `adapter_response` of each dbt result, so it's available in dbt artifacts such as [`run_results.json`](https://docs.getdbt.com/reference/artifacts/run-results-json).
+- On the ClickHouse side, you can look up the same ID in the [`system.query_log`](/reference/system-tables/query_log) table to inspect the timing and resource usage of the queries behind a model.
+
+```sql
+SELECT query_id, query, query_duration_ms, read_rows, memory_usage
+FROM system.query_log
+WHERE query_id = '<query_id from run_results.json>'
+  AND type = 'QueryFinish'
+```
+
+This also enables observability tools that consume dbt artifacts (for example, Elementary) to link dbt model runs to entries in `system.query_log` automatically.
 
 ## Limitations {#limitations}
 

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materialization-materialized-view.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materialization-materialized-view.mdx
@@ -459,7 +459,7 @@ To use a refreshable materialized view, add a `refreshable` config object to you
 
 | Option                | Description                                                                                                                                                              | Required | Default Value |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| refresh_interval      | The interval clause (required)                                                                                                                                           | Yes      |               |
+| interval              | The interval clause (required), such as `EVERY 5 MINUTE`                                                                                                                 | Yes      |               |
 | randomize             | The randomization clause, will appear after `RANDOMIZE FOR`                                                                                                              |          |               |
 | append                | If set to `True`, each refresh inserts rows into the table without deleting existing rows. The insert is not atomic, just like a regular INSERT SELECT.                  |          | False         |
 | depends_on            | A dependencies list for the refreshable mv. Please provide the dependencies in the following format `{schema}.{view_name}`                                               |          |               |
@@ -511,6 +511,17 @@ SELECT
 FROM {{ source('raw', 'events') }}
 GROUP BY event_date, event_type
 ```
+
+### Updating the refresh parameters {#refreshable-updating-parameters}
+
+Starting with dbt-clickhouse 1.10.2, changes to the refresh parameters (`interval`, `randomize` and `depends_on`) of an existing refreshable materialized view are applied in place on a regular `dbt run`, using `ALTER TABLE ... MODIFY REFRESH`. The materialized view is not dropped or recreated, so no data is lost and there is no "blind window" while the change is applied.
+
+Some transitions cannot be applied in place. Instead of silently ignoring them, dbt will fail the run with an error asking you to use `dbt run --full-refresh`:
+
+- Converting a regular materialized view into a refreshable one (adding the `refreshable` config), or the other way around (removing it).
+- Changing the `append` setting, since ClickHouse does not allow adding or removing `APPEND` via `MODIFY REFRESH`.
+
+Keep in mind that a `--full-refresh` drops and recreates the materialized view, with the implications described in [Behavior during active ingestion](#behavior-during-active-ingestion).
 
 ### Limitations {#refreshable-limitations}
 

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
@@ -296,11 +296,13 @@ There are important caveats to using this strategy:
 - It operates directly on the affected table without creating any intermediate or temporary tables, so if there is an
   issue during the operation, the data in the incremental model is likely to be in an invalid state.
 - It requires the ClickHouse setting `allow_nondeterministic_mutations`. The adapter enables it automatically for its
-  own sessions when possible; if the setting is read-only for your dbt user and can't be enabled, the adapter falls
-  back to the legacy strategy (or fails if `use_lw_deletes` is set). In some very rare cases using non-deterministic
-  `incremental_predicates` this could result in a race condition for the updated/deleted items. To ensure consistent
-  results, the incremental predicates should only include sub-queries on data that will not be modified during the
-  incremental materialization.
+  own sessions when possible. When it can't be enabled (for example, it's read-only for your dbt user), the behavior
+  depends on how the strategy was chosen: models relying on the default strategy silently fall back to the legacy
+  strategy, models that explicitly set `delete+insert` or `microbatch` fail at runtime, and `use_lw_deletes: true` in
+  the profile fails at connection time.
+- In some very rare cases, using non-deterministic `incremental_predicates` could result in a race condition for the
+  updated/deleted items. To ensure consistent results, the incremental predicates should only include sub-queries on
+  data that will not be modified during the incremental materialization.
 
 #### The Microbatch Strategy (Requires dbt-core >= 1.9) {#microbatch-strategy}
 

--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/materializations.mdx
@@ -289,27 +289,18 @@ expensive and slow to execute.
 
 #### The Delete+Insert Strategy {#delete-insert-strategy}
 
-ClickHouse added "lightweight deletes" as an experimental feature in version 22.8. Lightweight deletes are significantly
-faster than ALTER TABLE ... DELETE
-operations, because they don't require rewriting ClickHouse data parts. The incremental strategy `delete+insert`
-utilizes lightweight deletes to implement
-incremental materializations that perform significantly better than the "legacy" strategy. However, there are important
-caveats to using this strategy:
+The `delete+insert` strategy uses [lightweight deletes](/concepts/features/operations/delete/lightweight-delete) to remove the affected rows and then inserts the new ones. Because it doesn't copy the whole table, it performs significantly better than the "legacy" strategy. Setting `use_lw_deletes: true` in your profile makes `delete+insert` the default incremental strategy.
 
-- Lightweight deletes must be enabled on your ClickHouse server using the setting
-  `allow_experimental_lightweight_delete=1` or you
-  must set `use_lw_deletes=true` in your profile (which will enable that setting for your dbt sessions)
-- Lightweight deletes are now production ready, but there may be performance and other problems on ClickHouse versions
-  earlier than 23.3.
-- This strategy operates directly on the affected table/relation (with creating any intermediate or temporary tables),
-  so if there is an issue during the operation, the
-  data in the incremental model is likely to be in an invalid state
-- When using lightweight deletes, dbt-clickhouse enabled the setting `allow_nondeterministic_mutations`. In some very
-  rare cases using non-deterministic incremental_predicates
-  this could result in a race condition for the updated/deleted items (and related log messages in the ClickHouse logs).
-  To ensure consistent results the
-  incremental predicates should only include sub-queries on data that will not be modified during the incremental
-  materialization.
+There are important caveats to using this strategy:
+
+- It operates directly on the affected table without creating any intermediate or temporary tables, so if there is an
+  issue during the operation, the data in the incremental model is likely to be in an invalid state.
+- It requires the ClickHouse setting `allow_nondeterministic_mutations`. The adapter enables it automatically for its
+  own sessions when possible; if the setting is read-only for your dbt user and can't be enabled, the adapter falls
+  back to the legacy strategy (or fails if `use_lw_deletes` is set). In some very rare cases using non-deterministic
+  `incremental_predicates` this could result in a race condition for the updated/deleted items. To ensure consistent
+  results, the incremental predicates should only include sub-queries on data that will not be modified during the
+  incremental materialization.
 
 #### The Microbatch Strategy (Requires dbt-core >= 1.9) {#microbatch-strategy}
 
@@ -374,10 +365,67 @@ Due to its depth, this materialization has its own dedicated page. **[Go to the 
 
 ## Materialization: dictionary (experimental) {#materialization-dictionary}
 
-See the tests
-in https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/dictionary/test_dictionary.py for
-examples of how to
-implement materializations for ClickHouse dictionaries
+A dbt model can be created as a ClickHouse [dictionary](/concepts/features/dictionaries/index). On every `dbt run` the dictionary is replaced with the current model definition using `CREATE OR REPLACE DICTIONARY`.
+
+### Configurations {#dictionary-configurations}
+
+| Option                 | Description                                                                                                                                                                                                       | Required             |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| `fields`               | The dictionary structure, as a list of `(name, type)` pairs.                                                                                                                                                     | Yes                  |
+| `primary_key`          | The dictionary primary key. Must match the key type expected by the chosen layout (for example, a complex key for `COMPLEX_KEY_*` layouts).                                                                      | Yes                  |
+| `layout`               | The [layout](/reference/statements/create/dictionary/layouts/overview) used to store the dictionary in memory, such as `HASHED()`, `COMPLEX_KEY_HASHED()` or `DIRECT()`.                                        | Yes                  |
+| `source_type`          | Where the dictionary reads its data from: `clickhouse` (default, uses the model's SQL or the `table` option) or `http`.                                                                                          |                      |
+| `lifetime`             | The [`LIFETIME`](/reference/statements/create/dictionary/lifetime) clause controlling how often the dictionary is refreshed, e.g. `MIN 0 MAX 300`. Optional since dbt-clickhouse 1.10.0 — omit it for layouts that don't use it, such as `DIRECT()`. |                      |
+| `table`                | `clickhouse` source only. Read from an existing table instead of the model's SQL.                                                                                                                                |                      |
+| `update_field`         | `clickhouse` source only. Refresh the dictionary incrementally by fetching only rows whose value in this column changed since the previous update. See [LIFETIME](/reference/statements/create/dictionary/lifetime). Available since dbt-clickhouse 1.10.0. |                      |
+| `update_lag`           | `clickhouse` source only. Number of seconds subtracted from the previous update time when using `update_field`, to account for late-arriving updates. Available since dbt-clickhouse 1.10.0.                     |                      |
+| `connection_overrides` | `clickhouse` source only. Overrides for the credentials used in the dictionary's `SOURCE` clause, e.g. `{'user': 'dictionary_reader'}`.                                                                          |                      |
+| `url`, `format`        | `http` source only. The URL of the source file and its input format.                                                                                                                                             | Yes for `http`       |
+| `range`                | The `RANGE` clause for `RANGE_HASHED()` layouts, e.g. `'min start max stop'`.                                                                                                                                    |                      |
+
+### Example with a ClickHouse source {#dictionary-clickhouse-source-example}
+
+The model's SQL becomes the dictionary source query:
+
+```sql
+{{ config(
+       materialized='dictionary',
+       fields=[
+           ('id', 'UInt64'),
+           ('name', 'String'),
+       ],
+       primary_key='id',
+       layout='HASHED()',
+       lifetime='MIN 0 MAX 300'
+) }}
+
+select id, name from {{ source('raw', 'people') }}
+```
+
+### Example with an HTTP source {#dictionary-http-source-example}
+
+When using `source_type='http'` (or the `table` option), the model's SQL is not used as the source, but dbt still requires a body — use a `select 1` placeholder:
+
+```sql
+{{ config(
+       materialized='dictionary',
+       fields=[
+           ('LocationID', 'UInt16 DEFAULT 0'),
+           ('Borough', 'String'),
+           ('Zone', 'String'),
+       ],
+       primary_key='LocationID',
+       layout='HASHED()',
+       lifetime='MIN 0 MAX 0',
+       source_type='http',
+       url='https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/taxi_zone_lookup.csv',
+       format='CSVWithNames'
+) }}
+
+select 1
+```
+
+See the [dictionary tests](https://github.com/ClickHouse/dbt-clickhouse/blob/main/tests/integration/adapter/dictionary/test_dictionary.py) for more examples, including range and direct dictionaries.
 
 ## Materialization: distributed_table (experimental) {#materialization-distributed-table}
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

# Changes

Contains docs changes from the latest 1.10.1 and 1.10.2 releases https://github.com/ClickHouse/dbt-clickhouse/releases

### Refreshable materialized views: in-place refresh parameter updates (1.10.2, #688)
Documented that refresh parameters are now updated in place on `dbt run` via `MODIFY REFRESH`, and fixed the option name `refresh_interval` → `interval` (`materialization-materialized-view.mdx`).

### S3 `external_id` argument (1.10.2, #698)
Added `external_id` to the s3source arguments table (`features-and-configurations.mdx`).

### Query ID tracking (1.10.1, #634)
New section on correlating dbt runs with `system.query_log` via the `query_id` in `adapter_response` (`features-and-configurations.mdx`).

### `dbt clone` support (1.10.1, #655)
New section on zero-copy cloning for MergeTree tables and the view fallback for other cases (`features-and-configurations.mdx`), cross-linked from `index.mdx`.

### Dictionary materialization documentation (includes 1.10.0 additions, #580)
Replaced the "see the tests" stub with a config table and examples (`materializations.mdx`).

### s3source usage example
Added an inline config + model example to the s3source section (`features-and-configurations.mdx`).

### Delete+insert strategy cleanup
Removed outdated "experimental lightweight deletes" caveats and documented the current behavior (`materializations.mdx`).

### Stale fork link
Fixed a link pointing to the old `silentsokolov/dbt-clickhouse` fork (`index.mdx`).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116357&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116357](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116357+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.177` (included in `26.9` and later)
<!-- ch-version-info:end -->