### PR TITLE
Split out and skip the statements that create a table from a SQL-created named collection on the replicated-database CI arm

### DIFF
--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.reference
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.reference
@@ -7,6 +7,3 @@
 1
 1	Hello
 2	World
---- ENGINE = URL(named_collection) with format = auto persists the inferred format ---
-1
-1

--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format.sh
@@ -44,23 +44,3 @@ ${CLICKHOUSE_CLIENT} -q "SELECT create_table_query LIKE '%CSV%' FROM system.tabl
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_e ORDER BY a"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_e"
 rm -f "$ABS_CSV"
-
-echo "--- ENGINE = URL(named_collection) with format = auto persists the inferred format ---"
-NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_nc"
-NOEXT_NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_noext_nc"
-ABS_NOEXT_NC="${USER_FILES_PATH}/${NOEXT_NC}"
-printf '{"a":1,"b":"Hello"}\n{"a":2,"b":"World"}\n' > "$ABS_NOEXT_NC"
-# Reuse a leftover collection rather than recreating it: dropping it is refused while a leftover table
-# still references it.
-${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = 'file://${ABS_NOEXT_NC}'"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
-${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n ENGINE = URL(${NC})"
-# The persisted engine definition carries a concrete format, not 'auto' (quoted literal, see above).
-${CLICKHOUSE_CLIENT} -q "SELECT create_table_query NOT ILIKE '%''auto''%' FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
-# Reload after the source file is removed succeeds (no format re-inference).
-${CLICKHOUSE_CLIENT} -q "DETACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
-rm -f "$ABS_NOEXT_NC"
-${CLICKHOUSE_CLIENT} -q "ATTACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
-${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
-# Chained so the collection outlives the table: metadata must never reference a missing collection.
-${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"

--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format_named_collection.reference
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format_named_collection.reference
@@ -1,0 +1,3 @@
+--- ENGINE = URL(named_collection) with format = auto persists the inferred format ---
+1
+1

--- a/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format_named_collection.sh
+++ b/tests/queries/0_stateless/04320_url_engine_dispatch_partition_and_format_named_collection.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# no-fasttest: relies on the local user_files directory.
+# no-replicated-database: named collections are server-global, not database-scoped
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo "--- ENGINE = URL(named_collection) with format = auto persists the inferred format ---"
+NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_nc"
+NOEXT_NC="${CLICKHOUSE_TEST_UNIQUE_NAME}_noext_nc"
+ABS_NOEXT_NC="${USER_FILES_PATH}/${NOEXT_NC}"
+printf '{"a":1,"b":"Hello"}\n{"a":2,"b":"World"}\n' > "$ABS_NOEXT_NC"
+# Reuse a leftover collection rather than recreating it: dropping it is refused while a leftover table
+# still references it.
+${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = 'file://${ABS_NOEXT_NC}'"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n ENGINE = URL(${NC})"
+# The persisted engine definition carries a concrete format, not 'auto' (quoted literal, so that the
+# random database name in the DDL cannot match).
+${CLICKHOUSE_CLIENT} -q "SELECT create_table_query NOT ILIKE '%''auto''%' FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
+# Reload after the source file is removed succeeds (no format re-inference).
+${CLICKHOUSE_CLIENT} -q "DETACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
+rm -f "$ABS_NOEXT_NC"
+${CLICKHOUSE_CLIENT} -q "ATTACH TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_n'"
+# Chained so the collection outlives the table: metadata must never reference a missing collection.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_n" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"

--- a/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
+++ b/tests/queries/0_stateless/04327_s3queue_server_credentials.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-replicated-database
 # Tag no-fasttest: exercises the `S3Queue` engine, which is not compiled into the fast-test build.
+# Tag no-replicated-database: named collections are server-global, not database-scoped
 #
 # `S3Queue` must honor the S3 user-credential restriction the same way the `s3` table function and `S3`
 # engine do, including the per-session/profile `s3_allow_server_credentials_in_user_queries` override given

--- a/tests/queries/0_stateless/04511_remote_named_collection_complex_overrides.sh
+++ b/tests/queries/0_stateless/04511_remote_named_collection_complex_overrides.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database
+# no-replicated-database: named collections are server-global, not database-scoped
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04626_s3_base_setting.reference
+++ b/tests/queries/0_stateless/04626_s3_base_setting.reference
@@ -15,8 +15,5 @@
 --- S3 table engine with a relative URL, resolved URL is materialized into the DDL
 5
 1
---- S3 table engine from a named collection with a relative URL, resolved URL is materialized into the DDL
-1
-5
 --- s3_base without a scheme is an error
 must contain a scheme

--- a/tests/queries/0_stateless/04626_s3_base_setting.sh
+++ b/tests/queries/0_stateless/04626_s3_base_setting.sh
@@ -40,24 +40,5 @@ ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM test_s3_base"
 ${CLICKHOUSE_CLIENT} -q "SHOW CREATE TABLE test_s3_base FORMAT TabSeparatedRaw" | grep -cF "S3('${BUCKET_URL}/${FILE}'"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base"
 
-echo '--- S3 table engine from a named collection with a relative URL, resolved URL is materialized into the DDL'
-NC="nc_${CLICKHOUSE_TEST_UNIQUE_NAME}"
-# Never drop the named collection here: an interrupted previous run can leave both the collection and
-# the table behind, and dropping only the collection is exactly the broken state described at the end
-# of the test. Reuse a leftover collection instead of recreating it - its contents are deterministic -
-# and let the `DROP TABLE IF EXISTS` below remove a leftover table.
-${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = '${FILE}', access_key_id = 'test', secret_access_key = 'testtest', format = 'TSV'"
-${CLICKHOUSE_CLIENT} -q "SET s3_base = '${BUCKET_URL}/'; DROP TABLE IF EXISTS test_s3_base_nc; CREATE TABLE test_s3_base_nc (n UInt32, s String) ENGINE = S3(${NC});"
-${CLICKHOUSE_CLIENT} -q "SHOW CREATE TABLE test_s3_base_nc FORMAT TabSeparatedRaw" | grep -cF "url = '${BUCKET_URL}/${FILE}'"
-# The table must survive DETACH/ATTACH in a session where s3_base is not set.
-${CLICKHOUSE_CLIENT} -q "DETACH TABLE test_s3_base_nc"
-${CLICKHOUSE_CLIENT} -q "ATTACH TABLE test_s3_base_nc"
-${CLICKHOUSE_CLIENT} -q "SELECT count() FROM test_s3_base_nc"
-# Drop the named collection only after the table drop has succeeded. Under the stress test the
-# server can be killed mid-test; the failed `DROP TABLE` is then skipped while the `DROP NAMED
-# COLLECTION` succeeds against the restarted server, leaving a table whose `ATTACH` references a
-# missing named collection — and the next server restart fails to load metadata.
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base_nc" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"
-
 echo '--- s3_base without a scheme is an error'
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM s3('${FILE}', 'test', 'testtest', 'TSV', 'n UInt32, s String') SETTINGS s3_base = 'localhost:11111/test/'" 2>&1 | grep -oF 'must contain a scheme' | head -1

--- a/tests/queries/0_stateless/04626_s3_base_setting_named_collection.reference
+++ b/tests/queries/0_stateless/04626_s3_base_setting_named_collection.reference
@@ -1,0 +1,3 @@
+--- S3 table engine from a named collection with a relative URL, resolved URL is materialized into the DDL
+1
+5

--- a/tests/queries/0_stateless/04626_s3_base_setting_named_collection.sh
+++ b/tests/queries/0_stateless/04626_s3_base_setting_named_collection.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# Tag no-fasttest: Depends on S3 (minio)
+# Tag no-replicated-database: named collections are server-global, not database-scoped
+
+# Test the s3_base setting when the S3 table engine takes its relative URL from a named collection.
+# https://github.com/ClickHouse/ClickHouse/issues/59617
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+BUCKET_URL="http://localhost:11111/test"
+# ${CLICKHOUSE_TEST_UNIQUE_NAME} embeds this file's own test name, so the object and the collection
+# below cannot collide with 04626_s3_base_setting running at the same time.
+FILE="${CLICKHOUSE_TEST_UNIQUE_NAME}.tsv"
+
+# Prepare a file in minio using an absolute URL.
+${CLICKHOUSE_CLIENT} -q "INSERT INTO FUNCTION s3('${BUCKET_URL}/${FILE}', 'test', 'testtest', 'TSV', 'n UInt32, s String') SELECT number, concat('str_', toString(number)) FROM numbers(5) SETTINGS s3_truncate_on_insert = 1"
+
+echo '--- S3 table engine from a named collection with a relative URL, resolved URL is materialized into the DDL'
+NC="nc_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+# Never drop the named collection here: an interrupted previous run can leave both the collection and
+# the table behind, and dropping only the collection is exactly the broken state described at the end
+# of the test. Reuse a leftover collection instead of recreating it - its contents are deterministic -
+# and let the `DROP TABLE IF EXISTS` below remove a leftover table.
+${CLICKHOUSE_CLIENT} -q "CREATE NAMED COLLECTION IF NOT EXISTS ${NC} AS url = '${FILE}', access_key_id = 'test', secret_access_key = 'testtest', format = 'TSV'"
+${CLICKHOUSE_CLIENT} -q "SET s3_base = '${BUCKET_URL}/'; DROP TABLE IF EXISTS test_s3_base_nc; CREATE TABLE test_s3_base_nc (n UInt32, s String) ENGINE = S3(${NC});"
+${CLICKHOUSE_CLIENT} -q "SHOW CREATE TABLE test_s3_base_nc FORMAT TabSeparatedRaw" | grep -cF "url = '${BUCKET_URL}/${FILE}'"
+# The table must survive DETACH/ATTACH in a session where s3_base is not set.
+${CLICKHOUSE_CLIENT} -q "DETACH TABLE test_s3_base_nc"
+${CLICKHOUSE_CLIENT} -q "ATTACH TABLE test_s3_base_nc"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM test_s3_base_nc"
+# Drop the named collection only after the table drop has succeeded. Under the stress test the
+# server can be killed mid-test; the failed `DROP TABLE` is then skipped while the `DROP NAMED
+# COLLECTION` succeeds against the restarted server, leaving a table whose `ATTACH` references a
+# missing named collection, and the next server restart fails to load metadata.
+${CLICKHOUSE_CLIENT} -q "DROP TABLE test_s3_base_nc" && ${CLICKHOUSE_CLIENT} -q "DROP NAMED COLLECTION ${NC}"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/112052
Related: https://github.com/ClickHouse/ClickHouse/pull/112247


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Two stateless tests are skipped on the replicated-database CI arm, and two are split so their remaining assertions keep running there.

### Description

@ alexey-milovidov [asked for this on #112052](https://github.com/ClickHouse/ClickHouse/pull/112052#issuecomment-5165680640);
#112247's CI ledger owns `04511`.

`04511_remote_named_collection_complex_overrides`, `04327`, `04320` and `04626` fail the main pass
on **every** run of both `Stateless tests (amd_llvm_coverage, ..., DBReplicated, ...)` jobs with
`Code: 159 ... ReplicatedDatabase DDL task ... is not finished on 2 of 3 hosts`. The diagnostics
rerun drops `--replicated-database` and passes, so its `flaky` label force-sets coverage jobs to
`OK` unless the rerun also fails: over 25,000 such rows in 21 days, no genuine pass.

`CREATE NAMED COLLECTION` is server-global, not database-scoped, so it applies only on the receiving
host. `CREATE TABLE` inside a `Replicated` database *is* a replicated DDL entry, replayed on every
replica, where the collection is absent: it fails `Code: 669 NAMED_COLLECTION_DOESNT_EXIST`, then
enters lost-replica recovery, which replays the same metadata and fails identically. Raising
`distributed_ddl_task_timeout` cannot help, the entry never completes.

`no-replicated-database` is the repository's existing declaration for this: 18 of the 35 stateless
tests with `CREATE NAMED COLLECTION` already carry it, 8 with this reason string verbatim. These
four are the whole class. A *dictionary* built from its own collection is not a carrier: its
`SOURCE` resolves at load.

Only the refused statements are declared unsupported. `04511` and `04327` take the tag whole, every
assertion they make needs the collection. `04320` and `04626` do not, so their collection sections
move into new tests carrying the tag and the parents keep running: 9 of 12 reference lines for
`04320`, 19 of 22 for `04626`, confirmed from the job's own `query_log`. Those parents assert
positional `URL(...)`/`S3(...)` table definitions, replicated DDL entries no other arm replays.

Not fixed here: the timeout reports the replicas as still executing after both failed
non-retriably; the recovery retry is unbounded.

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112247&sha=66ee0b152db689826f5509ce55b0845246e1ae70&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20parallel%2C%201%2F3%29

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117234&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117234](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117234+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
