### PR TITLE
Disable tcache inside ScopedJemallocThreadArena by default

### DIFF
--- a/src/Common/Jemalloc.cpp
+++ b/src/Common/Jemalloc.cpp
@@ -292,7 +292,7 @@ std::string_view getLastFlushProfileForThread()
 
 }
 
-ScopedJemallocThreadArena::ScopedJemallocThreadArena(unsigned arena_idx)
+ScopedJemallocThreadArena::ScopedJemallocThreadArena(unsigned arena_idx, bool disable_tcache)
 {
     if (arena_idx == 0)
         return;
@@ -304,12 +304,29 @@ ScopedJemallocThreadArena::ScopedJemallocThreadArena(unsigned arena_idx)
     /// fall back to the previous behavior of allocating in the default arena. The cost is fragmentation,
     /// not correctness.
     active = (err == 0);
+
+    if (!active || !disable_tcache)
+        return;
+
+    /// Disabling also flushes the cache; the write returns the previous state via the read pointer.
+    /// Re-enable in the destructor only if it was enabled before (keeps nested scopes correct).
+    bool tcache_enabled = false;
+    bool previous_tcache_enabled = false;
+    size_t previous_tcache_size = sizeof(previous_tcache_enabled);
+    err = je_mallctl("thread.tcache.enabled", &previous_tcache_enabled, &previous_tcache_size, &tcache_enabled, sizeof(tcache_enabled));
+    tcache_switched = (err == 0) && previous_tcache_enabled;
 }
 
 ScopedJemallocThreadArena::~ScopedJemallocThreadArena()
 {
     if (!active)
         return;
+
+    if (tcache_switched)
+    {
+        bool tcache_enabled = true;
+        je_mallctl("thread.tcache.enabled", nullptr, nullptr, &tcache_enabled, sizeof(tcache_enabled));
+    }
 
     je_mallctl("thread.arena", nullptr, nullptr, &previous_arena, sizeof(previous_arena));
 }

--- a/src/Common/Jemalloc.h
+++ b/src/Common/Jemalloc.h
@@ -164,19 +164,25 @@ std::string getStats();
 ///
 /// Allocations made by the calling thread inside the scope (including those that go through
 /// global `operator new`/`malloc`, e.g. from third-party libraries or unrelated container code)
-/// land in `arena_idx`. Frees automatically return memory to whichever arena originally owned the
-/// pointer (jemalloc looks this up from per-extent metadata), so only allocation paths need scoping.
+/// land in `arena_idx`. Frees return memory to whichever arena originally owned the pointer
+/// (jemalloc looks this up from per-extent metadata), so frees need no scoping to land home.
+///
+/// The isolation is one-way though: a free outside any scope parks the chunk in the freeing
+/// thread's cache first, and a later same-size allocation on that thread can reuse it, serving
+/// `arena_idx` memory to unrelated code.
 ///
 /// On construction, the thread's previous preferred arena is captured and restored on destruction.
 /// Use this around tightly-bounded blocks of allocations whose lifetime differs from typical
 /// query-processing work; do not hold across calls that allocate ClickHouse data structures
 /// unrelated to the target subsystem.
 ///
+/// The thread cache is disabled for the scope by default, otherwise allocation may use old arena.
+///
 /// No-op when `arena_idx == 0` or when jemalloc is not compiled in.
 class ScopedJemallocThreadArena
 {
 public:
-    explicit ScopedJemallocThreadArena(unsigned arena_idx);
+    explicit ScopedJemallocThreadArena(unsigned arena_idx, bool disable_tcache = true);
     ~ScopedJemallocThreadArena();
 
     ScopedJemallocThreadArena(const ScopedJemallocThreadArena &) = delete;
@@ -185,6 +191,7 @@ public:
 private:
     unsigned previous_arena = 0;
     bool active = false;
+    bool tcache_switched = false;
 };
 
 }
@@ -198,7 +205,7 @@ namespace DB
 class ScopedJemallocThreadArena
 {
 public:
-    explicit ScopedJemallocThreadArena(unsigned /*arena_idx*/) {}
+    explicit ScopedJemallocThreadArena(unsigned /*arena_idx*/, bool /*disable_tcache*/ = true) {}
 };
 
 }

--- a/src/Common/tests/gtest_jemalloc_thread_arena.cpp
+++ b/src/Common/tests/gtest_jemalloc_thread_arena.cpp
@@ -1,0 +1,146 @@
+#include "config.h"
+
+#if USE_JEMALLOC
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <Common/Jemalloc.h>
+
+using namespace DB;
+
+/// Owning arena of a pointer, from jemalloc's per-extent metadata.
+static unsigned owningArena(void * ptr)
+{
+    unsigned arena = 0;
+    size_t arena_size = sizeof(arena);
+    EXPECT_EQ(je_mallctl("arenas.lookup", &arena, &arena_size, &ptr, sizeof(ptr)), 0);
+    return arena;
+}
+
+/// Both tests create a dedicated arena and force the thread cache on, and can bail out on a
+/// failed assertion at any point, with dedicated-arena chunks still parked in the thread cache.
+class ScopedJemallocThreadArenaTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        tcache_was_enabled = Jemalloc::getValue<bool>("thread.tcache.enabled");
+        /// The tests rely on the thread cache.
+        Jemalloc::setValue("thread.tcache.enabled", true);
+
+        /// Sampled small allocations are promoted to large and would skew the stats below.
+        bool prof_off = false;
+        size_t prof_size = sizeof(prof_was_active);
+        prof_active_saved = je_mallctl("thread.prof.active", &prof_was_active, &prof_size, &prof_off, sizeof(prof_off)) == 0;
+
+        size_t arena_size = sizeof(arena);
+        ASSERT_EQ(je_mallctl("arenas.create", &arena, &arena_size, nullptr, 0), 0);
+        arena_created = true;
+    }
+
+    void TearDown() override
+    {
+        /// Disabling the cache also flushes it, so no dedicated-arena chunks leak to later tests.
+        Jemalloc::setValue("thread.tcache.enabled", false);
+        Jemalloc::setValue("thread.tcache.enabled", tcache_was_enabled);
+
+        if (prof_active_saved && prof_was_active)
+            Jemalloc::setValue("thread.prof.active", true);
+
+        /// A failure message may hold a cached chunk of this arena; destroy would dangle it.
+        if (arena_created && !HasFailure())
+            EXPECT_EQ(je_mallctl(fmt::format("arena.{}.destroy", arena).c_str(), nullptr, nullptr, nullptr, 0), 0);
+    }
+
+    unsigned arena = 0;
+    bool arena_created = false;
+    bool tcache_was_enabled = true;
+    bool prof_was_active = false;
+    bool prof_active_saved = false;
+};
+
+/// The scope must bypass a warm thread cache: cached chunks belong to other arenas.
+/// Warm the cache, allocate inside the scope, check the arena grew by the full batch.
+TEST_F(ScopedJemallocThreadArenaTest, BypassesThreadCache)
+{
+    if (!Jemalloc::getValue<bool>("config.stats"))
+        GTEST_SKIP() << "jemalloc built without stats";
+
+    /// An exact small size class, so stats grow by exactly this amount per allocation.
+    constexpr size_t alloc_size = 128;
+    constexpr size_t count = 100;
+
+    /// Warm the cache from the default arena; with an empty cache the bug is invisible.
+    std::vector<void *> ptrs(count);
+    for (auto & ptr : ptrs)
+        ptr = je_malloc(alloc_size);
+    for (auto * ptr : ptrs)
+        je_free(ptr);
+
+    const auto small_allocated = [this]
+    {
+        uint64_t epoch = 1;
+        je_mallctl("epoch", nullptr, nullptr, &epoch, sizeof(epoch));
+        return Jemalloc::getValue<size_t>(fmt::format("stats.arenas.{}.small.allocated", arena).c_str());
+    };
+
+    const size_t before = small_allocated();
+    {
+        ScopedJemallocThreadArena scope(arena);
+        for (auto & ptr : ptrs)
+            ptr = je_malloc(alloc_size);
+    }
+    const size_t after = small_allocated();
+
+    /// Bypass the cache: a failure message below could pick up a parked arena chunk.
+    for (auto * ptr : ptrs)
+        je_sdallocx(ptr, alloc_size, MALLOCX_TCACHE_NONE);
+
+    EXPECT_GE(after, before + count * alloc_size);
+    /// The scope must restore the cache state it captured on entry.
+    EXPECT_TRUE(Jemalloc::getValue<bool>("thread.tcache.enabled"));
+}
+
+/// Chunks freed after the scope park in the thread cache and would be reused by unrelated
+/// code outside any scope. The next scope entry must flush them back to the arena.
+TEST_F(ScopedJemallocThreadArenaTest, EntryEvictsArenaChunksFromThreadCache)
+{
+    constexpr size_t alloc_size = 128;
+    constexpr size_t count = 100;
+
+    std::vector<void *> ptrs(count);
+    {
+        ScopedJemallocThreadArena scope(arena);
+        for (auto & ptr : ptrs)
+            ptr = je_malloc(alloc_size);
+    }
+    ASSERT_EQ(owningArena(ptrs.front()), arena);
+
+    /// Freed outside the scope: the chunks land in this thread's cache, not back in the arena.
+    for (auto * ptr : ptrs)
+        je_free(ptr);
+
+    /// An allocation outside any scope now reuses the most recently freed chunk.
+    void * unscoped = je_malloc(alloc_size);
+    const unsigned unscoped_arena = owningArena(unscoped);
+    je_free(unscoped);
+
+    {
+        ScopedJemallocThreadArena scope(arena);
+    }
+
+    /// The thread-cache GC may evict the parked chunks first. Checked only after the flush
+    /// above: a message allocated earlier could itself hold a parked arena chunk.
+    if (unscoped_arena != arena)
+        GTEST_SKIP() << "thread cache GC evicted the parked chunks first";
+
+    /// The scope entry above flushed the cache, so this refills from the thread's own arena.
+    void * clean = je_malloc(alloc_size);
+    EXPECT_NE(owningArena(clean), arena);
+    je_free(clean);
+}
+
+#endif

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -31,11 +31,10 @@ export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_PROBABILITY=0.001
 export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_PROBABILITY=0.001
 export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_PROBABILITY=0.001
 export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_PROBABILITY=0.001
-export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_TIME_US_MAX=10000
-
-export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_TIME_US_MAX=10000
-export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US_MAX=10000
-export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US_MAX=10000
+export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_TIME_US_MAX=1000
+export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_TIME_US_MAX=1000
+export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US_MAX=1000
+export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US_MAX=1000
 
 export THREAD_FUZZER_EXPLICIT_SLEEP_PROBABILITY=0.001
 export THREAD_FUZZER_EXPLICIT_MEMORY_EXCEPTION_PROBABILITY=0.001
@@ -323,7 +322,7 @@ rm -f /etc/clickhouse-server/config.d/fail_points_active.xml
 
 # Use a larger timeout for the post-stress restart: under sanitizers with
 # async_load_databases=false the server may need minutes to load all tables.
-start_server 10 || { echo "Failed to start server"; exit 1; }
+start_server 20 || { echo "Failed to start server"; exit 1; }
 
 check_server_start
 

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -358,7 +358,7 @@ function start_server()
     wait_server_ports_free
 
     counter=0
-    max_attempt=${1:-6}
+    max_attempt=${1:-12}
     until clickhouse-client --receive_timeout 30 --query "SELECT 1"
     do
         if [ "$counter" -gt "$max_attempt" ]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Disable tcache inside ScopedJemallocThreadArena by default (otherwise it may use old arena)

But, note that I did not found any envs that has higher memory fragmentation due to this, so it is 99% minor thing

Besides JemallocCacheArena behaves the same way

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116903&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116903](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116903+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
