### PR TITLE
Fix stat and chmod for DiskEncrypted

### DIFF
--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -28,6 +28,7 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int INCORRECT_DISK_INDEX;
+    extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
 }
 
@@ -285,6 +286,39 @@ namespace
     {
         return typeid(one) == typeid(another);
     }
+
+    class DiskEncryptedDirectoryIterator final : public IDirectoryIterator
+    {
+    public:
+        DiskEncryptedDirectoryIterator(DirectoryIteratorPtr delegate_, String path_prefix_)
+            : delegate(std::move(delegate_))
+            , path_prefix(std::move(path_prefix_))
+        {
+        }
+
+        void next() override { delegate->next(); }
+        bool isValid() const override { return delegate->isValid(); }
+
+        String path() const override
+        {
+            auto delegate_path = delegate->path();
+
+            if (!delegate_path.starts_with(path_prefix))
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Encrypted disk iterator returned path {} without expected prefix {}",
+                    quoteString(delegate_path),
+                    quoteString(path_prefix));
+
+            return delegate_path.substr(path_prefix.size());
+        }
+
+        String name() const override { return delegate->name(); }
+
+    private:
+        DirectoryIteratorPtr delegate;
+        String path_prefix;
+    };
 }
 
 class DiskEncryptedReservation : public IReservation
@@ -464,6 +498,11 @@ size_t DiskEncrypted::getFileSize(const String & path) const
     auto wrapped_path = wrappedPath(path);
     size_t size = delegate->getFileSize(wrapped_path);
     return size > FileEncryption::Header::kSize ? (size - FileEncryption::Header::kSize) : 0;
+}
+
+DirectoryIteratorPtr DiskEncrypted::iterateDirectory(const String & path) const
+{
+    return std::make_unique<DiskEncryptedDirectoryIterator>(delegate->iterateDirectory(wrappedPath(path)), disk_path);
 }
 
 UInt128 DiskEncrypted::getEncryptedFileIV(const String & path) const

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -76,11 +76,7 @@ public:
         tx->commit();
     }
 
-    DirectoryIteratorPtr iterateDirectory(const String & path) const override
-    {
-        auto wrapped_path = wrappedPath(path);
-        return delegate->iterateDirectory(wrapped_path);
-    }
+    DirectoryIteratorPtr iterateDirectory(const String & path) const override;
 
     void createFile(const String & path) override
     {
@@ -274,6 +270,18 @@ public:
     {
         auto wrapped_path = wrappedPath(path);
         return delegate->getLastChanged(wrapped_path);
+    }
+
+    struct stat stat(const String & path) const override
+    {
+        return delegate->stat(wrappedPath(path));
+    }
+
+    void chmod(const String & path, mode_t mode) override
+    {
+        auto tx = createEncryptedTransaction();
+        tx->chmod(path, mode);
+        tx->commit();
     }
 
     void setReadOnly(const String & path) override

--- a/tests/integration/test_store_cleanup/configs/store_cleanup.xml
+++ b/tests/integration/test_store_cleanup/configs/store_cleanup.xml
@@ -3,6 +3,24 @@
     <database_catalog_unused_dir_rm_timeout_sec>60</database_catalog_unused_dir_rm_timeout_sec>
     <database_catalog_unused_dir_cleanup_period_sec>1</database_catalog_unused_dir_cleanup_period_sec>
 
+    <storage_configuration>
+        <disks>
+            <default></default>
+            <encrypted_disk_inner>
+                <type>encrypted</type>
+                <disk>default</disk>
+                <path>encrypted_inner/</path>
+                <key>1234567812345678</key>
+            </encrypted_disk_inner>
+            <encrypted_disk>
+                <type>encrypted</type>
+                <disk>encrypted_disk_inner</disk>
+                <path>encrypted_outer/</path>
+                <key>8765432187654321</key>
+            </encrypted_disk>
+        </disks>
+    </storage_configuration>
+
     <!-- We don't really need [Zoo]Keeper for this test.
     And it makes sense to have at least one test with TestKeeper. -->
     <zookeeper>

--- a/tests/integration/test_store_cleanup/test.py
+++ b/tests/integration/test_store_cleanup/test.py
@@ -12,6 +12,13 @@ node1 = cluster.add_instance(
 )
 
 path_to_data = "/var/lib/clickhouse/"
+encrypted_uuid = "40000000-1000-4000-8000-000000000001"
+encrypted_logical_path = f"store/400/{encrypted_uuid}/"
+encrypted_inner_store_path = f"{path_to_data}encrypted_inner/store"
+encrypted_store_prefix = (
+    f"{path_to_data}encrypted_inner/encrypted_outer/store/400"
+)
+encrypted_orphan_path = f"{encrypted_store_prefix}/{encrypted_uuid}"
 
 
 @pytest.fixture(scope="module")
@@ -91,6 +98,10 @@ def test_store_cleanup(started_cluster):
     node1.exec_in_container(
         ["mkdir", f"{path_to_data}/store/456/45600000-1000-4000-8000-000000000004"]
     )
+    # Keep the inner disk's store directory available for its own cleanup pass.
+    node1.exec_in_container(["mkdir", "-p", encrypted_inner_store_path])
+    node1.exec_in_container(["mkdir", "-p", f"{encrypted_orphan_path}/nested"])
+    node1.exec_in_container(["touch", f"{encrypted_orphan_path}/nested/garbage"])
 
     node1.start_clickhouse()
     node1.query("DETACH DATABASE db2", settings=sync_drop)
@@ -103,6 +114,21 @@ def test_store_cleanup(started_cluster):
     )
     node1.wait_for_log_line(
         "directories from store", timeout=60, look_behind_lines=1000000
+    )
+    node1.wait_for_log_line(
+        f"Removing access rights for unused directory {encrypted_logical_path} from disk encrypted_disk",
+        timeout=60,
+        look_behind_lines=1000000,
+    )
+    node1.wait_for_log_line(
+        "Cleaned up 1 directories from store/ on disk encrypted_disk",
+        timeout=60,
+        look_behind_lines=1000000,
+    )
+
+    assert (
+        node1.exec_in_container(["stat", "-c", "%a", encrypted_orphan_path]).strip()
+        == "0"
     )
 
     store = node1.exec_in_container(["ls", f"{path_to_data}/store"])
@@ -164,6 +190,19 @@ def test_store_cleanup(started_cluster):
     node1.wait_for_log_line(
         "Nothing to clean up from store/", timeout=90, look_behind_lines=1000000
     )
+    node1.wait_for_log_line(
+        f"Removing unused directory {encrypted_logical_path} from disk encrypted_disk",
+        timeout=90,
+        look_behind_lines=1000000,
+    )
+    node1.wait_for_log_line(
+        "Cleaned up 1 directories from store/ on disk encrypted_disk",
+        timeout=90,
+        repetitions=2,
+        look_behind_lines=1000000,
+    )
+
+    assert not node1.path_exists(encrypted_orphan_path)
 
     store = node1.exec_in_container(["ls", f"{path_to_data}/store"])
     assert "100" in store


### PR DESCRIPTION
DiskEncrypted forwards supportsStat and supportsChmod to its underlying disk, but did not override the corresponding operations. When the underlying disk supports them, calls fell back to the default IDisk implementations and threw NOT_IMPLEMENTED.

This caused background cleanup of unused store/ directories on encrypted disks to fail before permissions could be revoked or the orphan directory removed.

Implement stat by forwarding the wrapped path to the underlying disk. Implement chmod through DiskEncryptedTransaction so path wrapping and transaction semantics remain consistent with other mutating operations.

Extend test_store_cleanup with an orphan directory on an encrypted disk. The test covers the already-wrapped path returned by iterateDirectory, permission removal with chmod(0), restoring owner permissions with chmod(S_IRWXU), and final recursive removal.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix background cleanup of unused store/ directories on encrypted disks. ClickHouse can now revoke permissions and remove these orphaned directories instead of failing during cleanup.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116919&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116919](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116919+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
