### PR TITLE
Preserve float canonicalization in `LowCardinality` range inserts

### DIFF
--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -242,10 +242,16 @@ void ColumnLowCardinality::doInsertRangeFrom(const IColumn & src, size_t start, 
     /// an empty column to avoid rebuilding it and keep its indexes unchanged through generic range insertions.
     /// A private source dictionary can still be mutated in place, while an incompatible dictionary must be
     /// rebuilt to perform conversions such as nullable promotion.
+    /// Shared floating-point dictionaries reconstructed from `MergeTree` on-disk dictionary streams can contain
+    /// separate entries for `-0.0` and `0.0`, or multiple `NaN` payloads. The on-disk reader can install such a
+    /// dictionary directly, while `insertRangeFrom` into a different dictionary has historically canonicalized
+    /// these representations through `ColumnUnique`. Sharing here would bypass that boundary and change the
+    /// existing insertion behavior.
     if (
         empty()
         && low_cardinality_src->isSharedDictionary()
         && getDictionary().nestedColumnIsNullable() == low_cardinality_src->getDictionary().nestedColumnIsNullable()
+        && !WhichDataType(low_cardinality_src->getDictionary().getNestedNotNullableColumn()->getDataType()).isFloat()
         && getDictionary().structureEquals(low_cardinality_src->getDictionary()))
         setSharedDictionary(low_cardinality_src->getDictionaryPtr());
 

--- a/src/Columns/ColumnLowCardinality.cpp
+++ b/src/Columns/ColumnLowCardinality.cpp
@@ -7,10 +7,14 @@
 #include <Common/Exception.h>
 #include <Common/HashTable/HashSet.h>
 #include <Common/HashTable/HashMap.h>
+#include <Common/NaNUtils.h>
 #include <Common/assert_cast.h>
 #include <base/types.h>
 #include <base/sort.h>
 #include <base/scope_guard.h>
+
+#include <bit>
+#include <limits>
 
 
 namespace DB
@@ -30,6 +34,28 @@ void throwUnexpectedLowCardinalityIndexType(size_t size)
 
 namespace
 {
+    bool dictionaryHasFloatingPointValues(const IColumnUnique & dictionary)
+    {
+        return WhichDataType(dictionary.getNestedNotNullableColumn()->getDataType()).isFloat();
+    }
+
+    template <typename T, typename UInt>
+    UInt64 getCanonicalFloatingPointBits(T value)
+    {
+        if (value == T{})
+            return 0;
+        if (isNaN(value))
+            return std::numeric_limits<UInt>::max();
+        return std::bit_cast<UInt>(value);
+    }
+
+    UInt64 getCanonicalFloatingPointBits(const IColumnUnique & dictionary, size_t index)
+    {
+        if (WhichDataType(dictionary.getNestedNotNullableColumn()->getDataType()).isFloat64())
+            return getCanonicalFloatingPointBits<Float64, UInt64>(dictionary.getFloat64(index));
+        return getCanonicalFloatingPointBits<Float32, UInt32>(dictionary.getFloat32(index));
+    }
+
     void checkColumn(const IColumn & column)
     {
         if (!dynamic_cast<const IColumnUnique *>(&column))
@@ -251,7 +277,7 @@ void ColumnLowCardinality::doInsertRangeFrom(const IColumn & src, size_t start, 
         empty()
         && low_cardinality_src->isSharedDictionary()
         && getDictionary().nestedColumnIsNullable() == low_cardinality_src->getDictionary().nestedColumnIsNullable()
-        && !WhichDataType(low_cardinality_src->getDictionary().getNestedNotNullableColumn()->getDataType()).isFloat()
+        && !dictionaryHasFloatingPointValues(low_cardinality_src->getDictionary())
         && getDictionary().structureEquals(low_cardinality_src->getDictionary()))
         setSharedDictionary(low_cardinality_src->getDictionaryPtr());
 
@@ -442,7 +468,7 @@ size_t ColumnLowCardinality::getEqualRangeEndAssumeSorted(size_t begin, size_t e
     /// dictionary built from deserialized data is not canonicalized (insert-time canonicalization unifies the
     /// NaNs of freshly inserted data, but does not apply when reading back, and -0.0 is not unified at all), so
     /// it can hold such value-equal entries separately. So for a floating-point inner type we compare values.
-    if (WhichDataType(getDictionary().getNestedNotNullableColumn()->getDataType()).isFloat())
+    if (dictionaryHasFloatingPointValues(getDictionary()))
         return IColumn::getEqualRangeEndAssumeSorted(begin, end, nan_direction_hint);
 
     /// We only require equal values to be contiguous. If the column is sorted, then equal values are contiguous.
@@ -454,6 +480,10 @@ bool ColumnLowCardinality::hasEqualValues() const
 {
     if (getDictionary().size() <= 1)
         return true;
+
+    /// This method is also used to skip hash-based scattering, for example when partitioning `MergeTree` blocks.
+    /// Floating-point values that compare equal can have distinct hashes, so only equal dictionary indexes prove
+    /// that all rows can safely take the same hash-based path.
     return getIndexes().hasEqualValues();
 }
 
@@ -692,12 +722,25 @@ size_t ColumnLowCardinality::estimateCardinalityInPermutedRange(const Permutatio
         return range_size;
 
     HashSet<UInt64> elements;
+    const bool compare_values = dictionaryHasFloatingPointValues(getDictionary());
+    bool has_null = false;
     for (size_t i = equal_range.from; i < equal_range.to; ++i)
     {
-        UInt64 index = getIndexes().getUInt(permutation[i]);
-        elements.insert(index);
+        const UInt64 index = getIndexes().getUInt(permutation[i]);
+        if (!compare_values)
+        {
+            elements.insert(index);
+        }
+        else if (getDictionary().isNullAt(index))
+        {
+            has_null = true;
+        }
+        else
+        {
+            elements.insert(getCanonicalFloatingPointBits(getDictionary(), index));
+        }
     }
-    return elements.size();
+    return elements.size() + has_null;
 }
 
 VectorWithMemoryTracking<MutableColumnPtr> ColumnLowCardinality::scatter(size_t num_columns, const Selector & selector) const

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -6,6 +6,9 @@
 #include <gtest/gtest.h>
 #include <Common/Exception.h>
 
+#include <bit>
+#include <cmath>
+
 using namespace DB;
 
 template <typename T>
@@ -125,6 +128,51 @@ TEST(ColumnLowCardinality, InsertRangeFromChecksBoundsAfterSharingDictionary)
     ASSERT_EQ(low_cardinality_destination.getSizeOfIndexType(), sizeof(UInt16));
     EXPECT_THROW(destination->insertRangeFrom(*source, source->size(), 1), Exception);
     EXPECT_TRUE(destination->empty());
+}
+
+static void testEmptyDestinationPreservesFloatingPointCanonicalization(MutableColumnPtr keys, const DataTypePtr & nested_type)
+{
+    SCOPED_TRACE(nested_type->getName());
+    MutableColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*nested_type, std::move(keys));
+    auto indexes = ColumnUInt8::create();
+    indexes->getData().assign({1, 2, 3});
+    auto source = ColumnLowCardinality::create(std::move(dictionary), std::move(indexes), /*is_shared=*/true);
+    auto destination = std::make_shared<DataTypeLowCardinality>(nested_type)->createColumn();
+
+    destination->insertRangeFrom(*source, 0, source->size());
+
+    const auto & low_cardinality_destination = assert_cast<const ColumnLowCardinality &>(*destination);
+    EXPECT_FALSE(low_cardinality_destination.isSharedDictionary());
+    EXPECT_NE(&low_cardinality_destination.getDictionary(), &source->getDictionary());
+    ASSERT_EQ(low_cardinality_destination.getDictionary().size(), 2);
+    ASSERT_EQ(destination->size(), 3);
+    EXPECT_EQ(low_cardinality_destination.getIndexes().getUInt(0), 0);
+    EXPECT_EQ(low_cardinality_destination.getIndexes().getUInt(1), 1);
+    EXPECT_EQ(low_cardinality_destination.getIndexes().getUInt(2), 1);
+    EXPECT_FALSE(std::signbit(destination->getFloat64(0)));
+    EXPECT_TRUE(std::isnan(destination->getFloat64(1)));
+    EXPECT_TRUE(std::isnan(destination->getFloat64(2)));
+}
+
+TEST(ColumnLowCardinality, EmptyDestinationPreservesFloatingPointCanonicalization)
+{
+    auto float64_keys = ColumnFloat64::create();
+    auto & float64_key_data = float64_keys->getData();
+    float64_key_data.push_back(0.0);
+    float64_key_data.push_back(-0.0);
+    float64_key_data.push_back(std::bit_cast<Float64>(UInt64{0x7ff8000000000001ULL}));
+    float64_key_data.push_back(std::bit_cast<Float64>(UInt64{0x7ff8000000000002ULL}));
+    testEmptyDestinationPreservesFloatingPointCanonicalization(
+        std::move(float64_keys), std::make_shared<DataTypeFloat64>());
+
+    auto bfloat16_keys = ColumnBFloat16::create();
+    auto & bfloat16_key_data = bfloat16_keys->getData();
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x0000));
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x8000));
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x7fc1));
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x7fc2));
+    testEmptyDestinationPreservesFloatingPointCanonicalization(
+        std::move(bfloat16_keys), std::make_shared<DataTypeBFloat16>());
 }
 
 TEST(ColumnLowCardinality, EmptyDictionaryEmptyIndexes)

--- a/src/Columns/tests/gtest_low_cardinality.cpp
+++ b/src/Columns/tests/gtest_low_cardinality.cpp
@@ -3,6 +3,7 @@
 
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <gtest/gtest.h>
 #include <Common/Exception.h>
 
@@ -173,6 +174,121 @@ TEST(ColumnLowCardinality, EmptyDestinationPreservesFloatingPointCanonicalizatio
     bfloat16_key_data.push_back(BFloat16::fromBits(0x7fc2));
     testEmptyDestinationPreservesFloatingPointCanonicalization(
         std::move(bfloat16_keys), std::make_shared<DataTypeBFloat16>());
+}
+
+static void testSharedFloatingPointDictionaryUsesValueComparisons(const ColumnPtr & dictionary)
+{
+    SCOPED_TRACE(dictionary->getName());
+    auto indexes = ColumnUInt8::create();
+    indexes->getData().assign({2, 0, 3, 1});
+    auto column = ColumnLowCardinality::create(dictionary, std::move(indexes), /*is_shared=*/true);
+
+    auto reversed_zero_indexes = ColumnUInt8::create();
+    reversed_zero_indexes->getData().assign({1, 0});
+    auto reversed_zero_column = ColumnLowCardinality::create(dictionary, std::move(reversed_zero_indexes), /*is_shared=*/true);
+
+    IColumn::Permutation stable_permutation;
+    reversed_zero_column->getPermutation(
+        IColumn::PermutationSortDirection::Ascending,
+        IColumn::PermutationSortStability::Stable,
+        0,
+        1,
+        stable_permutation);
+
+    ASSERT_EQ(stable_permutation.size(), 2);
+    EXPECT_EQ(stable_permutation[0], 0);
+    EXPECT_EQ(stable_permutation[1], 1);
+
+    IColumn::Permutation permutation{0, 1, 2, 3};
+    EqualRanges equal_ranges{{0, 4}};
+    column->updatePermutation(
+        IColumn::PermutationSortDirection::Ascending,
+        IColumn::PermutationSortStability::Stable,
+        0,
+        1,
+        permutation,
+        equal_ranges);
+
+    ASSERT_EQ(permutation.size(), 4);
+    EXPECT_EQ(permutation[0], 1);
+    EXPECT_EQ(permutation[1], 3);
+    EXPECT_EQ(permutation[2], 0);
+    EXPECT_EQ(permutation[3], 2);
+    ASSERT_EQ(equal_ranges.size(), 2);
+    EXPECT_EQ(equal_ranges[0].from, 0);
+    EXPECT_EQ(equal_ranges[0].to, 2);
+    EXPECT_EQ(equal_ranges[1].from, 2);
+    EXPECT_EQ(equal_ranges[1].to, 4);
+
+    auto tiebreaker = ColumnUInt64::create();
+    tiebreaker->getData().assign({40, 30, 20, 10});
+    tiebreaker->updatePermutation(
+        IColumn::PermutationSortDirection::Ascending,
+        IColumn::PermutationSortStability::Stable,
+        0,
+        1,
+        permutation,
+        equal_ranges);
+
+    ASSERT_EQ(permutation.size(), 4);
+    EXPECT_EQ(permutation[0], 3);
+    EXPECT_EQ(permutation[1], 1);
+    EXPECT_EQ(permutation[2], 2);
+    EXPECT_EQ(permutation[3], 0);
+
+    auto equal_indexes = ColumnUInt8::create();
+    equal_indexes->getData().assign({0, 1});
+    auto equal_column = ColumnLowCardinality::create(dictionary, std::move(equal_indexes), /*is_shared=*/true);
+    EXPECT_FALSE(equal_column->hasEqualValues());
+
+    auto equal_nan_indexes = ColumnUInt8::create();
+    equal_nan_indexes->getData().assign({2, 3});
+    auto equal_nan_column = ColumnLowCardinality::create(dictionary, std::move(equal_nan_indexes), /*is_shared=*/true);
+    EXPECT_FALSE(equal_nan_column->hasEqualValues());
+
+    IColumn::Permutation identity_permutation{0, 1, 2, 3};
+    EXPECT_EQ(column->estimateCardinalityInPermutedRange(identity_permutation, {0, 4}), 2);
+}
+
+TEST(ColumnLowCardinality, SharedFloatingPointDictionaryUsesValueComparisons)
+{
+    auto float64_keys = ColumnFloat64::create();
+    auto & float64_key_data = float64_keys->getData();
+    float64_key_data.push_back(0.0);
+    float64_key_data.push_back(-0.0);
+    float64_key_data.push_back(std::bit_cast<Float64>(UInt64{0x7ff8000000000001ULL}));
+    float64_key_data.push_back(std::bit_cast<Float64>(UInt64{0x7ff8000000000002ULL}));
+    testSharedFloatingPointDictionaryUsesValueComparisons(
+        DataTypeLowCardinality::createColumnUnique(DataTypeFloat64(), std::move(float64_keys)));
+
+    auto bfloat16_keys = ColumnBFloat16::create();
+    auto & bfloat16_key_data = bfloat16_keys->getData();
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x0000));
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x8000));
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x7fc1));
+    bfloat16_key_data.push_back(BFloat16::fromBits(0x7fc2));
+    testSharedFloatingPointDictionaryUsesValueComparisons(
+        DataTypeLowCardinality::createColumnUnique(DataTypeBFloat16(), std::move(bfloat16_keys)));
+}
+
+TEST(ColumnLowCardinality, SharedNullableFloatingPointDictionaryCardinality)
+{
+    auto keys = ColumnFloat64::create();
+    auto & key_data = keys->getData();
+    key_data.push_back(0.0);
+    key_data.push_back(0.0);
+    key_data.push_back(-0.0);
+    key_data.push_back(std::bit_cast<Float64>(UInt64{0x7ff8000000000001ULL}));
+    key_data.push_back(std::bit_cast<Float64>(UInt64{0x7ff8000000000002ULL}));
+
+    auto nested_type = makeNullable(std::make_shared<DataTypeFloat64>());
+    ColumnPtr dictionary = DataTypeLowCardinality::createColumnUnique(*nested_type, std::move(keys));
+    auto indexes = ColumnUInt8::create();
+    indexes->getData().assign({0, 1, 2, 3, 4});
+    auto column = ColumnLowCardinality::create(dictionary, std::move(indexes), /*is_shared=*/true);
+
+    IColumn::Permutation identity_permutation{0, 1, 2, 3, 4};
+    EXPECT_EQ(column->estimateCardinalityInPermutedRange(identity_permutation, {0, 5}), 3);
 }
 
 TEST(ColumnLowCardinality, EmptyDictionaryEmptyIndexes)


### PR DESCRIPTION
Shared dictionaries from Native input can contain signed zero and multiple NaN payloads. Avoid sharing floating-point dictionaries so `ColumnUnique` canonicalizes these values during different-dictionary insertion.

This is a regression from: https://github.com/ClickHouse/ClickHouse/pull/115961

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116637&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116637](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116637+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
