### PR TITLE
Docs: note the organization Prometheus metrics endpoint is deprecated

### DIFF
--- a/docs/products/cloud/features/monitoring/prometheus.mdx
+++ b/docs/products/cloud/features/monitoring/prometheus.mdx
@@ -23,8 +23,12 @@ If you're looking for the equivalent endpoint for [ClickHouse Managed Postgres](
 | Method | Path                                                                                                               | Description                                                        |
 | ------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
 | GET    | `https://api.clickhouse.cloud/v1/organizations/:organizationId/services/:serviceId/prometheus?filtered_metrics=[true \| false]` | Returns metrics for a specific service |
-| GET    | `https://api.clickhouse.cloud/v1/organizations/:organizationId/prometheus?filtered_metrics=[true \| false]` | Returns metrics for all services in an organization |
+| GET    | `https://api.clickhouse.cloud/v1/organizations/:organizationId/prometheus?filtered_metrics=[true \| false]` | **Deprecated.** Returns metrics for all services in an organization |
 | GET    | `https://api.clickhouse.cloud/v1/organizations/:organizationId/prometheus/discovery?filtered_metrics=[true \| false]` | Returns Prometheus scrape targets for all services in an organization, in the [HTTP service discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) format |
+
+<Note>
+The organization-wide metrics endpoint (`GET /v1/organizations/{organizationId}/prometheus`) is deprecated in favor of [automatic service discovery](#automatic-service-discovery). Existing organizations can continue using it; newly created organizations use the discovery endpoint instead. Contact ClickHouse support if you need access to this endpoint.
+</Note>
 
 **Request Parameters**
 


### PR DESCRIPTION
### Changelog category (leave one item):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Notes in the Cloud Prometheus integration docs that the organization-wide metrics endpoint (`GET /v1/organizations/{organizationId}/prometheus`) is deprecated and unavailable for organizations created on or after September 1, 2026, pointing readers to the [service discovery endpoint](https://api.clickhouse.cloud) instead.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116366&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116366](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116366+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.111` (included in `26.9` and later)
<!-- ch-version-info:end -->