### PR TITLE
Allow optimize_functions_to_subcolumns under FINAL for row-selecting merge engines

### DIFF
--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -90,6 +90,16 @@ bool columnSourceHasFinal(const QueryTreeNodePtr & column_source)
     return false;
 }
 
+/// FINAL blocks the rewrite unless the engine reports it safe (see supportsSubcolumnOptimizationWithFinal);
+/// an unknown storage is treated as unsafe.
+bool columnSourceFinalBlocksOptimization(const QueryTreeNodePtr & column_source)
+{
+    if (!columnSourceHasFinal(column_source))
+        return false;
+    auto storage = getStorageForColumnSource(column_source);
+    return !storage || !storage->supportsSubcolumnOptimizationWithFinal();
+}
+
 /// Keyed on the source NODE, not the StorageID: every `file()`/`s3()`/`url()` resolves to
 /// `_table_function.<name>`, so two such sources in one query would otherwise share a key.
 struct ColumnInSource
@@ -1148,7 +1158,7 @@ private:
     {
         /// For queries with FINAL converting function to subcolumn may alter
         /// special merging algorithms and produce wrong result of query.
-        if (columnSourceHasFinal(column_source))
+        if (columnSourceFinalBlocksOptimization(column_source))
             return;
 
         const auto & column = first_argument_column_node.getColumn();
@@ -1173,7 +1183,7 @@ private:
         const FunctionNode & function_node, const ColumnNode & first_argument_column_node,
         const QueryTreeNodePtr & column_source, std::vector<FunctionNode *> & intermediates)
     {
-        if (columnSourceHasFinal(column_source))
+        if (columnSourceFinalBlocksOptimization(column_source))
             return;
 
         const auto & column = first_argument_column_node.getColumn();

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -192,6 +192,10 @@ public:
     /// A storage that cannot serve synthesised subcolumns such as `.null`/`.size0` as standalone
     /// inputs may enable this while keeping supportsOptimizationToSubcolumns() false.
     virtual bool supportsOptimizationToTupleElementSubcolumns() const { return supportsOptimizationToSubcolumns(); }
+    /// True when a subcolumn read under FINAL equals the function computed on the merged column.
+    /// Safe for engines whose FINAL merge selects whole rows (Replacing/Collapsing/VersionedCollapsing);
+    /// unsafe for value-combining engines (Summing/Graphite/Coalescing) that recompute column values.
+    virtual bool supportsSubcolumnOptimizationWithFinal() const { return false; }
 
     /// Returns true if the storage supports transactions for SELECT, INSERT and ALTER queries.
     /// Storage may throw an exception later if some query kind is not fully supported.

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -958,6 +958,21 @@ bool MergeTreeData::supportsFinal() const
         || merging_params.mode == MergingParams::VersionedCollapsing;
 }
 
+bool MergeTreeData::supportsSubcolumnOptimizationWithFinal() const
+{
+    /// Safe only for whole-row-selecting merges: the surviving row's subcolumn equals the subcolumn
+    /// of its full row. Value-combining merges recompute column values, breaking that equality.
+    switch (merging_params.mode)
+    {
+        case MergingParams::Replacing:
+        case MergingParams::Collapsing:
+        case MergingParams::VersionedCollapsing:
+            return true;
+        default:
+            return false;
+    }
+}
+
 static void checkKeyExpression(const ExpressionActions & expr, const Block & sample_block, const String & key_name, bool allow_nullable_key)
 {
     if (expr.hasArrayJoin())

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -573,6 +573,8 @@ public:
 
     bool supportsSubcolumns() const override { return true; }
 
+    bool supportsSubcolumnOptimizationWithFinal() const override;
+
     bool supportsTTL() const override { return true; }
 
     bool supportsStatistics() const override { return true; }

--- a/tests/performance/optimize_functions_to_subcolumns_final.xml
+++ b/tests/performance/optimize_functions_to_subcolumns_final.xml
@@ -1,0 +1,31 @@
+<test>
+    <!--
+        optimize_functions_to_subcolumns under FINAL for row-selecting engines
+        (ReplacingMergeTree here). The rewrite lets FINAL read only the needed subcolumn
+        (e.g. m.size0, m.key_5, s.null) instead of the whole wide column, so these queries
+        are faster than on a build that disables the rewrite for any FINAL.
+    -->
+    <settings>
+        <max_insert_threads>4</max_insert_threads>
+    </settings>
+
+    <create_query>
+        CREATE TABLE t_subcolumns_final (k UInt64, ver UInt64, a Array(UInt64), s Nullable(String), m Map(String, UInt64))
+        ENGINE = ReplacingMergeTree(ver) ORDER BY k
+    </create_query>
+
+    <!-- Several parts with disjoint key ranges so FINAL runs but nothing collapses (row count and read volume stay high). -->
+    <fill_query>INSERT INTO t_subcolumns_final SELECT number,             1, range(number % 20), toString(number), mapFromArrays(range(number % 20), range(number % 20)) FROM numbers_mt(10000000)</fill_query>
+    <fill_query>INSERT INTO t_subcolumns_final SELECT number + 10000000, 1, range(number % 20), toString(number), mapFromArrays(range(number % 20), range(number % 20)) FROM numbers_mt(10000000)</fill_query>
+    <fill_query>INSERT INTO t_subcolumns_final SELECT number + 20000000, 1, range(number % 20), toString(number), mapFromArrays(range(number % 20), range(number % 20)) FROM numbers_mt(10000000)</fill_query>
+    <fill_query>INSERT INTO t_subcolumns_final SELECT number + 30000000, 1, range(number % 20), toString(number), mapFromArrays(range(number % 20), range(number % 20)) FROM numbers_mt(10000000)</fill_query>
+    <fill_query>INSERT INTO t_subcolumns_final SELECT number + 40000000, 1, range(number % 20), toString(number), mapFromArrays(range(number % 20), range(number % 20)) FROM numbers_mt(10000000)</fill_query>
+
+    <query>SELECT count() FROM t_subcolumns_final FINAL WHERE NOT ignore(length(a))</query>
+    <query>SELECT count() FROM t_subcolumns_final FINAL WHERE NOT ignore(length(m))</query>
+    <query>SELECT count() FROM t_subcolumns_final FINAL WHERE NOT ignore(m['5'])</query>
+    <query>SELECT count() FROM t_subcolumns_final FINAL WHERE isNotNull(s)</query>
+    <query>SELECT count(s) FROM t_subcolumns_final FINAL</query>
+
+    <drop_query>DROP TABLE t_subcolumns_final</drop_query>
+</test>

--- a/tests/queries/0_stateless/04926_functions_to_subcolumns_with_final.reference
+++ b/tests/queries/0_stateless/04926_functions_to_subcolumns_with_final.reference
@@ -1,0 +1,20 @@
+-- ReplacingMergeTree (safe): surviving row is ver=2, m={'x':9}, n=5 --
+length(m): rewritten
+m['x']: rewritten
+isNull(n): rewritten
+1	9	0	0
+-- CollapsingMergeTree (safe): surviving row is m={'x':9,'y':8}, n=5 --
+length(m): rewritten
+m['x']: rewritten
+isNull(n): rewritten
+2	9	0	0
+-- VersionedCollapsingMergeTree (safe): surviving row is m={'p':1,'q':2,'r':3}, n=7 --
+length(m): rewritten
+m['p']: rewritten
+isNull(n): rewritten
+3	1	0	0
+-- SummingMergeTree (unsafe): rewrite blocked under FINAL, allowed without FINAL --
+length(m) FINAL: not rewritten
+m['a'] FINAL: not rewritten
+length(m) no FINAL: rewritten
+m['a'] no FINAL: rewritten

--- a/tests/queries/0_stateless/04926_functions_to_subcolumns_with_final.sh
+++ b/tests/queries/0_stateless/04926_functions_to_subcolumns_with_final.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# optimize_functions_to_subcolumns is normally skipped under FINAL because reading a subcolumn
+# instead of computing the function may change the result for value-combining merge engines
+# (SummingMergeTree/GraphiteMergeTree/CoalescingMergeTree). It is safe for engines whose FINAL
+# merge only selects whole rows (Replacing/Collapsing/VersionedCollapsing), where the subcolumn of
+# the surviving row equals the subcolumn derived from that full row. This test checks that the
+# rewrite fires (and gives correct results) for the row-selecting engines under FINAL, and is still
+# blocked for SummingMergeTree.
+
+# Reports whether the rewrite happened by inspecting the reconstructed AST: a rewritten query reads
+# a subcolumn (m.size0 / m.key_x / n.null), otherwise it still calls the function.
+verdict() {
+    local label="$1" query="$2"
+    local ast
+    ast=$($CLICKHOUSE_CLIENT --optimize_functions_to_subcolumns=1 --query "EXPLAIN QUERY TREE dump_ast = 1 $query" | grep -E '^SELECT')
+    if echo "$ast" | grep -qE '\.size0|\.key_|\.null'; then
+        echo "$label: rewritten"
+    else
+        echo "$label: not rewritten"
+    fi
+}
+
+MAP_SETTINGS="map_serialization_version = 'basic', map_serialization_version_for_zero_level_parts = 'basic'"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t_final_repl"
+$CLICKHOUSE_CLIENT --query "
+CREATE TABLE t_final_repl (k UInt32, ver UInt32, m Map(String, UInt64), n Nullable(UInt64))
+ENGINE = ReplacingMergeTree(ver) ORDER BY k SETTINGS $MAP_SETTINGS;
+INSERT INTO t_final_repl VALUES (1, 1, {'a':1,'b':2}, NULL);
+INSERT INTO t_final_repl VALUES (1, 2, {'x':9}, 5);
+"
+echo "-- ReplacingMergeTree (safe): surviving row is ver=2, m={'x':9}, n=5 --"
+verdict "length(m)"  "SELECT length(m) FROM t_final_repl FINAL"
+verdict "m['x']"     "SELECT m['x'] FROM t_final_repl FINAL"
+verdict "isNull(n)"  "SELECT isNull(n) FROM t_final_repl FINAL"
+$CLICKHOUSE_CLIENT --optimize_functions_to_subcolumns=1 --query "
+SELECT length(m), m['x'], m['a'], isNull(n) FROM t_final_repl FINAL"
+$CLICKHOUSE_CLIENT --query "DROP TABLE t_final_repl"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t_final_coll"
+$CLICKHOUSE_CLIENT --query "
+CREATE TABLE t_final_coll (k UInt32, sign Int8, m Map(String, UInt64), n Nullable(UInt64))
+ENGINE = CollapsingMergeTree(sign) ORDER BY k SETTINGS $MAP_SETTINGS;
+INSERT INTO t_final_coll VALUES (1, 1, {'a':1}, NULL);
+INSERT INTO t_final_coll VALUES (1, -1, {'a':1}, NULL);
+INSERT INTO t_final_coll VALUES (1, 1, {'x':9,'y':8}, 5);
+"
+echo "-- CollapsingMergeTree (safe): surviving row is m={'x':9,'y':8}, n=5 --"
+verdict "length(m)"  "SELECT length(m) FROM t_final_coll FINAL"
+verdict "m['x']"     "SELECT m['x'] FROM t_final_coll FINAL"
+verdict "isNull(n)"  "SELECT isNull(n) FROM t_final_coll FINAL"
+$CLICKHOUSE_CLIENT --optimize_functions_to_subcolumns=1 --query "
+SELECT length(m), m['x'], m['a'], isNull(n) FROM t_final_coll FINAL"
+$CLICKHOUSE_CLIENT --query "DROP TABLE t_final_coll"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t_final_vcoll"
+$CLICKHOUSE_CLIENT --query "
+CREATE TABLE t_final_vcoll (k UInt32, sign Int8, ver UInt32, m Map(String, UInt64), n Nullable(UInt64))
+ENGINE = VersionedCollapsingMergeTree(sign, ver) ORDER BY k SETTINGS $MAP_SETTINGS;
+INSERT INTO t_final_vcoll VALUES (1, 1, 1, {'a':1}, NULL);
+INSERT INTO t_final_vcoll VALUES (1, -1, 1, {'a':1}, NULL);
+INSERT INTO t_final_vcoll VALUES (1, 1, 2, {'p':1,'q':2,'r':3}, 7);
+"
+echo "-- VersionedCollapsingMergeTree (safe): surviving row is m={'p':1,'q':2,'r':3}, n=7 --"
+verdict "length(m)"  "SELECT length(m) FROM t_final_vcoll FINAL"
+verdict "m['p']"     "SELECT m['p'] FROM t_final_vcoll FINAL"
+verdict "isNull(n)"  "SELECT isNull(n) FROM t_final_vcoll FINAL"
+$CLICKHOUSE_CLIENT --optimize_functions_to_subcolumns=1 --query "
+SELECT length(m), m['p'], m['a'], isNull(n) FROM t_final_vcoll FINAL"
+$CLICKHOUSE_CLIENT --query "DROP TABLE t_final_vcoll"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t_final_sum"
+$CLICKHOUSE_CLIENT --query "
+CREATE TABLE t_final_sum (k UInt32, m Map(String, UInt64), v UInt64)
+ENGINE = SummingMergeTree ORDER BY k SETTINGS $MAP_SETTINGS;
+INSERT INTO t_final_sum VALUES (1, {'a':1,'b':2}, 5);
+INSERT INTO t_final_sum VALUES (1, {'a':10,'c':3}, 7);
+"
+echo "-- SummingMergeTree (unsafe): rewrite blocked under FINAL, allowed without FINAL --"
+verdict "length(m) FINAL"    "SELECT length(m) FROM t_final_sum FINAL"
+verdict "m['a'] FINAL"       "SELECT m['a'] FROM t_final_sum FINAL"
+verdict "length(m) no FINAL" "SELECT length(m) FROM t_final_sum"
+verdict "m['a'] no FINAL"    "SELECT m['a'] FROM t_final_sum"
+$CLICKHOUSE_CLIENT --query "DROP TABLE t_final_sum"


### PR DESCRIPTION
The `optimize_functions_to_subcolumns` rewrite (e.g. `length(m)` -> `m.size0`, `m['k']` -> `m.key_k`, `isNull(n)` -> `n.null`) was skipped for any table read with `FINAL`. Under `FINAL` the merge runs over exactly the columns being read, so for value-combining engines (`SummingMergeTree`, `GraphiteMergeTree`, `CoalescingMergeTree`) a numeric subcolumn gets combined independently of its base column and no longer equals the function computed on the merged column — hence the blanket skip.

This is unnecessary for engines whose `FINAL` merge only selects whole rows: `ReplacingMergeTree`, `CollapsingMergeTree`, `VersionedCollapsingMergeTree`. There the subcolumn of the surviving row equals the subcolumn derived from that full row, so the rewrite is safe and lets `FINAL` read only the needed subcolumn.

A new virtual `IStorage::supportsSubcolumnOptimizationWithFinal` (default `false`) is overridden in `MergeTreeData` to return `true` only for those three row-selecting modes; the `FINAL` guard in `FunctionToSubcolumnsPass` now consults it. Unknown storages are treated as unsafe.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Apply the `optimize_functions_to_subcolumns` optimization to queries with `FINAL` over `ReplacingMergeTree`, `CollapsingMergeTree` and `VersionedCollapsingMergeTree`, where it is safe. Previously it was disabled for any query with `FINAL`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116562&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116562](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116562+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
