### PR TITLE
Trim the code comment and the test added by #112639

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -1034,18 +1034,13 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
             out.function = function_name == "equals" ? RPNElement::FUNCTION_EQUALS : RPNElement::FUNCTION_NOT_EQUALS;
             const DataTypePtr actual_type = BloomFilter::getPrimitiveType(index_type);
 
-            /// `String`/`FixedString` equality compares zero-padded, so a constant of M bytes matches
-            /// the whole family `value` + trailing '\0'*, while the index holds one hash per exact
-            /// stored value. The index is sound only where that family collapses to a single indexed
-            /// value: a `FixedString(N)` index with `N >= M` pads the constant into the one stored
-            /// form, while a `String` index, or a narrower `FixedString`, leaves the family unbounded
-            /// because `convertFieldToType` pads but never truncates.
-            /// The constant type is unwrapped here because `tryGetConstant` peels only an outer
-            /// `Nullable`. `Variant` and `Dynamic` keep their declared wrapper while handing out the
-            /// nested padded value, so an active `FixedString` alternative is indistinguishable from
-            /// a `String` one and both must be treated as possibly padded.
+            /// Where equality compares zero-padded, the constant can equal a stored value of a different byte
+            /// length, while the index holds only the hash of each value's exact bytes. It is then usable only
+            /// for a `FixedString(N)` index at least as wide, where padding gives the one value that can match.
             if (isStringOrFixedString(actual_type) && value_field.getType() == Field::Types::String)
             {
+                /// A `Variant` or `Dynamic` constant carries the nested padded value under its
+                /// declared type, so an active `FixedString` alternative cannot be told from a `String` one.
                 const WhichDataType which_constant(removeLowCardinalityAndNullable(value_type));
                 const bool constant_may_be_fixed_string
                     = which_constant.isFixedString() || which_constant.isVariant() || which_constant.isDynamic();

--- a/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.reference
+++ b/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.reference
@@ -1,21 +1,10 @@
-A1 String idx vs FixedString(2)	1
-A2 String idx vs FixedString(3)	1
-A3 String idx vs FixedString(5)	1
-A4 FixedString(3) idx vs FixedString(4)	1
-A5 FixedString(3) idx vs FixedString(5)	1
-A11 FixedString(3) idx vs 4-byte String const	1
-A12 FixedString(3) idx vs 5-byte String const	1
-A6 LowCardinality(String) idx vs FixedString(3)	1
-A7 Nullable(String) idx vs FixedString(3)	1
-A8 LowCardinality(FixedString(3)) idx vs FixedString(5)	1
-A9 String idx vs LowCardinality(FixedString(3)) const	1
-A10 String idx vs LowCardinality(Nullable(FixedString(3))) const	1
-A13 String idx vs Variant(FixedString(3)) const	1
-A14 String idx vs Dynamic(FixedString(3)) const	1
-B1 String idx vs String const still prunes	1
-B2 FixedString(3) idx vs String const still prunes	1
-B3 FixedString(3) idx vs FixedString(2) const still prunes	1
-B4 FixedString(3) idx vs FixedString(3) const still prunes	1
-B6 FixedString(3) idx vs 3-byte String const still prunes	1
-B5 String idx vs FixedString(3) const does not prune	0
-B7 FixedString(3) idx vs 4-byte String const does not prune	0
+String index, wrapped FixedString constant	3
+String index, Variant constant	3
+String index, Dynamic constant	3
+LowCardinality(FixedString) index, wider String constant	1
+FixedString index, wider String constant	1
+FixedString index, wider FixedString constant	1
+String index used, String constant	1
+FixedString index used, narrower FixedString constant	1
+FixedString index used, equal width FixedString constant	1
+FixedString index used, plain String constant	1

--- a/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.reference
+++ b/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.reference
@@ -8,3 +8,4 @@ String index used, String constant	1
 FixedString index used, narrower FixedString constant	1
 FixedString index used, equal width FixedString constant	1
 FixedString index used, plain String constant	1
+FixedString index prunes, equal width FixedString constant	1

--- a/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.sql
+++ b/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.sql
@@ -1,5 +1,5 @@
 -- Checks that a `bloom_filter` index skips no matching row when a `String` or `FixedString` constant
--- compares zero-padded, and that it stays usable where padding gives the one value that can match.
+-- compares zero-padded, and that it stays usable and prunes where padding gives the one value that can match.
 
 DROP TABLE IF EXISTS t_str;
 DROP TABLE IF EXISTS t_fs3;
@@ -27,3 +27,4 @@ SELECT 'String index used, String constant', count() FROM t_str WHERE v = 'V0' S
 SELECT 'FixedString index used, narrower FixedString constant', count() FROM t_fs3 WHERE v = toFixedString('V0', 2) SETTINGS force_data_skipping_indices = 'idx';
 SELECT 'FixedString index used, equal width FixedString constant', count() FROM t_fs3 WHERE v = toFixedString('V0', 3) SETTINGS force_data_skipping_indices = 'idx';
 SELECT 'FixedString index used, plain String constant', count() FROM t_fs3 WHERE v = 'V0' SETTINGS force_data_skipping_indices = 'idx';
+SELECT 'FixedString index prunes, equal width FixedString constant', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_fs3 WHERE v = toFixedString('V0', 3)) WHERE explain ILIKE '%Granules: 1/3%';

--- a/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.sql
+++ b/tests/queries/0_stateless/04653_bloom_filter_fixed_string_constant_scalar.sql
@@ -1,137 +1,29 @@
--- A FixedString(M) constant compares zero-padded, so it matches an unbounded family of stored
--- values ('V0', 'V0\0', 'V0\0\0', ...) while the bloom filter holds one hash per exact value.
--- The index must decline unless the padding maps the constant into exactly one indexed value,
--- i.e. only for a FixedString(N) index with N >= M.
+-- Checks that a `bloom_filter` index skips no matching row when a `String` or `FixedString` constant
+-- compares zero-padded, and that it stays usable where padding gives the one value that can match.
 
-SET allow_suspicious_low_cardinality_types = 1;
-
--- Direction A: correctness restored. Oracle is an ENGINE = Log table with the same rows.
-
-DROP TABLE IF EXISTS bf_str_log;
-DROP TABLE IF EXISTS bf_str_idx;
-CREATE TABLE bf_str_log (id UInt64, v String) ENGINE = Log;
-CREATE TABLE bf_str_idx (id UInt64, v String, INDEX idx v TYPE bloom_filter GRANULARITY 1)
+DROP TABLE IF EXISTS t_str;
+DROP TABLE IF EXISTS t_fs3;
+DROP TABLE IF EXISTS t_lcfs;
+CREATE TABLE t_str (id UInt64, v String, INDEX idx v TYPE bloom_filter GRANULARITY 1)
 ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO bf_str_log VALUES (0, 'V0'), (1, 'V0\0'), (2, 'V0\0\0'), (3, 'V0X'), (4, 'X');
-INSERT INTO bf_str_idx VALUES (0, 'V0'), (1, 'V0\0'), (2, 'V0\0\0'), (3, 'V0X'), (4, 'X');
-
-SELECT 'A1 String idx vs FixedString(2)', (SELECT count() FROM bf_str_log WHERE v = toFixedString('V0', 2)) = (SELECT count() FROM bf_str_idx WHERE v = toFixedString('V0', 2));
-SELECT 'A2 String idx vs FixedString(3)', (SELECT count() FROM bf_str_log WHERE v = toFixedString('V0', 3)) = (SELECT count() FROM bf_str_idx WHERE v = toFixedString('V0', 3));
-SELECT 'A3 String idx vs FixedString(5)', (SELECT count() FROM bf_str_log WHERE v = toFixedString('V0', 5)) = (SELECT count() FROM bf_str_idx WHERE v = toFixedString('V0', 5));
-
--- The index genuinely cannot serve the predicate, so it must be reported as unused.
-SELECT count() FROM bf_str_idx WHERE v = toFixedString('V0', 3) SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
-
--- A narrower FixedString index keeps the constant's wider padded bytes, which no longer map
--- into the index domain.
-DROP TABLE IF EXISTS bf_fs3_log;
-DROP TABLE IF EXISTS bf_fs3_idx;
-CREATE TABLE bf_fs3_log (id UInt64, v FixedString(3)) ENGINE = Log;
-CREATE TABLE bf_fs3_idx (id UInt64, v FixedString(3), INDEX idx v TYPE bloom_filter GRANULARITY 1)
+CREATE TABLE t_fs3 (id UInt64, v FixedString(3), INDEX idx v TYPE bloom_filter GRANULARITY 1)
 ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO bf_fs3_log VALUES (0, 'V0'), (1, 'V0X'), (2, 'X');
-INSERT INTO bf_fs3_idx VALUES (0, 'V0'), (1, 'V0X'), (2, 'X');
-
-SELECT 'A4 FixedString(3) idx vs FixedString(4)', (SELECT count() FROM bf_fs3_log WHERE v = toFixedString('V0', 4)) = (SELECT count() FROM bf_fs3_idx WHERE v = toFixedString('V0', 4));
-SELECT 'A5 FixedString(3) idx vs FixedString(5)', (SELECT count() FROM bf_fs3_log WHERE v = toFixedString('V0', 5)) = (SELECT count() FROM bf_fs3_idx WHERE v = toFixedString('V0', 5));
-
--- The rule is about byte length, not the constant's declared type: a plain String constant wider
--- than the index is padded by nothing (convertFieldToType never truncates), so it is hashed over
--- more bytes than the index stored while zero-padded comparison still matches at runtime.
--- 'V0\0\0' is a 4-byte String literal against a FixedString(3) index.
-SELECT 'A11 FixedString(3) idx vs 4-byte String const', (SELECT count() FROM bf_fs3_log WHERE v = 'V0\0\0') = (SELECT count() FROM bf_fs3_idx WHERE v = 'V0\0\0');
-SELECT 'A12 FixedString(3) idx vs 5-byte String const', (SELECT count() FROM bf_fs3_log WHERE v = 'V0\0\0\0') = (SELECT count() FROM bf_fs3_idx WHERE v = 'V0\0\0\0');
-
-SELECT count() FROM bf_fs3_idx WHERE v = 'V0\0\0' SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
-
--- Wrapped INDEX types: getPrimitiveType strips LowCardinality and Nullable.
-DROP TABLE IF EXISTS bf_lc_log;
-DROP TABLE IF EXISTS bf_lc_idx;
-CREATE TABLE bf_lc_log (id UInt64, v LowCardinality(String)) ENGINE = Log;
-CREATE TABLE bf_lc_idx (id UInt64, v LowCardinality(String), INDEX idx v TYPE bloom_filter GRANULARITY 1)
+CREATE TABLE t_lcfs (id UInt64, v LowCardinality(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1)
 ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO bf_lc_log VALUES (0, 'V0'), (1, 'V0\0'), (2, 'X');
-INSERT INTO bf_lc_idx VALUES (0, 'V0'), (1, 'V0\0'), (2, 'X');
-SELECT 'A6 LowCardinality(String) idx vs FixedString(3)', (SELECT count() FROM bf_lc_log WHERE v = toFixedString('V0', 3)) = (SELECT count() FROM bf_lc_idx WHERE v = toFixedString('V0', 3));
+INSERT INTO t_str VALUES (0, 'V0'), (1, 'V0\0'), (2, 'V0\0\0'), (3, 'V0X'), (4, 'X');
+INSERT INTO t_fs3 VALUES (0, 'V0'), (1, 'V0X'), (2, 'X');
+INSERT INTO t_lcfs VALUES (0, 'V0'), (1, 'V0X'), (2, 'X');
 
-DROP TABLE IF EXISTS bf_nl_log;
-DROP TABLE IF EXISTS bf_nl_idx;
-CREATE TABLE bf_nl_log (id UInt64, v Nullable(String)) ENGINE = Log;
-CREATE TABLE bf_nl_idx (id UInt64, v Nullable(String), INDEX idx v TYPE bloom_filter GRANULARITY 1)
-ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO bf_nl_log VALUES (0, 'V0'), (1, 'V0\0'), (2, 'X');
-INSERT INTO bf_nl_idx VALUES (0, 'V0'), (1, 'V0\0'), (2, 'X');
-SELECT 'A7 Nullable(String) idx vs FixedString(3)', (SELECT count() FROM bf_nl_log WHERE v = toFixedString('V0', 3)) = (SELECT count() FROM bf_nl_idx WHERE v = toFixedString('V0', 3));
+SELECT 'String index, wrapped FixedString constant', count() FROM t_str WHERE v = CAST(toFixedString('V0', 3) AS LowCardinality(Nullable(FixedString(3))));
+SELECT 'String index, Variant constant', count() FROM t_str WHERE v = CAST(toFixedString('V0', 3) AS Variant(FixedString(3), UInt64));
+SELECT 'String index, Dynamic constant', count() FROM t_str WHERE v = CAST(toFixedString('V0', 3) AS Dynamic);
+SELECT 'LowCardinality(FixedString) index, wider String constant', count() FROM t_lcfs WHERE v = 'V0\0\0';
+SELECT 'FixedString index, wider String constant', count() FROM t_fs3 WHERE v = 'V0\0\0';
+SELECT 'FixedString index, wider FixedString constant', count() FROM t_fs3 WHERE v = toFixedString('V0', 4);
 
-DROP TABLE IF EXISTS bf_lcfs_log;
-DROP TABLE IF EXISTS bf_lcfs_idx;
-CREATE TABLE bf_lcfs_log (id UInt64, v LowCardinality(FixedString(3))) ENGINE = Log;
-CREATE TABLE bf_lcfs_idx (id UInt64, v LowCardinality(FixedString(3)), INDEX idx v TYPE bloom_filter GRANULARITY 1)
-ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO bf_lcfs_log VALUES (0, 'V0'), (1, 'X');
-INSERT INTO bf_lcfs_idx VALUES (0, 'V0'), (1, 'X');
-SELECT 'A8 LowCardinality(FixedString(3)) idx vs FixedString(5)', (SELECT count() FROM bf_lcfs_log WHERE v = toFixedString('V0', 5)) = (SELECT count() FROM bf_lcfs_idx WHERE v = toFixedString('V0', 5));
+SELECT count() FROM t_str WHERE v = toFixedString('V0', 3) SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
 
--- Wrapped CONSTANT types: the guard peels LowCardinality and Nullable off the constant type too,
--- so a LowCardinality(Nullable(FixedString(N))) constant cannot slip past it.
-SELECT 'A9 String idx vs LowCardinality(FixedString(3)) const', (SELECT count() FROM bf_str_log WHERE v = CAST(toFixedString('V0', 3) AS LowCardinality(FixedString(3)))) = (SELECT count() FROM bf_str_idx WHERE v = CAST(toFixedString('V0', 3) AS LowCardinality(FixedString(3))));
-SELECT 'A10 String idx vs LowCardinality(Nullable(FixedString(3))) const', (SELECT count() FROM bf_str_log WHERE v = CAST(toFixedString('V0', 3) AS LowCardinality(Nullable(FixedString(3))))) = (SELECT count() FROM bf_str_idx WHERE v = CAST(toFixedString('V0', 3) AS LowCardinality(Nullable(FixedString(3)))));
-
--- Variant and Dynamic erase the active type: the declared type stays Variant/Dynamic while the
--- constant Field already holds the nested padded bytes, so a type-based FixedString test alone
--- cannot see them and the padding-unsound cell must be declined on the wrapper instead.
-SELECT 'A13 String idx vs Variant(FixedString(3)) const', (SELECT count() FROM bf_str_log WHERE v = CAST(toFixedString('V0', 3) AS Variant(FixedString(3), UInt64))) = (SELECT count() FROM bf_str_idx WHERE v = CAST(toFixedString('V0', 3) AS Variant(FixedString(3), UInt64)));
-SELECT 'A14 String idx vs Dynamic(FixedString(3)) const', (SELECT count() FROM bf_str_log WHERE v = CAST(toFixedString('V0', 3) AS Dynamic)) = (SELECT count() FROM bf_str_idx WHERE v = CAST(toFixedString('V0', 3) AS Dynamic));
-
-SELECT count() FROM bf_str_idx WHERE v = CAST(toFixedString('V0', 3) AS Variant(FixedString(3), UInt64)) SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
-
--- Direction B: pruning is preserved wherever the conversion is faithful. Each row asserts the
--- granule REDUCTION extracted from the plan text rather than pinning an exact plan rendering in
--- the .reference, so it keeps testing "the index still prunes" across plan-format churn.
-
-DROP TABLE IF EXISTS bf_keys_str;
-DROP TABLE IF EXISTS bf_keys_fs3;
-CREATE TABLE bf_keys_str (id UInt64, v String, INDEX idx v TYPE bloom_filter GRANULARITY 1)
-ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-CREATE TABLE bf_keys_fs3 (id UInt64, v FixedString(3), INDEX idx v TYPE bloom_filter GRANULARITY 1)
-ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO bf_keys_str SELECT number, concat('k', toString(number)) FROM numbers(64);
-INSERT INTO bf_keys_fs3 SELECT number, concat('k', toString(number)) FROM numbers(64);
-
-SELECT 'B1 String idx vs String const still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM bf_keys_str WHERE v = 'k7')
-WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain, 'Granules: (\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \d+/(\d+)'));
-
-SELECT 'B2 FixedString(3) idx vs String const still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM bf_keys_fs3 WHERE v = 'k7')
-WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain, 'Granules: (\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \d+/(\d+)'));
-
-SELECT 'B3 FixedString(3) idx vs FixedString(2) const still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM bf_keys_fs3 WHERE v = toFixedString('k7', 2))
-WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain, 'Granules: (\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \d+/(\d+)'));
-
-SELECT 'B4 FixedString(3) idx vs FixedString(3) const still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM bf_keys_fs3 WHERE v = toFixedString('k7', 3))
-WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain, 'Granules: (\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \d+/(\d+)'));
-
--- A plain String constant no wider than the FixedString index is padded into exactly one indexed
--- value, so the widened width rule must not start declining these sound cells.
-SELECT 'B6 FixedString(3) idx vs 3-byte String const still prunes', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM bf_keys_fs3 WHERE v = 'k7\0')
-WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain, 'Granules: (\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \d+/(\d+)'));
-
--- The declined cells must stop pruning: these rows are 1 before the fix and 0 after it, which is
--- what makes the Direction B assertions above non-vacuous.
-SELECT 'B5 String idx vs FixedString(3) const does not prune', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM bf_keys_str WHERE v = toFixedString('k7', 3))
-WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain, 'Granules: (\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \d+/(\d+)'));
-
-SELECT 'B7 FixedString(3) idx vs 4-byte String const does not prune', count() > 0 FROM (EXPLAIN indexes = 1 SELECT count() FROM bf_keys_fs3 WHERE v = 'k7\0\0')
-WHERE explain LIKE '%Granules: %/%' AND toUInt64OrZero(extract(explain, 'Granules: (\d+)/')) < toUInt64OrZero(extract(explain, 'Granules: \d+/(\d+)'));
-
-DROP TABLE bf_str_log;
-DROP TABLE bf_str_idx;
-DROP TABLE bf_fs3_log;
-DROP TABLE bf_fs3_idx;
-DROP TABLE bf_lc_log;
-DROP TABLE bf_lc_idx;
-DROP TABLE bf_nl_log;
-DROP TABLE bf_nl_idx;
-DROP TABLE bf_lcfs_log;
-DROP TABLE bf_lcfs_idx;
-DROP TABLE bf_keys_str;
-DROP TABLE bf_keys_fs3;
+SELECT 'String index used, String constant', count() FROM t_str WHERE v = 'V0' SETTINGS force_data_skipping_indices = 'idx';
+SELECT 'FixedString index used, narrower FixedString constant', count() FROM t_fs3 WHERE v = toFixedString('V0', 2) SETTINGS force_data_skipping_indices = 'idx';
+SELECT 'FixedString index used, equal width FixedString constant', count() FROM t_fs3 WHERE v = toFixedString('V0', 3) SETTINGS force_data_skipping_indices = 'idx';
+SELECT 'FixedString index used, plain String constant', count() FROM t_fs3 WHERE v = 'V0' SETTINGS force_data_skipping_indices = 'idx';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/112639


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Follow-up cleanup requested on #112639. Comment and test only: the src diff has no non-comment line.

The comment in `MergeTreeIndexBloomFilter.cpp` goes from 10 lines to 5, keeping the two properties a
reader cannot derive from the code below them. It also drops a false claim. A narrower `FixedString`
index does not leave the matching family unbounded: at most one stored value can match, and only when
every byte of the constant past the index width is zero. That cell is unsound for a different reason,
namely that the probe is hashed over the constant's own byte length while the index stored the hash of
the column's width.

The test is reduced in place from 137 lines to 30, from 12 tables to 3 and from 24 arms to 12. I
picked the arms by measurement rather than by reading the source, against a build carrying all 18
single-clause mutations of the guard plus pre-fix master. Six arms are the sole catcher of a
mutation; the rest keep routes into the same decision, the only observation of a declined cell, or
the pruning check below, that no single-clause mutation separates. The trimmed file catches 19 of
19; the merged 137-line version caught 18, missing a wrapped `FixedString` index read through its
declared type, where neither guard fires and the result is wrong rows rather than a lost
optimisation.

The twin `ENGINE = Log` oracle tables give way to counts pinned in the reference. The `EXPLAIN`
granule regex is reduced to one line rather than dropped: `force_data_skipping_indices` proves the
guard admitted the index, not that any granule was dropped, so a build that recognises the predicate
and then matches every granule leaves the other eleven arms green and only that line red.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116632&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116632](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116632+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.201` (included in `26.9` and later)
<!-- ch-version-info:end -->