### PR TITLE
Share sample blocks of MergeTreeRangeReader between read tasks

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -969,26 +969,16 @@ size_t MergeTreeRangeReader::ReadResult::numZerosInTail(const UInt8 * begin, con
 #endif
 }
 
-MergeTreeRangeReader::MergeTreeRangeReader(
-    IMergeTreeReader * merge_tree_reader_,
-    Block prev_reader_header_,
-    const PrewhereExprStep * prewhere_info_,
-    ReadStepPerformanceCountersPtr performance_counters_,
-    bool main_reader_,
-    bool can_read_incomplete_granules_)
-    : merge_tree_reader(merge_tree_reader_)
-    , index_granularity(&(merge_tree_reader->data_part_info_for_read->getIndexGranularity()))
-    , prewhere_info(prewhere_info_)
-    , performance_counters(std::move(performance_counters_))
-    , main_reader(main_reader_)
-    , can_read_incomplete_granules(can_read_incomplete_granules_)
+MergeTreeRangeReader::SampleBlocksPtr MergeTreeRangeReader::createSampleBlocks(
+    const IMergeTreeReader & reader, Block prev_reader_header, const PrewhereExprStep * prewhere_info)
 {
-    result_sample_block = std::move(prev_reader_header_);
+    auto sample_blocks = std::make_shared<SampleBlocks>();
+    sample_blocks->result = std::move(prev_reader_header);
 
-    for (const auto & name_and_type : merge_tree_reader->getColumns())
+    for (const auto & name_and_type : reader.getColumns())
     {
-        read_sample_block.insert({name_and_type.type->createColumn(), name_and_type.type, name_and_type.name});
-        result_sample_block.insert({name_and_type.type->createColumn(), name_and_type.type, name_and_type.name});
+        sample_blocks->read.insert({name_and_type.type->createColumn(), name_and_type.type, name_and_type.name});
+        sample_blocks->result.insert({name_and_type.type->createColumn(), name_and_type.type, name_and_type.name});
     }
 
     if (prewhere_info)
@@ -1002,12 +992,31 @@ MergeTreeRangeReader::MergeTreeRangeReader(
         if (step.type != PrewhereExprStep::None)
         {
             if (step.actions)
-                step.actions->execute(result_sample_block, true);
+                step.actions->execute(sample_blocks->result, true);
 
             if (step.remove_filter_column)
-                result_sample_block.erase(step.filter_column_name);
+                sample_blocks->result.erase(step.filter_column_name);
         }
     }
+
+    return sample_blocks;
+}
+
+MergeTreeRangeReader::MergeTreeRangeReader(
+    IMergeTreeReader * merge_tree_reader_,
+    SampleBlocksPtr sample_blocks_,
+    const PrewhereExprStep * prewhere_info_,
+    ReadStepPerformanceCountersPtr performance_counters_,
+    bool main_reader_,
+    bool can_read_incomplete_granules_)
+    : merge_tree_reader(merge_tree_reader_)
+    , index_granularity(&(merge_tree_reader->data_part_info_for_read->getIndexGranularity()))
+    , prewhere_info(prewhere_info_)
+    , sample_blocks(std::move(sample_blocks_))
+    , performance_counters(std::move(performance_counters_))
+    , main_reader(main_reader_)
+    , can_read_incomplete_granules(can_read_incomplete_granules_)
+{
 }
 
 size_t MergeTreeRangeReader::numReadRowsInCurrentGranule() const
@@ -1254,7 +1263,7 @@ void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & re
 
     auto add_offset_column = [&](const auto & column_name)
     {
-        size_t pos = read_sample_block.getPositionByName(column_name);
+        size_t pos = sample_blocks->read.getPositionByName(column_name);
         chassert(pos < columns.size());
 
         /// Column may be persisted in part.
@@ -1273,14 +1282,14 @@ void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & re
         }
     };
 
-    if (read_sample_block.has("_part_offset"))
+    if (sample_blocks->read.has("_part_offset"))
         add_offset_column("_part_offset");
 
     /// Column _block_offset is the same as _part_offset if it's not persisted in part.
-    if (read_sample_block.has(BlockOffsetColumn::name))
+    if (sample_blocks->read.has(BlockOffsetColumn::name))
         add_offset_column(BlockOffsetColumn::name);
 
-    if (read_sample_block.has("_part_granule_offset"))
+    if (sample_blocks->read.has("_part_granule_offset"))
         add_offset_column("_part_granule_offset");
 
     const auto & read_hints = merge_tree_reader->getReadHints();
@@ -1288,17 +1297,17 @@ void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & re
     /// share the same read hints but must not shrink the block before later stages.
     const bool apply_rescoring_row_filter = main_reader && read_hints.use_vector_search_result_filter;
     bool is_vector_search = read_hints.vector_search_results.has_value()
-        && (read_sample_block.has("_distance") || apply_rescoring_row_filter);
+        && (sample_blocks->read.has("_distance") || apply_rescoring_row_filter);
     if (is_vector_search)
     {
         ColumnPtr part_offsets_auto_column = createPartOffsetColumn(result);
         fillDistanceColumnAndFilterForVectorSearch(columns, result, part_offsets_auto_column);
     }
-    else if (read_sample_block.has("_distance"))
+    else if (sample_blocks->read.has("_distance"))
     {
         /// Fill `_distance` with a default value when vector search is not active
         /// but the column was requested (e.g. via SELECT * with asterisk_include_virtual_columns).
-        auto pos = read_sample_block.getPositionByName("_distance");
+        auto pos = sample_blocks->read.getPositionByName("_distance");
         if (!columns[pos])
             columns[pos] = ColumnFloat32::create(result.total_rows_per_granule, Float32(0));
     }
@@ -1340,7 +1349,7 @@ void MergeTreeRangeReader::fillDistanceColumnAndFilterForVectorSearch(Columns & 
     /// Populate the `_distance` virtual column from the distances we got from vector index
     /// only when the query plan requested it. Rescoring queries still use the row filter
     /// below, while the SQL pipeline computes the exact distance expression.
-    const bool fill_distance = read_sample_block.has("_distance");
+    const bool fill_distance = sample_blocks->read.has("_distance");
     MutableColumnPtr distance_column;
     Float32 * distances = nullptr;
     if (fill_distance)
@@ -1406,7 +1415,7 @@ void MergeTreeRangeReader::fillDistanceColumnAndFilterForVectorSearch(Columns & 
 
     if (fill_distance)
     {
-        auto distance_column_pos = read_sample_block.getPositionByName("_distance");
+        auto distance_column_pos = sample_blocks->read.getPositionByName("_distance");
         columns[distance_column_pos] = std::move(distance_column);
     }
     part_offsets_filter_for_vector_search = FilterWithCachedCount(std::move(filter_data));
@@ -1726,7 +1735,7 @@ void MergeTreeRangeReader::executePrewhereActionsAndFilterColumns(ReadResult & r
     /// share the same read hints but must not shrink the block before later stages.
     const bool apply_rescoring_row_filter = main_reader && read_hints.use_vector_search_result_filter;
     bool is_vector_search = read_hints.vector_search_results.has_value()
-        && (read_sample_block.has("_distance") || apply_rescoring_row_filter);
+        && (sample_blocks->read.has("_distance") || apply_rescoring_row_filter);
     if (is_vector_search && (part_offsets_filter_for_vector_search.size() == result.total_rows_per_granule))
     {
         auto current_filter = part_offsets_filter_for_vector_search;
@@ -1742,7 +1751,7 @@ void MergeTreeRangeReader::executePrewhereActionsAndFilterColumns(ReadResult & r
     if (!prewhere_info || prewhere_info->type == PrewhereExprStep::None)
         return;
 
-    const auto & header = read_sample_block;
+    const auto & header = sample_blocks->read;
     size_t num_columns = header.columns();
 
     /// Check that we have columns from previous steps and newly read required columns

--- a/src/Storages/MergeTree/MergeTreeRangeReader.h
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.h
@@ -170,9 +170,20 @@ public:
 class MergeTreeRangeReader
 {
 public:
+    /// Shared between read tasks, see `RangeReadersSampleBlocksCache`.
+    struct SampleBlocks
+    {
+        Block read;    /// Block with columns that are actually read from disk + non-const virtual columns that are filled at this step.
+        Block result;  /// Block with columns that are returned by this step.
+    };
+
+    using SampleBlocksPtr = std::shared_ptr<const SampleBlocks>;
+
+    static SampleBlocksPtr createSampleBlocks(const IMergeTreeReader & reader, Block prev_reader_header, const PrewhereExprStep * prewhere_info);
+
     MergeTreeRangeReader(
         IMergeTreeReader * merge_tree_reader_,
-        Block prev_reader_header_,
+        SampleBlocksPtr sample_blocks_,
         const PrewhereExprStep * prewhere_info_,
         ReadStepPerformanceCountersPtr performance_counters_,
         bool main_reader_,
@@ -447,8 +458,8 @@ public:
     ReadResult startReadingChain(size_t max_rows, MarkRanges & ranges);
     Columns continueReadingChain(ReadResult & result, size_t & num_rows);
 
-    const Block & getSampleBlock() const { return result_sample_block; }
-    const Block & getReadSampleBlock() const { return read_sample_block; }
+    const Block & getSampleBlock() const { return sample_blocks->result; }
+    const Block & getReadSampleBlock() const { return sample_blocks->read; }
 
     void executePrewhereActionsAndFilterColumns(ReadResult & result, const Block & previous_header, bool is_last_reader) const;
 
@@ -474,8 +485,7 @@ private:
 
     Stream stream;
 
-    Block read_sample_block;    /// Block with columns that are actually read from disk + non-const virtual columns that are filled at this step.
-    Block result_sample_block;  /// Block with columns that are returned by this step.
+    SampleBlocksPtr sample_blocks;
 
     FilterWithCachedCount part_offsets_filter_for_vector_search;
 

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -256,22 +256,35 @@ MergeTreeReadTask::Readers MergeTreeReadTask::createReaders(
     return new_readers;
 }
 
-MergeTreeRangeReader::SampleBlocksPtr RangeReadersSampleBlocksCache::get(size_t reader_idx, const IMergeTreeReader & reader, const PrewhereExprStepPtr & step)
+std::vector<MergeTreeRangeReader::SampleBlocksPtr> RangeReadersSampleBlocksCache::get(const std::vector<ChainReader> & chain)
 {
-    if (reader_idx >= entries.size())
-        entries.resize(reader_idx + 1);
+    std::lock_guard lock(mutex);
 
-    auto & entry = entries[reader_idx];
-    auto prev_reader_sample_blocks = reader_idx ? entries[reader_idx - 1].sample_blocks : nullptr;
+    if (entries.size() < chain.size())
+        entries.resize(chain.size());
 
-    if (entry.sample_blocks && entry.step == step && entry.prev_reader_sample_blocks == prev_reader_sample_blocks && entry.columns == reader.getColumns())
-        return entry.sample_blocks;
+    std::vector<MergeTreeRangeReader::SampleBlocksPtr> result;
+    result.reserve(chain.size());
 
-    entry.columns = reader.getColumns();
-    entry.step = step;
-    entry.prev_reader_sample_blocks = prev_reader_sample_blocks;
-    entry.sample_blocks = MergeTreeRangeReader::createSampleBlocks(reader, prev_reader_sample_blocks ? prev_reader_sample_blocks->result : Block{}, step.get());
-    return entry.sample_blocks;
+    /// Once an entry is rebuilt, all following entries are rebuilt too because they depend on the previous sample blocks.
+    bool prev_reused = true;
+    for (size_t i = 0; i < chain.size(); ++i)
+    {
+        const auto & [reader, step] = chain[i];
+        auto & entry = entries[i];
+
+        if (!(prev_reused && entry.sample_blocks && entry.step == step && entry.columns == reader->getColumns()))
+        {
+            entry.columns = reader->getColumns();
+            entry.step = step;
+            entry.sample_blocks = MergeTreeRangeReader::createSampleBlocks(*reader, i ? result.back()->result : Block{}, step.get());
+            prev_reused = false;
+        }
+
+        result.push_back(entry.sample_blocks);
+    }
+
+    return result;
 }
 
 MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
@@ -312,21 +325,39 @@ MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
         return collect_predicate_statistics ? read_steps_performance_counters.getCountersForStep(step) : nullptr;
     };
 
-    auto add_range_reader = [&](IMergeTreeReader * reader, const PrewhereExprStepPtr & step, ReadStepPerformanceCountersPtr counters, bool is_main_reader)
+    std::vector<RangeReadersSampleBlocksCache::ChainReader> chain;
+    std::vector<ReadStepPerformanceCountersPtr> counters;
+    std::vector<bool> is_main_reader;
+
+    auto add_chain_reader = [&](IMergeTreeReader * reader, const PrewhereExprStepPtr & step, ReadStepPerformanceCountersPtr reader_counters, bool is_main)
     {
-        auto sample_blocks = sample_blocks_cache.get(range_readers.size(), *reader, step);
-        range_readers.emplace_back(reader, std::move(sample_blocks), step.get(), std::move(counters), is_main_reader, can_read_incomplete_granules);
+        chain.emplace_back(reader, step);
+        counters.push_back(std::move(reader_counters));
+        is_main_reader.push_back(is_main);
     };
 
     if (task_readers.prepared_index)
-        add_range_reader(task_readers.prepared_index.get(), /*step=*/ nullptr, index_counter, /*is_main_reader=*/ false);
+        add_chain_reader(task_readers.prepared_index.get(), /*step=*/ nullptr, index_counter, /*is_main=*/ false);
 
     size_t counter_idx = 0;
     for (size_t i = 0; i < prewhere_actions.steps.size(); ++i)
-        add_range_reader(task_readers.prewhere[i].get(), prewhere_actions.steps[i], step_counter(counter_idx++), /*is_main_reader=*/ false);
+        add_chain_reader(task_readers.prewhere[i].get(), prewhere_actions.steps[i], step_counter(counter_idx++), /*is_main=*/ false);
 
     if (!task_readers.main->getColumns().empty())
-        add_range_reader(task_readers.main.get(), /*step=*/ nullptr, step_counter(counter_idx), /*is_main_reader=*/ true);
+        add_chain_reader(task_readers.main.get(), /*step=*/ nullptr, step_counter(counter_idx), /*is_main=*/ true);
+
+    auto sample_blocks = sample_blocks_cache.get(chain);
+
+    for (size_t i = 0; i < chain.size(); ++i)
+    {
+        range_readers.emplace_back(
+            chain[i].reader,
+            std::move(sample_blocks[i]),
+            chain[i].step.get(),
+            std::move(counters[i]),
+            is_main_reader[i],
+            can_read_incomplete_granules);
+    }
 
     return MergeTreeReadersChain{std::move(range_readers), task_readers.patches};
 }

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -256,11 +256,30 @@ MergeTreeReadTask::Readers MergeTreeReadTask::createReaders(
     return new_readers;
 }
 
+MergeTreeRangeReader::SampleBlocksPtr RangeReadersSampleBlocksCache::get(size_t reader_idx, const IMergeTreeReader & reader, const PrewhereExprStepPtr & step)
+{
+    if (reader_idx >= entries.size())
+        entries.resize(reader_idx + 1);
+
+    auto & entry = entries[reader_idx];
+    auto prev_reader_sample_blocks = reader_idx ? entries[reader_idx - 1].sample_blocks : nullptr;
+
+    if (entry.sample_blocks && entry.step == step && entry.prev_reader_sample_blocks == prev_reader_sample_blocks && entry.columns == reader.getColumns())
+        return entry.sample_blocks;
+
+    entry.columns = reader.getColumns();
+    entry.step = step;
+    entry.prev_reader_sample_blocks = prev_reader_sample_blocks;
+    entry.sample_blocks = MergeTreeRangeReader::createSampleBlocks(reader, prev_reader_sample_blocks ? prev_reader_sample_blocks->result : Block{}, step.get());
+    return entry.sample_blocks;
+}
+
 MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
     const Readers & task_readers,
     const PrewhereExprInfo & prewhere_actions,
     const ReadStepsPerformanceCounters & read_steps_performance_counters,
-    bool collect_predicate_statistics)
+    bool collect_predicate_statistics,
+    RangeReadersSampleBlocksCache & sample_blocks_cache)
 {
     if (prewhere_actions.steps.size() != task_readers.prewhere.size())
     {
@@ -293,39 +312,21 @@ MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
         return collect_predicate_statistics ? read_steps_performance_counters.getCountersForStep(step) : nullptr;
     };
 
-    if (task_readers.prepared_index)
+    auto add_range_reader = [&](IMergeTreeReader * reader, const PrewhereExprStepPtr & step, ReadStepPerformanceCountersPtr counters, bool is_main_reader)
     {
-        range_readers.emplace_back(
-            task_readers.prepared_index.get(),
-            Block{},
-            /*prewhere_info_=*/ nullptr,
-            index_counter,
-            /*main_reader_=*/ false,
-            can_read_incomplete_granules);
-    }
+        auto sample_blocks = sample_blocks_cache.get(range_readers.size(), *reader, step);
+        range_readers.emplace_back(reader, std::move(sample_blocks), step.get(), std::move(counters), is_main_reader, can_read_incomplete_granules);
+    };
+
+    if (task_readers.prepared_index)
+        add_range_reader(task_readers.prepared_index.get(), /*step=*/ nullptr, index_counter, /*is_main_reader=*/ false);
 
     size_t counter_idx = 0;
     for (size_t i = 0; i < prewhere_actions.steps.size(); ++i)
-    {
-        range_readers.emplace_back(
-            task_readers.prewhere[i].get(),
-            range_readers.empty() ? Block{} : range_readers.back().getSampleBlock(),
-            prewhere_actions.steps[i].get(),
-            step_counter(counter_idx++),
-            /*main_reader_=*/ false,
-            can_read_incomplete_granules);
-    }
+        add_range_reader(task_readers.prewhere[i].get(), prewhere_actions.steps[i], step_counter(counter_idx++), /*is_main_reader=*/ false);
 
     if (!task_readers.main->getColumns().empty())
-    {
-        range_readers.emplace_back(
-            task_readers.main.get(),
-            range_readers.empty() ? Block{} : range_readers.back().getSampleBlock(),
-            /*prewhere_info_=*/ nullptr,
-            step_counter(counter_idx),
-            /*main_reader_=*/ true,
-            can_read_incomplete_granules);
-    }
+        add_range_reader(task_readers.main.get(), /*step=*/ nullptr, step_counter(counter_idx), /*is_main_reader=*/ true);
 
     return MergeTreeReadersChain{std::move(range_readers), task_readers.patches};
 }
@@ -335,7 +336,8 @@ void MergeTreeReadTask::initializeReadersChain(
     MergeTreeIndexBuildContextPtr index_build_context,
     LazyMaterializingRowsPtr lazy_materializing_rows,
     const ReadStepsPerformanceCounters & read_steps_performance_counters,
-    bool collect_predicate_statistics)
+    bool collect_predicate_statistics,
+    RangeReadersSampleBlocksCache & sample_blocks_cache)
 {
     if (readers_chain.isInitialized())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Range readers chain is already initialized");
@@ -353,7 +355,7 @@ void MergeTreeReadTask::initializeReadersChain(
 
     readers_chain = createReadersChain(
         readers, all_prewhere_actions, read_steps_performance_counters,
-        collect_predicate_statistics);
+        collect_predicate_statistics, sample_blocks_cache);
 }
 
 void MergeTreeReadTask::initializeIndexReader(const MergeTreeIndexBuildContextPtr & index_build_context, const LazyMaterializingRowsPtr & lazy_materializing_rows)

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -137,6 +137,27 @@ struct MergeTreeReadTaskInfo
 
 using MergeTreeReadTaskInfoPtr = std::shared_ptr<const MergeTreeReadTaskInfo>;
 
+/// Cache of sample blocks of the range readers chain, one entry per position in the chain.
+/// Sample blocks depend only on the columns of the reader, the prewhere step and the sample blocks of the previous reader,
+/// which are usually the same for consecutive read tasks (even of different parts), so building them once per task is wasteful.
+class RangeReadersSampleBlocksCache
+{
+public:
+    /// Readers must be requested in the order of the chain, starting from index 0.
+    MergeTreeRangeReader::SampleBlocksPtr get(size_t reader_idx, const IMergeTreeReader & reader, const PrewhereExprStepPtr & step);
+
+private:
+    struct Entry
+    {
+        NamesAndTypesList columns;
+        PrewhereExprStepPtr step;
+        MergeTreeRangeReader::SampleBlocksPtr prev_reader_sample_blocks;
+        MergeTreeRangeReader::SampleBlocksPtr sample_blocks;
+    };
+
+    std::vector<Entry> entries;
+};
+
 /// A batch of work for MergeTreeSelectProcessor
 struct MergeTreeReadTask : private boost::noncopyable
 {
@@ -200,7 +221,8 @@ public:
         MergeTreeIndexBuildContextPtr index_build_context,
         LazyMaterializingRowsPtr lazy_materializing_rows,
         const ReadStepsPerformanceCounters & read_steps_performance_counters,
-        bool collect_predicate_statistics);
+        bool collect_predicate_statistics,
+        RangeReadersSampleBlocksCache & sample_blocks_cache);
 
     void initializeIndexReader(const MergeTreeIndexBuildContextPtr & index_build_context, const LazyMaterializingRowsPtr & lazy_materializing_rows);
 
@@ -241,7 +263,8 @@ public:
         const Readers & readers,
         const PrewhereExprInfo & prewhere_actions,
         const ReadStepsPerformanceCounters & read_steps_performance_counters,
-        bool collect_predicate_statistics);
+        bool collect_predicate_statistics,
+        RangeReadersSampleBlocksCache & sample_blocks_cache);
 
 private:
     using DataflowCacheUpdateCallback = std::function<void(

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <mutex>
 #include <vector>
 #include <Core/NamesAndTypes.h>
 #include <Storages/MergeTree/AlterConversions.h>
@@ -140,22 +141,29 @@ using MergeTreeReadTaskInfoPtr = std::shared_ptr<const MergeTreeReadTaskInfo>;
 /// Cache of sample blocks of the range readers chain, one entry per position in the chain.
 /// Sample blocks depend only on the columns of the reader, the prewhere step and the sample blocks of the previous reader,
 /// which are usually the same for consecutive read tasks (even of different parts), so building them once per task is wasteful.
+/// The whole chain is looked up atomically because the cache may be shared between threads
+/// (`MergeTreeSelectProcessor::readCurrentTask` can be called concurrently).
 class RangeReadersSampleBlocksCache
 {
 public:
-    /// Readers must be requested in the order of the chain, starting from index 0.
-    MergeTreeRangeReader::SampleBlocksPtr get(size_t reader_idx, const IMergeTreeReader & reader, const PrewhereExprStepPtr & step);
+    struct ChainReader
+    {
+        IMergeTreeReader * reader;
+        PrewhereExprStepPtr step;
+    };
+
+    std::vector<MergeTreeRangeReader::SampleBlocksPtr> get(const std::vector<ChainReader> & chain);
 
 private:
     struct Entry
     {
         NamesAndTypesList columns;
         PrewhereExprStepPtr step;
-        MergeTreeRangeReader::SampleBlocksPtr prev_reader_sample_blocks;
         MergeTreeRangeReader::SampleBlocksPtr sample_blocks;
     };
 
-    std::vector<Entry> entries;
+    std::mutex mutex;
+    std::vector<Entry> entries TSA_GUARDED_BY(mutex);
 };
 
 /// A batch of work for MergeTreeSelectProcessor

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -261,7 +261,8 @@ MergeTreeSelectProcessor::readCurrentTask(MergeTreeReadTask & current_task, IMer
     if (!current_task.getReadersChain().isInitialized())
         current_task.initializeReadersChain(
             prewhere_actions, merge_tree_index_build_context, lazy_materializing_rows,
-            read_steps_performance_counters, reader_settings.collect_predicate_statistics);
+            read_steps_performance_counters, reader_settings.collect_predicate_statistics,
+            range_readers_sample_blocks_cache);
 
     auto res = task_algorithm.readFromTask(current_task);
 

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -191,6 +191,8 @@ private:
 
     ReadStepsPerformanceCounters read_steps_performance_counters;
 
+    mutable RangeReadersSampleBlocksCache range_readers_sample_blocks_cache;
+
     /// Should we add part level to produced chunk. Part level is useful for next steps if query has FINAL
     bool add_part_level = false;
 

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -196,7 +196,7 @@ MergeTreeSequentialSource::MergeTreeSequentialSource(
 
     auto counters = std::make_shared<ReadStepPerformanceCounters>();
 
-    MergeTreeRangeReader range_reader(readers.main.get(), {}, nullptr, counters, true, readers.main->canReadIncompleteGranules());
+    MergeTreeRangeReader range_reader(readers.main.get(), MergeTreeRangeReader::createSampleBlocks(*readers.main, {}, nullptr), nullptr, counters, true, readers.main->canReadIncompleteGranules());
     readers_chain = MergeTreeReadersChain{{std::move(range_reader)}, readers.patches};
 
     /// Reading may start at a non-zero mark, so track the actual first mark

--- a/src/Storages/MergeTree/PatchParts/MergeTreePatchReader.cpp
+++ b/src/Storages/MergeTree/PatchParts/MergeTreePatchReader.cpp
@@ -56,7 +56,7 @@ static void fixPatchBlockTypes(Block & block, const IMergeTreeReader & patch_rea
 MergeTreePatchReader::MergeTreePatchReader(PatchPartInfoForReader patch_part_, MergeTreeReaderPtr reader_)
     : patch_part(std::move(patch_part_))
     , reader(std::move(reader_))
-    , range_reader(reader.get(), {}, nullptr, std::make_shared<ReadStepPerformanceCounters>(), false, reader->canReadIncompleteGranules())
+    , range_reader(reader.get(), MergeTreeRangeReader::createSampleBlocks(*reader, {}, nullptr), nullptr, std::make_shared<ReadStepPerformanceCounters>(), false, reader->canReadIncompleteGranules())
 {
 }
 

--- a/tests/performance/prewhere_many_parts.xml
+++ b/tests/performance/prewhere_many_parts.xml
@@ -3,13 +3,14 @@
         <max_threads>8</max_threads>
     </settings>
 
-    <create_query>CREATE TABLE mt_prewhere_many_parts (id UInt32, s String, val1 UInt32, val2 UInt32) ENGINE = MergeTree ORDER BY val1 PARTITION BY id % 2000 SETTINGS parts_to_throw_insert = 10000, parts_to_delay_insert = 10000</create_query>
+    <!-- Many small parts and many PREWHERE steps: the per-task cost of building the range readers chain
+         (sample blocks of the readers and dry-runs of the PREWHERE steps) dominates over reading the data. -->
+    <create_query>CREATE TABLE mt_prewhere_many_parts (id UInt32, s String, val1 UInt32, val2 UInt32) ENGINE = MergeTree ORDER BY val1 PARTITION BY id % 5000 SETTINGS parts_to_throw_insert = 10000, parts_to_delay_insert = 10000</create_query>
     <fill_query>SYSTEM STOP MERGES mt_prewhere_many_parts</fill_query>
-    <fill_query>INSERT INTO mt_prewhere_many_parts SELECT number, toString(number % 1000), rand() % 10000, rand() FROM numbers_mt(20000000) SETTINGS max_block_size = 10000000, max_insert_block_size = 10000000, max_partitions_per_insert_block = 2000</fill_query>
+    <fill_query>INSERT INTO mt_prewhere_many_parts SELECT number, toString(number % 1000), rand() % 10000, rand() FROM numbers_mt(500000) SETTINGS max_block_size = 1000000, max_insert_block_size = 1000000, max_partitions_per_insert_block = 5000</fill_query>
 
-    <query>SELECT count() FROM mt_prewhere_many_parts PREWHERE val1 = 7 FORMAT Null</query>
-    <query>SELECT count() FROM mt_prewhere_many_parts PREWHERE val1 % 10 = 1 AND s LIKE '%77%' WHERE val2 != 0 FORMAT Null</query>
-    <query>SELECT sum(val2) FROM mt_prewhere_many_parts PREWHERE s = '123' FORMAT Null</query>
+    <query>SELECT count() FROM mt_prewhere_many_parts PREWHERE val1 % 3 != 1 AND val1 % 4 != 1 AND val1 % 5 != 1 AND val1 % 6 != 1 AND val1 % 7 != 1 AND val1 % 8 != 1 AND val1 % 9 != 1 AND val1 % 10 != 1 AND val1 % 11 != 1 AND val1 % 12 != 1 AND val1 % 13 != 1 AND val1 % 14 != 1 AND val1 % 15 != 1 AND val1 % 16 != 1 AND val1 % 17 != 1 AND val1 % 18 != 1 AND val1 % 19 != 1 AND val1 % 20 != 1 AND val1 % 21 != 1 AND val1 % 22 != 1 AND val1 % 23 != 1 AND val1 % 24 != 1 AND val1 % 25 != 1 AND val1 % 26 != 1 AND val1 % 27 != 1 AND val1 % 28 != 1 AND val1 % 29 != 1 AND val1 % 30 != 1 AND val1 % 31 != 1 AND val1 % 32 != 1 AND val1 % 33 != 1 AND val1 % 34 != 1 AND val1 % 35 != 1 AND val1 % 36 != 1 AND val1 % 37 != 1 AND val1 % 38 != 1 AND val1 % 39 != 1 AND val1 % 40 != 1 AND val1 % 41 != 1 AND val1 % 42 != 1 FORMAT Null</query>
+    <query>SELECT sum(val2) FROM mt_prewhere_many_parts PREWHERE val1 % 3 != 1 AND val1 % 4 != 1 AND val1 % 5 != 1 AND val1 % 6 != 1 AND val1 % 7 != 1 AND val1 % 8 != 1 AND val1 % 9 != 1 AND val1 % 10 != 1 AND val1 % 11 != 1 AND val1 % 12 != 1 AND val1 % 13 != 1 AND val1 % 14 != 1 AND val1 % 15 != 1 AND val1 % 16 != 1 AND val1 % 17 != 1 AND val1 % 18 != 1 AND val1 % 19 != 1 AND val1 % 20 != 1 AND val1 % 21 != 1 AND val1 % 22 != 1 AND val1 % 23 != 1 AND val1 % 24 != 1 AND val1 % 25 != 1 AND val1 % 26 != 1 AND val1 % 27 != 1 AND val1 % 28 != 1 AND val1 % 29 != 1 AND val1 % 30 != 1 AND val1 % 31 != 1 AND val1 % 32 != 1 AND val1 % 33 != 1 AND val1 % 34 != 1 AND val1 % 35 != 1 AND val1 % 36 != 1 AND val1 % 37 != 1 AND val1 % 38 != 1 AND val1 % 39 != 1 AND val1 % 40 != 1 AND val1 % 41 != 1 AND val1 % 42 != 1 AND s LIKE '%77%' WHERE val2 != 0 FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS mt_prewhere_many_parts</drop_query>
 </test>

--- a/tests/performance/prewhere_many_parts.xml
+++ b/tests/performance/prewhere_many_parts.xml
@@ -1,0 +1,15 @@
+<test>
+    <settings>
+        <max_threads>8</max_threads>
+    </settings>
+
+    <create_query>CREATE TABLE mt_prewhere_many_parts (id UInt32, s String, val1 UInt32, val2 UInt32) ENGINE = MergeTree ORDER BY val1 PARTITION BY id % 2000 SETTINGS parts_to_throw_insert = 10000, parts_to_delay_insert = 10000</create_query>
+    <fill_query>SYSTEM STOP MERGES mt_prewhere_many_parts</fill_query>
+    <fill_query>INSERT INTO mt_prewhere_many_parts SELECT number, toString(number % 1000), rand() % 10000, rand() FROM numbers_mt(20000000) SETTINGS max_block_size = 10000000, max_insert_block_size = 10000000, max_partitions_per_insert_block = 2000</fill_query>
+
+    <query>SELECT count() FROM mt_prewhere_many_parts PREWHERE val1 = 7 FORMAT Null</query>
+    <query>SELECT count() FROM mt_prewhere_many_parts PREWHERE val1 % 10 = 1 AND s LIKE '%77%' WHERE val2 != 0 FORMAT Null</query>
+    <query>SELECT sum(val2) FROM mt_prewhere_many_parts PREWHERE s = '123' FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS mt_prewhere_many_parts</drop_query>
+</test>


### PR DESCRIPTION
`MergeTreeRangeReader` built its read and result sample blocks (creating empty columns and dry-running the `PREWHERE` step actions) in the constructor, i.e. once per range reader for every read task. They depend only on the reader columns, the prewhere step and the previous reader's sample blocks, so they are now cached per `MergeTreeSelectProcessor` and shared between consecutive read tasks, including tasks of different parts. In CPU profiles the share of samples spent in readers chain construction drops from 1-2.5% (`hits` with 2000 parts or small read tasks) to about 0.1-0.5%.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reuse the sample blocks of `MergeTreeRangeReader` between read tasks instead of rebuilding them (including a dry run of the `PREWHERE` actions) for every task. This reduces the per-task overhead of reading from `MergeTree` with `PREWHERE`, noticeable with many parts or small read tasks.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117089&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117089](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117089+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
