### PR TITLE
Fix concurrent stores of the same format schema failing with CANNOT_OPEN_FILE

### DIFF
--- a/src/Formats/FormatSchemaInfo.cpp
+++ b/src/Formats/FormatSchemaInfo.cpp
@@ -25,6 +25,7 @@
 #include <Common/SipHash.h>
 #include <Common/atomicRename.h>
 #include <Common/filesystemHelpers.h>
+#include <Common/getRandomASCIIString.h>
 #include <Common/logger_useful.h>
 namespace DB
 {
@@ -275,7 +276,9 @@ void FormatSchemaInfo::storeSchemaOnDisk(const fs::path & file_path, const Strin
         fs::create_directory(dir_path);
     }
 
-    auto temp_path = fs::path(file_path.string() + ".tmp");
+    /// The final file name is a hash of the schema source, so every writer of one schema targets
+    /// the same path; a shared temporary name would let them overwrite and delete each other's files.
+    auto temp_path = fs::path(file_path.string() + "." + getRandomASCIIString(8) + ".tmp");
 
     try
     {

--- a/tests/queries/0_stateless/05045_format_schema_cache_leftover_temp_file.reference
+++ b/tests/queries/0_stateless/05045_format_schema_cache_leftover_temp_file.reference
@@ -1,0 +1,2 @@
+data	Array(Array(Int32))					
+leftover file kept

--- a/tests/queries/0_stateless/05045_format_schema_cache_leftover_temp_file.sh
+++ b/tests/queries/0_stateless/05045_format_schema_cache_leftover_temp_file.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A schema given as a string is published into the schema cache through a temporary file. A
+# temporary file already sitting at that path belongs to another query storing the same schema, so
+# storing must neither fail because of it nor delete it.
+
+WORKDIR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR"
+
+SCHEMA='@0x844f048b15c12dab;\nstruct M { data @0 :List(List(Int32)); }'
+QUERY="DESC format(CapnProto, '')
+SETTINGS
+    format_schema_source = 'string',
+    format_schema = '${SCHEMA}',
+    format_schema_message_name = 'M'"
+
+# The cache directory of clickhouse-local is relative to the working directory.
+(cd "$WORKDIR" && ${CLICKHOUSE_LOCAL} --logger.console=0 --query "$QUERY" > /dev/null)
+
+CACHED=$(basename "$(ls "$WORKDIR"/__cache__/*.capnp)")
+
+if [ -z "$CACHED" ]; then
+    echo "FAIL: the first query stored no schema file to learn the name from"
+fi
+
+# Drop the published schema and leave a temporary file of it behind, so the next query has to store
+# the schema again while that temporary path is taken.
+rm -f "$WORKDIR"/__cache__/*.capnp
+echo 'leftover' > "$WORKDIR/__cache__/$CACHED.tmp"
+
+(cd "$WORKDIR" && ${CLICKHOUSE_LOCAL} --logger.console=0 --query "$QUERY")
+
+if [ -f "$WORKDIR/__cache__/$CACHED.tmp" ]; then
+    echo 'leftover file kept'
+else
+    echo 'leftover file removed'
+fi
+
+rm -rf "$WORKDIR"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113177
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/113177

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a valid format schema being rejected with `CANNOT_OPEN_FILE` or `ATOMIC_RENAME_FAIL` when two queries store the same `format_schema_source = 'string'` or `'query'` schema concurrently. The schema cache staged every writer's copy under one source-derived temporary file name, so concurrent writers of the same schema collided and deleted each other's in-flight files.

### Description

`FormatSchemaInfo::storeSchemaOnDisk` publishes a string- or query-sourced schema into `<format_schema_path>/__cache__/` through a temporary file, naming it `<final path>.tmp`. The final path is a hash of the schema source, so every concurrent writer of one schema used the same temporary path. The second writer's `O_EXCL` open fails with `EEXIST`; the `catch` block's unconditional `fs::remove` then deletes another writer's in-flight file, whose own `renameNoReplace` fails with `ENOENT`. The cache file does not exist yet, so the exception is rethrown and a valid schema is rejected for whichever writer loses.

This is reachable on an ordinary server, not just `clickhouse-local`: `format_schema_path` defaults to `/var/lib/clickhouse/format_schemas/`, its cache directory is shared by every session, and nothing on the path to `storeSchemaOnDisk` serialises it. Two concurrent queries on the same uncached schema are enough.

The change gives the temporary file a per-writer name. `O_EXCL` is kept: with a unique name it is an assertion rather than a coordination mechanism. Nothing depends on the temporary name and published files are unchanged, so a lone caller behaves identically.

Measured with 15 rounds of 6 concurrent clients on one fresh schema, 90 runs per arm: before, 36 failed (29 `CANNOT_OPEN_FILE`, 7 `ATOMIC_RENAME_FAIL`); after, none. The new test seeds the leftover temporary file a concurrent writer presents to its peer, and fails 50 of 50 runs before the change.

A crash between create and rename now leaks an inert file rather than one that breaks the next query for that schema, and `SYSTEM DROP FORMAT SCHEMA CACHE` reclaims it. Two residuals are left alone: `checkCapnProtoSchemaNestingDepth` still reads an unreadable cache file as depth zero, harmless once a published file is either absent or whole; and that statement still deletes in-flight temporary files of any name, so it can still fail a store racing it, as clearing a cache mid-fill inherently can.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116502&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116502](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116502+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.572` (included in `26.9` and later)
<!-- ch-version-info:end -->