### PR TITLE
Docs: add validated CLI tab to the configurable backups page

### DIFF
--- a/docs/products/cloud/guides/backups/configurable-backups.mdx
+++ b/docs/products/cloud/guides/backups/configurable-backups.mdx
@@ -10,6 +10,16 @@ doc_type: 'guide'
 import { CloudNotSupportedBadge } from "/snippets/components/CloudNotSupportedBadge/CloudNotSupportedBadge.jsx";
 import { ScalePlanFeatureBadge } from "/snippets/components/ScalePlanFeatureBadge/ScalePlanFeatureBadge.jsx";
 import { Image } from "/snippets/components/Image.jsx";
+import ConfigurableBackupsCLI from "/snippets/cloud/backups/_configurable_backups_cli.mdx";
+
+<Visibility for="agents">
+
+<ConfigurableBackupsCLI />
+
+</Visibility>
+
+<Visibility for="humans">
+<View title="Cloud UI">
 
 <ScalePlanFeatureBadge feature="Configurable Backups" linking_verb_are="True"/>
 
@@ -28,3 +38,14 @@ Start time and frequency are mutually exclusive. Start time takes precedence.
 <Note>
 Changing the backup schedule can cause higher monthly charges for storage as some of the backups might not be covered in the default backups for the service. See ["Understanding backup cost"](/products/cloud/guides/backups/review-and-restore-backups#understanding-backup-cost).
 </Note>
+
+</View>
+
+<View title="CLI">
+
+You can follow this path yourself, script it, or hand it to an AI agent. Switch to the **Cloud UI** view for the console version.
+
+<ConfigurableBackupsCLI />
+
+</View>
+</Visibility>

--- a/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
+++ b/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
@@ -1,0 +1,103 @@
+This page covers reading and changing the backup schedule of a ClickHouse Cloud service from the command line with the [ClickHouse CLI](/products/cloud/features/cli) (`clickhousectl`). Commands are non-interactive; `clickhousectl` emits JSON with `--json`.
+
+Configurable backups are available in the Scale and Enterprise plans.
+
+## Prerequisites {#prerequisites}
+
+Install the ClickHouse CLI:
+
+```bash
+curl https://clickhouse.com/cli | sh
+```
+
+You also need `jq`.
+
+Changing the backup configuration is a write operation and requires [API key authentication](/products/cloud/features/admin-features/api/openapi); OAuth login is read-only:
+
+```bash
+clickhousectl cloud auth login --api-key <YOUR_KEY> --api-secret <YOUR_SECRET>
+```
+
+Alternatively, set the `CLICKHOUSE_CLOUD_API_KEY` and `CLICKHOUSE_CLOUD_API_SECRET` environment variables. Verify with `clickhousectl cloud auth status`; expect an entry with scope `read/write`.
+
+## Find the service ID {#find-the-service-id}
+
+The backup configuration is set per service. Look up the ID of the service by name:
+
+```bash
+CH_ID=$(clickhousectl cloud service list --json \
+  | jq -r '.[] | select(.name=="<service-name>") | .id')
+```
+
+## Read the current backup configuration {#read-the-current-backup-configuration}
+
+```bash
+clickhousectl cloud service backup-config get "$CH_ID" --json
+```
+
+A service that still uses the default schedule reports:
+
+```json
+{
+  "backupPeriodInHours": 24.0,
+  "backupRetentionPeriodInHours": 24.0
+}
+```
+
+`backupStartTime` only appears in the output once a start time has been set.
+
+## Change retention and frequency {#change-retention-and-frequency}
+
+`backup-config update` takes the same settings as the console form — retention (`--backup-retention-period-hours`), frequency (`--backup-period-hours`), and start time (`--backup-start-time`) — and prints the resulting configuration. Flags you omit keep their current values:
+
+```bash
+clickhousectl cloud service backup-config update "$CH_ID" \
+  --backup-period-hours 12 \
+  --backup-retention-period-hours 48 \
+  --json
+```
+
+```json
+{
+  "backupPeriodInHours": 12.0,
+  "backupRetentionPeriodInHours": 48.0
+}
+```
+
+The change takes effect immediately; read the configuration back to confirm:
+
+```bash
+clickhousectl cloud service backup-config get "$CH_ID" --json
+```
+
+```json
+{
+  "backupPeriodInHours": 12.0,
+  "backupRetentionPeriodInHours": 48.0
+}
+```
+
+## Set a backup start time {#set-a-backup-start-time}
+
+`--backup-start-time` takes a daily start time in UTC (`HH:MM`). Start time and frequency are mutually exclusive; start time takes precedence, and the API only accepts a `--backup-period-hours` of `24` or `48` in combination with it:
+
+```bash
+clickhousectl cloud service backup-config update "$CH_ID" \
+  --backup-start-time 02:00 \
+  --backup-period-hours 24 \
+  --json
+```
+
+```json
+{
+  "backupPeriodInHours": 24.0,
+  "backupRetentionPeriodInHours": 48.0,
+  "backupStartTime": "02:00"
+}
+```
+
+Passing a start time while the period is any other value fails with `customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set` — the same restriction then applies to later period changes. Once set, the start time cannot be removed through the CLI or API, only changed to a different time.
+
+<Note>
+Changing the backup schedule can cause higher monthly charges for storage as some of the backups might not be covered in the default backups for the service. See ["Understanding backup cost"](/products/cloud/guides/backups/review-and-restore-backups#understanding-backup-cost).
+</Note>

--- a/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
+++ b/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
@@ -79,7 +79,7 @@ clickhousectl cloud service backup-config get "$CH_ID" --json
 
 ## Set a backup start time {#set-a-backup-start-time}
 
-`--backup-start-time` takes a daily start time in UTC (`HH:MM`). Start time and frequency are mutually exclusive; start time takes precedence, and the API only accepts a `--backup-period-hours` of `24` or `48` in combination with it:
+`--backup-start-time` takes a daily start time in UTC, on the hour (`HH:00`). Start time and frequency are mutually exclusive; start time takes precedence and requires a backup period of `24` or `48` hours — the CLI rejects any other combination. Setting a start time without passing `--backup-period-hours` defaults the period to 24 hours:
 
 ```bash
 clickhousectl cloud service backup-config update "$CH_ID" \
@@ -96,7 +96,7 @@ clickhousectl cloud service backup-config update "$CH_ID" \
 }
 ```
 
-Passing a start time while the period is any other value fails with `customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set` — the same restriction then applies to later period changes. Once set, the start time cannot be removed through the CLI or API, only changed to a different time.
+While a start time is stored, a later update that changes only `--backup-period-hours` to a value other than `24` or `48` fails at the API with `customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set`. Once set, the start time cannot be removed through the CLI or API, only changed to a different time.
 
 <Note>
 Changing the backup schedule can cause higher monthly charges for storage as some of the backups might not be covered in the default backups for the service. See ["Understanding backup cost"](/products/cloud/guides/backups/review-and-restore-backups#understanding-backup-cost).

--- a/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
+++ b/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
@@ -18,7 +18,7 @@ Changing the backup configuration is a write operation and requires [API key aut
 clickhousectl cloud auth login --api-key <YOUR_KEY> --api-secret <YOUR_SECRET>
 ```
 
-Alternatively, set the `CLICKHOUSE_CLOUD_API_KEY` and `CLICKHOUSE_CLOUD_API_SECRET` environment variables. Verify with `clickhousectl cloud auth status`; expect an entry with scope `read/write`.
+Alternatively, set the `CLICKHOUSE_CLOUD_API_KEY` and `CLICKHOUSE_CLOUD_API_SECRET` environment variables. Verify with `clickhousectl cloud auth status`: check that the **active** credential is the one with scope `read/write`. Credentials saved by an earlier `auth login` outrank environment variables; in that case the `Env vars` row can still show scope `read/write` but is marked inactive (`Configured (inactive, outranked by credentials file)`), and the write commands below run under the saved credentials instead. Run `clickhousectl cloud auth logout` first if you want the environment variables to be used.
 
 ## Find the service ID {#find-the-service-id}
 
@@ -28,6 +28,8 @@ The backup configuration is set per service. Look up the ID of the service by na
 CH_ID=$(clickhousectl cloud service list --json \
   | jq -r '.[] | select(.name=="<service-name>") | .id')
 ```
+
+If you belong to more than one organization, the organization cannot be auto-detected and this command fails with `Multiple organizations found. Specify --org-id to choose one.`. List your organizations with `clickhousectl cloud org list`, and pass `--org-id <org-id>` to this command and to every `backup-config` command below.
 
 ## Read the current backup configuration {#read-the-current-backup-configuration}
 

--- a/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
+++ b/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
@@ -79,7 +79,19 @@ clickhousectl cloud service backup-config get "$CH_ID" --json
 
 ## Set a backup start time {#set-a-backup-start-time}
 
-`--backup-start-time` takes a daily start time in UTC, on the hour (`HH:00`). Start time and frequency are mutually exclusive; start time takes precedence and requires a backup period of `24` or `48` hours — the CLI rejects any other combination. Setting a start time without passing `--backup-period-hours` defaults the period to 24 hours:
+`--backup-start-time` takes a daily start time in UTC, on the hour (`HH:00`). Start time and frequency are mutually exclusive; start time takes precedence and requires a backup period of `24` or `48` hours. Since `clickhousectl 0.4.2` both rules are enforced on the client, before any API call. A time that is not on the hour — or not zero-padded, such as `2:00` — is rejected by the argument parser with exit code `2`:
+
+```bash
+clickhousectl cloud service backup-config update "$CH_ID" --backup-start-time 02:30 --json
+```
+
+```text
+error: invalid value '02:30' for '--backup-start-time <BACKUP_START_TIME>': invalid backup start time '02:30': expected HH:00 with HH from 00 to 23
+```
+
+Passing `--backup-start-time` together with a `--backup-period-hours` other than `24` or `48` is likewise rejected locally, with `--backup-period-hours must be 24 or 48 when --backup-start-time is set`.
+
+A valid combination:
 
 ```bash
 clickhousectl cloud service backup-config update "$CH_ID" \
@@ -96,7 +108,9 @@ clickhousectl cloud service backup-config update "$CH_ID" \
 }
 ```
 
-While a start time is stored, a later update that changes only `--backup-period-hours` to a value other than `24` or `48` fails at the API with `customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set`. Once set, the start time cannot be removed through the CLI or API, only changed to a different time.
+`--backup-period-hours` can be omitted, in which case the service keeps the period it already has — but that stored period must itself be `24` or `48`. On a service still using the default schedule the period is `24`, so a start time on its own is enough; on a service whose period is, say, `12`, the update instead fails at the API with `customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set`. Passing the period explicitly avoids the problem.
+
+The same API error appears when a start time is already stored and a later update changes only `--backup-period-hours` to a value other than `24` or `48`: the client-side check applies only to a start time given in the same command. Once set, the start time cannot be removed through the CLI or API, only changed to a different time.
 
 <Note>
 Changing the backup schedule can cause higher monthly charges for storage as some of the backups might not be covered in the default backups for the service. See ["Understanding backup cost"](/products/cloud/guides/backups/review-and-restore-backups#understanding-backup-cost).

--- a/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
+++ b/docs/snippets/cloud/backups/_configurable_backups_cli.mdx
@@ -79,7 +79,7 @@ clickhousectl cloud service backup-config get "$CH_ID" --json
 
 ## Set a backup start time {#set-a-backup-start-time}
 
-`--backup-start-time` takes a daily start time in UTC, on the hour (`HH:00`). Start time and frequency are mutually exclusive; start time takes precedence and requires a backup period of `24` or `48` hours. Since `clickhousectl 0.4.2` both rules are enforced on the client, before any API call. A time that is not on the hour — or not zero-padded, such as `2:00` — is rejected by the argument parser with exit code `2`:
+`--backup-start-time` takes a daily start time in UTC, on the hour (`HH:00`). A start time constrains the frequency: the backup period must be `24` or `48` hours, either passed in the same command or already stored on the service. Since `clickhousectl 0.4.2` the format and the period rule are both checked on the client, before any API call. A time that is not on the hour — or not zero-padded, such as `2:00` — is rejected by the argument parser with exit code `2`:
 
 ```bash
 clickhousectl cloud service backup-config update "$CH_ID" --backup-start-time 02:30 --json
@@ -89,9 +89,23 @@ clickhousectl cloud service backup-config update "$CH_ID" --backup-start-time 02
 error: invalid value '02:30' for '--backup-start-time <BACKUP_START_TIME>': invalid backup start time '02:30': expected HH:00 with HH from 00 to 23
 ```
 
-Passing `--backup-start-time` together with a `--backup-period-hours` other than `24` or `48` is likewise rejected locally, with `--backup-period-hours must be 24 or 48 when --backup-start-time is set`.
+Passing `--backup-start-time` together with a `--backup-period-hours` other than `24` or `48` is likewise rejected before the request is sent, with exit code `1`:
 
-A valid combination:
+```text
+Error: --backup-period-hours must be 24 or 48 when --backup-start-time is set
+```
+
+`--backup-period-hours` can be omitted, in which case the service keeps the period it already has — but that stored period must itself be `24` or `48`. On a service still using the default schedule the period is `24`, so a start time on its own is enough. The service above was set to `12` in the previous step, so omitting the period fails: `clickhousectl` reads the stored configuration first and refuses with exit code `1`, again without calling the API:
+
+```bash
+clickhousectl cloud service backup-config update "$CH_ID" --backup-start-time 03:00 --json
+```
+
+```text
+Error: the stored backup period is 12 hours, but --backup-start-time requires 24 or 48. Pass --backup-period-hours 24 or --backup-period-hours 48 in the same call.
+```
+
+Passing the period explicitly is the valid combination:
 
 ```bash
 clickhousectl cloud service backup-config update "$CH_ID" \
@@ -108,9 +122,60 @@ clickhousectl cloud service backup-config update "$CH_ID" \
 }
 ```
 
-`--backup-period-hours` can be omitted, in which case the service keeps the period it already has — but that stored period must itself be `24` or `48`. On a service still using the default schedule the period is `24`, so a start time on its own is enough; on a service whose period is, say, `12`, the update instead fails at the API with `customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set`. Passing the period explicitly avoids the problem.
+The reverse case is not caught on the client: with a start time already stored, an update that changes only `--backup-period-hours` to a value other than `24` or `48` reaches the API and fails there, with exit code `1`:
 
-The same API error appears when a start time is already stored and a later update changes only `--backup-period-hours` to a value other than `24` or `48`: the client-side check applies only to a start time given in the same command. Once set, the start time cannot be removed through the CLI or API, only changed to a different time.
+```bash
+clickhousectl cloud service backup-config update "$CH_ID" --backup-period-hours 12 --json
+```
+
+```text
+Error: BAD_REQUEST: customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set
+```
+
+Clearing the start time in the same command avoids this, as shown next.
+
+## Clear the backup start time {#clear-the-backup-start-time}
+
+`--clear-backup-start-time` removes the stored start time and lifts the `24`/`48` hour restriction on the period:
+
+```bash
+clickhousectl cloud service backup-config update "$CH_ID" \
+  --clear-backup-start-time \
+  --json
+```
+
+```json
+{
+  "backupPeriodInHours": 24.0,
+  "backupRetentionPeriodInHours": 48.0
+}
+```
+
+`backupStartTime` disappears from the output rather than being reported as `null`, and `backup-config get` no longer returns it. Clearing a start time that was never set is a no-op that still exits `0`.
+
+Combine it with `--backup-period-hours` to clear the start time and set any period in a single command — this is the way out of the API error above:
+
+```bash
+clickhousectl cloud service backup-config update "$CH_ID" \
+  --clear-backup-start-time \
+  --backup-period-hours 12 \
+  --json
+```
+
+```json
+{
+  "backupPeriodInHours": 12.0,
+  "backupRetentionPeriodInHours": 48.0
+}
+```
+
+`--clear-backup-start-time` and `--backup-start-time` cannot be combined; the parser rejects the pair with exit code `2`:
+
+```text
+error: the argument '--clear-backup-start-time' cannot be used with '--backup-start-time <BACKUP_START_TIME>'
+```
+
+To move a start time rather than remove it, pass the new `--backup-start-time` on its own; it overwrites the stored one.
 
 <Note>
 Changing the backup schedule can cause higher monthly charges for storage as some of the backups might not be covered in the default backups for the service. See ["Understanding backup cost"](/products/cloud/guides/backups/review-and-restore-backups#understanding-backup-cost).


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116691

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Restructures the "Configure backup schedules" Cloud guide (`docs/products/cloud/guides/backups/configurable-backups.mdx`) into the UI/CLI tab pattern established in https://github.com/ClickHouse/ClickHouse/pull/116691:

- Agents are served the CLI content directly via `<Visibility for="agents">` content negotiation.
- Humans get two tabs: **Cloud UI** (the existing page content, unchanged, default tab) and **CLI**.
- The CLI content lives in a new shared snippet, `docs/snippets/cloud/backups/_configurable_backups_cli.mdx`, covering `clickhousectl cloud service backup-config get` and `backup-config update` — the same three settings the console form exposes (retention, frequency, start time), plus the plan requirement and the backup-cost note.

**Validation.** The whole flow was re-validated end-to-end against a real ClickHouse Cloud workspace on 2026-09-02 with `clickhousectl` 0.4.2: created a temporary service, waited for provisioning, read the default backup configuration (`24`/`24` hours, no `backupStartTime` key), updated frequency and retention (`--backup-period-hours 12 --backup-retention-period-hours 48`), read it back, exercised every start-time constraint (all three rejections and the accepted combination), set a start time (`--backup-start-time 02:00 --backup-period-hours 24`), moved it, cleared it, cleared it while setting a new period, and deleted the service. All output blocks in the snippet are real captured output (identifiers sanitized). The org was not tier-gated, so the update path was fully validated (no `403` to document).

**Start-time constraints, as confirmed on `clickhousectl` 0.4.2.** A start time requires the backup period to be `24` or `48` hours — either supplied in the same command or already stored on the service. All three violations are caught on the client, before any API call, and the snippet shows the real error output:

- A start time that is not exactly on the hour is rejected by the argument parser with exit code `2`: `error: invalid value '02:30' for '--backup-start-time <BACKUP_START_TIME>': invalid backup start time '02:30': expected HH:00 with HH from 00 to 23`. The same message and exit code apply to `2:00` (not zero-padded), `24:00` (out of range) and `""`.
- `--backup-start-time 02:00 --backup-period-hours 12` is rejected with exit code `1` and `Error: --backup-period-hours must be 24 or 48 when --backup-start-time is set`.
- `--backup-start-time 03:00` on its own, against a stored period of `12`, is rejected with exit code `1` and `Error: the stored backup period is 12 hours, but --backup-start-time requires 24 or 48. Pass --backup-period-hours 24 or --backup-period-hours 48 in the same call.` This case previously failed at the API; the CLI now reads the stored configuration first and refuses locally with an actionable message.

Omitting `--backup-period-hours` when setting a start time does **not** default the period to 24 hours; the API keeps the stored period, and that stored period must already be `24` or `48`. The `--help` text that used to claim otherwise (https://github.com/ClickHouse/clickhousectl/issues/642) is corrected in this build and now states the real rule, matching what the snippet documents.

**`--clear-backup-start-time`.** `clickhousectl` 0.4.2 adds a flag to remove a stored start time, which closes the one genuine product gap the earlier revision of this snippet had to document. Validated:

- `--clear-backup-start-time` alone removes the start time and exits `0`; `backupStartTime` disappears from `backup-config get --json` rather than being returned as `null`.
- Clearing when no start time is stored is a no-op that still exits `0`.
- `--clear-backup-start-time --backup-period-hours 12` in one command is accepted and leaves the service on a `12` hour period with no start time. This is the escape from the API error below.
- `--clear-backup-start-time --backup-start-time 02:00` is rejected by the parser with exit code `2`: `error: the argument '--clear-backup-start-time' cannot be used with '--backup-start-time <BACKUP_START_TIME>'`.

The snippet gains a `## Clear the backup start time` section covering all of this, and the previous statement that "once set, the start time cannot be removed through the CLI or API" is gone, because it is no longer true.

**Residual quirks/gaps (confirmed still present on `clickhousectl` 0.4.2, documented in the snippet):**

- If a start time is already stored server-side, updating only `--backup-period-hours` to a value other than `24`/`48` still fails at the API with exit code `1` and `Error: BAD_REQUEST: customBackupPeriod must be 24 or 48 hours when customBackupStartTime is set` — the client-side checks fire only when `--backup-start-time` or `--clear-backup-start-time` is in the same invocation. The snippet documents the one-command workaround (`--clear-backup-start-time --backup-period-hours <n>`).
- `backup-config get` omits `backupStartTime` from the JSON output until a start time has been set, and omits it again after it is cleared.
- No Cleanup section in the snippet: unlike the quickstart, this flow provisions nothing — it only changes settings on an existing service.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116775&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116775](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116775+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
