### PR TITLE
Delete the redundant 26.9 rename record for `enable_adaptive_codec_selection`

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1446,7 +1446,6 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     {
         addSettingsChanges(merge_tree_settings_changes_history, "26.9",
         {
-            {"enable_adaptive_codec_selection", false, false, "The setting was renamed. The previous name is `allow_experimental_adaptive_codec_selection`."},
             {"patch_parts_version", "v1", "v2", "New setting to control the on-disk serialization version of patch parts produced by lightweight updates. Older compatibility modes keep writing v1 patches, which all replicas in a mixed-version cluster can read."},
             {"shared_merge_tree_use_blobs_list_for_parts", false, false, "New setting which stores a SharedMergeTree part's per-file blob map in one consolidated Keeper node instead of one node per file"},
             {"shared_merge_tree_blobs_list_inline_file_max_bytes", 0, 0, "New setting which stores small files of a blob-list part inline in the consolidated blobs.list instead of separate blobs"},


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113479
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Requested by @ rienath in a review comment on #113479
(https://github.com/ClickHouse/ClickHouse/pull/113479#discussion_r3879062463): "Forgot to delete
this one (we do not need to mention rename here as we already have a new name in 26.8 section).
Could you open a follow-up PR that deletes just this line?"

Related: https://github.com/ClickHouse/ClickHouse/pull/113479

#113479 recorded `enable_adaptive_codec_selection` twice in
`getMergeTreeSettingsChangesHistory`: under its new name in the 26.8 block ("New setting."), and
again in the unreleased 26.9 block as a rename of
`allow_experimental_adaptive_codec_selection`.

The record is also unreachable. Its wording feeds `buildRenames` in
`StorageSystemDocumentation.cpp`, but that old-to-new map is consulted only by a record's canonical
name, and no record in the file is written under the old name.

Both records are `previous_value == new_value == false` and the compiled default is `false`, so
`compatibility` resolves to `0` for every version before and after. The MergeTree 26.9 row of
`system.settings_changes` loses one entry from its `changes` array, and the `system.documentation`
entry loses one `**History**` bullet with `**Introduced in:** v26.8` unchanged; the three
settings-history tests pass unchanged.

Master only: branch `26.8` does have a 26.9 block, but it has never contained this record, and
#116865 only renames the 26.8 record in place. Please let #116865 land on 26.8 before merging this
one. The Upgrade Check exempts a name the previous release lacks only when the history records it
above that release's version; today the previous release is `v26.7.5.10-stable` and the surviving
26.8 record exempts it, but a released 26.8 still carrying the old name would not be covered.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116881&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116881](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116881+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.283` (included in `26.9` and later)
<!-- ch-version-info:end -->