### PR TITLE
Serialize the integration tests' shutdown gdb attach

### DIFF
--- a/tests/integration/integration-tests-entrypoint.sh
+++ b/tests/integration/integration-tests-entrypoint.sh
@@ -26,20 +26,57 @@ PID=$!
 wait $PID
 server_exit_code=$?
 
+# How long the server is given to finish on its own before its stacks are dumped.
+GDB_ATTACH_DEADLINE=60
+
+# `docker compose stop` signals every container of a cluster at once, so every node that outlives
+# the deadline above reaches gdb at the same moment. gdb has to read the whole binary's debug info
+# to walk the stacks - measured at 3.4 GiB of anonymous memory on an ASan build and 4.3 GiB on the
+# coverage one - so a nine-node cluster asks for around 40 GiB, which is the entire budget of the
+# cgroup that holds the nested containers (`CI_DIND_NESTED_BUDGET`, see
+# ci/jobs/scripts/docker_in_docker.sh). The kernel then kills the gdb processes and the job reports
+# `Container memory budget exceeded (/docker)` with no stacktrace to show for it, so attaching one
+# at a time is not a restriction but the only way this dump produces anything at all. The lock sits
+# on the repository mount because that is the only path every ClickHouse container of every pytest
+# worker shares, which is what bounds the job as a whole rather than one cluster.
+GDB_ATTACH_LOCK=/debug/ci/tmp/integration-tests-gdb-attach.lock
+
+# The wait has to leave room inside `stop_grace_period` (10m, see helpers/cluster.py) for the
+# deadline above and for gdb itself, or docker would kill the container mid-dump and the queue
+# would produce nothing at all. A node that does not get its turn in time says so and is skipped:
+# the first stacktraces are what a shutdown hang is diagnosed from, and the nodes behind them are
+# waiting on the same thing.
+GDB_ATTACH_LOCK_WAIT=240
+
 function dump_stacktraces_on_shutdown()
 {
-    # 60 sec should be enough to finish the server
-    for _ in {1..60}; do
+    # GDB_ATTACH_DEADLINE sec should be enough to finish the server
+    for _ in $(seq "$GDB_ATTACH_DEADLINE"); do
         if ! kill -0 "$PID" 2>/dev/null; then
             return
         fi
         sleep 1
     done
 
-    if kill -0 "$PID"; then
+    if ! kill -0 "$PID" 2>/dev/null; then
+        return
+    fi
+
+    mkdir -p "$(dirname "$GDB_ATTACH_LOCK")"
+    (
+        if ! flock -w "$GDB_ATTACH_LOCK_WAIT" 9; then
+            echo "No gdb attach lock after ${GDB_ATTACH_LOCK_WAIT}s, skipping thread stacktraces"
+            exit 0
+        fi
+        # Re-checked under the lock: a server that was merely slow rather than stuck exits while
+        # its turn is waited for, and then there is nothing left to attach to.
+        if ! kill -0 "$PID" 2>/dev/null; then
+            echo "Server exited while waiting for the gdb attach lock"
+            exit 0
+        fi
         echo "Attaching gdb to obtain thread stacktraces"
         gdb -batch -ex 'thread apply all bt' -p "$PID" > /var/log/clickhouse-server/stdout.log
-    fi
+    ) 9>"$GDB_ATTACH_LOCK"
 }
 dump_stacktraces_on_shutdown &
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112984

`Integration tests` fails on master with `Container memory budget exceeded (/docker)` while every test in the batch passes:

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f14f29dd31bbb4861b7c9a4d47cd65750145d8a0&name_0=MasterCI&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%204%2F8%29

The kill is always a `gdb`, and there are always many of them at once:

```
oom_memcg=.../docker, task_memcg=.../docker/704cc..., task=gdb, pid=395383
Memory cgroup out of memory: Killed process 395383 (gdb) total-vm:10314840kB, anon-rss:4340704kB, file-rss:4449252kB
cgroup leaf /docker: peak 40.78 GiB of 40.78 GiB cap (AT CAP - demand is at least this)
```

The dump comes from `dump_stacktraces_on_shutdown` in `tests/integration/integration-tests-entrypoint.sh`: when a server outlives a 60 second deadline after `SIGTERM`, the container attaches `gdb` to collect thread stacktraces. `docker compose stop` signals every container of a cluster at once, so on a hung shutdown every node crosses that deadline at the same moment and attaches at the same moment. `gdb` has to read the whole binary's debug info to walk the stacks - 4.3 GiB of anonymous memory per instance on the coverage build, 3.4 GiB on ASan - so a nine-node cluster asks for around 40 GiB, which is the entire budget `ci/jobs/scripts/docker_in_docker.sh` gives the cgroup holding the nested containers. The kernel then kills the `gdb` processes, so the job gets no stacktrace *and* an infrastructure error.

This is not coverage-specific and not new; #112984 capped the nested containers inside the job's memory limit and so turned a pre-existing overrun into a reported failure. It is now the most frequent failure on master - 11 occurrences in the 24 hours to 2026-08-31 09:00, across four build flavours, hitting `Integration tests (amd_asan_ubsan, db disk, old analyzer)` shards 2/6, 5/6 and 6/6 on nearly every master run, plus `amd_tsan, 2/6`, `amd_cfi, 3/4` and `amd_llvm_coverage, 4/8`:

https://play.clickhouse.com/play?run=1&color_modes=%7B%22ppm%22%3A%22none%22%2C%22test_name%22%3A%22categorical%22%7D&tab=Failed%20checks#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IEhPVVIKICAgIEFORCAoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpKQogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKQogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSBERVNDLCBjaGVja19uYW1lLCB0ZXN0X25hbWU7CgpTRUxFQ1Qgcm91bmQoc3VtKCh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKSBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJykgLyBjb3VudCgpICogMTAwMDAwMCwgMikgQVMgcHBtIEZST00gY2hlY2tzCldIRVJFIGNoZWNrX3N0YXJ0X3RpbWUgPj0gbm93KCkgLSBJTlRFUlZBTCAyNCBIT1VSCiAgICBBTkQgKGhlYWRfcmVmID0gJ21hc3RlcicgQU5EIHN0YXJ0c1dpdGgoaGVhZF9yZXBvLCAnQ2xpY2tIb3VzZS8nKSkKICAgIEFORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCc7

`gdb` is not merely a contributor to those breaches, it is the entire overshoot. The kernel's task dump from one such job - `Integration tests (amd_asan_ubsan, db disk, old analyzer, 6/6)`, six memcg OOM events, victims 4 `gdb` and 2 `clickhouse` - resolves as:

| event | tasks | total anon | `clickhouse` | `gdb` |
| --- | --- | --- | --- | --- |
| 08:59:28 | 109 | 40.20 GiB | 33 x 1.00 = 32.86 GiB | 4 x 1.67 = 6.66 GiB |
| 08:59:31 | 107 | 40.22 GiB | 31 x 0.96 = 29.74 GiB | 4 x 2.44 = 9.75 GiB |
| 08:59:46 | 103 | 40.21 GiB | 31 x 1.02 = 31.60 GiB | 2 x 3.93 = 7.86 GiB |
| 09:29:02 |  86 | 40.33 GiB | 23 x 0.95 = 21.89 GiB | 4 x 4.06 = 16.22 GiB |

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3085f5d1de8ecf969a346d8d8b249dda99f7e8e8&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29

Total anonymous memory is pinned at the 40.78 GiB cap in every event, while the server fleet on its own never passes 33 GiB - so the 6.7 to 16.2 GiB the concurrent `gdb` processes hold is what carries the cgroup over, and in the last event stacktrace collection alone holds 40% of the whole job budget. Serialized to one attach, that worst event becomes 21.89 + 4.06 = 26 GiB and fits.

Note that `dmesg.log` alone does not show any of this: container create and destroy floods the kernel ring buffer with `veth`/bridge messages, so by the end of a run it retains only the last few minutes and the kills are long gone. The record above survives only in `dmesg-follow.log`, added in #117199.

The attach is now taken under a lock on the repository mount, the only path every ClickHouse container of every pytest worker shares (`{CLICKHOUSE_ROOT_DIR}:/debug:rw`, unconditional in `DOCKER_COMPOSE_TEMPLATE`), so the job as a whole holds one `gdb` at a time instead of one per node. Two details keep that from costing anything:

- the pid is re-checked once the lock is held, so a server that was merely slow rather than stuck - which is the overwhelmingly common case, this fired once in a 69 minute run - exits while its turn is waited for and is never attached to;
- a node that does not get its turn within 240s says so and is skipped, because the wait has to fit inside the container's 10 minute `stop_grace_period` alongside the 60s deadline and `gdb` itself. Losing the ninth node's stacktrace is not a regression: today all nine are lost to the OOM killer.

I found no existing issue or fix for this failure.

Verified locally by driving the script with a fake server that ignores `SIGTERM` and a fake `gdb` that records the window it occupies:

- three nodes contending, before the change: `start, start, start, end, end, end` - all three attach at once, the shape the CI kills show;
- three nodes contending, after: `start, end, start, end, start, end`;
- lock held from outside: `No gdb attach lock after Ns, skipping thread stacktraces`, and no attach;
- server exiting while it waits: `Server exited while waiting for the gdb attach lock`, and no attach.

`shellcheck` reports nothing new on the script.

One thing this does not address, visible in the table above: with 31 to 33 servers alive at once the fleet already sits at roughly 33 GiB of the 40.78 GiB cap even with no `gdb` at all, so the steady-state headroom on this flavour is thin and worth sizing separately.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.429` (included in `26.9` and later)
<!-- ch-version-info:end -->