### PR TITLE
Rename a broken detached part aside when a replicated ATTACH claims it

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2549,8 +2549,27 @@ MergeTreeData::MutableDataPartPtr StorageReplicatedMergeTree::attachPartHelperFo
                 tryLogCurrentException(log, fmt::format("part {} is broken, try to rename it as broken and ignore", detached_part_info.dir_name));
                 try
                 {
-                    part->renameToDetached("broken", /* ignore_error*/ false);
-                    rename_parts.old_and_new_names.front().old_dir.clear();
+                    /// `part_dir` here is `detached/`-qualified, so the target name is composed locally
+                    /// instead of derived from it. The rename refuses an occupied target instead of
+                    /// removing it, so a directory an earlier quarantine took survives.
+                    auto & rename_info = rename_parts.old_and_new_names.front();
+                    const String broken_dir = "broken_" + detached_part_info.dir_name;
+
+                    for (int try_no = 0; try_no < 10 && !rename_info.old_dir.empty(); ++try_no)
+                    {
+                        const String target = try_no ? broken_dir + DetachedPartInfo::TRY_N_SUFFIX + toString(try_no) : broken_dir;
+                        try
+                        {
+                            part->renameTo(fs::path(DETACHED_DIR_NAME) / target, /* remove_new_dir_if_exists */ false);
+                            rename_info.old_dir.clear();
+                        }
+                        catch (const Exception & e)
+                        {
+                            if (e.code() != ErrorCodes::DIRECTORY_ALREADY_EXISTS || try_no + 1 == 10)
+                                throw;
+                            LOG_WARNING(log, "Directory {} (to detach to) already exists. Will detach to directory with '_tryN' suffix.", target);
+                        }
+                    }
                 }
                 catch (...)
                 {

--- a/tests/integration/test_attach_broken_detached_part/test.py
+++ b/tests/integration/test_attach_broken_detached_part/test.py
@@ -1,0 +1,113 @@
+# A replicated `ATTACH_PART` log entry claims a candidate directory in `detached/` by renaming it
+# to `attaching_<dir>`. When the claimed part turns out to be broken it must be renamed aside
+# under a `broken_` prefix, which takes it out of ATTACH candidacy and leaves it removable with
+# SQL. The fixture removes `count.txt` from a detached part directory, so it manipulates the
+# server's on-disk data and lives here rather than in a stateless test.
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", with_zookeeper=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def exec_root(node, cmd):
+    return node.exec_in_container(["bash", "-c", cmd], privileged=True, user="root")
+
+
+def entry_exists(node, path):
+    return exec_root(node, f"if ls {path} >/dev/null 2>&1; then echo 1; else echo 0; fi").strip()
+
+
+def detached_parts(node, table, columns="name, reason, partition_id"):
+    return node.query(
+        f"SELECT {columns} FROM system.detached_parts"
+        f" WHERE database = 'default' AND table = '{table}' ORDER BY name"
+    )
+
+
+@pytest.mark.parametrize("name_taken", [False, True], ids=["free_name", "name_taken"])
+def test_broken_detached_part_is_quarantined(started_cluster, name_taken):
+    table = "t_attach_broken_taken" if name_taken else "t_attach_broken_free"
+
+    for replica, node in enumerate([node1, node2], start=1):
+        node.query(f"DROP TABLE IF EXISTS {table} SYNC")
+        node.query(
+            f"""
+            CREATE TABLE {table} (a UInt8)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/{table}', '{replica}')
+            ORDER BY a
+            """
+        )
+
+    node1.query(f"INSERT INTO {table} VALUES (1)")
+    node2.query(f"SYSTEM SYNC REPLICA {table}")
+
+    # The first block number is not necessarily 0 (it comes from a Keeper counter), so read the
+    # part name rather than hardcoding it.
+    part = node1.query(
+        f"SELECT name FROM system.parts"
+        f" WHERE database = 'default' AND table = '{table}' AND active"
+    ).strip()
+
+    node1.query(f"ALTER TABLE {table} DETACH PARTITION ID 'all' SETTINGS alter_sync = 2")
+    assert detached_parts(node1, table, "name") == f"{part}\n"
+    assert detached_parts(node2, table, "name") == f"{part}\n"
+
+    detached_dir = node1.query(
+        f"SELECT data_paths[1] FROM system.tables WHERE database = 'default' AND name = '{table}'"
+    ).strip() + "detached"
+
+    # Break node1's copy only. `checksums.txt` is left intact so the candidate filter still
+    # matches the entry's checksum, while loading the part throws the non-retryable
+    # `NO_FILE_IN_DATA_PART`.
+    exec_root(node1, f"rm -f {detached_dir}/{part}/count.txt")
+
+    # In the `name_taken` arm an earlier quarantine already holds the first candidate name. It
+    # must not be overwritten, and the broken part must land on the next `_tryN` name.
+    expected_dir = f"broken_{part}_try1" if name_taken else f"broken_{part}"
+    if name_taken:
+        exec_root(node1, f"mkdir -p {detached_dir}/broken_{part} && touch {detached_dir}/broken_{part}/older")
+
+    # node2 attaches its own intact copy, writing the `ATTACH_PART` log entry that node1 then
+    # executes against its own broken copy.
+    node2.query(f"ALTER TABLE {table} ATTACH PARTITION ID 'all'")
+    node1.query(f"SYSTEM SYNC REPLICA {table}")
+
+    assert node1.query(f"SELECT a FROM {table}") == "1\n"
+
+    # `partition_id` is NULL in `system.detached_parts` for a directory name that does not parse
+    # as a detached part name, so asserting it also pins the shape of the name produced here.
+    expected_rows = f"{expected_dir}\tbroken\tall\n"
+    if name_taken:
+        expected_rows = f"broken_{part}\tbroken\tall\n" + expected_rows
+    assert detached_parts(node1, table) == expected_rows
+
+    assert entry_exists(node1, f"{detached_dir}/{expected_dir}/checksums.txt") == "1"
+    if name_taken:
+        assert entry_exists(node1, f"{detached_dir}/broken_{part}/older") == "1"
+
+    assert not node1.contains_in_log("fail to rename part")
+    assert not node1.contains_in_log("broken_detached/")
+
+    # The quarantined part has left ATTACH candidacy, so ATTACH no longer fails on it, ...
+    node1.query(f"ALTER TABLE {table} ATTACH PARTITION ID 'all'")
+    # ... and it can be removed with SQL.
+    node1.query(
+        f"ALTER TABLE {table} DROP DETACHED PARTITION ID 'all' SETTINGS allow_drop_detached = 1"
+    )
+    assert detached_parts(node1, table) == ""
+
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE {table} SYNC")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/54748
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `ATTACH PARTITION` on `ReplicatedMergeTree` failing to rename a broken part in `detached/` aside. The broken part stayed an attach candidate, so every later `ATTACH PARTITION` for that partition kept failing on it.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/54748
Related: https://github.com/ClickHouse/ClickHouse/pull/116258

Reported by @ alexey-milovidov, from [this `Stateless tests (amd_asan, distributed plan, parallel, 2/2)` report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116258&sha=629bd7e0f725f065b6ea8e783f98ae4b3e28e067&name_0=BackportPR&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%20parallel%2C%202%2F2%29).

A replicated `ATTACH_PART` entry claims a candidate directory in `detached/` by renaming it to `attaching_<dir>`, builds the part with a `detached/`-qualified `part_dir`, and loads it. On a non-retryable load error the part is supposed to be renamed aside with a `broken_` prefix so it stops being an attach candidate.

That rename never worked. `getPartDirForPrefix` appends `part_dir` verbatim, so `detached/attaching_X` becomes `detached/broken_detached/attaching_X`, whose parent does not exist:

```
fail to rename part all_0_0_0 with broken prefix: ... in rename: No such file or directory
[".../detached/attaching_all_0_0_0/"] [".../detached/broken_detached/attaching_all_0_0_0/"
```

So the broken part is never quarantined, stays a candidate, and blocks its partition. No concurrency is needed. This is a regression: `a5eeba9e90649d59` added the quarantine as a local rename inside `detached/`, and `56cd154bcdbf11c` replaced it with `renameToDetached` under three hours later the same day.

I restore the local rename, targeting a free `detached/broken_<dir>[_tryN]`. That name parses as a valid detached part name, so it is excluded from both attach candidate filters and stays removable by `DROP DETACHED PART` and `DROP DETACHED PARTITION`; the rename refuses an occupied target instead of removing it, so an earlier quarantine is kept. Nothing generic changes, and the branch has no working caller to regress.

New integration test (it has to corrupt a part inside `detached/`): both arms fail before the change and pass after.

Not fixed here and unchanged: a rollback whose target name was re-taken concurrently still orphans `attaching_X`; the claim can still take a directory a concurrent `DETACH` is populating; and the pre-existing crash window between claim and rollback. This makes the quarantine work, it does not make `detached/attaching_*` leftovers impossible.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116734&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116734](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116734+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.269` (included in `26.10` and later)
<!-- ch-version-info:end -->