### PR TITLE
Canonicalize KeeperMap primary key metadata writes

### DIFF
--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -179,6 +179,16 @@ std::optional<std::string> tryCanonicalPrimaryKey(const std::string & primary_ke
     return std::string(expression);
 }
 
+std::string formatPrimaryKeyForMetadata(const ASTPtr & ast)
+{
+    auto primary_key = formattedAST(ast);
+    if (const auto canonical_primary_key = tryCanonicalPrimaryKey(primary_key + '\n'))
+        return *canonical_primary_key;
+
+    /// Preserve unsupported metadata spelling rather than guessing at equivalence.
+    return primary_key;
+}
+
 void verifyTableId(const StorageID & table_id)
 {
     if (!table_id.hasUUID())
@@ -438,7 +448,7 @@ StorageKeeperMap::StorageKeeperMap(
     WriteBufferFromOwnString out;
     out << "KeeperMap metadata format version: 1\n"
         << "columns: " << metadata.columns.toString(true)
-        << "primary key: " << formattedAST(metadata.getPrimaryKey().expression_list_ast) << "\n";
+        << "primary key: " << formatPrimaryKeyForMetadata(metadata.getPrimaryKey().expression_list_ast) << "\n";
     metadata_string = out.str();
 
     if (zk_root_path.empty())

--- a/src/Storages/StorageKeeperMap.cpp
+++ b/src/Storages/StorageKeeperMap.cpp
@@ -29,6 +29,7 @@
 #include <Core/Defines.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/parseQuery.h>
@@ -181,12 +182,16 @@ std::optional<std::string> tryCanonicalPrimaryKey(const std::string & primary_ke
 
 std::string formatPrimaryKeyForMetadata(const ASTPtr & ast)
 {
-    auto primary_key = formattedAST(ast);
-    if (const auto canonical_primary_key = tryCanonicalPrimaryKey(primary_key + '\n'))
-        return *canonical_primary_key;
+    const auto * expression_list = ast ? ast->as<ASTExpressionList>() : nullptr;
+    if (expression_list && expression_list->children.size() == 1)
+    {
+        auto primary_key = expression_list->children.front()->clone();
+        primary_key->setParenthesized(false);
+        return formattedAST(primary_key);
+    }
 
-    /// Preserve unsupported metadata spelling rather than guessing at equivalence.
-    return primary_key;
+    /// Preserve expression-list spelling until every supported reader canonicalizes each element.
+    return formattedAST(ast);
 }
 
 void verifyTableId(const StorageID & table_id)

--- a/tests/queries/0_stateless/05043_keeper_map_canonical_writer_metadata.reference
+++ b/tests/queries/0_stateless/05043_keeper_map_canonical_writer_metadata.reference
@@ -1,0 +1,10 @@
+data	1
+metadata	1
+data	1
+metadata	1
+1
+1	value
+data	1
+metadata	1
+data	1
+metadata	1

--- a/tests/queries/0_stateless/05043_keeper_map_canonical_writer_metadata.sql
+++ b/tests/queries/0_stateless/05043_keeper_map_canonical_writer_metadata.sql
@@ -1,0 +1,82 @@
+-- Tags: zookeeper, no-ordinary-database, no-fasttest
+
+SET ast_fuzzer_runs = 0;
+SET ast_fuzzer_any_query = 0;
+SET ignore_drop_queries_probability = 0;
+
+DROP TABLE IF EXISTS 05043_keeper_map_canonical_writer_parenthesized SYNC;
+DROP TABLE IF EXISTS 05043_keeper_map_canonical_writer_nested_second SYNC;
+DROP TABLE IF EXISTS 05043_keeper_map_canonical_writer_nested SYNC;
+DROP TABLE IF EXISTS 05043_keeper_map_canonical_writer_required SYNC;
+DROP TABLE IF EXISTS 05043_keeper_map_canonical_writer_expression_list SYNC;
+
+CREATE TABLE 05043_keeper_map_canonical_writer_parenthesized (key UInt64, value String)
+ENGINE = KeeperMap('/' || currentDatabase() || '/05043_keeper_map_canonical_writer_parenthesized')
+PRIMARY KEY(key);
+
+SELECT name, endsWith(value, 'primary key: key\n')
+FROM system.zookeeper
+WHERE path = '/test_keeper_map/' || currentDatabase() || '/05043_keeper_map_canonical_writer_parenthesized'
+    AND name IN ('data', 'metadata')
+ORDER BY name;
+
+CREATE TABLE 05043_keeper_map_canonical_writer_nested (key UInt64, value String)
+ENGINE = KeeperMap('/' || currentDatabase() || '/05043_keeper_map_canonical_writer_nested')
+PRIMARY KEY((key) + 1);
+
+SELECT name, endsWith(value, 'primary key: (key) + 1\n')
+FROM system.zookeeper
+WHERE path = '/test_keeper_map/' || currentDatabase() || '/05043_keeper_map_canonical_writer_nested'
+    AND name IN ('data', 'metadata')
+ORDER BY name;
+
+-- Simulate metadata written before canonical writes were introduced. A reader-first rollout must
+-- accept it and must not rewrite either shared znode while another table attaches to the path.
+INSERT INTO system.zookeeper (path, name, value)
+SELECT path, name, replaceOne(value, 'primary key: (key) + 1\n', 'primary key: ((key) + 1)\n')
+FROM system.zookeeper
+WHERE path = '/test_keeper_map/' || currentDatabase() || '/05043_keeper_map_canonical_writer_nested'
+    AND name IN ('data', 'metadata');
+
+CREATE TABLE 05043_keeper_map_canonical_writer_nested_second (key UInt64, value String)
+ENGINE = KeeperMap('/' || currentDatabase() || '/05043_keeper_map_canonical_writer_nested')
+PRIMARY KEY((key) + 1);
+
+SELECT count() = 2 AND countIf(endsWith(value, 'primary key: ((key) + 1)\n')) = 2
+FROM system.zookeeper
+WHERE path = '/test_keeper_map/' || currentDatabase() || '/05043_keeper_map_canonical_writer_nested'
+    AND name IN ('data', 'metadata');
+
+DETACH TABLE 05043_keeper_map_canonical_writer_nested;
+ATTACH TABLE 05043_keeper_map_canonical_writer_nested;
+
+INSERT INTO 05043_keeper_map_canonical_writer_nested VALUES (1, 'value');
+SELECT * FROM 05043_keeper_map_canonical_writer_nested_second;
+
+CREATE TABLE 05043_keeper_map_canonical_writer_required (key UInt64, value String)
+ENGINE = KeeperMap('/' || currentDatabase() || '/05043_keeper_map_canonical_writer_required')
+PRIMARY KEY(((key + 1) * 2));
+
+SELECT name, endsWith(value, 'primary key: (key + 1) * 2\n')
+FROM system.zookeeper
+WHERE path = '/test_keeper_map/' || currentDatabase() || '/05043_keeper_map_canonical_writer_required'
+    AND name IN ('data', 'metadata')
+ORDER BY name;
+
+CREATE TABLE 05043_keeper_map_canonical_writer_expression_list (key UInt64, value String)
+ENGINE = KeeperMap('/' || currentDatabase() || '/05043_keeper_map_canonical_writer_expression_list')
+PRIMARY KEY((key), sipHash64(key));
+
+-- The compatibility reader from #115642 canonicalizes one complete expression. Preserve the
+-- existing spelling for expression lists until every supported reader understands that format.
+SELECT name, endsWith(value, 'primary key: (key), sipHash64(key)\n')
+FROM system.zookeeper
+WHERE path = '/test_keeper_map/' || currentDatabase() || '/05043_keeper_map_canonical_writer_expression_list'
+    AND name IN ('data', 'metadata')
+ORDER BY name;
+
+DROP TABLE 05043_keeper_map_canonical_writer_parenthesized SYNC;
+DROP TABLE 05043_keeper_map_canonical_writer_nested_second SYNC;
+DROP TABLE 05043_keeper_map_canonical_writer_nested SYNC;
+DROP TABLE 05043_keeper_map_canonical_writer_required SYNC;
+DROP TABLE 05043_keeper_map_canonical_writer_expression_list SYNC;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115642

## Why

ClickHouse 26.6 started storing a redundant outer pair of parentheses around a
single-expression KeeperMap primary key. A 26.4 server expects the previous
spelling and can reject that metadata during a rolling upgrade or rollback.

The tolerant reader fix was merged first in #115642/#70018 and backported in
#70229/#70230. This PR stops new KeeperMap paths from producing the incompatible
spelling.

## What changed

For a single-expression primary key, format the already-parsed expression AST
without its top-level `parenthesized` flag. This avoids reparsing with unrelated
parser limits and preserves parentheses required inside the expression.

Expression-list spelling is deliberately unchanged because the tolerant reader
canonicalizes one complete expression. Existing Keeper znodes are never
rewritten; the change applies only when new metadata is created.

## Compatibility and rollout

This targets 26.8 and must be backported to 26.6, where the writer spelling first
changed.

Deploy the tolerant reader to every existing 26.6/26.7 peer before deploying
this writer change. An unpatched 26.6/26.7 reader still rejects the canonical
26.4 spelling; the mixed-version test includes that expected failure boundary.

## Tests

- Incremental `clickhouse` build on the disposable dev VM.
- Keeper-backed stateless regression: baseline reference mismatch, patched
  candidate exact reference match.
- 13/13 preregistered Chaos Lab mixed-version cases matched for 26.4, 26.6,
  26.7, and 26.8, including rolling restart/rollback and no-rewrite checks.
- Final AST candidate reproduced the exact persisted output after removing the
  writer-side reparse.

No documentation update is needed: this restores an internal persisted spelling
and does not change the SQL interface.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
KeeperMap now writes single-expression primary keys without redundant outer parentheses, so metadata created by newer servers remains readable by ClickHouse 26.4 during supported rolling upgrades and rollbacks.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116369&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116369](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116369+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.158` (included in `26.9` and later)
- Backported to: `26.8.1.2014`, `26.7.6.52`, `26.6.4.59`
<!-- ch-version-info:end -->