### PR TITLE
Fix flaky `test_insert_into_distributed::test_reconnect`

### DIFF
--- a/tests/integration/test_insert_into_distributed/test.py
+++ b/tests/integration/test_insert_into_distributed/test.py
@@ -5,7 +5,7 @@ import pytest
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from helpers.test_tools import TSV
+from helpers.test_tools import TSV, assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 
@@ -49,6 +49,7 @@ def started_cluster():
         instance_test_reconnect.query(
             """
 CREATE TABLE distributed (x UInt32) ENGINE = Distributed('test_cluster', 'default', 'local1')
+SETTINGS background_insert_sleep_time_ms = 100, background_insert_max_sleep_time_ms = 1000
 """
         )
 
@@ -157,27 +158,35 @@ CREATE TABLE single_replicated(date Date, id UInt32) ENGINE = ReplicatedMergeTre
 def test_reconnect(started_cluster):
     instance = instance_test_reconnect
 
+    errors = "SELECT sum(error_count) FROM system.distribution_queue WHERE table = 'distributed'"
+
     with PartitionManager() as pm:
         # Open a connection for insertion.
         instance.query("INSERT INTO distributed VALUES (1)")
-        time.sleep(1)
-        assert remote.query("SELECT count(*) FROM local1").strip() == "1"
+        assert_eq_with_retry(remote, "SELECT count(*) FROM local1", "1")
+
+        errors_before = instance.query(errors).strip()
 
         # Now break the connection.
         pm.partition_instances(
             instance, remote, action="REJECT --reject-with tcp-reset"
         )
         instance.query("INSERT INTO distributed VALUES (2)")
-        time.sleep(1)
+
+        # Wait until the background sender has actually observed the broken connection, so
+        # that healing the partition below exercises the reconnection. Waiting for a fixed
+        # time instead would be a race: every failed attempt doubles the sender's retry
+        # interval, so how many attempts fit into a given interval is not predictable.
+        assert_eq_with_retry(instance, f"SELECT ({errors}) > {errors_before}", "1")
 
         # Heal the partition and insert more data.
         # The connection must be reestablished and after some time all data must be inserted.
         pm.heal_all()
-        time.sleep(1)
         instance.query("INSERT INTO distributed VALUES (3)")
-        time.sleep(5)
 
-        assert remote.query("SELECT count(*) FROM local1").strip() == "3"
+        # A file inserted while the sender is already waiting out a retry interval does not
+        # shorten that interval, hence the generous number of retries here.
+        assert_eq_with_retry(remote, "SELECT count(*) FROM local1", "3", retry_count=60)
 
 
 def test_inserts_batching(started_cluster):


### PR DESCRIPTION
`test_insert_into_distributed::test_reconnect` breaks the connection between a `Distributed` table and its remote shard, heals it, and then waits a fixed 5 seconds for the background sender to deliver the two pending inserts. That wait races the sender's retry interval: every failed attempt doubles it, starting at `background_insert_sleep_time_ms` (100 ms) and growing up to `background_insert_max_sleep_time_ms`, which defaults to 30 seconds. A newly inserted file does not shorten an interval the sender is already waiting out, because `addFileAndSchedule` calls `scheduleAfter` with `overwrite = false`, which is a no-op for an already delayed task. When the interval outgrows the 5 seconds, the test sees only the first row and fails with `assert '1' == '3'`.

Measured with two local servers, stopping and restarting the shard in place of the network partition: after a 60 second outage the sender's `error_count` reaches 9, which saturates the interval at the 30 second cap, and all rows arrive 20.2 seconds after the shard comes back — four times the 5 seconds the test allowed. With `background_insert_max_sleep_time_ms = 1000` the same scenario delivers everything in 1.5 seconds.

The test now caps that setting on its table and waits for the observable state instead of sleeping: for the rows to appear on the shard, and — in place of the sleep that was there to let the send fail while the connection was down — for `error_count` in `system.distribution_queue` to grow. The latter also states the intent explicitly, that healing the partition has to exercise a reconnection. The setting is scoped to this test: `instance_test_reconnect`, its `distributed` table and `local1` are used by no other test in the file.

The test has never failed on `master`. In the last 90 days it failed four times, all of them on pull requests and all in instrumented builds (two under `amd_llvm_coverage`, two under `amd_msan`) — which is what a slow machine accumulating more failed attempts inside the same partition window looks like. There is no tracking issue for it.

CI report of the failure this came from: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114747&sha=ad14224d5f960e11c6fddf144128ac30beed5cc8&name_0=PR&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%206%2F8%29

Related: https://github.com/ClickHouse/ClickHouse/pull/114747

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117133&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117133](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117133+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.397` (included in `26.9` and later)
<!-- ch-version-info:end -->