### PR TITLE
Fix changelog.py lowercasing URLs via str.capitalize

### DIFF
--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -392,9 +392,10 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
     if re.match(r"^[\-\*] ", entry):
         entry = entry[2:]
 
-    # Better style.
+    # Better style. Uppercase only the first letter (str.capitalize lowercases
+    # the rest of the string, mangling URLs and identifiers).
     if re.match(r"^[a-z]", entry):
-        entry = entry.capitalize()
+        entry = entry[0].upper() + entry[1:]
 
     if not category:
         # Shouldn't happen, because description check in CI should catch such PRs.


### PR DESCRIPTION
```
In [3]: 'foo Bar bam'.capitalize()
Out[3]: 'Foo bar bam'
```

Uppercase only the first letter of the entry instead.

Noticed in: https://github.com/ClickHouse/ClickHouse/pull/116387#discussion_r3856807400

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116388&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116388](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116388+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.130` (included in `26.9` and later)
<!-- ch-version-info:end -->