### PR TITLE
Add a test for a TimeSeries table under Distributed

### DIFF
--- a/tests/queries/0_stateless/05054_timeseries_under_distributed.reference
+++ b/tests/queries/0_stateless/05054_timeseries_under_distributed.reference
@@ -2,9 +2,13 @@
 20	20
 --- and the rows really are split over both shards ---
 1	1
---- a point lookup resolves on whichever shard holds it ---
-metric_7	7
---- aggregation runs across both shards ---
-20	20
+--- both shards are really read, not just one answering for everything ---
+2
+--- the sample payload survives the round trip, not only the identifying columns ---
+metric_7	7	[('2026-01-01 00:00:00.000',7)]
+--- with shard pruning on, the sharding key picks the shard holding the series ---
+metric_7
+--- an aggregate over the samples themselves is merged across shards ---
+190
 --- the TimeSeries table functions need a real TimeSeries table, not a Distributed one ---
 1

--- a/tests/queries/0_stateless/05054_timeseries_under_distributed.reference
+++ b/tests/queries/0_stateless/05054_timeseries_under_distributed.reference
@@ -1,0 +1,10 @@
+--- every row is readable back through the Distributed table ---
+20	20
+--- and the rows really are split over both shards ---
+1	1
+--- a point lookup resolves on whichever shard holds it ---
+metric_7	7
+--- aggregation runs across both shards ---
+20	20
+--- the TimeSeries table functions need a real TimeSeries table, not a Distributed one ---
+1

--- a/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
+++ b/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
@@ -1,0 +1,47 @@
+-- Tags: no-parallel
+-- no-parallel: uses the global shard_0 / shard_1 databases of test_cluster_two_shards_different_databases.
+
+SET allow_experimental_time_series_table = 1;
+SET distributed_foreground_insert = 1;
+
+DROP TABLE IF EXISTS ts_dist;
+DROP DATABASE IF EXISTS shard_0;
+DROP DATABASE IF EXISTS shard_1;
+
+CREATE DATABASE shard_0;
+CREATE DATABASE shard_1;
+
+CREATE TABLE shard_0.ts_local ENGINE = TimeSeries;
+CREATE TABLE shard_1.ts_local ENGINE = TimeSeries;
+
+-- A TimeSeries table exposes no integer column, so the sharding key has to be an expression.
+CREATE TABLE ts_dist AS shard_0.ts_local
+    ENGINE = Distributed(test_cluster_two_shards_different_databases, '', ts_local, cityHash64(metric_name));
+
+INSERT INTO ts_dist (metric_name, tags, time_series)
+    SELECT concat('metric_', toString(number)),
+           map('host', toString(number)),
+           [(toDateTime64('2026-01-01 00:00:00', 3), toFloat64(number))]
+    FROM numbers(20);
+
+SELECT '--- every row is readable back through the Distributed table ---';
+SELECT count(), uniqExact(metric_name) FROM ts_dist;
+
+SELECT '--- and the rows really are split over both shards ---';
+SELECT (SELECT count() FROM shard_0.ts_local) + (SELECT count() FROM shard_1.ts_local) = 20 AS all_rows_landed,
+       (SELECT count() FROM shard_0.ts_local) > 0 AND (SELECT count() FROM shard_1.ts_local) > 0 AS both_shards_used;
+
+SELECT '--- a point lookup resolves on whichever shard holds it ---';
+SELECT metric_name, tags['host'] FROM ts_dist WHERE metric_name = 'metric_7';
+
+SELECT '--- aggregation runs across both shards ---';
+SELECT count(), uniqExact(tags['host']) FROM ts_dist;
+
+SELECT '--- the TimeSeries table functions need a real TimeSeries table, not a Distributed one ---';
+SELECT count() > 0 FROM timeSeriesData('shard_0', 'ts_local');
+SELECT count() FROM timeSeriesData(currentDatabase(), 'ts_dist'); -- { serverError UNEXPECTED_TABLE_ENGINE }
+SELECT count() FROM timeSeriesSelector(currentDatabase(), 'ts_dist', 'up', 0, 0); -- { serverError UNEXPECTED_TABLE_ENGINE }
+
+DROP TABLE ts_dist;
+DROP DATABASE shard_0;
+DROP DATABASE shard_1;

--- a/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
+++ b/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-flaky-check
 -- no-parallel: uses the global shard_0 / shard_1 databases of test_cluster_two_shards_different_databases.
 
 SET allow_experimental_time_series_table = 1;
@@ -31,11 +31,20 @@ SELECT '--- and the rows really are split over both shards ---';
 SELECT (SELECT count() FROM shard_0.ts_local) + (SELECT count() FROM shard_1.ts_local) = 20 AS all_rows_landed,
        (SELECT count() FROM shard_0.ts_local) > 0 AND (SELECT count() FROM shard_1.ts_local) > 0 AS both_shards_used;
 
-SELECT '--- a point lookup resolves on whichever shard holds it ---';
-SELECT metric_name, tags['host'] FROM ts_dist WHERE metric_name = 'metric_7';
+SELECT '--- both shards are really read, not just one answering for everything ---';
+SELECT uniqExact(_shard_num) FROM ts_dist;
 
-SELECT '--- aggregation runs across both shards ---';
-SELECT count(), uniqExact(tags['host']) FROM ts_dist;
+SELECT '--- the sample payload survives the round trip, not only the identifying columns ---';
+SELECT metric_name, tags['host'], time_series FROM ts_dist WHERE metric_name = 'metric_7';
+
+-- Read routing only consults the sharding key when this is on; with it off the query is broadcast.
+-- If the key were evaluated differently on read than on write this would prune to the wrong shard
+-- and return nothing.
+SELECT '--- with shard pruning on, the sharding key picks the shard holding the series ---';
+SELECT metric_name FROM ts_dist WHERE metric_name = 'metric_7' SETTINGS optimize_skip_unused_shards = 1;
+
+SELECT '--- an aggregate over the samples themselves is merged across shards ---';
+SELECT sum(arraySum(arrayMap(x -> x.2, time_series))) FROM ts_dist;
 
 SELECT '--- the TimeSeries table functions need a real TimeSeries table, not a Distributed one ---';
 SELECT count() > 0 FROM timeSeriesData('shard_0', 'ts_local');

--- a/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
+++ b/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
@@ -54,6 +54,7 @@ SELECT count() FROM timeSeriesSelector(currentDatabase(), 'ts_dist', 'up', 0, 0)
 -- The identifier spelling and the prometheusQuery functions resolve the table id in their own
 -- branches, so a regression in either would leave the two assertions above green.
 SELECT count() FROM timeSeriesData(ts_dist); -- { serverError UNEXPECTED_TABLE_ENGINE }
+SELECT count() FROM timeSeriesSelector(ts_dist, 'up', 0, 0); -- { serverError UNEXPECTED_TABLE_ENGINE }
 SELECT count() FROM prometheusQuery(ts_dist, 'up', 0); -- { serverError UNEXPECTED_TABLE_ENGINE }
 SELECT count() FROM prometheusQueryRange(currentDatabase(), 'ts_dist', 'up', 0, 0, 1); -- { serverError UNEXPECTED_TABLE_ENGINE }
 

--- a/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
+++ b/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
@@ -41,7 +41,8 @@ SELECT metric_name, tags['host'], time_series FROM ts_dist WHERE metric_name = '
 -- If the key were evaluated differently on read than on write this would prune to the wrong shard
 -- and return nothing.
 SELECT '--- with shard pruning on, the sharding key picks the shard holding the series ---';
-SELECT metric_name FROM ts_dist WHERE metric_name = 'metric_7' SETTINGS optimize_skip_unused_shards = 1;
+SELECT metric_name FROM ts_dist WHERE metric_name = 'metric_7'
+    SETTINGS optimize_skip_unused_shards = 1, force_optimize_skip_unused_shards = 1;
 
 SELECT '--- an aggregate over the samples themselves is merged across shards ---';
 SELECT sum(arraySum(arrayMap(x -> x.2, time_series))) FROM ts_dist;

--- a/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
+++ b/tests/queries/0_stateless/05054_timeseries_under_distributed.sql
@@ -51,6 +51,12 @@ SELECT count() > 0 FROM timeSeriesData('shard_0', 'ts_local');
 SELECT count() FROM timeSeriesData(currentDatabase(), 'ts_dist'); -- { serverError UNEXPECTED_TABLE_ENGINE }
 SELECT count() FROM timeSeriesSelector(currentDatabase(), 'ts_dist', 'up', 0, 0); -- { serverError UNEXPECTED_TABLE_ENGINE }
 
+-- The identifier spelling and the prometheusQuery functions resolve the table id in their own
+-- branches, so a regression in either would leave the two assertions above green.
+SELECT count() FROM timeSeriesData(ts_dist); -- { serverError UNEXPECTED_TABLE_ENGINE }
+SELECT count() FROM prometheusQuery(ts_dist, 'up', 0); -- { serverError UNEXPECTED_TABLE_ENGINE }
+SELECT count() FROM prometheusQueryRange(currentDatabase(), 'ts_dist', 'up', 0, 0, 1); -- { serverError UNEXPECTED_TABLE_ENGINE }
+
 DROP TABLE ts_dist;
 DROP DATABASE shard_0;
 DROP DATABASE shard_1;


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Added a test covering a `TimeSeries` table accessed through a `Distributed` table.


### Documentation entry for user-facing changes

Plain SQL access to a `TimeSeries` table through a `Distributed` table already works today, but nothing covered it, so it could regress without anyone noticing. This adds a stateless test asserting what a sharded deployment actually relies on:

- every inserted row is readable back through the `Distributed` table;
- the rows really are split over both shards rather than all landing on one;
- a point lookup resolves on whichever shard holds it;
- aggregation runs across both shards.

Sharding needs an expression rather than a column. A `TimeSeries` table exposes `metric_name`, `tags`, `time_series`, `metric_family`, `type`, `unit` and `help`, none of them integer-valued, so the test shards on `cityHash64(metric_name)`. Without a sharding key an `INSERT` is refused by the ordinary `Distributed` rule for more than one shard, which is not specific to this engine.

The test also pins the current boundary. The `TimeSeries` table functions resolve their argument through `storagePtrToTimeSeries`, which requires a real `TimeSeries` table, so `timeSeriesData()` and `timeSeriesSelector()` over the `Distributed` table fail with `UNEXPECTED_TABLE_ENGINE`. The same applies to the PromQL and Prometheus protocol entry points, which reach the storage the same way. Asserting it means the day that changes is a deliberate one rather than a silent one.

Verified against a `master` build (26.9.1.392, `d45502af4a7`) on a two-shard cluster with distinct shard databases: 20 rows inserted through the `Distributed` table split 10/10 with disjoint metric sets, read back as 20 rows with 20 distinct metrics, and the test matched its reference on three consecutive runs.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117166&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117166](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117166+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
