### PR TITLE
Make a `LowCardinality` argument transparent to the KQL `/`, `bin` and `bin_at`

### DIFF
--- a/src/Functions/Kusto/FunctionKQLBin.cpp
+++ b/src/Functions/Kusto/FunctionKQLBin.cpp
@@ -1,6 +1,7 @@
 #include <Columns/ColumnConst.h>
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeInterval.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
@@ -55,6 +56,7 @@ public:
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 2; }
     bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
 
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const override { return delegate(arguments); }
 
@@ -74,10 +76,11 @@ private:
         return std::move(plan).finish(name, arguments);
     }
 
+    /// `LowCardinality(Nullable(T))` reports itself as not nullable, so strip the wrapper first.
     static DataTypePtr retypedAsTicks(const DataTypePtr & original)
     {
         const DataTypePtr ticks = std::make_shared<DataTypeInt64>();
-        return original->isNullable() ? makeNullable(ticks) : ticks;
+        return removeLowCardinality(original)->isNullable() ? makeNullable(ticks) : ticks;
     }
 
     FunctionBasePtr delegate(const ColumnsWithTypeAndName & arguments) const
@@ -85,8 +88,8 @@ private:
         if (arguments.size() != 2)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly 2 arguments", getName());
 
-        const DataTypePtr value_type = removeNullable(arguments[0].type);
-        const DataTypePtr bin_type = removeNullable(arguments[1].type);
+        const DataTypePtr value_type = removeLowCardinalityAndNullable(arguments[0].type);
+        const DataTypePtr bin_type = removeLowCardinalityAndNullable(arguments[1].type);
 
         /// A NULL literal argument makes the whole result a NULL literal. `divide` short-circuits
         /// that itself, so delegating to it wholesale beats teaching the chain below about Nothing.

--- a/src/Functions/Kusto/FunctionKQLBinAt.cpp
+++ b/src/Functions/Kusto/FunctionKQLBinAt.cpp
@@ -4,6 +4,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeInterval.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNothing.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
@@ -200,6 +201,7 @@ public:
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 3; }
     bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
 
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const override
     {
@@ -224,10 +226,11 @@ private:
         return std::move(plan).finish(name, arguments);
     }
 
+    /// `LowCardinality(Nullable(T))` reports itself as not nullable, so strip the wrapper first.
     static DataTypePtr retypedAsTicks(const DataTypePtr & original)
     {
         const DataTypePtr ticks = std::make_shared<DataTypeInt64>();
-        return original->isNullable() ? makeNullable(ticks) : ticks;
+        return removeLowCardinality(original)->isNullable() ? makeNullable(ticks) : ticks;
     }
 
     FunctionBasePtr delegate(const ColumnsWithTypeAndName & arguments) const
@@ -235,9 +238,9 @@ private:
         if (arguments.size() != 3)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly 3 arguments", getName());
 
-        const DataTypePtr value_type = removeNullable(arguments[0].type);
-        const DataTypePtr bin_type = removeNullable(arguments[1].type);
-        const DataTypePtr fixed_type = removeNullable(arguments[2].type);
+        const DataTypePtr value_type = removeLowCardinalityAndNullable(arguments[0].type);
+        const DataTypePtr bin_type = removeLowCardinalityAndNullable(arguments[1].type);
+        const DataTypePtr fixed_type = removeLowCardinalityAndNullable(arguments[2].type);
 
         /// A NULL literal argument makes the whole result a NULL literal; the numeric chain
         /// below short-circuits it, so it must get the query regardless of the other types.

--- a/src/Functions/Kusto/FunctionKQLDivide.cpp
+++ b/src/Functions/Kusto/FunctionKQLDivide.cpp
@@ -1,4 +1,5 @@
 #include <DataTypes/DataTypeInterval.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
@@ -45,6 +46,7 @@ public:
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 2; }
     bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
 
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const override
     {
@@ -64,13 +66,15 @@ private:
         if (arguments.size() != 2)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly 2 arguments", getName());
 
-        const auto * value_interval = typeid_cast<const DataTypeInterval *>(removeNullable(arguments[0].type).get());
-        const auto * divisor_interval = typeid_cast<const DataTypeInterval *>(removeNullable(arguments[1].type).get());
+        const DataTypePtr value_type = removeLowCardinalityAndNullable(arguments[0].type);
+        const DataTypePtr divisor_type = removeLowCardinalityAndNullable(arguments[1].type);
+
+        const auto * value_interval = typeid_cast<const DataTypeInterval *>(value_type.get());
+        const auto * divisor_interval = typeid_cast<const DataTypeInterval *>(divisor_type.get());
         if (value_interval && divisor_interval)
             return divideIntervals(arguments, value_interval->getKind(), divisor_interval->getKind());
 
-        const bool both_integral
-            = isInteger(removeNullable(arguments[0].type)) && isInteger(removeNullable(arguments[1].type));
+        const bool both_integral = isInteger(value_type) && isInteger(divisor_type);
         return FunctionFactory::instance().get(both_integral ? "intDiv" : "divide", getContext())->build(arguments);
     }
 
@@ -82,10 +86,11 @@ private:
     {
         KQLPlanBuilder plan(getContext());
 
+        /// `LowCardinality(Nullable(T))` reports itself as not nullable, so strip the wrapper first.
         const auto retyped_as_ticks = [](const DataTypePtr & original) -> DataTypePtr
         {
             const DataTypePtr ticks = std::make_shared<DataTypeInt64>();
-            return original->isNullable() ? makeNullable(ticks) : ticks;
+            return removeLowCardinality(original)->isNullable() ? makeNullable(ticks) : ticks;
         };
 
         size_t value_slot = plan.argument(retyped_as_ticks(arguments[0].type));

--- a/src/Functions/Kusto/KQLPlan.h
+++ b/src/Functions/Kusto/KQLPlan.h
@@ -3,6 +3,7 @@
 #include <Columns/ColumnConst.h>
 #include <Core/ColumnsWithTypeAndName.h>
 #include <Core/Field.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
@@ -127,9 +128,11 @@ public:
     {
     }
 
-    size_t argument(DataTypePtr type)
+    /// An argument slot drops `LowCardinality`: the default implementation hands the plan an
+    /// already-converted full column, with its null map intact.
+    size_t argument(const DataTypePtr & type)
     {
-        slots.push_back({std::move(type), {}});
+        slots.push_back({recursiveRemoveLowCardinality(type), {}});
         return slots.size() - 1;
     }
 

--- a/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.reference
+++ b/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.reference
@@ -35,9 +35,31 @@ b
 -- integer and real division are unchanged --
 3
 3.5
+-- LowCardinality is transparent to /, bin and bin_at --
+3
+3
+3.75
+4
+4
+-6
+5
+5
+2
 -- kqlDivide over intervals from SQL --
 1.5
 2
 -- kqlBin over a datetime with a non-constant interval from SQL --
 2026-08-01 12:00:00.0000000
 2026-08-01 12:34:56.1230000
+-- LowCardinality arguments are transparent --
+LowCardinality(UInt8)	3
+1.5
+1.5
+1.5
+14
+4
+2026-08-01 12:00:00.0000000
+2026-08-01
+\N
+5
+-- a carrier the unwrapped form also rejects stays rejected --

--- a/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.reference
+++ b/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.reference
@@ -44,6 +44,7 @@ b
 -6
 5
 5
+2026-08-01 12:30:00.0000000
 2
 -- kqlDivide over intervals from SQL --
 1.5
@@ -62,4 +63,22 @@ LowCardinality(UInt8)	3
 2026-08-01
 \N
 5
+-- a LowCardinality(Nullable) timespan keeps its null map --
+14
+14
+15
+15
+\N
+\N
+Nullable(IntervalHour)
+Nullable(IntervalHour)
+-- LowCardinality is transparent to kqlBinAt on every branch --
+2026-08-01 12:30:00.0000000
+2026-08-01 12:30:00.0000000
+2026-08-01 00:00:00.0000000
+2026-08-01 00:00:00.0000000
+\N
+\N
+15
+15
 -- a carrier the unwrapped form also rejects stays rejected --

--- a/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.sql
+++ b/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.sql
@@ -1,6 +1,7 @@
--- Regression tests for three KQL fixes: a lone unbound name inside `in (...)` reads as a
--- column rather than a physical table, `bin` over a datetime takes a per-row bin size, and
--- a timespan divided by a timespan is their real-valued ratio.
+-- Regression tests for four KQL fixes: a lone unbound name inside `in (...)` reads as a
+-- column rather than a physical table, `bin` over a datetime takes a per-row bin size,
+-- a timespan divided by a timespan is their real-valued ratio, and a `LowCardinality`
+-- argument answers the same as its unwrapped form.
 
 SET allow_experimental_kusto_dialect = 1;
 SET dialect = 'kusto';
@@ -58,6 +59,17 @@ print '-- integer and real division are unchanged --';
 print 7 / 2;
 print 7.0 / 2;
 
+print '-- LowCardinality is transparent to /, bin and bin_at --';
+print toLowCardinality(7) / 2;
+print 7 / toLowCardinality(2);
+print toLowCardinality(7.5) / 2;
+print bin(toLowCardinality(4), 1);
+print bin(4, toLowCardinality(1));
+print bin(toLowCardinality(-5), 3);
+print bin_at(toLowCardinality(6), 2, 1);
+print bin_at(6, 2, toLowCardinality(1));
+print toLowCardinality(1h) / 30m;
+
 SET dialect = 'clickhouse';
 
 SELECT '-- kqlDivide over intervals from SQL --';
@@ -68,3 +80,19 @@ SELECT kqlDivide(toIntervalMonth(1), toIntervalHour(1)); -- { serverError ILLEGA
 SELECT '-- kqlBin over a datetime with a non-constant interval from SQL --';
 SELECT kqlBin(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), materialize(toIntervalHour(1)));
 SELECT kqlBin(toDateTime64('2026-08-01 12:34:56.123', 3, 'UTC'), toIntervalMicrosecond(700));
+
+SELECT '-- LowCardinality arguments are transparent --';
+SELECT toTypeName(kqlDivide(toLowCardinality(7), 2)), kqlDivide(toLowCardinality(7), 2);
+SELECT kqlDivide(toLowCardinality(toIntervalHour(15)), toIntervalHour(10));
+SELECT kqlDivide(toIntervalHour(15), toLowCardinality(toIntervalHour(10)));
+SELECT kqlDivide(toLowCardinality(toNullable(toIntervalHour(15))), toIntervalHour(10));
+SELECT kqlBin(toLowCardinality(toIntervalHour(16)), toIntervalHour(7));
+SELECT kqlBin(materialize(toLowCardinality(4)), 1);
+SELECT kqlBin(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(toIntervalHour(1)));
+SELECT kqlBin(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(toIntervalMonth(1)));
+SELECT kqlBin(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(toIntervalMonth(-1)));
+SELECT kqlBinAt(materialize(toLowCardinality(6)), 2, 1);
+
+SELECT '-- a carrier the unwrapped form also rejects stays rejected --';
+SELECT kqlBin(toLowCardinality('x'), 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT kqlBin(toLowCardinality(toDate('2026-01-01')), 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.sql
+++ b/tests/queries/0_stateless/04870_kql_in_column_bin_column_size_interval_division.sql
@@ -68,6 +68,7 @@ print bin(4, toLowCardinality(1));
 print bin(toLowCardinality(-5), 3);
 print bin_at(toLowCardinality(6), 2, 1);
 print bin_at(6, 2, toLowCardinality(1));
+print bin_at(datetime(2026-08-01 12:34:56), toLowCardinality(1h), datetime(2026-08-01 00:30:00));
 print toLowCardinality(1h) / 30m;
 
 SET dialect = 'clickhouse';
@@ -93,6 +94,27 @@ SELECT kqlBin(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(to
 SELECT kqlBin(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(toIntervalMonth(-1)));
 SELECT kqlBinAt(materialize(toLowCardinality(6)), 2, 1);
 
+SELECT '-- a LowCardinality(Nullable) timespan keeps its null map --';
+SELECT kqlBin(toLowCardinality(toNullable(toIntervalHour(16))), toIntervalHour(7));
+SELECT kqlBin(toNullable(toIntervalHour(16)), toIntervalHour(7));
+SELECT kqlBinAt(toLowCardinality(toNullable(toIntervalHour(16))), toIntervalHour(7), toIntervalHour(1));
+SELECT kqlBinAt(toNullable(toIntervalHour(16)), toIntervalHour(7), toIntervalHour(1));
+SELECT kqlBin(toLowCardinality(nullIf(toNullable(toIntervalHour(16)), toIntervalHour(16))), toIntervalHour(7));
+SELECT kqlBin(nullIf(toNullable(toIntervalHour(16)), toIntervalHour(16)), toIntervalHour(7));
+SELECT toTypeName(kqlBin(toLowCardinality(toNullable(toIntervalHour(16))), toIntervalHour(7)));
+SELECT toTypeName(kqlBin(toNullable(toIntervalHour(16)), toIntervalHour(7)));
+
+SELECT '-- LowCardinality is transparent to kqlBinAt on every branch --';
+SELECT kqlBinAt(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(toIntervalHour(1)), toDateTime64('2026-08-01 00:30:00', 7, 'UTC'));
+SELECT kqlBinAt(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toIntervalHour(1), toDateTime64('2026-08-01 00:30:00', 7, 'UTC'));
+SELECT kqlBinAt(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(toIntervalMonth(1)), toDateTime64('2026-01-01 00:00:00', 7, 'UTC'));
+SELECT kqlBinAt(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toIntervalMonth(1), toDateTime64('2026-01-01 00:00:00', 7, 'UTC'));
+SELECT kqlBinAt(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toLowCardinality(toIntervalMonth(-1)), toDateTime64('2026-01-01 00:00:00', 7, 'UTC'));
+SELECT kqlBinAt(toDateTime64('2026-08-01 12:34:56', 7, 'UTC'), toIntervalMonth(-1), toDateTime64('2026-01-01 00:00:00', 7, 'UTC'));
+SELECT kqlBinAt(toLowCardinality(toIntervalHour(16)), toIntervalHour(7), toIntervalHour(1));
+SELECT kqlBinAt(toIntervalHour(16), toIntervalHour(7), toIntervalHour(1));
+
 SELECT '-- a carrier the unwrapped form also rejects stays rejected --';
 SELECT kqlBin(toLowCardinality('x'), 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT kqlBin(toLowCardinality(toDate('2026-01-01')), 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT kqlBin(toLowCardinality(toDateTime('2026-01-01 00:00:00', 'UTC')), 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117162

No related open issue found.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required: the affected code was added to master after the latest release and exists on no release branch.

### Description

`kqlDivide` (KQL's `/`), `kqlBin` and `kqlBinAt` classify arguments by type, but their gates call
`removeNullable`, a no-op on `LowCardinality`, so every `isX` answers false for a wrapped argument.
`toLowCardinality(7) / 2` returns `3.5` instead of `3` (KQL divides two integers as integers), and
`bin`/`bin_at` reject arguments whose unwrapped forms they accept.

Root cause: `IFunctionOverloadResolver::build` calls `getReturnType(arguments)`, which strips
`LowCardinality` from a copy, then `buildImpl(arguments, ...)` with the original types. All three are
resolvers whose two entry points funnel into one `delegate`, so it runs twice over two different type
vectors and the second takes the wrong branch. Separately, a `KQLPlan` argument slot declared the
argument's own type while `FunctionKQLPlan`'s executable is handed already-converted full columns.

The fix mirrors `FunctionKQLParameterCast.cpp`: the three resolvers declare
`useDefaultImplementationForLowCardinalityColumns` false so both entry points see one vector, the
gates read the existing `removeLowCardinalityAndNullable`, and `KQLPlanBuilder::argument` normalises
slot types with `recursiveRemoveLowCardinality` - one edit covering all 20 slot call sites in the
directory. The direct delegates keep the wrapper, since that is what `intDiv` does natively.

Every affected branch was validated against its unwrapped control, in both dialects, over constants,
`materialize` and a real table column; wrapped and unwrapped rejections stay symmetric. 48 of 48 KQL
tests pass, 50 of 50 randomized.

Siblings: all 4 `KQLPlan`-building `kql*` functions were affected. This PR fixes the 3 named above;
the 4th, `kqlParameterCast`, is fixed by #117162 (same shape, disjoint files). The 3 plain
`IFunction` ones get transparency from the framework and measured sound. `LowCardinality` of
`DateTime64`, `Nothing` and `Decimal` is not constructible, so those branches are safe by
construction.

Not fixed here: `kqlParameterCast` rejects a `LowCardinality(String)` metadata argument the dialect
cannot reach; and `IFunction.h:504` documents an LC-stripping contract for `build` that
`IFunction.cpp` honours only for `getReturnType`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117190&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117190](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117190+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
