### PR TITLE
Replace two internal error messages for plain SQL mistakes

### DIFF
--- a/src/Analyzer/QueryNode.cpp
+++ b/src/Analyzer/QueryNode.cpp
@@ -37,6 +37,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int BAD_ARGUMENTS;
+    extern const int NUMBER_OF_COLUMNS_DOESNT_MATCH;
     extern const int UNSUPPORTED_METHOD;
 }
 
@@ -165,8 +166,11 @@ DataTypePtr QueryNode::getResultType() const
             return makeNullableOrLowCardinalityNullableSafe(projection_columns[0].type);
         }
         else
-            throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
-                "Method getResultType is supported only for correlated query node with 1 column, but got {}",
+            /// Reachable from plain SQL: dropping `EXISTS` from `NOT EXISTS (SELECT * FROM t WHERE t.a = o.b)`
+            /// leaves a correlated subquery of several columns where a single value is expected, so describe
+            /// the query rather than the method that could not answer for it.
+            throw Exception(ErrorCodes::NUMBER_OF_COLUMNS_DOESNT_MATCH,
+                "A correlated subquery used as an expression must return exactly one column, but it returns {}",
                 projection_columns.size());
     }
     throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Method getResultType is supported only for correlated query node");

--- a/src/Interpreters/convertFieldToType.cpp
+++ b/src/Interpreters/convertFieldToType.cpp
@@ -39,6 +39,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ARGUMENT_OUT_OF_BOUND;
+    extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int TYPE_MISMATCH;
     extern const int UNEXPECTED_DATA_AFTER_PARSED_VALUE;
     extern const int DECIMAL_OVERFLOW;
@@ -920,7 +921,11 @@ Field convertFieldToTypeImpl(const Field & src, const IDataType & type, const ID
         }
         catch (Exception & e)
         {
-            if (e.code() == ErrorCodes::UNEXPECTED_DATA_AFTER_PARSED_VALUE)
+            /// A value that ends before the deserializer expected is reported as an attempt to read after eof,
+            /// which says nothing about the query - it reads like a problem with the data. Comparing a numeric
+            /// column with an empty string, `WHERE n <> ''`, is a common mistake and deserves the same message
+            /// as `WHERE n <> 'abc'` already gets.
+            if (e.code() == ErrorCodes::UNEXPECTED_DATA_AFTER_PARSED_VALUE || e.code() == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF)
                 throw Exception(ErrorCodes::TYPE_MISMATCH, "Cannot convert string '{}' to type {}", src.safeGet<String>(), type.getName());
 
             e.addMessage(fmt::format("while converting '{}' to {}", src.safeGet<String>(), type.getName()));

--- a/tests/queries/0_stateless/01311_comparison_with_constant_string.sql
+++ b/tests/queries/0_stateless/01311_comparison_with_constant_string.sql
@@ -30,4 +30,4 @@ SELECT '---';
 SELECT toDateTime('2020-06-13 01:02:03') = '2020-06-13T01:02:03';
 SELECT '---';
 
-SELECT 0 = ''; -- { serverError ATTEMPT_TO_READ_AFTER_EOF }
+SELECT 0 = ''; -- { serverError TYPE_MISMATCH }

--- a/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.reference
+++ b/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.reference
@@ -1,0 +1,15 @@
+=== a string that a number cannot be parsed from is reported the same way whether it is empty or not
+--- SELECT toInt32(1) = 'abc'
+Code: 53. Cannot convert string 'abc' to type Int32
+--- SELECT toInt32(1) = '12abc'
+Code: 53. Cannot convert string '12abc' to type Int32
+--- SELECT toInt32(1) = ''
+Code: 53. Cannot convert string '' to type Int32
+--- SELECT toUInt8(1) IN ('', '1')
+Code: 53. Cannot convert string '' to type UInt8. (TYPE_MISMATCH)
+--- SELECT toDate('2020-01-01') = ''
+Code: 38. Cannot parse date: value is too short: while converting '' to Date
+
+=== a correlated subquery of several columns where a single value is expected
+--- SELECT a FROM outer_table WHERE NOT (SELECT * FROM inner_table WHERE b = a)
+Code: 20. A correlated subquery used as an expression must return exactly one column, but it returns 2. (NUMBER_OF_COLUMNS_DOESNT_MATCH)

--- a/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.reference
+++ b/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.reference
@@ -8,7 +8,7 @@ Code: 53. Cannot convert string '' to type Int32
 --- SELECT toUInt8(1) IN ('', '1')
 Code: 53. Cannot convert string '' to type UInt8. (TYPE_MISMATCH)
 --- SELECT toDate('2020-01-01') = ''
-Code: 38. Cannot parse date: value is too short: while converting '' to Date
+Code: 38. Cannot parse date: <reason>: while converting '' to Date
 
 === a correlated subquery of several columns where a single value is expected
 --- SELECT a FROM outer_table WHERE NOT (SELECT * FROM inner_table WHERE b = a)

--- a/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
+++ b/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Only the code and the message matter here, so drop the scope and the version from them.
+run()
+{
+    echo "--- $1"
+    ${CLICKHOUSE_CLIENT} -q "$1" 2>&1 | grep -m1 -E '^Code: ' \
+        | sed -e 's/^Code: \([0-9]*\)\. DB::Exception: Received from [^ ]* DB::Exception: /Code: \1. /' \
+              -e 's/^Code: \([0-9]*\)\. DB::Exception: /Code: \1. /' \
+              -e 's/: In scope .*//' -e 's/ (version [^)]*)$//'
+}
+
+echo '=== a string that a number cannot be parsed from is reported the same way whether it is empty or not'
+run "SELECT toInt32(1) = 'abc'"
+run "SELECT toInt32(1) = '12abc'"
+run "SELECT toInt32(1) = ''"
+run "SELECT toUInt8(1) IN ('', '1')"
+run "SELECT toDate('2020-01-01') = ''"
+
+echo
+echo '=== a correlated subquery of several columns where a single value is expected'
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE outer_table (a UInt32) ORDER BY a;
+    CREATE TABLE inner_table (b UInt32, c UInt32) ORDER BY b;
+"
+# `NOT EXISTS (...)` that lost its `EXISTS`.
+run "SELECT a FROM outer_table WHERE NOT (SELECT * FROM inner_table WHERE b = a)"

--- a/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
+++ b/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-old-analyzer
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
+++ b/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
@@ -12,7 +12,8 @@ run()
     ${CLICKHOUSE_CLIENT} -q "$1" 2>&1 | grep -m1 -E '^Code: ' \
         | sed -e 's/^Code: \([0-9]*\)\. DB::Exception: Received from [^ ]* DB::Exception: /Code: \1. /' \
               -e 's/^Code: \([0-9]*\)\. DB::Exception: /Code: \1. /' \
-              -e 's/: In scope .*//' -e 's/ (version [^)]*)$//'
+              -e 's/: In scope .*//' -e 's/ (version [^)]*)$//' \
+              -e 's/Cannot parse date: [^:]*/Cannot parse date: <reason>/'
 }
 
 echo '=== a string that a number cannot be parsed from is reported the same way whether it is empty or not'

--- a/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
+++ b/tests/queries/0_stateless/05047_internal_error_messages_for_sql_mistakes.sh
@@ -25,8 +25,12 @@ run "SELECT toDate('2020-01-01') = ''"
 echo
 echo '=== a correlated subquery of several columns where a single value is expected'
 ${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS outer_table;
+    DROP TABLE IF EXISTS inner_table;
     CREATE TABLE outer_table (a UInt32) ORDER BY a;
     CREATE TABLE inner_table (b UInt32, c UInt32) ORDER BY b;
 "
 # `NOT EXISTS (...)` that lost its `EXISTS`.
 run "SELECT a FROM outer_table WHERE NOT (SELECT * FROM inner_table WHERE b = a)"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE outer_table; DROP TABLE inner_table"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116806
Related: https://github.com/ClickHouse/ClickHouse/pull/116809

Two more findings from the survey of the error messages ClickHouse produces for mistakes in SQL queries (the queries of ClickBench, TPC-H, TPC-DS and the Join Order Benchmark, damaged at random). Both are rare in the corpus, but each answers an ordinary mistake with a message about ClickHouse internals rather than about the query.

**Comparing a number with an empty string reported an EOF error.** `WHERE numeric_column <> ''` is a common way to write "is not empty" for someone coming from another database, and it produced:

```
SELECT toInt32(1) = ''
Code: 32. DB::Exception: Attempt to read after eof: while converting '' to Int32 (ATTEMPT_TO_READ_AFTER_EOF)
```

`convertFieldToType` parses the string literal with `deserializeWholeText`, and a value that ends before the deserializer expected surfaces as `Attempt to read after eof` — which reads like a problem with the stored data, not with the query. The almost identical `= 'abc'` already gets a proper message, so the empty and truncated cases now get the same one:

```
Code: 53. DB::Exception: Cannot convert string '' to type Int32 (TYPE_MISMATCH)
```

**A correlated subquery of several columns named a C++ method.** Dropping `EXISTS` from `NOT EXISTS (SELECT * FROM orders WHERE o_custkey = c_custkey)`, which is what removing a single token from TPC-H Q22 does, leaves a correlated subquery of several columns where a single value is expected:

```
Code: 1. DB::Exception: Method getResultType is supported only for correlated query node with 1 column,
but got 9 (UNSUPPORTED_METHOD)
```

`getResultType` is an implementation detail, and `UNSUPPORTED_METHOD` is not what went wrong — the query is invalid:

```
Code: 20. DB::Exception: A correlated subquery used as an expression must return exactly one column,
but it returns 9 (NUMBER_OF_COLUMNS_DOESNT_MATCH)
```

The other `getResultType` throw in `QueryNode` (for a non-correlated node) is left alone: it is an internal invariant, and the way it is reached from SQL is a separate bug (#115835).

`01311_comparison_with_constant_string` asserted `ATTEMPT_TO_READ_AFTER_EOF` for `SELECT 0 = ''` and is updated to `TYPE_MISMATCH`. The other tests that expect `ATTEMPT_TO_READ_AFTER_EOF` (`01888_read_int_safe`, `00700_to_decimal_or_something_1`, `02477_invalid_reads`, `03716_topk_bad_data`, `03927_sumcount_compatibility`) go through the conversion functions or aggregate-state deserialization rather than `convertFieldToType` and are unaffected — they were run and pass.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Comparing a number with an empty or truncated string literal, such as `WHERE numeric_column <> ''`, now reports `Cannot convert string '' to type Int32` instead of `Attempt to read after eof`. A correlated subquery returning several columns where a single value is expected now says so, instead of reporting that the `getResultType` method is not supported.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116812&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116812](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116812+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.328` (included in `26.9` and later)
<!-- ch-version-info:end -->