### PR TITLE
Fix flaky 03100_lwu_07_merge_patches_v1

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_07_merge_patches_v1.sql
+++ b/tests/queries/0_stateless/03100_lwu_07_merge_patches_v1.sql
@@ -7,7 +7,10 @@ SET enable_lightweight_update = 1;
 
 CREATE TABLE t_lwu_merge_patches_v1 (id UInt64, c1 UInt64)
 ENGINE = MergeTree ORDER BY id
-SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v1';
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, patch_parts_version = 'v1',
+         -- the patch parts are listed one by one below, so only the explicit OPTIMIZE FINAL
+         -- (which ignores this limit) may merge them
+         max_bytes_to_merge_at_max_space_in_pool = 1;
 
 INSERT INTO t_lwu_merge_patches_v1 SELECT number, number FROM numbers(20);
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114236
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/114236

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03100_lwu_07_merge_patches_v1` lists the five patch parts its `UPDATE`s produce, runs an explicit
`OPTIMIZE ... PARTITION ID 'patch-...' FINAL`, and lists them again. Those parts are ordinary
background merge candidates, so a background merge can collapse them into `_3_11_1_10` before the
`OPTIMIZE` runs; the `OPTIMIZE` then re-merges that part and, since a merged part's level is
`max(source levels) + 1`, prints `_3_11_2_10`. One character, row counts unchanged.

This applies the same fix #114236 made to the v2 twin: pin
`max_bytes_to_merge_at_max_space_in_pool = 1` so only the explicit `OPTIMIZE FINAL`, which ignores
that limit, may merge the parts. Same shape as that PR: one file, +4/-1, `.reference` untouched. The
twin also carries a level mask from #108594, but that is not needed once background merges cannot
fire, and adding it would discard the level assertion, so the raw assertions stay and the test now
pins the final level to exactly 1.

`_v1` lacked the pin because it was cloned in c324f831097ec4c, before either hardening reached
master, and #116007 restored the file byte-identically.

Validation: with a widened window before the `OPTIMIZE`, the unmodified test fails 8/8 with exactly
the reported one-character diff and passes 8/8 with the pin, both against the same untouched
`.reference`. The pin does not make the test vacuous: with it the five parts survive the window
(without it only one remains), `OPTIMIZE FINAL` still collapses them 5 -> 1 into a 13-row part over
block range `_3_11_` at level 1 from all five sources, `system.part_log` shows one patch merge
instead of two, and the final `count()` is unchanged. 50 randomized runs of this test plus 50 of the
twin: 100/100 pass, every run at level 1.

`03100_lwu_03_join_v1` is asymmetric with its twin too, but correctly so: that twin's masks are
partition-hash masks, needed only to survive `patch_parts_version` randomization.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116377&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116377](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116377+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.143` (included in `26.9` and later)
<!-- ch-version-info:end -->