### PR TITLE
Docs: Fix stale links from clickhouse-client pages to the clickhousectl docs page

### DIFF
--- a/docs/clickstack/managing/admin.mdx
+++ b/docs/clickstack/managing/admin.mdx
@@ -13,7 +13,7 @@ Administrative operations typically involve executing DDL statements. The availa
 
 ## ClickStack Open Source {#clickstack-oss}
 
-For ClickStack Open Source deployments, users perform administrative tasks using the [ClickHouse client](/concepts/features/interfaces/cli). The client connects to the database over the native ClickHouse protocol and supports full DDL and administrative operations, as well as providing interactive feedback on queries.
+For ClickStack Open Source deployments, users perform administrative tasks using the [ClickHouse client](/concepts/features/interfaces/client). The client connects to the database over the native ClickHouse protocol and supports full DDL and administrative operations, as well as providing interactive feedback on queries.
 
 ## Managed ClickStack {#clickstack-managed}
 

--- a/docs/clickstack/managing/performance-tuning.mdx
+++ b/docs/clickstack/managing/performance-tuning.mdx
@@ -68,7 +68,7 @@ You're recommended to review the following ClickHouse documentation before under
 - [How ClickHouse stores data: parts and granules](/guides/clickhouse/data-modelling/sparse-primary-indexes) - More advanced guide on how data is structured and queried in ClickHouse, covering granules and primary keys in detail.
 - [MergeTree](/reference/engines/table-engines/mergetree-family/mergetree)- Advanced MergeTree reference guide useful for commands and for internal specifics.
 
-All optimizations described below can be applied directly to the underlying tables using standard ClickHouse SQL, either through the [ClickHouse Cloud SQL console](/integrations/connectors/sql-clients/sql-console) or via the [ClickHouse client](/concepts/features/interfaces/cli).
+All optimizations described below can be applied directly to the underlying tables using standard ClickHouse SQL, either through the [ClickHouse Cloud SQL console](/integrations/connectors/sql-clients/sql-console) or via the [ClickHouse client](/concepts/features/interfaces/client).
 
 ## Optimization 1. Materialize frequently queried attributes {#materialize-frequently-queried-attributes}
 

--- a/docs/clickstack/managing/ttl.mdx
+++ b/docs/clickstack/managing/ttl.mdx
@@ -46,7 +46,7 @@ TTLs aren't applied immediately but rather on a schedule, as noted above. The Me
 
 To modify TTL you can either:
 
-1. **Modify the table schemas (recommended)**. This requires connecting to the ClickHouse instance e.g. using the [clickhouse-client](/concepts/features/interfaces/cli) or [Cloud SQL Console](/products/cloud/features/sql-console-features/sql-console). For example, we can modify the TTL for the `otel_logs` table using the following DDL:
+1. **Modify the table schemas (recommended)**. This requires connecting to the ClickHouse instance e.g. using the [clickhouse-client](/concepts/features/interfaces/client) or [Cloud SQL Console](/products/cloud/features/sql-console-features/sql-console). For example, we can modify the TTL for the `otel_logs` table using the following DDL:
 
 ```sql
 ALTER TABLE default.otel_logs

--- a/docs/concepts/best-practices/selecting-an-insert-strategy.mdx
+++ b/docs/concepts/best-practices/selecting-an-insert-strategy.mdx
@@ -112,7 +112,7 @@ The impact of compression on CPU and memory is modest for LZ4, and moderate for 
 
 **Combining compression with batching and an efficient input format (like Native) yields the best ingestion performance.**
 
-When using the native interface (e.g. [clickhouse-client](/concepts/features/interfaces/cli)), LZ4 compression is enabled by default. You can optionally switch to ZSTD via settings.
+When using the native interface (e.g. [clickhouse-client](/concepts/features/interfaces/client)), LZ4 compression is enabled by default. You can optionally switch to ZSTD via settings.
 
 With the [HTTP interface](/concepts/features/interfaces/http), use the Content-Encoding header to apply compression (e.g. Content-Encoding: lz4). The entire payload must be compressed before sending.
 
@@ -134,7 +134,7 @@ When data arrives pre-sorted, ClickHouse can skip or simplify the internal sorti
 
 ### Native {#choose-an-interface-native}
 
-ClickHouse offers two main interfaces for data ingestion: the **native interface** and the **HTTP interface**—each with trade-offs between performance and flexibility. The native interface, used by [clickhouse-client](/concepts/features/interfaces/cli) and select language clients like Go and C++, is purpose-built for performance. It always transmits data in ClickHouse's highly efficient Native format, supports block-wise compression with LZ4 or ZSTD, and minimizes server-side processing by offloading work such as parsing and format conversion to the client. 
+ClickHouse offers two main interfaces for data ingestion: the **native interface** and the **HTTP interface**—each with trade-offs between performance and flexibility. The native interface, used by [clickhouse-client](/concepts/features/interfaces/client) and select language clients like Go and C++, is purpose-built for performance. It always transmits data in ClickHouse's highly efficient Native format, supports block-wise compression with LZ4 or ZSTD, and minimizes server-side processing by offloading work such as parsing and format conversion to the client. 
 
 It even enables client-side computation of MATERIALIZED and DEFAULT column values, allowing the server to skip these steps entirely. This makes the native interface ideal for high-throughput ingestion scenarios where efficiency is critical.
 

--- a/docs/concepts/features/interfaces/overview.mdx
+++ b/docs/concepts/features/interfaces/overview.mdx
@@ -16,7 +16,7 @@ ClickHouse provides two network interfaces (they can be optionally wrapped in TL
 
 In most cases it is recommended to use an appropriate tool or library instead of interacting with those directly. The following are officially supported by ClickHouse:
 
-- [Command-line client](/concepts/features/interfaces/cli)
+- [Command-line client](/concepts/features/interfaces/client)
 - [ADBC driver](/concepts/features/interfaces/adbc)
 - [JDBC driver](/concepts/features/interfaces/jdbc)
 - [ODBC driver](/concepts/features/interfaces/odbc)

--- a/docs/concepts/features/interfaces/tcp.mdx
+++ b/docs/concepts/features/interfaces/tcp.mdx
@@ -6,7 +6,7 @@ title: 'Native interface (TCP)'
 doc_type: 'reference'
 ---
 
-The native protocol is used in the [command-line client](/concepts/features/interfaces/cli), for inter-server communication during distributed query processing, and also in some language clients (e.g. [clickhouse-go](/integrations/language-clients/go/index#connection-details)).
+The native protocol is used in the [command-line client](/concepts/features/interfaces/client), for inter-server communication during distributed query processing, and also in some language clients (e.g. [clickhouse-go](/integrations/language-clients/go/index#connection-details)).
 
 ClickHouse provides official specifications for the native protocol and the columnar format it carries:
 

--- a/docs/concepts/features/operations/insert/inserting-data.mdx
+++ b/docs/concepts/features/operations/insert/inserting-data.mdx
@@ -87,7 +87,7 @@ Full details on configuring asynchronous inserts can be found [here](/concepts/f
 ClickHouse has clients in the most popular programming languages.
 These are optimized to ensure that inserts are performed correctly and natively support asynchronous inserts either directly as in e.g. the [Go client](/integrations/language-clients/go/clickhouse-api#async-insert), or indirectly when enabled in the query, user or connection level settings.
 
-See [Clients and Drivers](/concepts/features/interfaces/cli) for a full list of available ClickHouse clients and drivers.
+See [Native Clients and Interfaces](/concepts/features/interfaces/natives-clients-and-interfaces) for a full list of available ClickHouse clients and drivers.
 
 ### Prefer the native format {#prefer-the-native-format}
 

--- a/docs/concepts/features/operations/insert/inserting-data.mdx
+++ b/docs/concepts/features/operations/insert/inserting-data.mdx
@@ -87,7 +87,7 @@ Full details on configuring asynchronous inserts can be found [here](/concepts/f
 ClickHouse has clients in the most popular programming languages.
 These are optimized to ensure that inserts are performed correctly and natively support asynchronous inserts either directly as in e.g. the [Go client](/integrations/language-clients/go/clickhouse-api#async-insert), or indirectly when enabled in the query, user or connection level settings.
 
-See [Native Clients and Interfaces](/concepts/features/interfaces/natives-clients-and-interfaces) for a full list of available ClickHouse clients and drivers.
+See [Native Clients and Interfaces](/concepts/features/interfaces/native-clients-interfaces-index) for a full list of available ClickHouse clients and drivers.
 
 ### Prefer the native format {#prefer-the-native-format}
 

--- a/docs/get-started/migrate/bigquery/loading-data.mdx
+++ b/docs/get-started/migrate/bigquery/loading-data.mdx
@@ -64,7 +64,7 @@ This approach has a number of advantages:
 </Step>
 <Step title="Importing data into ClickHouse from GCS" id="2-importing-data-into-clickhouse-from-gcs">
 
-Once the export is complete, we can import this data into a ClickHouse table. You can use the [ClickHouse SQL console](/integrations/connectors/sql-clients/sql-console) or [`clickhouse-client`](/concepts/features/interfaces/cli) to execute the commands below.
+Once the export is complete, we can import this data into a ClickHouse table. You can use the [ClickHouse SQL console](/integrations/connectors/sql-clients/sql-console) or [`clickhouse-client`](/concepts/features/interfaces/client) to execute the commands below.
 
 You must first [create your table](/reference/statements/create/table) in ClickHouse:
 

--- a/docs/get-started/quickstarts/insert-data-using-clickhouse-client.mdx
+++ b/docs/get-started/quickstarts/insert-data-using-clickhouse-client.mdx
@@ -174,7 +174,7 @@ Check out the following quickstarts next:
 - [Create your first MergeTree table](/get-started/quickstarts/create-your-first-mergetree-table)
 
 Or go deeper with the reference documentation:
-- [clickhouse-client reference](/concepts/features/interfaces/cli)
+- [clickhouse-client reference](/concepts/features/interfaces/client)
 - [Supported input/output formats](/reference/formats/index)
 
 <ClickHouseAcademyCTA />

--- a/docs/get-started/quickstarts/writing-queries.mdx
+++ b/docs/get-started/quickstarts/writing-queries.mdx
@@ -71,7 +71,7 @@ Query id: 3604df1c-acfd-4117-9c56-f86c69721121
 
 <Note>
 ClickHouse supports over 70 input and output formats, so between the thousands of functions and all the data formats, you can use ClickHouse to perform some impressive and fast ETL-like data transformations. In fact, you don't even
-need a ClickHouse server up and running to transform data - you can use the `clickhouse-local` tool. View the [docs page of `clickhouse-local`](/concepts/features/interfaces/cli) for details.
+need a ClickHouse server up and running to transform data - you can use the `clickhouse-local` tool. View the [docs page of `clickhouse-local`](/concepts/features/tools-and-utilities/clickhouse-local) for details.
 </Note>
 
 <div className="mt-8">

--- a/docs/get-started/sample-datasets/playground.mdx
+++ b/docs/get-started/sample-datasets/playground.mdx
@@ -39,7 +39,7 @@ HTTPS endpoint example with `curl`:
 curl "https://play.clickhouse.com/?user=explorer" --data-binary "SELECT 'Play ClickHouse'"
 ```
 
-TCP endpoint example with [CLI](/concepts/features/interfaces/cli):
+TCP endpoint example with [ClickHouse client](/concepts/features/interfaces/client):
 
 ```bash
 clickhouse client --secure --host play.clickhouse.com --user explorer

--- a/docs/get-started/setup/cloud.mdx
+++ b/docs/get-started/setup/cloud.mdx
@@ -181,7 +181,7 @@ SELECT * FROM helloworld.my_first_table
 ```
 
 ### Add data using the ClickHouse Client {#add-data-using-the-clickhouse-client}
-You can also connect to your ClickHouse Cloud service using a command-line tool named [**clickhouse client**](/concepts/features/interfaces/cli). Click `Connect` on the left menu to access these details. From the dialog select `Native` from the drop-down:
+You can also connect to your ClickHouse Cloud service using a command-line tool named [**clickhouse client**](/concepts/features/interfaces/client). Click `Connect` on the left menu to access these details. From the dialog select `Native` from the drop-down:
 
 <Image img="/images/_snippets/client_details.webp" size="lg" alt='clickhouse client connection details' border/>
 <br/>

--- a/docs/get-started/setup/self-managed/docker.mdx
+++ b/docs/get-started/setup/self-managed/docker.mdx
@@ -57,7 +57,7 @@ docker run -it --rm --network=container:some-clickhouse-server --entrypoint clic
 docker exec -it some-clickhouse-server clickhouse-client
 ```
 
-See [ClickHouse client](/concepts/features/interfaces/cli) for more information about ClickHouse client.
+See [ClickHouse client](/concepts/features/interfaces/client) for more information about ClickHouse client.
 
 ### Connect to it using curl {#connect-to-it-using-curl}
 

--- a/docs/guides/use-cases/ai-ml/ai-powered-sql-generation.mdx
+++ b/docs/guides/use-cases/ai-ml/ai-powered-sql-generation.mdx
@@ -8,7 +8,7 @@ show_related_blogs: true
 doc_type: 'guide'
 ---
 
-Starting from ClickHouse 25.7, [ClickHouse Client](/concepts/features/interfaces/cli) and [clickhouse-local](/concepts/features/tools-and-utilities/clickhouse-local) include [AI-powered functionality](/concepts/features/interfaces/client#ai-sql-generation) that converts natural language descriptions into SQL queries. This feature allows you to describe your data requirements in plain text, which the system then translates into corresponding SQL statements.
+Starting from ClickHouse 25.7, [ClickHouse Client](/concepts/features/interfaces/client) and [clickhouse-local](/concepts/features/tools-and-utilities/clickhouse-local) include [AI-powered functionality](/concepts/features/interfaces/client#ai-sql-generation) that converts natural language descriptions into SQL queries. This feature allows you to describe your data requirements in plain text, which the system then translates into corresponding SQL statements.
 
 This capability is particularly useful if you're not familiar with complex SQL syntax or need to quickly generate queries for exploratory data analysis. The feature works with standard ClickHouse tables and supports common query patterns including filtering, aggregation, and joins.
 

--- a/docs/integrations/connectors/data-ingestion/insert-local-files.mdx
+++ b/docs/integrations/connectors/data-ingestion/insert-local-files.mdx
@@ -112,4 +112,4 @@ cat comments.tsv | clickhouse-client \
 "
 ```
 
-Visit the [docs page on `clickhouse-client`](/concepts/features/interfaces/cli) for details on how to install `clickhouse-client` on your local operating system.
+Visit the [docs page on `clickhouse-client`](/concepts/features/interfaces/client) for details on how to install `clickhouse-client` on your local operating system.

--- a/docs/integrations/connectors/data-ingestion/jdbc-with-clickhouse.mdx
+++ b/docs/integrations/connectors/data-ingestion/jdbc-with-clickhouse.mdx
@@ -101,7 +101,7 @@ We started the ClickHouse JDBC Bridge in foreground mode. In order to stop the B
 
 ClickHouse can now access MySQL data by either using the [jdbc table function](/reference/functions/table-functions/jdbc) or the [JDBC table engine](/reference/engines/table-engines/integrations/jdbc).
 
-The easiest way to execute the following examples is to copy and paste them into the [`clickhouse-client`](/concepts/features/interfaces/cli) or into the [Play UI](/concepts/features/interfaces/http).
+The easiest way to execute the following examples is to copy and paste them into the [`clickhouse-client`](/concepts/features/interfaces/client) or into the [Play UI](/concepts/features/interfaces/http).
 
 - jdbc Table Function:
 

--- a/docs/integrations/language-clients/js/index.mdx
+++ b/docs/integrations/language-clients/js/index.mdx
@@ -1034,7 +1034,7 @@ await client.query({
 })
 ```
 
-Check https://clickhouse.com/docs/interfaces/cli#cli-queries-with-parameters-syntax for additional details.
+Check https://clickhouse.com/docs/interfaces/client#cli-queries-with-parameters-syntax for additional details.
 
 ### Compression {#compression}
 

--- a/docs/resources/support-center/knowledge-base/data-import-export/file-export.mdx
+++ b/docs/resources/support-center/knowledge-base/data-import-export/file-export.mdx
@@ -76,4 +76,4 @@ Using the `File` table engine is incredibly handy for creating and querying file
 $ clickhouse-client --query "SELECT * from table" --format FormatName > result.txt
 ```
 
-See [clickhouse-client](/concepts/features/interfaces/cli).
+See [clickhouse-client](/concepts/features/interfaces/client).

--- a/docs/resources/support-center/knowledge-base/data-import-export/json-import.mdx
+++ b/docs/resources/support-center/knowledge-base/data-import-export/json-import.mdx
@@ -18,7 +18,7 @@ Using [HTTP interface](/concepts/features/interfaces/http):
 $ echo '{"foo":"bar"}' | curl 'http://localhost:8123/?query=INSERT%20INTO%20test%20FORMAT%20JSONEachRow' --data-binary @-
 ```
 
-Using [CLI interface](/concepts/features/interfaces/cli):
+Using [clickhouse-client](/concepts/features/interfaces/client):
 
 ``` bash
 $ echo '{"foo":"bar"}'  | clickhouse-client --query="INSERT INTO test FORMAT JSONEachRow"

--- a/docs/resources/support-center/knowledge-base/monitoring-debugging/check-query-cache-in-use.mdx
+++ b/docs/resources/support-center/knowledge-base/monitoring-debugging/check-query-cache-in-use.mdx
@@ -7,7 +7,7 @@ keywords: ['Query Cache']
 ---
 
 ## How can I check that query cache is being used in my query? {#how-can-i-check-that-query-cache-is-being-used-in-my-query}
-See this example using [clickhouse client](/concepts/features/interfaces/cli) and ClickHouse Cloud service.
+See this example using [clickhouse client](/concepts/features/interfaces/client) and ClickHouse Cloud service.
 
 create a `query_cache_test` table
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7685,7 +7685,7 @@ Rewrite count distinct to subquery of group by
 Avoid repeated inverse dictionary lookup by doing faster lookups into a precomputed set of possible key values.
 )", 0) \
     DECLARE(Bool, throw_if_no_data_to_insert, true, R"(
-Allows or forbids empty INSERTs, enabled by default (throws an error on an empty insert). Only applies to INSERTs using [`clickhouse-client`](/concepts/features/interfaces/cli) or using the [gRPC interface](/concepts/features/interfaces/grpc).
+Allows or forbids empty INSERTs, enabled by default (throws an error on an empty insert). Only applies to INSERTs using [`clickhouse-client`](/concepts/features/interfaces/client) or using the [gRPC interface](/concepts/features/interfaces/grpc).
 )", 0) \
     DECLARE(Bool, compatibility_ignore_auto_increment_in_create_table, false, R"(
 Ignore AUTO_INCREMENT keyword in column declaration if true, otherwise return error. It simplifies migration from MySQL


### PR DESCRIPTION
After the CLI split, `/interfaces/cli` points to `clickhousectl` while `/interfaces/client` is the `clickhouse client` reference. Many pages still link to `/interfaces/cli` from text about `clickhouse client`, so readers end up on the `clickhousectl` page instead of the client reference.

This fixes those links to point to `/interfaces/client`, plus two links that belong to neither page:

- "Clients and Drivers" in inserting-data now points to the Native Clients and Interfaces index (`/interfaces/natives-clients-and-interfaces`), since no dedicated clients-and-drivers page exists.
- The `clickhouse-local` link in writing-queries now points to its own page.
- The DECLARE doc for `throw_if_no_data_to_insert` in `src/Core/Settings.cpp` is fixed as the source of truth for the generated settings reference (the generated `docs/reference/settings/session-settings/other.mdx` is left for the autogeneration workflow).

Translations are not touched, they are handled automatically.

### Changelog category (leave one):

- [ ] Documentation (changelog entry is not required)

### Changelog entry (a human-readable short description of the change):

Fix stale documentation links that pointed to the `clickhousectl` page (`/interfaces/cli`) instead of the `clickhouse client` reference (`/interfaces/client`).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116694&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116694](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116694+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.223` (included in `26.9` and later)
<!-- ch-version-info:end -->