### PR TITLE
Fix wrong results for an ALIAS column with a window function over a Distributed table

### DIFF
--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -1516,10 +1516,15 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
             collectLeafColumnActionNames(expression_for_expected[i], *planner_context, leaf_names);
             for (const auto & leaf_name : leaf_names)
             {
+                /// Two shard columns share this name, so which one the leaf reads is undecidable. An exact-name hit
+                /// does not settle it either: the shard column of that exact name may belong to the other source.
+                auto normalized_leaf_name = normalizeGenuineQualifiers(leaf_name, genuine_qualifier_tails);
+                if (ambiguous_shard_names.contains(normalized_leaf_name))
+                    return {};
                 /// Already resolvable: the leaf names a shard column directly, or an earlier expression aliased it.
                 if (shard_column_names.contains(leaf_name) || !renamed_leaves.emplace(leaf_name).second)
                     continue;
-                auto leaf_it = shard_normalized_to_index.find(normalizeGenuineQualifiers(leaf_name, genuine_qualifier_tails));
+                auto leaf_it = shard_normalized_to_index.find(normalized_leaf_name);
                 if (leaf_it == shard_normalized_to_index.end())
                     continue;
                 dag.addAlias(*shard_input_nodes[leaf_it->second], leaf_name);

--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -1219,6 +1219,29 @@ void collectLeafColumnActionNames(
             collectLeafColumnActionNames(child, planner_context, leaf_names);
 }
 
+/// True if `node`'s value depends on which server evaluates it: a function that is not deterministic (`rand`, `now`,
+/// ...), or a `ConstantNode` the analyzer produced by folding a server-local call (`hostName`, `tcpPort`, ...), which
+/// the fold marks non-deterministic while a plain literal stays deterministic.
+bool containsNonDeterministicFunction(const QueryTreeNodePtr & node)
+{
+    if (!node)
+        return false;
+
+    if (const auto * function_node = node->as<FunctionNode>())
+        if (auto function = function_node->getFunction(); function && !function->isDeterministic())
+            return true;
+
+    if (const auto * constant_node = node->as<ConstantNode>())
+        if (!constant_node->isDeterministic())
+            return true;
+
+    for (const auto & child : node->getChildren())
+        if (containsNonDeterministicFunction(child))
+            return true;
+
+    return false;
+}
+
 /// Collect the set of genuine column-name tails of analyzer-generated table qualifiers in the query tree. A real
 /// qualifier in a column identifier has the form `__tableN.<tail>`, where `__tableN` is the alias
 /// `createUniqueAliasesIfNecessary` assigns to a table expression and `<tail>` is the rendered column name
@@ -1454,6 +1477,11 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
         auto alias_it = identifier_to_alias_expression.find(expected_name);
         if (alias_it == identifier_to_alias_expression.end())
             return {}; /// Cannot explain this column; let the caller fall back to its default reconciliation.
+
+        /// Evaluating the body here reproduces what the shard would have computed only while the body is a function of
+        /// the shard's columns alone. One whose value depends on the evaluating server would take this server's value.
+        if (containsNonDeterministicFunction(alias_it->second))
+            return {};
 
         shard_index_for_expected[i] = computed_from_expression;
         expression_for_expected[i] = alias_it->second;

--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -1161,9 +1161,8 @@ private:
 };
 
 /// Collect, for every `ALIAS` column in the query tree, the inlined clone of its defining expression, keyed by the
-/// column's identifier-based action name (the name `expected_header` uses). The clone is inlined exactly as
-/// `actionNameAfterAliasInlining` inlines it, so the action names of its leaves are the names the shard header
-/// carries and the expression can be evaluated on top of that header.
+/// column's identifier-based action name (the name `expected_header` uses). Nested `ALIAS` columns are inlined in the
+/// clone as well, so its `COLUMN` leaves are named as the shard header names them and it can be built on that header.
 class CollectInlinedAliasExpressionsVisitor : public InDepthQueryTreeVisitor<CollectInlinedAliasExpressionsVisitor>
 {
 public:
@@ -1449,10 +1448,9 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
             continue;
         }
 
-        /// An `ALIAS` column whose declared type differs from its body's type inlines to `_CAST(<body>, '<Type>')`,
-        /// and one declared over an expression inlines to that expression. Neither is a column the shard emits at a
-        /// mergeable-state boundary: the shard sends the raw columns the body reads. The value is still recoverable,
-        /// because the body's leaves are those raw columns, so evaluate the body here instead of looking it up.
+        /// An `ALIAS` whose declared type differs from its body's inlines to `_CAST(<body>, '<Type>')`, and one over an
+        /// expression to that expression; neither is a column the shard emits at a mergeable-state boundary. The body's
+        /// leaves are raw columns the shard does send, so evaluate the body here instead of looking the column up.
         auto alias_it = identifier_to_alias_expression.find(expected_name);
         if (alias_it == identifier_to_alias_expression.end())
             return {}; /// Cannot explain this column; let the caller fall back to its default reconciliation.
@@ -1509,9 +1507,8 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
         if (shard_index == computed_from_expression)
         {
             /// The body's leaves are named by the initiator's column identifiers, while the shard header carries the
-            /// shard's own independently renumbered qualifiers (see `normalizeGenuineQualifiers`). Where the two differ
-            /// only by that number, alias the shard column under the initiator's name so the expression resolves onto
-            /// the existing input instead of introducing an input the shard header does not have.
+            /// shard's own independently renumbered qualifiers (see `normalizeGenuineQualifiers`). Aliasing the shard
+            /// column under the initiator's name resolves the expression onto an existing input instead of adding one.
             std::unordered_set<String> leaf_names;
             collectLeafColumnActionNames(expression_for_expected[i], *planner_context, leaf_names);
             for (const auto & leaf_name : leaf_names)

--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -1203,6 +1203,23 @@ private:
     std::unordered_map<String, QueryTreeNodePtr> & alias_expressions;
 };
 
+/// Collect the identifier-based action name of every `COLUMN` leaf of an already-inlined expression. These are the
+/// names `PlannerActionsVisitor` will look up when it builds the expression, so they are what has to resolve to the
+/// shard header's columns.
+void collectLeafColumnActionNames(
+    const QueryTreeNodePtr & node, const PlannerContext & planner_context, std::unordered_set<String> & leaf_names)
+{
+    if (node->getNodeType() == QueryTreeNodeType::COLUMN)
+    {
+        leaf_names.emplace(calculateActionNodeName(node, planner_context, /*use_column_identifier_as_action_node_name=*/true));
+        return;
+    }
+
+    for (const auto & child : node->getChildren())
+        if (child)
+            collectLeafColumnActionNames(child, planner_context, leaf_names);
+}
+
 /// Collect the set of genuine column-name tails of analyzer-generated table qualifiers in the query tree. A real
 /// qualifier in a column identifier has the form `__tableN.<tail>`, where `__tableN` is the alias
 /// `createUniqueAliasesIfNecessary` assigns to a table expression and `<tail>` is the rendered column name
@@ -1461,12 +1478,17 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
 
     ActionsDAG dag;
     std::vector<const ActionsDAG::Node *> shard_input_nodes;
+    std::unordered_set<std::string_view> shard_column_names;
     shard_input_nodes.reserve(shard_header.columns());
+    shard_column_names.reserve(shard_header.columns());
     for (size_t i = 0; i < shard_header.columns(); ++i)
     {
         const auto & column = shard_header.getByPosition(i);
         shard_input_nodes.push_back(&dag.addInput(column.name, column.type));
+        shard_column_names.emplace(shard_input_nodes.back()->result_name);
     }
+    /// Leaf names already aliased onto a shard column by an earlier computed expression, so the alias is added once.
+    std::unordered_set<String> renamed_leaves;
 
     ActionsDAG::NodeRawConstPtrs outputs;
     outputs.reserve(expected_header.columns());
@@ -1474,6 +1496,9 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
     /// mapping onto the same shard column is a duplicate of that representative. Report those duplicates so a downstream
     /// aggregation merge can bucket by only the representative key columns (matching the shard's collapsed bucketing).
     std::unordered_map<size_t, String> representative_for_shard_index;
+    /// Collected locally and published to `duplicate_to_representative` only on the successful return, so that a
+    /// declining return always leaves the caller's map empty however many decline paths there are.
+    std::unordered_map<String, String> duplicates;
     ColumnNodePtrWithHashSet empty_correlated_columns_set;
     for (size_t i = 0; i < expected_header.columns(); ++i)
     {
@@ -1483,8 +1508,23 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
 
         if (shard_index == computed_from_expression)
         {
-            /// Evaluating the body over `dag` reads the shard columns it needs as existing inputs, because the body was
-            /// inlined with the same rule that names the shard header.
+            /// The body's leaves are named by the initiator's column identifiers, while the shard header carries the
+            /// shard's own independently renumbered qualifiers (see `normalizeGenuineQualifiers`). Where the two differ
+            /// only by that number, alias the shard column under the initiator's name so the expression resolves onto
+            /// the existing input instead of introducing an input the shard header does not have.
+            std::unordered_set<String> leaf_names;
+            collectLeafColumnActionNames(expression_for_expected[i], *planner_context, leaf_names);
+            for (const auto & leaf_name : leaf_names)
+            {
+                /// Already resolvable: the leaf names a shard column directly, or an earlier expression aliased it.
+                if (shard_column_names.contains(leaf_name) || !renamed_leaves.emplace(leaf_name).second)
+                    continue;
+                auto leaf_it = shard_normalized_to_index.find(normalizeGenuineQualifiers(leaf_name, genuine_qualifier_tails));
+                if (leaf_it == shard_normalized_to_index.end())
+                    continue;
+                dag.addAlias(*shard_input_nodes[leaf_it->second], leaf_name);
+            }
+
             PlannerActionsVisitor actions_visitor(planner_context, empty_correlated_columns_set, /*use_column_identifier_as_action_node_name=*/true);
             auto [expression_outputs, correlated_subtrees] = actions_visitor.visit(dag, expression_for_expected[i]);
             if (correlated_subtrees.notEmpty() || expression_outputs.size() != 1)
@@ -1505,9 +1545,16 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
         {
             auto [it, inserted] = representative_for_shard_index.emplace(shard_index, expected_name);
             if (!inserted && it->second != expected_name)
-                duplicate_to_representative->emplace(expected_name, it->second);
+                duplicates.emplace(expected_name, it->second);
         }
     }
+
+    /// The resulting DAG runs on the shard header, so every input it reads must be a column of that header. Building a
+    /// computed expression adds an input for any leaf that did not resolve above, and such a DAG would throw
+    /// `NOT_FOUND_COLUMN_IN_BLOCK` while the plan is built. Decline instead and let the caller reconcile.
+    for (const auto * input : dag.getInputs())
+        if (!shard_column_names.contains(input->result_name))
+            return {};
 
     /// Every shard column must be accounted for: either it feeds an expected column directly, or a computed expression
     /// above reads it. A leftover column means the mapping does not explain this header, so fall back to be safe.
@@ -1528,6 +1575,9 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
             if (!shard_column_used[i] && !reachable.contains(shard_input_nodes[i]))
                 return {};
     }
+
+    if (duplicate_to_representative)
+        *duplicate_to_representative = std::move(duplicates);
 
     dag.getOutputs() = std::move(outputs);
     return dag;

--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -13,7 +13,9 @@
 #include <Analyzer/SortNode.h>
 #include <Core/Block.h>
 #include <Planner/PlannerActionsVisitor.h>
+#include <Planner/PlannerCorrelatedSubqueries.h>
 
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -1158,6 +1160,49 @@ private:
     std::unordered_map<String, String> & translation;
 };
 
+/// Collect, for every `ALIAS` column in the query tree, the inlined clone of its defining expression, keyed by the
+/// column's identifier-based action name (the name `expected_header` uses). The clone is inlined exactly as
+/// `actionNameAfterAliasInlining` inlines it, so the action names of its leaves are the names the shard header
+/// carries and the expression can be evaluated on top of that header.
+class CollectInlinedAliasExpressionsVisitor : public InDepthQueryTreeVisitor<CollectInlinedAliasExpressionsVisitor>
+{
+public:
+    CollectInlinedAliasExpressionsVisitor(
+        const PlannerContext & planner_context_, std::unordered_map<String, QueryTreeNodePtr> & alias_expressions_)
+        : planner_context(planner_context_)
+        , alias_expressions(alias_expressions_)
+    {
+    }
+
+    void visitImpl(QueryTreeNodePtr & node)
+    {
+        if (node->getNodeType() != QueryTreeNodeType::COLUMN)
+            return;
+
+        auto inlined = getInlineableAliasColumnExpression(node);
+        if (!inlined)
+            return;
+
+        auto identifier_name = calculateActionNodeName(node, planner_context, /*use_column_identifier_as_action_node_name=*/true);
+        if (alias_expressions.contains(identifier_name))
+            return;
+
+        inlineAliasColumnsInExpression(inlined);
+        alias_expressions.emplace(std::move(identifier_name), std::move(inlined));
+    }
+
+    static bool needChildVisit(const QueryTreeNodePtr & /*parent*/, const QueryTreeNodePtr & child)
+    {
+        auto child_type = child->getNodeType();
+        return child_type != QueryTreeNodeType::QUERY && child_type != QueryTreeNodeType::UNION
+            && child_type != QueryTreeNodeType::TABLE_FUNCTION && child_type != QueryTreeNodeType::TABLE;
+    }
+
+private:
+    const PlannerContext & planner_context;
+    std::unordered_map<String, QueryTreeNodePtr> & alias_expressions;
+};
+
 /// Collect the set of genuine column-name tails of analyzer-generated table qualifiers in the query tree. A real
 /// qualifier in a column identifier has the form `__tableN.<tail>`, where `__tableN` is the alias
 /// `createUniqueAliasesIfNecessary` assigns to a table expression and `<tail>` is the rendered column name
@@ -1313,16 +1358,20 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
     if (!planner_context || !query_tree)
         return {};
 
-    /// The shard-side deduplication can only remove columns, so a recognized collapse has a strictly smaller shard header.
-    if (shard_header.columns() == 0 || shard_header.columns() >= expected_header.columns())
+    /// A zero-column shard header carries no expression to map from, so nothing here can explain it.
+    if (shard_header.columns() == 0)
         return {};
 
     std::unordered_map<String, String> identifier_to_inlined_name;
+    std::unordered_map<String, QueryTreeNodePtr> identifier_to_alias_expression;
     std::unordered_set<String> genuine_qualifier_tails;
     {
         QueryTreeNodePtr query_tree_for_visit = query_tree;
         CollectAliasNameTranslationVisitor visitor(*planner_context, identifier_to_inlined_name);
         visitor.visit(query_tree_for_visit);
+
+        CollectInlinedAliasExpressionsVisitor alias_visitor(*planner_context, identifier_to_alias_expression);
+        alias_visitor.visit(query_tree_for_visit);
 
         CollectGenuineQualifierTailsVisitor tails_visitor(*planner_context, genuine_qualifier_tails);
         tails_visitor.visit(query_tree_for_visit);
@@ -1335,15 +1384,25 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
     /// shard but `__tableK.x` (K > 1) in the initiator's tree. Erasing the genuine qualifier number on both sides
     /// removes exactly that difference, so corresponding columns match while every other difference (including user
     /// text that merely looks like a qualifier) is preserved. Matching is by name, not position, so it tolerates the
-    /// shard returning its deduplicated columns in a different order than the initiator expects. If two shard columns
-    /// share a normalized name we keep the first; the "every shard column used" guard below then rejects the ambiguous
-    /// case and we fall back safely.
+    /// shard returning its columns in a different order than the initiator expects. Two shard columns sharing a
+    /// normalized name make it undecidable which of them feeds an expected column resolving to that name, so such names
+    /// are recorded and any expected column hitting one is rejected below.
     std::unordered_map<String, size_t> shard_normalized_to_index;
+    std::unordered_set<String> ambiguous_shard_names;
     shard_normalized_to_index.reserve(shard_header.columns());
     for (size_t i = 0; i < shard_header.columns(); ++i)
-        shard_normalized_to_index.emplace(normalizeGenuineQualifiers(shard_header.getByPosition(i).name, genuine_qualifier_tails), i);
+    {
+        auto normalized = normalizeGenuineQualifiers(shard_header.getByPosition(i).name, genuine_qualifier_tails);
+        if (!shard_normalized_to_index.emplace(normalized, i).second)
+            ambiguous_shard_names.emplace(std::move(normalized));
+    }
+
+    /// Sentinel in `shard_index_for_expected`: this expected column has no single shard column feeding it and is
+    /// computed from the shard header by `expression_for_expected` instead.
+    static constexpr size_t computed_from_expression = std::numeric_limits<size_t>::max();
 
     std::vector<size_t> shard_index_for_expected(expected_header.columns());
+    std::vector<QueryTreeNodePtr> expression_for_expected(expected_header.columns());
     std::vector<bool> shard_column_used(shard_header.columns(), false);
     bool collapse_detected = false;
 
@@ -1356,25 +1415,49 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
             inlined_name = it->second;
 
         /// Match by normalized name so the independent shard/initiator qualifier numbering does not matter.
-        auto shard_it = shard_normalized_to_index.find(normalizeGenuineQualifiers(inlined_name, genuine_qualifier_tails));
-        if (shard_it == shard_normalized_to_index.end())
+        auto normalized_inlined_name = normalizeGenuineQualifiers(inlined_name, genuine_qualifier_tails);
+        if (ambiguous_shard_names.contains(normalized_inlined_name))
+            return {}; /// Two shard columns share this name, so which one feeds this column is undecidable.
+
+        auto shard_it = shard_normalized_to_index.find(normalized_inlined_name);
+        if (shard_it != shard_normalized_to_index.end())
+        {
+            shard_index_for_expected[i] = shard_it->second;
+            shard_column_used[shard_it->second] = true;
+            /// The matched shard column carries a name different from the initiator-side `expected_name` (whether by
+            /// the ALIAS inlining or only by the qualifier renumbering); that is the signature of an
+            /// inlined/deduplicated ALIAS column the shard collapsed.
+            if (shard_header.getByPosition(shard_it->second).name != expected_name)
+                collapse_detected = true;
+            continue;
+        }
+
+        /// An `ALIAS` column whose declared type differs from its body's type inlines to `_CAST(<body>, '<Type>')`,
+        /// and one declared over an expression inlines to that expression. Neither is a column the shard emits at a
+        /// mergeable-state boundary: the shard sends the raw columns the body reads. The value is still recoverable,
+        /// because the body's leaves are those raw columns, so evaluate the body here instead of looking it up.
+        auto alias_it = identifier_to_alias_expression.find(expected_name);
+        if (alias_it == identifier_to_alias_expression.end())
             return {}; /// Cannot explain this column; let the caller fall back to its default reconciliation.
 
-        shard_index_for_expected[i] = shard_it->second;
-        shard_column_used[shard_it->second] = true;
-        /// The matched shard column carries a name different from the initiator-side `expected_name` (whether by the
-        /// ALIAS inlining or only by the qualifier renumbering); that is the signature of an inlined/deduplicated
-        /// ALIAS column the shard collapsed.
-        if (shard_header.getByPosition(shard_it->second).name != expected_name)
-            collapse_detected = true;
+        shard_index_for_expected[i] = computed_from_expression;
+        expression_for_expected[i] = alias_it->second;
+        collapse_detected = true;
     }
 
     if (!collapse_detected)
         return {};
 
-    for (bool used : shard_column_used)
-        if (!used)
-            return {}; /// Some shard column is unaccounted for; fall back to be safe.
+    /// Every expected column reads the shard column at its own position and nothing has to be computed, so the caller's
+    /// positional reconciliation already produces exactly this mapping. Decline, to leave such plans untouched.
+    if (shard_header.columns() == expected_header.columns())
+    {
+        bool identity_mapping = true;
+        for (size_t i = 0; i < expected_header.columns() && identity_mapping; ++i)
+            identity_mapping = shard_index_for_expected[i] == i;
+        if (identity_mapping)
+            return {};
+    }
 
     ActionsDAG dag;
     std::vector<const ActionsDAG::Node *> shard_input_nodes;
@@ -1391,10 +1474,30 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
     /// mapping onto the same shard column is a duplicate of that representative. Report those duplicates so a downstream
     /// aggregation merge can bucket by only the representative key columns (matching the shard's collapsed bucketing).
     std::unordered_map<size_t, String> representative_for_shard_index;
+    ColumnNodePtrWithHashSet empty_correlated_columns_set;
     for (size_t i = 0; i < expected_header.columns(); ++i)
     {
-        const auto & expected_name = expected_header.getByPosition(i).name;
+        const auto & expected_column = expected_header.getByPosition(i);
+        const auto & expected_name = expected_column.name;
         const size_t shard_index = shard_index_for_expected[i];
+
+        if (shard_index == computed_from_expression)
+        {
+            /// Evaluating the body over `dag` reads the shard columns it needs as existing inputs, because the body was
+            /// inlined with the same rule that names the shard header.
+            PlannerActionsVisitor actions_visitor(planner_context, empty_correlated_columns_set, /*use_column_identifier_as_action_node_name=*/true);
+            auto [expression_outputs, correlated_subtrees] = actions_visitor.visit(dag, expression_for_expected[i]);
+            if (correlated_subtrees.notEmpty() || expression_outputs.size() != 1)
+                return {};
+
+            const auto * computed_node = expression_outputs.front();
+            if (!computed_node->result_type->equals(*expected_column.type))
+                return {};
+
+            outputs.push_back(&dag.addAlias(*computed_node, expected_name));
+            continue;
+        }
+
         const auto * source_node = shard_input_nodes[shard_index];
         outputs.push_back(&dag.addAlias(*source_node, expected_name));
 
@@ -1404,6 +1507,26 @@ std::optional<ActionsDAG> buildShardCollapseFanOut(
             if (!inserted && it->second != expected_name)
                 duplicate_to_representative->emplace(expected_name, it->second);
         }
+    }
+
+    /// Every shard column must be accounted for: either it feeds an expected column directly, or a computed expression
+    /// above reads it. A leftover column means the mapping does not explain this header, so fall back to be safe.
+    {
+        std::unordered_set<const ActionsDAG::Node *> reachable;
+        std::vector<const ActionsDAG::Node *> to_visit = outputs;
+        while (!to_visit.empty())
+        {
+            const auto * node = to_visit.back();
+            to_visit.pop_back();
+            if (!reachable.emplace(node).second)
+                continue;
+            for (const auto * child : node->children)
+                to_visit.push_back(child);
+        }
+
+        for (size_t i = 0; i < shard_header.columns(); ++i)
+            if (!shard_column_used[i] && !reachable.contains(shard_input_nodes[i]))
+                return {};
     }
 
     dag.getOutputs() = std::move(outputs);

--- a/src/Storages/buildQueryTreeForShard.h
+++ b/src/Storages/buildQueryTreeForShard.h
@@ -63,6 +63,9 @@ void rewriteJoinToGlobalJoin(QueryTreeNodePtr query_tree_to_modify, ContextPtr c
   * shard, which deduplicated those keys before computing its two-level bucket numbers - and reconstruct the duplicate
   * key columns after merging. Without this the initiator would bucket by more key columns than the shard did, so equal
   * groups coming from different shards could land in different buckets and never merge (wrong results).
+  *
+  * `duplicate_to_representative` is written only when an `ActionsDAG` is returned; it is left empty on `std::nullopt`.
+  * A caller that stores it unconditionally therefore never applies a collapse the returned plan does not perform.
   */
 std::optional<ActionsDAG> buildShardCollapseFanOut(
     const QueryTreeNodePtr & query_tree,

--- a/src/Storages/buildQueryTreeForShard.h
+++ b/src/Storages/buildQueryTreeForShard.h
@@ -50,7 +50,10 @@ void rewriteJoinToGlobalJoin(QueryTreeNodePtr query_tree_to_modify, ContextPtr c
   * `expected_header`) and its action name after inlining `ALIAS` columns (matching `shard_header`), and use this
   * translation to resolve which shard column feeds each expected column. A collapsed shard column is fanned back out to
   * every expected column that maps onto it. An expected column that no shard column can supply is computed from the
-  * shard header by evaluating the inlined `ALIAS` body, whose leaves are shard columns by construction.
+  * shard header by evaluating the inlined `ALIAS` body, which is done only while that body's value is a function of the
+  * shard's columns alone. A body whose value depends on the evaluating server (`hostName`, `tcpPort`, `rand`, ...) is
+  * declined instead, since evaluating it here would answer for the initiator rather than for the server that read the
+  * row, which is what `inlineAliasColumns` above exists to avoid.
   *
   * Returns the conversion `ActionsDAG` (input = `shard_header`, output = `expected_header` names), or `std::nullopt` when
   * the situation is not a recognized projection collapse, in which case the caller should fall back to its default

--- a/src/Storages/buildQueryTreeForShard.h
+++ b/src/Storages/buildQueryTreeForShard.h
@@ -37,16 +37,20 @@ void inlineAliasColumns(QueryTreeNodePtr & query_tree_to_modify);
 void rewriteJoinToGlobalJoin(QueryTreeNodePtr query_tree_to_modify, ContextPtr context);
 
 /** When a Distributed/parallel-replicas query is executed up to `WithMergeableState`, the shard's query tree has its
-  * `ALIAS` columns inlined into their defining expressions. If several projection (or sort/group/...) items expand to the
-  * same expression, the shard's `ActionsDAG` deduplicates them into a single output column, so the shard header can have
-  * fewer columns than the header the initiator expects (which keeps the columns distinct, since on the initiator the
-  * `ALIAS` columns are not inlined).
+  * `ALIAS` columns inlined into their defining expressions. The shard header can then differ from the header the
+  * initiator expects (which keeps the `ALIAS` columns un-inlined) in three ways: it can have fewer columns, because the
+  * shard's `ActionsDAG` deduplicates several projection (or sort/group/...) items that expand to the same expression;
+  * it can carry the same columns in a different order, because a boundary without a projection step orders its columns
+  * by first mention in the inlined tree; and it can be missing an `ALIAS` column altogether, because an `ALIAS` whose
+  * declared type differs from its body's type inlines to `_CAST(<body>, '<Type>')`, which is not a column the shard
+  * emits - it sends the raw columns the body reads.
   *
-  * This helper reconstructs the initiator's `expected_header` from the shard's `shard_header` by fanning out each
-  * collapsed shard column back to every expected column that maps onto it. The mapping is computed exactly: for every
-  * expression node in `query_tree` we compute both its identifier-based action name (matching `expected_header`) and its
-  * action name after inlining `ALIAS` columns (matching `shard_header`), and use this translation to resolve which shard
-  * column feeds each expected column.
+  * This helper reconstructs the initiator's `expected_header` from the shard's `shard_header`. The mapping is computed
+  * exactly: for every expression node in `query_tree` we compute both its identifier-based action name (matching
+  * `expected_header`) and its action name after inlining `ALIAS` columns (matching `shard_header`), and use this
+  * translation to resolve which shard column feeds each expected column. A collapsed shard column is fanned back out to
+  * every expected column that maps onto it. An expected column that no shard column can supply is computed from the
+  * shard header by evaluating the inlined `ALIAS` body, whose leaves are shard columns by construction.
   *
   * Returns the conversion `ActionsDAG` (input = `shard_header`, output = `expected_header` names), or `std::nullopt` when
   * the situation is not a recognized projection collapse, in which case the caller should fall back to its default

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
@@ -39,6 +39,9 @@ Empty	USD	1
 Empty	Empty	EMPTY	USD	1
 Empty	Empty	EMPTY	USD	2
 Empty	Empty	EMPTY	USD	1
+server dependent alias body
+1
+1
 distributed engine table
 Empty	USD	1
 Empty	USD	2

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
@@ -62,6 +62,9 @@ Empty	Empty	1
 Empty	USD	1
 Empty	USD	2
 Empty	USD	1
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
 deduplicated alias pair
 7	7	7	1
 7	7	7	2
@@ -80,8 +83,15 @@ window clauses
 Empty	USD	2
 Empty	USD	2
 Empty	USD	1
+Empty	2	1
+Empty	2	1
 Empty	2
 Empty	2
+parallel replicas
+Empty	USD	1
+Empty	USD	1
+EMPTY	USD	1
+EMPTY	USD	1
 negative controls
 Empty	USD	1
 Empty	USD	2

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
@@ -59,8 +59,6 @@ EMPTY	USD	1
 Empty	Empty	1
 Empty	Empty	2
 Empty	Empty	1
-2
-2
 Empty	USD	1
 Empty	USD	2
 Empty	USD	1
@@ -96,3 +94,15 @@ Empty	USD
 Empty	USD	1
 Empty	USD	2
 Empty	USD	1
+joined sources
+left	right	1
+left	right	2
+left	right	3
+left	right	4
+left	right	1
+left	right	1
+left	right	2
+left	right	3
+left	right	4
+left	right	1
+7	7	left	right	1

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
@@ -1,0 +1,66 @@
+case 1 wrong results
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+case 2 column count
+Empty	Empty	2024-01-01 00:00:00	1
+Empty	Empty	2024-01-01 00:00:00	2
+Empty	Empty	2024-01-01 00:00:00	1
+case 3 type mismatch
+Empty	2024-01-01 00:00:00	1
+Empty	2024-01-01 00:00:00	2
+Empty	2024-01-01 00:00:00	1
+positional variants
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+USD	Empty	1
+USD	Empty	2
+USD	Empty	1
+1	Empty	USD	1
+1	Empty	USD	2
+1	Empty	USD	1
+Empty	1
+Empty	2
+Empty	1
+alias body shapes
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+EMPTY	USD	1
+EMPTY	USD	2
+EMPTY	USD	1
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+Empty	Empty	EMPTY	USD	1
+Empty	Empty	EMPTY	USD	2
+Empty	Empty	EMPTY	USD	1
+distributed engine table
+Empty	USD	1
+Empty	USD	2
+Empty	Empty	2024-01-01 00:00:00	1
+Empty	Empty	2024-01-01 00:00:00	2
+Empty	USD	1
+Empty	USD	2
+window clauses
+Empty	USD	2
+Empty	USD	2
+Empty	USD	1
+Empty	2
+Empty	2
+negative controls
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+Empty	USD	2024-01-01 00:00:00	1
+Empty	USD	2024-01-01 00:00:00	2
+Empty	USD	1
+Empty	USD
+Empty	USD
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
@@ -42,10 +42,42 @@ Empty	Empty	EMPTY	USD	1
 distributed engine table
 Empty	USD	1
 Empty	USD	2
+Empty	USD	1
 Empty	Empty	2024-01-01 00:00:00	1
 Empty	Empty	2024-01-01 00:00:00	2
+Empty	Empty	2024-01-01 00:00:00	1
 Empty	USD	1
 Empty	USD	2
+Empty	USD	1
+nested subquery
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+EMPTY	USD	1
+EMPTY	USD	2
+EMPTY	USD	1
+Empty	Empty	1
+Empty	Empty	2
+Empty	Empty	1
+2
+2
+Empty	USD	1
+Empty	USD	2
+Empty	USD	1
+deduplicated alias pair
+7	7	7	1
+7	7	7	2
+7	7	7	1
+7	7	1
+7	7	2
+7	7	1
+7	7	7	1
+7	7	7	2
+7	7	7	1
+7	7	2
+7	7	2
+7	7	7	2
+7	7	7	2
 window clauses
 Empty	USD	2
 Empty	USD	2

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.reference
@@ -92,6 +92,8 @@ Empty	USD	1
 Empty	USD	1
 EMPTY	USD	1
 EMPTY	USD	1
+1
+1
 negative controls
 Empty	USD	1
 Empty	USD	2

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -219,13 +219,15 @@ SELECT 'parallel replicas';
 -- work instead of duplicating rows, so each arm returns the same rows as its single-replica oracle.
 -- Every setting a task-based parallel read requires is pinned per statement, including the analyzer:
 -- a server whose profile disables it refuses the parallel plan outright, and the rows alone do not
--- say which plan produced them, so each arm asserts below that replicas were really used.
+-- say which plan produced them, so each arm asserts below that replicas were really used. Only the
+-- query-based path reads at that boundary, so the plan-based one is pinned off too: it splits the read
+-- later in the plan, and the assertion below is positive either way.
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
 FROM loc_win ORDER BY rn
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
          cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
          parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1,
-         automatic_parallel_replicas_mode = 0, enable_analyzer = 1,
+         automatic_parallel_replicas_mode = 0, parallel_replicas_plan_based = 0, enable_analyzer = 1,
          log_comment = '05043_pr_alias';
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
 FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
@@ -235,7 +237,7 @@ FROM loc_win ORDER BY rn
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
          cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
          parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1,
-         automatic_parallel_replicas_mode = 0, enable_analyzer = 1,
+         automatic_parallel_replicas_mode = 0, parallel_replicas_plan_based = 0, enable_analyzer = 1,
          log_comment = '05043_pr_upper_alias';
 SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
 FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
@@ -299,7 +301,8 @@ SELECT * FROM (
 SELECT * FROM (
     SELECT l.al AS la, r.al AS ra, row_number() OVER (ORDER BY l.a) AS rn
     FROM loc_jl AS l INNER JOIN loc_jr AS r ON l.a = r.a
-) ORDER BY rn;
+) ORDER BY rn
+SETTINGS enable_parallel_replicas = 0;
 -- A plain JOIN of the two distributed sources reaches the same boundary.
 SELECT * FROM (
     SELECT l.al AS la, r.al AS ra, row_number() OVER (ORDER BY l.a) AS rn
@@ -309,7 +312,8 @@ SELECT * FROM (
 SELECT * FROM (
     SELECT l.al AS la, r.al AS ra, row_number() OVER (ORDER BY l.a) AS rn
     FROM loc_jl AS l INNER JOIN loc_jr AS r ON l.a = r.a
-) ORDER BY rn;
+) ORDER BY rn
+SETTINGS enable_parallel_replicas = 0;
 DROP TABLE loc_jl;
 DROP TABLE loc_jr;
 -- A same-body ALIAS pair collapses to one shard column, so a duplicate is already recorded when a later

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -11,8 +11,8 @@
 -- NUMBER_OF_COLUMNS_DOESNT_MATCH / CANNOT_PARSE_DATETIME.
 --
 -- An arm with a comparable single-node equivalent is followed by it as the oracle, so a result in
--- the wrong columns fails even though it raises no error. The negative controls and the
--- expected-error arm have none.
+-- the wrong columns fails even though it raises no error. Some arms deliberately have none, the
+-- expected-error one necessarily so.
 
 DROP TABLE IF EXISTS loc_win;
 DROP TABLE IF EXISTS dist_win;

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -96,6 +96,26 @@ SELECT al, same, upper_al, cur, row_number() OVER (ORDER BY a) AS rn
 FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
 SELECT al, same, upper_al, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
 
+SELECT 'server dependent alias body';
+-- An ALIAS body whose value depends on which server evaluates it is not a function of the shard's
+-- columns, so it cannot be reconstructed from the shard header: the read is rejected instead of
+-- answering with the initiator's value. Every shard here is the same server, so no value oracle can
+-- tell the two answers apart, and each arm pins the rejection. `hostName` is constant-folded during
+-- analysis while `rand64` stays a function call, which are the two node shapes carrying the property.
+DROP TABLE IF EXISTS loc_srv;
+CREATE TABLE loc_srv (a UInt64, x String,
+                      srv String ALIAS concat(x, '_', hostName()),
+                      nd String ALIAS concat(x, '_', toString(rand64())))
+ENGINE = MergeTree ORDER BY a;
+INSERT INTO loc_srv (a, x) VALUES (1, 'row');
+SELECT srv, x, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_srv) ORDER BY rn; -- { serverError NUMBER_OF_COLUMNS_DOESNT_MATCH }
+SELECT nd, x, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_srv) ORDER BY rn; -- { serverError NUMBER_OF_COLUMNS_DOESNT_MATCH }
+-- Without a window function the whole query reaches the shard, which evaluates the body itself.
+SELECT srv = concat(x, '_', hostName()) FROM remote('127.0.0.{1,2}', currentDatabase(), loc_srv) ORDER BY x;
+DROP TABLE loc_srv;
+
 SELECT 'distributed engine table';
 -- A real Distributed engine table takes the same path as remote().
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -136,13 +136,6 @@ SELECT * FROM (
 SELECT * FROM (
     SELECT al AS category, cat, row_number() OVER (ORDER BY a) AS rn FROM loc_win
 ) ORDER BY rn;
-SELECT count() FROM (
-    SELECT al, cat, row_number() OVER (ORDER BY a) AS rn
-    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
-);
-SELECT count() * 2 FROM (
-    SELECT al, cat, row_number() OVER (ORDER BY a) AS rn FROM loc_win
-);
 SELECT * FROM (SELECT * FROM (
     SELECT al AS category, cur, row_number() OVER (ORDER BY a) AS rn
     FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
@@ -153,9 +146,9 @@ SELECT * FROM (SELECT * FROM (
 
 SELECT 'deduplicated alias pair';
 -- Two ALIAS columns with the same body collapse to one shard column, so the initiator fans that column
--- back out and reports the duplicate. Adding a third ALIAS column the shard does not send at all puts
--- the fan-out and the computed path in one header, which is where a duplicate reported by a mapping the
--- plan then declined would be applied to a plan that does not perform the collapse.
+-- back out and reports the duplicate. Adding a third ALIAS column the shard does not send at all puts the
+-- fan-out and the computed path in one header. Every mapping in this block is accepted; a duplicate
+-- reported by a mapping that then declines is covered by the `joined sources` section.
 DROP TABLE IF EXISTS loc_dup;
 CREATE TABLE loc_dup
 (
@@ -227,6 +220,68 @@ SELECT mt AS category, cur, row_number() OVER (ORDER BY a) AS rn
 FROM remote('127.0.0.{1,2}', currentDatabase(), loc_mat) ORDER BY rn;
 SELECT mt AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_mat ORDER BY rn;
 DROP TABLE loc_mat;
+
+SELECT 'joined sources';
+-- Both joined sources expose a column of the same name, so the shard header carries two columns whose
+-- names differ only in the qualifier number (nesting is what makes them differ: the shard restarts its
+-- `__tableN` aliases at 1). A leaf of an ALIAS body then cannot be attributed to one source, not even by
+-- an exact name match, because the shard column of that exact name may belong to the other source. Such
+-- a header is reconciled positionally instead, which passes each shard column through unchanged, so the
+-- value-preserving ALIAS body keeps the result comparable to the single-node oracle.
+DROP TABLE IF EXISTS loc_jl;
+DROP TABLE IF EXISTS loc_jr;
+CREATE TABLE loc_jl (a UInt64, x String, al String ALIAS concat(x, '')) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE loc_jr (a UInt64, x String, al String ALIAS concat(x, '')) ENGINE = MergeTree ORDER BY a;
+INSERT INTO loc_jl VALUES (1, 'left');
+INSERT INTO loc_jr VALUES (1, 'right');
+SELECT * FROM (
+    SELECT l.al AS la, r.al AS ra, row_number() OVER (ORDER BY l.a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_jl) AS l
+    GLOBAL INNER JOIN remote('127.0.0.{1,2}', currentDatabase(), loc_jr) AS r ON l.a = r.a
+) ORDER BY rn;
+SELECT * FROM (
+    SELECT l.al AS la, r.al AS ra, row_number() OVER (ORDER BY l.a) AS rn
+    FROM loc_jl AS l INNER JOIN loc_jr AS r ON l.a = r.a
+) ORDER BY rn;
+-- A plain JOIN of the two distributed sources reaches the same boundary.
+SELECT * FROM (
+    SELECT l.al AS la, r.al AS ra, row_number() OVER (ORDER BY l.a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_jl) AS l
+    INNER JOIN remote('127.0.0.{1,2}', currentDatabase(), loc_jr) AS r ON l.a = r.a
+) ORDER BY rn;
+SELECT * FROM (
+    SELECT l.al AS la, r.al AS ra, row_number() OVER (ORDER BY l.a) AS rn
+    FROM loc_jl AS l INNER JOIN loc_jr AS r ON l.a = r.a
+) ORDER BY rn;
+DROP TABLE loc_jl;
+DROP TABLE loc_jr;
+-- A same-body ALIAS pair collapses to one shard column, so a duplicate is already recorded when a later
+-- ALIAS body turns out to read a column both sources expose. Declining then leaves one expected column
+-- with nothing to read, and reconciling positionally cannot invent it, so the query is rejected instead
+-- of returning values from the wrong source. The duplicate must not reach the plan, which performs no
+-- collapse here.
+DROP TABLE IF EXISTS loc_jdl;
+DROP TABLE IF EXISTS loc_jdr;
+CREATE TABLE loc_jdl (a UInt64, x String, y UInt8, s1 UInt8 ALIAS y, s2 UInt8 ALIAS y,
+                      ex String ALIAS concat(x, ''))
+ENGINE = MergeTree ORDER BY a;
+CREATE TABLE loc_jdr (a UInt64, x String, ex2 String ALIAS concat(x, '')) ENGINE = MergeTree ORDER BY a;
+INSERT INTO loc_jdl (a, x, y) VALUES (1, 'left', 7);
+INSERT INTO loc_jdr (a, x) VALUES (1, 'right');
+SELECT * FROM (
+    SELECT l.s1, l.s2, l.ex, r.ex2, row_number() OVER (ORDER BY l.a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_jdl) AS l
+    GLOBAL INNER JOIN remote('127.0.0.{1,2}', currentDatabase(), loc_jdr) AS r ON l.a = r.a
+) ORDER BY rn; -- { serverError NUMBER_OF_COLUMNS_DOESNT_MATCH }
+-- Reading over parallel replicas puts even a single-node query on a mergeable-state boundary, so it stops
+-- being a single-node oracle and reaches the same undecidable header; pinned off so this states the value.
+SELECT * FROM (
+    SELECT l.s1, l.s2, l.ex, r.ex2, row_number() OVER (ORDER BY l.a) AS rn
+    FROM loc_jdl AS l INNER JOIN loc_jdr AS r ON l.a = r.a
+) ORDER BY rn
+SETTINGS enable_parallel_replicas = 0;
+DROP TABLE loc_jdl;
+DROP TABLE loc_jdr;
 
 DROP TABLE dist_win;
 DROP TABLE loc_win;

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -283,7 +283,8 @@ SELECT 'joined sources';
 -- `__tableN` aliases at 1). A leaf of an ALIAS body then cannot be attributed to one source, not even by
 -- an exact name match, because the shard column of that exact name may belong to the other source. Such
 -- a header is reconciled positionally instead, which passes each shard column through unchanged, so the
--- value-preserving ALIAS body keeps the result comparable to the single-node oracle.
+-- value-preserving ALIAS body keeps the result comparable to the single-node oracle. A body that
+-- transforms its column returns it untransformed here, which is why these bodies preserve their value.
 DROP TABLE IF EXISTS loc_jl;
 DROP TABLE IF EXISTS loc_jr;
 CREATE TABLE loc_jl (a UInt64, x String, al String ALIAS concat(x, '')) ENGINE = MergeTree ORDER BY a;

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -143,12 +143,19 @@ SELECT * FROM (SELECT * FROM (
 SELECT * FROM (SELECT * FROM (
     SELECT al AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win
 )) ORDER BY rn;
+-- A CTE is a subquery scope as well, so it crosses the same renumbering.
+WITH cte AS (SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+             FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win))
+SELECT * FROM cte ORDER BY rn;
+WITH cte AS (SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+             FROM loc_win)
+SELECT * FROM cte ORDER BY rn;
 
 SELECT 'deduplicated alias pair';
 -- Two ALIAS columns with the same body collapse to one shard column, so the initiator fans that column
 -- back out and reports the duplicate. Adding a third ALIAS column the shard does not send at all puts the
--- fan-out and the computed path in one header. Every mapping in this block is accepted; a duplicate
--- reported by a mapping that then declines is covered by the `joined sources` section.
+-- fan-out and the computed path in one header. Every mapping in this block is accepted; a mapping that
+-- reports a duplicate and then declines is reached in the `joined sources` section.
 DROP TABLE IF EXISTS loc_dup;
 CREATE TABLE loc_dup
 (
@@ -192,10 +199,37 @@ SELECT al AS category, cur, sum(a) OVER (PARTITION BY cur ORDER BY dt) AS s
 FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY s;
 SELECT al AS category, cur, sum(a) OVER (PARTITION BY cur ORDER BY dt) AS s
 FROM loc_win ORDER BY s;
--- GROUP BY and a window function together take a different planner path; it must stay correct.
+-- GROUP BY with a window function: the shard aggregates, and the initiator adds the window on top of
+-- the merged result. Both headers list the group key first here, so the mapping declines to the identity.
+SELECT al AS category, count() AS c, row_number() OVER (ORDER BY al) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) GROUP BY al ORDER BY category;
+SELECT al AS category, count() * 2 AS c, row_number() OVER (ORDER BY al) AS rn
+FROM loc_win GROUP BY al ORDER BY category;
+-- GROUP BY alone also stops at a mergeable-state boundary, so it reaches the same reconciliation with
+-- no window function anywhere in the query.
 SELECT al AS category, count() AS c FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
 GROUP BY al ORDER BY category;
 SELECT al AS category, count() * 2 AS c FROM loc_win GROUP BY al ORDER BY category;
+
+SELECT 'parallel replicas';
+-- Reading a plain MergeTree table over parallel replicas stops at the same mergeable-state boundary, so
+-- the same reconciliation runs with no Distributed table and no remote() in the query. Replicas split the
+-- work instead of duplicating rows, so each arm returns the same rows as its single-replica oracle.
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM loc_win ORDER BY rn
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+         cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+         parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1;
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
+-- The same over an expression-bodied ALIAS, whose body is computed on the initiator.
+SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM loc_win ORDER BY rn
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+         cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+         parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1;
+SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
 
 SELECT 'negative controls';
 -- No ALIAS column: the two headers already agree, so nothing is reconstructed.
@@ -258,8 +292,9 @@ DROP TABLE loc_jr;
 -- A same-body ALIAS pair collapses to one shard column, so a duplicate is already recorded when a later
 -- ALIAS body turns out to read a column both sources expose. Declining then leaves one expected column
 -- with nothing to read, and reconciling positionally cannot invent it, so the query is rejected instead
--- of returning values from the wrong source. The duplicate must not reach the plan, which performs no
--- collapse here.
+-- of returning values from the wrong source. The arm pins that rejection, not the state of the reported
+-- duplicates: this header carries one more expected column than the shard sends, so the read never
+-- reaches an aggregation, which is the only thing that reads them.
 DROP TABLE IF EXISTS loc_jdl;
 DROP TABLE IF EXISTS loc_jdr;
 CREATE TABLE loc_jdl (a UInt64, x String, y UInt8, s1 UInt8 ALIAS y, s2 UInt8 ALIAS y,

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -1,0 +1,140 @@
+-- Tags: distributed
+
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/116333
+-- A window function forces a Distributed read to stop at WithMergeableState, and such a boundary
+-- carries no projection step, so its columns are ordered by first mention in the shard's
+-- ALIAS-inlined query tree. That order differs from the order the initiator expects, and an ALIAS
+-- column whose declared type differs from its body's type is not present on the shard at all (it
+-- inlines to a _CAST over the raw column the shard does send). Reconciling those two headers
+-- positionally silently returned values in the wrong columns, or raised
+-- NUMBER_OF_COLUMNS_DOESNT_MATCH / CANNOT_PARSE_DATETIME.
+--
+-- Every distributed query below is paired with the equivalent local query: the local result is the
+-- oracle, so a wrong-column result fails even though it raises no error.
+
+DROP TABLE IF EXISTS loc_win;
+DROP TABLE IF EXISTS dist_win;
+
+CREATE TABLE loc_win
+(
+    a UInt64,
+    cat LowCardinality(String),
+    cur LowCardinality(String),
+    dt DateTime,
+    -- Declared type differs from the body's type, so this inlines to a _CAST the shard never emits.
+    al String ALIAS cat,
+    -- Declared type equals the body's type, so this inlines to the plain shard column `cat`.
+    same LowCardinality(String) ALIAS cat,
+    -- Body is an expression rather than a bare column.
+    upper_al String ALIAS upper(cat),
+    -- ALIAS over an ALIAS: inlining unwraps transitively.
+    al_of_al String ALIAS al,
+    nul Nullable(String) ALIAS cat
+)
+ENGINE = MergeTree ORDER BY a;
+
+CREATE TABLE dist_win AS loc_win
+ENGINE = Distributed('test_cluster_two_shards_localhost', currentDatabase(), loc_win, rand());
+
+INSERT INTO loc_win (a, cat, cur, dt) VALUES (1, 'Empty', 'USD', '2024-01-01 00:00:00');
+
+SET enable_analyzer = 1;
+
+SELECT 'case 1 wrong results';
+-- Reported case 1: the two projected columns came back swapped, with no error at all.
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM loc_win ORDER BY rn;
+
+SELECT 'case 2 column count';
+-- Reported case 2: NUMBER_OF_COLUMNS_DOESNT_MATCH (source: 3 and result: 4).
+SELECT al, cat, dt, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT al, cat, dt, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+
+SELECT 'case 3 type mismatch';
+-- Reported case 3: the positional pairing cast a String onto a DateTime (CANNOT_PARSE_DATETIME).
+SELECT al, dt, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT al, dt, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+
+SELECT 'positional variants';
+SELECT al, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT al, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+SELECT cur, al, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT cur, al, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+SELECT a, al, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT a, al, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+-- A lone ALIAS column was already correct; it must stay correct.
+SELECT al, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT al, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+
+SELECT 'alias body shapes';
+-- Same-type ALIAS: resolved to the shard's own column by name.
+SELECT same AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT same AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+-- Expression-bodied ALIAS: computed on the initiator from the raw column the shard sent.
+SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+SELECT al_of_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT al_of_al AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+SELECT nul AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT nul AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+-- Several ALIAS columns of different shapes at once.
+SELECT al, same, upper_al, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT al, same, upper_al, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+
+SELECT 'distributed engine table';
+-- A real Distributed engine table takes the same path as remote().
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM dist_win ORDER BY rn;
+SELECT al, cat, dt, row_number() OVER (ORDER BY a) AS rn FROM dist_win ORDER BY rn;
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM dist_win ORDER BY rn SETTINGS prefer_localhost_replica = 0;
+
+SELECT 'window clauses';
+SELECT al AS category, cur, sum(a) OVER (PARTITION BY cur ORDER BY dt) AS s
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY s;
+SELECT al AS category, cur, sum(a) OVER (PARTITION BY cur ORDER BY dt) AS s
+FROM loc_win ORDER BY s;
+-- GROUP BY and a window function together take a different planner path; it must stay correct.
+SELECT al AS category, count() AS c FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
+GROUP BY al ORDER BY category;
+SELECT al AS category, count() * 2 AS c FROM loc_win GROUP BY al ORDER BY category;
+
+SELECT 'negative controls';
+-- No ALIAS column: the two headers already agree, so nothing is reconstructed.
+SELECT cat AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+SELECT cat AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
+-- Declared but unreferenced ALIAS columns must not perturb the read.
+SELECT cat, cur, dt, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY rn;
+-- A single shard needs no reconciliation at all.
+SELECT al AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.1', currentDatabase(), loc_win) ORDER BY rn;
+-- An ALIAS column without a window function stops at FetchColumns, which reconciles by name.
+SELECT al AS category, cur FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win) ORDER BY category;
+-- MATERIALIZED is a real stored column, so it is never inlined.
+DROP TABLE IF EXISTS loc_mat;
+CREATE TABLE loc_mat (a UInt64, cat LowCardinality(String), cur LowCardinality(String), dt DateTime,
+                      mt String MATERIALIZED cat)
+ENGINE = MergeTree ORDER BY a;
+INSERT INTO loc_mat (a, cat, cur, dt) VALUES (1, 'Empty', 'USD', '2024-01-01 00:00:00');
+SELECT mt AS category, cur, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_mat) ORDER BY rn;
+SELECT mt AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_mat ORDER BY rn;
+DROP TABLE loc_mat;
+
+DROP TABLE dist_win;
+DROP TABLE loc_win;

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -1,16 +1,18 @@
 -- Tags: distributed
 
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/116333
--- A window function forces a Distributed read to stop at WithMergeableState, and such a boundary
--- carries no projection step, so its columns are ordered by first mention in the shard's
+-- A window function forces a read to stop at WithMergeableState, reached both by a Distributed or
+-- remote() read of two or more shards and by a parallel-replicas read of a plain table. Such a
+-- boundary carries no projection step, so its columns are ordered by first mention in the shard's
 -- ALIAS-inlined query tree. That order differs from the order the initiator expects, and an ALIAS
 -- column whose declared type differs from its body's type is not present on the shard at all (it
 -- inlines to a _CAST over the raw column the shard does send). Reconciling those two headers
 -- positionally silently returned values in the wrong columns, or raised
 -- NUMBER_OF_COLUMNS_DOESNT_MATCH / CANNOT_PARSE_DATETIME.
 --
--- Every distributed query below is paired with the equivalent local query: the local result is the
--- oracle, so a wrong-column result fails even though it raises no error.
+-- An arm with a comparable single-node equivalent is followed by it as the oracle, so a result in
+-- the wrong columns fails even though it raises no error. The negative controls and the
+-- expected-error arm have none.
 
 DROP TABLE IF EXISTS loc_win;
 DROP TABLE IF EXISTS dist_win;
@@ -219,7 +221,8 @@ SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) 
 FROM loc_win ORDER BY rn
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
          cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
-         parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1;
+         parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1,
+         automatic_parallel_replicas_mode = 0;
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
 FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
 -- The same over an expression-bodied ALIAS, whose body is computed on the initiator.
@@ -227,7 +230,8 @@ SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
 FROM loc_win ORDER BY rn
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
          cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
-         parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1;
+         parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1,
+         automatic_parallel_replicas_mode = 0;
 SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
 FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
 

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -98,9 +98,101 @@ SELECT 'distributed engine table';
 -- A real Distributed engine table takes the same path as remote().
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
 FROM dist_win ORDER BY rn;
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM loc_win ORDER BY rn;
 SELECT al, cat, dt, row_number() OVER (ORDER BY a) AS rn FROM dist_win ORDER BY rn;
+SELECT al, cat, dt, row_number() OVER (ORDER BY a) AS rn FROM loc_win ORDER BY rn;
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
 FROM dist_win ORDER BY rn SETTINGS prefer_localhost_replica = 0;
+SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+FROM loc_win ORDER BY rn;
+
+SELECT 'nested subquery';
+-- A distributed read nested in a subquery is renumbered independently of the initiator's query tree
+-- (`createUniqueAliasesIfNecessary` restarts the `__tableN` aliases at 1), so an expected column and
+-- the shard column feeding it differ by that number as well as by the ALIAS inlining.
+SELECT * FROM (
+    SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
+) ORDER BY rn;
+SELECT * FROM (
+    SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
+    FROM loc_win
+) ORDER BY rn;
+-- An expression-bodied ALIAS is computed on the initiator, so its leaves have to resolve to the
+-- shard's renumbered columns.
+SELECT * FROM (
+    SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
+) ORDER BY rn;
+SELECT * FROM (
+    SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win
+) ORDER BY rn;
+-- The raw column the ALIAS body reads is selected alongside the ALIAS itself.
+SELECT * FROM (
+    SELECT al AS category, cat, row_number() OVER (ORDER BY a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
+) ORDER BY rn;
+SELECT * FROM (
+    SELECT al AS category, cat, row_number() OVER (ORDER BY a) AS rn FROM loc_win
+) ORDER BY rn;
+SELECT count() FROM (
+    SELECT al, cat, row_number() OVER (ORDER BY a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
+);
+SELECT count() * 2 FROM (
+    SELECT al, cat, row_number() OVER (ORDER BY a) AS rn FROM loc_win
+);
+SELECT * FROM (SELECT * FROM (
+    SELECT al AS category, cur, row_number() OVER (ORDER BY a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_win)
+)) ORDER BY rn;
+SELECT * FROM (SELECT * FROM (
+    SELECT al AS category, cur, row_number() OVER (ORDER BY a) AS rn FROM loc_win
+)) ORDER BY rn;
+
+SELECT 'deduplicated alias pair';
+-- Two ALIAS columns with the same body collapse to one shard column, so the initiator fans that column
+-- back out and reports the duplicate. Adding a third ALIAS column the shard does not send at all puts
+-- the fan-out and the computed path in one header, which is where a duplicate reported by a mapping the
+-- plan then declined would be applied to a plan that does not perform the collapse.
+DROP TABLE IF EXISTS loc_dup;
+CREATE TABLE loc_dup
+(
+    a UInt64,
+    x UInt8,
+    dt DateTime,
+    s1 UInt8 ALIAS x,
+    s2 UInt8 ALIAS x,
+    cst String ALIAS x
+)
+ENGINE = MergeTree ORDER BY a;
+INSERT INTO loc_dup (a, x, dt) VALUES (1, 7, '2024-01-01 00:00:00');
+SELECT s1, s2, cst, row_number() OVER (ORDER BY a) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_dup) ORDER BY rn;
+SELECT s1, s2, cst, row_number() OVER (ORDER BY a) AS rn FROM loc_dup ORDER BY rn;
+SELECT s1, s2, row_number() OVER (ORDER BY dt) AS rn
+FROM remote('127.0.0.{1,2}', currentDatabase(), loc_dup) ORDER BY rn;
+SELECT s1, s2, row_number() OVER (ORDER BY dt) AS rn FROM loc_dup ORDER BY rn;
+-- Nested, so the fan-out and the computed leaf both cross the qualifier renumbering.
+SELECT * FROM (
+    SELECT s1, s2, cst, row_number() OVER (ORDER BY a) AS rn
+    FROM remote('127.0.0.{1,2}', currentDatabase(), loc_dup)
+) ORDER BY rn;
+SELECT * FROM (
+    SELECT s1, s2, cst, row_number() OVER (ORDER BY a) AS rn FROM loc_dup
+) ORDER BY rn;
+-- An aggregation over the collapsed pair consumes the reported duplicate mapping. Two-level aggregation
+-- is pinned because the shard's bucket numbers depend on which key columns it deduplicated.
+SELECT s1, s2, count() AS c FROM remote('127.0.0.{1,2}', currentDatabase(), loc_dup)
+GROUP BY s1, s2 ORDER BY s1
+SETTINGS group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes = 1;
+SELECT s1, s2, count() * 2 AS c FROM loc_dup GROUP BY s1, s2 ORDER BY s1;
+SELECT s1, s2, cst, count() AS c FROM remote('127.0.0.{1,2}', currentDatabase(), loc_dup)
+GROUP BY s1, s2, cst ORDER BY s1
+SETTINGS group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes = 1;
+SELECT s1, s2, cst, count() * 2 AS c FROM loc_dup GROUP BY s1, s2, cst ORDER BY s1;
+DROP TABLE loc_dup;
 
 SELECT 'window clauses';
 SELECT al AS category, cur, sum(a) OVER (PARTITION BY cur ORDER BY dt) AS s

--- a/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
+++ b/tests/queries/0_stateless/05043_distributed_alias_column_window_order.sql
@@ -217,12 +217,16 @@ SELECT 'parallel replicas';
 -- Reading a plain MergeTree table over parallel replicas stops at the same mergeable-state boundary, so
 -- the same reconciliation runs with no Distributed table and no remote() in the query. Replicas split the
 -- work instead of duplicating rows, so each arm returns the same rows as its single-replica oracle.
+-- Every setting a task-based parallel read requires is pinned per statement, including the analyzer:
+-- a server whose profile disables it refuses the parallel plan outright, and the rows alone do not
+-- say which plan produced them, so each arm asserts below that replicas were really used.
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
 FROM loc_win ORDER BY rn
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
          cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
          parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1,
-         automatic_parallel_replicas_mode = 0;
+         automatic_parallel_replicas_mode = 0, enable_analyzer = 1,
+         log_comment = '05043_pr_alias';
 SELECT al AS category, cur, row_number() OVER (PARTITION BY a ORDER BY dt DESC) AS rn
 FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
 -- The same over an expression-bodied ALIAS, whose body is computed on the initiator.
@@ -231,9 +235,23 @@ FROM loc_win ORDER BY rn
 SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
          cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
          parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 1,
-         automatic_parallel_replicas_mode = 0;
+         automatic_parallel_replicas_mode = 0, enable_analyzer = 1,
+         log_comment = '05043_pr_upper_alias';
 SELECT upper_al AS category, cur, row_number() OVER (ORDER BY a) AS rn
 FROM loc_win ORDER BY rn SETTINGS enable_parallel_replicas = 0;
+SYSTEM FLUSH LOGS query_log;
+-- One aggregate row per arm however many rows carry the comment: a re-execution of the same query
+-- inherits it.
+SELECT max(ProfileEvents['ParallelReplicasUsedCount']) > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '05043_pr_alias'
+  AND type = 'QueryFinish' AND initial_query_id = query_id
+SETTINGS enable_parallel_replicas = 0;
+SELECT max(ProfileEvents['ParallelReplicasUsedCount']) > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '05043_pr_upper_alias'
+  AND type = 'QueryFinish' AND initial_query_id = query_id
+SETTINGS enable_parallel_replicas = 0;
 
 SELECT 'negative controls';
 -- No ALIAS column: the two headers already agree, so nothing is reconstructed.


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/116333
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/116333

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix wrong results when a query selects an `ALIAS` column together with a window function with `enable_analyzer = 1`, over a `Distributed` table (or `remote()`) with two or more shards, or over a table read with parallel replicas. Values could be returned in the wrong columns with no error, or the query could fail with `NUMBER_OF_COLUMNS_DOESNT_MATCH` or `CANNOT_PARSE_DATETIME`.


### Description

A window function makes `StorageDistributed::getQueryProcessingStage` refuse the optimized stage, so the read runs to `WithMergeableState`. The shard analyses the tree with `ALIAS` columns inlined and adds no projection step, so its boundary header is ordered by first mention in that inlined tree; the initiator derives its expected header from the un-inlined tree. Positional reconciliation then paired unrelated columns: silently wrong results (`USD Empty 1` for `Empty USD 1`), `Code: 20 NUMBER_OF_COLUMNS_DOESNT_MATCH`, or `Code: 41 CANNOT_PARSE_DATETIME`.

The name-based reconciliation for this boundary (`buildShardCollapseFanOut`) declined for three measured reasons, all fixed:

- its entry guard required a strictly smaller shard header, from the deduplication case it was written for; here the count is equal and only the order differs
- an `ALIAS` column whose declared type differs from its body's inlines to `_CAST(<body>, '<Type>')`, which the shard never emits; its body is now evaluated on the initiator from the raw column the shard sends, unless that body's value depends on which server evaluates it
- a nested read has its `__tableN` qualifiers renumbered independently of the initiator's tree, so the shard column feeding an expected column differed by that number too; this is also the reported query inside a derived table or CTE

Parallel replicas reach the same boundary, so a plain `MergeTree` read was silently wrong too; also fixed. Anything the mapping cannot explain still falls back, so plans that work today are unchanged. The change is initiator-side only, so the mergeable-state wire format is untouched.

Each regression arm is paired with its single-node equivalent, so the silent case fails. Two shapes stay wrong, identically to before, so they are separate: `StorageMerge` over a `Distributed` table, and a transforming `ALIAS` body over a column both sides of a distributed `JOIN` expose (two same-named shard columns leave that mapping undecidable).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116498&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116498](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116498+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.255` (included in `26.10` and later)
<!-- ch-version-info:end -->