### PR TITLE
Fix `ALTER TABLE ... PARTITION` for a partition key containing `modulo`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -9094,7 +9094,10 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr loc
 
     /// Re-parse partition key fields using the information about expected field types.
     auto metadata_snapshot = getInMemoryMetadataPtr(local_context, false);
-    const Block & key_sample_block = metadata_snapshot->getPartitionKey().sample_block;
+    /// Existing parts hold partition values produced with the adjusted partition key (`modulo` becomes
+    /// `moduloLegacy`, which can differ in signedness), so a value parsed here must use the same types.
+    const auto adjusted_partition_key = MergeTreePartition::adjustPartitionKey(metadata_snapshot, local_context);
+    const Block & key_sample_block = adjusted_partition_key.sample_block;
     size_t fields_count = key_sample_block.columns();
     if (partition_ast_fields_count != fields_count)
         throw Exception(ErrorCodes::INVALID_PARTITION_VALUE,
@@ -9189,10 +9192,12 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr loc
             existing_part_in_partition = getAnyPartInPartition(partition_id, readLockParts());
         if (existing_part_in_partition && existing_part_in_partition->partition.value != partition.value)
         {
-            auto partition_str = partition.serializeToString(existing_part_in_partition->getMetadataSnapshot());
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Parsed partition value: {} "
-                            "doesn't match partition value for an existing part with the same partition ID: {}",
-                            partition_str, existing_part_in_partition->name);
+            auto part_metadata_snapshot = existing_part_in_partition->getMetadataSnapshot();
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Parsed partition value {} does not match partition value {} "
+                            "of the existing part {} with the same partition ID",
+                            partition.serializeToString(part_metadata_snapshot),
+                            existing_part_in_partition->partition.serializeToString(part_metadata_snapshot),
+                            existing_part_in_partition->name);
         }
     }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -11461,7 +11461,7 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
         }
         else if (auto parsed_partition = MergeTreePartition::tryParseValueFromID(
                      new_part_info.getPartitionId(),
-                     table_metadata->getPartitionKey().sample_block))
+                     MergeTreePartition::adjustPartitionKey(table_metadata, getContext()).sample_block))
         {
             partition = MergeTreePartition(*parsed_partition);
         }

--- a/tests/integration/test_lost_part/test.py
+++ b/tests/integration/test_lost_part/test.py
@@ -307,6 +307,80 @@ def test_lost_last_part(start_cluster):
         node2.query("DROP TABLE IF EXISTS mt3 SYNC")
 
 
+def count_in_log(node, substring):
+    # Number of matching lines, including rotated logs. contains_in_log answers "ever", which a
+    # line left by an earlier run of the same test already satisfies; comparing this count across
+    # an action keeps a check about that action.
+    return len([line for line in node.grep_in_log(substring).splitlines() if line])
+
+
+def test_lost_last_part_modulo_partition_key(start_cluster):
+    # An empty part created instead of a lost one takes its partition value from the partition id,
+    # so that value must be typed like the one an INSERT produces. For a `modulo` whose left operand
+    # is unsigned and whose right operand is signed the two differ in signedness, and a partition
+    # value of the wrong signedness cannot be addressed by a later partition manipulation.
+    node1.query("DROP TABLE IF EXISTS mt_mod SYNC")
+    node2.query("DROP TABLE IF EXISTS mt_mod SYNC")
+
+    try:
+        for node in [node1, node2]:
+            node.query(
+                f"CREATE TABLE mt_mod (c0 Int32) ENGINE ReplicatedMergeTree('/clickhouse/tables/t_mod', '{node.name}') "
+                "ORDER BY tuple() PARTITION BY (37528 % c0) SETTINGS cleanup_delay_period=1, cleanup_delay_period_random_add=1,"
+                "cleanup_thread_preferred_points_per_iteration=0, merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000"
+            )
+
+        node1.query("SYSTEM STOP MERGES mt_mod")
+        # The other replica must never receive the part, otherwise the lost part is fetched
+        # instead of being replaced by an empty one.
+        node2.query("SYSTEM STOP REPLICATION QUEUES")
+
+        # Exactly one part: the partition must be left with no active part, or the empty part
+        # copies its partition value from a sibling instead of parsing the partition id.
+        node1.query(
+            "INSERT INTO mt_mod VALUES (167682982)",
+            settings={"insert_keeper_fault_injection_probability": 0},
+        )
+
+        part_name = node1.query(
+            "SELECT name FROM system.parts WHERE database = currentDatabase() AND table = 'mt_mod' AND active"
+        ).strip()
+        assert part_name.startswith("37528_"), part_name
+
+        created = f"Created empty part {part_name} instead of lost part"
+        # Either of these means the partition id was not parsed into a value, leaving nothing
+        # for this test to exercise.
+        unparsed = f"Empty part {part_name} is not created instead of lost part because there are no parts in partition"
+        gave_up = f"Cannot create empty part {part_name} instead of lost"
+        created_before = count_in_log(node1, created)
+        unparsed_before = count_in_log(node1, unparsed)
+        gave_up_before = count_in_log(node1, gave_up)
+
+        remove_part_from_disk(node1, "mt_mod", part_name)
+
+        node1.query("CHECK TABLE mt_mod")
+        node1.query("SYSTEM START MERGES mt_mod")
+
+        for _ in range(200):
+            if count_in_log(node1, created) > created_before:
+                break
+            time.sleep(0.5)
+        else:
+            assert False, "Empty part was not created instead of lost part " + part_name
+
+        assert count_in_log(node1, unparsed) == unparsed_before
+        assert count_in_log(node1, gave_up) == gave_up_before
+
+        # By value: the by-id spelling resolves the partition without parsing a value at all.
+        node1.query("ALTER TABLE mt_mod DROP PARTITION 37528")
+
+        assert_eq_with_retry(node1, "SELECT count() FROM mt_mod", "0")
+    finally:
+        node2.query("SYSTEM START REPLICATION QUEUES")
+        node1.query("DROP TABLE IF EXISTS mt_mod SYNC")
+        node2.query("DROP TABLE IF EXISTS mt_mod SYNC")
+
+
 def remove_part_dir_from_disk(node, table, part_name):
     # Unlike remove_part_from_disk, removes the whole part directory,
     # so the part becomes missing rather than broken (empty).

--- a/tests/queries/0_stateless/04947_modulo_partition_key_alter_partition.reference
+++ b/tests/queries/0_stateless/04947_modulo_partition_key_alter_partition.reference
@@ -1,0 +1,9 @@
+drop partition	0
+delete in partition	0
+complex key	0
+wide key	0
+out of range	1
+partition id	20200523-37528
+unsigned column	0
+signed left operand	0
+no modulo	0

--- a/tests/queries/0_stateless/04947_modulo_partition_key_alter_partition.sql
+++ b/tests/queries/0_stateless/04947_modulo_partition_key_alter_partition.sql
@@ -1,0 +1,51 @@
+-- Partition manipulation for a key containing `modulo` whose left operand is unsigned and whose right
+-- operand is signed: the value computed for a part and the value parsed from the query must agree.
+
+CREATE TABLE mod_drop (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (37528 % c0);
+INSERT INTO mod_drop VALUES (167682982);
+ALTER TABLE mod_drop DROP PARTITION 37528;
+SELECT 'drop partition', count() FROM mod_drop;
+
+SET mutations_sync = 2;
+CREATE TABLE mod_delete (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (37528 % c0);
+INSERT INTO mod_delete VALUES (167682982);
+DELETE FROM mod_delete IN PARTITION 37528 WHERE 1;
+SELECT 'delete in partition', count() FROM mod_delete;
+
+CREATE TABLE mod_complex (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (c0, 37528 % c0);
+INSERT INTO mod_complex VALUES (167682982);
+ALTER TABLE mod_complex DROP PARTITION (167682982, 37528);
+SELECT 'complex key', count() FROM mod_complex;
+
+-- The partition value is hashed into the partition ID once it no longer fits 8 bytes.
+CREATE TABLE mod_wide (c0 Int128) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (CAST(37528, 'UInt64') % c0);
+INSERT INTO mod_wide VALUES (167682982);
+ALTER TABLE mod_wide DROP PARTITION 37528;
+SELECT 'wide key', count() FROM mod_wide;
+
+-- A value outside the range of the partition key type addresses no partition and is rejected.
+CREATE TABLE mod_range (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (c0 % 37528);
+INSERT INTO mod_range VALUES (5);
+ALTER TABLE mod_range DROP PARTITION 40000; -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT 'out of range', count() FROM mod_range;
+
+-- Partition IDs must be unaffected.
+CREATE TABLE mod_id (d Date, c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (d, 37528 % c0);
+INSERT INTO mod_id VALUES ('2020-05-23', 167682982);
+SELECT 'partition id', partition_id FROM system.parts WHERE database = currentDatabase() AND table = 'mod_id' AND active;
+
+-- Keys whose two `modulo` operand types agree in signedness, and keys with no `modulo` at all.
+CREATE TABLE mod_unsigned (c0 UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (37528 % c0);
+INSERT INTO mod_unsigned VALUES (167682982);
+ALTER TABLE mod_unsigned DROP PARTITION 37528;
+SELECT 'unsigned column', count() FROM mod_unsigned;
+
+CREATE TABLE mod_signed_left (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (c0 % 37528);
+INSERT INTO mod_signed_left VALUES (5);
+ALTER TABLE mod_signed_left DROP PARTITION 5;
+SELECT 'signed left operand', count() FROM mod_signed_left;
+
+CREATE TABLE mod_none (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY positiveModulo(37528, c0);
+INSERT INTO mod_none VALUES (167682982);
+ALTER TABLE mod_none DROP PARTITION 37528;
+SELECT 'no modulo', count() FROM mod_none;

--- a/tests/queries/0_stateless/04947_modulo_partition_key_alter_partition.sql
+++ b/tests/queries/0_stateless/04947_modulo_partition_key_alter_partition.sql
@@ -22,6 +22,7 @@ CREATE TABLE mod_wide (c0 Int128) ENGINE = MergeTree ORDER BY tuple() PARTITION 
 INSERT INTO mod_wide VALUES (167682982);
 ALTER TABLE mod_wide DROP PARTITION 37528;
 SELECT 'wide key', count() FROM mod_wide;
+DROP TABLE mod_wide;
 
 -- A value outside the range of the partition key type addresses no partition and is rejected.
 CREATE TABLE mod_range (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (c0 % 37528);
@@ -34,7 +35,7 @@ CREATE TABLE mod_id (d Date, c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTI
 INSERT INTO mod_id VALUES ('2020-05-23', 167682982);
 SELECT 'partition id', partition_id FROM system.parts WHERE database = currentDatabase() AND table = 'mod_id' AND active;
 
--- Keys whose two `modulo` operand types agree in signedness, and keys with no `modulo` at all.
+-- Keys where the result signedness is the same either way, and keys with no `modulo` at all.
 CREATE TABLE mod_unsigned (c0 UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (37528 % c0);
 INSERT INTO mod_unsigned VALUES (167682982);
 ALTER TABLE mod_unsigned DROP PARTITION 37528;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `... PARTITION <value>` statements against a table whose `PARTITION BY` contains `modulo` with an unsigned left operand and a signed right operand, such as `PARTITION BY (37528 % c0)` with `c0 Int32`. Such a statement raised `LOGICAL_ERROR`, or silently affected no partition. A value outside the range of the partition key type is now rejected with `ARGUMENT_OUT_OF_BOUND` instead of silently matching nothing.

### Description

A `... PARTITION <value>` statement against a table whose `PARTITION BY` contains `modulo` with an unsigned left operand and a signed right operand raises `LOGICAL_ERROR`, aborting a debug or sanitizer build:

```sql
CREATE TABLE t (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY (37528 % c0);
INSERT INTO t VALUES (167682982);
ALTER TABLE t DROP PARTITION 37528;
-- Parsed partition value: 37528 doesn't match partition value for an
-- existing part with the same partition ID: 37528_1_1_0
```

Root cause: `adjustPartitionKey` rewrites `modulo` to `moduloLegacy`, whose result type is signed if either operand is signed rather than only the left, so `37528 % c0` with `c0 Int32` is `UInt32` under `modulo` and `Int32` under `moduloLegacy`. A part's value uses the adjusted key; `getPartitionIDFromQuery` parsed the query's with the unadjusted one. `getID` renders `UInt64` and `Int64` identically, so the ID matched and the part was found, while `Field::operator==` is type strict.

I parse with the adjusted key instead. `partition.getID` keeps the unadjusted block, exactly as `MergeTreeDataWriter` does, so no partition ID changes, and `tryParseValueFromID` gets the same treatment. Two siblings of the same cause are fixed too: past eight bytes the ID hashes the `Field` type tag, so the statement silently dropped nothing; and where the adjusted type is narrower, an out-of-range value silently matched nothing and now raises `ARGUMENT_OUT_OF_BOUND`.

Both tests pass with the change; the stateless one aborts on the parent commit, 50/50 randomized and 50/50 pinned, and the integration one reddens when only the `tryParseValueFromID` hunk is reverted. `SELECT partition FROM system.parts` still throws `BAD_GET` past eight bytes; that read-side site needs an API change and is out of scope.

Found by CI, no issue filed: `BuzzHouse (amd_debug)`, STID 3993-3f59, https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115630&sha=11816184dbcf3b8ffec3ae07bcad615625c4581c&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29 . STID 3993-6336 (`amd_msan`, 12 days earlier) is the same defect.

Closes https://github.com/ClickHouse/ClickHouse/issues/116737

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116606&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116606](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116606+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.867` (included in `26.9` and later)
<!-- ch-version-info:end -->