### PR TITLE
Keep the performance test runner at the tested version on the release_base arm

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1374,8 +1374,11 @@ def main():
             f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin {info.git_branch} ||:",
             verbose=True,
         )
+        # The test definitions must stay at the reference vintage (an old server cannot run new
+        # queries), but their runner `perf.py` is driven by this job and must match its version.
         Shell.check(
-            f"rm -rf ./tests/performance && git checkout {reference_sha} ./tests/performance",
+            f"rm -rf ./tests/performance && git checkout {reference_sha} ./tests/performance"
+            " && git checkout HEAD -- ./tests/performance/scripts/perf.py",
             verbose=True,
             strict=True,
         )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/116123

All 6 `Performance Comparison (arm_release, release_base, N/6)` shards have failed on every master
commit since 2026-08-25 ~17:00Z; `master_head` is unaffected. Per shard: 950 run errors across 95
tests, zero perf rows, no `all-query-metrics.tsv`.

**Root cause.** The arm replaces the whole `tests/performance` directory with the reference commit's
copy, so an old reference server is not asked to run queries it cannot support. That directory also
holds the *test runner* `perf.py`, so the revert downgrades the runner too. #116123 added
`--pr-number` to `perf.py` and made this job pass it unconditionally; the reference runner has no
such argument, so `argparse` takes the bare `0` as the positional `FILE`:

```
perf.py: error: argument FILE: can't open '0': [Errno 2] No such file or directory: '0'
```

The failing job's usage dump identifies which content ran: `--jemalloc-purge` present, `--pr-number`
absent, a combination only on the 26.8 line. This is structural rather than a typo in #116123: the
reference tree is always older than master, so any future runner argument reintroduces it.

**The change.** Restore the runner, and only the runner, right after the revert and in the same
command so the two cannot be separated. Test definitions stay at reference vintage, which is why the
revert exists; restoring the whole `scripts/` directory would instead feed master's `config.d` and
`users.d` to the older reference binary. This also repairs `compare.sh::confirm_changes`, which
resolves the same file and was silently losing coverage because it is fail-open.

**Validation.** Running the job's own revert command in a throwaway worktree, then its own `perf.py`
invocation: without this change `argparse` rejects the flag, with it the run proceeds past parsing.
Two mutants checked: deleting the restore reintroduces the old runner, widening it to the whole
directory breaks reference-config preservation.

⚠️ **This pull request's CI cannot exercise the fix.** `release_base` runs only on master
(`ci/workflows/master.py:58`); pull requests get `master_head` only, so verification is post-merge.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1c8f1a0e209b02ac33b67d413f40804c9e4a6167&name_0=MasterCI&name_1=Performance%20Comparison%20%28arm_release%2C%20release_base%2C%201%2F6%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116433&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116433](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116433+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.294` (included in `26.9` and later)
<!-- ch-version-info:end -->