### PR TITLE
Add the `default` cluster to the embedded server config

### DIFF
--- a/programs/server/embedded.xml
+++ b/programs/server/embedded.xml
@@ -14,6 +14,21 @@
 
     <mlock_executable>true</mlock_executable>
 
+    <!-- The `default` single-node cluster, same as in the packaged `config.xml`. Without it a
+         server started with no config file has no clusters at all, so `cluster('default', ...)`,
+         `clusterAllReplicas('default', ...)` and `cluster_for_parallel_replicas = 'default'` all
+         fail with `CLUSTER_DOESNT_EXIST`. -->
+    <remote_servers>
+        <default>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </default>
+    </remote_servers>
+
     <send_crash_reports>
         <enabled>true</enabled>
         <send_logical_errors>true</send_logical_errors>

--- a/programs/server/embedded.xml
+++ b/programs/server/embedded.xml
@@ -23,7 +23,6 @@
             <shard>
                 <replica>
                     <host>localhost</host>
-                    <port>9000</port>
                 </replica>
             </shard>
         </default>


### PR DESCRIPTION
A server started with no config file uses `programs/server/embedded.xml`, which - unlike the
packaged `programs/server/config.xml` - declares no `remote_servers`. Such a server therefore has no
clusters at all:

```
$ clickhouse server                         # in an empty directory, no config.xml
$ clickhouse client -q "SELECT count() FROM system.clusters"
0
$ clickhouse client -q "SELECT 1 FROM cluster('default', system.one)"
Code: 701. DB::Exception: Requested cluster 'default' not found. (CLUSTER_DOESNT_EXIST)
```

`clusterAllReplicas('default', ...)` and `cluster_for_parallel_replicas = 'default'` fail the same
way. This adds the same single-node `default` cluster the packaged config ships, so the two configs
agree on what a fresh server offers.

This is how the nightly SQLancer job hits it: the job starts the server without a config file, so
every oracle query over `cluster('default', ...)` died on the missing cluster instead of testing
anything. In the
[2026-08-25 run](https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/aeb16cd66cc85d7f53c79d12e4ae18aeb0282046/sqlancer_arm_release/analysis.txt)
that was 67 of the 87 findings - by far the largest group, and all of it self-inflicted.

Checked against a server started from an empty directory with a binary built from this branch:
`system.clusters` has one `default` row with `is_local = 1`, the oracle's exact query shape
(`SELECT count() FROM cluster('default', currentDatabase(), t0) WHERE c1 IN (1, 2) SETTINGS
enable_parallel_replicas = 1, max_parallel_replicas = 3, ...`) returns the right count,
`clusterAllReplicas('default', ...)` returns the right count, `cluster_for_parallel_replicas =
'default'` resolves, and startup logs no config errors. The same run against a binary without the
change reproduces the six `CLUSTER_DOESNT_EXIST` failures.

One deliberate choice worth a second opinion: this mirrors `config.xml` with **one** shard and
**one** replica. A single-replica cluster gives no parallel-replicas coverage, so a fuzzer that
wants that would still have to declare its own multi-replica cluster. Declaring three identical
localhost replicas here would buy that for free, at the cost of three confusing identical rows in
`system.clusters` for everyone running a config-less server - so I kept it consistent with the
packaged config instead. Happy to switch if you'd rather have the coverage.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A server started without a config file now declares the same single-node `default` cluster as the
packaged config, so `cluster('default', ...)` and `clusterAllReplicas('default', ...)` work instead
of failing with `CLUSTER_DOESNT_EXIST`.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116382&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116382](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116382+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
