### PR TITLE
Interleave the `iota` fill loops four ways on AArch64

### DIFF
--- a/src/Common/iota.cpp
+++ b/src/Common/iota.cpp
@@ -10,9 +10,8 @@ namespace DB
 /// separate function the compiler aligns the loop independently.
 /// (Previously the multi-target dispatch mechanism achieved this implicitly.)
 ///
-/// LLVM defaults AArch64's `MaxInterleaveFactor` to 2 and Neoverse-N1/V1 do not raise it, so on
-/// Linux aarch64 these fills need an explicit interleave hint to get the four accumulators that
-/// x86-64-v3 and Apple silicon already choose.
+/// LLVM's default interleave factor on AArch64 is 2, and a portable build (no `-mcpu=`) keeps that
+/// default. x86-64 and Darwin AArch64 already interleave these fills four ways.
 
 template <iota_supported_types T>
 void NO_INLINE iota(T * begin, size_t count, T first_value)

--- a/src/Common/iota.cpp
+++ b/src/Common/iota.cpp
@@ -11,7 +11,7 @@ namespace DB
 /// (Previously the multi-target dispatch mechanism achieved this implicitly.)
 ///
 /// LLVM's default interleave factor on AArch64 is 2, and a portable build (no `-mcpu=`) keeps that
-/// default. x86-64 and Darwin AArch64 already interleave these fills four ways.
+/// default. It is already 4 at the default `x86-64-v3` baseline and on Darwin AArch64.
 
 template <iota_supported_types T>
 void NO_INLINE iota(T * begin, size_t count, T first_value)

--- a/src/Common/iota.cpp
+++ b/src/Common/iota.cpp
@@ -9,11 +9,18 @@ namespace DB
 /// 64-byte boundary crossing, causing ~5% regression on modern CPUs. As a
 /// separate function the compiler aligns the loop independently.
 /// (Previously the multi-target dispatch mechanism achieved this implicitly.)
+///
+/// LLVM defaults AArch64's `MaxInterleaveFactor` to 2 and Neoverse-N1/V1 do not raise it, so on
+/// Linux aarch64 these fills need an explicit interleave hint to get the four accumulators that
+/// x86-64-v3 and Apple silicon already choose.
 
 template <iota_supported_types T>
 void NO_INLINE iota(T * begin, size_t count, T first_value)
 {
     T value = first_value;
+#if defined(__aarch64__) && !defined(OS_DARWIN)
+#pragma clang loop interleave_count(4)
+#endif
     for (size_t i = 0; i < count; i++)
     {
         *(begin + i) = value;
@@ -25,6 +32,9 @@ template <iota_supported_types T>
 void NO_INLINE iotaWithStep(T * begin, size_t count, T first_value, T step)
 {
     T value = first_value;
+#if defined(__aarch64__) && !defined(OS_DARWIN)
+#pragma clang loop interleave_count(4)
+#endif
     for (size_t i = 0; i < count; i++)
     {
         *(begin + i) = value;

--- a/tests/performance/numbers_with_step.xml
+++ b/tests/performance/numbers_with_step.xml
@@ -1,0 +1,11 @@
+<test>
+    <settings><max_threads>1</max_threads></settings>
+
+    <!-- `numbers` and `generate_series` with a step other than 1 fill their result blocks with a
+         different loop than the unit-step forms, which the existing `numbers(N)` tests cover.
+         Single threaded so the fill, and not thread scheduling, dominates the measurement. -->
+
+    <query>SELECT count() FROM numbers(0, 3000000000, 3) FORMAT Null</query>
+    <query>SELECT sum(number) FROM numbers(0, 3000000000, 3) FORMAT Null</query>
+    <query>SELECT count() FROM generate_series(0, 2999999999, 3) FORMAT Null</query>
+</test>


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/116581
Related: https://github.com/ClickHouse/ClickHouse/pull/97473
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/116581

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improved the performance of the `numbers` table function, sorting and other bulk index fills on AArch64 by giving the `iota` and `iotaWithStep` loops an explicit four-way interleave hint, which LLVM does not choose by default there. Results and x86-64/macOS code generation are unchanged.


### Description

Reported by @ egor-click in #116581 with the ARM measurements and the patch adopted here, [asking me](https://github.com/ClickHouse/ClickHouse/issues/116581#issuecomment-5430016444) to verify and open a PR.

`iota` and `iotaWithStep` are loop-carried fills that clang auto-vectorises everywhere, but AArch64 interleaves them 2x where the shipped `x86-64-v3` uses 4x. On Graviton3 he measured 1.21x on `count() FROM numbers(3e9)` and 1.13x on `sum(number)`; those timings are his, so Performance Comparison arbitrates. `iota` is a broad carrier: `numbers`, the identity permutation for numeric sorts, `_part_offset`, `rowNumberInBlock`.

His stated cause, the missing AArch64 `-mcpu=`, is not it: `-mcpu=neoverse-v1`, `-mtune=neoverse-v1` and `-mcpu=neoverse-n1` all leave the factor at 2. The lever is `FeatureMaxInterleaveFactor4` (`AArch64Features.td:926`), which AArch64 defaults off and Neoverse-N1/V1 do not set, unlike Neoverse-V2 and Apple M1. No cmake flag reaches it, so the general fix is upstream in LLVM and a per-loop hint is the only lever.

Guarded, unlike the proposed patch. On this file the pragma changes no instructions at `x86-64-v3` and `-v4`, but 380 lines at level 1, which `AMD_COMPAT` ships. `arm64-apple-macos11` is already at 4, so it is excluded. Same guard as `FunctionsConversion.h:1979`, whose `-Wpass-failed` suppression is for `vectorize_width`, not this hint.

Correctness: the AArch64 object links freestanding under `qemu-aarch64-static`, where 13.3M comparisons against a scalar reference stay hash-identical to base, and `value += 2` / `i <= count` mutants redden.

`iotaWithStep` is reached only by stepped `numbers` and `generate_series`, which had no perf test; `tests/performance/numbers_with_step.xml` adds three, breakpoint-verified to reach it and not `iota`.

`findExtreme.cpp` is left alone: he scoped that half as review input on #97473, not a competing change.

Residuals: only the `UInt64` instantiation is timed; small-`count` callers are unmeasured, of which `translate` and `arrayRandomSample` have no perf test; other AArch64 cores are untested, so the direction should hold, not the magnitude; the two `UInt32` instantiations gain one extra 32-byte-aligned block.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116616&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116616](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116616+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->




<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.320` (included in `26.9` and later)
<!-- ch-version-info:end -->