### PR TITLE
Make Keeper snapshot ZSTD compression level configurable

### DIFF
--- a/docs/guides/oss/deployment-and-scaling/keeper/index.mdx
+++ b/docs/guides/oss/deployment-and-scaling/keeper/index.mdx
@@ -71,6 +71,8 @@ Internal coordination settings are located in the `<keeper_server>.<coordination
 | `reserved_log_items`               | How many coordination log records to store before compaction.                                                                                                                                                            | `100000`                                                                                                     |
 | `snapshot_distance`                | How often ClickHouse Keeper will create new snapshots (in the number of records in logs).                                                                                                                                | `100000`                                                                                                     |
 | `snapshots_to_keep`                | How many snapshots to keep.                                                                                                                                                                                              | `3`                                                                                                          |
+| `compress_snapshots_with_zstd_format` | Write snapshots in the ZSTD format instead of the custom ClickHouse LZ4 block format.                                                                                                                                    | `true`                                                                                                       |
+| `snapshot_zstd_compression_level`  | ZSTD compression level for snapshots. Lower levels use less CPU but produce larger snapshots. Negative values select ZSTD fast levels. Used only when `compress_snapshots_with_zstd_format` is enabled.                  | `3`                                                                                                          |
 | `stale_log_gap`                    | Threshold when leader considers follower as stale and sends the snapshot to it instead of logs.                                                                                                                          | `10000`                                                                                                      |
 | `fresh_log_gap`                    | When node became fresh.                                                                                                                                                                                                  | `200`                                                                                                        |
 | `max_requests_batch_size`          | Max size of batch in requests count before it will be sent to RAFT.                                                                                                                                                      | `100`                                                                                                        |
@@ -288,6 +290,7 @@ quorum_reads=false
 force_sync=false
 compress_logs=true
 compress_snapshots_with_zstd_format=true
+snapshot_zstd_compression_level=3
 configuration_change_tries_count=20
 ```
 
@@ -561,6 +564,7 @@ After migration, consider tuning these settings for larger clusters or higher th
 | `force_sync` | `true` | `false` | Asynchronous log writes improve throughput |
 | `compress_logs` | `false` | `true` | Compresses Raft log files to reduce disk I/O |
 | `compress_snapshots_with_zstd_format` | `true` | — | Already enabled by default; compresses snapshots with zstd |
+| `snapshot_zstd_compression_level` | `3` | — | Lower values reduce snapshot compression CPU at the cost of larger snapshots |
 
 These settings are configured under `coordination_settings` in your [Keeper configuration](#internal-coordination-settings).
 

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -1,4 +1,5 @@
 #include <Coordination/CoordinationSettings.h>
+#include <Coordination/KeeperConstants.h>
 #include <Core/BaseSettings.h>
 #include <Core/BaseSettingsFwdMacrosImpl.h>
 #include <IO/WriteHelpers.h>
@@ -64,6 +65,7 @@ namespace ErrorCodes
     DECLARE(Bool, force_sync, true, "Call fsync on each change in RAFT changelog", 0) \
     DECLARE(Bool, compress_logs, false, "Write compressed coordination logs in ZSTD format", 0) \
     DECLARE(Bool, compress_snapshots_with_zstd_format, true, "Write compressed snapshots in ZSTD format (instead of custom LZ4)", 0) \
+    DECLARE(Int64, snapshot_zstd_compression_level, DEFAULT_KEEPER_SNAPSHOT_ZSTD_COMPRESSION_LEVEL, "ZSTD compression level for snapshots. Lower levels use less CPU but produce larger snapshots. Used only when compress_snapshots_with_zstd_format is enabled.", 0) \
     DECLARE(UInt64, configuration_change_tries_count, 20, "How many times we will try to apply configuration change (add/remove server) to the cluster", 0) \
     DECLARE(UInt64, max_log_file_size, 50 * 1024 * 1024, "Max size of the Raft log file. If possible, each created log file will preallocate this amount of bytes on disk. Set to 0 to disable the limit", 0) \
     DECLARE(UInt64, log_file_overallocate_size, 50 * 1024 * 1024, "If max_log_file_size is not set to 0, this value will be added to it for preallocating bytes on disk. If a log record is larger than this value, it could lead to uncaught out-of-space issues so a larger value is preferred", 0) \

--- a/src/Coordination/CoordinationSettings.h
+++ b/src/Coordination/CoordinationSettings.h
@@ -22,6 +22,7 @@ struct CoordinationSettingsImpl;
     M(CLASS_NAME, Bool) \
     M(CLASS_NAME, LogsLevel) \
     M(CLASS_NAME, Milliseconds) \
+    M(CLASS_NAME, Int64) \
     M(CLASS_NAME, UInt64) \
     M(CLASS_NAME, NonZeroUInt64) \
     M(CLASS_NAME, Float)

--- a/src/Coordination/KeeperConstants.h
+++ b/src/Coordination/KeeperConstants.h
@@ -26,6 +26,7 @@ const String keeper_availability_zone_path = keeper_system_path + "/availability
 const Int64 keeper_internal_get_session_id = -1;
 const Int64 keeper_internal_ttl_garbage_collector_session_id = -2;
 const Int64 keeper_internal_container_garbage_collector_session_id = -3;
+constexpr Int64 DEFAULT_KEEPER_SNAPSHOT_ZSTD_COMPRESSION_LEVEL = 3;
 
 /// Maximum allowed TTL value in milliseconds, matching ZooKeeper's
 /// `EphemeralType.TTL.maxValue()`. Prevents `time + ttl` from overflowing

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -28,6 +28,8 @@
 #include <Common/SharedLockGuard.h>
 #include <Common/Stopwatch.h>
 
+#include <zstd.h>
+
 namespace ProfileEvents
 {
     extern const Event KeeperSnapshotWrittenBytes;
@@ -48,6 +50,21 @@ namespace ErrorCodes
 
 namespace
 {
+    int validateSnapshotZstdCompressionLevel(Int64 level)
+    {
+        const int min_level = ZSTD_minCLevel();
+        const int max_level = ZSTD_maxCLevel();
+        if (level < min_level || level > max_level)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "snapshot_zstd_compression_level must be between {} and {}, got {}",
+                min_level,
+                max_level,
+                level);
+
+        return static_cast<int>(level);
+    }
+
     std::string getSnapshotFileName(uint64_t up_to_log_idx, bool compress_zstd)
     {
         /// Unique-from-birth name avoids collisions between concurrent same-index writes.
@@ -355,9 +372,11 @@ KeeperSnapshotManager::makeManagedSnapshotFileInfo(std::string path, DiskPtr dis
 KeeperSnapshotManager::KeeperSnapshotManager(
     size_t snapshots_to_keep_,
     const KeeperContextPtr & keeper_context_,
-    bool compress_snapshots_zstd_)
+    bool compress_snapshots_zstd_,
+    Int64 snapshot_zstd_compression_level_)
     : snapshots_to_keep(snapshots_to_keep_)
     , compress_snapshots_zstd(compress_snapshots_zstd_)
+    , snapshot_zstd_compression_level(validateSnapshotZstdCompressionLevel(snapshot_zstd_compression_level_))
     , keeper_context(keeper_context_)
 {
     std::unordered_set<DiskPtr> read_disks;
@@ -691,7 +710,8 @@ nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::serializeSnapshotToBuffer(con
     auto * buffer_raw_ptr = writer.get();
     std::unique_ptr<WriteBuffer> compressed_writer;
     if (compress_snapshots_zstd)
-        compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
+        compressed_writer = wrapWriteBufferWithCompressionMethod(
+            std::move(writer), CompressionMethod::Zstd, snapshot_zstd_compression_level);
     else
         compressed_writer = std::make_unique<CompressedWriteBuffer>(*writer);
 
@@ -904,7 +924,8 @@ SnapshotFileInfoPtr KeeperSnapshotManager::writeSnapshotFile(const KeeperStorage
         /// which is why only the uncompressed branch tracks the file buffer separately.
         WriteBuffer * unowned_file_buffer = nullptr;
         if (compress_snapshots_zstd)
-            compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
+            compressed_writer = wrapWriteBufferWithCompressionMethod(
+                std::move(writer), CompressionMethod::Zstd, snapshot_zstd_compression_level);
         else
         {
             unowned_file_buffer = writer.get();

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -6,6 +6,7 @@
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Coordination/ACLMap.h>
 #include <Coordination/KeeperCommon.h>
+#include <Coordination/KeeperConstants.h>
 #include <Coordination/KeeperStorage.h>
 #include <functional>
 #include <libnuraft/nuraft.hxx>
@@ -256,7 +257,8 @@ public:
     KeeperSnapshotManager(
         size_t snapshots_to_keep_,
         const KeeperContextPtr & keeper_context_,
-        bool compress_snapshots_zstd_ = true);
+        bool compress_snapshots_zstd_ = true,
+        Int64 snapshot_zstd_compression_level_ = DEFAULT_KEEPER_SNAPSHOT_ZSTD_COMPRESSION_LEVEL);
 
     /// TODO: We should probably allow arbitrary WriteBuffer/SeekableReadBuffer in most of these
     ///       methods, instead of requiring the whole snapshot to be read/written into memory first.
@@ -385,6 +387,8 @@ private:
     uint64_t protected_pending_snapshot_log_idx = 0;
     /// Compress snapshots in common ZSTD format instead of custom ClickHouse block LZ4 format
     const bool compress_snapshots_zstd;
+    /// ZSTD compression level used by both in-memory and on-disk snapshot writers
+    const int snapshot_zstd_compression_level;
 
     KeeperContextPtr keeper_context;
 

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -78,6 +78,7 @@ namespace CoordinationSetting
     extern const CoordinationSettingsBool compress_snapshots_with_zstd_format;
     extern const CoordinationSettingsMilliseconds dead_session_check_period_ms;
     extern const CoordinationSettingsUInt64 min_request_size_for_cache;
+    extern const CoordinationSettingsInt64 snapshot_zstd_compression_level;
     extern const CoordinationSettingsUInt64 snapshots_to_keep;
     extern const CoordinationSettingsUInt64 snapshot_transfer_chunk_size;
 }
@@ -121,7 +122,8 @@ KeeperStateMachine::KeeperStateMachine(
     , snapshot_manager(
           keeper_context_->getCoordinationSettings()[CoordinationSetting::snapshots_to_keep],
           keeper_context_,
-          keeper_context_->getCoordinationSettings()[CoordinationSetting::compress_snapshots_with_zstd_format])
+          keeper_context_->getCoordinationSettings()[CoordinationSetting::compress_snapshots_with_zstd_format],
+          keeper_context_->getCoordinationSettings()[CoordinationSetting::snapshot_zstd_compression_level])
 {
 }
 

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -46,6 +46,7 @@
 
 namespace DB::CoordinationSetting
 {
+    extern const CoordinationSettingsInt64 snapshot_zstd_compression_level;
     extern const CoordinationSettingsUInt64 write_snapshot_version;
 }
 
@@ -138,6 +139,28 @@ TEST(CoordinationSettingsParse, NuraftSnapshotSyncCtxTimeout)
                    "<nuraft_snapshot_sync_ctx_timeout_ms>3000000000</nuraft_snapshot_sync_ctx_timeout_ms>"
                    "</coordination_settings></keeper_server></clickhouse>"),
               std::numeric_limits<int32_t>::max());
+}
+
+TEST(CoordinationSettingsParse, SnapshotZstdCompressionLevel)
+{
+    auto load = [](const std::string & xml)
+    {
+        std::istringstream stream(xml); // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+        Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration(stream);
+        DB::CoordinationSettings settings;
+        settings.loadFromConfig("keeper_server.coordination_settings", *config);
+        return static_cast<Int64>(settings[DB::CoordinationSetting::snapshot_zstd_compression_level]);
+    };
+
+    EXPECT_EQ(
+        load("<clickhouse><keeper_server><coordination_settings>"
+             "</coordination_settings></keeper_server></clickhouse>"),
+        DB::DEFAULT_KEEPER_SNAPSHOT_ZSTD_COMPRESSION_LEVEL);
+    EXPECT_EQ(
+        load("<clickhouse><keeper_server><coordination_settings>"
+             "<snapshot_zstd_compression_level>-5</snapshot_zstd_compression_level>"
+             "</coordination_settings></keeper_server></clickhouse>"),
+        -5);
 }
 
 /// The composition that actually reaches NuRaft: config text -> setting -> `raft_params` field.

--- a/src/Coordination/tests/gtest_coordination_snapshot.cpp
+++ b/src/Coordination/tests/gtest_coordination_snapshot.cpp
@@ -8,9 +8,12 @@
 #include <Coordination/KeeperSnapshotManager.h>
 #include <Coordination/KeeperStateMachine.h>
 #include <Coordination/ReadBufferFromNuraftBuffer.h>
+#include <Coordination/WriteBufferFromNuraftBuffer.h>
 #include <Coordination/SnapshotableHashTable.h>
 #include <Coordination/KeeperStorage.h>
 
+#include <IO/CompressionMethod.h>
+#include <IO/ReadHelpers.h>
 #include <IO/copyData.h>
 
 #include <Common/SipHash.h>
@@ -365,6 +368,25 @@ std::vector<std::string> snapshotFilesForIdx(const std::string & dir, uint64_t i
             result.push_back(entry.path().filename().string());
     }
     return result;
+}
+
+nuraft::ptr<nuraft::buffer> serializeSnapshotWithZstdLevel(
+    const DB::KeeperStorageSnapshot & snapshot,
+    const DB::KeeperContextPtr & keeper_context,
+    int compression_level)
+{
+    auto writer = std::make_unique<DB::WriteBufferFromNuraftBuffer>();
+    auto * buffer_writer = writer.get();
+    auto compressed_writer = DB::wrapWriteBufferWithCompressionMethod(
+        std::move(writer), DB::CompressionMethod::Zstd, compression_level);
+    DB::KeeperStorageSnapshot::serialize(snapshot, *compressed_writer, keeper_context);
+    compressed_writer->finalize();
+    return buffer_writer->getBuffer();
+}
+
+bool nuraftBuffersEqual(const nuraft::ptr<nuraft::buffer> & lhs, const nuraft::ptr<nuraft::buffer> & rhs)
+{
+    return lhs->size() == rhs->size() && std::memcmp(lhs->data_begin(), rhs->data_begin(), lhs->size()) == 0;
 }
 
 template <typename Manager>
@@ -780,6 +802,59 @@ TEST_P(CoordinationTestWithCompression, TestStorageSnapshotSimple)
     /// Verify seq_num round-trip (int64_t, value > INT32_MAX)
     ASSERT_TRUE(restored_storage->nodes_storage->getCommittedNodeSimple("/", &stats, /*out_data=*/nullptr));
     EXPECT_EQ(stats.getSeqNum(), large_seq_num);
+}
+
+TEST(KeeperSnapshotCompressionLevel, ConfiguredLevelIsUsedForMemoryAndDiskSnapshots)
+{
+    ChangelogDirTest snapshots("./snapshots_zstd_level");
+    auto keeper_context = makeKeeperContext(false);
+    auto snapshot_disk = std::make_shared<DB::DiskLocal>("SnapshotDisk", "./snapshots_zstd_level");
+    keeper_context->setSnapshotDisk(snapshot_disk);
+
+    auto storage = DB::KeeperStorage::create(500, "", keeper_context);
+    std::string payload;
+    for (size_t i = 0; i < 2048; ++i)
+        payload += fmt::format("keeper-snapshot-compression-pattern-{:03};", i % 251);
+    for (size_t i = 0; i < 32; ++i)
+        addNode(*storage, fmt::format("/node_{}", i), payload + std::to_string(i));
+
+    const auto serialize_at_level = [&](int level)
+    {
+        DB::KeeperStorageSnapshot snapshot(storage.get(), 10, nullptr, keeper_context->getWriteSnapshotVersion());
+        return serializeSnapshotWithZstdLevel(snapshot, keeper_context, level);
+    };
+
+    auto expected_level_1 = serialize_at_level(1);
+    auto expected_level_3 = serialize_at_level(DB::DEFAULT_KEEPER_SNAPSHOT_ZSTD_COMPRESSION_LEVEL);
+    ASSERT_FALSE(nuraftBuffersEqual(expected_level_1, expected_level_3));
+
+    DB::KeeperSnapshotManager manager(3, keeper_context, true, 1);
+    DB::KeeperStorageSnapshot memory_snapshot(storage.get(), 10, nullptr, keeper_context->getWriteSnapshotVersion());
+    auto memory_buffer = manager.serializeSnapshotToBuffer(memory_snapshot);
+    EXPECT_TRUE(nuraftBuffersEqual(memory_buffer, expected_level_1));
+
+    DB::KeeperStorageSnapshot disk_snapshot(storage.get(), 10, nullptr, keeper_context->getWriteSnapshotVersion());
+    auto file_info = manager.serializeSnapshotToDisk(disk_snapshot);
+    auto disk_reader = snapshot_disk->readFile(file_info->path, {});
+    std::string disk_contents;
+    DB::readStringUntilEOF(disk_contents, *disk_reader);
+    ASSERT_EQ(disk_contents.size(), expected_level_1->size());
+    EXPECT_EQ(std::memcmp(disk_contents.data(), expected_level_1->data_begin(), disk_contents.size()), 0);
+}
+
+TEST(KeeperSnapshotCompressionLevel, RejectsUnsupportedLevel)
+{
+    ChangelogDirTest snapshots("./snapshots_invalid_zstd_level");
+    auto keeper_context = makeKeeperContext(false);
+    keeper_context->setSnapshotDisk(
+        std::make_shared<DB::DiskLocal>("SnapshotDisk", "./snapshots_invalid_zstd_level"));
+
+    EXPECT_THROW(
+        DB::KeeperSnapshotManager(3, keeper_context, true, std::numeric_limits<int64_t>::min()),
+        DB::Exception);
+    EXPECT_THROW(
+        DB::KeeperSnapshotManager(3, keeper_context, true, std::numeric_limits<int64_t>::max()),
+        DB::Exception);
 }
 
 TEST_P(CoordinationTestWithCompression, TestStorageSnapshotSerializeToDisk)


### PR DESCRIPTION
Keeper snapshot creation currently hardcodes ZSTD compression level 3 for both persistent snapshots and in-memory snapshots used for transfer. Snapshot compression can consume substantial CPU for large Keeper states, while the preferred CPU-to-size tradeoff depends on the deployment.

Add the restart-only `snapshot_zstd_compression_level` coordination setting. It defaults to 3 to preserve existing behavior, applies to both snapshot writers, and is validated against the compression-level range supported by the bundled ZSTD library, including negative fast levels. Snapshot decoding and the snapshot format remain unchanged.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added the `snapshot_zstd_compression_level` Keeper coordination setting to configure the ZSTD compression level used for snapshots. It defaults to `3`, preserving the existing behavior.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116866&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116866](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116866+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.575` (included in `26.9` and later)
<!-- ch-version-info:end -->