### PR TITLE
Remove `GroupConcatDataBase`

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.cpp
@@ -15,7 +15,7 @@ extern const int LOGICAL_ERROR;
 extern const int TOO_MANY_ARGUMENTS_FOR_FUNCTION;
 }
 
-void GroupConcatDataBase::checkAndUpdateSize(UInt64 add, Arena * arena)
+void GroupConcatData::checkAndUpdateSize(UInt64 add, Arena * arena)
 {
     if (data_size + add >= allocated_size)
     {
@@ -25,19 +25,11 @@ void GroupConcatDataBase::checkAndUpdateSize(UInt64 add, Arena * arena)
     }
 }
 
-void GroupConcatDataBase::insertChar(const char * str, UInt64 str_size, Arena * arena)
+void GroupConcatData::insertChar(const char * str, UInt64 str_size, Arena * arena)
 {
     checkAndUpdateSize(str_size, arena);
     memcpy(data + data_size, str, str_size);
     data_size += str_size;
-}
-
-void GroupConcatDataBase::insert(const IColumn * column, const SerializationPtr & serialization, size_t row_num, Arena * arena)
-{
-    WriteBufferFromOwnString buff;
-    serialization->serializeText(*column, row_num, buff, FormatSettings{});
-    auto string = buff.stringView();
-    insertChar(string.data(), string.size(), arena);
 }
 
 UInt64 GroupConcatData::getSize(size_t i) const

--- a/src/AggregateFunctions/AggregateFunctionGroupConcat.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupConcat.h
@@ -15,25 +15,20 @@ namespace DB
 {
 struct Settings;
 
-struct GroupConcatDataBase
-{
-    UInt64 data_size = 0;
-    UInt64 allocated_size = 0;
-    char * data = nullptr;
-
-    void checkAndUpdateSize(UInt64 add, Arena * arena);
-    void insertChar(const char * str, UInt64 str_size, Arena * arena);
-    void insert(const IColumn * column, const SerializationPtr & serialization, size_t row_num, Arena * arena);
-};
-
-struct GroupConcatData : public GroupConcatDataBase
+struct GroupConcatData
 {
     using Offset = UInt64;
     using Allocator = MixedAlignedArenaAllocator<alignof(Offset), 4096>;
     using Offsets = PODArray<Offset, 32, Allocator>;
 
+    UInt64 data_size = 0;
+    UInt64 allocated_size = 0;
+    char * data = nullptr;
     Offsets offsets;
     UInt64 num_rows = 0;
+
+    void checkAndUpdateSize(UInt64 add, Arena * arena);
+    void insertChar(const char * str, UInt64 str_size, Arena * arena);
 
     UInt64 getSize(size_t i) const;
     UInt64 getString(size_t i) const;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116795


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Internal cleanup of the `groupConcat` aggregate state. No user-visible change.

### Description

Follow-up to #116795, where @ azat asked for this base struct to go.

`GroupConcatData` was the only struct deriving from `GroupConcatDataBase`, and nothing else in the
tree named the base, so it held three fields and two helpers used by that single struct. This folds
them into `GroupConcatData`.

`GroupConcatDataBase::insert` was unreachable on top of that: `GroupConcatData::insert` has the
same signature and hides it, and the sole call site is `GroupConcatImpl::add` on a
`GroupConcatData` object. It was also wrong for that struct, writing through `insertChar`, which
never pushes the `offsets` pair nor increments `num_rows`. Merging the two structs makes the
identical signatures collide, so the dead one is deleted rather than carried over.

No behaviour and no format change: `serialize` and `deserialize` are untouched, and the state keeps
the same fields in the same order, so `sizeof` and `alignof` of `GroupConcatData` stay at 64 and 8
and every field keeps its offset. The existing `groupConcat` tests pass with no reference change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116842&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116842](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116842+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.422` (included in `26.9` and later)
<!-- ch-version-info:end -->