### PR TITLE
Report why the submodule checkout failed

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -246,7 +246,8 @@ def main():
 
         def do_checkout():
             res = Shell.check(
-                f"mkdir -p {build_dir} && git submodule sync && git submodule init"
+                f"mkdir -p {build_dir} && git submodule sync && git submodule init",
+                strict=True,
             )
 
             if os.path.isdir(".git/modules/contrib") and os.listdir(
@@ -266,11 +267,13 @@ def main():
                     command=f"xargs --max-procs={min(Utils.cpu_count(), 20)} --null --no-run-if-empty --max-args=1 git submodule update --depth 1 --single-branch --",
                     stdin_str="\0".join(submodules) + "\0",
                     retries=3,
+                    strict=True,
                 )
             else:
                 res = res and Shell.check(
                     "contrib/update-submodules.sh --max-procs 10",
                     retries=3,
+                    strict=True,
                 )
             return res
 

--- a/ci/jobs/collect_clickhouse_profiles.py
+++ b/ci/jobs/collect_clickhouse_profiles.py
@@ -562,8 +562,8 @@ def main():
     # --- Stage: Checkout submodules ---
     if res and JobStages.CHECKOUT_SUBMODULES in stages:
         def do_checkout():
-            r = Shell.check(f"mkdir -p {PGO_BUILD_DIR} && git submodule sync && git submodule init")
-            r = r and Shell.check("contrib/update-submodules.sh --max-procs 10", retries=3)
+            r = Shell.check(f"mkdir -p {PGO_BUILD_DIR} && git submodule sync && git submodule init", strict=True)
+            r = r and Shell.check("contrib/update-submodules.sh --max-procs 10", retries=3, strict=True)
             return r
 
         results.append(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A failing `Checkout Submodules` build step now reports the git error instead of failing silently.

### Description

`Checkout Submodules` runs `do_checkout` as a python callable whose git commands go through `Shell.check`'s predicate form: non-strict, and quiet by design - nothing echoed, nothing logged. `Result.from_commands_run` then has nothing to record, `Result.info` stays empty, and `Result.info` is what the CI database stores in `test_context_raw`. A failing checkout is therefore unexplained in `job.log`, the report JSON and the CI database. 30 days to 2026-08-28: 24 failures over 9 pull requests, 0 on master, 23 with an empty `test_context_raw`. One accounts for 15, with no diagnostic anywhere, raw GitHub Actions log included.

The four steps named `Checkout Submodules` split by call form:

| implementation | call form | `test_context_raw` on failure |
|---|---|---|
| `build_clickhouse.py` | callable, bare `Shell.check` | empty, 23 rows |
| `collect_clickhouse_profiles.py` | callable, bare `Shell.check` | no failure seen |
| `build_wasm_parser.py` | shell string list, so `verbose=True` and a log | `git: command not found` |
| `fast_test.py`, `clone_submodules` | callable, `verbose=True` | no failure seen |

`strict=True` makes `Shell.run` raise with all of `err_output`, and `from_commands_run` already records a callable's exception in `Result.info`. Measured per call site on the real `do_checkout`: `info` empty before, 19 lines after, carrying `fatal: No url found for submodule path 'contrib/spdlog'`; `retries=3` still makes 3 attempts; success is unchanged. It also stops the callable continuing past a failed `git submodule init`. A command writing its error only to stdout stays invisible, since `err_output` is stderr-only; git uses stderr.

`ci/praktika/` is untouched: its defaults are deliberate, and 312 of the 449 `Shell.check` call sites under `ci/` pass no `strict`, including expected-failure probes. `verbose=True` would add hundreds of lines to every successful build job: 139 submodules against 36 in `clone_submodules`.

The failures are caused by the pull requests carrying them; this only makes them legible.

CI reports:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115769&sha=c94de72bfb1cadd0f1d08db0e7342890df24bc31&name_0=PR&name_1=Build%20%28arm_tidy%29
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100406&sha=b2269ca6512df2f755def84bdfebcbf8af694b72&name_0=PR&name_1=Build%20%28arm_tidy%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116988&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116988](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116988+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.387` (included in `26.9` and later)
<!-- ch-version-info:end -->