### PR TITLE
Allow removing not yet released settings in the settings-history style check

### DIFF
--- a/ci/jobs/check_style.py
+++ b/ci/jobs/check_style.py
@@ -1092,6 +1092,77 @@ def check_clickhouse_spelling():
     return ""
 
 
+# Where the settings themselves are declared, per `SettingsChangesHistory.cpp` namespace. Used to
+# tell a setting that a change REMOVED from the code apart from one that still exists - only the
+# latter can be recorded in the history at all (see `check_settings_changes_history`). Mirrors
+# `LIST_OF_SETTINGS` in src/Core/Settings.cpp and `MERGE_TREE_SETTINGS` in
+# src/Storages/MergeTree/MergeTreeSettings.cpp.
+_SETTINGS_DECLARATION_SOURCES = {
+    "Session": ("src/Core/Settings.cpp", "src/Core/FormatFactorySettings.h"),
+    "MergeTree": ("src/Storages/MergeTree/MergeTreeSettings.cpp",),
+}
+
+# `DECLARE(Type, name, default, R"(...)", tier)` and its aliasing variant.
+_SETTINGS_DECLARE_RE = re.compile(
+    r"^\s*DECLARE(?:_WITH_ALIAS)?\(\s*[A-Za-z0-9_:]+\s*,\s*([A-Za-z0-9_]+)\s*,"
+)
+# `MAKE_OBSOLETE(M, Type, name, default)` and friends. An obsolete or deprecated setting is still
+# a setting - it keeps its row in system.settings - so its history records are still required.
+# The longest alternative comes first: `MAKE_OBSOLETE` is a prefix of
+# `MAKE_OBSOLETE_MERGE_TREE_SETTING`.
+_SETTINGS_OBSOLETE_RE = re.compile(
+    r"^\s*MAKE_(?:OBSOLETE_MERGE_TREE_SETTING|OBSOLETE|DEPRECATED_BY_SERVER_CONFIG)\("
+    r"\s*\w+\s*,\s*[A-Za-z0-9_:]+\s*,\s*([A-Za-z0-9_]+)\s*,"
+)
+# The alias of a `DECLARE_WITH_ALIAS` sits on the line that closes the declaration:
+# `)", 0, insert_distributed_sync) \`. An alias is a settable name of its own - system.settings
+# has a row for it and history records may use it, `applyCompatibilitySetting` resolves aliases -
+# so it counts as declared.
+_SETTINGS_ALIAS_RE = re.compile(r'^\)"\s*,\s*[^,]+,\s*([A-Za-z0-9_]+)\)\s*\\?\s*$')
+
+
+def declared_setting_names():
+    """`({namespace: {name, ...}}, "")` for every setting declared in the checked-out tree, or
+    `(None, error)` when the declarations could not be read.
+
+    Fail-close: a missing file or a namespace that parses to nothing means the declaration macros
+    or their files moved, and quietly returning an empty set would exempt every setting from the
+    current-version-block rule in `check_settings_changes_history`. Pure text parsing of the
+    declaration macros; `ci/tests/test_settings_history_removed_setting.py` guards it against rot
+    by requiring that every name recorded in SettingsChangesHistory.cpp resolves here."""
+    names = {}
+    for namespace, sources in _SETTINGS_DECLARATION_SOURCES.items():
+        found = set()
+        for source in sources:
+            source_path = Path(source)
+            if not source_path.is_file():
+                return None, (
+                    f"Cannot validate the settings history: the {namespace} settings are "
+                    f"declared in {source}, which does not exist. If the declarations moved, "
+                    f"update _SETTINGS_DECLARATION_SOURCES in ci/jobs/check_style.py."
+                )
+            for line in source_path.read_text(
+                encoding="utf-8", errors="ignore"
+            ).splitlines():
+                for regexp in (
+                    _SETTINGS_DECLARE_RE,
+                    _SETTINGS_OBSOLETE_RE,
+                    _SETTINGS_ALIAS_RE,
+                ):
+                    m = regexp.match(line)
+                    if m:
+                        found.add(m.group(1))
+                        break
+        if not found:
+            return None, (
+                f"Cannot validate the settings history: no {namespace} setting declaration was "
+                f"found in {', '.join(sources)}. If the declaration macros changed, update the "
+                f"parser in ci/jobs/check_style.py."
+            )
+        names[namespace] = found
+    return names, ""
+
+
 def check_settings_changes_history():
     """Every setting added, value-changed, removed, moved to another block, or sitting in a
     block whose `addSettingsChanges` header changed, in src/Core/SettingsChangesHistory.cpp by
@@ -1116,6 +1187,17 @@ def check_settings_changes_history():
     The old name cannot be demanded here: the setting is gone, and 03999_stateless_settings_history
     rejects a documented name that no longer exists, so requiring it would leave no history file
     that satisfies both guards.
+
+    A setting REMOVED from the code is exempt for the same reason: its records have to go with it.
+    A record naming a setting that is not in system.settings / system.merge_tree_settings is
+    rejected by 03999_stateless_settings_history, and `applyCompatibilitySetting` resolves every
+    recorded name, so nothing can be recorded for a setting that no longer exists - demanding an
+    entry would leave no way to drop a setting that was never released. The exemption is also safe:
+    `compatibility` only ever restores values of settings that exist, so a setting that is gone has
+    no default left for any release to disagree about - unlike the deletion of a record of a
+    setting that stays, which is what the removals paragraph above is about. A setting that is
+    merely made OBSOLETE keeps its row in system.settings, so its records stay required; only a
+    real removal is exempt.
 
     Runs only when that file changed; the list of changed setting names is provided by the
     store_data.py workflow hook (which parses the PR / merge-queue diff). Returns "" on
@@ -1189,6 +1271,28 @@ def check_settings_changes_history():
         # block) - nothing to validate against the current version block.
         return ""
 
+    declared, declared_error = declared_setting_names()
+    if declared_error:
+        return declared_error
+
+    def setting_still_exists(item):
+        """Whether the reported setting is still declared, i.e. whether the history can record it
+        at all - a setting this change removed from the code cannot be recorded anywhere (see the
+        removal paragraph in the docstring). Direction-agnostic on purpose: a record ADDED for a
+        name that is not declared is a dangling record, which 03999_stateless_settings_history
+        rejects outright, so there is nothing for this check to demand on top of that."""
+        declared_in_namespace = declared.get(item["namespace"])
+        if declared_in_namespace is None:
+            # An unrecognized namespace cannot be resolved to declarations - do not exempt it.
+            return True
+        return item["name"] in declared_in_namespace
+
+    changed = [item for item in changed if setting_still_exists(item)]
+    if not changed:
+        # Every reported setting was removed from the code by this change - nothing left to
+        # record in the current version block.
+        return ""
+
     version_txt = Path("cmake/autogenerated_versions.txt").read_text(encoding="utf-8")
     current_version = "{}.{}".format(
         re.search(r"SET\(VERSION_MAJOR (\d+)\)", version_txt).group(1),
@@ -1236,7 +1340,9 @@ def check_settings_changes_history():
             f"an entry for each under the '{current_version}' block (older blocks may keep their "
             f"entries for backports). If this is a correction of what an older release recorded "
             f"and not a default change made here, split it into a change that touches only "
-            f"{path}. If you RENAMED a setting, keep its record in the same block and change "
+            f"{path}. If you REMOVED a setting from the code, remove its declaration in this "
+            f"same change - a record is only demanded for a setting that is still declared. "
+            f"If you RENAMED a setting, keep its record in the same block and change "
             f"only the name in it - the values and the reason text must stay identical for the "
             f"rename to be recognized:\n" + "\n".join(sorted(set(violations)))
         )

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -194,7 +194,9 @@ def parse_settings_history_changes(patch, file_lines):
     (check_settings_changes_history), which enforces the rule as soon as any other C++ source
     file changed. A change that edits only this file - fixing what a past release recorded -
     is a historical correction, not a default change made now, so it is allowed there; that is
-    what keeps a phantom record deletable."""
+    what keeps a phantom record deletable. The caller also drops reported settings that are no
+    longer declared at all, so removing a setting that was never released - records included -
+    stays possible; nothing can be recorded for a setting that does not exist."""
     added = []  # (new_line_number, name, signature, body_without_name)
     removed = []  # (new_line_number, name, signature, body_without_name)
     headers_added = []  # new_line_number of an added `addSettingsChanges` header

--- a/ci/tests/test_settings_history_removed_setting.py
+++ b/ci/tests/test_settings_history_removed_setting.py
@@ -1,0 +1,218 @@
+"""
+Tests for the removed-setting exemption of the `settings_changes_history` style check in
+`ci/jobs/check_style.py`.
+
+A setting that a change deletes from the code cannot be recorded in
+`src/Core/SettingsChangesHistory.cpp` at all: `03999_stateless_settings_history` rejects a record
+naming a setting that is not in `system.settings` / `system.merge_tree_settings`, and
+`applyCompatibilitySetting` resolves every recorded name. So its records must be deleted together
+with it, and the check must not demand an entry under the current version block - otherwise a
+setting that was never released could not be dropped at all. A setting that merely becomes
+OBSOLETE keeps its row in `system.settings`, so its records stay required.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+# `praktika` is imported as a top-level module by the style-check job.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ci.jobs import check_style
+from ci.jobs.scripts.workflow_hooks.store_data import parse_settings_history_changes
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+HISTORY = "src/Core/SettingsChangesHistory.cpp"
+# The change removes the setting, so it necessarily touches the declarations too - which is what
+# makes the source-file gate enforce the current-version-block rule in the first place.
+CHANGED_FILES = [HISTORY, "src/Core/Settings.cpp"]
+
+
+class _FakeInfo:
+    def __init__(self, kv):
+        self._kv = kv
+
+    def __call__(self):
+        return self
+
+    def get_kv_data(self):
+        return self._kv
+
+
+def _run(monkeypatch, changed_settings, changed_files=None):
+    kv = {
+        "changed_files": changed_files if changed_files is not None else CHANGED_FILES,
+        "settings_history_changed_settings": changed_settings,
+    }
+    monkeypatch.setattr(check_style, "Info", _FakeInfo(kv))
+    monkeypatch.chdir(REPO_ROOT)
+    return check_style.check_settings_changes_history()
+
+
+def _removal_of(name, block='addSettingsChanges(settings_changes_history, "26.7",'):
+    """The parser's view of a change that deletes the only record of `name` from `block`."""
+    file_lines = ["        " + block, "        {", "        });"]
+    patch = (
+        "@@ -1,3 +1,3 @@\n"
+        " {\n"
+        f'-            {{"{name}", 0, 1, "Recorded in an older release"}},\n'
+        " });\n"
+    )
+    return parse_settings_history_changes(patch, file_lines)
+
+
+def test_removing_a_setting_that_no_longer_exists_is_allowed(monkeypatch):
+    # The setting is gone from the declarations, so its record cannot be kept anywhere: the
+    # deletion is the only correct thing to do and must not be reported.
+    changed = _removal_of("no_such_setting_at_all")
+    assert changed == [{"namespace": "Session", "name": "no_such_setting_at_all"}]
+    assert _run(monkeypatch, changed) == ""
+
+
+def test_removing_a_merge_tree_setting_that_no_longer_exists_is_allowed(monkeypatch):
+    changed = _removal_of(
+        "no_such_setting_at_all",
+        'addSettingsChanges(merge_tree_settings_changes_history, "26.7",',
+    )
+    assert changed == [{"namespace": "MergeTree", "name": "no_such_setting_at_all"}]
+    assert _run(monkeypatch, changed) == ""
+
+
+def test_removing_the_record_of_a_setting_that_stays_is_still_reported(monkeypatch):
+    # The setting is still declared, so deleting its record is the escape hatch the check exists
+    # to catch: the revert has to be recorded under the current version block instead.
+    changed = _removal_of("max_block_size")
+    assert changed == [{"namespace": "Session", "name": "max_block_size"}]
+    assert "max_block_size" in _run(monkeypatch, changed)
+
+
+def test_removing_the_record_of_a_merge_tree_setting_that_stays_is_still_reported(
+    monkeypatch,
+):
+    changed = _removal_of(
+        "index_granularity",
+        'addSettingsChanges(merge_tree_settings_changes_history, "26.7",',
+    )
+    assert changed == [{"namespace": "MergeTree", "name": "index_granularity"}]
+    assert "index_granularity" in _run(monkeypatch, changed)
+
+
+def test_an_obsolete_setting_is_not_a_removed_setting(monkeypatch):
+    # `MAKE_OBSOLETE` keeps the row in system.settings, so the records of such a setting are
+    # still resolvable and still required - making a setting obsolete is not a removal.
+    declared = check_style.declared_setting_names()[0]
+    obsolete = "allow_experimental_query_deduplication"
+    assert obsolete in declared["Session"], "expected an obsolete setting to count as declared"
+    assert obsolete in _run(
+        monkeypatch, [{"namespace": "Session", "name": obsolete}]
+    )
+
+
+def test_an_alias_counts_as_a_declared_setting(monkeypatch):
+    # History records may name an alias (`applyCompatibilitySetting` resolves them), and an alias
+    # has its own row in system.settings, so it must not be mistaken for a removed setting.
+    declared = check_style.declared_setting_names()[0]
+    assert "insert_distributed_sync" in declared["Session"]
+    assert "insert_distributed_timeout" in declared["Session"]
+
+
+def test_a_setting_of_the_other_namespace_does_not_count_as_declared(monkeypatch):
+    # The namespaces are resolved separately: an overlapping name that only exists as a MergeTree
+    # setting must not make a removed Session setting look declared.
+    declared = check_style.declared_setting_names()[0]
+    assert "index_granularity" in declared["MergeTree"]
+    assert "index_granularity" not in declared["Session"]
+
+
+def test_unrecognized_namespace_is_not_exempt(monkeypatch):
+    # Fail-close: a namespace that cannot be resolved to declarations is reported, not skipped.
+    assert "made_up_setting" in _run(
+        monkeypatch, [{"namespace": "NoSuchNamespace", "name": "made_up_setting"}]
+    )
+
+
+def test_every_recorded_setting_resolves_to_a_declaration(monkeypatch):
+    """Rot detector for the declaration parser: `03999_stateless_settings_history` rejects a
+    record that names a setting which does not exist, so on master every name recorded in
+    SettingsChangesHistory.cpp must be found by `declared_setting_names`. If this fails, the
+    parser (or `_SETTINGS_DECLARATION_SOURCES`) went stale and started exempting real settings
+    from the current-version-block rule."""
+    monkeypatch.chdir(REPO_ROOT)
+    declared, error = check_style.declared_setting_names()
+    assert error == "" and declared
+
+    namespace_by_map = {
+        "settings_changes_history": "Session",
+        "merge_tree_settings_changes_history": "MergeTree",
+    }
+    block_re = re.compile(r'addSettingsChanges\(\s*(\w+)\s*,\s*"([\d.]+)"')
+    entry_re = re.compile(r'^\s*\{\s*"([A-Za-z0-9_]+)"')
+    namespace = None
+    dangling = []
+    recorded = 0
+    with open(HISTORY, "r", encoding="utf-8") as f:
+        for line in f:
+            mb = block_re.search(line)
+            if mb:
+                namespace = namespace_by_map.get(mb.group(1))
+                continue
+            me = entry_re.match(line)
+            if me and namespace:
+                recorded += 1
+                if me.group(1) not in declared[namespace]:
+                    dangling.append(f"{namespace}: {me.group(1)}")
+    assert recorded > 100, "the history file was not parsed"
+    assert not dangling, "recorded settings not found in the declarations: " + ", ".join(
+        sorted(set(dangling))
+    )
+
+
+def test_missing_declaration_file_fails_closed(monkeypatch):
+    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.setattr(
+        check_style,
+        "_SETTINGS_DECLARATION_SOURCES",
+        {"Session": ("src/Core/NoSuchSettingsFile.cpp",)},
+    )
+    declared, error = check_style.declared_setting_names()
+    assert declared is None
+    assert "src/Core/NoSuchSettingsFile.cpp" in error
+
+
+def test_declaration_file_without_any_setting_fails_closed(monkeypatch):
+    # The file exists but no declaration matches: the macros moved or changed shape. Returning an
+    # empty set would exempt every setting, so this is an error instead.
+    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.setattr(
+        check_style,
+        "_SETTINGS_DECLARATION_SOURCES",
+        {"Session": ("src/Core/SettingsChangesHistory.cpp",)},
+    )
+    declared, error = check_style.declared_setting_names()
+    assert declared is None
+    assert "no Session setting declaration was found" in error
+
+
+def test_removal_reported_by_a_block_header_edit_is_filtered_too(monkeypatch):
+    # A block header edit reports every entry of the block; the ones whose setting is gone are
+    # filtered out the same way, and a header edit that only covers such entries is allowed.
+    entry = '            {"no_such_setting_at_all", 0, 1, "Recorded here"},'
+    file_lines = [
+        '        addSettingsChanges(settings_changes_history, "26.7",',
+        "        {",
+        entry,
+        "        });",
+    ]
+    patch = (
+        "@@ -1,4 +1,4 @@\n"
+        '-        addSettingsChanges(settings_changes_history, "26.8",\n'
+        '+        addSettingsChanges(settings_changes_history, "26.7",\n'
+        "         {\n"
+        f" {entry}\n"
+        "         });\n"
+    )
+    changed = parse_settings_history_changes(patch, file_lines)
+    assert changed == [{"namespace": "Session", "name": "no_such_setting_at_all"}]
+    assert _run(monkeypatch, changed) == ""

--- a/ci/tests/test_settings_history_source_gate.py
+++ b/ci/tests/test_settings_history_source_gate.py
@@ -35,8 +35,27 @@ class _FakeInfo:
         return self._kv
 
 
+def _stub_declared_settings(monkeypatch, kv):
+    """Make every reported name look like a declared setting.
+
+    The check exempts settings that are no longer declared - a setting a change removes from the
+    code cannot be recorded in the history at all (see
+    ci/tests/test_settings_history_removed_setting.py). These cells are about the source-file gate
+    and the rename path, not about which settings exist, and the names they use are placeholders
+    that no declaration file contains - `_run_standalone` even runs in a directory that holds no
+    declaration file at all."""
+    reported = kv.get("settings_history_changed_settings") or []
+    names = {item["name"] for item in reported}
+    monkeypatch.setattr(
+        check_style,
+        "declared_setting_names",
+        lambda: ({"Session": set(names), "MergeTree": set(names)}, ""),
+    )
+
+
 def _run(monkeypatch, kv):
     monkeypatch.setattr(check_style, "Info", _FakeInfo(kv))
+    _stub_declared_settings(monkeypatch, kv)
     monkeypatch.chdir(REPO_ROOT)
     return check_style.check_settings_changes_history()
 
@@ -47,7 +66,8 @@ def _run_standalone(monkeypatch, tmp_path, kv, version, file_lines):
     The check resolves the current version block from the version file and looks the
     reported names up in the history file, so a cell asserting that a name IS recorded
     has to supply both; reading the repo's own files would tie the outcome to whichever
-    release the checkout happens to be on.
+    release the checkout happens to be on. The settings declarations the check also reads are
+    stubbed out by `_stub_declared_settings`.
     """
     (tmp_path / "cmake").mkdir(parents=True, exist_ok=True)
     (tmp_path / "src" / "Core").mkdir(parents=True, exist_ok=True)
@@ -57,6 +77,7 @@ def _run_standalone(monkeypatch, tmp_path, kv, version, file_lines):
     )
     (tmp_path / HISTORY).write_text("\n".join(file_lines) + "\n", encoding="utf-8")
     monkeypatch.setattr(check_style, "Info", _FakeInfo(kv))
+    _stub_declared_settings(monkeypatch, kv)
     monkeypatch.chdir(tmp_path)
     return check_style.check_settings_changes_history()
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/111605
-->

## Motivation

The `settings_changes_history` style check reports every setting whose record in `src/Core/SettingsChangesHistory.cpp` a change touches - added, value-changed, moved, removed, or sitting in a block whose `addSettingsChanges` header changed - and demands an entry under the current version block.

For a setting that the same change removes from the code, that demand cannot be satisfied. The records of a removed setting have to go with it: `03999_stateless_settings_history` rejects a record naming a setting that is not in `system.settings` / `system.merge_tree_settings` (`SETTING IN SettingsChangesHistory.cpp DOES NOT EXIST (typo/rename?)`), and `applyCompatibilitySetting` resolves every recorded name. So keeping the record failed the functional test and deleting it failed the style check, which means a setting that was added and then dropped inside the same unreleased development cycle could not be removed at all.

## Changes

The check now drops reported settings that are no longer declared in the tree.

This cannot hide a default change. `compatibility` only ever restores values of settings that exist, so a setting that is gone has no default left for any release to disagree about - unlike deleting the record of a setting that stays, which keeps being reported, because that is how a revert of an unreleased default change could otherwise be hidden from both guards. A setting that is merely made obsolete (`MAKE_OBSOLETE`) keeps its row in `system.settings`, so its records stay required; only a real removal is exempt.

The declared names come from a text parse of `LIST_OF_SETTINGS` (`src/Core/Settings.cpp`, `src/Core/FormatFactorySettings.h`) and `MERGE_TREE_SETTINGS` (`src/Storages/MergeTree/MergeTreeSettings.cpp`), covering `DECLARE`, `DECLARE_WITH_ALIAS` including the alias name (an alias is a settable name of its own and history records use them), `MAKE_OBSOLETE` and `MAKE_DEPRECATED_BY_SERVER_CONFIG`. It fails close: a missing declaration file, or a namespace that parses to nothing, is an error rather than a blanket exemption.

The exemption is deliberately narrower than "not yet released". Deleting a record from the current unreleased block for a setting that still exists is still reported: that case has satisfiable alternatives, while allowing it would open holes exactly where `03999_stateless_settings_history` skips its value comparison (`auto(...)` defaults, `Map` settings, the drift-ignore list, Cloud-divergent defaults).

## Tests

New `ci/tests/test_settings_history_removed_setting.py`: a removed session or MergeTree setting is allowed, a deleted record of a setting that stays is still reported, an obsolete setting is not a removal, aliases count as declared, the two namespaces are resolved separately, an unrecognized namespace is not exempt, and both fail-close paths. One cell is a rot detector for the declaration parser: every name recorded in `SettingsChangesHistory.cpp` must resolve to a declaration, which is exactly the invariant `03999_stateless_settings_history` enforces at runtime.

`ci/tests/test_settings_history_source_gate.py` now stubs the declaration lookup in its two runners - those cells are about the source-file gate and the rename path, use placeholder setting names, and `_run_standalone` runs in a directory that holds no declaration file at all.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116421&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116421](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116421+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.128` (included in `26.9` and later)
<!-- ch-version-info:end -->