### PR TITLE
Do not consume an empty final chunk in merging transforms

### DIFF
--- a/src/Processors/Merges/IMergingTransform.cpp
+++ b/src/Processors/Merges/IMergingTransform.cpp
@@ -255,13 +255,26 @@ IProcessor::Status IMergingTransformBase::prepare()
             {
                 input.setNeeded();
             }
-            if (!input_chunk.hasRows() && !virtual_row && !input.isFinished())
+            if (!input_chunk.hasRows() && !virtual_row)
             {
-                input.setNeeded();
-                return Status::NeedData;
-            }
+                if (!input.isFinished())
+                {
+                    input.setNeeded();
+                    return Status::NeedData;
+                }
 
-            state.has_input = true;
+                /// The input finished with an empty chunk: there is nothing to consume.
+                /// Passing it to the algorithm would put an empty cursor into the sorting
+                /// queue (`Logical error: 'max_rows > 0'` in the batch merge, out-of-bounds
+                /// row access in the heap comparisons). Report the source as exhausted
+                /// instead, like the initialization path does for empty first chunks.
+                state.input_chunk.set(Chunk());
+                state.no_data = true;
+            }
+            else
+            {
+                state.has_input = true;
+            }
         }
         else
         {

--- a/src/QueryPipeline/tests/gtest_merging_sorted_empty_chunk.cpp
+++ b/src/QueryPipeline/tests/gtest_merging_sorted_empty_chunk.cpp
@@ -1,0 +1,162 @@
+#include <gtest/gtest.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/Block.h>
+#include <Core/SortDescription.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/IProcessor.h>
+#include <Processors/Merges/MergingSortedTransform.h>
+#include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/QueryPipeline.h>
+
+using namespace DB;
+
+namespace
+{
+
+Block getHeader()
+{
+    return Block{{ColumnUInt64::create(), std::make_shared<DataTypeUInt64>(), "x"}};
+}
+
+Chunk getChunk(const std::vector<UInt64> & values)
+{
+    auto column = ColumnUInt64::create();
+    for (UInt64 value : values)
+        column->insertValue(value);
+
+    size_t num_rows = column->size();
+    Columns columns;
+    columns.push_back(std::move(column));
+    return Chunk(std::move(columns), num_rows);
+}
+
+/// A source that finishes its output port in the same `prepare` call that pushes
+/// the last chunk, so the consumer pulls that chunk while the port is already
+/// finished. `BufferChunksTransform` (used under `MergingSortedTransform` for
+/// reads in order) drains its buffer the same way. With an empty last chunk this
+/// reproduced `Logical error: 'max_rows > 0'`: `IMergingTransformBase::prepare`
+/// passed the empty chunk to the algorithm, which pushed an empty cursor into
+/// the sorting queue.
+class FinishWithLastChunkSource : public IProcessor
+{
+public:
+    FinishWithLastChunkSource(SharedHeader header, std::vector<Chunk> chunks_)
+        : IProcessor({}, {std::move(header)})
+        , chunks(std::move(chunks_))
+    {
+    }
+
+    String getName() const override { return "FinishWithLastChunkSource"; }
+
+    Status prepare() override
+    {
+        auto & output = outputs.front();
+
+        if (output.isFinished())
+            return Status::Finished;
+
+        if (!output.canPush())
+            return Status::PortFull;
+
+        if (pos == chunks.size())
+        {
+            output.finish();
+            return Status::Finished;
+        }
+
+        output.push(std::move(chunks[pos]));
+        ++pos;
+
+        if (pos == chunks.size())
+        {
+            output.finish();
+            return Status::Finished;
+        }
+
+        return Status::PortFull;
+    }
+
+private:
+    std::vector<Chunk> chunks;
+    size_t pos = 0;
+};
+
+Pipe getPipe(std::vector<std::vector<Chunk>> inputs)
+{
+    auto header = std::make_shared<const Block>(getHeader());
+
+    Pipes pipes;
+    for (auto & chunks : inputs)
+        pipes.emplace_back(std::make_shared<FinishWithLastChunkSource>(header, std::move(chunks)));
+
+    return Pipe::unitePipes(std::move(pipes));
+}
+
+size_t countMergedRows(Pipe pipe, const SortDescription & sort_description, SortingQueueStrategy strategy)
+{
+    auto transform = std::make_shared<MergingSortedTransform>(
+        pipe.getSharedHeader(),
+        pipe.numOutputPorts(),
+        sort_description,
+        /*max_block_size_rows=*/ 8192,
+        /*max_block_size_bytes=*/ 0,
+        /*max_dynamic_subcolumns=*/ std::nullopt,
+        strategy,
+        /*limit=*/ 0,
+        /*always_read_till_end=*/ false,
+        /*out_row_sources_buf=*/ nullptr,
+        /*filter_column_name=*/ std::nullopt,
+        /*use_average_block_sizes=*/ false);
+
+    pipe.addTransform(std::move(transform));
+
+    QueryPipeline pipeline(std::move(pipe));
+    pipeline.setNumThreads(1);
+    PullingPipelineExecutor executor(pipeline);
+
+    size_t total_rows = 0;
+    Block block;
+    while (executor.pull(block))
+        total_rows += block.rows();
+
+    return total_rows;
+}
+
+}
+
+/// A single input whose last chunk is empty: the empty cursor became the only
+/// element of the batch sorting queue, and its zero-size batch failed
+/// `chassert(max_rows > 0)` in `MergedData::rowsToInsertBeforeFlush`.
+TEST(MergingSortedEmptyChunk, SingleInputTrailingEmptyChunk)
+{
+    SortDescription sort_description;
+    sort_description.emplace_back("x", 1, 1);
+
+    std::vector<std::vector<Chunk>> inputs;
+    inputs.push_back({});
+    inputs.back().push_back(getChunk({1, 2, 3, 4, 5}));
+    inputs.back().push_back(getChunk({}));
+
+    EXPECT_EQ(countMergedRows(getPipe(std::move(inputs)), sort_description, SortingQueueStrategy::Batch), 5u);
+}
+
+/// With another input still in the queue, pushing an empty cursor makes the heap
+/// comparison read row 0 of empty sort columns.
+TEST(MergingSortedEmptyChunk, TwoInputsTrailingEmptyChunk)
+{
+    SortDescription sort_description;
+    sort_description.emplace_back("x", 1, 1);
+
+    for (auto strategy : {SortingQueueStrategy::Batch, SortingQueueStrategy::Default})
+    {
+        std::vector<std::vector<Chunk>> inputs;
+        inputs.push_back({});
+        inputs.back().push_back(getChunk({1, 3, 5}));
+        inputs.back().push_back(getChunk({}));
+        inputs.push_back({});
+        inputs.back().push_back(getChunk({2, 4, 6, 8, 10}));
+
+        EXPECT_EQ(countMergedRows(getPipe(std::move(inputs)), sort_description, strategy), 8u);
+    }
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a logical error `max_rows > 0` (and possible incorrect merge results in release builds) in `MergingSortedTransform` when an input delivers a trailing empty chunk together with the end of its stream, e.g. under `optimize_read_in_order`.

### Description

When an input of `IMergingTransformBase` finishes its port in the same `prepare` cycle that delivers a trailing empty chunk — `BufferChunksTransform`, which sits under `MergingSortedTransform` for reads in order, drains its buffer exactly this way — the runtime path of `IMergingTransformBase::prepare` passed the empty chunk to the algorithm. `MergingSortedAlgorithm::consume` then pushed an empty cursor into the sorting queue:

- with `SortingQueueStrategy::Batch`, the zero-size batch fails `chassert(max_rows > 0)` in `MergedData::rowsToInsertBeforeFlush` — this is the AST fuzzer failure `Logical error: 'max_rows > 0'` on the query `SELECT untuple(arrayJoin(arrayJoin(col1.n))) FROM nested__fuzz_31 ORDER BY id DESC NULLS LAST LIMIT -2147483649, 1048575 SETTINGS optimize_read_in_order = 1`;
- with both strategies, the heap comparisons read row 0 of the empty cursor's sort columns, which mis-merges the remaining inputs in release builds: the new two-input unit test loses a row of the output without the fix.

The fix treats a finished input whose final chunk is empty (and not a virtual row) as exhausted (`onSourceExhausted`), exactly like the initialization path already handles empty first chunks. Algorithms with `empty_chunk_on_finish` (the join transforms) keep receiving their final empty `consume`, which the `no_data` path already produces.

The regression test is a unit test because the trigger — a source that finishes its output port in the same cycle that pushes a trailing empty chunk — cannot be constructed deterministically from SQL.

Found by AST fuzzer (`amd_debug, targeted`) on #96844: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96844&sha=a79e87275f6c044d21bd99b1b3881b795fcb79a4&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117048&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117048](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117048+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
