### PR TITLE
Verify a Parquet data page's row count against the offset index for array columns

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Decoding.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Decoding.cpp
@@ -86,6 +86,13 @@ struct BitPackedRLEDecoder : public PageDecoder
         out.resize(start + num_values);
         skipOrDecode<false>(num_values, &out[start]);
     }
+    /// Same, but adds the number of zero values to num_zeros.
+    void decodeArrayCountingZeros(size_t num_values, PaddedPODArray<T> & out, size_t & num_zeros)
+    {
+        size_t start = out.size();
+        out.resize(start + num_values);
+        skipOrDecode<false, /*count_zeros=*/ true>(num_values, &out[start], &num_zeros);
+    }
 
     void startRun()
     {
@@ -120,16 +127,21 @@ struct BitPackedRLEDecoder : public PageDecoder
         }
     }
 
-    template <bool skip>
-    void skipOrDecode(size_t num_values, T * out)
+    template <bool skip, bool count_zeros = false>
+    void skipOrDecode(size_t num_values, T * out, size_t * num_zeros = nullptr)
     {
         if (bit_width == 0)
         {
             /// bit_width == 0 means all values are 0.
             if constexpr (!skip)
                 memset(out, 0, num_values * sizeof(T));
+            if constexpr (count_zeros)
+                *num_zeros += num_values;
             return;
         }
+        /// Accumulate in a local: a store through num_zeros may alias `out`, which would cost a
+        /// load and a store per value in the bit-packed loop below.
+        [[maybe_unused]] size_t zeros_acc = 0;
 
         const T value_mask = T((1ul << bit_width) - 1);
         /// TODO [parquet]: May make sense to have specialized version of this loop for bit_width=1,
@@ -155,6 +167,11 @@ struct BitPackedRLEDecoder : public PageDecoder
                     std::fill(out, out + n, v);
                     out += n;
                 }
+                if constexpr (count_zeros)
+                {
+                    if (val == 0)
+                        zeros_acc += n;
+                }
             }
             else
             {
@@ -171,6 +188,8 @@ struct BitPackedRLEDecoder : public PageDecoder
                         *out = static_cast<T>(x);
                         ++out;
                         bit_idx += bit_width;
+                        if constexpr (count_zeros)
+                            zeros_acc += x == 0;
                     }
                 }
                 else
@@ -182,6 +201,8 @@ struct BitPackedRLEDecoder : public PageDecoder
                     data += run_bytes;
             }
         }
+        if constexpr (count_zeros)
+            *num_zeros += zeros_acc;
     }
 };
 
@@ -1133,15 +1154,26 @@ std::unique_ptr<PageDecoder> PageDecoderInfo::makeDecoder(
     throw Exception(ErrorCodes::INCORRECT_DATA, "Unexpected encoding {} for type {}", thriftToString(encoding), thriftToString(physical_type));
 }
 
-void decodeRepOrDefLevels(parq::Encoding::type encoding, UInt8 max, size_t num_values, std::span<const char> data, PaddedPODArray<UInt8> & out)
+void decodeRepOrDefLevels(parq::Encoding::type encoding, UInt8 max, size_t num_values, std::span<const char> data, PaddedPODArray<UInt8> & out, size_t * out_num_zeros)
 {
     if (max == 0)
+    {
+        /// All levels are implicitly 0, and `out` is left empty.
+        if (out_num_zeros)
+            *out_num_zeros += num_values;
         return;
+    }
     switch (encoding)
     {
         case parq::Encoding::RLE:
-            BitPackedRLEDecoder<UInt8>(data, size_t(max) + 1, /*has_header_byte=*/ false).decodeArray(num_values, out);
+        {
+            BitPackedRLEDecoder<UInt8> decoder(data, size_t(max) + 1, /*has_header_byte=*/ false);
+            if (out_num_zeros)
+                decoder.decodeArrayCountingZeros(num_values, out, *out_num_zeros);
+            else
+                decoder.decodeArray(num_values, out);
             break;
+        }
         case parq::Encoding::BIT_PACKED:
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "BIT_PACKED levels not implemented");
         default: throw Exception(ErrorCodes::INCORRECT_DATA, "Unexpected repetition/definition levels encoding: {}", thriftToString(encoding));

--- a/src/Processors/Formats/Impl/Parquet/Decoding.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Decoding.cpp
@@ -130,6 +130,10 @@ struct BitPackedRLEDecoder : public PageDecoder
     template <bool skip, bool count_zeros = false>
     void skipOrDecode(size_t num_values, T * out, size_t * num_zeros = nullptr)
     {
+        /// The skip path below advances `bit_idx` past a bit-packed run without looking at the
+        /// values, so it can't count zeros. Counting requires decoding.
+        static_assert(!(skip && count_zeros));
+
         if (bit_width == 0)
         {
             /// bit_width == 0 means all values are 0.

--- a/src/Processors/Formats/Impl/Parquet/Decoding.h
+++ b/src/Processors/Formats/Impl/Parquet/Decoding.h
@@ -414,7 +414,9 @@ struct GeoConverter : public StringConverter
 };
 
 
-void decodeRepOrDefLevels(parq::Encoding::type encoding, UInt8 max, size_t num_values, std::span<const char> data, PaddedPODArray<UInt8> & out);
+/// If out_num_zeros is not null, the number of zero levels is added to it, counted as part of the
+/// decoding.
+void decodeRepOrDefLevels(parq::Encoding::type encoding, UInt8 max, size_t num_values, std::span<const char> data, PaddedPODArray<UInt8> & out, size_t * out_num_zeros = nullptr);
 
 std::unique_ptr<PageDecoder> makeDictionaryIndicesDecoder(parq::Encoding::type encoding, size_t dictionary_size, std::span<const char> data);
 

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -28,7 +28,6 @@
 #include <Storages/MergeTree/MergeTreeRangeReader.h>
 #include <Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.h>
 
-#include <algorithm>
 #include <mutex>
 #include <lz4.h>
 #include <arrow/util/crc32.h>
@@ -2866,17 +2865,16 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
     UInt8 max_def = column_info.levels.back().def;
     UInt8 max_rep = column_info.levels.back().rep;
 
-    decodeRepOrDefLevels(rep_encoding, max_rep, page.num_values, std::span(encoded_rep, encoded_rep_size), page.rep);
-
     /// A repeated column's V1 data page header has no row count, so the check above had nothing to
     /// compare. When an offset index is present, pages begin on row boundaries, so the page's row
     /// count is its number of zero repetition levels.
-    if (max_rep > 0 && !num_rows_in_page.has_value() && end_row_idx.has_value())
-    {
-        size_t rows_in_page = size_t(std::count(page.rep.begin(), page.rep.end(), 0));
-        if (rows_in_page != *end_row_idx - next_row_idx)
-            throw Exception(ErrorCodes::INCORRECT_DATA, "Number of rows in page doesn't match offset index: {} != {}", rows_in_page, *end_row_idx - next_row_idx);
-    }
+    const bool check_row_count = max_rep > 0 && !num_rows_in_page.has_value() && end_row_idx.has_value();
+    size_t rows_in_page = 0;
+
+    decodeRepOrDefLevels(rep_encoding, max_rep, page.num_values, std::span(encoded_rep, encoded_rep_size), page.rep, check_row_count ? &rows_in_page : nullptr);
+
+    if (check_row_count && rows_in_page != *end_row_idx - next_row_idx)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Number of rows in page doesn't match offset index: {} != {}", rows_in_page, *end_row_idx - next_row_idx);
 
     /// Don't decode def levels in the common case of non-array column that's declared nullable but
     /// contains no nulls.

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -28,6 +28,7 @@
 #include <Storages/MergeTree/MergeTreeRangeReader.h>
 #include <Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.h>
 
+#include <algorithm>
 #include <mutex>
 #include <lz4.h>
 #include <arrow/util/crc32.h>
@@ -2866,6 +2867,16 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
     UInt8 max_rep = column_info.levels.back().rep;
 
     decodeRepOrDefLevels(rep_encoding, max_rep, page.num_values, std::span(encoded_rep, encoded_rep_size), page.rep);
+
+    /// A repeated column's V1 data page header has no row count, so the check above had nothing to
+    /// compare. When an offset index is present, pages begin on row boundaries, so the page's row
+    /// count is its number of zero repetition levels.
+    if (max_rep > 0 && !num_rows_in_page.has_value() && end_row_idx.has_value())
+    {
+        size_t rows_in_page = size_t(std::count(page.rep.begin(), page.rep.end(), 0));
+        if (rows_in_page != *end_row_idx - next_row_idx)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Number of rows in page doesn't match offset index: {} != {}", rows_in_page, *end_row_idx - next_row_idx);
+    }
 
     /// Don't decode def levels in the common case of non-array column that's declared nullable but
     /// contains no nulls.

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -29,6 +29,7 @@
 #include <Storages/MergeTree/MergeTreeSplitPrewhereIntoReadSteps.h>
 
 #include <mutex>
+#include <fmt/ranges.h>
 #include <lz4.h>
 #include <arrow/util/crc32.h>
 
@@ -2865,16 +2866,27 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
     UInt8 max_def = column_info.levels.back().def;
     UInt8 max_rep = column_info.levels.back().rep;
 
+    /// Invariant, from `PageLocation.first_row_index` in `parquet.thrift`: when an OffsetIndex is
+    /// present, every page begins on a row boundary (repetition level 0). So a page's row count is
+    /// its number of zero repetition levels, and it must equal the span the offset index declares
+    /// for that page.
+    ///
     /// A repeated column's V1 data page header has no row count, so the check above had nothing to
-    /// compare. When an offset index is present, pages begin on row boundaries, so the page's row
-    /// count is its number of zero repetition levels.
+    /// compare and the declared span seeded the row cursor unchecked. Count the zero repetition
+    /// levels as part of the decode - the same quantity the writer counts in `flush_page` in
+    /// `Write.cpp` - and require equality.
     const bool check_row_count = max_rep > 0 && !num_rows_in_page.has_value() && end_row_idx.has_value();
     size_t rows_in_page = 0;
 
     decodeRepOrDefLevels(rep_encoding, max_rep, page.num_values, std::span(encoded_rep, encoded_rep_size), page.rep, check_row_count ? &rows_in_page : nullptr);
 
     if (check_row_count && rows_in_page != *end_row_idx - next_row_idx)
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Number of rows in page doesn't match offset index: {} != {}", rows_in_page, *end_row_idx - next_row_idx);
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Number of rows in page of column {} doesn't match offset index: page has {} rows, "
+            "offset index declares rows [{}, {}). For a query without filters, use "
+            "input_format_parquet_use_offset_index=0 to read the file without the offset index",
+            fmt::join(column.meta->meta_data.path_in_schema, "."), rows_in_page, next_row_idx, *end_row_idx);
 
     /// Don't decode def levels in the common case of non-array column that's declared nullable but
     /// contains no nulls.
@@ -3081,6 +3093,9 @@ void Reader::readRowsInPage(size_t end_row_idx, ColumnSubchunk & subchunk, Colum
     /// readRowsInPage in page 0 will reach end of page, with next_row_idx == end_row_idx. Then
     /// readRowsInPage in page 1 will continue until it sees the end of the array, i.e. the start of
     /// the next row (rep == 0), still with next_row_idx == end_row_idx.
+    /// Note that a row can only straddle a page boundary like this on the sequential path. When an
+    /// offset index is present, pages must begin on row boundaries, and `initializeDataPage` rejects
+    /// a page whose repetition levels say otherwise.
     chassert(end_row_idx >= page.next_row_idx);
 
     size_t first_row_idx = page.next_row_idx;

--- a/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.reference
+++ b/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.reference
@@ -6,3 +6,6 @@ Code: 117
 Invalid offset index: first page starts at row
 Code: 117
 Page doesn't contain requested row
+ok
+Code: 117
+Number of rows in page doesn't match offset index

--- a/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.reference
+++ b/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.reference
@@ -8,4 +8,4 @@ Code: 117
 Page doesn't contain requested row
 ok
 Code: 117
-Number of rows in page doesn't match offset index
+doesn't match offset index: page has

--- a/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.sh
+++ b/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.sh
@@ -181,6 +181,6 @@ echo "${BAD_TYPE_ERR}" | grep -oF "Page doesn't contain requested row" | head -n
 ${CLICKHOUSE_LOCAL} -q "SELECT if(a[1] = id AND a[2] = id * 10, 'ok', 'wrong') FROM file('${GOOD_INTERIOR}', Parquet) WHERE id = ${MOVED_ROW}"
 BAD_INTERIOR_ERR=$(${CLICKHOUSE_LOCAL} -q "SELECT id, a FROM file('${BAD_INTERIOR}', Parquet) WHERE id = ${MOVED_ROW}" 2>&1)
 echo "${BAD_INTERIOR_ERR}" | grep -oF "Code: 117" | head -n 1
-echo "${BAD_INTERIOR_ERR}" | grep -oF "Number of rows in page doesn't match offset index" | head -n 1
+echo "${BAD_INTERIOR_ERR}" | grep -oF "doesn't match offset index: page has" | head -n 1
 
 rm -f "${GOOD_FLAT}" "${BAD_FLAT}" "${GOOD_ARR}" "${BAD_ARR}" "${BAD_TYPE}" "${GOOD_INTERIOR}" "${BAD_INTERIOR}"

--- a/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.sh
+++ b/tests/queries/0_stateless/04878_parquet_offset_index_first_row_anchor.sh
@@ -11,6 +11,8 @@ BAD_FLAT="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_bad_flat.parquet"
 GOOD_ARR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_good_arr.parquet"
 BAD_ARR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_bad_arr.parquet"
 BAD_TYPE="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_bad_type.parquet"
+GOOD_INTERIOR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_good_interior.parquet"
+BAD_INTERIOR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}_bad_interior.parquet"
 
 ${CLICKHOUSE_LOCAL} -q "
     INSERT INTO FUNCTION file('${GOOD_FLAT}', Parquet, 'id Int64, s String, p Int32')
@@ -22,15 +24,26 @@ ${CLICKHOUSE_LOCAL} -q "
     SELECT number, [number, number * 10] FROM numbers(20)
     SETTINGS engine_file_truncate_on_insert = 1, output_format_parquet_write_page_index = 1"
 
+# The fixtures above have one page per column chunk. Small pages and small write batches give the
+# array column several pages, which is what an interior page location needs.
+${CLICKHOUSE_LOCAL} -q "
+    INSERT INTO FUNCTION file('${GOOD_INTERIOR}', Parquet, 'id Int64, a Array(Int64)')
+    SELECT number, [number, number * 10] FROM numbers(400)
+    SETTINGS engine_file_truncate_on_insert = 1, output_format_parquet_write_page_index = 1,
+             output_format_parquet_data_page_size = 1024, output_format_parquet_batch_size = 64"
+
 # Corrupt one field of the offset index. Locations are found by structure, not by a fixed byte
 # offset, because the byte layout depends on the writer. Thrift compact encoding of a
 # PageLocation whose first_row_index is 0 is 0x16 <offset> 0x15 <size> 0x16 0x00 0x00, so each
 # match also carries the byte offset of the page it describes.
 #
-#   anchor: set the last column chunk's first PageLocation.first_row_index to a nonzero row.
-#   type:   leave every first_row_index at 0 and turn the first listed page into an INDEX_PAGE,
-#           which the reader skips, so the page picked from the offset index for a requested row
-#           turns out not to hold it.
+#   anchor:   set the last column chunk's first PageLocation.first_row_index to a nonzero row.
+#   type:     leave every first_row_index at 0 and turn the first listed page into an INDEX_PAGE,
+#             which the reader skips, so the page picked from the offset index for a requested row
+#             turns out not to hold it.
+#   interior: move an interior page's first_row_index forward, keeping the sequence strictly
+#             increasing and in range so every check on the offset index alone still passes. Prints
+#             the row it moved to.
 patch_offset_index() {
     python3 - "$1" "$2" "$3" <<'PY'
 import struct, sys
@@ -65,12 +78,69 @@ for i in range(footer_start):
         continue
     k = j + 1 + varint_len(j + 1)
     if k + 2 < footer_start and d[k] == 0x16 and d[k + 1] == 0x00 and d[k + 2] == 0x00:
-        locations.append((k + 1, read_zigzag(i + 1)))
+        locations.append((k + 1, read_zigzag(i + 1), i))
 
 assert locations, 'no offset index page location found'
 
+def write_zigzag(v):
+    assert v >= 0
+    u, out = v << 1, bytearray()
+    while True:
+        out.append((u & 0x7F) | (0x80 if u > 0x7F else 0))
+        u >>= 7
+        if not u:
+            return bytes(out)
+
+def walk_locations(start):
+    # A PageLocation list is written element after element, each of them
+    # 0x16 <offset> 0x15 <compressed_page_size> 0x16 <first_row_index> 0x00, so the whole list can
+    # be recovered from the first element. Returns [(offset, first_row_index_pos, first_row_index)].
+    out = []
+    i = start
+    while i < footer_start and d[i] == 0x16:
+        off_pos = i + 1
+        j = off_pos + varint_len(off_pos)
+        if j >= footer_start or d[j] != 0x15:
+            break
+        size_pos = j + 1
+        k = size_pos + varint_len(size_pos)
+        if k >= footer_start or d[k] != 0x16:
+            break
+        row_pos = k + 1
+        e = row_pos + varint_len(row_pos)
+        if e >= footer_start or d[e] != 0x00:
+            break
+        out.append((read_zigzag(off_pos), row_pos, read_zigzag(row_pos)))
+        i = e + 1
+    return out
+
 if mode == 'anchor':
     d[locations[-1][0]] = 0x08  # zigzag(4)
+elif mode == 'interior':
+    # Keep only lists that describe a real multi-page data column: at least three pages, strictly
+    # increasing first rows, and a DATA_PAGE header (0x15 0x00) where the first page starts. The
+    # byte scan above can also match inside page data, and the flat column has too few pages.
+    best = None
+    for _, _, start in locations:
+        locs = walk_locations(start)
+        rows = [r for _, _, r in locs]
+        if len(locs) < 3 or rows != sorted(set(rows)):
+            continue
+        off0 = locs[0][0]
+        if off0 + 1 < footer_start and d[off0] == 0x15 and d[off0 + 1] == 0x00:
+            best = locs
+    assert best, 'no column chunk with at least three data pages found'
+    # Move page 1 as far forward as its neighbour allows, so the span it declares no longer matches
+    # the page's real row count. The new value must encode in as many bytes as the old one,
+    # otherwise every later byte offset in the file shifts.
+    old, nxt, row_pos = best[1][2], best[2][2], best[1][1]
+    width = len(write_zigzag(old))
+    new = min(nxt - 1, ((1 << (7 * width)) - 1) >> 1)
+    assert old < new, 'no room to move page 1 (%d -> %d)' % (old, new)
+    enc = write_zigzag(new)
+    assert len(enc) == width, 'encoded width changed (%d -> %d)' % (width, len(enc))
+    d[row_pos:row_pos + width] = enc
+    print(new)
 else:
     page = locations[0][1]
     # Field 1 of PageHeader is the page type, an i32: 0x15 0x00 is zigzag(0) = DATA_PAGE.
@@ -84,6 +154,7 @@ PY
 patch_offset_index "${GOOD_FLAT}" "${BAD_FLAT}" anchor
 patch_offset_index "${GOOD_ARR}" "${BAD_ARR}" anchor
 patch_offset_index "${GOOD_FLAT}" "${BAD_TYPE}" type
+MOVED_ROW=$(patch_offset_index "${GOOD_INTERIOR}" "${BAD_INTERIOR}" interior)
 
 # Valid files still read correctly: the new check must not reject conforming offset indexes.
 ${CLICKHOUSE_LOCAL} -q "SELECT count(), sum(id) FROM file('${GOOD_FLAT}', Parquet)"
@@ -104,4 +175,12 @@ BAD_TYPE_ERR=$(${CLICKHOUSE_LOCAL} -q "SELECT * FROM file('${BAD_TYPE}', Parquet
 echo "${BAD_TYPE_ERR}" | grep -oF "Code: 117" | head -n 1
 echo "${BAD_TYPE_ERR}" | grep -oF "Page doesn't contain requested row" | head -n 1
 
-rm -f "${GOOD_FLAT}" "${BAD_FLAT}" "${GOOD_ARR}" "${BAD_ARR}" "${BAD_TYPE}"
+# An interior page location that disagrees with the page's real row count is rejected. Array
+# columns need their own check: their pages carry no row count in the header, so before the fix
+# the read silently returned another page's values under the requested row numbers.
+${CLICKHOUSE_LOCAL} -q "SELECT if(a[1] = id AND a[2] = id * 10, 'ok', 'wrong') FROM file('${GOOD_INTERIOR}', Parquet) WHERE id = ${MOVED_ROW}"
+BAD_INTERIOR_ERR=$(${CLICKHOUSE_LOCAL} -q "SELECT id, a FROM file('${BAD_INTERIOR}', Parquet) WHERE id = ${MOVED_ROW}" 2>&1)
+echo "${BAD_INTERIOR_ERR}" | grep -oF "Code: 117" | head -n 1
+echo "${BAD_INTERIOR_ERR}" | grep -oF "Number of rows in page doesn't match offset index" | head -n 1
+
+rm -f "${GOOD_FLAT}" "${BAD_FLAT}" "${GOOD_ARR}" "${BAD_ARR}" "${BAD_TYPE}" "${GOOD_INTERIOR}" "${BAD_INTERIOR}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/114464
Related: https://github.com/ClickHouse/ClickHouse/pull/114530


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed silently wrong results when reading a Parquet file whose offset index disagrees with the page data on an array, map or nested column. Such a page is now rejected with `INCORRECT_DATA` instead of returning another page's values under the requested row numbers.


### Description

@ PedroTadim asked about the other `location` elements in
[#114530 (comment)](https://github.com/ClickHouse/ClickHouse/pull/114530#discussion_r3769662143).

**What breaks.** #114530 anchored only the first page location. A shifted *interior* one still passes
every check and the array read returns wrong rows silently (rc = 0). On `a Array(Int64)`,
400 rows with writer defaults, pages `[0, 132, 242, 352]`: moving page 1 to 133 flips one footer
byte and returns row 132's array for row 133; at 200, `WHERE id = 200` returns `[132,1320,13200]`
instead of `[200,2000,20000]`.

**Root cause.** `initializeDataPage` compares the declared span with the page's row count only when
the header carries one. V1 supplies `num_values`, a row count only for non-repeated columns, and
ClickHouse always writes V1, so the span seeds the row cursor unchecked.

**Change.** Count zero repetition levels during the decode, the quantity the writer counted in
`Write.cpp:996-1000`, and require equality with the span. Exact, not tolerant: the spec
and both writers require row-boundary pages when an OffsetIndex is present. Gated on
`max_rep > 0` and on the offset index being in use, so flat columns, the sequential path and V2 are
untouched; no setting or format change.

**Compatibility.** Such a file already returns wrong rows, so rejecting it beats reading it;
the flat-column check beside it has no opt-out either.

**Validation.** `04878` gains an interior arm, proven live by two mutants; 50 randomized runs pass.
Counting inside the decode rather than in a second pass is what keeps it free: +6.8% -> +0.0% on a
selective scan of 1000-element arrays, 48 runs each.

**Not addressed.** `applyColumnIndex` prunes pages before any is decoded, so a shift whose adjacent
pages are both pruned escapes it; validating every page up front would defeat page skipping, as for
the merged anchor guard. A V2 header's row count is likewise unchecked, unreachable from this writer.

<details>
<summary>Why the equality is exact, and the measurement over all 243 in-tree Parquet fixtures</summary>

`parquet.thrift` on `PageLocation.first_row_index`: "When an OffsetIndex is present, pages must begin
on row boundaries (repetition_level = 0)." ClickHouse enforces that whenever it writes the index
(`Write.cpp:925-931`, and with the index off it writes no offset index at all), and arrow does the
same (`column_writer.cc:1324-1326`). This reader already states the invariant and already relies on it
for page-loop termination, so a tolerance would only let a genuine one-row shift through.

Every `*.parquet` file under `tests/` read with `SELECT * ... FORMAT Null`, one outcome token per
file, before and after: **identical on all 243** (183 read, the rest fail for pre-existing unrelated
reasons on both binaries), and the new message appears zero times.

Because that alone would not show the check ever runs, arming was measured rather than inferred.
Predicting from the footer which chunks have an offset index *and* a `REPEATED` ancestor gives 18
files. Sweeping the same 243 with a mutant that fails the equality on any conforming armed file flips
exactly those 18, with an empty set difference in both directions. So the check demonstrably executes
on those 18 and on none of the other 225, and with the real repetition-level count the equality holds
on all 18. They are all foreign-writer files: paimon, an iceberg `field_ids_complex_test` file, and
four `data_parquet/*` files.

Limit worth stating plainly: none of the 18 has more than one page, so no in-tree fixture carries an
interior page location at all. The corpus shows the equality holds on real third-party single-page
chunks; it cannot exercise the interior case, which is why the regression test synthesizes one.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116788&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116788](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116788+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



