### PR TITLE
Let the memcg OOM killer reach ClickHouse instances in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4879,6 +4879,8 @@ services:
         # will be done it will exit.
         stop_grace_period: 10m
         tmpfs: {tmpfs}
+        # The harness runs at 1000, so at the default 0 a memcg OOM reaps it, not the server.
+        oom_score_adj: 1000
         {mem_limit}
         {cpu_limit}
         {pids_limit}


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115785

`ci/praktika/runner.py` starts every job container with `--oom-score-adj=1000`, which the harness inherits: `dockerd`, `containerd-shim`, `pytest` and the xdist workers all run at 1000. Containers started by the inner `dockerd` get the containerd default of 0, so ClickHouse instances are protected from the killer relative to the harness supervising them - `oom_score_adj` adds `adj * total_pages / 1000` to the badness score, so a task at 1000 always outranks a task at 0 however little it holds.

In the report below, the last of eight memcg kills dumps 33 `clickhouse` processes holding 57.87 GiB of a 59.77 GiB limit, while every victim the killer picked was a harness process of 0.07-0.13 GiB. Usage never dropped: `total_cache` stayed at 22.7 MB with no swap, the cgroup sat at its limit for 42 minutes with `failcnt` climbing ~13750/s, and the job produced no test results before dying on its timeout with exit code 137.

Matching the instances to the harness restores usage-proportional selection inside the cgroup: the killer takes a multi-GB server, usage falls below the limit, and the run reports a real failure instead of stalling. The outer 1000 is unchanged, so the job container keeps its preference over the runner agent during a host-wide OOM.

Verified that `docker compose` applies the key - a container declaring `oom_score_adj: 1000` reads 1000 from `/proc/self/oom_score_adj`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115277&sha=8a253f5b442c2503d40d0606fc79197de555a851&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20flaky%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116514&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116514](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116514+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
