### PR TITLE
Allowlist the expected 04510 mutation error in the upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -379,6 +379,10 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       globally, exactly like the `Code: 236 ... Cancelled mutating parts` message that the same cancelled test
 #       mutations emit above. Matching the message rather than the task type also covers the wrapping
 #       `MergeTreeBackgroundExecutor` line of the replicated case in a single entry.
+# `Unexpected const virtual column: _table` (`NO_SUCH_COLUMN_IN_TABLE`, Code: 16) is the same class, from
+#       `04510_mutation_query_plan_only_virtual_columns`, whose `DELETE WHERE _table != ''` mutation is asserted to
+#       fail. Only a mutation command naming `_table` reaches that throw, since a query read fills it from the
+#       storage id, so the column name and the `MergeTreeSequentialSource` read path are matched together below.
 # `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
 # from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.
 # `Azure::Storage::StorageException.*Not found address of host` is a transient Azure blob DNS resolution failure
@@ -549,6 +553,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Cannot parse string 'a' as UInt32" \
            -e "Cannot parse string 'b' as UInt32" \
            -e "Cannot parse string 'fail' as Int8" \
+           -e "Unexpected const virtual column: _table: While executing MergeTreeSequentialSource." \
            -e "} <Error> TCPHandler: Code:" \
            -e "} <Error> executeQuery: Code:" \
            -e "Missing columns: 'v3' while processing query: 'v3, k, v1, v2, p'" \


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/39174
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Stop the upgrade check from failing on the mutation error that `04510_mutation_query_plan_only_virtual_columns` raises on purpose.


### Description

`Upgrade check (*)` reds on the job row `Error message in clickhouse-server.log` because of an error a test asserts on purpose.

`04510_mutation_query_plan_only_virtual_columns` runs `ALTER TABLE ... DELETE WHERE _table != '' -- { serverError UNFINISHED }`. `_table` comes from the local storage id, which a mutation cannot materialize, so the per-part read reaches `getFieldForConstVirtualColumn` and throws `NO_SUCH_COLUMN_IN_TABLE`. It happens in a background `MutatePlainMergeTreeTask`, so the client sees only the asserted `UNFINISHED` and the test passes, while `Code: 16` goes to the log at `<Error>` level.

The upgrade run then replays it: `upgrade_runner.sh` runs the previous release's test tree, and `--upgrade-check` implies `--fake-drop`, so the table and its failed mutation survive the test's own `DROP`. The new server loads the pending mutation and retries it, 84 times in the 60s observation window, three `<Error>` lines each. All 252 lines reach `upgrade_error_messages.txt` and red the job. This is the `FIXME #39174` class the surrounding comment block already documents: an intentionally-broken test mutation retried after upgrade.

I validated by replaying the failing run's real 140435-line pre-filter log through the real scan pipeline. Unmodified, it reproduces CI's `upgrade_error_messages.txt` byte-identically (252 lines); with the entry, 0 survive and the job reports `No Error messages after server upgrade`. Exactly those 252 lines go, nothing else.

The column name and the `MergeTreeSequentialSource` read path are both in the pattern, so `_sample_factor` from a mutation (that one is #78465, the bug 04510 guards) and the query-path variant still surface; dropping either from the pattern masks controls that must stay visible. `_database` is deliberately left unmasked: no test mutates on it today, so a first occurrence should be reviewed rather than pre-suppressed.

Related: #39174. `04510` came from #109813. Sibling allowlist PR on the same file with a different root cause: #113983.

Failing run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=113857&sha=bde3aeeaea976d74892ad3d48ac2b7c200629701&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117218&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117218](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117218+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.540` (included in `26.9` and later)
<!-- ch-version-info:end -->