### PR TITLE
Fix the text index postings unit test aborting on a null posting list codec

### DIFF
--- a/src/Storages/MergeTree/tests/gtest_text_index_postings_deserialization.cpp
+++ b/src/Storages/MergeTree/tests/gtest_text_index_postings_deserialization.cpp
@@ -6,6 +6,7 @@
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h>
 
 using namespace DB;
 
@@ -32,7 +33,7 @@ String serializePostings(const PostingList & postings)
 PostingsSerialization makeSerialization()
 {
     /// A posting list without the `IsCompressed` flag never consults the codec.
-    return PostingsSerialization(nullptr, MergeTreeTextIndexSerializationVersion::V2_WithPositions);
+    return PostingsSerialization(std::make_unique<PostingListCodecNone>(), MergeTreeTextIndexSerializationVersion::V2_WithPositions);
 }
 
 /// The whole payload is in the buffer, so `deserialize` deserializes it in place.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115222
Related: https://github.com/ClickHouse/ClickHouse/pull/116536
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/115222
Related: https://github.com/ClickHouse/ClickHouse/pull/116536

Base is `backport/26.7/115222`, the head branch of robot backport #116536, where
`Unit tests (asan_ubsan)` and `Unit tests (tsan)` fail.

`PostingsSerialization`'s constructor asserts its codec is non-null
(`chassert(posting_list_codec)`, `MergeTreeIndexText.cpp:218`), and the rewritten
`gtest_text_index_postings_deserialization.cpp` passes `nullptr`. `RoundTrip` therefore aborts
inside the constructor, before `deserialize` runs. The test's comment is about `deserialize`,
where `header = 0` indeed never consults the codec, but the constructor asserts first. Hence
every `Build` job is green (`chassert` is inert in release), the `function_prop_fuzzer` variants
pass because they filter this suite out, and `TruncatedPayloadRejected` never reported.

This passes a real `Type::None` codec instead. Two lines, test only. Coverage is unchanged:
`PostingListCodecNone::decode` is a no-op, so if the codec were consulted `RoundTrip` would get
an empty posting list and fail on cardinality; it passes, so the assertions still traverse the
`readSafe` bounding that #115222 added.

Validated with a Debug build on this branch's pinned clang-21, Build-ID asserted per arm.
Unpatched, `RoundTrip` aborts with `Logical error: 'posting_list_codec'.`; patched, both tests
pass. Reverting the merged `readSafe` bound while keeping this change makes
`TruncatedPayloadRejected` fail all four assertions, so the repaired test still catches the bug
the backport fixes.

I have no push access to `backport/26.7/115222` (`maintainerCanModify` is false on #116536), so
this is a fork PR against that base. No checks run on it, since CI triggers only for a base of
`master` or a release branch; the gate is #116536's own `Unit tests` re-run once this is merged
into its head branch. The same rewritten file is already merged onto 26.3 (#116533) and 26.5
(#116534), where `Unit tests` is not a BackportPR job so the abort is unobservable there; out of
scope here.