### PR TITLE
Report what the per-arch Bugfix validation jobs actually said

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -129,8 +129,10 @@ def per_arch_validation_states():
 
 
 def describe_per_arch_validation(states):
-    """Render the observed per-arch state, one line per job, with the job's own
-    `info` when it has one. The `info` is what tells apart a `SKIPPED` that
+    """Render the observed per-arch state, one line per job, with the reason the job
+    recorded for itself: its own `info`, then every note attached to it. A job dropped
+    behind a failed dependency carries an empty `info` and names the upstream job that
+    failed in a note instead. The `info` is what tells apart a `SKIPPED` that
     `filter_job` produced because this PR changed no test of that type from a
     `SKIPPED` the validator produced because the test still passed on master HEAD.
     """
@@ -141,7 +143,16 @@ def describe_per_arch_validation(states):
         )
     lines = ["Bugfix validation as seen by this check:"]
     for sub in states:
-        reason = " | ".join(part.strip() for part in sub.info.splitlines() if part.strip())
+        recorded = [sub.info] + [
+            str(note.get("message", ""))
+            for note in ((sub.ext or {}).get("notes") or [])
+        ]
+        reason = " | ".join(
+            part.strip()
+            for chunk in recorded
+            for part in chunk.splitlines()
+            if part.strip()
+        )
         lines.append(f"  {sub.name}: {sub.status}" + (f" ({reason})" if reason else ""))
     return "\n".join(lines)
 

--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -141,16 +141,17 @@ def describe_per_arch_validation(states):
         )
     lines = ["Bugfix validation as seen by this check:"]
     for sub in states:
-        lines.append(
-            f"  {sub.name}: {sub.status}" + (f" ({sub.info})" if sub.info else "")
-        )
+        reason = " | ".join(part.strip() for part in sub.info.splitlines() if part.strip())
+        lines.append(f"  {sub.name}: {sub.status}" + (f" ({reason})" if reason else ""))
     return "\n".join(lines)
 
 
 def any_bugfix_validation_passed(states=None):
     """Return True iff at least one per-arch Bugfix Validation job reported a
-    success status: OK or XFAIL, i.e. `Result.is_success` rather than `Result.is_ok`,
-    which would also accept `SKIPPED`.
+    success status: `OK` or `XFAIL`, i.e. `Result.is_success` rather than `Result.is_ok`,
+    which would also accept `SKIPPED`. A job that `filter_job` skipped because the
+    corresponding test type wasn't changed has no opinion on whether the bug was
+    validated, so `SKIPPED` cannot count as a pass.
     """
     if states is None:
         states = per_arch_validation_states()

--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -101,14 +101,14 @@ _BUGFIX_VALIDATE_PER_ARCH_JOB_NAMES = (
 )
 
 
-def any_bugfix_validation_passed():
-    """Return True iff at least one per-arch Bugfix Validation job in the
-    current workflow result reported a success status (OK / XFAIL).
+def per_arch_validation_states():
+    """Return the per-arch Bugfix Validation sub-results of the current workflow
+    result, in report order. Empty when none is present or the file is unreadable.
 
-    SKIPPED jobs do NOT count as a pass: a job that filter_job skipped
-    because the corresponding test type wasn't changed has no opinion on
-    whether the bug was validated. We use `is_success()` (strict - OK or
-    XFAIL only) rather than `is_ok()` (which treats SKIPPED as OK).
+    This is the snapshot as this post-hook sees it, which is not necessarily a job's
+    final status: `_finish_workflow` runs the post-hooks before it reconciles jobs
+    that GitHub has not completed, so a job read here as `PENDING` can end up
+    `ERROR` in the published report.
     """
     info = Info()
     try:
@@ -120,24 +120,43 @@ def any_bugfix_validation_passed():
             f"WARNING: failed to read workflow result for "
             f"[{info.workflow_name}]: {e}"
         )
-        return False
-    matched = []
-    passed = []
-    for sub in workflow_result.results:
-        if sub.name in _BUGFIX_VALIDATE_PER_ARCH_JOB_NAMES:
-            matched.append((sub.name, sub.status))
-            if sub.is_success():
-                passed.append(sub.name)
-    if matched:
-        print(
-            f"Bugfix validation per-arch jobs: {matched} - "
-            f"passed: {passed if passed else 'none'}"
+        return []
+    return [
+        sub
+        for sub in workflow_result.results
+        if sub.name in _BUGFIX_VALIDATE_PER_ARCH_JOB_NAMES
+    ]
+
+
+def describe_per_arch_validation(states):
+    """Render the observed per-arch state, one line per job, with the job's own
+    `info` when it has one. The `info` is what tells apart a `SKIPPED` that
+    `filter_job` produced because this PR changed no test of that type from a
+    `SKIPPED` the validator produced because the test still passed on master HEAD.
+    """
+    if not states:
+        return (
+            "No per-arch Bugfix validation job is present in the workflow result "
+            "as seen by this check."
         )
-    else:
-        print(
-            "WARNING: no Bugfix Validation per-arch jobs found in workflow "
-            "result - were they all filtered/skipped?"
+    lines = ["Bugfix validation as seen by this check:"]
+    for sub in states:
+        lines.append(
+            f"  {sub.name}: {sub.status}" + (f" ({sub.info})" if sub.info else "")
         )
+    return "\n".join(lines)
+
+
+def any_bugfix_validation_passed(states=None):
+    """Return True iff at least one per-arch Bugfix Validation job reported a
+    success status: OK or XFAIL, i.e. `Result.is_success` rather than `Result.is_ok`,
+    which would also accept `SKIPPED`.
+    """
+    if states is None:
+        states = per_arch_validation_states()
+    passed = [sub.name for sub in states if sub.is_success()]
+    if passed:
+        print(f"Bugfix validation passed on: {passed}")
     return bool(passed)
 
 
@@ -197,16 +216,16 @@ def check():
     # HEAD and is fixed on the PR). The presence of an additional unit
     # test alongside FT/IT does not relax this requirement either.
     if has_ft or has_it:
-        if any_bugfix_validation_passed():
+        states = per_arch_validation_states()
+        if any_bugfix_validation_passed(states):
             print(
                 "At least one per-arch Bugfix Validation job validated the bug - pass"
             )
             return True
+        print(describe_per_arch_validation(states))
         print(
-            "No per-arch Bugfix Validation job validated the bug - the test "
-            "either passes on master HEAD on every arch (so it's not actually "
-            "a regression test for the fix) or every arch errored out. See "
-            "the per-arch Bugfix validation jobs in the report."
+            "A bug fix is validated when at least one per-arch Bugfix validation "
+            "job reports OK or XFAIL; none did."
         )
         return False
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/113515
Related: https://github.com/ClickHouse/ClickHouse/pull/112978
Related: https://github.com/ClickHouse/ClickHouse/pull/116990
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

When no per-arch `Bugfix validation` job reports `OK` or `XFAIL`, the `new_tests_check`
post-hook blocks the merge with a hard-coded guess: *"the test either passes on master HEAD
on every arch ... or every arch errored out"*. It measured neither: the hook builds the
per-arch state, prints it, discards it, then asserts a cause.
One instance, PR 113515 @ `e486b57f`:
[CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113515&sha=e486b57f75f490d5c771f3225c96e4d7a16034e4&name_0=PR&name_1=Finish%20Workflow).

Measured 2026-08-29 over 30 days: 934 heads, 477 pull requests. Neither branch happened on
the dominant states: 2066 per-arch slots were `DROPPED` and 1598 `SKIPPED`, mostly by
`filter_job`. Only 6 were `FAIL` or `ERROR`. A callable post-hook's stdout becomes the
sub-result `info`, so the guess is the gate's entire user-visible output: an author with a
working regression test is told it is not one.

The gate is unchanged; the guess is replaced by the state the hook already holds: one line per job,
its status, and the reason it recorded. For `SKIPPED` that is the job's `info`, which separates
a `filter_job` skip from a validator reporting no repro, the one case the old sentence got
right. For the dominant `DROPPED` praktika records it in a note instead (`hook_html.py` builds
the dropped job with no `info`, then `add_note`), so the message reads both, naming the
upstream job that failed.

The merge rule is preserved verbatim (`ci/defs/job_configs.py:757`: pass iff at least one
per-arch job is `OK`/`XFAIL`). The verdict is byte-identical on all 934 heads plus 11
out-of-population ones, and the message infers no cause: it prints the status praktika
recorded.

Two questions for CI owners:

1. Should a validator that never ran block a bug-fix PR? This reports it distinctly;
   non-gating is a policy call.
2. Post-hooks run before praktika reconciles jobs GitHub has not completed, so this reads
   a pre-reconciliation snapshot. Reordering is worth 1 head in 30 days: follow-up?

<details>
<summary>Measurements (934 real heads / 477 PRs, 30 days, as of 2026-08-29)</summary>

| arm | master | with this change |
|---|---|---|
| heads asserting the unmeasured cause | 934/934 | 0/934 |
| recorded reason surfaced (out-of-population heads) | 12 missing | 0 missing |
| `check` verdict vs baseline | (baseline) | 0/945 moved |
| output for a 4-job head | 1 line | exactly one line per job, nothing elided |

Per-arch slots observed over those heads: `DROPPED` 2066, `SKIPPED` 1598, `PENDING` 59,
`RUNNING` 7, `FAIL` 4, `ERROR` 2.

Negative controls, each moving only its own assertion: reverting the message re-fails 934/934;
dropping `info` from the render fails only the reason assertion; dropping the note channel
fails only the arms that read a real dropped job; rendering notes on their own lines fails the
line-count arms; making `SKIPPED` count as a pass turns 6 rows of
`ci/tests/test_new_tests_check.py` red and moves 746/945 verdicts, which is what makes the
unchanged-verdict result meaningful.

All 24 rows of `ci/tests/test_new_tests_check.py` and
`ci/tests/test_new_tests_check_unit_gate.py` pass unmodified. No new row there: PR 115650
removes `ci/tests/` wholesale, so the population replay above is the oracle instead.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117038&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117038](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117038+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.336` (included in `26.9` and later)
<!-- ch-version-info:end -->