### PR TITLE
docs(clickstack): add agent-assisted instrumentation for the HackerNews Analyzer demo

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -217,17 +217,26 @@ body[data-scroll-locked] {
 .ch-agent-prompt-prompt-area {
     flex: 1 1 auto;
     min-width: 0;
-    overflow: hidden;
+    overflow-x: auto;
     padding: 6px 10px;
     border: 1px solid var(--agent-prompt-border);
     border-radius: 6px;
     background: var(--agent-prompt-bg);
+    scrollbar-width: thin;
+}
+
+.ch-agent-prompt-prompt-area::-webkit-scrollbar {
+    height: 6px;
+}
+
+.ch-agent-prompt-prompt-area::-webkit-scrollbar-thumb {
+    border-radius: 3px;
+    background: #FCFF74;
 }
 
 .prose .ch-agent-prompt-prompt-text,
 .ch-agent-prompt-prompt-text {
     display: block;
-    overflow-x: auto;
     padding: 0;
     border: 0;
     background: transparent;
@@ -235,25 +244,12 @@ body[data-scroll-locked] {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: 0.8125rem;
     white-space: nowrap;
-    scrollbar-width: thin;
-}
-
-.ch-agent-prompt-prompt-text::-webkit-scrollbar {
-    height: 6px;
-}
-
-.ch-agent-prompt-prompt-text::-webkit-scrollbar-thumb {
-    border-radius: 3px;
-    background: #FCFF74;
 }
 
 .ch-agent-prompt-copy-button {
-    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
     gap: 6px;
-    min-width: 8.25rem;
     padding: 7px 12px;
     border: 1px solid var(--agent-accent);
     border-radius: 6px;
@@ -262,29 +258,7 @@ body[data-scroll-locked] {
     cursor: pointer;
     font-size: 0.8125rem;
     font-weight: 600;
-    white-space: nowrap;
     transition: background-color 120ms ease, transform 80ms ease;
-}
-
-.ch-agent-prompt-copy-label {
-    display: grid;
-    justify-items: center;
-}
-
-.ch-agent-prompt-copy-label span {
-    grid-area: 1 / 1;
-}
-
-.ch-agent-prompt-copy-label span:last-child {
-    visibility: hidden;
-}
-
-.ch-agent-prompt-copy-button.is-copied .ch-agent-prompt-copy-label span:first-child {
-    visibility: hidden;
-}
-
-.ch-agent-prompt-copy-button.is-copied .ch-agent-prompt-copy-label span:last-child {
-    visibility: visible;
 }
 
 .ch-agent-prompt-copy-button:hover {
@@ -304,23 +278,18 @@ body[data-scroll-locked] {
 .ch-agent-prompt-sub-row {
     display: flex;
     align-items: baseline;
-    justify-content: space-between;
-    gap: 12px;
+    gap: 8px;
     padding-left: 2px;
-    padding-right: 2px;
     font-size: 0.8125rem;
     line-height: 1.4;
 }
 
 .ch-agent-prompt-description {
-    flex: 1 1 auto;
-    min-width: 0;
     color: var(--agent-text-muted);
 }
 
 .prose a.ch-agent-prompt-repository-link,
 .ch-agent-prompt-repository-link {
-    flex-shrink: 0;
     color: #135BE6 !important;
     font-weight: 600;
 }

--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -217,26 +217,17 @@ body[data-scroll-locked] {
 .ch-agent-prompt-prompt-area {
     flex: 1 1 auto;
     min-width: 0;
-    overflow-x: auto;
+    overflow: hidden;
     padding: 6px 10px;
     border: 1px solid var(--agent-prompt-border);
     border-radius: 6px;
     background: var(--agent-prompt-bg);
-    scrollbar-width: thin;
-}
-
-.ch-agent-prompt-prompt-area::-webkit-scrollbar {
-    height: 6px;
-}
-
-.ch-agent-prompt-prompt-area::-webkit-scrollbar-thumb {
-    border-radius: 3px;
-    background: #FCFF74;
 }
 
 .prose .ch-agent-prompt-prompt-text,
 .ch-agent-prompt-prompt-text {
     display: block;
+    overflow-x: auto;
     padding: 0;
     border: 0;
     background: transparent;
@@ -244,12 +235,25 @@ body[data-scroll-locked] {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: 0.8125rem;
     white-space: nowrap;
+    scrollbar-width: thin;
+}
+
+.ch-agent-prompt-prompt-text::-webkit-scrollbar {
+    height: 6px;
+}
+
+.ch-agent-prompt-prompt-text::-webkit-scrollbar-thumb {
+    border-radius: 3px;
+    background: #FCFF74;
 }
 
 .ch-agent-prompt-copy-button {
+    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 6px;
+    min-width: 8.25rem;
     padding: 7px 12px;
     border: 1px solid var(--agent-accent);
     border-radius: 6px;
@@ -258,7 +262,29 @@ body[data-scroll-locked] {
     cursor: pointer;
     font-size: 0.8125rem;
     font-weight: 600;
+    white-space: nowrap;
     transition: background-color 120ms ease, transform 80ms ease;
+}
+
+.ch-agent-prompt-copy-label {
+    display: grid;
+    justify-items: center;
+}
+
+.ch-agent-prompt-copy-label span {
+    grid-area: 1 / 1;
+}
+
+.ch-agent-prompt-copy-label span:last-child {
+    visibility: hidden;
+}
+
+.ch-agent-prompt-copy-button.is-copied .ch-agent-prompt-copy-label span:first-child {
+    visibility: hidden;
+}
+
+.ch-agent-prompt-copy-button.is-copied .ch-agent-prompt-copy-label span:last-child {
+    visibility: visible;
 }
 
 .ch-agent-prompt-copy-button:hover {
@@ -278,18 +304,23 @@ body[data-scroll-locked] {
 .ch-agent-prompt-sub-row {
     display: flex;
     align-items: baseline;
-    gap: 8px;
+    justify-content: space-between;
+    gap: 12px;
     padding-left: 2px;
+    padding-right: 2px;
     font-size: 0.8125rem;
     line-height: 1.4;
 }
 
 .ch-agent-prompt-description {
+    flex: 1 1 auto;
+    min-width: 0;
     color: var(--agent-text-muted);
 }
 
 .prose a.ch-agent-prompt-repository-link,
 .ch-agent-prompt-repository-link {
+    flex-shrink: 0;
     color: #135BE6 !important;
     font-weight: 600;
 }

--- a/docs/clickstack/example-datasets/index.mdx
+++ b/docs/clickstack/example-datasets/index.mdx
@@ -17,3 +17,4 @@ This section provides various sample datasets and examples to help you get start
 | [Session Replay Demo](/clickstack/example-datasets/session-replay) | Instrument a demo web application for session replay and view your interactions in ClickStack |
 | [Chrome Extension](/clickstack/example-datasets/chrome-extension) | Inject the Browser SDK into any website using the HyperDX Chrome extension, no application code changes required |
 | [Synthetic data with otelgen](/clickstack/example-datasets/otelgen) | Use `otelgen` to send synthetic logs, traces and metrics to a running ClickStack OpenTelemetry collector |
+| [HackerNews Analyzer](/clickstack/example-datasets/instrument-application) | Instrument a Node.js app with an agent (or by hand) and send logs, traces, metrics, and session replay to ClickStack |

--- a/docs/clickstack/example-datasets/instrument-application.mdx
+++ b/docs/clickstack/example-datasets/instrument-application.mdx
@@ -39,14 +39,13 @@ npm install
 cp .env.example .env
 ```
 
-You'll fill `.env` in the next steps, then run the agent from this directory.
+You'll fill `.env` in the next steps, then instrument from this directory.
 
 <InstrumentApplication />
 
 ## Learn more {#learn-more}
 
-- [HackerNews Analyzer README](https://github.com/ClickHouse/hn-news-analyzer): `reset.sh`, troubleshooting, and what to look at in traces (cache hits, year selector, log correlation).
-- [Agent instructions](https://github.com/ClickHouse/hn-news-analyzer/blob/main/agent.md): the prompt the Agent-Assisted Setup card copies.
+- [HackerNews Analyzer](https://github.com/ClickHouse/hn-news-analyzer): the demo repository this guide instruments.
 - [Session Replay](/clickstack/features/session-replay): feature overview, SDK options, and privacy controls.
 - [Session Replay Demo](/clickstack/example-datasets/session-replay): a self-contained demo with a local ClickStack instance.
 - [ClickStack Getting Started](/clickstack/getting-started/index): deploy ClickStack and ingest your first data.

--- a/docs/clickstack/example-datasets/instrument-application.mdx
+++ b/docs/clickstack/example-datasets/instrument-application.mdx
@@ -1,27 +1,52 @@
 ---
 slug: /use-cases/observability/clickstack/example-datasets/instrument-app
-title: 'Instrument an application with Managed ClickStack'
+title: 'HackerNews Analyzer demo'
 sidebarTitle: 'HackerNews Analyzer demo'
-description: 'Guide to instrument a Node.js application with OpenTelemetry and send logs, metrics, and traces to Managed ClickStack'
+description: 'Instrument a Node.js app with an agent and send logs, traces, metrics, and session replay to ClickStack'
 doc_type: 'guide'
-keywords: ['clickstack', 'instrumentation', 'opentelemetry', 'managed clickstack', 'observability']
+keywords: ['ClickStack', 'HackerNews Analyzer', 'OpenTelemetry', 'instrumentation', 'session replay', 'Node.js', 'OTLP']
 ---
 
 import InstrumentApplication from '/snippets/clickstack/_instrument_application.mdx';
 
-This guide shows how to instrument a simple Node.js application using OpenTelemetry and send its logs, metrics, and traces to [Managed ClickStack](/clickstack/getting-started/managed). The backend is instrumented with no changes to the application source code.
+<Note>
+**TL;DR**
 
-The [HackerNews Analyzer](https://github.com/ClickHouse/hn-news-analyzer) is a small Node.js app that queries the HackerNews dataset hosted in the public ClickHouse demo instance. Every chart, table, and search box is backed by a real ClickHouse query, so every interaction produces a trace whose main span is the HTTPS call from the backend out to ClickHouse.
+Clone the [HackerNews Analyzer](https://github.com/ClickHouse/hn-news-analyzer), fill `.env` with your OTLP endpoint and token, then paste the agent prompt. The backend needs no OpenTelemetry imports; the agent wires `@hyperdx/node-opentelemetry` at process start.
+
+Time required: about 10 minutes
+</Note>
+
+The HackerNews Analyzer is a Node.js app that queries the HackerNews dataset hosted in the public ClickHouse demo. Every chart, table, and search box is a real ClickHouse query, so every interaction produces a trace whose main span is the HTTPS call from the backend out to ClickHouse.
+
+This is a different job from the [session replay demo](/clickstack/example-datasets/session-replay), which instruments a browser-only app against local Docker ClickStack. Here you get backend auto-instrumentation, ClickHouse query spans, and session replay from the same app.
 
 ## Prerequisites {#prerequisites}
 
-- An OTel collector available and reachable, ingesting into your Managed ClickStack service. You need its OTLP endpoint and an ingestion token.
-- Node 18+ and npm.
+- Node 18+ and npm
+- A ClickStack OTLP/HTTP endpoint and ingestion token:
+  - **ClickHouse Cloud:** open the service, then **ClickStack** → **Configure your OpenTelemetry exporter** → **Env vars**. Protocol is `http/protobuf`. Headers are `authorization=<ingestion token>` with no `Bearer` prefix.
+  - **Local collector:** use `http://localhost:4318`. If the collector is unsecured, leave `authorization=` empty.
+
+## Clone the repository {#clone-the-repository}
+
+Clone [HackerNews Analyzer](https://github.com/ClickHouse/hn-news-analyzer), install dependencies, and copy the env template:
+
+```bash
+git clone https://github.com/ClickHouse/hn-news-analyzer.git
+cd hn-news-analyzer
+npm install
+cp .env.example .env
+```
+
+You'll fill `.env` in the next steps, then run the agent from this directory.
 
 <InstrumentApplication />
 
 ## Learn more {#learn-more}
 
+- [HackerNews Analyzer README](https://github.com/ClickHouse/hn-news-analyzer): `reset.sh`, troubleshooting, and what to look at in traces (cache hits, year selector, log correlation).
+- [Agent instructions](https://github.com/ClickHouse/hn-news-analyzer/blob/main/agent.md): the prompt the Agent-Assisted Setup card copies.
 - [Session Replay](/clickstack/features/session-replay): feature overview, SDK options, and privacy controls.
 - [Session Replay Demo](/clickstack/example-datasets/session-replay): a self-contained demo with a local ClickStack instance.
 - [ClickStack Getting Started](/clickstack/getting-started/index): deploy ClickStack and ingest your first data.

--- a/docs/clickstack/managed-onboarding/instrument-application.mdx
+++ b/docs/clickstack/managed-onboarding/instrument-application.mdx
@@ -3,7 +3,7 @@ slug: /use-cases/observability/clickstack/instrument-application
 title: 'Instrument an application in 5 mins with Managed ClickStack'
 description: 'Instrument a Node.js application with OpenTelemetry and send its logs, metrics, and traces into Managed ClickStack'
 doc_type: 'guide'
-keywords: ['clickstack', 'instrumentation', 'opentelemetry', 'managed', 'observability', 'sdk', 'nodejs']
+keywords: ['clickstack', 'instrumentation', 'opentelemetry', 'managed', 'observability', 'sdk', 'nodejs', 'agent']
 unlisted: true
 custom_edit_url: null
 hide_advert: true
@@ -11,22 +11,36 @@ hide_advert: true
 
 import InstrumentApplication from '/snippets/clickstack/_instrument_application.mdx';
 
-This guide shows how to instrument a small Node.js application with OpenTelemetry and send its logs, metrics, and traces into Managed ClickStack. The backend is instrumented with no changes to the application source code.
+This guide walks you through instrumenting a small Node.js application with OpenTelemetry and sending its logs, metrics, traces, and session replays into Managed ClickStack. The backend is instrumented with no changes to the application source code.
 
 The [HackerNews Analyzer](https://github.com/ClickHouse/hn-news-analyzer) is a Node.js app that queries the HackerNews dataset hosted in the public ClickHouse demo. Every chart, table, and search box is backed by a real ClickHouse query, so every interaction produces a trace whose main span is the HTTPS call from the backend out to ClickHouse.
 
-This guide assumes you've completed [Setting up your OpenTelemetry Collector](/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector) and have a ClickStack collector running and reachable from the machine you run this application on. **Ensure you have recorded its OTLP endpoint** and the `OTLP_AUTH_TOKEN` you set when deploying it.
+This guide assumes you've completed [Setting up your OpenTelemetry Collector](/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector) and have a ClickStack collector running and reachable from the machine you run this application on. **Ensure you have recorded its OTLP endpoint** and the `OTLP_AUTH_TOKEN` you set when deploying it. You will put those values in `.env` before running the agent.
 
 ## Prerequisites {#prerequisites}
 
 - A ClickStack collector reachable from this machine. If you haven't deployed one yet, follow [Setting up your OpenTelemetry Collector](/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector) first.
-- The OTLP endpoint of that collector and the `OTLP_AUTH_TOKEN` you set on it.
+- The OTLP/HTTP endpoint of that collector (commonly port `4318`) and the `OTLP_AUTH_TOKEN` you set on it. Use these as `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS=authorization=<token>`.
 - Node 18+ and npm.
+
+## Clone the repository {#clone-the-repository}
+
+Clone [HackerNews Analyzer](https://github.com/ClickHouse/hn-news-analyzer), install dependencies, and copy the env template:
+
+```bash
+git clone https://github.com/ClickHouse/hn-news-analyzer.git
+cd hn-news-analyzer
+npm install
+cp .env.example .env
+```
+
+You'll fill `.env` in the next steps, then run the agent from this directory.
 
 <InstrumentApplication />
 
 ## Further reading {#further-reading}
 
+- [Agent instructions](https://github.com/ClickHouse/hn-news-analyzer/blob/main/agent.md): the prompt the Agent-Assisted Setup card copies.
 - [Monitoring Kubernetes](/clickstack/managed-onboarding/monitoring-kubernetes): collect logs, infra metrics, and Kubernetes events from a cluster.
 - [Monitoring AWS CloudWatch logs](/clickstack/managed-onboarding/monitoring-aws-cloudwatch-logs): forward CloudWatch logs via the OpenTelemetry CloudWatch receiver.
 - [Session Replay](/clickstack/features/session-replay): feature overview, SDK options, and privacy controls.

--- a/docs/clickstack/managed-onboarding/instrument-application.mdx
+++ b/docs/clickstack/managed-onboarding/instrument-application.mdx
@@ -15,7 +15,7 @@ This guide walks you through instrumenting a small Node.js application with Open
 
 The [HackerNews Analyzer](https://github.com/ClickHouse/hn-news-analyzer) is a Node.js app that queries the HackerNews dataset hosted in the public ClickHouse demo. Every chart, table, and search box is backed by a real ClickHouse query, so every interaction produces a trace whose main span is the HTTPS call from the backend out to ClickHouse.
 
-This guide assumes you've completed [Setting up your OpenTelemetry Collector](/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector) and have a ClickStack collector running and reachable from the machine you run this application on. **Ensure you have recorded its OTLP endpoint** and the `OTLP_AUTH_TOKEN` you set when deploying it. You will put those values in `.env` before running the agent.
+This guide assumes you've completed [Setting up your OpenTelemetry Collector](/clickstack/managed-onboarding/setting-up-your-opentelemetry-collector) and have a ClickStack collector running and reachable from the machine you run this application on. **Ensure you have recorded its OTLP endpoint** and the `OTLP_AUTH_TOKEN` you set when deploying it. You will put those values in `.env` before instrumenting.
 
 ## Prerequisites {#prerequisites}
 
@@ -34,13 +34,12 @@ npm install
 cp .env.example .env
 ```
 
-You'll fill `.env` in the next steps, then run the agent from this directory.
+You'll fill `.env` in the next steps, then instrument from this directory.
 
 <InstrumentApplication />
 
 ## Further reading {#further-reading}
 
-- [Agent instructions](https://github.com/ClickHouse/hn-news-analyzer/blob/main/agent.md): the prompt the Agent-Assisted Setup card copies.
 - [Monitoring Kubernetes](/clickstack/managed-onboarding/monitoring-kubernetes): collect logs, infra metrics, and Kubernetes events from a cluster.
 - [Monitoring AWS CloudWatch logs](/clickstack/managed-onboarding/monitoring-aws-cloudwatch-logs): forward CloudWatch logs via the OpenTelemetry CloudWatch receiver.
 - [Session Replay](/clickstack/features/session-replay): feature overview, SDK options, and privacy controls.

--- a/docs/snippets/clickstack/_instrument_application.mdx
+++ b/docs/snippets/clickstack/_instrument_application.mdx
@@ -1,16 +1,10 @@
+import { AgentPrompt } from '/snippets/components/AgentPrompt/AgentPrompt.jsx';
+
+## Instrument the application {#instrument-the-application}
 
 <Steps>
-<Step title="Clone and run the application" id="clone-and-run-the-application">
-Clone the repository, install dependencies, and create your `.env` file:
-
-```bash
-git clone https://github.com/ClickHouse/hn-news-analyzer.git
-cd hn-news-analyzer
-npm install
-cp .env.example .env
-```
-
-The ClickHouse data source defaults to the public read-only demo cluster, so the app runs without any further configuration. Start it:
+<Step title="Run the application" id="run-the-application">
+From the cloned `hn-news-analyzer` directory, start the app. The ClickHouse data source defaults to the public read-only demo cluster, so it runs without any further configuration:
 
 ```bash
 ./run.sh
@@ -22,73 +16,110 @@ Open [http://localhost:5001](http://localhost:5001). You will see a year selecto
   <img src="/images/clickstack/getting-started/hackernews_main.webp" alt="The HackerNews Analyzer application running locally" />
 </Frame>
 
-At this point the application is running but uninstrumented. ClickStack shows no data: it is waiting for telemetry. This is the "before" state.
+At this point the application is running but uninstrumented. ClickStack shows no data: it is waiting for telemetry.
 </Step>
-<Step title="Get the connection details" id="get-connection-details">
-The application needs two values to reach the collector:
 
-- `OTEL_EXPORTER_OTLP_ENDPOINT`: the OTLP endpoint your collector exposes (commonly port `4318` for OTLP over HTTP).
-- `OTEL_EXPORTER_OTLP_HEADERS`: the authorization header carrying your ingestion token, in the form `authorization=<token>`.
-
-Open `.env` and set them:
+<Step title="Configure environment" id="configure-environment">
+The SDKs read standard OpenTelemetry exporter variables. They are not hardcoded in source. Open `.env` and set:
 
 ```bash
 OTEL_SERVICE_NAME=hn-analyzer-api
-OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-collector-endpoint>:4318
+OTEL_EXPORTER_OTLP_ENDPOINT=<your-otlp-http-endpoint>
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_HEADERS=authorization=<your-ingestion-token>
+OTEL_TRACES_EXPORTER=otlp
+OTEL_METRICS_EXPORTER=otlp
+OTEL_LOGS_EXPORTER=otlp
 ```
 
-The SDK uses `OTEL_EXPORTER_OTLP_HEADERS` to set the authorization header for all three signals: traces, metrics, and logs. If your collector runs locally and doesn't enforce auth, you can leave the value empty (`OTEL_EXPORTER_OTLP_HEADERS=authorization=`), but the variable must be present; the SDK skips initialization entirely if it's unset or fully empty.
+`OTEL_EXPORTER_OTLP_ENDPOINT` is the OTLP/HTTP endpoint (port `4318`). `OTEL_EXPORTER_OTLP_HEADERS` is the authorization header, in the form `authorization=<token>` with no `Bearer` prefix.
+
+If the collector does not enforce auth, leave the token empty (`OTEL_EXPORTER_OTLP_HEADERS=authorization=`). The variable must still be present; the SDK skips initialization if it is unset or fully empty.
+
+The browser SDK reuses these same values. `vite.config.ts` bakes the endpoint and token into the public bundle at build time, so use a throwaway ingestion token, not a production one.
 </Step>
-<Step title="Instrument the application" id="instrument-the-application">
+
+<Step title="Instrument with an agent" id="instrument-with-an-agent">
+With the repo cloned and `.env` filled in, paste this prompt into a coding agent **in that directory**. The agent uses the values already in `.env` and does not ask for them again.
+
+<AgentPrompt
+  prompt="Use curl to download, read and follow: github.com/ClickHouse/hn-news-analyzer/blob/main/agent.md"
+  description="After you clone hn-news-analyzer and fill .env, run this prompt from that directory. Works with Claude Code, Cursor, Codex, and other coding agents."
+  outline={[
+    "Confirm you are in the cloned hn-news-analyzer directory and that .env already has OTEL_EXPORTER_OTLP_* values. Stop if either is missing.",
+    "Install @hyperdx/node-opentelemetry and switch run.sh to opentelemetry-instrument.",
+    "Install @hyperdx/browser and enable HyperDX.init plus HyperDX.addAction.",
+    "Start the app, confirm OTLP health checks pass, and tell you to click around at http://localhost:5001.",
+  ]}
+/>
+
+If you prefer to do the edits yourself, continue with [Instrument the application](#instrument-manually).
+</Step>
+
+<Step title="Instrument the application" id="instrument-manually">
 Instrumentation has three parts: install the SDKs, switch the launch command, and enable the browser SDK. None of it changes the application's business logic.
 
-### Install the SDKs {#install-sdks}
-Install both the backend and browser OpenTelemetry SDKs:
+### Install the Node SDK {#install-node-sdk}
 
 ```bash
-npm install @hyperdx/node-opentelemetry @hyperdx/browser
+npm install @hyperdx/node-opentelemetry
 ```
 
-### Use the opentelemetry-instrument CLI {#use-open-telemetry-cli}
-The application is launched by `run.sh`, which has two `exec` lines at the bottom: one active, one commented. Switch which one is active so Node is wrapped by `opentelemetry-instrument`:
+### Enable the wrapper in run.sh {#enable-run-sh-wrapper}
+
+The bottom of `run.sh` has two `exec` lines. Comment the plain `node` line and uncomment the instrumented one:
 
 ```diff
- # BEFORE: plain node, no instrumentation, collector stays silent:
+ # BEFORE: plain node, no instrumentation:
 -exec node scripts/entrypoint.js
 +# exec node scripts/entrypoint.js
 
- # AFTER: same source, wrapped by opentelemetry-instrument CLI.
+ # AFTER: same source, wrapped by opentelemetry-instrument:
 -# exec npx opentelemetry-instrument scripts/entrypoint.js
 +exec npx opentelemetry-instrument scripts/entrypoint.js
 ```
 
-That is the entire backend change. The auto-instrumentation is loaded by `opentelemetry-instrument` at process start.
+Keep launching through `scripts/entrypoint.js`. That shim calls `require('console')` so console capture wraps `console.log`. Pointing `opentelemetry-instrument` at `dist/server/index.js` directly ships traces but silently drops logs.
 
 ### Enable the browser SDK {#enable-browser-sdk}
-To capture distributed traces (browser to backend) and session replays, enable the browser SDK in `src/web/telemetry.ts`. Uncomment the import and the `HyperDX.init({...})` block:
 
-```javascript
-import HyperDX from '@hyperdx/browser';
-
-export function initTelemetry(): void {
-  HyperDX.init({
-    url: __OTLP_ENDPOINT__,
-    apiKey: __OTLP_AUTH_TOKEN__,
-    service: 'hn-analyzer-web',
-    tracePropagationTargets: [/localhost:5001/i, /\/api\//i],
-    consoleCapture: true,
-    advancedNetworkCapture: true,
-  });
-}
+```bash
+npm install @hyperdx/browser
 ```
 
-No extra `.env` edits are required. `__OTLP_ENDPOINT__` and `__OTLP_AUTH_TOKEN__` are compile-time constants injected by `vite.config.ts`: the endpoint is `OTEL_EXPORTER_OTLP_ENDPOINT` and the token is parsed out of `OTEL_EXPORTER_OTLP_HEADERS`, the same values the backend uses.
+In `src/web/telemetry.ts`, uncomment the import, the `HyperDX.init({...})` block, and `HyperDX.addAction` in `recordAction()`:
+
+```diff
+-// import HyperDX from '@hyperdx/browser';
++import HyperDX from '@hyperdx/browser';
+
+ export function initTelemetry(): void {
+-  // HyperDX.init({
+-  //   url: __OTLP_ENDPOINT__,
+-  //   apiKey: __OTLP_AUTH_TOKEN__,
+-  //   service: 'hn-analyzer-web',
+-  //   tracePropagationTargets: [/localhost:5001/i, /\/api\//i],
+-  //   consoleCapture: true,
+-  //   advancedNetworkCapture: true,
+-  // });
++  HyperDX.init({
++    url: __OTLP_ENDPOINT__,
++    apiKey: __OTLP_AUTH_TOKEN__,
++    service: 'hn-analyzer-web',
++    tracePropagationTargets: [/localhost:5001/i, /\/api\//i],
++    consoleCapture: true,
++    advancedNetworkCapture: true,
++  });
+ }
+```
+
+`__OTLP_ENDPOINT__` and `__OTLP_AUTH_TOKEN__` are compile-time constants injected by `vite.config.ts` from the same `OTEL_EXPORTER_OTLP_*` values the backend uses.
 
 <Warning>
-The ingestion token is baked into the public browser bundle and is readable by anyone inspecting the network tab.
+The ingestion token is baked into the public browser bundle and is readable by anyone inspecting the network tab. Use a throwaway token.
 </Warning>
 </Step>
+
 <Step title="Generate traffic and view telemetry" id="generate-traffic-and-view-telemetry">
 Restart the application so the new launch command and freshly built browser bundle take effect:
 
@@ -97,28 +128,41 @@ Restart the application so the new launch command and freshly built browser bund
 ./run.sh
 ```
 
-Reload the browser tab so Vite serves the updated bundle, then refresh the app a few times, switch years, and click into stories to generate traffic.
+Confirm the startup banner prints three "Health check passed" lines for `/v1/traces`, `/v1/metrics`, and `/v1/logs`. Reload the browser tab so Vite serves the updated bundle, then switch years and click into stories to generate traffic.
 
 Open the ClickStack UI:
 
 1. Go to **Search** and filter to the last 5 minutes. Logs for `hn-analyzer-api` stream in.
 
 <Frame>
-  <img src="/images/clickstack/getting-started/instrument_app_clickstack_logs.webp" alt="ClickStack Logs" />
+  <img src="/images/clickstack/getting-started/instrument_app_clickstack_logs.webp" alt="ClickStack search showing hn-analyzer-api logs from the last five minutes" />
 </Frame>
 
-2. Click into a request and walk up the trace. You will see the Express handler span, a child HTTP span pointing at the ClickHouse cluster with real network duration, and correlated `console.log` records on the same trace.
+2. Click into a request and walk up the trace. You will see the Express handler span, a child HTTP span pointing at `sql-clickhouse.clickhouse.com` with real network duration, and correlated `console.log` records on the same trace.
 
 <Frame>
-  <img src="/images/clickstack/getting-started/instrument_app_clickstack_traces.webp" alt="ClickStack Traces" />
+  <img src="/images/clickstack/getting-started/instrument_app_clickstack_traces.webp" alt="ClickStack trace with an Express handler span and a child HTTP span to ClickHouse" />
 </Frame>
 
 3. Open **Session Replay** to play back a scrubbable video of a browser session, synced to the trace timeline.
 
 <Frame>
-  <img src="/images/clickstack/getting-started/instrument_app_clickstack_sessions.webp" alt="ClickStack Sessions" />
+  <img src="/images/clickstack/getting-started/instrument_app_clickstack_sessions.webp" alt="ClickStack session replay synced to the trace timeline" />
 </Frame>
 
-Logs, metrics, traces, and session replays all land in the same UI, share the same query language, and are correlated automatically.
+Logs, metrics, traces, and session replays land in the same UI, share the same query language, and are correlated automatically.
 </Step>
 </Steps>
+
+## Use the instrumented branch {#use-the-instrumented-branch}
+
+To skip instrumentation and start with an already instrumented application, check out the [`instrumented` branch](https://github.com/ClickHouse/hn-news-analyzer/tree/instrumented).
+
+```bash
+git checkout instrumented
+npm install
+```
+
+Fill `.env` with the OTLP values from [Configure environment](#configure-environment) if you have not already, then `./run.sh` and continue with [Generate traffic and view telemetry](#generate-traffic-and-view-telemetry).
+
+Don't run `./reset.sh` on this branch unless you want to strip the SDKs.

--- a/docs/snippets/clickstack/_instrument_application.mdx
+++ b/docs/snippets/clickstack/_instrument_application.mdx
@@ -39,8 +39,13 @@ If the collector does not enforce auth, leave the token empty (`OTEL_EXPORTER_OT
 The browser SDK reuses these same values. `vite.config.ts` bakes the endpoint and token into the public bundle at build time, so use a throwaway ingestion token, not a production one.
 </Step>
 
-<Step title="Instrument with an agent" id="instrument-with-an-agent">
-With the repo cloned and `.env` filled in, paste this prompt into a coding agent **in that directory**. The agent uses the values already in `.env` and does not ask for them again.
+<Step title="Instrument the application" id="instrument">
+Pick one path. All three end at the same instrumented app.
+
+<Tabs>
+<Tab title="Agent instrumentation" id="instrument-with-an-agent">
+
+With the repo cloned and `.env` filled in, paste this prompt into a coding agent **in that directory** to instrument the application.
 
 <AgentPrompt
   prompt="Use curl to download, read and follow: github.com/ClickHouse/hn-news-analyzer/blob/main/agent.md"
@@ -53,10 +58,9 @@ With the repo cloned and `.env` filled in, paste this prompt into a coding agent
   ]}
 />
 
-If you prefer to do the edits yourself, continue with [Instrument the application](#instrument-manually).
-</Step>
+</Tab>
+<Tab title="Manual instrumentation" id="instrument-manually">
 
-<Step title="Instrument the application" id="instrument-manually">
 Instrumentation has three parts: install the SDKs, switch the launch command, and enable the browser SDK. None of it changes the application's business logic.
 
 ### Install the Node SDK {#install-node-sdk}
@@ -118,6 +122,21 @@ In `src/web/telemetry.ts`, uncomment the import, the `HyperDX.init({...})` block
 <Warning>
 The ingestion token is baked into the public browser bundle and is readable by anyone inspecting the network tab. Use a throwaway token.
 </Warning>
+
+</Tab>
+<Tab title="Use a pre-instrumented branch" id="use-the-instrumented-branch">
+
+To skip instrumentation and start with an already instrumented application, check out the [`instrumented` branch](https://github.com/ClickHouse/hn-news-analyzer/tree/instrumented).
+
+```bash
+git checkout instrumented
+npm install
+```
+
+Don't run `./reset.sh` on this branch unless you want to strip the SDKs.
+
+</Tab>
+</Tabs>
 </Step>
 
 <Step title="Generate traffic and view telemetry" id="generate-traffic-and-view-telemetry">
@@ -153,16 +172,3 @@ Open the ClickStack UI:
 Logs, metrics, traces, and session replays land in the same UI, share the same query language, and are correlated automatically.
 </Step>
 </Steps>
-
-## Use the instrumented branch {#use-the-instrumented-branch}
-
-To skip instrumentation and start with an already instrumented application, check out the [`instrumented` branch](https://github.com/ClickHouse/hn-news-analyzer/tree/instrumented).
-
-```bash
-git checkout instrumented
-npm install
-```
-
-Fill `.env` with the OTLP values from [Configure environment](#configure-environment) if you have not already, then `./run.sh` and continue with [Generate traffic and view telemetry](#generate-traffic-and-view-telemetry).
-
-Don't run `./reset.sh` on this branch unless you want to strip the SDKs.

--- a/docs/snippets/components/AgentPrompt/AgentPrompt.jsx
+++ b/docs/snippets/components/AgentPrompt/AgentPrompt.jsx
@@ -49,7 +49,7 @@ export const AgentPrompt = ({
         </div>
         <button
           type="button"
-          className="ch-agent-prompt-copy-button"
+          className={`ch-agent-prompt-copy-button${copied ? " is-copied" : ""}`}
           onClick={handleCopy}
           aria-label={copied ? "Copied" : "Copy prompt"}
         >
@@ -83,7 +83,10 @@ export const AgentPrompt = ({
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
             </svg>
           )}
-          <span>{copied ? "Copied" : "Copy Prompt"}</span>
+          <span className="ch-agent-prompt-copy-label">
+            <span>Copy Prompt</span>
+            <span>Copied</span>
+          </span>
         </button>
       </div>
       {(description || repositoryUrl) && (

--- a/docs/snippets/components/AgentPrompt/AgentPrompt.jsx
+++ b/docs/snippets/components/AgentPrompt/AgentPrompt.jsx
@@ -44,12 +44,18 @@ export const AgentPrompt = ({
         <div className="ch-agent-prompt-left">
           <span className="ch-agent-prompt-title">{title}</span>
         </div>
-        <div className="ch-agent-prompt-prompt-area">
-          <code className="ch-agent-prompt-prompt-text">{prompt}</code>
+        <div className="ch-agent-prompt-prompt-area" style={{ overflow: "hidden" }}>
+          <code className="ch-agent-prompt-prompt-text" style={{ overflowX: "auto" }}>{prompt}</code>
         </div>
         <button
           type="button"
-          className={`ch-agent-prompt-copy-button${copied ? " is-copied" : ""}`}
+          className="ch-agent-prompt-copy-button"
+          style={{
+            boxSizing: "border-box",
+            justifyContent: "center",
+            minWidth: "8.25rem",
+            whiteSpace: "nowrap",
+          }}
           onClick={handleCopy}
           aria-label={copied ? "Copied" : "Copy prompt"}
         >
@@ -83,9 +89,13 @@ export const AgentPrompt = ({
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
             </svg>
           )}
-          <span className="ch-agent-prompt-copy-label">
-            <span>Copy Prompt</span>
-            <span>Copied</span>
+          <span style={{ display: "grid", justifyItems: "center" }}>
+            <span style={{ gridArea: "1 / 1", visibility: copied ? "hidden" : "visible" }}>
+              Copy Prompt
+            </span>
+            <span style={{ gridArea: "1 / 1", visibility: copied ? "visible" : "hidden" }}>
+              Copied
+            </span>
           </span>
         </button>
       </div>


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Not required.

## Summary
- Prefer agent-assisted OpenTelemetry setup on the HackerNews Analyzer guides (nurture + example datasets), sharing one snippet. Clone and `.env` come first; the agent prompt assumes those are done.
- Keep manual SDK edits and an `instrumented` branch as fallbacks. List the demo on the sample datasets index.
- Fix AgentPrompt copy-button layout (stable width, matching padding). English `docs/` only; translations are generated.

## Test plan
- [ ] Preview with `mint dev` from `docs/`
- [ ] Nurture: http://127.0.0.1:3000/clickstack/managed-onboarding/instrument-application
- [ ] Evergreen: http://127.0.0.1:3000/clickstack/example-datasets/instrument-application
- [ ] Confirm clone → fill `.env` → AgentPrompt → optional manual steps → instrumented branch as a sibling H2
- [ ] Copy Prompt does not resize; no repo link on the agent card
- [ ] Sample datasets index lists HackerNews Analyzer


Made with [Cursor](https://cursor.com)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116887&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116887](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116887+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
