### PR TITLE
Add a regression test for pushed external roles read through a plain view

### DIFF
--- a/tests/integration/test_ldap_external_user_directory/test.py
+++ b/tests/integration/test_ldap_external_user_directory/test.py
@@ -159,6 +159,9 @@ def test_push_role_to_other_nodes(ldap_cluster):
     instance2.query("CREATE USER remote_user IDENTIFIED WITH plaintext_password BY 'qwerty'", user="common_user", password="qwerty")
 
     instance1.query("DROP TABLE IF EXISTS distributed_table SYNC", user="common_user", password="qwerty")
+    instance1.query("DROP TABLE IF EXISTS distributed_table_view SYNC", user="common_user", password="qwerty")
+    instance1.query("DROP VIEW IF EXISTS local_table_view SYNC", user="common_user", password="qwerty")
+    instance2.query("DROP VIEW IF EXISTS local_table_view SYNC", user="common_user", password="qwerty")
     instance1.query("DROP TABLE IF EXISTS local_table SYNC", user="common_user", password="qwerty")
     instance2.query("DROP TABLE IF EXISTS local_table SYNC", user="common_user", password="qwerty")
 
@@ -201,7 +204,26 @@ def test_push_role_to_other_nodes(ldap_cluster):
     )
     assert result.strip() == "6"
 
+    # A view without DEFINER or SQL SECURITY carries no security context of its own, so the pushed
+    # role must authorize a read through it too. Every shard of the cluster needs the view.
+    instance1.query(
+        "CREATE VIEW IF NOT EXISTS local_table_view AS SELECT * FROM local_table", user="common_user", password="qwerty"
+    )
+    instance2.query(
+        "CREATE VIEW IF NOT EXISTS local_table_view AS SELECT * FROM local_table", user="common_user", password="qwerty"
+    )
+    instance1.query(
+        "CREATE TABLE IF NOT EXISTS distributed_table_view AS local_table ENGINE = Distributed(test_ldap_cluster, default, local_table_view)", user="common_user", password="qwerty"
+    )
+    result = instance1.query(
+        "SELECT sum(id) FROM distributed_table_view", user="johndoe", password="qwertz"
+    )
+    assert result.strip() == "6"
+
     instance1.query("DROP TABLE IF EXISTS distributed_table SYNC", user="common_user", password="qwerty")
+    instance1.query("DROP TABLE IF EXISTS distributed_table_view SYNC", user="common_user", password="qwerty")
+    instance1.query("DROP VIEW IF EXISTS local_table_view SYNC", user="common_user", password="qwerty")
+    instance2.query("DROP VIEW IF EXISTS local_table_view SYNC", user="common_user", password="qwerty")
     instance1.query("DROP TABLE IF EXISTS local_table SYNC", user="common_user", password="qwerty")
     instance2.query("DROP TABLE IF EXISTS local_table SYNC", user="common_user", password="qwerty")
     instance1.query("DROP ROLE IF EXISTS role_read", user="common_user", password="qwerty")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/116840
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Cover a pushed external role authorizing a `Distributed` read through an ordinary view.


### Description

Related: #116840

@ BorisTyshkevich reported that with `push_external_roles_in_interserver_queries = 1` a `Distributed`
read authorized by an LDAP-pushed external role succeeds against a base table and is denied when the
remote object is an ordinary view, and [asked for coverage](https://github.com/ClickHouse/ClickHouse/issues/116840#issuecomment-5450439793).
His diagnosis holds: for unset or `INVOKER` `SQL SECURITY`, `StorageView::getViewContext` builds the
view context with `Context::createCopy` and then calls `setSettings`, forcing an access
recalculation. If `ContextData`'s copy constructor does not carry `external_roles`, the pushed role is
gone and a user with no locally granted role is denied.

Master already preserves it: `external_roles(o.external_roles)` in that copy constructor, added in
74fd238f9a09e4619ee406cb4c5699d7007ed1b4 (#110144, merged 2026-08-26). **This PR adds no source
change**, only the missing guard.

Nothing observed that initializer: both cases in `gtest_context_external_roles.cpp` set the external
roles via `setUser` on each copy, so deleting it leaves both green. This extends the existing
interserver pushed-role test with the view arm. Measured with two binaries one line apart: with the
initializer it passes; without it, it fails with `johndoe: Not enough privileges ... SELECT ON default.local_table`
while the base-table assertion still passes. 5/5 repeats and the whole module are green.

One arm covers the class: `external_roles` has a single inheritance site, so every other
`Context::createCopy` consumer (materialized views, dictionaries, table functions, `Distributed` over
`Distributed`) rides on the same initializer.

A stateless `.sh` form needs a receiver where the user's only authorization is the pushed role; the
LDAP directory there has no role mapping and gives that, a local user does not.

@alexey-milovidov the fix is absent from every release branch (26.9 is the first to carry it), but
#110144 is a feature PR, so a whole-PR backport label is probably not what you want - which route do
you prefer? Please do not label this test PR: the new arm fails wherever the fix is absent.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116876&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116876](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116876+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
