### PR TITLE
Fix `optimize_trivial_group_by_limit_query` dropping a `max_rows_to_group_by` throw limit

### DIFF
--- a/src/Analyzer/Passes/OptimizeTrivialGroupByLimitPass.cpp
+++ b/src/Analyzer/Passes/OptimizeTrivialGroupByLimitPass.cpp
@@ -94,12 +94,15 @@ void OptimizeTrivialGroupByLimitPass::run(QueryTreeNodePtr & query_tree_node, Co
     if (max_rows == 0)
         return;
 
-    /// If the user has already set `max_rows_to_group_by`, we only apply the optimization
-    /// when our derived value is strictly smaller — otherwise the user's setting is tighter
-    /// and ours would be a no-op. When the user has a tighter throw/break contract, we'd
-    /// also break their semantics (already guarded by the `mode_is_changed` check above).
+    /// A `max_rows_to_group_by` cap set by the user is a contract: unless the overflow mode is
+    /// `ANY`, the query has to fail (or break) once the cap is exceeded. That holds for the
+    /// default mode, `THROW`, just as much as for an explicitly set one, so the mode check above
+    /// is not enough here. Overwriting the cap with `LIMIT + OFFSET` and switching the mode to
+    /// `ANY` would silently turn the limit into "return the first `LIMIT` keys".
+    /// In `ANY` mode we only apply the optimization when our derived value is strictly smaller —
+    /// otherwise the user's setting is tighter and ours would be a no-op.
     const UInt64 user_max_rows = settings[Setting::max_rows_to_group_by];
-    if (user_max_rows != 0 && user_max_rows <= max_rows)
+    if (user_max_rows != 0 && (!mode_is_any || user_max_rows <= max_rows))
         return;
 
     auto & mutable_context = query->getMutableContext();

--- a/tests/queries/0_stateless/05057_trivial_group_by_limit_max_rows_contract.reference
+++ b/tests/queries/0_stateless/05057_trivial_group_by_limit_max_rows_contract.reference
@@ -1,0 +1,7 @@
+break
+1
+any
+3
+no user cap
+3
+3

--- a/tests/queries/0_stateless/05057_trivial_group_by_limit_max_rows_contract.sql
+++ b/tests/queries/0_stateless/05057_trivial_group_by_limit_max_rows_contract.sql
@@ -1,0 +1,31 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/116912
+-- `optimize_trivial_group_by_limit_query` must not silently drop a `max_rows_to_group_by` cap whose
+-- overflow mode throws or breaks. The default mode, `throw`, carries the same contract as an
+-- explicitly set one.
+
+DROP TABLE IF EXISTS t_trivial_group_by_limit;
+CREATE TABLE t_trivial_group_by_limit (k UInt32) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_trivial_group_by_limit SELECT number % 100 FROM numbers(1000);
+
+SET optimize_trivial_group_by_limit_query = 1;
+SET max_rows_to_group_by = 10;
+
+-- The mode is left at its default, `throw`.
+SELECT k FROM t_trivial_group_by_limit GROUP BY k LIMIT 3; -- { serverError TOO_MANY_ROWS }
+SELECT k FROM t_trivial_group_by_limit GROUP BY k LIMIT 3 SETTINGS optimize_trivial_group_by_limit_query = 0; -- { serverError TOO_MANY_ROWS }
+-- Setting the mode explicitly to the same value must not change the result.
+SELECT k FROM t_trivial_group_by_limit GROUP BY k LIMIT 3 SETTINGS group_by_overflow_mode = 'throw'; -- { serverError TOO_MANY_ROWS }
+
+SELECT 'break';
+SELECT count() <= 10 FROM (SELECT k FROM t_trivial_group_by_limit GROUP BY k LIMIT 3 SETTINGS group_by_overflow_mode = 'break');
+
+SELECT 'any';
+SELECT count() FROM (SELECT k FROM t_trivial_group_by_limit GROUP BY k LIMIT 3 SETTINGS group_by_overflow_mode = 'any');
+
+-- Without a user cap the optimization still applies.
+SELECT 'no user cap';
+SET max_rows_to_group_by = 0;
+SELECT count() FROM (SELECT k FROM t_trivial_group_by_limit GROUP BY k LIMIT 3);
+SELECT count() FROM (SELECT k FROM t_trivial_group_by_limit GROUP BY k LIMIT 3 SETTINGS optimize_trivial_group_by_limit_query = 0);
+
+DROP TABLE t_trivial_group_by_limit;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/116912

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the default-enabled `optimize_trivial_group_by_limit_query` silently dropping a
`max_rows_to_group_by` limit whose overflow mode throws or breaks. A `SELECT ... GROUP BY k LIMIT n`
that has to fail with `TOO_MANY_ROWS` returned the first `n` keys instead.


### Description

The pass declined only when `group_by_overflow_mode` had been *explicitly* set to something other
than `any`. The default mode is `throw` with `changed == false`, so for a user-set
`max_rows_to_group_by` looser than `LIMIT + OFFSET` the pass fell through and overwrote both
settings: `max_rows_to_group_by = LIMIT + OFFSET` and `group_by_overflow_mode = 'any'`.

The result was also inconsistent with itself: setting `group_by_overflow_mode = 'throw'` — the same
value as the default — made the pass decline, so two sessions with identical effective settings gave
different results.

A user-set `max_rows_to_group_by` is now treated as a contract whenever the effective overflow mode
is not `any`, regardless of whether the mode was set explicitly. With no user cap the optimization
applies as before.

Test `05057_trivial_group_by_limit_max_rows_contract` covers the default `throw`, the explicit
`throw`, `break`, `any`, and the no-user-cap case.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117213&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117213](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117213+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
