### PR TITLE
Docs: Clarify availability indicators for public cloud regions

### DIFF
--- a/docs/products/cloud/reference/supported-regions.mdx
+++ b/docs/products/cloud/reference/supported-regions.mdx
@@ -11,7 +11,7 @@ import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanF
 
 ## Supported regions {#supported-regions}
 
-The following tables list supported regions by cloud provider. Badges indicate Public, Private Region, HIPAA, and PCI availability.
+The following tables list supported regions by cloud provider. Badges indicate availability: `Public` for generally available regions, and `Private`, `HIPAA`, or `PCI` for regions that offer those options.
 
 <Tabs>
 <Tab title="AWS" id="aws-regions" icon="aws">
@@ -23,23 +23,23 @@ The following tables list supported regions by cloud provider. Badges indicate P
 | `ap-east-2` | <Badge color="purple">Private</Badge> |
 | `ap-northeast-1` | <Badge color="yellow">Public</Badge> |
 | `ap-northeast-2` | <Badge color="yellow">Public</Badge> |
-| `ap-south-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-south-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `ap-southeast-1` | <Badge color="yellow">Public</Badge> |
 | `ap-southeast-2` | <Badge color="yellow">Public</Badge> |
 | `ap-southeast-3` | <Badge color="purple">Private</Badge> |
 | `ap-southeast-5` | <Badge color="purple">Private</Badge> |
-| `ca-central-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-central-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ca-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `eu-north-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `il-central-1` | <Badge color="yellow">Public</Badge> |
 | `me-central-1` | <Badge color="yellow">Public</Badge> |
 | `mx-central-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `sa-east-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-west-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 
 </Tab>
 <Tab title="Google Cloud" id="google-cloud-regions" icon="/images/icons/cloud-providers/google-cloud-color.svg">
@@ -51,11 +51,11 @@ The following tables list supported regions by cloud provider. Badges indicate P
 | `australia-southeast1` | <Badge color="purple">Private</Badge> |
 | `europe-west2` | <Badge color="yellow">Public</Badge> |
 | `europe-west3` | <Badge color="purple">Private</Badge> |
-| `europe-west4` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `europe-west4` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `europe-west6` | <Badge color="purple">Private</Badge> |
 | `northamerica-northeast1` | <Badge color="purple">Private</Badge> |
-| `us-central1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-central1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `us-west1` | <Badge color="purple">Private</Badge> |
 
 </Tab>

--- a/docs/products/cloud/reference/supported-regions.mdx
+++ b/docs/products/cloud/reference/supported-regions.mdx
@@ -11,35 +11,35 @@ import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanF
 
 ## Supported regions {#supported-regions}
 
-The following tables list supported regions by cloud provider. Every listed region is publicly available. Additional badges indicate Private Region, HIPAA, and PCI availability.
+The following tables list supported regions by cloud provider. Badges indicate Public, Private Region, HIPAA, and PCI availability.
 
 <Tabs>
 <Tab title="AWS" id="aws-regions" icon="aws">
 
 | Region | Availability |
 | --- | --- |
-| `af-south-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `ap-east-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
-| `ap-east-2` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `af-south-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-east-1` | <Badge color="purple">Private</Badge> |
+| `ap-east-2` | <Badge color="purple">Private</Badge> |
 | `ap-northeast-1` | <Badge color="yellow">Public</Badge> |
 | `ap-northeast-2` | <Badge color="yellow">Public</Badge> |
-| `ap-south-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-south-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `ap-southeast-1` | <Badge color="yellow">Public</Badge> |
 | `ap-southeast-2` | <Badge color="yellow">Public</Badge> |
-| `ap-southeast-3` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
-| `ap-southeast-5` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
-| `ca-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-north-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-southeast-3` | <Badge color="purple">Private</Badge> |
+| `ap-southeast-5` | <Badge color="purple">Private</Badge> |
+| `ca-central-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-central-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-north-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 | `il-central-1` | <Badge color="yellow">Public</Badge> |
 | `me-central-1` | <Badge color="yellow">Public</Badge> |
-| `mx-central-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `sa-east-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `mx-central-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `sa-east-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-west-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 
 </Tab>
 <Tab title="Google Cloud" id="google-cloud-regions" icon="/images/icons/cloud-providers/google-cloud-color.svg">
@@ -48,26 +48,26 @@ The following tables list supported regions by cloud provider. Every listed regi
 | --- | --- |
 | `asia-northeast1` | <Badge color="yellow">Public</Badge> |
 | `asia-southeast1` | <Badge color="yellow">Public</Badge> |
-| `australia-southeast1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `australia-southeast1` | <Badge color="purple">Private</Badge> |
 | `europe-west2` | <Badge color="yellow">Public</Badge> |
-| `europe-west3` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
-| `europe-west4` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `europe-west6` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
-| `northamerica-northeast1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
-| `us-central1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-west1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `europe-west3` | <Badge color="purple">Private</Badge> |
+| `europe-west4` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `europe-west6` | <Badge color="purple">Private</Badge> |
+| `northamerica-northeast1` | <Badge color="purple">Private</Badge> |
+| `us-central1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-west1` | <Badge color="purple">Private</Badge> |
 
 </Tab>
 <Tab title="Azure" id="azure-regions" icon="/images/icons/cloud-providers/azure.svg">
 
 | Region | Availability |
 | --- | --- |
-| `Australia East` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `Australia East` | <Badge color="purple">Private</Badge> |
 | `East US 2` | <Badge color="yellow">Public</Badge> |
 | `Germany West Central` | <Badge color="yellow">Public</Badge> |
-| `Japan East` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
-| `UAE North` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `Japan East` | <Badge color="purple">Private</Badge> |
+| `UAE North` | <Badge color="purple">Private</Badge> |
 | `West US 3` | <Badge color="yellow">Public</Badge> |
 
 </Tab>

--- a/docs/products/cloud/reference/supported-regions.mdx
+++ b/docs/products/cloud/reference/supported-regions.mdx
@@ -11,64 +11,64 @@ import { EnterprisePlanFeatureBadge } from "/snippets/components/EnterprisePlanF
 
 ## Supported regions {#supported-regions}
 
-The following tables list supported regions by cloud provider. Badges indicate Private Region, HIPAA, and PCI availability. Regions without a badge don't currently offer any of these options.
+The following tables list supported regions by cloud provider. Every listed region is publicly available. Additional badges indicate Private Region, HIPAA, and PCI availability.
 
 <Tabs>
 <Tab title="AWS" id="aws-regions" icon="aws">
 
 | Region | Availability |
 | --- | --- |
-| `af-south-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `ap-east-1` | <Badge color="purple">Private</Badge> |
-| `ap-east-2` | <Badge color="purple">Private</Badge> |
-| `ap-northeast-1` | — |
-| `ap-northeast-2` | — |
-| `ap-south-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `ap-southeast-1` | — |
-| `ap-southeast-2` | — |
-| `ap-southeast-3` | <Badge color="purple">Private</Badge> |
-| `ap-southeast-5` | <Badge color="purple">Private</Badge> |
-| `ca-central-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-central-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-north-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `eu-west-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `il-central-1` | — |
-| `me-central-1` | — |
-| `mx-central-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `sa-east-1` | <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-west-2` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `af-south-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-east-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `ap-east-2` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `ap-northeast-1` | <Badge color="yellow">Public</Badge> |
+| `ap-northeast-2` | <Badge color="yellow">Public</Badge> |
+| `ap-south-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `ap-southeast-1` | <Badge color="yellow">Public</Badge> |
+| `ap-southeast-2` | <Badge color="yellow">Public</Badge> |
+| `ap-southeast-3` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `ap-southeast-5` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `ca-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-central-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-north-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `eu-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `il-central-1` | <Badge color="yellow">Public</Badge> |
+| `me-central-1` | <Badge color="yellow">Public</Badge> |
+| `mx-central-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `sa-east-1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-west-2` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
 
 </Tab>
 <Tab title="Google Cloud" id="google-cloud-regions" icon="/images/icons/cloud-providers/google-cloud-color.svg">
 
 | Region | Availability |
 | --- | --- |
-| `asia-northeast1` | — |
-| `asia-southeast1` | — |
-| `australia-southeast1` | <Badge color="purple">Private</Badge> |
-| `europe-west2` | — |
-| `europe-west3` | <Badge color="purple">Private</Badge> |
-| `europe-west4` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `europe-west6` | <Badge color="purple">Private</Badge> |
-| `northamerica-northeast1` | <Badge color="purple">Private</Badge> |
-| `us-central1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-east1` | <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
-| `us-west1` | <Badge color="purple">Private</Badge> |
+| `asia-northeast1` | <Badge color="yellow">Public</Badge> |
+| `asia-southeast1` | <Badge color="yellow">Public</Badge> |
+| `australia-southeast1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `europe-west2` | <Badge color="yellow">Public</Badge> |
+| `europe-west3` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `europe-west4` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `europe-west6` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `northamerica-northeast1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `us-central1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-east1` | <Badge color="yellow">Public</Badge> <Badge color="green">HIPAA</Badge> <Badge color="blue">PCI</Badge> |
+| `us-west1` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
 
 </Tab>
 <Tab title="Azure" id="azure-regions" icon="/images/icons/cloud-providers/azure.svg">
 
 | Region | Availability |
 | --- | --- |
-| `Australia East` | <Badge color="purple">Private</Badge> |
-| `East US 2` | — |
-| `Germany West Central` | — |
-| `Japan East` | <Badge color="purple">Private</Badge> |
-| `UAE North` | <Badge color="purple">Private</Badge> |
-| `West US 3` | — |
+| `Australia East` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `East US 2` | <Badge color="yellow">Public</Badge> |
+| `Germany West Central` | <Badge color="yellow">Public</Badge> |
+| `Japan East` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `UAE North` | <Badge color="yellow">Public</Badge> <Badge color="purple">Private</Badge> |
+| `West US 3` | <Badge color="yellow">Public</Badge> |
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
Public availability was previously implicit: some generally available regions used an em dash, while others showed only additional `HIPAA` and `PCI` options. Add a yellow `Public` badge to all 23 generally available regions, including those with compliance options, while leaving private-only regions without the badge.

Related: https://github.com/ClickHouse/ClickHouse/pull/116948

Linear: https://linear.app/clickhouse/issue/DOC-1022/clarify-availability-indicators-for-public-cloud-regions

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116951&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116951](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116951+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.298` (included in `26.9` and later)
<!-- ch-version-info:end -->