### PR TITLE
Backport #115222 to 26.6, with the aborting unit test fixed

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -254,14 +254,14 @@ PostingListPtr PostingsSerialization::deserialize(ReadBuffer & istr, UInt64 head
         /// If the posting list is completely in the buffer, avoid copying.
         if (istr.position() && istr.position() + num_bytes <= istr.buffer().end())
         {
-            auto result = std::make_shared<PostingList>(PostingList::read(istr.position()));
+            auto result = std::make_shared<PostingList>(PostingList::readSafe(istr.position(), num_bytes));
             istr.position() += num_bytes;
             return result;
         }
 
         deserialization_buffer.resize(num_bytes);
         istr.readStrict(deserialization_buffer.data(), num_bytes);
-        return std::make_shared<PostingList>(PostingList::read(deserialization_buffer.data()));
+        return std::make_shared<PostingList>(PostingList::readSafe(deserialization_buffer.data(), num_bytes));
     }
 }
 

--- a/src/Storages/MergeTree/tests/gtest_text_index_postings_deserialization.cpp
+++ b/src/Storages/MergeTree/tests/gtest_text_index_postings_deserialization.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include <IO/ConcatReadBuffer.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/MergeTreeIndexTextPostingListCodec.h>
+
+using namespace DB;
+
+namespace
+{
+
+/// Wraps `payload` the way `PostingsSerialization::serialize` writes an uncompressed posting list:
+/// [VarUInt: number of bytes][portable serialization of a roaring bitmap].
+String encodePostingsPayload(const String & payload)
+{
+    WriteBufferFromOwnString out;
+    writeVarUInt(payload.size(), out);
+    out.write(payload.data(), payload.size());
+    return out.str();
+}
+
+String serializePostings(const PostingList & postings)
+{
+    String payload(postings.getSizeInBytes(), '\0');
+    postings.write(payload.data());
+    return payload;
+}
+
+PostingsSerialization makeSerialization()
+{
+    /// The constructor requires a codec; an uncompressed posting list never uses it.
+    return PostingsSerialization(std::make_unique<PostingListCodecNone>(), MergeTreeTextIndexSerializationVersion::V2_WithPositions);
+}
+
+/// The whole payload is in the buffer, so `deserialize` deserializes it in place.
+PostingList decodePostingsInPlace(const String & encoded)
+{
+    auto serialization = makeSerialization();
+    ReadBufferFromString in(encoded);
+    return *serialization.deserialize(in, /*header=*/ 0, /*cardinality=*/ 0);
+}
+
+/// The payload spans two buffers, so `deserialize` copies it out before deserializing.
+PostingList decodePostingsAcrossBuffers(const String & encoded)
+{
+    auto serialization = makeSerialization();
+    size_t split_at = encoded.size() / 2;
+    ReadBufferFromMemory head(encoded.data(), split_at);
+    ReadBufferFromMemory tail(encoded.data() + split_at, encoded.size() - split_at);
+    ConcatReadBuffer in(head, tail);
+    return *serialization.deserialize(in, /*header=*/ 0, /*cardinality=*/ 0);
+}
+
+}
+
+/// Bounding the deserialization must not reject posting lists that the index writer produces.
+TEST(TextIndexPostingsDeserializationTest, RoundTrip)
+{
+    PostingList empty;
+
+    PostingList array_container;
+    for (uint32_t row_id = 0; row_id < 100; ++row_id)
+        array_container.add(row_id * 7);
+
+    /// More than 4096 row ids per 65536-row range are stored as a bitset container.
+    PostingList bitset_container;
+    for (uint32_t row_id = 0; row_id < 30000; ++row_id)
+        bitset_container.add(row_id * 2);
+
+    PostingList run_container;
+    run_container.addRangeClosed(1000, 500000);
+    run_container.runOptimize();
+
+    for (const auto & postings : {empty, array_container, bitset_container, run_container})
+    {
+        const String encoded = encodePostingsPayload(serializePostings(postings));
+
+        auto decoded_in_place = decodePostingsInPlace(encoded);
+        EXPECT_EQ(decoded_in_place.cardinality(), postings.cardinality());
+        EXPECT_TRUE(decoded_in_place == postings);
+
+        auto decoded_across_buffers = decodePostingsAcrossBuffers(encoded);
+        EXPECT_EQ(decoded_across_buffers.cardinality(), postings.cardinality());
+        EXPECT_TRUE(decoded_across_buffers == postings);
+    }
+}
+
+/// A container that claims more values than the declared payload holds must not be deserialized:
+/// the deserializer would read past the end of the buffer and return leaked heap bytes as row ids.
+TEST(TextIndexPostingsDeserializationTest, TruncatedPayloadRejected)
+{
+    PostingList postings;
+    for (uint32_t row_id = 0; row_id < 3 * 4096; ++row_id)
+        postings.add(row_id * 16);
+
+    const String payload = serializePostings(postings);
+    ASSERT_GT(payload.size(), 64u);
+
+    /// Truncate the payload while the declared size stays consistent with what is actually passed in,
+    /// so only the container headers claim data that is not there. `Roaring::readSafe` reports this as
+    /// `std::runtime_error`, so assert on the common base rather than on the concrete exception type.
+    for (size_t size : {payload.size() / 2, payload.size() - 1})
+    {
+        const String encoded = encodePostingsPayload(payload.substr(0, size));
+        EXPECT_THROW(decodePostingsInPlace(encoded), std::exception) << "size = " << size;
+        EXPECT_THROW(decodePostingsAcrossBuffers(encoded), std::exception) << "size = " << size;
+    }
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115222
Related: https://github.com/ClickHouse/ClickHouse/pull/116535
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed an out-of-bounds read while deserializing corrupted posting lists of a text index.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/115222
Related: https://github.com/ClickHouse/ClickHouse/pull/116535

Requested by @ CurtizJ on #116535: https://github.com/ClickHouse/ClickHouse/pull/116535#issuecomment-5432214504

The 26.6 backport of #115222, on top of current `26.6`, with the unit test it ships fixed.

`Unit tests (asan_ubsan)` and `Unit tests (tsan)` fail on #116535 because `unit_tests_dbms` aborts, so the job writes no result file at all. `PostingsSerialization`'s constructor asserts that its codec is non-null (`MergeTreeIndexText.cpp:152`), and the version of the test rewritten for the release branches passes `nullptr`. That is safe as far as `deserialize` goes, which never consults the codec for an uncompressed posting list, but the constructor asserts first: `RoundTrip` aborted before `deserialize` was entered, and `TruncatedPayloadRejected` never ran. The fix passes a `PostingListCodecNone`, which is what `TextIndexUtils.cpp` already does when no codec is configured. `master` is unaffected because its version of the test never constructs `PostingsSerialization`.

Validated on this branch with a Debug build: `RoundTrip` aborts in that constructor before the change, and both `RoundTrip` and `TruncatedPayloadRejected` pass after it, over five repeats. With the backported `PostingList::readSafe` bound reverted to `PostingList::read`, `TruncatedPayloadRejected` fails at all four of its assertions while `RoundTrip` stays green, so the test does cover the bound this backport exists for.

This supersedes #116535. Basing it on `backport/26.6/115222` instead would be a stacked pull request, which the rulebook forbids and which draws no checks, and I have no push access to that branch. Closing #116535 is yours to decide; the one-line patch is in that thread if you would rather apply it there.

26.3 and 26.5 already carry this test merged but never executed, since neither branch runs a `Unit tests` job.