### PR TITLE
Score a job GitHub never scheduled as dropped, not as a script error

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -1090,11 +1090,13 @@ def _finish_workflow(workflow, job_name):
             normalized_name = Utils.normalize_string(result.name)
             gh_job = workflow_job_data.get(normalized_name, {})
             gh_job_result = (gh_job.get("result") or "").lower()
-            if gh_job_result in ("cancelled", "canceled"):
+            # `abandoned` is GitHub's undocumented verdict for a job it queued and never assigned a runner.
+            if gh_job_result in ("cancelled", "canceled", "abandoned"):
                 print(
                     f"NOTE: not finished job [{result.name}] in the workflow but GitHub status is [{gh_job_result}] - set status to dropped"
                 )
                 result.status = Result.Status.DROPPED
+                result.add_note(f"{ResultInfo.JOB_DID_NOT_FINISH} [{gh_job_result}]")
                 workflow_result.dump()
                 workflow_result.ext["is_cancelled"] = True
                 update_final_report = True
@@ -1110,7 +1112,8 @@ def _finish_workflow(workflow, job_name):
                 continue
             else:
                 print(
-                    f"ERROR: not finished job [{result.name}] in the workflow - set status to error"
+                    f"ERROR: not finished job [{result.name}] in the workflow, "
+                    f"GitHub verdict [{gh_job_result or 'none'}] - set status to error"
                 )
                 result.status = Result.Status.ERROR
                 result.add_error(ResultInfo.NOT_FINALIZED)

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1211,6 +1211,7 @@ class ResultInfo:
     OPEN_ISSUES_CHECK_ERROR = "Failed to check open issues"
 
     NOT_FINALIZED = "Job failed to produce Result due to a script error or CI runner issue"
+    JOB_DID_NOT_FINISH = "Job did not finish, GitHub reported"
 
     S3_ERROR = "S3 call failure"
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/116260 (witness, one abandoned job)
Related: https://github.com/ClickHouse/ClickHouse/pull/113737 (witness, eight of them, surviving two re-runs)
Related: https://github.com/ClickHouse/ClickHouse/pull/115745 (why the retry layer is untouched; no open issue exists for this class)


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Nothing here retries, reschedules or filters any job. The change is only how praktika *scores* a job that produced no result.

GitHub reports an undocumented fifth `needs.<job>.result` value, `abandoned`, for a job it queued and never assigned a runner. `_finish_workflow` matched only `cancelled`/`canceled`, so such a job fell through to the `else` branch and was scored `ERROR` with `Job failed to produce Result due to a script error or CI runner issue` for a job that ran zero commands. `Mergeable Check` then said `Failed: <job name>`, naming a job that never started, and `is_cancelled` was never set. Once the node is `ERROR` it is `is_completed`, so a re-run's carried-forward `cancelled` record cannot repair it either.

I read the verdicts out of the `Finish Workflow` job logs, where the `toJson(needs)` heredoc is echoed: jobs 98272432828 and 98250718152. Matching every `needs` key against the jobs API over 4 attempts gives 688 job/verdict pairs with zero off-diagonal: `abandoned` pairs with zero-step-cancelled 10/10, `cancelled` 8/8. Report for one witness: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116260&sha=9dd6a67f4ee2c7272ae707a47769a9a9efdcefbe&name_0=PR

The merge gate deliberately still blocks: `dropped_results` keeps `Mergeable Check` at FAIL and `DROPPED` still maps to a GitHub `error` status, so a check that did not run is not laundered into green. Only the description changes, from `Failed: <job name>` to `Failed: 0, Dropped: 1`.

Out of scope, and disclosed: the abandonment itself is GitHub-side with no in-repo lever, and job retry lives in the out-of-repo Lambda, per @ maxknv on #115745. The class is episodic rather than steady - it took 10 jobs across two of my PRs on 2026-08-26, while a 300-run sample of `pull_request.yml` runs started over the following 11 hours holds none.

Nothing committed pins this: https://github.com/ClickHouse/ClickHouse/pull/115650 removes `ci/tests` and the `CI Tests` job, so I validated with a throwaway harness per `AGENTS.md`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116648&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116648](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116648+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1110` (included in `26.9` and later)
<!-- ch-version-info:end -->