### PR TITLE
Anchor the apt mirror fallback on the sentence buildx actually prints

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -299,7 +299,8 @@ def terminal_build_failure(info: str) -> str:
     """Output of the step the build stopped on, fences included.
 
     A failed `docker buildx build --progress=plain` ends with the failing step's own
-    output fenced between `------` lines and then `ERROR: failed to solve: ...`.
+    output fenced between `------` lines and then
+    `ERROR: failed to build: failed to solve: ...`.
     Everything above that fence belongs to steps that succeeded. Empty when the shape
     is absent - a timed-out or truncated log - so callers fail closed.
     """

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -291,7 +291,7 @@ APT_MIRROR_ERRORS = [
 # stopped on, and apt's own `E:` severity, which distinguishes "could not get the
 # file" from a miss apt recovered from.
 BUILDX_FAILURE_FENCE = "------"
-BUILDX_SOLVE_ERROR = "ERROR: failed to solve:"
+BUILDX_SOLVE_ERROR = "failed to solve:"
 APT_ERROR_SEVERITY = "E: "
 
 

--- a/ci/tests/test_docker_apt_mirror_fallback.py
+++ b/ci/tests/test_docker_apt_mirror_fallback.py
@@ -60,7 +60,7 @@ def _buildx_failure(step, body):
         f" > [linux/arm64 stage-0 4/6] RUN {step}:\n"
         + "".join(f"61.2 {line}\n" for line in body)
         + "------\n"
-        f"ERROR: failed to solve: {run}\n"
+        f"ERROR: failed to build: failed to solve: {run}\n"
     )
 
 
@@ -92,6 +92,9 @@ def test_only_the_step_the_build_stopped_on_decides():
     assert not is_apt_mirror_failure(RECOVERED_UPDATE + BROKEN_PACKAGE_NAME)
     # The premise of the arm: the ignored warning really is in the text being matched.
     assert "Failed to fetch" in RECOVERED_UPDATE
+    # And that the fixture ends the way buildx really ends a failed build, since that
+    # sentence is what locates the terminal step.
+    assert "ERROR: failed to build: failed to solve:" in MIRROR_WITHHELD_FILE
 
 
 def test_apt_severity_decides_inside_the_failing_step_too():


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115726
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/115726

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

#115726 rebuilds a Docker image against Canonical when the in-region apt mirror
withholds a `.deb`. That rebuild has never been selected: its gate looks for
`ERROR: failed to solve:`, and buildx prints `ERROR: failed to build: failed to
solve:`. `terminal_build_failure` fails closed to `""` when the anchor is absent, so
`is_apt_mirror_failure` is unconditionally `False` and the mirror loop always breaks
after the first attempt.

Master today, sha `0f7cac9ea103e2101c7162fb6657bf5578ea2c77`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0f7cac9ea103e2101c7162fb6657bf5578ea2c77&name_0=MasterCI&name_1=Docker%20server%20image)):
six `apt mirror 1/2`, zero `apt mirror 2/2`, no `exhausted its retries` line. That job
log contains the code's spelling 0 times and buildx's 4 times.

Driving the predicate over every `Docker%image%` failure row of the year ending
2026-08-25 00:00 UTC (249 rows): the shipped anchor is `True` on **0**, this one on
**41**, and each of those 41 carries an `E:` apt error inside the step the build
stopped on. The bare spelling never appeared in that year; all 145 solve errors use
the prefixed form.

I changed the literal and the docstring above it, which documented the same wrong
sentence. The fence and the `E:` severity narrowing #115726 added are both correct and
are kept: the earlier buffer-wide match would fire on 82 rows instead of 41, which is
the recovered `W: Failed to fetch` false positive that narrowing exists to prevent.

The fixture hard-coded the same wrong spelling, so the suite passed identically with
the classifier dead. Correcting it makes four of its arms fail against the old code.

Still out of scope: when a brownout withholds the package *indexes*, `apt-get update`
only warns and the build dies later with
`E: Package 'busybox' has no installation candidate` - indistinguishable from a genuine
packaging error, which the suite has an arm against, so no token list covers it. Some
rows of the current brownout are that shape.

<details>
<summary>Sweep over the year ending 2026-08-25 00:00 UTC</summary>

| variant | rows `True` (of 249) |
|---|---|
| shipped `ERROR: failed to solve:` | 0 |
| this PR `failed to solve:` | 41 |
| buffer-wide (pre-refinement form) | 82 |
| negative-control needle | 0 |

Token census over the same rows: `ERROR: failed to build: failed to solve:` in 145,
`ERROR: failed to solve:` in 0, negative control 0. Both Docker image checks, all
arches, all three Dockerfiles.

The shorter literal is not laxer: on those 249 rows it selects a byte-identical
terminal block to the full sentence (145 identical, 104 both empty, 0 differing),
against a wrong-anchor control that differs on 145.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116441&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116441](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116441+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116441&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116441](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116441+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
