### PR TITLE
Fix `optimize_rewrite_sum_if_to_count_if` for a `LowCardinality(Nullable)` condition

### DIFF
--- a/src/Analyzer/Passes/SumIfToCountIfPass.cpp
+++ b/src/Analyzer/Passes/SumIfToCountIfPass.cpp
@@ -8,7 +8,7 @@
 #include <Analyzer/Utils.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/Context.h>
 
@@ -129,15 +129,12 @@ public:
             return;
         }
 
-        if (if_true_condition_value == 0 && !cond_argument->getResultType()->isNullable())
+        /// `LowCardinality(Nullable(...))` has to be refused just like `Nullable(...)`: an ordinary
+        /// comparison over a `LowCardinality(Nullable(String))` column produces exactly that type,
+        /// and `isNullable` alone is false for the `LowCardinality` wrapper.
+        if (if_true_condition_value == 0 && !isNullableOrLowCardinalityNullable(cond_argument->getResultType()))
         {
             /// Rewrite `sum(if(cond, 0, 1))` into `countIf(not(cond))` if condition is not Nullable (otherwise the result can be different).
-            DataTypePtr not_function_result_type = std::make_shared<DataTypeUInt8>();
-
-            const auto & condition_result_type = nested_if_function_arguments_nodes[0]->getResultType();
-            if (condition_result_type->isNullable())
-                not_function_result_type = makeNullable(not_function_result_type);
-
             auto not_function = std::make_shared<FunctionNode>("not");
             not_function->markAsOperator();
 

--- a/tests/queries/0_stateless/05058_sum_if_to_count_if_lowcardinality_nullable.reference
+++ b/tests/queries/0_stateless/05058_sum_if_to_count_if_lowcardinality_nullable.reference
@@ -1,0 +1,9 @@
+LowCardinality(Nullable(UInt8))
+2
+2
+246
+246
+2
+not nullable
+2
+1

--- a/tests/queries/0_stateless/05058_sum_if_to_count_if_lowcardinality_nullable.sql
+++ b/tests/queries/0_stateless/05058_sum_if_to_count_if_lowcardinality_nullable.sql
@@ -1,0 +1,34 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/116938
+-- `optimize_rewrite_sum_if_to_count_if` rewrites `sum(if(cond, 0, 1))` into `countIf(not(cond))`,
+-- which is wrong for a condition that can be NULL: `if` sends a NULL condition down the else
+-- branch, while `not(NULL)` is NULL and `countIf` skips the row. The guard has to see through the
+-- `LowCardinality` wrapper - an ordinary comparison over `LowCardinality(Nullable(String))`
+-- produces `LowCardinality(Nullable(UInt8))`.
+
+SET optimize_rewrite_sum_if_to_count_if = 1, optimize_rewrite_aggregate_function_with_if = 0;
+
+DROP TABLE IF EXISTS t_sum_if_lc_nullable;
+CREATE TABLE t_sum_if_lc_nullable (s LowCardinality(Nullable(String))) ENGINE = Memory;
+INSERT INTO t_sum_if_lc_nullable VALUES ('y'), ('n'), (NULL);
+
+SELECT toTypeName(s = 'y') FROM t_sum_if_lc_nullable LIMIT 1;
+
+SELECT sum(if(s = 'y', 0, 1)) FROM t_sum_if_lc_nullable;
+SELECT sum(if(s = 'y', 0, 1)) FROM t_sum_if_lc_nullable SETTINGS optimize_rewrite_sum_if_to_count_if = 0;
+
+SELECT sum(if(s = 'y', 0, 123)) FROM t_sum_if_lc_nullable;
+SELECT sum(if(s = 'y', 0, 123)) FROM t_sum_if_lc_nullable SETTINGS optimize_rewrite_sum_if_to_count_if = 0;
+
+-- A plain Nullable condition was already refused, and stays refused.
+SELECT sum(if(nullIf(s, 'zzz') = 'y', 0, 1)) FROM t_sum_if_lc_nullable;
+
+-- The rewrite still fires for a condition that cannot be NULL.
+SELECT 'not nullable';
+DROP TABLE IF EXISTS t_sum_if_plain;
+CREATE TABLE t_sum_if_plain (s LowCardinality(String)) ENGINE = Memory;
+INSERT INTO t_sum_if_plain VALUES ('y'), ('n'), ('n');
+SELECT sum(if(s = 'y', 0, 1)) FROM t_sum_if_plain;
+SELECT count() > 0 FROM (EXPLAIN QUERY TREE SELECT sum(if(s = 'y', 0, 1)) FROM t_sum_if_plain) WHERE explain LIKE '%countIf%';
+
+DROP TABLE t_sum_if_lc_nullable;
+DROP TABLE t_sum_if_plain;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/116938
Related: https://github.com/ClickHouse/ClickHouse/issues/116937

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix wrong results from the default-enabled `optimize_rewrite_sum_if_to_count_if` when the condition
of `sum(if(cond, 0, x))` has type `LowCardinality(Nullable(...))`. Rows whose condition was NULL
were dropped from the count.


### Description

The pass rewrites `sum(if(cond, 0, 1))` into `countIf(not(cond))` and already refused a `Nullable`
condition, because `if` sends a NULL condition down the else branch while `not(NULL)` is NULL and
`countIf` skips the row. `isNullable` is false for the `LowCardinality` wrapper, so the guard was
bypassed by `LowCardinality(Nullable(...))` — which is exactly what an ordinary comparison over a
`LowCardinality(Nullable(String))` column produces, since functions propagate the `LowCardinality`
wrapper. No exotic schema is needed to reach it.

The guard now uses `isNullableOrLowCardinalityNullable`. The `not_function_result_type` local right
below it was already dead (computed and never used) and is removed.

Test `05058_sum_if_to_count_if_lowcardinality_nullable`, which also asserts the rewrite still fires
for a condition that cannot be NULL.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117220&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117220](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117220+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
