### PR TITLE
Keep both -mllvm option groups in the per-test LLVM coverage build

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -172,7 +172,9 @@ if (WITH_COVERAGE)
     # (integration tests do this on purpose) leaves an intact profile instead of a
     # half-written one that crashes llvm-profdata later. Without %c at runtime the
     # flag is inert (the bias stays zero).
-    set (COVERAGE_FLAGS -fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation)
+    # Each -mllvm pair is one `SHELL:` group: CMake de-duplicates compile options, so a
+    # repeated bare -mllvm is dropped and orphans its value.
+    set (COVERAGE_FLAGS -fprofile-instr-generate -fcoverage-mapping "SHELL:-mllvm -runtime-counter-relocation")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 
     if (WITH_COVERAGE_DEPTH)
@@ -193,7 +195,7 @@ if (WITH_COVERAGE)
         # Without this flag, LLVMProfileData::Values is always NULL and indirect-call data
         # cannot be collected. Only enabled for per-test coverage builds to avoid changing
         # the regular amd_llvm_coverage build behaviour.
-        set (COVERAGE_FLAGS ${COVERAGE_FLAGS} -mllvm -enable-value-profiling=true)
+        set (COVERAGE_FLAGS ${COVERAGE_FLAGS} "SHELL:-mllvm -enable-value-profiling=true")
     endif()
 
     if (WITH_COVERAGE_XRAY)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115623
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `amd_llvm_coverage_per_test` build, which stopped compiling because two `-mllvm` option groups in `COVERAGE_FLAGS` collapsed into one under CMake option de-duplication.


### Description

`Build (amd_llvm_coverage_per_test)` (workflow `NightlyCoverage`) fails on master with

    clang++-22: error: unknown argument: '-enable-value-profiling=true'

first red `89f0cefc`, last green `7083055`, 0 failures in the preceding 60 days. The build stops about 4 minutes in, so the nightly measurement produces nothing.

`COVERAGE_FLAGS` is a CMake list, and CMake de-duplicates `COMPILE_OPTIONS` on the semicolon-split values, so it cannot tell that `-mllvm` and the token after it are one option group. #115623 added `-mllvm -runtime-counter-relocation` to the base `WITH_COVERAGE` list, which made the depth-only `-mllvm -enable-value-profiling=true` a second `-mllvm`. The repeat is dropped and its value reaches the driver bare. Only one of the two values is reported unknown, which is the signature of group collapse, not of an invalid flag.

`WITH_COVERAGE_DEPTH=ON` is set only for `amd_llvm_coverage_per_test`, which no pull request builds, so the break is nightly-only and invisible to PR CI, including on this PR.

This wraps each pair in a `SHELL:` group so de-duplication treats it as one element. Both `set()` lines are converted, so a future `-mllvm` cannot re-break a job that no pull request can run.

Validated in both directions on the real cmake graph with CI's own `PER_TEST_COVERAGE` flags: the object fails with the message above without the change and compiles with it, carrying both `__llvm_profile_counter_bias` and `__llvm_profile_instrument_target`. The `amd_llvm_coverage` compile line stays byte-identical to master's, every instrumented ClickHouse object carries both `-mllvm` pairs, and no literal `SHELL:` reaches a command line.

`tests/lexer/CMakeLists.txt:5` feeds the same list to `target_link_options`, where `LINK_OPTIONS` de-duplicates the same way, so the change covers that carrier too. No CI job builds it with coverage on: both coverage build types set `-DENABLE_LEXER_TEST=0`.

Confirmation comes from the next nightly, not from this PR.

Related: https://github.com/ClickHouse/ClickHouse/pull/115623

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116834&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116834](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116834+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.281` (included in `26.9` and later)
<!-- ch-version-info:end -->