### PR TITLE
Fix flaky test_hedged_requests::test_async_query_sending

### DIFF
--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -499,11 +499,16 @@ def test_async_query_sending(started_cluster):
         Distributed('test_cluster_three_shards', 'default', 'test_hedged')"""
     )
 
-    # Create big enough temporary table
+    # The temporary table is sent to the shards along with the query, and sending it
+    # has to be suspended at least once, so the table must be large enough to overflow
+    # the socket buffers. Half a gigabyte is orders of magnitude more than any socket
+    # buffer size. It used to be ten times larger, and under sanitizers that exceeded
+    # the `mem_limit` of the container above - a temporary table is kept in memory on
+    # the initiator.
     NODES["node"].query("DROP TABLE IF EXISTS tmp")
     NODES["node"].query(
         "CREATE TEMPORARY TABLE tmp (number UInt64, s String) "
-        "as select number, randomString(number % 1000) from numbers(10000000)"
+        "as select number, randomString(number % 1000) from numbers(1000000)"
     )
 
     NODES["node"].query(


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/53783

`test_hedged_requests/test.py::test_async_query_sending` creates a temporary table of 10 million rows of `randomString(number % 1000)` - about 5 GB of data, kept in memory on the initiator, because a temporary table uses the `Memory` engine. Under sanitizers the real memory usage is several times the tracked memory, so the server reaches the 14 GiB `mem_limit` declared for that instance in the same test file and gets killed by the cgroup OOM killer in the middle of the `CREATE TEMPORARY TABLE` statement.

In the report below, the server log of `node` stops mid-insert with no shutdown or exception line, the last entry being `MemoryTracker: (total) current memory usage: 4.05 GiB` at about 60% of the insert, while the host metrics of the job show the resident size growing by roughly 12 GiB over the 40 seconds of that statement and then collapsing. The client reports `ATTEMPT_TO_READ_AFTER_EOF`; in the runs where the initiator survives a bit longer, the test hits the 900 second pytest timeout instead. This is a long-standing flake - it fails a handful of times a month, always in an `amd_asan_ubsan` shard.

The table only has to be large enough to overflow the socket buffers, so that sending it to a shard is suspended at least once and the `SuspendSendingQueryToShard` event is incremented. Half a gigabyte is more than ten times the largest socket buffer the kernel can autotune to, so this reduces the number of rows tenfold. It also makes the test considerably faster - the table is sent to three shards on every attempt.

Checked on a standalone server with three shards pointing at a user whose profile sets `sleep_after_receiving_query_ms` to 5000, exactly as the test configures its shards. With 1 million rows the temporary table is 484 MiB, the event is still empty after the query with `async_query_sending_for_remote = 0` (so the `check_if_query_sending_was_not_suspended` assertion holds), and it reaches 79 after the first query with `async_query_sending_for_remote = 1` - the loop breaks on attempt 0 with a wide margin. For reference, the same sequence without any temporary table only reaches 3, so the external table data really is what is being suspended on.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e1e0186e3aa5e32028457904fb1ac84c61a7430e&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117134&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117134](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117134+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
