### PR TITLE
Fix `h3Line` returning uninitialized memory when the line crosses pentagon distortion

### DIFF
--- a/src/Functions/h3Line.cpp
+++ b/src/Functions/h3Line.cpp
@@ -146,7 +146,15 @@ public:
                 continue;
             }
             budget.charge(size * sizeof(H3Index));
-            gridPathCells(start, end, ptr + current_offset);
+            /// The sizing pass above validates only the two endpoints, so this call can still fail on
+            /// an intermediate cell in pentagon distortion, leaving the rest of the row's slots unwritten.
+            H3Error err = gridPathCells(start, end, ptr + current_offset);
+            if (err)
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Line cannot be computed between start H3 index {} and end H3 index {}, error: {}",
+                    start, end, err);
+
             current_offset += size;
         }
 

--- a/tests/queries/0_stateless/02293_h3_line.sql
+++ b/tests/queries/0_stateless/02293_h3_line.sql
@@ -53,4 +53,10 @@ SELECT length(h3Line(stringToH3(start), stringToH3(end))) FROM h3_indexes ORDER 
 
 SELECT h3Line(0xffffffffffffff, 0xffffffffffffff); -- { serverError INCORRECT_DATA }
 
+-- A line whose endpoints are valid but which crosses pentagon distortion: the length of the line can
+-- be computed while the line itself cannot, so the query must fail rather than return a partially
+-- written array.
+SELECT h3Line(toUInt64(585609238802333695), toUInt64(585624631965122559)); -- { serverError INCORRECT_DATA }
+SELECT h3Line(materialize(toUInt64(585609238802333695)), materialize(toUInt64(585624631965122559))); -- { serverError INCORRECT_DATA }
+
 DROP TABLE h3_indexes;

--- a/tests/queries/0_stateless/04034_h3_functions_default_if_invalid.sql
+++ b/tests/queries/0_stateless/04034_h3_functions_default_if_invalid.sql
@@ -42,3 +42,8 @@ SELECT h3GetUnidirectionalEdgesFromHexagon(toUInt64(0));
 SELECT h3IndexesAreNeighbors(toUInt64(0), toUInt64(0));
 SELECT h3CellAreaM2(toUInt64(0));
 SELECT h3CellAreaRads2(toUInt64(0));
+
+-- The setting only substitutes a default for an invalid cell. Both endpoints below are valid, so a
+-- line that cannot be drawn between them is still an error.
+SELECT h3Line(toUInt64(585609238802333695), toUInt64(585624631965122559))
+SETTINGS functions_h3_default_if_invalid = 1; -- { serverError INCORRECT_DATA }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `h3Line` returning uninitialized memory in the tail of the result array when a line between two valid H3 indices cannot be drawn because it crosses pentagon distortion. Such a call now throws `INCORRECT_DATA`.


### Description

`h3Line` builds its result in two passes: a sizing pass that calls `gridPathCellsSize` and checks its `H3Error`, then `PODArray::resize`, which does not initialize elements, then a fill pass that called `gridPathCells` and discarded its `H3Error`.

The two passes validate different things. `gridPathCellsSize` validates only the two endpoints, while `gridPathCells` walks the intermediate cells and returns `E_PENTAGON` after a partial write when the line crosses pentagon distortion. The slots it never reached were returned to the client:

```sql
SELECT h3Line(toUInt64(585609238802333695), toUInt64(585624631965122559));
```

On master this returns a 3-element array whose third element is not a valid H3 index. The observed values were pointer-shaped and changed between calls, so a constant query with plain `SELECT` discloses server memory.

This fix checks the error, matching the sizing pass above and the sibling `h3HexRing`, which already checks it. `h3Line` and `h3HexRing` are the only two h3 functions that fill a `resize()`d `PODArray` this way, so the whole class now checks; the other h3 functions that discard an `H3Error` fill value-initializing containers.

`gridPathCells` fails only by returning early from its fill loop, so it never fails after writing every slot. The calls that now throw are exactly those that previously returned a partly uninitialized array. That includes `functions_h3_default_if_invalid = 1`: it substitutes a default for an invalid *cell*, and both endpoints here are valid. A test arm pins it.

Validation: the three new arms fail on master, pass with the fix, and survive 50 randomized-settings runs; the two untouched `h3Line` tests pass on both; the same pair throws through `materialize`, `Nullable`, `LowCardinality` and batched shapes, and non-pentagon inputs stay byte-identical to master.

Reported to me privately as a core-security issue, with @ nikitamikhaylov asking for a public fix. The carrier is public code, so the fix belongs here; there is no public issue to link.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116583&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116583](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116583+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.194` (included in `26.9` and later)
- Backported to: `26.8.3.57`, `26.7.7.38`, `26.6.5.65`, `26.3.33.10`
<!-- ch-version-info:end -->