### PR TITLE
Docs: note that ClickPipes metrics are included in the Prometheus endpoints

### DIFF
--- a/docs/products/cloud/features/monitoring/prometheus.mdx
+++ b/docs/products/cloud/features/monitoring/prometheus.mdx
@@ -12,6 +12,8 @@ import { Image } from "/snippets/components/Image.jsx";
 
 The feature supports integrating [Prometheus](https://prometheus.io/) to monitor ClickHouse Cloud services. Access to Prometheus metrics is exposed via the [ClickHouse Cloud API](/products/cloud/features/admin-features/api/api-overview) endpoint that allows you to securely connect and export metrics into your Prometheus metrics collector. These metrics can be integrated with dashboards e.g., Grafana, Datadog for visualization.
 
+Metrics for [ClickPipes](/integrations/clickpipes) attached to a service are included alongside that service's ClickHouse metrics.
+
 To get started, [generate an API key](/products/cloud/features/admin-features/api/openapi).
 
 If you're looking for the equivalent endpoint for [ClickHouse Managed Postgres](/products/managed-postgres/overview) services, see the [ClickHouse Managed Postgres Prometheus endpoint](/products/managed-postgres/monitoring/prometheus).


### PR DESCRIPTION
### Changelog category (leave one item):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Notes upfront in the Cloud Prometheus integration docs that metrics for ClickPipes attached to a service are returned alongside that service's ClickHouse metrics — previously this was only discoverable by reading the sample response further down the page.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116368&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116368](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116368+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
