### PR TITLE
Fix flaky test_move_after_processing_preserve_path

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -364,6 +364,25 @@ def test_tag_after_processing(started_cluster, engine_name):
         assert blob_count == files_num, f"blob count mismatch: {blob_count} != {files_num}"
 
 
+def wait_for_object_counts(count_objects, started_cluster, expected, timeout=60):
+    """Wait until every `(bucket, prefix): count` entry of `expected` holds, and return the counts.
+
+    The after-processing move is executed by `StorageObjectStorageQueue::postProcess`, which runs
+    only after the rows have been committed to the materialized view target. So a row count that
+    has already reached its final value does not imply the objects have been moved yet: the caller
+    must poll the object storage rather than assert on it once.
+    """
+    def counts():
+        return {key: count_objects(started_cluster, *key) for key in expected}
+
+    deadline = time.monotonic() + timeout
+    current = counts()
+    while current != expected and time.monotonic() < deadline:
+        time.sleep(0.1)
+        current = counts()
+    return current
+
+
 @pytest.mark.parametrize("engine_name", ["S3Queue", "AzureQueue"])
 @pytest.mark.parametrize("move_to", ["same_bucket", "another_bucket"])
 def test_move_after_processing(started_cluster, engine_name, move_to):
@@ -456,20 +475,24 @@ def test_move_after_processing(started_cluster, engine_name, move_to):
 
     if engine_name == "S3Queue":
         src_bucket = started_cluster.minio_bucket
-        dst_bucket = processed_bucket if move_to == "another_bucket" else src_bucket
-        moved_count = count_minio_objects(started_cluster, dst_bucket, processed_prefix)
-        assert moved_count == files_num, f"moved object count mismatch: {moved_count} != {files_num}"
-
-        object_count = count_minio_objects(started_cluster, src_bucket, files_path)
-        assert object_count == 0, f"objects left: {object_count}"
+        count_objects = count_minio_objects
     else:
-        src_container = started_cluster.azurite_container
-        dst_container = processed_bucket if move_to == "another_bucket" else src_container
-        moved_count = count_azurite_blobs(started_cluster, dst_container, processed_prefix)
-        assert moved_count == files_num, f"moved blob count mismatch: {moved_count} != {files_num}"
+        src_bucket = started_cluster.azurite_container
+        count_objects = count_azurite_blobs
 
-        blob_count = count_azurite_blobs(started_cluster, src_container, files_path)
-        assert blob_count == 0, f"blobs left: {blob_count}"
+    dst_bucket = processed_bucket if move_to == "another_bucket" else src_bucket
+
+    expected_counts = {
+        (dst_bucket, processed_prefix): files_num,
+        (src_bucket, files_path): 0,
+    }
+    counts = wait_for_object_counts(count_objects, started_cluster, expected_counts)
+    assert counts[(dst_bucket, processed_prefix)] == files_num, (
+        f"moved object count mismatch: {counts[(dst_bucket, processed_prefix)]} != {files_num}"
+    )
+    assert counts[(src_bucket, files_path)] == 0, (
+        f"objects left: {counts[(src_bucket, files_path)]}"
+    )
 
 
 @pytest.mark.parametrize("engine_name", ["S3Queue", "AzureQueue"])
@@ -538,9 +561,13 @@ def test_move_after_processing_preserve_path(started_cluster, engine_name, move_
 
     dst_bucket = processed_bucket if move_to == "another_bucket" else src_bucket
 
-    assert count_objects(started_cluster, dst_bucket, expected_key) == 1
-    assert count_objects(started_cluster, dst_bucket, processed_prefix) == 1
-    assert count_objects(started_cluster, src_bucket, files_path) == 0
+    expected_counts = {
+        (dst_bucket, expected_key): 1,
+        (dst_bucket, processed_prefix): 1,
+        (src_bucket, files_path): 0,
+    }
+    counts = wait_for_object_counts(count_objects, started_cluster, expected_counts)
+    assert counts == expected_counts
 
 
 @pytest.mark.parametrize("engine_name", ["S3Queue", "AzureQueue"])


### PR DESCRIPTION
Fixes a rare flake of `test_storage_s3_queue/test_0.py::test_move_after_processing_preserve_path`, seen once in ~11950 `master` runs:

```
assert count_objects(started_cluster, dst_bucket, expected_key) == 1
AssertionError: assert 0 == 1
 +  where 0 = count_minio_objects(<ClickHouseCluster>, 'root',
                                  'sink/move_after_processing_preserve_S3Queue_kudmif_data/a.csv')
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=dcf60013dc275ac8a3c4c8187e83ff95d58efcdc&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29

`StorageObjectStorageQueue::postProcess`, which performs the `after_processing = 'move'` action, is called from `StorageObjectStorageQueue::commit`, and `commit` runs only *after* the rows have been inserted into the materialized view target table. So reaching the final row count does not imply the objects have been moved yet — there is a window in which the rows are already visible and the copy-then-delete is still in flight.

Both `after_processing = 'move'` tests waited for `SELECT count()` on the target table to reach its final value and then asserted on the object storage immediately, so a move still in that window was reported as a lost object. They now poll the object counts until they match instead of asserting once. `test_move_after_processing` was racy the same way; it only never failed because it happens to issue `SYSTEM FLUSH LOGS` and several `system.*_log` queries between the row-count wait and the object assertions, which usually hides the window.

The polling helper returns the counts it last observed, so a genuine failure still fails, with the observed counts in the assertion message rather than a bare `0 == 1`.

Not fixed here, but worth noting: `test_tag_after_processing` has the same latent race — `after_processing = 'tag'` goes through the same `postProcess` — but it has 0 failures in ~12000 `master` runs, and its per-object tag assertions do not fit the count-based helper.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117066&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117066](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117066+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.362` (included in `26.9` and later)
<!-- ch-version-info:end -->