### PR TITLE
Separate the stress server restart count from the readiness wait in `start_server`

### DIFF
--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -323,7 +323,7 @@ rm -f /etc/clickhouse-server/config.d/fail_points_active.xml
 
 # Use a larger timeout for the post-stress restart: under sanitizers with
 # async_load_databases=false the server may need minutes to load all tables.
-start_server 10 || { echo "Failed to start server"; exit 1; }
+start_server 10 600 || { echo "Failed to start server"; exit 1; }
 
 check_server_start
 

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -7,6 +7,7 @@ FAIL="\tFAIL\t\\N\t"
 
 FAILURE_CONTEXT_LINES=100
 FAILURE_CONTEXT_MAX_LINE_WIDTH=3000
+START_SERVER_READY_TIMEOUT=120
 
 function escaped()
 {
@@ -346,6 +347,16 @@ function wait_server_ports_free()
     done
 }
 
+function report_start_failure()
+{
+    echo "Cannot start clickhouse-server"
+    rg --text "<Error>.*Application" /var/log/clickhouse-server/clickhouse-server.log > /test_output/application_errors.txt ||:
+    echo -e "Cannot start clickhouse-server$FAIL$1$(trim_server_logs application_errors.txt)" >> /test_output/test_results.tsv
+    cat /var/log/clickhouse-server/stdout.log
+    tail -n100 /var/log/clickhouse-server/stderr.log
+    tail -n100000 /var/log/clickhouse-server/clickhouse-server.log | rg -F -v -e '<Warning> RaftInstance:' -e '<Information> RaftInstance' | tail -n100
+}
+
 function start_server()
 {
     # After safeExit (forceful shutdown), the kernel may still be cleaning up sockets,
@@ -354,27 +365,33 @@ function start_server()
 
     counter=0
     max_attempt=${1:-6}
-    until clickhouse-client --receive_timeout 30 --query "SELECT 1"
+    local ready_timeout=${2:-$START_SERVER_READY_TIMEOUT}
+    # The client port opens only after the databases are loaded, so a running server is bounded
+    # by time and only a server that exited is bounded by the number of starts.
+    local wait_start=$SECONDS
+    until clickhouse-client --handshake_timeout_ms=30000 --receive_timeout 30 --query "SELECT 1"
     do
-        if [ "$counter" -gt "$max_attempt" ]
-        then
-            echo "Cannot start clickhouse-server"
-            rg --text "<Error>.*Application" /var/log/clickhouse-server/clickhouse-server.log > /test_output/application_errors.txt ||:
-            echo -e "Cannot start clickhouse-server$FAIL$(trim_server_logs application_errors.txt)" >> /test_output/test_results.tsv
-            cat /var/log/clickhouse-server/stdout.log
-            tail -n100 /var/log/clickhouse-server/stderr.log
-            tail -n100000 /var/log/clickhouse-server/clickhouse-server.log | rg -F -v -e '<Warning> RaftInstance:' -e '<Information> RaftInstance' | tail -n100
-            return 1
-        fi
         # Only wait for ports and restart if the previous daemon actually exited.
         # If the process is still alive, the ports are bound by a healthy but
         # slow-starting server — just retry the readiness check.
-        if [ "$counter" -eq 0 ] || ! pgrep -x clickhouse-serv > /dev/null 2>&1; then
+        if [ "$counter" -eq 0 ] || ! pgrep -x clickhouse-serv > /dev/null 2>&1
+        then
+            if [ "$counter" -gt "$max_attempt" ]
+            then
+                report_start_failure "server process is not running after $counter start attempts"
+                return 1
+            fi
             [ "$counter" -gt 0 ] && wait_server_ports_free
             clickhouse start --user root >/var/log/clickhouse-server/stdout.log 2>>/var/log/clickhouse-server/stderr.log
+            counter=$((counter + 1))
+            # The deadline covers one daemon instance, so each start re-anchors it.
+            wait_start=$SECONDS
+        elif [ "$SECONDS" -ge "$((wait_start + ready_timeout))" ]
+        then
+            report_start_failure "a clickhouse-server process is running but did not become ready in $((SECONDS - wait_start))s after start attempt $counter completed"
+            return 1
         fi
         sleep 10
-        counter=$((counter + 1))
     done
 }
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/115198
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #115198

`start_server` gives up when a *poll* counter exceeds `max_attempt`, so one variable means both the
restart count and the wait length. The client port opens only after a synchronous database load,
32-61 s on debug, while `sleep 10` polls leave the default sites ~71 s; the job exits
before the stress workload runs
([reference run](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116903&sha=e41414d24ff69302b271766d61ca0673c763c95a&name_0=PR&name_1=Stress%20test%20%28amd_debug%29):
eight refused polls, `application_errors.txt` empty).

Both were tuned, each eroding the other. `6e2f9ac2d8f6eb2f` raised the post-stress
restart to ~620 s for synchronous loading; `9b791d800704b7e`, `8d67399ecab53370` and
`4c492a270916d6bf` left that site at 111 s, while its justifying comment survives at
`stress_runner.sh:324-325`. Both are reasonable, so I separated the quantities rather than
raising a number. Values are yours.

`max_attempt` keeps its meaning and default, charged only for restarts, so `clickhouse start` counts
are unchanged: 7 default, 11 at `:326`. A second argument is the readiness deadline.
Both are precedented: `START_SERVER_READY_TIMEOUT=120` matches
`clickhouse_proc.py`'s `wait_ready`, 600 matches
`collect_clickhouse_profiles.py`'s `SERVER_READINESS_TIMEOUT_S`. The poll gains
`--handshake_timeout_ms=30000`; without it the client's handshake bound is 300 s and the deadline
is unenforceable.

The give-up now names the state observed: 48% of these rows have empty context, so "still
loading" and "exited 11 times" look identical; `test_name` is unchanged. A wedged server
costs the deadline, re-anchored per restart, so `max_attempt + 1` of them can be charged: with each
cycle's start and probe, ~1.3 ks default and ~7.4 ks at `:326` of a 10800 s job.

Validated by 16 stubbed arms, one modelling `clickhouse start`'s 60 s pid-file wait, pinning
those counts; deleting the re-anchor reddens it. No test file; `ci/tests/` is being removed
(PR 115650).

Out of scope: `check_server_start`'s handshake bound (#112927's follow-up). Four of my PRs
are open in these files (#112927, #111873, #114029, #113857); the last three touch hunks this PR
moves, so the second to merge needs a rebase.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117094&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117094](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117094+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
