### PR TITLE
Revert "Print Pipeline on Unfinished Processor Removal"

### DIFF
--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -5,11 +5,6 @@
 #include <Processors/IProcessor.h>
 #include <Processors/Port.h>
 
-#include <QueryPipeline/printPipeline.h>
-
-#include <IO/WriteBufferFromString.h>
-#include <IO/Operators.h>
-
 #include <Common/Stopwatch.h>
 #include <Common/CurrentThread.h>
 #include <Common/ThreadStatus.h>
@@ -66,7 +61,7 @@ ExecutingGraph::Node & ExecutingGraph::addNode(Processors::iterator processor_it
 
     const auto [_, inserted] = processors_map.emplace(processor, &new_node);
     if (!inserted)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Processor {} was already added to pipeline. Graph: {}", processor->getName(), dump(false));
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Processor {} was already added to pipeline", processor->getName());
 
     return new_node;
 }
@@ -75,14 +70,14 @@ std::pair<const ExecutingGraph::Node *, std::unordered_set<const void *>> Execut
 {
     auto node_it = processors_map.find(processor.get());
     if (node_it == processors_map.end())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Processor {} does not exist in pipeline. Graph: {}", processor->getName(), dump(false));
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Processor {} does not exist in pipeline", processor->getName());
 
     auto * node = node_it->second;
     if (!node->last_processor_status)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}. Graph: {}", processor->getName(), dump(false));
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}", processor->getName());
 
     if (node->last_processor_status.value() != IProcessor::Status::Finished)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}. Graph: {}", processor->getName(), dump(false));
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}", processor->getName());
 
     std::unordered_set<const void *> removed_edges;
     removed_edges.insert_range(node->direct_edges | std::views::transform([](const auto & edge) { return edge.update_info.id; }));
@@ -341,38 +336,6 @@ void ExecutingGraph::accountFinishedProcessorInGroup(const ProcessorPtr & proces
         return;
 
     group_it->second->not_finished.fetch_sub(1);
-}
-
-String ExecutingGraph::dump(bool with_profile_counters) const
-{
-    if (with_profile_counters)
-    {
-        for (const auto & node : nodes)
-        {
-            WriteBufferFromOwnString buffer;
-            buffer << "(" << node.num_executed_jobs << " jobs";
-
-#ifndef NDEBUG
-            buffer << ", execution time: " << static_cast<double>(node.execution_time_ns) / 1e9 << " sec.";
-            buffer << ", preparation time: " << static_cast<double>(node.preparation_time_ns) / 1e9 << " sec.";
-#endif
-
-            buffer << ")";
-            node.processor()->setDescription(buffer.str());
-        }
-    }
-
-    std::vector<std::optional<IProcessor::Status>> statuses;
-    statuses.reserve(nodes.size());
-
-    for (const auto & node : nodes)
-        statuses.emplace_back(node.last_processor_status);
-
-    WriteBufferFromOwnString out;
-    printPipeline(getProcessors(), statuses, out, false, true);
-    out.finalize();
-
-    return out.str();
 }
 
 void ExecutingGraph::initializeExecution(Queue & queue, Queue & async_queue)

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -141,7 +141,6 @@ public:
     explicit ExecutingGraph(std::shared_ptr<Processors> processors_, bool profile_processors_);
 
     const Processors & getProcessors() const { return *processors; }
-    String dump(bool with_profile_counters = true) const;
 
     /// Traverse graph the first time to update all the childless nodes.
     void initializeExecution(Queue & queue, Queue & async_queue);

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -229,7 +229,7 @@ void PipelineExecutor::execute(size_t num_threads, bool concurrency_control)
         span.addAttribute(DB::ExecutionStatus::fromCurrentException());
 
 #ifndef NDEBUG
-        LOG_TRACE(log, "Exception while executing query. Current state:\n{}", graph->dump());
+        LOG_TRACE(log, "Exception while executing query. Current state:\n{}", dumpPipeline());
 #endif
         throw;
     }
@@ -347,7 +347,7 @@ void PipelineExecutor::finalizeExecution()
     }
 
     if (!all_processors_finished)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Pipeline stuck. Current state:\n{}\n{}", graph->dump(), tasks.dump());
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Pipeline stuck. Current state:\n{}\n{}", dumpPipeline(), tasks.dump());
 }
 
 void PipelineExecutor::executeSingleThread(size_t thread_num, WorkloadResources && resources)
@@ -739,6 +739,42 @@ void PipelineExecutor::executeImpl(size_t num_threads, bool concurrency_control)
 
         throw;
     }
+}
+
+String PipelineExecutor::dumpPipeline() const
+{
+    for (const auto & node : graph->nodes)
+    {
+        {
+            WriteBufferFromOwnString buffer;
+            buffer << "(" << node.num_executed_jobs << " jobs";
+
+#ifndef NDEBUG
+            buffer << ", execution time: " << static_cast<double>(node.execution_time_ns) / 1e9 << " sec.";
+            buffer << ", preparation time: " << static_cast<double>(node.preparation_time_ns) / 1e9 << " sec.";
+#endif
+
+            buffer << ")";
+            node.processor()->setDescription(buffer.str());
+        }
+    }
+
+    std::vector<std::optional<IProcessor::Status>> statuses;
+    std::vector<IProcessor *> proc_list;
+    statuses.reserve(graph->nodes.size());
+    proc_list.reserve(graph->nodes.size());
+
+    for (const auto & node : graph->nodes)
+    {
+        proc_list.emplace_back(node.processor());
+        statuses.emplace_back(node.last_processor_status);
+    }
+
+    WriteBufferFromOwnString out;
+    printPipeline(graph->getProcessors(), statuses, out);
+    out.finalize();
+
+    return out.str();
 }
 
 }

--- a/src/Processors/Executors/PipelineExecutor.h
+++ b/src/Processors/Executors/PipelineExecutor.h
@@ -142,6 +142,8 @@ private:
 
     /// If execution_status == from, change it to desired.
     bool tryUpdateExecutionStatus(ExecutionStatus expected, ExecutionStatus desired);
+
+    String dumpPipeline() const;
 };
 
 using PipelineExecutorPtr = std::shared_ptr<PipelineExecutor>;


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#115584

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117128&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117128](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117128+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.376` (included in `26.9` and later)
- Backported to: `26.8.3.11`
<!-- ch-version-info:end -->