### PR TITLE
Do not fail the Stress test job when the server stops during the shutdown grace period

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -304,7 +304,7 @@ function stop_server()
       kill -s 0 "$pid" && sleep 60
 
       # The server could finally stop while we were terminating gdb, let's recheck if it's still running
-      kill -s 0 "$pid" || return
+      kill -s 0 "$pid" || return 0
       echo -e "Possible deadlock on shutdown (see gdb.log)$FAIL" >> /test_output/test_results.tsv
       echo "thread apply all backtrace (on stop)" >> /test_output/gdb.log
       timeout 30m gdb -batch -ex 'thread apply all backtrace' -p "$pid" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109225


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`stop_server` in `tests/docker_scripts/stress_tests.lib` returns a failing status on the
branch that means the server shut down cleanly, just slowly.

After `clickhouse stop --do-not-kill` times out it writes `Warning: server did not stop yet`,
terminates gdb, waits 60 seconds and rechecks the pid:

```bash
kill -s 0 "$pid" || return
```

A bare `return` propagates the last command's status, here the `kill -s 0` that just failed
because the process is gone. So the branch whose own comment reads "the server
could finally stop" returns 1. `stress_runner.sh` runs under `set -e` and calls `stop_server`
bare at line 330, so the script aborts and the job becomes `Check failed with exit code 1`.

Two costs: the job invents a failure on a run where the server did stop, and the steps below
line 330 never run, so `check_logs_for_critical_errors` never applies its `S3_ERROR No such
key thrown` and lost-SharedMergeTree detectors.

Over 30 days, among `Stress test` runs carrying the warning row (grouped per PR, commit and
check): 5 groups / 5 PRs (1 on master) lack a `Possible deadlock on shutdown` row and failed;
30 groups / 27 PRs (2 on master) have it and passed. Perfectly anti-diagonal: deterministic,
not flaky. `upgrade_runner.sh:349` reaches the same line and is fixed with it.

Reference run (`arm_debug`):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109225&sha=b339930e18c91cefedc528a8370375ce7a2da4e9&name_0=PR&name_1=Stress%20test%20%28arm_debug%29

No test added: this is a docker-only bash function reached through hardcoded absolute paths,
and `ci/tests/` is being removed. I validated locally by driving the real function text with
stubbed `clickhouse`, `gdb`, `pidof` and `ts` in three fixtures (server dies inside the grace
window, outlives it, already gone); reverting the token reddens the first and third, an
unconditional return reddens the second. The remaining detector is CI itself: a `Stress test`
run carrying the warning row and no `Possible deadlock on shutdown` must be green.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116841&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116841](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116841+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.267` (included in `26.9` and later)
<!-- ch-version-info:end -->