### PR TITLE
Fix a replication queue stuck forever on a duplicated `ALTER_METADATA` entry

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAltersSequence.cpp
@@ -34,16 +34,25 @@ void ReplicatedMergeTreeAltersSequence::addMetadataAlter(
 
 void ReplicatedMergeTreeAltersSequence::finishMetadataAlter(int alter_version, std::unique_lock<SharedMutex> & /*state_lock*/)
 {
-    /// Sequence must not be empty
-    chassert(!queue_state.empty());
-    /// Alters have to be finished in order
-    chassert(queue_state.begin()->first == alter_version);
+    /// The queue may contain several `ALTER_METADATA` entries with the same `alter_version`: a replica that clones
+    /// another one prepends a dummy `ALTER_METADATA` entry to its own queue (see
+    /// `StorageReplicatedMergeTree::cloneMetadataIfNeeded`), and the copied queue of the source replica may already
+    /// contain an entry with that very version. Every such entry finishes the same alter, and all completions but the
+    /// first one have nothing left to do. Note that we must not use `operator[]` here: it would insert the alter back
+    /// into the sequence as unfinished, and, being the smallest version, it would block every later metadata alter
+    /// forever.
+    auto it = queue_state.find(alter_version);
+    if (it == queue_state.end())
+        return;
 
-    /// If metadata stage finished (or was never added) than we can remove this alter
-    if (queue_state[alter_version].data_finished)
-        queue_state.erase(alter_version);
+    /// Alters have to be finished in order
+    chassert(it == queue_state.begin());
+
+    /// If data stage finished (or was never added) than we can remove this alter
+    if (it->second.data_finished)
+        queue_state.erase(it);
     else
-        queue_state[alter_version].metadata_finished = true;
+        it->second.metadata_finished = true;
 }
 
 void ReplicatedMergeTreeAltersSequence::finishDataAlter(int alter_version, std::lock_guard<SharedMutex> & /*state_lock*/)
@@ -81,7 +90,15 @@ bool ReplicatedMergeTreeAltersSequence::canExecuteDataAlter(int alter_version, s
 
 bool ReplicatedMergeTreeAltersSequence::canExecuteMetaAlter(int alter_version, std::unique_lock<SharedMutex> & /*state_lock*/) const
 {
-    chassert(!queue_state.empty());
+    /// The sequence is empty when the alter is already finished, which happens when the queue holds several
+    /// `ALTER_METADATA` entries with the same version (see `finishMetadataAlter`). Executing such an entry is a no-op,
+    /// so let it through instead of postponing it forever.
+    if (queue_state.empty())
+        return true;
+
+    /// All versions smaller than head are finished already, they can be executed
+    if (alter_version < queue_state.begin()->first)
+        return true;
 
     /// We can execute only alters of metadata which are in head.
     return queue_state.begin()->first == alter_version;

--- a/src/Storages/tests/gtest_replicated_merge_tree_alters_sequence.cpp
+++ b/src/Storages/tests/gtest_replicated_merge_tree_alters_sequence.cpp
@@ -1,0 +1,157 @@
+#include <gtest/gtest.h>
+
+#include <Storages/MergeTree/ReplicatedMergeTreeAltersSequence.h>
+
+using namespace DB;
+
+namespace
+{
+
+/// `ReplicatedMergeTreeAltersSequence` expects its caller to hold the queue state lock. The locks are
+/// not used for anything else, so a private mutex is enough to drive the sequence from a test.
+class SequenceUnderLock
+{
+public:
+    void addMutationForAlter(int alter_version)
+    {
+        std::lock_guard lock(mutex);
+        sequence.addMutationForAlter(alter_version, lock);
+    }
+
+    void addMetadataAlter(int alter_version)
+    {
+        std::lock_guard lock(mutex);
+        sequence.addMetadataAlter(alter_version, lock);
+    }
+
+    void finishMetadataAlter(int alter_version)
+    {
+        std::unique_lock lock(mutex);
+        sequence.finishMetadataAlter(alter_version, lock);
+    }
+
+    void finishDataAlter(int alter_version)
+    {
+        std::lock_guard lock(mutex);
+        sequence.finishDataAlter(alter_version, lock);
+    }
+
+    bool canExecuteMetaAlter(int alter_version)
+    {
+        std::unique_lock lock(mutex);
+        return sequence.canExecuteMetaAlter(alter_version, lock);
+    }
+
+    bool canExecuteDataAlter(int alter_version)
+    {
+        std::unique_lock lock(mutex);
+        return sequence.canExecuteDataAlter(alter_version, lock);
+    }
+
+    int getHeadAlterVersion()
+    {
+        std::unique_lock lock(mutex);
+        return sequence.getHeadAlterVersion(lock);
+    }
+
+private:
+    SharedMutex mutex;
+    ReplicatedMergeTreeAltersSequence sequence;
+};
+
+}
+
+TEST(ReplicatedMergeTreeAltersSequence, AltersAreExecutedInOrder)
+{
+    SequenceUnderLock sequence;
+
+    sequence.addMutationForAlter(1);
+    sequence.addMetadataAlter(1);
+    sequence.addMutationForAlter(2);
+    sequence.addMetadataAlter(2);
+
+    ASSERT_EQ(sequence.getHeadAlterVersion(), 1);
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(1));
+    ASSERT_FALSE(sequence.canExecuteMetaAlter(2));
+    /// The data alter has to wait for the metadata of the same version.
+    ASSERT_FALSE(sequence.canExecuteDataAlter(1));
+
+    sequence.finishMetadataAlter(1);
+    ASSERT_TRUE(sequence.canExecuteDataAlter(1));
+    ASSERT_FALSE(sequence.canExecuteMetaAlter(2));
+
+    sequence.finishDataAlter(1);
+    ASSERT_EQ(sequence.getHeadAlterVersion(), 2);
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(2));
+}
+
+/// A replica created by cloning another one ends up with two `ALTER_METADATA` entries of the same
+/// version in its queue: the dummy one prepended by `StorageReplicatedMergeTree::cloneMetadataIfNeeded`
+/// and the one copied from the source replica's queue. Both of them finish the same alter, and that
+/// used to leave the finished alter in the sequence forever, blocking every later metadata alter --
+/// the replication queue got stuck and `SYSTEM SYNC REPLICA` hung until `receive_timeout`.
+TEST(ReplicatedMergeTreeAltersSequence, DuplicateMetadataAlterVersionDoesNotBlockLaterAlters)
+{
+    SequenceUnderLock sequence;
+
+    sequence.addMetadataAlter(7);
+    sequence.addMetadataAlter(7);
+
+    /// The next alter is pulled from the log while both entries are still in the queue.
+    sequence.addMutationForAlter(8);
+    sequence.addMetadataAlter(8);
+
+    /// Both entries of version 7 are picked up by the background pool before either of them completes.
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(7));
+    sequence.finishMetadataAlter(7);
+    sequence.finishMetadataAlter(7);
+
+    /// Version 7 is done, so version 8 is at the head and can be executed.
+    ASSERT_EQ(sequence.getHeadAlterVersion(), 8);
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(8));
+
+    sequence.finishDataAlter(8);
+    sequence.finishMetadataAlter(8);
+
+    /// And so can the alter after it.
+    sequence.addMutationForAlter(9);
+    sequence.addMetadataAlter(9);
+    ASSERT_EQ(sequence.getHeadAlterVersion(), 9);
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(9));
+}
+
+/// The same two entries, but the second one is checked only after the first one has completed.
+TEST(ReplicatedMergeTreeAltersSequence, DuplicateMetadataAlterVersionIsExecutableAfterTheFirstOne)
+{
+    SequenceUnderLock sequence;
+
+    sequence.addMetadataAlter(7);
+    sequence.addMetadataAlter(7);
+    sequence.addMutationForAlter(8);
+    sequence.addMetadataAlter(8);
+
+    sequence.finishMetadataAlter(7);
+
+    /// Executing the second entry of version 7 is a no-op, but it still has to be executed to leave the queue.
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(7));
+    sequence.finishMetadataAlter(7);
+
+    ASSERT_EQ(sequence.getHeadAlterVersion(), 8);
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(8));
+}
+
+/// The duplicated alter is the only one in the queue, so the sequence becomes empty in the middle.
+TEST(ReplicatedMergeTreeAltersSequence, DuplicateMetadataAlterVersionAsTheOnlyEntry)
+{
+    SequenceUnderLock sequence;
+
+    sequence.addMetadataAlter(7);
+    sequence.addMetadataAlter(7);
+
+    sequence.finishMetadataAlter(7);
+    ASSERT_EQ(sequence.getHeadAlterVersion(), -1);
+
+    ASSERT_TRUE(sequence.canExecuteMetaAlter(7));
+    sequence.finishMetadataAlter(7);
+    ASSERT_EQ(sequence.getHeadAlterVersion(), -1);
+}


### PR DESCRIPTION
A replica created by cloning another one ends up with **two `ALTER_METADATA` entries of the same `alter_version`** in its replication queue:

* the dummy one prepended by `StorageReplicatedMergeTree::cloneMetadataIfNeeded`, and
* the one copied from the source replica's queue (the source replica has already advanced its `/metadata_version` but has not drained that entry yet).

Both entries finish the same alter, and `ReplicatedMergeTreeAltersSequence::finishMetadataAlter` used `operator[]`, which **inserts**. So the second completion put the already erased alter back into the sequence as unfinished. Being the smallest version it stayed at the head forever, and every later metadata alter was postponed:

```
Cannot execute alter metadata queue-0000000003 with version 9 because another alter 7 must be executed before
```

The replication queue never drained, so `SYSTEM SYNC REPLICA` hung until `receive_timeout` and the replica never picked up the newer schema.

In the opposite interleaving, where the second entry is examined only after the first one has completed, `canExecuteMetaAlter` postponed that entry forever instead, because its version was already below the head - so the queue got stuck either way.

Both cases are fixed:

* a repeated `finishMetadataAlter` is a no-op instead of resurrecting the alter, and
* an `ALTER_METADATA` entry whose alter is already finished is allowed to execute, which `StorageReplicatedMergeTree::executeMetadataAlter` already handles as a no-op ("Attempt to update metadata of version ... to older version ...").

Added `src/Storages/tests/gtest_replicated_merge_tree_alters_sequence.cpp`, which replays the exact sequence of sequence operations taken from the failing CI log, in both interleavings.

This is the root cause of the long-standing flakiness of `test_replicated_database/test.py::test_simple_alter_table[ReplicatedMergeTree]`, which is the test that creates a replica after a delay and then synchronizes it.

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=db05a1cdad9653e2ac26ae6c1ecd819a07ac77e5&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29

Closes: https://github.com/ClickHouse/ClickHouse/issues/53498

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a replication queue of a `ReplicatedMergeTree` table getting stuck forever after a new replica was added by cloning an existing one. The queue could contain two `ALTER_METADATA` entries for the same `ALTER`, and finishing the second one made all subsequent `ALTER`s wait indefinitely, so `SYSTEM SYNC REPLICA` timed out and the new replica never picked up the newer schema.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117107&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117107](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117107+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
