### PR TITLE
Fix the CI infrastructure auto-retry and rerun an infra job in a mixed run

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -51,6 +51,10 @@ jobs:
             echo "Checking run $run_url ..."
 
             should_rerun=false
+            consistent=false
+            infra_count=0
+            infra_id=""
+            infra_name=""
 
             # Fetch all job data once (reused for multiple checks below)
             jobs_raw=$(gh api "repos/$GH_REPO/actions/runs/$run_id/jobs?per_page=100" --paginate)
@@ -92,57 +96,94 @@ jobs:
 
             # Fetch run metadata once for all checks below
             run_data=$(gh api "repos/$GH_REPO/actions/runs/$run_id" \
-              --jq '{pr: .pull_requests[0].number, sha: .head_sha}')
+              --jq '{pr: .pull_requests[0].number, sha: .head_sha,
+                     head_owner: .head_repository.owner.login, head_branch: .head_branch}')
             pr_number=$(echo "$run_data" | jq -r '.pr // empty')
             run_sha=$(echo "$run_data" | jq -r '.sha')
 
-            # If the job-level heuristic didn't trigger, check Praktika result JSONs
-            # on S3 for infrastructure-related failures:
-            # - "Checkout Submodules" failures (transient DNS/git issues)
-            # - Results with the "infra" label (e.g. Docker image pull failures)
-            if [ "$should_rerun" = "false" ] && [ -n "$verdicts" ] && [ -n "$pr_number" ] && [ -n "$run_sha" ]; then
-              # Get names of failed jobs (excluding pipeline plumbing)
-              failed_job_names=$(echo "$jobs_raw" | jq -r '
+            # ".pull_requests" is populated only for a head branch that lives in this
+            # repository, so a pull request from a fork is found by its head reference.
+            if [ -z "$pr_number" ]; then
+              head_owner=$(echo "$run_data" | jq -r '.head_owner // empty')
+              head_branch=$(echo "$run_data" | jq -r '.head_branch // empty')
+              if [ -n "$head_owner" ] && [ -n "$head_branch" ]; then
+                pr_number=$(gh api --method GET "repos/$GH_REPO/pulls" \
+                  -f "head=$head_owner:$head_branch" -f state=all -f per_page=1 \
+                  --jq '.[0].number // empty' 2>/dev/null || true)
+              fi
+            fi
+
+            if [ -z "$pr_number" ]; then
+              echo "  Cannot resolve the pull request for this run, skipping."
+              continue
+            fi
+
+            pr_data=$(gh api "repos/$GH_REPO/pulls/$pr_number" \
+              --jq '{sha: .head.sha, updated: .updated_at}' 2>/dev/null || true)
+            pr_sha=$(echo "$pr_data" | jq -r '.sha // empty')
+            pr_updated=$(echo "$pr_data" | jq -r '.updated // empty')
+
+            # "Mergeable Check" is a commit status and a rerun keeps the original head
+            # commit, so a run whose commit is no longer the head of the pull request
+            # cannot unblock it however it is rerun.
+            if [ -z "$pr_sha" ] || [ "$run_sha" != "$pr_sha" ]; then
+              echo "  Run commit is not the head of PR #$pr_number, skipping."
+              continue
+            fi
+
+            # If the job-level heuristic didn't trigger, classify each failed job from the
+            # Praktika results on S3. The workflow-level result is the same artifact
+            # "Finish Workflow" reads for "Mergeable Check", so the two cannot disagree.
+            if [ "$should_rerun" = "false" ] && [ -n "$verdicts" ]; then
+              result_url="https://s3.amazonaws.com/clickhouse-test-reports/PRs/${pr_number}/${run_sha}/result_pr.json"
+              result_json=$(curl -sf --compressed "$result_url" 2>/dev/null || true)
+
+              failed_jobs=$(echo "$jobs_raw" | jq -r '
                 .jobs[] | select(.conclusion == "failure") |
                 select(.name != "Config Workflow" and .name != "Finish Workflow") |
-                .name
+                "\(.id)\t\(.name)"
               ')
 
-              all_infra_failures=true
-              while IFS= read -r job_name; do
-                [ -z "$job_name" ] && continue
-                # Normalize job name to match Praktika result file naming:
-                # lowercase, replace non-alphanumeric chars with underscore, collapse runs
-                normalized=$(echo "$job_name" | tr '[:upper:]' '[:lower:]' | \
-                  sed 's/[^a-z0-9_]/_/g; s/__*/_/g')
-                result_url="https://s3.amazonaws.com/clickhouse-test-reports/PRs/${pr_number}/${run_sha}/result_${normalized}.json"
+              real_failure=false
+              if [ -n "$result_json" ] && [ -n "$failed_jobs" ]; then
+                consistent=true
+                while IFS=$'\t' read -r job_id job_name; do
+                  [ -z "$job_name" ] && continue
+                  # The S3 key names a pull request and a commit but no run, so two runs
+                  # at one commit share this file: an entry describes this job only when
+                  # its own "run_url" points at it. Anything else is unclassifiable.
+                  verdict=$(echo "$result_json" | jq -r \
+                    --arg name "$job_name" --arg job_url "$run_url/job/$job_id" '
+                    [.results[]? | select(.name == $name)] | .[0] as $r |
+                    if $r == null then "foreign"
+                    elif ($r.ext.run_url // "") != $job_url then "foreign"
+                    elif (["FAIL", "ERROR", "UNKNOWN", "XPASS", "DROPPED"]
+                          | index($r.status)) == null then "foreign"
+                    elif (($r.ext.labels // [])
+                          | any((if type == "object" then .name else . end) == "infra"))
+                      then "infra"
+                    elif (($r.results // []) | length) > 0
+                         and all($r.results[]; .name == "Checkout Submodules") then "infra"
+                    else "real"
+                    end
+                  ')
+                  case "$verdict" in
+                    infra)
+                      infra_count=$((infra_count + 1))
+                      infra_id="$job_id"
+                      infra_name="$job_name"
+                      ;;
+                    real) real_failure=true ;;
+                    *)
+                      consistent=false
+                      echo "  Praktika results do not describe job '$job_name' of this run."
+                      break
+                      ;;
+                  esac
+                done <<< "$failed_jobs"
+              fi
 
-                result_json=$(curl -sf --compressed "$result_url" 2>/dev/null || true)
-                if [ -z "$result_json" ]; then
-                  all_infra_failures=false
-                  break
-                fi
-
-                # Check if the top-level result has the "infra" label
-                has_infra_label=$(echo "$result_json" | jq -r '
-                  (.ext.labels // []) | any(. == "infra")
-                ')
-                if [ "$has_infra_label" = "true" ]; then
-                  continue
-                fi
-
-                # Check: all failed sub-results must be "Checkout Submodules"
-                has_non_checkout_failure=$(echo "$result_json" | jq -r '
-                  [.results[] | select(.status == "failure" or .status == "error") |
-                   .name] | map(select(. != "Checkout Submodules")) | length > 0
-                ')
-                if [ "$has_non_checkout_failure" = "true" ]; then
-                  all_infra_failures=false
-                  break
-                fi
-              done <<< "$failed_job_names"
-
-              if [ "$all_infra_failures" = "true" ] && [ -n "$failed_job_names" ]; then
+              if [ "$consistent" = "true" ] && [ "$infra_count" -gt 0 ] && [ "$real_failure" = "false" ]; then
                 should_rerun=true
                 echo "  Infrastructure failure detected (Praktika results indicate infra issue)."
               fi
@@ -161,16 +202,9 @@ jobs:
                 ] | first // empty
               ')
 
-              if [ -n "$config_failed_at" ] && [ -n "$pr_number" ]; then
-                pr_data=$(gh api "repos/$GH_REPO/pulls/$pr_number" \
-                  --jq '{sha: .head.sha, updated: .updated_at}')
-                pr_sha=$(echo "$pr_data" | jq -r '.sha')
-                pr_updated=$(echo "$pr_data" | jq -r '.updated')
-
-                if [ "$run_sha" = "$pr_sha" ] && [[ "$pr_updated" > "$config_failed_at" ]]; then
-                  should_rerun=true
-                  echo "  Config Workflow failed but PR #$pr_number was updated after — rerunning."
-                fi
+              if [ -n "$config_failed_at" ] && [[ "$pr_updated" > "$config_failed_at" ]]; then
+                should_rerun=true
+                echo "  Config Workflow failed but PR #$pr_number was updated after, rerunning."
               fi
             fi
 
@@ -180,6 +214,17 @@ jobs:
                 echo "  Triggered rerun: $run_url/attempts/2"
               else
                 echo "  Failed to trigger rerun (may already be rerunning)"
+              fi
+            elif [ "$consistent" = "true" ] && [ "$infra_count" -eq 1 ]; then
+              # Rerunning a whole run that also failed for real is pointless, so rerun the
+              # one infrastructure job. That also reruns its dependents, which its own
+              # failure had skipped, and "Finish Workflow", which reposts "Mergeable
+              # Check". One job per run: a rerun stales every other job id of this attempt.
+              if gh run rerun --job "$infra_id" --repo "$GH_REPO"; then
+                rerun_count=$((rerun_count + 1))
+                echo "  Triggered rerun of infrastructure job '$infra_name': $run_url"
+              else
+                echo "  Failed to trigger rerun of '$infra_name'"
               fi
             else
               echo "  Not an infrastructure failure, skipping."

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -320,10 +320,8 @@ class Runner:
             "NOTE: job truncated by a docker daemon failure - "
             "labeling as infrastructure error for auto-retry"
         )
-        # Append the bare label string, not the dict set_label() would store:
-        # retry_infra_failures.yml matches with `any(. == "infra")`, which only
-        # sees a plain string. The other readers (_label_name, json.html
-        # normalizeLabels, gh.py) already accept the string form.
+        # Append the bare label string rather than the dict `set_label` stores:
+        # every reader of `ext["labels"]` accepts the string form.
         labels = result.ext.setdefault("labels", [])
         if Result.Label.INFRA not in labels:
             labels.append(Result.Label.INFRA)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109673 (the `infra` label this acts on)
Related: https://github.com/ClickHouse/ClickHouse/pull/113564 (candidate selector)
Related: https://github.com/ClickHouse/ClickHouse/pull/115569 (job-level heuristic)
Related: https://github.com/ClickHouse/ClickHouse/pull/116701 (duplicate runs at one commit)


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The hourly auto-retry has never acted on the `infra` label #109673 added. A `SQLLogic test` job
killed at exit 125 by a host docker daemon death 67 minutes in is labelled correctly and
never retried ([job log](https://s3.amazonaws.com/clickhouse-test-reports/PRs/116805/6b4fa927f8f6af2fec67d903b2c26346ce7d9714/sqllogic_test/job.log)).
Five defects sit in one block of `retry_infra_failures.yml`:

- a fork run carries no pull request number and the whole Praktika path is gated on one, so it
  is dead on every fork PR;
- the job-name-to-filename normalization does not match praktika's, so most result URLs 403
  and the loop breaks on the first;
- the failed-sub-result test compares lowercase statuses against praktika's uppercase ones, so
  it is always false; fixing only the URL would start rerunning real failures;
- the label predicate matches a bare string only, missing the dict form `set_label` writes;
- the only action is a whole-run rerun, correctly refused when the run also failed for real, so
  a mixed run was unrecoverable.

Classification now reads the run's `result_pr.json` once, the artifact `Finish Workflow` reads
for `Mergeable Check`, joining each entry to its job by `ext.run_url`. A mixed run with exactly
one infra job gets that job rerun, which also reruns its dependents and `Finish Workflow`; the
all-infra case still reruns whole.

Two side effects. `Mergeable Check` is a commit status and a rerun keeps the original commit, so
a run whose commit is no longer its pull request's head is now skipped; that narrows the existing
whole-run path too. A run sharing a commit with a concurrent run is left alone rather
than acted on from an artifact both wrote, which #116701 would fix at its source.

Untouched: the daemon death is a host condition (five distinct `m8g.4xlarge` hosts inside 36
minutes); two or more infra jobs in one run; `master.yml` runs; the legacy `hlabels` form.

<details>
<summary>Measurements and validation</summary>

Each defect, measured on live runs: `.pull_requests` is populated for 0 of 33 fork heads sampled
and for 7 of 7 same-repo heads; the normalization omits praktika's `rstrip("_")`, so 155 of
170 job names build a key that does not exist; praktika statuses are `FAIL` and `ERROR`, never
`failure` or `error`; `33b1f35c0ad` fixed the dict-form label and `7d022e880fef` reverted it
asking for a reapply; all three runs that have ever carried the label are mixed, so 3 of 3 uses
of the label were unrecoverable.

Validated over the 16 real (PR, commit) pairs that produced a `SQLLogic test` job-level failure
in 30 days. The step body was extracted from the YAML and driven over them with the rerun call
stubbed, beside the same harness running master's step.

| step | reruns | what fired |
|---|---|---|
| master | 1 | whole-run rerun of [run `32038224339`](https://github.com/ClickHouse/ClickHouse/actions/runs/32038224339), whose pull request is now closed at a different commit |
| this change | 1 | per-job rerun of `SQLLogic test` in [run `33331951492`](https://github.com/ClickHouse/ClickHouse/actions/runs/33331951492), a mixed run still at its pull request's head |
| this change, head-commit guard neutralised | 3 | the two above plus `SQLLogic test` of #116805's run, which the guard skips because that PR has moved on |

Two of the 16 runs share their commit with a concurrent run, and their `result_pr.json` does
carry entries stamped by both, so the per-job join is what keeps them from being acted on. Only
3 of the generated workflow's 170 jobs lack the `pipeline_status` guard, so a per-job rerun
re-runs at most one job that could have passed.

</details>

The three open pull requests above merge cleanly with this change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117282&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117282](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117282+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
