### PR TITLE
Let the hung check read the processlist when the server is over its memory limit

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -903,16 +903,22 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
     # Even if all clickhouse-test processes are finished, there are probably some sh scripts,
     # which still run some new queries. Let's ignore them.
     try:
-        query = 'clickhouse client --receive_timeout=30 -q "SELECT count() FROM system.processes where elapsed > 300" '
         output = (
-            check_output(query, shell=True, stderr=STDOUT, timeout=30)
+            check_output(
+                make_query_command(
+                    "SELECT count() FROM system.processes where elapsed > 300"
+                ),
+                shell=True,
+                stderr=STDOUT,
+                timeout=30,
+            )
             .decode("utf-8")
             .strip()
         )
         if int(output) == 0:
             return False
-    except:
-        pass
+    except Exception as ex:
+        logging.error("Failed to check for long running queries: %s", str(ex))
     return True
 
 
@@ -1018,11 +1024,6 @@ def run_stress_test(args: argparse.Namespace) -> None:
                     # NOTE: memory_profiler_step should be also adjusted, because:
                     #
                     #     untracked_memory_limit = min(settings.max_untracked_memory, settings.memory_profiler_step)
-                    #
-                    # NOTE: that if there will be queries with GROUP BY, this trick
-                    # will not work due to CurrentMemoryTracker::check() from
-                    # Aggregator code.
-                    # But right now it should work, since neither hung check, nor 00001_select_1 has GROUP BY.
                     "--client-option",
                     "max_untracked_memory=1Gi",
                     "max_memory_usage_for_user=0",

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -924,44 +924,49 @@ def need_retry(args, stdout, stderr, total_time):
 
 
 def get_processlist_size(args):
+    # The rows are counted client-side: aggregation performs a memory limit check
+    # that a server over its per-user limit cannot pass, and this query has to
+    # answer in exactly that state.
     if args.replicated_database:
-        return int(
+        return len(
             clickhouse_execute(
                 args,
                 """
-                SELECT
-                    count()
+                SELECT 1
                 FROM clusterAllReplicas('test_cluster_database_replicated', system.processes)
                 WHERE query NOT LIKE '%system.processes%'
                 AND query NOT LIKE '%system.minio_%_logs%'
                 """,
-            ).strip()
+            ).splitlines()
         )
     if args.shared_catalog:
-        return int(
+        return len(
             clickhouse_execute(
                 args,
                 """
-                SELECT
-                    count()
+                SELECT 1
                 FROM clusterAllReplicas('test_cluster_shared_catalog', system.processes)
                 WHERE query NOT LIKE '%system.processes%'
                 AND query NOT LIKE '%system.minio_%_logs%'
                 """,
-            ).strip()
+            ).splitlines()
         )
-    return int(
+    return len(
         clickhouse_execute(
             args,
             """
-                SELECT
-                    count()
+                SELECT 1
                 FROM system.processes
                 WHERE query NOT LIKE '%system.processes%'
                 AND query NOT LIKE '%system.minio_%_logs%'
             """,
-        ).strip()
+        ).splitlines()
     )
+
+
+# The stacktrace query below is the one hung-check query that cannot avoid
+# aggregating, so it is the only one that needs the per-user limit lifted.
+HUNG_CHECK_QUERY_SETTINGS = {"max_memory_usage_for_user": 0}
 
 
 def get_processlist_with_stacktraces(args):
@@ -987,6 +992,7 @@ def get_processlist_with_stacktraces(args):
         ORDER BY elapsed DESC FORMAT Vertical
         """,
             settings={
+                **HUNG_CHECK_QUERY_SETTINGS,
                 "allow_introspection_functions": 1,
             },
             timeout=120,
@@ -1013,6 +1019,7 @@ def get_processlist_with_stacktraces(args):
         ORDER BY elapsed DESC FORMAT Vertical
         """,
             settings={
+                **HUNG_CHECK_QUERY_SETTINGS,
                 "allow_introspection_functions": 1,
             },
             timeout=120,
@@ -1034,6 +1041,7 @@ def get_processlist_with_stacktraces(args):
         ORDER BY elapsed DESC FORMAT Vertical
         """,
         settings={
+            **HUNG_CHECK_QUERY_SETTINGS,
             "allow_introspection_functions": 1,
         },
         timeout=120,
@@ -5117,7 +5125,7 @@ def check_server_started(args):
 
     sys.stdout.flush()
     retry_count = args.server_check_retries
-    query = "SELECT version(), arrayStringConcat(groupArray(value), ' ') FROM system.build_options WHERE name IN ('GIT_HASH', 'GIT_BRANCH')"
+    query = "SELECT version(), (SELECT value FROM system.build_options WHERE name = 'GIT_HASH'), (SELECT value FROM system.build_options WHERE name = 'GIT_BRANCH')"
     while retry_count > 0:
         try:
             res = (
@@ -5861,7 +5869,7 @@ def main(args):
     tests_start_time = time()
 
     if not check_server_started(args):
-        msg = "Server is not responding. Cannot execute 'SELECT 1' query."
+        msg = "Server is not responding. Cannot query the server version."
         if args.hung_check:
             print(msg)
             print_c_stacktraces(args)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110626
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/110626 (requested in [this comment](https://github.com/ClickHouse/ClickHouse/pull/110626#issuecomment-5424612945); I posted a [correction](https://github.com/ClickHouse/ClickHouse/pull/110626#issuecomment-5425791999) to my first analysis of it)

`Stress test (amd_debug)` reported `Hung check failed, possible deadlock found`, but the hung check had not managed to look at the server: all 180 of its liveness retries were refused with `Code: 241`. Something really was hung, so the verdict was right by accident; the check itself never read `system.processes`.

Root cause. `stress.py` passes `--client-option max_memory_usage_for_user=0` to the hung check for exactly this reason, but those settings only become URL parameters inside `if args.cloud:` (`clickhouse-test:7202`), and every `clickhouse_execute_http` URL is built from that string. Meanwhile `Aggregator::checkLimits` calls `CurrentMemoryTracker::check()`, a zero-sized allocation whose `will_be` is the current amount, so no untracked-memory setting can affect it. Aggregation is therefore the exposure, and the check aggregated in all three of its own queries: the startup probe, `get_processlist_size` (`count()`) and the stacktrace dump. The `NOTE` claiming "neither hung check, nor `00001_select_1` has GROUP BY" was never true.

The change drops the aggregation from the probe and from `get_processlist_size` (including its two `clusterAllReplicas` branches), exempts the one query that must aggregate in all three of its branches, routes `stress.py`'s last un-overridden query through `make_query_command`, stops a bare `except:` from reporting "I could not tell" as "yes" with no log line, and corrects a message that named a `SELECT 1` it never runs. Nothing suppresses a verdict.

Reports: [Stress test (amd_debug)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110626&sha=ea9134efe69c320d41096724451db30487871965&name_0=PR&name_1=Stress%20test%20%28amd_debug%29). Adjacent in intent: #115692.

I am sending the server-side hang, `Context::setCurrentDatabase` deadlocking against its own `Context::mutex` through a database-name hint, as a separate PR. Note that even with this change that hang would not have been named: it happens before the process-list insertion (`executeQuery.cpp:2651` against `:2791`), so those threads were never in `system.processes`.

<details><summary>Validation (no test home exists for runner code; <code>ci/tests/</code> is being removed)</summary>

Fixture: a 953.67 MiB per-user cap and a query holding 2.0-2.8 GiB: the flap `setOrRaiseHardLimit(0)` and `ProcessList.cpp:397` produce in CI. Counters, not the exit code, are the oracle: both arms exit non-zero.

| counter | base | C1 only | with fix |
|---|---|---|---|
| `Connection error, will retry` | 180 | 0 | 0 |
| `All connection tries failed` | 1 | 0 | 0 |
| `Server is not responding` | 2 | 0 | 0 |
| `Failed to get processlist size` | 0 | 1 | 0 |
| `Found hung queries in processlist` | 0 | 0 | 1 |

The base column matches the CI run's `hung_check.log` exactly (180/1/2). The middle column is a de-aggregated probe only: the failure moves to `get_processlist_size`, so both changes are needed. With the fix the check names the holding query. Without memory pressure both arms exit 0 with `No queries hung.`, and 20 of 20 invocations plus `--test-runs 50` pass.

Blast radius, from `query_log`: `max_memory_usage_for_user = 0` on the stacktrace query (1 execution), the profile value on all 47157 other runner queries. Client-side counting is latency-neutral (p90 2 ms).

The `clusterAllReplicas` branches carry the same exemption. Measured with the cap armed: unexempted they fail with `chunk of 0.00 B`, exempted they return the dump, on the initiator's own local shard; against a replica that is itself over its cap the exemption changes nothing, since `ClusterProxy/executeQuery.cpp` marks the setting unchanged before forwarding and the test cluster has no `<secret>`. The initiator is the server the runner talks to, so it accumulates the workload.

One bound: `setOrRaiseHardLimit` restores a positive limit, so a query inserted while the dump runs re-arms the cap and the dump can still fail (measured). A large positive value defeats that but is never lowered again, so 0 is kept; when the race fires the check prints the server's own error.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116545&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116545](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116545+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

