### PR TITLE
Docs: Fix MCP link on documentation homepage

### DIFF
--- a/docs/_site/customizations/tab-nav.js
+++ b/docs/_site/customizations/tab-nav.js
@@ -8,6 +8,7 @@
     'Solutions':    '/products/cloud/getting-started/cloud-get-started',
     'Integrations': '/integrations/home',
   };
+  var MCP_GUIDE_URL = '/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
 
   // Locales with their own page tree; each has a localized homepage at
   // /<locale> and mirrors the English paths beneath it.
@@ -27,6 +28,12 @@
     var locale = currentLocale();
     var localized = locale ? '/' + locale + (url === '/' ? '' : url) : url;
     return BASE + localized;
+  }
+
+  function patchHomepageLinks() {
+    document.querySelectorAll('a[data-galaxy-event="docs.home.mcp-server"]').forEach(function (link) {
+      link.setAttribute('href', localizeUrl(MCP_GUIDE_URL));
+    });
   }
 
   function patchTabButtons() {
@@ -218,6 +225,7 @@
   function init() {
     applyHomepageClass();
     setupHomepageNavbar();
+    patchHomepageLinks();
     patchTabButtons();
     styleDropdownHeaders();
     markNavbarReady();
@@ -233,6 +241,7 @@
         applyHomepageClass();
         setupHomepageNavbar();
         updateLogoTheme();
+        patchHomepageLinks();
         patchTabButtons();
         styleDropdownHeaders();
         markNavbarReady();
@@ -244,6 +253,7 @@
     window.addEventListener('popstate', function () {
       applyHomepageClass();
       setupHomepageNavbar();
+      patchHomepageLinks();
     });
 
     // Failsafe: never leave the navbar hidden. If an injection never completes

--- a/docs/_site/customizations/tab-nav.js
+++ b/docs/_site/customizations/tab-nav.js
@@ -8,7 +8,6 @@
     'Solutions':    '/products/cloud/getting-started/cloud-get-started',
     'Integrations': '/integrations/home',
   };
-  var MCP_GUIDE_URL = '/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
 
   // Locales with their own page tree; each has a localized homepage at
   // /<locale> and mirrors the English paths beneath it.
@@ -28,12 +27,6 @@
     var locale = currentLocale();
     var localized = locale ? '/' + locale + (url === '/' ? '' : url) : url;
     return BASE + localized;
-  }
-
-  function patchHomepageLinks() {
-    document.querySelectorAll('a[data-galaxy-event="docs.home.mcp-server"]').forEach(function (link) {
-      link.setAttribute('href', localizeUrl(MCP_GUIDE_URL));
-    });
   }
 
   function patchTabButtons() {
@@ -225,7 +218,6 @@
   function init() {
     applyHomepageClass();
     setupHomepageNavbar();
-    patchHomepageLinks();
     patchTabButtons();
     styleDropdownHeaders();
     markNavbarReady();
@@ -241,7 +233,6 @@
         applyHomepageClass();
         setupHomepageNavbar();
         updateLogoTheme();
-        patchHomepageLinks();
         patchTabButtons();
         styleDropdownHeaders();
         markNavbarReady();
@@ -253,7 +244,6 @@
     window.addEventListener('popstate', function () {
       applyHomepageClass();
       setupHomepageNavbar();
-      patchHomepageLinks();
     });
 
     // Failsafe: never leave the navbar hidden. If an injection never completes

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/ar/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/ar/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/ar/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/ar/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/ar/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/ar/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/ar/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/es/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/es/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/es/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/es/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/es/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/es/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/es/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/fr/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/fr/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/fr/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/fr/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/fr/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/fr/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/fr/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -173,11 +173,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -173,7 +173,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -173,7 +173,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -175,11 +175,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -178,6 +178,7 @@ export const McpLink = ({ children }) => {
         <a
             href={href}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = href; }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -178,7 +178,6 @@ export const McpLink = ({ children }) => {
         <a
             href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = href; }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/ja/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/ja/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/ja/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/ja/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/ja/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/ja/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/ja/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/ko/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/ko/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/ko/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/ko/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/ko/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/ko/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/ko/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/pt-BR/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/pt-BR/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/pt-BR/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/pt-BR/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/pt-BR/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/pt-BR/index.mdx
+++ b/docs/pt-BR/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/pt-BR/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/pt-BR/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/ru/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/ru/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/ru/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/ru/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/ru/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/ru/index.mdx
+++ b/docs/ru/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/ru/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/ru/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/docs/zh/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const href = '/zh/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -174,11 +174,13 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = '/zh/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const path = '/zh/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
+    const withBase = (p) => assetBase + p;
     return (
         <a
-            href={href}
+            href={path}
             data-galaxy-event="docs.home.mcp-server"
+            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -174,7 +174,7 @@ export const HighlightedClickHouse = () => {
 
 export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
-    const href = `${assetBase}/zh/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`;
+    const href = '/docs/zh/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     return (
         <a
             href={href}

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -176,11 +176,16 @@ export const McpLink = ({ children }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const path = '/zh/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server';
     const withBase = (p) => assetBase + p;
+    const href = withBase(path);
     return (
         <a
-            href={path}
+            href={href}
             data-galaxy-event="docs.home.mcp-server"
-            onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
+            onClick={(e) => {
+                if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                window.location.href = href;
+            }}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
             <span


### PR DESCRIPTION
The MCP server shortcut is rewritten differently by Mintlify across deployments. Production turned the client-computed route into `/docs/docs/resources/...`, while the Mintlify preview turned the source route into `/docs/resources/...` even though preview pages are hosted at `/resources/...`.

Use the base detection already used by the homepage cards to build an environment-correct destination: root-hosted previews and localhost use the locale-specific `/resources/...` path, while production adds `/docs` once. Render that destination in the anchor and intercept only an unmodified primary click, preserving `Cmd`/`Ctrl`-click, context-menu actions, and other native link behavior. Apply the same implementation to the English homepage and all eight localized homepages.

Verified every homepage in local and hosted Mintlify previews, and checked route composition for both root-hosted previews and the production `/docs` base.

https://clickhouse.com/docs


### Changelog category (leave one):
- Documentation


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116867&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116867](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116867+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.260` (included in `26.9` and later)
<!-- ch-version-info:end -->