### PR TITLE
Fix dangling remote host filter references in S3 client configurations

### DIFF
--- a/src/Coordination/KeeperSnapshotManagerS3.cpp
+++ b/src/Coordination/KeeperSnapshotManagerS3.cpp
@@ -107,6 +107,7 @@ void KeeperSnapshotManagerS3::updateS3Configuration(const Poco::Util::AbstractCo
         static constexpr bool s3_slow_all_threads_after_network_error = true;
         static constexpr bool s3_slow_all_threads_after_retryable_error = false;
         static constexpr bool enable_s3_requests_logging = false;
+        static const RemoteHostFilter remote_host_filter;
 
         if (!new_uri.key.empty())
         {
@@ -116,7 +117,7 @@ void KeeperSnapshotManagerS3::updateS3Configuration(const Poco::Util::AbstractCo
 
         S3::PocoHTTPClientConfiguration client_configuration = S3::ClientFactory::instance().createClientConfiguration(
             auth_settings[S3AuthSetting::region],
-            RemoteHostFilter(),
+            remote_host_filter,
             s3_max_redirects,
             S3::PocoHTTPClientConfiguration::RetryStrategy{.max_retries = s3_retry_attempts},
             s3_slow_all_threads_after_network_error,

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -491,7 +491,7 @@ TEST(IOTestAwsS3Client, AssumeRole)
 
     TestPocoHTTPStsServer sts_http(std::string{role_access_key}, std::string{role_secret_key});
 
-    DB::RemoteHostFilter remote_host_filter;
+    static const DB::RemoteHostFilter remote_host_filter;
     unsigned int s3_max_redirects = 100;
     unsigned int s3_retry_attempts = 0;
     bool s3_slow_all_threads_after_network_error = true;

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -939,7 +939,7 @@ private:
 
 std::shared_ptr<DB::S3::Client> createTestS3Client(const DB::S3::URI & uri)
 {
-    DB::RemoteHostFilter remote_host_filter;
+    static const DB::RemoteHostFilter remote_host_filter;
     DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
         "us-east-1",
         remote_host_filter,

--- a/src/IO/tests/gtest_readbuffer_s3.cpp
+++ b/src/IO/tests/gtest_readbuffer_s3.cpp
@@ -113,6 +113,13 @@ private:
 
 using GetObjectFn = std::function<Aws::S3::Model::GetObjectOutcome(const Aws::S3::Model::GetObjectRequest & request)>;
 
+/// The configuration holds the filter by reference, so the filter must outlive every client built from it.
+static const DB::RemoteHostFilter & allowAnyHost()
+{
+    static const DB::RemoteHostFilter filter;
+    return filter;
+}
+
 struct ClientFake : DB::S3::Client
 {
     explicit ClientFake()
@@ -122,7 +129,7 @@ struct ClientFake : DB::S3::Client
               std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>("test_access_key", "test_secret"),
               DB::S3::ClientFactory::instance().createClientConfiguration(
                   "test_region",
-                  DB::RemoteHostFilter(),
+                  allowAnyHost(),
                   1,
                   DB::S3::PocoHTTPClientConfiguration::RetryStrategy{.max_retries = 0},
                   true,

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -279,7 +279,7 @@ struct Client : DB::S3::Client
 
     static DB::S3::PocoHTTPClientConfiguration GetClientConfiguration()
     {
-        DB::RemoteHostFilter remote_host_filter;
+        static const DB::RemoteHostFilter remote_host_filter;
         auto configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
             "some-region",
             remote_host_filter,

--- a/src/Storages/Kafka/AWSMSKIAMAuth.cpp
+++ b/src/Storages/Kafka/AWSMSKIAMAuth.cpp
@@ -8,6 +8,7 @@
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
 #include <Common/re2.h>
+#include <Common/RemoteHostFilter.h>
 #include <Core/SettingsFields.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/URI.h>
@@ -180,8 +181,11 @@ void setupAuthentication(
 
     if (!context_holder)
     {
+        /// The configuration holds the filter by reference, so the filter must outlive `context_holder->provider`.
+        static const RemoteHostFilter remote_host_filter;
+
         auto aws_client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
-            effective_region, {}, 0, {}, false, false, false, false, {}, {});
+            effective_region, remote_host_filter, 0, {}, false, false, false, false, {}, {});
 
         S3::CredentialsConfiguration credentials_configuration;
         credentials_configuration.use_environment_credentials = use_environment_credentials;


### PR DESCRIPTION
Fix dangling remote host filter references in S3 client configurations

Related: https://github.com/ClickHouse/ClickHouse/pull/114357


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog: removes undefined behaviour (a dangling reference read) with no observable behaviour change.

### Description

`S3::PocoHTTPClientConfiguration` holds the remote host filter as a reference member
(`src/IO/S3/PocoHTTPClient.h:69`), and the HTTP client built from it re-binds that same reference
(`PocoHTTPClient.cpp:221`). The configuration is a freely copied value type, so a copy re-binds the
referent rather than owning it: the filter must outlive the configuration, every copy of it, and
every client and credentials provider derived from it, including providers kept for the life of the
process in `CredentialsProviderCache::instance()` (`Credentials.cpp:180-184`), whose key does not
include the filter.

Six call sites pass a filter that dies first. Reading it afterwards is undefined behaviour; the
read is `is_initialized` in `RemoteHostFilter::checkForDirectEntry` (`RemoteHostFilter.cpp:64`),
reached from `checkURL` at `PocoHTTPClient.cpp:685` on a 307 and `Client.cpp:1073` on a 301. At the
Kafka `AWS_MSK_IAM` site with `kafka.use_environment_credentials = 1`, the chain built from the dead
binding is then kept in `StorageKafka::oauth_context` and in that process-wide cache, so it outlives
the function without bound; `s3_max_redirects = 0` there does not help, because
`PocoHTTPClient.cpp:545` still runs its body once. The read is behind a redirect, which is why the
class is mostly latent today.

This gives the filter static storage duration at each site, the same idiom as
`src/IO/AzureBlobStorage/PocoHTTPClient.cpp:628`. Behaviour is unchanged: a default-constructed
filter has `is_initialized == false`, so `checkForDirectEntry` returns true unconditionally and
`checkURL` cannot throw. Only the storage duration changes.

Validated under ASan with `-fsanitize-address-use-after-scope`. Making the read unconditional
reproduces `stack-use-after-return` at `__cxx_atomic_load<bool>` with ASan naming the dead filter
and its declaration line, and a two-directions arm over the credentials-provider cache aborts with
a scope-local filter and passes with a static one while reaching the same read in both arms. No new
test ships: the read needs a 307/301 redirect that no unit test induces, and detecting it needs a
sanitizer.

<details><summary>Public CI reports where this class already fires (two of these sites, on #114357's branch)</summary>

`Unit tests (asan_ubsan)`, `stack-use-after-return` in
`IOTestAwsS3Client.ReadDetectsObjectReplacedDuringRead`, 2026-08-28 14:24:44:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114357&sha=0a9db0f669c240c8376d6086821cacb02254fd4b&name_0=PR&name_1=Unit%20tests%20%28asan_ubsan%29

`Integration tests (amd_asan_ubsan, db disk, old analyzer, 2/6)`,
`test_keeper_s3_snapshot/test.py::test_s3_upload` aborting on thread `KeeperSnapS3`, 2026-08-28 15:57:06:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114357&sha=2239539ed0de8a1168655a44cf62b4bcec7597d0&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29

Both frames are the same `__cxx_atomic_load<bool>` at
`contrib/llvm-project/libcxx/include/__atomic/support/c11.h:81:10`.

</details>

The two hunks added at #114357's sites are byte-identical to rorylshanks', placement included, so
whichever of the two merges first the other resolves as a same-change no-op (`git merge-tree`
returns 0, with both sides' fixes present).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117010&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117010](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117010+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

