### PR TITLE
Assert the authentication refusal in test_mysqljs_client, and keep the client output

### DIFF
--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -1207,7 +1207,7 @@ def test_mysqljs_client(started_cluster, nodejs_container):
         ),
         demux=True,
     )
-    assert code == 1
+    assert code == 1, stderr
     assert (
         "MySQL is requesting the sha256_password authentication method, which is not supported."
         in stderr.decode()
@@ -1219,23 +1219,26 @@ def test_mysqljs_client(started_cluster, nodejs_container):
         ),
         demux=True,
     )
-    assert code == 0
+    assert code == 0, stderr
 
-    code, (_, _) = nodejs_container.exec_run(
+    code, (_, stderr) = nodejs_container.exec_run(
         "node test.js {host} {port} user_with_double_sha1 abacaba".format(
             host=started_cluster.get_instance_ip("node"), port=server_port
         ),
         demux=True,
     )
-    assert code == 0
+    assert code == 0, stderr
 
-    code, (_, _) = nodejs_container.exec_run(
+    code, (_, stderr) = nodejs_container.exec_run(
         "node test.js {host} {port} user_with_empty_password 123".format(
             host=started_cluster.get_instance_ip("node"), port=server_port
         ),
         demux=True,
     )
-    assert code == 1
+    assert code == 1, stderr
+    # An uncaught error anywhere in the client also exits 1, so the exit code alone
+    # does not tell a refused password from a client that never reached the server.
+    assert b"Authentication failed" in (stderr or b""), stderr
 
 
 def test_java_client_text(started_cluster, java_container):


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115004


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The last arm of `test_mysqljs_client` now asserts the server's authentication refusal, not only the client's exit status, and all four arms keep the client's stderr on failure.

### Description

`test_mysql_protocol/test.py::test_mysqljs_client` failed on #115004 with `assert 134 == 1` at its last arm ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115004&sha=c104f4fa83d41225807189bb6627249a24313ad2&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29)). 134 is 128 + 6: the node client died on SIGABRT, where the arm expects exit status 1.

No client output exists for that arm anywhere in the report, by construction: the two last arms were written `code, (_, _) = exec_run(..., demux=True)`, discarding both streams, and this function is the only one in `tests/integration` that discards a demux stream (4 of 53 `exec_run` sites). So the mechanism is not recoverable from that run, and I assert none. The retained server log does show the client never opened a socket: `MySQLHandlerFactory`'s connection ids are contiguous across the window, and the mysqljs container accounts for three connections against four `exec_run` calls. The server reported nothing, on an ASan+UBSan build.

So `assert code == 1` was never a statement about authentication: any uncaught client error exits 1. That argv pointed at a closed port, an unroutable address or the HTTP port exits 1 each time and satisfied it; with arm 4 pointed at a closed port the test passes on master.

This keeps the exact exit status and adds the missing oracle: the server's own refusal message from the MySQL `ERR` packet, so the arm tells a refused password from a client that never got there. All four arms now carry their stderr into the assertion message; arm 1 needed it too, its bare code assertion short-circuiting before the message assertion it has.

A recurrence becomes attributable, not impossible. Validated: 20/20 repetitions of the test, 24/24 of the module, and the closed-port case now fails with the client's output where master passes.

Noticed, not changed: the client image installs `mysql` unpinned; it resolves to 2.18.1, unchanged for 6.5 years, so a pin changes nothing here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117044&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117044](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117044+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.374` (included in `26.9` and later)
<!-- ch-version-info:end -->