### PR TITLE
Fix logical error reading a whole Tuple subcolumn of Dynamic or Variant from a part

### DIFF
--- a/src/DataTypes/Serializations/SerializationDynamicElement.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamicElement.cpp
@@ -281,4 +281,23 @@ size_t SerializationDynamicElement::allocatedBytes() const
     return sizeof(*this) + dynamic_element_name.capacity() + nested_subcolumn.capacity();
 }
 
+MutableColumnPtr SerializationDynamicElement::wrapColumnForDeserialization(MutableColumnPtr column) const
+{
+    /// The null map subcolumn is a UInt8 column read through SerializationVariantElementNullMap;
+    /// nested_serialization serializes the requested type, which is not what is read here.
+    if (is_null_map_subcolumn)
+        return column;
+
+    /// Same level ownership as in SerializationVariantElement, which this delegates to at read time.
+    if (isColumnNullable(*column))
+    {
+        const auto & nullable = assert_cast<const ColumnNullable &>(*column);
+        return ColumnNullable::create(
+            nested_serialization->wrapColumnForDeserialization(nullable.getNestedColumnPtr()->cloneEmpty()),
+            nullable.getNullMapColumnPtr()->cloneEmpty());
+    }
+
+    return nested_serialization->wrapColumnForDeserialization(std::move(column));
+}
+
 }

--- a/src/DataTypes/Serializations/SerializationDynamicElement.h
+++ b/src/DataTypes/Serializations/SerializationDynamicElement.h
@@ -30,6 +30,7 @@ public:
     static SerializationPtr create(const SerializationPtr & nested_, const SerializationPtr & shared_variant_serialization_, const String & dynamic_element_name_, const String & nested_subcolumn_, bool is_null_map_subcolumn_ = false);
     size_t allocatedBytes() const override;
     bool supportsPooling() const override { return SerializationWrapper::supportsPooling() && shared_variant_serialization->supportsPooling(); }
+    MutableColumnPtr wrapColumnForDeserialization(MutableColumnPtr column) const override;
 
     void enumerateStreams(
         EnumerateStreamsSettings & settings,

--- a/src/DataTypes/Serializations/SerializationVariantElement.cpp
+++ b/src/DataTypes/Serializations/SerializationVariantElement.cpp
@@ -427,4 +427,20 @@ size_t SerializationVariantElement::allocatedBytes() const
     return sizeof(*this) + variant_element_name.capacity();
 }
 
+MutableColumnPtr SerializationVariantElement::wrapColumnForDeserialization(MutableColumnPtr column) const
+{
+    /// The Nullable level of the result column belongs to this serialization: its null map is filled from the
+    /// discriminators, and deserializeBinaryBulkWithMultipleStreams peels the same level off before recursing.
+    /// A LowCardinality(Nullable) result is deserialized as a whole and keeps its wrapper.
+    if (isColumnNullable(*column))
+    {
+        const auto & nullable = assert_cast<const ColumnNullable &>(*column);
+        return ColumnNullable::create(
+            nested_serialization->wrapColumnForDeserialization(nullable.getNestedColumnPtr()->cloneEmpty()),
+            nullable.getNullMapColumnPtr()->cloneEmpty());
+    }
+
+    return nested_serialization->wrapColumnForDeserialization(std::move(column));
+}
+
 }

--- a/src/DataTypes/Serializations/SerializationVariantElement.h
+++ b/src/DataTypes/Serializations/SerializationVariantElement.h
@@ -42,6 +42,7 @@ public:
         ColumnVariant::Discriminator variant_discriminator_,
         size_t num_variants_ = 0);
     size_t allocatedBytes() const override;
+    MutableColumnPtr wrapColumnForDeserialization(MutableColumnPtr column) const override;
 
     void enumerateStreams(
         EnumerateStreamsSettings & settings,

--- a/tests/queries/0_stateless/05045_nullable_tuple_subcolumn_of_dynamic_variant_from_part.reference
+++ b/tests/queries/0_stateless/05045_nullable_tuple_subcolumn_of_dynamic_variant_from_part.reference
@@ -1,0 +1,15 @@
+Nullable(Tuple(a UInt32, b String))
+1	(1,'s')
+2	\N
+1	1
+2	\N
+1	0
+2	1
+1	(1,'s')
+2	\N
+1	(1,'s')
+2	\N
+1	(NULL,'s')
+2	\N
+1	(1,'s')
+2	\N

--- a/tests/queries/0_stateless/05045_nullable_tuple_subcolumn_of_dynamic_variant_from_part.sh
+++ b/tests/queries/0_stateless/05045_nullable_tuple_subcolumn_of_dynamic_variant_from_part.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reading a whole `Tuple` subcolumn of a `Dynamic` or `Variant` column out of a MergeTree part, while
+# extracted subcolumns are allowed to be `Nullable`.
+# `allow_nullable_tuple_in_extracted_subcolumns` is read from the global context, so it has to be passed
+# on the command line: a session level SET does not reach the extraction (see
+# 03918_allow_nullable_tuple_in_extracted_subcolumns_not_changeable).
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_LOCAL} --allow_nullable_tuple_in_extracted_subcolumns=1 --query "
+-- The extracted whole-tuple subcolumn is Nullable only while the setting is on.
+SELECT toTypeName(value.\`Tuple(a UInt32, b String)\`)
+FROM (SELECT CAST(tuple(1, 's'), 'Tuple(a UInt32, b String)')::Dynamic AS value);
+
+CREATE TABLE t_dyn_compact (id UInt64, value Dynamic) ENGINE = MergeTree ORDER BY id
+    SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000000;
+INSERT INTO t_dyn_compact VALUES (1, CAST(tuple(1, 's'), 'Tuple(a UInt32, b String)')), (2, 42::UInt64);
+SELECT id, value.\`Tuple(a UInt32, b String)\` FROM t_dyn_compact ORDER BY id;
+SELECT id, value.\`Tuple(a UInt32, b String)\`.a FROM t_dyn_compact ORDER BY id;
+SELECT id, value.\`Tuple(a UInt32, b String)\`.null FROM t_dyn_compact ORDER BY id;
+
+CREATE TABLE t_dyn_wide (id UInt64, value Dynamic) ENGINE = MergeTree ORDER BY id
+    SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+INSERT INTO t_dyn_wide VALUES (1, CAST(tuple(1, 's'), 'Tuple(a UInt32, b String)')), (2, 42::UInt64);
+SELECT id, value.\`Tuple(a UInt32, b String)\` FROM t_dyn_wide ORDER BY id;
+
+CREATE TABLE t_var (id UInt64, value Variant(Tuple(a UInt32, b String), UInt64))
+    ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_var VALUES (1, CAST(tuple(1, 's'), 'Tuple(a UInt32, b String)')), (2, 42::UInt64);
+SELECT id, value.\`Tuple(a UInt32, b String)\` FROM t_var ORDER BY id;
+
+CREATE TABLE t_dyn_nullable_elem (id UInt64, value Dynamic) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_dyn_nullable_elem VALUES
+    (1, CAST(tuple(CAST(NULL, 'Nullable(UInt32)'), 's'), 'Tuple(a Nullable(UInt32), b String)')), (2, 42::UInt64);
+SELECT id, value.\`Tuple(a Nullable(UInt32), b String)\` FROM t_dyn_nullable_elem ORDER BY id;
+
+-- max_types = 0 leaves no typed variant, so the tuple can only come back from the shared variant.
+CREATE TABLE t_dyn_shared (id UInt64, value Dynamic(max_types = 0)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_dyn_shared VALUES (1, CAST(tuple(1, 's'), 'Tuple(a UInt32, b String)')), (2, 42::UInt64);
+SELECT id, value.\`Tuple(a UInt32, b String)\` FROM t_dyn_shared ORDER BY id;
+"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111427
Related: https://github.com/ClickHouse/ClickHouse/pull/112338
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not user-visible; the defect exists only on master.


### Description

Related: #111427 (introduced this), #112338.

With `allow_nullable_tuple_in_extracted_subcolumns = 1`, reading a whole `Tuple` subcolumn of a
`Dynamic` or `Variant` column out of a MergeTree part throws
`LOGICAL_ERROR: Bad cast from type DB::ColumnNullable to DB::ColumnTuple`:

```sql
CREATE TABLE td (id UInt64, value Dynamic) ENGINE = MergeTree ORDER BY id;
INSERT INTO td VALUES (1, CAST(tuple(1, 's'), 'Tuple(a UInt32, b String)'));
SELECT value.`Tuple(a UInt32, b String)` FROM td;
```

`IDataType::createColumn(const ISerialization &)` builds the read column from the type, so with that
setting it is a `ColumnNullable`, and `SerializationWrapper::wrapColumnForDeserialization` forwards it to
`SerializationTuple`, whose `assert_cast<const ColumnTuple &>` fires. The forward is wrong for
`SerializationVariantElement` and `SerializationDynamicElement`, which own that level: their
`deserializeBinaryBulkWithMultipleStreams` peels it off and fills its null map from the discriminators.
Both now override the wrap to mirror that unwrap, and `SerializationDynamicElement` returns a null map
subcolumn untouched, since that one is a `ColumnUInt8` read through
`SerializationVariantElementNullMap` where the forward produced a second signature.

Introduced on master by #111427; no release branch is affected. In a release build `assert_cast` is a
`static_cast`, so the pre-fix behaviour there is undefined (unmeasured). Only a startup profile can set
the setting; the AST fuzzer jobs set it for every run, which is where this surfaced:
[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112338&sha=d5ac8d5d2b91f08ff8f746113b2fcdad37555b54&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29).

The new test covers both types, both part formats, typed and shared variants, a `Nullable` element and
the `.null` subcolumn; its output matches the pre-regression snapshot byte for byte.

Ordering with #112338: it narrows the matching unwrap to `nullable_added_by_extraction &&
isColumnNullable`, so once it lands that bit should gate these two wraps as well. Benign in either
order today: the nested wrap is the identity in the intrinsically-nullable case.

#111427 carries `v26.8-must-backport` and its backport #116547 is open, so 26.8 would get the regression
too. Could a maintainer apply `v26.8-must-backport` here?

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116739&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116739](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116739+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.9`
<!-- ch-version-info:end -->