### PR TITLE
Pin fuzzer and DROP behavior in the KeeperMap metadata test on 26.6

### DIFF
--- a/tests/queries/0_stateless/05024_keeper_map_parenthesized_metadata.sql
+++ b/tests/queries/0_stateless/05024_keeper_map_parenthesized_metadata.sql
@@ -1,5 +1,14 @@
 -- Tags: zookeeper, no-ordinary-database, no-fasttest
 
+-- The test rewrites a shared `metadata` znode with `replaceOne`. The stress test profile enables the
+-- server-side AST fuzzer for every query type, and a permuted argument list makes the replacement
+-- literal the haystack, so the znode is left holding that bare literal instead of a full definition.
+SET ast_fuzzer_runs = 0;
+SET ast_fuzzer_any_query = 0;
+
+-- Every assertion below reads the state a preceding statement left in Keeper, so a DROP has to drop.
+SET ignore_drop_queries_probability = 0;
+
 DROP TABLE IF EXISTS 05024_keeper_map_parenthesized_metadata_bad SYNC;
 DROP TABLE IF EXISTS 05024_keeper_map_parenthesized_metadata_malformed SYNC;
 DROP TABLE IF EXISTS 05024_keeper_map_parenthesized_metadata_terminated SYNC;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

Backport of the test hardening from https://github.com/ClickHouse/ClickHouse/pull/115941 (master) to `26.6`: pin `ast_fuzzer_runs`, `ast_fuzzer_any_query`, and `ignore_drop_queries_probability` to 0 in `05024_keeper_map_parenthesized_metadata`.

The stress test profile enables the server-side AST fuzzer and probabilistic DROP skipping. In the `Stress test (amd_tsan)` run of the backport PR https://github.com/ClickHouse/ClickHouse/pull/116265, the fuzzer permuted `replaceOne` arguments while the test was rewriting the shared `metadata` znode, leaving it corrupted, and the skipped `DROP` left the table behind — so the server could not restart: `Invalid KeeperMap metadata format version or columns definition in ZK`. Master already carries this hardening; `26.6` got the test via the backport of https://github.com/ClickHouse/ClickHouse/pull/115642 without it.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116265&sha=87a16e9e33d4bd2f5c5665c50278bc11262b2ee8&name_0=BackportPR&name_1=Stress%20test%20%28amd_tsan%29

Related: https://github.com/ClickHouse/ClickHouse/pull/116265
Related: https://github.com/ClickHouse/ClickHouse/pull/115941
Related: https://github.com/ClickHouse/ClickHouse/pull/115642


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.4.29`
<!-- ch-version-info:end -->