### PR TITLE
Fix row-order-dependent window assertions in 04503_tuple_combinator_multiple_tuples

### DIFF
--- a/tests/queries/0_stateless/04503_tuple_combinator_multiple_tuples.sql
+++ b/tests/queries/0_stateless/04503_tuple_combinator_multiple_tuples.sql
@@ -1,6 +1,8 @@
 -- The -Tuple combinator takes one Tuple argument per argument of the underlying aggregate
 -- function; all tuples must have the same number of elements, and the aggregation at element
 -- position i receives the i-th element of every tuple.
+-- A ROWS frame is positional, so the windowed checks below order by a unique n. Neither fixture is
+-- stored in n order, so that ordering is load-bearing rather than incidental.
 
 SELECT 'two tuples';
 SELECT corrTuple((toFloat64(number), toFloat64(number * 2)), (toFloat64(number * 3), toFloat64(100 - number))) FROM numbers(10);
@@ -20,23 +22,29 @@ SELECT corrTuple((NULL, toFloat64(number)), (toFloat64(number), toFloat64(100 - 
 
 SELECT 'sparse elements with two tuples';
 DROP TABLE IF EXISTS test_tuple_multiple_sparse;
-CREATE TABLE test_tuple_multiple_sparse (x Tuple(a Int64, b Float64)) ENGINE = MergeTree ORDER BY tuple()
+CREATE TABLE test_tuple_multiple_sparse (n UInt64, x Tuple(a Int64, b Float64)) ENGINE = MergeTree ORDER BY tuple()
     SETTINGS ratio_of_defaults_for_sparse_serialization = 0.1;
-INSERT INTO test_tuple_multiple_sparse SELECT if(number % 100 = 0, (number, toFloat64(number)), (0, 0.0)) FROM numbers(1000);
+-- Number 900 has the unique maximum x.a; stored first, its unordered frame is a single row.
+INSERT INTO test_tuple_multiple_sparse
+SELECT number, if(number % 100 = 0, (number, toFloat64(number)), (0, 0.0))
+FROM (SELECT number FROM numbers(1000) ORDER BY number = 900 DESC, number)
+SETTINGS max_insert_threads = 1;
 SELECT corrTuple(x, x) FROM test_tuple_multiple_sparse;
-SELECT corrTuple(x, x) OVER (ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) FROM test_tuple_multiple_sparse ORDER BY x.a DESC LIMIT 1;
+SELECT corrTuple(x, x) OVER (ORDER BY n ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) FROM test_tuple_multiple_sparse ORDER BY x.a DESC LIMIT 1;
 DROP TABLE test_tuple_multiple_sparse;
 
 SELECT 'mixed sparse and dense elements with two tuples';
 DROP TABLE IF EXISTS test_tuple_multiple_mixed;
-CREATE TABLE test_tuple_multiple_mixed (t1 Tuple(v Float64, w Float64), t2 Tuple(v Float64, w Float64)) ENGINE = MergeTree ORDER BY tuple()
+CREATE TABLE test_tuple_multiple_mixed (n UInt64, t1 Tuple(v Float64, w Float64), t2 Tuple(v Float64, w Float64)) ENGINE = MergeTree ORDER BY tuple()
     SETTINGS ratio_of_defaults_for_sparse_serialization = 0.5;
 INSERT INTO test_tuple_multiple_mixed SELECT
+    number,
     (if(cityHash64(number) % 10 = 0, toFloat64(number % 83), 0), toFloat64(1 + number % 3)),
     (toFloat64(1 + number % 7), toFloat64(1 + number % 5))
-FROM numbers(1000);
+FROM (SELECT number FROM numbers(1000) ORDER BY cityHash64(number), number)
+SETTINGS max_insert_threads = 1;
 SELECT (round(r.1, 3), round(r.2, 3)) FROM (SELECT avgWeightedTuple(t1, t2) AS r FROM test_tuple_multiple_mixed);
-SELECT round(sum(x.1), 3), round(sum(x.2), 3) FROM (SELECT avgWeightedTuple(t1, t2) OVER (ROWS BETWEEN 9 PRECEDING AND CURRENT ROW) AS x FROM test_tuple_multiple_mixed);
+SELECT round(sum(x.1), 3), round(sum(x.2), 3) FROM (SELECT avgWeightedTuple(t1, t2) OVER (ORDER BY n ROWS BETWEEN 9 PRECEDING AND CURRENT ROW) AS x FROM test_tuple_multiple_mixed);
 DROP TABLE test_tuple_multiple_mixed;
 
 SELECT 'errors';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/98190
Related: https://github.com/ClickHouse/ClickHouse/pull/104591
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make the windowed assertions in `04503_tuple_combinator_multiple_tuples` independent of physical row order.


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/98190
Related: https://github.com/ClickHouse/ClickHouse/pull/104591

The last two windowed assertions in this test are a function of physical row order, not of the data. Both windows have no `PARTITION BY` and no `ORDER BY`, so no sorting step is created and `WindowStep` feeds them through a resize that does not preserve order, while a `ROWS` frame is positional. Frame membership therefore follows the physical layout, and the `.reference` records one arbitrary order.

This has already cost a workaround: PR 104591 hit it on `Fast test` ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104591&sha=9e02d87331672d01b9ae7d22f1f22f79dad4085b&name_0=PR&name_1=Fast%20test)) and pinned `optimize_row_order_if_no_order_by = 0` on both fixtures in acae6c7. That pin cannot come to master, because the setting does not exist here yet, and the defect is reachable on master today: the existing `optimize_row_order = 1` reproduces that recorded value, `3797.375  1981.608`.

Each window now orders by a new unique `n` row id, so the asserted quantity is a function of the data. Both fixtures are stored out of `n` order, so each clause is individually load-bearing: deleting only its own window `ORDER BY n` makes `clickhouse-test` fail 20 of 20 randomized runs, the mixed assertion returning `4002.539  2001.456` and the sparse one `(nan,nan)`. `ORDER BY tuple()` and the sparse serialization of `t1.v`, `x.a`, `x.b` are unchanged, so both blocks keep the coverage they exist for, and `04505` still covers that frame shape.

**The `.reference` is not modified.** `ORDER BY n` reproduces the ascending `number` order the recorded values came from, so the unchanged reference is itself the check that this pins the intended semantics rather than re-baselining.

As shipped the test passes 50 of 50 randomized runs. This conflicts with PR 104591 on the two `CREATE TABLE` lines and makes its 04503 pin unnecessary. Other stateless tests share this shape; I have not attributed their failures to row order.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117097&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117097](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117097+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.371` (included in `26.9` and later)
<!-- ch-version-info:end -->