### PR TITLE
Fix minmax skip index pruning a granule whose Array or Map value contains a NaN

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -5,6 +5,8 @@
 #include <Common/FieldAccurateComparison.h>
 #include <Common/quoteString.h>
 
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>
 
 #include <IO/ReadHelpers.h>
@@ -146,8 +148,25 @@ namespace
 /// Both ends of a `minmax` range must bound the granule under the order `KeyCondition` compares with,
 /// in which a `NaN` element is above every number. `IColumn::getExtremes` reports the `min` and `max`
 /// aggregates instead, and those exclude a value that contains a `NaN`.
-void getTotalOrderExtremes(const IColumn & column, size_t start, size_t end, FieldRef & min_value, FieldRef & max_value)
+void getTotalOrderExtremes(const IColumn & column, size_t start, size_t end, Field & min_value, Field & max_value)
 {
+    /// A `Map` value is materialized through its nested array, which refuses more than a million elements.
+    if (const auto * column_map = typeid_cast<const ColumnMap *>(&column))
+    {
+        Field nested_min;
+        Field nested_max;
+        getTotalOrderExtremes(column_map->getNestedColumn(), start, end, nested_min, nested_max);
+
+        const auto & nested_min_value = nested_min.safeGet<Array>();
+        const auto & nested_max_value = nested_max.safeGet<Array>();
+        min_value = Map(nested_min_value.begin(), nested_min_value.end());
+        max_value = Map(nested_max_value.begin(), nested_max_value.end());
+        return;
+    }
+
+    min_value = Array();
+    max_value = Array();
+
     if (start >= end)
         return;
 
@@ -184,7 +203,7 @@ bool needsTotalOrderExtremes(const IDataType & type)
 
         if (!(isArray(node) || isMap(node) || isTuple(node) || node.lowCardinality()
               || node.isValueRepresentedByNumber() || isStringOrFixedString(node)
-              || isUUID(node) || isIPv4(node) || isIPv6(node)))
+              || isUUID(node) || isIPv6(node)))
             tag_stable = false;
     };
 

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -140,9 +140,69 @@ void MergeTreeIndexGranuleMinMax::deserializeBinary(ReadBuffer & istr, MergeTree
     }
 }
 
-MergeTreeIndexAggregatorMinMax::MergeTreeIndexAggregatorMinMax(const String & index_name_, const Block & index_sample_block_)
+namespace
+{
+
+/// Both ends of a `minmax` range must bound the granule under the order `KeyCondition` compares with,
+/// in which a `NaN` element is above every number. `IColumn::getExtremes` reports the `min` and `max`
+/// aggregates instead, and those exclude a value that contains a `NaN`.
+void getTotalOrderExtremes(const IColumn & column, size_t start, size_t end, FieldRef & min_value, FieldRef & max_value)
+{
+    if (start >= end)
+        return;
+
+    static constexpr int nan_direction_hint = 1;
+
+    size_t min_idx = start;
+    size_t max_idx = start;
+    for (size_t i = start + 1; i < end; ++i)
+    {
+        if (column.compareAt(i, min_idx, column, nan_direction_hint) < 0)
+            min_idx = i;
+        else if (column.compareAt(i, max_idx, column, nan_direction_hint) > 0)
+            max_idx = i;
+    }
+
+    column.get(min_idx, min_value);
+    column.get(max_idx, max_value);
+}
+
+/// `Field::operator<` compares the type tag before the value, so it agrees with `IColumn::compareAt`
+/// only while every node of the type tree yields a single tag. That is why this is an allow-list.
+bool needsTotalOrderExtremes(const IDataType & type)
+{
+    if (!isArray(type) && !isMap(type))
+        return false;
+
+    bool tag_stable = true;
+    bool has_float = false;
+
+    auto visit = [&](const IDataType & node)
+    {
+        if (isFloat(node))
+            has_float = true;
+
+        if (!(isArray(node) || isMap(node) || isTuple(node) || node.lowCardinality()
+              || node.isValueRepresentedByNumber() || isStringOrFixedString(node)
+              || isUUID(node) || isIPv4(node) || isIPv6(node)))
+            tag_stable = false;
+    };
+
+    visit(type);
+    type.forEachChild(visit);
+
+    return tag_stable && has_float;
+}
+
+}
+
+MergeTreeIndexAggregatorMinMax::MergeTreeIndexAggregatorMinMax(
+    const String & index_name_,
+    const Block & index_sample_block_,
+    std::shared_ptr<const std::vector<UInt8>> needs_total_order_extremes_)
     : index_name(index_name_)
     , index_sample_block(index_sample_block_)
+    , needs_total_order_extremes(std::move(needs_total_order_extremes_))
 {
 }
 
@@ -172,7 +232,9 @@ void MergeTreeIndexAggregatorMinMax::update(const Block & block, size_t * pos, s
         /// sentinel; otherwise IS NULL wrongly prunes). getExtremes on LC materializes internally too,
         /// so this adds no extra work.
         const auto column = src_column->lowCardinality() ? src_column->convertToFullColumnIfLowCardinality() : src_column;
-        if (const auto * column_nullable = typeid_cast<const ColumnNullable *>(column.get()))
+        if ((*needs_total_order_extremes)[i])
+            getTotalOrderExtremes(*column, range_start, range_end, field_min, field_max);
+        else if (const auto * column_nullable = typeid_cast<const ColumnNullable *>(column.get()))
             column_nullable->getExtremesNullLast(field_min, field_max, range_start, range_end);
         else
             column->getExtremes(field_min, field_max, range_start, range_end);
@@ -236,6 +298,16 @@ std::string MergeTreeIndexConditionMinMax::getDescription() const
     return condition.getDescription().condition;
 }
 
+MergeTreeIndexMinMax::MergeTreeIndexMinMax(StorageMetadataPtr metadata_snapshot_, const IndexDescription & index_)
+    : IMergeTreeIndex(std::move(metadata_snapshot_), index_)
+{
+    auto flags = std::make_shared<std::vector<UInt8>>();
+    flags->reserve(index.sample_block.columns());
+    for (const auto & column : index.sample_block)
+        flags->push_back(needsTotalOrderExtremes(*column.type));
+    needs_total_order_extremes = std::move(flags);
+}
+
 MergeTreeIndexGranulePtr MergeTreeIndexMinMax::createIndexGranule() const
 {
     return std::make_shared<MergeTreeIndexGranuleMinMax>(index.name, index.sample_block);
@@ -244,7 +316,7 @@ MergeTreeIndexGranulePtr MergeTreeIndexMinMax::createIndexGranule() const
 
 MergeTreeIndexAggregatorPtr MergeTreeIndexMinMax::createIndexAggregator() const
 {
-    return std::make_shared<MergeTreeIndexAggregatorMinMax>(index.name, index.sample_block);
+    return std::make_shared<MergeTreeIndexAggregatorMinMax>(index.name, index.sample_block, needs_total_order_extremes);
 }
 
 MergeTreeIndexConditionPtr MergeTreeIndexMinMax::createIndexCondition(

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.h
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.h
@@ -37,7 +37,10 @@ struct MergeTreeIndexGranuleMinMax final : public IMergeTreeIndexGranule
 
 struct MergeTreeIndexAggregatorMinMax final : IMergeTreeIndexAggregator
 {
-    MergeTreeIndexAggregatorMinMax(const String & index_name_, const Block & index_sample_block);
+    MergeTreeIndexAggregatorMinMax(
+        const String & index_name_,
+        const Block & index_sample_block,
+        std::shared_ptr<const std::vector<UInt8>> needs_total_order_extremes_);
     ~MergeTreeIndexAggregatorMinMax() override = default;
 
     bool empty() const override { return hyperrectangle.empty(); }
@@ -47,6 +50,7 @@ struct MergeTreeIndexAggregatorMinMax final : IMergeTreeIndexAggregator
     String index_name;
     Block index_sample_block;
     Ranges hyperrectangle;
+    std::shared_ptr<const std::vector<UInt8>> needs_total_order_extremes;
 };
 
 
@@ -74,9 +78,7 @@ private:
 class MergeTreeIndexMinMax : public IMergeTreeIndex
 {
 public:
-    MergeTreeIndexMinMax(StorageMetadataPtr metadata_snapshot_, const IndexDescription & index_)
-        : IMergeTreeIndex(std::move(metadata_snapshot_), index_)
-    {}
+    MergeTreeIndexMinMax(StorageMetadataPtr metadata_snapshot_, const IndexDescription & index_);
 
     ~MergeTreeIndexMinMax() override = default;
 
@@ -96,6 +98,9 @@ public:
         const MergeTreeDataPartChecksums & checksums,
         const std::string & path_prefix,
         const IDataPartStorage * storage) const override;
+
+private:
+    std::shared_ptr<const std::vector<UInt8>> needs_total_order_extremes;
 };
 
 struct MergeTreeIndexBulkGranulesMinMax final : public IMergeTreeIndexBulkGranules

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
@@ -1,0 +1,17 @@
+array positive indexed	1
+array positive no index	1
+array positive prunes other granule	1
+array negated indexed	4
+array negated no index	4
+map positive indexed	1
+map positive no index	1
+nullable element indexed	2
+nullable element no index	2
+finite array still prunes	1
+finite array indexed	1
+finite array no index	1
+string array still prunes	1
+string array indexed	1
+string array no index	1
+mixed leaves indexed	1
+mixed leaves no index	1

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
@@ -3,6 +3,10 @@ array positive no index	1
 array positive prunes other granule	1
 array negated indexed	4
 array negated no index	4
+granularity 2 nan in first mark indexed	1
+granularity 2 nan in first mark no index	1
+granularity 2 nan in second mark indexed	1
+granularity 2 nan in second mark no index	1
 map positive indexed	1
 map positive no index	1
 nullable element indexed	2

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
@@ -21,6 +21,7 @@ string array indexed	1
 string array no index	1
 mixed leaves indexed	1
 mixed leaves no index	1
+mixed leaves still prunes	1
 bool leaf indexed	1
 bool leaf no index	1
 bool leaf still prunes	1

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.reference
@@ -5,10 +5,12 @@ array negated indexed	4
 array negated no index	4
 granularity 2 nan in first mark indexed	1
 granularity 2 nan in first mark no index	1
+granularity 2 nan in first mark prunes finite entry	1
 granularity 2 nan in second mark indexed	1
 granularity 2 nan in second mark no index	1
 map positive indexed	1
 map positive no index	1
+map still prunes	1
 nullable element indexed	2
 nullable element no index	2
 finite array still prunes	1
@@ -19,3 +21,6 @@ string array indexed	1
 string array no index	1
 mixed leaves indexed	1
 mixed leaves no index	1
+bool leaf indexed	1
+bool leaf no index	1
+bool leaf still prunes	1

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
@@ -18,6 +18,26 @@ SELECT 'array positive prunes other granule', count() > 0 FROM (
 SELECT 'array negated indexed', count() FROM t_arr WHERE NOT (a <= [3.]);
 SELECT 'array negated no index', count() FROM t_arr WHERE NOT (a <= [3.]) SETTINGS use_skip_indexes = 0;
 
+-- GRANULARITY 2 spans two marks, so the bound is merged across two update() calls. The merge keeps
+-- its own right end when the NaN arrives first and takes the new one when it arrives second.
+DROP TABLE IF EXISTS t_g2_first;
+CREATE TABLE t_g2_first (id UInt64, a Array(Float64), INDEX idx_a a TYPE minmax GRANULARITY 2)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_g2_first VALUES (1, [1.]), (2, [nan]), (3, [3.]), (4, [100.]), (5, [150.]), (6, [200.]);
+
+SELECT 'granularity 2 nan in first mark indexed', count() FROM t_g2_first WHERE a > [500.];
+SELECT 'granularity 2 nan in first mark no index', count() FROM t_g2_first WHERE a > [500.] SETTINGS use_skip_indexes = 0;
+
+DROP TABLE IF EXISTS t_g2_second;
+CREATE TABLE t_g2_second (id UInt64, a Array(Float64), INDEX idx_a a TYPE minmax GRANULARITY 2)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_g2_second VALUES (1, [100.]), (2, [150.]), (3, [200.]), (4, [1.]), (5, [nan]), (6, [3.]);
+
+SELECT 'granularity 2 nan in second mark indexed', count() FROM t_g2_second WHERE a > [500.];
+SELECT 'granularity 2 nan in second mark no index', count() FROM t_g2_second WHERE a > [500.] SETTINGS use_skip_indexes = 0;
+
 DROP TABLE IF EXISTS t_map;
 CREATE TABLE t_map (id UInt64, a Map(String, Float64), INDEX idx_a a TYPE minmax GRANULARITY 1)
 ENGINE = MergeTree ORDER BY id
@@ -88,6 +108,8 @@ WHERE a > [(500., 'a', toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), toLowCard
 SETTINGS use_skip_indexes = 0;
 
 DROP TABLE t_arr;
+DROP TABLE t_g2_first;
+DROP TABLE t_g2_second;
 DROP TABLE t_map;
 DROP TABLE t_nullable;
 DROP TABLE t_finite;

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
@@ -1,0 +1,95 @@
+-- A minmax index on an array or map column must not skip a granule holding a NaN, because a NaN
+-- element sorts after every number and such a value can satisfy the query.
+
+DROP TABLE IF EXISTS t_arr;
+CREATE TABLE t_arr (id UInt64, a Array(Float64), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_arr VALUES (1, [1.]), (2, [nan]), (3, [3.]);
+INSERT INTO t_arr VALUES (4, [100.]), (5, [150.]), (6, [200.]);
+
+SELECT 'array positive indexed', count() FROM t_arr WHERE a > [500.];
+SELECT 'array positive no index', count() FROM t_arr WHERE a > [500.] SETTINGS use_skip_indexes = 0;
+SELECT 'array positive prunes other granule', count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT sum(id) FROM t_arr WHERE a > [500.]
+    SETTINGS use_skip_indexes_on_data_read = 0, optimize_use_implicit_projections = 0
+) WHERE explain LIKE '%Granules: 1/2%';
+
+SELECT 'array negated indexed', count() FROM t_arr WHERE NOT (a <= [3.]);
+SELECT 'array negated no index', count() FROM t_arr WHERE NOT (a <= [3.]) SETTINGS use_skip_indexes = 0;
+
+DROP TABLE IF EXISTS t_map;
+CREATE TABLE t_map (id UInt64, a Map(String, Float64), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_map VALUES (1, map('k', 1.)), (2, map('k', nan)), (3, map('k', 3.));
+INSERT INTO t_map VALUES (4, map('k', 100.)), (5, map('k', 150.)), (6, map('k', 200.));
+
+SELECT 'map positive indexed', count() FROM t_map WHERE a > map('k', 500.);
+SELECT 'map positive no index', count() FROM t_map WHERE a > map('k', 500.) SETTINGS use_skip_indexes = 0;
+
+DROP TABLE IF EXISTS t_nullable;
+CREATE TABLE t_nullable (id UInt64, a Array(Nullable(Float64)), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_nullable VALUES (1, [0.]), (2, [1., 10.]), (3, [1., NULL]);
+
+SELECT 'nullable element indexed', count() FROM t_nullable WHERE a > [1., 5.];
+SELECT 'nullable element no index', count() FROM t_nullable WHERE a > [1., 5.] SETTINGS use_skip_indexes = 0;
+
+DROP TABLE IF EXISTS t_finite;
+CREATE TABLE t_finite (id UInt64, a Array(Float64), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_finite VALUES (1, [1.]), (2, [2.]), (3, [3.]);
+INSERT INTO t_finite VALUES (4, [100.]), (5, [150.]), (6, [200.]);
+
+SELECT 'finite array still prunes', count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT sum(id) FROM t_finite WHERE a > [150.]
+    SETTINGS use_skip_indexes_on_data_read = 0, optimize_use_implicit_projections = 0
+) WHERE explain LIKE '%Granules: 1/2%';
+SELECT 'finite array indexed', count() FROM t_finite WHERE a > [150.];
+SELECT 'finite array no index', count() FROM t_finite WHERE a > [150.] SETTINGS use_skip_indexes = 0;
+
+DROP TABLE IF EXISTS t_str;
+CREATE TABLE t_str (id UInt64, a Array(String), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_str VALUES (1, ['a']), (2, ['b']), (3, ['c']);
+INSERT INTO t_str VALUES (4, ['x']), (5, ['y']), (6, ['z']);
+
+SELECT 'string array still prunes', count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT sum(id) FROM t_str WHERE a > ['y']
+    SETTINGS use_skip_indexes_on_data_read = 0, optimize_use_implicit_projections = 0
+) WHERE explain LIKE '%Granules: 1/2%';
+SELECT 'string array indexed', count() FROM t_str WHERE a > ['y'];
+SELECT 'string array no index', count() FROM t_str WHERE a > ['y'] SETTINGS use_skip_indexes = 0;
+
+DROP TABLE IF EXISTS t_mixed;
+CREATE TABLE t_mixed (
+    id UInt64,
+    a Array(Tuple(Float64, String, UUID, LowCardinality(String), IPv6, Date)),
+    INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_mixed VALUES
+    (1, [(1., 'a', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', 'x', '::1', '2020-01-01')]),
+    (2, [(nan, 'a', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', 'x', '::1', '2020-01-01')]),
+    (3, [(3., 'a', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', 'x', '::1', '2020-01-01')]);
+INSERT INTO t_mixed VALUES
+    (4, [(100., 'a', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', 'x', '::1', '2020-01-01')]),
+    (5, [(150., 'a', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', 'x', '::1', '2020-01-01')]),
+    (6, [(200., 'a', '61f0c404-5cb3-11e7-907b-a6006ad3dba0', 'x', '::1', '2020-01-01')]);
+
+SELECT 'mixed leaves indexed', count() FROM t_mixed
+WHERE a > [(500., 'a', toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), toLowCardinality('x'), toIPv6('::1'), toDate('2020-01-01'))];
+SELECT 'mixed leaves no index', count() FROM t_mixed
+WHERE a > [(500., 'a', toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), toLowCardinality('x'), toIPv6('::1'), toDate('2020-01-01'))]
+SETTINGS use_skip_indexes = 0;
+
+DROP TABLE t_arr;
+DROP TABLE t_map;
+DROP TABLE t_nullable;
+DROP TABLE t_finite;
+DROP TABLE t_str;
+DROP TABLE t_mixed;

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
@@ -18,16 +18,21 @@ SELECT 'array positive prunes other granule', count() > 0 FROM (
 SELECT 'array negated indexed', count() FROM t_arr WHERE NOT (a <= [3.]);
 SELECT 'array negated no index', count() FROM t_arr WHERE NOT (a <= [3.]) SETTINGS use_skip_indexes = 0;
 
--- GRANULARITY 2 spans two marks, so the bound is merged across two update() calls. The merge keeps
--- its own right end when the NaN arrives first and takes the new one when it arrives second.
+-- With GRANULARITY 2 an index entry spans two marks, so the NaN must set the upper bound
+-- whichever of the two marks it arrives in.
 DROP TABLE IF EXISTS t_g2_first;
 CREATE TABLE t_g2_first (id UInt64, a Array(Float64), INDEX idx_a a TYPE minmax GRANULARITY 2)
 ENGINE = MergeTree ORDER BY id
 SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
-INSERT INTO t_g2_first VALUES (1, [1.]), (2, [nan]), (3, [3.]), (4, [100.]), (5, [150.]), (6, [200.]);
+INSERT INTO t_g2_first VALUES (1, [1.]), (2, [nan]), (3, [3.]), (4, [100.]), (5, [150.]), (6, [200.]),
+    (7, [10.]), (8, [20.]), (9, [30.]), (10, [40.]), (11, [50.]), (12, [60.]);
 
 SELECT 'granularity 2 nan in first mark indexed', count() FROM t_g2_first WHERE a > [500.];
 SELECT 'granularity 2 nan in first mark no index', count() FROM t_g2_first WHERE a > [500.] SETTINGS use_skip_indexes = 0;
+SELECT 'granularity 2 nan in first mark prunes finite entry', count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT sum(id) FROM t_g2_first WHERE a > [500.]
+    SETTINGS use_skip_indexes_on_data_read = 0, optimize_use_implicit_projections = 0
+) WHERE explain LIKE '%Granules: 2/4%';
 
 DROP TABLE IF EXISTS t_g2_second;
 CREATE TABLE t_g2_second (id UInt64, a Array(Float64), INDEX idx_a a TYPE minmax GRANULARITY 2)
@@ -47,6 +52,10 @@ INSERT INTO t_map VALUES (4, map('k', 100.)), (5, map('k', 150.)), (6, map('k', 
 
 SELECT 'map positive indexed', count() FROM t_map WHERE a > map('k', 500.);
 SELECT 'map positive no index', count() FROM t_map WHERE a > map('k', 500.) SETTINGS use_skip_indexes = 0;
+SELECT 'map still prunes', count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT sum(id) FROM t_map WHERE a > map('k', 500.)
+    SETTINGS use_skip_indexes_on_data_read = 0, optimize_use_implicit_projections = 0
+) WHERE explain LIKE '%Granules: 1/2%';
 
 DROP TABLE IF EXISTS t_nullable;
 CREATE TABLE t_nullable (id UInt64, a Array(Nullable(Float64)), INDEX idx_a a TYPE minmax GRANULARITY 1)
@@ -107,6 +116,20 @@ SELECT 'mixed leaves no index', count() FROM t_mixed
 WHERE a > [(500., 'a', toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), toLowCardinality('x'), toIPv6('::1'), toDate('2020-01-01'))]
 SETTINGS use_skip_indexes = 0;
 
+DROP TABLE IF EXISTS t_bool;
+CREATE TABLE t_bool (id UInt64, a Array(Tuple(Float64, Bool)), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO t_bool VALUES (1, [(1., true)]), (2, [(nan, true)]), (3, [(3., true)]);
+INSERT INTO t_bool VALUES (4, [(100., true)]), (5, [(150., true)]), (6, [(200., true)]);
+
+SELECT 'bool leaf indexed', count() FROM t_bool WHERE a > [(500., true)];
+SELECT 'bool leaf no index', count() FROM t_bool WHERE a > [(500., true)] SETTINGS use_skip_indexes = 0;
+SELECT 'bool leaf still prunes', count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT sum(id) FROM t_bool WHERE a > [(500., true)]
+    SETTINGS use_skip_indexes_on_data_read = 0, optimize_use_implicit_projections = 0
+) WHERE explain LIKE '%Granules: 1/2%';
+
 DROP TABLE t_arr;
 DROP TABLE t_g2_first;
 DROP TABLE t_g2_second;
@@ -115,3 +138,4 @@ DROP TABLE t_nullable;
 DROP TABLE t_finite;
 DROP TABLE t_str;
 DROP TABLE t_mixed;
+DROP TABLE t_bool;

--- a/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
+++ b/tests/queries/0_stateless/05045_minmax_index_array_nan_upper_bound.sql
@@ -115,6 +115,11 @@ WHERE a > [(500., 'a', toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), toLowCard
 SELECT 'mixed leaves no index', count() FROM t_mixed
 WHERE a > [(500., 'a', toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), toLowCardinality('x'), toIPv6('::1'), toDate('2020-01-01'))]
 SETTINGS use_skip_indexes = 0;
+SELECT 'mixed leaves still prunes', count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT sum(id) FROM t_mixed
+    WHERE a > [(500., 'a', toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0'), toLowCardinality('x'), toIPv6('::1'), toDate('2020-01-01'))]
+    SETTINGS use_skip_indexes_on_data_read = 0, optimize_use_implicit_projections = 0
+) WHERE explain LIKE '%Granules: 1/2%';
 
 DROP TABLE IF EXISTS t_bool;
 CREATE TABLE t_bool (id UInt64, a Array(Tuple(Float64, Bool)), INDEX idx_a a TYPE minmax GRANULARITY 1)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107074
Related: https://github.com/ClickHouse/ClickHouse/pull/115151
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The `minmax` skip index no longer skips a granule whose `Array` or `Map` value contains a `NaN`, which previously made such a query return fewer rows than it should. Index granules written before the upgrade keep the old bound until their part is rewritten by a merge, `OPTIMIZE` or a re-insert.


### Description

A `minmax` skip index on an `Array` or `Map` column returns too few rows:

```sql
CREATE TABLE arr (id UInt64, a Array(Float64), INDEX idx_a a TYPE minmax GRANULARITY 1)
ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 3;
INSERT INTO arr VALUES (1, [1.]), (2, [nan]), (3, [3.]);
INSERT INTO arr VALUES (4, [100.]), (5, [150.]), (6, [200.]);

SELECT count() FROM arr WHERE a > [500.];                                -- 0, wrong
SELECT count() FROM arr WHERE a > [500.] SETTINGS use_skip_indexes = 0;  -- 1
```

`[nan] > [500.]` is true: arrays compare through `compareAt`, whose order ranks `NaN` above every
number.

The writer stored the `IColumn::getExtremes` pair, whose upper end is chosen in an order that ranks
`NaN` lowest. `KeyCondition` compares that range under `accurateLess`, where such a value is the
largest, so the granule looks out of range.

For admitted columns `MergeTreeIndexAggregatorMinMax::update` now computes both ends in one
`compareAt(..., 1)` scan instead of calling `getExtremes`. A stored range only widens, so no query can
return fewer rows than before. Insert cost is unchanged (numbers in the review comment below); the
`NaN`-free granule above is still skipped.

A column is admitted iff it is a top-level `Array` or `Map`, its type tree holds a float, and every
node in that tree yields a single `Field` tag. `Field::operator<` compares the tag before the value,
and admitting `Nullable` was measured to introduce wrong results on a shape correct today.

Unaddressed, each measured: the part-level index, a nested `Nullable` even with no `NULL` values, a
top-level `Tuple` (#107074), `JSON`/`Dynamic`/`Variant`, and a nested `Bool`, which returns too few
rows for an upper-bounded comparison on a tied float prefix, before and after alike. `Bool` is
admitted anyway: excluding it reintroduces this bug for that shape without fixing the separate one.

Related: https://github.com/ClickHouse/ClickHouse/pull/107074
Related: https://github.com/ClickHouse/ClickHouse/pull/115151

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116728&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116728](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116728+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
