### PR TITLE
Fix `02995_new_settings_history` on the 26.7 branch

### DIFF
--- a/tests/queries/0_stateless/02995_new_settings_history.sh
+++ b/tests/queries/0_stateless/02995_new_settings_history.sh
@@ -19,6 +19,10 @@ IGNORE_SETTINGS_FOR_SANITIZERS="1=1"
 
 # Note that this is a broad check. A per version check is done in the upgrade test
 # Baselines generated with v26.6.1 (pre-release)
+# The baselines come from a *pre-release* of 26.6, so a setting introduced later in the 26.6 series
+# (for example by a backport into 26.6.2) is missing from them while its `SettingsChangesHistory.cpp`
+# entry legitimately says `26.6`. That is why the version comparison below accepts `26.6` as well:
+# every setting absent from the baseline must carry a history entry of 26.6 or later.
 # clickhouse local --query "select name, default from system.settings order by name format TSV" > 02995_settings_26_6_1.tsv
 # clickhouse local --query "select name, value from system.merge_tree_settings order by name format TSV" > 02995_merge_tree_settings_settings_26_6_1.tsv
 $CLICKHOUSE_LOCAL --query "
@@ -48,7 +52,7 @@ $CLICKHOUSE_LOCAL --query "
         )) AND (name NOT IN (
             SELECT arrayJoin(tupleElement(changes, 'name'))
             FROM system.settings_changes
-            WHERE type = 'Session' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 > 6))
+            WHERE type = 'Session' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 >= 6))
         ))
         UNION ALL
         (
@@ -60,7 +64,7 @@ $CLICKHOUSE_LOCAL --query "
             )) AND (name NOT IN (
                 SELECT arrayJoin(tupleElement(changes, 'name'))
                 FROM system.settings_changes
-                WHERE type = 'MergeTree' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 > 6))
+                WHERE type = 'MergeTree' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 >= 6))
             ))
         )
         UNION ALL
@@ -71,7 +75,7 @@ $CLICKHOUSE_LOCAL --query "
             WHERE (new_settings.default != old_settings.default) AND (name NOT IN (
                 SELECT arrayJoin(tupleElement(changes, 'name'))
                 FROM system.settings_changes
-                WHERE type = 'Session' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 > 6))
+                WHERE type = 'Session' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 >= 6))
             )) AND ${IGNORE_SETTINGS_FOR_SANITIZERS}
         )
         UNION ALL
@@ -82,7 +86,7 @@ $CLICKHOUSE_LOCAL --query "
             WHERE (new_merge_tree_settings.default != old_merge_tree_settings.default) AND (name NOT IN (
                 SELECT arrayJoin(tupleElement(changes, 'name'))
                 FROM system.settings_changes
-                WHERE type = 'MergeTree' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 > 6))
+                WHERE type = 'MergeTree' AND (splitByChar('.', version)[1]::UInt64 > 26 OR (splitByChar('.', version)[1]::UInt64 == 26 AND splitByChar('.', version)[2]::UInt64 >= 6))
             )) AND ${IGNORED_MERGETREE_SETTINGS_FOR_CLOUD}
         )
     )


### PR DESCRIPTION
`02995_new_settings_history` fails deterministically for **every** pull request based on `26.7`:

```
PLEASE ADD THE NEW MERGE_TREE_SETTING TO SettingsChangesHistory.cpp: text_index_serialization_version WAS ADDED
```

The test compares `system.settings` / `system.merge_tree_settings` against baselines captured from a *pre-release* of 26.6, and required every setting missing from the baselines to have a `SettingsChangesHistory.cpp` entry with a version strictly greater than `26.6`.

That is too strict for a setting introduced later in the 26.6 series. The `MergeTree` setting `text_index_serialization_version` was added to the `26.6` branch by the backport of https://github.com/ClickHouse/ClickHouse/pull/111803, i.e. after the v26.6.1 pre-release the baselines were generated from, so it is absent from `02995_merge_tree_settings_settings_26_6_1.tsv` while its history entry correctly says `26.6`.

This accepts `26.6` in the version comparison: a setting that is absent from the baselines must carry a history entry of 26.6 or later. No strictness is lost, because settings that were already present in the baselines never reach this predicate.

On `master` the test no longer exists - it was replaced by `03999_stateless_settings_history` in https://github.com/ClickHouse/ClickHouse/pull/111605 - so this fix is only needed on the release branch.

Example of the failure (one of many): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116466&sha=ce1b461c7587e671c8e4756ba87c66910efa5539&name_0=BackportPR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29

Related: https://github.com/ClickHouse/ClickHouse/pull/116466
Related: https://github.com/ClickHouse/ClickHouse/pull/111605

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.6.21`
<!-- ch-version-info:end -->