### PR TITLE
Filter the TTL delete block in one pass instead of column by column

### DIFF
--- a/src/Processors/TTL/TTLDeleteAlgorithm.cpp
+++ b/src/Processors/TTL/TTLDeleteAlgorithm.cpp
@@ -22,38 +22,40 @@ void TTLDeleteAlgorithm::execute(Block & block)
     auto ttl_column = executeExpressionAndGetColumn(ttl_expressions.expression, block, description.result_column);
     auto where_column = executeExpressionAndGetColumn(ttl_expressions.where_expression, block, description.where_result_column);
 
-    MutableColumns result_columns;
-    const auto & column_names = block.getNames();
+    /// Decide once for the whole block, then filter the columns in one vectorized pass. A forced
+    /// algorithm runs on every merge of a value-combining mode, where the common case is that
+    /// nothing expires - and then the block is handed on untouched.
+    const size_t rows = block.rows();
+    IColumn::Filter filter(rows);
+    size_t removed = 0;
 
-    result_columns.reserve(column_names.size());
-    for (auto it = column_names.begin(); it != column_names.end(); ++it)
+    for (size_t i = 0; i < rows; ++i)
     {
-        const IColumn * values_column = block.getByName(*it).column.get();
-        MutableColumnPtr result_column = values_column->cloneEmpty();
-        result_column->reserve(block.rows());
+        Int64 cur_ttl = getTimestampByIndex(ttl_column.get(), i);
+        bool where_filter_passed = !where_column || where_column->getBool(i);
+        bool remove = isTTLExpired(cur_ttl) && where_filter_passed;
 
-        for (size_t i = 0; i < block.rows(); ++i)
+        filter[i] = !remove;
+
+        if (remove)
         {
-            Int64 cur_ttl = getTimestampByIndex(ttl_column.get(), i);
-            bool where_filter_passed = !where_column || where_column->getBool(i);
-
-            if (!isTTLExpired(cur_ttl) || !where_filter_passed)
-            {
-                /// Update ttl info only if row passes the filter.
-                /// Rows that don't pass the filter should not affect TTL.
-                if (where_filter_passed)
-                    new_ttl_info.update(cur_ttl);
-
-                result_column->insertFrom(*values_column, i);
-            }
-            else if (it == column_names.begin())
-                ++rows_removed;
+            ++removed;
         }
-
-        result_columns.emplace_back(std::move(result_column));
+        else if (where_filter_passed)
+        {
+            /// Update ttl info only if row passes the filter.
+            /// Rows that don't pass the filter should not affect TTL.
+            new_ttl_info.update(cur_ttl);
+        }
     }
 
-    block = block.cloneWithColumns(std::move(result_columns));
+    rows_removed += removed;
+
+    if (removed == 0)
+        return;
+
+    for (auto & column : block)
+        column.column = column.column->filter(filter, rows - removed);
 }
 
 void TTLDeleteAlgorithm::finalize(const MutableDataPartPtr & data_part) const


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112262

## Problem

`TTLDeleteAlgorithm::execute` decides per row, but it does so inside a loop over every column. For each column it clones an empty column, reserves, and then copies the surviving rows across one `insertFrom` at a time:

```cpp
for (auto it = column_names.begin(); it != column_names.end(); ++it)
{
    MutableColumnPtr result_column = values_column->cloneEmpty();
    result_column->reserve(block.rows());

    for (size_t i = 0; i < block.rows(); ++i)
    {
        Int64 cur_ttl = getTimestampByIndex(ttl_column.get(), i);
        ...
        result_column->insertFrom(*values_column, i);
    }
}
block = block.cloneWithColumns(std::move(result_columns));
```

So the cost is `O(rows × columns)` virtual calls plus one allocation per column, and it is paid **in full even when the block has nothing to delete** — which is the common case for a part that merely carries a TTL rule and is being merged for an unrelated reason. There is no early exit: the block is rebuilt either way.

## Solution

Decide once for the whole block into an `IColumn::Filter`, return the block untouched when nothing is removed, and otherwise apply one vectorized `IColumn::filter` per column.

Behaviour is unchanged. The three things that look like they might have moved do not:

- **The `new_ttl_info` update condition.** Old: `(!expired || !passed) && passed`. New: `!remove && passed`, where `remove = expired && passed`. Both reduce to `passed && !expired`.
- **`rows_removed`.** The old loop guarded the increment with `it == column_names.begin()` so a row counted once; the new one adds `removed` once per block.
- **How often `new_ttl_info.update` runs.** Once per row *per column* before, once per row now. It is a min/max, so the result is identical.

Two details that make the rewrite safe:

- `ITTLAlgorithm::executeExpressionAndGetColumn` evaluates on a private copy of the block and does not insert its result into it, so iterating the block and filtering every column touches exactly the data columns.
- `Block::empty` is `!columns()`, so a block that has columns but no rows still reaches the loop, computes `removed == 0` and is returned untouched — the old code returned equally empty columns, so the observable result is the same.

## Evidence

Merging two 3M-row parts of an 11-column `AggregatingMergeTree`, three runs each. The baseline column is the same table with the TTL removed, so the "overhead" column is what having a TTL delete step in the merge costs. Debug build, so the absolute numbers are inflated and the ratio is the point — a debug build also penalises virtual calls more than vectorized work, so the improvement is likely smaller in release.

| `execute` | with rows-`WHERE` TTL | baseline | overhead |
|---|---|---|---|
| column-by-column (before, i.e. `master`) | 6265 / 6303 / 6422 ms | ~4200 ms | **+50%** |
| filter mask (this PR) | 4305 / 4334 / 4410 ms | ~4275 ms | **+1.8%** |
| filter mask + batch timestamp extraction | 4382 / 4386 ms | ~4335 ms | +0.5–1% |

The third row is why this PR stops at the filter mask. The remaining per-row cost is the type dispatch in `ITTLAlgorithm::getTimestampByIndex`, which could be replaced by the batch extractor that already exists as `TTLDeleteFilterTransform::extractTimestamps` (and which `getTimestampByIndex` carries a `TODO` pointing at). It is worth at most another 1%, and hoisting it touches code shared by every TTL path — a much wider surface for that much. Left out deliberately.

No perf test is added: `tests/performance/ttl_group_by_consecutive_keys.xml` is the only TTL entry and it exercises `TTLAggregationAlgorithm`, not this function. Happy to add a focused one for a rows TTL over a wide part if a reviewer wants the number in CI rather than in this description.

Correctness is covered by the existing TTL tests, which exercise both the "some rows removed" and the "nothing removed" paths.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Made TTL deletion during merges cheaper: the block is now filtered in a single vectorized pass instead of being rebuilt column by column, and a block with nothing to delete is passed through untouched instead of being copied.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116623&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116623](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116623+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.193` (included in `26.9` and later)
<!-- ch-version-info:end -->