### PR TITLE
jemalloc: lower lg_extent_max_active_fit to default 6, to reduce fragmentation

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -21,11 +21,8 @@ endif ()
 #   dirty_decay_ms:5000        Purge dirty pages 5s after they go idle, off the allocation path.
 #   background_thread:true     Purge on jemalloc's own threads rather than from application allocations,
 #                              keeping RSS bounded without eager (per-free) purging.
-#   lg_extent_max_active_fit:8 Reuse an extent for requests up to 2^8 (256x) smaller; default 6 (64x).
-#                              Lets ClickBench Q35's 256 coalesced 16KB sub-hashtables be split and
-#                              reused instead of faulting via MADV_DONTNEED.
-#                              https://github.com/ClickHouse/ClickHouse/pull/80245
-#                              https://github.com/jemalloc/jemalloc/pull/2842
+#   lg_extent_max_active_fit:6 Default
+#                              Previously was 8 to let Q35 ClickBench query works better, but this may significantly increase fragmentation
 # Linux and macOS:
 #   prof:true,prof_active:true,prof_thread_active_init:false
 #                              Compile in and globally arm sampling but leave it off per-thread, so it can
@@ -51,7 +48,7 @@ endif ()
 #                              madvise on the oversize arena (JEMALLOC_HAVE_MADVISE_HUGE, absent on macOS)
 #                              and is unvalidated there.
 if (OS_LINUX)
-    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:67108864,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8")
+    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:67108864,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:6")
 elseif (OS_DARWIN)
     # background_thread is unavailable in upstream jemalloc on Darwin; we enable it via the Darwin config
     # headers (include_darwin_*/jemalloc/internal/jemalloc_internal_defs.h.in), where the full rationale
@@ -60,10 +57,10 @@ elseif (OS_DARWIN)
     # assumption that background_thread was unavailable; see
     # https://github.com/ClickHouse/ClickHouse/issues/108429
     # percpu_arena relies on malloc_getcpu, which reads the CPU number via TPIDR_EL0/sidt on macOS (see above).
-    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8")
+    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:6")
 else()
     # FreeBSD and any other non-Linux target. background_thread is supported out of the box.
-    set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,background_thread:true,lg_extent_max_active_fit:8")
+    set (JEMALLOC_CONFIG_MALLOC_CONF "oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,background_thread:true,lg_extent_max_active_fit:6")
 endif()
 # CACHE variable is empty to allow changing defaults without the necessity
 # to purge cache


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
jemalloc: lower `lg_extent_max_active_fit` to default 6, to reduce fragmentation

I don't think that optimizing jemalloc allocator for very specific environment is a good idea, in the initial PR the setup was 2x240 vCPUs system, which is not very common. Besides usually we have other queries in parallel, so we will not have perfect landing of memory allocation like with one sequential query.

From the other side increasing `lg_extent_max_active_fit` may increase memory usage for most common setups.

Also my testing does not show 40% improvement (though I tested on 32 CPUs AMD) - https://pastila.nl/?0018b836/78075c5193410598fc48923dbc32e71a#DsNwxTbiFJC4KypWee2Y/A==GCM

And I don't see improvements in page faults either - https://pastila.nl/?00ad19b5/1c76c59644840106d627ae1b309d8dc8#BTq0VGroX6xCTvKLcgSQAQ==GCM

Plus it will work differently with 64KiB pages (arm64)

Reverts: https://github.com/ClickHouse/ClickHouse/pull/80245 (cc @jiebinn)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116836&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116836](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116836+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.433` (included in `26.9` and later)
<!-- ch-version-info:end -->