### PR TITLE
Put the actionable part of analyzer error messages first

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -448,14 +448,16 @@ QueryTreeNodePtr IdentifierResolver::tryResolveIdentifierFromCompoundExpression(
             compound_expression_from_error_message += compound_expression_source;
         }
 
+        /// The hint is the actionable part of the message, so it goes before the formatted query, which
+        /// can be many kilobytes long.
         throw Exception(ErrorCodes::UNKNOWN_IDENTIFIER,
-            "Identifier {} nested path {} cannot be resolved from type {}{}. In scope {}{}",
+            "Identifier {} nested path {} cannot be resolved from type {}{}{}. In scope {}",
             expression_identifier,
             nested_path,
             expression_type->getName(),
             compound_expression_from_error_message,
-            scope.scope_node->formatASTForErrorMessage(),
-            getHintsErrorMessageSuffix(hints));
+            getHintsErrorMessageSuffix(hints),
+            scope.scope_node->formatASTForErrorMessage());
     }
 
     return wrapExpressionNodeInSubcolumn(compound_expression, std::string(nested_path.getFullName()), scope.context);
@@ -730,9 +732,23 @@ IdentifierResolveResult IdentifierResolver::tryResolveIdentifierFromStorage(
 
     bool clone_is_needed = true;
 
+    /// `table_expression_name` is the alias when the table expression has one, so a query that lost a comma
+    /// in the FROM clause - `FROM date_dim AS dt, store_sales item` - reports that `item.i_brand` cannot be
+    /// resolved from "table with name item" while a table named `item` does exist. Name the table the alias
+    /// actually refers to, which is what makes the mistake visible.
     String table_expression_source = table_expression_data.table_expression_description;
     if (!table_expression_data.table_expression_name.empty())
+    {
         table_expression_source += " with name " + table_expression_data.table_expression_name;
+
+        const bool name_is_an_alias = !table_expression_data.table_name.empty()
+            && table_expression_data.table_expression_name != table_expression_data.table_name
+            && table_expression_data.table_expression_name
+                != table_expression_data.database_name + "." + table_expression_data.table_name;
+
+        if (name_is_an_alias)
+            table_expression_source += " (an alias of " + table_expression_data.table_name + ")";
+    }
 
     if (!result_expression)
     {
@@ -760,11 +776,11 @@ IdentifierResolveResult IdentifierResolver::tryResolveIdentifierFromStorage(
 
         auto hints = TypoCorrection::collectIdentifierTypoHints(identifier, valid_identifiers);
 
-        throw Exception(ErrorCodes::UNKNOWN_IDENTIFIER, "Identifier '{}' cannot be resolved from {}. In scope {}{}",
+        throw Exception(ErrorCodes::UNKNOWN_IDENTIFIER, "Identifier '{}' cannot be resolved from {}{}. In scope {}",
             identifier.getFullName(),
             table_expression_source,
-            scope.scope_node->formatASTForErrorMessage(),
-            getHintsErrorMessageSuffix(hints));
+            getHintsErrorMessageSuffix(hints),
+            scope.scope_node->formatASTForErrorMessage());
     }
 
     if (clone_is_needed)

--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -741,13 +741,20 @@ IdentifierResolveResult IdentifierResolver::tryResolveIdentifierFromStorage(
     {
         table_expression_source += " with name " + table_expression_data.table_expression_name;
 
-        const bool name_is_an_alias = !table_expression_data.table_name.empty()
-            && table_expression_data.table_expression_name != table_expression_data.table_name
+        /// A materialized CTE is a table node over a temporary table whose name is generated, so use the
+        /// name the user wrote instead of leaking `_materialized_cte_<name>_<rng>`.
+        String underlying_name = table_expression_data.table_name;
+        if (const auto * table_node = table_expression_node->as<TableNode>())
+            if (table_node->isMaterializedCTE())
+                underlying_name = table_node->getMaterializedCTE()->cte_name;
+
+        const bool name_is_an_alias = !underlying_name.empty()
+            && table_expression_data.table_expression_name != underlying_name
             && table_expression_data.table_expression_name
-                != table_expression_data.database_name + "." + table_expression_data.table_name;
+                != table_expression_data.database_name + "." + underlying_name;
 
         if (name_is_an_alias)
-            table_expression_source += " (an alias of " + table_expression_data.table_name + ")";
+            table_expression_source += " (an alias of " + underlying_name + ")";
     }
 
     if (!result_expression)

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3440,15 +3440,17 @@ ProjectionNames QueryAnalyzer::resolveExpressionNode(
                     }
                 }
 
-                /// Keep the original five-placeholder `message_format_string` for `text_log`
-                /// (see `03096_text_log_format_string_args_not_empty`) and attach the optional
-                /// `FROM`-clause hint via `addMessage` so the format string stays stable.
-                Exception exception(ErrorCodes::UNKNOWN_IDENTIFIER, "Unknown {}{} identifier {} in scope {}{}",
+                /// The typo hint goes before the formatted query, which can be many kilobytes long, so that
+                /// the actionable part of the message does not end up behind it. The optional `FROM`-clause
+                /// hint is still attached via `addMessage` to keep the number of placeholders in
+                /// `message_format_string` for `text_log` at five
+                /// (see `03096_text_log_format_string_args_not_empty`).
+                Exception exception(ErrorCodes::UNKNOWN_IDENTIFIER, "Unknown {}{} identifier {}{}. In scope {}",
                     toStringLowercase(IdentifierLookupContext::EXPRESSION),
                     message_clarification,
                     backQuote(unresolved_identifier.getFullName()),
-                    scope.scope_node->formatASTForErrorMessage(),
-                    getHintsErrorMessageSuffix(hints));
+                    getHintsErrorMessageSuffix(hints),
+                    scope.scope_node->formatASTForErrorMessage());
                 if (!from_clause_hint.empty())
                     exception.addMessage(from_clause_hint);
                 throw exception; /// NOLINT(hicpp-exception-baseclass,cert-err09-cpp,cert-err61-cpp,misc-throw-by-value-catch-by-reference)
@@ -4259,13 +4261,13 @@ void QueryAnalyzer::initializeQueryJoinTreeNode(QueryTreeNodePtr & join_tree_nod
                         = IdentifierResolver::tryGetTableNameHint(from_table_identifier.getIdentifier(), scope.context);
                     if (!hint_database_name.empty())
                         throw Exception(ErrorCodes::UNKNOWN_TABLE,
-                            "Unknown table expression identifier '{}' in scope {}. Maybe you meant {}.{}?",
+                            "Unknown table expression identifier '{}'. Maybe you meant {}.{}? In scope {}",
                             from_table_identifier.getIdentifier().getFullName(),
-                            scope.scope_node->formatASTForErrorMessage(),
                             backQuoteIfNeed(hint_database_name),
-                            backQuoteIfNeed(hint_table_name));
+                            backQuoteIfNeed(hint_table_name),
+                            scope.scope_node->formatASTForErrorMessage());
                     throw Exception(ErrorCodes::UNKNOWN_TABLE,
-                        "Unknown table expression identifier '{}' in scope {}",
+                        "Unknown table expression identifier '{}'. In scope {}",
                         from_table_identifier.getIdentifier().getFullName(),
                         scope.scope_node->formatASTForErrorMessage());
                 }

--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -2686,9 +2686,10 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
     {
         if (!AggregateFunctionFactory::instance().isAggregateFunctionName(function_name))
         {
-            throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION, "Aggregate function with name '{}' does not exist. In scope {}{}",
-                            function_name, scope.scope_node->formatASTForErrorMessage(),
-                            getHintsErrorMessageSuffix(AggregateFunctionFactory::instance().getHints(function_name)));
+            throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION, "Aggregate function with name '{}' does not exist{}. In scope {}",
+                            function_name,
+                            getHintsErrorMessageSuffix(AggregateFunctionFactory::instance().getHints(function_name)),
+                            scope.scope_node->formatASTForErrorMessage());
         }
 
         if (!function_lambda_arguments_indexes.empty())
@@ -2814,10 +2815,10 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
             auto hints = NamePrompter<2>::getHints(function_name, possible_function_names);
 
             throw Exception(ErrorCodes::UNKNOWN_FUNCTION,
-                "Function with name {} does not exist. In scope {}{}",
+                "Function with name {} does not exist{}. In scope {}",
                 backQuote(function_name),
-                scope.scope_node->formatASTForErrorMessage(),
-                getHintsErrorMessageSuffix(hints));
+                getHintsErrorMessageSuffix(hints),
+                scope.scope_node->formatASTForErrorMessage());
         }
 
         if (!function_lambda_arguments_indexes.empty())

--- a/tests/integration/test_storage_azure_blob_storage/test.py
+++ b/tests/integration/test_storage_azure_blob_storage/test.py
@@ -1810,7 +1810,7 @@ def test_hive_partitioning_without_setting(cluster):
         f"blob_path='{path}', format='CSVWithNames', structure='{table_format}');"
     )
     pattern = re.compile(
-        r"DB::Exception: Unknown expression identifier `.*` in scope.*", re.DOTALL
+        r"DB::Exception: Unknown expression identifier .*In scope.*", re.DOTALL
     )
 
     with pytest.raises(Exception, match=pattern):

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -1430,7 +1430,7 @@ def test_hive_partitioning_without_setting(started_cluster):
         == "Elizabeth\tGordon\n"
     )
     pattern = re.compile(
-        r"DB::Exception: Unknown expression identifier `.*` in scope.*", re.DOTALL
+        r"DB::Exception: Unknown expression identifier .*In scope.*", re.DOTALL
     )
 
     with pytest.raises(QueryRuntimeException, match=pattern):

--- a/tests/queries/0_stateless/03096_text_log_format_string_args_not_empty.sh
+++ b/tests/queries/0_stateless/03096_text_log_format_string_args_not_empty.sh
@@ -15,7 +15,7 @@ SET max_rows_to_read = 0; -- system.text_log can be really big
 SET max_threads = 0; -- override random settings, scanning text_log with 1 thread under TSan is too slow
 
 
-select count() > 0 from system.text_log where event_date >= yesterday() and level = 'Error' and message_format_string = 'Unknown {}{} identifier {} in scope {}{}' and value1 = 'expression' and value3 = '\`unknown_identifier\`' and value4 = 'SELECT unknown_identifier' and query_id = '${query_id}_1';
+select count() > 0 from system.text_log where event_date >= yesterday() and level = 'Error' and message_format_string = 'Unknown {}{} identifier {}{}. In scope {}' and value1 = 'expression' and value3 = '\`unknown_identifier\`' and value5 = 'SELECT unknown_identifier' and query_id = '${query_id}_1';
 
-select count() > 0 from system.text_log where event_date >= yesterday() AND event_time >= now() - 600 and level = 'Error' and message_format_string = 'Function with name {} does not exist. In scope {}{}' and value1 = '\`conut\`' and value2 = 'SELECT conut()' and value3 != '' and query_id = '${query_id}_2';
+select count() > 0 from system.text_log where event_date >= yesterday() AND event_time >= now() - 600 and level = 'Error' and message_format_string = 'Function with name {} does not exist{}. In scope {}' and value1 = '\`conut\`' and value2 != '' and value3 = 'SELECT conut()' and query_id = '${query_id}_2';
 "

--- a/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.reference
+++ b/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.reference
@@ -6,3 +6,4 @@ table: hint first
 
 alias of another table: cannot be resolved from table with name item (an alias of store_sales)
 not an alias: 0
+materialized CTE: an alias of cte

--- a/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.reference
+++ b/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.reference
@@ -1,0 +1,8 @@
+column: hint first
+qualified column: hint first
+function: hint first
+window function: hint first
+table: hint first
+
+alias of another table: cannot be resolved from table with name item (an alias of store_sales)
+not an alias: 0

--- a/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
+++ b/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE date_dim (d_date_sk UInt32, d_year Int64) ORDER BY d_date_sk;
+    CREATE TABLE store_sales (ss_sold_date_sk UInt32, ss_item_sk Int64) ORDER BY ss_sold_date_sk;
+    CREATE TABLE item (i_item_sk Int64, i_brand_id Int64) ORDER BY i_item_sk;
+"
+
+# The whole formatted query goes into the message, so the part that says what to do about the mistake must
+# come before it - otherwise it is behind kilobytes of text for a query of a realistic size.
+hint_comes_before_the_query()
+{
+    echo -n "$1: "
+    ${CLICKHOUSE_CLIENT} -q "$2" 2>&1 | grep -m1 -F 'Maybe you meant' | awk '
+        {
+            found = 1
+            hint = index($0, "Maybe you meant")
+            query = index($0, "In scope")
+            print (query > 0 && hint < query) ? "hint first" : "BAD: " $0
+        }
+        END { if (!found) print "BAD: no hint in the message" }'
+}
+
+hint_comes_before_the_query "column"            "SELECT d_yaer FROM date_dim"
+hint_comes_before_the_query "qualified column"  "SELECT date_dim.d_yaer FROM date_dim"
+hint_comes_before_the_query "function"          "SELECT conut() FROM date_dim"
+hint_comes_before_the_query "window function"   "SELECT avgf(d_year) OVER () FROM date_dim"
+hint_comes_before_the_query "table"             "SELECT count() FROM date_dm"
+
+echo
+# A comma missing between two table names in the FROM clause silently turns the second one into an alias of
+# the first. The message used to blame a "table with name item" while a table named `item` does exist.
+echo -n 'alias of another table: '
+${CLICKHOUSE_CLIENT} -q "SELECT item.i_brand_id FROM date_dim AS dt, store_sales item WHERE dt.d_date_sk = 1" 2>&1 \
+    | grep -m1 -oF "cannot be resolved from table with name item (an alias of store_sales)"
+
+# A genuine table reference must not be described as an alias of itself.
+echo -n 'not an alias: '
+${CLICKHOUSE_CLIENT} -q "SELECT item.no_such_column FROM item" 2>&1 | grep -cF "an alias of" || true

--- a/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
+++ b/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-old-analyzer
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
+++ b/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
@@ -46,4 +46,10 @@ ${CLICKHOUSE_CLIENT} -q "SELECT item.i_brand_id FROM date_dim AS dt, store_sales
 echo -n 'not an alias: '
 ${CLICKHOUSE_CLIENT} -q "SELECT item.no_such_column FROM item" 2>&1 | grep -cF "an alias of" || true
 
+# A materialized CTE is backed by a temporary table with a generated name; the CTE name is what the user
+# wrote, so that is what the message must show.
+echo -n 'materialized CTE: '
+${CLICKHOUSE_CLIENT} -q "WITH cte AS MATERIALIZED (SELECT 1 AS x) SELECT a.no_such FROM cte AS a" 2>&1 \
+    | grep -m1 -oE "an alias of [A-Za-z_][A-Za-z_0-9]*" || true
+
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE date_dim; DROP TABLE store_sales; DROP TABLE item"

--- a/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
+++ b/tests/queries/0_stateless/05046_analyzer_error_message_hint_before_the_query.sh
@@ -6,6 +6,9 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 ${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS date_dim;
+    DROP TABLE IF EXISTS store_sales;
+    DROP TABLE IF EXISTS item;
     CREATE TABLE date_dim (d_date_sk UInt32, d_year Int64) ORDER BY d_date_sk;
     CREATE TABLE store_sales (ss_sold_date_sk UInt32, ss_item_sk Int64) ORDER BY ss_sold_date_sk;
     CREATE TABLE item (i_item_sk Int64, i_brand_id Int64) ORDER BY i_item_sk;
@@ -42,3 +45,5 @@ ${CLICKHOUSE_CLIENT} -q "SELECT item.i_brand_id FROM date_dim AS dt, store_sales
 # A genuine table reference must not be described as an alias of itself.
 echo -n 'not an alias: '
 ${CLICKHOUSE_CLIENT} -q "SELECT item.no_such_column FROM item" 2>&1 | grep -cF "an alias of" || true
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE date_dim; DROP TABLE store_sales; DROP TABLE item"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116806

Continues the survey of the error messages that ClickHouse produces for mistakes in SQL queries: the queries of ClickBench, TPC-H, TPC-DS and the Join Order Benchmark were damaged at random (dropping a token, a bracket or a comma, changing, dropping, inserting or transposing a single letter, swapping or duplicating a token, truncating the query), which gave 8340 queries and 7752 errors. 2471 of them carry a `Maybe you meant` hint, and 85% of the `UNKNOWN_IDENTIFIER` errors do - the typo correction works well.

**The hint was printed after the whole query.** It is the part of the message that says what to do about the mistake, and the formatted query goes into the message in full, so in the median a user had to read 523 characters before reaching it, in 22% of the cases more than a thousand, and at worst 6588 - several screens of a terminal for a query of the size TPC-DS queries have:

```
Code: 47. DB::Exception: Unknown expression or function identifier `w_warehoufe_sq_ft` in scope SELECT
w_warehouse_name, w_warehouse_sq_ft, w_city, ... 6 kilobytes of query ... LIMIT 100. Maybe you meant:
['w_warehouse_sq_ft']. (UNKNOWN_IDENTIFIER)
```

Moving the hint in front of the query drops the median distance to it from 523 to 81 characters and the maximum from 6588 to 162:

```
Code: 47. DB::Exception: Unknown expression identifier `w_warehoufe_sq_ft`. Maybe you meant:
['w_warehouse_sq_ft']. In scope SELECT w_warehouse_name, ... (UNKNOWN_IDENTIFIER)
```

This applies to the unknown-identifier, unknown-column-of-a-table-expression, nested-path, unknown-function, unknown-aggregate-function and unknown-table messages. `in scope` became `. In scope` so that the messages read as sentences.

**A comma missing in the FROM clause produced a misleading message.** In

```sql
SELECT item.i_brand_id FROM date_dim AS dt, store_sales item WHERE dt.d_date_sk = 1
```

`item` silently becomes an alias of `store_sales`, and the reference to `item.i_brand_id` was reported as

```
Identifier 'item.i_brand_id' cannot be resolved from table with name item
```

while a table named `item` does exist and does have an `i_brand_id` column. The message named the alias without ever saying that it is one, so it looked like the server had lost the column. It now names the table the alias stands for, which is what makes the missing comma visible:

```
Identifier 'item.i_brand_id' cannot be resolved from table with name item (an alias of store_sales)
```

`03096_text_log_format_string_args_not_empty` is updated for the new `message_format_string` values. Validated by running the 121 stateless tests that mention any of these messages; the only failures are unrelated environment ones (no ZooKeeper, no writeable access storage, no test clusters, no system log tables in the local setup), and every hint-sensitive test passes.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `Maybe you meant` hint in the error messages for an unknown column, function or table is now printed before the query instead of after it, so it is no longer behind kilobytes of text for a large query. When a column cannot be resolved from a table expression that has an alias, the message now also names the table the alias refers to, which makes a comma missing between two table names in the `FROM` clause visible.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116809&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116809](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116809+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
