### PR TITLE
distroless: bump base pin to current base-nossl-debian13 digests

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -164,8 +164,8 @@ RUN mkdir -p \
 # Stage 2: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
-FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:12224264396c6637ae850ff7f82fb5c759115d9aa4c8b55f4aa7d40059c2e6f1 AS debug
 
 COPY --from=ch-builder /output/ /
 
@@ -186,8 +186,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 3: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
-FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:5cab74e7f8a5e7c5f1c8a9e6268b1f352f053c36c656f493308340bcecbc636c AS production
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -182,8 +182,8 @@ RUN { \
 # Stage 2: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
-FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:12224264396c6637ae850ff7f82fb5c759115d9aa4c8b55f4aa7d40059c2e6f1 AS debug
 
 COPY --from=ch-builder /output/ /
 
@@ -204,8 +204,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 3: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
-FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
+# Pinned 2026-08-28. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:5cab74e7f8a5e7c5f1c8a9e6268b1f352f053c36c656f493308340bcecbc636c AS production
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
Digest-only refresh of the distroless base pins. Upstream retagged `gcr.io/distroless/base-nossl-debian13`, so the pins from 2026-06-18 are one digest behind:

```
nonroot        sha256:20f009ee6f69... -> sha256:5cab74e7f8a5...
debug-nonroot  sha256:a5fef528b61d... -> sha256:12224264396c...
```

Package delta on the production base is `libc6 2.41-12+deb13u2 -> u3` and `base-files 13.8+deb13u5 -> u6`. Trivy HIGH/CRITICAL is 0 on both the old and new digest, so this bump on its own is hygiene, not a CVE fix.

The reason it's worth landing now is the auto-rebuild it triggers. The scanner run on 2026-08-28 flagged 6 of 12 tracked floating tags, and the actual blocker there isn't the digest move:

```
HIGH  CVE-2026-14456  libssl3t64 3.5.6-1~deb13u2  fix=3.5.7-1~deb13u2
      OpenSSL: DoS via unbounded memory growth in QUIC server listener
```

`clickhouse-{server,keeper}:{25.8,26.3,26.4}-distroless` are still built on `cc-debian13` and carry `libssl3t64`. They've never been rebuilt since the base-nossl swap in #107837. Layer counts tell the story: those six are 23 layers (cc base), while `latest`, `25.10` and `25.12` are 16 (base-nossl) and come back clean. `base-nossl-debian13` doesn't ship `libssl3t64` at all, so a rebuild deletes the package rather than patching it. Reachability is nil either way since ClickHouse statically links its own OpenSSL and never loads the distro one, but it's a fixable HIGH in a runtime package so it blocks by policy.

Merging this fires `DistrolessAutoRebuild` (#108113), which dispatches `BackfillDistroless` across the tracked fleet and picks up both the new libc6 and the `cc-debian13` removal in one pass. If for some reason the auto-trigger doesn't fire, the manual equivalent is:

```
gh workflow run BackfillDistroless --repo ClickHouse/ClickHouse --ref master \
  -f versions="26.4.5.143 26.3.25.2 25.8.33.6" -f dry-run=false
```

Nothing outside the four pinned `FROM` lines and their dated comments changed, and server and keeper stay in sync. Refresh command is in the comment above each pin.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116929&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116929](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116929+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.463` (included in `26.9` and later)
<!-- ch-version-info:end -->