### PR TITLE
Create protoc output directory in `PROTOBUF_GENERATE_GRPC_CPP`

### DIFF
--- a/contrib/grpc-cmake/protobuf_generate_grpc.cmake
+++ b/contrib/grpc-cmake/protobuf_generate_grpc.cmake
@@ -204,8 +204,11 @@ function(protobuf_generate_grpc)
     endif()
     list(APPEND _generated_srcs_all ${_generated_srcs})
 
+    # protoc does not create the output directory, and the Makefiles generator
+    # (unlike Ninja) does not create directories of custom command outputs.
     add_custom_command(
       OUTPUT ${_generated_srcs}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${protobuf_generate_grpc_PROTOC_OUT_DIR}
       COMMAND ${NATIVE_protoc}
       ARGS --${protobuf_generate_grpc_LANGUAGE}_out ${_dll_export_decl}${protobuf_generate_grpc_PROTOC_OUT_DIR}
            --grpc_out ${_dll_export_decl}${protobuf_generate_grpc_PROTOC_OUT_DIR}


### PR DESCRIPTION
`protoc` fails with `No such file or directory` when the `--cpp_out` directory does not exist, and it does not create it. The `Ninja` generator creates directories of declared custom command outputs automatically, so CI never hits this. The `Unix Makefiles` generator does not create them, so a fresh Make-based build fails on `FlightSql.pb.h`:

```
[ 54%] Running cpp protocol buffer compiler on .../contrib/arrow/format/FlightSql.proto
/home/ubuntu/ClickHouse/build/contrib/arrow-cmake/cpp/src/arrow/flight/sql/: No such file or directory
gmake[2]: *** [contrib/arrow-cmake/CMakeFiles/_arrow_flight.dir/build.make:94: contrib/arrow-cmake/cpp/src/arrow/flight/sql/FlightSql.pb.h] Error 1
```

The fix creates `PROTOC_OUT_DIR` explicitly before running `protoc` in `PROTOBUF_GENERATE_GRPC_CPP`. This covers all users of the macro, including `Flight.proto` and `FlightSql.proto` from `contrib/arrow-cmake/flight.cmake`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the build of `ArrowFlight` protobuf files with the CMake `Unix Makefiles` generator: create the `protoc` output directory before running `protoc`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116879&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116879](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116879+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
