### PR TITLE
Split release-branch `Integration tests (db disk)` into 6 batches to stop the chronic `Timeout`

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -995,11 +995,11 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Unit tests (msan)' --workflow "ReleaseBranchCI" --ci --timestamp
 
-  integration_tests_amd_asan_ubsan_db_disk_1_4:
+  integration_tests_amd_asan_ubsan_db_disk_1_6:
     runs-on: [self-hosted, amd-medium]
     needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
-    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCAxLzQp') }}
-    name: "Integration tests (amd_asan_ubsan, db disk, 1/4)"
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCAxLzYp') }}
+    name: "Integration tests (amd_asan_ubsan, db disk, 1/6)"
     outputs:
       data: ${{ steps.run.outputs.DATA }}
       pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
@@ -1028,13 +1028,13 @@ jobs:
         id: run
         run: |
           . ./ci/tmp/praktika_setup_env.sh
-          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 1/4)' --workflow "ReleaseBranchCI" --ci --timestamp
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 1/6)' --workflow "ReleaseBranchCI" --ci --timestamp
 
-  integration_tests_amd_asan_ubsan_db_disk_2_4:
+  integration_tests_amd_asan_ubsan_db_disk_2_6:
     runs-on: [self-hosted, amd-medium]
     needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
-    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCAyLzQp') }}
-    name: "Integration tests (amd_asan_ubsan, db disk, 2/4)"
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCAyLzYp') }}
+    name: "Integration tests (amd_asan_ubsan, db disk, 2/6)"
     outputs:
       data: ${{ steps.run.outputs.DATA }}
       pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
@@ -1063,13 +1063,13 @@ jobs:
         id: run
         run: |
           . ./ci/tmp/praktika_setup_env.sh
-          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 2/4)' --workflow "ReleaseBranchCI" --ci --timestamp
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 2/6)' --workflow "ReleaseBranchCI" --ci --timestamp
 
-  integration_tests_amd_asan_ubsan_db_disk_3_4:
+  integration_tests_amd_asan_ubsan_db_disk_3_6:
     runs-on: [self-hosted, amd-medium]
     needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
-    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCAzLzQp') }}
-    name: "Integration tests (amd_asan_ubsan, db disk, 3/4)"
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCAzLzYp') }}
+    name: "Integration tests (amd_asan_ubsan, db disk, 3/6)"
     outputs:
       data: ${{ steps.run.outputs.DATA }}
       pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
@@ -1098,13 +1098,13 @@ jobs:
         id: run
         run: |
           . ./ci/tmp/praktika_setup_env.sh
-          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 3/4)' --workflow "ReleaseBranchCI" --ci --timestamp
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 3/6)' --workflow "ReleaseBranchCI" --ci --timestamp
 
-  integration_tests_amd_asan_ubsan_db_disk_4_4:
+  integration_tests_amd_asan_ubsan_db_disk_4_6:
     runs-on: [self-hosted, amd-medium]
     needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
-    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCA0LzQp') }}
-    name: "Integration tests (amd_asan_ubsan, db disk, 4/4)"
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCA0LzYp') }}
+    name: "Integration tests (amd_asan_ubsan, db disk, 4/6)"
     outputs:
       data: ${{ steps.run.outputs.DATA }}
       pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
@@ -1133,7 +1133,77 @@ jobs:
         id: run
         run: |
           . ./ci/tmp/praktika_setup_env.sh
-          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 4/4)' --workflow "ReleaseBranchCI" --ci --timestamp
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 4/6)' --workflow "ReleaseBranchCI" --ci --timestamp
+
+  integration_tests_amd_asan_ubsan_db_disk_5_6:
+    runs-on: [self-hosted, amd-medium]
+    needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCA1LzYp') }}
+    name: "Integration tests (amd_asan_ubsan, db disk, 5/6)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 5/6)' --workflow "ReleaseBranchCI" --ci --timestamp
+
+  integration_tests_amd_asan_ubsan_db_disk_6_6:
+    runs-on: [self-hosted, amd-medium]
+    needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'SW50ZWdyYXRpb24gdGVzdHMgKGFtZF9hc2FuX3Vic2FuLCBkYiBkaXNrLCA2LzYp') }}
+    name: "Integration tests (amd_asan_ubsan, db disk, 6/6)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, 6/6)' --workflow "ReleaseBranchCI" --ci --timestamp
 
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_1_6:
     runs-on: [self-hosted, amd-medium]
@@ -1907,7 +1977,7 @@ jobs:
 
   finish_workflow:
     runs-on: [self-hosted, style-checker-aarch64]
-    needs: [build_amd_asan_ubsan, build_amd_darwin, build_amd_debug, build_amd_msan, build_amd_release, build_amd_tsan, build_arm_asan_ubsan, build_arm_darwin, build_arm_debug, build_arm_msan, build_arm_release, build_arm_tsan, config_workflow, docker_keeper_image, docker_server_image, dockers_build_amd, dockers_build_arm, install_packages_amd_release, install_packages_arm_release, integration_tests_amd_asan_ubsan_db_disk_1_4, integration_tests_amd_asan_ubsan_db_disk_2_4, integration_tests_amd_asan_ubsan_db_disk_3_4, integration_tests_amd_asan_ubsan_db_disk_4_4, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_1_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_2_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_3_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_4_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_5_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_6_6, integration_tests_amd_tsan_1_6, integration_tests_amd_tsan_2_6, integration_tests_amd_tsan_3_6, integration_tests_amd_tsan_4_6, integration_tests_amd_tsan_5_6, integration_tests_amd_tsan_6_6, sign_macos_binary_amd_darwin, sign_macos_binary_arm_darwin, stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_1_3, stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_2_3, stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_3_3, stateless_tests_amd_asan_ubsan_distributed_plan_parallel, stress_test_amd_asan_ubsan, stress_test_amd_debug, stress_test_amd_msan, stress_test_amd_tsan, stress_test_arm_asan_ubsan, stress_test_arm_asan_ubsan_s3, stress_test_arm_debug, stress_test_arm_msan, stress_test_arm_release, stress_test_arm_tsan, unit_tests_asan_ubsan, unit_tests_msan, unit_tests_tsan]
+    needs: [build_amd_asan_ubsan, build_amd_darwin, build_amd_debug, build_amd_msan, build_amd_release, build_amd_tsan, build_arm_asan_ubsan, build_arm_darwin, build_arm_debug, build_arm_msan, build_arm_release, build_arm_tsan, config_workflow, docker_keeper_image, docker_server_image, dockers_build_amd, dockers_build_arm, install_packages_amd_release, install_packages_arm_release, integration_tests_amd_asan_ubsan_db_disk_1_6, integration_tests_amd_asan_ubsan_db_disk_2_6, integration_tests_amd_asan_ubsan_db_disk_3_6, integration_tests_amd_asan_ubsan_db_disk_4_6, integration_tests_amd_asan_ubsan_db_disk_5_6, integration_tests_amd_asan_ubsan_db_disk_6_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_1_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_2_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_3_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_4_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_5_6, integration_tests_amd_asan_ubsan_db_disk_old_analyzer_6_6, integration_tests_amd_tsan_1_6, integration_tests_amd_tsan_2_6, integration_tests_amd_tsan_3_6, integration_tests_amd_tsan_4_6, integration_tests_amd_tsan_5_6, integration_tests_amd_tsan_6_6, sign_macos_binary_amd_darwin, sign_macos_binary_arm_darwin, stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_1_3, stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_2_3, stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_3_3, stateless_tests_amd_asan_ubsan_distributed_plan_parallel, stress_test_amd_asan_ubsan, stress_test_amd_debug, stress_test_amd_msan, stress_test_amd_tsan, stress_test_arm_asan_ubsan, stress_test_arm_asan_ubsan_s3, stress_test_arm_debug, stress_test_arm_msan, stress_test_arm_release, stress_test_arm_tsan, unit_tests_asan_ubsan, unit_tests_msan, unit_tests_tsan]
     if: ${{ always() }}
     name: "Finish Workflow"
     outputs:

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1227,7 +1227,8 @@ class JobConfigs:
             requires=[ArtifactNames.DEB_AMD_RELEASE],
         ),
     )
-    # why it's master only?
+    # Despite the name, this set is referenced only by `ci/workflows/release_branches.py`,
+    # so these jobs run on release branches and never on master.
     integration_test_asan_master_jobs = common_integration_test_job_config.parametrize(
         *[
             Job.ParamSet(
@@ -1235,7 +1236,11 @@ class JobConfigs:
                 runs_on=RunnerLabels.AMD_MEDIUM,
                 requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
             )
-            for total_batches in (4,)
+            # 6, not 4: at 4 batches each shard carries ~1.5x the modules of the
+            # `old analyzer` and `amd_tsan` variants below and overruns the 7200s
+            # pytest `--session-timeout`, reporting a bare `Timeout` with no test
+            # results. The 6-batch variants land at 5500-6500s of that same budget.
+            for total_batches in (6,)
             for batch in range(1, total_batches + 1)
         ]
     )


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/116064

`Integration tests (amd_asan_ubsan, db disk, N/4)` fails on most release-branch commits with a bare `Timeout` and no individual test results. Over the last 14 days on `26.6`/`26.7`/`26.8` it timed out on 116-156 of ~180 commits per shard, while its two sibling variants, `db disk, old analyzer` and `amd_tsan`, timed out 2 times out of ~1080 shard-runs combined:

| Job | commits | `Timeout` |
| --- | --- | --- |
| `db disk, 1/4` | 144 | 116 |
| `db disk, 2/4` | 179 | 149 |
| `db disk, 3/4` | 180 | 156 |
| `db disk, 4/4` | 181 | 116 |
| `db disk, old analyzer, 1..6/6` | ~180 each | 0, 0, 1, 0, 1, 0 |
| `amd_tsan, 1..6/6` | 180 each | all 0 |

The cause is the batch count, not a hung test. This job splits into 4 batches; the siblings split into 6. All three run 3 pytest workers against the same 7200s `--session-timeout`, so at 4 batches each shard carries ~1.5x the load and overruns the budget. In the report linked above every shard was cut off mid-suite, with every test that did run passing:

```
!!!!!!! xdist.dsession.Interrupted: session-timeout: 7200.0 sec exceeded !!!!!!!
```

The four shards reached only 87%, 84%, 88% and 93%, which extrapolates to ~7700-8600s needed against the 7200s available. The 6-batch siblings finish in 5545-6523s.

This raises the batch count to 6. The splitter is duration-weighted, and at 6 batches it emits exactly the same partition as the two passing variants (per-batch weight 8104 -> 5402, 249-306 modules -> 168-214), so the failing job's per-shard load becomes equal to a load already proven to fit rather than merely smaller.

The `# why it's master only?` comment above the block is also corrected: `integration_test_asan_master_jobs` is referenced only by `ci/workflows/release_branches.py`, so despite the name these jobs run on release branches and never on master. That is why the timeout shows up only on release branches, and why this PR's own CI will not exercise the changed jobs.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=26.8&sha=537693a9b20b947a3cf0c4ac90c7c966eee963c9&name_0=ReleaseBranchCI

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117152&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117152](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117152+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
