### PR TITLE
Fix `moduloOrNull` and the other `*OrNull` division functions losing NULL

### DIFF
--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -3185,6 +3185,21 @@ ColumnPtr executeStringInteger(const ColumnsWithTypeAndName & arguments, const A
         const auto & left_argument = arguments[0];
         const auto & right_argument = arguments[1];
 
+        /// A constant's value is independent of its size, but the null map carrying the
+        /// division-by-zero outcome has one entry per row, so a zero-row call keeps the value and
+        /// loses the NULL. Constant arguments give the same answer for every row.
+        if constexpr (is_division_or_null)
+        {
+            if (input_rows_count == 0 && result_type->isNullable() && !right_nullmap && !result_nullmap
+                && isColumnConst(*left_argument.column) && isColumnConst(*right_argument.column))
+            {
+                ColumnsWithTypeAndName one_row = arguments;
+                for (auto & argument : one_row)
+                    argument.column = argument.column->cloneResized(1);
+                return executeImpl2(one_row, result_type, 1)->cloneResized(0);
+            }
+        }
+
         /// Process special case when operation is divide, intDiv or modulo and denominator
         /// is Nullable(Something) to prevent division by zero error.
         ///

--- a/tests/queries/0_stateless/05045_or_null_division_subquery_wrap_no_lost_null.reference
+++ b/tests/queries/0_stateless/05045_or_null_division_subquery_wrap_no_lost_null.reference
@@ -1,0 +1,25 @@
+wrapped	\N
+wrapped	\N
+wrapped	\N
+wrapped	\N
+direct	\N	\N	\N	\N
+direct	\N	\N	\N	\N
+direct	\N	\N	\N	\N
+direct	\N	\N	\N	\N
+family	4	4	4	4	4
+divisor types	4	4	4	4
+lowcardinality	4	4
+lowcardinality nullable	4	4
+always null divisor	4	4
+stored	4	4
+view	4	4
+ctas	4	4
+non-const dividend	4	4	4
+non-const divisor	4	4
+or zero	4	0	0
+nonzero divisor	4	0	4
+row values	1	1
+row values	2	2
+row values	3	0
+row values	4	1
+type	Nullable(UInt8)

--- a/tests/queries/0_stateless/05045_or_null_division_subquery_wrap_no_lost_null.sql
+++ b/tests/queries/0_stateless/05045_or_null_division_subquery_wrap_no_lost_null.sql
@@ -1,0 +1,63 @@
+-- Division by a constant zero must return NULL from the *OrNull functions no matter which projection consumes the value.
+-- See https://github.com/ClickHouse/ClickHouse/issues/116500
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS test;
+DROP TABLE IF EXISTS sink;
+DROP VIEW IF EXISTS v;
+DROP TABLE IF EXISTS ctas;
+
+CREATE TABLE test (x UInt32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test VALUES (1), (2), (3), (4);
+
+-- The reported shape: a passthrough subquery around a constant-folding dividend.
+SELECT 'wrapped', m FROM (SELECT moduloOrNull(byteSize(x), 0) AS m FROM test);
+
+-- The same expressions evaluated without an outer projection.
+SELECT 'direct', moduloOrNull(byteSize(x), 0), intDivOrNull(byteSize(x), 0), positiveModuloOrNull(byteSize(x), 0), divideOrNull(byteSize(x), 0) FROM test;
+
+-- All four functions of the family, consumed through an outer projection.
+SELECT 'family', count(), countIf(m1 IS NULL), countIf(m2 IS NULL), countIf(m3 IS NULL), countIf(m4 IS NULL)
+FROM (SELECT moduloOrNull(byteSize(x), 0) AS m1, intDivOrNull(byteSize(x), 0) AS m2,
+             positiveModuloOrNull(byteSize(x), 0) AS m3, divideOrNull(byteSize(x), 0) AS m4 FROM test);
+
+-- Float, wide and Nullable divisors reach different type dispatch paths.
+SELECT 'divisor types', count(), countIf(f IS NULL), countIf(w IS NULL), countIf(n IS NULL)
+FROM (SELECT moduloOrNull(byteSize(x), 0.) AS f, moduloOrNull(byteSize(x), toInt128(0)) AS w,
+             moduloOrNull(byteSize(x), toNullable(0)) AS n FROM test);
+
+SELECT 'lowcardinality', count(), countIf(m IS NULL) FROM (SELECT moduloOrNull(byteSize(x), toLowCardinality(0)) AS m FROM test);
+SELECT 'lowcardinality nullable', count(), countIf(m IS NULL) FROM (SELECT moduloOrNull(byteSize(x), toLowCardinality(toNullable(0))) AS m FROM test);
+
+SELECT 'always null divisor', count(), countIf(m IS NULL) FROM (SELECT moduloOrNull(byteSize(x), CAST(NULL, 'Nullable(UInt8)')) AS m FROM test);
+
+-- A stored result keeps whatever the projection produced.
+CREATE TABLE sink (m Nullable(UInt8)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO sink SELECT * FROM (SELECT moduloOrNull(byteSize(x), 0) AS m FROM test);
+SELECT 'stored', count(), countIf(m IS NULL) FROM sink;
+
+-- Selecting from a view is itself a wrap, so a view needs no explicit subquery.
+CREATE VIEW v AS SELECT moduloOrNull(byteSize(x), 0) AS m FROM test;
+SELECT 'view', count(), countIf(m IS NULL) FROM v;
+CREATE TABLE ctas ENGINE = MergeTree ORDER BY tuple() AS SELECT * FROM (SELECT moduloOrNull(byteSize(x), 0) AS m FROM test);
+SELECT 'ctas', count(), countIf(m IS NULL) FROM ctas;
+
+-- A dividend or divisor that stays non-constant never takes the constant path.
+SELECT 'non-const dividend', count(), countIf(a IS NULL), countIf(b IS NULL)
+FROM (SELECT moduloOrNull(x, 0) AS a, moduloOrNull(materialize(x), 0) AS b FROM test);
+SELECT 'non-const divisor', count(), countIf(m IS NULL) FROM (SELECT moduloOrNull(byteSize(x), x - x) AS m FROM test);
+
+-- intDivOrZero is outside the family and keeps returning zero.
+SELECT 'or zero', count(), countIf(m IS NULL), sum(m) FROM (SELECT intDivOrZero(byteSize(x), 0) AS m FROM test);
+
+-- A divisor that does not raise keeps its value.
+SELECT 'nonzero divisor', count(), countIf(m IS NULL), sum(m) FROM (SELECT moduloOrNull(byteSize(x), 3) AS m FROM test);
+SELECT 'row values', x, moduloOrNull(x, 3) FROM test ORDER BY x;
+
+SELECT 'type', toTypeName(m) FROM (SELECT * FROM (SELECT moduloOrNull(byteSize(x), 0) AS m FROM test)) LIMIT 1;
+
+DROP VIEW v;
+DROP TABLE ctas;
+DROP TABLE sink;
+DROP TABLE test;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/116500
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `moduloOrNull`, `intDivOrNull`, `divideOrNull` and `positiveModuloOrNull` returning the raw division result instead of `NULL` when dividing by a constant zero inside a subquery whose result an outer query consumes, such as a passthrough `SELECT * FROM (...)` or a view. `INSERT ... SELECT` and `CREATE TABLE AS SELECT` over such a subquery persist the wrong value. Closes #116500.

### Description

Dividing by a constant zero returns the raw result instead of `NULL` once an outer projection consumes it:

```sql
CREATE TABLE test (x UInt32) ENGINE = MergeTree ORDER BY tuple(); INSERT INTO test VALUES (1), (2), (3), (4);
SELECT moduloOrNull(byteSize(x), 0) FROM test;                  -- NULL, correct
SELECT * FROM (SELECT moduloOrNull(byteSize(x), 0) FROM test);  -- 0, wrong
```

`divideOrNull` yields `inf`, showing the value survives while the null flag is dropped. It also persists: `INSERT INTO sink SELECT * FROM (...)` writes four rows of `0`. Reproduces on 25.8.33.6, 26.5.8.25 and 26.8.1.2011, not a regression; analyzer only.

`ActionsDAG::updateHeader` builds a step's output header by really executing each function node at `input_rows_count = 0`, and `byteSize` returns a `ColumnConst` whenever its argument type is fixed size, so the function runs on two zero-row constants. A constant's value is size-independent, so `4 % 0` survives, but the division-by-zero flag lives in a null map sized from `input_rows_count`, which is empty; `wrapInNullable` reads that empty map as NOT NULL and returns a constant asserting "0, not NULL", which the outer projection bakes.

The fix answers a zero-row constant call by evaluating one row and shrinking the result back, the normalization `getFunctionArguments` already applies for the DAG-building path (`2cc3cd15ecb93a6`, which names `moduloOrNull`). `ColumnConst::cloneResized` keeps the data column, so the header still reports a constant, now `NULL`. Real execution is untouched.

Two reported triggers do not reproduce (`moduloOrNull(x, 0)` and `moduloOrNull(materialize(x), 0)` are `NULL` in both spellings): what matters is a dividend that turns constant at zero rows, which `byteSize(x)` does by type and `x` does not.

Validated: the new test fails on the parent commit across eight arms and passes with it, 50/50 randomized runs, and a 780-test local sweep with no regression, including `04053_totals_having_const_mismatch`, which pins the constness contract.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116594&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116594](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116594+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.569` (included in `26.9` and later)
- Backported to: `26.8.3.18`
<!-- ch-version-info:end -->