### PR TITLE
Compile microbenchmark sources in unit-test builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ include (cmake/block_build_time_checks.cmake)
 
 option(ENABLE_TESTS "Provide unit_tests_dbms target with Google.Test unit tests" ON)
 option(ENABLE_EXAMPLES "Build all example programs in 'examples' subdirectories" OFF)
-option(ENABLE_BENCHMARKS "Link all microbenchmark executables in the default build; their sources are always compiled" OFF)
+option(ENABLE_BENCHMARKS "Build all benchmark programs in 'benchmarks' subdirectories" OFF)
 
 if (OS_LINUX AND (ARCH_AMD64 OR ARCH_AARCH64) AND NOT USE_MUSL)
     # Only for Linux, x86_64 or aarch64.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ include (cmake/block_build_time_checks.cmake)
 
 option(ENABLE_TESTS "Provide unit_tests_dbms target with Google.Test unit tests" ON)
 option(ENABLE_EXAMPLES "Build all example programs in 'examples' subdirectories" OFF)
-option(ENABLE_BENCHMARKS "Build all benchmark programs in 'benchmarks' subdirectories" OFF)
+option(ENABLE_BENCHMARKS "Link all microbenchmark executables in the default build; their sources are always compiled" OFF)
 
 if (OS_LINUX AND (ARCH_AMD64 OR ARCH_AARCH64) AND NOT USE_MUSL)
     # Only for Linux, x86_64 or aarch64.

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -243,7 +243,9 @@ add_contrib (xxHash-cmake xxHash)
 
 add_contrib (libbcrypt-cmake libbcrypt)
 
-add_contrib (google-benchmark-cmake google-benchmark)
+if (ENABLE_TESTS OR ENABLE_BENCHMARKS)
+    add_contrib (google-benchmark-cmake google-benchmark)
+endif ()
 add_contrib (ulid-c-cmake ulid-c)
 
 add_contrib (libssh-cmake libssh)

--- a/contrib/google-benchmark-cmake/CMakeLists.txt
+++ b/contrib/google-benchmark-cmake/CMakeLists.txt
@@ -22,8 +22,11 @@ set (SRCS
   "${SRC_DIR}/sysinfo.cc"
   "${SRC_DIR}/timers.cc")
 
+add_library(google_benchmark_headers INTERFACE)
+target_include_directories(google_benchmark_headers SYSTEM INTERFACE "${SRC_DIR}/../include")
+
 add_library(google_benchmark "${SRCS}")
-target_include_directories(google_benchmark SYSTEM PUBLIC "${SRC_DIR}/../include")
+target_link_libraries(google_benchmark PUBLIC google_benchmark_headers)
 
 add_library(google_benchmark_main "${SRC_DIR}/benchmark_main.cc")
 target_link_libraries(google_benchmark_main PUBLIC google_benchmark)
@@ -31,4 +34,5 @@ target_link_libraries(google_benchmark_main PUBLIC google_benchmark)
 add_library(google_benchmark_all INTERFACE)
 target_link_libraries(google_benchmark_all INTERFACE google_benchmark google_benchmark_main)
 
+add_library(ch_contrib::gbenchmark_headers ALIAS google_benchmark_headers)
 add_library(ch_contrib::gbenchmark_all ALIAS google_benchmark_all)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,39 +40,42 @@ endif()
 set(dbms_headers)
 set(dbms_sources)
 
-# Compile microbenchmark translation units in every build, but keep their comparatively expensive
-# executable links out of the default build unless ENABLE_BENCHMARKS is set. Individual executables
-# and the clickhouse-microbenchmarks aggregate target can still be built explicitly.
-add_custom_target (clickhouse-microbenchmarks-objects)
+# Unit-test builds compile microbenchmark translation units to catch source regressions without
+# linking the comparatively expensive benchmark executables. ENABLE_BENCHMARKS additionally builds
+# those executables as part of the default build.
+if (ENABLE_TESTS OR ENABLE_BENCHMARKS)
+    add_custom_target (clickhouse-microbenchmarks-objects ALL)
 
-if (ENABLE_BENCHMARKS)
-    add_custom_target (clickhouse-microbenchmarks ALL)
-else ()
-    add_custom_target (clickhouse-microbenchmarks)
-endif ()
-
-function (clickhouse_add_microbenchmark target)
-    cmake_parse_arguments (MICROBENCHMARK "" "" "SOURCES;LIBRARIES" ${ARGN})
-    if (NOT MICROBENCHMARK_SOURCES OR MICROBENCHMARK_UNPARSED_ARGUMENTS)
-        message (FATAL_ERROR "clickhouse_add_microbenchmark requires SOURCES and accepts optional LIBRARIES")
+    if (ENABLE_BENCHMARKS)
+        add_custom_target (clickhouse-microbenchmarks ALL)
     endif ()
 
-    set (object_target "${target}_objects")
-    add_library (${object_target} OBJECT ${MICROBENCHMARK_SOURCES})
-    target_link_libraries (${object_target} PRIVATE
-        ch_contrib::gbenchmark_all
-        ${MICROBENCHMARK_LIBRARIES})
-    add_dependencies (clickhouse-microbenchmarks-objects ${object_target})
+    function (clickhouse_add_microbenchmark target)
+        cmake_parse_arguments (MICROBENCHMARK "" "" "SOURCES;LIBRARIES" ${ARGN})
+        if (NOT MICROBENCHMARK_SOURCES OR MICROBENCHMARK_UNPARSED_ARGUMENTS)
+            message (FATAL_ERROR "clickhouse_add_microbenchmark requires SOURCES and accepts optional LIBRARIES")
+        endif ()
 
-    clickhouse_add_executable (${target} EXCLUDE_FROM_ALL $<TARGET_OBJECTS:${object_target}>)
-    target_link_libraries (${target} PRIVATE
-        ch_contrib::gbenchmark_all
-        ${MICROBENCHMARK_LIBRARIES})
-    # Retaining debug sections from ClickHouse dependencies can make each executable several GiB.
-    # Strip only the final executable; benchmark code generation still follows the configured build type.
-    target_link_options (${target} PRIVATE "LINKER:-S")
-    add_dependencies (clickhouse-microbenchmarks ${target})
-endfunction ()
+        set (object_target "${target}_objects")
+        add_library (${object_target} OBJECT ${MICROBENCHMARK_SOURCES})
+        set_property (TARGET ${object_target} PROPERTY EXCLUDE_FROM_ALL TRUE)
+        target_link_libraries (${object_target} PRIVATE
+            ch_contrib::gbenchmark_headers
+            ${MICROBENCHMARK_LIBRARIES})
+        add_dependencies (clickhouse-microbenchmarks-objects ${object_target})
+
+        if (ENABLE_BENCHMARKS)
+            clickhouse_add_executable (${target} EXCLUDE_FROM_ALL $<TARGET_OBJECTS:${object_target}>)
+            target_link_libraries (${target} PRIVATE
+                ch_contrib::gbenchmark_all
+                ${MICROBENCHMARK_LIBRARIES})
+            # Retaining debug sections from ClickHouse dependencies can make each executable several GiB.
+            # Strip only the final executable; benchmark code generation still follows the configured build type.
+            target_link_options (${target} PRIVATE "LINKER:-S")
+            add_dependencies (clickhouse-microbenchmarks ${target})
+        endif ()
+    endfunction ()
+endif ()
 
 add_subdirectory (Access)
 add_subdirectory (Backups)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ set(dbms_sources)
 # Compile microbenchmark translation units in every build, but keep their comparatively expensive
 # executable links out of the default build unless ENABLE_BENCHMARKS is set. Individual executables
 # and the clickhouse-microbenchmarks aggregate target can still be built explicitly.
+add_custom_target (clickhouse-microbenchmarks-objects)
+
 if (ENABLE_BENCHMARKS)
     add_custom_target (clickhouse-microbenchmarks ALL)
 else ()
@@ -60,6 +62,7 @@ function (clickhouse_add_microbenchmark target)
     target_link_libraries (${object_target} PRIVATE
         ch_contrib::gbenchmark_all
         ${MICROBENCHMARK_LIBRARIES})
+    add_dependencies (clickhouse-microbenchmarks-objects ${object_target})
 
     clickhouse_add_executable (${target} EXCLUDE_FROM_ALL $<TARGET_OBJECTS:${object_target}>)
     target_link_libraries (${target} PRIVATE
@@ -977,6 +980,7 @@ if (ENABLE_TESTS)
     # attach all dbms gtest sources
     grep_gtest_sources("${ClickHouse_SOURCE_DIR}/src" dbms_gtest_sources)
     clickhouse_add_executable(unit_tests_dbms ${dbms_gtest_sources})
+    add_dependencies (unit_tests_dbms clickhouse-microbenchmarks-objects)
 
     # gtest framework has substandard code
     target_compile_options(unit_tests_dbms PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,37 @@ endif()
 set(dbms_headers)
 set(dbms_sources)
 
+# Compile microbenchmark translation units in every build, but keep their comparatively expensive
+# executable links out of the default build unless ENABLE_BENCHMARKS is set. Individual executables
+# and the clickhouse-microbenchmarks aggregate target can still be built explicitly.
+if (ENABLE_BENCHMARKS)
+    add_custom_target (clickhouse-microbenchmarks ALL)
+else ()
+    add_custom_target (clickhouse-microbenchmarks)
+endif ()
+
+function (clickhouse_add_microbenchmark target)
+    cmake_parse_arguments (MICROBENCHMARK "" "" "SOURCES;LIBRARIES" ${ARGN})
+    if (NOT MICROBENCHMARK_SOURCES OR MICROBENCHMARK_UNPARSED_ARGUMENTS)
+        message (FATAL_ERROR "clickhouse_add_microbenchmark requires SOURCES and accepts optional LIBRARIES")
+    endif ()
+
+    set (object_target "${target}_objects")
+    add_library (${object_target} OBJECT ${MICROBENCHMARK_SOURCES})
+    target_link_libraries (${object_target} PRIVATE
+        ch_contrib::gbenchmark_all
+        ${MICROBENCHMARK_LIBRARIES})
+
+    clickhouse_add_executable (${target} EXCLUDE_FROM_ALL $<TARGET_OBJECTS:${object_target}>)
+    target_link_libraries (${target} PRIVATE
+        ch_contrib::gbenchmark_all
+        ${MICROBENCHMARK_LIBRARIES})
+    # Retaining debug sections from ClickHouse dependencies can make each executable several GiB.
+    # Strip only the final executable; benchmark code generation still follows the configured build type.
+    target_link_options (${target} PRIVATE "LINKER:-S")
+    add_dependencies (clickhouse-microbenchmarks ${target})
+endfunction ()
+
 add_subdirectory (Access)
 add_subdirectory (Backups)
 add_subdirectory (Columns)

--- a/src/Columns/CMakeLists.txt
+++ b/src/Columns/CMakeLists.txt
@@ -2,4 +2,6 @@ if (ENABLE_EXAMPLES)
     add_subdirectory (examples)
 endif ()
 
-add_subdirectory(benchmarks)
+if (ENABLE_TESTS OR ENABLE_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif ()

--- a/src/Columns/CMakeLists.txt
+++ b/src/Columns/CMakeLists.txt
@@ -2,6 +2,4 @@ if (ENABLE_EXAMPLES)
     add_subdirectory (examples)
 endif ()
 
-if (ENABLE_BENCHMARKS)
-    add_subdirectory(benchmarks)
-endif()
+add_subdirectory(benchmarks)

--- a/src/Columns/benchmarks/CMakeLists.txt
+++ b/src/Columns/benchmarks/CMakeLists.txt
@@ -1,9 +1,7 @@
-clickhouse_add_executable(column_insert_many_from benchmark_column_insert_many_from.cpp)
-target_link_libraries (column_insert_many_from PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
+clickhouse_add_microbenchmark(column_insert_many_from
+    SOURCES benchmark_column_insert_many_from.cpp
+    LIBRARIES dbms)
 
-clickhouse_add_executable(benchmark_compute_hash_into benchmark_compute_hash_into.cpp)
-target_link_libraries (benchmark_compute_hash_into PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
+clickhouse_add_microbenchmark(benchmark_compute_hash_into
+    SOURCES benchmark_compute_hash_into.cpp
+    LIBRARIES dbms)

--- a/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
+++ b/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
@@ -65,7 +65,7 @@ static void BM_insertManyFrom(benchmark::State & state)
     auto type = DataTypeFactory::instance().get(str_type);
     auto src = mockColumn(type, ROWS);
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         state.PauseTiming();
         auto dst = type->createColumn();

--- a/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
+++ b/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <random>
 #include <Columns/IColumn.h>
 #include <Core/Block.h>
 #include <DataTypes/DataTypeArray.h>
@@ -20,8 +21,14 @@ static ColumnPtr mockColumn(const DataTypePtr & type, size_t rows)
         auto data_col = mockColumn(type_array->getNestedType(), rows);
         auto offset_col = ColumnArray::ColumnOffsets::create(rows);
         auto & offsets = offset_col->getData();
-        for (size_t i = 0; i < data_col->size(); ++i)
-            offsets[i] = offsets[i - 1] + (rand() % 10);
+        std::mt19937_64 random_engine(std::random_device{}());
+        std::uniform_int_distribution<size_t> random_length(0, 9);
+        size_t offset = 0;
+        for (auto & current_offset : offsets)
+        {
+            offset += random_length(random_engine);
+            current_offset = offset;
+        }
         auto new_data_col = data_col->replicate(offsets);
 
         return ColumnArray::create(new_data_col, std::move(offset_col));

--- a/src/Columns/benchmarks/benchmark_compute_hash_into.cpp
+++ b/src/Columns/benchmarks/benchmark_compute_hash_into.cpp
@@ -17,7 +17,6 @@
 #include <Common/HashTable/Hash.h>
 #include <Common/MapToRange.h>
 #include <Common/PODArray.h>
-#include <Common/randomSeed.h>
 
 #include <benchmark/benchmark.h>
 
@@ -31,11 +30,13 @@ using namespace DB;
 namespace
 {
 
+constexpr UInt32 rng_seed = 42;
+
 /// ─── Data generators ──────────────────────────────────────────────────────
 
 std::vector<ColumnPtr> makeUInt32Columns(size_t K, size_t n)
 {
-    std::mt19937 rng(randomSeed());
+    std::mt19937 rng(rng_seed); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic benchmark data
     std::vector<ColumnPtr> cols;
     for (size_t k = 0; k < K; ++k)
     {
@@ -49,7 +50,7 @@ std::vector<ColumnPtr> makeUInt32Columns(size_t K, size_t n)
 
 std::vector<ColumnPtr> makeUInt64Columns(size_t K, size_t n)
 {
-    std::mt19937_64 rng(randomSeed());
+    std::mt19937_64 rng(rng_seed); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic benchmark data
     std::vector<ColumnPtr> cols;
     for (size_t k = 0; k < K; ++k)
     {
@@ -63,7 +64,7 @@ std::vector<ColumnPtr> makeUInt64Columns(size_t K, size_t n)
 
 std::vector<ColumnPtr> makeStringColumns(size_t K, size_t n, size_t avg_len = 16)
 {
-    std::mt19937 rng(randomSeed());
+    std::mt19937 rng(rng_seed); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic benchmark data
     std::uniform_int_distribution<size_t> len_dist(4, 2 * avg_len);
     std::vector<ColumnPtr> cols;
     for (size_t k = 0; k < K; ++k)
@@ -82,7 +83,7 @@ std::vector<ColumnPtr> makeStringColumns(size_t K, size_t n, size_t avg_len = 16
 
 std::vector<ColumnPtr> makeNullableUInt32Columns(size_t K, size_t n)
 {
-    std::mt19937 rng(randomSeed());
+    std::mt19937 rng(rng_seed); // NOLINT(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic benchmark data
     std::vector<ColumnPtr> cols;
     for (size_t k = 0; k < K; ++k)
     {

--- a/src/Columns/benchmarks/benchmark_compute_hash_into.cpp
+++ b/src/Columns/benchmarks/benchmark_compute_hash_into.cpp
@@ -106,7 +106,7 @@ void BM_ComputeHashInto(benchmark::State & state, const std::vector<ColumnPtr> &
     const size_t ncols = cols.size();
     PaddedPODArray<UInt32> hash_buf(n);
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         bool initial = true;
         for (size_t k = 0; k < ncols; ++k)
@@ -141,7 +141,7 @@ void BM_HashAndFastrange_New(benchmark::State & state, const std::vector<ColumnP
     PaddedPODArray<UInt32> hash_buf(n);
     PaddedPODArray<UInt64> pids(n); // mapToRange writes a UInt64 selector
     const UInt32 p32 = static_cast<UInt32>(num_shards);
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         std::fill(hash_buf.begin(), hash_buf.end(), WEAK_HASH32_INITIAL_VALUE);
         for (size_t k = 0; k < ncols; ++k)

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(benchmarks)
+if (ENABLE_TESTS OR ENABLE_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif ()
 
 if (ENABLE_EXAMPLES)
     add_subdirectory(examples)

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -1,6 +1,4 @@
-if (ENABLE_BENCHMARKS)
-    add_subdirectory(benchmarks)
-endif()
+add_subdirectory(benchmarks)
 
 if (ENABLE_EXAMPLES)
     add_subdirectory(examples)

--- a/src/Common/benchmarks/CMakeLists.txt
+++ b/src/Common/benchmarks/CMakeLists.txt
@@ -1,34 +1,27 @@
-clickhouse_add_executable(integer_hash_tables_and_hashes integer_hash_tables_and_hashes.cpp orc_string_dictionary.cpp)
-target_link_libraries (integer_hash_tables_and_hashes PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms
-    ch_contrib::abseil_swiss_tables
-    ch_contrib::sparsehash
-    ch_contrib::wyhash
-    ch_contrib::farmhash
-    ch_contrib::xxHash)
+clickhouse_add_microbenchmark(integer_hash_tables_and_hashes
+    SOURCES integer_hash_tables_and_hashes.cpp
+    LIBRARIES
+        clickhouse_common_io
+        ch_contrib::wyhash
+        ch_contrib::farmhash
+        ch_contrib::xxHash)
 
-clickhouse_add_executable(orc_string_dictionary orc_string_dictionary.cpp)
-target_link_libraries (orc_string_dictionary PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
+clickhouse_add_microbenchmark(orc_string_dictionary
+    SOURCES orc_string_dictionary.cpp
+    LIBRARIES common)
 
-clickhouse_add_executable(benchmark_radix_sort radix_sort.cpp)
-target_link_libraries (benchmark_radix_sort PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
+clickhouse_add_microbenchmark(benchmark_radix_sort
+    SOURCES radix_sort.cpp
+    LIBRARIES dbms)
 
-clickhouse_add_executable(wrap_in_nullable wrap_in_nullable.cpp)
-target_link_libraries (wrap_in_nullable PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
+clickhouse_add_microbenchmark(wrap_in_nullable
+    SOURCES wrap_in_nullable.cpp
+    LIBRARIES dbms)
 
-clickhouse_add_executable(profile_events profile_events.cpp)
-target_link_libraries (profile_events PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
+clickhouse_add_microbenchmark(profile_events
+    SOURCES profile_events.cpp
+    LIBRARIES clickhouse_common_io)
 
-clickhouse_add_executable(benchmark_sched_getcpu sched_getcpu.cpp)
-target_link_libraries (benchmark_sched_getcpu PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
+clickhouse_add_microbenchmark(benchmark_sched_getcpu
+    SOURCES sched_getcpu.cpp
+    LIBRARIES ${CMAKE_DL_LIBS})

--- a/src/Common/benchmarks/integer_hash_tables_and_hashes.cpp
+++ b/src/Common/benchmarks/integer_hash_tables_and_hashes.cpp
@@ -1,24 +1,14 @@
 #include <benchmark/benchmark.h>
 
-#include <iomanip>
+#include <functional>
 #include <random>
 #include <vector>
-
-#include <unordered_map>
-
-#include <sparsehash/dense_hash_map>
-#include <sparsehash/sparse_hash_map>
-#include <absl/container/flat_hash_map.h>
-
-#include <Common/Stopwatch.h>
 
 //#define DBMS_HASH_MAP_COUNT_COLLISIONS
 //#define DBMS_HASH_MAP_DEBUG_RESIZES
 
 #include <farmhash.h>
 #include <wyhash.h>
-#include <Compression/CompressedReadBuffer.h>
-#include <IO/ReadBufferFromFile.h>
 #include <base/types.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/SipHash.h>

--- a/src/Common/benchmarks/orc_string_dictionary.cpp
+++ b/src/Common/benchmarks/orc_string_dictionary.cpp
@@ -296,7 +296,7 @@ template <typename DictionaryImpl, size_t cardinality>
 static void BM_writeStringDictionary(benchmark::State & state)
 {
     auto strs = mockStrings<cardinality>();
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         auto dict = createAndWriteStringDictionary<DictionaryImpl>(strs);
         benchmark::DoNotOptimize(dict);

--- a/src/Common/benchmarks/orc_string_dictionary.cpp
+++ b/src/Common/benchmarks/orc_string_dictionary.cpp
@@ -1,11 +1,9 @@
 #include <base/defines.h>
 
-#include <cstdlib>
+#include <random>
 #include <unordered_map>
 
 #include <benchmark/benchmark.h>
-
-#include <unordered_map>
 
 class OldSortedStringDictionary
 {
@@ -89,26 +87,20 @@ void OldSortedStringDictionary::reorder(std::vector<int64_t> & idxBuffer) const
     // iterate the dictionary to get mapping from insertion order to value order
     std::vector<size_t> mapping(dict.size());
     size_t dictIdx = 0;
-    for (auto it = dict.cbegin(); it != dict.cend(); ++it)
-    {
-        mapping[it->second] = dictIdx++;
-    }
+    for (const auto & item : dict)
+        mapping[item.second] = dictIdx++;
 
     // do the transformation
-    for (size_t i = 0; i != idxBuffer.size(); ++i)
-    {
-        idxBuffer[i] = static_cast<int64_t>(mapping[static_cast<size_t>(idxBuffer[i])]);
-    }
+    for (auto & index : idxBuffer)
+        index = static_cast<int64_t>(mapping[static_cast<size_t>(index)]);
 }
 
 // get dict entries in insertion order
 void OldSortedStringDictionary::getEntriesInInsertionOrder(std::vector<const DictEntry *> & entries) const
 {
     entries.resize(dict.size());
-    for (auto it = dict.cbegin(); it != dict.cend(); ++it)
-    {
-        entries[it->second] = &(it->first);
-    }
+    for (const auto & item : dict)
+        entries[item.second] = &item.first;
 }
 
 // return count of entries
@@ -221,16 +213,13 @@ void NewSortedStringDictionary::reorder(std::vector<int64_t> & idxBuffer) const
 {
     // iterate the dictionary to get mapping from insertion order to value order
     std::vector<size_t> mapping(flatDict_.size());
-    for (size_t i = 0; i < flatDict_.size(); ++i)
-    {
-        mapping[flatDict_[i].index] = i;
-    }
+    size_t dictIdx = 0;
+    for (const auto & item : flatDict_)
+        mapping[item.index] = dictIdx++;
 
     // do the transformation
-    for (size_t i = 0; i != idxBuffer.size(); ++i)
-    {
-        idxBuffer[i] = static_cast<int64_t>(mapping[static_cast<size_t>(idxBuffer[i])]);
-    }
+    for (auto & index : idxBuffer)
+        index = static_cast<int64_t>(mapping[static_cast<size_t>(index)]);
 }
 
 // get dict entries in insertion order
@@ -270,11 +259,13 @@ void NewSortedStringDictionary::clear()
 template <size_t cardinality>
 static std::vector<std::string> mockStrings()
 {
+    static_assert(cardinality > 0);
+    std::mt19937_64 random_engine(std::random_device{}());
+    std::uniform_int_distribution<size_t> random_index(0, cardinality - 1);
+
     std::vector<std::string> res(1000000);
     for (auto & s : res)
-    {
-        s = "test string dictionary " + std::to_string(rand() % cardinality);
-    }
+        s = "test string dictionary " + std::to_string(random_index(random_engine));
     return res;
 }
 

--- a/src/Common/benchmarks/profile_events.cpp
+++ b/src/Common/benchmarks/profile_events.cpp
@@ -112,7 +112,7 @@ bool pinToCPU(unsigned cpu)
 /// benchmark in the binary, so a leaked pin would confine all subsequent ones to a single core.
 struct AffinityRestorer
 {
-    cpu_set_t saved;
+    cpu_set_t saved{};
     bool valid = false;
     AffinityRestorer() { valid = pthread_getaffinity_np(pthread_self(), sizeof(saved), &saved) == 0; }
     ~AffinityRestorer()
@@ -264,7 +264,13 @@ struct LatencyHist
 void BM_ProfileEventsReadLatency(benchmark::State & state)
 {
     const int64_t reader_period_us = state.range(0);
-    const size_t batch = static_cast<size_t>(state.range(1));
+    const int64_t batch_arg = state.range(1);
+    if (batch_arg <= 0)
+    {
+        state.SkipWithError("batch size must be positive");
+        return;
+    }
+    const size_t batch = static_cast<size_t>(batch_arg);
     const bool with_reader = reader_period_us >= 0;
 
     const uint32_t num_cpus = PerCPU::getNumCPUs();

--- a/src/Common/benchmarks/profile_events.cpp
+++ b/src/Common/benchmarks/profile_events.cpp
@@ -187,7 +187,7 @@ void run(benchmark::State & state, int64_t reader_period_us)
         });
     }
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         sync_start.arrive_and_wait();
         sync_end.arrive_and_wait();
@@ -337,7 +337,7 @@ void BM_ProfileEventsReadLatency(benchmark::State & state)
 
     LatencyHist hist;
     Stopwatch sw(CLOCK_MONOTONIC);
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         sw.restart();
         for (size_t i = 0; i < batch; ++i)
@@ -375,7 +375,7 @@ void BM_ProfileEventsReadAll(benchmark::State & state)
     ProfileEvents::Counters counters(per_cpu ? VariableContext::User : VariableContext::Thread, nullptr);
 
     const size_t end = ProfileEvents::end();
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         ProfileEvents::Count acc = 0;
         for (size_t e = 0; e < end; ++e)

--- a/src/Common/benchmarks/radix_sort.cpp
+++ b/src/Common/benchmarks/radix_sort.cpp
@@ -12,7 +12,7 @@ static void BM_RadixSort_UInt8(benchmark::State & state)
     auto type = std::make_shared<DataTypeUInt8>();
     auto column = fillColumnWithRandomData(type, limit, 0, 0, rng);
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         IColumn::Permutation res;
         column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);
@@ -27,7 +27,7 @@ static void BM_RadixSort_Int16(benchmark::State & state)
     auto type = std::make_shared<DataTypeInt16>();
     auto column = fillColumnWithRandomData(type, limit, 0, 0, rng);
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         IColumn::Permutation res;
         column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);
@@ -42,7 +42,7 @@ static void BM_RadixSort_Int32(benchmark::State & state)
     auto type = std::make_shared<DataTypeInt32>();
     auto column = fillColumnWithRandomData(type, limit, 0, 0, rng);
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         IColumn::Permutation res;
         column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);
@@ -57,7 +57,7 @@ static void BM_RadixSort_UInt64(benchmark::State & state)
     auto type = std::make_shared<DataTypeUInt64>();
     auto column = fillColumnWithRandomData(type, limit, 0, 0, rng);
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         IColumn::Permutation res;
         column->getPermutation(IColumn::PermutationSortDirection::Ascending, IColumn::PermutationSortStability::Unstable, 0, 0, res);

--- a/src/Common/benchmarks/sched_getcpu.cpp
+++ b/src/Common/benchmarks/sched_getcpu.cpp
@@ -79,7 +79,7 @@ void BM_sched_getcpu_rseq(benchmark::State & state)
         state.SkipWithError("rseq is not registered by libc or its cpu_id is not initialized");
         return;
     }
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
         benchmark::DoNotOptimize(rseqCurrentCPU());
 }
 BENCHMARK(BM_sched_getcpu_rseq);

--- a/src/Common/benchmarks/sched_getcpu.cpp
+++ b/src/Common/benchmarks/sched_getcpu.cpp
@@ -96,7 +96,7 @@ void BM_sched_getcpu_vsyscall(benchmark::State & state)
         return;
     }
     unsigned cpu = 0;
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         fn(&cpu, nullptr, nullptr);
         benchmark::DoNotOptimize(cpu);
@@ -107,7 +107,7 @@ BENCHMARK(BM_sched_getcpu_vsyscall);
 void BM_sched_getcpu_syscall(benchmark::State & state)
 {
     unsigned cpu = 0;
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         syscall(SYS_getcpu, &cpu, nullptr, nullptr);
         benchmark::DoNotOptimize(cpu);

--- a/src/Common/benchmarks/sched_getcpu.cpp
+++ b/src/Common/benchmarks/sched_getcpu.cpp
@@ -36,8 +36,8 @@ extern "C"
 {
     /// The rseq area location of the libc registration, exported by glibc >= 2.35.
     /// Weak so the binary links against libcs without them; the address is then null.
-    extern const ptrdiff_t __rseq_offset __attribute__((weak));
-    extern const unsigned int __rseq_size __attribute__((weak));
+    extern const ptrdiff_t __rseq_offset __attribute__((weak)); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+    extern const unsigned int __rseq_size __attribute__((weak)); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 }
 #pragma clang diagnostic pop
 

--- a/src/Common/benchmarks/sched_getcpu.cpp
+++ b/src/Common/benchmarks/sched_getcpu.cpp
@@ -67,7 +67,7 @@ bool rseqUsable()
 
 void BM_sched_getcpu_current(benchmark::State & state)
 {
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
         benchmark::DoNotOptimize(sched_getcpu());
 }
 BENCHMARK(BM_sched_getcpu_current);

--- a/src/Common/benchmarks/wrap_in_nullable.cpp
+++ b/src/Common/benchmarks/wrap_in_nullable.cpp
@@ -22,7 +22,7 @@ static void BM_WrapInNullable1(benchmark::State & state)
         = fillColumnWithRandomData(removeNullable(nullable_float64), limit, max_array_length, max_string_length, rng);
 
     DataTypePtr uint8_type = std::make_shared<DataTypeUInt8>();
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         state.PauseTiming();
         ColumnPtr null_map_column = fillColumnWithRandomData(uint8_type, limit, max_array_length, max_string_length, rng);
@@ -45,7 +45,7 @@ static void BM_WrapInNullable2(benchmark::State & state)
     ColumnPtr src_column = fillColumnWithRandomData(nullable_float64, limit, max_array_length, max_string_length, rng);
 
     DataTypePtr uint8_type = std::make_shared<DataTypeUInt8>();
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         state.PauseTiming();
         ColumnPtr null_map_column = fillColumnWithRandomData(uint8_type, limit, max_array_length, max_string_length, rng);

--- a/src/Common/benchmarks/wrap_in_nullable.cpp
+++ b/src/Common/benchmarks/wrap_in_nullable.cpp
@@ -26,10 +26,10 @@ static void BM_WrapInNullable1(benchmark::State & state)
     {
         state.PauseTiming();
         ColumnPtr null_map_column = fillColumnWithRandomData(uint8_type, limit, max_array_length, max_string_length, rng);
-        ColumnPtr src_column = ColumnNullable::create(denull_src_column, std::move(null_map_column));
+        ColumnPtr src_column = ColumnNullable::create(denull_src_column, null_map_column);
         state.ResumeTiming();
 
-        auto result = wrapInNullable(std::move(src_column), args, nullable_float64, limit);
+        auto result = wrapInNullable(src_column, args, nullable_float64, limit);
         benchmark::DoNotOptimize(result);
     }
 }

--- a/src/Storages/CMakeLists.txt
+++ b/src/Storages/CMakeLists.txt
@@ -4,7 +4,9 @@ if (ENABLE_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-add_subdirectory(benchmarks)
+if (ENABLE_TESTS OR ENABLE_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif ()
 
 if (ENABLE_FUZZING)
     add_subdirectory(fuzzers)

--- a/src/Storages/CMakeLists.txt
+++ b/src/Storages/CMakeLists.txt
@@ -4,9 +4,7 @@ if (ENABLE_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if (ENABLE_BENCHMARKS)
-    add_subdirectory(benchmarks)
-endif()
+add_subdirectory(benchmarks)
 
 if (ENABLE_FUZZING)
     add_subdirectory(fuzzers)

--- a/src/Storages/benchmarks/CMakeLists.txt
+++ b/src/Storages/benchmarks/CMakeLists.txt
@@ -1,11 +1,3 @@
-clickhouse_add_executable(benchmark_statistics
-    benchmark_statistics.cpp)
-target_link_libraries(benchmark_statistics PRIVATE
-    ch_contrib::gbenchmark_all
-    dbms)
-
-# This benchmark links a subset of dbms and is useful as a local diagnostic tool, but RelWithDebInfo
-# debug sections make the binary multiple GiB. Keep the final target small regardless of build type.
-# `-S` strips debug info and is accepted by GNU ld, lld, and Apple ld; use CMake's LINKER wrapper
-# so the compiler driver receives the right platform-specific spelling.
-target_link_options(benchmark_statistics PRIVATE "LINKER:-S")
+clickhouse_add_microbenchmark(benchmark_statistics
+    SOURCES benchmark_statistics.cpp
+    LIBRARIES dbms)

--- a/src/Storages/benchmarks/benchmark_statistics.cpp
+++ b/src/Storages/benchmarks/benchmark_statistics.cpp
@@ -45,9 +45,9 @@ createBenchmarkUniqCombined64(const String &, const DataTypes & argument_types, 
     const WhichDataType which(argument_types[0]);
     /// Keep precision 12 and the UInt64 hash type in sync with StatisticsUniqV2.
     if (which.isUInt64())
-        return std::make_shared<AggregateFunctionUniqCombined<UInt64, 12, UInt64>>(argument_types, parameters);
+        return std::make_shared<AggregateFunctionUniqCombined<UInt64, ColumnVector<UInt64>, 12, UInt64>>(argument_types, parameters);
     if (which.isFloat64())
-        return std::make_shared<AggregateFunctionUniqCombined<Float64, 12, UInt64>>(argument_types, parameters);
+        return std::make_shared<AggregateFunctionUniqCombined<Float64, ColumnVector<Float64>, 12, UInt64>>(argument_types, parameters);
 
     throw Exception(
         ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,

--- a/src/Storages/benchmarks/benchmark_statistics.cpp
+++ b/src/Storages/benchmarks/benchmark_statistics.cpp
@@ -174,7 +174,7 @@ void benchmarkSerialize(benchmark::State & state, const std::vector<StatisticsTy
     String data;
     data.reserve(bytes);
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         data.clear();
         WriteBufferFromString buffer(data);
@@ -196,7 +196,7 @@ void benchmarkBuild(benchmark::State & state, const std::vector<StatisticsType> 
     auto column = makeColumn(kind, benchmark_rows);
     const auto column_bytes = column->byteSize();
 
-    for (auto _ : state)
+    for (auto _ [[maybe_unused]] : state)
     {
         auto statistics = makeStatistics(types, data_type);
         statistics->build(column);


### PR DESCRIPTION
When `ENABLE_BENCHMARKS` is disabled, the microbenchmark directories are excluded entirely. Their translation units therefore do not compile in regular CI builds and can silently drift from the core code they exercise. Breaking API changes are discovered only when someone explicitly enables the benchmarks.                                            
                                                                                                                        
Building every benchmark executable by default is undesirable: several depend on the monolithic `dbms` library, making links expensive and producing approximately 477 MiB of stripped artifacts.
                                                                                                                        
This PR keeps the existing `ENABLE_BENCHMARKS` semantics while adding compile coverage to unit-test builds:
                                                                                                                        
   - When `ENABLE_TESTS=ON` or `ENABLE_BENCHMARKS=ON`, microbenchmark translation units are compiled through CMake object libraries.
   - `clickhouse-microbenchmarks-objects` is part of `ALL`.
   - `unit_tests_dbms` depends on `clickhouse-microbenchmarks-objects`, so explicitly building `unit_tests_dbms` also compiles every microbenchmark source.
   - When `ENABLE_BENCHMARKS=ON`, the benchmark executables and the `clickhouse-microbenchmarks` aggregate are also     
 part of `ALL`.
   - When both options are disabled, no microbenchmark or Google Benchmark targets are configured. This preserves reduced builds such as FastTest.
   - Unit-test-only builds consume a headers-only Google Benchmark interface; the Google Benchmark runtime and `benchmark_main` are linked only into benchmark executables.
                                                                                                                        
The resulting behavior is:

   | `ENABLE_TESTS` | `ENABLE_BENCHMARKS` | Object files | Executables |
   |---|---|---|---|
   | `OFF` | `OFF` | No | No |
   | `ON` | `OFF` | Yes | No |
   | `OFF` | `ON` | Yes | Yes |
   | `ON` | `ON` | Yes | Yes |

This catches compilation failures in benchmarked code paths during unit-test builds without paying the disk and      
 link-time cost of every benchmark executable

Affected targets and their artifact sizes, measured in an AArch64 `RelWithDebInfo` build with stripped executables:  
                                                                                                                        
   | Target | Unlinked object | Linked executable |                                                                     
   |---|---:|---:|                                                                                                      
   | `benchmark_statistics` | 0.85 MiB | 92.65 MiB |                                                                    
   | `integer_hash_tables_and_hashes` | 0.72 MiB | 3.78 MiB |                                                           
   | `benchmark_compute_hash_into` | 0.35 MiB | 92.44 MiB |                                                             
   | `orc_string_dictionary` | 0.30 MiB | 3.64 MiB |                                                                    
   | `profile_events` | 0.29 MiB | 3.64 MiB |                                                                           
   | `column_insert_many_from` | 0.20 MiB | 92.40 MiB |                                                                 
   | `wrap_in_nullable` | 0.15 MiB | 92.45 MiB |                                                                        
   | `benchmark_radix_sort` | 0.14 MiB | 92.46 MiB |                                                                    
   | `benchmark_sched_getcpu` | 0.04 MiB | 3.61 MiB |                                                                   
   | **Total** | **3.04 MiB** | **477.07 MiB** |                                                                        

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116542&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116542](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116542+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.276` (included in `26.9` and later)
<!-- ch-version-info:end -->