### PR TITLE
Rename the streaming-exchange connection credential to auth_token

### DIFF
--- a/src/Server/DistributedQuery/ExchangeServer.cpp
+++ b/src/Server/DistributedQuery/ExchangeServer.cpp
@@ -263,7 +263,7 @@ void ExchangeServer::handleConnection(Poco::Net::StreamSocket socket, ExchangeCo
     /// so an unauthenticated peer is never rendezvoused with a local sink. A failure
     /// throws and the connection is dropped without a SinkHello.
     if (authenticate)
-        authenticate(source_hello.jwt_token);
+        authenticate(source_hello.auth_token);
 
     send_sink_hello();
 

--- a/src/Server/DistributedQuery/ExchangeServer.h
+++ b/src/Server/DistributedQuery/ExchangeServer.h
@@ -14,12 +14,12 @@
 namespace DB
 {
 
-/// Authenticates an incoming exchange connection from the JWT presented in
+/// Authenticates an incoming exchange connection from the auth token presented in
 /// SourceHello (empty when the peer sent none). Throws to reject the connection
 /// before it is registered. Empty (default, and the case when no authenticator is
 /// configured) means authentication is not enforced and the token is ignored; a
 /// caller can inject a closure that verifies the token.
-using ExchangeConnectionAuthenticator = std::function<void(const String & jwt_token)>;
+using ExchangeConnectionAuthenticator = std::function<void(const String & auth_token)>;
 
 /// Accepts connections for streaming exchanges used by distributed queries.
 //  Reads first packet from the connections that contains distributed query id and exchange stream id.
@@ -37,7 +37,7 @@ public:
 
     /// Runs the SourceHello/SinkHello handshake on `socket` and registers the
     /// resulting connection in `connections` on success. When `authenticate`
-    /// is set, the SourceHello JWT is checked before registration and a failure
+    /// is set, the SourceHello auth token is checked before registration and a failure
     /// throws without registering. Throws on protocol mismatch or transport
     /// failure without registering. Exposed for tests.
     static void handleConnection(Poco::Net::StreamSocket socket, ExchangeConnectionsPtr connections, LoggerPtr log, const ExchangeConnectionAuthenticator & authenticate);

--- a/src/Server/DistributedQuery/StreamingExchangeProtocol.cpp
+++ b/src/Server/DistributedQuery/StreamingExchangeProtocol.cpp
@@ -25,7 +25,7 @@ void SourceHelloBody::readAfterVersion(ReadBuffer & in)
 {
     readStringBinary(query_id, in);
     readStringBinary(stream_name, in);
-    readStringBinary(jwt_token, in);
+    readStringBinary(auth_token, in);
 }
 
 void SourceHelloBody::write(WriteBuffer & out) const
@@ -33,7 +33,7 @@ void SourceHelloBody::write(WriteBuffer & out) const
     writeIntBinary(source_version, out);
     writeStringBinary(query_id, out);
     writeStringBinary(stream_name, out);
-    writeStringBinary(jwt_token, out);
+    writeStringBinary(auth_token, out);
 }
 
 void SinkHelloBody::read(ReadBuffer & in)

--- a/src/Server/DistributedQuery/StreamingExchangeProtocol.h
+++ b/src/Server/DistributedQuery/StreamingExchangeProtocol.h
@@ -17,7 +17,7 @@ namespace StreamingExchangeProtocol
 {
     /// Wire-format version, exchanged in SourceHello/SinkHello and required to match
     /// exactly on both ends. Bumped on any change to packet layouts. Version 3 carries a
-    /// `jwt_token` in `SourceHelloBody` for authenticating the connecting source (empty
+    /// `auth_token` in `SourceHelloBody` for authenticating the connecting source (empty
     /// when authentication is not used).
     static constexpr UInt64 PROTOCOL_VERSION = 3;
 
@@ -62,8 +62,8 @@ namespace StreamingExchangeProtocol
         UInt64 source_version = 0;
         String query_id;
         String stream_name;
-        /// Bearer JWT for authenticating the source; empty when the source has no token.
-        String jwt_token;
+        /// Auth token for authenticating the source; empty when the source has none.
+        String auth_token;
 
         static UInt64 readVersion(ReadBuffer & in);
         void readAfterVersion(ReadBuffer & in);

--- a/src/Server/DistributedQuery/StreamingExchangeSource.cpp
+++ b/src/Server/DistributedQuery/StreamingExchangeSource.cpp
@@ -72,7 +72,7 @@ void StreamingExchangeSource::sendHello()
         .source_version = StreamingExchangeProtocol::PROTOCOL_VERSION,
         .query_id = query_id,
         .stream_name = stream_name,
-        .jwt_token = jwt_token,
+        .auth_token = auth_token,
     };
     source_hello.write(body);
     body.finalize();

--- a/src/Server/DistributedQuery/StreamingExchangeSource.h
+++ b/src/Server/DistributedQuery/StreamingExchangeSource.h
@@ -17,13 +17,13 @@ namespace DB
 class StreamingExchangeSource final : public ISource
 {
 public:
-    explicit StreamingExchangeSource(SharedHeader header_, String query_id_, String stream_name_, String host_, UInt16 port_, String jwt_token_ = {})
+    explicit StreamingExchangeSource(SharedHeader header_, String query_id_, String stream_name_, String host_, UInt16 port_, String auth_token_ = {})
         : ISource(std::move(header_))
         , host(std::move(host_))
         , port(port_)
         , query_id(std::move(query_id_))
         , stream_name(std::move(stream_name_))
-        , jwt_token(std::move(jwt_token_))
+        , auth_token(std::move(auth_token_))
     {
 #if defined(OS_LINUX) || defined(OS_DARWIN)
         wait_events_epoll.add(output_update_wakeup.fd());
@@ -65,8 +65,8 @@ private:
     const UInt16 port;
     const String query_id;
     const String stream_name;
-    /// Bearer JWT presented to the sink in SourceHello (empty when unauthenticated).
-    const String jwt_token;
+    /// Auth token presented to the sink in SourceHello (empty when unauthenticated).
+    const String auth_token;
 
     bool finished_reading = false;  /// All data has been read from socket.
     bool output_finished = false;   /// Output port is finished, do not need to receive more data.

--- a/src/Server/DistributedQuery/tests/gtest_exchange_server_handshake.cpp
+++ b/src/Server/DistributedQuery/tests/gtest_exchange_server_handshake.cpp
@@ -204,15 +204,15 @@ TEST(ExchangeConnectionsRendezvous, ConnectionAfterReleaseRejected)
 
 namespace
 {
-    /// Drive a v3 SourceHello carrying `jwt_token` over `client`, run the server-side
+    /// Drive a v3 SourceHello carrying `auth_token` over `client`, run the server-side
     /// handshake (with `authenticate`) on `server_side`, and return the error code thrown
     /// by `handleConnection` (nullopt on success). The token captured by `authenticate`
     /// is what the source actually serialized into SourceHello.
-    std::optional<int> runJwtHandshake(
+    std::optional<int> runAuthHandshake(
         Poco::Net::StreamSocket client,
         Poco::Net::StreamSocket server_side,
         const ExchangeConnectionsPtr & connections,
-        const String & jwt_token,
+        const String & auth_token,
         const ExchangeConnectionAuthenticator & authenticate)
     {
         using namespace StreamingExchangeProtocol;
@@ -236,7 +236,7 @@ namespace
             .source_version = PROTOCOL_VERSION,
             .query_id = "query",
             .stream_name = "stream",
-            .jwt_token = jwt_token,
+            .auth_token = auth_token,
         };
         source_hello.write(body);
         body.finalize();
@@ -254,7 +254,7 @@ namespace
 
 /// A valid token (per the injected authenticator) is accepted, the connection is
 /// registered, and the token the source sent round-trips to the authenticator.
-TEST(ExchangeServerHandshake, ValidJwtAcceptedAndRegistered)
+TEST(ExchangeServerHandshake, ValidTokenAcceptedAndRegistered)
 {
     auto connections = std::make_shared<ExchangeConnections>();
     auto [client, server_side] = makeConnectedPair();
@@ -262,7 +262,7 @@ TEST(ExchangeServerHandshake, ValidJwtAcceptedAndRegistered)
     String seen_token;
     ExchangeConnectionAuthenticator authenticate = [&](const String & token) { seen_token = token; };
 
-    auto code = runJwtHandshake(client, server_side, connections, "good-token", authenticate);
+    auto code = runAuthHandshake(client, server_side, connections, "good-token", authenticate);
     EXPECT_FALSE(code.has_value());
     EXPECT_EQ(seen_token, "good-token");
 
@@ -272,7 +272,7 @@ TEST(ExchangeServerHandshake, ValidJwtAcceptedAndRegistered)
 }
 
 /// When the authenticator rejects (throws), the connection must NOT be registered.
-TEST(ExchangeServerHandshake, RejectedJwtNotRegistered)
+TEST(ExchangeServerHandshake, RejectedTokenNotRegistered)
 {
     auto connections = std::make_shared<ExchangeConnections>();
     auto [client, server_side] = makeConnectedPair();
@@ -283,7 +283,7 @@ TEST(ExchangeServerHandshake, RejectedJwtNotRegistered)
             throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "bad exchange token");
     };
 
-    auto code = runJwtHandshake(client, server_side, connections, "bad-token", authenticate);
+    auto code = runAuthHandshake(client, server_side, connections, "bad-token", authenticate);
     ASSERT_TRUE(code.has_value());
     EXPECT_EQ(*code, ErrorCodes::AUTHENTICATION_FAILED);
 
@@ -298,7 +298,7 @@ TEST(ExchangeServerHandshake, NoAuthenticatorIgnoresToken)
     auto connections = std::make_shared<ExchangeConnections>();
     auto [client, server_side] = makeConnectedPair();
 
-    auto code = runJwtHandshake(client, server_side, connections, "whatever", {});
+    auto code = runAuthHandshake(client, server_side, connections, "whatever", {});
     EXPECT_FALSE(code.has_value());
 
     auto future = connections->getConnection("query", "stream");
@@ -306,9 +306,9 @@ TEST(ExchangeServerHandshake, NoAuthenticatorIgnoresToken)
     EXPECT_NO_THROW(future->getSocket());
 }
 
-/// A require-JWT authenticator rejects a peer that sends an empty token, so enabling auth
+/// A require-auth authenticator rejects a peer that sends an empty token, so enabling auth
 /// closes the door on un-credentialed connections.
-TEST(ExchangeServerHandshake, RequireJwtRejectsTokenlessSource)
+TEST(ExchangeServerHandshake, RequireAuthRejectsTokenlessSource)
 {
     auto connections = std::make_shared<ExchangeConnections>();
     auto [client, server_side] = makeConnectedPair();
@@ -319,8 +319,8 @@ TEST(ExchangeServerHandshake, RequireJwtRejectsTokenlessSource)
             throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "missing exchange token");
     };
 
-    auto code = runJwtHandshake(client, server_side, connections,
-        /*jwt_token=*/"", require_token);
+    auto code = runAuthHandshake(client, server_side, connections,
+        /*auth_token=*/"", require_token);
     ASSERT_TRUE(code.has_value());
     EXPECT_EQ(*code, ErrorCodes::AUTHENTICATION_FAILED);
 


### PR DESCRIPTION
The streaming-exchange `SourceHello` handshake carries an optional bearer credential used to authenticate the connecting source (added in #109349). This renames that field and the related identifiers from `jwt_token` to `auth_token`, so the name reflects that it is a generic bearer token rather than specifically a JWT — any bearer credential can be carried and validated by the injected authenticator.

Pure rename, no behavior change: the field is serialized positionally in the handshake, so the wire format is unchanged and `PROTOCOL_VERSION` stays `3`. Renamed `SourceHelloBody::jwt_token`, the `StreamingExchangeSource` constructor argument/member, the `ExchangeConnectionAuthenticator` parameter, and the handshake gtests; comments updated to match.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Internal rename of a streaming-exchange handshake field; no user-facing change.


### Documentation entry for user-facing changes:

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116386&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116386](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116386+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.180` (included in `26.9` and later)
<!-- ch-version-info:end -->