### PR TITLE
Do not report a thread's pre-attach untracked memory as the query's

### DIFF
--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -2,8 +2,10 @@
 
 #include <gtest/gtest.h>
 
+#include <base/scope_guard.h>
 #include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
+#include <Common/PerCPUMemory.h>
 #include <Common/ProfileEvents.h>
 #include <Common/ThreadGroupSwitcher.h>
 #include <Common/ThreadStatus.h>
@@ -149,6 +151,13 @@ TEST(ThreadGroupAttach, PreAttachUntrackedMemoryIsNotChargedToTheGroup)
     {
         ThreadStatus ts;
         auto group = std::make_shared<ThreadGroup>(getContext().context, 0);
+
+        /// Any allocation between the seeding below and `setParent` can commit the balance through
+        /// the shared per-CPU budget, whose occupancy other threads control. Lifting the budget
+        /// leaves the per-thread cap asserted below as the only trigger that can commit it.
+        const Int64 saved_budget = per_cpu_memory.budgetCapacity();
+        per_cpu_memory.setBudgetCapacity(PerCPUMemory::UNLIMITED_BUDGET);
+        SCOPE_EXIT({ per_cpu_memory.setBudgetCapacity(saved_budget); });
 
         const auto group_events_before = group->performance_counters[ProfileEvents::MemoryAllocatedWithoutCheck];
         const auto group_bytes_before = group->performance_counters[ProfileEvents::MemoryAllocatedWithoutCheckBytes];

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -140,8 +140,7 @@ TEST(ThreadGroupSwitcher, RestoresBorrowedThreadName)
 /// Reparenting a thread's `MemoryTracker` flushes the untracked balance the thread carried in, and that
 /// flush increments `MemoryAllocatedWithoutCheck` and `MemoryAllocatedWithoutCheckBytes` on whatever
 /// `ProfileEvents::Counters` chain is in force. Those bytes predate the group, so they must not appear on
-/// the group's counters -- `system.query_log` reports the group's counters as the query's. The invariant is
-/// stated on `MemoryTracker::setParent`, and `detachFromGroup` observes it on the way out.
+/// the group's counters: `system.query_log` reports the group's counters as the query's.
 TEST(ThreadGroupAttach, PreAttachUntrackedMemoryIsNotChargedToTheGroup)
 {
     /// A dedicated thread so `current_thread` starts as nullptr and the balance below is this thread's

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -168,6 +168,15 @@ TEST(ThreadGroupAttach, PreAttachUntrackedMemoryIsNotChargedToTheGroup)
         constexpr Int64 pre_attach_bytes = 1024 * 1024;
         ts.untracked_memory.add(pre_attach_bytes);
 
+        /// `~ThreadStatus` flushes whatever balance is left into `total_memory_tracker`, so the seed must
+        /// be netted out on the early return of a failed assertion below too. One unconditional subtraction
+        /// covers both paths (the balance is a running total), and it belongs after the tracker is reparented.
+        SCOPE_EXIT({
+            CurrentThread::detachFromGroupIfNotDetached();
+            ts.untracked_memory.add(-pre_attach_bytes);
+            ts.flushUntrackedMemory();
+        });
+
         /// The balance is still pending: any commit would have zeroed it.
         ASSERT_GE(ts.untracked_memory.load(), pre_attach_bytes);
         ASSERT_LT(ts.untracked_memory.load(), ts.untracked_memory_limit);
@@ -182,13 +191,6 @@ TEST(ThreadGroupAttach, PreAttachUntrackedMemoryIsNotChargedToTheGroup)
         EXPECT_GE(
             ProfileEvents::global_counters[ProfileEvents::MemoryAllocatedWithoutCheckBytes] - global_bytes_before,
             static_cast<UInt64>(pre_attach_bytes));
-
-        CurrentThread::detachFromGroupIfNotDetached();
-
-        /// Nothing was really allocated, so give the seeded bytes back now that the tracker is parented
-        /// to `total_memory_tracker` again, or the rest of this binary sees them as global usage.
-        ts.untracked_memory.add(-pre_attach_bytes);
-        ts.flushUntrackedMemory();
     });
     t.join();
 }

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -4,11 +4,18 @@
 
 #include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
+#include <Common/ProfileEvents.h>
 #include <Common/ThreadGroupSwitcher.h>
 #include <Common/ThreadStatus.h>
 #include <Common/setThreadName.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Interpreters/Context.h>
+
+namespace ProfileEvents
+{
+    extern const Event MemoryAllocatedWithoutCheck;
+    extern const Event MemoryAllocatedWithoutCheckBytes;
+}
 
 namespace DB
 {
@@ -126,6 +133,54 @@ TEST(ThreadGroupSwitcher, RestoresBorrowedThreadName)
                 << "borrowed thread's name must be restored, not left as the async-pool name";
             CurrentThread::detachFromGroupIfNotDetached();
         }
+    });
+    t.join();
+}
+
+/// Reparenting a thread's `MemoryTracker` flushes the untracked balance the thread carried in, and that
+/// flush increments `MemoryAllocatedWithoutCheck` and `MemoryAllocatedWithoutCheckBytes` on whatever
+/// `ProfileEvents::Counters` chain is in force. Those bytes predate the group, so they must not appear on
+/// the group's counters -- `system.query_log` reports the group's counters as the query's. The invariant is
+/// stated on `MemoryTracker::setParent`, and `detachFromGroup` observes it on the way out.
+TEST(ThreadGroupAttach, PreAttachUntrackedMemoryIsNotChargedToTheGroup)
+{
+    /// A dedicated thread so `current_thread` starts as nullptr and the balance below is this thread's
+    /// alone, independent of whatever other gtests in unit_tests_dbms left behind.
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto group = std::make_shared<ThreadGroup>(getContext().context, 0);
+
+        const auto group_events_before = group->performance_counters[ProfileEvents::MemoryAllocatedWithoutCheck];
+        const auto group_bytes_before = group->performance_counters[ProfileEvents::MemoryAllocatedWithoutCheckBytes];
+        const auto global_bytes_before = ProfileEvents::global_counters[ProfileEvents::MemoryAllocatedWithoutCheckBytes];
+
+        /// Written straight into the counter instead of allocated: a real allocation of this size can
+        /// be committed early by the shared per-CPU budget, which no setting of ours controls.
+        constexpr Int64 pre_attach_bytes = 1024 * 1024;
+        ts.untracked_memory.add(pre_attach_bytes);
+
+        /// The balance is still pending: any commit would have zeroed it.
+        ASSERT_GE(ts.untracked_memory.load(), pre_attach_bytes);
+        ASSERT_LT(ts.untracked_memory.load(), ts.untracked_memory_limit);
+
+        CurrentThread::attachToGroup(group);
+
+        EXPECT_EQ(group->performance_counters[ProfileEvents::MemoryAllocatedWithoutCheckBytes], group_bytes_before)
+            << "untracked memory carried into the group must not be reported as the group's";
+        EXPECT_EQ(group->performance_counters[ProfileEvents::MemoryAllocatedWithoutCheck], group_events_before)
+            << "the flush event itself must not be reported as the group's either";
+        /// Attribution, not suppression: the flush is still counted, outside the group.
+        EXPECT_GE(
+            ProfileEvents::global_counters[ProfileEvents::MemoryAllocatedWithoutCheckBytes] - global_bytes_before,
+            static_cast<UInt64>(pre_attach_bytes));
+
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        /// Nothing was really allocated, so give the seeded bytes back now that the tracker is parented
+        /// to `total_memory_tracker` again, or the rest of this binary sees them as global usage.
+        ts.untracked_memory.add(-pre_attach_bytes);
+        ts.flushUntrackedMemory();
     });
     t.join();
 }

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -384,8 +384,10 @@ void ThreadStatus::attachToGroupImpl(const ThreadGroupPtr & thread_group_)
     thread_group = thread_group_;
     try
     {
-        performance_counters.setParent(&thread_group->performance_counters);
+        /// Reparenting the memory tracker flushes the untracked balance the thread carried in, so the
+        /// counters must be reparented after it, or those bytes are reported as this group's.
         memory_tracker.setParent(&thread_group->memory_tracker);
+        performance_counters.setParent(&thread_group->performance_counters);
 
         query_context = thread_group->query_context;
         global_context = thread_group->global_context;

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -5,8 +5,9 @@
 # columns by enumerating every dot split of the name and formatting a lookup key per split. The
 # name embeds the text of a folded constant, so a large dotted constant made index analysis
 # quadratic in the constant's length.
-# Each arm compares a dotted constant against a no-dots constant of the same length, measured in
-# allocated bytes rather than wall clock.
+# Each arm compares a dotted constant against a no-dots constant of the same length. The oracle is
+# the allocated-bytes counter rather than wall clock: it is exactly reproducible, whereas the
+# ~2.6s planning delta is smaller than debug-build client startup jitter.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -15,11 +16,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 set -e
 
 REPEATS=100000
+# Measured on a debug build: pre-fix the dotted arm allocates 2.8x-3.0x the control in every arm,
+# post-fix 1.0003x. 1.5 sits an order of magnitude away from the fixed behavior and ~1.9x below
+# the regression, so it discriminates with margin on both sides.
 MAX_RATIO_PERCENT=150
-# The reading is quantised by `min(max_untracked_memory, memory_profiler_step)`, so both are pinned
-# below: the stateless profile sets `1Mi` while the source default is `4Mi`, and a ratio calibrated
-# without pinning them is calibrated for whichever server happens to run it.
-UNTRACKED_MEMORY_QUANTUM=1048576
 
 LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))
 
@@ -68,8 +68,7 @@ alloc_bytes_for() {
     local query_id_prefix="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
     local run
     for run in $(seq 1 $ALLOC_RUNS); do
-        $CLICKHOUSE_CLIENT --query_id "${query_id_prefix}-${run}" --max_query_size 1048576 --max_execution_time 300 \
-            --max_untracked_memory "$UNTRACKED_MEMORY_QUANTUM" --memory_profiler_step "$UNTRACKED_MEMORY_QUANTUM" -q "
+        $CLICKHOUSE_CLIENT --query_id "${query_id_prefix}-${run}" --max_query_size 1048576 --max_execution_time 300 -q "
             SELECT count() FROM (
                 EXPLAIN indexes = 1
                 SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -5,9 +5,8 @@
 # columns by enumerating every dot split of the name and formatting a lookup key per split. The
 # name embeds the text of a folded constant, so a large dotted constant made index analysis
 # quadratic in the constant's length.
-# Each arm compares a dotted constant against a no-dots constant of the same length. The oracle is
-# the allocated-bytes counter rather than wall clock: it is exactly reproducible, whereas the
-# ~2.6s planning delta is smaller than debug-build client startup jitter.
+# Each arm compares a dotted constant against a no-dots constant of the same length, measured in
+# allocated bytes rather than wall clock.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -16,10 +15,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 set -e
 
 REPEATS=100000
-# Measured on a debug build: pre-fix the dotted arm allocates 2.8x-3.0x the control in every arm,
-# post-fix 1.0003x. 1.5 sits an order of magnitude away from the fixed behavior and ~1.9x below
-# the regression, so it discriminates with margin on both sides.
 MAX_RATIO_PERCENT=150
+# The reading is quantised by `min(max_untracked_memory, memory_profiler_step)` and scales with it,
+# so both are pinned below: the stateless profile sets `1Mi` while the source default is `4Mi`, and a
+# ratio calibrated without pinning them is calibrated for whichever server happens to run it.
+UNTRACKED_MEMORY_QUANTUM=1048576
 
 LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))
 
@@ -68,7 +68,8 @@ alloc_bytes_for() {
     local query_id_prefix="04780-${CLICKHOUSE_DATABASE}-${table}-${unit}-${RANDOM}"
     local run
     for run in $(seq 1 $ALLOC_RUNS); do
-        $CLICKHOUSE_CLIENT --query_id "${query_id_prefix}-${run}" --max_query_size 1048576 --max_execution_time 300 -q "
+        $CLICKHOUSE_CLIENT --query_id "${query_id_prefix}-${run}" --max_query_size 1048576 --max_execution_time 300 \
+            --max_untracked_memory "$UNTRACKED_MEMORY_QUANTUM" --memory_profiler_step "$UNTRACKED_MEMORY_QUANTUM" -q "
             SELECT count() FROM (
                 EXPLAIN indexes = 1
                 SELECT count() FROM ${table} WHERE position(repeat('${unit}', ${REPEATS}), s) = 1

--- a/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
+++ b/tests/queries/0_stateless/04780_json_subcolumn_index_match_not_quadratic.sh
@@ -16,9 +16,9 @@ set -e
 
 REPEATS=100000
 MAX_RATIO_PERCENT=150
-# The reading is quantised by `min(max_untracked_memory, memory_profiler_step)` and scales with it,
-# so both are pinned below: the stateless profile sets `1Mi` while the source default is `4Mi`, and a
-# ratio calibrated without pinning them is calibrated for whichever server happens to run it.
+# The reading is quantised by `min(max_untracked_memory, memory_profiler_step)`, so both are pinned
+# below: the stateless profile sets `1Mi` while the source default is `4Mi`, and a ratio calibrated
+# without pinning them is calibrated for whichever server happens to run it.
 UNTRACKED_MEMORY_QUANTUM=1048576
 
 LONG_SUFFIX=$(printf 'a%.0s' $(seq 1 170))


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/113003
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the per-query `MemoryAllocatedWithoutCheck` and `MemoryAllocatedWithoutCheckBytes` values in `system.query_log`. A thread's untracked memory balance is flushed when the thread is attached to a query, and that flush was reported as the query's, so memory allocated before the query existed was charged to it.

### Description

Related: #113003
Requested in https://github.com/ClickHouse/ClickHouse/pull/112705#issuecomment-5276141544

`ThreadStatus::attachToGroupImpl` reparented the thread's `ProfileEvents` counters before its `MemoryTracker`. `MemoryTracker::setParent` flushes the thread's untracked balance before installing the new parent, that flush increments the two events above, and `Counters::increment` propagates at increment time, so bytes allocated before the query existed (connection setup, query text) landed on the query's thread group, which `system.query_log` reports. The accounting deliberately excludes them: `setParent`'s comment states the invariant, and `detachFromGroup` flushes above both reparenting calls. The `ProfileEvent` did not.

The fix reorders the two adjacent calls. Accounting is bit-identical either way: the flush precedes `parent.store` in both orderings, so only the ProfileEvents destination changes.

`3069db71f1cc` introduced the invariant; its test was later deleted, so nothing guarded it. The gtest lives in an existing module: it fails on master, charging 2201952 bytes to the group, and passes with the change, bytes still visible globally. It is a gtest, not SQL: a shared per-CPU budget any thread can trip also commits the balance, so a SQL probe would silently stop testing.

`04780_json_subcolumn_index_match_not_quadratic` divides two readings of these events, so it is the visible consumer of the misattribution (39-42 KB per reading on debug, 320-336 bytes under AddressSanitizer). I am not claiming this fixes its flakiness; that signature never reproduced locally over 200 measured arm rows, and the test is left unchanged: `tests/config/users.d/memory_profiler.xml` already pins `max_untracked_memory` and `memory_profiler_step` to `1Mi` for every stateless job, and changing any file under `tests/queries/0_stateless` would make `new_tests_check.py` require a per-arch Bugfix Validation pass that `04780` cannot give, since it passes on the merge-base binary. `Bugfix validation (unit tests)` reports the bug reproduced on the gtest.

Deliberately unchanged: `MemoryTrackerSwitcher` has the same asymmetry, with its own documented reasoning and no observed defect.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116505&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116505](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116505+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.256` (included in `26.10` and later)
<!-- ch-version-info:end -->