### PR TITLE
Report the exception in the performance comparison Run Errors table and count tests, not rows

### DIFF
--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -1767,8 +1767,8 @@ do
     {
         # The second grep is a heuristic for error messages like
         # "socket.timeout: timed out".
-        rg --no-filename --max-count=2 -i '\(Exception\|Error\):[^:]' "$log" \
-            || rg --no-filename --max-count=2 -i '^[^ ]\+: ' "$log" \
+        rg --no-filename --max-count=2 -i '(Exception|Error):[^:]' "$log" \
+            || rg --no-filename --max-count=2 -i '^[^ ]+: ' "$log" \
             || head -10 "$log"
     } | sed "s/^/$test\t/" >> run-errors.tsv ||:
 done

--- a/ci/jobs/scripts/perf/report.py
+++ b/ci/jobs/scripts/perf/report.py
@@ -392,7 +392,8 @@ if args.report == "main":
         exit(0)
 
     run_error_rows = tsvRows("run-errors.tsv")
-    error_tests += len(run_error_rows)
+    # row[0] is the test name, and one failing test can produce several rows.
+    error_tests += len({row[0] for row in run_error_rows if row})
     addSimpleTable("Run Errors", ["Test", "Error"], run_error_rows)
     if run_error_rows:
         errors_explained.append(


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109409
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `Performance Comparison` check reporting a single failing performance test as ten errors, and made its Run Errors table show the exception instead of the top of the traceback.

### Description

A failing performance test is reported as **`10 errors`**, and the ten rows it puts in the
report's Run Errors table are the first ten lines of a Python traceback, never the exception
line at the bottom. In the 30 days to 2026-08-26 the `errors` term reds 141
`Performance Comparison (*, master_head, *)` runs across 46 pull requests, plus 9 runs on
`master` whose message begins with exactly `10 errors`.

Root cause: `compare.sh` extracts the blurb with `rg`, but both selective patterns were written
in GNU basic-regex syntax (`\(`, `\|`, `\+`). ripgrep's dialect reads those escapes as the
literal characters `(`, `|`, `+`, so neither can match a traceback. They are valid regexes, so
`rg` exits 1 rather than erroring and the `||` chain silently falls through to `head -10`. In
the CIDB sink `default.perf_run_errors_v1` that is, as of 2026-08-26, 345,880 groups of exactly
ten rows per run and test and **zero** of one or two, though `--max-count=2` emits at most two.

I delete six backslashes, and count distinct tests rather than rows in `report.py`, which is
what the `error_tests` name already claimed.

This cannot turn a red shard green: `head -10` is kept and `rg` exiting 1 still falls through,
so a non-empty error log still yields at least one row, and `report.py` hardcodes the plural
`" errors"` for every count, so the substring gate in `performance_tests.py` still fails the
shard on `1 errors`. Only the number and the text change.

Validated against the artifacts of [one real failing job](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109409&sha=df8ae7fc889947c579f11950f9d1e2777c1bb551&name_0=PR&name_1=Performance%20Comparison%20%28arm_release%2C%20master_head%2C%204%2F6%29):
beforehand my local run reproduces its `10 errors, 11 too long, 4 unstable` byte-for-byte,
afterwards the same inputs give `1 errors, ...` and the table holds the two lines naming the
timeout. CI-script tests are throwaway per `.claude/CLAUDE.md`, and `ci/tests` is being removed
in #115650.

Related: https://github.com/ClickHouse/ClickHouse/pull/109409

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116491&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116491](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116491+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
