### PR TITLE
Follow the kernel log for the whole integration test run instead of snapshotting a wrapped buffer

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -51,10 +51,15 @@ LATE_DMESG_LOG = "./ci/tmp/dmesg-after-merge.log"
 DMESG_FOLLOW_LOG = "./ci/tmp/dmesg-follow.log"
 
 # Rides a dmesg-derived NEGATIVE that is not a proven one, where `oom_memcg` scoping cannot help:
-# a record that starts after the kill simply does not hold it. The converse caveat belongs on the
-# positive: an uncleared buffer can show another job's kill, but its silence still covers this run.
+# a record that starts after the kill simply does not hold it.
 PARTIAL_DMESG_CAVEAT = (
     " (the record does not cover the whole run, so an earlier kill would not be in it)"
+)
+
+# Rides the POSITIVE, which is unsound in the opposite direction: a buffer still holding a
+# previous job's records can show a kill that is not this run's, while its silence still covers it.
+UNCLEARED_DMESG_CAVEAT = (
+    " (buffer not cleared for this run, so a kill may be a previous job's)"
 )
 
 # `docker_in_docker.sh`'s own output, which holds the containment decision and any refusal.
@@ -502,9 +507,12 @@ def start_dmesg_follow() -> Optional[subprocess.Popen]:
     The clear-to-here window needs no marker: `--follow` prints the buffer it starts with
     before following, so anything logged in between is still there and is captured.
 
-    The argv is a list, not a shell string: a shell in between would make `poll()` report the
-    shell rather than `dmesg`, and `poll()` is what coverage rests on. `sudo` forks a child of
+    The argv is a list, not a shell string: a shell in between would make `poll` report the
+    shell rather than `dmesg`, and `poll` is what coverage rests on. `sudo` forks a child of
     its own regardless, hence the new session, so both can be signalled as one group.
+
+    A refusal that takes longer to surface than the delay below is not lost: coverage is decided
+    by polling this process again where the record is read, not by what is returned here.
     """
     with open(DMESG_FOLLOW_LOG, "w") as log_file:
         proc = subprocess.Popen(
@@ -513,10 +521,13 @@ def start_dmesg_follow() -> Optional[subprocess.Popen]:
             stderr=subprocess.STDOUT,
             start_new_session=True,
         )
+    # `Popen` reports only that the fork happened, so a `sudo` or `dmesg` that exits at once is
+    # still running here. `start_docker_in_docker` waits the same way before trusting its daemon.
+    time.sleep(1)
     if proc.poll() is not None:
         print(
             f"WARNING: could not follow dmesg (rc={proc.returncode}); the kernel record will "
-            f"cover only what the ring buffer still holds at the end of the run"
+            "cover only what the ring buffer still holds at the end of the run"
         )
         return None
     print(f"Following dmesg into {DMESG_FOLLOW_LOG} with PID {proc.pid}")
@@ -538,25 +549,23 @@ def read_dmesg_follow() -> bytes:
         return follow_file.read()
 
 
-def stop_dmesg_follow(proc: Optional[subprocess.Popen]) -> bool:
-    """Stop the follower, and say whether it was still running when asked.
+def stop_dmesg_follow(proc: Optional[subprocess.Popen]) -> None:
+    """Stop the follower.
 
     `Utils.terminate_process_group` neither waits nor reports the outcome, so the wait is what
-    makes the stop observable and what keeps the child from being left unreaped. Escalating to
-    `SIGKILL` bounds the job: this runs after the last diagnostic, where a stuck child would
-    otherwise hold the job open for as long as it liked.
+    makes the stop observable and what keeps the child from being left unreaped. `SIGKILL` needs
+    no second wait to confirm it, and this runs one statement before the job's report is written,
+    where waiting again on a child that already ignored `SIGTERM` would cost the run that report.
     """
     if proc is None or proc.poll() is not None:
         # Signalling a group whose leader is already reaped only logs an ESRCH error.
-        return False
+        return
     Utils.terminate_process_group(proc.pid)
     try:
         proc.wait(timeout=30)
     except subprocess.TimeoutExpired:
         print("WARNING: dmesg follower ignored SIGTERM; killing it")
         Utils.terminate_process_group(proc.pid, force=True)
-        proc.wait(timeout=30)
-    return True
 
 
 def print_oom_lines(dmesg: str, caveat: str = "", partial: str = "") -> None:
@@ -583,7 +592,9 @@ def print_oom_lines(dmesg: str, caveat: str = "", partial: str = "") -> None:
         print(f"No kernel memory kill in dmesg{partial}")
 
 
-def print_timeout_diagnostics(env, follow_proc=None, cgroup_root=DIND_CGROUP_ROOT) -> None:
+def print_timeout_diagnostics(
+    env, follow_proc=None, dmesg_cleared=False, cgroup_root=DIND_CGROUP_ROOT
+) -> None:
     """Print what a run killed by the time budget was doing, to stdout.
 
     Everything else on this path is an uploaded artifact, and an upload needs the job to survive
@@ -596,17 +607,22 @@ def print_timeout_diagnostics(env, follow_proc=None, cgroup_root=DIND_CGROUP_ROO
     follower's record is read with it, since the snapshot alone reaches back only as far as the
     ring buffer still holds.
 
-    `follow_proc=None` is UNCOVERED rather than "no follower wanted": the only caller runs when
-    the clear succeeded, which is also when the follower is started, so its absence means the
-    start failed. The file's existence cannot stand in for the process, either - a follower that
-    died early leaves a file that begins right where a healthy one would.
+    Both defaults are UNCOVERED and UNCLEARED, because this runs on every non-local hard timeout
+    whatever the clear did. The file's existence cannot stand in for the follower, either - one
+    that died early leaves a file that begins right where a healthy one would.
+
+    An empty snapshot is read as a failed one, since `Shell.get_output` returns `""` for both a
+    failure and a genuinely empty buffer. That conflation over-warns, which is the safe direction.
     """
     print_leaf_peak_usage(env, cgroup_root=cgroup_root)
-    covers_run = follow_proc is not None and follow_proc.poll() is None
-    dmesg = read_dmesg_follow().decode(errors="replace") + Shell.get_output(
-        "dmesg -T", verbose=True
+    follow_dmesg = read_dmesg_follow().decode(errors="replace")
+    snapshot = Shell.get_output("dmesg -T", verbose=True)
+    covers_run = follow_proc is not None and follow_proc.poll() is None and bool(snapshot)
+    print_oom_lines(
+        follow_dmesg + snapshot,
+        caveat="" if dmesg_cleared else UNCLEARED_DMESG_CAVEAT,
+        partial="" if covers_run else PARTIAL_DMESG_CAVEAT,
     )
-    print_oom_lines(dmesg, partial="" if covers_run else PARTIAL_DMESG_CAVEAT)
 
 
 ncpu = Utils.cpu_count()
@@ -1906,6 +1922,10 @@ tar -czf ./ci/tmp/logs.tar.gz \
     # Follows the buffer this clears, because the tests below wrap it long before it is read.
     dmesg_follow_proc = None
     if not info.is_local_run:
+        # `ci/tmp` is git-ignored, so the clean between jobs on a runner leaves this file behind
+        # and a previous job's kernel record would be read and uploaded as this run's. Before the
+        # clear, because the writer below is only started when the clear succeeds.
+        Path(DMESG_FOLLOW_LOG).unlink(missing_ok=True)
         try:
             dmesg_cleared = Utils.clear_dmesg()
         except Exception as ex:
@@ -2107,7 +2127,9 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
     # Before the archive below, which on this path is what the cancellation cuts off.
     if hard_killed and not info.is_local_run:
-        print_timeout_diagnostics(os.environ, follow_proc=dmesg_follow_proc)
+        print_timeout_diagnostics(
+            os.environ, follow_proc=dmesg_follow_proc, dmesg_cleared=dmesg_cleared
+        )
 
     # Collect logs before re-run
     attached_files = []
@@ -2201,29 +2223,29 @@ tar -czf ./ci/tmp/logs.tar.gz \
     # Whether this dump succeeded. Neither the buffer nor the path answers that: a successful
     # dump can legitimately be empty, and a failed one still leaves the redirect's empty file.
     dmesg_dumped = False
-    # Whether the record spans the run, which only a follower still running here establishes. The
-    # dump's own success cannot: it succeeds just the same on a buffer that wrapped long ago.
+    # Whether the record spans the run. Both halves are needed: a follower still running proves
+    # the earlier window, and only the snapshot proves the tail it has not consumed yet.
     dmesg_covers_run = False
     if not info.is_local_run:
         print("Dumping dmesg")
         follow_dmesg = read_dmesg_follow()
-        dmesg_covers_run = (
-            dmesg_follow_proc is not None and dmesg_follow_proc.poll() is None
-        )
+        # Polled where the record is read, so a follower alive here consumed the buffer up to it.
+        follow_alive = dmesg_follow_proc is not None and dmesg_follow_proc.poll() is None
         # Not `strict`: raising here would skip the report this dump feeds, so a run whose dmesg
         # is unreadable would lose the counter-based reports too, which do not need dmesg at all.
         if Shell.check("dmesg -T > ./ci/tmp/dmesg.log", verbose=True):
             dmesg_dumped = True
             with open("./ci/tmp/dmesg.log", "rb") as dmesg_file:
-                # A superset of the snapshot alone, so no detector below can lose a signal it
-                # would have had. The overlapping lines stay: every consumer returns a set or a
-                # boolean, and `-T`'s one-second resolution makes deduping merge same-second kills.
+                # A superset of the snapshot alone, so no detector below can lose a signal. The
+                # overlap stays: only `print_oom_lines` renders per match, and deduping at `-T`'s
+                # one-second resolution would merge distinct same-second kills.
                 dmesg = follow_dmesg + dmesg_file.read()
         else:
             print(
                 "WARNING: could not dump dmesg; leaf OOMs will be reported from the counters only"
             )
             dmesg = follow_dmesg
+        dmesg_covers_run = follow_alive and dmesg_dumped
 
     # `ERROR` plus `has_error` matches the existing OOM treatment on every path, not just
     # bugfix validation - a resource kill is never a test verdict, and the `ERROR` keeps the
@@ -2293,10 +2315,9 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 and any(r.has_label(Result.Label.INFRA) for r in test_results)
             )
         ):
-            uncleared = " (buffer not cleared for this run, so a kill may be a previous job's)"
             print_oom_lines(
                 dmesg.decode(errors="replace"),
-                caveat="" if dmesg_cleared else uncleared,
+                caveat="" if dmesg_cleared else UNCLEARED_DMESG_CAVEAT,
                 partial="" if dmesg_covers_run else PARTIAL_DMESG_CAVEAT,
             )
             if dmesg_dumped:
@@ -2531,7 +2552,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
     late_dmesg_covers_run = False
     if not info.is_local_run and dmesg_cleared:
         late_follow_dmesg = read_dmesg_follow()
-        late_dmesg_covers_run = (
+        late_follow_alive = (
             dmesg_follow_proc is not None and dmesg_follow_proc.poll() is None
         )
         # Read only what this re-dump wrote: a surviving earlier file would report a kill
@@ -2546,6 +2567,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 "is only reportable from the counters"
             )
             late_dmesg = late_follow_dmesg
+        late_dmesg_covers_run = late_follow_alive and late_dmesg_dumped
     for meaning in dind_unreportable_ooms(os.environ, late_dmesg_covers_run):
         print(
             f"WARNING: {meaning} cannot be detected on this run (cgroup v1 charges the kill to "

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -45,6 +45,18 @@ OOM_IN_DMESG_TEST_NAME = "OOM in dmesg"
 # first scan may already have queued for upload: both dumps redirect, and `>` truncates on open.
 LATE_DMESG_LOG = "./ci/tmp/dmesg-after-merge.log"
 
+# The kernel record for the whole run, captured as it is emitted. A snapshot cannot stand in for
+# it: the container churn below logs several kernel lines per veth pair, which wraps the ring
+# buffer many times over in a run. Its own path, because `on_error_hook` truncates `dmesg.log`.
+DMESG_FOLLOW_LOG = "./ci/tmp/dmesg-follow.log"
+
+# Rides a dmesg-derived NEGATIVE that is not a proven one, where `oom_memcg` scoping cannot help:
+# a record that starts after the kill simply does not hold it. The converse caveat belongs on the
+# positive: an uncleared buffer can show another job's kill, but its silence still covers this run.
+PARTIAL_DMESG_CAVEAT = (
+    " (the record does not cover the whole run, so an earlier kill would not be in it)"
+)
+
 # `docker_in_docker.sh`'s own output, which holds the containment decision and any refusal.
 DOCKER_IN_DOCKER_LOG = "./ci/tmp/docker-in-docker.log"
 
@@ -309,7 +321,7 @@ def leaf_oom_results(cgroup_root=DIND_CGROUP_ROOT) -> List[Result]:
 
 
 def dind_unreportable_ooms(
-    env, have_dmesg: bool, cgroup_root=DIND_CGROUP_ROOT
+    env, have_covering_dmesg: bool, cgroup_root=DIND_CGROUP_ROOT
 ) -> List[str]:
     """The reports this run cannot produce, so a green result does not rule them out.
 
@@ -320,6 +332,10 @@ def dind_unreportable_ooms(
     indistinguishable from a clean run - a resource kill that reads as clean is the failure mode
     this whole path exists to remove.
 
+    The argument is that a record SPANS this run, not merely that a dump was produced: a dump of
+    a buffer that already wrapped succeeds while holding none of the window a kill would be in,
+    and silencing this warning on one leaves exactly the clean-looking kill above.
+
     One probe answers both, since a cgroup and its child are always the same version.
 
     Only under required containment: elsewhere `/docker` is the host's own cgroup, and naming a
@@ -327,7 +343,7 @@ def dind_unreportable_ooms(
     """
     if env.get("CI_DIND_REQUIRE_CGROUP_CONTAINMENT") != "1":
         return []
-    if have_dmesg:
+    if have_covering_dmesg:
         return []
     docker = dind_leaf_root(cgroup_root) / "docker"
     on_v2 = _cgroup_field(docker, "memory.events.local", "oom") is not None
@@ -480,7 +496,70 @@ def report_late_leaf_ooms(
     return rows
 
 
-def print_oom_lines(dmesg: str, caveat: str = "") -> None:
+def start_dmesg_follow() -> Optional[subprocess.Popen]:
+    """Capture kernel messages from now on, or `None` when following was refused.
+
+    The clear-to-here window needs no marker: `--follow` prints the buffer it starts with
+    before following, so anything logged in between is still there and is captured.
+
+    The argv is a list, not a shell string: a shell in between would make `poll()` report the
+    shell rather than `dmesg`, and `poll()` is what coverage rests on. `sudo` forks a child of
+    its own regardless, hence the new session, so both can be signalled as one group.
+    """
+    with open(DMESG_FOLLOW_LOG, "w") as log_file:
+        proc = subprocess.Popen(
+            ["sudo", "dmesg", "-T", "--follow"],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    if proc.poll() is not None:
+        print(
+            f"WARNING: could not follow dmesg (rc={proc.returncode}); the kernel record will "
+            f"cover only what the ring buffer still holds at the end of the run"
+        )
+        return None
+    print(f"Following dmesg into {DMESG_FOLLOW_LOG} with PID {proc.pid}")
+    return proc
+
+
+def read_dmesg_follow() -> bytes:
+    """Everything the follower has captured so far, whole.
+
+    Unwindowed at every read point: `report_late_leaf_ooms` dedupes by `already_reported`, so a
+    cumulative buffer yields one row per breach however many scans see it.
+
+    The final line can be torn mid-write. Harmless: every consumer matches whole tokens, so a
+    torn line fails to match, and the same line reappears complete in the terminal snapshot.
+    """
+    if not Path(DMESG_FOLLOW_LOG).exists():
+        return b""
+    with open(DMESG_FOLLOW_LOG, "rb") as follow_file:
+        return follow_file.read()
+
+
+def stop_dmesg_follow(proc: Optional[subprocess.Popen]) -> bool:
+    """Stop the follower, and say whether it was still running when asked.
+
+    `Utils.terminate_process_group` neither waits nor reports the outcome, so the wait is what
+    makes the stop observable and what keeps the child from being left unreaped. Escalating to
+    `SIGKILL` bounds the job: this runs after the last diagnostic, where a stuck child would
+    otherwise hold the job open for as long as it liked.
+    """
+    if proc is None or proc.poll() is not None:
+        # Signalling a group whose leader is already reaped only logs an ESRCH error.
+        return False
+    Utils.terminate_process_group(proc.pid)
+    try:
+        proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        print("WARNING: dmesg follower ignored SIGTERM; killing it")
+        Utils.terminate_process_group(proc.pid, force=True)
+        proc.wait(timeout=30)
+    return True
+
+
+def print_oom_lines(dmesg: str, caveat: str = "", partial: str = "") -> None:
     """Print the kernel's memory-kill lines, whichever scope each one happened in.
 
     Read without attribution: the point is to say whether the kernel killed anything at all,
@@ -488,8 +567,10 @@ def print_oom_lines(dmesg: str, caveat: str = "") -> None:
     same as absent, so no result row is derived from it here - `leaf_oom_report` owns that, on a
     buffer it can scope. An empty buffer is a third outcome and not "no kill", so it says so.
 
-    `caveat` rides on the header, so a reader cannot take the kills for this run's when the
-    buffer holds more than this run. `OOM_DMESG_MARKERS` are `str`: a bytes caller decodes.
+    The two caveats ride opposite branches, because a buffer is unsound in opposite directions.
+    `caveat` rides the kills, so a reader cannot take another job's for this run's. `partial`
+    rides the absence, which a record that does not span the run cannot establish.
+    `OOM_DMESG_MARKERS` are `str`: a bytes caller decodes.
     """
     if not dmesg:
         print("WARNING: no dmesg available, so a kernel kill can neither be shown nor ruled out")
@@ -499,10 +580,10 @@ def print_oom_lines(dmesg: str, caveat: str = "") -> None:
         for line in oom_lines:
             print(f"  {line}")
     else:
-        print("No kernel memory kill in dmesg")
+        print(f"No kernel memory kill in dmesg{partial}")
 
 
-def print_timeout_diagnostics(env, cgroup_root=DIND_CGROUP_ROOT) -> None:
+def print_timeout_diagnostics(env, follow_proc=None, cgroup_root=DIND_CGROUP_ROOT) -> None:
     """Print what a run killed by the time budget was doing, to stdout.
 
     Everything else on this path is an uploaded artifact, and an upload needs the job to survive
@@ -511,10 +592,21 @@ def print_timeout_diagnostics(env, cgroup_root=DIND_CGROUP_ROOT) -> None:
     on job 95139621296, where the archive got 13.3 s. The job LOG is the one channel that is kept
     regardless, so the small diagnostics go there and go first.
 
-    dmesg is read here rather than reused: this path runs before the end-of-run dump.
+    dmesg is read here rather than reused: this path runs before the end-of-run dump. The
+    follower's record is read with it, since the snapshot alone reaches back only as far as the
+    ring buffer still holds.
+
+    `follow_proc=None` is UNCOVERED rather than "no follower wanted": the only caller runs when
+    the clear succeeded, which is also when the follower is started, so its absence means the
+    start failed. The file's existence cannot stand in for the process, either - a follower that
+    died early leaves a file that begins right where a healthy one would.
     """
     print_leaf_peak_usage(env, cgroup_root=cgroup_root)
-    print_oom_lines(Shell.get_output("dmesg -T", verbose=True))
+    covers_run = follow_proc is not None and follow_proc.poll() is None
+    dmesg = read_dmesg_follow().decode(errors="replace") + Shell.get_output(
+        "dmesg -T", verbose=True
+    )
+    print_oom_lines(dmesg, partial="" if covers_run else PARTIAL_DMESG_CAVEAT)
 
 
 ncpu = Utils.cpu_count()
@@ -1397,6 +1489,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
         [
             "./ci/tmp/logs.tar.gz",
             "./ci/tmp/dmesg.log",
+            DMESG_FOLLOW_LOG,
             DOCKER_IN_DOCKER_LOG,
         ],
         strict=False,
@@ -1810,6 +1903,8 @@ tar -czf ./ci/tmp/logs.tar.gz \
     # Do this only in CI (non-local runs) and via a non-interactive privileged helper.
     # Every dmesg-derived verdict, leaf or host-wide, is only admissible on a buffer this cleared.
     dmesg_cleared = False
+    # Follows the buffer this clears, because the tests below wrap it long before it is read.
+    dmesg_follow_proc = None
     if not info.is_local_run:
         try:
             dmesg_cleared = Utils.clear_dmesg()
@@ -1821,6 +1916,8 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 "previous job's records, so leaf OOMs will be reported from the counters only "
                 "and a host OOM is not reportable at all on this run"
             )
+        else:
+            dmesg_follow_proc = start_dmesg_follow()
 
     clear_rabbitmq_recreation_scan_inputs()
 
@@ -2010,7 +2107,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
     # Before the archive below, which on this path is what the cancellation cuts off.
     if hard_killed and not info.is_local_run:
-        print_timeout_diagnostics(os.environ)
+        print_timeout_diagnostics(os.environ, follow_proc=dmesg_follow_proc)
 
     # Collect logs before re-run
     attached_files = []
@@ -2104,18 +2201,29 @@ tar -czf ./ci/tmp/logs.tar.gz \
     # Whether this dump succeeded. Neither the buffer nor the path answers that: a successful
     # dump can legitimately be empty, and a failed one still leaves the redirect's empty file.
     dmesg_dumped = False
+    # Whether the record spans the run, which only a follower still running here establishes. The
+    # dump's own success cannot: it succeeds just the same on a buffer that wrapped long ago.
+    dmesg_covers_run = False
     if not info.is_local_run:
         print("Dumping dmesg")
+        follow_dmesg = read_dmesg_follow()
+        dmesg_covers_run = (
+            dmesg_follow_proc is not None and dmesg_follow_proc.poll() is None
+        )
         # Not `strict`: raising here would skip the report this dump feeds, so a run whose dmesg
         # is unreadable would lose the counter-based reports too, which do not need dmesg at all.
         if Shell.check("dmesg -T > ./ci/tmp/dmesg.log", verbose=True):
             dmesg_dumped = True
             with open("./ci/tmp/dmesg.log", "rb") as dmesg_file:
-                dmesg = dmesg_file.read()
+                # A superset of the snapshot alone, so no detector below can lose a signal it
+                # would have had. The overlapping lines stay: every consumer returns a set or a
+                # boolean, and `-T`'s one-second resolution makes deduping merge same-second kills.
+                dmesg = follow_dmesg + dmesg_file.read()
         else:
             print(
                 "WARNING: could not dump dmesg; leaf OOMs will be reported from the counters only"
             )
+            dmesg = follow_dmesg
 
     # `ERROR` plus `has_error` matches the existing OOM treatment on every path, not just
     # bugfix validation - a resource kill is never a test verdict, and the `ERROR` keeps the
@@ -2187,10 +2295,14 @@ tar -czf ./ci/tmp/logs.tar.gz \
         ):
             uncleared = " (buffer not cleared for this run, so a kill may be a previous job's)"
             print_oom_lines(
-                dmesg.decode(errors="replace"), caveat="" if dmesg_cleared else uncleared
+                dmesg.decode(errors="replace"),
+                caveat="" if dmesg_cleared else uncleared,
+                partial="" if dmesg_covers_run else PARTIAL_DMESG_CAVEAT,
             )
             if dmesg_dumped:
                 attached_files.append("./ci/tmp/dmesg.log")
+            if Path(DMESG_FOLLOW_LOG).exists():
+                attached_files.append(DMESG_FOLLOW_LOG)
 
     # For targeted, flaky checks, and bugfix validation, the synthetic "Timeout"
     # result must not be propagated as a top-level `FAIL`: for targeted checks a
@@ -2414,23 +2526,31 @@ tar -czf ./ci/tmp/logs.tar.gz \
     # Whether this run has a dmesg it can attribute a leaf with, which an empty buffer does not
     # answer: a successful dump can legitimately be empty, and the file only exists on this path.
     late_dmesg_dumped = False
+    # And whether that record spans the run, which is the stronger property the gap warning below
+    # needs: a dump of a wrapped buffer succeeds while holding none of the window it is asked about.
+    late_dmesg_covers_run = False
     if not info.is_local_run and dmesg_cleared:
+        late_follow_dmesg = read_dmesg_follow()
+        late_dmesg_covers_run = (
+            dmesg_follow_proc is not None and dmesg_follow_proc.poll() is None
+        )
         # Read only what this re-dump wrote: a surviving earlier file would report a kill
         # during the merge as absent.
         if Shell.check(f"dmesg -T > {LATE_DMESG_LOG}", verbose=True):
             late_dmesg_dumped = True
             with open(LATE_DMESG_LOG, "rb") as late_dmesg_file:
-                late_dmesg = late_dmesg_file.read()
+                late_dmesg = late_follow_dmesg + late_dmesg_file.read()
         else:
             print(
                 "WARNING: could not re-dump dmesg after the coverage merge; a leaf killed there "
                 "is only reportable from the counters"
             )
-    for meaning in dind_unreportable_ooms(os.environ, late_dmesg_dumped):
+            late_dmesg = late_follow_dmesg
+    for meaning in dind_unreportable_ooms(os.environ, late_dmesg_covers_run):
         print(
             f"WARNING: {meaning} cannot be detected on this run (cgroup v1 charges the kill to "
-            "the victim's own cgroup, and no dmesg is available), so a green result does not "
-            "rule it out"
+            "the victim's own cgroup, and no dmesg covering this run is available), so a green "
+            "result does not rule it out"
         )
     late_breach = report_late_leaf_ooms(
         R,
@@ -2442,6 +2562,15 @@ tar -czf ./ci/tmp/logs.tar.gz \
     # Only on the path that produced the file.
     if late_breach and late_dmesg_dumped and LATE_DMESG_LOG not in R.files:
         R.files.append(LATE_DMESG_LOG)
+    # A run whose only failure is a late breach never met the attach block above, so the record
+    # that names the breach is otherwise not uploaded at all.
+    if late_breach and Path(DMESG_FOLLOW_LOG).exists() and DMESG_FOLLOW_LOG not in R.files:
+        R.files.append(DMESG_FOLLOW_LOG)
+
+    # The last reader of the follow log is above, and every run that started a follower reaches
+    # here: the only `complete_job` after the start is the one below, and nothing returns in
+    # between. A run the runner hard-kills instead leaves it to die with the job's container.
+    stop_dmesg_follow(dmesg_follow_proc)
 
     report_rabbitmq_recreations(R)
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/117104
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #117104, the diagnostics half.

The integration test job clears the kernel ring buffer at the start and reads it back at the end.
Nothing bounds it in between: the job's container churn logs several kernel lines per veth
pair, wrapping it every few minutes while the job runs for over an hour.

Measured on three red `Integration tests (amd_asan_ubsan, db disk, old analyzer, 6/6)` runs on
2026-08-30 ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117161&sha=6d6a82cf461929649de89b205af5b04e4e6a59a9&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29)):
the uploaded `dmesg.log` held 7m47s of a 103-minute run, 4017 of 4017 lines were veth churn, and
the OOM kill happened 42 minutes before its earliest retained line. All three printed `No kernel
memory kill in dmesg` and reported no leaf breach: false-cleans on runs where a server was killed.

The code that interprets the record is unchanged; it was never fed a buffer holding the kill.

This starts `dmesg -T --follow` after the clear and feeds every detector `follow + snapshot`. The
union is a strict superset of today's input, so no detector can lose a signal it has now. Coverage
is derived from the follower still being alive, and a negative says so when the record does not
cover the run. A missing or dead follower counts as uncovered, so this fails closed, and
`dind_unreportable_ooms` now takes coverage rather than "the dump succeeded", which a wrapped
buffer also satisfies. Runs whose kill fell outside the retained window now show the red row
they should have.

Container limits, worker sizing and `test_s3_plain_rewritable` are unchanged: naming the breaching
cgroup is what was missing; capacity is a separate question. The other clear-then-read sites in
`ci/` lack this job's container churn.

Verified on the real wrapped artifact: the existing detector names `Container memory budget
exceeded (/docker)` once the kill is in the union.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117199&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117199](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117199+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.408` (included in `26.9` and later)
<!-- ch-version-info:end -->