### PR TITLE
Fix `Not-ready Set` when a one-block system table filters on an `IN` subquery

### DIFF
--- a/src/Storages/System/IStorageSystemOneBlock.cpp
+++ b/src/Storages/System/IStorageSystemOneBlock.cpp
@@ -167,6 +167,8 @@ void ReadFromSystemOneBlock::initializePipeline(QueryPipelineBuilder & pipeline,
 {
     auto sample_block = getOutputHeader();
 
+    storage->checkAccessRights(context);
+
     if (filter && dagHasUnbuiltSubquerySet(*filter))
     {
         /// `CreatingSetsStep` holds back every output of this pipeline until it has filled the sets, so

--- a/src/Storages/System/IStorageSystemOneBlock.cpp
+++ b/src/Storages/System/IStorageSystemOneBlock.cpp
@@ -3,19 +3,102 @@
 // #include <DataTypes/DataTypeString.h>
 // #include <Storages/ColumnsDescription.h>
 // #include <Storages/IStorage.h>
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnSet.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
+#include <Functions/IFunctionAdaptors.h>
+#include <Functions/indexHint.h>
+#include <Interpreters/PreparedSets.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/System/getQueriedColumnsMaskAndHeader.h>
 #include <Storages/VirtualColumnUtils.h>
+#include <Processors/ISource.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 
+#include <functional>
+
 namespace DB
 {
+
+namespace
+{
+
+/// A subquery set is only filled by `CreatingSetsStep`, which runs after the pipeline starts; sets of
+/// every other kind are ready as soon as they are constructed.
+bool dagHasUnbuiltSubquerySet(const ActionsDAG & dag)
+{
+    for (const auto & node : dag.getNodes())
+    {
+        if (node.type == ActionsDAG::ActionType::COLUMN)
+        {
+            const ColumnSet * column_set = checkAndGetColumn<const ColumnSet>(&node.column->getDataColumn());
+            if (column_set)
+            {
+                auto future_set = column_set->getData();
+                if (!future_set->get() && typeid_cast<FutureSetFromSubquery *>(future_set.get()))
+                    return true;
+            }
+        }
+
+        /// `splitFilterNodeForAllowedInputs` keeps `indexHint` arguments, and their sets live in a
+        /// separate DAG that this one only references through the function object.
+        if (node.type == ActionsDAG::ActionType::FUNCTION && node.function_base)
+        {
+            if (const auto * adaptor = typeid_cast<const FunctionToFunctionBaseAdaptor *>(node.function_base.get()))
+                if (const auto * index_hint = typeid_cast<const FunctionIndexHint *>(adaptor->getFunction().get()))
+                    if (dagHasUnbuiltSubquerySet(index_hint->getActions()))
+                        return true;
+        }
+    }
+
+    return false;
+}
+
+class SystemOneBlockLazySource : public ISource
+{
+public:
+    using FillFunc = std::function<void(MutableColumns &, const ActionsDAG::Node *, std::vector<UInt8>)>;
+
+    SystemOneBlockLazySource(SharedHeader header_, FillFunc fill_, ActionsDAG filter_, std::vector<UInt8> columns_mask_)
+        : ISource(std::move(header_))
+        , fill(std::move(fill_))
+        , filter(std::move(filter_))
+        , columns_mask(std::move(columns_mask_))
+    {
+    }
+
+    String getName() const override { return "SystemOneBlockLazy"; }
+
+protected:
+    Chunk generate() override
+    {
+        if (generated)
+            return {};
+        generated = true;
+
+        MutableColumns res_columns = getPort().getHeader().cloneEmptyColumns();
+        fill(res_columns, filter.getOutputs().at(0), std::move(columns_mask));
+
+        UInt64 num_rows = res_columns.at(0)->size();
+        if (num_rows == 0)
+            return {};
+
+        return Chunk(std::move(res_columns), num_rows);
+    }
+
+private:
+    FillFunc fill;
+    ActionsDAG filter;
+    std::vector<UInt8> columns_mask;
+    bool generated = false;
+};
+
+}
 
 class ReadFromSystemOneBlock : public SourceStepWithFilter
 {
@@ -83,6 +166,20 @@ void IStorageSystemOneBlock::readImpl(
 void ReadFromSystemOneBlock::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
     auto sample_block = getOutputHeader();
+
+    if (filter && dagHasUnbuiltSubquerySet(*filter))
+    {
+        /// `CreatingSetsStep` holds back every output of this pipeline until it has filled the sets, so
+        /// a predicate that needs one of them can be evaluated from a source but not from here.
+        auto fill = [source_storage = storage, source_context = context](
+                        MutableColumns & columns, const ActionsDAG::Node * predicate, std::vector<UInt8> mask)
+        { source_storage->fillData(columns, source_context, predicate, std::move(mask)); };
+
+        pipeline.init(Pipe(std::make_shared<SystemOneBlockLazySource>(
+            sample_block, std::move(fill), std::move(*filter), std::move(columns_mask))));
+        return;
+    }
+
     MutableColumns res_columns = sample_block->cloneEmptyColumns();
     const ActionsDAG::Node * predicate = filter ? filter->getOutputs().at(0) : nullptr;
     storage->fillData(res_columns, context, predicate, std::move(columns_mask));
@@ -108,10 +205,6 @@ void ReadFromSystemOneBlock::applyFilters(ActionDAGNodes added_filter_nodes)
         return;
 
     filter = VirtualColumnUtils::splitFilterDagForAllowedInputs(filter_actions_dag->getOutputs().at(0), &sample, context);
-
-    /// Must prepare sets here, initializePipeline() would be too late, see comment on FutureSetFromSubquery.
-    if (filter)
-        VirtualColumnUtils::buildSetsForDAG(*filter, context);
 }
 
 VirtualColumnsDescription IStorageSystemOneBlock::createVirtuals()

--- a/src/Storages/System/IStorageSystemOneBlock.h
+++ b/src/Storages/System/IStorageSystemOneBlock.h
@@ -33,6 +33,11 @@ protected:
         return {};
     }
 
+    /// Access checks that must reject the query even when no row is ever read. `fillData` is not the
+    /// place for them: it can run lazily, and a consumer that closes the read port before asking for
+    /// a chunk (`LIMIT 0`) never enters it.
+    virtual void checkAccessRights(ContextPtr /*context*/) const {}
+
     virtual bool supportsColumnsMask() const { return false; }
 
     friend class ReadFromSystemOneBlock;

--- a/src/Storages/System/StorageSystemUsers.cpp
+++ b/src/Storages/System/StorageSystemUsers.cpp
@@ -290,12 +290,18 @@ ColumnsDescription StorageSystemUsers::getColumnsDescription()
 }
 
 
-void StorageSystemUsers::fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node * predicate, std::vector<UInt8>) const
+void StorageSystemUsers::checkAccessRights(ContextPtr context) const
 {
     /// If "select_from_system_db_requires_grant" is enabled the access rights were already checked in InterpreterSelectQuery.
     const auto & access_control = context->getAccessControl();
     if (!access_control.doesSelectFromSystemDatabaseRequireGrant())
         context->checkAccess(AccessType::SHOW_USERS);
+}
+
+
+void StorageSystemUsers::fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node * predicate, std::vector<UInt8>) const
+{
+    const auto & access_control = context->getAccessControl();
 
     size_t column_index = 0;
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);

--- a/src/Storages/System/StorageSystemUsers.h
+++ b/src/Storages/System/StorageSystemUsers.h
@@ -21,6 +21,7 @@ protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;
     void fillData(MutableColumns & res_columns, ContextPtr context, const ActionsDAG::Node * predicate, std::vector<UInt8>) const override;
     Block getFilterSampleBlock() const override;
+    void checkAccessRights(ContextPtr context) const override;
 };
 
 }

--- a/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
@@ -38,6 +38,24 @@ def reset_after_test():
         pass
 
 
+def test_system_users_with_unbuilt_subquery_set():
+    # An `IN` subquery set is filled only once the pipeline runs, so `system.users` produces its rows
+    # from a source instead of while the pipeline is built, and `LIMIT 0` closes that source's port
+    # before any chunk is requested. The grant is therefore not checked on the row-producing path.
+    expected_error = "necessary to have the grant SHOW USERS ON *.*"
+    queries = [
+        f"SELECT * FROM system.users WHERE name IN (SELECT toString(number) FROM numbers(3)){suffix}"
+        for suffix in ["", " LIMIT 1", " LIMIT 0", " LIMIT 0 OFFSET 5"]
+    ]
+
+    for query in queries:
+        assert expected_error in node.query_and_get_error(query, user="another"), query
+
+    node.query("GRANT SHOW USERS ON *.* TO sqluser")
+    for query in queries:
+        node.query(query, user="sqluser")
+
+
 def test_system_db():
     assert node.query("SELECT count()>0 FROM system.settings") == "1\n"
     assert node.query("SELECT count()>0 FROM system.users") == "1\n"

--- a/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.reference
+++ b/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.reference
@@ -1,7 +1,9 @@
 1
 0
-databases IN: 0
-mutations IN: 0
-iceberg_history IN: 0
-databases GLOBAL IN: 0
+rows read for one matching database: 2
+rows read for no matching database: 1
+databases IN: 0 ok
+mutations IN: 0 ok
+iceberg_history IN: 0 ok
+databases GLOBAL IN: 0 ok
 alive

--- a/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.reference
+++ b/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.reference
@@ -1,5 +1,7 @@
 1
 0
+set filled inside the pipeline: 1
+read waits for the set: 1
 rows read for one matching database: 2
 rows read for no matching database: 1
 databases IN: 0 ok

--- a/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.reference
+++ b/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.reference
@@ -1,0 +1,7 @@
+1
+0
+databases IN: 0
+mutations IN: 0
+iceberg_history IN: 0
+databases GLOBAL IN: 0
+alive

--- a/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
+++ b/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
@@ -38,9 +38,12 @@ BIG="(SELECT toString(number) FROM numbers(300000000))"
 
 # Report the client's exit status next to the count, so that a query failing for an unrelated reason
 # is distinguishable from one that succeeded.
+# The subquery has to keep reading until the time limit stops it, so the read limit must be lifted:
+# the functional-test profile caps reads at 20M rows, and a read limit, unlike a time limit, still
+# lets the set finish building.
 check() {
     local out="${CLICKHOUSE_TMP}/05048_${CLICKHOUSE_DATABASE}_$1_${3// /_}.out"
-    $CLICKHOUSE_CLIENT --max_execution_time 0.3 --timeout_overflow_mode break \
+    $CLICKHOUSE_CLIENT --max_rows_to_read 0 --max_execution_time 0.3 --timeout_overflow_mode break \
         --query "SELECT count() FROM system.$1 WHERE $2 $3 $BIG FORMAT Null" > "$out" 2>&1
     local rc=$?
     echo "$1 $3: $(grep -c -F 'Not-ready Set' "$out") $([ "$rc" -eq 0 ] && echo ok || echo "rc=$rc")"

--- a/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
+++ b/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
@@ -12,14 +12,39 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.databases WHERE name IN (SELECT 'system')"
 $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.databases WHERE name IN (SELECT '05048_no_such_database')"
 
+# `ReadFromSystemOneBlock` emits exactly the rows that `fillData` produces as a single chunk, so the
+# `read_rows` recorded in `system.query_log` is a reliable witness of how many rows the predicate left:
+# one row per matching database, plus the single row the subquery itself reads. An unpruned read would
+# instead scale with the number of databases on the server. (`max_rows_to_read` is intentionally not
+# used as the witness: it is not enforced for this single-chunk source.)
+read_rows() {
+    $CLICKHOUSE_CLIENT --query_id "$1" --ast_fuzzer_runs 0 --query "$2" > /dev/null
+    $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS query_log"
+    $CLICKHOUSE_CLIENT --query "
+        SELECT read_rows FROM system.query_log
+        WHERE query_id = '$1' AND type = 'QueryFinish' AND current_database = currentDatabase()
+        ORDER BY event_time_microseconds DESC LIMIT 1"
+}
+
+echo -n "rows read for one matching database: "
+read_rows "05048_prune_one_${CLICKHOUSE_DATABASE}" \
+    "SELECT name FROM system.databases WHERE name IN (SELECT '${CLICKHOUSE_DATABASE}') FORMAT Null"
+echo -n "rows read for no matching database: "
+read_rows "05048_prune_none_${CLICKHOUSE_DATABASE}" \
+    "SELECT name FROM system.databases WHERE name IN (SELECT '${CLICKHOUSE_DATABASE}_absent') FORMAT Null"
+
 # A subquery that a time limit stops in `break` mode leaves the set unbuilt and unbuildable.
 BIG="(SELECT toString(number) FROM numbers(300000000))"
 
+# Report the client's exit status next to the count, so that a query failing for an unrelated reason
+# is distinguishable from one that succeeded.
 check() {
-    echo -n "$1 $3: "
+    local out="${CLICKHOUSE_TMP}/05048_${CLICKHOUSE_DATABASE}_$1_${3// /_}.out"
     $CLICKHOUSE_CLIENT --max_execution_time 0.3 --timeout_overflow_mode break \
-        --query "SELECT count() FROM system.$1 WHERE $2 $3 $BIG FORMAT Null" 2>&1 \
-        | grep -c -F 'Not-ready Set' || true
+        --query "SELECT count() FROM system.$1 WHERE $2 $3 $BIG FORMAT Null" > "$out" 2>&1
+    local rc=$?
+    echo "$1 $3: $(grep -c -F 'Not-ready Set' "$out") $([ "$rc" -eq 0 ] && echo ok || echo "rc=$rc")"
+    rm -f "$out"
 }
 
 check databases       name     "IN"

--- a/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
+++ b/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# An `IN` subquery set is filled by `CreatingSetsStep`, which runs only once the pipeline runs, so a
+# one-block system table cannot apply a predicate holding one while its pipeline is still being built.
+
+# The set is unbuilt when the pipeline is built, so these go through the deferred path and must still
+# select exactly the matching rows.
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM system.databases WHERE name IN (SELECT 'system')"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM system.databases WHERE name IN (SELECT '05048_no_such_database')"
+
+# A subquery that a time limit stops in `break` mode leaves the set unbuilt and unbuildable.
+BIG="(SELECT toString(number) FROM numbers(300000000))"
+
+check() {
+    echo -n "$1 $3: "
+    $CLICKHOUSE_CLIENT --max_execution_time 0.3 --timeout_overflow_mode break \
+        --query "SELECT count() FROM system.$1 WHERE $2 $3 $BIG FORMAT Null" 2>&1 \
+        | grep -c -F 'Not-ready Set' || true
+}
+
+check databases       name     "IN"
+check mutations       database "IN"
+check iceberg_history database "IN"
+check databases       name     "GLOBAL IN"
+
+$CLICKHOUSE_CLIENT --query "SELECT 'alive'"

--- a/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
+++ b/tests/queries/0_stateless/05048_not_ready_set_system_table_prefilter.sh
@@ -26,6 +26,19 @@ read_rows() {
         ORDER BY event_time_microseconds DESC LIMIT 1"
 }
 
+# `ReadFromSystemOneBlock` reads behind the `CreatingSets` gate, so both processors are planned only
+# while the set is still unfilled when the pipeline is built. A build that filled it earlier would
+# plan neither, and would still return the same rows and prune the same way.
+explain_has() {
+    $CLICKHOUSE_CLIENT --query "
+        SELECT count() > 0 FROM (
+            EXPLAIN PIPELINE
+            SELECT name FROM system.databases WHERE name IN (SELECT '${CLICKHOUSE_DATABASE}')
+        ) WHERE explain ILIKE '%$1%'"
+}
+echo -n "set filled inside the pipeline: "; explain_has CreatingSetsTransform
+echo -n "read waits for the set: "; explain_has DelayedPorts
+
 echo -n "rows read for one matching database: "
 read_rows "05048_prune_one_${CLICKHOUSE_DATABASE}" \
     "SELECT name FROM system.databases WHERE name IN (SELECT '${CLICKHOUSE_DATABASE}') FORMAT Null"
@@ -38,9 +51,9 @@ BIG="(SELECT toString(number) FROM numbers(300000000))"
 
 # Report the client's exit status next to the count, so that a query failing for an unrelated reason
 # is distinguishable from one that succeeded.
-# The subquery has to keep reading until the time limit stops it, so the read limit must be lifted:
-# the functional-test profile caps reads at 20M rows, and a read limit, unlike a time limit, still
-# lets the set finish building.
+# The subquery has to keep reading until the time limit stops it, so `max_rows_to_read` must be
+# lifted: the functional-test profile caps it at 20M rows, and a read limit, unlike a time limit,
+# still lets the set finish building.
 check() {
     local out="${CLICKHOUSE_TMP}/05048_${CLICKHOUSE_DATABASE}_$1_${3// /_}.out"
     $CLICKHOUSE_CLIENT --max_rows_to_read 0 --max_execution_time 0.3 --timeout_overflow_mode break \


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108786#issuecomment-5460018708
Related: https://github.com/ClickHouse/ClickHouse/issues/92319
Related: https://github.com/ClickHouse/ClickHouse/issues/102803
Related: https://github.com/ClickHouse/ClickHouse/issues/115010
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the logical error `Not-ready Set is passed as the second argument for function 'in'` when a query filters a system table such as `system.databases`, `system.mutations` or `system.iceberg_history` on an `IN` subquery whose set could not be built ahead of time, for example because a time limit stopped it with `timeout_overflow_mode = 'break'`.

### Description

Reported on #108786 as the `BuzzHouse (arm_asan_ubsan)` variant of `STID 0250-4e52`, reached through `StorageSystemIcebergHistory` and `VirtualColumnUtils::filterBlockWithPredicate`. CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108786&sha=e15eeb0d00a56433a5c40057ddb5f62f091476f4&name_0=PR&name_1=BuzzHouse%20%28arm_asan_ubsan%29 . The same signature was auto-filed and closed three times: #92319, #102803, #115010. In a release build this is an exception; in debug and sanitizer builds a `LOGICAL_ERROR` aborts the server.

Root cause: `ReadFromSystemOneBlock::applyFilters` built the pre-filter's sets speculatively through `FutureSetFromSubquery::buildSetInplace`, which moves the subquery plan out and never checks that the set was actually created. When that in-place pipeline stops early the set is left unbuilt and unbuildable, no `CreatingSetStep` is created either, and `fillData` then evaluated the predicate during pipeline build, outside any cancellable region. Ordinary tables survive because their `FunctionIn` runs inside the pipeline, which the exceeded limit cancels first.

The fix evaluates that pre-filter from a source instead, so it runs once `CreatingSetsStep` has filled the sets, and drops the speculative build. The deferred path is taken only for a pre-filter holding a subquery set; every other predicate keeps the previous synchronous path unchanged. Only the 10 of 104 `IStorageSystemOneBlock` subclasses that override `getFilterSampleBlock` can reach it at all.

Deferring rather than skipping the filter is deliberate: `StorageSystemObjectStorageQueueMetadata` must not probe unrelated queues and `StorageSystemIcebergHistory` must not open remote connections. Measured after the change, the filter still prunes.

Deferring also moved `StorageSystemUsers`'s `SHOW USERS` check off the build path, where `LIMIT 0` skipped it when `select_from_system_db_requires_grant` is disabled. It now runs from an `IStorageSystemOneBlock::checkAccessRights` hook regardless of whether a row is pulled, covered by `test_disabled_access_control_improvements`.

Out of scope: `system.tables`, `system.columns` and `system.parts` reach the same logical error through their own read steps and filter lifecycles. I can extend this PR to those if you prefer one change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117039&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117039](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117039+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

