### PR TITLE
Do not use a key or index range over a container whose elements can be NULL

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -11,6 +11,7 @@
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/FieldToDataType.h>
 #include <DataTypes/getLeastSupertype.h>
+#include <DataTypes/hasNullable.h>
 #include <DataTypes/Utils.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/TreeRewriter.h>
@@ -33,6 +34,7 @@
 #include <Common/typeid_cast.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeFixedString.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnSet.h>
@@ -1461,6 +1463,46 @@ ActionsDAGWithInversionPushDown::ActionsDAGWithInversionPushDown(const ActionsDA
 }
 
 
+/// True if a range over values of this type does not bound what the predicate compares: inside a
+/// container, `FieldVisitorAccurateLess` orders a nested `Null` first, by its `Field` type tag, while
+/// the data and `IColumn::compareAt` order it last. A top-level `NULL` is ordered consistently through
+/// the `+Inf` sentinel that key and index analysis write for it, so look under a `Nullable`.
+static bool hasContainerElementOrderMismatch(const DataTypePtr & type)
+{
+    const DataTypePtr inner = removeNullable(type);
+
+    if (const auto * array = typeid_cast<const DataTypeArray *>(inner.get()))
+        return hasTypeThatCanContainNulls(array->getNestedType());
+    if (const auto * tuple = typeid_cast<const DataTypeTuple *>(inner.get()))
+        return std::ranges::any_of(tuple->getElements(), hasTypeThatCanContainNulls);
+    if (const auto * map = typeid_cast<const DataTypeMap *>(inner.get()))
+        return hasTypeThatCanContainNulls(map->getKeyType()) || hasTypeThatCanContainNulls(map->getValueType());
+    return false;
+}
+
+/// `FUNCTION_UNKNOWN` is the neutral element of the RPN and is always relaxed, so atoms on the other
+/// key columns keep pruning and the exactness checks (`isRelaxed`, `alwaysUnknownOrTrue`) stay accurate.
+static void unsetAtomsOnColumnsWithoutUsableRange(
+    KeyCondition::RPN & rpn, const KeyCondition::ColumnIndices & key_columns, const Block & key_sample_block)
+{
+    std::unordered_set<size_t> unusable_columns;
+    for (const auto & column : key_sample_block)
+    {
+        auto it = key_columns.find(column.name);
+        if (it != key_columns.end() && hasContainerElementOrderMismatch(column.type))
+            unusable_columns.insert(it->second);
+    }
+
+    if (unusable_columns.empty())
+        return;
+
+    for (auto & element : rpn)
+    {
+        if (std::ranges::any_of(element.key_columns, [&](size_t position) { return unusable_columns.contains(position); }))
+            element = KeyCondition::RPNElement(KeyCondition::RPNElement::FUNCTION_UNKNOWN);
+    }
+}
+
 KeyCondition::KeyCondition(
     const ActionsDAGWithInversionPushDown & filter_dag,
     ContextPtr context,
@@ -1518,6 +1560,8 @@ KeyCondition::KeyCondition(
     rpn = std::move(builder).extractRPN();
 
     findHyperrectanglesForArgumentsOfSpaceFillingCurves();
+
+    unsetAtomsOnColumnsWithoutUsableRange(rpn, key_columns, key_expr_->getSampleBlock());
 }
 
 KeyCondition::KeyCondition(

--- a/tests/queries/0_stateless/03464_projections_with_subcolumns.reference
+++ b/tests/queries/0_stateless/03464_projections_with_subcolumns.reference
@@ -27,18 +27,9 @@ Expression ((Project names + Projection))
 ReadFromMergeTree (p2)
 (1,1)
 Expression ((Project names + Projection))
-  Expression
-    ReadFromMergeTree (p3)
-    Indexes:
-      PrimaryKey
-        Keys:
-          json.c.:`Array(JSON)`.d.:`Int64`
-        Condition: (json.c.:`Array(JSON)`.d.:`Int64` in [[1], [1]])
-        Parts: 1/1
-        Granules: 2/100
-        Search Algorithm: binary search
-      Ranges: 1
-ReadFromMergeTree (p3)
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test)
+ReadFromMergeTree (default.test)
 {"a":1,"b":"str","c":[{"d":1}]}
 Expression ((Project names + Projection))
   Expression
@@ -71,18 +62,9 @@ ReadFromMergeTree (p2)
 (1,1)
 (1,1)
 Expression ((Project names + Projection))
-  Expression
-    ReadFromMergeTree (p3)
-    Indexes:
-      PrimaryKey
-        Keys:
-          json.c.:`Array(JSON)`.d.:`Int64`
-        Condition: (json.c.:`Array(JSON)`.d.:`Int64` in [[1], [1]])
-        Parts: 1/1
-        Granules: 3/200
-        Search Algorithm: binary search
-      Ranges: 1
-ReadFromMergeTree (p3)
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test)
+ReadFromMergeTree (default.test)
 {"a":1,"b":"str","c":[{"d":1}]}
 {"a":1,"b":"str","c":[{"d":1}]}
 ------------------------------------------------------------------
@@ -115,16 +97,7 @@ Expression ((Project names + Projection))
 ReadFromMergeTree (p2)
 (1,1)
 Expression ((Project names + Projection))
-  Expression
-    ReadFromMergeTree (p3)
-    Indexes:
-      PrimaryKey
-        Keys:
-          json.c.:`Array(JSON)`.d.:`Int64`
-        Condition: (json.c.:`Array(JSON)`.d.:`Int64` in [[1], [1]])
-        Parts: 1/1
-        Granules: 2/100
-        Search Algorithm: binary search
-      Ranges: 1
-ReadFromMergeTree (p3)
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test)
+ReadFromMergeTree (default.test)
 {"a":1,"b":"str","c":[{"d":1}]}

--- a/tests/queries/0_stateless/03464_projections_with_subcolumns.sql
+++ b/tests/queries/0_stateless/03464_projections_with_subcolumns.sql
@@ -27,6 +27,8 @@ explain indexes=1 select t from test where t.a = 1 settings enable_parallel_repl
 select trimLeft(*) from (explain indexes=1 select t from test where t.a = 1) where explain like '%ReadFromMergeTree%';
 select t from test where t.a = 1;
 
+-- The sorting key of p3 is `Array(Nullable(Int64))`: a range over such values orders a nested NULL
+-- first while the data and the predicate order it last, so it cannot bound what the predicate compares.
 explain indexes=1 select json from test where json.c[].d.:Int64 = [1] settings enable_parallel_replicas=0;
 select trimLeft(*) from (explain indexes=1 select json from test where json.c[].d.:Int64 = [1]) where explain like '%ReadFromMergeTree%';
 select json from test where json.c[].d.:Int64 = [1];

--- a/tests/queries/0_stateless/03464_projections_with_subcolumns.sql
+++ b/tests/queries/0_stateless/03464_projections_with_subcolumns.sql
@@ -5,6 +5,8 @@ set enable_analyzer=1;
 set mutations_sync=1;
 set parallel_replicas_local_plan = 1, parallel_replicas_support_projection = 1, optimize_aggregation_in_order = 0;
 SET optimize_use_projections = 1, optimize_use_implicit_projections = 1, optimize_use_projection_filtering = 1;
+-- A `WHERE` moved to `PREWHERE` renders as `Expression`, not `Filter`, in the plans asserted below.
+SET optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1;
 
 drop table if exists test;
 

--- a/tests/queries/0_stateless/03733_has_function_key_condition_explain.reference
+++ b/tests/queries/0_stateless/03733_has_function_key_condition_explain.reference
@@ -136,6 +136,8 @@ SELECT
     ),
     toString(number)
 FROM numbers(100000);
+-- Range analysis is declined for a key whose container elements can be NULL: a range over such values
+-- orders a nested NULL first, while the data and the predicate order it last, so it bounds nothing.
 EXPLAIN indexes = 1
 SELECT count()
 FROM test_has_idx_tuple_col_nullable_elements
@@ -147,13 +149,10 @@ Expression ((Project names + Projection))
         ReadFromMergeTree (default.test_has_idx_tuple_col_nullable_elements)
         Indexes:
           PrimaryKey
-            Keys:
-              key_tuple
-            Condition: (key_tuple in 5-element set)
+            Condition: true
             Parts: 1/1
-            Granules: 2/100
-            Search Algorithm: generic exclusion search
-          Ranges: 2
+            Granules: 100/100
+          Ranges: 1
 DROP TABLE IF EXISTS test_has_idx_array_col;
 CREATE TABLE test_has_idx_array_col
 (

--- a/tests/queries/0_stateless/03733_has_function_key_condition_explain.sql
+++ b/tests/queries/0_stateless/03733_has_function_key_condition_explain.sql
@@ -86,6 +86,8 @@ SELECT
     toString(number)
 FROM numbers(100000);
 
+-- Range analysis is declined for a key whose container elements can be NULL: a range over such values
+-- orders a nested NULL first, while the data and the predicate order it last, so it bounds nothing.
 EXPLAIN indexes = 1
 SELECT count()
 FROM test_has_idx_tuple_col_nullable_elements

--- a/tests/queries/0_stateless/05045_pruning_container_null_element.reference
+++ b/tests/queries/0_stateless/05045_pruning_container_null_element.reference
@@ -8,6 +8,7 @@ pk_arr	[2,3]
 pk_tup	[3]
 pk_ntup	[3]
 comp_in	1
+json_proj	[7,8,9]
 keep_float_pk	1
 keep_float_idx	1
 keep_nullable_idx	1

--- a/tests/queries/0_stateless/05045_pruning_container_null_element.reference
+++ b/tests/queries/0_stateless/05045_pruning_container_null_element.reference
@@ -1,0 +1,16 @@
+arr_gt	1
+map_gt	1
+part_gt	1
+partval_gt	[2,3]
+partval_count	2
+set_gt	1
+pk_arr	[2,3]
+pk_tup	[3]
+pk_ntup	[3]
+comp_in	1
+keep_float_pk	1
+keep_float_idx	1
+keep_nullable_idx	1
+keep_ntup_pk	1
+keep_comp_idx	1
+keep_set_idx	1

--- a/tests/queries/0_stateless/05045_pruning_container_null_element.sql
+++ b/tests/queries/0_stateless/05045_pruning_container_null_element.sql
@@ -1,0 +1,133 @@
+-- Range-based pruning must not drop rows when a container value has a NULL element: the range
+-- arithmetic orders a nested Null before every value, while the data and the predicate order it after
+-- every value, so a range over such values does not bound what the predicate compares.
+-- The keep-pruning arms are EXPLAIN arms on purpose. Declining an atom only ever over-reads, so it
+-- cannot change an answer, and only a granule count can show that pruning was kept.
+
+SET enable_nullable_tuple_type = 1;
+
+-- minmax skip index over Array(Nullable(String))
+CREATE TABLE t_arr (id UInt64, a Array(Nullable(String)), INDEX i a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_arr VALUES (1, ['a']), (2, [NULL]), (3, ['c']);
+
+SELECT 'arr_gt', count() FROM t_arr WHERE a > ['zzz'] SETTINGS use_skip_indexes = 1;
+
+-- minmax skip index over Map(String, Nullable(String))
+CREATE TABLE t_map (id UInt64, a Map(String, Nullable(String)), INDEX i a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_map VALUES (1, map('k', 'a')), (2, map('k', NULL)), (3, map('k', 'c'));
+
+SELECT 'map_gt', count() FROM t_map WHERE a > map('k', 'zzz') SETTINGS use_skip_indexes = 1;
+
+-- part-level minmax index over a partition key expression
+CREATE TABLE t_part (id UInt64, a Array(Nullable(String)))
+ENGINE = MergeTree PARTITION BY length(a) ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_part VALUES (1, ['a']), (2, [NULL]), (3, ['c']);
+
+SELECT 'part_gt', count() FROM t_part WHERE a > ['zzz'];
+
+-- partition pruner, and the trivial count by a partition predicate
+CREATE TABLE t_partval (id UInt64, a Array(Nullable(String)))
+ENGINE = MergeTree PARTITION BY a ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, allow_nullable_key = 1;
+INSERT INTO t_partval VALUES (1, ['a']), (2, [NULL]), (3, ['c']);
+
+SELECT 'partval_gt', arraySort(groupArray(id)) FROM t_partval WHERE a > ['b'];
+SELECT 'partval_count', count() FROM t_partval WHERE a > ['b'] SETTINGS optimize_trivial_count_query = 1;
+
+-- set skip index: its hyperrectangle is consulted only when bulk filtering is off
+CREATE TABLE t_set (id UInt64, a Array(Nullable(String)), INDEX i a TYPE set(100) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_set VALUES (1, ['a']), (2, ['b']), (3, ['c']), (4, ['x']), (5, [NULL]), (6, ['z']);
+
+SELECT 'set_gt', count() FROM t_set WHERE a > ['zzz'] SETTINGS use_skip_indexes = 1, secondary_indices_enable_bulk_filtering = 0;
+
+-- primary key over Array(Nullable(String)): the row that disappears is an ordinary one
+CREATE TABLE t_pk_arr (id UInt64, a Array(Nullable(String)))
+ENGINE = MergeTree ORDER BY a
+SETTINGS index_granularity = 1, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, allow_nullable_key = 1;
+INSERT INTO t_pk_arr VALUES (1, ['a']), (2, [NULL]), (3, ['c']);
+
+SELECT 'pk_arr', arraySort(groupArray(id)) FROM t_pk_arr WHERE a > ['b'];
+
+-- primary key over Tuple(Nullable(String)): a Tuple establishes container context
+CREATE TABLE t_pk_tup (id UInt64, a Tuple(Nullable(String)))
+ENGINE = MergeTree ORDER BY a
+SETTINGS index_granularity = 1, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, allow_nullable_key = 1;
+INSERT INTO t_pk_tup VALUES (1, tuple('a')), (2, tuple(NULL)), (3, tuple('c'));
+
+SELECT 'pk_tup', arraySort(groupArray(id)) FROM t_pk_tup WHERE a > tuple('b');
+
+-- primary key over Nullable(Tuple(Nullable(String))): a top-level Nullable must not end the walk
+CREATE TABLE t_pk_ntup (id UInt64, a Nullable(Tuple(Nullable(String))))
+ENGINE = MergeTree ORDER BY a
+SETTINGS index_granularity = 1, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, allow_nullable_key = 1;
+INSERT INTO t_pk_ntup VALUES (1, tuple('a')), (2, tuple(NULL)), (3, tuple('c'));
+
+SELECT 'pk_ntup', arraySort(groupArray(id)) FROM t_pk_ntup WHERE a > tuple('b');
+
+-- an atom can read several key columns at once, here `(u, a) IN (...)` over a composite index
+CREATE TABLE t_comp_in (id UInt64, u UInt64, a Array(Nullable(String)), INDEX i (u, a) TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_comp_in VALUES (1, 2, ['a']), (2, 2, [NULL]), (3, 2, ['c']), (4, 2, ['x']), (5, 2, ['y']), (6, 2, ['z']);
+
+SELECT 'comp_in', count() FROM t_comp_in WHERE (u, a) IN ((2, [NULL])) SETTINGS use_skip_indexes = 1;
+
+-- Keep-pruning arms.
+
+-- Array(Float64) with a NaN: the two orders agree for a nested NaN, so both the index and the
+-- primary key must keep pruning
+CREATE TABLE t_keep_float (id UInt64, a Array(Float64), INDEX i a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY a
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_keep_float VALUES (1, [1.]), (2, [2.]), (3, [3.]), (4, [4.]), (5, [20.]), (6, [nan]);
+
+SELECT 'keep_float_pk', count() > 0 FROM (EXPLAIN indexes = 1 SELECT sum(id) FROM t_keep_float WHERE a > [10.] SETTINGS use_skip_indexes = 0) WHERE explain ILIKE '%Granules: 1/2%';
+SELECT 'keep_float_idx', count() > 0 FROM (EXPLAIN indexes = 1 SELECT sum(id) FROM t_keep_float WHERE a > [10.] SETTINGS use_primary_key = 0, use_skip_indexes = 1) WHERE explain ILIKE '%Granules: 1/2%';
+
+-- top-level Nullable: the +Inf sentinel already orders it, so it must keep pruning
+CREATE TABLE t_keep_nullable (id UInt64, a Nullable(String), INDEX i a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_keep_nullable VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'x'), (5, NULL), (6, 'z');
+
+SELECT 'keep_nullable_idx', count() > 0 FROM (EXPLAIN indexes = 1 SELECT sum(id) FROM t_keep_nullable WHERE a > 'w' SETTINGS use_skip_indexes = 1) WHERE explain ILIKE '%Granules: 1/2%';
+
+-- Nullable(Tuple(String)): looking under the Nullable must not over-decline
+CREATE TABLE t_keep_ntup (id UInt64, a Nullable(Tuple(String)))
+ENGINE = MergeTree ORDER BY a
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, allow_nullable_key = 1;
+INSERT INTO t_keep_ntup VALUES (1, tuple('a')), (2, tuple('b')), (3, tuple('c')), (4, tuple('d')), (5, tuple('y')), (6, tuple('z'));
+
+SELECT 'keep_ntup_pk', count() > 0 FROM (EXPLAIN indexes = 1 SELECT sum(id) FROM t_keep_ntup WHERE a > tuple('x')) WHERE explain ILIKE '%Granules: 1/2%';
+
+-- a composite minmax index must keep pruning on its safe column
+CREATE TABLE t_keep_comp (id UInt64, u UInt64, a Array(Nullable(String)), INDEX i (u, a) TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_keep_comp VALUES (1, 1, ['a']), (2, 2, [NULL]), (3, 3, ['c']), (4, 100, ['a']), (5, 200, [NULL]), (6, 300, ['c']);
+
+SELECT 'keep_comp_idx', count() > 0 FROM (EXPLAIN indexes = 1 SELECT sum(id) FROM t_keep_comp WHERE u > 50 AND a > ['zzz'] SETTINGS use_skip_indexes = 1) WHERE explain ILIKE '%Granules: 1/2%';
+
+-- the set index must keep pruning: it evaluates the predicate over its stored set
+SELECT 'keep_set_idx', count() > 0 FROM (EXPLAIN indexes = 1 SELECT sum(id) FROM t_set WHERE a > ['w'] SETTINGS use_skip_indexes = 1, secondary_indices_enable_bulk_filtering = 0) WHERE explain ILIKE '%Granules: 1/2%';
+
+DROP TABLE t_arr;
+DROP TABLE t_map;
+DROP TABLE t_part;
+DROP TABLE t_partval;
+DROP TABLE t_set;
+DROP TABLE t_comp_in;
+DROP TABLE t_pk_arr;
+DROP TABLE t_pk_tup;
+DROP TABLE t_pk_ntup;
+DROP TABLE t_keep_float;
+DROP TABLE t_keep_nullable;
+DROP TABLE t_keep_ntup;
+DROP TABLE t_keep_comp;

--- a/tests/queries/0_stateless/05045_pruning_container_null_element.sql
+++ b/tests/queries/0_stateless/05045_pruning_container_null_element.sql
@@ -79,6 +79,17 @@ INSERT INTO t_comp_in VALUES (1, 2, ['a']), (2, 2, [NULL]), (3, 2, ['c']), (4, 2
 
 SELECT 'comp_in', count() FROM t_comp_in WHERE (u, a) IN ((2, [NULL])) SETTINGS use_skip_indexes = 1;
 
+-- A projection sorting key reaches the same arithmetic, and two properties are unique to this arm:
+-- `json.c[].d.:Int64` is `Array(Nullable(Int64))` though no column declares that type, and a projection
+-- sorting key needs no `allow_nullable_key`. The element is NULL wherever the JSON path is absent.
+CREATE TABLE t_json_proj (id UInt32, json JSON, PROJECTION p (SELECT json, id ORDER BY json.c[].d.:Int64))
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
+INSERT INTO t_json_proj SELECT number, toJSONString(map('c', [toJSONString(map('d', number::UInt32))::JSON]))
+FROM numbers(1, 8) SETTINGS use_variant_as_common_type = 1;
+INSERT INTO t_json_proj VALUES (9, '{"c":[{"e":1}]}');
+
+SELECT 'json_proj', arraySort(groupArray(id)) FROM t_json_proj WHERE json.c[].d.:Int64 > [6] SETTINGS optimize_use_projections = 1;
+
 -- Keep-pruning arms.
 
 -- Array(Float64) with a NaN: the two orders agree for a nested NaN, so both the index and the
@@ -124,6 +135,7 @@ DROP TABLE t_part;
 DROP TABLE t_partval;
 DROP TABLE t_set;
 DROP TABLE t_comp_in;
+DROP TABLE t_json_proj;
 DROP TABLE t_pk_arr;
 DROP TABLE t_pk_tup;
 DROP TABLE t_pk_ntup;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107074
Related: https://github.com/ClickHouse/ClickHouse/pull/116455
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix wrong results when a `minmax` skip index, a `PARTITION BY` expression or a sorting key is built over a container column whose elements can be `NULL`, such as `Array(Nullable(String))`, `Map(String, Nullable(String))` or `Tuple(Nullable(String))`. Matching rows were silently dropped, including rows that contain no `NULL` themselves.

### Description
Related: #107074, #116455 (no open issue).

```sql
CREATE TABLE s (id UInt64, a Array(Nullable(String)), INDEX i a TYPE minmax GRANULARITY 1)
ENGINE = MergeTree ORDER BY id
SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
INSERT INTO s VALUES (1,['a']),(2,[NULL]),(3,['c']);
SELECT count() FROM s WHERE a > ['zzz'];                                -- 0
SELECT count() FROM s WHERE a > ['zzz'] SETTINGS use_skip_indexes = 0;  -- 1
```

The predicate orders container values with `IColumn::compareAt`, where a `NULL` element sorts last, and
the data is stored that way. `KeyCondition`'s range arithmetic uses `accurateLess`, whose container arm
falls through to `Field::operator<`, which compares the type tag first, so a nested `Null` sorts first and
the range bounds nothing.

I decline the atom: after the RPN is built, an atom reading such a key column becomes the neutral
`FUNCTION_UNKNOWN`, documented always relaxed, so `isRelaxed`, `alwaysUnknownOrTrue` and trivial-count
exactness stay correct while other key columns keep pruning. `KeyCondition.cpp` already does this for a
`Nullable` key. One seam fixes all seven carriers: `minmax` skip index, part-level minmax, partition
pruner, `count()` by a partition predicate, primary-key marks, the `set` index without bulk filtering,
and a projection sorting key.

The projection carrier hides: no column declares it. `json.c[].d.:Int64` is
`Array(Nullable(Int64))`, and a projection sorting key is not gated by `allow_nullable_key`. On master,
with one array element missing that path, `json.c[].d.:Int64 > [6]` returns `[7,8]` where the answer is
`[7,8,9]`, so `03464_projections_with_subcolumns` was asserting unsound pruning and its reference is
regenerated.

Cost: such a key stops pruning even with no `NULL` present, so `force_primary_key` there now raises
`INDEX_NOT_USED`, and `03733_has_function_key_condition_explain`'s reference is regenerated. Its
results-only sibling is unchanged: declining only over-reads. Recovering it needs a minmax
format version with an out-of-band bound, or aligning the two orders across `accurateLess`.

`Variant`/`Dynamic` keys are refused with `Code: 549`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116655&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116655](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116655+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


