### PR TITLE
Rewrite how `ssd_cache` dictionary skips columns and remove `IColumn::skipSerializedInArena`

### DIFF
--- a/src/Columns/ColumnAggregateFunction.cpp
+++ b/src/Columns/ColumnAggregateFunction.cpp
@@ -32,7 +32,6 @@ namespace ErrorCodes
     extern const int PARAMETER_OUT_OF_BOUND;
     extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int NOT_IMPLEMENTED;
     extern const int MEMORY_LIMIT_EXCEEDED;
 }
 
@@ -696,11 +695,6 @@ void ColumnAggregateFunction::deserializeAndInsertFromArena(ReadBuffer & in, con
     Arena & dst_arena = createOrGetArena();
     pushBackAndCreateState(data, dst_arena, func.get());
     func->deserialize(data.back(), in, version, &dst_arena);
-}
-
-void ColumnAggregateFunction::skipSerializedInArena(ReadBuffer &) const
-{
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method skipSerializedInArena is not supported for {}", getName());
 }
 
 void ColumnAggregateFunction::popBack(size_t n)

--- a/src/Columns/ColumnAggregateFunction.h
+++ b/src/Columns/ColumnAggregateFunction.h
@@ -179,8 +179,6 @@ public:
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 
-    void skipSerializedInArena(ReadBuffer & in) const override;
-
     void updateHashWithValue(size_t n, SipHash & hash) const override;
 
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const override;

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -315,15 +315,6 @@ void ColumnArray::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::
     getOffsets().push_back(getOffsets().back() + array_size);
 }
 
-void ColumnArray::skipSerializedInArena(ReadBuffer & in) const
-{
-    size_t array_size = 0;
-    readBinaryLittleEndian<size_t>(array_size, in);
-
-    for (size_t i = 0; i < array_size; ++i)
-        getData().skipSerializedInArena(in);
-}
-
 void ColumnArray::updateHashWithValue(size_t n, SipHash & hash) const
 {
     size_t array_size = sizeAt(n);

--- a/src/Columns/ColumnArray.h
+++ b/src/Columns/ColumnArray.h
@@ -83,7 +83,6 @@ public:
     char * serializeValueIntoMemory(size_t, char * memory, const IColumn::SerializationSettings * settings) const override;
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     void updateHashWithValue(size_t n, SipHash & hash) const override;
     void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const override;
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const override;

--- a/src/Columns/ColumnBLOB.h
+++ b/src/Columns/ColumnBLOB.h
@@ -162,7 +162,6 @@ public:
     std::string_view serializeValueIntoArena(size_t, Arena &, char const *&, const IColumn::SerializationSettings *) const override { throwInapplicable(); }
     char * serializeValueIntoMemory(size_t, char *, const IColumn::SerializationSettings *) const override { throwInapplicable(); }
     void deserializeAndInsertFromArena(ReadBuffer &, const IColumn::SerializationSettings *) override { throwInapplicable(); }
-    void skipSerializedInArena(ReadBuffer &) const override { throwInapplicable(); }
     void updateHashWithValue(size_t, SipHash &) const override { throwInapplicable(); }
     void computeHashInto(size_t, size_t, UInt32 *, bool) const override { throwInapplicable(); }
     void updateHashFast(SipHash &) const override { throwInapplicable(); }

--- a/src/Columns/ColumnCompressed.h
+++ b/src/Columns/ColumnCompressed.h
@@ -100,7 +100,6 @@ public:
     std::string_view serializeValueIntoArena(size_t, Arena &, char const *&, const IColumn::SerializationSettings *) const override { throwMustBeDecompressed(); }
     char * serializeValueIntoMemory(size_t, char *, const IColumn::SerializationSettings *) const override { throwMustBeDecompressed(); }
     void deserializeAndInsertFromArena(ReadBuffer &, const IColumn::SerializationSettings *) override { throwMustBeDecompressed(); }
-    void skipSerializedInArena(ReadBuffer &) const override { throwMustBeDecompressed(); }
     void updateHashWithValue(size_t, SipHash &) const override { throwMustBeDecompressed(); }
     void computeHashInto(size_t, size_t, UInt32 *, bool) const override { throwMustBeDecompressed(); }
     void updateHashFast(SipHash &) const override { throwMustBeDecompressed(); }

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -218,11 +218,6 @@ public:
         ++s;
     }
 
-    void skipSerializedInArena(ReadBuffer & in) const override
-    {
-        data->skipSerializedInArena(in);
-    }
-
     void updateHashWithValue(size_t, SipHash & hash) const override
     {
         data->updateHashWithValue(0, hash);

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -132,12 +132,6 @@ void ColumnDecimal<T>::deserializeAndInsertFromArena(ReadBuffer & in, const ICol
 }
 
 template <is_decimal T>
-void ColumnDecimal<T>::skipSerializedInArena(ReadBuffer & in) const
-{
-    in.ignore(sizeof(T));
-}
-
-template <is_decimal T>
 UInt64 ColumnDecimal<T>::get64([[maybe_unused]] size_t n) const
 {
     if constexpr (sizeof(T) > sizeof(UInt64))

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -101,7 +101,6 @@ public:
     Float64 getFloat64(size_t n) const final;
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) final;
-    void skipSerializedInArena(ReadBuffer & in) const final;
     void updateHashWithValue(size_t n, SipHash & hash) const final;
     void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const final;
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const final;

--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -886,18 +886,6 @@ void ColumnDynamic::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn
     }
 }
 
-void ColumnDynamic::skipSerializedInArena(ReadBuffer & in) const
-{
-    UInt8 null_bit = 0;
-    readBinaryLittleEndian<UInt8>(null_bit, in);
-    if (null_bit)
-        return;
-
-    size_t type_and_value_size = 0;
-    readBinaryLittleEndian<size_t>(type_and_value_size, in);
-    in.ignore(type_and_value_size);
-}
-
 void ColumnDynamic::updateHashWithValue(size_t n, SipHash & hash) const
 {
     const auto & variant_col = getVariantColumn();

--- a/src/Columns/ColumnDynamic.h
+++ b/src/Columns/ColumnDynamic.h
@@ -186,7 +186,6 @@ public:
 
     std::string_view serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     std::optional<size_t> getSerializedValueSize(size_t, const IColumn::SerializationSettings *) const override { return std::nullopt; }
 
     void updateHashWithValue(size_t n, SipHash & hash) const override;

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -137,11 +137,6 @@ void ColumnFixedString::deserializeAndInsertFromArena(ReadBuffer & in, const ICo
     in.readStrict(reinterpret_cast<char *>(chars.data() + old_size), n);
 }
 
-void ColumnFixedString::skipSerializedInArena(ReadBuffer & in) const
-{
-    in.ignore(n);
-}
-
 void ColumnFixedString::updateHashWithValue(size_t index, SipHash & hash) const
 {
     hash.update(reinterpret_cast<const char *>(&chars[n * index]), n);

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -134,8 +134,6 @@ public:
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 
-    void skipSerializedInArena(ReadBuffer & in) const override;
-
     void updateHashWithValue(size_t index, SipHash & hash) const override;
     void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const override;
 

--- a/src/Columns/ColumnFunction.h
+++ b/src/Columns/ColumnFunction.h
@@ -117,11 +117,6 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot deserialize to {}", getName());
     }
 
-    void skipSerializedInArena(ReadBuffer &) const override
-    {
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot skip serialized {}", getName());
-    }
-
     void updateHashWithValue(size_t n, SipHash & hash) const override;
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const override;
     void updateHashFast(SipHash & hash) const override;

--- a/src/Columns/ColumnLazy.cpp
+++ b/src/Columns/ColumnLazy.cpp
@@ -156,11 +156,6 @@ void ColumnLazy::deserializeAndInsertFromArena(ReadBuffer &, const IColumn::Seri
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method deserializeAndInsertFromArena is not supported for {}", getName());
 }
 
-void ColumnLazy::skipSerializedInArena(ReadBuffer &) const
-{
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method skipSerializedInArena is not supported for {}", getName());
-}
-
 void ColumnLazy::updateHashWithValue(size_t, SipHash &) const
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method updateHashWithValue is not supported for {}", getName());

--- a/src/Columns/ColumnLazy.h
+++ b/src/Columns/ColumnLazy.h
@@ -91,7 +91,6 @@ public:
     void insertDefault() override;
     void popBack(size_t n) override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     void updateHashWithValue(size_t n, SipHash & hash) const override;
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const override;
     void updateHashFast(SipHash & hash) const override;

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -322,11 +322,6 @@ void ColumnLowCardinality::deserializeAndInsertFromArena(ReadBuffer & in, const 
     idx.insertIndex(getDictionary().uniqueDeserializeAndInsertFromArena(in, settings));
 }
 
-void ColumnLowCardinality::skipSerializedInArena(ReadBuffer & in) const
-{
-    getDictionary().skipSerializedInArena(in);
-}
-
 void ColumnLowCardinality::computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const
 {
     const auto & nested = getDictionary().getNestedColumn();

--- a/src/Columns/ColumnLowCardinality.h
+++ b/src/Columns/ColumnLowCardinality.h
@@ -109,8 +109,6 @@ public:
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 
-    void skipSerializedInArena(ReadBuffer & in) const override;
-
     void updateHashWithValue(size_t n, SipHash & hash) const override
     {
         getDictionary().updateHashWithValue(getIndexes().getUInt(n), hash);

--- a/src/Columns/ColumnMap.cpp
+++ b/src/Columns/ColumnMap.cpp
@@ -173,11 +173,6 @@ void ColumnMap::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::Se
     nested->deserializeAndInsertFromArena(in, settings);
 }
 
-void ColumnMap::skipSerializedInArena(ReadBuffer & in) const
-{
-    nested->skipSerializedInArena(in);
-}
-
 void ColumnMap::updateHashWithValue(size_t n, SipHash & hash) const
 {
     nested->updateHashWithValue(n, hash);

--- a/src/Columns/ColumnMap.h
+++ b/src/Columns/ColumnMap.h
@@ -77,7 +77,6 @@ public:
     char * serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const override;
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     void updateHashWithValue(size_t n, SipHash & hash) const override;
     void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const override;
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const override;

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -248,15 +248,6 @@ void ColumnNullable::deserializeAndInsertFromArena(ReadBuffer & in, const IColum
         getNestedColumn().insertDefault();
 }
 
-void ColumnNullable::skipSerializedInArena(ReadBuffer & in) const
-{
-    UInt8 val = 0;
-    readBinaryLittleEndian<UInt8>(val, in);
-
-    if (val == 0)
-        getNestedColumn().skipSerializedInArena(in);
-}
-
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
 void ColumnNullable::insertRangeFrom(const IColumn & src, size_t start, size_t length)
 #else

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -71,7 +71,6 @@ public:
     char * serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const override;
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
     void insertRangeFrom(const IColumn & src, size_t start, size_t length) override;
 #else

--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -1239,28 +1239,6 @@ void ColumnObject::deserializeDynamicPathsAndSharedDataFromArena(ReadBuffer & in
     }
 }
 
-void ColumnObject::skipSerializedInArena(ReadBuffer & in) const
-{
-    /// First, skip all values of typed paths;
-    for (auto path : sorted_typed_paths)
-        typed_paths.find(path)->second->skipSerializedInArena(in);
-
-    /// Second, skip all other paths and values.
-    size_t num_paths = 0;
-    readBinaryLittleEndian<size_t>(num_paths, in);
-
-    for (size_t i = 0; i != num_paths; ++i)
-    {
-        size_t path_size = 0;
-        readBinaryLittleEndian<size_t>(path_size, in);
-        in.ignore(path_size);
-
-        size_t value_size = 0;
-        readBinaryLittleEndian<size_t>(value_size, in);
-        in.ignore(value_size);
-    }
-}
-
 void ColumnObject::updateHashWithValue(size_t n, SipHash & hash) const
 {
     for (auto path : sorted_typed_paths)

--- a/src/Columns/ColumnObject.h
+++ b/src/Columns/ColumnObject.h
@@ -140,7 +140,6 @@ public:
 
     std::string_view serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     std::optional<size_t> getSerializedValueSize(size_t, const IColumn::SerializationSettings *) const override { return std::nullopt; }
 
     void updateHashWithValue(size_t n, SipHash & hash) const override;

--- a/src/Columns/ColumnQBit.h
+++ b/src/Columns/ColumnQBit.h
@@ -131,7 +131,6 @@ public:
     {
         tuple->deserializeAndInsertFromArena(in, settings);
     }
-    void skipSerializedInArena(ReadBuffer & in) const override { tuple->skipSerializedInArena(in); }
     void updateHashWithValue(size_t n, SipHash & hash) const override { tuple->updateHashWithValue(n, hash); }
     void updateHashFast(SipHash & hash) const override { tuple->updateHashFast(hash); }
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const override

--- a/src/Columns/ColumnReplicated.cpp
+++ b/src/Columns/ColumnReplicated.cpp
@@ -224,11 +224,6 @@ void ColumnReplicated::deserializeAndInsertFromArena(ReadBuffer & in, const ICol
     indexes.insertIndex(nested_column->size() - 1);
 }
 
-void ColumnReplicated::skipSerializedInArena(ReadBuffer & in) const
-{
-    nested_column->skipSerializedInArena(in);
-}
-
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
 void ColumnReplicated::insertRangeFrom(const IColumn & src, size_t start, size_t length)
 #else

--- a/src/Columns/ColumnReplicated.h
+++ b/src/Columns/ColumnReplicated.h
@@ -83,7 +83,6 @@ public:
     char * serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const override;
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
     void insertRangeFrom(const IColumn & src, size_t start, size_t length) override;
 #else

--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -178,11 +178,6 @@ void ColumnSparse::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn:
     insertSingleValue([&](IColumn & column) { column.deserializeAndInsertFromArena(in, settings); });
 }
 
-void ColumnSparse::skipSerializedInArena(ReadBuffer & in) const
-{
-    values->skipSerializedInArena(in);
-}
-
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
 void ColumnSparse::insertRangeFrom(const IColumn & src, size_t start, size_t length)
 #else

--- a/src/Columns/ColumnSparse.h
+++ b/src/Columns/ColumnSparse.h
@@ -80,7 +80,6 @@ public:
     char * serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const override;
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
     void insertRangeFrom(const IColumn & src, size_t start, size_t length) override;
 #else

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -377,13 +377,6 @@ void ColumnString::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn:
     offsets.push_back(new_size);
 }
 
-void ColumnString::skipSerializedInArena(ReadBuffer & in) const
-{
-    size_t string_size = 0;
-    readBinaryLittleEndian<size_t>(string_size, in);
-    in.ignore(string_size);
-}
-
 ColumnPtr ColumnString::index(const IColumn & indexes, size_t limit) const
 {
     return selectIndexImpl(*this, indexes, limit);

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -219,8 +219,6 @@ public:
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 
-    void skipSerializedInArena(ReadBuffer & in) const override;
-
     void updateHashWithValue(size_t n, SipHash & hash) const override;
     void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const override;
 

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -450,18 +450,6 @@ void ColumnTuple::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::
         column->deserializeAndInsertFromArena(in, settings);
 }
 
-void ColumnTuple::skipSerializedInArena(ReadBuffer & in) const
-{
-    if (columns.empty())
-    {
-        in.ignore(1);
-        return;
-    }
-
-    for (const auto & column : columns)
-        column->skipSerializedInArena(in);
-}
-
 void ColumnTuple::updateHashWithValue(size_t n, SipHash & hash) const
 {
     for (const auto & column : columns)

--- a/src/Columns/ColumnTuple.h
+++ b/src/Columns/ColumnTuple.h
@@ -82,7 +82,6 @@ public:
     char * serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const override;
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     void updateHashWithValue(size_t n, SipHash & hash) const override;
     void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const override;
     void computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const override;

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -94,7 +94,6 @@ public:
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
     std::string_view serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const IColumn::SerializationSettings * settings) const override;
     char * serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     void updateHashWithValue(size_t n, SipHash & hash_func) const override;
 
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
@@ -599,12 +598,6 @@ size_t ColumnUnique<ColumnType>::uniqueDeserializeAndInsertAggregationStateValue
     in.ignore(string_size_with_zero_byte);
 
     return ret;
-}
-
-template <typename ColumnType>
-void ColumnUnique<ColumnType>::skipSerializedInArena(ReadBuffer &) const
-{
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method skipSerializedInArena is not supported for {}", this->getName());
 }
 
 template <typename ColumnType>

--- a/src/Columns/ColumnVariant.cpp
+++ b/src/Columns/ColumnVariant.cpp
@@ -872,19 +872,6 @@ void ColumnVariant::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn
     variants[local_discr]->deserializeAndInsertFromArena(in, settings);
 }
 
-void ColumnVariant::skipSerializedInArena(ReadBuffer & in) const
-{
-    Discriminator global_discr = 0;
-    readBinaryLittleEndian<Discriminator>(global_discr, in);
-
-    if (global_discr == NULL_DISCRIMINATOR)
-        return;
-
-    checkDiscriminatorValue(global_discr, variants.size(), /* allow_logical_error= */ true);
-
-    variants[localDiscriminatorByGlobal(global_discr)]->skipSerializedInArena(in);
-}
-
 char * ColumnVariant::serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const
 {
     Discriminator global_discr = globalDiscriminatorAt(n);

--- a/src/Columns/ColumnVariant.h
+++ b/src/Columns/ColumnVariant.h
@@ -218,7 +218,6 @@ public:
     void popBack(size_t n) override;
     std::string_view serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const IColumn::SerializationSettings * settings) const override;
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
-    void skipSerializedInArena(ReadBuffer & in) const override;
     char * serializeValueIntoMemory(size_t n, char * memory, const IColumn::SerializationSettings * settings) const override;
     std::optional<size_t> getSerializedValueSize(size_t n, const IColumn::SerializationSettings * settings) const override;
 

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -64,12 +64,6 @@ void ColumnVector<T>::deserializeAndInsertFromArena(ReadBuffer & in, const IColu
 }
 
 template <typename T>
-void ColumnVector<T>::skipSerializedInArena(ReadBuffer & in) const
-{
-    in.ignore(sizeof(T));
-}
-
-template <typename T>
 void ColumnVector<T>::updateHashWithValue(size_t n, SipHash & hash) const
 {
     hash.update(data[n]);

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -107,8 +107,6 @@ public:
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 
-    void skipSerializedInArena(ReadBuffer & in) const override;
-
     void updateHashWithValue(size_t n, SipHash & hash) const override;
     void updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const override;
 

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -390,9 +390,6 @@ public:
     /// Note that it needs to deal with user input
     virtual void deserializeAndInsertFromArena(ReadBuffer & in, const SerializationSettings * settings) = 0;
 
-    /// Skip previously serialized value that was serialized using IColumn::serializeValueIntoArena method.
-    virtual void skipSerializedInArena(ReadBuffer & in) const = 0;
-
     /// Update state of hash function with value of n-th element.
     /// On subsequent calls of this method for sequence of column values of arbitrary types,
     ///  passed bytes to hash must identify sequence of values unambiguously.

--- a/src/Columns/IColumnDummy.cpp
+++ b/src/Columns/IColumnDummy.cpp
@@ -55,11 +55,6 @@ void IColumnDummy::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn:
     in.ignore(1);
 }
 
-void IColumnDummy::skipSerializedInArena(ReadBuffer & in) const
-{
-    in.ignore(1);
-}
-
 ColumnPtr IColumnDummy::filter(const Filter & filt, ssize_t /*result_size_hint*/) const
 {
     size_t bytes = countBytesInFilter(filt);

--- a/src/Columns/IColumnDummy.h
+++ b/src/Columns/IColumnDummy.h
@@ -58,8 +58,6 @@ public:
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 
-    void skipSerializedInArena(ReadBuffer & in) const override;
-
     void updateHashWithValue(size_t /*n*/, SipHash & /*hash*/) const override
     {
     }

--- a/src/Columns/tests/gtest_column_dynamic.cpp
+++ b/src/Columns/tests/gtest_column_dynamic.cpp
@@ -1053,33 +1053,6 @@ TEST(ColumnDynamic, SerializeDeserializeFromArenaOverflow2)
     ASSERT_EQ(column_to->getSharedVariant().size(), 2);
 }
 
-TEST(ColumnDynamic, skipSerializedInArena)
-{
-    auto column_from = ColumnDynamic::create(3);
-    column_from->insert(Field(42));
-    column_from->insert(Field(42.42));
-    column_from->insert(Field("str"));
-    column_from->insert(Field(Null()));
-
-    Arena arena;
-    const char * pos = nullptr;
-    auto ref1 = column_from->serializeValueIntoArena(0, arena, pos, nullptr);
-    column_from->serializeValueIntoArena(1, arena, pos, nullptr);
-    column_from->serializeValueIntoArena(2, arena, pos, nullptr);
-    column_from->serializeValueIntoArena(3, arena, pos, nullptr);
-
-    auto column_to = ColumnDynamic::create(254);
-    ReadBufferFromString in({ref1.data(), arena.usedBytes()}); /// NOLINT(bugprone-suspicious-stringview-data-usage)
-    column_to->skipSerializedInArena(in);
-    column_to->skipSerializedInArena(in);
-    column_to->skipSerializedInArena(in);
-    column_to->skipSerializedInArena(in);
-
-    ASSERT_TRUE(in.eof());
-    ASSERT_EQ(column_to->getVariantInfo().variant_name_to_discriminator.at("SharedVariant"), 0);
-    ASSERT_EQ(column_to->getVariantInfo().variant_names, Names{"SharedVariant"});
-}
-
 TEST(ColumnDynamic, compare)
 {
     auto column_from = ColumnDynamic::create(3);

--- a/src/Columns/tests/gtest_column_object.cpp
+++ b/src/Columns/tests/gtest_column_object.cpp
@@ -336,29 +336,6 @@ TEST(ColumnObject, SerializeDeserializerFromArena)
     ASSERT_EQ(col_object2[2], (Object{{"b.d", Field(442u)}, {"a.b", Array{"Str11", "Str22"}}, {"a.a", Tuple{"Str33", 444u}}, {"a.c", Field("Str44")}, {"a.d", Array{Field(445), Field(446)}}, {"a.e", Field(447)}}));
 }
 
-TEST(ColumnObject, SkipSerializedInArena)
-{
-    auto type = DataTypeFactory::instance().get("JSON(max_dynamic_types=10, max_dynamic_paths=2, b.d UInt32, a.b Array(String))");
-    auto col = type->createColumn();
-    auto & col_object = assert_cast<ColumnObject &>(*col);
-    col_object.insert(Object{{"b.d", Field(42u)}, {"a.b", Array{"Str1", "Str2"}}, {"a.a", Tuple{"Str3", 441u}}, {"a.c", Field("Str4")}, {"a.d", Array{Field(45), Field(46)}}, {"a.e", Field(47)}});
-    col_object.insert(Object{{"b.a", Field(48)}, {"b.b", Array{Field(49), Field(50)}}});
-    col_object.insert(Object{{"b.d", Field(442u)}, {"a.b", Array{"Str11", "Str22"}}, {"a.a", Tuple{"Str33", 444u}}, {"a.c", Field("Str44")}, {"a.d", Array{Field(445), Field(446)}}, {"a.e", Field(447)}});
-
-    Arena arena;
-    const char * pos = nullptr;
-    auto ref1 = col_object.serializeValueIntoArena(0, arena, pos, nullptr);
-    col_object.serializeValueIntoArena(1, arena, pos, nullptr);
-    col_object.serializeValueIntoArena(2, arena, pos, nullptr);
-
-    auto col2 = type->createColumn();
-    ReadBufferFromString in({ref1.data(), arena.usedBytes()}); /// NOLINT(bugprone-suspicious-stringview-data-usage)
-    col2->skipSerializedInArena(in);
-    col2->skipSerializedInArena(in);
-    col2->skipSerializedInArena(in);
-    ASSERT_TRUE(in.eof());
-}
-
 TEST(ColumnObject, rollback)
 {
     auto type = DataTypeFactory::instance().get("JSON(max_dynamic_types=10, max_dynamic_paths=2, a.a UInt32, a.b UInt32)");

--- a/src/Dictionaries/DictionaryHelpers.h
+++ b/src/Dictionaries/DictionaryHelpers.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <base/unaligned.h>
 #include <Common/HashTable/HashMap.h>
 #include <Columns/IColumn.h>
 #include <Columns/ColumnString.h>
@@ -17,7 +18,7 @@
 #include <DataTypes/DataTypeObject.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Core/Block.h>
-#include <IO/ReadBuffer.h>
+#include <IO/ReadBufferFromString.h>
 #include <Dictionaries/IDictionary.h>
 #include <Dictionaries/DictionaryStructure.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
@@ -235,12 +236,16 @@ static inline void insertDefaultValuesIntoColumns( /// NOLINT
 static inline void deserializeAndInsertIntoColumns( /// NOLINT
     MutableColumns & columns,
     const DictionaryStorageFetchRequest & fetch_request,
-    ReadBuffer & in)
+    ReadBufferFromString & in)
 {
     size_t columns_size = columns.size();
 
-    VectorWithMemoryTracking<UInt32> serialized_sizes(columns_size);
-    in.readStrict(reinterpret_cast<char *>(serialized_sizes.data()), columns_size * sizeof(UInt32));
+    /// The buffer is contiguous and never refills, so the header is read in
+    /// place and stays addressable while the values are deserialized.
+    size_t sizes_header_size = columns_size * sizeof(UInt32);
+    chassert(in.available() >= sizes_header_size);
+    const char * sizes_header = in.position();
+    in.ignore(sizes_header_size);
 
     for (size_t column_index = 0; column_index < columns_size; ++column_index)
     {
@@ -249,7 +254,7 @@ static inline void deserializeAndInsertIntoColumns( /// NOLINT
         if (fetch_request.shouldFillResultColumnWithIndex(column_index))
             column->deserializeAndInsertFromArena(in, nullptr);
         else
-            in.ignore(serialized_sizes[column_index]);
+            in.ignore(unalignedLoad<UInt32>(sizes_header + column_index * sizeof(UInt32)));
     }
 }
 

--- a/src/Dictionaries/DictionaryHelpers.h
+++ b/src/Dictionaries/DictionaryHelpers.h
@@ -17,6 +17,7 @@
 #include <DataTypes/DataTypeObject.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Core/Block.h>
+#include <IO/ReadBuffer.h>
 #include <Dictionaries/IDictionary.h>
 #include <Dictionaries/DictionaryStructure.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
@@ -67,8 +68,8 @@ private:
 
     The main idea is that during fetch we create all columns, but fill only columns that client requested.
 
-    We need to create other columns during fetch, because in case of serialized storage we can skip
-    unnecessary columns serialized in cache with skipSerializedInArena method.
+    We need to create other columns during fetch, because in case of serialized storage the serialized
+    values of unnecessary columns are skipped using the header of serialized sizes that prefixes them.
 
     When result is fetched from the storage client of storage can filterOnlyNecessaryColumns
     and get only columns that match attributes_names_to_fetch.
@@ -228,14 +229,18 @@ static inline void insertDefaultValuesIntoColumns( /// NOLINT
     }
 }
 
-/// Deserialize column value and insert it in columns.
-/// Skip unnecessary columns that were not requested from deserialization.
+/// Deserialize column values and insert them into columns.
+/// The values are prefixed with a header of their serialized sizes,
+/// which is used to skip over columns that were not requested.
 static inline void deserializeAndInsertIntoColumns( /// NOLINT
     MutableColumns & columns,
     const DictionaryStorageFetchRequest & fetch_request,
     ReadBuffer & in)
 {
     size_t columns_size = columns.size();
+
+    VectorWithMemoryTracking<UInt32> serialized_sizes(columns_size);
+    in.readStrict(reinterpret_cast<char *>(serialized_sizes.data()), columns_size * sizeof(UInt32));
 
     for (size_t column_index = 0; column_index < columns_size; ++column_index)
     {
@@ -244,7 +249,7 @@ static inline void deserializeAndInsertIntoColumns( /// NOLINT
         if (fetch_request.shouldFillResultColumnWithIndex(column_index))
             column->deserializeAndInsertFromArena(in, nullptr);
         else
-            column->skipSerializedInArena(in);
+            in.ignore(serialized_sizes[column_index]);
     }
 }
 

--- a/src/Dictionaries/SSDCacheDictionaryStorage.h
+++ b/src/Dictionaries/SSDCacheDictionaryStorage.h
@@ -3,6 +3,7 @@
 #if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_DARWIN)
 
 #include <chrono>
+#include <limits>
 
 #include <pcg_random.hpp>
 #include <filesystem>
@@ -1182,11 +1183,29 @@ private:
 
             auto key = keys[key_index];
 
+            /// Values are prefixed with a header of their serialized sizes,
+            /// so that on fetch the columns that were not requested can be skipped.
+            const size_t sizes_header_size = columns_to_serialize_size * sizeof(UInt32);
+            if (sizes_header_size)
+            {
+                temporary_values_pool.allocContinue(sizes_header_size, block_start);
+                allocated_size_for_columns += sizes_header_size;
+            }
+
             for (size_t column_index = 0; column_index < columns_to_serialize_size; ++column_index)
             {
                 auto & column = columns[column_index];
                 temporary_column_data[column_index] = column->serializeValueIntoArena(key_index, temporary_values_pool, block_start, nullptr);
                 allocated_size_for_columns += temporary_column_data[column_index].size();
+            }
+
+            char * sizes_header_start = const_cast<char *>(block_start);
+            for (size_t column_index = 0; column_index < columns_to_serialize_size; ++column_index)
+            {
+                size_t serialized_size = temporary_column_data[column_index].size();
+                if (serialized_size > std::numeric_limits<UInt32>::max())
+                    throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Serialized column value size is too large for SSD cache");
+                unalignedStore<UInt32>(sizes_header_start + column_index * sizeof(UInt32), static_cast<UInt32>(serialized_size));
             }
 
             SSDCacheKeyType ssd_cache_key { key, allocated_size_for_columns, block_start };


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Rewrite how `ssd_cache` dictionary skips columns (this changes on-disk format, but, this should not be an issue since server never read old files) and remove `IColumn::skipSerializedInArena` (used only for `ssd_cache` and contain a bug, less code - less bugs)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116397&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116397](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116397+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.608` (included in `26.9` and later)
<!-- ch-version-info:end -->