### PR TITLE
Make writes synchronous for the SQLancer++ user

### DIFF
--- a/ci/jobs/sqlancer_pp_job.sh
+++ b/ci/jobs/sqlancer_pp_job.sh
@@ -126,9 +126,20 @@ done
 # 'password='"). Creating a dedicated user with a non-empty password is the
 # least invasive workaround. Fail loud if either statement errors out -
 # silently swallowing this would leave every oracle hitting an auth wall.
+#
+# The settings are the ones `sqlancer_job.sh` pins on its server (it copies the provider's
+# `.claude/clickhouse-config/*.xml`, which this checkout does not ship): every oracle here compares
+# two reads, so a write issued by one iteration has to be visible to the next read of that same
+# iteration. With the defaults, `mutations_sync = 0` lets an `ALTER ... DELETE` / `DELETE FROM`
+# complete, fail or partially apply *between* the two reads, and `async_insert` is on, so an INSERT
+# need not be visible to the read that follows it. Either one turns a two-query oracle into a race
+# and its mismatch into a false positive. Attaching them to this user rather than to a profile in
+# `config.d/` keeps the change scoped to the fuzzer's own connection - the server here is started
+# from the binary's embedded config with no config directory at all.
 SQLANCER_USER="sqlancer"
 SQLANCER_PASSWORD="sqlancer"
-wget -q -O- --tries=1 --content-on-error --post-data="CREATE USER OR REPLACE ${SQLANCER_USER} IDENTIFIED WITH plaintext_password BY '${SQLANCER_PASSWORD}'" 'http://localhost:8123/'
+SQLANCER_USER_SETTINGS="mutations_sync = 2, alter_sync = 2, async_insert = 0"
+wget -q -O- --tries=1 --content-on-error --post-data="CREATE USER OR REPLACE ${SQLANCER_USER} IDENTIFIED WITH plaintext_password BY '${SQLANCER_PASSWORD}' SETTINGS ${SQLANCER_USER_SETTINGS}" 'http://localhost:8123/'
 # Grant everything the `default` user itself holds (CURRENT GRANTS) rather than
 # `GRANT ALL`: on the embedded-config server the default user does not hold the
 # full ALL set (e.g. it lacks `SHOW NAMED COLLECTIONS SECRETS`), so a plain


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/116422
-->

Every oracle SQLancer++ runs compares two reads, so a write issued by one iteration has to be visible
to the next read of that same iteration. The server `sqlancer_pp_job.sh` starts has no config
overrides at all, so it keeps the defaults: `mutations_sync = 0` lets an `ALTER ... DELETE` /
`DELETE FROM` complete, fail or partially apply *between* the two reads, and `async_insert` is on, so
an INSERT need not be visible to the read that follows it. Either one turns a two-query oracle into a
race and its mismatch into a false positive.

`sqlancer_job.sh` already pins exactly these settings, and says why — it copies the provider's
`.claude/clickhouse-config/*.xml`, which pins `async_insert=0`, `alter_sync=2` and `mutations_sync=2`
"so an INSERT/ALTER/mutation is visible to the next read in the same oracle iteration". The
SQLancer++ checkout ships no such files, and this job never grew an equivalent:
`grep -n 'mutations_sync\|alter_sync\|config.d' ci/jobs/sqlancer_pp_job.sh` returns nothing.

They are attached to the user the job already provisions rather than to a profile in `config.d/`,
because the server is started from the binary's embedded config with no config directory — so this
stays one statement and is scoped to the fuzzer's own connection.

Verified against a server started the same way (embedded config, no `config.d`): the `sqlancer` user
then reports

```
mutations_sync   alter_sync   async_insert
2                2            false
```

while `default` still reports `0`, `1`, `true`, and a `DELETE FROM` is complete when it returns —
500 of 1000 rows gone, `system.mutations` showing no unfinished entry.

### The finding that led here

`SQLancerPP (arm_asan_ubsan)`, nightly of 2026-08-25, `WHERE` oracle
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=aeb16cd66cc85d7f53c79d12e4ae18aeb0282046&name_0=NightlySQLancer&name_1=SQLancerPP%20%28arm_asan_ubsan%29)):
a base query returned 3 rows and its three-way TLP partition 2. The reproducer's statement stream
ends with a `DELETE FROM` whose predicate contains `CAST(... AS BOOLEAN)`, which legitimately errors
on NULL rows (`BOOLEAN` is non-nullable `Bool`, so casting NULL raises `Code: 349` — in a plain
`SELECT` too), leaving a mutation that keeps failing. Replaying those statements on master, the base
query and the partition agree in every configuration I tried; what does reproduce is the timing
dependence itself — the same replay flips between "mutation applied" and `Code: 341` across runs.

Issue #116422 has the full triage, including the second half of the problem this PR does not fix:
SQLancer++ puts every thread's tables in one database, so sibling-thread statements never reach the
per-database reproducer the job attaches.

### Changelog category (leave one):
- CI Fix or Improvement


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116426&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116426](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116426+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.135` (included in `26.9` and later)
<!-- ch-version-info:end -->