### PR TITLE
Fix flaky test_trace_log_memory_context: attribute the forced global peak to its own query

### DIFF
--- a/tests/integration/test_trace_log_memory_context/test.py
+++ b/tests/integration/test_trace_log_memory_context/test.py
@@ -52,13 +52,9 @@ def test_memory_context_in_trace_log(started_cluster):
     #   * `JemallocSample` is emitted by `jemalloc`'s own profile sampler
     #     (~1 MiB of allocated memory per sample with `lg_prof_sample=20`),
     #     and a single small query is not guaranteed to allocate enough.
-    #   * `Memory`/`MemoryPeak` with `memory_context = 'Global'` require the
-    #     `total_memory_tracker` to cross its `total_memory_profiler_step`
-    #     watermark (4 MiB by default), which depends on cumulative
-    #     server-wide allocations including background activity, not just
-    #     this query's allocations.
     # Retrying bounds the test runtime while keeping it reliable.
     peak_forcing_attempt = 0
+    peak_forcing_query_id = None
     for attempt in range(0, 15):
         # Generate some logs to generate entries with memory_blocked_context=Global and trace_type=JemallocSample
         for i in range(10):
@@ -68,21 +64,20 @@ def test_memory_context_in_trace_log(started_cluster):
 
         node.query("SYSTEM FLUSH LOGS system.trace_log")
 
-        # `Memory`/`MemoryPeak` with `memory_context = 'Global'` are sent only when the
-        # server-wide memory usage grows past its previous peak by at least
-        # `total_memory_profiler_step` (4 MiB). The peak reached during server startup can
-        # be above anything the small queries here allocate, in which case retrying alone
-        # never helps. Force a new global peak by allocating more memory on each attempt
-        # where these events are still missing. The escalation is decoupled from the
-        # probabilistic per-query sample checks below, so retries that only miss a
-        # `MemorySample`/`JemallocSample` do not keep increasing the allocation size.
-        # `max_threads = 1` keeps the growth per attempt close to ~100 MB.
+        # `Memory`/`MemoryPeak` with `memory_context = 'Global'` are emitted by the thread whose
+        # allocation both crosses the 4 MiB `total_memory_profiler_step` watermark of
+        # `total_memory_tracker` and sets a new global peak. Both watermarks only ever grow, so
+        # after a query has raised them a query-less thread has to out-allocate that query to emit
+        # again: count the events of the query that forces the peak. `max_threads = 1` keeps the
+        # growth per attempt close to ~100 MB.
         if (
-            get_trace_events("Global", "Max", "Memory") == 0 or
-            get_trace_events("Global", "Max", "MemoryPeak") == 0
+            peak_forcing_query_id is None or
+            get_trace_events("Global", "Max", "Memory", peak_forcing_query_id) == 0 or
+            get_trace_events("Global", "Max", "MemoryPeak", peak_forcing_query_id) == 0
         ):
             peak_forcing_attempt += 1
-            node.query(f"SELECT groupArray(number) FROM numbers({peak_forcing_attempt * 12500000}) SETTINGS max_threads = 1 FORMAT Null")
+            peak_forcing_query_id = uuid.uuid4().hex
+            node.query(f"SELECT groupArray(number) FROM numbers({peak_forcing_attempt * 12500000}) SETTINGS max_threads = 1 FORMAT Null", query_id=peak_forcing_query_id)
             node.query("SYSTEM FLUSH LOGS system.trace_log")
 
         if (
@@ -90,8 +85,8 @@ def test_memory_context_in_trace_log(started_cluster):
             get_trace_events("Unknown", "Max", "JemallocSample", query_id) > 0 and
             get_trace_events("Unknown", "Max", "JemallocSample") > 0 and
             get_trace_events("Unknown", "Global", "JemallocSample") > 0 and
-            get_trace_events("Global", "Max", "Memory") > 0 and
-            get_trace_events("Global", "Max", "MemoryPeak") > 0 and
+            get_trace_events("Global", "Max", "Memory", peak_forcing_query_id) > 0 and
+            get_trace_events("Global", "Max", "MemoryPeak", peak_forcing_query_id) > 0 and
             True
         ):
             break
@@ -103,7 +98,7 @@ def test_memory_context_in_trace_log(started_cluster):
 
     for memory_context in ["Global"]:
         for trace_type in ["Memory", "MemoryPeak"]:
-            assert get_trace_events(memory_context, "Max", trace_type) > 0
+            assert get_trace_events(memory_context, "Max", trace_type, peak_forcing_query_id) > 0
 
     assert get_trace_events("Unknown", "Max", "MemorySample", query_id) > 0
     # It is better not to check for memory_blocked_context=Global, since we


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113688
Related: https://github.com/ClickHouse/ClickHouse/issues/87995
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Requested in https://github.com/ClickHouse/ClickHouse/pull/56335#issuecomment-5448835986
Related: #113688, #87995
Failing run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=56335&sha=a3c5c38948ecdf544994b54043184abfa82c5e60&name_0=PR&name_1=Integration%20tests%20%28amd_binary_excluded_from_llvm%29

The test required `Global`/`MemoryPeak` events with `empty(query_id)`, that is, emitted by a thread
with no query attached. 8 PRs in 120 days, 0 on master.

Root cause: `MemoryPeak` is emitted only when a single `commitAllocation` on `total_memory_tracker`
both crosses `total_memory_profiler_step` and sets a new global peak, and `TraceSender` stamps the
event with the emitting thread's query id. Both watermarks only ever rise, so once a query has
raised them a query-less thread must out-allocate that query to emit again. #113688 forces the peak
with a query, so its own events carry that query's id and were excluded, and each escalation raised
the watermarks further, making the next attempt less likely to help.

The change counts the `Global` `Memory`/`MemoryPeak` events of the query that forces the peak, in
the break condition and the assertion together so they cannot diverge. Nothing is relaxed: both rows
are still required in the `Global` context with `memory_blocked_context = 'Max'`. What changes is
which thread emits them, from any query-less thread to the one the test issues for that purpose,
which also pins `query_id` where `empty(query_id)` could not.
`01092_memory_profiler.sql` already scopes `MemoryPeak` this way.

Validation: I rebuilt the failing run's own `system.trace_log` from its artifacts. The old predicate
reads 0 there; the new one reads 6 over 5 query ids, every one an escalation query, so the events
existed and only the `query_id` filter hid them. 30 runs of the real job config pass, converging on
the first forcing query in 29 of 30; the retry loop absorbs the rest. Shrinking that query to
`numbers(1)` makes the new assertion fail, so it still catches regressions. I used the job's own
`amd_binary` artifact because the `MALLOC_CONF` this test sets hangs a debug binary at startup.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116855&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116855](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116855+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.266` (included in `26.9` and later)
<!-- ch-version-info:end -->