### PR TITLE
Docs: delegate dbt documentation navigation to dbt-clickhouse

### DIFF
--- a/docs/integrations/connectors/data-ingestion/etl-tools/dbt/navigation.json
+++ b/docs/integrations/connectors/data-ingestion/etl-tools/dbt/navigation.json
@@ -1,0 +1,11 @@
+{
+  "expanded": false,
+  "group": "dbt",
+  "pages": [
+    "integrations/connectors/data-ingestion/etl-tools/dbt/index",
+    "integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations",
+    "integrations/connectors/data-ingestion/etl-tools/dbt/materializations",
+    "integrations/connectors/data-ingestion/etl-tools/dbt/materialization-materialized-view",
+    "integrations/connectors/data-ingestion/etl-tools/dbt/guides"
+  ]
+}

--- a/docs/integrations/connectors/navigation.json
+++ b/docs/integrations/connectors/navigation.json
@@ -148,17 +148,7 @@
           ]
         },
         "integrations/connectors/data-ingestion/etl-tools/bladepipe-and-clickhouse",
-        {
-          "expanded": false,
-          "group": "dbt",
-          "pages": [
-            "integrations/connectors/data-ingestion/etl-tools/dbt/index",
-            "integrations/connectors/data-ingestion/etl-tools/dbt/features-and-configurations",
-            "integrations/connectors/data-ingestion/etl-tools/dbt/materializations",
-            "integrations/connectors/data-ingestion/etl-tools/dbt/materialization-materialized-view",
-            "integrations/connectors/data-ingestion/etl-tools/dbt/guides"
-          ]
-        },
+        { "$ref": "data-ingestion/etl-tools/dbt/navigation.json" },
         "integrations/connectors/data-ingestion/etl-tools/dlt-and-clickhouse",
         {
           "group": "Fivetran",


### PR DESCRIPTION
Move the dbt sidebar definition into the mirrored documentation directory so
`ClickHouse/dbt-clickhouse` can synchronize page ordering together with the
documentation content. The published page paths and sidebar ordering remain
unchanged.

Related: https://github.com/ClickHouse/ClickHouse/pull/116357
Related: https://github.com/ClickHouse/dbt-clickhouse/pull/728

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116726&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116726](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116726+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
