### PR TITLE
Fabric docs: document access revocation limitation

### DIFF
--- a/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
+++ b/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
@@ -256,7 +256,8 @@ The ClickHouse workload is in public preview. The limitations below are the curr
 
 ### Access and identity {#access-and-identity}
 
-* **Role changes apply on next open.** Your ClickHouse organization role is mapped from your Fabric workspace role when you open a ClickHouse item. Fabric cannot notify ClickHouse of role changes, so a changed workspace role takes effect the next time you open the item, not immediately.
+* **Role changes apply on next open.** Your ClickHouse organization role is mapped from your Fabric workspace role each time you open a ClickHouse item. Fabric cannot notify ClickHouse of role changes, so a changed workspace role does not take effect immediately.
+* **Removing or downgrading a user in Fabric does not revoke their ClickHouse access.** Because roles are only applied when a user opens a ClickHouse item, a user who is removed from the workspace or downgraded may retain their existing access on the ClickHouse Cloud side, and if they never open the item again that change never propagates at all. To revoke access immediately and reliably, remove the user from the organization in the ClickHouse Cloud console.
 * **Workspace-level access.** Everyone in the workspace can use its ClickHouse items. Granular, per-table permission sync from OneLake is currently not supported.
 * **Console SSO requires an email on your Entra profile.** ClickHouse Cloud users need an email address; if your Microsoft Entra profile has none set, signing in to the Cloud console will fail.
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Documentation entry for user-facing changes

Part of https://github.com/ClickHouse/ClickHouse/issues/116380 (reference only — this does not close the issue).

Adds one bullet to **Known limitations → Access and identity** on the [ClickHouse for Microsoft Fabric](https://clickhouse.com/docs/integrations/microsoft-fabric) page: removing or downgrading a user in Fabric does not revoke their ClickHouse access.

Branched off `master` (#116188 and #116567 are merged). The page stays unlisted (`hidden: true` in frontmatter, untouched).

#### The change

New bullet, placed directly after "Role changes apply on next open" since it is the consequence of the same mechanism:

> * **Removing or downgrading a user in Fabric does not revoke their ClickHouse access.** Because roles are only applied when a user opens a ClickHouse item, a user who is removed from the workspace or downgraded may retain their existing access on the ClickHouse Cloud side, and if they never open the item again that change never propagates at all. To revoke access immediately and reliably, remove the user from the organization in the ClickHouse Cloud console.

The preceding bullet is lightly reworded so the two read as a pair rather than repeating each other. It previously ended with "takes effect the next time you open the item, not immediately", which the new bullet now covers in more detail:

- "…mapped from your Fabric workspace role **when** you open a ClickHouse item" → "**each time** you open a ClickHouse item" (the mapping is re-applied on every open, which is what makes the never-opens-again case possible)
- "…takes effect the next time you open the item, not immediately" → "…**does not take effect immediately**"

No security detail was dropped in the reconciliation: the "may never propagate" case and the Cloud console as the reliable revocation path are both stated explicitly in the new bullet.

#### Flagged for visibility, not changed here

- **This limitation should probably be reflected in the [attestation](https://clickhouse.com/legal/clickhouse-microsoft-fabric-workload-attestation) and in the in-product UI copy.** Access revocation is the kind of thing a reviewer will look for outside the docs too. Raising it here only so it is on the record — happy to open a separate issue if reviewers agree it belongs there.
- **Unrelated: the "Lakehouse tables only" bullet on `master` looks accidentally truncated.** Commit db028f03 (a suggestion applied in #116567) reduced it to "Sync reads tables from a Lakehouse in the same workspace. " with a trailing space, dropping "Delta" and the sentence about Warehouse / KQL / mirrored databases not being supported as sources. Left alone as out of scope for this PR.

#### Checks run locally

- `navigation_check.py` — passes; page stays unlisted, not re-added to the sidebar
- `snippet_component_imports_check.py` — 109 snippet files and 97 local image references OK
- `mint validate` — build validation passed
- `lychee_check.py --mode links` — 32,388 unique links, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116718&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116718](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116718+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.210` (included in `26.9` and later)
<!-- ch-version-info:end -->