### PR TITLE
[fix](iceberg) Read snapshots without schema-id

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -399,7 +399,7 @@ static Poco::JSON::Object::Ptr traverseMetadataAndFindNecessarySnapshotObject(
 }
 
 IcebergDataSnapshotPtr IcebergMetadata::createIcebergDataSnapshotFromSnapshotJSON(
-    Poco::JSON::Object::Ptr snapshot_object, Int64 snapshot_id, ContextPtr local_context) const
+    Poco::JSON::Object::Ptr snapshot_object, Int64 snapshot_id, Int32 fallback_schema_id, ContextPtr local_context) const
 {
     if (!snapshot_object->has(f_manifest_list))
         throw Exception(
@@ -426,9 +426,9 @@ IcebergDataSnapshotPtr IcebergMetadata::createIcebergDataSnapshotFromSnapshotJSO
         }
     }
 
-    if (!snapshot_object->has(f_schema_id) || snapshot_object->isNull(f_schema_id))
-        throw Exception(ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "No schema id found for snapshot id `{}`", snapshot_id);
-    Int32 schema_id = snapshot_object->getValue<Int32>(f_schema_id);
+    const Int32 schema_id = snapshot_object->has(f_schema_id) && !snapshot_object->isNull(f_schema_id)
+        ? snapshot_object->getValue<Int32>(f_schema_id)
+        : fallback_schema_id;
 
 
     return std::make_shared<IcebergDataSnapshot>(
@@ -440,14 +440,14 @@ IcebergDataSnapshotPtr IcebergMetadata::createIcebergDataSnapshotFromSnapshotJSO
         total_position_deletes);
 }
 
-IcebergDataSnapshotPtr
-IcebergMetadata::getIcebergDataSnapshot(Poco::JSON::Object::Ptr metadata_object, Int64 snapshot_id, ContextPtr local_context) const
+IcebergDataSnapshotPtr IcebergMetadata::getIcebergDataSnapshot(
+    Poco::JSON::Object::Ptr metadata_object, Int64 snapshot_id, Int32 fallback_schema_id, ContextPtr local_context) const
 {
     auto object = traverseMetadataAndFindNecessarySnapshotObject(metadata_object, snapshot_id, persistent_components.schema_processor);
     if (!object)
         throw Exception(ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "No snapshot found for id `{}`", snapshot_id);
 
-    return createIcebergDataSnapshotFromSnapshotJSON(object, snapshot_id, local_context);
+    return createIcebergDataSnapshotFromSnapshotJSON(object, snapshot_id, fallback_schema_id, local_context);
 }
 
 bool IcebergMetadata::optimize(
@@ -541,6 +541,7 @@ IcebergMetadata::getStateImpl(const ContextPtr & local_context, Poco::JSON::Obje
             "Time travel with timestamp and snapshot id for iceberg table by path {} cannot be changed simultaneously",
             persistent_components.table_path);
     }
+    const Int32 current_table_schema_id = parseTableSchema(metadata_object, *persistent_components.schema_processor, log);
     if (timestamp_changed)
     {
         if (!metadata_object->has(f_snapshot_log))
@@ -569,31 +570,29 @@ IcebergMetadata::getStateImpl(const ContextPtr & local_context, Poco::JSON::Obje
                 ErrorCodes::BAD_ARGUMENTS,
                 "No snapshot found in snapshot log before requested timestamp for iceberg table {}",
                 persistent_components.table_path);
-        auto data_snapshot = getIcebergDataSnapshot(metadata_object, *current_snapshot_id, local_context);
+        auto data_snapshot = getIcebergDataSnapshot(metadata_object, *current_snapshot_id, current_table_schema_id, local_context);
         return {data_snapshot, static_cast<Int32>(data_snapshot->schema_id_on_snapshot_commit)};
     }
     else if (snapshot_id_changed)
     {
         Int64 current_snapshot_id = local_context->getSettingsRef()[Setting::iceberg_snapshot_id];
-        auto data_snapshot = getIcebergDataSnapshot(metadata_object, current_snapshot_id, local_context);
+        auto data_snapshot = getIcebergDataSnapshot(metadata_object, current_snapshot_id, current_table_schema_id, local_context);
         return {data_snapshot, static_cast<Int32>(data_snapshot->schema_id_on_snapshot_commit)};
     }
     else
     {
-        auto schema_id = parseTableSchema(metadata_object, *persistent_components.schema_processor, log);
         if (!metadata_object->has(f_current_snapshot_id))
         {
-            return {nullptr, schema_id};
+            return {nullptr, current_table_schema_id};
         }
-        Int64 current_snapshot_id = metadata_object->isNull(f_current_snapshot_id)
-            ? -1
-            : metadata_object->getValue<Int64>(f_current_snapshot_id);
+        Int64 current_snapshot_id
+            = metadata_object->isNull(f_current_snapshot_id) ? -1 : metadata_object->getValue<Int64>(f_current_snapshot_id);
         if (current_snapshot_id < 0)
         {
-            return {nullptr, schema_id};
+            return {nullptr, current_table_schema_id};
         }
-        auto data_snapshot = getIcebergDataSnapshot(metadata_object, current_snapshot_id, local_context);
-        return {data_snapshot, schema_id};
+        auto data_snapshot = getIcebergDataSnapshot(metadata_object, current_snapshot_id, current_table_schema_id, local_context);
+        return {data_snapshot, current_table_schema_id};
     }
 }
 
@@ -909,7 +908,8 @@ Iceberg::IcebergDataSnapshotPtr IcebergMetadata::getRelevantDataSnapshotFromTabl
     Poco::JSON::Object::Ptr snapshot_object = traverseMetadataAndFindNecessarySnapshotObject(
         metadata_object, *table_state_snapshot.snapshot_id, persistent_components.schema_processor);
 
-    return createIcebergDataSnapshotFromSnapshotJSON(snapshot_object, *table_state_snapshot.snapshot_id, local_context);
+    return createIcebergDataSnapshotFromSnapshotJSON(
+        snapshot_object, *table_state_snapshot.snapshot_id, table_state_snapshot.schema_id, local_context);
 }
 
 DataLakeMetadataPtr IcebergMetadata::create(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -384,10 +384,13 @@ static Poco::JSON::Object::Ptr traverseMetadataAndFindNecessarySnapshotObject(
     for (size_t i = 0; i < snapshots->size(); ++i)
     {
         const auto snapshot = snapshots->getObject(static_cast<UInt32>(i));
-        auto current_snapshot_id = snapshot->getValue<Int64>(f_metadata_snapshot_id);
-        auto current_schema_id = snapshot->getValue<Int32>(f_schema_id);
-        schema_processor->registerSnapshotWithSchemaId(current_snapshot_id, current_schema_id);
-        if (snapshot->getValue<Int64>(f_metadata_snapshot_id) == snapshot_id)
+        const auto current_snapshot_id = snapshot->getValue<Int64>(f_metadata_snapshot_id);
+        if (snapshot->has(f_schema_id) && !snapshot->isNull(f_schema_id))
+        {
+            const auto current_schema_id = snapshot->getValue<Int32>(f_schema_id);
+            schema_processor->registerSnapshotWithSchemaId(current_snapshot_id, current_schema_id);
+        }
+        if (current_snapshot_id == snapshot_id)
         {
             current_snapshot = snapshot;
         }
@@ -423,7 +426,7 @@ IcebergDataSnapshotPtr IcebergMetadata::createIcebergDataSnapshotFromSnapshotJSO
         }
     }
 
-    if (!snapshot_object->has(f_schema_id))
+    if (!snapshot_object->has(f_schema_id) || snapshot_object->isNull(f_schema_id))
         throw Exception(ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "No schema id found for snapshot id `{}`", snapshot_id);
     Int32 schema_id = snapshot_object->getValue<Int32>(f_schema_id);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -207,10 +207,11 @@ private:
         ContextPtr context_,
         LoggerPtr log);
 
-    Iceberg::IcebergDataSnapshotPtr
-    getIcebergDataSnapshot(Poco::JSON::Object::Ptr metadata_object, Int64 snapshot_id, ContextPtr local_context) const;
+    Iceberg::IcebergDataSnapshotPtr getIcebergDataSnapshot(
+        Poco::JSON::Object::Ptr metadata_object, Int64 snapshot_id, Int32 fallback_schema_id, ContextPtr local_context) const;
 
-    Iceberg::IcebergDataSnapshotPtr createIcebergDataSnapshotFromSnapshotJSON(Poco::JSON::Object::Ptr snapshot_object, Int64 snapshot_id, ContextPtr local_context) const;
+    Iceberg::IcebergDataSnapshotPtr createIcebergDataSnapshotFromSnapshotJSON(
+        Poco::JSON::Object::Ptr snapshot_object, Int64 snapshot_id, Int32 fallback_schema_id, ContextPtr local_context) const;
     std::pair<Iceberg::IcebergDataSnapshotPtr, Int32>
     getStateImpl(const ContextPtr & local_context, Poco::JSON::Object::Ptr metadata_object) const;
     std::pair<Iceberg::IcebergDataSnapshotPtr, Iceberg::TableStateSnapshot>

--- a/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.reference
+++ b/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.reference
@@ -1,7 +1,7 @@
 1
-absent schema-id rejected
 1
-null schema-id rejected
+1
 2
 2
+1
 OK

--- a/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.reference
+++ b/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.reference
@@ -1,0 +1,7 @@
+1
+absent schema-id rejected
+1
+null schema-id rejected
+2
+2
+OK

--- a/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.sh
+++ b/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.sh
@@ -9,6 +9,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+latest_metadata_file()
+{
+    local metadata_path=$1
+
+    for metadata_file in "${metadata_path}"/v*.metadata.json
+    do
+        basename "${metadata_file}"
+    done | sort -t v -k2 -n | tail -1
+}
+
 rewrite_metadata()
 {
     local metadata_path=$1
@@ -55,11 +65,11 @@ ${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE1} (c Int32) ENGINE = IcebergL
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE1} VALUES (1)"
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE1}"
 
-LATEST1=$(ls "${PATH1}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+LATEST1=$(latest_metadata_file "${PATH1}metadata")
 rewrite_metadata "${PATH1}metadata" "${LATEST1}" absent
 ${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE1}"
 
-LATEST1=$(ls "${PATH1}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+LATEST1=$(latest_metadata_file "${PATH1}metadata")
 rewrite_metadata "${PATH1}metadata" "${LATEST1}" null
 ${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE1}"
 
@@ -72,7 +82,7 @@ ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INS
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE2} VALUES (2)"
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE2}"
 
-LATEST2=$(ls "${PATH2}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+LATEST2=$(latest_metadata_file "${PATH2}metadata")
 HISTORICAL_SNAPSHOT_ID=$(rewrite_metadata "${PATH2}metadata" "${LATEST2}" historical)
 
 ${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE2}"

--- a/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.sh
+++ b/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# Tag no-replicated-database: IcebergLocal is non-replicated.
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/100304
+# Historical snapshots may omit `schema-id`. Selected snapshots with a missing or null
+# `schema-id` must return `ICEBERG_SPECIFICATION_VIOLATION`, not a Poco exception.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+rewrite_metadata()
+{
+    local metadata_path=$1
+    local latest=$2
+    local mode=$3
+
+    python3 - "${metadata_path}" "${latest}" "${mode}" <<'PY'
+import json
+import os
+import re
+import sys
+
+metadata_path, latest, mode = sys.argv[1:]
+with open(os.path.join(metadata_path, latest)) as metadata_file:
+    metadata = json.load(metadata_file)
+
+current_snapshot_id = metadata["current-snapshot-id"]
+if mode == "historical":
+    snapshot = next(snapshot for snapshot in metadata["snapshots"] if snapshot["snapshot-id"] != current_snapshot_id)
+else:
+    snapshot = next(snapshot for snapshot in metadata["snapshots"] if snapshot["snapshot-id"] == current_snapshot_id)
+
+if mode == "null":
+    snapshot["schema-id"] = None
+else:
+    snapshot.pop("schema-id", None)
+
+metadata["last-updated-ms"] = metadata.get("last-updated-ms", 0) + 60000
+version = int(re.match(r"v(\d+)\.metadata\.json", latest).group(1)) + 1
+temporary = os.path.join(metadata_path, ".tmp_next")
+with open(temporary, "w") as metadata_file:
+    json.dump(metadata, metadata_file)
+os.rename(temporary, os.path.join(metadata_path, f"v{version}.metadata.json"))
+PY
+}
+
+TABLE1="t1_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PATH1="${USER_FILES_PATH}/${TABLE1}/"
+rm -rf "${PATH1}" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE1} (c Int32) ENGINE = IcebergLocal('${PATH1}')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE1} VALUES (1)"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE1}"
+
+LATEST1=$(ls "${PATH1}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+rewrite_metadata "${PATH1}metadata" "${LATEST1}" absent
+
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE1}" 2>&1 \
+    | grep -q -E "No schema id found for snapshot id.*ICEBERG_SPECIFICATION_VIOLATION" \
+    && echo "absent schema-id rejected" || echo "NOT REJECTED"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE1}"
+rm -rf "${PATH1}" 2>/dev/null
+
+TABLE2="t2_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PATH2="${USER_FILES_PATH}/${TABLE2}/"
+rm -rf "${PATH2}" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE2} (c Int32) ENGINE = IcebergLocal('${PATH2}')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE2} VALUES (1)"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE2}"
+
+LATEST2=$(ls "${PATH2}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+rewrite_metadata "${PATH2}metadata" "${LATEST2}" null
+
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE2}" 2>&1 \
+    | grep -q -E "No schema id found for snapshot id.*ICEBERG_SPECIFICATION_VIOLATION" \
+    && echo "null schema-id rejected" || echo "NOT REJECTED"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE2}"
+rm -rf "${PATH2}" 2>/dev/null
+
+TABLE3="t3_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PATH3="${USER_FILES_PATH}/${TABLE3}/"
+rm -rf "${PATH3}" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE3} (c Int32) ENGINE = IcebergLocal('${PATH3}')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE3} VALUES (1)"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE3} VALUES (2)"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE3}"
+
+LATEST3=$(ls "${PATH3}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+rewrite_metadata "${PATH3}metadata" "${LATEST3}" historical
+
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE3}"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE3}"
+rm -rf "${PATH3}" 2>/dev/null
+
+echo "OK"

--- a/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.sh
+++ b/tests/queries/0_stateless/05052_iceberg_optional_snapshot_schema_id.sh
@@ -3,8 +3,7 @@
 # Tag no-replicated-database: IcebergLocal is non-replicated.
 
 # Regression test for https://github.com/ClickHouse/ClickHouse/issues/100304
-# Historical snapshots may omit `schema-id`. Selected snapshots with a missing or null
-# `schema-id` must return `ICEBERG_SPECIFICATION_VIOLATION`, not a Poco exception.
+# Snapshot `schema-id` is optional. ClickHouse falls back to the current table schema.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -43,6 +42,8 @@ temporary = os.path.join(metadata_path, ".tmp_next")
 with open(temporary, "w") as metadata_file:
     json.dump(metadata, metadata_file)
 os.rename(temporary, os.path.join(metadata_path, f"v{version}.metadata.json"))
+if mode == "historical":
+    print(snapshot["snapshot-id"])
 PY
 }
 
@@ -56,13 +57,11 @@ ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE1}"
 
 LATEST1=$(ls "${PATH1}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
 rewrite_metadata "${PATH1}metadata" "${LATEST1}" absent
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE1}"
 
-${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE1}" 2>&1 \
-    | grep -q -E "No schema id found for snapshot id.*ICEBERG_SPECIFICATION_VIOLATION" \
-    && echo "absent schema-id rejected" || echo "NOT REJECTED"
-
-${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE1}"
-rm -rf "${PATH1}" 2>/dev/null
+LATEST1=$(ls "${PATH1}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
+rewrite_metadata "${PATH1}metadata" "${LATEST1}" null
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE1}"
 
 TABLE2="t2_${CLICKHOUSE_DATABASE}_${RANDOM}"
 PATH2="${USER_FILES_PATH}/${TABLE2}/"
@@ -70,33 +69,17 @@ rm -rf "${PATH2}" 2>/dev/null
 
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE2} (c Int32) ENGINE = IcebergLocal('${PATH2}')"
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE2} VALUES (1)"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE2} VALUES (2)"
 ${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE2}"
 
 LATEST2=$(ls "${PATH2}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
-rewrite_metadata "${PATH2}metadata" "${LATEST2}" null
+HISTORICAL_SNAPSHOT_ID=$(rewrite_metadata "${PATH2}metadata" "${LATEST2}" historical)
 
-${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE2}" 2>&1 \
-    | grep -q -E "No schema id found for snapshot id.*ICEBERG_SPECIFICATION_VIOLATION" \
-    && echo "null schema-id rejected" || echo "NOT REJECTED"
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE2}"
+${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --iceberg_snapshot_id="${HISTORICAL_SNAPSHOT_ID}" \
+    --query "SELECT count() FROM ${TABLE2}"
 
-${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE2}"
-rm -rf "${PATH2}" 2>/dev/null
-
-TABLE3="t3_${CLICKHOUSE_DATABASE}_${RANDOM}"
-PATH3="${USER_FILES_PATH}/${TABLE3}/"
-rm -rf "${PATH3}" 2>/dev/null
-
-${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE3} (c Int32) ENGINE = IcebergLocal('${PATH3}')"
-${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE3} VALUES (1)"
-${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --query "INSERT INTO ${TABLE3} VALUES (2)"
-${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${TABLE3}"
-
-LATEST3=$(ls "${PATH3}metadata/" | grep -E '^v[0-9]+\.metadata\.json$' | sort -t v -k2 -n | tail -1)
-rewrite_metadata "${PATH3}metadata" "${LATEST3}" historical
-
-${CLICKHOUSE_CLIENT} --iceberg_metadata_staleness_ms=0 --query "SELECT count() FROM ${TABLE3}"
-
-${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE3}"
-rm -rf "${PATH3}" 2>/dev/null
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE1}, ${TABLE2}"
+rm -rf "${PATH1}" "${PATH2}" 2>/dev/null
 
 echo "OK"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/100304
Related: https://github.com/ClickHouse/ClickHouse/pull/114465

Iceberg snapshots may omit the optional `schema-id` field. ClickHouse currently converts the missing value to an integer unconditionally, so one valid current or historical snapshot can make the table unreadable with `Poco::InvalidAccessException`.

This change uses the table's current schema as the fallback, matching Iceberg's reference behavior. Explicit snapshot schema IDs still take precedence, and manifest reads retain their existing schema fallback.

### Testing

The official master build at `2af4f37af27fba2b561f4984d95ff1703a7e2c00` reproduces both forms:

```text
== snapshot omits schema-id ==
baseline rows: 1
Code: 1001. DB::Exception: Poco::InvalidAccessException: Invalid access. (STD_EXCEPTION)

== snapshot has "schema-id": null ==
baseline rows: 1
Code: 1001. DB::Exception: Poco::InvalidAccessException: Invalid access. (STD_EXCEPTION)
```

The new stateless test covers absent and null IDs on the selected snapshot, an older historical snapshot without an ID, and time travel to that snapshot. A post-fix ClickHouse binary was not available locally, so runtime green is deferred to CI. The shell and embedded Python parse cleanly; shellcheck and changed-line clang-format pass.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix reading Iceberg tables when a current or historical snapshot omits its optional schema ID.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117112&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117112](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117112+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
