### PR TITLE
Fix dropped rows and `LOGICAL_ERROR` for a primary-key condition with a widening integer cast

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -5199,7 +5199,10 @@ std::optional<Range> KeyCondition::applyMonotonicFunctionsChainToRange(
         /// on the given range, the Field values are guaranteed to be unchanged.
         /// We can skip the expensive function application that creates columns and executes the function.
         /// The monotonicity check already verified that the values fit in the target type.
-        bool skip_apply = functionIsIntegerCastPreservingFieldRepresentation(func, current_type, result_type);
+        /// A bound referencing a column in the index block is advanced by the application itself:
+        /// skipping would leave it on the previous column while `current_type` moves on.
+        bool skip_apply = key_range.left.isExplicit() && key_range.right.isExplicit()
+            && functionIsIntegerCastPreservingFieldRepresentation(func, current_type, result_type);
 
         if (!skip_apply)
         {

--- a/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.reference
+++ b/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.reference
@@ -1,0 +1,8 @@
+open range	(9,-294876)	(9,-294876)
+closed range	(9,-294876)	(9,-294876)
+two functions after cast	(15,-119)	(15,-119)
+single point	(1,-50)	(1,-50)
+functions in the other order	(15,-119)	(15,-119)
+unsigned key	(11,165)	(11,165)
+granules read	1
+no cast	(15,-119)	(15,-119)

--- a/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.reference
+++ b/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.reference
@@ -4,7 +4,10 @@ two functions after cast	(15,-119)	(15,-119)
 single point	(1,-50)	(1,-50)
 functions in the other order	(15,-119)	(15,-119)
 unsigned key	(11,165)	(11,165)
+wrapped in	(3,-20)	(3,-20)
 granules read	1
 no cast	(15,-119)	(15,-119)
 chain granules read, lightweight analysis	1
+wrapped in granules read, lightweight analysis	1
 chain granules read, full analysis	1
+wrapped in granules read, full analysis	1

--- a/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.reference
+++ b/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.reference
@@ -6,3 +6,5 @@ functions in the other order	(15,-119)	(15,-119)
 unsigned key	(11,165)	(11,165)
 granules read	1
 no cast	(15,-119)	(15,-119)
+chain granules read, lightweight analysis	1
+chain granules read, full analysis	1

--- a/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
+++ b/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
@@ -56,13 +56,14 @@ SELECT 'granules read', count() > 0
 FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE toInt64(x) BETWEEN -50 AND -40)
 WHERE explain ILIKE '%Granules: 2/8%';
 
--- Without a cast the same shape was always correct, so a failure here means something else broke.
+-- The same chain with no cast, as a control: a failure here points outside the cast path.
 SELECT 'no cast',
     (SELECT (count(), sum(x)) FROM t_wpk_chain WHERE abs(negate(x)) BETWEEN 10 AND 20),
     (SELECT (count(), sum(x)) FROM t_wpk_chain_unsorted WHERE abs(negate(x)) BETWEEN 10 AND 20);
 
--- The chain shapes the fix is about must still prune. Result comparisons alone cannot show this: a
--- chain that declines analysis reads every granule and returns the same correct rows.
+-- A widening cast followed by another monotonic function must still prune. Result comparisons
+-- alone cannot show this: a chain that declines analysis reads every granule and returns the
+-- same correct rows.
 SET use_lightweight_primary_key_index_analysis = 1;
 SELECT 'chain granules read, lightweight analysis', count() > 0
 FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) BETWEEN 10 AND 20)

--- a/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
+++ b/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
@@ -1,0 +1,69 @@
+-- A condition that wraps the primary key in a widening integer cast and then applies another
+-- monotonic function on top of it must return exactly the rows a table without a sort key returns.
+-- Every check prints (count, sum) for the sorted table next to (count, sum) for an identical table
+-- with no sort key, so the two tuples on a line must be equal.
+
+DROP TABLE IF EXISTS t_wpk_edge;
+DROP TABLE IF EXISTS t_wpk_edge_unsorted;
+DROP TABLE IF EXISTS t_wpk_chain;
+DROP TABLE IF EXISTS t_wpk_chain_unsorted;
+DROP TABLE IF EXISTS t_wpk_unsigned;
+DROP TABLE IF EXISTS t_wpk_unsigned_unsorted;
+
+CREATE TABLE t_wpk_edge (x Int16) ENGINE = MergeTree ORDER BY x SETTINGS index_granularity = 8;
+CREATE TABLE t_wpk_edge_unsorted (x Int16) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8;
+INSERT INTO t_wpk_edge SELECT toInt64(number) - 32768 FROM numbers(16);
+INSERT INTO t_wpk_edge_unsorted SELECT toInt64(number) - 32768 FROM numbers(16);
+
+CREATE TABLE t_wpk_chain (x Int16) ENGINE = MergeTree ORDER BY x SETTINGS index_granularity = 8;
+CREATE TABLE t_wpk_chain_unsorted (x Int16) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8;
+INSERT INTO t_wpk_chain SELECT toInt64(number) - 50 FROM numbers(64);
+INSERT INTO t_wpk_chain_unsorted SELECT toInt64(number) - 50 FROM numbers(64);
+
+CREATE TABLE t_wpk_unsigned (x UInt16) ENGINE = MergeTree ORDER BY x SETTINGS index_granularity = 8;
+CREATE TABLE t_wpk_unsigned_unsorted (x UInt16) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8;
+INSERT INTO t_wpk_unsigned SELECT number FROM numbers(64);
+INSERT INTO t_wpk_unsigned_unsorted SELECT number FROM numbers(64);
+
+-- The cast reaches the smallest value of the key type, where the extra width changes the result.
+SELECT 'open range',
+    (SELECT (count(), sum(x)) FROM t_wpk_edge WHERE negate(toInt64(x)) >= 32760),
+    (SELECT (count(), sum(x)) FROM t_wpk_edge_unsorted WHERE negate(toInt64(x)) >= 32760);
+
+SELECT 'closed range',
+    (SELECT (count(), sum(x)) FROM t_wpk_edge WHERE negate(toInt64(x)) BETWEEN 32760 AND 32768),
+    (SELECT (count(), sum(x)) FROM t_wpk_edge_unsorted WHERE negate(toInt64(x)) BETWEEN 32760 AND 32768);
+
+-- Two more functions after the cast.
+SELECT 'two functions after cast',
+    (SELECT (count(), sum(x)) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) BETWEEN 10 AND 20),
+    (SELECT (count(), sum(x)) FROM t_wpk_chain_unsorted WHERE abs(negate(toInt64(x))) BETWEEN 10 AND 20);
+
+SELECT 'single point',
+    (SELECT (count(), sum(x)) FROM t_wpk_chain WHERE abs(negate(toInt32(x))) = 50),
+    (SELECT (count(), sum(x)) FROM t_wpk_chain_unsorted WHERE abs(negate(toInt32(x))) = 50);
+
+SELECT 'functions in the other order',
+    (SELECT (count(), sum(x)) FROM t_wpk_chain WHERE negate(abs(toInt64(x))) BETWEEN -20 AND -10),
+    (SELECT (count(), sum(x)) FROM t_wpk_chain_unsorted WHERE negate(abs(toInt64(x))) BETWEEN -20 AND -10);
+
+SELECT 'unsigned key',
+    (SELECT (count(), sum(x)) FROM t_wpk_unsigned WHERE abs(negate(toUInt64(x))) BETWEEN 10 AND 20),
+    (SELECT (count(), sum(x)) FROM t_wpk_unsigned_unsorted WHERE abs(negate(toUInt64(x))) BETWEEN 10 AND 20);
+
+-- A cast alone still narrows the read down to the granules that can hold matching rows.
+SELECT 'granules read', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE toInt64(x) BETWEEN -50 AND -40)
+WHERE explain ILIKE '%Granules: 2/8%';
+
+-- Without a cast the same shape was always correct, so a failure here means something else broke.
+SELECT 'no cast',
+    (SELECT (count(), sum(x)) FROM t_wpk_chain WHERE abs(negate(x)) BETWEEN 10 AND 20),
+    (SELECT (count(), sum(x)) FROM t_wpk_chain_unsorted WHERE abs(negate(x)) BETWEEN 10 AND 20);
+
+DROP TABLE t_wpk_edge;
+DROP TABLE t_wpk_edge_unsorted;
+DROP TABLE t_wpk_chain;
+DROP TABLE t_wpk_chain_unsorted;
+DROP TABLE t_wpk_unsigned;
+DROP TABLE t_wpk_unsigned_unsorted;

--- a/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
+++ b/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
@@ -61,6 +61,18 @@ SELECT 'no cast',
     (SELECT (count(), sum(x)) FROM t_wpk_chain WHERE abs(negate(x)) BETWEEN 10 AND 20),
     (SELECT (count(), sum(x)) FROM t_wpk_chain_unsorted WHERE abs(negate(x)) BETWEEN 10 AND 20);
 
+-- The chain shapes the fix is about must still prune. Result comparisons alone cannot show this: a
+-- chain that declines analysis reads every granule and returns the same correct rows.
+SET use_lightweight_primary_key_index_analysis = 1;
+SELECT 'chain granules read, lightweight analysis', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) BETWEEN 10 AND 20)
+WHERE explain ILIKE '%Granules: 5/8%';
+
+SET use_lightweight_primary_key_index_analysis = 0;
+SELECT 'chain granules read, full analysis', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) BETWEEN 10 AND 20)
+WHERE explain ILIKE '%Granules: 5/8%';
+
 DROP TABLE t_wpk_edge;
 DROP TABLE t_wpk_edge_unsorted;
 DROP TABLE t_wpk_chain;

--- a/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
+++ b/tests/queries/0_stateless/04948_key_condition_widening_cast_block_ref.sql
@@ -51,6 +51,12 @@ SELECT 'unsigned key',
     (SELECT (count(), sum(x)) FROM t_wpk_unsigned WHERE abs(negate(toUInt64(x))) BETWEEN 10 AND 20),
     (SELECT (count(), sum(x)) FROM t_wpk_unsigned_unsorted WHERE abs(negate(toUInt64(x))) BETWEEN 10 AND 20);
 
+-- A set membership test reaches the key bounds through the key's set index, so a chain wrapped in
+-- `IN` is analysed over the same bounds as one wrapped in a range comparison.
+SELECT 'wrapped in',
+    (SELECT (count(), sum(x)) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) IN (10, 20)),
+    (SELECT (count(), sum(x)) FROM t_wpk_chain_unsorted WHERE abs(negate(toInt64(x))) IN (10, 20));
+
 -- A cast alone still narrows the read down to the granules that can hold matching rows.
 SELECT 'granules read', count() > 0
 FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE toInt64(x) BETWEEN -50 AND -40)
@@ -69,9 +75,17 @@ SELECT 'chain granules read, lightweight analysis', count() > 0
 FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) BETWEEN 10 AND 20)
 WHERE explain ILIKE '%Granules: 5/8%';
 
+SELECT 'wrapped in granules read, lightweight analysis', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) IN (10, 20))
+WHERE explain ILIKE '%Granules: 5/8%';
+
 SET use_lightweight_primary_key_index_analysis = 0;
 SELECT 'chain granules read, full analysis', count() > 0
 FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) BETWEEN 10 AND 20)
+WHERE explain ILIKE '%Granules: 5/8%';
+
+SELECT 'wrapped in granules read, full analysis', count() > 0
+FROM (EXPLAIN indexes = 1 SELECT sum(x) FROM t_wpk_chain WHERE abs(negate(toInt64(x))) IN (10, 20))
 WHERE explain ILIKE '%Granules: 5/8%';
 
 DROP TABLE t_wpk_edge;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/116580
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed index analysis for a condition that wraps the primary key in a widening integer cast such as `toInt64` and then applies another monotonic function such as `negate` or `abs`. Such a condition could silently drop matching rows, or fail with `LOGICAL_ERROR: abs's argument does not match the expected data type`. Present since 26.5.

### Description

Pre-existing on master; found while working on #116580.

`KeyCondition` skips applying an integer cast that cannot change the `Field` value. On the primary-key path the bounds are not plain values: they reference a column in the part's index block, which only the application advances alongside its type. Skipping advanced the type alone, so the next chain function was built for the new type and read the previous column. One further monotonic function made the granule range wrong and dropped matching rows silently; two made the dispatch fail and throw `LOGICAL_ERROR`, which aborts a debug or sanitizer server.

The fast path is now taken only when both bounds are explicit; `Range::shrinkToIncludedIfPossible` already applies the same test before rewriting a bound in place. Only primary-key analysis gives it up, and there it also covers set-index chains, so wrapped `IN` and `has` conditions are fixed too. The minmax skip index it was added for keeps it; the text index token scan never had it, its key being a `String`.

Correct on 26.4.6.2, broken on 26.5.8.28 through 26.8.1.2016; I will ask for a 26.5 backport once merged.

The primary key now applies the cast, as before the fast path existed. That costs one evaluation over the part's index column per query, memoised per (function, column): on a debug build with 4 million rows in one part, primary-key mark filtering goes from 13 to 46 microseconds at the default granularity, and from 22 to 490 at `index_granularity = 8`. Selected marks are identical; secondary-key mark filtering is unchanged.

A same-size `UInt8` to `Bool` cast fails the same premise for a different reason; #116656 fixes that and edits this same statement, so whichever lands second needs a one-line conflict resolution. My earlier #112231 catches the exception instead of preventing it and stays open.

Related: https://github.com/ClickHouse/ClickHouse/issues/116580

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116699&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116699](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116699+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
