### PR TITLE
Prometheus HTTP API: implement /api/v1/labels

### DIFF
--- a/docs/concepts/features/interfaces/prometheus.mdx
+++ b/docs/concepts/features/interfaces/prometheus.mdx
@@ -221,7 +221,7 @@ datasources:
 Grafana appends `/api/v1/query` or `/api/v1/query_range` to this base URL and adds `customQueryParameters` to each request.
 
 <Note>
-Only the query endpoints `/api/v1/query` and `/api/v1/query_range` and the series metadata endpoint `/api/v1/series` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. The label metadata endpoints a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete (`/api/v1/labels`, `/api/v1/label/<name>/values`) are not implemented and return an error. Write PromQL expressions in code mode instead of the query builder.
+Only the query endpoints `/api/v1/query` and `/api/v1/query_range` and the metadata endpoints `/api/v1/series` and `/api/v1/labels` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. `/api/v1/labels` accepts the same parameters, with `match[]` being optional, and returns the sorted label names of the matched series (or of all series when no selectors are given). The label values endpoint (`/api/v1/label/<name>/values`), which a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete, is not implemented and returns an error. Write PromQL expressions in code mode instead of the query builder.
 </Note>
 
 #### SQL entry points {#sql-entry-points}

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -449,6 +449,22 @@ public:
         return !reserved_param_names.contains(name);
     }
 
+    /// Parses the optional `limit` parameter of the metadata endpoints: the maximum number of returned items,
+    /// with 0 (the default) meaning no limit.
+    UInt64 getLimitParam() const
+    {
+        String limit_param = params->get("limit", "");
+        if (limit_param.empty())
+            return 0;
+
+        Int64 parsed_limit = 0;
+        if (!tryParse(parsed_limit, limit_param.data(), limit_param.size()) || (parsed_limit < 0))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Invalid value of the 'limit' parameter: '{}', expected a non-negative integer",
+                            limit_param);
+        return static_cast<UInt64>(parsed_limit);
+    }
+
     void handlingRequestWithContext(HTTPServerRequest & request, HTTPServerResponse & response) override
     {
         const String & uri = request.getURI();
@@ -533,29 +549,18 @@ public:
                 Strings match = params->getAll("match[]");
                 String start = params->get("start", "");
                 String end = params->get("end", "");
-
-                /// The optional `limit` parameter caps the number of returned series (0 means no limit, which is also the default).
-                UInt64 limit = 0;
-                String limit_param = params->get("limit", "");
-                if (!limit_param.empty())
-                {
-                    Int64 parsed_limit = 0;
-                    if (!tryParse(parsed_limit, limit_param.data(), limit_param.size()) || (parsed_limit < 0))
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                                        "Invalid value of the 'limit' parameter: '{}', expected a non-negative integer",
-                                        limit_param);
-                    limit = static_cast<UInt64>(parsed_limit);
-                }
+                UInt64 limit = getLimitParam();
 
                 protocol.getSeries(getOutputStream(response), match, start, end, limit, query_finish_callback);
             }
             else if (uri_path.ends_with("/labels"))
             {
-                String match = params->get("match[]", "");
+                Strings match = params->getAll("match[]");
                 String start = params->get("start", "");
                 String end = params->get("end", "");
+                UInt64 limit = getLimitParam();
 
-                protocol.getLabels(getOutputStream(response), match, start, end);
+                protocol.getLabels(getOutputStream(response), match, start, end, limit, query_finish_callback);
             }
             else if (auto label_name = extractLabelValuesName(uri_path))
             {

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -609,12 +609,116 @@ void PrometheusHTTPProtocolAPI::getSeries(
 
 void PrometheusHTTPProtocolAPI::getLabels(
     WriteBuffer & response,
-    const String & /* match_param */,
-    const String & /* start_param */,
-    const String & /* end_param */)
+    const Strings & match_params,
+    const String & start_param,
+    const String & end_param,
+    UInt64 limit,
+    QueryFinishCallback query_finish_callback)
 {
-    UNUSED(response);
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The labels endpoint is not implemented");
+    /// Unlike /api/v1/series, the `match[]` selectors are optional here: without them the endpoint
+    /// returns the label names of all the time series stored in the table.
+    Strings selectors = match_params;
+    if (selectors.empty())
+        selectors.push_back(R"({__name__!=""})");
+
+    auto series_ids_query = makeSeriesIDsQuery(selectors, start_param, end_param);
+
+    /// SELECT arraySort(groupUniqArrayArray(tupleElement(timeSeriesIdToTags(series_id), 1))) AS labels FROM (<series_ids_query>)
+    /// timeSeriesIdToTags returns the tags registered by the inner query (including `__name__`), so the label names
+    /// are the first elements of the returned pairs; groupUniqArrayArray dedups them across all the matched series,
+    /// and arraySort returns them in sorted order like Prometheus does.
+    auto labels_expression = makeASTFunction(
+        "arraySort",
+        makeASTFunction(
+            "groupUniqArrayArray",
+            makeASTFunction(
+                "tupleElement",
+                makeASTFunction("timeSeriesIdToTags", make_intrusive<ASTIdentifier>("series_id")),
+                make_intrusive<ASTLiteral>(1u))));
+    labels_expression->setAlias("labels");
+
+    auto sql_query = makeSelectFromSubquery({std::move(labels_expression)}, std::move(series_ids_query), /* distinct = */ false, {});
+
+    LOG_TRACE(log, "SQL query to execute:\n{}", sql_query->formatForLogging());
+
+    /// Functions timeSeriesStoreTags() and timeSeriesIdToTags() are supported by the analyzer only.
+    getContext()->setSetting("allow_experimental_analyzer", true);
+
+    auto [ast, io] = executeQuery(sql_query->formatWithSecretsOneLine(), getContext(), {}, QueryProcessingStage::Complete);
+
+    try
+    {
+        PullingAsyncPipelineExecutor executor(io.pipeline);
+
+        /// Pull the first non-empty block before writing the header so an early exception still produces the correct error response.
+        /// The aggregation produces exactly one row holding the array of all the label names.
+        bool has_output = false;
+        Block block;
+        while (executor.pull(block))
+        {
+            if (block.rows() > 0)
+            {
+                has_output = true;
+                break;
+            }
+        }
+
+        writeString(R"({"status":"success","data":[)", response);
+
+        UInt64 written = 0;
+        bool truncated = false;
+
+        auto write_block = [&](const Block & result_block)
+        {
+            const auto & array_column = typeid_cast<const ColumnArray &>(*result_block.getByName("labels").column);
+            const auto & offsets = array_column.getOffsets();
+            const auto & name_column = array_column.getData();
+
+            for (size_t i = 0; i < result_block.rows(); ++i)
+            {
+                size_t start = (i == 0) ? 0 : offsets[i - 1];
+                for (size_t j = start; j < offsets[i]; ++j)
+                {
+                    if (limit && (written == limit))
+                    {
+                        truncated = true;
+                        return;
+                    }
+                    if (written)
+                        writeString(",", response);
+                    writeJSONString(name_column.getDataAt(j), response, format_settings);
+                    ++written;
+                }
+            }
+        };
+
+        if (has_output)
+        {
+            write_block(block);
+            while (!truncated && executor.pull(block))
+            {
+                if (block.rows() > 0)
+                    write_block(block);
+            }
+        }
+
+        if (truncated)
+            writeString(R"(],"warnings":["results truncated due to limit"]})", response);
+        else
+            writeString("]}", response);
+
+        /// Finalize the query result cache write before the executor's destructor cancels the pipeline.
+        /// The SQL query doesn't depend on `limit`, so its result is complete even when the response is truncated.
+        io.pipeline.finalizeWriteInQueryResultCache();
+    }
+    catch (...)
+    {
+        io.onException();
+        throw;
+    }
+
+    /// Release the query slot early, flush the response and record QueryFinish.
+    finishExecutedQuery(io, query_finish_callback);
 }
 
 void PrometheusHTTPProtocolAPI::getLabelValues(
@@ -683,14 +787,4 @@ void PrometheusHTTPProtocolAPI::writeScalar(WriteBuffer & response, Float64 valu
     }
 }
 
-
-void PrometheusHTTPProtocolAPI::writeLabelsResponse(WriteBuffer & response, const Block & /* result_block */)
-{
-    writeString(R"({"status":"success","data":["__name__","job","instance"]})", response);
-}
-
-void PrometheusHTTPProtocolAPI::writeLabelValuesResponse(WriteBuffer & response, const Block & /* result_block */)
-{
-    writeString(R"({"status":"success","data":[]})", response);
-}
 }

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -8,6 +8,14 @@
 #include <IO/WriteHelpers.h>
 #include <Storages/StorageTimeSeries.h>
 #include <Storages/StorageTimeSeriesSelector.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTSubquery.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
 #include <Parsers/Prometheus/PrometheusQueryResultType.h>
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
@@ -70,6 +78,42 @@ Decimal64 parsePrometheusLookbackDelta(const String & value, UInt32 timestamp_sc
         ++timestamp_ticks;
 
     return Decimal64{timestamp_ticks};
+}
+
+/// Makes a "SELECT [DISTINCT] <expressions> FROM (<subquery>) [LIMIT <limit>]" query.
+ASTPtr makeSelectFromSubquery(ASTs select_list, ASTPtr subquery, bool distinct, std::optional<UInt64> limit)
+{
+    auto select_query = make_intrusive<ASTSelectQuery>();
+    select_query->distinct = distinct;
+
+    auto select_list_exp = make_intrusive<ASTExpressionList>();
+    select_list_exp->children = std::move(select_list);
+    select_query->setExpression(ASTSelectQuery::Expression::SELECT, std::move(select_list_exp));
+
+    /// FROM (<subquery>)
+    auto subquery_ast = make_intrusive<ASTSubquery>(std::move(subquery));
+    auto table_exp = make_intrusive<ASTTableExpression>();
+    table_exp->subquery = subquery_ast;
+    table_exp->children.push_back(std::move(subquery_ast));
+
+    auto table = make_intrusive<ASTTablesInSelectQueryElement>();
+    table->table_expression = table_exp;
+    table->children.push_back(std::move(table_exp));
+
+    auto tables = make_intrusive<ASTTablesInSelectQuery>();
+    tables->children.push_back(std::move(table));
+    select_query->setExpression(ASTSelectQuery::Expression::TABLES, std::move(tables));
+
+    if (limit)
+        select_query->setExpression(ASTSelectQuery::Expression::LIMIT_LENGTH, make_intrusive<ASTLiteral>(*limit));
+
+    /// Wrap the select query into ASTSelectWithUnionQuery, the form produced by the parser.
+    auto select_with_union_query = make_intrusive<ASTSelectWithUnionQuery>();
+    auto list_of_selects = make_intrusive<ASTExpressionList>();
+    list_of_selects->children.push_back(std::move(select_query));
+    select_with_union_query->children.push_back(std::move(list_of_selects));
+    select_with_union_query->list_of_selects = select_with_union_query->children.back();
+    return select_with_union_query;
 }
 }
 
@@ -398,20 +442,11 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
 }
 
 
-void PrometheusHTTPProtocolAPI::getSeries(
-    WriteBuffer & response,
+ASTPtr PrometheusHTTPProtocolAPI::makeSeriesIDsQuery(
     const Strings & match_params,
     const String & start_param,
-    const String & end_param,
-    UInt64 limit,
-    QueryFinishCallback query_finish_callback)
+    const String & end_param)
 {
-    /// Prometheus requires at least one `match[]` selector here; without it the endpoint would scan the whole tags table.
-    if (match_params.empty())
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "The Prometheus /api/v1/series endpoint requires at least one 'match[]' series selector");
-
     auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(getContext(), false);
     auto timestamp_data_type = splitTimeSeriesType(time_series_metadata->columns.get(TimeSeriesColumnNames::TimeSeries).type).first;
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
@@ -438,7 +473,10 @@ void PrometheusHTTPProtocolAPI::getSeries(
     auto tags_table_id = time_series_storage->getTargetTableID(ViewTarget::Tags, getContext());
 
     /// Each `match[]` value must be an instant selector; the result is the union of the series matched by each selector.
-    String inner_query;
+    auto union_query = make_intrusive<ASTSelectWithUnionQuery>();
+    union_query->union_mode = SelectUnionMode::UNION_ALL;
+    auto list_of_selects = make_intrusive<ASTExpressionList>();
+
     for (const auto & match_param : match_params)
     {
         PrometheusQueryTree selector;
@@ -457,24 +495,51 @@ void PrometheusHTTPProtocolAPI::getSeries(
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "The value {} of the 'match[]' parameter must contain at least one matcher",
                             quoteString(match_param));
 
-        if (!inner_query.empty())
-            inner_query += " UNION ALL ";
-        inner_query += StorageTimeSeriesSelector::makeSelectIDsQuery(
-            tags_table_id, matchers, *time_series_settings, min_time, max_time, timestamp_data_type)->formatWithSecretsOneLine();
+        auto select_ids_query = StorageTimeSeriesSelector::makeSelectIDsQuery(
+            tags_table_id, matchers, *time_series_settings, min_time, max_time, timestamp_data_type);
+        const auto & select_ids = typeid_cast<const ASTSelectWithUnionQuery &>(*select_ids_query);
+        list_of_selects->children.push_back(select_ids.list_of_selects->children.at(0));
     }
 
-    /// timeSeriesIdToTags() returns the tags registered by the inner query (including `__name__`); `DISTINCT` dedups, and one extra row detects truncation.
-    String sql_query = fmt::format(
-        "SELECT DISTINCT timeSeriesIdToTags(series_id) AS {} FROM ({})", TimeSeriesColumnNames::Tags, inner_query);
-    if (limit)
-        sql_query += fmt::format(" LIMIT {}", limit + 1);
+    union_query->children.push_back(std::move(list_of_selects));
+    union_query->list_of_selects = union_query->children.back();
+    return union_query;
+}
 
-    LOG_TRACE(log, "SQL query to execute:\n{}", sql_query);
+
+void PrometheusHTTPProtocolAPI::getSeries(
+    WriteBuffer & response,
+    const Strings & match_params,
+    const String & start_param,
+    const String & end_param,
+    UInt64 limit,
+    QueryFinishCallback query_finish_callback)
+{
+    /// Prometheus requires at least one `match[]` selector here; without it the endpoint would scan the whole tags table.
+    if (match_params.empty())
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "The Prometheus /api/v1/series endpoint requires at least one 'match[]' series selector");
+
+    auto series_ids_query = makeSeriesIDsQuery(match_params, start_param, end_param);
+
+    /// SELECT DISTINCT timeSeriesIdToTags(series_id) AS tags FROM (<series_ids_query>) [LIMIT <limit> + 1]
+    /// timeSeriesIdToTags returns the tags registered by the inner query (including `__name__`); `DISTINCT` dedups, and one extra row detects truncation.
+    auto tags_expression = makeASTFunction("timeSeriesIdToTags", make_intrusive<ASTIdentifier>("series_id"));
+    tags_expression->setAlias(TimeSeriesColumnNames::Tags);
+
+    std::optional<UInt64> sql_limit;
+    if (limit)
+        sql_limit = limit + 1;
+
+    auto sql_query = makeSelectFromSubquery({std::move(tags_expression)}, std::move(series_ids_query), /* distinct = */ true, sql_limit);
+
+    LOG_TRACE(log, "SQL query to execute:\n{}", sql_query->formatForLogging());
 
     /// Functions timeSeriesStoreTags() and timeSeriesIdToTags() are supported by the analyzer only.
     getContext()->setSetting("allow_experimental_analyzer", true);
 
-    auto [ast, io] = executeQuery(sql_query, getContext(), {}, QueryProcessingStage::Complete);
+    auto [ast, io] = executeQuery(sql_query->formatWithSecretsOneLine(), getContext(), {}, QueryProcessingStage::Complete);
 
     try
     {

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -58,12 +58,15 @@ public:
         UInt64 limit,
         QueryFinishCallback query_finish_callback = {});
 
-    /// Get all label names (/api/v1/labels)
+    /// Get label names (/api/v1/labels): the sorted unique label names of the series matched by the `match[]`
+    /// selectors (or of all series if no selectors are given), capped by `limit` (0 means no limit).
     void getLabels(
         WriteBuffer & response,
-        const String & match_param,
+        const Strings & match_params,
         const String & start_param,
-        const String & end_param);
+        const String & end_param,
+        UInt64 limit,
+        QueryFinishCallback query_finish_callback = {});
 
     /// Get values for a specific label (/api/v1/label/<name>/values)
     void getLabelValues(
@@ -93,12 +96,6 @@ private:
     void writeTags(WriteBuffer & response, const Block & result_block, size_t row_index);
     void writeTimestamp(WriteBuffer & response, DateTime64 value, UInt32 scale);
     void writeScalar(WriteBuffer & response, Float64 value);
-
-    /// Write JSON response for labels
-    void writeLabelsResponse(WriteBuffer & response, const Block & result_block);
-
-    /// Write JSON response for label values
-    void writeLabelValuesResponse(WriteBuffer & response, const Block & result_block);
 
     std::shared_ptr<const StorageTimeSeries> time_series_storage;
     FormatSettings format_settings;

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -74,6 +74,11 @@ public:
         const String & end_param);
 
 private:
+    /// Parses the `match[]` instant selectors and the optional `start` and `end` bounds of the metadata endpoints
+    /// and makes a UNION ALL query selecting the ids (`series_id`) of the series matched by any of the selectors,
+    /// with their tags registered for timeSeriesIdToTags.
+    ASTPtr makeSeriesIDsQuery(const Strings & match_params, const String & start_param, const String & end_param);
+
     /// Writes the result of a prometheus query as a JSON.
     void writeQueryResponse(WriteBuffer & response, PullingAsyncPipelineExecutor & pulling_executor, PrometheusQueryResultType result_type);
 

--- a/tests/integration/test_prometheus_protocols/test_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_labels_api.py
@@ -1,0 +1,216 @@
+"""Tests for the Prometheus /api/v1/labels endpoint."""
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+from .prometheus_test_utils import (
+    convert_time_series_to_protobuf,
+    send_protobuf_to_remote_write,
+)
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=["configs/allow_experimental_time_series_table.xml"],
+    handle_prometheus_remote_write=(9093, "/write"),
+)
+
+ALL_LABELS = ["__name__", "datacenter", "host", "region", "service", "status"]
+
+
+def send_test_data():
+    time_series = [
+        (
+            {"__name__": "cpu_usage", "host": "server1", "datacenter": "us-east"},
+            {1000: 0.5, 1030: 0.7},
+        ),
+        (
+            {"__name__": "cpu_usage", "host": "server2", "datacenter": "us-west"},
+            {1000: 0.3, 1030: 0.5},
+        ),
+        (
+            {"__name__": "memory_usage", "host": "server1", "region": "eu"},
+            {1000: 0.8},
+        ),
+        (
+            {"__name__": "http_requests", "service": "web", "status": "200"},
+            {1000: 1.0},
+        ),
+    ]
+    send_protobuf_to_remote_write(
+        node.ip_address, 9093, "/write", convert_time_series_to_protobuf(time_series)
+    )
+
+
+def get_json_from_api(path, **kwargs):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", **kwargs)
+    assert (
+        response.status_code == 200
+    ), f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Expected success, got: {data}"
+    return data
+
+
+def get_bad_data_from_api(path, **kwargs):
+    response = requests.get(f"http://{node.ip_address}:9093{path}", **kwargs)
+    assert (
+        response.status_code == 400
+    ), f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "error", f"Expected error, got: {data}"
+    assert data["errorType"] == "bad_data", f"Expected bad_data, got: {data}"
+    return data
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    try:
+        cluster.start()
+        # The `host` tag is stored in a dedicated column: the endpoint must still report it
+        # under its tag name.
+        node.query(
+            "CREATE TABLE prometheus ENGINE=TimeSeries "
+            "SETTINGS tags_to_columns = {'host': 'host_column'}"
+        )
+        node.query(
+            "CREATE TABLE prometheus_no_bounds ENGINE=TimeSeries "
+            "SETTINGS store_min_time_and_max_time = 0"
+        )
+        node.query(
+            "INSERT INTO prometheus_no_bounds (metric_name, tags, time_series) VALUES "
+            "('cpu_usage', {'host': 'server1'}, [(toDateTime64(1000, 3), 0.5)])"
+        )
+        send_test_data()
+        assert_eq_with_retry(node, "SELECT count() > 0 FROM timeSeriesData(prometheus)", "1")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_labels_returns_all_label_names_sorted():
+    # No `match[]` selectors: the label names of all the series, in sorted order.
+    # `host` is stored in a dedicated column (`tags_to_columns`) but is reported under its tag name.
+    assert get_json_from_api("/api/v1/labels")["data"] == ALL_LABELS
+
+
+def test_labels_match_selector_filters():
+    data = get_json_from_api("/api/v1/labels?match[]=cpu_usage")["data"]
+    assert data == ["__name__", "datacenter", "host"]
+
+
+def test_labels_label_matcher():
+    data = get_json_from_api("/api/v1/labels", params={"match[]": '{host="server1"}'})["data"]
+    assert data == ["__name__", "datacenter", "host", "region"]
+
+
+def test_labels_repeated_match_is_union():
+    data = get_json_from_api(
+        "/api/v1/labels",
+        params=[("match[]", "memory_usage"), ("match[]", "http_requests")],
+    )["data"]
+    assert data == ["__name__", "host", "region", "service", "status"]
+
+
+def test_labels_no_matching_series_returns_empty():
+    assert get_json_from_api("/api/v1/labels?match[]=missing_metric")["data"] == []
+
+
+def test_labels_post_urlencoded_match():
+    response = requests.post(
+        f"http://{node.ip_address}:9093/api/v1/labels",
+        data=[("match[]", "memory_usage"), ("match[]", "http_requests")],
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"] == ["__name__", "host", "region", "service", "status"]
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        "",  # explicitly empty value
+        "{}",  # selector without matchers
+        "cpu_usage[5m]",  # range selector, not an instant selector
+        "rate(cpu_usage[5m])",  # PromQL expression, not a selector
+        'cpu_usage{host="server1"',  # unparsable
+    ],
+)
+def test_labels_rejects_invalid_selectors(selector):
+    get_bad_data_from_api("/api/v1/labels", params={"match[]": selector})
+
+
+def test_labels_time_range():
+    # All test samples are within [1000, 1030].
+    assert get_json_from_api("/api/v1/labels?start=990&end=1040")["data"] == ALL_LABELS
+    assert get_json_from_api("/api/v1/labels?start=2000&end=3000")["data"] == []
+    assert get_json_from_api("/api/v1/labels?start=0&end=500")["data"] == []
+
+
+def test_labels_time_range_is_inclusive_and_supports_one_sided_bounds():
+    # Only the cpu_usage series extend to 1030; the other series end at 1000.
+    assert get_json_from_api("/api/v1/labels?start=1030")["data"] == [
+        "__name__",
+        "datacenter",
+        "host",
+    ]
+    assert get_json_from_api("/api/v1/labels?end=1000")["data"] == ALL_LABELS
+    assert get_json_from_api("/api/v1/labels?start=1031")["data"] == []
+    assert get_json_from_api("/api/v1/labels?end=999")["data"] == []
+
+
+def test_labels_rejects_inverted_time_range():
+    get_bad_data_from_api("/api/v1/labels?start=1030&end=1000")
+
+
+def test_labels_empty_optional_parameters_are_ignored():
+    data = get_json_from_api("/api/v1/labels?start=&end=&limit=")["data"]
+    assert data == ALL_LABELS
+
+
+def test_labels_time_range_is_ignored_without_stored_time_bounds():
+    # Without stored min_time/max_time the time range is ignored (a superset is allowed by Prometheus).
+    data = get_json_from_api("/no_bounds/api/v1/labels?start=2000&end=3000")["data"]
+    assert data == ["__name__", "host"]
+
+
+def test_labels_limit_reports_truncation():
+    data = get_json_from_api("/api/v1/labels?limit=2")
+    assert data["data"] == ALL_LABELS[:2]
+    assert data["warnings"] == ["results truncated due to limit"]
+
+
+def test_labels_exact_limit_is_not_reported_as_truncated():
+    data = get_json_from_api(f"/api/v1/labels?limit={len(ALL_LABELS)}")
+    assert data["data"] == ALL_LABELS
+    assert "warnings" not in data
+
+
+def test_labels_zero_limit_is_unlimited():
+    data = get_json_from_api("/api/v1/labels?limit=0")
+    assert data["data"] == ALL_LABELS
+    assert "warnings" not in data
+
+
+@pytest.mark.parametrize("limit", ["-1", "abc", "1.5"])
+def test_labels_rejects_invalid_limit(limit):
+    get_bad_data_from_api(f"/api/v1/labels?limit={limit}")
+
+
+def test_labels_records_query_finish():
+    get_json_from_api("/api/v1/labels?match[]=http_requests")
+    node.query("SYSTEM FLUSH LOGS query_log")
+    assert (
+        int(
+            node.query(
+                "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' "
+                "AND query LIKE '%groupUniqArrayArray%' AND query NOT LIKE '%query_log%'"
+            )
+        )
+        > 0
+    )


### PR DESCRIPTION
A minimal implementation of the label-names endpoint `/api/v1/labels` of the Prometheus HTTP API over a `TimeSeries` table. The endpoint runs one aggregating query over the same per-selector series-ids union that `/api/v1/series` uses:

```sql
SELECT arraySort(groupUniqArrayArray(tupleElement(timeSeriesIdToTags(series_id), 1))) AS labels
FROM (<one query per selector made by StorageTimeSeriesSelector::makeSelectIDsQuery> UNION ALL ...)
```

The `match[]` selectors are optional (all series are matched when absent), and the optional `start`, `end` and `limit` parameters behave like on the series endpoint, including the `results truncated due to limit` warning. `/api/v1/label/<name>/values` remains unimplemented.

The first commit is a behavior-preserving refactoring: the `getSeries` query construction moves from an fmt-formatted SQL string to AST nodes, extracting the shared `makeSeriesIDsQuery` helper.

A minimal rewrite of https://github.com/ClickHouse/ClickHouse/pull/114868.

Related: https://github.com/ClickHouse/ClickHouse/pull/114868

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Implement the `/api/v1/labels` endpoint of the Prometheus HTTP API: it returns the sorted unique label names of the time series matched by the optional `match[]` selectors, supporting the optional `start`, `end`, and `limit` parameters.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116731&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116731](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116731+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.256` (included in `26.9` and later)
<!-- ch-version-info:end -->