### PR TITLE
Fix a data race on the cached storage ID in BackgroundJobsAssignee

### DIFF
--- a/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
@@ -115,6 +115,9 @@ String BackgroundJobsAssignee::toString(Type type)
 
 void BackgroundJobsAssignee::start()
 {
+    /// Read the cached id before taking holder_mutex so that the two locks are never nested.
+    const auto current_storage_id = getStorageID();
+
     std::lock_guard lock(holder_mutex);
     if (!holder)
     {
@@ -122,10 +125,10 @@ void BackgroundJobsAssignee::start()
         {
         case Type::DataProcessing:
         case Type::Moving:
-            holder = getContext()->getSchedulePool()->createTask(storage_id, "BackgroundJobsAssignee:" + toString(type), [this]{ threadFunc(); });
+            holder = getContext()->getSchedulePool()->createTask(current_storage_id, "BackgroundJobsAssignee:" + toString(type), [this]{ threadFunc(); });
             break;
         case Type::Streaming:
-            holder = getContext()->getStreamingSchedulePool()->createTask(storage_id, "BackgroundJobsAssignee:" + toString(type), [this]{ threadFunc(); });
+            holder = getContext()->getStreamingSchedulePool()->createTask(current_storage_id, "BackgroundJobsAssignee:" + toString(type), [this]{ threadFunc(); });
             break;
         }
     }
@@ -135,7 +138,14 @@ void BackgroundJobsAssignee::start()
 
 void BackgroundJobsAssignee::updateStorageID(const StorageID & new_id)
 {
+    std::lock_guard lock(storage_id_mutex);
     storage_id = new_id;
+}
+
+StorageID BackgroundJobsAssignee::getStorageID() const
+{
+    std::lock_guard lock(storage_id_mutex);
+    return storage_id;
 }
 
 void BackgroundJobsAssignee::finish()
@@ -154,10 +164,11 @@ void BackgroundJobsAssignee::finish()
     {
         local_holder->deactivate();
 
-        getContext()->getMovesExecutor()->removeTasksCorrespondingToStorage(storage_id);
-        getContext()->getFetchesExecutor()->removeTasksCorrespondingToStorage(storage_id);
-        getContext()->getMergeMutateExecutor()->removeTasksCorrespondingToStorage(storage_id);
-        getContext()->getCommonExecutor()->removeTasksCorrespondingToStorage(storage_id);
+        const auto current_storage_id = getStorageID();
+        getContext()->getMovesExecutor()->removeTasksCorrespondingToStorage(current_storage_id);
+        getContext()->getFetchesExecutor()->removeTasksCorrespondingToStorage(current_storage_id);
+        getContext()->getMergeMutateExecutor()->removeTasksCorrespondingToStorage(current_storage_id);
+        getContext()->getCommonExecutor()->removeTasksCorrespondingToStorage(current_storage_id);
     }
 }
 

--- a/src/Storages/MergeTree/BackgroundJobsAssignee.h
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.h
@@ -85,7 +85,8 @@ public:
 
 private:
     IBackgroundOperation & data;
-    StorageID storage_id;
+    StorageID storage_id TSA_GUARDED_BY(storage_id_mutex);
+    mutable std::mutex storage_id_mutex;
 
     /// Useful for random backoff timeouts generation
     pcg64 rng;
@@ -108,5 +109,7 @@ private:
     void threadFunc();
 
     BackgroundTaskSchedulingSettings getSettings() const;
+
+    StorageID getStorageID() const;
 };
 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Description

`MergeTreeData::renameInMemory` caches the table's `StorageID` in three background job
assignees. `IStorage::renameInMemory` assigns its own copy under `id_mutex`;
`BackgroundJobsAssignee::updateStorageID` took no lock, while `finish()` read that field from
the `DropTables` pool and `start()` from the schedule pool. `StorageID` holds two
`std::string` members, so the unsynchronized assignment copies a string buffer while another thread reads it.

ThreadSanitizer reported that pair twice, 37 days apart, on two unrelated pull requests and
two architectures (STID 2169-405a): the write at
`BackgroundJobsAssignee.cpp:138:16` under a `CREATE OR REPLACE` rename, the read at `:160:78` in `finish()` under a concurrent `DROP DATABASE`.

- `Stress test (arm_tsan)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113833&sha=7945a1b32b8243c22d67e7f18a71d70f167a9b3e&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29
- `Stress test (amd_tsan)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110730&sha=ab4b1c8be5d993ea5ace3eb919a13119b568e737&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29

`storage_id` is now `TSA_GUARDED_BY` a dedicated `storage_id_mutex`, read through a private
by-value `getStorageID()`. It is a strict leaf: each critical section is one `StorageID` copy
with no call inside, and `start()` copies before taking `holder_mutex`. I did not reuse `holder_mutex`: it is held across calls into the storage and the
schedule pool, and documents a deadlock across `deactivate()`. `finish()` also re-read
the member four times, so a rename mid-sequence could hand the four executors
different ids; it now takes one copy.

No test ships: a race seen twice in 90 days admits no deterministic assertion, and the guard
is the compiler: under `-Wthread-safety -Werror` an unguarded access to this field fails the
build, verified by deleting the `lock_guard`. I ran the rename, exchange, drop-database and create-or-replace stateless tests against a TSan build of this commit with the deadlock
detector on: no lock-order inversion. #99366 fixed the sibling
`holder` race in this class the same way, under this category.

Left alone, no sanitizer evidence: `MergeTreeData::relative_data_path`,
`StorageDictionary::dictionary_name`, `remove_repository_callback`, and executor cleanup
matching a task's schedule-time `StorageID`, which a rename makes stale only without a UUID
(deprecated `Ordinary` databases).

Related: #97242 (introduced the unguarded writer), #99366.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116808&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116808](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116808+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.247` (included in `26.10` and later)
<!-- ch-version-info:end -->