### PR TITLE
Docs: add a validated CLI tab to the Cloud file-upload guide

### DIFF
--- a/docs/products/cloud/guides/migration/upload-a-csv-file.mdx
+++ b/docs/products/cloud/guides/migration/upload-a-csv-file.mdx
@@ -6,6 +6,16 @@ doc_type: 'guide'
 ---
 
 import { Image } from "/snippets/components/Image.jsx";
+import UploadCsvCLI from "/snippets/cloud/migration/_upload_csv_cli.mdx";
+
+<Visibility for="agents">
+
+<UploadCsvCLI />
+
+</Visibility>
+
+<Visibility for="humans">
+<View title="Cloud UI">
 
 ClickHouse Cloud provides an easy way to import your files and supports the
 following formats:
@@ -101,3 +111,14 @@ the data based on the error message for the failed insert.
 <Image img="/images/cloud/migrate/csv_10.webp" alt="upload_file_11" />
 </Step>
 </Steps>
+
+</View>
+
+<View title="CLI">
+
+You can follow this path yourself, script it, or hand it to an AI agent. Switch to the **Cloud UI** view for the console version.
+
+<UploadCsvCLI />
+
+</View>
+</Visibility>

--- a/docs/snippets/cloud/migration/_upload_csv_cli.mdx
+++ b/docs/snippets/cloud/migration/_upload_csv_cli.mdx
@@ -1,0 +1,142 @@
+This page covers uploading a local file (for example, a CSV) into a table on a ClickHouse Cloud service from the command line with the [ClickHouse CLI](/products/cloud/features/cli) (`clickhousectl`). The flow mirrors the console's file-upload wizard: inspect the file's schema, create the destination table, and insert the file over HTTP with the Query API — no `clickhouse` binary or service password required.
+
+## Prerequisites {#cli-prerequisites}
+
+Install the ClickHouse CLI:
+
+```bash
+curl https://clickhouse.com/cli | sh
+```
+
+You also need `jq`.
+
+Write operations require [API key authentication](/products/cloud/features/admin-features/api/openapi); OAuth login is read-only:
+
+```bash
+clickhousectl cloud auth login --api-key <YOUR_KEY> --api-secret <YOUR_SECRET>
+```
+
+Verify with `clickhousectl cloud auth status`; expect an entry with scope `read/write`.
+
+## Pick a service {#pick-a-service}
+
+This guide assumes you already have a running service. If you don't, see the [Cloud quick start](/get-started/setup/cloud) for creating one from the CLI. Look up the ID of your service by name:
+
+```bash
+CH_ID=$(clickhousectl cloud service list --json \
+  | jq -r '.[] | select(.name=="my-service") | .id')
+```
+
+## Prepare the file {#prepare-the-file}
+
+Suppose the following text is in a CSV file named `data.csv`. The first line is a header row, so the matching input format is `CSVWithNames`:
+
+```text title="data.csv"
+user_id,url,visited_at,duration_ms
+101,https://clickhouse.com/docs,2026-08-14 09:15:32,4210
+102,https://clickhouse.com/pricing,2026-08-14 09:16:01,1830
+101,https://clickhouse.com/cloud,2026-08-14 09:17:45,2650
+103,https://clickhouse.com/blog,2026-08-15 11:02:10,980
+102,https://clickhouse.com/docs/cloud,2026-08-15 11:05:44,3120
+```
+
+## Inspect the schema {#inspect-the-schema}
+
+Where the console wizard shows you the inferred type of each source field, the CLI equivalent is `DESCRIBE` on the [`format`](/reference/functions/table-functions/format) table function with a sample of the file inlined:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" --format PrettyCompact \
+  --query "DESCRIBE format(CSVWithNames, '$(head -n 3 data.csv)')"
+```
+
+The first `query` call provisions a Query API endpoint and a service-scoped API key for the service automatically:
+
+```text
+Provisioning Query API endpoint + key for service 'my-service'...
+   ┌─name────────┬─type───────────────┬─default_type─┬─default_expression─┬─comment─┬─codec_expression─┬─ttl_expression─┐
+1. │ user_id     │ Nullable(Int64)    │              │                    │         │                  │                │
+2. │ url         │ Nullable(String)   │              │                    │         │                  │                │
+3. │ visited_at  │ Nullable(DateTime) │              │                    │         │                  │                │
+4. │ duration_ms │ Nullable(Int64)    │              │                    │         │                  │                │
+   └─────────────┴────────────────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┘
+```
+
+The sample is spliced into a SQL string literal, so it must not contain single quotes or backslashes; for files where it does, escape them or just write the `CREATE TABLE` by hand.
+
+## Create the table {#create-the-table}
+
+Everything the wizard's "Configure table" step offers — adjusting the inferred types, nullability, defaults, excluded fields, the table engine, and the sorting, partitioning, and primary key expressions — is a plain [`CREATE TABLE`](/reference/statements/create/table) here. For example, tightening the inferred types and picking a sorting key:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "CREATE TABLE default.website_visits (
+    user_id UInt32,
+    url String,
+    visited_at DateTime,
+    duration_ms UInt32
+  ) ENGINE = MergeTree
+  ORDER BY (user_id, visited_at)"
+```
+
+The command prints `OK`. To load into an existing table instead, skip this step.
+
+## Upload the file {#upload-the-file}
+
+`INSERT ... FORMAT` reads the data from stdin, so pipe the query and the file together:
+
+```bash
+printf 'INSERT INTO default.website_visits FORMAT CSVWithNames\n' | cat - data.csv \
+  | clickhousectl cloud service query --id "$CH_ID"
+```
+
+The command prints `OK`.
+
+<Warning>
+**Pipe the query and the data together**
+
+Passing the `INSERT` via `--query` and redirecting the file into stdin (`--query "INSERT ..." < data.csv`) does not work: `--query` takes precedence over stdin, so the data is ignored and zero rows are inserted — without an error. Always send the query and the data through stdin as one stream, as shown above.
+</Warning>
+
+Verify the rows landed:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "SELECT count() FROM default.website_visits"
+```
+
+```text
+{"count()":5}
+```
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" --format PrettyCompact \
+  --query "SELECT * FROM default.website_visits ORDER BY visited_at"
+```
+
+```text
+   ┌─user_id─┬─url───────────────────────────────┬──────────visited_at─┬─duration_ms─┐
+1. │     101 │ https://clickhouse.com/docs       │ 2026-08-14 09:15:32 │        4210 │
+2. │     102 │ https://clickhouse.com/pricing    │ 2026-08-14 09:16:01 │        1830 │
+3. │     101 │ https://clickhouse.com/cloud      │ 2026-08-14 09:17:45 │        2650 │
+4. │     103 │ https://clickhouse.com/blog       │ 2026-08-15 11:02:10 │         980 │
+5. │     102 │ https://clickhouse.com/docs/cloud │ 2026-08-15 11:05:44 │        3120 │
+   └─────────┴───────────────────────────────────┴─────────────────────┴─────────────┘
+```
+
+## Other file formats {#other-file-formats}
+
+The same pattern works for any [input format](/reference/formats/index) ClickHouse supports — including all the formats the console's upload wizard accepts, such as `CSV`, `JSONEachRow`, and `TabSeparatedWithNames`. Only the format name in the `INSERT` changes:
+
+```bash
+printf 'INSERT INTO default.website_visits FORMAT TabSeparatedWithNames\n' | cat - data.tsv \
+  | clickhousectl cloud service query --id "$CH_ID"
+```
+
+## Cleanup {#cleanup}
+
+If this was a trial run, drop the table to remove the imported data:
+
+```bash
+clickhousectl cloud service query --id "$CH_ID" \
+  --query "DROP TABLE default.website_visits"
+```

--- a/docs/snippets/cloud/migration/_upload_csv_cli.mdx
+++ b/docs/snippets/cloud/migration/_upload_csv_cli.mdx
@@ -94,13 +94,19 @@ The command prints `OK`.
 <Warning>
 **Pipe the query and the data together**
 
-Passing the `INSERT` via `--query` and redirecting the file into stdin (`--query "INSERT ..." < data.csv`) does not work: `--query` takes precedence over stdin, so the data is ignored and zero rows are inserted — without an error. Always send the query and the data through stdin as one stream, as shown above.
+Passing the `INSERT` via `--query` and redirecting or piping the file into stdin (`--query "INSERT ..." < data.csv`) does not work: `--query` never reads stdin, so the data would go nowhere. The CLI refuses the combination outright rather than inserting nothing silently — it exits `1`, inserts no rows, and prints:
+
+```text
+Error: --query cannot be combined with SQL or data on stdin. The Query API sends one request body, so redirected data is never read. Pipe the statement and its data together on stdin instead: printf 'INSERT INTO t FORMAT CSV\n' | cat - data.csv | clickhousectl cloud service query --id <id>. Or read a whole statement from stdin with --queries-file -.
+```
+
+Always send the query and the data through stdin as one stream, as shown above. Only stdin that actually carries data conflicts with `--query`, so `--query` on its own still works in scripts and pipelines where stdin is not a terminal.
 </Warning>
 
 Verify the rows landed:
 
 ```bash
-clickhousectl cloud service query --id "$CH_ID" \
+clickhousectl cloud service query --id "$CH_ID" --json \
   --query "SELECT count() FROM default.website_visits"
 ```
 

--- a/docs/snippets/cloud/migration/_upload_csv_cli.mdx
+++ b/docs/snippets/cloud/migration/_upload_csv_cli.mdx
@@ -131,7 +131,7 @@ clickhousectl cloud service query --id "$CH_ID" --format PrettyCompact \
 
 ## Other file formats {#other-file-formats}
 
-The same pattern works for any [input format](/reference/formats/index) ClickHouse supports — including all the formats the console's upload wizard accepts, such as `CSV`, `JSONEachRow`, and `TabSeparatedWithNames`. Only the format name in the `INSERT` changes:
+The same pattern works for any [input format](/reference/formats/index) ClickHouse supports — including all the formats the console's upload wizard accepts, such as `CSV`, `JSONEachRow`, and `TabSeparatedWithNames`. For another format, change the format name consistently in both the `DESCRIBE format(...)` schema-inference step and the `INSERT ... FORMAT` statement, and use a sample file that matches that format (a TSV sample for `TabSeparatedWithNames`, a JSON-lines sample for `JSONEachRow`, and so on). For example, the upload step for a TSV file becomes:
 
 ```bash
 printf 'INSERT INTO default.website_visits FORMAT TabSeparatedWithNames\n' | cat - data.tsv \


### PR DESCRIPTION
Docs: add a validated CLI tab to the Cloud file-upload guide
https://github.com/ClickHouse/ClickHouse/pull/116778

Related: https://github.com/ClickHouse/ClickHouse/pull/116691

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Restructures the Cloud file-upload guide (`docs/products/cloud/guides/migration/upload-a-csv-file.mdx`, slug `/cloud/migrate/upload-a-csv-file`) into the established UI/CLI tab pattern, following the Cloud quick start (`docs/get-started/setup/cloud.mdx`):

- Humans see the existing Cloud console wizard content unchanged as the default **Cloud UI** tab, plus a new **CLI** tab.
- Agents are served the CLI content directly via `<Visibility for="agents">`.
- The CLI content lives in a new shared snippet, `docs/snippets/cloud/migration/_upload_csv_cli.mdx`, used by both the agent view and the CLI tab.

The CLI flow mirrors the wizard for uploading a local file into a table with `clickhousectl`:

- looking up the service ID with `clickhousectl cloud service list --json` + `jq`;
- schema inference (the wizard's "Source fields" preview) via `DESCRIBE format(CSVWithNames, '...')` with a sample of the file inlined;
- table configuration (types, nullability, engine, sorting key) as an explicit `CREATE TABLE`;
- the upload itself as `INSERT INTO ... FORMAT CSVWithNames` with the file streamed over the Query API;
- a note that the same pattern covers the other formats the wizard accepts (validated with `TabSeparatedWithNames`);
- a `Cleanup` section dropping the trial table.

**Validation.** Every command in the snippet was run end-to-end on 2026-08-27 against a real, freshly provisioned ClickHouse Cloud service (created, polled to `running`, used, and deleted afterwards). All output blocks are real captured output, sanitized (service name/ID replaced with consistent placeholders).

**Re-validated on 2026-09-02 against `clickhousectl` 0.4.2.** The whole snippet was run again, in order, against another freshly provisioned service (created, polled to `running`, used, deleted). Every step succeeds — `DESCRIBE format(...)` inference, `CREATE TABLE`, the piped `INSERT`, the row count, the `SELECT *` readback, the `TabSeparatedWithNames` variant and the `DROP TABLE` cleanup — and every output block still matches. Two documentation corrections came out of the run, both now in the snippet.

**Correction 1 — `--query` combined with stdin is now a hard error, not a silent no-op.** The warning in the doc previously said the data was ignored and zero rows inserted without an error. In 0.4.2 the CLI rejects the combination up front. Both forms behave identically:

- `clickhousectl cloud service query --id <id> --query "INSERT INTO default.website_visits FORMAT CSVWithNames" < data.csv` — exit code `1`, empty stdout, `count() = 0`.
- `cat data.csv | clickhousectl cloud service query --id <id> --query "INSERT INTO default.website_visits FORMAT CSVWithNames"` — exit code `1`, empty stdout, `count() = 0`.

Both print, on stderr:

```text
Error: --query cannot be combined with SQL or data on stdin. The Query API sends one request body, so redirected data is never read. Pipe the statement and its data together on stdin instead: printf 'INSERT INTO t FORMAT CSV\n' | cat - data.csv | clickhousectl cloud service query --id <id>. Or read a whole statement from stdin with --queries-file -.
```

The doc's recommendation is unchanged and is now the CLI's own advice: pipe the statement and its data together, `printf 'INSERT INTO default.website_visits FORMAT CSVWithNames\n' | cat - data.csv | clickhousectl cloud service query --id "$CH_ID"` (exit `0`, `OK`, `count() = 5`). `--queries-file -` fed the same combined stream is an equivalent alternative (exit `0`, `count() = 5`).

The check keys off stdin actually carrying data, not off stdin being a non-terminal, so scripted and agent use of `--query` is unaffected: `--query "SELECT 1"` returns `{"1":1}` with exit `0` when stdin is `/dev/null`, an empty pipe, or inherited from a non-interactive shell.

**Correction 2 — `--json` added to the `SELECT count()` step.** That step showed a `{"count()":5}` output block but passed neither `--json` nor `--format`. Piped output defaults to `TabSeparated`, so the JSON block only matched because of the CLI's agent auto-detection; in a clean environment the same command prints `5`. The command now passes `--json`, which produces exactly the block shown. Same fix as https://github.com/ClickHouse/ClickHouse/pull/117574 made for the quickstart snippet.

**Other `service query` behaviour confirmed on 0.4.2** (none of it affects the snippet, which uses only single statements, but it is useful context for anyone copying these commands):

- Multi-statement SQL is rejected by the server, not by the client. `--query 'SELECT 1; SELECT 2'` exits `1` with `Error: SQL error 62: Syntax error (Multi-statements are not allowed): failed at position 9 (end of query): ; SELECT 2. .` A two-statement file via `--queries-file` and two `;`-separated statements piped on bare stdin fail the same way, with the same `SQL error 62`. A single statement with a trailing semicolon (`--query 'SELECT 1;'`) is fine.
- `--query` and `--queries-file` are mutually exclusive: `error: the argument '--query <QUERY>' cannot be used with '--queries-file <QUERIES_FILE>'`, exit code `2`, before any network call.
- `--json` and `--format` conflict: `error: the argument '--json' cannot be used with '--format <FORMAT>'`, exit code `2`.
- The default response format when output is piped is still `TabSeparated` (`PrettyCompact` on a TTY), which is why the snippet passes `--format PrettyCompact` explicitly for the table-shaped output blocks.
- Not a CLI behaviour, but worth knowing when re-running the flow: re-inserting byte-identical rows into the same table is deduplicated server-side, so a second load of the same data leaves the row count unchanged.

**Known gaps (intentionally not faked in the CLI flow):** the wizard's `Data upload history` status tracking (`queued`/`failed` badges, `View Details`) and `Open as query` have no CLI equivalent — the CLI insert is synchronous and reports errors directly. Also, the schema-inference sample is spliced into a SQL string literal, so samples containing single quotes/backslashes need escaping; the doc notes this.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116778&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116778](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116778+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
