### PR TITLE
Do not allocate from sizes a peer declares in the Native protocol

### DIFF
--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -164,6 +164,10 @@ static void readHeaderAndGetCodecAndSize(
         throw Exception(ErrorCodes::TOO_LARGE_SIZE_COMPRESSED, "Too large size_compressed_without_checksum: {}. "
                         "Most likely corrupted data.", size_compressed_without_checksum);
 
+    if (size_decompressed > DBMS_MAX_DECOMPRESSED_SIZE)
+        throw Exception(ErrorCodes::TOO_LARGE_SIZE_COMPRESSED, "Too large size_decompressed: {}. "
+                        "Most likely corrupted data.", size_decompressed);
+
     if (size_compressed_without_checksum < header_size)
         throw Exception(external_data ? ErrorCodes::CANNOT_DECOMPRESS : ErrorCodes::CORRUPTED_DATA, "Can't decompress data: "
             "the compressed data size ({}, this should include header size) is less than the header size ({})",

--- a/src/Compression/CompressionInfo.h
+++ b/src/Compression/CompressionInfo.h
@@ -6,6 +6,13 @@
 
 constexpr uint64_t DBMS_MAX_COMPRESSED_SIZE = 0x40000000ULL;    /// 1GB
 
+/** The decompressed size of a block is taken from the block header, and the buffer for it is
+  * allocated before the block is decompressed, so it has to be bounded as well: a block that
+  * declares a huge decompressed size makes the reader allocate that much from a tiny payload.
+  * Blocks are written with `max_compress_block_size`, which is 1 MB by default.
+  */
+constexpr uint64_t DBMS_MAX_DECOMPRESSED_SIZE = 0x40000000ULL;  /// 1GB
+
 /** one byte for method, 4 bytes for compressed size, 4 bytes for uncompressed size */
 constexpr uint8_t COMPRESSED_BLOCK_HEADER_SIZE = 9;
 

--- a/src/Core/Defines.h
+++ b/src/Core/Defines.h
@@ -161,8 +161,13 @@ static constexpr auto DEFAULT_REMOVE_SHARED_RECURSIVE_FILE_LIMIT = 1000uz;
 
 static constexpr auto DEFAULT_NATIVE_BINARY_MAX_NUM_COLUMNS = 1'000'000uz;
 
+/// The row count of a block is read from the wire before the block data, and the bulk
+/// deserialization resizes the column to it before reading, so a block header declaring a huge row
+/// count allocates that much from a payload that may be a few bytes. A block of a billion rows is
+/// already two orders of magnitude larger than anything ClickHouse produces.
+///
 /// Not `uz`: the value does not fit into `size_t` on 32-bit platforms, and it is compared against
 /// a row count read from the wire as `UInt64`.
-static constexpr auto DEFAULT_NATIVE_BINARY_MAX_NUM_ROWS = 1'000'000'000'000ULL;
+static constexpr auto DEFAULT_NATIVE_BINARY_MAX_NUM_ROWS = 1'000'000'000ULL;
 
 }

--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -177,6 +177,13 @@ Block NativeReader::read()
     if (columns == 0 && header.empty() && rows != 0)
         throw Exception(ErrorCodes::INCORRECT_DATA, "Zero columns but {} rows in Native format.", rows);
 
+    /// `rows` comes from the block header, and the limit it is checked against is deliberately
+    /// generous, so it must not be used to preallocate the columns: a header declaring a huge row
+    /// count would reserve that much per column before a single byte of column data is read.
+    /// Reserving is only an optimization here - deserialization appends to the column anyway - so
+    /// bound it by a plausible block size and let the column grow past that on its own.
+    const size_t rows_to_reserve = std::min<size_t>(rows, DEFAULT_INSERT_BLOCK_SIZE);
+
     for (size_t i = 0; i < columns; ++i)
     {
         if (use_index)
@@ -222,14 +229,14 @@ Block NativeReader::read()
 
             serialization = column.type->getSerialization(*info);
             auto new_column = column.type->createColumn(*serialization);
-            new_column->reserve(rows);
+            new_column->reserve(rows_to_reserve);
             read_column = std::move(new_column);
         }
         else
         {
             serialization = column.type->getDefaultSerialization();
             auto new_column = column.type->createColumn(*serialization);
-            new_column->reserve(rows);
+            new_column->reserve(rows_to_reserve);
             read_column = std::move(new_column);
         }
 

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -2069,6 +2069,29 @@ bool trySkipJSONField(ReadBuffer & buf, std::string_view name_of_field, const Fo
 }
 
 
+/// The same as `readStringBinary`, but the string grows as the bytes arrive instead of being resized
+/// to the declared size first, so that a size declared by the peer cannot become an allocation on
+/// its own when the payload never follows.
+static void readStringBinaryGrowing(String & s, ReadBuffer & buf, size_t max_string_size = DEFAULT_MAX_STRING_SIZE)
+{
+    size_t size = 0;
+    readVarUInt(size, buf);
+
+    if (size > max_string_size)
+        throw Exception(ErrorCodes::TOO_LARGE_STRING_SIZE, "Too large string size.");
+
+    s.clear();
+    while (s.size() < size)
+    {
+        if (buf.eof())
+            throwReadAfterEOF();
+
+        const size_t bytes_to_copy = std::min(size - s.size(), buf.available());
+        s.append(buf.position(), bytes_to_copy);
+        buf.position() += bytes_to_copy;
+    }
+}
+
 Exception readException(ReadBuffer & buf, const String & additional_message, bool remote_exception)
 {
     int code = 0;
@@ -2078,9 +2101,11 @@ Exception readException(ReadBuffer & buf, const String & additional_message, boo
     bool has_nested = false;    /// Obsolete
 
     readBinaryLittleEndian(code, buf);
-    readBinary(name, buf);
-    readBinary(message, buf);
-    readBinary(stack_trace, buf);
+    /// This is the first thing read from a server during the handshake, and the sizes of these
+    /// strings come from the other side, so read them without preallocating the declared size.
+    readStringBinaryGrowing(name, buf);
+    readStringBinaryGrowing(message, buf);
+    readStringBinaryGrowing(stack_trace, buf);
     readBinary(has_nested, buf);
 
     WriteBufferFromOwnString out;

--- a/tests/queries/0_stateless/05052_client_untrusted_server_allocations.reference
+++ b/tests/queries/0_stateless/05052_client_untrusted_server_allocations.reference
@@ -1,0 +1,4 @@
+block declaring a 2 GiB decompressed size: Too large size_decompressed
+block declaring 1e12 rows: TOO_LARGE_ARRAY_SIZE
+exception from the server: reported
+exception with a 1 GiB message that is not sent: reported

--- a/tests/queries/0_stateless/05052_client_untrusted_server_allocations.sh
+++ b/tests/queries/0_stateless/05052_client_untrusted_server_allocations.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A client allocates from sizes that the server puts on the wire, so a size on its own must not turn
+# into an allocation: the strings of an exception received during the handshake are read as they
+# arrive, the decompressed size of a block is bounded, and the row count of a block is not used to
+# preallocate the columns.
+
+# The decompressed size of a block is taken from its header, before the payload is read.
+# `[checksum: 16][method: 1][size_compressed: 4][size_decompressed: 4]`, method `0x82` is LZ4.
+printf '%s' "00000000000000000000000000000000821300000000000080" | xxd -r -p > "${CLICKHOUSE_TMP}/05052_huge_block.compressed"
+echo -n 'block declaring a 2 GiB decompressed size: '
+$CLICKHOUSE_COMPRESSOR --decompress --no-checksum-validation --input "${CLICKHOUSE_TMP}/05052_huge_block.compressed" --output "${CLICKHOUSE_TMP}/05052_huge_block.decompressed" 2>&1 | grep -o -m1 'Too large size_decompressed'
+
+# A `Native` block with one `UInt64` column that declares a thousand billion rows and carries none.
+printf '%s' "0180a094a58d1d01780655496e74363400" | xxd -r -p > "${CLICKHOUSE_TMP}/05052_huge_rows.native"
+echo -n 'block declaring 1e12 rows: '
+$CLICKHOUSE_LOCAL --query "SELECT count() FROM file('${CLICKHOUSE_TMP}/05052_huge_rows.native', 'Native', 'x UInt64')" 2>&1 | grep -o -m1 -e 'TOO_LARGE_ARRAY_SIZE' -e 'MEMORY_LIMIT_EXCEEDED'
+
+CLICKHOUSE_CLIENT_BINARY="$CLICKHOUSE_CLIENT_BINARY" python3 - <<'PYTHON'
+import os
+import shlex
+import socket
+import struct
+import subprocess
+import threading
+
+client = shlex.split(os.environ["CLICKHOUSE_CLIENT_BINARY"])
+
+
+def varint(value):
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out.append(byte | 0x80 if value else byte)
+        if not value:
+            return bytes(out)
+
+
+def string(value):
+    return varint(len(value)) + value
+
+
+def exception_packet(message, declared_message_size=None):
+    """An `Exception` packet: type, code, name, message, stack trace, `has_nested`."""
+    body = string(b"DB::Exception")
+    if declared_message_size is None:
+        body += string(message)
+    else:
+        body += varint(declared_message_size) + message
+    body += string(b"") + b"\x00"
+    return varint(2) + struct.pack("<i", 999) + body
+
+
+def serve(sock, reply):
+    connection, _ = sock.accept()
+    with connection:
+        connection.recv(4096)  # the `Hello` of the client
+        connection.sendall(reply)
+
+
+def run_client(reply):
+    sock = socket.create_server(("127.0.0.1", 0))
+    sock.settimeout(30)
+    port = sock.getsockname()[1]
+    thread = threading.Thread(target=serve, args=(sock, reply), daemon=True)
+    thread.start()
+    try:
+        result = subprocess.run(
+            client + ["--host", "127.0.0.1", "--port", str(port), "--query", "SELECT 1"],
+            capture_output=True, timeout=60)
+        return (result.stdout + result.stderr).decode("utf-8", "replace")
+    except subprocess.TimeoutExpired:
+        return "TIMEOUT"
+    finally:
+        thread.join(timeout=30)
+        sock.close()
+
+
+output = run_client(exception_packet(b"Mock server error 12345"))
+print("exception from the server:", "reported" if "Mock server error 12345" in output else "UNEXPECTED " + repr(output[:200]))
+
+# The same, but the message declares a gigabyte and the payload never arrives.
+output = run_client(exception_packet(b"x" * 16, declared_message_size=1 << 30))
+print("exception with a 1 GiB message that is not sent:", "reported" if "TIMEOUT" not in output else "TIMEOUT")
+PYTHON
+rm -f "${CLICKHOUSE_TMP}"/05052_huge_block.* "${CLICKHOUSE_TMP}"/05052_huge_rows.native


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/clickhouse-private/issues/71254

A client allocates from sizes that the server puts on the wire, before the corresponding payload arrives, and the client has no memory limit to stop it.

- The strings of an exception, which is the first thing a client can receive during the handshake, were resized to their declared size before the text arrived. They are now read as the bytes arrive.
- The decompressed size of a compressed block was not bounded, while the compressed size was. It is bounded the same way now.
- The row count of a block was only checked against a limit of a thousand billion rows, and the bulk deserialization resizes the column to it before reading. The limit is now a billion rows, which is still far above anything ClickHouse produces, and the columns are no longer preallocated from a row count that no data has backed yet.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Sizes declared by a server in the Native protocol no longer make the client allocate memory for data that has not arrived: exception strings are read as they arrive, the decompressed size of a block is bounded, and the maximum number of rows in a `Native` block is now a billion.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117011&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117011](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117011+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.1.2041`, `26.7.7.47`, `26.6.4.50`, `26.3.27.3`
<!-- ch-version-info:end -->