### PR TITLE
Do not lose an `executable_pool` slot when the process fails to spawn

### DIFF
--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -11,6 +11,8 @@
 #include <Common/setThreadName.h>
 #include <Common/ThreadGroupSwitcher.h>
 #include <Common/ErrnoException.h>
+#include <Common/LockMemoryExceptionInThread.h>
+#include <Common/scope_guard_safe.h>
 
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
@@ -514,23 +516,23 @@ namespace
             , process_pool(process_pool_)
             , check_exit_code(check_exit_code_)
         {
-            auto context_for_reading = Context::createCopy(context);
-            /// Currently parallel parsing input format cannot read exactly max_block_size rows from input,
-            /// so it will be blocked on ReadBufferFromFileDescriptor because this file descriptor represent pipe that does not have eof.
-            if (configuration.read_fixed_number_of_rows)
-                context_for_reading->setSetting("input_format_parallel_parsing", false);
-            /// Here header auto detection can only cause troubles, since if it
-            /// will find "header" the number of input and output rows will not
-            /// match.
-            context_for_reading->setSetting("input_format_csv_detect_header", false);
-            context_for_reading->setSetting("input_format_tsv_detect_header", false);
-            context_for_reading->setSetting("input_format_custom_detect_header", false);
-            context = context_for_reading;
-
-            auto thread_group = CurrentThread::getGroup();
-
             try
             {
+                auto context_for_reading = Context::createCopy(context);
+                /// Currently parallel parsing input format cannot read exactly max_block_size rows from input,
+                /// so it will be blocked on ReadBufferFromFileDescriptor because this file descriptor represent pipe that does not have eof.
+                if (configuration.read_fixed_number_of_rows)
+                    context_for_reading->setSetting("input_format_parallel_parsing", false);
+                /// Here header auto detection can only cause troubles, since if it
+                /// will find "header" the number of input and output rows will not
+                /// match.
+                context_for_reading->setSetting("input_format_csv_detect_header", false);
+                context_for_reading->setSetting("input_format_tsv_detect_header", false);
+                context_for_reading->setSetting("input_format_custom_detect_header", false);
+                context = context_for_reading;
+
+                auto thread_group = CurrentThread::getGroup();
+
                 for (auto && send_data_task : send_data_tasks)
                 {
                     send_data_threads.emplace_back([thread_group, task = std::move(send_data_task), this]() mutable
@@ -656,10 +658,24 @@ namespace
             {
                 bool valid_command = configuration.read_fixed_number_of_rows && current_read_rows >= configuration.number_of_rows_to_read;
 
+                /// Nothing is unwinding when `cleanup` runs from a `catch` handler or an ordinary
+                /// destructor call, so the memory tracker is free to throw: reaping the worker
+                /// allocates inside a destructor, and handing the slot back would lose it.
+                LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
+
+                /// A worker that will not be reused is reaped before its slot is published.
                 if (command && valid_command)
                     command_holder->returnCommand(std::move(command));
-
-                process_pool->returnObject(std::move(command_holder));
+                else
+                    command = nullptr;
+                try
+                {
+                    process_pool->returnObject(std::move(command_holder));
+                }
+                catch (...)
+                {
+                    tryLogCurrentException("ShellCommandSource");
+                }
             }
         }
 
@@ -841,6 +857,17 @@ Pipe ShellCommandSourceCoordinator::createPipe(
 
     std::unique_ptr<ShellCommand> process;
     std::unique_ptr<ShellCommandHolder> process_holder;
+
+    /// Ownership of a pool holder reaches `ShellCommandSource` (whose `cleanup` returns it) only at
+    /// the end of this function; a holder still owned here is a slot the pool never gets back.
+    /// Publishing the slot wakes a borrower that spawns at once, so the worker goes first.
+    SCOPE_EXIT_SAFE({
+        if (process_holder && process_pool)
+        {
+            process.reset();
+            process_pool->returnObject(std::move(process_holder));
+        }
+    });
 
     auto destructor_strategy = ShellCommand::DestructorStrategy{true /*terminate_in_destructor*/, SIGTERM, configuration.command_termination_timeout_seconds};
     command_config.terminate_in_destructor_strategy = destructor_strategy;

--- a/tests/queries/0_stateless/05046_executable_pool_slot_leak_on_spawn_error.reference
+++ b/tests/queries/0_stateless/05046_executable_pool_slot_leak_on_spawn_error.reference
@@ -1,0 +1,2 @@
+first call failed as expected
+Pipe capacity 2147483648 exceeds maximum supported value

--- a/tests/queries/0_stateless/05046_executable_pool_slot_leak_on_spawn_error.sh
+++ b/tests/queries/0_stateless/05046_executable_pool_slot_leak_on_spawn_error.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# An executable_pool worker whose process fails to start must not cost the pool a slot.
+# The function below is configured with a pipe capacity that is out of range, so every
+# attempt to start a worker fails. With a pool of one, the second call must still report
+# that configuration error instead of waiting for a worker the pool can no longer create.
+# Both calls have to run in one clickhouse-local process, because a fresh process gets a
+# fresh pool.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+WORK_DIR=$(mktemp -d "${CLICKHOUSE_TMP}/exec_pool_slot_leak_XXXXXX")
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+cat > "${WORK_DIR}/echo_udf.sh" << 'SCRIPT'
+#!/usr/bin/env bash
+while IFS= read -r x; do printf '%s\n' "$x"; done
+SCRIPT
+chmod +x "${WORK_DIR}/echo_udf.sh"
+
+cat > "${WORK_DIR}/udf.xml" << EOF
+<functions>
+    <function>
+        <type>executable_pool</type>
+        <name>leak_udf</name>
+        <return_type>UInt64</return_type>
+        <argument><type>UInt64</type></argument>
+        <format>TabSeparated</format>
+        <command>echo_udf.sh</command>
+        <execute_direct>1</execute_direct>
+        <pool_size>1</pool_size>
+        <max_command_execution_time>1</max_command_execution_time>
+        <command_pipe_capacity>2147483648</command_pipe_capacity>
+    </function>
+</functions>
+EOF
+
+cat > "${WORK_DIR}/config.xml" << EOF
+<clickhouse>
+    <user_scripts_path>${WORK_DIR}/</user_scripts_path>
+    <user_defined_executable_functions_config>${WORK_DIR}/udf.xml</user_defined_executable_functions_config>
+</clickhouse>
+EOF
+
+# The last statement is deliberately not annotated so that its error reaches stderr.
+cat > "${WORK_DIR}/queries.sql" << 'EOF'
+SELECT leak_udf(1); -- { serverError UDF_EXECUTION_FAILED }
+SELECT 'first call failed as expected';
+SELECT leak_udf(2);
+EOF
+
+$CLICKHOUSE_LOCAL --config-file="${WORK_DIR}/config.xml" --queries-file="${WORK_DIR}/queries.sql" \
+    < /dev/null > "${WORK_DIR}/out.txt" 2> "${WORK_DIR}/err.txt"
+
+cat "${WORK_DIR}/out.txt"
+grep -oE 'Pipe capacity [0-9]+ exceeds maximum supported value|Could not get process from pool' \
+    "${WORK_DIR}/err.txt" | tail -1


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/116467
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `executable_pool` dictionaries, user defined functions and the `ExecutablePool` table engine permanently losing a pool slot when a worker process fails to start. After `pool_size` such failures every call reported `Could not get process from pool` instead of the real error, for as long as the dictionary, function or table stayed loaded.


### Description

A pooled worker is borrowed before its child process exists, and the borrow is only accounted as returned by `ShellCommandSource::cleanup`. Ownership reaches that object only at the end of `ShellCommandSourceCoordinator::createPipe`, so every throw in between destroys the holder without returning it: the spawn, the missing write descriptor check, and the buffer, format and pipeline construction after it. `BorrowedObjectPool` counts an allocated object on borrow and never lowers that counter, so the pool loses that slot for its lifetime.

Reproducer: an `executable_pool` function with `pool_size` 1 and a `command_pipe_capacity` above the maximum a pipe accepts. The first call reports the real error, the second waits out the borrow timeout and reports `Could not get process from pool`.

A scope guard now hands the holder back unless the transfer completed. The holder is adopted in the member initializer list, so a throw from the first statements of the constructor body escaped both that guard and the constructor's own handler; the existing `try` now opens at the top of the body. Reaping a worker and handing its slot back must not throw, and `cleanup` also runs where nothing is unwinding (a `catch` handler, an ordinary destructor call), so it holds the memory tracker lock across both.

All three pooled surfaces share `createPipe`: `executable_pool` dictionaries and functions, and the `ExecutablePool` table engine. The `executable` table function and non-pool dictionaries never borrow. Still uncovered, neither with a deterministic trigger: `BorrowedObjectPool` also loses a slot when the factory itself throws, which no caller-side guard reaches, and `ShellCommand::executeImpl` leaves the child unreaped when the wrapper construction right after `vfork` throws.

The new test reports `Could not get process from pool` without the fix and the real error with it, and goes red again when only the guard is removed.

Related: #116467

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116619&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116619](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116619+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

