### PR TITLE
Report a timed-out bounded request in the handler body tests as a diff

### DIFF
--- a/tests/queries/0_stateless/04655_handler_bodyless_put_delete.sh
+++ b/tests/queries/0_stateless/04655_handler_bodyless_put_delete.sh
@@ -33,14 +33,16 @@ $CLICKHOUSE_CLIENT -q "CREATE HANDLER \`$HDEL\` URL '${P}/del' METHODS (DELETE) 
 # A lengthless non-chunked body ends only when the connection closes, so a server that waits for it deadlocks
 # against a client that waits for the response. Bound these two requests well below the test timeout, so that
 # such a regression shows up as a diff here instead of killing the whole test run.
+# Keep them silent and turn a nonzero exit into a stdout line: the harness fails on any stderr before it
+# compares the reference, so an error line there would take the place of that diff.
 CURL_BOUNDED="${CLICKHOUSE_CURL_COMMAND} -q -s --max-time 30"
 
 echo "=== a lengthless non-chunked PUT to a handler that does not read the body succeeds ==="
 # `-X PUT` with no data sends neither Content-Length nor chunked Transfer-Encoding.
-${CURL_BOUNDED} -sS -X PUT "${BASE}${P}/put"
+${CURL_BOUNDED} -X PUT "${BASE}${P}/put" || echo "curl failed: $?"
 
 echo "=== a lengthless non-chunked DELETE to a handler that does not read the body succeeds ==="
-${CURL_BOUNDED} -sS -X DELETE "${BASE}${P}/del"
+${CURL_BOUNDED} -X DELETE "${BASE}${P}/del" || echo "curl failed: $?"
 
 echo "=== a handler reading _request_body still requires the length up front ==="
 $CLICKHOUSE_CLIENT -q "CREATE HANDLER \`$HPARAM\` URL '${P}/param' METHODS (PUT) AS SELECT {_request_body:String} AS a FORMAT TSV"

--- a/tests/queries/0_stateless/04691_handler_insert_select_body.sh
+++ b/tests/queries/0_stateless/04691_handler_insert_select_body.sh
@@ -30,6 +30,8 @@ $CLICKHOUSE_CLIENT -q "CREATE TABLE ${DB}.t (x UInt64) ENGINE = MergeTree ORDER 
 # A lengthless non-chunked body ends only when the connection closes, so a server that waits for it deadlocks
 # against a client that waits for the response. Bound these requests well below the test timeout, so that such
 # a regression shows up as a diff here instead of killing the whole test run.
+# Keep them silent and turn a nonzero exit into a stdout line: the harness fails on any stderr before it
+# compares the reference, so an error line there would take the place of that diff.
 CURL_BOUNDED="${CLICKHOUSE_CURL_COMMAND} -q -s --max-time 30"
 
 echo "=== an INSERT ... SELECT handler may mix read-only and body-carrying methods ==="
@@ -41,10 +43,10 @@ $CLICKHOUSE_CLIENT -q "CREATE HANDLER \`$HSEL\` URL '${P}/sel' METHODS (GET) AS 
 
 echo "=== a lengthless bodyless PUT to an INSERT ... SELECT handler works ==="
 $CLICKHOUSE_CLIENT -q "CREATE HANDLER \`$HSEL\` URL '${P}/sel' METHODS (PUT, DELETE) AS INSERT INTO ${DB}.t SELECT 3"
-${CURL_BOUNDED} -sS -o /dev/null -w '%{http_code}\n' -X PUT "${BASE}${P}/sel"
+${CURL_BOUNDED} -o /dev/null -w '%{http_code}\n' -X PUT "${BASE}${P}/sel" || echo "curl failed: $?"
 
 echo "=== a lengthless bodyless DELETE to an INSERT ... SELECT handler works ==="
-${CURL_BOUNDED} -sS -o /dev/null -w '%{http_code}\n' -X DELETE "${BASE}${P}/sel"
+${CURL_BOUNDED} -o /dev/null -w '%{http_code}\n' -X DELETE "${BASE}${P}/sel" || echo "curl failed: $?"
 
 echo "=== both requests inserted their row ==="
 $CLICKHOUSE_CLIENT -q "SELECT count(), min(x), max(x) FROM ${DB}.t"

--- a/tests/queries/0_stateless/04821_handler_bodyless_post.sh
+++ b/tests/queries/0_stateless/04821_handler_bodyless_post.sh
@@ -28,11 +28,13 @@ $CLICKHOUSE_CLIENT -q "CREATE HANDLER \`$HPOST\` URL '${P}/post' METHODS (POST) 
 # A lengthless non-chunked body ends only when the connection closes, so a server that waits for it deadlocks
 # against a client that waits for the response. Bound the request well below the test timeout, so that
 # such a regression shows up as a diff here instead of killing the whole test run.
+# Keep it silent and turn a nonzero exit into a stdout line: the harness fails on any stderr before it
+# compares the reference, so an error line there would take the place of that diff.
 CURL_BOUNDED="${CLICKHOUSE_CURL_COMMAND} -q -s --max-time 30"
 
 echo "=== a lengthless non-chunked POST to a handler that does not read the body succeeds ==="
 # `-X POST` with no data sends neither Content-Length nor chunked Transfer-Encoding.
-${CURL_BOUNDED} -sS -X POST "${BASE}${P}/post"
+${CURL_BOUNDED} -X POST "${BASE}${P}/post" || echo "curl failed: $?"
 
 echo "=== a handler reading _request_body still requires the length up front ==="
 $CLICKHOUSE_CLIENT -q "CREATE HANDLER \`$HPARAM\` URL '${P}/param' METHODS (POST) AS SELECT {_request_body:String} AS a FORMAT TSV"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A timed-out bounded request in the SQL-defined handler body tests is now reported as a reference diff naming the `curl` exit code, instead of as unattributed stderr noise.


### Description

`04691_handler_insert_select_body.sh`, `04655_handler_bodyless_put_delete.sh` and
`04821_handler_bodyless_post.sh` bound their lengthless bodyless `PUT` / `DELETE` / `POST`
with their own `--max-time 30`, so that a server waiting for a body that only ends at
connection close would "show up as a diff here instead of killing the whole test run".

That contract did not hold. `CURL_BOUNDED` already contains `-s`, but every call site added
` -sS`, re-enabling the error output. `clickhouse-test` fails a test on any non-empty
stderr and returns before it compares the reference, so the promised diff was replaced by
`having stderror:`. 04691 failed that way once on a slow sanitizer lane
(`curl: (28) Operation timed out after 30001 milliseconds with 0 bytes received`) and was
closed as transient.

Silencing stderr alone is not enough, because these scripts do not propagate `curl`'s exit
status: a server that sends a complete-looking body and then withholds the terminating
chunk leaves exit code 28 with reference-matching stdout. Against a listener that does
exactly that, deleting ` -sS` alone makes the test report `[ OK ]` through a 30 s hang.

At the five bounded sites I delete ` -sS` and append `|| echo "curl failed: $?"`. On
success the branch is not taken, so no `.reference` changes and success-path stdout stays
byte-identical.

I left `--max-time 30` alone: these tests have no `curl: (28)` failure in 90 days of public
CI, and two 120 s waits would exceed the 180 s flaky-check limit.

Siblings: `04826_handler_lengthless_body_keep_alive.sh` already grades its socket timeout
on stdout; `00601_kill_running_query.sh` and
`02293_http_header_full_summary_without_progress.sh` discard or capture stderr at the call
site. The `${CLICKHOUSE_CURL}` sites at the default 120 s are untouched: they carry no
"show a hang as a diff" contract.

No open issue tracks this; the failure was on an internal lane. 04691 was added in
`430ff7fc8b30f1b`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117204&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117204](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117204+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.486` (included in `26.9` and later)
<!-- ch-version-info:end -->