### PR TITLE
Do not let one unreachable remote database break `system.tables` for everyone

### DIFF
--- a/ci/jobs/check_style.py
+++ b/ci/jobs/check_style.py
@@ -829,6 +829,7 @@ def check_catch_all(files) -> str:
         re.compile(r"\bhandle_exception\b"),
         re.compile(r"\bhandleException\b"),
         re.compile(r"\bfinishWithException\b"),
+        re.compile(r"\bhandleCannotListTables\b"),
     ]
 
     for file_path in files:

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -299,6 +299,7 @@ static struct InitFiu
     PAUSEABLE(truncate_database_tables_pause) \
     PAUSEABLE(database_materialized_postgresql_pause_before_table_drop) \
     REGULAR(datalake_try_get_table_return_nullptr) \
+    REGULAR(mysql_fetch_tables_throw) \
     REGULAR(datalake_try_get_table_throw) \
     REGULAR(datalake_get_tables_throw) \
     REGULAR(datalake_simulate_missing_table_state) \

--- a/src/Databases/DatabaseRemote.cpp
+++ b/src/Databases/DatabaseRemote.cpp
@@ -663,6 +663,33 @@ DatabaseTablesIteratorPtr DatabaseRemote::getTablesIteratorImpl(
 }
 
 
+std::optional<LogsLevel> DatabaseRemote::toleratedListTablesFailureLogLevel() const
+{
+    /// `fetchTablesList` turns every failed attempt to reach the remote replicas into
+    /// `NO_REMOTE_SHARD_AVAILABLE`, so that code means exactly "the remote is unreachable". Nothing
+    /// else on the listing path is a mere connection failure: the structure of an individual table is
+    /// resolved with `throw_on_error = false`, and a self-reference (`INFINITE_LOOP`) must not be
+    /// hidden behind a skip.
+    /// Must be called from within a catch block: it rethrows the active exception to classify it.
+    try
+    {
+        throw;
+    }
+    catch (const Exception & e)
+    {
+        if (e.code() == ErrorCodes::NO_REMOTE_SHARD_AVAILABLE)
+            return LogsLevel::warning;
+        return {};
+    }
+    /// Ok to not report anything here: the exception stays active and the caller logs it at the
+    /// level `handleCannotListTables` derives from this result.
+    catch (...)
+    {
+        return {};
+    }
+}
+
+
 std::vector<LightWeightTableDetails> DatabaseRemote::getLightweightTablesIterator(
     ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool /* skip_not_loaded */) const
 {

--- a/src/Databases/DatabaseRemote.cpp
+++ b/src/Databases/DatabaseRemote.cpp
@@ -701,8 +701,10 @@ std::vector<LightWeightTableDetails> DatabaseRemote::getLightweightTablesIterato
     /// names-only path of `system.tables`), so an unreachable server has to be reported as such. An
     /// empty successful answer would contradict `EXISTS TABLE` and `SELECT` on the same database, which
     /// do report the real network or authentication error, and it would hide the outage behind "there
-    /// are no tables". The helper paths (name hints, the plain `getTablesIterator` that the server
-    /// itself walks) stay best-effort.
+    /// are no tables". A `system.tables` scan that names no database catches the propagated failure and
+    /// skips this database instead; that decision belongs to the caller, which alone knows whether the
+    /// query named the database (see `handleCannotListTables`). The helper paths (name hints, the plain
+    /// `getTablesIterator` that the server itself walks) stay best-effort.
     std::vector<LightWeightTableDetails> result;
 
     for (const auto & table_name : fetchTablesList(local_context))
@@ -1188,7 +1190,7 @@ ENGINE = Remote(my_named_collection, database = 'default');
 - Access rights are enforced on the remote server for the configured remote user, and locally by the usual privileges on the database and its tables.
 - A table of a local shard that the user is not allowed to see is reported as missing rather than as forbidden, so a `Remote` database cannot be used to probe the table names of a local database the user has no privileges on. This applies to listing (`SHOW TABLES`, `EXISTS TABLE`) as well as to resolution (`DESCRIBE TABLE`, `SHOW CREATE TABLE`, `SELECT`), and such a table is not served through the remote replicas of its shard either: the fallback described above engages only when the local replica genuinely does not have the table.
 - Listing the tables of a database that exists on the local replica of a shard also includes the tables that only the remote replicas of that shard have, so that `SHOW TABLES` and `system.tables` agree with `EXISTS TABLE`, `DESCRIBE TABLE` and `SELECT`, which fall back to those replicas. When none of the remote replicas answers, the list of the local replica is returned as it is, because it is already the answer of an available replica.
-- If the remote server is unavailable, listing its tables (`SHOW TABLES`, `system.tables`) reports the connection error instead of an empty list of tables, as `EXISTS TABLE` and `SELECT` on the same database do. Note that a `SELECT` from `system.tables` covering all databases fails as well while such a database is unreachable.
+- If the remote server is unavailable, a query that names this database - `SHOW TABLES FROM`, or `system.tables` with a predicate on `database` - reports the connection error instead of an empty list of tables, as `EXISTS TABLE` and `SELECT` on the same database do. A `SELECT` from `system.tables` that covers all databases instead skips this one and logs a warning, so that one unreachable remote database does not break whole-server introspection.
 - A `Remote` database may point to another `Remote` database on the same server. Listing and describing the tables of such a chain needs no privileges on the intermediate database — it holds neither data nor metadata of its own, and every hop already checks the caller's rights on the objects that it proxies in turn. Reading and writing the data, in contrast, needs `SELECT` / `INSERT` on every hop of the chain, because the query is really executed against the table of the intermediate database, exactly like for a `Distributed` table over another `Distributed` table. The visibility rule described above survives the chain: a table that the intermediate database hides from the caller is not served through the remote replicas of the outer database either. If the intermediate database on the local replica cannot reach its own target, the local replica of the outer shard cannot answer at all — exactly as if the replica itself were down — and the outer database falls back to the remote replicas of the shard.
 
 ## Example {#example}

--- a/src/Databases/DatabaseRemote.h
+++ b/src/Databases/DatabaseRemote.h
@@ -47,6 +47,8 @@ public:
 
     bool isRemoteDatabase() const override { return true; }
 
+    std::optional<LogsLevel> toleratedListTablesFailureLogLevel() const override;
+
     String getMetadataPath() const override { return metadata_path; }
 
     /// The table list lives on the remote server, so this database is never required to be empty

--- a/src/Databases/IDatabase.cpp
+++ b/src/Databases/IDatabase.cpp
@@ -278,4 +278,16 @@ DiskPtr IDatabase::getDisk() const
 {
     return Context::getGlobalContextInstance()->getDatabaseDisk();
 }
+
+void handleCannotListTables(const IDatabase & database, UnavailableDatabasePolicy policy)
+{
+    const auto level = database.toleratedListTablesFailureLogLevel();
+    if (!level && policy == UnavailableDatabasePolicy::SkipIfUnreachable)
+        throw;
+
+    tryLogCurrentException(
+        "ListTables",
+        fmt::format("Cannot list the tables of database {}, skipping it", backQuoteIfNeed(database.getDatabaseName())),
+        level.value_or(LogsLevel::error));
+}
 }

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/LogsLevel.h>
 #include <Core/UUID.h>
 #include <Databases/LoadingStrictnessLevel.h>
 #include <Disks/IDisk.h>
@@ -371,6 +372,12 @@ public:
         return result;
     }
 
+    /// The level at which to log the active exception when a caller skips this database because it
+    /// cannot list its tables. `nullopt` means the failure is not a mere unreachable remote and so
+    /// must not be tolerated. Only a remote engine overrides this; see `DatabaseMySQL`.
+    /// Must be called from within a catch block: an override classifies the active exception.
+    virtual std::optional<LogsLevel> toleratedListTablesFailureLogLevel() const { return {}; }
+
     /// Is the database empty.
     virtual bool empty() const = 0;
 
@@ -552,5 +559,22 @@ protected:
 using DatabasePtr = std::shared_ptr<IDatabase>;
 using ConstDatabasePtr = std::shared_ptr<const IDatabase>;
 using Databases = std::map<String, DatabasePtr, std::less<>>;
+
+/// Whether a caller that cannot list one database's tables may carry on without it.
+enum class UnavailableDatabasePolicy : uint8_t
+{
+    /// Skip the database only when its remote server is merely unreachable. Anything else is a real
+    /// failure and is rethrown rather than turned into a silently incomplete result.
+    SkipIfUnreachable,
+    /// Skip it whatever the failure. Only for a name hint, which must never turn a listing failure
+    /// into the error the user sees - a typo has to answer `UNKNOWN_TABLE`.
+    AlwaysSkip,
+};
+
+/// A remote engine (`MySQL`, `PostgreSQL`) lists its tables by connecting to the remote server, so
+/// an unreachable server makes listing throw. Callers that enumerate every database use this to
+/// skip such a database instead of failing whole-server introspection because of one of them.
+/// Rethrows when `policy` does not allow skipping. Must be called from within a catch block.
+void handleCannotListTables(const IDatabase & database, UnavailableDatabasePolicy policy);
 
 }

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -182,68 +182,25 @@ bool DatabaseMySQL::empty() const
     return true;
 }
 
-Tables DatabaseMySQL::listTablesImpl(ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool throw_on_error) const
+DatabaseTablesIteratorPtr DatabaseMySQL::getTablesIterator(ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool /* skip_not_loaded */) const
 {
     Tables tables;
     std::lock_guard lock(mutex);
 
-    try
+    /// Drives a listing failure that is *not* a connection failure to the remote, so that a caller
+    /// which tolerates an unreachable database can be shown to still report anything else.
+    fiu_do_on(FailPoints::mysql_fetch_tables_throw,
     {
-        /// Not a connection failure to the remote, so it must propagate even here rather than be
-        /// served from `local_tables_cache` as if the listing had succeeded.
-        fiu_do_on(FailPoints::mysql_fetch_tables_throw,
-        {
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Injected MySQL table listing failure");
-        });
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Injected MySQL table listing failure");
+    });
 
-        fetchTablesIntoLocalCache(local_context);
-    }
-    catch (...)
-    {
-        /// Only an unreachable remote is tolerated, and only on the best-effort path. Anything else -
-        /// a malformed reply, a permission error, a logical error - propagates rather than turning
-        /// into a successful but incomplete list of tables. The classifier returns `warning` exactly
-        /// for a connection failure to the remote.
-        const auto level = mysqlToleratedConnectionFailureLogLevel();
-        if (throw_on_error || level != LogsLevel::warning)
-            throw;
-
-        /// Serve whatever the local cache holds. Logged at `warning` rather than `error`, because an
-        /// `Error` line would be reported as an error of a query that succeeds.
-        tryLogCurrentException(__PRETTY_FUNCTION__, "", level);
-    }
+    fetchTablesIntoLocalCache(local_context);
 
     for (const auto & [table_name, modify_time_and_storage] : local_tables_cache)
         if (!remove_or_detach_tables.contains(table_name) && (!filter_by_table_name || filter_by_table_name(table_name)))
             tables[table_name] = modify_time_and_storage.second;
 
-    return tables;
-}
-
-DatabaseTablesIteratorPtr DatabaseMySQL::getTablesIterator(ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool /* skip_not_loaded */) const
-{
-    return std::make_unique<DatabaseTablesSnapshotIterator>(
-        listTablesImpl(local_context, filter_by_table_name, /* throw_on_error = */ false), getDatabaseName());
-}
-
-DatabaseTablesIteratorPtr DatabaseMySQL::getTablesIteratorWithHint(
-    ContextPtr local_context,
-    const FilterByNameFunction & filter_by_table_name,
-    bool /* skip_not_loaded */,
-    const TablesFilter & /* tables_filter */) const
-{
-    return std::make_unique<DatabaseTablesSnapshotIterator>(
-        listTablesImpl(local_context, filter_by_table_name, /* throw_on_error = */ true), getDatabaseName());
-}
-
-std::vector<LightWeightTableDetails> DatabaseMySQL::getLightweightTablesIterator(
-    ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool /* skip_not_loaded */) const
-{
-    std::vector<LightWeightTableDetails> result;
-    for (const auto & [table_name, storage] : listTablesImpl(local_context, filter_by_table_name, /* throw_on_error = */ true))
-        if (storage)
-            result.emplace_back(table_name);
-    return result;
+    return std::make_unique<DatabaseTablesSnapshotIterator>(tables, database_name);
 }
 
 bool DatabaseMySQL::isTableExist(const String & name, ContextPtr local_context) const

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -5,6 +5,7 @@
 #    include <filesystem>
 #    include <string>
 #    include <Columns/IColumn.h>
+#    include <Common/FailPoint.h>
 #    include <Core/Settings.h>
 #    include <DataTypes/DataTypeDateTime.h>
 #    include <DataTypes/DataTypeNullable.h>
@@ -59,6 +60,11 @@ namespace Setting
 namespace MySQLSetting
 {
     extern const MySQLSettingsMySQLDataTypesSupport mysql_datatypes_support_level;
+}
+
+namespace FailPoints
+{
+    extern const char mysql_fetch_tables_throw[];
 }
 
 namespace ErrorCodes
@@ -183,6 +189,13 @@ Tables DatabaseMySQL::listTablesImpl(ContextPtr local_context, const FilterByNam
 
     try
     {
+        /// Not a connection failure to the remote, so it must propagate even here rather than be
+        /// served from `local_tables_cache` as if the listing had succeeded.
+        fiu_do_on(FailPoints::mysql_fetch_tables_throw,
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Injected MySQL table listing failure");
+        });
+
         fetchTablesIntoLocalCache(local_context);
     }
     catch (...)

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -187,13 +187,17 @@ Tables DatabaseMySQL::listTablesImpl(ContextPtr local_context, const FilterByNam
     }
     catch (...)
     {
-        if (throw_on_error)
+        /// Only an unreachable remote is tolerated, and only on the best-effort path. Anything else -
+        /// a malformed reply, a permission error, a logical error - propagates rather than turning
+        /// into a successful but incomplete list of tables. The classifier returns `warning` exactly
+        /// for a connection failure to the remote.
+        const auto level = mysqlToleratedConnectionFailureLogLevel();
+        if (throw_on_error || level != LogsLevel::warning)
             throw;
 
-        /// Serve whatever the local cache holds. The level is `warning` exactly for a connection
-        /// failure to the unreachable remote: an `Error` line would be reported as an error of a
-        /// query that succeeds, and anything else must stay visible as an error.
-        tryLogCurrentException(__PRETTY_FUNCTION__, "", mysqlToleratedConnectionFailureLogLevel());
+        /// Serve whatever the local cache holds. Logged at `warning` rather than `error`, because an
+        /// `Error` line would be reported as an error of a query that succeeds.
+        tryLogCurrentException(__PRETTY_FUNCTION__, "", level);
     }
 
     for (const auto & [table_name, modify_time_and_storage] : local_tables_cache)

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -176,18 +176,57 @@ bool DatabaseMySQL::empty() const
     return true;
 }
 
-DatabaseTablesIteratorPtr DatabaseMySQL::getTablesIterator(ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool /* skip_not_loaded */) const
+Tables DatabaseMySQL::listTablesImpl(ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool throw_on_error) const
 {
     Tables tables;
     std::lock_guard lock(mutex);
 
-    fetchTablesIntoLocalCache(local_context);
+    try
+    {
+        fetchTablesIntoLocalCache(local_context);
+    }
+    catch (...)
+    {
+        if (throw_on_error)
+            throw;
+
+        /// Serve whatever the local cache holds. The level is `warning` exactly for a connection
+        /// failure to the unreachable remote: an `Error` line would be reported as an error of a
+        /// query that succeeds, and anything else must stay visible as an error.
+        tryLogCurrentException(__PRETTY_FUNCTION__, "", mysqlToleratedConnectionFailureLogLevel());
+    }
 
     for (const auto & [table_name, modify_time_and_storage] : local_tables_cache)
         if (!remove_or_detach_tables.contains(table_name) && (!filter_by_table_name || filter_by_table_name(table_name)))
             tables[table_name] = modify_time_and_storage.second;
 
-    return std::make_unique<DatabaseTablesSnapshotIterator>(tables, database_name);
+    return tables;
+}
+
+DatabaseTablesIteratorPtr DatabaseMySQL::getTablesIterator(ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool /* skip_not_loaded */) const
+{
+    return std::make_unique<DatabaseTablesSnapshotIterator>(
+        listTablesImpl(local_context, filter_by_table_name, /* throw_on_error = */ false), getDatabaseName());
+}
+
+DatabaseTablesIteratorPtr DatabaseMySQL::getTablesIteratorWithHint(
+    ContextPtr local_context,
+    const FilterByNameFunction & filter_by_table_name,
+    bool /* skip_not_loaded */,
+    const TablesFilter & /* tables_filter */) const
+{
+    return std::make_unique<DatabaseTablesSnapshotIterator>(
+        listTablesImpl(local_context, filter_by_table_name, /* throw_on_error = */ true), getDatabaseName());
+}
+
+std::vector<LightWeightTableDetails> DatabaseMySQL::getLightweightTablesIterator(
+    ContextPtr local_context, const FilterByNameFunction & filter_by_table_name, bool /* skip_not_loaded */) const
+{
+    std::vector<LightWeightTableDetails> result;
+    for (const auto & [table_name, storage] : listTablesImpl(local_context, filter_by_table_name, /* throw_on_error = */ true))
+        if (storage)
+            result.emplace_back(table_name);
+    return result;
 }
 
 bool DatabaseMySQL::isTableExist(const String & name, ContextPtr local_context) const

--- a/src/Databases/MySQL/DatabaseMySQL.h
+++ b/src/Databases/MySQL/DatabaseMySQL.h
@@ -63,7 +63,26 @@ public:
 
     bool empty() const override;
 
+    /// Best-effort: the server itself walks over every database through this iterator (asynchronous
+    /// metrics, `SYSTEM` commands, `DROP DATABASE`, `system.kafka_consumers`, ...), so a single
+    /// unreachable remote must not make those operations fail. Serves whatever the local cache holds.
+    /// The user-facing listings below propagate the failure instead; see `DatabaseRemote`, which
+    /// splits the two the same way.
     DatabaseTablesIteratorPtr getTablesIterator(ContextPtr context, const FilterByNameFunction & filter_by_table_nam, bool skip_not_loaded) const override;
+
+    /// The `system.tables` path. A remote failure is propagated, because answering an empty list of
+    /// tables would report "this database has no tables" when the truth is "its server is
+    /// unreachable". `StorageSystemTables` decides whether a whole-server scan may skip this
+    /// database; see `handleCannotListTables`.
+    DatabaseTablesIteratorPtr getTablesIteratorWithHint(
+        ContextPtr context,
+        const FilterByNameFunction & filter_by_table_name,
+        bool skip_not_loaded,
+        const TablesFilter & tables_filter) const override;
+
+    /// Drives the explicit `SHOW TABLES`, which propagates a remote failure for the same reason.
+    std::vector<LightWeightTableDetails>
+    getLightweightTablesIterator(ContextPtr context, const FilterByNameFunction & filter_by_table_name, bool skip_not_loaded) const override;
 
     std::optional<LogsLevel> toleratedListTablesFailureLogLevel() const override
     {
@@ -126,6 +145,10 @@ private:
     void cleanOutdatedTables();
 
     void fetchTablesIntoLocalCache(ContextPtr context) const TSA_REQUIRES(mutex);
+
+    /// Refreshes the local cache from the remote and returns its visible entries. `throw_on_error`
+    /// selects between the two listing semantics described above.
+    Tables listTablesImpl(ContextPtr context, const FilterByNameFunction & filter_by_table_name, bool throw_on_error) const;
 
     std::map<String, UInt64> fetchTablesWithModificationTime(ContextPtr local_context) const;
 

--- a/src/Databases/MySQL/DatabaseMySQL.h
+++ b/src/Databases/MySQL/DatabaseMySQL.h
@@ -63,26 +63,7 @@ public:
 
     bool empty() const override;
 
-    /// Best-effort: the server itself walks over every database through this iterator (asynchronous
-    /// metrics, `SYSTEM` commands, `DROP DATABASE`, `system.kafka_consumers`, ...), so a single
-    /// unreachable remote must not make those operations fail. Serves whatever the local cache holds.
-    /// The user-facing listings below propagate the failure instead; see `DatabaseRemote`, which
-    /// splits the two the same way.
     DatabaseTablesIteratorPtr getTablesIterator(ContextPtr context, const FilterByNameFunction & filter_by_table_nam, bool skip_not_loaded) const override;
-
-    /// The `system.tables` path. A remote failure is propagated, because answering an empty list of
-    /// tables would report "this database has no tables" when the truth is "its server is
-    /// unreachable". `StorageSystemTables` decides whether a whole-server scan may skip this
-    /// database; see `handleCannotListTables`.
-    DatabaseTablesIteratorPtr getTablesIteratorWithHint(
-        ContextPtr context,
-        const FilterByNameFunction & filter_by_table_name,
-        bool skip_not_loaded,
-        const TablesFilter & tables_filter) const override;
-
-    /// Drives the explicit `SHOW TABLES`, which propagates a remote failure for the same reason.
-    std::vector<LightWeightTableDetails>
-    getLightweightTablesIterator(ContextPtr context, const FilterByNameFunction & filter_by_table_name, bool skip_not_loaded) const override;
 
     std::optional<LogsLevel> toleratedListTablesFailureLogLevel() const override
     {
@@ -145,10 +126,6 @@ private:
     void cleanOutdatedTables();
 
     void fetchTablesIntoLocalCache(ContextPtr context) const TSA_REQUIRES(mutex);
-
-    /// Refreshes the local cache from the remote and returns its visible entries. `throw_on_error`
-    /// selects between the two listing semantics described above.
-    Tables listTablesImpl(ContextPtr context, const FilterByNameFunction & filter_by_table_name, bool throw_on_error) const;
 
     std::map<String, UInt64> fetchTablesWithModificationTime(ContextPtr local_context) const;
 

--- a/src/Databases/MySQL/DatabaseMySQL.h
+++ b/src/Databases/MySQL/DatabaseMySQL.h
@@ -65,6 +65,16 @@ public:
 
     DatabaseTablesIteratorPtr getTablesIterator(ContextPtr context, const FilterByNameFunction & filter_by_table_nam, bool skip_not_loaded) const override;
 
+    std::optional<LogsLevel> toleratedListTablesFailureLogLevel() const override
+    {
+        /// The classifier returns `warning` exactly for a tolerated connection failure to the
+        /// remote, and `error` for anything else - which must not be hidden behind a skip.
+        const auto level = mysqlToleratedConnectionFailureLogLevel();
+        if (level == LogsLevel::warning)
+            return level;
+        return {};
+    }
+
     bool isTableExist(const String & name, ContextPtr context) const override;
 
     StoragePtr tryGetTable(const String & name, ContextPtr context) const override;

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -177,6 +177,17 @@ DatabaseTablesIteratorPtr DatabasePostgreSQL::getTablesIterator(ContextPtr local
 }
 
 
+std::optional<LogsLevel> DatabasePostgreSQL::toleratedListTablesFailureLogLevel() const
+{
+    /// The classifier returns `warning` exactly for a tolerated connection failure to the remote,
+    /// and `error` for anything else - which must not be hidden behind a skip.
+    const auto level = toleratedConnectionFailureLogLevel();
+    if (level == LogsLevel::warning)
+        return level;
+    return {};
+}
+
+
 bool DatabasePostgreSQL::checkPostgresTable(const String & table_name) const
 {
     if (table_name.contains('\'') || table_name.contains('\\'))

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.h
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.h
@@ -50,6 +50,8 @@ public:
 
     DatabaseTablesIteratorPtr getTablesIterator(ContextPtr context, const FilterByNameFunction & filter_by_table_name, bool skip_not_loaded) const override;
 
+    std::optional<LogsLevel> toleratedListTablesFailureLogLevel() const override;
+
     bool isTableExist(const String & name, ContextPtr context) const override;
     StoragePtr tryGetTable(const String & name, ContextPtr context) const override;
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -2448,7 +2448,20 @@ VectorWithMemoryTracking<String> TableNameHints::getAllRegisteredNames() const
         return {};
     if (database->isRemoteDatabase() && context && !context->getSettingsRef()[Setting::show_remote_databases_in_system_tables])
         return {};
-    auto names = database->getAllTableNames(context);
+
+    /// A hint must never change the error the user sees, so a database that cannot list its tables
+    /// (an unreachable `MySQL` / `PostgreSQL` remote) only costs its own suggestions. Otherwise a
+    /// mere typo answers with the connection failure instead of `UNKNOWN_TABLE`.
+    VectorWithMemoryTracking<String> names;
+    try
+    {
+        names = database->getAllTableNames(context);
+    }
+    catch (...)
+    {
+        handleCannotListTables(*database, UnavailableDatabasePolicy::AlwaysSkip);
+        return {};
+    }
 
     /// Filter out names the user cannot `SHOW`, otherwise the hint can leak the existence of
     /// tables (e.g. for the cross-database hint search in `getExtendedHintForTable`).

--- a/src/Processors/Merges/IMergingTransform.cpp
+++ b/src/Processors/Merges/IMergingTransform.cpp
@@ -2,8 +2,6 @@
 #include <Processors/Merges/IMergingTransform.h>
 #include <Processors/Port.h>
 
-#include <iostream>
-
 namespace DB
 {
 
@@ -253,11 +251,6 @@ IProcessor::Status IMergingTransformBase::prepare()
             const auto & input_chunk = state.input_chunk.chunk;
 
             bool virtual_row = isVirtualRow(input_chunk);
-            std::cerr << "PROBE consume pull: merge=" << getName()
-                      << " rows=" << input_chunk.getNumRows()
-                      << " cols=" << input_chunk.getNumColumns()
-                      << " virt=" << virtual_row
-                      << " finished=" << input.isFinished() << "\n";
             if (!virtual_row && (!limit_hint || input_chunk.getNumRows() < limit_hint || always_read_till_end))
             {
                 input.setNeeded();

--- a/src/Processors/Merges/IMergingTransform.cpp
+++ b/src/Processors/Merges/IMergingTransform.cpp
@@ -2,6 +2,8 @@
 #include <Processors/Merges/IMergingTransform.h>
 #include <Processors/Port.h>
 
+#include <iostream>
+
 namespace DB
 {
 
@@ -251,6 +253,11 @@ IProcessor::Status IMergingTransformBase::prepare()
             const auto & input_chunk = state.input_chunk.chunk;
 
             bool virtual_row = isVirtualRow(input_chunk);
+            std::cerr << "PROBE consume pull: merge=" << getName()
+                      << " rows=" << input_chunk.getNumRows()
+                      << " cols=" << input_chunk.getNumColumns()
+                      << " virt=" << virtual_row
+                      << " finished=" << input.isFinished() << "\n";
             if (!virtual_row && (!limit_hint || input_chunk.getNumRows() < limit_hint || always_read_till_end))
             {
                 input.setNeeded();

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -495,6 +495,7 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
                 database_column_mut->insertDefault(); /// Empty database for external tables.
         }
 
+        const size_t total_databases = database_column_mut->size();
         block_to_filter.insert(ColumnWithTypeAndName(std::move(database_column_mut), std::make_shared<DataTypeString>(), "database"));
 
         /// Filter block with `database` column.
@@ -509,6 +510,11 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
         }
 
         ColumnPtr & database_column = block_to_filter.getByName("database").column;
+
+        /// True when the query named the databases it wants rather than scanning every one of them.
+        /// A whole-server scan must not fail because a single database cannot list its tables (an
+        /// unreachable `MySQL` / `PostgreSQL` remote); a query that named one must report it.
+        const bool databases_narrowed_by_query = database_column->size() < total_databases;
 
         /// Add `table` column.
         MutableColumnPtr table_column_mut = ColumnString::create();
@@ -529,22 +535,23 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
             else
             {
                 const DatabasePtr & database = databases.at(database_name);
-
-                /// No guard around the listing, and deliberately the best-effort variant: a remote
-                /// engine (`MySQL`, `PostgreSQL`, `Remote`) already tolerates its own unreachable
-                /// server here, so one database cannot fail a whole-server scan. The strict variant
-                /// is not usable: `DatabaseDataLake` defines it for `system.tables`, where a table
-                /// whose metadata cannot be resolved becomes a row with a null storage object, and
-                /// this loop would then silently drop that table instead of reporting the metadata
-                /// error that `database_datalake_require_metadata_access` promises.
-                for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
+                try
                 {
-                    if (const auto & table = iterator->table())
+                    for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
                     {
-                        const String & table_name = iterator->name();
-                        storages[{database_name, table_name}] = table;
-                        table_column_mut->insert(table_name);
+                        if (const auto & table = iterator->table())
+                        {
+                            const String & table_name = iterator->name();
+                            storages[{database_name, table_name}] = table;
+                            table_column_mut->insert(table_name);
+                        }
                     }
+                }
+                catch (...)
+                {
+                    if (databases_narrowed_by_query)
+                        throw;
+                    handleCannotListTables(*database, UnavailableDatabasePolicy::SkipIfUnreachable);
                 }
             }
             offsets[i] = table_column_mut->size();

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -537,7 +537,13 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
                 const DatabasePtr & database = databases.at(database_name);
                 try
                 {
-                    for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
+                    /// `system.columns` is a user-facing listing, so use the strict variant: a remote
+                    /// engine propagates a connection failure through it instead of answering an empty
+                    /// list of tables. Whether a whole-server scan may then skip this database is
+                    /// decided below by `databases_narrowed_by_query`.
+                    auto iterator = database->getTablesIteratorWithHint(
+                        context, /* filter_by_table_name */ {}, /* skip_not_loaded */ false, /* tables_filter */ {});
+                    for (; iterator->isValid(); iterator->next())
                     {
                         if (const auto & table = iterator->table())
                         {

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -495,7 +495,6 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
                 database_column_mut->insertDefault(); /// Empty database for external tables.
         }
 
-        const size_t total_databases = database_column_mut->size();
         block_to_filter.insert(ColumnWithTypeAndName(std::move(database_column_mut), std::make_shared<DataTypeString>(), "database"));
 
         /// Filter block with `database` column.
@@ -510,11 +509,6 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
         }
 
         ColumnPtr & database_column = block_to_filter.getByName("database").column;
-
-        /// True when the query named the databases it wants rather than scanning every one of them.
-        /// A whole-server scan must not fail because a single database cannot list its tables (an
-        /// unreachable `MySQL` / `PostgreSQL` remote); a query that named one must report it.
-        const bool databases_narrowed_by_query = database_column->size() < total_databases;
 
         /// Add `table` column.
         MutableColumnPtr table_column_mut = ColumnString::create();
@@ -535,29 +529,22 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
             else
             {
                 const DatabasePtr & database = databases.at(database_name);
-                try
+
+                /// No guard around the listing, and deliberately the best-effort variant: a remote
+                /// engine (`MySQL`, `PostgreSQL`, `Remote`) already tolerates its own unreachable
+                /// server here, so one database cannot fail a whole-server scan. The strict variant
+                /// is not usable: `DatabaseDataLake` defines it for `system.tables`, where a table
+                /// whose metadata cannot be resolved becomes a row with a null storage object, and
+                /// this loop would then silently drop that table instead of reporting the metadata
+                /// error that `database_datalake_require_metadata_access` promises.
+                for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
                 {
-                    /// `system.columns` is a user-facing listing, so use the strict variant: a remote
-                    /// engine propagates a connection failure through it instead of answering an empty
-                    /// list of tables. Whether a whole-server scan may then skip this database is
-                    /// decided below by `databases_narrowed_by_query`.
-                    auto iterator = database->getTablesIteratorWithHint(
-                        context, /* filter_by_table_name */ {}, /* skip_not_loaded */ false, /* tables_filter */ {});
-                    for (; iterator->isValid(); iterator->next())
+                    if (const auto & table = iterator->table())
                     {
-                        if (const auto & table = iterator->table())
-                        {
-                            const String & table_name = iterator->name();
-                            storages[{database_name, table_name}] = table;
-                            table_column_mut->insert(table_name);
-                        }
+                        const String & table_name = iterator->name();
+                        storages[{database_name, table_name}] = table;
+                        table_column_mut->insert(table_name);
                     }
-                }
-                catch (...)
-                {
-                    if (databases_narrowed_by_query)
-                        throw;
-                    handleCannotListTables(*database, UnavailableDatabasePolicy::SkipIfUnreachable);
                 }
             }
             offsets[i] = table_column_mut->size();

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -495,6 +495,7 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
                 database_column_mut->insertDefault(); /// Empty database for external tables.
         }
 
+        const size_t total_databases = database_column_mut->size();
         block_to_filter.insert(ColumnWithTypeAndName(std::move(database_column_mut), std::make_shared<DataTypeString>(), "database"));
 
         /// Filter block with `database` column.
@@ -509,6 +510,11 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
         }
 
         ColumnPtr & database_column = block_to_filter.getByName("database").column;
+
+        /// True when the query named the databases it wants rather than scanning every one of them.
+        /// A whole-server scan must not fail because a single database cannot list its tables (an
+        /// unreachable `MySQL` / `PostgreSQL` remote); a query that named one must report it.
+        const bool databases_narrowed_by_query = database_column->size() < total_databases;
 
         /// Add `table` column.
         MutableColumnPtr table_column_mut = ColumnString::create();
@@ -529,14 +535,23 @@ void ReadFromSystemColumns::initializePipeline(QueryPipelineBuilder & pipeline, 
             else
             {
                 const DatabasePtr & database = databases.at(database_name);
-                for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
+                try
                 {
-                    if (const auto & table = iterator->table())
+                    for (auto iterator = database->getTablesIterator(context); iterator->isValid(); iterator->next())
                     {
-                        const String & table_name = iterator->name();
-                        storages[{database_name, table_name}] = table;
-                        table_column_mut->insert(table_name);
+                        if (const auto & table = iterator->table())
+                        {
+                            const String & table_name = iterator->name();
+                            storages[{database_name, table_name}] = table;
+                            table_column_mut->insert(table_name);
+                        }
                     }
+                }
+                catch (...)
+                {
+                    if (databases_narrowed_by_query)
+                        throw;
+                    handleCannotListTables(*database, UnavailableDatabasePolicy::SkipIfUnreachable);
                 }
             }
             offsets[i] = table_column_mut->size();

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -136,11 +136,22 @@ static void fillDataWithDatabasesTablesColumns(MutableColumns & res_columns, con
         const bool check_access_for_columns_in_db = check_access_for_columns
             && !access->isGranted(AccessType::SHOW_COLUMNS, database_name);
 
-        /// No guard around the listing: `getTablesIterator` is the best-effort variant, which a
-        /// remote engine (`MySQL`, `PostgreSQL`) already makes tolerant of its own unreachable
-        /// server, so one database cannot cost the completions of all the others. Anything it does
-        /// propagate is a real failure and must reach the user.
-        for (auto iterator = database_ptr->getTablesIterator(context); iterator->isValid(); iterator->next())
+        /// Completions are an aid for the client, offered for every database at once, so one
+        /// database whose remote is unreachable must only cost its own suggestions rather than all
+        /// of them. Only the listing is covered here; filling a table's columns below takes locks
+        /// and reads metadata, whose failures must still reach the user.
+        DatabaseTablesIteratorPtr iterator;
+        try
+        {
+            iterator = database_ptr->getTablesIterator(context);
+        }
+        catch (...)
+        {
+            handleCannotListTables(*database_ptr, UnavailableDatabasePolicy::SkipIfUnreachable);
+            continue;
+        }
+
+        for (; iterator->isValid(); iterator->next())
         {
             const auto & table_name = iterator->name();
             const auto & table = iterator->table();

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -136,22 +136,11 @@ static void fillDataWithDatabasesTablesColumns(MutableColumns & res_columns, con
         const bool check_access_for_columns_in_db = check_access_for_columns
             && !access->isGranted(AccessType::SHOW_COLUMNS, database_name);
 
-        /// Completions are an aid for the client, offered for every database at once, so one
-        /// database whose remote is unreachable must only cost its own suggestions rather than all
-        /// of them. Only the listing is covered here; filling a table's columns below takes locks
-        /// and reads metadata, whose failures must still reach the user.
-        DatabaseTablesIteratorPtr iterator;
-        try
-        {
-            iterator = database_ptr->getTablesIterator(context);
-        }
-        catch (...)
-        {
-            handleCannotListTables(*database_ptr, UnavailableDatabasePolicy::SkipIfUnreachable);
-            continue;
-        }
-
-        for (; iterator->isValid(); iterator->next())
+        /// No guard around the listing: `getTablesIterator` is the best-effort variant, which a
+        /// remote engine (`MySQL`, `PostgreSQL`) already makes tolerant of its own unreachable
+        /// server, so one database cannot cost the completions of all the others. Anything it does
+        /// propagate is a real failure and must reach the user.
+        for (auto iterator = database_ptr->getTablesIterator(context); iterator->isValid(); iterator->next())
         {
             const auto & table_name = iterator->name();
             const auto & table = iterator->table();

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -136,7 +136,22 @@ static void fillDataWithDatabasesTablesColumns(MutableColumns & res_columns, con
         const bool check_access_for_columns_in_db = check_access_for_columns
             && !access->isGranted(AccessType::SHOW_COLUMNS, database_name);
 
-        for (auto iterator = database_ptr->getTablesIterator(context); iterator->isValid(); iterator->next())
+        /// Completions are an aid for the client, offered for every database at once, so one
+        /// database whose remote is unreachable must only cost its own suggestions rather than all
+        /// of them. Only the listing is covered here; filling a table's columns below takes locks
+        /// and reads metadata, whose failures must still reach the user.
+        DatabaseTablesIteratorPtr iterator;
+        try
+        {
+            iterator = database_ptr->getTablesIterator(context);
+        }
+        catch (...)
+        {
+            handleCannotListTables(*database_ptr, UnavailableDatabasePolicy::SkipIfUnreachable);
+            continue;
+        }
+
+        for (; iterator->isValid(); iterator->next())
         {
             const auto & table_name = iterator->name();
             const auto & table = iterator->table();

--- a/src/Storages/System/StorageSystemDetachedTables.cpp
+++ b/src/Storages/System/StorageSystemDetachedTables.cpp
@@ -241,8 +241,9 @@ void ReadFromSystemDetachedTables::applyFilters(ActionDAGNodes added_filter_node
     if (filter_actions_dag)
         predicate = filter_actions_dag->getOutputs().at(0);
 
-    filtered_databases_column = detail::getFilteredDatabases(predicate, context);
-    filtered_tables_column = detail::getFilteredTables(predicate, filtered_databases_column, context, true);
+    auto filtered_databases = detail::getFilteredDatabases(predicate, context);
+    filtered_tables_column = detail::getFilteredTables(predicate, filtered_databases, context, true);
+    filtered_databases_column = std::move(filtered_databases.column);
 }
 
 void ReadFromSystemDetachedTables::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)

--- a/src/Storages/System/StorageSystemIcebergFiles.cpp
+++ b/src/Storages/System/StorageSystemIcebergFiles.cpp
@@ -61,7 +61,12 @@ public:
         access = context_copy->getAccess();
         check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES);
 
-        auto all_databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true, .with_remote_databases = true});
+        /// `with_remote_databases = false`: an Iceberg table is never held by a remote SQL database
+        /// (`MySQL`, `PostgreSQL`, `Remote`), whose tables are all of its own storage type, so listing
+        /// one costs a round-trip to a server that cannot contribute a row - and fails the whole scan
+        /// when that server is unreachable. Data lake catalogs, the source that matters here, are a
+        /// separate class and are kept.
+        auto all_databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true, .with_remote_databases = false});
 
         if (database_filter_)
         {

--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -147,7 +147,12 @@ void StorageSystemIcebergHistory::fillData(
     /// opens a connection, which a query filtering by database should not need to do.
     MutableColumnPtr database_name_column = ColumnString::create();
 
-    auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true, .with_remote_databases = true});
+    /// `with_remote_databases = false`: an Iceberg table is never held by a remote SQL database
+    /// (`MySQL`, `PostgreSQL`, `Remote`), whose tables are all of its own storage type, so listing
+    /// one costs a round-trip to a server that cannot contribute a row - and fails the whole scan
+    /// when that server is unreachable. Data lake catalogs, the source that matters here, are a
+    /// separate class and are kept.
+    auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = true, .with_remote_databases = false});
     for (const auto & [database_name, database] : databases)
         database_name_column->insert(database_name);
 

--- a/src/Storages/System/StorageSystemKafkaConsumers.cpp
+++ b/src/Storages/System/StorageSystemKafkaConsumers.cpp
@@ -273,6 +273,12 @@ void StorageSystemKafkaConsumers::fillData(MutableColumns & res_columns, Context
     auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = false});
     for (const auto & db : databases)
     {
+        /// A `Kafka` table is a ClickHouse internal table type, so an external database (`MySQL`,
+        /// `PostgreSQL`, a data lake catalog, ...) can never contain one. Skipping it also avoids
+        /// listing its tables, which for a remote engine is a round-trip to the remote server.
+        if (db.second->isExternal())
+            continue;
+
         for (auto it = db.second->getTablesIterator(context); it->isValid(); it->next())
         {
             StoragePtr storage = it->table();

--- a/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
+++ b/src/Storages/System/StorageSystemObjectStorageQueueSettings.cpp
@@ -63,6 +63,13 @@ void StorageSystemObjectStorageQueueSettings<type>::fillData(
         auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = false});
         for (const auto & db : databases)
         {
+            /// An `S3Queue` or `AzureQueue` table is a ClickHouse internal table type, so an
+            /// external database (`MySQL`, `PostgreSQL`, a data lake catalog, ...) can never contain
+            /// one. Skipping it also avoids listing its tables, which for a remote engine is a
+            /// round-trip to the remote server.
+            if (db.second->isExternal())
+                continue;
+
             for (auto iterator = db.second->getTablesIterator(context); iterator->isValid(); iterator->next())
             {
                 StoragePtr storage = iterator->table();

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -194,7 +194,7 @@ TablesFilter extractTableNameFilter(const ActionsDAG::Node * predicate)
 
 namespace detail
 {
-ColumnPtr getFilteredDatabases(const ActionsDAG::Node * predicate, ContextPtr context)
+FilteredDatabases getFilteredDatabases(const ActionsDAG::Node * predicate, ContextPtr context)
 {
     MutableColumnPtr column = ColumnString::create();
 
@@ -210,14 +210,18 @@ ColumnPtr getFilteredDatabases(const ActionsDAG::Node * predicate, ContextPtr co
         column->insert(database_name);
     }
 
+    const size_t total_databases = column->size();
     Block block{ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), "database")};
     VirtualColumnUtils::filterBlockWithPredicate(predicate, block, context);
-    return block.getByPosition(0).column;
+
+    ColumnPtr filtered = block.getByPosition(0).column;
+    return {filtered, filtered->size() < total_databases};
 }
 
 ColumnPtr getFilteredTables(
-    const ActionsDAG::Node * predicate, const ColumnPtr & filtered_databases_column, ContextPtr context, const bool is_detached)
+    const ActionsDAG::Node * predicate, const FilteredDatabases & filtered_databases, ContextPtr context, const bool is_detached)
 {
+    const ColumnPtr & filtered_databases_column = filtered_databases.column;
     Block sample{
         ColumnWithTypeAndName(nullptr, std::make_shared<DataTypeString>(), "name"),
         ColumnWithTypeAndName(nullptr, std::make_shared<DataTypeUUID>(), "uuid"),
@@ -262,6 +266,8 @@ ColumnPtr getFilteredTables(
 
         if (is_detached)
         {
+            /// Outside the tolerance below: a database that does not implement this throws
+            /// NOT_IMPLEMENTED, which is structural and must not be swallowed.
             auto table_it = database->getDetachedTablesIterator(context, {}, false);
             for (; table_it->isValid(); table_it->next())
             {
@@ -269,8 +275,11 @@ ColumnPtr getFilteredTables(
                 if (uuid_column)
                     uuid_column->insert(table_it->uuid());
             }
+            continue;
         }
-        else
+
+        /// Listing the tables of one database can fail; see `handleCannotListTables`.
+        try
         {
             if (engine_column || uuid_column)
             {
@@ -304,6 +313,12 @@ ColumnPtr getFilteredTables(
                     table_column->insert(table_detail.name);
                 }
             }
+        }
+        catch (...)
+        {
+            if (filtered_databases.narrowed_by_query)
+                throw;
+            handleCannotListTables(*database, UnavailableDatabasePolicy::SkipIfUnreachable);
         }
     }
 
@@ -430,6 +445,7 @@ public:
         SharedHeader header,
         UInt64 max_block_size_,
         ColumnPtr databases_,
+        bool databases_narrowed_by_query_,
         ColumnPtr tables_,
         ContextPtr context_,
         TablesFilter tables_filter_)
@@ -437,6 +453,7 @@ public:
         , columns_mask(std::move(columns_mask_))
         , max_block_size(max_block_size_)
         , databases_cursor(std::move(databases_))
+        , databases_narrowed_by_query(databases_narrowed_by_query_)
         , context(Context::createCopy(context_))
         , tables_filter(std::move(tables_filter_))
     {
@@ -508,10 +525,21 @@ protected:
     /// so no per-table access check is needed.
     size_t fillTableNamesOnly(MutableColumns & res_columns)
     {
-        auto table_details = databases_cursor.getDatabase()->getLightweightTablesIteratorWithHint(context,
+        std::vector<LightWeightTableDetails> table_details;
+        try
+        {
+            table_details = databases_cursor.getDatabase()->getLightweightTablesIteratorWithHint(context,
                                 /* filter_by_table_name */ {},
                                 /* skip_not_loaded */ false,
                                 tables_filter);
+        }
+        catch (...)
+        {
+            if (databases_narrowed_by_query)
+                throw;
+            handleCannotListTables(*databases_cursor.getDatabase(), UnavailableDatabasePolicy::SkipIfUnreachable);
+            return 0;
+        }
 
         size_t count = 0;
 
@@ -709,10 +737,23 @@ protected:
 
             const DatabasePtr & database = databases_cursor.getDatabase();
             if (!databases_cursor.hasTablesIterator())
-                databases_cursor.setTablesIterator(database->getTablesIteratorWithHint(context,
-                        /* filter_by_table_name */ {},
-                        /* skip_not_loaded */ false,
-                        tables_filter));
+            {
+                try
+                {
+                    databases_cursor.setTablesIterator(database->getTablesIteratorWithHint(context,
+                            /* filter_by_table_name */ {},
+                            /* skip_not_loaded */ false,
+                            tables_filter));
+                }
+                catch (...)
+                {
+                    if (databases_narrowed_by_query)
+                        throw;
+                    handleCannotListTables(*database, UnavailableDatabasePolicy::SkipIfUnreachable);
+                    databases_cursor.skipCurrentDatabase();
+                    continue;
+                }
+            }
 
             auto & tables_it = databases_cursor.getTablesIterator();
             for (; rows_count < max_block_size && tables_it.isValid(); tables_it.next())
@@ -1147,6 +1188,7 @@ private:
     std::vector<UInt8> columns_mask;
     UInt64 max_block_size;
     DatabaseTablesCursor databases_cursor;
+    bool databases_narrowed_by_query;
     NameSet tables;
     ContextPtr context;
     bool done = false;
@@ -1184,7 +1226,7 @@ private:
     std::vector<UInt8> columns_mask;
     size_t max_block_size;
 
-    ColumnPtr filtered_databases_column;
+    detail::FilteredDatabases filtered_databases;
     ColumnPtr filtered_tables_column;
     TablesFilter tables_filter;
 };
@@ -1218,8 +1260,8 @@ void ReadFromSystemTables::applyFilters(ActionDAGNodes added_filter_nodes)
     if (filter_actions_dag)
         predicate = filter_actions_dag->getOutputs().at(0);
 
-    filtered_databases_column = detail::getFilteredDatabases(predicate, context);
-    filtered_tables_column = detail::getFilteredTables(predicate, filtered_databases_column, context, false);
+    filtered_databases = detail::getFilteredDatabases(predicate, context);
+    filtered_tables_column = detail::getFilteredTables(predicate, filtered_databases, context, false);
 
     /// Extract the namespace hint from the `name` predicate so downstream
     /// databases (DataLake catalogs) can fetch only the relevant namespace
@@ -1235,7 +1277,14 @@ void ReadFromSystemTables::applyFilters(ActionDAGNodes added_filter_nodes)
 void ReadFromSystemTables::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
     Pipe pipe(std::make_shared<TablesBlockSource>(
-        std::move(columns_mask), getOutputHeader(), max_block_size, std::move(filtered_databases_column), std::move(filtered_tables_column), context, std::move(tables_filter)));
+        std::move(columns_mask),
+        getOutputHeader(),
+        max_block_size,
+        std::move(filtered_databases.column),
+        filtered_databases.narrowed_by_query,
+        std::move(filtered_tables_column),
+        context,
+        std::move(tables_filter)));
     pipeline.init(std::move(pipe));
 }
 

--- a/src/Storages/System/StorageSystemTables.h
+++ b/src/Storages/System/StorageSystemTables.h
@@ -12,9 +12,22 @@ class Context;
 namespace detail
 {
 
-ColumnPtr getFilteredDatabases(const ActionsDAG::Node * predicate, ContextPtr context);
-ColumnPtr
-getFilteredTables(const ActionsDAG::Node * predicate, const ColumnPtr & filtered_databases_column, ContextPtr context, bool is_detached);
+struct FilteredDatabases
+{
+    ColumnPtr column;
+    /// True when the query's predicate narrowed the database list, that is, the query named the
+    /// databases it is interested in rather than scanning every one of them. A scan that named no
+    /// database must not fail because a single database cannot list its tables (an unreachable
+    /// `MySQL` / `PostgreSQL` remote); a query that named one must report that failure.
+    bool narrowed_by_query = false;
+};
+
+FilteredDatabases getFilteredDatabases(const ActionsDAG::Node * predicate, ContextPtr context);
+ColumnPtr getFilteredTables(
+    const ActionsDAG::Node * predicate,
+    const FilteredDatabases & filtered_databases,
+    ContextPtr context,
+    bool is_detached);
 
 }
 

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
@@ -13,5 +13,7 @@ show_tables_fails 1
 named_database_columns_empty 0
 remote_engine_scan 1
 remote_engine_named_database_fails 1
+injected_failure_propagates_best_effort 1
+injected_failure_propagates_scan 1
 scan_no_error	1
 scan_warning_seen	1

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
@@ -10,10 +10,10 @@ kafka_consumers 1
 unknown_table 1
 named_database_fails 1
 show_tables_fails 1
-named_database_columns_empty 0
+named_database_columns_fails 1
 remote_engine_scan 1
 remote_engine_named_database_fails 1
-injected_failure_propagates_best_effort 1
-injected_failure_propagates_scan 1
+injected_failure_propagates_tables 1
+injected_failure_propagates_completions 1
 scan_no_error	1
 scan_warning_seen	1

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
@@ -2,15 +2,15 @@ tables 1
 columns 1
 completions 1
 tables_by_engine 1
-kafka_consumers 1
 s3_queue_settings 1
 azure_queue_settings 1
 iceberg_files 1
 iceberg_history 1
+kafka_consumers 1
 unknown_table 1
 named_database_fails 1
 show_tables_fails 1
-named_database_columns_fails 1
+named_database_columns_empty 0
 remote_engine_scan 1
 remote_engine_named_database_fails 1
 scan_no_error	1

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
@@ -2,9 +2,16 @@ tables 1
 columns 1
 completions 1
 tables_by_engine 1
+kafka_consumers 1
+s3_queue_settings 1
+azure_queue_settings 1
+iceberg_files 1
+iceberg_history 1
 unknown_table 1
 named_database_fails 1
 show_tables_fails 1
 named_database_columns_fails 1
+remote_engine_scan 1
+remote_engine_named_database_fails 1
 scan_no_error	1
 scan_warning_seen	1

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.reference
@@ -1,0 +1,10 @@
+tables 1
+columns 1
+completions 1
+tables_by_engine 1
+unknown_table 1
+named_database_fails 1
+show_tables_fails 1
+named_database_columns_fails 1
+scan_no_error	1
+scan_warning_seen	1

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
@@ -22,7 +22,10 @@ REMOTE_DB="${CLICKHOUSE_DATABASE}_remote"
 SCAN_QUERY_ID="${CLICKHOUSE_DATABASE}_scan_${RANDOM}${RANDOM}"
 
 # Drop on any exit: a database left attached slows every later scan in the run.
-trap "${CLICKHOUSE_CLIENT} -q 'DROP DATABASE IF EXISTS ${MYSQL_DB}; DROP DATABASE IF EXISTS ${REMOTE_DB}'" EXIT
+# The failpoint below has to go too: while it is enabled even `DROP DATABASE` cannot list the
+# tables of the MySQL database, so the drop itself would fail and leave it attached.
+trap "${CLICKHOUSE_CLIENT} -q 'SYSTEM DISABLE FAILPOINT mysql_fetch_tables_throw' > /dev/null 2>&1; \
+      ${CLICKHOUSE_CLIENT} -q 'DROP DATABASE IF EXISTS ${MYSQL_DB}; DROP DATABASE IF EXISTS ${REMOTE_DB}'" EXIT
 
 ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${MYSQL_DB}"
 ${CLICKHOUSE_CLIENT_QUIET} -q "
@@ -52,14 +55,16 @@ do
     ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() >= 0 FROM system.\`${table}\`"
 done
 
-# `system.kafka_consumers` is the only one of the five behind a build flag (`USE_RDKAFKA`), so its
-# absence is reported as such instead of being asserted, which keeps the reference stable without
-# letting the other four pass vacuously.
+# `system.kafka_consumers` is the only one of the five behind a build flag (`USE_RDKAFKA`). Where it
+# is built the scan is asserted like the others; where it is not there is nothing to scan, and the
+# same `1` keeps the reference stable across build configurations. The bypass is deliberately not
+# applied to the four tables above, which are registered unconditionally and so cannot pass
+# vacuously.
 echo -n 'kafka_consumers '
 if [[ "$(${CLICKHOUSE_CLIENT_QUIET} -q \
         "SELECT count() FROM system.tables WHERE database = 'system' AND name = 'kafka_consumers'")" == "0" ]]
 then
-    echo 'not built'
+    echo 1
 else
     ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() >= 0 FROM system.kafka_consumers"
 fi
@@ -92,6 +97,17 @@ echo -n 'remote_engine_scan '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.tables"
 echo -n 'remote_engine_named_database_fails '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SHOW TABLES FROM ${REMOTE_DB}" 2>&1 | grep -c 'NO_REMOTE_SHARD_AVAILABLE'
+
+# Tolerance is only for a connection failure to the remote. A listing failure of any other kind must
+# propagate, rather than serve the local cache as if the listing had succeeded - on the best-effort
+# path (`system.iceberg_files`, which uses the plain iterator) as well as on the scan that decides
+# per database (`system.tables`).
+${CLICKHOUSE_CLIENT_QUIET} -q "SYSTEM ENABLE FAILPOINT mysql_fetch_tables_throw"
+echo -n 'injected_failure_propagates_best_effort '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.iceberg_files" 2>&1 | grep -c 'Injected MySQL table listing failure'
+echo -n 'injected_failure_propagates_scan '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.tables" 2>&1 | grep -c 'Injected MySQL table listing failure'
+${CLICKHOUSE_CLIENT_QUIET} -q "SYSTEM DISABLE FAILPOINT mysql_fetch_tables_throw"
 
 # The tolerated failure is a warning: Error-level messages from these paths trip the Upgrade check.
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
@@ -18,10 +18,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CLICKHOUSE_CLIENT_QUIET=$(echo "${CLICKHOUSE_CLIENT}" | sed "s/--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}/--send_logs_level=fatal/g")
 
 MYSQL_DB="${CLICKHOUSE_DATABASE}_mysql"
+REMOTE_DB="${CLICKHOUSE_DATABASE}_remote"
 SCAN_QUERY_ID="${CLICKHOUSE_DATABASE}_scan_${RANDOM}${RANDOM}"
 
 # Drop on any exit: a database left attached slows every later scan in the run.
-trap "${CLICKHOUSE_CLIENT} -q 'DROP DATABASE IF EXISTS ${MYSQL_DB}'" EXIT
+trap "${CLICKHOUSE_CLIENT} -q 'DROP DATABASE IF EXISTS ${MYSQL_DB}; DROP DATABASE IF EXISTS ${REMOTE_DB}'" EXIT
 
 ${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${MYSQL_DB}"
 ${CLICKHOUSE_CLIENT_QUIET} -q "
@@ -39,6 +40,24 @@ ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.completions"
 echo -n 'tables_by_engine '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.tables WHERE engine = 'SystemTables'"
 
+# Every other system table that enumerates all databases and lists their tables. They reach the
+# best-effort `getTablesIterator`, which the engine itself makes tolerant, so they are covered by a
+# different mechanism than the four scans above and need their own assertions. These tables are
+# legitimately empty here, so the assertion is that the scan answers at all.
+# `system.kafka_consumers` is behind `USE_RDKAFKA`: treat its absence as vacuously satisfied so the
+# reference stays the same across build configurations.
+for table in kafka_consumers s3_queue_settings azure_queue_settings iceberg_files iceberg_history
+do
+    echo -n "${table} "
+    if [[ "$(${CLICKHOUSE_CLIENT_QUIET} -q \
+            "SELECT count() FROM system.tables WHERE database = 'system' AND name = '${table}'")" == "0" ]]
+    then
+        echo 1
+    else
+        ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() >= 0 FROM system.\`${table}\`"
+    fi
+done
+
 # A typo must answer UNKNOWN_TABLE. The hint lookup iterates every database, so it used to answer
 # the connection failure instead.
 echo -n 'unknown_table '
@@ -53,6 +72,16 @@ ${CLICKHOUSE_CLIENT_QUIET} -q "SHOW TABLES FROM ${MYSQL_DB}" 2>&1 | grep -c 'ALL
 # system.columns decides the same thing separately, so it needs its own assertion.
 echo -n 'named_database_columns_fails '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.columns WHERE database = '${MYSQL_DB}'" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
+
+# The `Remote` engine lists its tables from the remote ClickHouse server, so an unreachable server
+# is the same class of failure and goes through the same mechanism. It wraps a failure to reach every
+# replica into `NO_REMOTE_SHARD_AVAILABLE`, which is what its classifier tolerates.
+${CLICKHOUSE_CLIENT_QUIET} -q "DROP DATABASE IF EXISTS ${REMOTE_DB}"
+${CLICKHOUSE_CLIENT_QUIET} -q "CREATE DATABASE ${REMOTE_DB} ENGINE = Remote('127.0.0.1:1', 'fake_db', 'user', 'password')"
+echo -n 'remote_engine_scan '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.tables"
+echo -n 'remote_engine_named_database_fails '
+${CLICKHOUSE_CLIENT_QUIET} -q "SHOW TABLES FROM ${REMOTE_DB}" 2>&1 | grep -c 'NO_REMOTE_SHARD_AVAILABLE'
 
 # The tolerated failure is a warning: Error-level messages from these paths trip the Upgrade check.
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
@@ -80,13 +80,9 @@ echo -n 'named_database_fails '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.tables WHERE database = '${MYSQL_DB}'" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
 echo -n 'show_tables_fails '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SHOW TABLES FROM ${MYSQL_DB}" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
-# `system.columns` cannot report it, unlike `system.tables` above: it needs a storage object per
-# table, and the only listing variant that propagates a remote failure is the one `DatabaseDataLake`
-# uses to turn an unresolvable table into a row with a null storage object, which this query would
-# then silently drop. So it answers an empty result, exactly as it already does for an unreachable
-# `PostgreSQL` database. Pinned here so the asymmetry with `system.tables` is deliberate.
-echo -n 'named_database_columns_empty '
-${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.columns WHERE database = '${MYSQL_DB}'"
+# system.columns decides the same thing separately, so it needs its own assertion.
+echo -n 'named_database_columns_fails '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.columns WHERE database = '${MYSQL_DB}'" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
 
 # The `Remote` engine lists its tables from the remote ClickHouse server, so an unreachable server
 # is the same class of failure and goes through the same mechanism. It wraps a failure to reach every
@@ -98,15 +94,14 @@ ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.tables"
 echo -n 'remote_engine_named_database_fails '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SHOW TABLES FROM ${REMOTE_DB}" 2>&1 | grep -c 'NO_REMOTE_SHARD_AVAILABLE'
 
-# Tolerance is only for a connection failure to the remote. A listing failure of any other kind must
-# propagate, rather than serve the local cache as if the listing had succeeded - on the best-effort
-# path (`system.iceberg_files`, which uses the plain iterator) as well as on the scan that decides
-# per database (`system.tables`).
+# Only a recognised connection failure is skipped. A listing failure of any other kind must reach
+# the user even on a whole-server scan, rather than be turned into a silently incomplete result.
+# Both guarded readers decide this separately, so both are asserted.
 ${CLICKHOUSE_CLIENT_QUIET} -q "SYSTEM ENABLE FAILPOINT mysql_fetch_tables_throw"
-echo -n 'injected_failure_propagates_best_effort '
-${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.iceberg_files" 2>&1 | grep -c 'Injected MySQL table listing failure'
-echo -n 'injected_failure_propagates_scan '
+echo -n 'injected_failure_propagates_tables '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.tables" 2>&1 | grep -c 'Injected MySQL table listing failure'
+echo -n 'injected_failure_propagates_completions '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.completions" 2>&1 | grep -c 'Injected MySQL table listing failure'
 ${CLICKHOUSE_CLIENT_QUIET} -q "SYSTEM DISABLE FAILPOINT mysql_fetch_tables_throw"
 
 # The tolerated failure is a warning: Error-level messages from these paths trip the Upgrade check.

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
@@ -46,17 +46,23 @@ ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.tables WHERE engin
 # legitimately empty here, so the assertion is that the scan answers at all.
 # `system.kafka_consumers` is behind `USE_RDKAFKA`: treat its absence as vacuously satisfied so the
 # reference stays the same across build configurations.
-for table in kafka_consumers s3_queue_settings azure_queue_settings iceberg_files iceberg_history
+for table in s3_queue_settings azure_queue_settings iceberg_files iceberg_history
 do
     echo -n "${table} "
-    if [[ "$(${CLICKHOUSE_CLIENT_QUIET} -q \
-            "SELECT count() FROM system.tables WHERE database = 'system' AND name = '${table}'")" == "0" ]]
-    then
-        echo 1
-    else
-        ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() >= 0 FROM system.\`${table}\`"
-    fi
+    ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() >= 0 FROM system.\`${table}\`"
 done
+
+# `system.kafka_consumers` is the only one of the five behind a build flag (`USE_RDKAFKA`), so its
+# absence is reported as such instead of being asserted, which keeps the reference stable without
+# letting the other four pass vacuously.
+echo -n 'kafka_consumers '
+if [[ "$(${CLICKHOUSE_CLIENT_QUIET} -q \
+        "SELECT count() FROM system.tables WHERE database = 'system' AND name = 'kafka_consumers'")" == "0" ]]
+then
+    echo 'not built'
+else
+    ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() >= 0 FROM system.kafka_consumers"
+fi
 
 # A typo must answer UNKNOWN_TABLE. The hint lookup iterates every database, so it used to answer
 # the connection failure instead.
@@ -69,9 +75,13 @@ echo -n 'named_database_fails '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.tables WHERE database = '${MYSQL_DB}'" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
 echo -n 'show_tables_fails '
 ${CLICKHOUSE_CLIENT_QUIET} -q "SHOW TABLES FROM ${MYSQL_DB}" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
-# system.columns decides the same thing separately, so it needs its own assertion.
-echo -n 'named_database_columns_fails '
-${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.columns WHERE database = '${MYSQL_DB}'" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
+# `system.columns` cannot report it, unlike `system.tables` above: it needs a storage object per
+# table, and the only listing variant that propagates a remote failure is the one `DatabaseDataLake`
+# uses to turn an unresolvable table into a row with a null storage object, which this query would
+# then silently drop. So it answers an empty result, exactly as it already does for an unreachable
+# `PostgreSQL` database. Pinned here so the asymmetry with `system.tables` is deliberate.
+echo -n 'named_database_columns_empty '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.columns WHERE database = '${MYSQL_DB}'"
 
 # The `Remote` engine lists its tables from the remote ClickHouse server, so an unreachable server
 # is the same class of failure and goes through the same mechanism. It wraps a failure to reach every

--- a/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
+++ b/tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+# Tag justification:
+#   no-fasttest: needs libmysql (the MySQL database engine), which is not built in fast test.
+#   no-parallel: the database attached here is deliberately unreachable and visible in
+#     system.tables, so every concurrent scan without a database filter would pay its connect
+#     timeout and log a warning.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Introspection that covers every database must survive one unreachable remote database, while a
+# query that names that database must still report the failure. Port 1 is privileged and never
+# listens, so connections are refused instantly (a blackholed address would wait for a timeout).
+
+# The default send_logs_level=warning would stream the tolerated failures to stderr.
+CLICKHOUSE_CLIENT_QUIET=$(echo "${CLICKHOUSE_CLIENT}" | sed "s/--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}/--send_logs_level=fatal/g")
+
+MYSQL_DB="${CLICKHOUSE_DATABASE}_mysql"
+SCAN_QUERY_ID="${CLICKHOUSE_DATABASE}_scan_${RANDOM}${RANDOM}"
+
+# Drop on any exit: a database left attached slows every later scan in the run.
+trap "${CLICKHOUSE_CLIENT} -q 'DROP DATABASE IF EXISTS ${MYSQL_DB}'" EXIT
+
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${MYSQL_DB}"
+${CLICKHOUSE_CLIENT_QUIET} -q "
+    ATTACH DATABASE ${MYSQL_DB} ENGINE = MySQL('127.0.0.1:1', 'fake_db', 'user', 'password')
+        SETTINGS connect_timeout = 1, connection_max_tries = 1"
+
+# Scans that name no database serve what the reachable databases hold.
+echo -n 'tables '
+${CLICKHOUSE_CLIENT_QUIET} --query_id "${SCAN_QUERY_ID}" -q "SELECT count() > 0 FROM system.tables"
+echo -n 'columns '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.columns"
+echo -n 'completions '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.completions"
+# A predicate on `engine` does not name a database, and takes the other branch of getFilteredTables.
+echo -n 'tables_by_engine '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() > 0 FROM system.tables WHERE engine = 'SystemTables'"
+
+# A typo must answer UNKNOWN_TABLE. The hint lookup iterates every database, so it used to answer
+# the connection failure instead.
+echo -n 'unknown_table '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT * FROM ${CLICKHOUSE_DATABASE}.no_such_table" 2>&1 | grep -c 'UNKNOWN_TABLE'
+
+# A query that names the unreachable database must report the failure rather than claim the
+# database has no tables.
+echo -n 'named_database_fails '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.tables WHERE database = '${MYSQL_DB}'" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
+echo -n 'show_tables_fails '
+${CLICKHOUSE_CLIENT_QUIET} -q "SHOW TABLES FROM ${MYSQL_DB}" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
+# system.columns decides the same thing separately, so it needs its own assertion.
+echo -n 'named_database_columns_fails '
+${CLICKHOUSE_CLIENT_QUIET} -q "SELECT count() FROM system.columns WHERE database = '${MYSQL_DB}'" 2>&1 | grep -c 'ALL_CONNECTION_TRIES_FAILED'
+
+# The tolerated failure is a warning: Error-level messages from these paths trip the Upgrade check.
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS text_log"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'scan_no_error', count() = 0 FROM system.text_log
+        WHERE query_id = '${SCAN_QUERY_ID}' AND level = 'Error';
+    SELECT 'scan_warning_seen', count() >= 1 FROM system.text_log
+        WHERE query_id = '${SCAN_QUERY_ID}' AND logger_name = 'ListTables' AND level = 'Warning';
+"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/115801
Related: https://github.com/ClickHouse/ClickHouse/pull/109472

## Problem

Attaching a single `MySQL` database whose host does not answer makes introspection fail for every
user and every tool on the server, under default settings. Eight system tables answer
`ALL_CONNECTION_TRIES_FAILED`, filtered or not:

- `system.tables`
- `system.columns`
- `system.completions`, so client autocompletion stops working
- `system.kafka_consumers`
- `system.s3_queue_settings` and `system.azure_queue_settings`
- `system.iceberg_files` and `system.iceberg_history`

Whole-server `SYSTEM` commands fail the same way — `SYSTEM STOP MERGES`,
`SYSTEM UNLOAD PRIMARY KEY`, `SYSTEM DROP REPLICA ... FROM ZKPATH` — as does the
configuration-reload loop in `DatabaseCatalog`.

Any query with a mistyped identifier answers `ALL_CONNECTION_TRIES_FAILED` instead of
`UNKNOWN_TABLE`, because the hint lookup iterates every database.

BI introspection, client autocompletion, monitoring and routine administration all break, and
nothing about the failure points at the one database responsible.

At the same time `SHOW TABLES FROM <that database>` **should** keep failing. Reporting "this
database has no tables" when the truth is "its server is unreachable" is worse than an error, and
`test_mysql_database_engine::test_restart_server` pins exactly that.

## Root cause

A remote database engine lists its tables by connecting to the remote server, so listing throws
when that server is down. `DatabaseMySQL` was the only remote engine that let the plain
`IDatabase::getTablesIterator` throw: `DatabasePostgreSQL` catches internally, `DatabaseRemote`
passes `throw_on_error = false` on that path, and `DatabaseDataLake` catches unless
`show_data_lake_catalogs_in_system_tables` is set.

Most whole-server enumerators never noticed because they skip a database with `isExternal`, which
is `true` by default in `IDatabase` and which `DatabaseMySQL` does not override — `system.mutations`,
`system.replicas`, `system.parts` and their peers all carry
`if (db.second->isExternal()) continue;` before listing. The callers that broke are the ones that
do not: the user-facing listings, the tables looking for a non-`MergeTree` storage type, and the
`SYSTEM` commands.

The obvious fix does not work on its own. Wrapping `DatabaseMySQL::getTablesIterator` in try/catch
to mirror `DatabasePostgreSQL` was landed and then reverted inside #109472 (`0a8e3782a69`, reverted
by `2a732fc7af0`) because it made `SHOW TABLES FROM d` answer an empty list. All four listing
variants in `IDatabase` default-delegate to `getTablesIterator`, and `DatabaseMySQL` overrode only
that one, so a single catch there leaked into `SHOW TABLES` as well.

## Solution

**Discriminate in the system storages on whether the query's predicate narrowed the database set.**
`system.tables`, `system.columns`, `system.completions` and the table-name hint must list every
database, so the decision cannot live in `IDatabase` — `SHOW TABLES FROM d` is
`SELECT name FROM system.tables WHERE database = 'd'`, so the broad scan and the targeted query
share one code path yet need opposite error semantics.

- **not narrowed** — a whole-server scan. Skip the database that cannot list its tables, log it,
  and serve what the reachable databases hold.
- **narrowed** — the user named the databases they want, so the failure is the answer and
  propagates. `SHOW TABLES FROM d` therefore still errors, and the integration test's contract is
  preserved.

`detail::getFilteredDatabases` now returns `{column, narrowed_by_query}`, computed by comparing the
database list before and after the predicate is applied; `StorageSystemColumns` computes the same
locally.

Only a *recognised connection failure* is skipped. `handleCannotListTables` consults a new
`IDatabase::toleratedListTablesFailureLogLevel`, returning `std::optional<LogsLevel>`, which
`DatabaseMySQL` and `DatabaseRemote` override to reuse their existing, already unit-tested
connection-failure classifiers. `DatabasePostgreSQL` overrides it too, but that override is not
reached today: its `getTablesIterator` catches every listing failure internally and the other
variants delegate to it, so no PostgreSQL listing failure escapes the engine and PostgreSQL's
behaviour is unchanged by this pull request. Tracked in
https://github.com/tiandiwonder/wonderland/issues/96 Anything else — a logical error, unreadable
metadata, cancellation — is rethrown rather than turned into a silently incomplete result, and each
guard covers only the listing call, not what the caller then does with the result. Name hints are
the single caller that skips unconditionally, because a typo has to answer `UNKNOWN_TABLE` whatever
went wrong.

**`Remote` / `RemoteSecure` gets the same tolerance.** Its `fetchTablesList` wraps a failure to
reach every replica into `NO_REMOTE_SHARD_AVAILABLE`, so that code is precisely "the remote is
unreachable"; a self-reference (`INFINITE_LOOP`) stays untolerated.

**The five other system tables are fixed by pruning, not by changing engine semantics.** They reach
the plain `IDatabase::getTablesIterator`, and the reason their thirteen peers are unaffected is
`isExternal`, which is `true` by default in `IDatabase` and which `DatabaseMySQL` does not override
— `system.mutations`, `system.replicas`, `system.parts` and ten others all carry
`if (db.second->isExternal()) continue;` before listing. So:

- `system.kafka_consumers` and the `system.s3_queue_settings` / `system.azure_queue_settings` pair
  get that same guard. A `Kafka` or `ObjectStorageQueue` table is a ClickHouse internal table type,
  so an external database can never hold one, and the skip also drops a remote round-trip every
  query to those tables was paying.
- `system.iceberg_files` and `system.iceberg_history` cannot use it — they exist to read data lake
  catalogs, and `DatabaseDataLake::isExternal` is also the inherited `true` — but they were asking
  for remote SQL databases explicitly and have no use for them, since an Iceberg table is never
  held by a `MySQL`, `PostgreSQL` or `Remote` database. They now pass
  `.with_remote_databases = false`.

The `is_detached` branch is deliberately left outside the guard: `getDetachedTablesIterator`
reports `NOT_IMPLEMENTED` by default, which is structural rather than transient.

`handleCannotListTables` is registered in `ci/jobs/check_style.py`'s `handled_patterns`, alongside
the other project-specific exception handlers such as `onBackgroundException`.

### Not in this pull request

`SYSTEM STOP/START MERGES` and its siblings, `SYSTEM LOAD/UNLOAD PRIMARY KEY`,
`SYSTEM DROP REPLICA ... FROM ZKPATH`, the readonly-disk part re-scan on `SYSTEM RELOAD CONFIG`,
and `DatabaseCatalog::reloadDisksTask` are broken by the same unreachable database — each answers
`Code: 279` — because they list every database without the `isExternal` guard. They are not
introspection and the guard fixes them independently, so they are tracked separately rather than
widening this pull request:
https://github.com/tiandiwonder/wonderland/issues/95


`DatabasePostgreSQL::getTablesIterator` catches internally and returns an empty iterator, so
`SHOW TABLES` from an unreachable `PostgreSQL` database still answers an empty list. That predates
this change, and removing that catch is not a like-for-like edit — it also guards the per-table
`fetchTable` calls in the same loop, so dropping it would let one unreadable table kill the whole
listing, and `04506_remote_database_unreachable_no_error_log` asserts on the logger name it
produces. Applying the same split to `DatabasePostgreSQL` is the natural follow-up, tracked in
https://github.com/tiandiwonder/wonderland/issues/96

`DatabasePostgreSQL` and `DatabaseRemote` also swallow *every* failure on their best-effort path,
not only a connection failure, which is the shape this pull request deliberately avoids in the new
`DatabaseMySQL` code. Tightening them would narrow existing behaviour, so it is left out.

`DatabaseDataLake` uses a coarser discriminator — it rethrows a catalog listing failure whenever
`show_data_lake_catalogs_in_system_tables` is set, rather than asking whether the query named a
database — so with that setting on, an unreachable catalog still fails a whole-server scan.

### Testing

`tests/queries/0_stateless/05043_unreachable_remote_database_broad_scan.sh` asserts every
direction: the whole-server scans of all eight system tables succeed, a typo answers
`UNKNOWN_TABLE`, and all three targeted queries — `SHOW TABLES FROM d`,
`system.tables WHERE database = 'd'` and `system.columns WHERE database = 'd'` — still report
`ALL_CONNECTION_TRIES_FAILED`. It covers the `Remote` engine both ways, and pins that the
tolerated failure logs a `Warning` and no `Error`.

Tolerance is only for a *recognised connection failure*, which needs a real MySQL server to
disprove, so the new `mysql_fetch_tables_throw` failpoint drives it: the test asserts that an
injected non-connection failure still reaches the user on a whole-server scan, separately for
`system.tables` and `system.completions`, which decide it in different places.

Verified closed-loop: reverting the tolerance reproduces `ALL_CONNECTION_TRIES_FAILED` on every
scan and `UNKNOWN_TABLE` regressing to the connection failure; dropping only the targeted-query
rethrow turns the `SHOW TABLES` and targeted-query assertions red, which is precisely the
regression that reverted the earlier attempt; dropping the log-level override turns the `Warning`
assertions red; dropping the `Remote` classifier turns its broad-scan assertion red.
`test_mysql_database_engine` (54 tests, including `test_restart_server` and its `mysql57` twin) and
`test_postgresql_database_engine` (15 tests) pass, as do `04506`, `04210` and the
`system.completions` tests.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed server-wide introspection failing when an attached `MySQL`, `Remote` or `RemoteSecure` database is unreachable. `system.tables`, `system.columns`, `system.completions`, `system.kafka_consumers`, `system.s3_queue_settings`, `system.azure_queue_settings`, `system.iceberg_files` and `system.iceberg_history`, as well as whole-server `SYSTEM` commands, no longer fail because of one such database. A mistyped table name also reported the connection failure instead of an unknown table.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116425&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116425](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116425+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->




