### PR TITLE
Fix key and index range analysis dropping rows when a container holds a Bool

### DIFF
--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -980,6 +980,32 @@ String fieldToString(const Field & x)
         x);
 }
 
+void normalizeBoolFields(Field & field)
+{
+    if (field.getType() == Field::Types::Bool)
+    {
+        field = field.safeGet<UInt64>();
+    }
+    else if (field.getType() == Field::Types::Tuple)
+    {
+        auto & tuple = field.safeGet<Tuple>();
+        for (auto & elem : tuple)
+            normalizeBoolFields(elem);
+    }
+    else if (field.getType() == Field::Types::Array)
+    {
+        auto & array = field.safeGet<Array>();
+        for (auto & elem : array)
+            normalizeBoolFields(elem);
+    }
+    else if (field.getType() == Field::Types::Map)
+    {
+        auto & map = field.safeGet<Map>();
+        for (auto & elem : map)
+            normalizeBoolFields(elem);
+    }
+}
+
 std::string_view fieldTypeToString(Field::Types::Which type)
 {
     switch (type)

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -912,6 +912,14 @@ Field readFieldBinary(ReadBuffer & buf);
 
 String fieldToString(const Field & x);
 
+/// Rewrite every `Bool`-tagged `Field` inside `field`, recursively through `Tuple`/`Array`/`Map`, as
+/// the `UInt64` form `IColumn::get` produces: a boolean has both representations, and `Field`
+/// comparison and hashing read the tag before the value, so the two forms neither compare equal nor
+/// hash alike. An `Object` is deliberately not entered, because its paths disagree: a dynamic path
+/// keeps the `Bool` form on both sides, since `ColumnDynamic::get` rebuilds it, while a typed path is
+/// read from its declared column as `UInt64`. Entering it needs path-aware handling, not this rewrite.
+void normalizeBoolFields(Field & field);
+
 /// Check if a Field contains a NaN value.
 /// Float32 is stored as Float64 internally, so checking Float64 is sufficient.
 inline bool isNaNField(const Field & f)

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -213,6 +213,9 @@ void IMergeTreeDataPart::MinMaxIndex::load(const IMergeTreeDataPart & part)
         Field max_val;
         serialization->deserializeBinary(max_val, *file, format_settings);
 
+        normalizeBoolFields(min_val);
+        normalizeBoolFields(max_val);
+
         // NULL_LAST
         if (min_val.isNull())
             min_val = POSITIVE_INFINITY;

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -4181,6 +4181,11 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
         out.monotonic_functions_chain = std::move(chain);
         out.argument_num_of_space_filling_curve = argument_num_of_space_filling_curve;
 
+        /// Outside an `Object` the key side carries the `UInt64` form of a boolean that `IColumn::get`
+        /// produces. `Field` comparison inside a container reads the tag before the value, so a
+        /// `Bool`-tagged element would order against the whole key domain, not against the booleans it holds.
+        normalizeBoolFields(const_value);
+
         return atom_it->second(out, const_value);
     }
     if (node.tryGetConstant(const_value, const_type))

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -128,6 +128,9 @@ void MergeTreeIndexGranuleMinMax::deserializeBinary(ReadBuffer & istr, MergeTree
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown index version {}.", version);
         }
 
+        normalizeBoolFields(min_ref);
+        normalizeBoolFields(max_ref);
+
         if (update_in_place)
         {
             hyperrectangle[i].left_included = true;
@@ -313,6 +316,9 @@ void MergeTreeIndexBulkGranulesMinMax::deserializeBinary(size_t granule_num, Rea
         serialization->deserializeBinary(scratch, istr, format_settings);
         serialization->deserializeBinary(value, istr, format_settings);
     }
+
+    normalizeBoolFields(value);
+
     /// If index granularity is not 1, we insert the same value as the min
     /// or max for all the corresponding granules. For our top-K purpose, this
     /// is safe and maybe lead to false positives, but never wrong results.

--- a/src/Storages/MergeTree/MergeTreePartition.cpp
+++ b/src/Storages/MergeTree/MergeTreePartition.cpp
@@ -199,42 +199,16 @@ namespace
         }
     };
 
+}
+
+MergeTreePartition::MergeTreePartition(Row value_) : value(std::move(value_))
+{
     /// During INSERT, partition values are extracted from columns via `column->get()`,
     /// which produces UInt64 Fields for Bool columns (ColumnUInt8 → NearestFieldType → UInt64).
     /// But the query path (ALTER TABLE DROP/DETACH/ATTACH PARTITION) uses `convertFieldToType`,
     /// which faithfully produces Bool-typed Fields. Since `LegacyFieldVisitorHash` hashes
     /// Bool (type tag 28) differently from UInt64 (type tag 1), partition IDs won't match.
-    /// We cannot change the INSERT path or the hash without breaking existing partition IDs on disk,
-    /// so normalize Bool → UInt64 recursively to cover Tuple/Array/Map containers.
-    void normalizeBoolFields(Field & field)
-    {
-        if (field.getType() == Field::Types::Bool)
-        {
-            field = field.safeGet<UInt64>();
-        }
-        else if (field.getType() == Field::Types::Tuple)
-        {
-            auto & tuple = field.safeGet<Tuple>();
-            for (auto & elem : tuple)
-                normalizeBoolFields(elem);
-        }
-        else if (field.getType() == Field::Types::Array)
-        {
-            auto & array = field.safeGet<Array>();
-            for (auto & elem : array)
-                normalizeBoolFields(elem);
-        }
-        else if (field.getType() == Field::Types::Map)
-        {
-            auto & map = field.safeGet<Map>();
-            for (auto & elem : map)
-                normalizeBoolFields(elem);
-        }
-    }
-}
-
-MergeTreePartition::MergeTreePartition(Row value_) : value(std::move(value_))
-{
+    /// We cannot change the INSERT path or the hash without breaking existing partition IDs on disk.
     for (auto & field : value)
         normalizeBoolFields(field);
 }

--- a/tests/queries/0_stateless/05046_minmax_index_nested_bool.reference
+++ b/tests/queries/0_stateless/05046_minmax_index_nested_bool.reference
@@ -1,0 +1,39 @@
+array	3	6
+array noidx	3	6
+map	3	6
+map noidx	3	6
+scalar	3	6
+scalar noidx	3	6
+partition	3	6
+partition noidx	3	6
+partition uint8	3	6
+partition uint8 noidx	3	6
+order by =	6
+order by = oracle	6
+order by >=	21
+order by >= oracle	21
+nullable <=	3	6
+nullable <= noidx	3	6
+nullable >=	6	21
+nullable >= noidx	6	21
+nullable map >=	6	21
+nullable map >= noidx	6	21
+json >=	6	21
+json >= noidx	6	21
+json <=	3	6
+json <= noidx	3	6
+top-k asc	[false,false,false,false,false,false]
+top-k asc noidx	[false,false,false,false,false,false]
+top-k desc	[true,true,true,true,true,true]
+top-k desc noidx	[true,true,true,true,true,true]
+top-k uint8 asc	[0,0,0,0,0,0]
+top-k uint8 desc	[1,1,1,1,1,1]
+array prunes	1
+map prunes	1
+scalar prunes	1
+partition prunes	1
+partition minmax entry	1
+pk prunes	1
+json prunes	1
+top-k wide	8	false	false
+top-k wide skips	1

--- a/tests/queries/0_stateless/05046_minmax_index_nested_bool.sql
+++ b/tests/queries/0_stateless/05046_minmax_index_nested_bool.sql
@@ -118,27 +118,30 @@ SELECT 'json <= noidx', count(), sum(id) FROM oj WHERE j <= '{"a": false}' SETTI
 
 -- All five settings below are randomized, and each one decides whether these arms reach the
 -- comparison at all - including query_plan_max_limit_for_top_k_optimization, which is drawn from a
--- set containing 1 and then refuses the rewrite because the LIMIT is larger. The clause belongs on
--- the outer query: the top-K rewrite is a plan-level optimization and reads these from the outer
--- context, so a SETTINGS clause on the subquery alone leaves the arms silently vacuous.
+-- set containing 1 and then refuses the rewrite because the LIMIT is larger. The two row limits are
+-- pinned to their default 0 as well: the stateless-test user profile sets max_rows_to_read, and a
+-- throwing row limit turns off skip indexes on data read, which is the path the granule comparison
+-- below runs on (see 04812_row_policy_top_k_optimization). The clause belongs on the outer query:
+-- the top-K rewrite is a plan-level optimization and reads these from the outer context, so a
+-- SETTINGS clause on the subquery alone leaves the arms silently vacuous.
 SELECT 'top-k asc', groupArray(f) FROM (SELECT f FROM tk ORDER BY f ASC LIMIT 6)
   SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
-           query_plan_max_limit_for_top_k_optimization = 0;
+           query_plan_max_limit_for_top_k_optimization = 0, max_rows_to_read = 0, max_rows_to_read_leaf = 0;
 SELECT 'top-k asc noidx', groupArray(f) FROM (SELECT f FROM tk ORDER BY f ASC LIMIT 6)
   SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 0, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
-           query_plan_max_limit_for_top_k_optimization = 0;
+           query_plan_max_limit_for_top_k_optimization = 0, max_rows_to_read = 0, max_rows_to_read_leaf = 0;
 SELECT 'top-k desc', groupArray(f) FROM (SELECT f FROM tk ORDER BY f DESC LIMIT 6)
   SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
-           query_plan_max_limit_for_top_k_optimization = 0;
+           query_plan_max_limit_for_top_k_optimization = 0, max_rows_to_read = 0, max_rows_to_read_leaf = 0;
 SELECT 'top-k desc noidx', groupArray(f) FROM (SELECT f FROM tk ORDER BY f DESC LIMIT 6)
   SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 0, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
-           query_plan_max_limit_for_top_k_optimization = 0;
+           query_plan_max_limit_for_top_k_optimization = 0, max_rows_to_read = 0, max_rows_to_read_leaf = 0;
 SELECT 'top-k uint8 asc', groupArray(f) FROM (SELECT f FROM tk8 ORDER BY f ASC LIMIT 6)
   SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
-           query_plan_max_limit_for_top_k_optimization = 0;
+           query_plan_max_limit_for_top_k_optimization = 0, max_rows_to_read = 0, max_rows_to_read_leaf = 0;
 SELECT 'top-k uint8 desc', groupArray(f) FROM (SELECT f FROM tk8 ORDER BY f DESC LIMIT 6)
   SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
-           query_plan_max_limit_for_top_k_optimization = 0;
+           query_plan_max_limit_for_top_k_optimization = 0, max_rows_to_read = 0, max_rows_to_read_leaf = 0;
 
 -- The index must still prune, otherwise the rows above would be correct only because it stopped working.
 SELECT 'array prunes', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM arr WHERE a <= [(1., false)]) WHERE explain LIKE '%Granules: 1/2%';
@@ -163,7 +166,7 @@ SELECT 'json prunes', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT 
 SELECT 'top-k wide', count(), min(f), max(f) FROM (SELECT f FROM tkw ORDER BY f ASC LIMIT 8)
   SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
            query_plan_max_limit_for_top_k_optimization = 0, max_threads = 1, enable_parallel_replicas = 0,
-           ast_fuzzer_runs = 0, log_comment = '05046_tkw';
+           max_rows_to_read = 0, max_rows_to_read_leaf = 0, ast_fuzzer_runs = 0, log_comment = '05046_tkw';
 SYSTEM FLUSH LOGS query_log;
 SELECT 'top-k wide skips', read_rows < 48 FROM system.query_log
 WHERE event_date >= yesterday() AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '05046_tkw';

--- a/tests/queries/0_stateless/05046_minmax_index_nested_bool.sql
+++ b/tests/queries/0_stateless/05046_minmax_index_nested_bool.sql
@@ -1,0 +1,169 @@
+-- The automatic statistics part pruner emits its own Granules: line, and auto_statistics_types is
+-- randomized, so the EXPLAIN assertions below would match the wrong entry without this.
+SET use_statistics_for_part_pruning = 0;
+
+CREATE TABLE arr (id UInt64, a Array(Tuple(Float64, Bool)), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO arr VALUES (1, [(1., false)]), (2, [(1., false)]), (3, [(1., false)]);
+INSERT INTO arr VALUES (4, [(1., true)]), (5, [(1., true)]), (6, [(1., true)]);
+
+-- SerializationMap reads a Field through its own body, not through SerializationArray.
+CREATE TABLE m (id UInt64, a Map(String, Bool), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO m VALUES (1, map('k', false)), (2, map('k', false)), (3, map('k', false));
+INSERT INTO m VALUES (4, map('k', true)), (5, map('k', true)), (6, map('k', true));
+
+CREATE TABLE s (id UInt64, f Bool, INDEX idx_f f TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO s VALUES (1, false), (2, false), (3, false);
+INSERT INTO s VALUES (4, true), (5, true), (6, true);
+
+-- Part-level minmax over a partition key. DETACH + ATTACH is required: without it the bounds are
+-- still the writer-produced ones held in memory and MinMaxIndex::load never runs.
+CREATE TABLE p (id UInt64, a Array(Bool)) ENGINE = MergeTree PARTITION BY a ORDER BY id
+SETTINGS index_granularity = 3, min_bytes_for_wide_part = 0;
+INSERT INTO p VALUES (1, [false]), (2, [false]), (3, [false]);
+INSERT INTO p VALUES (4, [true]), (5, [true]), (6, [true]);
+
+CREATE TABLE pc (id UInt64, a Array(UInt8)) ENGINE = MergeTree PARTITION BY a ORDER BY id
+SETTINGS index_granularity = 3, min_bytes_for_wide_part = 0;
+INSERT INTO pc VALUES (1, [0]), (2, [0]), (3, [0]);
+INSERT INTO pc VALUES (4, [1]), (5, [1]), (6, [1]);
+
+DETACH TABLE p; ATTACH TABLE p;
+DETACH TABLE pc; ATTACH TABLE pc;
+
+-- ORDER BY takes its bounds from primary.cidx through columns, so no Field is read back on this
+-- path and only the query-side constant can carry the other representation. `ora` has no key on a.
+CREATE TABLE ora (id UInt64, a Array(Nullable(Bool))) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO ora VALUES (1, [false]), (2, [false]), (3, [false]), (4, [true]), (5, [true]), (6, [true]);
+
+CREATE TABLE pk (id UInt64, a Array(Nullable(Bool))) ENGINE = MergeTree ORDER BY (a, id)
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, allow_nullable_key = 1;
+INSERT INTO pk VALUES (1, [false]), (2, [false]), (3, [false]), (4, [true]), (5, [true]), (6, [true]);
+
+-- A nullable element also moves the query-side constant to the other representation, so each bound
+-- direction is decided by a different side of the comparison and both are needed.
+CREATE TABLE nu (id UInt64, a Array(Nullable(Bool)), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO nu VALUES (1, [false]), (2, [false]), (3, [false]);
+INSERT INTO nu VALUES (4, [true]), (5, [true]), (6, [true]);
+
+CREATE TABLE mnu (id UInt64, a Map(String, Nullable(Bool)), INDEX idx_a a TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO mnu VALUES (1, map('k', false)), (2, map('k', false)), (3, map('k', false));
+INSERT INTO mnu VALUES (4, map('k', true)), (5, map('k', true)), (6, map('k', true));
+
+-- `j` declares no paths, so `a` is a dynamic path, and a dynamic path is the one place inside a
+-- container where both sides of the comparison already agree. These arms pin that range analysis
+-- stays unchanged there. Only the >= direction ever returned the wrong rows, so a <=-only arm
+-- would not have caught it.
+CREATE TABLE oj (id UInt64, j JSON, INDEX idx_j j TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0,
+         allow_minmax_index_for_json = 1;
+INSERT INTO oj VALUES (1, '{"a": false}'), (2, '{"a": false}'), (3, '{"a": false}');
+INSERT INTO oj VALUES (4, '{"a": true}'), (5, '{"a": true}'), (6, '{"a": true}');
+
+-- Top-K reads the bound through a third granule reader and compares it against a threshold taken
+-- from live column data, so a scalar Bool is enough here. Every granule holds both values, so
+-- neither sort direction can be answered from the first granule read: LIMIT 6 selects all 6
+-- granules and max_block_size = 8 makes the threshold appear once the first one has been read.
+CREATE TABLE tk (id UInt64, f Bool, INDEX idx_f f TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO tk SELECT number, number % 2 = 0 FROM numbers(48);
+
+CREATE TABLE tk8 (id UInt64, f UInt8, INDEX idx_f f TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO tk8 SELECT number, number % 2 = 0 FROM numbers(48);
+
+-- Granule 0 holds both values, granule 1 is all false, granules 2-5 are all true.
+CREATE TABLE tkw (id UInt64, f Bool, INDEX idx_f f TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
+INSERT INTO tkw SELECT number, (number >= 4 AND number < 8) OR number >= 16 FROM numbers(48);
+
+SELECT 'array', count(), sum(id) FROM arr WHERE a <= [(1., false)];
+SELECT 'array noidx', count(), sum(id) FROM arr WHERE a <= [(1., false)] SETTINGS use_skip_indexes = 0;
+SELECT 'map', count(), sum(id) FROM m WHERE a <= map('k', false);
+SELECT 'map noidx', count(), sum(id) FROM m WHERE a <= map('k', false) SETTINGS use_skip_indexes = 0;
+SELECT 'scalar', count(), sum(id) FROM s WHERE f <= false;
+SELECT 'scalar noidx', count(), sum(id) FROM s WHERE f <= false SETTINGS use_skip_indexes = 0;
+SELECT 'partition', count(), sum(id) FROM p WHERE a <= [false];
+SELECT 'partition noidx', count(), sum(id) FROM p WHERE a <= [false] SETTINGS use_skip_indexes = 0;
+SELECT 'partition uint8', count(), sum(id) FROM pc WHERE a <= [0];
+SELECT 'partition uint8 noidx', count(), sum(id) FROM pc WHERE a <= [0] SETTINGS use_skip_indexes = 0;
+SELECT 'order by =', sum(id) FROM pk WHERE a = [false];
+SELECT 'order by = oracle', sum(id) FROM ora WHERE a = [false];
+SELECT 'order by >=', sum(id) FROM pk WHERE a >= [false];
+SELECT 'order by >= oracle', sum(id) FROM ora WHERE a >= [false];
+SELECT 'nullable <=', count(), sum(id) FROM nu WHERE a <= [false];
+SELECT 'nullable <= noidx', count(), sum(id) FROM nu WHERE a <= [false] SETTINGS use_skip_indexes = 0;
+SELECT 'nullable >=', count(), sum(id) FROM nu WHERE a >= [false];
+SELECT 'nullable >= noidx', count(), sum(id) FROM nu WHERE a >= [false] SETTINGS use_skip_indexes = 0;
+SELECT 'nullable map >=', count(), sum(id) FROM mnu WHERE a >= map('k', false);
+SELECT 'nullable map >= noidx', count(), sum(id) FROM mnu WHERE a >= map('k', false) SETTINGS use_skip_indexes = 0;
+SELECT 'json >=', count(), sum(id) FROM oj WHERE j >= '{"a": false}';
+SELECT 'json >= noidx', count(), sum(id) FROM oj WHERE j >= '{"a": false}' SETTINGS use_skip_indexes = 0;
+SELECT 'json <=', count(), sum(id) FROM oj WHERE j <= '{"a": false}';
+SELECT 'json <= noidx', count(), sum(id) FROM oj WHERE j <= '{"a": false}' SETTINGS use_skip_indexes = 0;
+
+-- All five settings below are randomized, and each one decides whether these arms reach the
+-- comparison at all - including query_plan_max_limit_for_top_k_optimization, which is drawn from a
+-- set containing 1 and then refuses the rewrite because the LIMIT is larger. The clause belongs on
+-- the outer query: the top-K rewrite is a plan-level optimization and reads these from the outer
+-- context, so a SETTINGS clause on the subquery alone leaves the arms silently vacuous.
+SELECT 'top-k asc', groupArray(f) FROM (SELECT f FROM tk ORDER BY f ASC LIMIT 6)
+  SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
+           query_plan_max_limit_for_top_k_optimization = 0;
+SELECT 'top-k asc noidx', groupArray(f) FROM (SELECT f FROM tk ORDER BY f ASC LIMIT 6)
+  SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 0, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
+           query_plan_max_limit_for_top_k_optimization = 0;
+SELECT 'top-k desc', groupArray(f) FROM (SELECT f FROM tk ORDER BY f DESC LIMIT 6)
+  SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
+           query_plan_max_limit_for_top_k_optimization = 0;
+SELECT 'top-k desc noidx', groupArray(f) FROM (SELECT f FROM tk ORDER BY f DESC LIMIT 6)
+  SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 0, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
+           query_plan_max_limit_for_top_k_optimization = 0;
+SELECT 'top-k uint8 asc', groupArray(f) FROM (SELECT f FROM tk8 ORDER BY f ASC LIMIT 6)
+  SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
+           query_plan_max_limit_for_top_k_optimization = 0;
+SELECT 'top-k uint8 desc', groupArray(f) FROM (SELECT f FROM tk8 ORDER BY f DESC LIMIT 6)
+  SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
+           query_plan_max_limit_for_top_k_optimization = 0;
+
+-- The index must still prune, otherwise the rows above would be correct only because it stopped working.
+SELECT 'array prunes', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM arr WHERE a <= [(1., false)]) WHERE explain LIKE '%Granules: 1/2%';
+SELECT 'map prunes', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM m WHERE a <= map('k', false)) WHERE explain LIKE '%Granules: 1/2%';
+SELECT 'scalar prunes', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM s WHERE f = false) WHERE explain LIKE '%Granules: 1/2%';
+-- Part-level minmax and partition pruning are redundant over the same key, and the `Parts:`
+-- denominators are chained, so whichever of them declines the other renders `Parts: 1/2` instead.
+-- Requiring that no entry passed both parts through pins the part-level one.
+SELECT 'partition prunes', count() = 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM p WHERE a <= [false]) WHERE explain LIKE '%Parts: 2/2%';
+-- A negative assertion is also satisfied by absence, so the part-level entry is pinned as present too.
+SELECT 'partition minmax entry', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM p WHERE a <= [false]) WHERE explain LIKE '%Min-Max%';
+SELECT 'pk prunes', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM pk WHERE a = [false]) WHERE explain LIKE '%Granules: 1/2%';
+SELECT 'json prunes', count() > 0 FROM (EXPLAIN indexes = 1, actions = 0 SELECT sum(id) FROM oj WHERE j <= '{"a": false}') WHERE explain LIKE '%Granules: 1/2%';
+-- The two Nullable-element fixtures deliberately carry no pruning arm: inside a container a nested
+-- NULL orders by its Field tag while the data orders it last, so pruning there is not sound to pin.
+
+-- LIMIT 8 is above the granule count, so every granule is selected and only the runtime threshold
+-- can skip one. The row count is the only observable separating an active threshold filter from one
+-- that declines, since a decline answers correctly; the bounds are asserted too because a filter
+-- that skips too much also reads fewer rows. max_threads, enable_parallel_replicas and
+-- ast_fuzzer_runs are pinned so the count comes from one local reader with one log row.
+SELECT 'top-k wide', count(), min(f), max(f) FROM (SELECT f FROM tkw ORDER BY f ASC LIMIT 8)
+  SETTINGS max_block_size = 8, use_skip_indexes_for_top_k = 1, use_skip_indexes_on_data_read = 1, use_top_k_dynamic_filtering = 1,
+           query_plan_max_limit_for_top_k_optimization = 0, max_threads = 1, enable_parallel_replicas = 0,
+           ast_fuzzer_runs = 0, log_comment = '05046_tkw';
+SYSTEM FLUSH LOGS query_log;
+SELECT 'top-k wide skips', read_rows < 48 FROM system.query_log
+WHERE event_date >= yesterday() AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = '05046_tkw';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/116655
Related: https://github.com/ClickHouse/ClickHouse/pull/116763
Related: https://github.com/ClickHouse/ClickHouse/pull/116455
Related: https://github.com/ClickHouse/ClickHouse/pull/116728
Related: https://github.com/ClickHouse/ClickHouse/pull/116656
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes wrong results when a `minmax` skip index, `ORDER BY` or `PARTITION BY` is built over an `Array`, `Tuple` or `Map` holding a `Bool`, such as `Array(Tuple(Float64, Bool))` or `Map(String, Bool)`, and when a `minmax` index serves an `ORDER BY ... LIMIT` over a `Bool` column. Previously, rows that the predicate accepts could be dropped, because the stored bound and the value compared against it represented the boolean differently.


### Description

A boolean has two `Field` representations, `Bool` (tag 28) and `UInt64` (tag 1). Container comparison reads the tag before the value, so the two forms never compare equal and one always sorts above the other. Range analysis compares a query-side `Field` against a data-side one, so a disagreement prunes rows the predicate accepts.

```sql
CREATE TABLE b (id UInt64, a Array(Tuple(Float64, Bool)), INDEX idx_a a TYPE minmax GRANULARITY 1)
ENGINE = MergeTree ORDER BY id
SETTINGS index_granularity = 3, index_granularity_bytes = 0, min_bytes_for_wide_part = 0;
INSERT INTO b VALUES (1, [(1., false)]), (2, [(1., false)]), (3, [(1., false)]);
INSERT INTO b VALUES (4, [(1., true)]), (5, [(1., true)]), (6, [(1., true)]);
SELECT count() FROM b WHERE a <= [(1., false)];   -- 0 on master, 3 is correct
```

Two producers pick the non-canonical form; fixing one alone moves the wrong answer to the other bound:

- the three `minmax` bound readers re-tag a bound on deserialization. Two are compared against a query constant; the third feeds top-K threshold filtering from live column data, so a scalar `Bool` breaks there too: `ORDER BY f LIMIT 6` returned rows outside the answer;
- `KeyCondition`'s atom constant comes back `Bool`-tagged when its type is widened, so `ORDER BY (a, id)` over `Array(Nullable(Bool))` returned 15 of 21 rows for `a >= [false]`, with no index reader involved.

`UInt64` is canonical: `IColumn::get` produces it and the index writer stores it, so each reader normalizes the bound it just read, reusing `MergeTreePartition`'s recursive `normalizeBoolFields`, hoisted into `Field.cpp`. It stops at `Object`, where a *dynamic* path keeps the `Bool` tag on the column side too, so both sides agree: rewriting it, or setting `read_bool_field_as_int`, would break the one path that was correct. A *declared* path needs type-aware handling; see below.

Index files are byte-identical to master's: no format change, no `SettingsChangesHistory.cpp` entry.

<details><summary>Residuals, and how this was validated</summary>

A `minmax` index on a `JSON` column with a declared `Bool` path is a separate pre-existing defect, tracked on its own: the bound comes back through `SerializationBool` while the query side takes it from the declared column, so the two tags mismatch with or without this change (indexed `<=` reads 0 rows where 3 are correct, identically on master). It needs a normalizer that can tell a declared path from a dynamic one, since rewriting dynamic paths would break them; `allow_minmax_index_for_json` is off by default.

#116655, open, declines a key or index range whose container elements can be `NULL`, which removes the `Array(Nullable(Bool))` symptom as a side effect; the defect fixed here needs no `NULL` and reaches non-nullable containers, which that PR leaves unchanged. Whichever of the two merges second drops the `pk prunes` assertion in the test here, since the atom is then unset there by design.

A second residual: at container nesting depth around 36 an index range comparison becomes exponential, roughly 4x per level. It is pre-existing and not `Bool`-specific, since an all-`UInt8` key takes 14.6 s at depth 36 and 234 s at depth 38 on both binaries, and #116455 fixes the mechanism. A deeply nested `Bool` key escaped that cost only by answering wrongly.

883 existing `minmax`, `skip_index`, `bool`, `partition`, `JSON` and top-K tests ran on both binaries: nothing fails only with the fix, the only test failing only on master is the new one, and the two failure sets are otherwise byte-identical. Every changed line has a mutant reddening a distinct set of the new reference lines, and the `Map`, part-level, primary-key and top-K pruning assertions are additionally checked against a mutant that declines to prune while still answering correctly. 50 randomized runs pass, and over 125,000 granules the added work stays below master's own spread.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116897&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116897](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116897+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.649` (included in `26.9` and later)
<!-- ch-version-info:end -->