### PR TITLE
Avoid a per-row string copy and strlen when writing JSON object keys

### DIFF
--- a/src/Formats/JSONUtils.cpp
+++ b/src/Formats/JSONUtils.cpp
@@ -357,22 +357,24 @@ namespace JSONUtils
 
     void writeFieldCompactDelimiter(WriteBuffer & out) { writeCString(", ", out); }
 
-    static void writeTitle(const char * title, WriteBuffer & out, size_t indent, const char * after_delimiter)
+    static void writeTitle(std::string_view title, WriteBuffer & out, size_t indent, std::string_view after_delimiter)
     {
         writeChar('\t', indent, out);
         writeChar('"', out);
-        writeCString(title, out);
-        writeCString("\":", out);
-        writeCString(after_delimiter, out);
+        out.write(title.data(), title.size());
+        out.write("\":", 2);
+        if (!after_delimiter.empty())
+            out.write(after_delimiter.data(), after_delimiter.size());
     }
 
-    static void writeTitlePretty(const char * title, WriteBuffer & out, const FormatSettings & settings, size_t indent, const char * after_delimiter)
+    static void writeTitlePretty(std::string_view title, WriteBuffer & out, const FormatSettings & settings, size_t indent, std::string_view after_delimiter)
     {
         writeChar(settings.json.pretty_print_indent, indent * settings.json.pretty_print_indent_multiplier, out);
         writeChar('"', out);
-        writeCString(title, out);
-        writeCString("\":", out);
-        writeCString(after_delimiter, out);
+        out.write(title.data(), title.size());
+        out.write("\":", 2);
+        if (!after_delimiter.empty())
+            out.write(after_delimiter.data(), after_delimiter.size());
     }
 
     void writeObjectStart(WriteBuffer & out, size_t indent, const char * title)
@@ -435,20 +437,20 @@ namespace JSONUtils
         bool yield_strings,
         const FormatSettings & settings,
         WriteBuffer & out,
-        const std::optional<String> & name,
+        std::optional<std::string_view> name,
         size_t indent,
-        const char * title_after_delimiter,
+        std::string_view title_after_delimiter,
         bool pretty_json)
     {
         if (name.has_value())
         {
             if (pretty_json)
             {
-                writeTitlePretty(name->data(), out, settings, indent, title_after_delimiter);
+                writeTitlePretty(*name, out, settings, indent, title_after_delimiter);
             }
             else
             {
-                writeTitle(name->data(), out, indent, title_after_delimiter);
+                writeTitle(*name, out, indent, title_after_delimiter);
             }
         }
 

--- a/src/Formats/JSONUtils.h
+++ b/src/Formats/JSONUtils.h
@@ -9,6 +9,8 @@
 #include <Core/NamesAndTypes.h>
 #include <Common/Stopwatch.h>
 #include <functional>
+#include <optional>
+#include <string_view>
 #include <utility>
 
 namespace DB
@@ -127,9 +129,9 @@ namespace JSONUtils
         bool yield_strings,
         const FormatSettings & settings,
         WriteBuffer & out,
-        const std::optional<String> & name = std::nullopt,
+        std::optional<std::string_view> name = std::nullopt,
         size_t indent = 0,
-        const char * title_after_delimiter = " ",
+        std::string_view title_after_delimiter = " ",
         bool pretty_json = false);
 
     void writeColumns(

--- a/src/Processors/Formats/Impl/JSONObjectEachRowRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONObjectEachRowRowOutputFormat.cpp
@@ -109,7 +109,7 @@ void registerOutputFormatJSONObjectEachRow(FormatFactory & factory)
             /// The values of the column selected by `format_json_object_each_row_column_for_object_name`
             /// become the outer object keys, and they are written verbatim: `writeRowStartDelimiter`
             /// passes them to `JSONUtils::writeCompactObjectStart`, which emits the title with
-            /// `writeCString` - no escaping and no UTF-8 validation. So an arbitrary `String` value
+            /// no escaping and no UTF-8 validation. So an arbitrary `String` value
             /// (a quote, a newline, or non-UTF-8 bytes) makes the whole output non-textual, and that
             /// is data-dependent, not knowable from the header. Fail close: whenever such a column is
             /// selected, the carrier counts as possibly producing raw bytes, so the text framings

--- a/tests/performance/json_key_formatting.xml
+++ b/tests/performance/json_key_formatting.xml
@@ -1,0 +1,24 @@
+<test>
+    <!-- Cost of emitting the object keys in JSON row output formats, which is paid once per field
+         per row. `max_threads = 1` keeps that per-row cost visible instead of hiding it behind
+         threading, and `formatRow` keeps the output in memory so the sink is never the bottleneck. -->
+
+    <create_query>
+        CREATE TABLE json_key_formatting (id UInt64, event_count UInt64,
+            a_column_name_longer_than_the_small_string_limit UInt64) ENGINE = Memory
+    </create_query>
+    <fill_query>
+        INSERT INTO json_key_formatting SELECT number, number + 1, number + 2 FROM numbers(10000000)
+    </fill_query>
+
+    <!-- One narrow field, key short enough to fit a small-string buffer -->
+    <query>SELECT count() FROM json_key_formatting WHERE NOT ignore(formatRow('JSONEachRow', id)) SETTINGS max_threads = 1</query>
+    <!-- Same, with a key too long for a small-string buffer -->
+    <query>SELECT count() FROM json_key_formatting WHERE NOT ignore(formatRow('JSONEachRow', a_column_name_longer_than_the_small_string_limit)) SETTINGS max_threads = 1</query>
+    <!-- Three keys per row -->
+    <query>SELECT count() FROM json_key_formatting WHERE NOT ignore(formatRow('JSONEachRow', id, event_count, a_column_name_longer_than_the_small_string_limit)) SETTINGS max_threads = 1</query>
+    <!-- Scope control: a format that emits no keys, so it must not move -->
+    <query>SELECT count() FROM json_key_formatting WHERE NOT ignore(formatRow('TSV', id)) SETTINGS max_threads = 1</query>
+
+    <drop_query>DROP TABLE IF EXISTS json_key_formatting</drop_query>
+</test>


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117043
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/117043


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Writing rows in the JSON output formats that emit object keys (`JSONEachRow` and its aliases, `PrettyJSONEachRow`, `JSON`, `JSONStrings`, `JSONStringsEachRow`, `JSONObjectEachRow` and `GeoJSON`) is now faster: the key of each field is no longer copied into a temporary string and re-measured once per row. The gain grows with the length and the number of keys per row. The compact formats emit no keys and are unaffected. The output is unchanged.


### Description

Reported by @ snelheidai in https://github.com/ClickHouse/ClickHouse/issues/117043, who asked me to review it and open a PR if it held up: https://github.com/ClickHouse/ClickHouse/issues/117043#issuecomment-5461777278

`JSONUtils::writeFieldFromColumn` took the field title as `const std::optional<String> &`. No caller owns an `optional`: of its six call sites, the four that pass a title pass a `String` lvalue owned by a format member, so each of those calls materialised a temporary `std::optional<String>`, copying and destroying a `std::string` once per field per row. The body then passed `name->data()`, discarding the length, which `writeCString` recovered with `strlen`. Both costs are fixed by the column header. This change carries the title as `std::optional<std::string_view>` and writes it by size (+19/-15 in `src/`).

Output is byte-identical, so I added no stateless test, since one would pass on master too. I checked identity across 67 shapes: every JSON output format that reaches `writeTitle`, keys containing NUL, non-UTF-8 bytes, quotes and newlines, eight `output_format_json_*` settings at 0 and 1, empty and non-empty after-colon delimiters, and the HTTP exception-framing path. Each shape was shown live by a deliberately corrupted third build. A 492-test `json` sweep gives identical failing-name sets on both arms.

Measured with `-DCMAKE_BUILD_TYPE=None -DENABLE_THINLTO=0`, clang-22, x86_64, 15 interleaved rounds, medians with bootstrap CIs: one short key 8.9% faster, one key longer than the small-string buffer 37.3% faster, three keys per row 27.6% faster. `TSV`, which emits no keys, moves 1.2% against a 1.1% concurrent noise floor, so it sits at the measurement boundary; no `TSV` translation unit is recompiled, leaving binary layout as the only route. Release builds enable ThinLTO, so `tests/performance/json_key_formatting.xml` gets the release figure on x86 and ARM from CI.

I left out the issue's direct-buffer fast path: it only pays off where `WriteBuffer::write` is out of line, which is not the shipped configuration, and it would bypass the `finalized`/`canceled` checks.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117082&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117082](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117082+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.369` (included in `26.9` and later)
<!-- ch-version-info:end -->