### PR TITLE
Do not read `system.query_log` through the distributed plan in 05047

### DIFF
--- a/tests/queries/0_stateless/05047_distributed_plan_finished_stages_drain.sql
+++ b/tests/queries/0_stateless/05047_distributed_plan_finished_stages_drain.sql
@@ -18,6 +18,11 @@ SETTINGS log_comment = '05047_finished_stages_drain';
 
 SYSTEM FLUSH LOGS query_log;
 
+-- Read the log through the ordinary plan. A distributed read serializes the part names chosen by the
+-- coordinator and resolves them again on the worker, so a background merge of `system.query_log`
+-- landing in between makes a selected part unavailable and the read fails with `NO_SUCH_DATA_PART`.
+SET make_distributed_plan = 0;
+
 -- The unfixed driver needs at least 100 ms x 40 stages > 4 seconds; the healthy run takes well
 -- under a second even on slow builds, so the threshold cannot flap in either direction.
 SELECT max(query_duration_ms) < 3000 FROM system.query_log


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109722

`05047_distributed_plan_finished_stages_drain` sets `make_distributed_plan = 1` for the whole session, so its final verification query reads `system.query_log` through the distributed plan as well. A distributed read serializes the part names chosen by the coordinator and resolves them again on the worker (`ReadFromMergeTree::initializePipeline`), so a background merge of `system.query_log` landing in between makes a selected part unavailable and the read fails:

```
Code: 232. DB::Exception: Distributed read: part 202608_166_176_2 selected by the coordinator
is not available on this replica (diverged by merge or replication lag); retry the query:
While executing ReadFromDistributedPlanSource. (NO_SUCH_DATA_PART)
```

Reading the log through a distributed plan has nothing to do with what the test asserts — the wall-clock duration of the preceding 40-stage query — so this pins `make_distributed_plan = 0` for that read, the way `04505_distributed_plan_any_scatter_spread` and `04656_distributed_plan_workers_disable_jit_and_skip_index_read` already do.

Twelve occurrences in the last 30 days, four of them on `master`. `EXPLAIN` confirms the setting is what selects the racy path: with `make_distributed_plan = 1` the log read goes through `GatherExchange`, and with it pinned off it is a plain `ReadFromMergeTree (system.query_log)`.

Seen in the merge queue for https://github.com/ClickHouse/ClickHouse/pull/109722:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=gh-readonly-queue/master/pr-109722-88f51c8dbe08130ecb6a364723da3e6458c5051d&sha=de14afdfd44fee06b20f53dcabac33a9cccc63bc&name_0=MergeQueueCI&name_1=Fast%20test

The other failure class of this test, a `result differs` flap on slow builds, was already handled by its `no-flaky-check` and `no-*san` tags and is not touched here.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117167&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117167](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117167+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
