### PR TITLE
good-prs skill: show a PR conflicting in the public repository

### DIFF
--- a/.claude/skills/good-prs/SKILL.md
+++ b/.claude/skills/good-prs/SKILL.md
@@ -26,6 +26,19 @@ running). The `CH Inc sync` state is then reported as one of:
 - **NOSYNC** — there is no `CH Inc sync` check at all and everything else is green
   (typically release-branch backports).
 
+Independently of CI, a PR can also conflict with its base branch in the public
+repository, which blocks the merge whatever the checks say. That is shown in the same
+first column, as a suffix on the sync label:
+
+- **`+CONFLICT`** — GitHub reports the PR as `CONFLICTING` against its base; it needs a
+  merge (or a rebase) before it can go in. E.g. `GREEN+CONFLICT` = all checks green, but
+  the branch does not merge cleanly.
+- **`+UNKNOWN`** — GitHub had not finished computing mergeability, so the conflict state
+  is genuinely unknown rather than clean.
+
+Within one sync bucket, clean rows are listed first, then `+UNKNOWN`, then `+CONFLICT`,
+so the most actionable PRs stay at the top of each section.
+
 Already-merged or closed PRs are excluded. Each row also shows whether the PR was
 **approved by anyone at least once** (any historical `APPROVED` review event; it does
 *not* require the approval to still be current after later pushes).
@@ -49,17 +62,19 @@ bash .claude/skills/good-prs/report.sh $ARGUMENTS
 ```
 
 The script fetches PR lists with `gh pr list`, classifies each PR's checks with
-`gh pr checks`, and looks up state + approvals with `gh pr view`, all parallelized with
-`xargs -P 12`. For groeneai-sized author sets (~200 open PRs) it takes roughly a minute.
+`gh pr checks`, and looks up state + approvals + `mergeable` with `gh pr view`, all
+parallelized with `xargs -P 12`. For groeneai-sized author sets (~200 open PRs) it takes roughly a minute.
 Every `gh` call is pinned to `--repo ClickHouse/ClickHouse`, so the report is correct
 regardless of the directory the skill is run from.
 
 ## Testing
 
 `test.sh` runs `report.sh` against a stubbed `gh` (no network) and checks the
-`bucket`→label classification, the "only `CH Inc sync` is non-green" criterion, empty
-input, `--repo` pinning, the fail-loud-on-real-error behaviour, and the retry policy
-(a transient failure is retried until it succeeds, a permanent one is not retried):
+`bucket`→label classification, the "only `CH Inc sync` is non-green" criterion, the
+`+CONFLICT` / `+UNKNOWN` merge-state suffixes and their sort order, the re-query of a
+lazily computed `UNKNOWN` mergeability, empty input, `--repo` pinning, the
+fail-loud-on-real-error behaviour, and the retry policy (a transient failure is retried
+until it succeeds, a permanent one is not retried):
 
 ```bash
 bash .claude/skills/good-prs/test.sh
@@ -98,4 +113,15 @@ bash .claude/skills/good-prs/test.sh
 - A run costs a large share of the hourly GraphQL quota (5000 points), so a few
   back-to-back runs can exhaust it. Check with
   `gh api rate_limit --jq .resources.graphql`.
+- `mergeable` is computed lazily by GitHub: for a PR nobody has looked at recently the
+  first query only schedules the test merge and answers `UNKNOWN`. The script therefore
+  re-asks an open PR up to `GH_MERGEABLE_TRIES` times (default 3) with
+  `GH_MERGEABLE_DELAY` seconds (default 2) in between, so a conflicting PR is not shown
+  as clean merely because it was asked about first. Rows that stay `UNKNOWN` are marked
+  `+UNKNOWN` rather than assumed mergeable.
+- `mergeable` rides along on the `gh pr view` call that already fetches state and
+  reviews, so the conflict column costs no extra quota except for those re-queries.
+- A `+CONFLICT` row is still listed: the criterion for inclusion is about CI checks. If
+  the user wants only mergeable-right-now PRs, filter the rows without a `+CONFLICT`
+  (and, to be strict, without `+UNKNOWN`) suffix after running.
 - The script needs `gh` authenticated and `jq` available.

--- a/.claude/skills/good-prs/report.sh
+++ b/.claude/skills/good-prs/report.sh
@@ -11,6 +11,9 @@
 # For every PR we report:
 #   - the "CH Inc sync" state: GREEN (also passed), FAILED, INPROG (still running),
 #     or NOSYNC (no such check, e.g. release-branch backports)
+#   - whether it conflicts with its base branch in the public repository: the sync
+#     label is then suffixed with "+CONFLICT" (or "+UNKNOWN" when GitHub has not
+#     computed mergeability yet), because such a PR cannot be merged as it is
 #   - whether it was APPROVED by anyone at least once
 # Already-merged / closed PRs are excluded.
 #
@@ -134,10 +137,16 @@ echo "$json" | jq -r --arg n "$n" '
 SH
 chmod +x "$WORK/classify.sh"
 
-# ---- helper invoked per-PR by xargs: state + ever-approved -----------------
-# Output: "<num>\t<STATE>\t<true|false>"
+# ---- helper invoked per-PR by xargs: state + ever-approved + mergeable ------
+# Output: "<num>\t<STATE>\t<true|false>\t<MERGEABLE|CONFLICTING|UNKNOWN>"
 # A valid PR always yields data here; an empty result means a real gh failure, so
 # we surface the diagnostic and abort rather than silently dropping the row.
+#
+# `mergeable` comes from the same call as the state and the reviews, so reporting
+# conflicts costs no extra quota - except when GitHub answers UNKNOWN, see below.
+GH_MERGEABLE_TRIES=${GH_MERGEABLE_TRIES:-3}
+GH_MERGEABLE_DELAY=${GH_MERGEABLE_DELAY:-2}
+export GH_MERGEABLE_TRIES GH_MERGEABLE_DELAY
 cat > "$WORK/approval.sh" <<'SH'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -145,13 +154,29 @@ set -uo pipefail
 n="$1"
 err=$(mktemp)
 trap 'rm -f "$err"' EXIT
-if gh_retry "$err" gh pr view "$n" --repo "$REPO" --json state,reviews \
-  --jq '[.state, ([.reviews[].state] | any(. == "APPROVED"))] | @tsv'; then
-  printf '%s\t%s\n' "$n" "$GH_OUT"
-else
-  echo "good-prs: 'gh pr view $n' failed: $(tr '\n' ' ' <"$err")" >&2
-  exit 255
-fi
+attempt=1
+while :; do
+  if gh_retry "$err" gh pr view "$n" --repo "$REPO" --json state,reviews,mergeable \
+    --jq '[.state, ([.reviews[].state] | any(. == "APPROVED")), .mergeable] | @tsv'; then
+    out="$GH_OUT"
+  else
+    echo "good-prs: 'gh pr view $n' failed: $(tr '\n' ' ' <"$err")" >&2
+    exit 255
+  fi
+  # GitHub computes mergeability lazily: for a PR nobody looked at recently the
+  # first query only schedules the test merge and answers UNKNOWN. Asking again
+  # shortly after returns the real verdict, so a conflicting PR is not reported
+  # as clean just because it was asked about first. Only an OPEN PR is worth
+  # re-asking - a closed or merged one is dropped from the report anyway.
+  case "$out" in
+    OPEN*UNKNOWN) ;;
+    *) break ;;
+  esac
+  [ "$attempt" -ge "$GH_MERGEABLE_TRIES" ] && break
+  sleep "$GH_MERGEABLE_DELAY"
+  attempt=$(( attempt + 1 ))
+done
+printf '%s\t%s\n' "$n" "$out"
 SH
 chmod +x "$WORK/approval.sh"
 
@@ -193,8 +218,9 @@ emit() {
   awk -F'\t' '$3==0 && ($2=="GREEN"||$2=="FAILED"||$2=="INPROG"||$2=="NOSYNC"){print $1"\t"$2}' \
     "$WORK/checks.tsv" \
   | while IFS=$'\t' read -r n st; do
-      a=$(awk -F'\t' -v n="$n" '$1==n{print $2"\t"$3}' "$WORK/appr.tsv")
+      a=$(awk -F'\t' -v n="$n" '$1==n{print $2"\t"$3"\t"$4}' "$WORK/appr.tsv")
       state=$(echo "$a" | cut -f1); approved=$(echo "$a" | cut -f2)
+      mergeable=$(echo "$a" | cut -f3)
       [ "$state" != "OPEN" ] && continue
       line=$(grep -m1 "^$n	" "$meta") || continue
       [ -z "$line" ] && continue
@@ -205,10 +231,18 @@ emit() {
         FAILED) g=1; gl="FAILED";; INPROG) g=2; gl="INPROG";;
         GREEN)  g=3; gl="GREEN";;  NOSYNC) g=4; gl="NOSYNC";;
       esac
+      # A PR that conflicts with its base branch cannot be merged whatever CI
+      # says, so the conflict is shown in the same first column as the sync
+      # state, and such rows are sorted after the clean ones within a bucket.
+      case "$mergeable" in
+        CONFLICTING) c=2; gl="$gl+CONFLICT";;
+        MERGEABLE)   c=0;;
+        *)           c=1; gl="$gl+UNKNOWN";;   # UNKNOWN, or absent for any reason
+      esac
       [ "$approved" = "true" ] && av="yes" || av="-"
-      printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$g" "$gl" "$n" "$av" "$auth" "$title"
-    done | sort -t$'\t' -k1,1n -k3,3n \
-  | while IFS=$'\t' read -r g gl n av auth title; do
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$g" "$c" "$gl" "$n" "$av" "$auth" "$title"
+    done | sort -t$'\t' -k1,1n -k2,2n -k4,4n \
+  | while IFS=$'\t' read -r g c gl n av auth title; do
       if [ "$showauth" = "1" ]; then
         printf '| %s | %s | [#%s](https://github.com/ClickHouse/ClickHouse/pull/%s) | %s | %s |\n' \
           "$gl" "$av" "$n" "$n" "$auth" "$title"
@@ -223,25 +257,25 @@ excl_csv=$(IFS=,; echo "${TRACK_AUTHORS[*]}")
 
 echo "# Good PRs — only \`CH Inc sync\` blocking (or fully green)"
 echo
-echo "_Legend: GREEN = fully green / merge-ready · FAILED = only \`CH Inc sync\` failed · INPROG = only \`CH Inc sync\` still running · NOSYNC = no \`CH Inc sync\` check, everything else green (e.g. release-branch backports). Approved = approved by someone at least once. Merged/closed PRs excluded._"
+echo "_Legend: GREEN = fully green / merge-ready · FAILED = only \`CH Inc sync\` failed · INPROG = only \`CH Inc sync\` still running · NOSYNC = no \`CH Inc sync\` check, everything else green (e.g. release-branch backports). A \`+CONFLICT\` suffix means the PR conflicts with its base branch in the public repository and needs a merge before it can go in; \`+UNKNOWN\` means GitHub had not finished computing mergeability. Approved = approved by someone at least once. Merged/closed PRs excluded._"
 echo
 echo "## 1. Your own PRs (authored by \`$ME\`)"
 echo
-echo "| sync | approved | PR | title |"
-echo "|------|:--:|----|-------|"
+echo "| sync / merge | approved | PR | title |"
+echo "|--------------|:--:|----|-------|"
 emit "$WORK/authored.meta" 0 ""
 echo
 echo "## 2. Assigned to you, authored by others (excluding: ${excl_csv})"
 echo
-echo "| sync | approved | PR | author | title |"
-echo "|------|:--:|----|--------|-------|"
+echo "| sync / merge | approved | PR | author | title |"
+echo "|--------------|:--:|----|--------|-------|"
 emit "$WORK/assigned.meta" 1 "$ME,$excl_csv"
 for a in "${TRACK_AUTHORS[@]}"; do
   echo
   echo "## 3. PRs by \`$a\` (regardless of assignee)"
   echo
-  echo "| sync | approved | PR | title |"
-  echo "|------|:--:|----|-------|"
+  echo "| sync / merge | approved | PR | title |"
+  echo "|--------------|:--:|----|-------|"
   grep -P "^\d+\t$a\t" "$WORK/tracked.meta" > "$WORK/one_author.meta" || true
   emit "$WORK/one_author.meta" 0 ""
 done

--- a/.claude/skills/good-prs/test.sh
+++ b/.claude/skills/good-prs/test.sh
@@ -3,7 +3,8 @@
 # Focused tests for report.sh. No network access: `gh` is replaced by a stub on
 # PATH that serves canned fixtures, so the tests exercise report.sh's own logic
 # (bucket -> label classification, the "only CH Inc sync is non-green" criterion,
-# empty-input handling, --repo pinning, and fail-loud-on-real-error behaviour).
+# the public-repo conflict marker, empty-input handling, --repo pinning, and
+# fail-loud-on-real-error behaviour).
 #
 # Usage: bash test.sh
 #
@@ -14,6 +15,8 @@ REPORT="$HERE/report.sh"
 
 # Keep the retry wrapper's timing out of the tests: same code path, no sleeping.
 export GH_RETRIES=3 GH_RETRY_DELAY=0
+# Same for the UNKNOWN-mergeability re-query: keep the attempts, drop the wait.
+export GH_MERGEABLE_TRIES=3 GH_MERGEABLE_DELAY=0
 
 RC=0
 ok()  { printf '  ok   - %s\n' "$*"; }
@@ -63,6 +66,16 @@ case "$sub" in
   "pr view")
     n="$3"
     if [ -f "$GH_STUB_DIR/view/$n.err" ]; then cat "$GH_STUB_DIR/view/$n.err" >&2; exit 1; fi
+    # <n>.lazy holds a count of leading calls that answer with <n>.tsv.first,
+    # mimicking GitHub's lazily computed mergeability (UNKNOWN until the test
+    # merge it schedules has run).
+    if [ -f "$GH_STUB_DIR/view/$n.lazy" ]; then
+      cnt=$(cat "$GH_STUB_DIR/view/$n.vcount" 2>/dev/null || echo 0)
+      cnt=$(( cnt + 1 )); printf '%s\n' "$cnt" > "$GH_STUB_DIR/view/$n.vcount"
+      if [ "$cnt" -le "$(cat "$GH_STUB_DIR/view/$n.lazy")" ]; then
+        cat "$GH_STUB_DIR/view/$n.tsv.first"; exit 0
+      fi
+    fi
     cat "$GH_STUB_DIR/view/$n.tsv"
     ;;
   *)
@@ -113,6 +126,9 @@ printf 'testuser\n' > "$A/fix/me"
   printf '107\ttestuser\tSync QUEUED\n'
   printf '108\ttestuser\tSync CANCELLED\n'
   printf '109\ttestuser\tSync SKIPPED\n'
+  printf '110\ttestuser\tGreen but conflicting\n'
+  printf '111\ttestuser\tConflict known only on the second ask\n'
+  printf '112\ttestuser\tMergeability never computed\n'
 } > "$A/fix/list/author_testuser.tsv"
 printf '201\tgroeneai\tGroeneai green PR\n' > "$A/fix/list/author_groeneai.tsv"
 
@@ -126,17 +142,26 @@ c 106 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build"
 c 107 '[{"name":"CH Inc sync","state":"QUEUED","bucket":"pending"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
 c 108 '[{"name":"CH Inc sync","state":"CANCELLED","bucket":"cancel"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
 c 109 '[{"name":"CH Inc sync","state":"SKIPPED","bucket":"skipping"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 110 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 111 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 112 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
 c 201 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
 
-v() { printf '%s\t%s\n' "$2" "$3" > "$A/fix/view/$1.tsv"; }
+# v <pr> <state> <ever-approved> [mergeable, default MERGEABLE]
+v() { printf '%s\t%s\t%s\n' "$2" "$3" "${4:-MERGEABLE}" > "$A/fix/view/$1.tsv"; }
 v 101 OPEN true
 v 102 OPEN false
 v 103 OPEN false
 v 104 OPEN false
-v 106 MERGED false
+v 106 MERGED false UNKNOWN
 v 107 OPEN false
 v 108 OPEN false
 v 109 OPEN false
+v 110 OPEN false CONFLICTING
+v 111 OPEN false CONFLICTING
+printf 'OPEN\tfalse\tUNKNOWN\n' > "$A/fix/view/111.tsv.first"
+printf '1\n' > "$A/fix/view/111.lazy"     # UNKNOWN once, then the real verdict
+v 112 OPEN false UNKNOWN
 v 201 OPEN true
 
 run_report "$A"
@@ -151,7 +176,32 @@ row_has "$OUT" 107 INPROG "#107 sync QUEUED (bucket pending) -> INPROG"
 row_has "$OUT" 108 FAILED "#108 sync CANCELLED (bucket cancel) -> FAILED"
 row_has "$OUT" 109 NOSYNC "#109 sync SKIPPED (bucket skipping) -> NOSYNC"
 row_has "$OUT" 201 GREEN  "#201 groeneai section rendered"
-assert_repo_pinned "$A/calls.log" "every PR-scoped gh call pins --repo ClickHouse/ClickHouse"
+row_has "$OUT" 110 'GREEN+CONFLICT' "#110 conflicting in the public repo -> GREEN+CONFLICT"
+row_has "$OUT" 111 'GREEN+CONFLICT' "#111 conflict found on the re-query -> GREEN+CONFLICT"
+row_has "$OUT" 112 'GREEN+UNKNOWN'  "#112 mergeability never computed -> GREEN+UNKNOWN"
+if [ "$(grep -c '^pr view 111 ' "$A/calls.log")" = 2 ]; then
+  ok "UNKNOWN mergeability re-queried until GitHub computed it"
+else
+  bad "UNKNOWN mergeability re-queried until GitHub computed it (got $(grep -c '^pr view 111 ' "$A/calls.log") calls)"
+fi
+if [ "$(grep -c '^pr view 106 ' "$A/calls.log")" = 1 ]; then
+  ok "a non-OPEN PR's UNKNOWN mergeability is not re-queried"
+else
+  bad "a non-OPEN PR's UNKNOWN mergeability is not re-queried (got $(grep -c '^pr view 106 ' "$A/calls.log") calls)"
+fi
+if [ "$(grep -c '^pr view 112 ' "$A/calls.log")" = "$GH_MERGEABLE_TRIES" ]; then
+  ok "a permanently UNKNOWN mergeability stops after GH_MERGEABLE_TRIES"
+else
+  bad "a permanently UNKNOWN mergeability stops after GH_MERGEABLE_TRIES (got $(grep -c '^pr view 112 ' "$A/calls.log") calls)"
+fi
+# Within one sync bucket: clean rows first, then unknown, then conflicting.
+order=$(grep -oE '#(101|110|111|112)' "$OUT" | tr -d '#' | tr '\n' ' ')
+if [ "$order" = "101 112 110 111 " ]; then
+  ok "conflicting rows sorted after the clean ones in the same bucket"
+else
+  bad "conflicting rows sorted after the clean ones in the same bucket (got: $order)"
+fi
+if grep -q '| sync / merge |' "$OUT"; then ok "first column header names the merge state"; else bad "first column header names the merge state"; fi
 rm -rf "$A"
 
 ############################ Test B: empty input ###############################
@@ -195,7 +245,7 @@ printf 'testuser\n' > "$E/fix/me"
 { printf '501\ttestuser\tNo checks reported\n'; printf '502\ttestuser\tGreen PR\n'; } > "$E/fix/list/author_testuser.tsv"
 : > "$E/fix/checks/501.nochecks"
 printf '%s\n' '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"}]' > "$E/fix/checks/502.json"
-v502() { printf 'OPEN\ttrue\n' > "$E/fix/view/502.tsv"; }; v502
+v502() { printf 'OPEN\ttrue\tMERGEABLE\n' > "$E/fix/view/502.tsv"; }; v502
 run_report "$E"
 [ "$EXIT" = 0 ] && ok "exit code 0 (no-checks is legitimate)" || { bad "exit code 0 (got $EXIT)"; cat "$ERRF"; }
 not_present 501 "$OUT" "#501 with no checks -> excluded"
@@ -209,7 +259,7 @@ printf 'testuser\n' > "$F/fix/me"
 printf '601\ttestuser\tFlaky then green\n' > "$F/fix/list/author_testuser.tsv"
 printf '2\n' > "$F/fix/checks/601.flaky"   # fail twice, succeed on the third call
 printf '%s\n' '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"}]' > "$F/fix/checks/601.json"
-printf 'OPEN\ttrue\n' > "$F/fix/view/601.tsv"
+printf 'OPEN\ttrue\tMERGEABLE\n' > "$F/fix/view/601.tsv"
 run_report "$F"
 [ "$EXIT" = 0 ] && ok "exit code 0 after retried 503s" || { bad "exit code 0 after retried 503s (got $EXIT)"; cat "$ERRF"; }
 row_has "$OUT" 601 GREEN "#601 rendered after the transient failures"


### PR DESCRIPTION
The `good-prs` skill reports open pull requests whose only non-green check is `CH Inc sync`, so they are effectively ready to merge. It did not look at mergeability, so a pull request that conflicts with its base branch in the public repository was listed as `GREEN` - which reads as merge-ready when it is not.

The conflict state is now shown in the same first column as the sync state: the sync label gains a `+CONFLICT` suffix when GitHub reports the pull request as `CONFLICTING`, or `+UNKNOWN` when GitHub has not finished computing mergeability, so an uncomputed verdict is never shown as clean. Within one sync bucket, clean rows come first, then `+UNKNOWN`, then `+CONFLICT`, so the actionable rows stay at the top of each section.

`mergeable` rides along on the `gh pr view` call that already fetches the state and the reviews, so this costs no extra quota. GitHub computes mergeability lazily, though: for a pull request nobody looked at recently, the first query only schedules the test merge and answers `UNKNOWN`, and asking again shortly after returns the real verdict. An open pull request is therefore re-queried up to `GH_MERGEABLE_TRIES` times (default 3) with `GH_MERGEABLE_DELAY` seconds (default 2) in between; a closed or merged one is not, since it is dropped from the report anyway.

On a full run over the 233 qualifying pull requests, 15 turned out to be conflicting - 10 of them otherwise fully green - and no row was left `+UNKNOWN` after the re-query. Spot checks agree with GitHub's own merge state.

`test.sh` gains a lazy-mergeability fixture in the `gh` stub and covers both suffixes, the sort order, the re-query until GitHub computes the verdict, that a non-open pull request is not re-queried, and that a permanently `UNKNOWN` one stops after the try limit. All of its assertions pass.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116996&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/116996](https://github.com/search?q=head%3Async-upstream%2Fpr%2F116996+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.325` (included in `26.9` and later)
<!-- ch-version-info:end -->