### PR TITLE
Fix the apt mirror fallback for the Docker image jobs never running

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -291,21 +291,50 @@ APT_MIRROR_ERRORS = [
 # stopped on, and apt's own `E:` severity, which distinguishes "could not get the
 # file" from a miss apt recovered from.
 BUILDX_FAILURE_FENCE = "------"
-BUILDX_SOLVE_ERROR = "ERROR: failed to solve:"
+# buildx has reworded this line: it used to read `ERROR: failed to solve: ...` and
+# since 0.23 reads `ERROR: failed to build: failed to solve: ...` (measured on 0.30.1).
+# Matching the whole phrase pinned the old wording, so `terminal_build_failure` found
+# no terminal step, every failure was classified as "not the mirror", and the fallback
+# below was dead code from the day it was added: on 2026-08-26 the arm64 server and
+# keeper images reded on master on a `503` from `us-east-1.ec2.ports.ubuntu.com`
+# without ever rebuilding against Canonical. Anchor on the two parts that did not
+# move - buildx starts its top-level errors at the beginning of the line with
+# `ERROR: `, and this one names the solve step - so a future infix cannot break it.
+BUILDX_ERROR_PREFIX = "ERROR: "
+BUILDX_SOLVE_ERROR = "failed to solve:"
+# Inside the fence, buildx repeats the failing step's command as a header before its
+# output. That is the recipe, not what happened: `RUN ... && apt-get install ...` names
+# apt, and a `RUN` that echoes or greps for one of the signatures below would match on
+# its own text alone. Only the output lines get a verdict.
+BUILDX_STEP_HEADER_PREFIX = " > "
 APT_ERROR_SEVERITY = "E: "
+
+
+def is_buildx_solve_error(line: str) -> bool:
+    """Is this buildx's own top-level "the build failed" line?
+
+    The step output that precedes it repeats the same text, so requiring the line to
+    *start* with `ERROR: ` is what keeps the per-step `#12 ERROR: ...` copy and the
+    fenced `61.2 E: ...` body from standing in for the terminal line.
+    """
+    return line.startswith(BUILDX_ERROR_PREFIX) and BUILDX_SOLVE_ERROR in line
 
 
 def terminal_build_failure(info: str) -> str:
     """Output of the step the build stopped on, fences included.
 
     A failed `docker buildx build --progress=plain` ends with the failing step's own
-    output fenced between `------` lines and then `ERROR: failed to solve: ...`.
-    Everything above that fence belongs to steps that succeeded. Empty when the shape
-    is absent - a timed-out or truncated log - so callers fail closed.
+    output fenced between `------` lines, then the offending `Dockerfile` lines, then a
+    top-level `ERROR: ... failed to solve: ...`. Everything above that fence belongs to
+    steps that succeeded, and everything below it is source, not output - so the block
+    ends at the closing fence, while the top-level error still has to be there as proof
+    that this is where the build stopped. Empty when the shape is absent - a timed-out
+    or truncated log - so callers fail closed.
     """
     lines = info.splitlines()
-    # Retries append their whole output, so only the last attempt is the terminal one.
-    ends = [i for i, line in enumerate(lines) if BUILDX_SOLVE_ERROR in line]
+    # Retries truncate the log, so a log with several attempts in it is one that was
+    # concatenated; either way the last solve error is the one that ended the build.
+    ends = [i for i, line in enumerate(lines) if is_buildx_solve_error(line)]
     if not ends:
         return ""
     end = ends[-1]
@@ -314,13 +343,15 @@ def terminal_build_failure(info: str) -> str:
     ]
     if len(fences) < 2:
         return ""
-    return "\n".join(lines[fences[-2] : end + 1])
+    return "\n".join(lines[fences[-2] : fences[-1] + 1])
 
 
 def is_apt_mirror_failure(info: str) -> bool:
     """Did the step that stopped the build fail because a mirror withheld a file?"""
     return any(
-        APT_ERROR_SEVERITY in line and any(error in line for error in APT_MIRROR_ERRORS)
+        not line.startswith(BUILDX_STEP_HEADER_PREFIX)
+        and APT_ERROR_SEVERITY in line
+        and any(error in line for error in APT_MIRROR_ERRORS)
         for line in terminal_build_failure(info).splitlines()
     )
 
@@ -533,6 +564,19 @@ def build_and_push_image(
                 retry_errors=BUILDX_RETRY_ERRORS,
             )
             if build_result.is_ok() or not should_try_next_mirror(build_result.info):
+                if not build_result.is_ok() and not terminal_build_failure(
+                    build_result.info
+                ):
+                    # Fail-closed and silent is what let a reworded buildx error keep
+                    # this loop from ever running: say so, so the next log shows it.
+                    logging.info(
+                        "Image %s:%s for arch %s failed and no terminal build step "
+                        "could be identified in its output, so no apt mirror can be "
+                        "blamed for it; not trying another mirror",
+                        image.name,
+                        tag,
+                        arch,
+                    )
                 break
             logging.info(
                 "Image %s:%s for arch %s exhausted its retries on a failure the apt "

--- a/ci/tests/test_docker_apt_mirror_fallback.py
+++ b/ci/tests/test_docker_apt_mirror_fallback.py
@@ -13,6 +13,13 @@ image build, and reading "this mirror withheld a file" out of a log that merely
 mentions apt would both waste that build and bury a genuine packaging error behind it.
 So the arms below pin that only the step the build stopped on is consulted, that apt's
 own `W:`/`E:` severity is respected, and that the loop is actually wired to it.
+
+The classifier reaches none of that unless it can find the failing step first, and it
+finds it by the wording of buildx's own top-level error. That wording moved - buildx
+0.23 turned `ERROR: failed to solve:` into `ERROR: failed to build: failed to solve:` -
+which made the fallback dead code and reded every arm64 server and keeper image on
+master on 2026-08-26 on a `503` from `us-east-1.ec2.ports.ubuntu.com`. Hence the first
+arm: the fixture below speaks the current wording, and both are pinned.
 """
 
 import os
@@ -37,6 +44,14 @@ from ci.praktika.result import Result
 
 REGION = "us-east-1"
 
+# How buildx words its top-level failure. It printed the first form up to 0.22 and the
+# second from 0.23 on (measured on 0.30.1); the classifier must read both, because
+# pinning one of them is what broke the fallback - see the module docstring.
+SOLVE_ERROR_WORDINGS = [
+    "ERROR: failed to solve:",
+    "ERROR: failed to build: failed to solve:",
+]
+
 # An `apt-get update` that missed an index and carried on. apt marks it `W:`, the step
 # is `DONE`, and the image is built from the stale lists - this is not why any later
 # build failed, and it is the shape that makes matching the whole log wrong.
@@ -49,8 +64,13 @@ RECOVERED_UPDATE = """\
 """
 
 
-def _buildx_failure(step, body):
-    """A failed `docker buildx build --progress=plain` tail, in its real shape."""
+def _buildx_failure(step, body, solve_error=SOLVE_ERROR_WORDINGS[-1]):
+    """A failed `docker buildx build --progress=plain` tail, in its real shape.
+
+    Including the source-context block buildx prints after the closing fence, because
+    its `--------------------` rules are near-misses for the `------` fence the
+    classifier keys on and so belong in every arm below.
+    """
     run = f'process "/bin/sh -c {step}" did not complete successfully: exit code: 100'
     return (
         f"#12 [linux/arm64 stage-0 4/6] RUN {step}\n"
@@ -60,7 +80,13 @@ def _buildx_failure(step, body):
         f" > [linux/arm64 stage-0 4/6] RUN {step}:\n"
         + "".join(f"61.2 {line}\n" for line in body)
         + "------\n"
-        f"ERROR: failed to solve: {run}\n"
+        "Dockerfile.distroless:31\n"
+        "--------------------\n"
+        "  30 |     # The same uid/gid (101) is used both for alpine and ubuntu.\n"
+        f"  31 | >>> RUN {step}\n"
+        "  32 |     \n"
+        "--------------------\n"
+        f"{solve_error} {run}\n"
     )
 
 
@@ -78,6 +104,26 @@ BROKEN_PACKAGE_NAME = _buildx_failure(
     "apt-get install -y clickhosue-server",
     ["E: Unable to locate package clickhosue-server"],
 )
+
+
+def test_every_buildx_wording_of_the_top_level_error_is_read():
+    """The regression that made the whole fallback dead code.
+
+    `terminal_build_failure` identifies the failing step by scanning for buildx's
+    top-level error, so the exact wording of that one line decides whether any of the
+    classifier runs at all. buildx reworded it, the old spelling stopped appearing, and
+    every arm64 image failure on master was silently classified as "no mirror to blame".
+    A canned fixture cannot notice the *next* rewording, so match the parts that carry
+    the meaning rather than the sentence, and keep both known spellings passing.
+    """
+    for wording in SOLVE_ERROR_WORDINGS:
+        withheld = _buildx_failure(
+            "apt-get install -y tzdata",
+            ["E: Failed to fetch http://mirror/tzdata_2026c_all.deb  503"],
+            solve_error=wording,
+        )
+        assert is_apt_mirror_failure(withheld), wording
+        assert should_try_next_mirror(withheld), wording
 
 
 def test_only_the_step_the_build_stopped_on_decides():


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115726

`Docker server image` and `Docker keeper image` keep going red on master whenever `us-east-1.ec2.ports.ubuntu.com` answers `503`. Only the arm64 tags fail, because arm64 fetches its `.deb` packages from `ports.ubuntu.com` while amd64 uses `archive.ubuntu.com`:

```
E: Failed to fetch http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports/pool/main/o/openssl/openssl_3.0.2-0ubuntu1.29_arm64.deb  503  Service Unavailable
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

`ci/jobs/docker_server.py` already carries the remedy for exactly this — added in #115726, it rebuilds the image against Canonical's mirror once the retries against the in-region one are used up — but it never ran. `terminal_build_failure` identifies the step the build stopped on by scanning for `buildx`'s top-level error, matching the literal `ERROR: failed to solve:`. `buildx` 0.23 reworded that line to `ERROR: failed to build: failed to solve:` (measured on 0.30.1), so no terminal step was ever found, `is_apt_mirror_failure` answered "not the mirror" for every failure, and the fallback was dead code from the day it was added.

This anchors the match on the two parts that did not move — a line that starts with `ERROR: ` and names the solve step — so a future infix cannot break it again. Replaying the failing job's own log through the classifier now returns "try the next mirror", where master returns "no".

Two adjacent errors turned up while checking the classifier against real `docker buildx` output rather than a canned string: the matched region ran past the closing fence into the `Dockerfile` source that `buildx` echoes after it, and it included the step header inside the fence, which repeats the `RUN` command. Both are recipe text rather than build output, so a `RUN` line that merely names apt could decide the verdict; the block now ends at the closing fence and the header line is skipped. The fail-closed path is logged now too — being silent is what kept this from being noticed.

The fallback is a working remedy: `ports.ubuntu.com` answers `200` from an AWS host while `us-east-1.ec2.ports.ubuntu.com` answers `503`, and building the failing step for `linux/arm64` against Canonical fetches at 12.7 MB/s and succeeds.

The updated test fails 5 of its arms against master and passes against this change; `ci/tests/test_docker_apt_mirror_fallback.py` and `ci/tests/test_docker_buildx_timeout.py` are green (31 passed).

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=887b93e16db98a72906f035e47af9b2ffbf58aa2&name_0=MasterCI&name_1=Docker%20server%20image

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116444&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116444](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116444+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
