### PR TITLE
Version-gate the silk test config so the upgrade check can start the previous release

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -145,7 +145,12 @@ ln -sf $SRC_PATH/config.d/top_level_domains_path.xml $DEST_SERVER_PATH/config.d/
 
 ln -sf $SRC_PATH/config.d/transactions_info_log.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/transactions.xml $DEST_SERVER_PATH/config.d/
-ln -sf $SRC_PATH/config.d/silk.xml $DEST_SERVER_PATH/config.d/
+# `enable_silk_runtime` and the `silk` section first exist in 26.9, so an older server rejects
+# them as unknown config elements and refuses to start. Gate the drop-in on the installed
+# server's version to keep the upgrade check's previous-release server bootable.
+if check_clickhouse_version 26.9; then
+    ln -sf $SRC_PATH/config.d/silk.xml $DEST_SERVER_PATH/config.d/
+fi
 
 ln -sf $SRC_PATH/config.d/encryption.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/zookeeper_log.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/112667
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Install the `silk` test config only on servers that can parse it, so the upgrade check can start the previous release.

### Description

`Upgrade check (amd_release)` went red on every PR from 2026-08-30 13:48Z: the previous-release
server refused to start on every attempt, so no test ran.

```
Code: 137. DB::Exception: Unknown elements 'enable_silk_runtime', 'silk' found in config
/etc/clickhouse-server/config.xml. ... (UNKNOWN_ELEMENT_IN_CONFIG)
```

`tests/config/install.sh` applies the current-master test configs to the previous-release server,
which is the point of the job. Line 148 symlinked `config.d/silk.xml` unconditionally, and that
file declares two top-level elements, `enable_silk_runtime` and `silk`, that first exist in 26.9.
A comment at the top of `install.sh` already states the rule the line broke: a new config must
check the ClickHouse version so it does not break validations that run a previous version.

The line landed on 2026-08-26 but only bit four days later. `v26.8.1.2041-lts` was published
2026-08-30T13:47:42Z, which moved `previous_release_tag` from 26.7 to 26.8. 26.7 has no
unknown-key validator, so it tolerated both; 26.8 has one and does not know them. A passing and a
failing run seven minutes apart build the same master package and differ only in that tag.

I gate the symlink on the installed server's version, the same way the same file already gates
`http_url_prefix.xml` on 26.8 for this defect class. A server that can parse the drop-in still
gets it, so the post-upgrade phase keeps its coverage.

Validated against the `v26.8.1.2041-lts` packages CI itself downloads: before the change the 26.8
server reproduces the error above, after it the drop-in is skipped and the server gets past config
validation on both `configure` flag branches, and a 26.9 binary still installs it.

A style-check rule forbidding a new ungated drop-in would guard the whole class, but it has a much
wider blast radius and there is no second offender today.

No open issue exists for this failure. CI report for a failing run:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113857&sha=6dadc6c55d0db93d36c63700720da36b81482bb4&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29

Related: https://github.com/ClickHouse/ClickHouse/pull/112667

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117172&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117172](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117172+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.407` (included in `26.9` and later)
<!-- ch-version-info:end -->