### PR TITLE
Fix Iceberg OPTIMIZE rejecting a mixed-format snapshot that SELECT reads

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -298,11 +298,25 @@ static Plan getPlan(
         if (partition_index >= plan.partitions.size())
             continue;
 
+        /// `lower/upper_reference_data_file_path` bound the delete file's own `file_path` column,
+        /// so a data file outside them has no deleted rows recorded in this delete file.
+        const auto & lower = delete_file->parsed_entry->lower_reference_data_file_path;
+        const auto & upper = delete_file->parsed_entry->upper_reference_data_file_path;
+
         for (auto & data_file : plan.partitions[partition_index])
         {
-            if (data_file->data_object_info->info.sequence_number <= delete_file->sequence_number)
-                data_file->data_object_info->addPositionDeleteObject(
-                    delete_file, persistent_table_components.path_resolver.resolve(delete_file->parsed_entry->file_path_key));
+            if (data_file->data_object_info->info.sequence_number > delete_file->sequence_number)
+                continue;
+
+            const auto & data_file_path = data_file->data_object_info->info.data_object_file_path_key;
+            bool can_contain_data_file_deletes
+                = (!lower.has_value() || *lower <= data_file_path)
+                && (!upper.has_value() || *upper >= data_file_path);
+            if (!can_contain_data_file_deletes)
+                continue;
+
+            data_file->data_object_info->addPositionDeleteObject(
+                delete_file, persistent_table_components.path_resolver.resolve(delete_file->parsed_entry->file_path_key));
         }
     }
     plan.history = std::move(snapshots_info);

--- a/tests/integration/test_storage_iceberg_with_spark/test_optimize.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_optimize.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from datetime import datetime, timezone
 import time
@@ -7,7 +8,8 @@ from helpers.iceberg_utils import (
     default_upload_directory,
     default_download_directory,
     get_uuid_str,
-    get_last_snapshot
+    get_last_snapshot,
+    parse_manifest_entry
 )
 
 @pytest.mark.parametrize("storage_type", ["local", "s3", "azure"])
@@ -186,3 +188,122 @@ def test_optimize_manifest_per_file_stats(started_cluster_iceberg_with_spark):
             data_entries_checked += 1
 
     assert data_entries_checked > 0
+
+
+def test_optimize_mixed_format_position_delete_reference_bounds(
+    started_cluster_iceberg_with_spark,
+):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    storage_type = "local"
+    TABLE_NAME = "test_optimize_mixed_format_bounds_" + get_uuid_str()
+
+    # An ORC data file whose sequence number is below a position delete that references only the
+    # Parquet data file. Every write is Spark's: ClickHouse refuses its own DELETE while a
+    # non-Parquet data file is live in the current snapshot.
+    spark.sql(
+        f"""
+        CREATE TABLE {TABLE_NAME} (id long, data string) USING iceberg TBLPROPERTIES (
+            'format-version' = '2',
+            'write.update.mode' = 'merge-on-read',
+            'write.delete.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read',
+            'write.format.default' = 'orc',
+            'write.delete.format.default' = 'parquet'
+        )
+        """
+    )
+    spark.sql(f"INSERT INTO {TABLE_NAME} select id, char(id + ascii('a')) from range(0, 10)")
+    spark.sql(f"ALTER TABLE {TABLE_NAME} SET TBLPROPERTIES ('write.format.default' = 'parquet')")
+    spark.sql(f"INSERT INTO {TABLE_NAME} select id, char(id + ascii('a')) from range(10, 20)")
+    spark.sql(f"DELETE FROM {TABLE_NAME} WHERE id = 15")
+
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+    create_iceberg_table(
+        storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark
+    )
+
+    # Arming condition: the current snapshot mixes one ORC and one Parquet data file, and the ORC
+    # one is not newer than the position delete. Without both, compaction never reaches the
+    # data-file format restriction and this test would pass whatever the planning pass decides.
+    files = [
+        line.split("\t")
+        for line in instance.query(
+            f"""
+            SELECT content, file_format, sequence_number, file_path FROM system.iceberg_files
+            WHERE database = currentDatabase() AND table = '{TABLE_NAME}' FORMAT TSV
+            """
+        )
+        .strip()
+        .splitlines()
+    ]
+    orc = [f for f in files if f[0] == "DATA" and f[1].upper() == "ORC"]
+    parquet = [f for f in files if f[0] == "DATA" and f[1].upper() == "PARQUET"]
+    deletes = [f for f in files if f[0] == "POSITION_DELETE"]
+    assert (
+        len(orc) == len(parquet) == len(deletes) == 1
+    ), f"not the mixed-format carrier: {files}"
+    assert int(orc[0][2]) <= int(
+        deletes[0][2]
+    ), f"the ORC data file is newer than the position delete: {files}"
+
+    # Arming condition: the position delete records reference-data-file bounds that exclude the
+    # ORC data file. With no bounds recorded, a read of this snapshot throws too, and compaction
+    # is then right to refuse it.
+    query_id = TABLE_NAME + "_manifest_entries"
+    instance.query(
+        f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_log_level = 'manifest_file_entry'",
+        query_id=query_id,
+    )
+    instance.query("SYSTEM FLUSH LOGS")
+    entries = [
+        parse_manifest_entry(json.loads(line))
+        for line in instance.query(
+            f"""
+            SELECT DISTINCT content FROM system.iceberg_metadata_log
+            WHERE content != '' AND content IS NOT NULL
+              AND content_type = 'ManifestFileEntry' AND query_id = '{query_id}'
+            """
+        )
+        .strip()
+        .splitlines()
+        if line
+    ]
+    delete_entries = [e for e in entries if e.content_type == 1]
+    assert len(delete_entries) == 1, f"expected one position delete manifest entry, got {entries}"
+    lower, upper = delete_entries[0].lower_bound, delete_entries[0].upper_bound
+    orc_path, parquet_path = orc[0][3], parquet[0][3]
+    assert (
+        lower is not None and upper is not None
+    ), f"the position delete records no reference-data-file bounds: {delete_entries[0].file_path}"
+    # The Parquet file being inside the bounds is what makes the ORC file being outside them a
+    # real exclusion rather than a difference in how the two sources spell the same path.
+    assert lower <= parquet_path <= upper, f"bounds ({lower}, {upper}) miss {parquet_path}"
+    assert not lower <= orc_path <= upper, f"bounds ({lower}, {upper}) cover {orc_path}"
+
+    expected_ids = instance.query("SELECT number FROM numbers(20) WHERE number != 15")
+    assert instance.query(f"SELECT id FROM {TABLE_NAME} ORDER BY id") == expected_ids
+
+    instance.query(
+        f"OPTIMIZE TABLE {TABLE_NAME};",
+        settings={"allow_experimental_iceberg_compaction": 1},
+    )
+
+    assert instance.query(f"SELECT id FROM {TABLE_NAME} ORDER BY id") == expected_ids
+    assert (
+        int(
+            instance.query(
+                f"""
+                SELECT count() FROM system.iceberg_files
+                WHERE database = currentDatabase() AND table = '{TABLE_NAME}'
+                  AND content = 'POSITION_DELETE'
+                """
+            )
+        )
+        == 0
+    )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110069
Related: https://github.com/ClickHouse/ClickHouse/issues/102508
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `OPTIMIZE TABLE` on an Iceberg table failing with `Position deletes are only supported for data files of Parquet format in Iceberg` on a snapshot that `SELECT` reads correctly. Compaction attached a position delete to every data file in the partition with a low enough sequence number, without the read path's test that the delete's recorded reference-data-file bounds can cover that data file, so a non-Parquet data file the delete does not reference was rejected.

### Description

**What breaks.** On an Iceberg v2 table whose snapshot holds, in one partition, a non-Parquet data file whose sequence number is not above a position delete's, `OPTIMIZE TABLE t` fails while `SELECT` over the same snapshot succeeds:

```
Code: 48. DB::Exception: Position deletes are only supported for data files
of Parquet format in Iceberg, but got ORC. (NOT_IMPLEMENTED)
```

Such a table has to be written by another engine: ClickHouse's own `DELETE` and `UPDATE` refuse while a non-Parquet data file is live in the current snapshot (`validateSnapshotDataFileFormatsForMutation`).

**Root cause.** Compaction and the read path both decide whether a position delete applies to a data file, and compaction's has one term fewer. `IcebergIterator::next` also tests the delete's `lower_reference_data_file_path` and `upper_reference_data_file_path` against the data file's own path. `getPlan` did not, so it handed a delete that provably does not name a data file to `addPositionDeleteFile`, which rejects non-Parquet data files.

**What the change does.** It adds that test, and only it, to compaction's attachment pass, so the **per-pair** decision matches the read path's. Absent bounds mean no pruning, exactly as on read, so a delete recording no bounds still produces the error a `SELECT` produces. Results were never wrong: both delete transforms call `filterChunkToCurrentDataFile`, so an over-attached delete could not delete another file's rows. Equality deletes are unaffected, since `getPlan` collects only position deletes and `addEqualityDeleteObject` has no format precondition. The pass still buckets deletes by partition value without `common_partition_specification`; that is left alone, as data compaction rebinds every rewritten manifest to one spec.

**Validation.** A new integration test builds the snapshot with Spark and asserts the row set is unchanged across the `OPTIMIZE`. It fails on master with the error above.

Related: #110069, where this was reported, and #102508 / #105893, the mutation half of the same restriction.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116941&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116941](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116941+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

