### PR TITLE
fix(S3Queue): do not misattribute retried registry as fresh create

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -92,6 +92,7 @@ static struct InitFiu
     ONCE(object_storage_queue_cancel_in_generate) \
     ONCE(object_storage_queue_sleep_in_generate) \
     ONCE(object_storage_queue_fail_tags_fetch) \
+    ONCE(object_storage_queue_fail_register_once) \
     ONCE(distributed_cache_fail_continue_request) \
     ONCE(distributed_cache_fail_continue_read_request) \
     ONCE(distributed_cache_fail_choose_server) \

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -16,6 +16,7 @@
 #include <base/sleep.h>
 #include <Common/CurrentThread.h>
 #include <Common/DimensionalMetrics.h>
+#include <Common/FailPoint.h>
 #include <Common/ThreadPool.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/ZooKeeperWithFaultInjection.h>
@@ -55,6 +56,11 @@ namespace ErrorCodes
     extern const int REPLICA_ALREADY_EXISTS;
     extern const int SUPPORT_IS_DISABLED;
     extern const int TIMEOUT_EXCEEDED;
+}
+
+namespace FailPoints
+{
+    extern const char object_storage_queue_fail_register_once[];
 }
 
 namespace Setting
@@ -788,6 +794,11 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
         zk_retries.resetFailures();
         zk_retries.retryLoop([&]
         {
+            fiu_do_on(FailPoints::object_storage_queue_fail_register_once, {
+                throw zkutil::KeeperException::fromMessage(
+                    Coordination::Error::ZCONNECTIONLOSS, "Failed to register table");
+            });
+
             auto zk_client = getZooKeeper();
             bool registry_exists = zk_client->tryGet(registry_path, registry_str, &stat);
             if (registry_exists)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -795,14 +795,6 @@ void ObjectStorageQueueMetadata::registerNonActive(const StorageID & storage_id,
                 std::vector<std::string_view> registered;
                 splitInto<','>(registered, registry_str);
 
-                if (zk_retries.isRetry() && registered.size() == 1 && (Info::deserialize(registered[0]) == self))
-                {
-                    LOG_TRACE(log, "Table {} is already registered after retry", self.table_id);
-                    created_new_metadata = true;
-                    code = Coordination::Error::ZOK;
-                    return;
-                }
-
                 created_new_metadata = false;
 
                 for (auto elem : registered)

--- a/tests/integration/test_storage_s3_queue/test_registry_retry.py
+++ b/tests/integration/test_storage_s3_queue/test_registry_retry.py
@@ -1,0 +1,109 @@
+import uuid
+
+import pytest
+from kazoo.exceptions import NoNodeError
+
+from helpers.cluster import ClickHouseCluster
+from helpers.s3_queue_common import (
+    create_table,
+    generate_random_files,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "instance",
+            user_configs=["configs/users.xml"],
+            with_minio=True,
+            with_zookeeper=True,
+            main_configs=[
+                "configs/zookeeper.xml",
+                "configs/s3queue_log.xml",
+            ],
+            stay_alive=True,
+        )
+
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_registered_after_retry_is_not_a_fresh_create(started_cluster):
+    """A keeper retry while reading the registry must not look like a fresh create.
+
+    `registerNonActive` reports `created_new_metadata` back to `startup()`, which
+    passes it as `is_drop` to `ObjectStorageQueueMetadataFactory::remove()` when
+    startup fails.  With `is_drop=true` and nothing left in the registry, that
+    calls `removeRecursive()` on the whole keeper path, taking processed-file
+    state with it.
+
+    So a table that was *already* in the registry before this call -- the state a
+    hard-killed server leaves behind, because shutdown never ran to unregister it
+    -- must report `created_new_metadata=false` even if a keeper retry happens
+    while it reads the registry.
+    """
+    node = started_cluster.instances["instance"]
+
+    table_name = f"test_register_retry_{uuid.uuid4().hex[:8]}"
+    keeper_path = f"/clickhouse/test_{table_name}"
+    files_path = f"{table_name}_data"
+    registry_path = f"{keeper_path}/registry"
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={
+            "keeper_path": keeper_path,
+            # Commit on SELECT so the file below is durably recorded as processed
+            # in Keeper; that committed state is what must survive.
+            "commit_on_select": 1,
+        },
+    )
+
+    generate_random_files(started_cluster, files_path, 1, start_ind=0, row_num=10)
+    assert 10 == int(node.query(f"SELECT count() FROM {table_name}"))
+
+    zk = started_cluster.get_kazoo_client("zoo1")
+
+    registry_str = zk.get(registry_path)[0]
+    assert registry_str, "table should be registered after creation"
+
+    # DETACH unregisters the table but keeps the metadata (is_drop=false).
+    node.query(f"DETACH TABLE {table_name}")
+
+    # Put the entry back so the table looks like it is still registered from a
+    # previous incarnation.
+    zk.set(registry_path, registry_str)
+
+    # Fail the first keeper attempt inside registerNonActive, so the read that
+    # finds this table already in the registry happens on a retry; then fail
+    # startup, so the cleanup path has to decide whether to drop the metadata.
+    node.query("SYSTEM ENABLE FAILPOINT object_storage_queue_fail_register_once")
+    node.query("SYSTEM ENABLE FAILPOINT object_storage_queue_fail_startup")
+    try:
+        assert "Failed to startup" in node.query_and_get_error(
+            f"ATTACH TABLE {table_name}"
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT object_storage_queue_fail_startup")
+        node.query("SYSTEM DISABLE FAILPOINT object_storage_queue_fail_register_once")
+
+    # This table did not create the metadata, so the failed startup must not have
+    # dropped it.  Before the fix the retry was read as a fresh create and the
+    # whole path -- processed files included -- was removed here.
+    try:
+        zk.get(keeper_path)
+    except NoNodeError:
+        pytest.fail("keeper metadata was dropped by a table that did not create it")
+
+    # And the processed state is really still there: re-attaching must not
+    # reprocess the file that was already consumed above.
+    node.query(f"ATTACH TABLE {table_name}")
+    assert 0 == int(node.query(f"SELECT count() FROM {table_name}"))


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry:
Fixed S3Queue/AzureQueue retry misattribution that deleted processed files on startup failure due to an incorrect `created_new_metadata` flag.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116294

## Details

Bug: `registerNonActive` in `ObjectStorageQueueMetadata.cpp:806` has an `isRetry` fast path that treats an existing single-entry registry equal to self as a fresh create. It sets `created_new_metadata=true` and returns `ZOK`. On startup failure, the `SCOPE_EXIT` in `StorageObjectStorageQueue::startup` then removes the keeper path, deleting processed files.

Fix: remove the `isRetry` branch (8 lines). The normal already-registered path then runs, setting `created_new_metadata=false` and returning `ZOK`, preserving the registry.

Verification: simulated the retry case. The buggy version returns true and triggers deletion; the fixed version returns false and preserves data.
