### PR TITLE
Clarify that sql-console-role roles are incompatible with JWT authentication and document Custom data access limits

### DIFF
--- a/docs/products/cloud/guides/security/cloud-access-management/common-access-management-queries.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/common-access-management-queries.mdx
@@ -46,6 +46,10 @@ Admin users are assigned the `sql_console_admin` role by default, so nothing cha
 
 ### Granular access control {#granular-access-control}
 
+<Tip>
+Prefer [cloud-managed database roles](/products/cloud/guides/security/cloud-access-management/manage-custom-roles#manage-database-roles) (beta) to manage database access from the console. `sql-console-role:<email>` roles are not compatible with [JWT authentication](/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup).
+</Tip>
+
 This access control functionality can also be configured manually for user-level granularity. Before assigning the new `sql_console_*` roles to users, SQL console user-specific database roles matching the namespace `sql-console-role:<email>` should be created. For example: 
 
 ```sql

--- a/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
@@ -106,13 +106,13 @@ Select `Read-only`, `Admin`, or `Custom` access. With `Custom` access, define sp
 </Step>
 <Step title="Create the role" id="create-role-with-data-permissions">
 
-Click `Create role`. The database roles are created in the selected services.
+Click `Create role`. The database roles are created in the selected services. The roles can take up to 10 minutes to propagate to a service, but users assigned the role receive its permissions immediately when they query the service.
 </Step>
 </Steps>
 
 ### Verify database roles {#verify-database-roles}
 
-Roles managed through the console are created in the database with the `cloud:` prefix and the `cloud` storage type. To list them, query the `system.roles` table in the service:
+Roles managed through the console are created in the database with the `cloud:` prefix and the `cloud` storage type, and can take up to 10 minutes to appear after creation. To list them, query the `system.roles` table in the service:
 
 ```sql
 SELECT * FROM system.roles;

--- a/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
@@ -100,11 +100,7 @@ Select the service the permissions apply to. Add more services to apply the same
 </Step>
 <Step title="Choose the access level" id="choose-data-access-level">
 
-Select `Read-only`, `Admin`, or `Custom` access. With `Custom` access, define specific data access permissions using ClickHouse [`GRANT` statements](/reference/statements/grant).
-
-<Note>
-`Custom` access can only be selected when the permissions target a single service. To define custom permissions for multiple services, add a separate `Data` permission for each service, each targeting the specific service it applies to.
-</Note>
+Select `Read-only`, `Admin`, or `Custom` access. With `Custom` access, define specific data access permissions using ClickHouse [`GRANT` statements](/reference/statements/grant). `Custom` access can only be selected when the permissions target a single service; to define custom permissions for multiple services, add a separate `Data` permission for each service.
 
 <Image img="/images/cloud/guides/control_plane/manage_custom_roles/create_role_data_permissions.webp" alt="Create new role dialog with data permissions defined by custom grant statements" size="md"/>
 </Step>

--- a/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
@@ -96,11 +96,15 @@ Custom database roles on a service depend on [JWT authentication](/products/clou
 </Step>
 <Step title="Select the service" id="select-data-permissions-service">
 
-Select the service the permissions apply to. Add more services to apply permissions across multiple services.
+Select the service the permissions apply to. Add more services to apply the same `Read-only` or `Admin` permissions across multiple services.
 </Step>
 <Step title="Choose the access level" id="choose-data-access-level">
 
 Select `Read-only`, `Admin`, or `Custom` access. With `Custom` access, define specific data access permissions using ClickHouse [`GRANT` statements](/reference/statements/grant).
+
+<Note>
+`Custom` access can only be selected when the permissions target a single service. To define custom permissions for multiple services, add a separate `Data` permission for each service, each targeting the specific service it applies to.
+</Note>
 
 <Image img="/images/cloud/guides/control_plane/manage_custom_roles/create_role_data_permissions.webp" alt="Create new role dialog with data permissions defined by custom grant statements" size="md"/>
 </Step>

--- a/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-custom-roles.mdx
@@ -79,9 +79,9 @@ This feature is in beta and is available for services running ClickHouse version
 
 When you add data permissions to a custom role, ClickHouse Cloud creates a matching role in each selected service, prefixed with `cloud:`. For example, a custom role named `readonly` appears in the database as `cloud:readonly`. Members of the custom role receive these database permissions when they connect to the service through SQL console passwordless authentication.
 
-<Info>
-Roles assigned manually in the database using the [`sql-console-role:<email>` naming convention](/products/cloud/guides/security/cloud-access-management/manage-database-users#sql-console-users-and-roles) take precedence over roles assigned through the console.
-</Info>
+<Tip>
+Cloud-managed database roles replace manually assigned [`sql-console-role:<email>`](/products/cloud/guides/security/cloud-access-management/manage-database-users#sql-console-users-and-roles) roles, which are not compatible with [JWT authentication](/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup).
+</Tip>
 
 ### Prerequisites {#manage-database-roles-prerequisites}
 

--- a/docs/products/cloud/guides/security/cloud-access-management/manage-database-users.mdx
+++ b/docs/products/cloud/guides/security/cloud-access-management/manage-database-users.mdx
@@ -18,11 +18,9 @@ SQL console users are created for each session and authenticated using X.509 cer
 
 Basic SQL console roles can be assigned to users with Service Read Only and Service Admin permissions. For more information, refer to [Manage SQL Console Role Assignments](/products/cloud/guides/security/cloud-access-management/manage-sql-console-role-assignments). This guide demonstrates how to create a custom role for a SQL console user.
 
-<Note>
-**Manage database roles from the console (beta)**
-
-You can also manage database roles directly from the ClickHouse Cloud console by adding data permissions to custom roles. This feature is in beta and is available for services running ClickHouse version 26.4 and above. Roles assigned manually using the `sql-console-role:<email>` naming convention take precedence over roles assigned through the console. For more information, see [Manage database roles](/products/cloud/guides/security/cloud-access-management/manage-custom-roles#manage-database-roles).
-</Note>
+<Tip>
+Prefer [cloud-managed database roles](/products/cloud/guides/security/cloud-access-management/manage-custom-roles#manage-database-roles) (beta) to manage database access from the console. `sql-console-role:<email>` roles are not compatible with [JWT authentication](/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup).
+</Tip>
 
 To create a custom role for a SQL console user and grant it a general role, run the following commands. The email address must match the user's email address in the console. 
 

--- a/docs/resources/support-center/knowledge-base/security/set-role-not-persisting-in-sql-console.mdx
+++ b/docs/resources/support-center/knowledge-base/security/set-role-not-persisting-in-sql-console.mdx
@@ -12,6 +12,10 @@ keywords: ['SQL Console', 'SET ROLE', 'RBAC', 'Access Control']
 
 When you run `SET ROLE` in the ClickHouse Cloud SQL Console, the role might appear to change for one query and then revert for the next query. Use a per-user SQL Console role when permissions must persist across queries and sessions.
 
+<Tip>
+Prefer [cloud-managed database roles](/products/cloud/guides/security/cloud-access-management/manage-custom-roles#manage-database-roles) (beta) to manage database access from the console. `sql-console-role:<email>` roles are not compatible with [JWT authentication](/products/cloud/guides/security/cloud-access-management/jwt-authentication-setup).
+</Tip>
+
 ## Symptoms {#symptoms}
 
 You might observe one or more of the following:


### PR DESCRIPTION
The callouts about managing database roles from the console said that roles assigned manually with the `sql-console-role:<email>` naming convention take precedence over roles assigned through the console. That is not accurate: `sql-console-role:<email>` roles are not compatible with JWT authentication, and cloud-managed database roles require JWT authentication to be enabled.

Reworded the callouts in `manage-custom-roles.mdx` and `manage-database-users.mdx` to state the incompatibility and direct users to cloud-managed database roles, and changed them from `Info`/`Note` boxes to `Tip` so they stand out instead of rendering as grey boxes. Added the same tip to the granular access control section of `common-access-management-queries.mdx` and to the `SET ROLE` knowledge base article, which document the manual `sql-console-role:<email>` approach.

Also documented two details of data permissions in custom roles:
- `Custom` access can only be selected when the permissions target a single service; applying custom permissions to multiple services requires a separate `Data` permission per service.
- Cloud-managed database roles can take up to 10 minutes to propagate to a service and appear in `system.roles`, but users assigned the role receive its permissions immediately when they query the service.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116559&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116559](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116559+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
