### PR TITLE
Synchronize `01599_multiline_input_and_singleline_comments` on the client prompt instead of a `sleep`

### DIFF
--- a/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
+++ b/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
@@ -1,41 +1,40 @@
 #!/usr/bin/expect -f
 
-set script_path [info script]
-set CURDIR [file dirname [file normalize $script_path]]
-
-set CLICKHOUSE_CLIENT_BINARY ""
-set CLICKHOUSE_CLIENT_BINARY [exec bash -c "source $CURDIR/../shell_config.sh && echo \$CLICKHOUSE_CLIENT_BINARY"]
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+set history_file $CLICKHOUSE_TMP/$basename.history
 
 log_user 0
-
 set timeout 60
-
 match_max 100000
 
-if ![info exists env(CLICKHOUSE_PORT_TCP)] {set env(CLICKHOUSE_PORT_TCP) 9000}
+expect_after {
+    # Do not ignore eof from expect
+    -i $any_spawn_id eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    -i $any_spawn_id timeout { exit 1 }
+}
 
-spawn "$CLICKHOUSE_CLIENT_BINARY" --multiline --disable_suggestion --port "$env(CLICKHOUSE_PORT_TCP)"
+# A single-line comment inside a multiline query must not hide the rest of the query:
+# input keeps being collected after it, and the final `;` runs `SELECT 1, 2`.
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --multiline --history_file=$history_file"
 expect ":) "
 
-# Make a query
 send -- "SELECT 1\r"
+expect ":-] "
 send -- "-- xxx\r"
+expect ":-] "
 send -- ", 2\r"
-send -- ";"
-
-# For some reason this sleep is required for this test to work properly
-sleep 1
-send -- "\r"
-
-expect {
-    "│ 1 │ 2 │" { }
-    timeout { exit 1 }
-}
-
+expect ":-] "
+send -- ";\r"
+expect "│ 1 │ 2 │"
 expect ":) "
 
-send -- ""
-expect {
-    eof { exit 0 }
-    timeout { exit 1 }
-}
+send -- "\4"
+expect eof


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/13654
Related: https://github.com/ClickHouse/ClickHouse/pull/61440
Related: https://github.com/ClickHouse/ClickHouse/pull/61371

It wedges to the 60 s cap on `Fast test (arm_darwin)`: 5 failures / 8601 runs in 30 d, four on 2026-08-29,
all pinned at the cap against a 5.04 s green p100; 0 / 16679 on Linux. So it hangs, not drifts.
No open issue.
[Report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111273&sha=009adc1dd81d3a046760ae556d504f45494af53d&name_0=PR&name_1=Fast%20test%20%28arm_darwin%29).

Root cause: it synchronized on wall-clock time, not client output. Under `--multiline` with
highlighting on, replxx commits a line only when a "last token is a delimiter" global is set, which
the highlighter callback writes on redraw. So the query ran only if a redraw processed the `;`
before Enter arrived. The removed `sleep 1` bet on that; send `;` and Enter together and the client
waits forever.

One test file, no source change, adopting the interactive-test convention:
`CLICKHOUSE_CLIENT_EXPECT_OPT` (hence `--highlight 0`) with `expect ":-] "` between sends replacing
the `sleep`, `expect_after` so every `expect` fails on timeout, `--history_file`, and `exp_internal`
for the debug log `clickhouse-test` appends to failures. 01599 did not write it, which is why every
sighting carries no test output.

That also restores what the test is for: its invariant is the newline line-join in
`LineReader::readLine` that #13654 fixed, reached only when `readLine` accumulates more than one
line. Under highlighting the whole query arrives in one read, so the `sleep` form never reached it;
reverting that join reddens the new form 5/5 and leaves the `sleep` form green. The trade: nothing
now drives `--multiline` with highlighting on, which cannot be deterministic while commitment
depends on that kludge. `01755` covers `--highlight 1`, not multiline commitment.

Validation: with `;` and Enter as one write, varying only `--highlight`, 1 wedges 10/10 and 0 passes
10/10; 200/200 unrandomized, 50/50 randomized, p50 1.48 s to 0.43 s, three mutants confirming it
can still fail. Only post-merge CIDB confirms darwin.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117053&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117053](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117053+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
