### PR TITLE
Docs: move ClickStack to Open source navigation section

### DIFF
--- a/docs/ar/docs.json
+++ b/docs/ar/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "مفتوح المصدر"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,9 +94,6 @@
                 "$ref": "./products/managed-postgres/navigation.json"
               },
               {
-                "$ref": "./clickstack/navigation.json"
-              },
-              {
                 "href": "https://langfuse.com/docs",
                 "icon": "/images/icons/logo-langfuse.svg",
                 "item": "Langfuse"
@@ -105,6 +102,9 @@
                 "href": "#",
                 "icon": "/images/icons/section-header.svg",
                 "item": "Open source"
+              },
+              {
+                "$ref": "./clickstack/navigation.json"
               },
               {
                 "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/es/docs.json
+++ b/docs/es/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "Código abierto"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/fr/docs.json
+++ b/docs/fr/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "Open source"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/ja/docs.json
+++ b/docs/ja/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "オープンソース"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/ko/docs.json
+++ b/docs/ko/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "오픈소스"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/pt-BR/docs.json
+++ b/docs/pt-BR/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "Código aberto"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/ru/docs.json
+++ b/docs/ru/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "С открытым исходным кодом"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"

--- a/docs/zh/docs.json
+++ b/docs/zh/docs.json
@@ -37,9 +37,6 @@
           "$ref": "./products/managed-postgres/navigation.json"
         },
         {
-          "$ref": "./clickstack/navigation.json"
-        },
-        {
           "href": "https://langfuse.com/docs",
           "icon": "/images/icons/logo-langfuse.svg",
           "item": "Langfuse"
@@ -48,6 +45,9 @@
           "href": "#",
           "icon": "/images/icons/section-header.svg",
           "item": "开源"
+        },
+        {
+          "$ref": "./clickstack/navigation.json"
         },
         {
           "$ref": "./products/agentic-data-stack/navigation.json"


### PR DESCRIPTION
Moves `ClickStack` from the ClickHouse Cloud section to the Open source section
of the top Solutions navigation, where it now appears as the first item. The
ordering is updated consistently across all localized navigation configurations.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry:
Not applicable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116558&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116558](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116558+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.250` (included in `26.9` and later)
<!-- ch-version-info:end -->