### PR TITLE
Add CLI variant to the ClickHouse Cloud quick start

### DIFF
--- a/docs/get-started/setup/cloud.mdx
+++ b/docs/get-started/setup/cloud.mdx
@@ -1,14 +1,23 @@
 ---
 slug: /getting-started/quick-start/cloud
 sidebarTitle: 'Cloud'
-keywords: ['clickhouse', 'install', 'getting started', 'quick start']
+keywords: ['clickhouse', 'install', 'getting started', 'quick start', 'clickhousectl', 'CLI', 'automation', 'AI agents']
 title: 'ClickHouse Cloud quick start'
 description: 'Quick start guide for ClickHouse Cloud'
 doc_type: 'guide'
 ---
 
 import { Image } from "/snippets/components/Image.jsx";
+import CloudQuickstartCLI from "/snippets/quickstarts/_cloud_quickstart_cli.mdx";
 
+<Visibility for="agents">
+
+<CloudQuickstartCLI />
+
+</Visibility>
+
+<Visibility for="humans">
+<View title="Cloud UI">
 
 > The quickest and easiest way to get up and running with ClickHouse is to create a new
 service in [ClickHouse Cloud](https://console.clickhouse.cloud). In this quick start guide, we'll get you setup
@@ -181,7 +190,7 @@ SELECT * FROM helloworld.my_first_table
 ```
 
 ### Add data using the ClickHouse Client {#add-data-using-the-clickhouse-client}
-You can also connect to your ClickHouse Cloud service using a command-line tool named [**clickhouse client**](/concepts/features/interfaces/cli). Click `Connect` on the left menu to access these details. From the dialog select `Native` from the drop-down:
+You can also connect to your ClickHouse Cloud service using a command-line tool named [**clickhouse client**](/concepts/features/interfaces/client). Click `Connect` on the left menu to access these details. From the dialog select `Native` from the drop-down:
 
 <Image img="/images/_snippets/client_details.webp" size="lg" alt='clickhouse client connection details' border/>
 <br/>
@@ -302,3 +311,14 @@ See ["Setting IP filters"](/products/cloud/guides/security/connectivity/setting-
 - If your data is coming from an external source, view our [collection of integration guides](/integrations/home) for connecting to message queues, databases, pipelines and more
 - If you're using a UI/BI visualization tool, view the [user guides for connecting a UI to ClickHouse](/integrations/connectors/data-visualization/index)
 - The user guide on [primary keys](/guides/clickhouse/data-modelling/sparse-primary-indexes) is everything you need to know about primary keys and how to define them
+
+</View>
+
+<View title="CLI">
+
+You can follow this path yourself, script it, or hand it to an AI agent. Switch to the **Cloud UI** view for the console version.
+
+<CloudQuickstartCLI />
+
+</View>
+</Visibility>

--- a/docs/snippets/quickstarts/_cloud_quickstart_cli.mdx
+++ b/docs/snippets/quickstarts/_cloud_quickstart_cli.mdx
@@ -1,0 +1,219 @@
+This page covers provisioning a ClickHouse Cloud service, connecting to it, and loading data, all from the command line with the [ClickHouse CLI](/products/cloud/features/cli) (`clickhousectl`). Commands are non-interactive; `clickhousectl` emits JSON with `--json`.
+
+## Prerequisites {#prerequisites}
+
+Install the ClickHouse CLI:
+
+```bash
+curl https://clickhouse.com/cli | sh
+```
+
+You also need `jq`.
+
+You need a ClickHouse Cloud account. If you don't have one yet, `clickhousectl cloud auth signup` opens the sign-up page in your browser.
+
+Write operations (create, delete) require [API key authentication](/products/cloud/features/admin-features/api/openapi); OAuth login is read-only:
+
+```bash
+clickhousectl cloud auth login --api-key <YOUR_KEY> --api-secret <YOUR_SECRET>
+```
+
+Alternatively, set the `CLICKHOUSE_CLOUD_API_KEY` and `CLICKHOUSE_CLOUD_API_SECRET` environment variables. Verify with `clickhousectl cloud auth status`; expect an entry with scope `read/write`.
+
+## Create a ClickHouse service {#create-service}
+
+Create the service and save the response; the password for the `default` user is shown only once:
+
+```bash
+clickhousectl cloud service create \
+  --name quickstart-ch \
+  --region us-east-1 \
+  --json > ch.json
+```
+
+The response includes the service ID, endpoints, and the generated password (trimmed here; the full response also contains scaling settings, the IP access list, and tags):
+
+```json
+{
+  "password": "dK7mPq2x_-TzrL9vNw0s",
+  "service": {
+    "id": "4f7b92f3-4163-403a-b538-b9bc6e2e8f66",
+    "name": "quickstart-ch",
+    "provider": "aws",
+    "region": "us-east-1",
+    "state": "provisioning",
+    "endpoints": [
+      {
+        "host": "quickstart-abc123.us-east-1.aws.clickhouse.cloud",
+        "port": 9440,
+        "protocol": "nativesecure"
+      },
+      {
+        "host": "quickstart-abc123.us-east-1.aws.clickhouse.cloud",
+        "port": 8443,
+        "protocol": "https"
+      }
+    ],
+    "numReplicas": 3,
+    "minReplicaMemoryGb": 16.0,
+    "maxReplicaMemoryGb": 120.0
+  }
+}
+```
+
+Extract what the rest of this guide needs:
+
+```bash
+CH_ID=$(jq -r .service.id ch.json)
+CH_PASSWORD=$(jq -r .password ch.json)
+CH_HOST=$(jq -r '.service.endpoints[] | select(.protocol=="nativesecure") | .host' ch.json)
+```
+
+If the password is lost, generate a new one with `clickhousectl cloud service reset-password "$CH_ID"`.
+
+Services created with `clickhousectl` default to an IP access list that allows all (`0.0.0.0/0`). To restrict access, pass `--ip-allow` when creating the service; see ["Setting IP filters"](/products/cloud/guides/security/connectivity/setting-ip-filters).
+
+## Wait for the service to provision {#wait-for-provisioning}
+
+Provisioning takes about a minute. Poll until the state is `running`:
+
+```bash
+while [ "$(clickhousectl cloud service get "$CH_ID" --json | jq -r .state)" != "running" ]; do
+  sleep 15
+done
+```
+
+## Run SQL with the Query API {#run-sql}
+
+`clickhousectl cloud service query` runs SQL over HTTP — no local `clickhouse` binary or service password required. The first call provisions a Query API endpoint and a service-scoped API key automatically:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" --query "SHOW databases"
+```
+
+```text
+Provisioning Query API endpoint + key for service 'quickstart-ch'...
+{"name":"INFORMATION_SCHEMA"}
+{"name":"default"}
+{"name":"information_schema"}
+{"name":"system"}
+```
+
+Piped output defaults to `JSONEachRow`; pass `--format PrettyCompact` for table-formatted output instead.
+
+## Create a database and table {#create-database-and-table}
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "CREATE DATABASE IF NOT EXISTS helloworld"
+
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "CREATE TABLE helloworld.my_first_table (
+    user_id UInt32,
+    message String,
+    timestamp DateTime,
+    metric Float32
+  ) ENGINE = MergeTree()
+  PRIMARY KEY (user_id, timestamp)"
+```
+
+Both commands print `OK`. Insert a few rows:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "INSERT INTO helloworld.my_first_table (user_id, message, timestamp, metric) VALUES
+    (101, 'Hello, ClickHouse!', now(), -1.0),
+    (102, 'Insert a lot of rows per batch', yesterday(), 1.41421),
+    (102, 'Sort your data based on your commonly-used queries', today(), 2.718),
+    (101, 'Granules are the smallest chunks of data read', now() + 5, 3.14159)"
+```
+
+Verify it worked:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "SELECT * FROM helloworld.my_first_table ORDER BY timestamp"
+```
+
+```text
+{"user_id":102,"message":"Insert a lot of rows per batch","timestamp":"2026-08-26 00:00:00","metric":1.41421}
+{"user_id":102,"message":"Sort your data based on your commonly-used queries","timestamp":"2026-08-27 00:00:00","metric":2.718}
+{"user_id":101,"message":"Hello, ClickHouse!","timestamp":"2026-08-27 10:41:28","metric":-1}
+{"user_id":101,"message":"Granules are the smallest chunks of data read","timestamp":"2026-08-27 10:41:33","metric":3.14159}
+```
+
+The timestamps depend on when you ran the insert, so yours will differ.
+
+## Load a CSV file {#load-csv-file}
+
+Suppose the following text is in a CSV file named `data.csv`:
+
+```text title="data.csv"
+102,This is data in a file,2022-02-22 10:43:28,123.45
+101,It is comma-separated,2022-02-23 00:00:00,456.78
+103,Use FORMAT to specify the format,2022-02-21 10:43:30,678.90
+```
+
+`INSERT ... FORMAT` reads the data from stdin, so pipe the query and the file together:
+
+```bash
+printf 'INSERT INTO helloworld.my_first_table FORMAT CSV\n' | cat - data.csv \
+  | clickhousectl cloud service query --id "$CH_ID"
+```
+
+Verify the new rows landed:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "SELECT count() FROM helloworld.my_first_table"
+```
+
+```text
+{"count()":7}
+```
+
+## Connect with clickhouse client {#native-client}
+
+You can also connect over the native protocol with [**clickhouse client**](/concepts/features/interfaces/client). The ClickHouse CLI manages the `clickhouse` binary for you, so you don't need a separate client install:
+
+```bash
+clickhousectl local use latest
+```
+
+This installs the latest `clickhouse` binary and symlinks it to `~/.local/bin/clickhouse`, so the plain `clickhouse` command is available globally on your `PATH`.
+
+Then connect using the hostname and password from the create response. With `--query`, the result is printed and the client exits; without it you get the interactive prompt (`:)`), which you leave with `exit`:
+
+```bash
+clickhouse client --host "$CH_HOST" --secure --port 9440 \
+  --user default --password "$CH_PASSWORD" \
+  --query "SELECT * FROM helloworld.my_first_table ORDER BY timestamp FORMAT TabSeparated"
+```
+
+```text
+102	Insert a lot of rows per batch	2026-08-26 00:00:00	1.41421
+102	Sort your data based on your commonly-used queries	2026-08-27 00:00:00	2.718
+101	Hello, ClickHouse!	2026-08-27 10:41:28	-1
+101	Granules are the smallest chunks of data read	2026-08-27 10:41:33	3.14159
+103	Use FORMAT to specify the format	2022-02-21 10:43:30	678.9
+102	This is data in a file	2022-02-22 10:43:28	123.45
+101	It is comma-separated	2022-02-23 00:00:00	456.78
+```
+
+The same command form uploads files:
+
+```bash
+clickhouse client --host "$CH_HOST" --secure --port 9440 \
+  --user default --password "$CH_PASSWORD" \
+  --query='INSERT INTO helloworld.my_first_table FORMAT CSV' < data.csv
+```
+
+## Cleanup {#cleanup}
+
+Deleting a service removes all of its data permanently. `--force` stops a running service first:
+
+```bash
+clickhousectl cloud service delete "$CH_ID" --force
+```
+
+To keep the data but stop paying for compute, idle the service with `clickhousectl cloud service stop "$CH_ID"` instead.


### PR DESCRIPTION
The [ClickHouse Cloud quick start](https://clickhouse.com/docs/get-started/setup/cloud) only covered the console flow. Following the same pattern as the Managed Postgres quickstart, it now offers two views:

- **Humans:** a Cloud UI / CLI tab split, with the Cloud UI tab as the default (the existing console walkthrough, unchanged)
- **Agents:** the CLI-only variant served directly via `<Visibility for="agents">`

The CLI tab is a new snippet (`docs/snippets/quickstarts/_cloud_quickstart_cli.mdx`) covering installing `clickhousectl`, authenticating with an API key, creating a service, running SQL through the Query API (`cloud service query`, which auto-provisions the endpoint and key), loading a CSV file, connecting with `clickhouse client` installed via `clickhousectl local use latest`, and cleanup.

Every command in the snippet was validated end-to-end against a real org with the current CLI (service create, polling, query API, CSV insert, native client over port 9440, `reset-password`, and `delete --force`), across three full create/delete cycles.

One behavior worth noting: `cloud service query --query "INSERT ... FORMAT CSV" < file.csv` silently inserts zero rows because `--query` takes precedence over stdin, so the snippet pipes the query and data together through stdin instead.

Also fixes the `clickhouse client` link in the cloud quick start: `/concepts/features/interfaces/cli` now resolves to the clickhousectl page, so the client link points to `/concepts/features/interfaces/client`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116691&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116691](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116691+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.219` (included in `26.9` and later)
<!-- ch-version-info:end -->