### PR TITLE
Speed up aggregation batches with non-null states

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionIf.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionIf.h
@@ -157,6 +157,21 @@ public:
         nested_func->addBatch(row_begin, row_end, places, place_offset, columns, arena, num_arguments - 1);
     }
 
+    void addBatchWithNonNullPlaces(
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * __restrict places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t) const override
+    {
+        if (only_null_condition)
+            return;
+        nested_func->addBatchWithNonNullPlaces(
+            row_begin, row_end, places, place_offset, columns, arena, num_arguments - 1);
+    }
+
     void addBatchSinglePlace(
         size_t row_begin,
         size_t row_end,

--- a/src/AggregateFunctions/Combinators/AggregateFunctionOrFill.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionOrFill.h
@@ -164,6 +164,33 @@ public:
         }
     }
 
+    void addBatchWithNonNullPlaces( /// NOLINT
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const override
+    {
+        if (if_argument_pos >= 0)
+        {
+            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
+            for (size_t i = row_begin; i < row_end; ++i)
+            {
+                if (flags[i])
+                    add(places[i] + place_offset, columns, i, arena);
+            }
+        }
+        else
+        {
+            nested_function->addBatchWithNonNullPlaces(
+                row_begin, row_end, places, place_offset, columns, arena, if_argument_pos);
+            for (size_t i = row_begin; i < row_end; ++i)
+                (places[i] + place_offset)[size_of_data] = 1;
+        }
+    }
+
     void addBatchSinglePlace( /// NOLINT
         size_t row_begin,
         size_t row_end,

--- a/src/AggregateFunctions/Combinators/AggregateFunctionTuple.cpp
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionTuple.cpp
@@ -185,7 +185,7 @@ void AggregateFunctionTuple::add(AggregateDataPtr __restrict place, const IColum
     }
 }
 
-template <bool has_null_map, typename GetPlace>
+template <bool has_null_map, bool all_places_are_non_null, typename GetPlace>
 void AggregateFunctionTuple::addBatchImpl(
     size_t row_begin,
     size_t row_end,
@@ -301,7 +301,9 @@ void AggregateFunctionTuple::addBatchImpl(
                 if (null_map[i])
                     continue;
             }
-            if (AggregateDataPtr place = get_place(i))
+            if constexpr (all_places_are_non_null)
+                add_row(get_place(i), i);
+            else if (AggregateDataPtr place = get_place(i))
                 add_row(place, i);
         }
     }
@@ -314,7 +316,9 @@ void AggregateFunctionTuple::addBatchImpl(
                 if (null_map[i])
                     continue;
             }
-            if (AggregateDataPtr place = get_place(i))
+            if constexpr (all_places_are_non_null)
+                add_row(get_place(i), i);
+            else if (AggregateDataPtr place = get_place(i))
                 add_row(place, i);
         }
     }
@@ -329,8 +333,21 @@ void AggregateFunctionTuple::addBatch( /// NOLINT
     Arena * arena,
     ssize_t if_argument_pos) const
 {
-    addBatchImpl<false>(row_begin, row_end, columns, nullptr, if_argument_pos, arena,
+    addBatchImpl<false, false>(row_begin, row_end, columns, nullptr, if_argument_pos, arena,
         [&](size_t i) { return places[i] ? places[i] + place_offset : nullptr; });
+}
+
+void AggregateFunctionTuple::addBatchWithNonNullPlaces( /// NOLINT
+    size_t row_begin,
+    size_t row_end,
+    AggregateDataPtr * places,
+    size_t place_offset,
+    const IColumn ** columns,
+    Arena * arena,
+    ssize_t if_argument_pos) const
+{
+    addBatchImpl<false, true>(row_begin, row_end, columns, nullptr, if_argument_pos, arena,
+        [&](size_t i) { return places[i] + place_offset; });
 }
 
 void AggregateFunctionTuple::addBatchSinglePlace( /// NOLINT
@@ -341,7 +358,7 @@ void AggregateFunctionTuple::addBatchSinglePlace( /// NOLINT
     Arena * arena,
     ssize_t if_argument_pos) const
 {
-    addBatchImpl<false>(row_begin, row_end, columns, nullptr, if_argument_pos, arena,
+    addBatchImpl<false, true>(row_begin, row_end, columns, nullptr, if_argument_pos, arena,
         [&](size_t) { return place; });
 }
 
@@ -356,7 +373,7 @@ void AggregateFunctionTuple::addBatchSinglePlaceNotNull( /// NOLINT
 {
     /// Reached from `AggregateFunctionNullUnary` for `Nullable(Tuple(...))` inputs: rows whose tuple
     /// is NULL are skipped via the null map.
-    addBatchImpl<true>(row_begin, row_end, columns, null_map, if_argument_pos, arena,
+    addBatchImpl<true, true>(row_begin, row_end, columns, null_map, if_argument_pos, arena,
         [&](size_t) { return place; });
 }
 

--- a/src/AggregateFunctions/Combinators/AggregateFunctionTuple.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionTuple.h
@@ -78,6 +78,14 @@ public:
         const IColumn ** columns,
         Arena * arena,
         ssize_t if_argument_pos = -1) const override;
+    void addBatchWithNonNullPlaces( /// NOLINT
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const override;
     void addBatchSinglePlace( /// NOLINT
         size_t row_begin,
         size_t row_end,
@@ -159,7 +167,7 @@ private:
     /// Shared implementation of the batch add overrides. Hoists the per-element column pointers, so
     /// no per-row unwrapping work remains in the row loop.
     /// `get_place` returns the aggregation state for a row, or nullptr when the row has none.
-    template <bool has_null_map, typename GetPlace>
+    template <bool has_null_map, bool all_places_are_non_null, typename GetPlace>
     void addBatchImpl(
         size_t row_begin,
         size_t row_end,

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -331,6 +331,21 @@ public:
         Arena * arena,
         ssize_t if_argument_pos = -1) const = 0;
 
+    /** A version of `addBatch` for callers that guarantee that every entry in `places` is non-null.
+      * Implementations that don't benefit from this guarantee can use the default implementation.
+      */
+    virtual void addBatchWithNonNullPlaces( /// NOLINT
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const
+    {
+        addBatch(row_begin, row_end, places, place_offset, columns, arena, if_argument_pos);
+    }
+
     /// The version of "addBatch", that handle sparse columns as arguments.
     virtual void addBatchSparse(
         size_t row_begin,
@@ -854,6 +869,31 @@ public:
             std::is_same_v<decltype(&IAggregateFunctionDataHelper::hasTrivialDestructor), decltype(&Derived::hasTrivialDestructor)>;
         static_assert(declares_destroy_and_has_trivial_destructor,
             "destroy() and hasTrivialDestructor() methods of an aggregate function must be either both overridden or not");
+    }
+
+    void addBatchWithNonNullPlaces( /// NOLINT
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const override
+    {
+        if (if_argument_pos >= 0)
+        {
+            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
+            for (size_t i = row_begin; i < row_end; ++i)
+            {
+                if (flags[i])
+                    static_cast<const Derived *>(this)->add(places[i] + place_offset, columns, i, arena);
+            }
+        }
+        else
+        {
+            for (size_t i = row_begin; i < row_end; ++i)
+                static_cast<const Derived *>(this)->add(places[i] + place_offset, columns, i, arena);
+        }
     }
 
     void create(AggregateDataPtr __restrict place) const override /// NOLINT

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -571,6 +571,31 @@ public:
         }
     }
 
+    void addBatchWithNonNullPlaces( /// NOLINT
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const override
+    {
+        if (if_argument_pos >= 0)
+        {
+            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
+            for (size_t i = row_begin; i < row_end; ++i)
+            {
+                if (flags[i])
+                    static_cast<const Derived *>(this)->add(places[i] + place_offset, columns, i, arena);
+            }
+        }
+        else
+        {
+            for (size_t i = row_begin; i < row_end; ++i)
+                static_cast<const Derived *>(this)->add(places[i] + place_offset, columns, i, arena);
+        }
+    }
+
     void serializeBatch(const PaddedPODArray<AggregateDataPtr> & data, size_t start, size_t size, WriteBuffer & buf, std::optional<size_t> version) const final // NOLINT
     {
         for (size_t i = start; i < size; ++i)
@@ -869,31 +894,6 @@ public:
             std::is_same_v<decltype(&IAggregateFunctionDataHelper::hasTrivialDestructor), decltype(&Derived::hasTrivialDestructor)>;
         static_assert(declares_destroy_and_has_trivial_destructor,
             "destroy() and hasTrivialDestructor() methods of an aggregate function must be either both overridden or not");
-    }
-
-    void addBatchWithNonNullPlaces( /// NOLINT
-        size_t row_begin,
-        size_t row_end,
-        AggregateDataPtr * places,
-        size_t place_offset,
-        const IColumn ** columns,
-        Arena * arena,
-        ssize_t if_argument_pos = -1) const override
-    {
-        if (if_argument_pos >= 0)
-        {
-            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = row_begin; i < row_end; ++i)
-            {
-                if (flags[i])
-                    static_cast<const Derived *>(this)->add(places[i] + place_offset, columns, i, arena);
-            }
-        }
-        else
-        {
-            for (size_t i = row_begin; i < row_end; ++i)
-                static_cast<const Derived *>(this)->add(places[i] + place_offset, columns, i, arena);
-        }
     }
 
     void create(AggregateDataPtr __restrict place) const override /// NOLINT

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -201,6 +201,22 @@ public:
         }
     }
 
+    void addBatchWithNonNullPlaces(
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr * places,
+        size_t place_offset,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos) const override
+    {
+        if (array_arguments)
+            Base::addBatchWithNonNullPlaces(
+                row_begin, row_end, places, place_offset, columns, arena, if_argument_pos);
+        else
+            addBatch(row_begin, row_end, places, place_offset, columns, arena, if_argument_pos);
+    }
+
     void addBatchSinglePlace(
         size_t row_begin,
         size_t row_end,

--- a/src/Interpreters/AdaptiveAggregationKernels.cpp
+++ b/src/Interpreters/AdaptiveAggregationKernels.cpp
@@ -653,6 +653,7 @@ void NO_INLINE Aggregator::executeFrozenImpl(
             /*key_start=*/row_begin,
             /*has_only_one_value_since_last_reset=*/false,
             /*all_keys_are_const=*/false,
+            /*all_places_are_non_null=*/false,
             /*use_compiled_functions=*/false);
 }
 
@@ -1427,6 +1428,7 @@ void NO_INLINE Aggregator::drainAdaptiveBucketImpl(
         /*key_start=*/slice_begin,
         /*has_only_one_value_since_last_reset=*/false,
         /*all_keys_are_const=*/false,
+        /*all_places_are_non_null=*/true,
         use_compiled_functions);
 }
 

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1746,6 +1746,8 @@ void NO_INLINE Aggregator::executeImplBatch(
     state.resetCache();
 
     [[maybe_unused]] std::vector<DestroyedState> destroyed_states;
+    /// Assign at the branch tails so `no_more_keys` is not live across either loop.
+    bool all_places_are_non_null = false;
 
     /// For all rows.
     if (!no_more_keys)
@@ -1862,6 +1864,8 @@ void NO_INLINE Aggregator::executeImplBatch(
                 }
             }
         }
+
+        all_places_are_non_null = !top_k;
     }
     else
     {
@@ -1876,6 +1880,8 @@ void NO_INLINE Aggregator::executeImplBatch(
                 aggregate_data = overflow_row;
             places[i] = aggregate_data;
         }
+
+        all_places_are_non_null = false;
     }
 
     if constexpr (top_k)
@@ -1898,6 +1904,7 @@ void NO_INLINE Aggregator::executeImplBatch(
             key_start,
             has_only_one_value,
             all_keys_are_const,
+            all_places_are_non_null,
             use_jit);
 }
 
@@ -1910,6 +1917,7 @@ void Aggregator::executeAggregateInstructions(
     size_t key_start,
     bool has_only_one_value_since_last_reset,
     bool all_keys_are_const,
+    bool all_places_are_non_null,
     bool use_compiled_functions [[maybe_unused]]) const
 {
 #if USE_EMBEDDED_COMPILER
@@ -1962,7 +1970,7 @@ void Aggregator::executeAggregateInstructions(
         }
         else
         {
-            addBatch(row_begin, row_end, inst, places, aggregates_pool);
+            addBatch(row_begin, row_end, inst, places, aggregates_pool, all_places_are_non_null);
         }
     }
 
@@ -2026,7 +2034,8 @@ void Aggregator::addBatch(
     size_t row_begin, size_t row_end,
     const AggregateFunctionInstruction * inst,
     AggregateDataPtr * places,
-    Arena * arena)
+    Arena * arena,
+    bool all_places_are_non_null)
 {
     if (inst->offsets)
         inst->batch_that->addBatchArray(
@@ -2037,6 +2046,12 @@ void Aggregator::addBatch(
             arena);
     else if (inst->has_sparse_arguments)
         inst->batch_that->addBatchSparse(
+            row_begin, row_end, places,
+            inst->state_offset,
+            inst->batch_arguments,
+            arena);
+    else if (all_places_are_non_null)
+        inst->batch_that->addBatchWithNonNullPlaces(
             row_begin, row_end, places,
             inst->state_offset,
             inst->batch_arguments,

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -839,6 +839,7 @@ private:
         size_t key_start,
         bool has_only_one_value_since_last_reset,
         bool all_keys_are_const,
+        bool all_places_are_non_null,
         bool use_compiled_functions) const;
 
     /// For case when there are no keys (all aggregate into one row).
@@ -1223,7 +1224,8 @@ private:
         size_t row_begin, size_t row_end,
         const AggregateFunctionInstruction * inst,
         AggregateDataPtr * places,
-        Arena * arena);
+        Arena * arena,
+        bool all_places_are_non_null);
 
     static void addBatchSinglePlace(
         size_t row_begin, size_t row_end,


### PR DESCRIPTION
Aggregations with lots of buckets can get expensive. Here's an excerpt from a profile:

```
ROUTINE ======================== DB::IAggregateFunctionHelper<DB::AggregateFunctionSum<unsigned long, unsigned long, DB::AggregateFunctionSumData<unsigned long>, (DB::AggregateFunctionSumType)0> >::addBatch(unsigned long, unsigned long, char**, unsigned long, DB::IColumn const**, DB::Arena*, long) const in src/AggregateFunctions/IAggregateFunction.h
     1.79s      2.32s (flat, cum) 15.07% of Total
         .          .    549:            }
         .          .    550:        }
         .          .    551:        else
         .          .    552:        {
         .          .    553:            for (size_t i = row_begin; i < row_end; ++i)
     1.79s      1.79s    554:                if (places[i])
         .   526.32ms    555:                    static_cast<const Derived *>(this)->add(places[i] + place_offset, columns, i, arena);
         .          .    556:        }
         .          .    557:    }
         .          .    558:
         .          .    559:    void serializeBatch(const PaddedPODArray<AggregateDataPtr> & data, size_t start, size_t size, WriteBuffer & buf, std::optional<size_t> version) const final // NOLINT
         .          .    560:    {
```

We can get some of this back by specializing the common non-null version.

For a big query doing a very wide aggregation (with improvements from #115925):

* 1 thread: 77.7s -> 74.3s (both wall and cpu)
* 64 threads: 17.0s -> 16.0s (wall), 99.5s -> 92.4s (cpu)

Before:

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/1aaac7f9-c713-4dde-a17b-6aba5103f44d" />

After:

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/c35c8213-0dc8-4ae5-bb48-6e0aff09d83a" />


With a synthetic benchmark:

* Baseline: 1.24s

```
$ ../bench.py --clickhouse=/tmp/clickhouse-baseline --path=$HOME/clickhouse-no-nulls --runs=3 --query="SELECT toUInt16(bitAnd(number, 8191)) AS key, sum(number) FROM numbers(500000000) GROUP BY key FORMAT Null SETTINGS max_threads = 1"
wall:   1.24s, cpu:   1.23s, memory:   0.00GiB
wall:   1.25s, cpu:   1.24s, memory:   0.00GiB
wall:   1.23s, cpu:   1.23s, memory:   0.00GiB
```

* Patched: 1.10s

```
$ ../bench.py --clickhouse=/tmp/clickhouse-no-nulls --path=$HOME/clickhouse-no-nulls --runs=3 --query="SELECT toUInt16(bitAnd(number, 8191)) AS key, sum(number) FROM numbers(500000000) GROUP BY key FORMAT Null SETTINGS max_threads = 1"
wall:   1.10s, cpu:   1.09s, memory:   0.00GiB
wall:   1.10s, cpu:   1.09s, memory:   0.00GiB
wall:   1.11s, cpu:   1.10s, memory:   0.00GiB
```

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Speed up aggregation batches with non-null states.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117009&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117009](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117009+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1381` (included in `26.9` and later)
<!-- ch-version-info:end -->