### PR TITLE
Fix flaky test_simple_alter_table: do not block on a full SYNC REPLICA

### DIFF
--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -83,11 +83,13 @@ bad_settings_node = cluster.add_instance(
 uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 
 
-def assert_create_query(nodes, table_name, expected):
+def assert_create_query(nodes, table_name, expected, retry_count=20):
     replace_uuid = lambda x: re.sub(uuid_regex, "uuid", x)
     query = "show create table {}".format(table_name)
     for node in nodes:
-        assert_eq_with_retry(node, query, expected, get_result=replace_uuid)
+        assert_eq_with_retry(
+            node, query, expected, retry_count=retry_count, get_result=replace_uuid
+        )
 
 
 def zk_rmr_with_retries(zk, path):
@@ -283,14 +285,23 @@ def test_simple_alter_table(started_cluster, engine):
         "SETTINGS index_granularity = 8192".format(name, full_engine)
     )
 
-    # Ensure all replicas are synchronized before asserting schema equality
+    # Ensure all replicas are synchronized before asserting schema equality.
+    # Waiting for the database DDL log is cheap and cannot block on table data.
+    # For the table itself only pull the log entries into the replication queue: a
+    # plain `SYSTEM SYNC REPLICA` waits for the whole queue to drain and, when the
+    # replica is slow to catch up, spends the full `receive_timeout` (300s by
+    # default) before failing the test with `TIMEOUT_EXCEEDED`. `LIGHTWEIGHT` is not
+    # an option here, because it skips exactly the `ALTER_METADATA` entries this test
+    # asserts on. Convergence is instead awaited by retrying the assertion below.
     dummy_node.query(f"SYSTEM SYNC DATABASE REPLICA {database}")
     competing_node.query(f"SYSTEM SYNC DATABASE REPLICA {database}")
     if "Replicated" in engine:
-        dummy_node.query(f"SYSTEM SYNC REPLICA {name}")
-        competing_node.query(f"SYSTEM SYNC REPLICA {name}")
+        dummy_node.query(f"SYSTEM SYNC REPLICA {name} PULL")
+        competing_node.query(f"SYSTEM SYNC REPLICA {name} PULL")
 
-    assert_create_query([main_node, dummy_node, competing_node], name, expected)
+    assert_create_query(
+        [main_node, dummy_node, competing_node], name, expected, retry_count=120
+    )
     main_node.query(f"DROP DATABASE {database} SYNC")
     dummy_node.query(f"DROP DATABASE {database} SYNC")
     competing_node.query(f"DROP DATABASE {database} SYNC")


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115032
Related: https://github.com/ClickHouse/ClickHouse/pull/95111

`test_replicated_database/test.py::test_simple_alter_table[ReplicatedMergeTree]` intermittently fails with:

```
Code: 159. DB::Exception: SYNC REPLICA test_simple_alter_table_ReplicatedMergeTree.alter_test:
command timed out. See the 'receive_timeout' setting. (TIMEOUT_EXCEEDED)
(query: SYSTEM SYNC REPLICA test_simple_alter_table_ReplicatedMergeTree.alter_test)
```

The blocking `SYSTEM SYNC REPLICA` was added in #95111 to make the `SHOW CREATE TABLE` assertion deterministic. In its default mode it waits for the entire replication queue to drain, so when a replica is slow to catch up it spends the full `receive_timeout` (300 seconds by default) and then fails the test - instead of the assertion simply converging a moment later. The test has no `INSERT`s at all, so nothing about the assertion needs a full queue drain.

This change only pulls the log entries into the queue with `SYSTEM SYNC REPLICA ... PULL`, which cannot block, and waits for convergence by retrying the assertion itself - the condition the test actually checks.

`LIGHTWEIGHT` is not usable here: its entry set is `GET_PART`, `ATTACH_PART`, `DROP_RANGE`, `REPLACE_RANGE` and `DROP_PART`, so it skips exactly the `ALTER_METADATA` entries this test asserts on.

The retry budget of `assert_create_query` is raised from 10 to 60 seconds for this test only (other call sites keep the previous default), because catching up was observed to take about 26 seconds locally under load.

Verified locally with `--count 3` for both engine parametrizations - 6/6 passed:

```
OK test_simple_alter_table[MergeTree-1-3]                3.41s
OK test_simple_alter_table[MergeTree-2-3]               66.76s
OK test_simple_alter_table[MergeTree-3-3]                2.84s
OK test_simple_alter_table[ReplicatedMergeTree-1-3]      4.40s
OK test_simple_alter_table[ReplicatedMergeTree-2-3]      4.65s
OK test_simple_alter_table[ReplicatedMergeTree-3-3]     25.79s
```

Failing CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115032&sha=5fa2be804ec22aaeeb27f2cd3d59fd80c216ba24&name_0=PR&name_1=Integration%20tests%20(arm_binary%2C%20distributed%20plan%2C%204%2F4)

Master history over the last 90 days shows this test failing on 13 separate days across 10 unrelated pull requests, and on `master` itself. Note that this change removes the observed failure mode; it does not explain why a replica with no data parts would need more than 300 seconds to drain its queue. The server logs for the failing run had already rotated, so that remains open.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117105&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117105](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117105+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
