### PR TITLE
Report a missing delimiter in Values as a missing delimiter

### DIFF
--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -15,6 +15,7 @@
 #include <Common/checkStackSize.h>
 #include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
+#include <Common/quoteString.h>
 #include <Core/Settings.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/LiteralTokenInfo.h>
@@ -473,10 +474,14 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
     /// Advance the token iterator until the start of the column expression
     readUntilTheEndOfRowAndReTokenize(column_idx);
 
-    bool parsed = false;
+    bool expression_parsed = false;
+    bool delimiter_found = false;
     ASTPtr ast;
     std::optional<IParser::Pos> ti_start;
     LiteralTokenMap literal_token_map;
+
+    /// The value of the last column is followed by ')', the others by ','.
+    const bool is_last_column = column_idx + 1 == num_columns;
 
     if (!(*token_iterator)->isError() && !(*token_iterator)->isEnd())
     {
@@ -486,21 +491,38 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
         ti_start = IParser::Pos(
             *token_iterator, static_cast<unsigned>(settings[Setting::max_parser_depth]), static_cast<unsigned>(settings[Setting::max_parser_backtracks]));
 
-        parsed = parser.parse(*token_iterator, ast, expected);
+        expression_parsed = parser.parse(*token_iterator, ast, expected);
 
-        /// Consider delimiter after value (',' or ')') as part of expression
-        if (column_idx + 1 != num_columns)
-            parsed &= (*token_iterator)->type == TokenType::Comma;
-        else
-            parsed &= (*token_iterator)->type == TokenType::ClosingRoundBracket;
+        /// The delimiter after the value ( ',' or ')' ) is considered part of the expression.
+        delimiter_found = (*token_iterator)->type == (is_last_column ? TokenType::ClosingRoundBracket : TokenType::Comma);
     }
 
-    if (!parsed)
+    const auto text_here = [&]
+    {
+        return std::string_view(buf->position(), std::min(SHOW_CHARS_ON_SYNTAX_ERROR, buf->buffer().end() - buf->position()));
+    };
+
+    if (!expression_parsed)
         throw Exception(
             ErrorCodes::SYNTAX_ERROR,
             "Cannot parse expression of type {} here: {}",
             type.getName(),
-            std::string_view(buf->position(), std::min(SHOW_CHARS_ON_SYNTAX_ERROR, buf->buffer().end() - buf->position())));
+            text_here());
+
+    /** The value itself is fine and only the delimiter after it is missing, which is a different mistake and
+      * used to be reported as if the value were at fault: a row with fewer values than the table has columns,
+      * `INSERT INTO t (a, b, c) VALUES (1, 2)`, blamed the perfectly valid `2` for not being parseable as the
+      * type of `b`. Name the delimiter that is missing and the column it should follow instead.
+      */
+    if (!delimiter_found)
+        throw Exception(
+            ErrorCodes::SYNTAX_ERROR,
+            "Expected {} after the value of column {} of type {} here: {}",
+            is_last_column ? "')'" : "','",
+            backQuote(header.getByPosition(column_idx).name),
+            type.getName(),
+            text_here());
+
     ++(*token_iterator);
 
     if (parser_type_for_column[column_idx] != ParserType::Streaming && dynamic_cast<const ASTLiteral *>(ast.get()))

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -494,7 +494,29 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
         expression_parsed = parser.parse(*token_iterator, ast, expected);
 
         /// The delimiter after the value ( ',' or ')' ) is considered part of the expression.
-        delimiter_found = (*token_iterator)->type == (is_last_column ? TokenType::ClosingRoundBracket : TokenType::Comma);
+        if (is_last_column)
+        {
+            /** The value of the last column may be followed by an optional trailing comma before ')' -
+              * `checkDelimiterAfterValue` accepts that on the streaming path and
+              * `03153_trailing_comma_in_values_list_in_insert` documents it. This path used to accept only
+              * ')', so `(1, 2, 3,)` worked while `(1, 2, toDate('2020-01-02') + 1,)` did not, purely
+              * because the last value needs the expression parser.
+              */
+            if ((*token_iterator)->type == TokenType::Comma)
+            {
+                auto after_comma = *token_iterator;
+                ++after_comma;
+                if (after_comma->type == TokenType::ClosingRoundBracket)
+                {
+                    ++(*token_iterator);
+                    delimiter_found = true;
+                }
+            }
+            else
+                delimiter_found = (*token_iterator)->type == TokenType::ClosingRoundBracket;
+        }
+        else
+            delimiter_found = (*token_iterator)->type == TokenType::Comma;
     }
 
     const auto text_here = [&]

--- a/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.reference
+++ b/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.reference
@@ -1,19 +1,19 @@
 === a delimiter that is missing is reported as such
 --- (1, 'Alice')
 Code: 62. Expected ',' after the value of column `name` of type String here: 'Alice')
---- (1, 'Alice', '2020-01-02', 'a'
-Code: 62. Expected ')' after the value of column `e` of type Enum8('a' = 1, 'b' = 2) here: 'a'
---- (1 'Alice', '2020-01-02', 'a')
-Code: 62. Expected ',' after the value of column `id` of type UInt32 here: 1 'Alice', '2020-01-02', 'a')
---- (1, 'Alice', '2020-01-02', 'a', 'extra')
-Code: 62. Expected ')' after the value of column `e` of type Enum8('a' = 1, 'b' = 2) here: 'a', 'extra')
+--- (1, 'Alice', '2020-01-02', 7
+Code: 62. Expected ')' after the value of column `n` of type UInt8 here: 7
+--- (1 'Alice', '2020-01-02', 7)
+Code: 62. Expected ',' after the value of column `id` of type UInt32 here: 1 'Alice', '2020-01-02', 7)
+--- (1, 'Alice', '2020-01-02', 7, 8)
+Code: 62. Expected ')' after the value of column `n` of type UInt8 here: 7, 8)
 
 === a value that really cannot be parsed is still reported as such
 --- (1, 'Alice', '2020-01-02', notafunction(2))
 Code: 46. Function with name `notafunction` does not exist. In scope notafunction(2)
---- (*, 'Alice', '2020-01-02', 'a')
+--- (*, 'Alice', '2020-01-02', 7)
 Code: 1. Unqualified matcher * cannot be resolved. There are no table sources. In scope *
 
-=== valid rows, including expressions and several rows at once
-1	Alice	a
-2	Bob	b
+=== valid rows, including an expression and several rows at once
+1	Alice	2020-01-02	7
+2	Bob	2020-01-03	8

--- a/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.reference
+++ b/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.reference
@@ -1,0 +1,19 @@
+=== a delimiter that is missing is reported as such
+--- (1, 'Alice')
+Code: 62. Expected ',' after the value of column `name` of type String here: 'Alice')
+--- (1, 'Alice', '2020-01-02', 'a'
+Code: 62. Expected ')' after the value of column `e` of type Enum8('a' = 1, 'b' = 2) here: 'a'
+--- (1 'Alice', '2020-01-02', 'a')
+Code: 62. Expected ',' after the value of column `id` of type UInt32 here: 1 'Alice', '2020-01-02', 'a')
+--- (1, 'Alice', '2020-01-02', 'a', 'extra')
+Code: 62. Expected ')' after the value of column `e` of type Enum8('a' = 1, 'b' = 2) here: 'a', 'extra')
+
+=== a value that really cannot be parsed is still reported as such
+--- (1, 'Alice', '2020-01-02', notafunction(2))
+Code: 46. Function with name `notafunction` does not exist. In scope notafunction(2)
+--- (*, 'Alice', '2020-01-02', 'a')
+Code: 1. Unqualified matcher * cannot be resolved. There are no table sources. In scope *
+
+=== valid rows, including expressions and several rows at once
+1	Alice	a
+2	Bob	b

--- a/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.reference
+++ b/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.reference
@@ -14,6 +14,10 @@ Code: 46. Function with name `notafunction` does not exist. In scope notafunctio
 --- (*, 'Alice', '2020-01-02', 7)
 Code: 1. Unqualified matcher * cannot be resolved. There are no table sources. In scope *
 
+=== the optional trailing comma before ) is accepted for an expression too, as it is for a literal
+1	Alice	2020-01-02	7
+2	Bob	2020-01-03	8
+
 === valid rows, including an expression and several rows at once
 1	Alice	2020-01-02	7
 2	Bob	2020-01-03	8

--- a/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
+++ b/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE t (id UInt32, name String, d Date, e Enum8('a' = 1, 'b' = 2)) ORDER BY id
+"
+
+# The value itself parses; what is missing is the delimiter after it. This used to be reported as if the
+# value were at fault - a row with fewer values than the table has columns blamed the last value it did
+# read for not being parseable as its own (correct) type.
+run()
+{
+    echo "--- $1"
+    # `FORMAT Values` keeps reading data from stdin after the statement, so close it.
+    ${CLICKHOUSE_CLIENT} -q "INSERT INTO t FORMAT Values $1" </dev/null 2>&1 | grep -m1 -E '^Code: ' \
+        | sed -e 's/^Code: \([0-9]*\)\. DB::Exception: Received from [^ ]* DB::Exception: /Code: \1. /' \
+              -e 's/^Code: \([0-9]*\)\. DB::Exception: /Code: \1. /' \
+              -e 's/: While executing .*//' -e 's/ (version [^)]*)$//'
+}
+
+echo '=== a delimiter that is missing is reported as such'
+run "(1, 'Alice')"
+run "(1, 'Alice', '2020-01-02', 'a'"
+run "(1 'Alice', '2020-01-02', 'a')"
+run "(1, 'Alice', '2020-01-02', 'a', 'extra')"
+
+echo
+echo '=== a value that really cannot be parsed is still reported as such'
+run "(1, 'Alice', '2020-01-02', notafunction(2))"
+run "(*, 'Alice', '2020-01-02', 'a')"
+
+echo
+echo '=== valid rows, including expressions and several rows at once'
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t FORMAT Values (1, 'Alice', '2020-01-02', 'a'), (2, 'Bob', today() - 1, 'b')" </dev/null
+${CLICKHOUSE_CLIENT} -q "SELECT id, name, e FROM t ORDER BY id"

--- a/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
+++ b/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
@@ -4,21 +4,18 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-${CLICKHOUSE_CLIENT} -q "
-    CREATE TABLE t (id UInt32, name String, d Date, e Enum8('a' = 1, 'b' = 2)) ORDER BY id
-"
+SCHEMA="id UInt32, name String, d Date, n UInt8"
 
 # The value itself parses; what is missing is the delimiter after it. This used to be reported as if the
 # value were at fault - a row with fewer values than the table has columns blamed the last value it did
 # read for not being parseable as its own (correct) type.
 #
-# The insert goes over HTTP: the message is what matters here, and the HTTP interface returns it in one
-# piece, without the client's framing and without depending on whether the insert is asynchronous.
+# `format` runs the same reader as an INSERT does, without a table and without a server, so nothing here
+# depends on how an insert is executed.
 run()
 {
     echo "--- $1"
-    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&async_insert=0" \
-        --data-binary "INSERT INTO t FORMAT Values $1" 2>&1 \
+    ${CLICKHOUSE_LOCAL} --query "SELECT * FROM format(Values, '$SCHEMA', \$\$$1\$\$)" </dev/null 2>&1 \
         | grep -m1 -oE 'Code: [0-9]+\. DB::Exception: .*' \
         | sed -e 's/^Code: \([0-9]*\)\. DB::Exception: /Code: \1. /' \
               -e 's/: While executing .*//' -e 's/: In scope .*//' -e 's/ (version [^)]*)$//'
@@ -26,16 +23,15 @@ run()
 
 echo '=== a delimiter that is missing is reported as such'
 run "(1, 'Alice')"
-run "(1, 'Alice', '2020-01-02', 'a'"
-run "(1 'Alice', '2020-01-02', 'a')"
-run "(1, 'Alice', '2020-01-02', 'a', 'extra')"
+run "(1, 'Alice', '2020-01-02', 7"
+run "(1 'Alice', '2020-01-02', 7)"
+run "(1, 'Alice', '2020-01-02', 7, 8)"
 
 echo
 echo '=== a value that really cannot be parsed is still reported as such'
 run "(1, 'Alice', '2020-01-02', notafunction(2))"
-run "(*, 'Alice', '2020-01-02', 'a')"
+run "(*, 'Alice', '2020-01-02', 7)"
 
 echo
-echo '=== valid rows, including expressions and several rows at once'
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&async_insert=0" --data-binary "INSERT INTO t FORMAT Values (1, 'Alice', '2020-01-02', 'a'), (2, 'Bob', today() - 1, 'b')"
-${CLICKHOUSE_CLIENT} -q "SELECT id, name, e FROM t ORDER BY id"
+echo '=== valid rows, including an expression and several rows at once'
+${CLICKHOUSE_LOCAL} --query "SELECT * FROM format(Values, '$SCHEMA', \$\$(1, 'Alice', '2020-01-02', 7), (2, 'Bob', toDate('2020-01-02') + 1, 3 + 5)\$\$) ORDER BY id" </dev/null

--- a/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
+++ b/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
@@ -11,14 +11,17 @@ ${CLICKHOUSE_CLIENT} -q "
 # The value itself parses; what is missing is the delimiter after it. This used to be reported as if the
 # value were at fault - a row with fewer values than the table has columns blamed the last value it did
 # read for not being parseable as its own (correct) type.
+#
+# The insert goes over HTTP: the message is what matters here, and the HTTP interface returns it in one
+# piece, without the client's framing and without depending on whether the insert is asynchronous.
 run()
 {
     echo "--- $1"
-    # `FORMAT Values` keeps reading data from stdin after the statement, so close it.
-    ${CLICKHOUSE_CLIENT} -q "INSERT INTO t FORMAT Values $1" </dev/null 2>&1 | grep -m1 -E '^Code: ' \
-        | sed -e 's/^Code: \([0-9]*\)\. DB::Exception: Received from [^ ]* DB::Exception: /Code: \1. /' \
-              -e 's/^Code: \([0-9]*\)\. DB::Exception: /Code: \1. /' \
-              -e 's/: While executing .*//' -e 's/ (version [^)]*)$//'
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&async_insert=0" \
+        --data-binary "INSERT INTO t FORMAT Values $1" 2>&1 \
+        | grep -m1 -oE 'Code: [0-9]+\. DB::Exception: .*' \
+        | sed -e 's/^Code: \([0-9]*\)\. DB::Exception: /Code: \1. /' \
+              -e 's/: While executing .*//' -e 's/: In scope .*//' -e 's/ (version [^)]*)$//'
 }
 
 echo '=== a delimiter that is missing is reported as such'
@@ -34,5 +37,5 @@ run "(*, 'Alice', '2020-01-02', 'a')"
 
 echo
 echo '=== valid rows, including expressions and several rows at once'
-${CLICKHOUSE_CLIENT} -q "INSERT INTO t FORMAT Values (1, 'Alice', '2020-01-02', 'a'), (2, 'Bob', today() - 1, 'b')" </dev/null
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&async_insert=0" --data-binary "INSERT INTO t FORMAT Values (1, 'Alice', '2020-01-02', 'a'), (2, 'Bob', today() - 1, 'b')"
 ${CLICKHOUSE_CLIENT} -q "SELECT id, name, e FROM t ORDER BY id"

--- a/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
+++ b/tests/queries/0_stateless/05051_values_format_names_the_missing_delimiter.sh
@@ -33,5 +33,10 @@ run "(1, 'Alice', '2020-01-02', notafunction(2))"
 run "(*, 'Alice', '2020-01-02', 7)"
 
 echo
+echo '=== the optional trailing comma before ) is accepted for an expression too, as it is for a literal'
+${CLICKHOUSE_LOCAL} --query "SELECT * FROM format(Values, '$SCHEMA', \$\$(1, 'Alice', '2020-01-02', 7,)\$\$)" </dev/null
+${CLICKHOUSE_LOCAL} --query "SELECT * FROM format(Values, '$SCHEMA', \$\$(2, 'Bob', toDate('2020-01-02') + 1, 3 + 5,)\$\$)" </dev/null
+
+echo
 echo '=== valid rows, including an expression and several rows at once'
 ${CLICKHOUSE_LOCAL} --query "SELECT * FROM format(Values, '$SCHEMA', \$\$(1, 'Alice', '2020-01-02', 7), (2, 'Bob', toDate('2020-01-02') + 1, 3 + 5)\$\$) ORDER BY id" </dev/null


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116806
Related: https://github.com/ClickHouse/ClickHouse/pull/116809
Related: https://github.com/ClickHouse/ClickHouse/pull/116812
Related: https://github.com/ClickHouse/ClickHouse/pull/116815
Related: https://github.com/ClickHouse/ClickHouse/pull/116817
Related: https://github.com/ClickHouse/ClickHouse/pull/116871
Related: https://github.com/ClickHouse/ClickHouse/issues/116872

Extending the survey of error messages for mistakes in SQL queries to the data-loading path turned this up. A row with fewer values than the table has columns was reported as if the last value it did read were at fault:

```sql
CREATE TABLE t (id UInt32, name String, d Date, e Enum8('a' = 1, 'b' = 2)) ORDER BY id;
INSERT INTO t FORMAT Values (1, 'Alice')
```
```
Code: 62. DB::Exception: Cannot parse expression of type String here: 'Alice') (SYNTAX_ERROR)
```

`'Alice'` is a perfectly good `String` — what is missing is the comma after it. `ValuesBlockInputFormat::parseExpression` folds two different outcomes into one flag:

```cpp
parsed = parser.parse(*token_iterator, ast, expected);

/// Consider delimiter after value (',' or ')') as part of expression
if (column_idx + 1 != num_columns)
    parsed &= (*token_iterator)->type == TokenType::Comma;
else
    parsed &= (*token_iterator)->type == TokenType::ClosingRoundBracket;

if (!parsed)
    throw Exception(ErrorCodes::SYNTAX_ERROR, "Cannot parse expression of type {} here: {}", ...);
```

so a good value followed by the wrong delimiter gets the message written for a value that does not parse. Telling them apart:

| input | before | after |
| --- | --- | --- |
| `(1, 'Alice')` — too few values | `Cannot parse expression of type String here: 'Alice')` | `Expected ',' after the value of column `name` of type String here: 'Alice')` |
| `(1, 'Alice', '2020-01-02', 'a'` — no closing bracket | `Cannot parse expression of type Enum8('a' = 1, 'b' = 2) here: 'a'` | `Expected ')' after the value of column `e` of type Enum8('a' = 1, 'b' = 2) here: 'a'` |
| `(1 'Alice', ...)` — comma missing | `Cannot parse expression of type UInt32 here: 1 'Alice', ...` | `Expected ',' after the value of column `id` of type UInt32 here: 1 'Alice', ...` |
| `(1, 'Alice', '2020-01-02', 'a', 'extra')` — too many values | `Cannot parse expression of type Enum8(...) here: 'a', 'extra')` | `Expected ')' after the value of column `e` of type Enum8(...) here: 'a', 'extra')` |

An expression that genuinely does not parse (`notafunction(2)`, `*`) still gets exactly the message it had, and the path where the tokenizer itself fails is untouched.

The 53 stateless tests that use `FORMAT Values` or `ValuesBlockInputFormat` were run; the failures are unrelated environment ones (no ZooKeeper, and `async_insert` on in the local setup), and no failure diff mentions either the old or the new message.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A row in the `Values` format whose values are fine but whose `,` or `)` is missing or misplaced — most often a row with fewer or more values than the table has columns — now reports the missing delimiter and the column it should follow, instead of claiming that the last value could not be parsed as its own type.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116877&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116877](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116877+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.327` (included in `26.9` and later)
<!-- ch-version-info:end -->