### PR TITLE
Retry Kafka admin client construction on `NodeNotReadyError` too

### DIFF
--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -152,8 +152,8 @@ def existing_kafka_topic(admin_client, topic_name, max_retries=50):
 
 
 def get_admin_client(kafka_cluster, retries=15):
-    # A broker that is not up yet surfaces as NoBrokersAvailable when the readiness
-    # probe is cluster-wide, and as NodeNotReadyError when it targets a specific node.
+    # A broker that is not up yet surfaces as `NoBrokersAvailable` when the readiness
+    # probe is cluster-wide, and as `NodeNotReadyError` when it targets a specific node.
     errors = []
     for _ in range(retries):
         try:

--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -152,15 +152,15 @@ def existing_kafka_topic(admin_client, topic_name, max_retries=50):
 
 
 def get_admin_client(kafka_cluster, retries=15):
-    # Broker may not be reachable yet; retry like get_kafka_producer() instead of
-    # raising NoBrokersAvailable on the first attempt.
+    # A broker that is not up yet surfaces as NoBrokersAvailable when the readiness
+    # probe is cluster-wide, and as NodeNotReadyError when it targets a specific node.
     errors = []
     for _ in range(retries):
         try:
             return KafkaAdminClient(
                 bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
             )
-        except kafka.errors.NoBrokersAvailable as e:
+        except (kafka.errors.NoBrokersAvailable, kafka.errors.NodeNotReadyError) as e:
             errors += [str(e)]
             time.sleep(1)
 

--- a/tests/integration/test_kafka_bad_messages/test.py
+++ b/tests/integration/test_kafka_bad_messages/test.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-from kafka import KafkaAdminClient
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -65,9 +64,7 @@ def dead_letter_queue_test(expected_num_messages, topic_name):
 def bad_messages_parsing_mode(
     kafka_cluster, handle_error_mode, additional_dml, check_method
 ):
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     for format_name in [
         "TSV",
@@ -226,9 +223,7 @@ def test_bad_messages_parsing_dead_letter_queue(kafka_cluster):
 
 
 def test_bad_messages_parsing_exception(kafka_cluster, max_retries=20):
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     for format_name in [
         "Avro",
@@ -287,9 +282,7 @@ Cannot parse input: expected \\'{\\' before: \\'qwertyuiop\\': (at row 1)\\n: wh
 
 
 def test_bad_messages_to_mv(kafka_cluster, max_retries=20):
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     k.kafka_create_topic(admin_client, "tomv")
 

--- a/tests/integration/test_kafka_bad_messages/test_1.py
+++ b/tests/integration/test_kafka_bad_messages/test_1.py
@@ -1,6 +1,5 @@
 import logging
 
-from kafka import KafkaAdminClient
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -26,9 +25,7 @@ def kafka_cluster():
 
 
 def test_system_kafka_consumers_grant(kafka_cluster, max_retries=20):
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     k.kafka_create_topic(admin_client, "visible")
     k.kafka_create_topic(admin_client, "hidden")

--- a/tests/integration/test_kafka_bad_messages/test_admin_client_helper.py
+++ b/tests/integration/test_kafka_bad_messages/test_admin_client_helper.py
@@ -1,0 +1,68 @@
+"""Regression tests for the `get_admin_client` readiness retry.
+
+These tests drive `helpers.kafka.common.get_admin_client` with a stub constructor and need
+neither a ClickHouse instance nor a Kafka broker. `KafkaAdminClient` reports a broker that
+is not up yet as `NoBrokersAvailable` when its readiness probe is cluster-wide, and as
+`NodeNotReadyError` when the probe targets a specific node; a real broker cannot be made to
+pick one of the two on demand.
+
+`IncompatibleBrokerVersion` and `UnrecognizedBrokerVersion` come out of the same constructor
+but mean a genuine version mismatch rather than a broker that is still starting, so they
+must fail fast instead of being retried.
+"""
+
+import kafka.errors
+import pytest
+
+import helpers.kafka.common as k
+
+# Every failed attempt sleeps one second, so keep the budget small. Three is the smallest
+# value that admits two failures followed by a success.
+RETRIES = 3
+
+SENTINEL = "admin client"
+
+
+class FakeKafkaCluster:
+    kafka_port = 9092
+
+
+def failing_ctor(exc_cls, fail_times):
+    """A `KafkaAdminClient` stand-in raising `exc_cls` on its first `fail_times` calls."""
+    state = {"calls": 0}
+
+    def ctor(**kwargs):
+        state["calls"] += 1
+        if state["calls"] <= fail_times:
+            raise exc_cls()
+        return SENTINEL
+
+    return ctor, state
+
+
+@pytest.mark.parametrize(
+    "exc_cls", [kafka.errors.NoBrokersAvailable, kafka.errors.NodeNotReadyError]
+)
+def test_readiness_errors_are_retried(monkeypatch, exc_cls):
+    ctor, state = failing_ctor(exc_cls, RETRIES - 1)
+    monkeypatch.setattr(k, "KafkaAdminClient", ctor)
+
+    assert k.get_admin_client(FakeKafkaCluster(), retries=RETRIES) is SENTINEL
+    # A broker that answered the first probe would return the client too, so pin the
+    # number of attempts: both failures have to have been retried.
+    assert state["calls"] == RETRIES
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [kafka.errors.IncompatibleBrokerVersion, kafka.errors.UnrecognizedBrokerVersion],
+)
+def test_version_errors_are_not_retried(monkeypatch, exc_cls):
+    ctor, state = failing_ctor(exc_cls, RETRIES)
+    monkeypatch.setattr(k, "KafkaAdminClient", ctor)
+
+    with pytest.raises(exc_cls):
+        k.get_admin_client(FakeKafkaCluster(), retries=RETRIES)
+    # One attempt, so the version mismatch is reported as itself instead of being buried
+    # under the exhaustion message a retry loop would raise.
+    assert state["calls"] == 1

--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -7,7 +7,7 @@ import random
 import threading
 import time
 
-from kafka import KafkaAdminClient, KafkaProducer
+from kafka import KafkaProducer
 import kafka.errors
 import pytest
 
@@ -2146,9 +2146,7 @@ def test_kafka_insert_avro(kafka_cluster, create_query_generator):
     suffix = k.random_string(6)
     kafka_table = f"kafka_{suffix}"
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
     topic_config = {
         # default retention, since predefined timestamp_ms is used.
         "retention.ms": "-1",
@@ -2263,9 +2261,7 @@ def test_kafka_flush_by_time(kafka_cluster, create_query_generator):
     suffix = k.random_string(6)
     kafka_table = f"kafka_{suffix}"
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
     topic_name = "flush_by_time" + k.get_topic_postfix(create_query_generator)
 
     with k.kafka_topic(admin_client, topic_name):
@@ -2408,9 +2404,7 @@ def test_kafka_lot_of_partitions_partial_commit_of_bulk(
     suffix = k.random_string(6)
     kafka_table = f"kafka_{suffix}"
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     topic_name = "topic_with_multiple_partitions2" + k.get_topic_postfix(
         create_query_generator
@@ -2473,9 +2467,7 @@ def test_kafka_no_holes_when_write_suffix_failed(kafka_cluster, create_query_gen
     suffix = k.random_string(6)
     kafka_table = f"kafka_{suffix}"
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
     topic_name = "no_holes_when_write_suffix_failed" + k.get_topic_postfix(
         create_query_generator
     )
@@ -3014,9 +3006,7 @@ def test_kafka_predefined_configuration(kafka_cluster):
     suffix = k.random_string(6)
     kafka_table = f"kafka_{suffix}"
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
     topic_name = "conf"
     k.kafka_create_topic(admin_client, topic_name)
 
@@ -3353,9 +3343,7 @@ def test_system_kafka_consumers(kafka_cluster, create_query_generator, consumer_
     suffix = k.random_string(6)
     kafka_table = f"kafka_{suffix}"
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     topic_name = "system_kafka_cons" + k.get_topic_postfix(create_query_generator)
 
@@ -3455,9 +3443,7 @@ def test_system_kafka_consumers_rebalance(kafka_cluster, max_retries=15):
     kafka_table = f"kafka_{suffix}"
 
     # based on test_kafka_consumer_hang2
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     producer = KafkaProducer(
         bootstrap_servers="localhost:{}".format(cluster.kafka_port),
@@ -3576,9 +3562,7 @@ def test_system_kafka_consumers_rebalance_mv(kafka_cluster, max_retries=15):
     suffix = k.random_string(6)
     kafka_table = f"kafka_{suffix}"
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     producer = KafkaProducer(
         bootstrap_servers="localhost:{}".format(cluster.kafka_port),

--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -63,9 +63,7 @@ def kafka_setup_teardown():
 def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator):
     # data was dumped from clickhouse itself in a following manner
     # clickhouse-client --format=Native --query='SELECT toInt64(number) as id, toUInt16( intDiv( id, 65536 ) ) as blockNo, reinterpretAsString(19777) as val1, toFloat32(0.5) as val2, toUInt8(1) as val3 from numbers(100) ORDER BY id' | xxd -ps | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
-    admin_client = k.KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     all_formats = {
         ## Text formats ##

--- a/tests/integration/test_storage_kafka/test_batch_slow_5.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_5.py
@@ -1,7 +1,6 @@
 """Long running tests, longer than 30 seconds"""
 
 
-from kafka import KafkaAdminClient
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -49,9 +48,7 @@ def kafka_setup_teardown():
 
 
 def test_formats_errors(kafka_cluster):
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     for format_name in [
         "Template",

--- a/tests/integration/test_storage_kafka/test_batch_slow_6.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_6.py
@@ -5,7 +5,6 @@ import logging
 import threading
 import time
 
-from kafka import KafkaAdminClient
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -208,9 +207,7 @@ def test_kafka_rebalance(kafka_cluster, create_query_generator, log_line):
         ORDER BY key;
     """)
 
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
     topic_name = "topic_with_multiple_partitions" + k.get_topic_postfix(
         create_query_generator
     )

--- a/tests/integration/test_storage_kafka/test_produce_http_interface.py
+++ b/tests/integration/test_storage_kafka/test_produce_http_interface.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-from kafka import KafkaAdminClient
 
 from helpers.cluster import ClickHouseCluster
 import helpers.kafka.common as k
@@ -47,9 +46,7 @@ def kafka_setup_teardown():
 
 def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
     # reproduction of #61060 with validating the written messages
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     topic_prefix = "http_row_"
 
@@ -179,9 +176,7 @@ def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
 
 def test_kafka_produce_http_interface_single_column_format(kafka_cluster):
     # Test formats that only support a single column: LineAsString, RawBLOB, Npy
-    admin_client = KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+    admin_client = k.get_admin_client(kafka_cluster)
 
     topic_prefix = "http_single_col_"
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/115294
Related: https://github.com/ClickHouse/ClickHouse/pull/107337
Related: https://github.com/ClickHouse/ClickHouse/pull/108635

`test_storage_kafka/test_partition_affinity.py::test_partition_affinity_settings_validation` errored
with `kafka.errors.NodeNotReadyError` out of the `autouse` fixture, not the test body:
[Integration tests (amd_asan_ubsan, db disk, old analyzer, 4/6)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115294&sha=47d8d03a62c562bfc1e9a4adb9c2091d2f4a02fd&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%204%2F6%29).

`get_admin_client` already retries a broker that is not up yet, but its `except` named only
`kafka.errors.NoBrokersAvailable`. A `KafkaAdminClient` runs several readiness probes on construction,
and kafka-python picks the exception class by whether the probe names a node: a cluster-wide probe
raises `NoBrokersAvailable`, the controller probe raises `NodeNotReadyError`, as
`KafkaClient.check_version`'s own docstring documents. So the loop covered half the class it was
written for. I added it in #107337, so the single-class catch was mine.

CIDB over 365 days at this call, split at the instant #107337 merged: 10 `NoBrokersAvailable` and 1
`NodeNotReadyError` before, 0 and 2 after, against a larger denominator. It reached master once, on
2026-06-02, before the loop existed.

Separately, 17 places constructed a `KafkaAdminClient` directly with no retry, four of them in modules
with no `autouse` fixture, where that construction is the module's first admin client. All 17 now call
the helper, following #108635, which converged this suite's `delete_topics` calls the same way. The one
direct construction left, in the `casa_del_dolor` fuzzer, is in no CI job.

`tests/integration/test_kafka_bad_messages/test_admin_client_helper.py` covers this with a stub
constructor and no broker: two ids for the classes to retry, two for `IncompatibleBrokerVersion` and
`UnrecognizedBrokerVersion`, which are `retriable=False` and must fail fast rather than stall for 15
seconds. Three mutations of the `except` clause redden pairwise disjoint subsets of the four ids, so no
id is redundant; the first is byte-identical to the clause before this change, so it doubles as the
negative control.

Not fixed here: a failed attempt strands a partially constructed client, because kafka-python builds
its internal client before the probes that can raise.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116700&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116700](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116700+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.400` (included in `26.9` and later)
<!-- ch-version-info:end -->