### PR TITLE
Drop the timing limit from the 04648_replicate_generic_no_quadratic_realloc arms that cannot carry it

### DIFF
--- a/tests/queries/0_stateless/04648_replicate_generic_no_quadratic_realloc.sql
+++ b/tests/queries/0_stateless/04648_replicate_generic_no_quadratic_realloc.sql
@@ -1,6 +1,8 @@
 -- A constant Array(JSON) argument to an aggregate reaches ColumnArray::replicateGeneric, which appended
 -- shared data one row at a time and re-reserved the whole nested column each time, so the bytes copied
 -- grew quadratically. max_execution_time only guards a return; the runner's own timeout trips first.
+-- The time limit is only on the arms that hold a JSON object, because the other shapes never reach
+-- the quadratic path and their wall clock says nothing about it.
 
 SET enable_analyzer = 1;
 SET max_block_size = 400000;
@@ -17,10 +19,10 @@ SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [map('a', 1
 SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [map('k', map('a', 1)::JSON)] AS c FROM numbers(400000)) GROUP BY k SETTINGS max_execution_time = 60;
 SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [map('a', 1)::JSON::Dynamic] AS c FROM numbers(400000)) GROUP BY k SETTINGS max_execution_time = 60;
 SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [map('a', 1)::JSON::Variant(UInt64, JSON)] AS c FROM numbers(400000)) GROUP BY k SETTINGS max_execution_time = 60;
-SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [1::Dynamic, 'x'::Dynamic] AS c FROM numbers(400000)) GROUP BY k SETTINGS max_execution_time = 60;
-SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [1::Variant(UInt64, String)] AS c FROM numbers(400000)) GROUP BY k SETTINGS max_execution_time = 60;
-SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [map('a', 1)] AS c FROM numbers(400000)) GROUP BY k SETTINGS max_execution_time = 60;
-SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [toLowCardinality('x')] AS c FROM numbers(400000)) GROUP BY k SETTINGS max_execution_time = 60;
+SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [1::Dynamic, 'x'::Dynamic] AS c FROM numbers(400000)) GROUP BY k;
+SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [1::Variant(UInt64, String)] AS c FROM numbers(400000)) GROUP BY k;
+SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [map('a', 1)] AS c FROM numbers(400000)) GROUP BY k;
+SELECT any(c) IS NOT NULL, count() FROM (SELECT materialize(1) AS k, [toLowCardinality('x')] AS c FROM numbers(400000)) GROUP BY k;
 
 -- Appending offsets must not raise peak memory, since IColumn::reserve affects performance only. These
 -- pass from the same limit as before the fix; an object with no shared-data pair is the tight case,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112897
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Keep the per-query wall-clock limit in `04648_replicate_generic_no_quadratic_realloc` only on the arms whose runtime depends on the defect the test guards.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/112897
Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116793&sha=16339a314a676f37f92305c920121b571f3dd414&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29

All 13 aggregate arms carried `SETTINGS max_execution_time = 60`. Four hold no JSON object, so they never reach `ColumnArray::insertManyDefaults`, where the quadratic reallocation lived. Their wall clock does not depend on the defect, so no value of the limit can make them redden on a regression; it can only fire under load. One did: `[toLowCardinality('x')]` reported `elapsed 66020.597 ms, maximum: 60000.000 ms` on the `amd_llvm_coverage, ParallelReplicas, s3 storage` lane, on a build containing the fix, after producing the right answer. #112897 measures that shape at 1.60 s before the fix and 1.59 s after.

I classified them with a counter in `ColumnArray::insertManyDefaults`: the nine arms holding a JSON object call it 400006 to 400008 times, the four de-capped here zero times, and a `SELECT 1` control also zero, so the zeros are measurements not a dead probe. The split is by JSON presence, not wrapper name: `JSON::Dynamic` and `JSON::Variant(UInt64, JSON)` are carriers and keep their limits. Of the four, `[toLowCardinality('x')]` is the slowest by 3.6x, hence the likeliest to false-red; none has detection value.

The nine carriers keep 60 s rather than a looser bound: their unfixed runtime is measured only under ASan, where it exceeds the runner's 600 s bound, so a looser limit risks sitting above the unfixed runtime on a faster build. Their coverage-lane margin is unmeasured, so a carrier false red stays possible.

On ASan the shipped file passes in 9.77 s and still fails with the override deleted, through a carrier arm this diff does not touch. Debug: 50/50 randomized.

`b86bdb039bda6ea` narrowed the h3 oracle the same way; `c137b3982451b38a` instead raised the limit and named the real guard, reasoning that such a limit guards the blowup, not the fixed runtime. `04910_h3_array_building_no_quadratic_realloc.sql` is untouched: 0 failures in 19913 runs.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116918&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116918](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116918+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
