### PR TITLE
Fix `sum(if(cond, 0, 1))` for `LowCardinality(Nullable)` conditions

### DIFF
--- a/src/Analyzer/Passes/SumIfToCountIfPass.cpp
+++ b/src/Analyzer/Passes/SumIfToCountIfPass.cpp
@@ -8,7 +8,7 @@
 #include <Analyzer/Utils.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/Context.h>
 
@@ -129,15 +129,9 @@ public:
             return;
         }
 
-        if (if_true_condition_value == 0 && !cond_argument->getResultType()->isNullable())
+        if (if_true_condition_value == 0 && !isNullableOrLowCardinalityNullable(cond_argument->getResultType()))
         {
-            /// Rewrite `sum(if(cond, 0, 1))` into `countIf(not(cond))` if condition is not Nullable (otherwise the result can be different).
-            DataTypePtr not_function_result_type = std::make_shared<DataTypeUInt8>();
-
-            const auto & condition_result_type = nested_if_function_arguments_nodes[0]->getResultType();
-            if (condition_result_type->isNullable())
-                not_function_result_type = makeNullable(not_function_result_type);
-
+            /// Rewrite `sum(if(cond, 0, 1))` into `countIf(not(cond))` only if the condition cannot be NULL
             auto not_function = std::make_shared<FunctionNode>("not");
             not_function->markAsOperator();
 
@@ -153,7 +147,7 @@ public:
 
             if (if_false_condition_value != 1)
             {
-                /// Rewrite `sum(if(cond, 0, 123))` into `123 * countIf(not(cond))` if condition is not Nullable (otherwise the result can be different).
+                /// Same NULL restriction as above.
                 node = getMultiplyFunction(nested_if_function_arguments_nodes[2], node);
             }
             return;

--- a/tests/queries/0_stateless/05048_sum_if_to_count_if_low_cardinality_nullable.reference
+++ b/tests/queries/0_stateless/05048_sum_if_to_count_if_low_cardinality_nullable.reference
@@ -1,0 +1,18 @@
+LowCardinality(Nullable(UInt8))
+-- LowCardinality(Nullable) condition: rewrite must not fire
+2
+10
+2
+10
+0
+-- Nullable condition: rewrite must not fire
+2
+2
+0
+-- Non-nullable condition: rewrite must still fire
+2
+1
+-- The un-negated direction agrees with `countIf` even for NULL conditions and must still be rewritten
+1
+1
+1

--- a/tests/queries/0_stateless/05048_sum_if_to_count_if_low_cardinality_nullable.sql
+++ b/tests/queries/0_stateless/05048_sum_if_to_count_if_low_cardinality_nullable.sql
@@ -1,0 +1,49 @@
+-- `optimize_rewrite_sum_if_to_count_if` rewrites `sum(if(cond, 0, 1))` into `countIf(not(cond))`.
+-- That rewrite is only valid when the condition cannot be NULL: `if` takes the else branch on a NULL
+-- condition and the row counts, while `not(NULL)` is NULL and `countIf` skips it.
+-- The guard used to ask the condition type `isNullable`, which is false for a `LowCardinality` wrapper,
+-- so the rewrite fired for `LowCardinality(Nullable(...))` conditions and undercounted.
+
+SET enable_analyzer = 1;
+SET optimize_rewrite_sum_if_to_count_if = 1;
+-- Isolate this pass: `optimize_rewrite_aggregate_function_with_if` can reach the same rewrite by another route.
+SET optimize_rewrite_aggregate_function_with_if = 0;
+
+DROP TABLE IF EXISTS t_sum_if_lc_nullable;
+
+CREATE TABLE t_sum_if_lc_nullable
+(
+    s LowCardinality(Nullable(String)),
+    n Nullable(UInt8),
+    u UInt8
+)
+ENGINE = Memory;
+
+INSERT INTO t_sum_if_lc_nullable VALUES ('y', 1, 1), ('n', 0, 0), (NULL, NULL, 0);
+
+-- A comparison over a LowCardinality(Nullable(...)) column keeps the LowCardinality wrapper.
+SELECT DISTINCT toTypeName(s = 'y') FROM t_sum_if_lc_nullable;
+
+SELECT '-- LowCardinality(Nullable) condition: rewrite must not fire';
+-- Both 'n' and NULL take the else branch, so the answer is 2, and 10 for the multiplier variant.
+SELECT sum(if(s = 'y', 0, 1)) FROM t_sum_if_lc_nullable;
+SELECT sum(if(s = 'y', 0, 5)) FROM t_sum_if_lc_nullable;
+SELECT sum(if(s = 'y', 0, 1)) FROM t_sum_if_lc_nullable SETTINGS optimize_rewrite_sum_if_to_count_if = 0;
+SELECT sum(if(s = 'y', 0, 5)) FROM t_sum_if_lc_nullable SETTINGS optimize_rewrite_sum_if_to_count_if = 0;
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT sum(if(s = 'y', 0, 1)) FROM t_sum_if_lc_nullable) WHERE explain ILIKE '%countIf%';
+
+SELECT '-- Nullable condition: rewrite must not fire';
+SELECT sum(if(n = 1, 0, 1)) FROM t_sum_if_lc_nullable;
+SELECT sum(if(n = 1, 0, 1)) FROM t_sum_if_lc_nullable SETTINGS optimize_rewrite_sum_if_to_count_if = 0;
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT sum(if(n = 1, 0, 1)) FROM t_sum_if_lc_nullable) WHERE explain ILIKE '%countIf%';
+
+SELECT '-- Non-nullable condition: rewrite must still fire';
+SELECT sum(if(u = 1, 0, 1)) FROM t_sum_if_lc_nullable;
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT sum(if(u = 1, 0, 1)) FROM t_sum_if_lc_nullable) WHERE explain ILIKE '%countIf%';
+
+SELECT '-- The un-negated direction agrees with `countIf` even for NULL conditions and must still be rewritten';
+SELECT sum(if(s = 'y', 1, 0)) FROM t_sum_if_lc_nullable;
+SELECT sum(if(s = 'y', 1, 0)) FROM t_sum_if_lc_nullable SETTINGS optimize_rewrite_sum_if_to_count_if = 0;
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT sum(if(s = 'y', 1, 0)) FROM t_sum_if_lc_nullable) WHERE explain ILIKE '%countIf%';
+
+DROP TABLE t_sum_if_lc_nullable;


### PR DESCRIPTION

Closes: https://github.com/ClickHouse/ClickHouse/issues/116938 
\
`optimize_rewrite_sum_if_to_count_if` (enabled by default) rewrites `sum(if(cond, 0, 1))` into `countIf(not(cond))`. This is valid only when the condition can't be `NULL`. The if conditional takes the else branch on a `NULL` condition, and the row count is included in the sum, while `not(NULL)` is `NULL` and `countIf` skips the row.

Previously, the guard tested `cond_argument->getResultType()->isNullable()`, which is false for a `LowCardinality` wrapper, so a `LowCardinality(Nullable(...))` condition bypasses it and the aggregate silently undercounts.

Functions propagate the `LowCardinality` wrapper, so a comparison over a `LowCardinality(Nullable(String))` column produces a `LowCardinality(Nullable(UInt8))` condition:
```sql
CREATE TABLE tlc (s LowCardinality(Nullable(String))) ENGINE = Memory;
INSERT INTO tlc VALUES ('y'), ('n'), (NULL);

SELECT sum(if(s = 'y', 0, 1)) FROM tlc;
-- returns 1; the correct answer is 2, since 'n' and NULL both take the else branch
```

The guard now checks `isNullableOrLowCardinalityNullable`, which looks through the LowCardinality wrapper. This also drops the `not_function_result_type computation`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed incorrect results from `sum(if(cond, 0, 1))` when cond has type `LowCardinality(Nullable(...))` and `optimize_rewrite_sum_if_to_count_if` is enabled (the default). Rows where the condition was `NULL` were not counted.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117046&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117046](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117046+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
