### PR TITLE
Expose unconfigured system logs in `system.documentation`

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -349,6 +349,27 @@ String escapeStringForRegexp(const String & s)
 
 }
 
+std::vector<SystemLogTableMetadata> getSystemLogTableMetadata()
+{
+    std::vector<SystemLogTableMetadata> result;
+
+#define ADD_SYSTEM_LOG_METADATA(log_type, member, descr) \
+    { \
+        auto columns = log_type::Element::getColumnsDescription(); \
+        columns.setAliases(log_type::Element::getNamesAndAliases()); \
+        result.push_back({#member, descr, std::move(columns)}); \
+    }
+
+    LIST_OF_ALL_SYSTEM_LOGS(ADD_SYSTEM_LOG_METADATA)
+#if CLICKHOUSE_CLOUD
+    LIST_OF_CLOUD_SYSTEM_LOGS(ADD_SYSTEM_LOG_METADATA)
+#endif
+
+#undef ADD_SYSTEM_LOG_METADATA
+
+    return result;
+}
+
 
 SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConfiguration & config)
 {

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -11,7 +11,10 @@
 #include <Parsers/CommonParsers.h>
 
 #include <Interpreters/SystemLogFlushPolicy.h>
+#include <Storages/ColumnsDescription.h>
 #include <boost/noncopyable.hpp>
+
+#include <vector>
 
 #define LIST_OF_ALL_SYSTEM_LOGS(M) \
     M(QueryLog,              query_log,            "Contains information about executed queries, for example, start time, duration of processing, error messages.") \
@@ -193,6 +196,15 @@ struct SystemLogSettings
     bool union_table_merge_rotated_tables = false;
     String union_table_cluster;
 };
+
+struct SystemLogTableMetadata
+{
+    String name;
+    String comment;
+    ColumnsDescription columns;
+};
+
+std::vector<SystemLogTableMetadata> getSystemLogTableMetadata();
 
 template <typename LogElement>
 class SystemLog : public SystemLogBase<LogElement>, private boost::noncopyable, public WithContext

--- a/src/Storages/System/StorageSystemDocumentation.cpp
+++ b/src/Storages/System/StorageSystemDocumentation.cpp
@@ -3,13 +3,6 @@
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/Combinators/AggregateFunctionCombinatorFactory.h>
 #include <Columns/IColumn.h>
-#include <Common/AsynchronousMetrics.h>
-#include <Common/CurrentMetrics.h>
-#include <Common/Documentation.h>
-#include <Common/FunctionDocumentation.h>
-#include <Common/ProfileEvents.h>
-#include <Common/StringUtils.h>
-#include <Common/re2.h>
 #include <Compression/CompressionFactory.h>
 #include <Core/Field.h>
 #include <Core/ServerSettings.h>
@@ -29,6 +22,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/SystemLog.h>
 #include <Parsers/StatementFactory.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
@@ -37,11 +31,19 @@
 #include <Storages/StorageInMemoryMetadata.h>
 #include <Storages/System/SystemTableSourceRegistry.h>
 #include <TableFunctions/TableFunctionFactory.h>
+#include <Common/AsynchronousMetrics.h>
+#include <Common/CurrentMetrics.h>
+#include <Common/Documentation.h>
+#include <Common/FunctionDocumentation.h>
+#include <Common/ProfileEvents.h>
+#include <Common/StringUtils.h>
+#include <Common/re2.h>
 
 #include <algorithm>
 #include <source_location>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <Poco/String.h>
@@ -115,6 +117,7 @@ constexpr std::string_view MERGE_TREE_SETTINGS_SOURCE = "src/Storages/MergeTree/
 constexpr std::string_view SERVER_SETTINGS_SOURCE = "src/Core/ServerSettings.cpp";
 constexpr std::string_view PROFILE_EVENTS_SOURCE = "src/Common/ProfileEvents.cpp";
 constexpr std::string_view CURRENT_METRICS_SOURCE = "src/Common/CurrentMetrics.cpp";
+constexpr std::string_view SYSTEM_LOGS_SOURCE = "src/Interpreters/SystemLog.h";
 
 /// The source paths captured by `std::source_location` (in `Documentation`/`FunctionDocumentation`) are produced by
 /// the compiler: relative to the repository root when the build remaps source paths (`ENABLE_BUILD_PATH_MAPPING`,
@@ -1061,10 +1064,20 @@ void StorageSystemDocumentation::fillData(MutableColumns & res_columns, ContextP
     addDocumented(res_columns, EntityType::Statement, StatementFactory::instance());
 
     /// System tables document themselves with their table comment, authored at the attachment site.
+    /// System logs are defined independently of whether the corresponding table is configured, so keep their
+    /// metadata available even when there is no live table to inspect.
+    const auto system_log_tables = getSystemLogTableMetadata();
+    std::unordered_map<std::string_view, const SystemLogTableMetadata *> system_log_tables_by_name;
+    system_log_tables_by_name.reserve(system_log_tables.size());
+    for (const auto & metadata : system_log_tables)
+        system_log_tables_by_name.emplace(metadata.name, &metadata);
+
+    std::unordered_set<String> attached_system_logs;
     if (const auto system_database = DatabaseCatalog::instance().tryGetDatabase(DatabaseCatalog::SYSTEM_DATABASE))
     {
         for (auto iterator = system_database->getTablesIterator(context); iterator->isValid(); iterator->next())
         {
+            const String table_name = iterator->name();
             if (const auto & table = iterator->table())
             {
                 const auto metadata_snapshot = table->getInMemoryMetadataPtr(context, false);
@@ -1073,12 +1086,31 @@ void StorageSystemDocumentation::fillData(MutableColumns & res_columns, ContextP
                     /// Bind to a reference first: `typeid(*table)` would warn about evaluating an expression with
                     /// side effects (the smart pointer dereference) as the operand of a polymorphic `typeid`.
                     const IStorage & storage = *table;
-                    addRow(res_columns, EntityType::SystemTable, iterator->name(),
+                    const auto system_log = system_log_tables_by_name.find(table_name);
+                    addRow(
+                        res_columns,
+                        EntityType::SystemTable,
+                        table_name,
                         renderSystemTableDoc(metadata_snapshot->comment, metadata_snapshot->getColumns()),
-                        makeRepoRelative(getSystemTableSource(typeid(storage))));
+                        system_log == system_log_tables_by_name.end() ? makeRepoRelative(getSystemTableSource(typeid(storage)))
+                                                                      : String(SYSTEM_LOGS_SOURCE));
+                    if (system_log != system_log_tables_by_name.end())
+                        attached_system_logs.emplace(table_name);
                 }
             }
         }
+    }
+
+    for (const auto & metadata : system_log_tables)
+    {
+        if (attached_system_logs.contains(metadata.name))
+            continue;
+        addRow(
+            res_columns,
+            EntityType::SystemTable,
+            metadata.name,
+            renderSystemTableDoc(metadata.comment, metadata.columns),
+            String(SYSTEM_LOGS_SOURCE));
     }
 }
 

--- a/tests/queries/0_stateless/05047_system_documentation_unconfigured_logs.reference
+++ b/tests/queries/0_stateless/05047_system_documentation_unconfigured_logs.reference
@@ -1,0 +1,3 @@
+error_log	0	src/Interpreters/SystemLog.h	1	1
+query_log	0	src/Interpreters/SystemLog.h	1	1
+trace_log	0	src/Interpreters/SystemLog.h	1	1

--- a/tests/queries/0_stateless/05047_system_documentation_unconfigured_logs.sh
+++ b/tests/queries/0_stateless/05047_system_documentation_unconfigured_logs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# System log tables are documented even when they are not configured and therefore do not exist in `system.tables`.
+$CLICKHOUSE_LOCAL --query "
+    SELECT
+        name,
+        name IN
+        (
+            SELECT name
+            FROM system.tables
+            WHERE database = 'system'
+        ) AS attached,
+        source,
+        notEmpty(description),
+        position(description, '**Columns**') > 0
+    FROM system.documentation
+    WHERE type = 'System Table'
+        AND name IN ('error_log', 'query_log', 'trace_log')
+    ORDER BY name"


### PR DESCRIPTION
Makes every canonical system log visible in `system.documentation`, even when the corresponding table is not configured. Names, descriptions, and columns come from `LIST_OF_ALL_SYSTEM_LOGS`; configured tables continue to use their live metadata.

Related: https://github.com/ClickHouse/ClickHouse/pull/116291

This addresses the separate visibility issue identified in https://github.com/ClickHouse/ClickHouse/pull/116291#issuecomment-5452327252.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
System log tables are now listed in `system.documentation` even when they are not configured.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116936&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116936](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116936+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
