### PR TITLE
Do not count rows read by File/URL/object storage inner pipelines twice

### DIFF
--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -299,6 +299,7 @@ public:
                     });
                 }
                 pipeline = std::make_unique<QueryPipeline>(std::move(pipe));
+                pipeline->disableProfileEventUpdate();
                 reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
             }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -1391,6 +1391,8 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
     });
 
     auto pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
+    /// Is accounted by the source that owns this reader.
+    pipeline->disableProfileEventUpdate();
     auto current_reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 
     ProfileEvents::increment(ProfileEvents::EngineFileLikeReadFiles);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -1391,7 +1391,6 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
     });
 
     auto pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
-    /// Is accounted by the source that owns this reader.
     pipeline->disableProfileEventUpdate();
     auto current_reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1925,7 +1925,6 @@ Chunk StorageFileSource::generate()
             });
 
             pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
-            /// Is accounted by the outer source in progress below.
             pipeline->disableProfileEventUpdate();
             reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1925,7 +1925,7 @@ Chunk StorageFileSource::generate()
             });
 
             pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
-            /// Is accounted by the outer source in progress() below.
+            /// Is accounted by the outer source in progress below.
             pipeline->disableProfileEventUpdate();
             reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -1593,6 +1593,7 @@ bool StorageFileSource::tryGetCountFromCache(const struct stat & file_stat)
         return std::make_shared<ExtractColumnsTransform>(header, requested_columns);
     });
     pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
+    pipeline->disableProfileEventUpdate();
     reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
     return true;
 }
@@ -1714,6 +1715,7 @@ Chunk StorageFileSource::generate()
                 if (storage->format_name == "Distributed")
                 {
                     pipeline = std::make_unique<QueryPipeline>(std::make_shared<DistributedAsyncInsertSource>(current_path));
+                    pipeline->disableProfileEventUpdate();
                     reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
                     continue;
                 }
@@ -1923,6 +1925,8 @@ Chunk StorageFileSource::generate()
             });
 
             pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
+            /// Is accounted by the outer source in progress() below.
+            pipeline->disableProfileEventUpdate();
             reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 
             ProfileEvents::increment(ProfileEvents::EngineFileLikeReadFiles);
@@ -2543,6 +2547,7 @@ public:
                 });
 
                 pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
+                pipeline->disableProfileEventUpdate();
                 reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 
                 ProfileEvents::increment(ProfileEvents::EngineFileLikeReadFiles);

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -484,7 +484,7 @@ StorageURLSource::StorageURLSource(
         });
 
         pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
-        /// Is accounted by the outer source in generate().
+        /// Is accounted by the outer source in generate.
         pipeline->disableProfileEventUpdate();
         reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -484,6 +484,8 @@ StorageURLSource::StorageURLSource(
         });
 
         pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
+        /// Is accounted by the outer source in generate().
+        pipeline->disableProfileEventUpdate();
         reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 
         ProfileEvents::increment(ProfileEvents::EngineFileLikeReadFiles);

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -484,7 +484,6 @@ StorageURLSource::StorageURLSource(
         });
 
         pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
-        /// Is accounted by the outer source in generate.
         pipeline->disableProfileEventUpdate();
         reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -385,7 +385,7 @@ def test_selected_rows_not_double_counted(started_cluster, cluster):
     # goes through a copy inside `user_files`. Both names carry the cluster to keep the two
     # parametrized runs independent.
     file_name = f"distr_counters_{cluster}.bin"
-    log_comment = f"116301_distfmt_{cluster}"
+    query_id = f"116301_distfmt_{cluster}"
     node.exec_in_container(
         [
             "bash",
@@ -398,9 +398,9 @@ def test_selected_rows_not_double_counted(started_cluster, cluster):
 
     node.query(
         f"select * from file('{file_name}', 'Distributed') format Null",
+        query_id=query_id,
         settings={
-            "log_comment": log_comment,
-            # A fuzzed re-execution inherits `log_comment` and would be read back below.
+            # The server-side AST fuzzer would re-run this read as extra queries.
             "ast_fuzzer_runs": "0",
         },
     )
@@ -411,7 +411,8 @@ def test_selected_rows_not_double_counted(started_cluster, cluster):
         select read_rows, read_bytes,
                ProfileEvents['SelectedRows'], ProfileEvents['SelectedBytes']
         from system.query_log
-        where type = 'QueryFinish' and log_comment = '{log_comment}'
+        where query_id = '{query_id}' and type = 'QueryFinish'
+        order by event_time_microseconds desc limit 1
         """
     ).split()
 

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -363,3 +363,68 @@ def test_long_directory_name_rejected_before_local_write(started_cluster):
 
     node.query("drop table test.distr_mixed_path sync")
     node.query("drop table test.local_mixed_path sync")
+
+
+@cluster_param
+def test_selected_rows_not_double_counted(started_cluster, cluster):
+    # `Distributed` is read through an inner pipeline whose source accounts the rows on its own,
+    # so `SelectedRows` and `SelectedBytes` are twice `read_rows`/`read_bytes` of the same query
+    # unless that pipeline has profile event updates disabled. See #116301.
+    node.query("drop table if exists test.distr_counters sync")
+    node.query(
+        "create table test.distr_counters (x UInt64, s String) engine = "
+        "Distributed('{}', database, table)".format(cluster)
+    )
+    node.query(
+        "insert into test.distr_counters values (1, 'a'), (2, 'bb'), (3, 'ccc')",
+        settings={"use_compact_format_in_distributed_parts_names": "1"},
+    )
+    path = get_dist_path(cluster, node, "distr_counters", 1)
+
+    # The spool file lives under the table's data path, which `file` refuses to read, so the read
+    # goes through a copy inside `user_files`. Both names carry the cluster to keep the two
+    # parametrized runs independent.
+    file_name = f"distr_counters_{cluster}.bin"
+    log_comment = f"116301_distfmt_{cluster}"
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p /var/lib/clickhouse/user_files && cp {path}/1.bin /var/lib/clickhouse/user_files/{file_name}",
+        ],
+        privileged=True,
+        user="root",
+    )
+
+    node.query(
+        f"select * from file('{file_name}', 'Distributed') format Null",
+        settings={
+            "log_comment": log_comment,
+            # A fuzzed re-execution inherits `log_comment` and would be read back below.
+            "ast_fuzzer_runs": "0",
+        },
+    )
+    node.query("system flush logs query_log")
+
+    read_rows, read_bytes, selected_rows, selected_bytes = node.query(
+        f"""
+        select read_rows, read_bytes,
+               ProfileEvents['SelectedRows'], ProfileEvents['SelectedBytes']
+        from system.query_log
+        where type = 'QueryFinish' and log_comment = '{log_comment}'
+        """
+    ).split()
+
+    # The read amounts are pinned as well, so a query that stops reading the spool file cannot
+    # satisfy the equalities with both sides at zero.
+    assert read_rows == "3", (read_rows, read_bytes)
+    assert read_bytes != "0", (read_rows, read_bytes)
+    assert selected_rows == read_rows, (selected_rows, read_rows)
+    assert selected_bytes == read_bytes, (selected_bytes, read_bytes)
+
+    node.exec_in_container(
+        ["bash", "-c", f"rm -f /var/lib/clickhouse/user_files/{file_name}"],
+        privileged=True,
+        user="root",
+    )
+    node.query("drop table test.distr_counters sync")

--- a/tests/integration/test_distributed_format/test.py
+++ b/tests/integration/test_distributed_format/test.py
@@ -386,46 +386,47 @@ def test_selected_rows_not_double_counted(started_cluster, cluster):
     # parametrized runs independent.
     file_name = f"distr_counters_{cluster}.bin"
     query_id = f"116301_distfmt_{cluster}"
-    node.exec_in_container(
-        [
-            "bash",
-            "-c",
-            f"mkdir -p /var/lib/clickhouse/user_files && cp {path}/1.bin /var/lib/clickhouse/user_files/{file_name}",
-        ],
-        privileged=True,
-        user="root",
-    )
+    try:
+        node.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"mkdir -p /var/lib/clickhouse/user_files && cp {path}/1.bin /var/lib/clickhouse/user_files/{file_name}",
+            ],
+            privileged=True,
+            user="root",
+        )
 
-    node.query(
-        f"select * from file('{file_name}', 'Distributed') format Null",
-        query_id=query_id,
-        settings={
-            # The server-side AST fuzzer would re-run this read as extra queries.
-            "ast_fuzzer_runs": "0",
-        },
-    )
-    node.query("system flush logs query_log")
+        node.query(
+            f"select * from file('{file_name}', 'Distributed') format Null",
+            query_id=query_id,
+            settings={
+                # The server-side AST fuzzer would re-run this read as extra queries.
+                "ast_fuzzer_runs": "0",
+            },
+        )
+        node.query("system flush logs query_log")
 
-    read_rows, read_bytes, selected_rows, selected_bytes = node.query(
-        f"""
-        select read_rows, read_bytes,
-               ProfileEvents['SelectedRows'], ProfileEvents['SelectedBytes']
-        from system.query_log
-        where query_id = '{query_id}' and type = 'QueryFinish'
-        order by event_time_microseconds desc limit 1
-        """
-    ).split()
+        read_rows, read_bytes, selected_rows, selected_bytes = node.query(
+            f"""
+            select read_rows, read_bytes,
+                   ProfileEvents['SelectedRows'], ProfileEvents['SelectedBytes']
+            from system.query_log
+            where query_id = '{query_id}' and type = 'QueryFinish'
+            order by event_time_microseconds desc limit 1
+            """
+        ).split()
 
-    # The read amounts are pinned as well, so a query that stops reading the spool file cannot
-    # satisfy the equalities with both sides at zero.
-    assert read_rows == "3", (read_rows, read_bytes)
-    assert read_bytes != "0", (read_rows, read_bytes)
-    assert selected_rows == read_rows, (selected_rows, read_rows)
-    assert selected_bytes == read_bytes, (selected_bytes, read_bytes)
-
-    node.exec_in_container(
-        ["bash", "-c", f"rm -f /var/lib/clickhouse/user_files/{file_name}"],
-        privileged=True,
-        user="root",
-    )
-    node.query("drop table test.distr_counters sync")
+        # The read amounts are pinned as well, so a query that stops reading the spool file cannot
+        # satisfy the equalities with both sides at zero.
+        assert read_rows == "3", (read_rows, read_bytes)
+        assert read_bytes != "0", (read_rows, read_bytes)
+        assert selected_rows == read_rows, (selected_rows, read_rows)
+        assert selected_bytes == read_bytes, (selected_bytes, read_bytes)
+    finally:
+        node.exec_in_container(
+            ["bash", "-c", f"rm -f /var/lib/clickhouse/user_files/{file_name}"],
+            privileged=True,
+            user="root",
+        )
+        node.query("drop table test.distr_counters sync")

--- a/tests/integration/test_hive_query/test.py
+++ b/tests/integration/test_hive_query/test.py
@@ -208,3 +208,56 @@ def test_hive_files_cache_is_table_local(started_cluster):
     # Table A is likewise unaffected by table B's reads (independent cache entries).
     assert node.query("SELECT count(*) FROM default.hive_orc_a").strip() == "4"
     assert node.query("SELECT id, score FROM default.hive_orc_a ORDER BY score") == "a\t1\nb\t2\nc\t10\nd\t11\n"
+
+
+def test_selected_rows_not_double_counted(started_cluster):
+    # StorageHiveSource reads each file's format through an inner pipeline
+    # (StorageHive.cpp: QueryPipeline + PullingPipelineExecutor) and reports the chunk it
+    # returns again through ISource auto-progress, so `SelectedRows` / `SelectedBytes` end up
+    # at twice the query's own `read_rows` / `read_bytes` unless that inner pipeline has
+    # profile event updates disabled. See #116301.
+    node = started_cluster.instances["h0_0_0"]
+
+    node.query("DROP TABLE IF EXISTS default.hive_counters")
+    node.query(
+        """
+        CREATE TABLE default.hive_counters (`id` Nullable(String), `score` Nullable(Int32), `day` Nullable(String))
+        ENGINE = Hive('thrift://hivetest:9083', 'test', 'demo') PARTITION BY(day)
+        """
+    )
+
+    # Establish connectivity to the metastore before the measured query, so that the row read
+    # back below is a single execution and not one of several retries.
+    assert query_with_retry(node, "SELECT count(*) FROM default.hive_counters").strip() == "4"
+
+    # The measured query must request non-partition columns: with only partition columns (as in
+    # `count(*)`) `to_read_block` is empty, and for Parquet/ORC the source then serves rows from
+    # file metadata without constructing the inner pipeline at all.
+    query_id = "hive_selected_rows_double_count"
+    node.query(
+        "SELECT id, score FROM default.hive_counters FORMAT Null", query_id=query_id
+    )
+    node.query("SYSTEM FLUSH LOGS query_log")
+
+    read_rows, read_bytes, selected_rows, selected_bytes = (
+        node.query(
+            f"""
+            SELECT read_rows, read_bytes,
+                   ProfileEvents['SelectedRows'], ProfileEvents['SelectedBytes']
+            FROM system.query_log
+            WHERE query_id = '{query_id}' AND type = 'QueryFinish'
+            ORDER BY event_time_microseconds DESC LIMIT 1
+            """
+        )
+        .strip()
+        .split("\t")
+    )
+
+    # The read amounts are pinned as well, so a select that stopped reading the files cannot
+    # satisfy the equalities with both sides at zero.
+    assert read_rows == "4", (read_rows, read_bytes)
+    assert read_bytes != "0", (read_rows, read_bytes)
+    assert selected_rows == read_rows, (selected_rows, read_rows)
+    assert selected_bytes == read_bytes, (selected_bytes, read_bytes)
+
+    node.query("DROP TABLE default.hive_counters SYNC")

--- a/tests/integration/test_storage_s3_queue/test_3.py
+++ b/tests/integration/test_storage_s3_queue/test_3.py
@@ -1324,3 +1324,61 @@ def test_system_queue_metadata_broken_mandatory_folder(started_cluster):
     # Restore the layout so the table can be dropped normally.
     zk.create(f"{keeper_path}/failed")
     node.query(f"DROP TABLE {table_name} SYNC")
+
+
+def test_selected_rows_not_double_counted(started_cluster):
+    # The queue source reads the file's format through the inner pipeline of
+    # StorageObjectStorageSource::createReader and reports the same rows again through
+    # ISource auto-progress, so `SelectedRows` and `SelectedBytes` are twice the query's own
+    # `read_rows`/`read_bytes` unless that inner pipeline has profile event updates disabled.
+    # See #116301.
+    node = started_cluster.instances["instance"]
+    table_name = f"test_selected_rows_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+    row_num = 10
+
+    generate_random_files(started_cluster, files_path, 1, row_num=row_num)
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={
+            "keeper_path": f"/clickhouse/test_{table_name}_{generate_random_string()}"
+        },
+    )
+
+    # A direct select runs the queue source in the foreground, so its counters land in the
+    # query's own `query_log` row. The streaming path has no row to read them from: its insert
+    # is executed straight from `InterpreterInsertQuery`, never through `executeQuery`.
+    query_id = f"{table_name}_direct"
+    node.query(
+        f"SELECT * FROM {table_name} FORMAT Null",
+        query_id=query_id,
+        settings={"stream_like_engine_allow_direct_select": 1},
+    )
+    node.query("SYSTEM FLUSH LOGS query_log")
+
+    read_rows, read_bytes, selected_rows, selected_bytes = (
+        node.query(
+            f"""
+            SELECT read_rows, read_bytes,
+                   ProfileEvents['SelectedRows'], ProfileEvents['SelectedBytes']
+            FROM system.query_log
+            WHERE query_id = '{query_id}' AND type = 'QueryFinish'
+            ORDER BY event_time_microseconds DESC LIMIT 1
+            """
+        )
+        .strip()
+        .split("\t")
+    )
+
+    # The read amounts are pinned as well, so a select that stopped reading the file cannot
+    # satisfy the equalities with both sides at zero.
+    assert read_rows == str(row_num), (read_rows, read_bytes)
+    assert read_bytes != "0", (read_rows, read_bytes)
+    assert selected_rows == read_rows, (selected_rows, read_rows)
+    assert selected_bytes == read_bytes, (selected_bytes, read_bytes)
+
+    node.query(f"DROP TABLE {table_name} SYNC")

--- a/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.reference
+++ b/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.reference
@@ -1,0 +1,6 @@
+05043_file_engine	ok
+05043_file_function	ok
+05043_mergetree	ok
+05043_numbers	ok
+05043_s3_function	ok
+05043_url_function	ok

--- a/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.reference
+++ b/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.reference
@@ -1,5 +1,7 @@
+05043_file_count_cache	ok
 05043_file_engine	ok
 05043_file_function	ok
+05043_file_lazy_rows	ok
 05043_mergetree	ok
 05043_numbers	ok
 05043_s3_function	ok

--- a/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.sql
+++ b/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.sql
@@ -1,0 +1,97 @@
+-- Tags: no-fasttest
+-- ^ no-fasttest: the s3 table function is gated on build flags
+
+-- The File, URL and object storage engines read their format through an inner pipeline and
+-- report the rows again from the outer source, so `SelectedRows` and `SelectedBytes` must not be
+-- accounted by the inner one. Every cell below reads a known number of rows, so the counters
+-- have to equal `read_rows` and `read_bytes` of the same query. `currentDatabase` scopes the
+-- server-global `query_log`, so concurrent copies of this test cannot read each other's rows.
+--
+-- `SelectedBytes` is asserted against `read_bytes` rather than against a computed constant: for a
+-- file read it is the size consumed off the storage layer, not the materialised size of the rows
+-- (a 50000-row UInt64 file is 288890 bytes on disk against 400000 in memory), and the two billing
+-- layers reported those two different figures.
+--
+-- Both engine and table function forms are covered for File, and the MergeTree and `numbers`
+-- cells are controls: a fix that deflated every read path would still have to leave them at 1x.
+-- Each cell asserts its own row count too, so a cell cannot silently stop reading its source and
+-- still report `ok`.
+--
+-- `ast_fuzzer_runs` is pinned because the stress profile enables the server-side AST fuzzer for
+-- any query, and a fuzzed re-execution inherits `log_comment` and would win the `argMax` below.
+
+DROP TABLE IF EXISTS t_file_engine;
+DROP TABLE IF EXISTS t_mergetree;
+
+INSERT INTO FUNCTION file('05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
+    SELECT number FROM numbers(50000) SETTINGS engine_file_truncate_on_insert = 1;
+
+CREATE TABLE t_file_engine (x UInt64) ENGINE = File(TSV);
+INSERT INTO t_file_engine SELECT number FROM numbers(50000);
+
+CREATE TABLE t_mergetree (x UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_mergetree SELECT number FROM numbers(50000);
+
+INSERT INTO FUNCTION s3('http://localhost:11111/test/05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
+    SELECT number FROM numbers(50000) SETTINGS s3_truncate_on_insert = 1;
+
+-- file() table function
+SELECT * FROM file('05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
+SETTINGS log_queries = 1, log_comment = '05043_file_function', ast_fuzzer_runs = 0
+FORMAT Null;
+
+-- File engine
+SELECT * FROM t_file_engine
+SETTINGS log_queries = 1, log_comment = '05043_file_engine', ast_fuzzer_runs = 0
+FORMAT Null;
+
+-- url() table function
+SELECT * FROM url('http://localhost:8123/?query=SELECT+number+FROM+numbers(50000)', 'TSV', 'x UInt64')
+SETTINGS log_queries = 1, log_comment = '05043_url_function', ast_fuzzer_runs = 0
+FORMAT Null;
+
+-- s3() table function; the same source serves every other object storage, azureBlobStorage included
+SELECT * FROM s3('http://localhost:11111/test/05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
+SETTINGS log_queries = 1, log_comment = '05043_s3_function', ast_fuzzer_runs = 0
+FORMAT Null;
+
+-- MergeTree control: has no inner pipeline on its read path and was never affected
+SELECT * FROM t_mergetree
+SETTINGS log_queries = 1, log_comment = '05043_mergetree', ast_fuzzer_runs = 0
+FORMAT Null;
+
+-- numbers() control
+SELECT number FROM numbers(50000)
+SETTINGS log_queries = 1, log_comment = '05043_numbers', ast_fuzzer_runs = 0
+FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- `log_comment` is matched exactly rather than by prefix: the test runner injects a client-level
+-- comment that also starts with 05043, and it would otherwise be measured too.
+SELECT
+    cell,
+    if(read_rows = 50000 AND selected_rows = read_rows AND selected_bytes = read_bytes,
+        'ok',
+        'fail: read_rows=' || toString(read_rows)
+            || ' SelectedRows=' || toString(selected_rows)
+            || ' read_bytes=' || toString(read_bytes)
+            || ' SelectedBytes=' || toString(selected_bytes)) AS result
+FROM
+(
+    SELECT log_comment AS cell,
+        argMax(read_rows, event_time_microseconds) AS read_rows,
+        argMax(read_bytes, event_time_microseconds) AS read_bytes,
+        argMax(ProfileEvents['SelectedRows'], event_time_microseconds) AS selected_rows,
+        argMax(ProfileEvents['SelectedBytes'], event_time_microseconds) AS selected_bytes
+    FROM system.query_log
+    WHERE type = 'QueryFinish' AND event_date >= yesterday() AND event_time >= now() - 600
+        AND current_database = currentDatabase()
+        AND log_comment IN ('05043_file_function', '05043_file_engine', '05043_url_function',
+            '05043_s3_function', '05043_mergetree', '05043_numbers')
+    GROUP BY cell
+)
+ORDER BY cell;
+
+DROP TABLE t_file_engine;
+DROP TABLE t_mergetree;

--- a/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.sql
+++ b/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.sql
@@ -1,5 +1,7 @@
--- Tags: no-fasttest
--- ^ no-fasttest: the s3 table function is gated on build flags
+-- Tags: no-fasttest, no-parallel-replicas
+-- no-fasttest: uses the S3 mock server on localhost:11111
+-- no-parallel-replicas: s3 and url are rewritten to their Cluster variants, and the initiator
+-- then reports both counters from one remote progress packet, so the equality holds on either arm
 
 -- The File, URL and object storage engines read their format through an inner pipeline and
 -- report the rows again from the outer source, so `SelectedRows` and `SelectedBytes` must not be
@@ -26,16 +28,27 @@ DROP TABLE IF EXISTS t_mergetree;
 INSERT INTO FUNCTION file('05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
     SELECT number FROM numbers(50000) SETTINGS engine_file_truncate_on_insert = 1;
 
+INSERT INTO FUNCTION file('05043_' || currentDatabase() || '.parquet', Parquet, 'k UInt64, s String')
+    SELECT number, concat('v', toString(number)) FROM numbers(1000)
+    SETTINGS engine_file_truncate_on_insert = 1, output_format_parquet_row_group_size = 100;
+
 CREATE TABLE t_file_engine (x UInt64) ENGINE = File(TSV);
 INSERT INTO t_file_engine SELECT number FROM numbers(50000);
 
 CREATE TABLE t_mergetree (x UInt64) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_mergetree SELECT number FROM numbers(50000);
 
-INSERT INTO FUNCTION s3('http://localhost:11111/test/05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
+INSERT INTO FUNCTION s3('http://localhost:11111/test/05043_' || currentDatabase() || '.tsv', 'test', 'testtest', 'TSV', 'x UInt64')
     SELECT number FROM numbers(50000) SETTINGS s3_truncate_on_insert = 1;
 
--- file() table function
+-- A row-count cache entry is discarded again unless the file's mtime is strictly older than the
+-- entry's registration time, and both have one-second granularity. The reads below therefore have
+-- to start more than a second after the writes above, or the count cell would fall back to
+-- parsing the file and would stop covering the cached-count pipeline.
+SELECT sleep(2) FORMAT Null;
+
+-- file() table function. This also populates the per-path row-count cache the count cell below
+-- reads: `StorageFileSource::generate` stores `total_rows_in_file` once the file is exhausted.
 SELECT * FROM file('05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
 SETTINGS log_queries = 1, log_comment = '05043_file_function', ast_fuzzer_runs = 0
 FORMAT Null;
@@ -51,8 +64,30 @@ SETTINGS log_queries = 1, log_comment = '05043_url_function', ast_fuzzer_runs = 
 FORMAT Null;
 
 -- s3() table function; the same source serves every other object storage, azureBlobStorage included
-SELECT * FROM s3('http://localhost:11111/test/05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
+SELECT * FROM s3('http://localhost:11111/test/05043_' || currentDatabase() || '.tsv', 'test', 'testtest', 'TSV', 'x UInt64')
 SETTINGS log_queries = 1, log_comment = '05043_s3_function', ast_fuzzer_runs = 0
+FORMAT Null;
+
+-- Row count served from the schema cache, which reads through a separate inner pipeline over
+-- `ConstChunkGenerator` instead of parsing the file.
+-- All three settings are pinned because the runner randomizes `optimize_count_from_files` and
+-- `optimize_trivial_count_query` off with probability 0.05 each, and either one sends this query
+-- back to parsing the file, which would silently stop covering the cached-count pipeline.
+SELECT count() FROM file('05043_' || currentDatabase() || '.tsv', 'TSV', 'x UInt64')
+SETTINGS log_queries = 1, log_comment = '05043_file_count_cache', ast_fuzzer_runs = 0,
+    optimize_count_from_files = 1, use_cache_for_count_from_files = 1,
+    optimize_trivial_count_query = 1
+FORMAT Null;
+
+-- Lazy materialization reads the deferred columns of the surviving rows in a second pass, through
+-- an inner pipeline of its own. The two passes read 1000 + 3 rows, which is what arms this cell:
+-- with the optimization off the same query reads 1000.
+SELECT s FROM file('05043_' || currentDatabase() || '.parquet', Parquet, 'k UInt64, s String')
+ORDER BY k LIMIT 3
+SETTINGS log_queries = 1, log_comment = '05043_file_lazy_rows', ast_fuzzer_runs = 0,
+    enable_analyzer = 1, query_plan_optimize_lazy_materialization = 1,
+    query_plan_max_limit_for_lazy_materialization = 0,
+    query_plan_optimize_lazy_materialization_for_file = 1
 FORMAT Null;
 
 -- MergeTree control: has no inner pipeline on its read path and was never affected
@@ -69,11 +104,20 @@ SYSTEM FLUSH LOGS query_log;
 
 -- `log_comment` is matched exactly rather than by prefix: the test runner injects a client-level
 -- comment that also starts with 05043, and it would otherwise be measured too.
+--
+-- `expected_rows` pins each cell to the rows it must have read, so a cell cannot silently stop
+-- reading its source and still report `ok`. The two cells that need more than a row count carry
+-- an extra arming term: the count cell must have been served from the cache rather than by
+-- parsing (a TSV `UInt64` cannot be parsed at less than two bytes per row, so `read_bytes` below
+-- `read_rows` can only come from the fabricated chunks), and the lazy cell's 1003 rows are
+-- themselves the proof that its second pass ran.
 SELECT
     cell,
-    if(read_rows = 50000 AND selected_rows = read_rows AND selected_bytes = read_bytes,
+    if(read_rows = expected_rows AND armed AND selected_rows = read_rows AND selected_bytes = read_bytes,
         'ok',
         'fail: read_rows=' || toString(read_rows)
+            || ' expected_rows=' || toString(expected_rows)
+            || ' armed=' || toString(armed)
             || ' SelectedRows=' || toString(selected_rows)
             || ' read_bytes=' || toString(read_bytes)
             || ' SelectedBytes=' || toString(selected_bytes)) AS result
@@ -83,12 +127,15 @@ FROM
         argMax(read_rows, event_time_microseconds) AS read_rows,
         argMax(read_bytes, event_time_microseconds) AS read_bytes,
         argMax(ProfileEvents['SelectedRows'], event_time_microseconds) AS selected_rows,
-        argMax(ProfileEvents['SelectedBytes'], event_time_microseconds) AS selected_bytes
+        argMax(ProfileEvents['SelectedBytes'], event_time_microseconds) AS selected_bytes,
+        if(cell = '05043_file_lazy_rows', 1003, 50000) AS expected_rows,
+        if(cell = '05043_file_count_cache', read_bytes < read_rows, 1) AS armed
     FROM system.query_log
     WHERE type = 'QueryFinish' AND event_date >= yesterday() AND event_time >= now() - 600
         AND current_database = currentDatabase()
         AND log_comment IN ('05043_file_function', '05043_file_engine', '05043_url_function',
-            '05043_s3_function', '05043_mergetree', '05043_numbers')
+            '05043_s3_function', '05043_file_count_cache', '05043_file_lazy_rows',
+            '05043_mergetree', '05043_numbers')
     GROUP BY cell
 )
 ORDER BY cell;

--- a/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.sql
+++ b/tests/queries/0_stateless/05043_selected_rows_file_url_double_count.sql
@@ -1,7 +1,5 @@
--- Tags: no-fasttest, no-parallel-replicas
+-- Tags: no-fasttest
 -- no-fasttest: uses the S3 mock server on localhost:11111
--- no-parallel-replicas: s3 and url are rewritten to their Cluster variants, and the initiator
--- then reports both counters from one remote progress packet, so the equality holds on either arm
 
 -- The File, URL and object storage engines read their format through an inner pipeline and
 -- report the rows again from the outer source, so `SelectedRows` and `SelectedBytes` must not be
@@ -58,14 +56,21 @@ SELECT * FROM t_file_engine
 SETTINGS log_queries = 1, log_comment = '05043_file_engine', ast_fuzzer_runs = 0
 FORMAT Null;
 
+-- url() and s3() are the two cells rewritten to their Cluster variants once parallel replicas
+-- are enabled. The initiator then takes both counters from one remote progress packet, so those
+-- two cells would report `ok` with the fix reverted; the rest of the test stays meaningful, so
+-- the setting is pinned here instead of tagging the whole test.
+
 -- url() table function
 SELECT * FROM url('http://localhost:8123/?query=SELECT+number+FROM+numbers(50000)', 'TSV', 'x UInt64')
-SETTINGS log_queries = 1, log_comment = '05043_url_function', ast_fuzzer_runs = 0
+SETTINGS log_queries = 1, log_comment = '05043_url_function', ast_fuzzer_runs = 0,
+    enable_parallel_replicas = 0
 FORMAT Null;
 
 -- s3() table function; the same source serves every other object storage, azureBlobStorage included
 SELECT * FROM s3('http://localhost:11111/test/05043_' || currentDatabase() || '.tsv', 'test', 'testtest', 'TSV', 'x UInt64')
-SETTINGS log_queries = 1, log_comment = '05043_s3_function', ast_fuzzer_runs = 0
+SETTINGS log_queries = 1, log_comment = '05043_s3_function', ast_fuzzer_runs = 0,
+    enable_parallel_replicas = 0
 FORMAT Null;
 
 -- Row count served from the schema cache, which reads through a separate inner pipeline over


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116301
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/116301

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `ProfileEvents['SelectedRows']` and `ProfileEvents['SelectedBytes']` being counted twice for reads from the `File`, `URL`, `S3`, `AzureBlobStorage`, `HDFS`, `Hive`, `Iceberg`, `DeltaLake`, `Hudi` and `Paimon` table engines, their `Cluster` variants, `S3Queue`/`AzureQueue` and the corresponding table functions. They now agree with `read_rows` and `read_bytes`, as does the `Read:` line of `EXPLAIN ANALYZE`.

### Description

These storages read their format through an inner `QueryPipeline`. Its source is an `ISource` with `enable_auto_progress` on, so `ISource::work` bills every chunk, and then the outer storage source bills the same chunk again from its `generate`. `read_rows` stays correct because only the outer report reaches `updateProgressIn`: the inner pipelines set no process-list element, progress callback, quota or storage limits, so `update_profile_events` is their only query-visible channel.

The fix calls `QueryPipeline::disableProfileEventUpdate()` on each inner pipeline, which is what `MergeTask` and `MutateTask` already do for their inner pipelines. Rows, bytes, quotas, limits and throttling are untouched; measured before/after on the same query, `read_rows`, `read_bytes` and `result_rows` are identical while `SelectedRows` goes 2000 -> 1000 and `SelectedBytes` 11890 -> 3890.

Seven carriers are fixed: three in `StorageFile` (main read, count-from-cache, lazy-rows source), one in `StorageURL`, one in the `Distributed`-format branch of `StorageFile`, one in `StorageObjectStorageSource::createReader`, which serves S3, Azure, HDFS, the data lakes and the `Cluster` variants through the same code, and one in `StorageHive`. Three of them are not in the report: the lazy-rows source, `File(Distributed, '<path>')` and `Hive`, each measured at 2.00x as well.

Note `S3Queue`/`AzureQueue` share that `createReader`, so their `SelectedRows`/`SelectedBytes` halve too. That is the same defect and the correct value, but it is a second surface, so anyone alerting on the inflated number will see it change. Their commit-threshold counters (`processed_rows`/`processed_bytes`) are computed straight from the chunk and are unaffected. A direct select over an `S3Queue` table pins that in `tests/integration/test_storage_s3_queue/test_3.py`.

<details>
<summary>Sibling coverage, and what is deliberately left alone</summary>

Fixed (each measured at 2.00x):

| Site | Path |
|---|---|
| `StorageFile.cpp:1596` | count-from-cache (`ConstChunkGenerator`) |
| `StorageFile.cpp:1718` | `Distributed` format |
| `StorageFile.cpp:1928` | main read |
| `StorageFile.cpp:2549` | `StorageFileLazyRowsSource` |
| `StorageURL.cpp:487` | `URL` engine and `url()` |
| `StorageObjectStorageSource.cpp:1394` | S3, Azure, HDFS, web, local, queues |
| `StorageHive.cpp:302` | `Hive` engine |

Real carriers, same mechanism, left out; each is one line if you want them: `ReadFromLoopStep.cpp:163` (`loop` re-reads its inner table by design, so the semantics are your call), and `ShellCommandSource.cpp:573,684` (executable UDFs and dictionaries). Read, not measured.

Checked and not carriers: `StorageHive.cpp:634` (parse during planning), `TableFunctionFormat.cpp:127` (`format` parses during analysis: two reads, billed once each), and the object storage lazy branch, which splices its source into the outer pipeline instead of owning an inner one. `Dictionary` is untouched on purpose: its first-read 2.00x is a real lazy load.

This does not help #61907, whose INSERT contribution comes from a different increment site; #114844 and #114843 are different mechanisms too.

New test `05043_selected_rows_file_url_double_count.sql` asserts `SelectedRows = read_rows` and `SelectedBytes = read_bytes` per engine, with MergeTree and `numbers` controls. Reverting any single one of the five lines it covers reddens the cells that read through it, controls staying green. The other two need a server the stateless suite cannot give them: the `Distributed` format wants a spooled async-insert file, and `Hive` a metastore, so they are covered by `tests/integration/test_distributed_format/test.py` and `tests/integration/test_hive_query/test.py`. No Azure cell, since no stateless test reads Azure rows successfully; the S3 cell covers that line.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116427&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116427](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116427+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



