### PR TITLE
Do not run two PR workflows at the same commit

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ['2[1-9].[1-9][0-9]', '2[1-9].[1-9]']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
 env:
   # Force the stdout and stderr streams to be unbuffered
   PYTHONUNBUFFERED: 1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ['master']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
 env:
   # Force the stdout and stderr streams to be unbuffered
   PYTHONUNBUFFERED: 1

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -648,11 +648,18 @@ class PullRequestPushYamlGen:
         )
         res = template_1.format(*job_items)
 
-        # Only a pull_request event carries the context the group is keyed on, so
-        # exactly the pull_request workflows are the ones that reference it.
+        # Only a `pull_request` event carries the context the group is keyed on, so
+        # exactly the `pull_request` workflows are the ones that reference it.
         if self.workflow_config.event in (Workflow.Event.PULL_REQUEST,):
+            concurrency_block = (
+                "concurrency:\n"
+                "  group: ${{ github.workflow }}"
+                "-${{ github.event.pull_request.number }}"
+                "-${{ github.event.pull_request.head.sha }}\n"
+                "  cancel-in-progress: true"
+            )
             assert (
-                "concurrency:" in res and "github.event.pull_request.number" in res
+                concurrency_block in res
             ), f"[{self.workflow_config.name}] misses the per-commit concurrency group"
         else:
             assert (

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -648,6 +648,17 @@ class PullRequestPushYamlGen:
         )
         res = template_1.format(*job_items)
 
+        # Only a pull_request event carries the context the group is keyed on, so
+        # exactly the pull_request workflows are the ones that reference it.
+        if self.workflow_config.event in (Workflow.Event.PULL_REQUEST,):
+            assert (
+                "concurrency:" in res and "github.event.pull_request.number" in res
+            ), f"[{self.workflow_config.name}] misses the per-commit concurrency group"
+        else:
+            assert (
+                "github.event.pull_request" not in res
+            ), f"[{self.workflow_config.name}] must not reference github.event.pull_request"
+
         return res
 
 

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -37,7 +37,7 @@ on:
   {EVENT}:
     branches: [{BRANCHES}]
 
-env:
+{CONCURRENCY}env:
   # Force the stdout and stderr streams to be unbuffered
   PYTHONUNBUFFERED: 1
 {ENV_CHECKOUT_REFERENCE}
@@ -46,6 +46,15 @@ env:
 
 jobs:
 {JOBS}\
+"""
+        # Two pull_request events can dispatch at one head commit onto state that
+        # praktika keys by (PR, sha) alone, so the newer run must supersede the
+        # older. The head sha is part of the group, so a push is never cancelled.
+        TEMPLATE_CONCURRENCY_PR = """\
+concurrency:
+  group: ${{{{ github.workflow }}}}-${{{{ github.event.pull_request.number }}}}-${{{{ github.event.pull_request.head.sha }}}}
+  cancel-in-progress: true
+
 """
         TEMPLATE_GH_TOKEN_PERMISSIONS = """\
 # Allow updating GH commit statuses and PR comments to post an actual job reports link
@@ -529,10 +538,15 @@ class PullRequestPushYamlGen:
                 ENV_CHECKOUT_REFERENCE = (
                     YamlGenerator.Templates.TEMPLATE_ENV_CHECKOUT_REF_PR
                 )
+                format_kwargs["CONCURRENCY"] = (
+                    YamlGenerator.Templates.TEMPLATE_CONCURRENCY_PR
+                )
             else:
                 ENV_CHECKOUT_REFERENCE = (
                     YamlGenerator.Templates.TEMPLATE_ENV_CHECKOUT_REF_DEFAULT
                 )
+                # github.event.pull_request is null on a push.
+                format_kwargs["CONCURRENCY"] = ""
         elif self.workflow_config.event in (Workflow.Event.SCHEDULE,):
             base_template = YamlGenerator.Templates.TEMPLATE_SCHEDULE
             format_kwargs = {


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/116641
Related: https://github.com/ClickHouse/ClickHouse/pull/116642

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Give the `pull_request` workflows a concurrency group so two runs cannot race at one commit.

### Description

A PR is opened and reopened seconds later, so two `pull_request` events dispatch two full `PR` runs
at one head commit. Both are `run_attempt = 1` and neither supersedes the other, because the
generated workflow has no `concurrency` block. praktika keys their shared state by `(PR, sha)`,
never by `RUN_ID`, so each run overwrites the other's S3 artifacts and reads its in-flight statuses
from `result_<workflow>.json`.

On #116641 nine legs of one run died in the pre-run download with `PreconditionFailed`:
the other run re-uploaded the key mid-download, invalidating the ranged GET's ETag. All nine are
`success` in the sibling run at the identical tree, two of them `flaky check`. On #116642 the
losing `Finish Workflow` read that shared document mid-run and published
`No per-arch Bugfix Validation job validated the bug`, which the sibling run contradicts with three
`success` jobs.

This adds a `concurrency` group of workflow, PR number and head sha with `cancel-in-progress`, for
`pull_request` only. The head sha is in the group, so a push starts a new group and never cancels
the previous run. `master.yml` and `release_branches.yml` share the template and stay
byte-identical, because `github.event.pull_request` is null on a push. The generator now refuses to
emit a `pull_request` workflow without that block, or another workflow referencing it.

The close-and-reopen comes from an app outside this repository that this change does not touch.

Residuals: `CacheRunnerHooks.pre_run` can still aim a download at another PR's prefix,
`any_bugfix_validation_passed` still reads a `RUNNING` per-arch job as a refutation, and
`Finish Workflow` is emitted with `always()`, so the group cannot stop a superseded finalizer that
already started; in the measured 8-second window only `Config Workflow` exists.

The two runs and their shared report:
[33040674324](https://github.com/ClickHouse/ClickHouse/actions/runs/33040674324),
[33040682270](https://github.com/ClickHouse/ClickHouse/actions/runs/33040682270),
[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116641&sha=c4d18f8753d67a0411f41c5a67a72cd6988574f9&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20flaky%20check%29).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116701&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116701](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116701+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.513` (included in `26.9` and later)
<!-- ch-version-info:end -->