### PR TITLE
Wait for in-flight workload entity notifications when unsubscribing

### DIFF
--- a/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
@@ -3855,6 +3855,9 @@ struct UnsubscribeProbe
     std::mutex mutex;
     std::condition_variable blocker_entered_cv;
     bool blocker_entered = false;
+    std::condition_variable release_cv;
+    bool release_blocker = false;
+    std::chrono::seconds blocker_hold{2};
     std::atomic<bool> armed{false};
     std::atomic<int> blocker_in_flight{0};
     std::atomic<int> unsubscribed_handler_calls{0};
@@ -3895,8 +3898,12 @@ struct UnsubscribeTestSubscriber
                             shared_probe->blocker_entered = true;
                         }
                         shared_probe->blocker_entered_cv.notify_all();
-                        // Widens the window; no test asserts on this duration.
-                        std::this_thread::sleep_for(std::chrono::seconds(2));
+                        // Held until the test releases it, or for blocker_hold if the test has nothing to signal.
+                        {
+                            std::unique_lock lock{shared_probe->mutex};
+                            shared_probe->release_cv.wait_for(
+                                lock, shared_probe->blocker_hold, [&] { return shared_probe->release_blocker; });
+                        }
                         shared_probe->blocker_in_flight.fetch_sub(1);
                         break;
                     }
@@ -3942,6 +3949,7 @@ TEST(SchedulerWorkloadResourceManager, UnsubscribeWaitsForInFlightNotification)
     EXPECT_EQ(probe->blocker_in_flight.load(), 1) << "Handler is not in flight, so the barrier was never exercised";
 
     // Destroys the scope_guard returned by getAllEntitiesAndSubscribe.
+    // The handler must still be running when unsubscribe is entered, so only the blocked thread could signal a release.
     blocker.reset();
 
     EXPECT_EQ(probe->blocker_in_flight.load(), 0) << "Unsubscribe returned while the handler was still running";
@@ -3963,6 +3971,7 @@ TEST(SchedulerWorkloadResourceManager, UnsubscribeSkipsHandlerNotYetReached)
     auto live = std::make_unique<UnsubscribeTestSubscriber>(
         storage, probe, UnsubscribeTestSubscriber::Role::CountLive);
 
+    probe->blocker_hold = std::chrono::seconds(60);
     probe->armed.store(true);
 
     ThreadFromGlobalPool notifier([&storage]
@@ -3975,6 +3984,12 @@ TEST(SchedulerWorkloadResourceManager, UnsubscribeSkipsHandlerNotYetReached)
     // The notifier already copied all three handlers out of the list and is parked in the first
     // one, so this unsubscribe cannot wait for anything and must return immediately.
     unsubscribed.reset();
+
+    {
+        std::lock_guard lock{probe->mutex};
+        probe->release_blocker = true;
+    }
+    probe->release_cv.notify_all();
 
     notifier.join();
 

--- a/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
@@ -3971,6 +3971,7 @@ TEST(SchedulerWorkloadResourceManager, UnsubscribeSkipsHandlerNotYetReached)
     auto live = std::make_unique<UnsubscribeTestSubscriber>(
         storage, probe, UnsubscribeTestSubscriber::Role::CountLive);
 
+    // A deadlock escape that must never fire; the release after the unsubscribe below ends the hold.
     probe->blocker_hold = std::chrono::seconds(60);
     probe->armed.store(true);
 
@@ -3983,7 +3984,9 @@ TEST(SchedulerWorkloadResourceManager, UnsubscribeSkipsHandlerNotYetReached)
 
     // The notifier already copied all three handlers out of the list and is parked in the first
     // one, so this unsubscribe cannot wait for anything and must return immediately.
-    unsubscribed.reset();
+    // Only the guard is dropped: the subscriber stays alive so that a handler invoked in breach of
+    // the contract reads live state and fails the assertion below instead of reading freed memory.
+    unsubscribed->subscription.reset();
 
     {
         std::lock_guard lock{probe->mutex};

--- a/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
@@ -3848,3 +3848,138 @@ TEST(SchedulerWorkloadResourceManager, PreemptiveCPUSchedulingEagerDefaultIsUnch
 
     t.wait();
 }
+
+// Shared with in-flight handlers, so it must outlive every subscriber that owns a subscription.
+struct UnsubscribeProbe
+{
+    std::mutex mutex;
+    std::condition_variable blocker_entered_cv;
+    bool blocker_entered = false;
+    std::atomic<bool> armed{false};
+    std::atomic<int> blocker_in_flight{0};
+    std::atomic<int> unsubscribed_handler_calls{0};
+    std::atomic<int> live_handler_calls{0};
+};
+
+// Captures `this` in its handler, like every real subscriber of getAllEntitiesAndSubscribe.
+// `subscription` is declared last, so it is destroyed before any state the handler reads.
+struct UnsubscribeTestSubscriber
+{
+    enum class Role
+    {
+        Blocker, // holds the notification inside the handler for a while
+        CountUnsubscribed, // increments unsubscribed_handler_calls
+        CountLive, // increments live_handler_calls
+    };
+
+    UnsubscribeTestSubscriber(WorkloadEntityTestStorage & storage, std::shared_ptr<UnsubscribeProbe> probe_, Role role_)
+        : probe(std::move(probe_)), role(role_)
+    {
+        subscription = storage.getAllEntitiesAndSubscribe(
+            [this, shared_probe = probe] (const std::vector<IWorkloadEntityStorage::Event> &)
+            {
+                // Reading a member is what makes the `this` capture load-bearing.
+                if (state.empty())
+                    return;
+
+                if (!shared_probe->armed.load())
+                    return;
+
+                switch (role)
+                {
+                    case Role::Blocker:
+                    {
+                        shared_probe->blocker_in_flight.fetch_add(1);
+                        {
+                            std::lock_guard lock{shared_probe->mutex};
+                            shared_probe->blocker_entered = true;
+                        }
+                        shared_probe->blocker_entered_cv.notify_all();
+                        // Widens the window; no test asserts on this duration.
+                        std::this_thread::sleep_for(std::chrono::seconds(2));
+                        shared_probe->blocker_in_flight.fetch_sub(1);
+                        break;
+                    }
+                    case Role::CountUnsubscribed:
+                        shared_probe->unsubscribed_handler_calls.fetch_add(1);
+                        break;
+                    case Role::CountLive:
+                        shared_probe->live_handler_calls.fetch_add(1);
+                        break;
+                }
+            });
+    }
+
+    std::shared_ptr<UnsubscribeProbe> probe;
+    Role role;
+    String state = "subscribed";
+    scope_guard subscription;
+};
+
+// Blocks until the blocker handler is provably inside its window.
+static bool waitForBlocker(UnsubscribeProbe & probe)
+{
+    std::unique_lock lock{probe.mutex};
+    return probe.blocker_entered_cv.wait_for(lock, std::chrono::seconds(60), [&] { return probe.blocker_entered; });
+}
+
+TEST(SchedulerWorkloadResourceManager, UnsubscribeWaitsForInFlightNotification)
+{
+    WorkloadEntityTestStorage storage;
+    auto probe = std::make_shared<UnsubscribeProbe>();
+    auto blocker = std::make_unique<UnsubscribeTestSubscriber>(
+        storage, probe, UnsubscribeTestSubscriber::Role::Blocker);
+
+    // The initial handler(current_state) call already happened above, with `armed == false`.
+    probe->armed.store(true);
+
+    ThreadFromGlobalPool notifier([&storage]
+    {
+        storage.executeQuery("CREATE RESOURCE res1 (WRITE DISK disk1, READ DISK disk1)");
+    });
+
+    EXPECT_TRUE(waitForBlocker(*probe)) << "Handler never started, so the barrier was never exercised";
+    EXPECT_EQ(probe->blocker_in_flight.load(), 1) << "Handler is not in flight, so the barrier was never exercised";
+
+    // Destroys the scope_guard returned by getAllEntitiesAndSubscribe.
+    blocker.reset();
+
+    EXPECT_EQ(probe->blocker_in_flight.load(), 0) << "Unsubscribe returned while the handler was still running";
+
+    notifier.join();
+}
+
+TEST(SchedulerWorkloadResourceManager, UnsubscribeSkipsHandlerNotYetReached)
+{
+    WorkloadEntityTestStorage storage;
+    auto probe = std::make_shared<UnsubscribeProbe>();
+
+    // Subscription order is notification order, so the blocker holds the notification before it
+    // reaches the two handlers below.
+    auto blocker = std::make_unique<UnsubscribeTestSubscriber>(
+        storage, probe, UnsubscribeTestSubscriber::Role::Blocker);
+    auto unsubscribed = std::make_unique<UnsubscribeTestSubscriber>(
+        storage, probe, UnsubscribeTestSubscriber::Role::CountUnsubscribed);
+    auto live = std::make_unique<UnsubscribeTestSubscriber>(
+        storage, probe, UnsubscribeTestSubscriber::Role::CountLive);
+
+    probe->armed.store(true);
+
+    ThreadFromGlobalPool notifier([&storage]
+    {
+        storage.executeQuery("CREATE RESOURCE res1 (WRITE DISK disk1, READ DISK disk1)");
+    });
+
+    EXPECT_TRUE(waitForBlocker(*probe)) << "Blocker handler never started, so nothing was exercised";
+
+    // The notifier already copied all three handlers out of the list and is parked in the first
+    // one, so this unsubscribe cannot wait for anything and must return immediately.
+    unsubscribed.reset();
+
+    notifier.join();
+
+    EXPECT_EQ(probe->live_handler_calls.load(), 1)
+        << "The notification never reached the handlers after the blocker, so the assertion below is vacuous";
+    EXPECT_EQ(probe->unsubscribed_handler_calls.load(), 0)
+        << "A handler was called after its subscription guard had already been destroyed";
+}

--- a/src/Common/Scheduler/Workload/IWorkloadEntityStorage.h
+++ b/src/Common/Scheduler/Workload/IWorkloadEntityStorage.h
@@ -83,6 +83,7 @@ public:
     using OnChangedHandler = std::function<void(const std::vector<Event> &)>;
 
     /// Gets all current entries, pass them through `handler` and subscribes for all later changes.
+    /// Destroying the returned guard stops further calls and, if `handler` is already running, waits for it to return.
     virtual scope_guard getAllEntitiesAndSubscribe(const OnChangedHandler & handler) = 0;
 
     /// Returns the name of resource used for CPU scheduling of the master query threads

--- a/src/Common/Scheduler/Workload/IWorkloadEntityStorage.h
+++ b/src/Common/Scheduler/Workload/IWorkloadEntityStorage.h
@@ -84,6 +84,7 @@ public:
 
     /// Gets all current entries, pass them through `handler` and subscribes for all later changes.
     /// Destroying the returned guard stops further calls and, if `handler` is already running, waits for it to return.
+    /// Destroy it before any state `handler` reads.
     virtual scope_guard getAllEntitiesAndSubscribe(const OnChangedHandler & handler) = 0;
 
     /// Returns the name of resource used for CPU scheduling of the master query threads

--- a/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp
+++ b/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp
@@ -345,6 +345,13 @@ WorkloadEntityStorageBase::WorkloadEntityStorageBase(ContextPtr global_context_,
     }
 }
 
+WorkloadEntityStorageBase::~WorkloadEntityStorageBase()
+{
+    /// The chain subscription must be dropped before members are destroyed: its handler reads
+    /// `log` and `global_context`, which are declared after `subscription` and would die first.
+    subscription.reset();
+}
+
 ASTPtr WorkloadEntityStorageBase::get(const String & entity_name) const
 {
     if (auto result = tryGet(entity_name))
@@ -600,12 +607,17 @@ scope_guard WorkloadEntityStorageBase::getAllEntitiesAndSubscribe(const OnChange
         current_state = orderEntities(entities);
 
         std::lock_guard lock2{handlers->mutex};
-        handlers->list.push_back(handler);
+        handlers->list.push_back(std::make_shared<HandlerEntry>(handler));
         auto handler_it = std::prev(handlers->list.end());
-        result = [my_handlers = handlers, handler_it]
+        result = [my_handlers = handlers, entry = *handler_it, handler_it]
         {
-            std::lock_guard lock3{my_handlers->mutex};
-            my_handlers->list.erase(handler_it);
+            {
+                std::lock_guard lock3{my_handlers->mutex};
+                my_handlers->list.erase(handler_it);
+            }
+
+            std::lock_guard exec_lock{entry->exec_mutex};
+            entry->unsubscribed = true;
         };
     }
 
@@ -646,7 +658,7 @@ void WorkloadEntityStorageBase::unlockAndNotify(
     if (tx.empty())
         return;
 
-    std::vector<OnChangedHandler> current_handlers;
+    std::vector<HandlerEntryPtr> current_handlers;
     {
         std::lock_guard handlers_lock{handlers->mutex};
         boost::range::copy(handlers->list, std::back_inserter(current_handlers));
@@ -654,11 +666,14 @@ void WorkloadEntityStorageBase::unlockAndNotify(
 
     lock.unlock();
 
-    for (const auto & handler : current_handlers)
+    for (const auto & entry : current_handlers)
     {
         try
         {
-            handler(tx);
+            std::lock_guard exec_lock{entry->exec_mutex};
+            if (entry->unsubscribed)
+                continue;
+            entry->handler(tx);
         }
         catch (...)
         {

--- a/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp
+++ b/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.cpp
@@ -348,7 +348,7 @@ WorkloadEntityStorageBase::WorkloadEntityStorageBase(ContextPtr global_context_,
 WorkloadEntityStorageBase::~WorkloadEntityStorageBase()
 {
     /// The chain subscription must be dropped before members are destroyed: its handler reads
-    /// `log` and `global_context`, which are declared after `subscription` and would die first.
+    /// `log`, which is declared after `subscription` and would die first.
     subscription.reset();
 }
 

--- a/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.h
+++ b/src/Common/Scheduler/Workload/WorkloadEntityStorageBase.h
@@ -18,6 +18,8 @@ class WorkloadEntityStorageBase : public IWorkloadEntityStorage
 {
 public:
     explicit WorkloadEntityStorageBase(ContextPtr global_context_, std::unique_ptr<IWorkloadEntityStorage> next_storage_ = {});
+    ~WorkloadEntityStorageBase() override;
+
     ASTPtr get(const String & entity_name) const override;
 
     ASTPtr tryGet(const String & entity_name) const override;
@@ -111,10 +113,23 @@ private:
         const std::unordered_map<String, ASTPtr> & all_entities,
         std::optional<Event> change = {});
 
+    /// Held by shared_ptr so a subscription outlives both its list node and the storage.
+    /// `exec_mutex` is held for the whole invocation, so acquiring it waits for an in-flight call.
+    /// `unsubscribed` stops an entry a notifier already copied out of `list` from being invoked.
+    struct HandlerEntry
+    {
+        explicit HandlerEntry(OnChangedHandler handler_) : handler(std::move(handler_)) {}
+
+        OnChangedHandler handler;
+        std::mutex exec_mutex;
+        bool unsubscribed = false; /// guarded by exec_mutex
+    };
+    using HandlerEntryPtr = std::shared_ptr<HandlerEntry>;
+
     struct Handlers
     {
         std::mutex mutex;
-        std::list<OnChangedHandler> list;
+        std::list<HandlerEntryPtr> list;
     };
     /// shared_ptr is here for safety because WorkloadEntityStorageBase can be destroyed before all subscriptions are removed.
     std::shared_ptr<Handlers> handlers;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/101447
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a use-after-free where a subscriber of workload entity changes, such as an object storage disk, could be destroyed while its own change callback was still running. Destroying a workload entity subscription now waits for an in-flight callback and stops new ones from starting. Reachable from a `CREATE TABLE` with an inline `disk(...)` definition whose startup fails, concurrently with `CREATE RESOURCE` or `DROP RESOURCE` from another session.

### Description

Related: #101447

`getAllEntitiesAndSubscribe` returns a `scope_guard` that only de-registers. `unlockAndNotify` copies the handler list out under its mutex, releases that mutex, then invokes each handler, so erasing the node cannot stop an invocation already copied out: the guard returns, the subscriber is destroyed, and the callback writes through a dangling `this`. All three subscribers capture raw `this`, none joins, and `WorkloadResourceManager`'s destructor already assumes the barrier, so the fix belongs in the handle.

A `CREATE TABLE` with an inline `disk(...)` whose `startup()` fails constructs, subscribes and then destroys a `DiskObjectStorage` on a user query thread; observed on a live server against a writable-path control.

Each subscription now owns a `shared_ptr<HandlerEntry>`. The notifier holds that entry's mutex across the invocation, which is what makes destroying the guard a join, and skips entries already marked unsubscribed; the guard erases the node, releases the list mutex, then takes the entry's mutex and marks it. A storage releases its list mutex before taking any entry mutex, and locks are only taken outward along the chain. `WorkloadEntityStorageBase` also gains a destructor whose only statement is `subscription.reset()`, because `log` is declared after `subscription` and the chain handler logs through it.

Two deterministic tests, one per half: removing either half reddens exactly one, and both fail on unmodified master. 67/67, 10/10 repeats.

Notes:
- Concurrent notifications of one handler are now serialised.
- A handler that notified the same storage re-entrantly, or destroyed a subscriber whose handler runs, would self-deadlock. Neither is reachable; `StopCallback` accepts the same limitation (`src/Common/StopToken.cpp:43-46`).
- `DiskObjectStorage` and `WorkloadResourceManager` are unmodified: both already drop the subscription before any state their handler reads.
- The destructor half has no arm: a negative one would read a destroyed `shared_ptr`.
- `AccessChangesNotifier` and `EnabledRoles` share this shape, untouched: different subsystem, unmeasured reachability.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116607&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116607](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116607+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.271` (included in `26.9` and later)
<!-- ch-version-info:end -->