### PR TITLE
Reserve host memory for the CI runner agent in the fuzzer jobs

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -20,6 +20,9 @@ IMAGE_NAME = "clickhouse/fuzzer"
 # Maximum number of reproduce commands to display inline before writing to file
 MAX_INLINE_REPRODUCE_COMMANDS = 20
 
+# The runner agent lives on the host, outside this container, so it is only safe if the container cannot take the whole box.
+RUNNER_MEMORY_RESERVE = 8 * 1024**3
+
 cwd = Utils.cwd()
 WORKSPACE_PATH = Path(cwd) / "ci/tmp/workspace"
 
@@ -242,6 +245,7 @@ def get_run_command(
         # For sysctl
         "--privileged "
         "--network=host "
+        f"--memory={Utils.physical_memory() - RUNNER_MEMORY_RESERVE} "
         "--tmpfs /tmp/clickhouse:mode=1777 "
         f"--volume={WORKSPACE_PATH}:/workspace "
         f"--volume={cwd}:/repo "


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111892
Related: https://github.com/ClickHouse/ClickHouse/pull/115915
Related: https://github.com/ClickHouse/ClickHouse/pull/116666
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bound the AST fuzzer and BuzzHouse containers so a fuzz run cannot exhaust the CI runner host.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/111892
Related: https://github.com/ClickHouse/ClickHouse/pull/115915
Related: https://github.com/ClickHouse/ClickHouse/pull/116666

`AST fuzzer (amd_debug, targeted)` on #116666 reported `failure` having published nothing: the
`Run` step was `cancelled` after the runner agent lost communication, so CI DB has **0 rows** for
it. The twin arm and four more passed on it.
[Report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116666&sha=7293ca29e4e4ae89e9d7d555dc7d9489f361e3db&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29),
[job log](https://github.com/ClickHouse/ClickHouse/actions/runs/33060238687/job/98558727242).

Nothing bounds the job's share of the host: `get_run_command` passes no `--memory`, and inside the
container `max_server_memory_usage` stays `0` with only the 0.75 ratio set, so the server sized
itself at 46.33 of the runner's 61.78 GiB. The container then reached `current RSS: 57.14 GiB`
against `maximum: 46.18 GiB` with every query refused. That RSS is the container cgroup's anon and
charges the client and two `gdb` processes too, so the server's ratio cannot bound it; 4.6 GiB was
left for the agent.

I add `--memory=Utils.physical_memory() - RUNNER_MEMORY_RESERVE` to that `docker run`, in the shape
`ci/defs/job_configs.py` already uses; 8 GiB because 4.6 was not enough. A kernel bound holds
whatever the server, `gdb` and the client do, and the launcher stays on the host, so an
in-container kill still publishes a result.

The 0.75 ratio is unchanged and becomes the inner margin: on that runner the cap is 53.78 GiB and
the server's ceiling 40.33 instead of 46.33 GiB. Lowering that ratio on the stateless jobs was
tried and reverted the same day (#110293, #110572) for flooding master with
`MEMORY_LIMIT_EXCEEDED`, by a different mechanism (below).

Validated with this job's exact flags including `--privileged`: the cap binds and ClickHouse
reports the container size. All 10 fuzzer job digests change; 164 others do not.

Known and unchanged: a cap trip that kills `clickhouse-client` instead of the server is still
reported `OK` with no artifacts; the 10.81 GiB overshoot is one sample; the stress and libFuzzer
jobs have their own uncapped containers, untouched here.

<details>
<summary>Memory envelope before and after, on a 61.78 GiB <code>*-medium</code> runner</summary>

| | before | after |
|---|---|---|
| container | unbounded | 53.78 GiB, kernel-enforced |
| server ceiling (0.75 ratio, unchanged) | 46.33 GiB | 40.33 GiB |
| room for what the server does not track (client, two `gdb`, shell) | 15.45 GiB | 13.45 GiB |
| left outside the container, shared by the agent, dockerd and the kernel | whatever is spare: 4.6 GiB when the agent lost communication | 8.00 GiB, kernel-enforced |

The overshoot on #116666 was 10.81 GiB, so a run of that shape keeps ~2.6 GiB of container slack. A
larger overshoot becomes an in-container OOM kill, which the job reports, instead of a lost runner,
which it cannot.

Fuzzed queries therefore meet `MEMORY_LIMIT_EXCEEDED` sooner. Three existing paths already absorb
that: the client clears a server-side 241 and keeps fuzzing (`FuzzLoop.cpp`), the post-fuzz liveness
probe treats 241 as alive-and-busy (`run-fuzzer.sh`), and a terminal server-survived 241 is reported
`OK` (`ast_fuzzer_job.py`). The reverted stateless change is not the same mechanism: the comment at
`ci/jobs/functional_tests.py:909-927` describes that flood as the *aggregate* RSS of dozens of
concurrent `clickhouse-client` processes, whereas the fuzzer drives one client at a time
(`run-fuzzer.sh:274`) under a `max_memory_usage` of 10G from its own profile.

The server sees the cap because these runners are cgroups v1 and the reader is scoped to the
container, not to the controller root: a retained fuzzer server log on the same runner class
(#111394) shows `Will create cgroup reader from '/sys/fs/cgroup/memory' (cgroups version: v1)` and
then `resident: 156.19 MiB` from that same reader at server startup, which the controller root could
not report while the runner agent alone holds ~2.4 GiB. `--memory` is enforced by the kernel either
way, so the 8 GiB reserve does not depend on this.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116782&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116782](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116782+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116782&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116782](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116782+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.610` (included in `26.9` and later)
<!-- ch-version-info:end -->