### PR TITLE
Skip or fix five stateless tests that fail on a Replicated database

### DIFF
--- a/tests/queries/0_stateless/04001_attach_clone_part_level_reset.reference
+++ b/tests/queries/0_stateless/04001_attach_clone_part_level_reset.reference
@@ -1,10 +1,6 @@
 src level	1
-clone level	0
-clone final	1
-clone after optimize	1
 attach level	0
 attach final	1
-summing final	1	30
 aggregating level	0
 aggregating final	1	30
 move level	0

--- a/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
+++ b/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
@@ -1,6 +1,5 @@
--- Tags: no-random-merge-tree-settings, no-replicated-database
+-- Tags: no-random-merge-tree-settings
 -- ^ test asserts exact part levels, which randomized merge tree settings can perturb
--- Tag no-replicated-database: Unsupported type of CREATE TABLE ... CLONE AS ... query
 
 -- Adopting a part from a plain MergeTree into a collapsing engine (Replacing/Summing/
 -- Aggregating) used to keep the source part's merge level. A lone level>0 part is treated
@@ -13,9 +12,7 @@
 -- already-merged.
 
 DROP TABLE IF EXISTS src_mt;
-DROP TABLE IF EXISTS dst_rmt_clone;
 DROP TABLE IF EXISTS dst_rmt_attach;
-DROP TABLE IF EXISTS dst_smt;
 DROP TABLE IF EXISTS src_mt_agg;
 DROP TABLE IF EXISTS dst_amt;
 DROP TABLE IF EXISTS src_mt_move;
@@ -34,12 +31,6 @@ INSERT INTO src_mt VALUES (1, 20);
 OPTIMIZE TABLE src_mt FINAL;
 SELECT 'src level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'src_mt' AND active;
 
--- CLONE AS into ReplacingMergeTree: adopted part must be reset to level 0 and dedup.
-CREATE TABLE dst_rmt_clone CLONE AS src_mt ENGINE = ReplacingMergeTree;
-SELECT 'clone level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_clone' AND active;
-SELECT 'clone final', count() FROM dst_rmt_clone FINAL;
-OPTIMIZE TABLE dst_rmt_clone FINAL;
-SELECT 'clone after optimize', count() FROM dst_rmt_clone FINAL;
 
 -- ATTACH PARTITION FROM into ReplacingMergeTree.
 CREATE TABLE dst_rmt_attach (a UInt32, b UInt32) ENGINE = ReplacingMergeTree ORDER BY a;
@@ -47,9 +38,6 @@ ALTER TABLE dst_rmt_attach ATTACH PARTITION tuple() FROM src_mt;
 SELECT 'attach level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_attach' AND active;
 SELECT 'attach final', count() FROM dst_rmt_attach FINAL;
 
--- CLONE AS into SummingMergeTree: rows with the same key must sum.
-CREATE TABLE dst_smt CLONE AS src_mt ENGINE = SummingMergeTree;
-SELECT 'summing final', a, b FROM dst_smt FINAL ORDER BY a;
 
 -- ATTACH PARTITION FROM into AggregatingMergeTree (source column type matches the target's
 -- SimpleAggregateFunction state, as ATTACH PARTITION FROM requires identical structure).
@@ -112,9 +100,7 @@ SELECT 'replacing diff is_deleted level', max(level) FROM system.parts WHERE dat
 SELECT 'replacing diff is_deleted final', count() FROM dst_rmt_ver_del FINAL;
 
 DROP TABLE src_mt;
-DROP TABLE dst_rmt_clone;
 DROP TABLE dst_rmt_attach;
-DROP TABLE dst_smt;
 DROP TABLE src_mt_agg;
 DROP TABLE dst_amt;
 DROP TABLE src_mt_move;

--- a/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
+++ b/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
@@ -1,5 +1,6 @@
--- Tags: no-random-merge-tree-settings
+-- Tags: no-random-merge-tree-settings, no-replicated-database
 -- ^ test asserts exact part levels, which randomized merge tree settings can perturb
+-- Tag no-replicated-database: Unsupported type of CREATE TABLE ... CLONE AS ... query
 
 -- Adopting a part from a plain MergeTree into a collapsing engine (Replacing/Summing/
 -- Aggregating) used to keep the source part's merge level. A lone level>0 part is treated

--- a/tests/queries/0_stateless/04001_clone_as_part_level_reset.reference
+++ b/tests/queries/0_stateless/04001_clone_as_part_level_reset.reference
@@ -1,0 +1,5 @@
+src level	1
+clone level	0
+clone final	1
+clone after optimize	1
+summing final	1	30

--- a/tests/queries/0_stateless/04001_clone_as_part_level_reset.sql
+++ b/tests/queries/0_stateless/04001_clone_as_part_level_reset.sql
@@ -3,28 +3,28 @@
 -- Tag no-replicated-database: `CREATE CLONE AS is not supported with Replicated databases`
 
 -- A part adopted into a collapsing engine counts as already merged while its level stays >0, so
--- FINAL/OPTIMIZE skip it and duplicate keys survive. The level has to be reset to 0.
+-- `FINAL`/`OPTIMIZE` skip it and duplicate keys survive. The level has to be reset to 0.
 -- The `ALTER ... ATTACH/MOVE PARTITION` forms are in 04001_attach_clone_part_level_reset.sql.
 
 DROP TABLE IF EXISTS src_mt;
 DROP TABLE IF EXISTS dst_rmt_clone;
 DROP TABLE IF EXISTS dst_smt;
 
--- A source MergeTree part at level 1 (merged, but no dedup under MergeTree semantics).
+-- A source `MergeTree` part at level 1 (merged, but no dedup under `MergeTree` semantics).
 CREATE TABLE src_mt (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
 INSERT INTO src_mt VALUES (1, 10);
 INSERT INTO src_mt VALUES (1, 20);
 OPTIMIZE TABLE src_mt FINAL;
 SELECT 'src level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'src_mt' AND active;
 
--- CLONE AS into ReplacingMergeTree: adopted part must be reset to level 0 and dedup.
+-- `CLONE AS` into `ReplacingMergeTree`: adopted part must be reset to level 0 and dedup.
 CREATE TABLE dst_rmt_clone CLONE AS src_mt ENGINE = ReplacingMergeTree;
 SELECT 'clone level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_clone' AND active;
 SELECT 'clone final', count() FROM dst_rmt_clone FINAL;
 OPTIMIZE TABLE dst_rmt_clone FINAL;
 SELECT 'clone after optimize', count() FROM dst_rmt_clone FINAL;
 
--- CLONE AS into SummingMergeTree: rows with the same key must sum.
+-- `CLONE AS` into `SummingMergeTree`: rows with the same key must sum.
 CREATE TABLE dst_smt CLONE AS src_mt ENGINE = SummingMergeTree;
 SELECT 'summing final', a, b FROM dst_smt FINAL ORDER BY a;
 

--- a/tests/queries/0_stateless/04001_clone_as_part_level_reset.sql
+++ b/tests/queries/0_stateless/04001_clone_as_part_level_reset.sql
@@ -1,0 +1,33 @@
+-- Tags: no-random-merge-tree-settings, no-replicated-database
+-- ^ test asserts exact part levels, which randomized merge tree settings can perturb
+-- Tag no-replicated-database: `CREATE CLONE AS is not supported with Replicated databases`
+
+-- A part adopted into a collapsing engine counts as already merged while its level stays >0, so
+-- FINAL/OPTIMIZE skip it and duplicate keys survive. The level has to be reset to 0.
+-- The `ALTER ... ATTACH/MOVE PARTITION` forms are in 04001_attach_clone_part_level_reset.sql.
+
+DROP TABLE IF EXISTS src_mt;
+DROP TABLE IF EXISTS dst_rmt_clone;
+DROP TABLE IF EXISTS dst_smt;
+
+-- A source MergeTree part at level 1 (merged, but no dedup under MergeTree semantics).
+CREATE TABLE src_mt (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO src_mt VALUES (1, 10);
+INSERT INTO src_mt VALUES (1, 20);
+OPTIMIZE TABLE src_mt FINAL;
+SELECT 'src level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'src_mt' AND active;
+
+-- CLONE AS into ReplacingMergeTree: adopted part must be reset to level 0 and dedup.
+CREATE TABLE dst_rmt_clone CLONE AS src_mt ENGINE = ReplacingMergeTree;
+SELECT 'clone level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_clone' AND active;
+SELECT 'clone final', count() FROM dst_rmt_clone FINAL;
+OPTIMIZE TABLE dst_rmt_clone FINAL;
+SELECT 'clone after optimize', count() FROM dst_rmt_clone FINAL;
+
+-- CLONE AS into SummingMergeTree: rows with the same key must sum.
+CREATE TABLE dst_smt CLONE AS src_mt ENGINE = SummingMergeTree;
+SELECT 'summing final', a, b FROM dst_smt FINAL ORDER BY a;
+
+DROP TABLE src_mt;
+DROP TABLE dst_rmt_clone;
+DROP TABLE dst_smt;

--- a/tests/queries/0_stateless/04903_mutation_partition_pruning_without_validation.sql
+++ b/tests/queries/0_stateless/04903_mutation_partition_pruning_without_validation.sql
@@ -27,8 +27,13 @@ ALTER TABLE mutation_pruning_without_validation DELETE WHERE d IN (SELECT d FROM
 -- The mutation entry is created in ZooKeeper synchronously by the ALTER, while
 -- `system.mutations` is populated asynchronously by the mutations-updating task,
 -- so only the former can be asserted without a race.
+-- The path comes from `system.replicas`, not from the literal above: the engine arguments a user
+-- writes are not necessarily the path the table ends up at.
 SELECT count()
 FROM system.zookeeper
-WHERE path = '/clickhouse/tables/' || currentDatabase() || '/mutation_pruning_without_validation/mutations';
+WHERE path IN (
+    SELECT zookeeper_path || '/mutations'
+    FROM system.replicas
+    WHERE database = currentDatabase() AND table = 'mutation_pruning_without_validation');
 
 DROP TABLE mutation_pruning_without_validation SYNC;

--- a/tests/queries/0_stateless/04909_totime_key_persist_clone_and_on_cluster.reference
+++ b/tests/queries/0_stateless/04909_totime_key_persist_clone_and_on_cluster.reference
@@ -1,0 +1,5 @@
+clone	toTime(c0)
+on_cluster_oldest_entry	toTimeWithFixedDate(c0)
+on_cluster_oldest_entry_udf	toTimeWithFixedDate(c0)
+on_cluster_oldest_entry_mv	ORDER BY toTimeWithFixedDate(c0)
+on_cluster_oldest_entry_projection	ORDER BY toTimeWithFixedDate

--- a/tests/queries/0_stateless/04909_totime_key_persist_clone_and_on_cluster.sh
+++ b/tests/queries/0_stateless/04909_totime_key_persist_clone_and_on_cluster.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# Tag no-replicated-database: `CREATE CLONE AS is not supported with Replicated databases`, `ON CLUSTER is not allowed for Replicated database`
+# A clone copies its definition out of stored metadata and an `ON CLUSTER` worker sees only the
+# query text, so neither can recover the spelling from the issuing session's settings.
+# The UDF name includes the test database because SQL UDFs are server-global and this test runs
+# concurrently with itself in flaky-check mode.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+UDF="totime_04909_clone_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 1 -q "CREATE FUNCTION ${UDF} AS x -> toTime(x);"
+
+# A clone must retain its source definition verbatim. Unlike plain AS, changing its key spelling
+# makes the subsequent partition copy reject the source and destination as structurally different.
+${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 -q "
+CREATE TABLE t_clone_source (c0 DateTime) ENGINE = MergeTree() ORDER BY toTime(c0);
+"
+${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 1 --multiquery -q "
+CREATE TABLE t_clone_key CLONE AS t_clone_source;
+SELECT 'clone', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_clone_key';
+"
+
+# The oldest DDL entry format ships the query text as written and carries no settings, so the
+# spelling a worker receives has to be unambiguous already.
+OLDEST_VERSION=1
+${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 1 \
+    --distributed_ddl_entry_format_version $OLDEST_VERSION --distributed_ddl_output_mode none --multiquery -q "
+CREATE TABLE t_on_cluster_key ON CLUSTER test_shard_localhost (c0 DateTime) ENGINE = MergeTree() ORDER BY toTime(c0);
+SELECT 'on_cluster_oldest_entry', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_key';
+
+-- The same, with the key expression carried by a SQL UDF body.
+CREATE TABLE t_on_cluster_udf_key ON CLUSTER test_shard_localhost (c0 DateTime) ENGINE = MergeTree() ORDER BY ${UDF}(c0);
+SELECT 'on_cluster_oldest_entry_udf', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_udf_key';
+
+-- A materialized view keeps its inner table's key outside the top-level storage definition.
+CREATE TABLE ${CLICKHOUSE_DATABASE}.t_on_cluster_mv_src (c0 DateTime) ENGINE = MergeTree() ORDER BY tuple();
+CREATE MATERIALIZED VIEW ${CLICKHOUSE_DATABASE}.t_on_cluster_mv ON CLUSTER test_shard_localhost
+ENGINE = MergeTree() ORDER BY toTime(c0) AS SELECT c0 FROM ${CLICKHOUSE_DATABASE}.t_on_cluster_mv_src;
+SELECT 'on_cluster_oldest_entry_mv', extract(create_table_query, 'ORDER BY [^ ]*') FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_mv';
+
+-- A projection carries its own physical sorting key, declared inside the column list.
+CREATE TABLE ${CLICKHOUSE_DATABASE}.t_on_cluster_projection_key ON CLUSTER test_shard_localhost
+(c0 DateTime, v UInt32, PROJECTION pr (SELECT c0, v ORDER BY toTime(c0))) ENGINE = MergeTree() ORDER BY tuple();
+SELECT 'on_cluster_oldest_entry_projection', extract(create_table_query, 'ORDER BY toTime[A-Za-z]*') FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_projection_key';
+"
+
+${CLICKHOUSE_CLIENT} --multiquery -q "
+DROP TABLE t_clone_key;
+DROP TABLE t_clone_source;
+DROP TABLE t_on_cluster_key;
+DROP TABLE t_on_cluster_udf_key;
+DROP TABLE t_on_cluster_mv;
+DROP TABLE t_on_cluster_projection_key;
+DROP TABLE t_on_cluster_mv_src;
+DROP FUNCTION ${UDF};
+"

--- a/tests/queries/0_stateless/04909_totime_key_persist_legacy_udf_and_attach.reference
+++ b/tests/queries/0_stateless/04909_totime_key_persist_legacy_udf_and_attach.reference
@@ -1,7 +1,6 @@
 udf	toTimeWithFixedDate(c0)
 qualified	toTimeWithFixedDate(c0)
 as	toTimeWithFixedDate(c0)
-clone	toTime(c0)
 attach	toTimeWithFixedDate(c0)
 stored_key_type
 part_name	String
@@ -15,7 +14,3 @@ mark_number	UInt64
 rows_in_granule	UInt64
 toTimeWithFixedDate(c0)	DateTime
 ttl_group_by	toTimeWithFixedDate(c0)
-on_cluster_oldest_entry	toTimeWithFixedDate(c0)
-on_cluster_oldest_entry_udf	toTimeWithFixedDate(c0)
-on_cluster_oldest_entry_mv	ORDER BY toTimeWithFixedDate(c0)
-on_cluster_oldest_entry_projection	ORDER BY toTimeWithFixedDate

--- a/tests/queries/0_stateless/04909_totime_key_persist_legacy_udf_and_attach.sh
+++ b/tests/queries/0_stateless/04909_totime_key_persist_legacy_udf_and_attach.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database
+# Tag no-replicated-database: Unsupported type of CREATE TABLE ... CLONE AS ... query, ON CLUSTER is not allowed
 # The explicit legacy spelling must be persisted for every definition a user supplies, including one
 # whose key expression only becomes visible after SQL UDF substitution and one supplied by a
 # full-definition ATTACH. Definitions replayed from stored metadata must be left alone.

--- a/tests/queries/0_stateless/04909_totime_key_persist_legacy_udf_and_attach.sh
+++ b/tests/queries/0_stateless/04909_totime_key_persist_legacy_udf_and_attach.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-replicated-database
-# Tag no-replicated-database: Unsupported type of CREATE TABLE ... CLONE AS ... query, ON CLUSTER is not allowed
 # The explicit legacy spelling must be persisted for every definition a user supplies, including one
 # whose key expression only becomes visible after SQL UDF substitution and one supplied by a
 # full-definition ATTACH. Definitions replayed from stored metadata must be left alone.
@@ -28,16 +26,6 @@ SELECT 'qualified', sorting_key FROM system.tables WHERE database = currentDatab
 CREATE TABLE t_as_source (c0 DateTime) ENGINE = MergeTree() ORDER BY toTime(c0);
 CREATE TABLE t_as_key AS t_as_source;
 SELECT 'as', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_as_key';
-"
-
-# A clone must retain its source definition verbatim. Unlike plain AS, changing its key spelling
-# makes the subsequent partition copy reject the source and destination as structurally different.
-${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 -q "
-CREATE TABLE t_clone_source (c0 DateTime) ENGINE = MergeTree() ORDER BY toTime(c0);
-"
-${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 1 --multiquery -q "
-CREATE TABLE t_clone_key CLONE AS t_clone_source;
-SELECT 'clone', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_clone_key';
 "
 
 # A full-definition ATTACH is CREATE-like user input and persists what it is given. The server warns
@@ -73,44 +61,13 @@ TTL c0 + INTERVAL 1 DAY GROUP BY toTime(c0) SET v = max(v);
 SELECT 'ttl_group_by', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_ttl_key';
 "
 
-# The oldest DDL entry format ships the query text as written and carries no settings, so the
-# spelling a worker receives has to be unambiguous already.
-OLDEST_VERSION=1
-${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 1 \
-    --distributed_ddl_entry_format_version $OLDEST_VERSION --distributed_ddl_output_mode none --multiquery -q "
-CREATE TABLE t_on_cluster_key ON CLUSTER test_shard_localhost (c0 DateTime) ENGINE = MergeTree() ORDER BY toTime(c0);
-SELECT 'on_cluster_oldest_entry', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_key';
-
--- The same, with the key expression carried by a SQL UDF body.
-CREATE TABLE t_on_cluster_udf_key ON CLUSTER test_shard_localhost (c0 DateTime) ENGINE = MergeTree() ORDER BY ${UDF}(c0);
-SELECT 'on_cluster_oldest_entry_udf', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_udf_key';
-
--- A materialized view keeps its inner table's key outside the top-level storage definition.
-CREATE TABLE ${CLICKHOUSE_DATABASE}.t_on_cluster_mv_src (c0 DateTime) ENGINE = MergeTree() ORDER BY tuple();
-CREATE MATERIALIZED VIEW ${CLICKHOUSE_DATABASE}.t_on_cluster_mv ON CLUSTER test_shard_localhost
-ENGINE = MergeTree() ORDER BY toTime(c0) AS SELECT c0 FROM ${CLICKHOUSE_DATABASE}.t_on_cluster_mv_src;
-SELECT 'on_cluster_oldest_entry_mv', extract(create_table_query, 'ORDER BY [^ ]*') FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_mv';
-
--- A projection carries its own physical sorting key, declared inside the column list.
-CREATE TABLE ${CLICKHOUSE_DATABASE}.t_on_cluster_projection_key ON CLUSTER test_shard_localhost
-(c0 DateTime, v UInt32, PROJECTION pr (SELECT c0, v ORDER BY toTime(c0))) ENGINE = MergeTree() ORDER BY tuple();
-SELECT 'on_cluster_oldest_entry_projection', extract(create_table_query, 'ORDER BY toTime[A-Za-z]*') FROM system.tables WHERE database = currentDatabase() AND name = 't_on_cluster_projection_key';
-"
-
 ${CLICKHOUSE_CLIENT} --multiquery -q "
 DROP TABLE t_udf_key;
 DROP TABLE t_attach_key;
 DROP TABLE t_qualified_key;
 DROP TABLE t_as_key;
 DROP TABLE t_as_source;
-DROP TABLE t_clone_key;
-DROP TABLE t_clone_source;
 DROP TABLE t_replayed_key;
 DROP TABLE t_ttl_key;
-DROP TABLE t_on_cluster_key;
-DROP TABLE t_on_cluster_udf_key;
-DROP TABLE t_on_cluster_mv;
-DROP TABLE t_on_cluster_projection_key;
-DROP TABLE t_on_cluster_mv_src;
 DROP FUNCTION ${UDF};
 "

--- a/tests/queries/0_stateless/04910_to_time_legacy_alter_key_definitions.reference
+++ b/tests/queries/0_stateless/04910_to_time_legacy_alter_key_definitions.reference
@@ -3,5 +3,3 @@ GROUP BY toUInt32(toTimeWithFixedDate
 toUInt32(toTimeWithFixedDate(c0))
 toUInt32(toTimeWithFixedDate(c0)), c1
 toUInt32(toTimeWithFixedDate(c0))
-toUInt32(toTime(c0)), c1
-1

--- a/tests/queries/0_stateless/04910_to_time_legacy_alter_key_definitions.sh
+++ b/tests/queries/0_stateless/04910_to_time_legacy_alter_key_definitions.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-replicated-database
-# Tag no-replicated-database: Unsupported type of CREATE TABLE ... CLONE AS ... query
 # The UDF name includes the test database because SQL UDFs are server-global and this test runs
 # concurrently with itself in flaky-check mode.
 
@@ -39,15 +37,4 @@ SELECT sampling_key FROM system.tables WHERE database = currentDatabase() AND na
 
 DROP TABLE t_totime_alter_key_udf;
 DROP FUNCTION ${UDF};
-
-SET use_legacy_to_time = 0;
-CREATE TABLE t_totime_clone_source (c0 DateTime, c1 UInt32)
-ENGINE = MergeTree() ORDER BY (toUInt32(toTime(c0)), c1);
-INSERT INTO t_totime_clone_source VALUES ('2026-01-01 01:02:03', 1);
-SET use_legacy_to_time = 1;
-CREATE TABLE t_totime_clone CLONE AS t_totime_clone_source;
-SELECT sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_totime_clone';
-SELECT count() FROM t_totime_clone;
-DROP TABLE t_totime_clone;
-DROP TABLE t_totime_clone_source;
 "

--- a/tests/queries/0_stateless/04910_to_time_legacy_alter_key_definitions.sh
+++ b/tests/queries/0_stateless/04910_to_time_legacy_alter_key_definitions.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database
+# Tag no-replicated-database: Unsupported type of CREATE TABLE ... CLONE AS ... query
 # The UDF name includes the test database because SQL UDFs are server-global and this test runs
 # concurrently with itself in flaky-check mode.
 

--- a/tests/queries/0_stateless/04910_to_time_legacy_clone_key_definition.reference
+++ b/tests/queries/0_stateless/04910_to_time_legacy_clone_key_definition.reference
@@ -1,0 +1,2 @@
+toUInt32(toTime(c0)), c1
+1

--- a/tests/queries/0_stateless/04910_to_time_legacy_clone_key_definition.sh
+++ b/tests/queries/0_stateless/04910_to_time_legacy_clone_key_definition.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# Tag no-replicated-database: `CREATE CLONE AS is not supported with Replicated databases`
+# A clone copies its source definition out of stored metadata, so the spelling the source declared
+# has to survive verbatim even when the cloning session asks for the legacy one.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 1 --multiquery -q "
+SET use_legacy_to_time = 0;
+CREATE TABLE t_totime_clone_source (c0 DateTime, c1 UInt32)
+ENGINE = MergeTree() ORDER BY (toUInt32(toTime(c0)), c1);
+INSERT INTO t_totime_clone_source VALUES ('2026-01-01 01:02:03', 1);
+SET use_legacy_to_time = 1;
+CREATE TABLE t_totime_clone CLONE AS t_totime_clone_source;
+SELECT sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 't_totime_clone';
+SELECT count() FROM t_totime_clone;
+DROP TABLE t_totime_clone;
+DROP TABLE t_totime_clone_source;
+"

--- a/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.reference
+++ b/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.reference
@@ -1,6 +1,5 @@
 source	toTime(c0)
 oldest_as NOT_IMPLEMENTED
 oldest_clone NOT_IMPLEMENTED
-settings_in_zk_as	toTimeWithFixedDate(c0)
 settings_in_zk_clone NOT_IMPLEMENTED
 local_as	toTimeWithFixedDate(c0)

--- a/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.sh
+++ b/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-replicated-database
-# Tag no-replicated-database: `ON CLUSTER is not allowed for Replicated database`
 # `CREATE TABLE ... AS` ON CLUSTER materializes the source definition on the worker, so the initiator
 # cannot rewrite the legacy `toTime` spelling for it. Only `distributed_ddl_entry_format_version = 1`
 # drops the query settings, so only that version has to be rejected: version 2 carries
@@ -31,18 +29,13 @@ ${CLICKHOUSE_CLIENT} "${LEGACY[@]}" --distributed_ddl_entry_format_version 1 -q 
 CREATE TABLE ${CLICKHOUSE_DATABASE}.dst_clone_v1 ON CLUSTER test_shard_localhost CLONE AS ${CLICKHOUSE_DATABASE}.src;
 " 2>&1 | grep -o -m1 'NOT_IMPLEMENTED' | sed 's/^/oldest_clone /'
 
-# The entry format that carries the settings executes deterministically on the worker.
-${CLICKHOUSE_CLIENT} "${LEGACY[@]}" --distributed_ddl_entry_format_version 2 -q "
-CREATE TABLE ${CLICKHOUSE_DATABASE}.dst_v2 ON CLUSTER test_shard_localhost AS ${CLICKHOUSE_DATABASE}.src;
-SELECT 'settings_in_zk_as', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 'dst_v2';
-"
-
 # A clone must keep its source definition verbatim, so it cannot be made unambiguous by the setting.
 ${CLICKHOUSE_CLIENT} "${LEGACY[@]}" --distributed_ddl_entry_format_version 2 -q "
 CREATE TABLE ${CLICKHOUSE_DATABASE}.dst_clone_v2 ON CLUSTER test_shard_localhost CLONE AS ${CLICKHOUSE_DATABASE}.src;
 " 2>&1 | grep -o -m1 'NOT_IMPLEMENTED' | sed 's/^/settings_in_zk_clone /'
 
-# The same query without ON CLUSTER: the version-2 result above must match it.
+# The same query without ON CLUSTER: this is the spelling a worker has to end up with too, asserted
+# for `ON CLUSTER` in `05030_totime_on_cluster_as_settings_in_zk_worker.sh`.
 ${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 1 -q "
 CREATE TABLE dst_local AS src;
 SELECT 'local_as', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 'dst_local';
@@ -50,6 +43,5 @@ SELECT 'local_as', sorting_key FROM system.tables WHERE database = currentDataba
 
 ${CLICKHOUSE_CLIENT} -q "
 DROP TABLE dst_local;
-DROP TABLE dst_v2;
 DROP TABLE src;
 "

--- a/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.sh
+++ b/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database
+# Tag no-replicated-database: ON CLUSTER is not allowed
 # `CREATE TABLE ... AS` ON CLUSTER materializes the source definition on the worker, so the initiator
 # cannot rewrite the legacy `toTime` spelling for it. Only `distributed_ddl_entry_format_version = 1`
 # drops the query settings, so only that version has to be rejected: version 2 carries

--- a/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.sh
+++ b/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: no-replicated-database
-# Tag no-replicated-database: ON CLUSTER is not allowed
+# Tag no-replicated-database: `ON CLUSTER is not allowed for Replicated database`
 # `CREATE TABLE ... AS` ON CLUSTER materializes the source definition on the worker, so the initiator
 # cannot rewrite the legacy `toTime` spelling for it. Only `distributed_ddl_entry_format_version = 1`
 # drops the query settings, so only that version has to be rejected: version 2 carries

--- a/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_worker.reference
+++ b/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_worker.reference
@@ -1,0 +1,2 @@
+source	toTime(c0)
+settings_in_zk_as	toTimeWithFixedDate(c0)

--- a/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_worker.sh
+++ b/tests/queries/0_stateless/05030_totime_on_cluster_as_settings_in_zk_worker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# Tag no-replicated-database: `ON CLUSTER is not allowed for Replicated database`
+# `distributed_ddl_entry_format_version = 2` carries `use_legacy_to_time` to the worker, which
+# then stores exactly what a local `CREATE` stores.
+# Names are database-qualified: the pre-`NORMALIZE_CREATE_ON_INITIATOR_VERSION` entry ships the query
+# text as written, so a worker resolves unqualified names in its own default database.
+# The source is created with `use_legacy_to_time = 0`, so its stored key is the raw `toTime` spelling
+# and a verbatim copy is distinguishable from a rewritten one.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --allow_experimental_time_time64_type 1 --use_legacy_to_time 0 -q "
+CREATE TABLE src (c0 DateTime) ENGINE = MergeTree() ORDER BY toTime(c0);
+SELECT 'source', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 'src';
+"
+
+LEGACY=(--allow_experimental_time_time64_type 1 --use_legacy_to_time 1 --distributed_ddl_output_mode none)
+
+${CLICKHOUSE_CLIENT} "${LEGACY[@]}" --distributed_ddl_entry_format_version 2 -q "
+CREATE TABLE ${CLICKHOUSE_DATABASE}.dst_v2 ON CLUSTER test_shard_localhost AS ${CLICKHOUSE_DATABASE}.src;
+SELECT 'settings_in_zk_as', sorting_key FROM system.tables WHERE database = currentDatabase() AND name = 'dst_v2';
+"
+
+${CLICKHOUSE_CLIENT} -q "
+DROP TABLE dst_v2;
+DROP TABLE src;
+"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112247


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

On the `DBReplicated` coverage flavours the runner puts each stateless test on a `Replicated`
database, and five tests then fail the main pass on every run. The failures are hidden today: the
diagnostics rerun drops the job's `--replicated-database` flag, so they re-run without it, pass, and
are labelled `flaky` and force-set `OK`. #112247 fixes that visibility; this makes the five stop
failing.

Two mechanisms are unconditional server refusals: `InterpreterCreateQuery.cpp:2034` refuses
`CREATE ... CLONE AS` on a `Replicated` database, and `DatabaseReplicated.cpp:1475` refuses
`ON CLUSTER` DDL it would have to enqueue into its own log. The third is a rewrite:
`DatabaseReplicated.cpp:1276` appends `auto_{shard}` to a user-supplied `Replicated*MergeTree` path.

A refusal reaches individual statements, not whole files, so a whole-file tag also drops assertions
that run correctly on that lane. Measured there, reference lines produced today against lines the
server genuinely refuses: `04910` 5 of 7 against 2, `04909` 16 of 21 against 5, `04001` 1 of 17
against 4, `05030` 5 of 6 against 1. So the refused statements move into four new tests that carry
`no-replicated-database`, and the four parents lose the tag and keep running: **39 assertions
recovered** that whole-file tags would have silenced. `04903` needs no tag; it hard-coded the
rewritten path and now reads it back from `system.replicas`.

<details>
<summary>Per-test disposition and validation</summary>

| test | refused statement | disposition |
|---|---|---|
| `04910_to_time_legacy_alter_key_definitions` | `CLONE AS` | tag removed; clone arm moved to `04910_to_time_legacy_clone_key_definition` |
| `04909_totime_key_persist_legacy_udf_and_attach` | `CLONE AS`, `ON CLUSTER` | tag removed; both arms moved to `04909_totime_key_persist_clone_and_on_cluster` |
| `04001_attach_clone_part_level_reset` | `CLONE AS` | tag removed; clone arms moved to `04001_clone_as_part_level_reset` |
| `05030_totime_on_cluster_as_settings_in_zk_version` | `ON CLUSTER`, only with `distributed_ddl_entry_format_version = 2` | tag removed; that arm moved to `05030_totime_on_cluster_as_settings_in_zk_worker` |
| `04903_mutation_partition_pruning_without_validation` | none; rewritten path | derive the path from `system.replicas` |

`04001` produces only its first reference line because its `CLONE AS` is the second statement group
and aborts the rest of the file, not because the remainder is unsupported. `05030`'s three other
`ON CLUSTER` arms are refused on the initiator by the legacy-`toTime` check with the same
`NOT_IMPLEMENTED` they assert on any other engine, so only the version-2 arm needs the tag.

`no-replicated-database` records a server-enforced engine incompatibility, not a randomization
silencer, so no `no-random-*` tag is added. It also skips Cloud and shared-catalog runs, which is a
further reason to scope it to the arms that need it.

Validation, 50 randomized runs of all nine tests: 450/450 `OK` on the normal path; on
`--replicated-database`, 250 `OK` plus 200 skipped, against 50 `OK` plus 200 skipped before any
split. Each refusal was reproduced with its exact error code on a single-node `Replicated` database.
Mutating one reference line of any test reddens it, on the arm where it runs.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117192&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117192](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117192+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
