### PR TITLE
Require privileges on an `Alias` target in the `loop` table function

### DIFF
--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -9,6 +9,7 @@
 #include <Common/Exception.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Storages/checkAndGetLiteralArgument.h>
+#include <Storages/StorageAlias.h>
 #include <Storages/StorageLoop.h>
 #include <TableFunctions/registerTableFunctions.h>
 
@@ -19,6 +20,7 @@ namespace DB
         extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
         extern const int ILLEGAL_TYPE_OF_ARGUMENT;
         extern const int UNKNOWN_TABLE;
+        extern const int ACCESS_DENIED;
     }
     namespace
     {
@@ -140,6 +142,16 @@ namespace DB
             if (!storage)
                 throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table '{}' not found in database '{}'", loop_table_name, database_name);
             context->checkAccess(AccessType::SELECT, database_name, loop_table_name);
+
+            /// An Alias publishes its target's metadata to the caller before any row is read, so the
+            /// target must be readable in full here; the per-column check happens later, once the
+            /// loop's own SELECT runs.
+            if (const auto * alias = storage->as<StorageAlias>();
+                alias && !alias->isTargetTableGranted(context, AccessType::SELECT, {}))
+                throw Exception(
+                    ErrorCodes::ACCESS_DENIED,
+                    "Not enough privileges to read the table that {} points to",
+                    StorageID{database_name, loop_table_name}.getNameForLogs());
         }
         else
         {

--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -143,9 +143,9 @@ namespace DB
                 throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table '{}' not found in database '{}'", loop_table_name, database_name);
             context->checkAccess(AccessType::SELECT, database_name, loop_table_name);
 
-            /// An Alias publishes its target's metadata to the caller before any row is read, so the
-            /// target must be readable in full here; the per-column check happens later, once the
-            /// loop's own SELECT runs.
+            /// An `Alias` publishes its target's metadata to the caller before any row is read, so
+            /// the target must be readable in full here; the per-column check happens later, once
+            /// the loop's own `SELECT` runs.
             if (const auto * alias = storage->as<StorageAlias>();
                 alias && !alias->isTargetTableGranted(context, AccessType::SELECT, {}))
                 throw Exception(

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.reference
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.reference
@@ -1,9 +1,27 @@
 Without SELECT on the loop table
 ACCESS_DENIED
 With SELECT on the loop table
+ACCESS_DENIED
+Describing the dangling alias directly
+ACCESS_DENIED
+With SELECT on the dropped target name
 UNSUPPORTED_METHOD
 With SELECT on a live alias but not on its target
+ACCESS_DENIED
+Reading no rows through loop without a grant on the target
+ACCESS_DENIED
+Describing a row-less loop subquery without a grant on the target
+ACCESS_DENIED
+Reading no rows from the live alias directly
+ACCESS_DENIED
+With only a column grant on the target, through loop
+ACCESS_DENIED
+With only a column grant on the target, reading the alias directly
+c0
+With only SHOW COLUMNS on the target, through loop
 ACCESS_DENIED
 With SELECT on a live alias and on its target
 1
 1
+Reading no rows through loop with SELECT on the target
+c0

--- a/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
+++ b/tests/queries/0_stateless/04945_loop_over_table_expression_without_columns_access.sh
@@ -5,9 +5,13 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 username="user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+user_col="${username}_col"
+user_show="${username}_show"
 
 ${CLICKHOUSE_CLIENT} -m --query "
     DROP USER IF EXISTS ${username};
+    DROP USER IF EXISTS ${user_col};
+    DROP USER IF EXISTS ${user_show};
     DROP TABLE IF EXISTS loop_access_target;
     DROP TABLE IF EXISTS loop_access_alias;
     DROP TABLE IF EXISTS loop_access_live_target;
@@ -23,6 +27,16 @@ ${CLICKHOUSE_CLIENT} -m --query "
 
     CREATE USER ${username} NOT IDENTIFIED;
     GRANT CREATE TEMPORARY TABLE ON *.* TO ${username};
+
+    CREATE USER ${user_col} NOT IDENTIFIED;
+    GRANT CREATE TEMPORARY TABLE ON *.* TO ${user_col};
+    GRANT SELECT ON loop_access_live_alias TO ${user_col};
+    GRANT SELECT(c0) ON loop_access_live_target TO ${user_col};
+
+    CREATE USER ${user_show} NOT IDENTIFIED;
+    GRANT CREATE TEMPORARY TABLE ON *.* TO ${user_show};
+    GRANT SELECT ON loop_access_live_alias TO ${user_show};
+    GRANT SHOW COLUMNS ON loop_access_live_target TO ${user_show};
 "
 
 echo "Without SELECT on the loop table"
@@ -35,6 +49,17 @@ ${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON loop_access_alias TO ${username};"
 echo "With SELECT on the loop table"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query \
     "SELECT count() FROM loop(currentDatabase(), 'loop_access_alias');" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+echo "Describing the dangling alias directly"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "DESCRIBE TABLE loop_access_alias;" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+echo "With SELECT on the dropped target name"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON loop_access_target TO ${username};"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT count() FROM loop(currentDatabase(), 'loop_access_alias');" 2>&1 |
     grep -o "UNSUPPORTED_METHOD" | uniq
 
 echo "With SELECT on a live alias but not on its target"
@@ -43,13 +68,48 @@ ${CLICKHOUSE_CLIENT} --user="${username}" --query \
     "SELECT 1 FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 2;" 2>&1 |
     grep -o "ACCESS_DENIED" | uniq
 
+echo "Reading no rows through loop without a grant on the target"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT * FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 0 FORMAT TSVWithNames;" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+echo "Describing a row-less loop subquery without a grant on the target"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "DESCRIBE TABLE (SELECT * FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 0);" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+echo "Reading no rows from the live alias directly"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT * FROM loop_access_live_alias LIMIT 0 FORMAT TSVWithNames;" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+echo "With only a column grant on the target, through loop"
+${CLICKHOUSE_CLIENT} --user="${user_col}" --query \
+    "SELECT c0 FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 0 FORMAT TSVWithNames;" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
+echo "With only a column grant on the target, reading the alias directly"
+${CLICKHOUSE_CLIENT} --user="${user_col}" --query \
+    "SELECT c0 FROM loop_access_live_alias LIMIT 0 FORMAT TSVWithNames;"
+
+echo "With only SHOW COLUMNS on the target, through loop"
+${CLICKHOUSE_CLIENT} --user="${user_show}" --query \
+    "SELECT * FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 0 FORMAT TSVWithNames;" 2>&1 |
+    grep -o "ACCESS_DENIED" | uniq
+
 echo "With SELECT on a live alias and on its target"
 ${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON loop_access_live_target TO ${username};"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query \
     "SELECT 1 FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 2;"
 
+echo "Reading no rows through loop with SELECT on the target"
+${CLICKHOUSE_CLIENT} --user="${username}" --query \
+    "SELECT * FROM loop(currentDatabase(), 'loop_access_live_alias') LIMIT 0 FORMAT TSVWithNames;"
+
 ${CLICKHOUSE_CLIENT} -m --query "
     DROP USER IF EXISTS ${username};
+    DROP USER IF EXISTS ${user_col};
+    DROP USER IF EXISTS ${user_show};
     DROP TABLE IF EXISTS loop_access_alias;
     DROP TABLE IF EXISTS loop_access_live_alias;
     DROP TABLE IF EXISTS loop_access_live_target;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116793
Related: https://github.com/ClickHouse/ClickHouse/pull/116647


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `loop` table function disclosing the column names and types of an `Alias` table's target to a user who holds no privilege on that target: a query that read no rows received them in its response header. `loop` now requires table-level `SELECT` on the target, matching what it already requires of the table name it is given.


### Description

`loop` authorizes the name it is given, but an `Alias` publishes its target's metadata eagerly while authorizing the target lazily. `StorageLoop`'s constructor copies the inner storage's metadata, which for a `StorageAlias` is the target's, so the response header is populated before any row is read; the target is only checked inside `LoopSource::initLoop`'s synthetic `SELECT`, which a row-less query never reaches.

A user with `SELECT` on the alias and nothing on the target gets its structure from any row-less form: `SELECT * FROM loop(db, ali) LIMIT 0`, the same query under `EXPLAIN header = 1`, or `DESCRIBE TABLE (SELECT ... LIMIT 0)`, while `DESCRIBE ali` and `SELECT * FROM ali LIMIT 0` deny that user. Rows are never disclosed; it reproduces on master.

The fix adds a name-based target grant check in `TableFunctionLoop::executeImpl`, before `StorageLoop` is constructed. `PlannerJoinTree.cpp` designates `ITableFunction::execute` as that seam; it runs at query-tree resolution, not pipeline setup, which covers the `DESCRIBE` subquery. The probe never resolves the target, so a dangling `Alias` still reports `UNSUPPORTED_METHOD` to a caller granted the dropped name; full-access behaviour is unchanged. One merged arm of `04945_loop_over_table_expression_without_columns_access` changes to `ACCESS_DENIED`; added arms show it is a tightening.

Validated both directions: a mutation per new arm, 50 randomized runs, and a base-versus-fix run of the `loop`/`alias` suite.

Table-level `SELECT` is the tier, so a caller holding only a column-level grant on the target loses `loop` over the alias, though reading it directly still works; the permissive tiers are unsound. #116793 closes the structure seam of this invariant, `DESCRIBE loop(db, alias)`, at that seam's own `SHOW COLUMNS` tier, so until it merges that form still discloses the columns. Two further residuals: an unauthorized `CREATE TABLE ... AS loop(...)` succeeds through the global context `ITableFunction::execute` uses, and `merge` reads an `Alias`'s metadata the same way, uncovered.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116873&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116873](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116873+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
