### PR TITLE
Backport #111701 to 26.6: Fix flaky test_kafka_formats_with_broken_message

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -311,7 +311,6 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
             data_prefix = data_prefix + [""]
         if format_opts.get("printable", False) == False:
             raw_message = "hex(_raw_message)"
-        k.kafka_produce(kafka_cluster, topic_name, data_prefix + data_sample)
         create_query = create_query_generator(
             f"kafka_{format_name}",
             "id Int64, blockNo UInt16, val1 String, val2 Float32, val3 UInt8",
@@ -323,6 +322,10 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
                 "kafka_flush_interval_ms": 1000,
             },
         )
+        # Create both materialized views, then detach/re-attach the Kafka table,
+        # before producing any message. Creating the first view starts the
+        # streaming loop, so producing earlier lets the loop consume and commit
+        # the broken message before the errors view is attached, leaving it empty.
         instance.query(
             f"""
             DROP TABLE IF EXISTS test.kafka_{format_name};
@@ -338,8 +341,12 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
             CREATE MATERIALIZED VIEW test.kafka_errors_{format_name}_mv ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT {raw_message} as raw_message, _error as error, _topic as topic, _partition as partition, _offset as offset FROM test.kafka_{format_name}
                 WHERE length(_error) > 0;
+
+            DETACH TABLE test.kafka_{format_name};
+            ATTACH TABLE test.kafka_{format_name};
             """
         )
+        k.kafka_produce(kafka_cluster, topic_name, data_prefix + data_sample)
 
     raw_expected = """\
 0	0	AM	0.5	1	{topic_name}	0	{offset_0}


### PR DESCRIPTION
Backport of https://github.com/ClickHouse/ClickHouse/pull/111701 to `26.6`.

The flaky integration test `test_kafka_formats_with_broken_message` fails on `26.6` backport PRs (e.g. twice on https://github.com/ClickHouse/ClickHouse/pull/115954, report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115954&sha=8b34c82b2ac9b9f4d220d81512790facd9db85bd&name_0=BackportPR&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29) because the broken Kafka message can be consumed and committed before the errors materialized view is attached, leaving `kafka_errors_*_mv` empty. The fix produces the messages only after both materialized views are created and the Kafka table is re-attached.

Related: https://github.com/ClickHouse/ClickHouse/pull/115954

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.4.31`
<!-- ch-version-info:end -->