### PR TITLE
Fix Iceberg reads when the metadata file is deeper than the queried table path

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -207,6 +207,7 @@ Iceberg::PersistentTableComponents IcebergMetadata::initializePersistentTableCom
         }
     }
     auto table_path = configuration->getPathForRead().path;
+    auto root_derivation = IcebergPathResolver::deriveTableRoot(table_location, table_path, metadata_file_path);
     return PersistentTableComponents{
         .schema_processor = std::make_shared<IcebergSchemaProcessor>(context_->getSettingsRef()[Setting::allow_experimental_geo_types_in_iceberg]),
         .metadata_cache = cache_ptr,
@@ -215,7 +216,9 @@ Iceberg::PersistentTableComponents IcebergMetadata::initializePersistentTableCom
         .metadata_compression_method = compression_method,
         .table_path = table_path,
         .table_uuid = table_uuid,
-        .path_resolver = IcebergPathResolver(table_location, table_path, configuration->getTypeName(), configuration->getNamespace()),
+        .path_resolver = IcebergPathResolver(
+            table_location, root_derivation.table_root, configuration->getTypeName(), configuration->getNamespace()),
+        .table_root_was_derived = root_derivation.relation == IcebergPathResolver::RootRelation::AdoptedDescendant,
     };
 }
 
@@ -452,6 +455,8 @@ bool IcebergMetadata::optimize(
     [[maybe_unused]] ContextPtr context,
     [[maybe_unused]] const std::optional<FormatSettings> & format_settings)
 {
+    checkTableRootIsQueriedPath("OPTIMIZE");
+
 #if CLICKHOUSE_CLOUD
     if (!compaction_enabled)
         throw Exception(
@@ -493,6 +498,8 @@ bool IcebergMetadata::optimizeManifestFiles(
        std::shared_ptr<DataLake::ICatalog> catalog,
        const StorageID & storage_id)
 {
+    checkTableRootIsQueriedPath("OPTIMIZE TABLE ... MANIFEST");
+
     if (context->getSettingsRef()[Setting::allow_experimental_iceberg_compaction])
     {
         /// Reject manifest compaction on format-version 3: the writer does not yet round-trip the row-lineage `first_row_id`, so a rewrite would drop row ids (fail-close).
@@ -677,8 +684,25 @@ void IcebergMetadata::mutate(
         catalog);
 }
 
+void IcebergMetadata::checkTableRootIsQueriedPath(std::string_view operation) const
+{
+    if (!persistent_components.table_root_was_derived)
+        return;
+
+    throw Exception(
+        ErrorCodes::NOT_IMPLEMENTED,
+        "{} is not supported for an Iceberg table whose directory '{}' is below the queried path '{}'. "
+        "Query the table directory itself instead of naming a deeper metadata file with the "
+        "iceberg_metadata_file_path setting.",
+        operation,
+        persistent_components.path_resolver.getTableRoot(),
+        persistent_components.table_path);
+}
+
 void IcebergMetadata::checkMutationIsPossible(const MutationCommands & commands)
 {
+    checkTableRootIsQueriedPath("Mutation");
+
     if (commands.size() > 1)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Iceberg does not support multiple mutation commands in a single ALTER");
 
@@ -691,6 +715,8 @@ void IcebergMetadata::checkMutationIsPossible(const MutationCommands & commands)
 
 void IcebergMetadata::checkAlterIsPossible(const AlterCommands & commands)
 {
+    checkTableRootIsQueriedPath("ALTER");
+
     for (const auto & command : commands)
     {
         if (command.type != AlterCommand::Type::ADD_COLUMN && command.type != AlterCommand::Type::DROP_COLUMN
@@ -753,6 +779,7 @@ Pipe IcebergMetadata::executeCommand(
                 "To allow its usage, enable setting allow_experimental_expire_snapshots");
         }
 
+        checkTableRootIsQueriedPath("expire_snapshots");
         return Iceberg::executeExpireSnapshots(
             args, context, object_storage_, data_lake_settings, persistent_components,
             write_format, catalog_, storage_id.getTableName());
@@ -767,6 +794,7 @@ Pipe IcebergMetadata::executeCommand(
                 "To allow its usage, enable setting allow_iceberg_remove_orphan_files");
         }
 
+        checkTableRootIsQueriedPath("remove_orphan_files");
         return Iceberg::executeRemoveOrphanFiles(
             args, context, object_storage_, data_lake_settings, persistent_components);
     }
@@ -1499,6 +1527,7 @@ SinkToStoragePtr IcebergMetadata::write(
 {
     if (context->getSettingsRef()[Setting::allow_insert_into_iceberg])
     {
+        checkTableRootIsQueriedPath("INSERT");
         return std::make_shared<IcebergStorageSink>(object_storage, configuration, format_settings, sample_block, context, catalog, persistent_components, table_id);
     }
     else
@@ -1514,6 +1543,19 @@ void IcebergMetadata::drop(ContextPtr context)
 {
     if (context->getSettingsRef()[Setting::iceberg_delete_data_on_drop].value)
     {
+        /// Skipped rather than refused: this runs after the table is already marked as dropped, so
+        /// throwing here only makes `DatabaseCatalog` retry the drop forever.
+        if (persistent_components.table_root_was_derived)
+        {
+            LOG_WARNING(
+                log,
+                "Keeping the data of the Iceberg table at '{}': it is below the queried path '{}', which also covers "
+                "other tables. Drop it while querying the table directory itself to delete the data.",
+                persistent_components.path_resolver.getTableRoot(),
+                persistent_components.table_path);
+            return;
+        }
+
         auto files = listFiles(*object_storage, persistent_components.table_path, persistent_components.table_path, "");
         for (const auto & file : files)
             object_storage->removeObjectIfExists(StoredObject(file));
@@ -1603,7 +1645,9 @@ DataLakeMetadataPtr IcebergMetadata::createWithDeserialization(
             table_location,
             standard_persistent_components.table_path,
             configuration_ptr->getTypeName(),
-            configuration_ptr->getNamespace())};
+            configuration_ptr->getNamespace()),
+        /// Consistent with the resolver above, which is rooted at `table_path` itself.
+        .table_root_was_derived = false};
     auto metadata = std::make_unique<IcebergMetadata>(object_storage, configuration.lock(), std::move(deserialized_persistent_components), local_context);
     return metadata;
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -219,6 +219,10 @@ private:
     getRelevantDataSnapshotFromTableStateSnapshot(Iceberg::TableStateSnapshot table_state_snapshot, ContextPtr local_context) const;
     StorageObjectStorageConfigurationPtr getConfiguration() const;
 
+    /// Refuse `operation` while the table root is deeper than the queried path, because anything
+    /// scoped to the queried path reaches beyond this table there.
+    void checkTableRootIsQueriedPath(std::string_view operation) const;
+
     LoggerPtr log;
     const ObjectStoragePtr object_storage;
     const DB::Iceberg::PersistentTableComponents persistent_components;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.cpp
@@ -46,11 +46,18 @@ IcebergPathResolver::TableRootDerivation IcebergPathResolver::deriveTableRoot(
     if (!is_descendant)
         return {queried_path, RootRelation::Unknown};
 
+    auto strip_leading_slash = [](std::string_view str) { return str.starts_with('/') ? str.substr(1) : str; };
+
     /// Adopt only when the declared location denotes that same directory, whatever its spelling.
-    auto location = trimTrailingSlashes(table_location);
-    const bool location_agrees = location == candidate
-        || (location.size() > candidate.size() && location.ends_with(candidate)
-            && location[location.size() - candidate.size() - 1] == '/');
+    /// A leading slash is outside the comparison: the storage path may be absolute while `location`
+    /// carries a URI authority, whose last character then sits where a separator would be.
+    auto location = strip_leading_slash(trimTrailingSlashes(table_location));
+    auto tail = strip_leading_slash(candidate);
+    if (tail.empty())
+        return {queried_path, RootRelation::Unknown};
+    const bool location_agrees = location == tail
+        || (location.size() > tail.size() && location.ends_with(tail)
+            && location[location.size() - tail.size() - 1] == '/');
     if (!location_agrees)
         return {queried_path, RootRelation::Unknown};
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.cpp
@@ -11,6 +11,52 @@ extern const int BAD_ARGUMENTS;
 namespace DB::Iceberg
 {
 
+namespace
+{
+std::string_view trimTrailingSlashes(std::string_view str)
+{
+    while (!str.empty() && str.back() == '/')
+        str.remove_suffix(1);
+    return str;
+}
+}
+
+IcebergPathResolver::TableRootDerivation IcebergPathResolver::deriveTableRoot(
+    const String & table_location, const String & queried_path, const String & metadata_file_key)
+{
+    static constexpr std::string_view metadata_dir = "/metadata/";
+
+    auto queried = trimTrailingSlashes(queried_path);
+    auto key = trimTrailingSlashes(metadata_file_key);
+
+    /// Only a document directly inside the table's own `metadata` directory names the table root.
+    auto metadata_dir_pos = key.rfind(metadata_dir);
+    if (metadata_dir_pos == std::string_view::npos
+        || key.find('/', metadata_dir_pos + metadata_dir.size()) != std::string_view::npos)
+        return {queried_path, RootRelation::Unknown};
+    auto candidate = key.substr(0, metadata_dir_pos);
+
+    if (candidate == queried)
+        return {queried_path, RootRelation::Same};
+
+    /// A component-aligned proper descendant; an empty queried path is the storage root.
+    const bool is_descendant = queried.empty()
+        ? !candidate.empty()
+        : candidate.size() > queried.size() && candidate.starts_with(queried) && candidate[queried.size()] == '/';
+    if (!is_descendant)
+        return {queried_path, RootRelation::Unknown};
+
+    /// Adopt only when the declared location denotes that same directory, whatever its spelling.
+    auto location = trimTrailingSlashes(table_location);
+    const bool location_agrees = location == candidate
+        || (location.size() > candidate.size() && location.ends_with(candidate)
+            && location[location.size() - candidate.size() - 1] == '/');
+    if (!location_agrees)
+        return {queried_path, RootRelation::Unknown};
+
+    return {String(candidate), RootRelation::AdoptedDescendant};
+}
+
 // This function is used to get the file path inside the directory which corresponds to Iceberg table from the full blob path which is written in manifest and metadata files.
 // For example, if the full blob path is s3://bucket/table_name/data/00000-1-1234567890.avro, the function will return table_name/data/00000-1-1234567890.avro
 // Common path should end with "<table_name>" or "<table_name>/".

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.cpp
@@ -48,16 +48,21 @@ IcebergPathResolver::TableRootDerivation IcebergPathResolver::deriveTableRoot(
 
     auto strip_leading_slash = [](std::string_view str) { return str.starts_with('/') ? str.substr(1) : str; };
 
-    /// Adopt only when the declared location denotes that same directory, whatever its spelling.
-    /// A leading slash is outside the comparison: the storage path may be absolute while `location`
-    /// carries a URI authority, whose last character then sits where a separator would be.
+    /// Adopt only when the declared location denotes that same directory. It may differ from the
+    /// storage path by a leading slash and by a `<scheme>://<authority>/` prefix, both of which
+    /// still name that directory; a prefix carrying a path component names a different one.
     auto location = strip_leading_slash(trimTrailingSlashes(table_location));
     auto tail = strip_leading_slash(candidate);
     if (tail.empty())
         return {queried_path, RootRelation::Unknown};
-    const bool location_agrees = location == tail
-        || (location.size() > tail.size() && location.ends_with(tail)
-            && location[location.size() - tail.size() - 1] == '/');
+    bool location_agrees = location == tail;
+    if (!location_agrees && location.size() > tail.size() && location.ends_with(tail)
+        && location[location.size() - tail.size() - 1] == '/')
+    {
+        auto prefix = location.substr(0, location.size() - tail.size());
+        auto scheme_end = prefix.find("://");
+        location_agrees = scheme_end != std::string_view::npos && prefix.find('/', scheme_end + 3) == prefix.size() - 1;
+    }
     if (!location_agrees)
         return {queried_path, RootRelation::Unknown};
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h
@@ -56,9 +56,32 @@ private:
 /// Converts Iceberg metadata paths to actual object storage paths.
 ///
 /// This is the ONLY way to go from a metadata path to a storage path.
+///
+/// `table_root` is the storage directory the metadata `location` field denotes. That is usually the
+/// queried path, but not when the queried path is an ancestor of it; `deriveTableRoot` tells which.
 class IcebergPathResolver
 {
 public:
+    /// What `deriveTableRoot` established about the queried path.
+    enum class RootRelation
+    {
+        Same,              /// The queried path is the table root.
+        AdoptedDescendant, /// The table root is a proper descendant of the queried path.
+        Unknown,           /// Not established; the queried path is used unchanged.
+    };
+
+    struct TableRootDerivation
+    {
+        String table_root;
+        RootRelation relation;
+    };
+
+    /// Locate the table root from where its metadata document actually sits, accepted only if the
+    /// location that document declares names the same directory. Returns `queried_path` unchanged
+    /// whenever the two cannot be shown to agree.
+    static TableRootDerivation
+    deriveTableRoot(const String & table_location, const String & queried_path, const String & metadata_file_key);
+
     IcebergPathResolver(String table_location_, String table_root_, String blob_storage_type_name_ = {}, String blob_storage_namespace_name_ = {})
         : table_location(std::move(table_location_))
         , table_root(std::move(table_root_))

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h
@@ -25,6 +25,9 @@ struct PersistentTableComponents
     const String table_path;
     const std::optional<String> table_uuid;
     const IcebergPathResolver path_resolver;
+    /// True when the resolver works against a table root deeper than `table_path`. Operations scoped
+    /// to `table_path` then reach outside this table, so they must refuse to run.
+    const bool table_root_was_derived;
 
     /// Invalidate cached metadata for this table under both keys we may have used to cache it
     /// (`table_path` and `table_uuid`).

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_path_resolver.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_path_resolver.cpp
@@ -37,14 +37,53 @@ TEST(IcebergDeriveTableRoot, AbsoluteStoragePath)
         "/warehouse/tbl/metadata/v2.metadata.json",
         "/warehouse/tbl", IcebergPathResolver::RootRelation::AdoptedDescendant});
 
-    /// The document sits somewhere other than where its own `location` says; the root is still the
-    /// directory it sits in, and it is still inside the queried path.
-    check({"moved document", "hdfs://h:9000/other/warehouse/tbl", "/warehouse",
-        "/warehouse/tbl/metadata/v2.metadata.json",
-        "/warehouse/tbl", IcebergPathResolver::RootRelation::AdoptedDescendant});
-
     /// The tail matches only mid-component, so the two paths name different directories.
     check({"tail is not component-aligned", "hdfs://h:9000/xwarehouse/tbl", "/warehouse",
+        "/warehouse/tbl/metadata/v2.metadata.json",
+        "/warehouse", IcebergPathResolver::RootRelation::Unknown});
+}
+
+/// Every spelling in which a backend names one directory: what `location` carries in front of the
+/// storage path is a scheme and an authority, which name a host rather than a directory.
+TEST(IcebergDeriveTableRoot, LocationDiffersOnlyByAuthority)
+{
+    check({"hdfs", "hdfs://host:9000/tbl/UUIDDIR", "/tbl", "/tbl/UUIDDIR/metadata/v2.metadata.json",
+        "/tbl/UUIDDIR", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    check({"abfss", "abfss://container@account.dfs.core.windows.net/tbl/UUIDDIR", "tbl",
+        "tbl/UUIDDIR/metadata/v2.metadata.json",
+        "tbl/UUIDDIR", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    check({"virtual-hosted s3", "https://mybucket.s3.amazonaws.com/tbl/UUIDDIR", "tbl",
+        "tbl/UUIDDIR/metadata/v2.metadata.json",
+        "tbl/UUIDDIR", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    check({"no scheme", "/tbl/UUIDDIR", "tbl", "tbl/UUIDDIR/metadata/v2.metadata.json",
+        "tbl/UUIDDIR", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    check({"s3", "s3://warehouse/tbl/UUIDDIR", "tbl", "tbl/UUIDDIR/metadata/v2.metadata.json",
+        "tbl/UUIDDIR", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    /// A Spark warehouse of many tables, queried at the warehouse instead of at one table.
+    check({"spark warehouse", "s3a://spark-bucket/warehouse/db/spark_table", "warehouse",
+        "warehouse/db/spark_table/metadata/v2.metadata.json",
+        "warehouse/db/spark_table", IcebergPathResolver::RootRelation::AdoptedDescendant});
+}
+
+/// `location` ending with the document's own directory is a coincidence once a directory of its own
+/// precedes it: the table then lives under a different prefix, and the queried path, which does
+/// hold the document, stays the root that every file already resolves against.
+TEST(IcebergDeriveTableRoot, LocationHasUnmatchedPathComponent)
+{
+    check({"stale copied location", "s3://old/backup/warehouse/db/t", "warehouse",
+        "warehouse/db/t/metadata/v2.metadata.json",
+        "warehouse", IcebergPathResolver::RootRelation::Unknown});
+
+    check({"no scheme", "/backup/warehouse/db/t", "warehouse",
+        "warehouse/db/t/metadata/v2.metadata.json",
+        "warehouse", IcebergPathResolver::RootRelation::Unknown});
+
+    check({"absolute storage path", "hdfs://h:9000/other/warehouse/tbl", "/warehouse",
         "/warehouse/tbl/metadata/v2.metadata.json",
         "/warehouse", IcebergPathResolver::RootRelation::Unknown});
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_path_resolver.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_path_resolver.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h>
+
+using namespace DB;
+using Iceberg::IcebergPathResolver;
+
+namespace
+{
+
+struct DeriveTableRootCase
+{
+    std::string_view name;
+    String table_location;
+    String queried_path;
+    String metadata_file_key;
+    String expected_table_root;
+    IcebergPathResolver::RootRelation expected_relation;
+};
+
+void check(const DeriveTableRootCase & test_case)
+{
+    auto derivation = IcebergPathResolver::deriveTableRoot(
+        test_case.table_location, test_case.queried_path, test_case.metadata_file_key);
+    EXPECT_EQ(derivation.table_root, test_case.expected_table_root) << test_case.name;
+    EXPECT_EQ(static_cast<int>(derivation.relation), static_cast<int>(test_case.expected_relation)) << test_case.name;
+}
+
+}
+
+/// A storage path is absolute on some backends (HDFS always makes it so) while the `location` the
+/// document declares carries a URI authority. The character preceding the shared tail is then part
+/// of the authority rather than a path separator, so the two spellings still denote one directory.
+TEST(IcebergDeriveTableRoot, AbsoluteStoragePath)
+{
+    check({"authority location", "hdfs://hdfs1:9000/warehouse/tbl", "/warehouse",
+        "/warehouse/tbl/metadata/v2.metadata.json",
+        "/warehouse/tbl", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    /// The document sits somewhere other than where its own `location` says; the root is still the
+    /// directory it sits in, and it is still inside the queried path.
+    check({"moved document", "hdfs://h:9000/other/warehouse/tbl", "/warehouse",
+        "/warehouse/tbl/metadata/v2.metadata.json",
+        "/warehouse/tbl", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    /// The tail matches only mid-component, so the two paths name different directories.
+    check({"tail is not component-aligned", "hdfs://h:9000/xwarehouse/tbl", "/warehouse",
+        "/warehouse/tbl/metadata/v2.metadata.json",
+        "/warehouse", IcebergPathResolver::RootRelation::Unknown});
+}
+
+TEST(IcebergDeriveTableRoot, RelativeStoragePath)
+{
+    check({"uri location", "s3://test/dir/t1/sub", "dir/t1", "dir/t1/sub/metadata/v2.metadata.json",
+        "dir/t1/sub", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    check({"absolute location", "/dir/t1/sub", "dir/t1", "dir/t1/sub/metadata/v2.metadata.json",
+        "dir/t1/sub", IcebergPathResolver::RootRelation::AdoptedDescendant});
+
+    /// `location` names the queried path itself, so it contradicts the document's position and
+    /// neither source can be trusted over the other.
+    check({"location shallower than the document", "/dir/t4", "dir/t4",
+        "dir/t4/archive/metadata/v2.metadata.json",
+        "dir/t4", IcebergPathResolver::RootRelation::Unknown});
+
+    check({"document at the queried path", "/dir/t3/sub", "dir/t3", "dir/t3/metadata/v2.metadata.json",
+        "dir/t3", IcebergPathResolver::RootRelation::Same});
+
+    check({"no location", "", "dir/t1", "dir/t1/sub/metadata/v2.metadata.json",
+        "dir/t1", IcebergPathResolver::RootRelation::Unknown});
+}
+
+/// The storage root is not a table root: comparing the two empty tails would otherwise agree.
+TEST(IcebergDeriveTableRoot, EmptyTailIsNotARoot)
+{
+    check({"storage root", "", "", "//metadata/v2.metadata.json",
+        "", IcebergPathResolver::RootRelation::Unknown});
+}

--- a/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.reference
+++ b/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.reference
@@ -1,0 +1,7 @@
+A control  [1,2,3]
+B absolute [1,2,3]
+C full-uri [1,2,3]
+D kept     [7,8]
+E refused  NOT_IMPLEMENTED
+G kept     [5,6]
+G write    OK

--- a/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.reference
+++ b/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.reference
@@ -2,6 +2,12 @@ A control  [1,2,3]
 B absolute [1,2,3]
 C full-uri [1,2,3]
 D kept     [7,8]
-E refused  NOT_IMPLEMENTED
-G kept     [5,6]
-G write    OK
+E insert   NOT_IMPLEMENTED
+F alter    NOT_IMPLEMENTED
+G mutation NOT_IMPLEMENTED
+H optimize NOT_IMPLEMENTED
+I manifest NOT_IMPLEMENTED
+J expire   NOT_IMPLEMENTED
+K orphans  NOT_IMPLEMENTED
+L kept     [5,6]
+M write    OK

--- a/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
+++ b/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
@@ -81,16 +81,40 @@ echo -n 'D kept     '
 ${CLICKHOUSE_CLIENT} $NC -q "
     SELECT groupArray(x) FROM (SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t3') ORDER BY x)"
 
-# Writing to a table whose root had to be derived is refused: everything scoped to the queried
-# path would reach the sibling tables under it.
+# Every operation scoped to the queried path would reach the sibling tables under it, so all of
+# them are refused while the table root had to be derived. One arm per refusing site.
 ${CLICKHOUSE_CLIENT} $NC -q "
     DROP TABLE IF EXISTS t1_deep_05048;
     CREATE TABLE t1_deep_05048 ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t1')
     SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json';
 "
-echo -n 'E refused  '
+echo -n 'E insert   '
 ${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 -q "
     INSERT INTO t1_deep_05048 VALUES (9, 'z')" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
+
+echo -n 'F alter    '
+${CLICKHOUSE_CLIENT} $NC -q "
+    ALTER TABLE t1_deep_05048 ADD COLUMN y UInt8" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
+
+echo -n 'G mutation '
+${CLICKHOUSE_CLIENT} $NC -q "
+    ALTER TABLE t1_deep_05048 DELETE WHERE x = 1" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
+
+echo -n 'H optimize '
+${CLICKHOUSE_CLIENT} $NC -q "
+    OPTIMIZE TABLE t1_deep_05048" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
+
+echo -n 'I manifest '
+${CLICKHOUSE_CLIENT} $NC -q "
+    OPTIMIZE TABLE t1_deep_05048 MANIFEST" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
+
+echo -n 'J expire   '
+${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 --allow_experimental_expire_snapshots 1 -q "
+    ALTER TABLE t1_deep_05048 EXECUTE expire_snapshots()" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
+
+echo -n 'K orphans  '
+${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 --allow_iceberg_remove_orphan_files 1 -q "
+    ALTER TABLE t1_deep_05048 EXECUTE remove_orphan_files()" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
 
 # t4: the document is deeper, but `location` still names the queried path, so the two sources
 # disagree and the table root must NOT be derived. Reads and writes stay as they are.
@@ -107,7 +131,7 @@ ${CLICKHOUSE_CLIENT} -q "
     SELECT * FROM s3(s3_conn, filename='${DIR}/t4/metadata/v2.metadata.json', structure='line String', format='LineAsString')
 "
 
-echo -n 'G kept     '
+echo -n 'L kept     '
 ${CLICKHOUSE_CLIENT} $NC -q "
     SELECT groupArray(x) FROM (
         SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t4',
@@ -118,7 +142,7 @@ ${CLICKHOUSE_CLIENT} $NC -q "
     CREATE TABLE t4_arch_05048 ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t4')
     SETTINGS iceberg_metadata_file_path = 'archive/metadata/v2.metadata.json';
 "
-echo -n 'G write    '
+echo -n 'M write    '
 if ${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 -q "
     INSERT INTO t4_arch_05048 VALUES (99, 'ok')" > /dev/null 2>&1
 then

--- a/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
+++ b/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Reproduces https://github.com/ClickHouse/ClickHouse/issues/116985
+# Reading an Iceberg table through a path that is an ancestor of the table directory, with the
+# metadata document named by iceberg_metadata_file_path, resolved every data path against the
+# queried path and so dropped the intermediate directories from every key.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+DIR="05048_iceberg_deeper/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+# The Iceberg metadata files cache would serve the copy read while the table was created.
+NC="--use_iceberg_metadata_files_cache 0"
+
+# t1: metadata `location` is an absolute path (the default).
+${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
+    DROP TABLE IF EXISTS t1_05048;
+    CREATE TABLE t1_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t1/sub');
+    INSERT INTO t1_05048 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    DROP TABLE t1_05048;
+"
+
+echo -n 'A control  '
+${CLICKHOUSE_CLIENT} $NC -q "
+    SELECT groupArray(x) FROM (SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t1/sub') ORDER BY x)"
+
+echo -n 'B absolute '
+${CLICKHOUSE_CLIENT} $NC -q "
+    SELECT groupArray(x) FROM (
+        SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t1',
+            SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json') ORDER BY x)"
+
+# t2: metadata `location` is a full URI.
+${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 --write_full_path_in_iceberg_metadata 1 -q "
+    DROP TABLE IF EXISTS t2_05048;
+    CREATE TABLE t2_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t2/sub');
+    INSERT INTO t2_05048 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    DROP TABLE t2_05048;
+"
+
+echo -n 'C full-uri '
+${CLICKHOUSE_CLIENT} $NC -q "
+    SELECT groupArray(x) FROM (
+        SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t2',
+            SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json') ORDER BY x)"
+
+# t3: `location` names a directory DEEPER than the one the metadata document sits in, so the
+# document's own position is the only sound source for the table root. Re-rooting at the queried
+# path must be kept here.
+${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
+    DROP TABLE IF EXISTS t3_05048;
+    CREATE TABLE t3_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t3');
+    INSERT INTO t3_05048 VALUES (7, 'd'), (8, 'e');
+    DROP TABLE t3_05048;
+"
+# input_format_parallel_parsing=0: the metadata file is pretty-printed and parallel parsing
+# returns its lines out of order, which breaks the json.load below.
+${CLICKHOUSE_CLIENT} --input_format_parallel_parsing 0 --output_format_parallel_formatting 0 -q "
+    SELECT * FROM s3(s3_conn, filename='${DIR}/t3/metadata/v2.metadata.json', structure='line String', format='LineAsString')
+" | python3 -c "
+import json, sys
+m = json.load(sys.stdin)
+old = m['location'].rstrip('/')
+new = old + '/sub'
+m['location'] = new
+for s in m.get('snapshots', []):
+    ml = s['manifest-list']
+    for prefix in [old + '/', old]:
+        if ml.startswith(prefix):
+            s['manifest-list'] = new + '/' + ml[len(prefix):].lstrip('/')
+            break
+print(json.dumps(m))
+" | ${CLICKHOUSE_CLIENT} -q "
+    INSERT INTO FUNCTION s3(s3_conn, filename='${DIR}/t3/metadata/v2.metadata.json', structure='line String', format='LineAsString')
+    SETTINGS s3_truncate_on_insert=1
+    SELECT * FROM input('line String') FORMAT LineAsString
+"
+
+echo -n 'D kept     '
+${CLICKHOUSE_CLIENT} $NC -q "
+    SELECT groupArray(x) FROM (SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t3') ORDER BY x)"
+
+# Writing to a table whose root had to be derived is refused: everything scoped to the queried
+# path would reach the sibling tables under it.
+${CLICKHOUSE_CLIENT} $NC -q "
+    DROP TABLE IF EXISTS t1_deep_05048;
+    CREATE TABLE t1_deep_05048 ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t1')
+    SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json';
+"
+echo -n 'E refused  '
+${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 -q "
+    INSERT INTO t1_deep_05048 VALUES (9, 'z')" 2>&1 | grep -o "NOT_IMPLEMENTED" | head -1
+
+# t4: the document is deeper, but `location` still names the queried path, so the two sources
+# disagree and the table root must NOT be derived. Reads and writes stay as they are.
+${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
+    DROP TABLE IF EXISTS t4_05048;
+    CREATE TABLE t4_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t4');
+    INSERT INTO t4_05048 VALUES (5, 'g'), (6, 'h');
+    DROP TABLE t4_05048;
+"
+# A plain copy of the document one level down, with no edit, so `location` is left alone.
+${CLICKHOUSE_CLIENT} -q "
+    INSERT INTO FUNCTION s3(s3_conn, filename='${DIR}/t4/archive/metadata/v2.metadata.json', structure='line String', format='LineAsString')
+    SETTINGS s3_truncate_on_insert=1, input_format_parallel_parsing=0, output_format_parallel_formatting=0
+    SELECT * FROM s3(s3_conn, filename='${DIR}/t4/metadata/v2.metadata.json', structure='line String', format='LineAsString')
+"
+
+echo -n 'G kept     '
+${CLICKHOUSE_CLIENT} $NC -q "
+    SELECT groupArray(x) FROM (
+        SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t4',
+            SETTINGS iceberg_metadata_file_path = 'archive/metadata/v2.metadata.json') ORDER BY x)"
+
+${CLICKHOUSE_CLIENT} $NC -q "
+    DROP TABLE IF EXISTS t4_arch_05048;
+    CREATE TABLE t4_arch_05048 ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t4')
+    SETTINGS iceberg_metadata_file_path = 'archive/metadata/v2.metadata.json';
+"
+echo -n 'G write    '
+if ${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 -q "
+    INSERT INTO t4_arch_05048 VALUES (99, 'ok')" > /dev/null 2>&1
+then
+    echo 'OK'
+else
+    echo 'REFUSED'
+fi
+
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t1_deep_05048;
+    DROP TABLE IF EXISTS t4_arch_05048;
+"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/116985
Related: https://github.com/ClickHouse/ClickHouse/pull/109071

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a 404 (`S3_ERROR`) when reading an Iceberg table through a path that is a parent of the table directory, with the metadata document named by the `iceberg_metadata_file_path` setting: every data and manifest key was resolved against the queried path, so the directories between it and the table were dropped from the key. Writes and maintenance operations on such a table are now refused instead of acting outside the table.


### Description

Reads through a path shallower than the table's own directory failed with
`Code: 499 ... HTTP response code: 404: while reading tbl/data/data-<uuid>.parquet`.

`IcebergPathResolver` is built from the metadata `location` field and the queried path, and
`resolve` re-roots each metadata path from the first onto the second, sound only when both name the
same directory. `iceberg_metadata_file_path` lets the queried path be a parent of the table
directory, and the re-rooting then deletes the components in between: `location`
`s3://warehouse/tbl/UUIDDIR` queried as `tbl` gives `tbl/data/data-<uuid>.parquet`. The condition
that rejected this was swapped for a component-boundary check in #99935 (26.4). Both spellings reach
that branch, so `write_full_path_in_iceberg_metadata` is not involved.

The resolver now gets the table's root directory, derived from where the metadata document sits
(`<root>/metadata/<file>`) and adopted only if `location` names that directory, differing at most by
a leading slash and a `<scheme>://<authority>/` prefix. Today's mapping is kept whenever the two
cannot be shown to agree, so the ordinary layout is unaffected. `resolve` is untouched and fixed
through its single construction site. The derived root is the queried path plus one or more
components, so re-rooted paths cannot leave it; `system.iceberg_metadata_log.table_path` reports it.

`INSERT`, `ALTER`, mutations, `OPTIMIZE`, `expire_snapshots` and `remove_orphan_files` are refused
while the root had to be derived, since they are scoped to the queried path and would reach the
sibling tables under it. `DROP` warns and keeps the data rather than throwing, which would only make
the catalog retry forever. Reads 404 today in this state, so no working setup is refused.

New test `05048_iceberg_metadata_deeper_than_table_path` fails on master (9 of 13 arms) and passes
here; `deriveTableRoot` also gets a gtest matrix. Restoring the removed `ends_with` condition is not
an option: it would reject the cross-bucket layout that `04034_iceberg_spark_style_location` pins,
which stays green here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117037&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117037](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117037+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.457` (included in `26.9` and later)
- Backported to: `26.8.2.6`, `26.7.6.55`, `26.6.5.20`
<!-- ch-version-info:end -->