### PR TITLE
Fix logical error reading a text-indexed column after a lazy or unfinished ALTER

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReadersChain.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadersChain.cpp
@@ -449,8 +449,12 @@ void MergeTreeReadersChain::executeActionsBeforePrewhere(
     /// `prewhere_info->columns_overwritten_by_chain` is the set of columns the chain
     /// will overwrite. Null those out around `performRequiredConversions` so they are
     /// skipped, then restore them so the step's action sees them in their on-disk form.
-    /// An empty skip set means the chain has nothing to skip, so the conversion is a
-    /// no-op for this step and we leave the columns untouched.
+    /// When the skip set is empty (e.g. a metadata-only / lazy `ALTER MODIFY COLUMN` with no
+    /// chained UPDATE/DELETE) the loop below is a pass-through and every read column is
+    /// converted. Not converting here would leave an on-disk column (e.g. a lazy JSON
+    /// type-hint path still stored as `Dynamic`) advertising the post-`MODIFY` metadata type,
+    /// which later trips `materialize` in `evaluateMissingDefaults` when the column is read
+    /// through the text-index paths (exact-equals direct read or the LIKE fallback).
     ///
     /// A column is exempt from conversion ONLY when its on-disk value is about to be
     /// discarded and replaced before anything genuinely reads it. If a mutation step consumes
@@ -463,7 +467,7 @@ void MergeTreeReadersChain::executeActionsBeforePrewhere(
     {
         merge_tree_reader->performRequiredConversions(read_columns);
     }
-    else if (!prewhere_info->columns_overwritten_by_chain.empty())
+    else
     {
         const auto & reader_columns = merge_tree_reader->getColumns();
         const auto & skip = prewhere_info->columns_overwritten_by_chain;

--- a/tests/queries/0_stateless/04935_text_index_lazy_alter_conversion.reference
+++ b/tests/queries/0_stateless/04935_text_index_lazy_alter_conversion.reference
@@ -1,0 +1,8 @@
+-- exact equals via text-index direct read (computed on the no-granule part from data)
+714
+-- LIKE via the text-index fallback path
+714
+-- control: the same answer without the skip index
+714
+-- regular ALTER MODIFY with an interrupted mutation, read via text index
+714

--- a/tests/queries/0_stateless/04935_text_index_lazy_alter_conversion.sql
+++ b/tests/queries/0_stateless/04935_text_index_lazy_alter_conversion.sql
@@ -1,0 +1,60 @@
+-- Tags: no-fasttest
+-- no-fasttest: needs the JSON type and the text (full-text) index.
+
+-- A metadata-only / lazy `ALTER MODIFY COLUMN` (here a lazy JSON type hint) leaves an old part's
+-- path stored in its on-disk representation (Dynamic) while metadata already says the hinted type
+-- (Nullable(String)). Reading that column through the `text` index code paths must still apply the
+-- read-time alter conversion. Before the fix the on-disk Dynamic column reached `materialize` in
+-- `evaluateMissingDefaults` mislabeled as Nullable(String) and threw
+-- `Unexpected return type from materialize`.
+
+SET allow_experimental_json_lazy_type_hints = 1;
+SET allow_experimental_full_text_index = 1;
+
+DROP TABLE IF EXISTS t_text_lazy_alter;
+
+CREATE TABLE t_text_lazy_alter (id UInt64, doc JSON) ENGINE = MergeTree ORDER BY id;
+
+-- Part written before the hint/index: doc.a.id is stored as Dynamic and has no index granule.
+INSERT INTO t_text_lazy_alter SELECT number, '{"a":{"id":"actor' || toString(number % 7) || '"}}' FROM numbers(4000);
+
+-- Lazy type hint: metadata-only, the existing part is not rewritten.
+ALTER TABLE t_text_lazy_alter MODIFY COLUMN doc JSON(`a.id` Nullable(String));
+
+-- Text index with the `array` tokenizer -> exact-equals direct read (drops the residual equals).
+ALTER TABLE t_text_lazy_alter ADD INDEX idx doc.a.id TYPE text(tokenizer = array) GRANULARITY 100000000;
+
+-- Part written after the index: it has the granule, so the optimizer picks direct read.
+INSERT INTO t_text_lazy_alter SELECT number + 500000, '{"a":{"id":"actor' || toString(number % 7) || '"}}' FROM numbers(1000);
+
+SELECT '-- exact equals via text-index direct read (computed on the no-granule part from data)';
+SELECT count() FROM t_text_lazy_alter WHERE doc.a.id = 'actor3'
+    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+
+SELECT '-- LIKE via the text-index fallback path';
+SELECT count() FROM t_text_lazy_alter WHERE doc.a.id LIKE '%actor3%'
+    SETTINGS use_skip_indexes = 1, text_index_like_min_pattern_length = 1, text_index_like_max_postings_to_read = 1;
+
+SELECT '-- control: the same answer without the skip index';
+SELECT count() FROM t_text_lazy_alter WHERE doc.a.id = 'actor3' SETTINGS use_skip_indexes = 0;
+
+DROP TABLE t_text_lazy_alter;
+
+-- Not JSON-specific: a regular `ALTER MODIFY COLUMN` with an unfinished mutation (interrupted by
+-- KILL MUTATION, so the on-disk String stays under the new Nullable(String) type) hits the same path.
+DROP TABLE IF EXISTS t_text_regular_alter;
+
+CREATE TABLE t_text_regular_alter (id UInt64, s String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_text_regular_alter SELECT number, 'actor' || toString(number % 7) FROM numbers(4000);
+
+SYSTEM STOP MERGES t_text_regular_alter;
+ALTER TABLE t_text_regular_alter MODIFY COLUMN s Nullable(String) SETTINGS mutations_sync = 0, alter_sync = 0;
+KILL MUTATION WHERE table = 't_text_regular_alter' AND database = currentDatabase() FORMAT Null;
+ALTER TABLE t_text_regular_alter ADD INDEX idx s TYPE text(tokenizer = array) GRANULARITY 100000000 SETTINGS mutations_sync = 0, alter_sync = 0;
+INSERT INTO t_text_regular_alter SELECT number + 500000, 'actor' || toString(number % 7) FROM numbers(1000);
+
+SELECT '-- regular ALTER MODIFY with an interrupted mutation, read via text index';
+SELECT count() FROM t_text_regular_alter WHERE s = 'actor3'
+    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+
+DROP TABLE t_text_regular_alter;

--- a/tests/queries/0_stateless/04935_text_index_lazy_alter_conversion.sql
+++ b/tests/queries/0_stateless/04935_text_index_lazy_alter_conversion.sql
@@ -29,11 +29,11 @@ INSERT INTO t_text_lazy_alter SELECT number + 500000, '{"a":{"id":"actor' || toS
 
 SELECT '-- exact equals via text-index direct read (computed on the no-granule part from data)';
 SELECT count() FROM t_text_lazy_alter WHERE doc.a.id = 'actor3'
-    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1;
 
 SELECT '-- LIKE via the text-index fallback path';
 SELECT count() FROM t_text_lazy_alter WHERE doc.a.id LIKE '%actor3%'
-    SETTINGS use_skip_indexes = 1, text_index_like_min_pattern_length = 1, text_index_like_max_postings_to_read = 1;
+    SETTINGS use_skip_indexes = 1, query_plan_direct_read_from_text_index = 1, text_index_like_min_pattern_length = 1, text_index_like_max_postings_to_read = 1;
 
 SELECT '-- control: the same answer without the skip index';
 SELECT count() FROM t_text_lazy_alter WHERE doc.a.id = 'actor3' SETTINGS use_skip_indexes = 0;
@@ -55,6 +55,6 @@ INSERT INTO t_text_regular_alter SELECT number + 500000, 'actor' || toString(num
 
 SELECT '-- regular ALTER MODIFY with an interrupted mutation, read via text index';
 SELECT count() FROM t_text_regular_alter WHERE s = 'actor3'
-    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1;
+    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 1, query_plan_direct_read_from_text_index = 1;
 
 DROP TABLE t_text_regular_alter;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/112213

Reading a column that has a `text` (full-text) index through the index — the exact-equals direct read (with the `array` tokenizer) or the LIKE fallback — threw the `Unexpected return type from materialize` logical error when the part still needed a read-time type conversion that no mutation had materialized yet. This happens after a metadata-only or not-yet-finished `ALTER MODIFY COLUMN` whose mutation is absent — killed, dropped, or never created (lazy JSON type hints via `allow_experimental_json_lazy_type_hints`).

`MergeTreeReadersChain::executeActionsBeforePrewhere` skipped `performRequiredConversions` when `perform_alter_conversions` was false and `columns_overwritten_by_chain` was empty. That set is populated only from chained `UPDATE`/`DELETE`, so a metadata-only / lazy `MODIFY` (no `UPDATE`/`DELETE`) left the on-disk column (e.g. a JSON path still stored as `Dynamic`) unconverted under its post-`MODIFY` type. The fix always runs `performRequiredConversions` in that branch, skipping only the overwritten-and-not-consumed columns.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed the `Unexpected return type from materialize` logical error when reading a column that has a `text` index through the index after a metadata-only or not-yet-materialized `ALTER MODIFY COLUMN` (including lazy JSON type hints) that requires a read-time type conversion.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116549&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116549](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116549+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.27`, `26.7.7.18`, `26.6.5.43`
<!-- ch-version-info:end -->