### PR TITLE
Fix legacy toTime rewrite (#110958)

### DIFF
--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -95,9 +95,10 @@ void normalizeLegacyToTimeInAlterMetadataDefinitions(ASTAlterQuery & alter)
         auto * command = child->as<ASTAlterCommand>();
 
         /// Every slot that reaches table metadata, so that a reload re-derives the same spelling the
-        /// statement resolved. Mutation expressions (`predicate`, `update_assignments`) need it too:
-        /// they are persisted in mutation entries and resolved by the background executor and by
-        /// replicas with the server default settings, not with the settings of this session.
+        /// statement resolved. Mutation expressions (`predicate`, `update_assignments`, the
+        /// `IN PARTITION` value in `partition`) need it too: they are persisted in mutation entries
+        /// and resolved by the background executor and by replicas with the server default settings,
+        /// not with the settings of this session.
         for (IAST * payload : {command->col_decl,
                                command->order_by,
                                command->sample_by,
@@ -107,7 +108,8 @@ void normalizeLegacyToTimeInAlterMetadataDefinitions(ASTAlterQuery & alter)
                                command->ttl,
                                command->select,
                                command->predicate,
-                               command->update_assignments})
+                               command->update_assignments,
+                               command->partition})
         {
             if (payload)
                 replaceLegacyToTime(*payload);

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -14,6 +14,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/FunctionNameNormalizer.h>
+#include <Interpreters/replaceLegacyToTime.h>
 #include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/InterpreterCreateQuery.h>
 #include <Interpreters/MutationsInterpreter.h>
@@ -27,7 +28,6 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTColumnDeclaration.h>
-#include <Parsers/ASTFunction.h>
 #include <QueryPipeline/QueryPlanResourceHolder.h>
 #include <Storages/AlterCommands.h>
 #include <Storages/MutationCommands.h>
@@ -88,24 +88,6 @@ namespace ErrorCodes
 namespace
 {
 
-void replaceLegacyToTimeInAlterExpression(IAST * ast)
-{
-    if (auto * function = ast->as<ASTFunction>(); function && Poco::toLower(function->name) == "totime")
-        function->name = "toTimeWithFixedDate";
-
-    for (const auto & child : ast->children)
-        replaceLegacyToTimeInAlterExpression(child.get());
-
-    /// TTL GROUP BY keys are not `children` of their `ASTTTLElement`.
-    if (auto * ttl_element = ast->as<ASTTTLElement>())
-    {
-        for (const auto & group_by_key : ttl_element->group_by_key)
-            replaceLegacyToTimeInAlterExpression(group_by_key.get());
-        for (const auto & group_by_assignment : ttl_element->group_by_assignments)
-            replaceLegacyToTimeInAlterExpression(group_by_assignment.get());
-    }
-}
-
 void normalizeLegacyToTimeInAlterMetadataDefinitions(ASTAlterQuery & alter)
 {
     for (const auto & child : alter.command_list->children)
@@ -113,9 +95,9 @@ void normalizeLegacyToTimeInAlterMetadataDefinitions(ASTAlterQuery & alter)
         auto * command = child->as<ASTAlterCommand>();
 
         /// Every slot that reaches table metadata, so that a reload re-derives the same spelling the
-        /// statement resolved. Slots that only drive a one-off mutation (`predicate`,
-        /// `update_assignments`) are left alone: their expression is never stored as metadata,
-        /// so it must keep resolving as the session wrote it.
+        /// statement resolved. Mutation expressions (`predicate`, `update_assignments`) need it too:
+        /// they are persisted in mutation entries and resolved by the background executor and by
+        /// replicas with the server default settings, not with the settings of this session.
         for (IAST * payload : {command->col_decl,
                                command->order_by,
                                command->sample_by,
@@ -123,10 +105,12 @@ void normalizeLegacyToTimeInAlterMetadataDefinitions(ASTAlterQuery & alter)
                                command->constraint_decl,
                                command->projection_decl,
                                command->ttl,
-                               command->select})
+                               command->select,
+                               command->predicate,
+                               command->update_assignments})
         {
             if (payload)
-                replaceLegacyToTimeInAlterExpression(payload);
+                replaceLegacyToTime(*payload);
         }
     }
 }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -44,7 +44,6 @@
 #include <Parsers/ASTQualifiedAsterisk.h>
 #include <Parsers/ASTSelectIntersectExceptQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
-#include <Parsers/ASTTTLElement.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/parseQuery.h>
 
@@ -66,6 +65,7 @@
 #include <Interpreters/DDLTask.h>
 #include <Interpreters/InterpreterFactory.h>
 #include <Interpreters/InterpreterCreateQuery.h>
+#include <Interpreters/replaceLegacyToTime.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
 #include <Interpreters/InterpreterInsertQuery.h>
@@ -205,25 +205,6 @@ namespace fs = std::filesystem;
 namespace
 {
 
-void replaceLegacyToTimeInCreateQuery(ASTPtr & ast)
-{
-    if (auto * function = ast->as<ASTFunction>(); function && Poco::toLower(function->name) == "totime")
-        function->name = "toTimeWithFixedDate";
-
-    for (auto & child : ast->children)
-        replaceLegacyToTimeInCreateQuery(child);
-
-    /// A TTL element keeps these outside `children`, so they need the same walk `FunctionNameNormalizer`
-    /// gives them: a GROUP BY key rewritten inconsistently with the primary key stops being its prefix.
-    if (auto * ttl_element = ast->as<ASTTTLElement>())
-    {
-        for (auto & group_by_key : ttl_element->group_by_key)
-            replaceLegacyToTimeInCreateQuery(group_by_key);
-        for (auto & group_by_assignment : ttl_element->group_by_assignments)
-            replaceLegacyToTimeInCreateQuery(group_by_assignment);
-    }
-}
-
 /// Substitutes SQL UDFs the way `createTable` does, but never into an engine: an engine is an
 /// `ASTFunction` too, and a UDF may carry an engine's name, so substituting there would replace the
 /// engine with a function body. Key expressions live in several places (storage, a view's inner
@@ -257,7 +238,7 @@ void normalizeLegacyToTimeInCreateQuery(ASTPtr & query, const ContextPtr & conte
 {
     if (!UserDefinedSQLFunctionFactory::instance().empty())
         substituteUserDefinedFunctionsOutsideEngines(query, context);
-    replaceLegacyToTimeInCreateQuery(query);
+    replaceLegacyToTime(*query);
 }
 
 }
@@ -1975,7 +1956,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     if (!create.is_clone_as && !create.attach_short_syntax && !is_restore_from_backup
         && getContext()->getSettingsRef()[Setting::use_legacy_to_time])
     {
-        replaceLegacyToTimeInCreateQuery(query_ptr);
+        replaceLegacyToTime(*query_ptr);
 
         /// `properties` was derived before the rewrite, and the live table below is built from it while
         /// the metadata written to disk comes from the rewritten query. `CREATE TABLE ... AS src` copies

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1954,22 +1954,23 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     /// `CREATE TABLE ... AS` materializes copied columns and key expressions only there. A replayed
     /// definition (short attach, metadata load, backup restore) already records its spelling.
     if (!create.is_clone_as && !create.attach_short_syntax && !is_restore_from_backup
-        && getContext()->getSettingsRef()[Setting::use_legacy_to_time])
+        && getContext()->getSettingsRef()[Setting::use_legacy_to_time]
+        && replaceLegacyToTime(*query_ptr))
     {
-        replaceLegacyToTime(*query_ptr);
-
         /// `properties` was derived before the rewrite, and the live table below is built from it while
         /// the metadata written to disk comes from the rewritten query. `CREATE TABLE ... AS src` copies
-        /// the source column expressions verbatim, so without re-deriving them a `DEFAULT`, `MATERIALIZED`,
-        /// `ALIAS` or column `TTL` mentioning `toTime` would keep the source spelling in memory while the
-        /// metadata records `toTimeWithFixedDate`, and the same insert would produce different values
-        /// before and after a reload.
-        if (create.columns_list && create.columns_list->columns)
+        /// the source column expressions verbatim, so a `DEFAULT`, `MATERIALIZED`, `ALIAS` or column
+        /// `TTL` mentioning `toTime` would keep the source spelling in memory while the metadata records
+        /// `toTimeWithFixedDate`, and the same insert would produce different values before and after a
+        /// reload. The expressions are rewritten in place: re-deriving the whole `ColumnsDescription`
+        /// is not idempotent for the `AS SELECT` / `AS src` branches — `getColumnsDescription` would
+        /// flatten `Nested` columns that those branches deliberately keep intact.
+        for (const auto & column : properties.columns)
         {
-            const bool check_defaults_over_virtual_columns
-                = !(create.is_ordinary_view || create.is_materialized_view_with_external_target());
-            properties.columns = getColumnsDescription(
-                *create.columns_list->columns, getContext(), mode, is_restore_from_backup, check_defaults_over_virtual_columns);
+            if (column.default_desc.expression)
+                replaceLegacyToTime(*column.default_desc.expression);
+            if (column.ttl)
+                replaceLegacyToTime(*column.ttl);
         }
 
         /// Constraints need the same treatment: `MergeTree` reparses them from the rewritten AST, but most

--- a/src/Interpreters/InterpreterDeleteQuery.cpp
+++ b/src/Interpreters/InterpreterDeleteQuery.cpp
@@ -1,6 +1,8 @@
 #include <Interpreters/InterpreterDeleteQuery.h>
 #include <Interpreters/InterpreterFactory.h>
 #include <Interpreters/replaceLegacyToTime.h>
+#include <Functions/UserDefined/UserDefinedSQLFunctionFactory.h>
+#include <Functions/UserDefined/UserDefinedSQLFunctionVisitor.h>
 
 #include <Access/ContextAccess.h>
 #include <Core/Settings.h>
@@ -69,8 +71,13 @@ BlockIO InterpreterDeleteQuery::execute()
 
     /// The spelling must be canonical before the query is enqueued for a Replicated database or
     /// lowered into an UPDATE / ALTER text: the replaying host may not carry this session's settings.
+    /// SQL UDF bodies are inlined first, so a `toTime` hidden in one is canonicalized too.
     if (getContext()->getSettingsRef()[Setting::use_legacy_to_time])
+    {
+        if (!UserDefinedSQLFunctionFactory::instance().empty())
+            UserDefinedSQLFunctionVisitor::visit(query_ptr, getContext());
         replaceLegacyToTime(*query_ptr);
+    }
 
     const ASTDeleteQuery & delete_query = query_ptr->as<ASTDeleteQuery &>();
     auto table_id = getContext()->resolveStorageID(delete_query, Context::ResolveOrdinary);

--- a/src/Interpreters/InterpreterDeleteQuery.cpp
+++ b/src/Interpreters/InterpreterDeleteQuery.cpp
@@ -1,5 +1,6 @@
 #include <Interpreters/InterpreterDeleteQuery.h>
 #include <Interpreters/InterpreterFactory.h>
+#include <Interpreters/replaceLegacyToTime.h>
 
 #include <Access/ContextAccess.h>
 #include <Core/Settings.h>
@@ -28,6 +29,7 @@ namespace DB
 {
 namespace Setting
 {
+    extern const SettingsBool use_legacy_to_time;
     extern const SettingsBool enable_lightweight_delete;
     extern const SettingsUInt64 lightweight_deletes_sync;
     extern const SettingsSeconds lock_acquire_timeout;
@@ -64,6 +66,12 @@ InterpreterDeleteQuery::InterpreterDeleteQuery(const ASTPtr & query_ptr_, Contex
 BlockIO InterpreterDeleteQuery::execute()
 {
     FunctionNameNormalizer::visit(query_ptr.get());
+
+    /// The spelling must be canonical before the query is enqueued for a Replicated database or
+    /// lowered into an UPDATE / ALTER text: the replaying host may not carry this session's settings.
+    if (getContext()->getSettingsRef()[Setting::use_legacy_to_time])
+        replaceLegacyToTime(*query_ptr);
+
     const ASTDeleteQuery & delete_query = query_ptr->as<ASTDeleteQuery &>();
     auto table_id = getContext()->resolveStorageID(delete_query, Context::ResolveOrdinary);
 

--- a/src/Interpreters/InterpreterUpdateQuery.cpp
+++ b/src/Interpreters/InterpreterUpdateQuery.cpp
@@ -9,6 +9,7 @@
 #include <Interpreters/ApplyWithSubqueryVisitor.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/FunctionNameNormalizer.h>
+#include <Interpreters/replaceLegacyToTime.h>
 #include <Interpreters/InterpreterAlterQuery.h>
 #include <Interpreters/MutationsInterpreter.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -41,6 +42,7 @@ namespace Setting
 {
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsBool enable_lightweight_update;
+    extern const SettingsBool use_legacy_to_time;
     extern const SettingsUInt64 max_parser_depth;
     extern const SettingsUInt64 max_parser_backtracks;
 }
@@ -92,6 +94,12 @@ BlockIO InterpreterUpdateQuery::execute()
     /// the database of the updated table.
     if (!UserDefinedSQLFunctionFactory::instance().empty())
         UserDefinedSQLFunctionVisitor::visit(query_ptr, getContext());
+
+    /// The spelling must be canonical before the query is enqueued for ON CLUSTER or a Replicated
+    /// database: the oldest DDL entry format carries no settings, so the replaying host would
+    /// otherwise resolve `toTime` with its own default.
+    if (settings[Setting::use_legacy_to_time])
+        replaceLegacyToTime(*query_ptr);
 
     auto & update_query = query_ptr->as<ASTUpdateQuery &>();
 

--- a/src/Interpreters/replaceLegacyToTime.cpp
+++ b/src/Interpreters/replaceLegacyToTime.cpp
@@ -1,0 +1,65 @@
+#include <Interpreters/replaceLegacyToTime.h>
+
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTTTLElement.h>
+#include <Parsers/ASTWithAlias.h>
+
+#include <Poco/String.h>
+
+namespace DB
+{
+
+bool replaceLegacyToTime(IAST & ast)
+{
+    bool changed = false;
+
+    /// The case-insensitive match mirrors the legacy remapping in `FunctionFactory::tryGetImpl`.
+    if (auto * function = ast.as<ASTFunction>(); function && Poco::toLower(function->name) == "totime")
+    {
+        function->name = "toTimeWithFixedDate";
+        changed = true;
+    }
+
+    const IAST * select_expression_list = nullptr;
+    if (const auto * select = ast.as<ASTSelectQuery>())
+        select_expression_list = select->select().get();
+
+    for (const auto & child : ast.children)
+    {
+        if (child.get() != select_expression_list)
+        {
+            changed |= replaceLegacyToTime(*child);
+            continue;
+        }
+
+        for (const auto & expression : child->children)
+        {
+            const auto * with_alias = dynamic_cast<const ASTWithAlias *>(expression.get());
+
+            String original_name;
+            if (with_alias && with_alias->alias.empty())
+                original_name = expression->getColumnName();
+
+            if (replaceLegacyToTime(*expression))
+            {
+                changed = true;
+                if (!original_name.empty())
+                    expression->setAlias(original_name);
+            }
+        }
+    }
+
+    /// TTL GROUP BY keys and assignments are not `children` of their `ASTTTLElement`.
+    if (auto * ttl_element = ast.as<ASTTTLElement>())
+    {
+        for (const auto & group_by_key : ttl_element->group_by_key)
+            changed |= replaceLegacyToTime(*group_by_key);
+        for (const auto & group_by_assignment : ttl_element->group_by_assignments)
+            changed |= replaceLegacyToTime(*group_by_assignment);
+    }
+
+    return changed;
+}
+
+}

--- a/src/Interpreters/replaceLegacyToTime.h
+++ b/src/Interpreters/replaceLegacyToTime.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Parsers/IAST_fwd.h>
+
+namespace DB
+{
+
+/// Replaces the setting-dependent `toTime` spelling with the explicit legacy `toTimeWithFixedDate`
+/// in a definition that is about to be persisted, so that later sessions, metadata reloads and
+/// replicas resolve it independently of `use_legacy_to_time`.
+/// A changed top-level SELECT expression without an alias keeps its automatic column name through
+/// an alias: materialized views and views match columns by name against the stored column list,
+/// and an outer query may reference the automatic name as an identifier.
+/// Returns whether anything was changed.
+bool replaceLegacyToTime(IAST & ast);
+
+}

--- a/tests/integration/test_totime_legacy_replicated_delete/test.py
+++ b/tests/integration/test_totime_legacy_replicated_delete/test.py
@@ -1,0 +1,71 @@
+# A standalone `DELETE FROM` on a `Replicated` database is enqueued as query text and replayed by
+# the other replica's DDL worker. With the oldest DDL entry format no settings ride along, so a
+# legacy `toTime` — including one hidden in a SQL UDF body — must be inlined and canonicalized by
+# the initiator (`InterpreterDeleteQuery`), or the replaying replica resolves it with its own
+# default and deletes a different row set. The tables are plain MergeTree, so each replica applies
+# the mutation to its own copy of the data and the divergence is observable per node.
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", with_zookeeper=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_legacy_totime_replicated_delete(started_cluster):
+    node1.query(
+        "CREATE DATABASE rdb ENGINE = Replicated('/test/rdb', 'shard1', 'replica1')"
+    )
+    node2.query(
+        "CREATE DATABASE rdb ENGINE = Replicated('/test/rdb', 'shard1', 'replica2')"
+    )
+
+    # SQL UDFs are per-server; the replaying replica needs the name resolvable for the raw spelling.
+    for node in [node1, node2]:
+        node.query("CREATE FUNCTION udf_totime AS x -> toUInt32(toTime(x))")
+
+    node1.query(
+        "CREATE TABLE rdb.t (c0 DateTime('UTC')) ENGINE = MergeTree ORDER BY tuple()",
+        settings={"distributed_ddl_output_mode": "none"},
+    )
+    assert_eq_with_retry(
+        node2,
+        "SELECT count() FROM system.tables WHERE database = 'rdb' AND name = 't'",
+        "1",
+    )
+
+    # Plain MergeTree data is local to each database replica.
+    node1.query("INSERT INTO rdb.t VALUES ('2020-01-02 03:04:05')")
+    node2.query("INSERT INTO rdb.t VALUES ('2020-01-02 03:04:05')")
+
+    # Under the legacy setting the predicate matches the row: 86400 + 11045 = 97445.
+    node1.query(
+        "DELETE FROM rdb.t WHERE udf_totime(c0) = 97445",
+        settings={
+            "use_legacy_to_time": 1,
+            "distributed_ddl_entry_format_version": 1,
+            "distributed_ddl_output_mode": "none",
+        },
+    )
+
+    # The replay lowers to a background mutation, so poll; without the canonicalization the
+    # replica resolves the new `toTime` (11045), deletes nothing, and this times out at 1.
+    assert_eq_with_retry(node2, "SELECT count() FROM rdb.t", "0")
+    assert node1.query("SELECT count() FROM rdb.t").strip() == "0"
+
+    node1.query("DROP DATABASE rdb SYNC")
+    node2.query("DROP DATABASE IF EXISTS rdb SYNC")
+    for node in [node1, node2]:
+        node.query("DROP FUNCTION udf_totime")

--- a/tests/queries/0_stateless/05047_totime_legacy_select_column_names.reference
+++ b/tests/queries/0_stateless/05047_totime_legacy_select_column_names.reference
@@ -1,0 +1,10 @@
+mv	1970-01-02 03:04:05
+view	1970-01-02 03:04:05
+after_modify_query	1970-01-02 03:04:05
+after_modify_query	1970-01-02 03:04:06
+reloaded_mv	1970-01-02 03:04:05
+reloaded_mv	1970-01-02 03:04:06
+reloaded_mv	1970-01-02 03:04:07
+reloaded_view	1970-01-02 03:04:05
+reloaded_view	1970-01-02 03:04:06
+reloaded_view	1970-01-02 03:04:07

--- a/tests/queries/0_stateless/05047_totime_legacy_select_column_names.sql
+++ b/tests/queries/0_stateless/05047_totime_legacy_select_column_names.sql
@@ -1,0 +1,38 @@
+-- The legacy `toTime` rewrite must not change the automatic output column names of a persisted
+-- SELECT: materialized views and views match columns by name against the stored column list.
+
+DROP TABLE IF EXISTS mv_totime_names;
+DROP TABLE IF EXISTS v_totime_names;
+DROP TABLE IF EXISTS t_totime_names_src;
+
+SET use_legacy_to_time = 1;
+
+CREATE TABLE t_totime_names_src (c0 DateTime('UTC')) ENGINE = MergeTree ORDER BY tuple();
+
+-- An unaliased expression keeps its automatic name through an alias in the rewritten text.
+CREATE MATERIALIZED VIEW mv_totime_names ENGINE = MergeTree ORDER BY tuple() AS SELECT toTime(c0) FROM t_totime_names_src;
+INSERT INTO t_totime_names_src VALUES ('2020-01-02 03:04:05');
+SELECT 'mv', * FROM mv_totime_names;
+
+CREATE VIEW v_totime_names AS SELECT toTime(c0) FROM t_totime_names_src;
+SELECT 'view', * FROM v_totime_names;
+
+-- The rewritten replacement query must keep matching the inner table column by name.
+ALTER TABLE mv_totime_names MODIFY QUERY SELECT toTime(c0) FROM t_totime_names_src;
+INSERT INTO t_totime_names_src VALUES ('2020-01-02 03:04:06');
+SELECT 'after_modify_query', * FROM mv_totime_names ORDER BY ALL;
+
+-- The reloaded definitions resolve identically under the default setting.
+DETACH TABLE mv_totime_names;
+DETACH TABLE v_totime_names;
+SET use_legacy_to_time = 0;
+ATTACH TABLE mv_totime_names;
+ATTACH TABLE v_totime_names;
+
+INSERT INTO t_totime_names_src VALUES ('2020-01-02 03:04:07');
+SELECT 'reloaded_mv', * FROM mv_totime_names ORDER BY ALL;
+SELECT 'reloaded_view', * FROM v_totime_names ORDER BY ALL;
+
+DROP TABLE mv_totime_names;
+DROP TABLE v_totime_names;
+DROP TABLE t_totime_names_src;

--- a/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.reference
+++ b/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.reference
@@ -3,3 +3,4 @@ session	90000
 updated	97445
 updated	90000
 after_delete	90000	90000
+in_partition	1

--- a/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.reference
+++ b/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.reference
@@ -1,0 +1,5 @@
+session	97445
+session	90000
+updated	97445
+updated	90000
+after_delete	90000	90000

--- a/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.sql
+++ b/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.sql
@@ -1,0 +1,20 @@
+-- Mutation expressions are persisted in mutation entries and resolved by the background executor
+-- with the server default settings, so a legacy `toTime` spelling must be canonicalized in them:
+-- the same expression cannot give one value in SELECT and another in UPDATE within one session.
+
+DROP TABLE IF EXISTS t_totime_mutation;
+
+SET use_legacy_to_time = 1;
+
+CREATE TABLE t_totime_mutation (c0 DateTime('UTC'), v UInt32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_totime_mutation VALUES ('2020-01-02 03:04:05', 0), ('2020-01-03 01:00:00', 0);
+
+SELECT 'session', toUInt32(toTime(c0)) FROM t_totime_mutation ORDER BY c0;
+
+ALTER TABLE t_totime_mutation UPDATE v = toUInt32(toTime(c0)) WHERE 1 SETTINGS mutations_sync = 2;
+SELECT 'updated', v FROM t_totime_mutation ORDER BY c0;
+
+ALTER TABLE t_totime_mutation DELETE WHERE toUInt32(toTime(c0)) = 97445 SETTINGS mutations_sync = 2;
+SELECT 'after_delete', toUInt32(toTime(c0)), v FROM t_totime_mutation;
+
+DROP TABLE t_totime_mutation;

--- a/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.sql
+++ b/tests/queries/0_stateless/05048_totime_legacy_mutation_expressions.sql
@@ -18,3 +18,17 @@ ALTER TABLE t_totime_mutation DELETE WHERE toUInt32(toTime(c0)) = 97445 SETTINGS
 SELECT 'after_delete', toUInt32(toTime(c0)), v FROM t_totime_mutation;
 
 DROP TABLE t_totime_mutation;
+
+-- The `IN PARTITION` value is re-evaluated from the persisted entry by the background executor too.
+DROP TABLE IF EXISTS t_totime_mutation_partition;
+
+CREATE TABLE t_totime_mutation_partition (c0 DateTime('UTC'), v UInt32)
+ENGINE = MergeTree PARTITION BY toUInt32(toTimeWithFixedDate(c0)) ORDER BY tuple();
+INSERT INTO t_totime_mutation_partition VALUES ('2020-01-02 03:04:05', 0);
+
+ALTER TABLE t_totime_mutation_partition
+UPDATE v = 1 IN PARTITION tuple(toUInt32(toTime(toDateTime('2020-01-02 03:04:05', 'UTC')))) WHERE 1
+SETTINGS mutations_sync = 2;
+SELECT 'in_partition', v FROM t_totime_mutation_partition;
+
+DROP TABLE t_totime_mutation_partition;

--- a/tests/queries/0_stateless/05049_totime_legacy_create_as_nested.reference
+++ b/tests/queries/0_stateless/05049_totime_legacy_create_as_nested.reference
@@ -1,0 +1,3 @@
+n	Nested(a UInt8, b String)
+[(1,'a')]
+n	Nested(a UInt8, b String)

--- a/tests/queries/0_stateless/05049_totime_legacy_create_as_nested.sql
+++ b/tests/queries/0_stateless/05049_totime_legacy_create_as_nested.sql
@@ -1,0 +1,20 @@
+-- The column set of `CREATE TABLE ... AS` must not depend on `use_legacy_to_time`: re-deriving
+-- columns after the legacy `toTime` rewrite flattened `Nested` columns that the `AS SELECT` and
+-- `AS src` branches keep intact.
+
+DROP TABLE IF EXISTS t_nested_legacy;
+DROP TABLE IF EXISTS t_nested_legacy_dst;
+
+SET flatten_nested = 1;
+SET use_legacy_to_time = 1;
+
+CREATE TABLE t_nested_legacy ENGINE = Memory AS SELECT [(1, 'a')]::Nested(a UInt8, b String) AS n;
+SELECT name, type FROM system.columns WHERE database = currentDatabase() AND table = 't_nested_legacy' ORDER BY name;
+SELECT * FROM t_nested_legacy;
+
+-- A plain copy of the `Nested`-typed source must stay intact under the legacy setting too.
+CREATE TABLE t_nested_legacy_dst AS t_nested_legacy;
+SELECT name, type FROM system.columns WHERE database = currentDatabase() AND table = 't_nested_legacy_dst' ORDER BY name;
+
+DROP TABLE t_nested_legacy;
+DROP TABLE t_nested_legacy_dst;

--- a/tests/queries/0_stateless/05050_totime_legacy_update_on_cluster.reference
+++ b/tests/queries/0_stateless/05050_totime_legacy_update_on_cluster.reference
@@ -1,0 +1,3 @@
+session	97445
+updated_on_cluster	97445
+after_delete	0

--- a/tests/queries/0_stateless/05050_totime_legacy_update_on_cluster.sql
+++ b/tests/queries/0_stateless/05050_totime_legacy_update_on_cluster.sql
@@ -1,0 +1,29 @@
+-- Tags: distributed, no-replicated-database
+-- Tag no-replicated-database: ON CLUSTER is not allowed
+
+-- The oldest DDL entry format carries no settings, so a legacy `toTime` in a standalone
+-- UPDATE / DELETE must be canonicalized before the query text is enqueued: the replaying
+-- host would otherwise resolve it with its own default.
+
+SET distributed_ddl_output_mode = 'none';
+SET distributed_ddl_entry_format_version = 1;
+SET use_legacy_to_time = 1;
+SET mutations_sync = 2;
+
+DROP TABLE IF EXISTS t_totime_lwu;
+
+CREATE TABLE t_totime_lwu (c0 DateTime('UTC'), v UInt32) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+INSERT INTO t_totime_lwu VALUES ('2020-01-02 03:04:05', 0);
+
+SELECT 'session', toUInt32(toTime(c0)) FROM t_totime_lwu;
+
+UPDATE {CLICKHOUSE_DATABASE:Identifier}.t_totime_lwu ON CLUSTER test_shard_localhost
+    SET v = toUInt32(toTime(c0)) WHERE 1;
+SELECT 'updated_on_cluster', v FROM t_totime_lwu;
+
+DELETE FROM {CLICKHOUSE_DATABASE:Identifier}.t_totime_lwu ON CLUSTER test_shard_localhost
+    WHERE toUInt32(toTime(c0)) = 97445;
+SELECT 'after_delete', count() FROM t_totime_lwu;
+
+DROP TABLE t_totime_lwu;

--- a/tests/queries/0_stateless/05050_totime_legacy_update_on_cluster.sql
+++ b/tests/queries/0_stateless/05050_totime_legacy_update_on_cluster.sql
@@ -8,7 +8,10 @@
 SET distributed_ddl_output_mode = 'none';
 SET distributed_ddl_entry_format_version = 1;
 SET use_legacy_to_time = 1;
-SET mutations_sync = 2;
+SET enable_lightweight_update = 1;
+-- The synchronous lowering: with entry format 1 the worker does not receive `mutations_sync`
+-- either, so an `ALTER`-lowered delete would race the count below.
+SET lightweight_delete_mode = 'lightweight_update_force';
 
 DROP TABLE IF EXISTS t_totime_lwu;
 

--- a/tests/queries/0_stateless/05051_totime_legacy_udf_update_delete_on_cluster.reference
+++ b/tests/queries/0_stateless/05051_totime_legacy_udf_update_delete_on_cluster.reference
@@ -1,0 +1,3 @@
+session	97445
+updated	97445
+after_delete	0

--- a/tests/queries/0_stateless/05051_totime_legacy_udf_update_delete_on_cluster.sh
+++ b/tests/queries/0_stateless/05051_totime_legacy_udf_update_delete_on_cluster.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Tags: distributed, no-replicated-database
+# Tag no-replicated-database: ON CLUSTER is not allowed
+
+# A legacy `toTime` hidden in a SQL UDF body must be inlined and canonicalized before the standalone
+# UPDATE / DELETE query text is enqueued, so a replaying host without this session's settings (the
+# oldest DDL entry format carries none) resolves the same expression. The UDF name includes the test
+# database because SQL UDFs are server-global and this test runs concurrently with itself.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+UDF="totime_05051_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} --use_legacy_to_time 1 --distributed_ddl_entry_format_version 1 \
+    --distributed_ddl_output_mode none --enable_lightweight_update 1 \
+    --lightweight_delete_mode lightweight_update_force -q "
+CREATE FUNCTION ${UDF} AS x -> toUInt32(toTime(x));
+
+CREATE TABLE ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu (c0 DateTime('UTC'), v UInt32)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+INSERT INTO ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu VALUES ('2020-01-02 03:04:05', 0);
+
+SELECT 'session', ${UDF}(c0) FROM ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu;
+
+UPDATE ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu ON CLUSTER test_shard_localhost
+    SET v = ${UDF}(c0) WHERE 1;
+SELECT 'updated', v FROM ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu;
+
+DELETE FROM ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu ON CLUSTER test_shard_localhost
+    WHERE ${UDF}(c0) = 97445;
+SELECT 'after_delete', count() FROM ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu;
+
+DROP TABLE ${CLICKHOUSE_DATABASE}.t_totime_udf_lwu;
+DROP FUNCTION ${UDF};
+"


### PR DESCRIPTION


<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/117001

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116953&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116953](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116953+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.372` (included in `26.9` and later)
<!-- ch-version-info:end -->