### PR TITLE
Fix remote query executor cancel hang

### DIFF
--- a/src/Client/ConnectionEstablisher.cpp
+++ b/src/Client/ConnectionEstablisher.cpp
@@ -247,12 +247,16 @@ void ConnectionEstablisherAsync::processAsyncEvent(int fd, Poco::Timespan socket
 
 void ConnectionEstablisherAsync::clearAsyncEvent()
 {
-    timeout_descriptor.reset();
+    /// Unregister the socket before anything that can throw. If it were left registered, the next
+    /// `processAsyncEvent` would add a descriptor that is already in the epoll set and fail with
+    /// `EEXIST`. See `RemoteQueryExecutorReadContext::clearAsyncEvent` for the same rule.
     if (socket_fd != -1)
     {
         epoll.remove(socket_fd);
         socket_fd = -1;
     }
+
+    timeout_descriptor.reset();
 }
 
 bool ConnectionEstablisherAsync::checkBeforeTaskResume()

--- a/src/Common/AsyncTaskExecutor.h
+++ b/src/Common/AsyncTaskExecutor.h
@@ -114,6 +114,11 @@ protected:
     /// Can be called in cancelBefore().
     void resumeUnlocked();
 
+    /// True if the routine has already run to completion, normally or with an exception.
+    /// In that case resume() has already destroyed the coroutine, so resumeUnlocked() must not be
+    /// called and no further async event can ever be delivered.
+    bool isRoutineFinished() const { return routine_is_finished; }
+
 private:
     struct Routine;
 

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -42,6 +42,7 @@ static struct InitFiu
     REGULAR(merge_tree_sink_on_start_random_sleep) \
     REGULAR(use_delayed_remote_source) \
     ONCE(remote_query_executor_cancel_before_send) \
+    REGULAR(timer_descriptor_drain_fail) \
     PAUSEABLE_ONCE(remote_query_executor_receive_packet_pause) \
     PAUSEABLE_ONCE(remote_query_executor_finish_drain_pause) \
     ONCE(connection_stale_on_establish) \

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -118,7 +118,7 @@ void TimerDescriptor::drain() const
     poll_fd.fd = timer_fd;
     poll_fd.events = POLLIN;
 
-    int poll_res;
+    int poll_res = 0;
     do
     {
         poll_res = ::poll(&poll_fd, 1, /* timeout_ms= */ 0);

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -3,14 +3,15 @@
 #include <Common/TimerDescriptor.h>
 #include <Common/Exception.h>
 #include <Common/ErrnoException.h>
+#include <Common/FailPoint.h>
 
 #include <cerrno>
 #include <utility>
 #include <unistd.h>
 
 #if defined(OS_LINUX)
-#include <Common/Epoll.h>
 #include <Common/logger_useful.h>
+#include <poll.h>
 #include <sys/timerfd.h>
 #include <fmt/format.h>
 #else
@@ -22,11 +23,17 @@
 namespace DB
 {
 
+namespace FailPoints
+{
+    extern const char timer_descriptor_drain_fail[];
+}
+
 namespace ErrorCodes
 {
     extern const int CANNOT_CREATE_TIMER;
     extern const int CANNOT_SET_TIMER_PERIOD;
     extern const int CANNOT_READ_FROM_SOCKET;
+    extern const int FAULT_INJECTED;
 }
 
 /// Methods that do not depend on the underlying timer mechanism are shared between platforms.
@@ -86,6 +93,11 @@ void TimerDescriptor::drain() const
     if (timer_fd == -1)
         return;
 
+    fiu_do_on(FailPoints::timer_descriptor_drain_fail,
+    {
+        throw Exception(ErrorCodes::FAULT_INJECTED, "Manually triggered exception in TimerDescriptor::drain");
+    });
+
     /// It is expected that socket returns 8 bytes when readable.
     /// Read in loop anyway cause signal may interrupt read call.
 
@@ -97,12 +109,25 @@ void TimerDescriptor::drain() const
 
     /// Due to a bug in Linux Kernel, reading from timerfd in non-blocking mode can be still blocking.
     /// Avoid it with polling.
-    Epoll epoll;
-    epoll.add(timer_fd);
-    epoll_event event{};
-    event.data.fd = -1;
-    size_t ready_count = epoll.getManyReady(1, &event, 0);
-    if (!ready_count)
+    ///
+    /// Use `poll` rather than `Epoll`: `epoll_create1` needs a new file descriptor, so when the process
+    /// has run out of them this function would throw. `drain` and `reset` are used as a cleanup step,
+    /// and throwing there leaves the caller half torn down -- see
+    /// `RemoteQueryExecutorReadContext::clearAsyncEvent`. `poll` does not allocate anything.
+    pollfd poll_fd{};
+    poll_fd.fd = timer_fd;
+    poll_fd.events = POLLIN;
+
+    int poll_res;
+    do
+    {
+        poll_res = ::poll(&poll_fd, 1, /* timeout_ms= */ 0);
+    } while (poll_res < 0 && errno == EINTR);
+
+    if (poll_res < 0)
+        throw ErrnoException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot poll timer_fd {}", timer_fd);
+
+    if (poll_res == 0)
         return;
 
     uint64_t buf = 0;

--- a/src/Common/tests/gtest_timer_descriptor.cpp
+++ b/src/Common/tests/gtest_timer_descriptor.cpp
@@ -1,0 +1,92 @@
+#if defined(OS_LINUX)
+
+#include <gtest/gtest.h>
+
+#include <Common/TimerDescriptor.h>
+#include <base/scope_guard.h>
+
+#include <poll.h>
+#include <unistd.h>
+#include <sys/resource.h>
+
+#include <cerrno>
+#include <chrono>
+#include <thread>
+
+namespace
+{
+
+bool isReadable(int fd)
+{
+    pollfd poll_fd{};
+    poll_fd.fd = fd;
+    poll_fd.events = POLLIN;
+    int res = ::poll(&poll_fd, 1, 0);
+    EXPECT_GE(res, 0);
+    return res > 0;
+}
+
+/// Arm a short timer and wait for it to fire.
+void armAndAwait(const DB::TimerDescriptor & timer)
+{
+    timer.setRelative(static_cast<uint64_t>(1000));
+    for (int i = 0; i < 1000 && !isReadable(timer.getDescriptor()); ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    ASSERT_TRUE(isReadable(timer.getDescriptor())) << "timer never fired";
+}
+
+}
+
+TEST(TimerDescriptor, ResetConsumesExpiration)
+{
+    DB::TimerDescriptor timer;
+
+    /// Not armed: reset is a no-op, must not throw and must be idempotent.
+    ASSERT_NO_THROW(timer.reset());
+    ASSERT_NO_THROW(timer.reset());
+    ASSERT_FALSE(isReadable(timer.getDescriptor()));
+
+    armAndAwait(timer);
+
+    ASSERT_NO_THROW(timer.reset());
+    ASSERT_FALSE(isReadable(timer.getDescriptor())) << "reset did not drain the expiration";
+}
+
+/// `reset` must not need a new file descriptor. It used to build a temporary `Epoll` to poll the
+/// timer, so under descriptor exhaustion it threw and left its callers half torn down --
+/// see `RemoteQueryExecutorReadContext::clearAsyncEvent`.
+TEST(TimerDescriptor, ResetSurvivesFileDescriptorExhaustion)
+{
+    DB::TimerDescriptor timer;
+    armAndAwait(timer);
+
+    /// glibc defines `RLIMIT_NOFILE` as the recursive macro `RLIMIT_NOFILE`, which trips
+    /// `-Wdisabled-macro-expansion` when used as a function argument.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdisabled-macro-expansion"
+    rlimit old_limit{};
+    ASSERT_EQ(0, ::getrlimit(RLIMIT_NOFILE, &old_limit));
+
+    /// Find the lowest free descriptor number and clamp the soft limit to it. Descriptors that are
+    /// already open stay valid, but every new allocation fails with EMFILE. Much cheaper and less
+    /// invasive than actually opening every descriptor up to the limit.
+    int probe = ::dup(timer.getDescriptor());
+    ASSERT_NE(-1, probe);
+    ASSERT_EQ(0, ::close(probe));
+
+    rlimit new_limit = old_limit;
+    new_limit.rlim_cur = static_cast<rlim_t>(probe);
+    if (0 != ::setrlimit(RLIMIT_NOFILE, &new_limit))
+        GTEST_SKIP() << "Cannot lower RLIMIT_NOFILE";
+
+    SCOPE_EXIT({ ::setrlimit(RLIMIT_NOFILE, &old_limit); });
+#pragma clang diagnostic pop
+
+    ASSERT_EQ(-1, ::dup(timer.getDescriptor())) << "descriptors are still available, test is not testing anything";
+    ASSERT_EQ(EMFILE, errno);
+
+    ASSERT_NO_THROW(timer.reset());
+    ASSERT_FALSE(isReadable(timer.getDescriptor())) << "reset did not drain the expiration";
+}
+
+#endif

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -102,9 +102,20 @@ void RemoteQueryExecutorReadContext::processAsyncEvent(
 
 void RemoteQueryExecutorReadContext::clearAsyncEvent()
 {
+    /// Clear the flag before any cleanup that can throw.
+    ///
+    /// From this point the coroutine is no longer suspended waiting for an event on `connection_fd`,
+    /// whether or not the cleanup below succeeds. If the flag were left set after a throw -- for
+    /// example `timer.reset` failing because the process ran out of file descriptors -- then
+    /// `cancelBefore` would block forever in `checkTimeout` waiting for an event that can no longer
+    /// be delivered: the timer has been disarmed and `connection_fd` has been unregistered, and only
+    /// `processAsyncEvent` arms them again, which is never reached.
+    ///
+    /// `PacketReceiver::clearAsyncEvent` already clears its flag first, for the same reason.
+    is_in_progress.store(false);
+
     epoll.remove(connection_fd);
     timer.reset();
-    is_in_progress.store(false);
 }
 
 bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking)
@@ -159,7 +170,11 @@ void RemoteQueryExecutorReadContext::cancelBefore()
         /// planning phase for a packet that will be discarded. The connection is disconnected by
         /// `~RemoteQueryExecutor` in that case rather than reused, so it cannot be left
         /// unsynchronised for anyone else.
-        while (!skip_drain_on_cancel.load(std::memory_order_relaxed) && is_in_progress.load(std::memory_order_relaxed))
+        /// Stop if the routine has already finished, for instance because it threw: resume() has
+        /// destroyed the coroutine by then, so resumeUnlocked() would resume a moved-from one, and
+        /// no async event can be delivered any more, so the wait below could never be satisfied.
+        while (!isRoutineFinished() && !skip_drain_on_cancel.load(std::memory_order_relaxed)
+            && is_in_progress.load(std::memory_order_relaxed))
         {
             checkTimeout(/* blocking= */ true);
             resumeUnlocked();

--- a/tests/queries/0_stateless/05045_remote_query_executor_clear_async_event_hang.reference
+++ b/tests/queries/0_stateless/05045_remote_query_executor_clear_async_event_hang.reference
@@ -1,0 +1,4 @@
+query terminated
+0
+1
+10

--- a/tests/queries/0_stateless/05045_remote_query_executor_clear_async_event_hang.sh
+++ b/tests/queries/0_stateless/05045_remote_query_executor_clear_async_event_hang.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+# Tag no-fasttest: needs libfiu for failpoints
+# Tag no-parallel: failpoints are global for the whole process
+#
+# Regression test for a hang in `RemoteQueryExecutorReadContext`.
+#
+# `clearAsyncEvent` used to store `is_in_progress = false` only after `timer.reset`. When
+# `timer.reset` threw -- in production `TimerDescriptor::drain` built a temporary `Epoll` and
+# `epoll_create1` failed with `EMFILE` -- the flag stayed set while the timer had already been
+# disarmed and `connection_fd` had already been unregistered. The cancellation that followed then
+# blocked forever in `cancelBefore` waiting on an epoll set that could never become ready. The
+# stuck thread holds the pipeline's processor mutex, so `KILL QUERY` could not recover it either;
+# only restarting the server could.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+QUERY_ID="rqe_clear_async_event_${CLICKHOUSE_DATABASE}_$$"
+
+# shellcheck disable=SC2064
+trap "${CLICKHOUSE_CLIENT} -q 'SYSTEM DISABLE FAILPOINT timer_descriptor_drain_fail' > /dev/null 2>&1" EXIT
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM ENABLE FAILPOINT timer_descriptor_drain_fail"
+
+# A distributed read that has to wait on the socket goes through `clearAsyncEvent`, where
+# `timer.reset` -> `drain` now throws. The query must fail promptly rather than wedge the
+# read context.
+#
+# use_hedged_requests=0 picks the `MultiplexedConnections` + `RemoteQueryExecutorReadContext` path
+# rather than `HedgedConnections` / `PacketReceiver`.
+timeout 60 ${CLICKHOUSE_CLIENT} \
+    --query_id "$QUERY_ID" \
+    --use_hedged_requests 0 \
+    --async_socket_for_remote 1 \
+    --function_sleep_max_microseconds_per_block 10000000 \
+    -q "SELECT sleepEachRow(0.2) FROM remote('127.0.0.2', numbers(10)) FORMAT Null" > /dev/null 2>&1
+rc=$?
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT timer_descriptor_drain_fail"
+
+# The point of the test: the query terminates. 124 is what `timeout` returns when it kills.
+if [ "$rc" -eq 124 ]; then
+    echo "FAIL: query did not terminate"
+else
+    echo "query terminated"
+fi
+
+# The wedged thread used to sit in `ExecutingGraph::cancel` holding the processor mutex, so the
+# query stayed in `system.processes` forever and could not be killed.
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.processes WHERE query_id = '$QUERY_ID'"
+
+# The query must have actually hit the failpoint, otherwise this test silently proves nothing.
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS query_log"
+${CLICKHOUSE_CLIENT} -q "
+    SELECT exception_code = 710
+    FROM system.query_log
+    WHERE query_id = '$QUERY_ID' AND current_database = currentDatabase() AND type != 'QueryStart'
+    ORDER BY event_time_microseconds DESC
+    LIMIT 1"
+
+# And the server still serves distributed queries afterwards.
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM remote('127.0.0.2', numbers(10))"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In remote serve queries like `remote`, `remoteSecure` if we, even briefly, cannot get a file descriptor while waiting (polling), we would break in a way that `KILL QUERY` cannot fix.  A refreshable materialized view whose `SELECT` reads from a remote server can be left stuck this way indefinitely, with no error raised and its status still reported as running.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116959&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116959](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116959+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
