### PR TITLE
Reduce `test_query_condition_cache` row groups

### DIFF
--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -3591,7 +3591,7 @@ def test_query_condition_cache(started_cluster):
         f"""
         INSERT INTO {table_name}
         SELECT number AS id, toString(number) AS val
-        FROM numbers(1000)
+        FROM numbers(200)
         """
     )
 


### PR DESCRIPTION
Reduce `test_query_condition_cache` from 1,000 one-row Parquet row groups to 200. The flaky ASan job runs the module three times concurrently; 200 still exercises 100 cache misses and 100 pruned row groups without stalling all workers until the job timeout.

Related: https://github.com/ClickHouse/ClickHouse/pull/114357

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114357&sha=eefc929addb540d12c2d2fae25de47bbbe9bcd9f&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20flaky%29


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.