### PR TITLE
Fix(S3): Non-strict S3 upload failure handling

### DIFF
--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -163,15 +163,18 @@ class S3:
             )
             if not no_strict:
                 raise
+            return False
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "")
             print(f"ERROR: Failed to upload to S3 using boto3: {error_code}")
             if not no_strict:
                 raise
+            return False
         except Exception as e:
             print(f"ERROR: Failed to upload to S3 using boto3: {e}")
             if not no_strict:
                 raise
+            return False
 
         # Common cleanup and return for both paths
         try:

--- a/ci/tests/test_s3_upload.py
+++ b/ci/tests/test_s3_upload.py
@@ -1,0 +1,41 @@
+"""Tests for Praktika's non-versioned S3 upload behavior."""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+pytest.importorskip("boto3")
+from botocore.exceptions import ClientError
+
+from ci.praktika.s3 import S3
+from ci.praktika.usage import StorageUsage
+
+
+class _FailingS3Client:
+    def upload_file(self, *_args, **_kwargs):
+        raise ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            "UploadFile",
+        )
+
+
+def test_no_strict_upload_failure_returns_false_without_recording_usage(
+    tmp_path, monkeypatch
+):
+    local_file = tmp_path / "artifact.txt"
+    local_file.write_text("payload")
+    add_uploaded = Mock()
+
+    monkeypatch.setattr(S3, "_boto3_client", _FailingS3Client())
+    monkeypatch.setattr(StorageUsage, "add_uploaded", add_uploaded)
+
+    result = S3.copy_file_to_s3(
+        s3_path="bucket/key", local_path=str(local_file), no_strict=True
+    )
+
+    assert result is False
+    add_uploaded.assert_not_called()


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog (CI-only change, no changelog entry required).

### Description

`GitCommit.push_to_s3()` calls `S3.copy_file_to_s3(..., no_strict=True)` and checks the return value. When the boto3 upload fails, `copy_file_to_s3()` catches the error but still returns a URL. It also adds the file size to `StorageUsage`.

This makes a failed upload look successful to the caller.

Return `False` after a swallowed upload error. Failed uploads are no longer counted.

### Tests

- Added a regression test for a failed boto3 upload.
- Checked that the return value is `False`.
- Checked that `StorageUsage.add_uploaded()` is not called.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116792&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116792](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116792+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->