### PR TITLE
Reduce logging for INSERTs into MergeTree/ReplicatedMergeTree

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSink.cpp
+++ b/src/Storages/MergeTree/MergeTreeSink.cpp
@@ -80,7 +80,7 @@ MergeTreeSink::MergeTreeSink(
     , storage_snapshot(storage.getStorageSnapshotWithoutData(metadata_snapshot, context_))
     , deduplicate((*storage.getSettings())[MergeTreeSetting::non_replicated_deduplication_window] > 0 && storage.getDeduplicationLog() != nullptr)
 {
-    LOG_DEBUG(storage.log, "Create MergeTreeSink, deduplicate={}", deduplicate);
+    LOG_TEST(storage.log, "Create MergeTreeSink, deduplicate={}", deduplicate);
 
     /// It's only allowed to throw "too many parts" before write,
     /// because interrupting long-running INSERT query in the middle is not convenient for users.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -152,7 +152,7 @@ ReplicatedMergeTreeSink::ReplicatedMergeTreeSink(
             ErrorCodes::LOGICAL_ERROR,
             "Should be checked earlier: async inserts with quorum only make sense with enabled insert_quorum_parallel setting");
 
-    LOG_DEBUG(log, "Create ReplicatedMergeTreeSink {} async_insert={}, deduplicate={}, quorum_size={}, max_parts_per_block={}, quorum_parallel={}, is_attach={}",
+    LOG_TEST(log, "Create ReplicatedMergeTreeSink {} async_insert={}, deduplicate={}, quorum_size={}, max_parts_per_block={}, quorum_parallel={}, is_attach={}",
         storage.getStorageID().getNameForLogs(),
         is_async_insert,
         deduplicate,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This log appears too much times, since for one INSERT usually multiple sinks will be created - https://pastila.nl/?01210393/abc8b9f4c6f4b479bae4aefdeacc88fd#D9Uxw/GcEb4ggDc4PydnlA==GCM

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116486&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116486](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116486+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.903` (included in `26.9` and later)
<!-- ch-version-info:end -->