### PR TITLE
Fix flaky test `04267_ttl_drop_merge_no_data_read` under a small `index_granularity`

### DIFF
--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.reference
@@ -15,7 +15,7 @@ TTLDropMerge	0	200
 50
 50
 -- Case 6: Rows TTL + column TTL is not short-circuited
-TTLDropMerge	0	200
+TTLDropMerge	0	1
 0
 -- Case 7: Rows TTL + GROUP BY TTL is not short-circuited
 TTLDropMerge	100	200

--- a/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
+++ b/tests/queries/0_stateless/04267_ttl_drop_merge_no_data_read.sh
@@ -303,6 +303,9 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_ttl_drop_then_insert;"
 # -------------------------------------------------------------------
 # Case 6: Rows TTL + column TTL — not short-circuited
 # hasOnlyRowsTTL is false when column TTL is present, so data IS read.
+# The rows TTL alone covers every row, so `TTLTransform` closes the read side
+# once the merge emits its first block. How many rows the sources pushed before
+# that depends on the granule size, so assert only that they were read at all.
 # -------------------------------------------------------------------
 echo "-- Case 6: Rows TTL + column TTL is not short-circuited"
 
@@ -335,7 +338,7 @@ ${CLICKHOUSE_CLIENT} -q "
     SELECT
         merge_reason,
         rows,
-        read_rows
+        read_rows > 0
     FROM system.part_log
     WHERE
         database = currentDatabase()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/105859
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Stabilize the stateless test `04267_ttl_drop_merge_no_data_read` when `index_granularity` is randomized to a small value.


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/105859

Case 6 asserts an exact `system.part_log.read_rows` for a background `TTLDrop` merge. When CI
randomizes `index_granularity` to 1 the value collapses from 200 and the test fails, while cases
1-5 and 7 pass in the same run. The runner's own diagnosis names `--index_granularity 1` as the
sole culprit. There are 0 master failures in 30 days, and 7 unrelated PRs since 2026-08-03.
Example
[report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114344&sha=b32f1027cefb381aff529195496cc457c8cadb3e&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29).

`read_rows` here is not the number of rows the merge needed, it is the number the sources pushed
before the read side was closed. Case 6's rows TTL covers every row, so `TTLTransform` sets
`all_data_dropped` and calls `finishConsume` on its first block, which closes the sources. How
much they had emitted by then follows the granule size, so the assertion was pinned to an
emergent quantity rather than to the property under test, which is that the `TTLDrop`
short-circuit did not fire. `200` is only the saturated end of that curve: I measure 7 at
granularity 1 and 200 at every value from 2 up, and the failing value is itself build-dependent,
7 locally against 6 in CI.

Case 6 now asserts `read_rows > 0`. That loses no discriminating power, because the short-circuit
path yields exactly 0 while a built pipeline always yields at least 1: `TTLTransform::consume`
cannot run before a chunk exists. I confirmed the assertion is not vacuous by mutation, dropping
the `hasOnlyRowsTTL()` guard so the short-circuit fires unconditionally, and the Case 6 line then
flips to 0. Validation on one binary: 0 of 20 runs pass before the change at granularity 1, 20 of
20 after, plus 50 of 50 randomized runs.

Pinning the setting instead would freeze the same emergent number, stay movable by
`index_granularity_bytes`, and at file level would drop small-granularity coverage from the six
cases that are correct today.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117081&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117081](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117081+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
