### PR TITLE
AST fuzzer oracle: collapse per-oracle dispatch + fix neighbor/runningAccumulate false mismatch

### DIFF
--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -81,6 +81,11 @@ const std::unordered_set<String> non_deterministic_functions = {
     "now", "now64", "today", "yesterday",
     "rowNumberInBlock", "blockNumber", "blockSize",
     "runningDifference", "runningDifferenceStartingWithFirstValue",
+    /// `neighbor` and `runningAccumulate` read across rows in physical block
+    /// order (offset neighbours / a running state), so any rewrite that reorders,
+    /// repartitions or reblocks the input (TLP partitions, NoREC, DQP setting
+    /// toggles, multi-thread reads) changes their per-row output legitimately.
+    "neighbor", "runningAccumulate",
     "currentDatabase", "queryID", "serverUUID",
     "getSetting", "fuzzBits", "throwIf",
     /// `indexHint` filters at granule granularity: the rows that survive it

--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -2558,162 +2558,49 @@ bool QueryOracleChecker::check(const ASTPtr & query_ast, const ContextMutablePtr
 
     bool any_check_performed = false;
 
+    /// Run one oracle under a uniform guard: its own mismatch
+    /// (`AST_FUZZER_ORACLE_MISMATCH`) propagates and is annotated with the
+    /// reproduction settings by the outer handler below; any other execution
+    /// error means the rewrite was not comparable on this query (e.g. a
+    /// function the rewrite cannot analyse), so it is swallowed and the
+    /// remaining oracles still run. `name` reproduces the per-oracle log wording.
+    auto run_oracle = [&](std::string_view name, auto && check_fn)
+    {
+        try
+        {
+            if (check_fn())
+                any_check_performed = true;
+        }
+        catch (const Exception & e)
+        {
+            if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
+                throw;
+            LOG_TRACE(logger, "{} oracle execution error (skipping): {}", name, e.message());
+        }
+        catch (...)
+        {
+            LOG_TRACE(logger, "{} oracle execution error (skipping): {}", name, getCurrentExceptionMessage(false));
+        }
+    };
+
     try
     {
-
-    /// TLP WHERE oracle
-    try
-    {
-        if (checkTLPWhere(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "TLP WHERE oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "TLP WHERE oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// NoREC oracle
-    try
-    {
-        if (checkNoREC(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "NoREC oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "NoREC oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// TLP Aggregate oracle (uses State/Merge combinators for any aggregate)
-    try
-    {
-        if (checkTLPAggregate(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "TLP Aggregate oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "TLP Aggregate oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// TLP DISTINCT oracle (uses UNION DISTINCT instead of UNION ALL)
-    try
-    {
-        if (checkTLPDistinct(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "TLP DISTINCT oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "TLP DISTINCT oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// TLP GROUP BY oracle (set comparison for non-aggregate GROUP BY)
-    try
-    {
-        if (checkTLPGroupBy(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "TLP GROUP BY oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "TLP GROUP BY oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// TLP HAVING oracle (partitions on HAVING instead of WHERE)
-    try
-    {
-        if (checkTLPHaving(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "TLP HAVING oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "TLP HAVING oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// DQP oracle (differential query plans — same query, different optimizer settings)
-    try
-    {
-        if (checkDQP(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "DQP oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "DQP oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// Identity WHERE oracle (rewrites WHERE into equivalent forms — NOT(NOT p), p AND 1, p OR 0)
-    try
-    {
-        if (checkIdentityWhere(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "Identity WHERE oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "Identity WHERE oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
-    /// Subquery wrap oracle (wraps original as subquery and verifies identical result)
-    try
-    {
-        if (checkSubqueryWrap(*select, context))
-            any_check_performed = true;
-    }
-    catch (const Exception & e)
-    {
-        if (e.code() == ErrorCodes::AST_FUZZER_ORACLE_MISMATCH)
-            throw;
-        LOG_TRACE(logger, "Subquery wrap oracle execution error (skipping): {}", e.message());
-    }
-    catch (...)
-    {
-        LOG_TRACE(logger, "Subquery wrap oracle execution error (skipping): {}", getCurrentExceptionMessage(false));
-    }
-
+        run_oracle("TLP WHERE", [&] { return checkTLPWhere(*select, context); });
+        run_oracle("NoREC", [&] { return checkNoREC(*select, context); });
+        /// TLP Aggregate oracle (uses State/Merge combinators for any aggregate).
+        run_oracle("TLP Aggregate", [&] { return checkTLPAggregate(*select, context); });
+        /// TLP DISTINCT oracle (uses UNION DISTINCT instead of UNION ALL).
+        run_oracle("TLP DISTINCT", [&] { return checkTLPDistinct(*select, context); });
+        /// TLP GROUP BY oracle (set comparison for non-aggregate GROUP BY).
+        run_oracle("TLP GROUP BY", [&] { return checkTLPGroupBy(*select, context); });
+        /// TLP HAVING oracle (partitions on HAVING instead of WHERE).
+        run_oracle("TLP HAVING", [&] { return checkTLPHaving(*select, context); });
+        /// DQP oracle (differential query plans — same query, different optimizer settings).
+        run_oracle("DQP", [&] { return checkDQP(*select, context); });
+        /// Identity WHERE oracle (rewrites WHERE into equivalent forms — NOT(NOT p), p AND 1, p OR 0).
+        run_oracle("Identity WHERE", [&] { return checkIdentityWhere(*select, context); });
+        /// Subquery wrap oracle (wraps original as subquery and verifies identical result).
+        run_oracle("Subquery wrap", [&] { return checkSubqueryWrap(*select, context); });
     }
     catch (Exception & e)
     {


### PR DESCRIPTION
Two related cleanups to the server-side AST-fuzzer oracle dispatcher:

1. check() ran each of the nine oracles inside an identical try/catch block —
   re-throwing AST_FUZZER_ORACLE_MISMATCH, swallowing every other error with the
   same log line. That was ~150 lines of copy-paste every new oracle had to
   duplicate. They now go through one run_oracle(name, fn) guard; the per-oracle
   log wording and the outer mismatch-settings annotation are preserved.

2. neighbor and runningAccumulate read across rows in physical block order, so
   any oracle rewrite that reorders/repartitions/reblocks the input changes their
   per-row output legitimately. They were missing from non_deterministic_functions
   and could produce a false oracle mismatch; add them next to rowNumberInBlock /
   runningDifference.

Behavior-preserving: the existing oracle stateless tests still pass and the
oracles still fire (generic ProfileEvent 0->103, TLP-aggregate 0->1 in a local run).

Related: https://github.com/ClickHouse/ClickHouse/pull/99980

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117189&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117189](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117189+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.497` (included in `26.9` and later)
<!-- ch-version-info:end -->