### PR TITLE
Rebuild a `Dynamic` column's `DateTime` variants per read instead of sharing them between sessions

### DIFF
--- a/docs/reference/interfaces/specs/NativeFormat.mdx
+++ b/docs/reference/interfaces/specs/NativeFormat.mdx
@@ -1296,6 +1296,8 @@ The discriminator width is the smallest unsigned integer that can index `num_typ
 
 The state prefix (version + type list) is read at the start of every block with rows > 0; header and empty blocks emit nothing.
 
+A type-list entry that names `DateTime` or `DateTime64(s)` without a timezone parameter pins no timezone of its own (see [DateTime](#datetime)), so a decoder resolves it against its own context and must not reuse a runtime type it resolved for a different one.
+
 <Info>
 **Malformed counts**
 

--- a/src/DataTypes/Serializations/SerializationDynamic.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamic.cpp
@@ -393,7 +393,7 @@ ISerialization::DeserializeBinaryBulkStatePtr SerializationDynamic::deserializeD
                 else
                 {
                     readStringBinary(data_type_name, *structure_stream);
-                    structure_state->flattened_data_types.push_back(getDataTypesCache().getType(data_type_name));
+                    structure_state->flattened_data_types.push_back(getSimpleDataTypesCache().getType(data_type_name));
                 }
             }
 
@@ -426,11 +426,13 @@ ISerialization::DeserializeBinaryBulkStatePtr SerializationDynamic::deserializeD
             }
             else
             {
+                /// These instances become the column's data type, and a `DateTime`/`DateTime64` with no declared zone
+                /// captures the ambient one at construction, so they must not come from a process-wide name-keyed memo.
                 String data_type_name;
                 for (size_t i = 0; i != structure_state->num_dynamic_types; ++i)
                 {
                     readStringBinary(data_type_name, *structure_stream);
-                    variants.push_back(getDataTypesCache().getType(data_type_name));
+                    variants.push_back(getSimpleDataTypesCache().getType(data_type_name));
                 }
             }
             /// Add shared variant, Dynamic column should always have it.

--- a/src/DataTypes/Serializations/SerializationDynamic.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamic.cpp
@@ -377,6 +377,8 @@ ISerialization::DeserializeBinaryBulkStatePtr SerializationDynamic::deserializeD
         UInt64 structure_version = 0;
         readBinaryLittleEndian(structure_version, *structure_stream);
         auto structure_state = std::make_shared<DeserializeBinaryBulkStateDynamicStructure>(structure_version);
+        /// A variant name that declares no time zone, `DateTime` or `DateTime64(s)`, pins none, so the two
+        /// name-keyed branches below build such a type per read instead of taking one from a thread-local cache.
         if (structure_state->structure_version.value == SerializationVersion::FLATTENED)
         {
             /// Read the flattened list of types.
@@ -426,8 +428,6 @@ ISerialization::DeserializeBinaryBulkStatePtr SerializationDynamic::deserializeD
             }
             else
             {
-                /// These instances become the column's data type, and a `DateTime`/`DateTime64` with no declared zone
-                /// captures the ambient one at construction, so they must not come from a process-wide name-keyed memo.
                 String data_type_name;
                 for (size_t i = 0; i != structure_state->num_dynamic_types; ++i)
                 {

--- a/tests/queries/0_stateless/05056_dynamic_datetime_timezone.reference
+++ b/tests/queries/0_stateless/05056_dynamic_datetime_timezone.reference
@@ -1,0 +1,14 @@
+fixture v2	1
+fixture v3	1
+v2 tokyo	1970-01-01 09:00:00
+v2 utc	1970-01-01 00:00:00
+v2 tokyo again	1970-01-01 09:00:00
+v2 renderings per query	1
+v3 tokyo	1970-01-01 09:00:00
+v3 utc	1970-01-01 00:00:00
+explicit tokyo	1970-01-01 01:00:00
+explicit utc	1970-01-01 01:00:00
+v2 datetime64 tokyo	1970-01-01 09:00:00.000
+v2 datetime64 utc	1970-01-01 00:00:00.000
+v2 format tokyo	1970-01-01 09:00:00
+v2 format utc	1970-01-01 00:00:00

--- a/tests/queries/0_stateless/05056_dynamic_datetime_timezone.sql
+++ b/tests/queries/0_stateless/05056_dynamic_datetime_timezone.sql
@@ -43,9 +43,11 @@ SELECT 'v2 utc', any(toString(d)) FROM dynamic_datetime_v2
 SELECT 'v2 tokyo again', any(toString(d)) FROM dynamic_datetime_v2
     SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 16;
 
--- All rows of one query must render identically, however many threads read them.
+-- All rows of one query must render identically, however many threads read them. The zone here is
+-- not the server's, so a thread that fell back to the server default also shows up as a second
+-- rendering.
 SELECT 'v2 renderings per query', count(DISTINCT toString(d)) FROM dynamic_datetime_v2
-    SETTINGS session_timezone = 'UTC', max_threads = 16;
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 16;
 
 -- Control on byte-identical data written with the current default version. It answers in the
 -- reading session's time zone both before and after this fix, so a passing v2 arm above is not

--- a/tests/queries/0_stateless/05056_dynamic_datetime_timezone.sql
+++ b/tests/queries/0_stateless/05056_dynamic_datetime_timezone.sql
@@ -1,0 +1,80 @@
+-- This test checks that a DateTime or DateTime64 stored in a Dynamic column renders in the
+-- reading session's time zone, and not in the time zone of whichever session happened to read
+-- the column first. Parts written with dynamic_serialization_version v1 or v2 persist variant
+-- type names as text and rebuild the types when read; the name of a DateTime that declares no
+-- time zone carries none, so such a type must be built per read.
+
+DROP TABLE IF EXISTS dynamic_datetime_v2;
+DROP TABLE IF EXISTS dynamic_datetime_v3;
+DROP TABLE IF EXISTS dynamic_datetime_explicit;
+DROP TABLE IF EXISTS dynamic_datetime64_v2;
+
+CREATE TABLE dynamic_datetime_v2 (d Dynamic) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS dynamic_serialization_version = 'v2';
+CREATE TABLE dynamic_datetime_v3 (d Dynamic) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS dynamic_serialization_version = 'v3';
+CREATE TABLE dynamic_datetime_explicit (d Dynamic) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS dynamic_serialization_version = 'v2';
+CREATE TABLE dynamic_datetime64_v2 (d Dynamic) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS dynamic_serialization_version = 'v2';
+
+INSERT INTO dynamic_datetime_v2 SELECT toDateTime(0)::Dynamic FROM numbers(1000)
+    SETTINGS session_timezone = 'UTC';
+INSERT INTO dynamic_datetime_v3 SELECT toDateTime(0)::Dynamic FROM numbers(1000)
+    SETTINGS session_timezone = 'UTC';
+INSERT INTO dynamic_datetime_explicit SELECT toDateTime(0, 'Europe/Berlin')::Dynamic FROM numbers(1000)
+    SETTINGS session_timezone = 'UTC';
+INSERT INTO dynamic_datetime64_v2 SELECT toDateTime64(0, 3)::Dynamic FROM numbers(1000)
+    SETTINGS session_timezone = 'UTC';
+
+-- The test runner randomizes dynamic_serialization_version, so confirm the tables kept the
+-- versions this test needs. An explicit table setting is never overridden by the runner.
+SELECT 'fixture v2', engine_full LIKE '%dynamic_serialization_version = \'v2\'%'
+FROM system.tables WHERE database = currentDatabase() AND name = 'dynamic_datetime_v2';
+SELECT 'fixture v3', engine_full LIKE '%dynamic_serialization_version = \'v3\'%'
+FROM system.tables WHERE database = currentDatabase() AND name = 'dynamic_datetime_v3';
+
+-- Read under Asia/Tokyo first, then UTC, then Asia/Tokyo again. Every read must answer in its
+-- own time zone. max_threads = 16 spreads the first read over many threads.
+SELECT 'v2 tokyo', any(toString(d)) FROM dynamic_datetime_v2
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 16;
+SELECT 'v2 utc', any(toString(d)) FROM dynamic_datetime_v2
+    SETTINGS session_timezone = 'UTC', max_threads = 16;
+SELECT 'v2 tokyo again', any(toString(d)) FROM dynamic_datetime_v2
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 16;
+
+-- All rows of one query must render identically, however many threads read them.
+SELECT 'v2 renderings per query', count(DISTINCT toString(d)) FROM dynamic_datetime_v2
+    SETTINGS session_timezone = 'UTC', max_threads = 16;
+
+-- Control on byte-identical data written with the current default version. It answers in the
+-- reading session's time zone both before and after this fix, so a passing v2 arm above is not
+-- passing because the two time zones fail to discriminate.
+SELECT 'v3 tokyo', any(toString(d)) FROM dynamic_datetime_v3
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 16;
+SELECT 'v3 utc', any(toString(d)) FROM dynamic_datetime_v3
+    SETTINGS session_timezone = 'UTC', max_threads = 16;
+
+-- A variant that declares its own time zone keeps it under every reading session.
+SELECT 'explicit tokyo', any(toString(d)) FROM dynamic_datetime_explicit
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 16;
+SELECT 'explicit utc', any(toString(d)) FROM dynamic_datetime_explicit
+    SETTINGS session_timezone = 'UTC', max_threads = 16;
+
+-- DateTime64 is a separate variant name, so it exercises the same path independently.
+SELECT 'v2 datetime64 tokyo', any(toString(d)) FROM dynamic_datetime64_v2
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 16;
+SELECT 'v2 datetime64 utc', any(toString(d)) FROM dynamic_datetime64_v2
+    SETTINGS session_timezone = 'UTC', max_threads = 16;
+
+-- Output through a text format resolves the time zone when the value is written, which is a
+-- different path from the one above. It answers in the reading session's time zone already.
+SELECT 'v2 format tokyo', d FROM dynamic_datetime_v2 LIMIT 1
+    SETTINGS session_timezone = 'Asia/Tokyo';
+SELECT 'v2 format utc', d FROM dynamic_datetime_v2 LIMIT 1
+    SETTINGS session_timezone = 'UTC';
+
+DROP TABLE dynamic_datetime_v2;
+DROP TABLE dynamic_datetime_v3;
+DROP TABLE dynamic_datetime_explicit;
+DROP TABLE dynamic_datetime64_v2;

--- a/tests/queries/0_stateless/05057_dynamic_datetime_timezone_native.reference
+++ b/tests/queries/0_stateless/05057_dynamic_datetime_timezone_native.reference
@@ -1,0 +1,6 @@
+berlin tokyo	1970-01-01 01:00:00
+berlin utc	1970-01-01 01:00:00
+dynamic tokyo	1970-01-01 09:00:00
+dynamic utc	1970-01-01 00:00:00
+plain tokyo	1970-01-01 09:00:00
+plain utc	1970-01-01 00:00:00

--- a/tests/queries/0_stateless/05057_dynamic_datetime_timezone_native.sh
+++ b/tests/queries/0_stateless/05057_dynamic_datetime_timezone_native.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# The FLATTENED Dynamic serialization of the Native format lists its variant types by name, and the
+# name of a DateTime that declares no time zone carries none, so such a type has to be built again
+# for every read. Each pair below runs in one client invocation, so its second read runs where the
+# first one has already built that type.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+mkdir -p "${USER_FILES_PATH}"
+payload=${CLICKHOUSE_TEST_UNIQUE_NAME}.native
+
+$CLICKHOUSE_CLIENT --output_format_native_use_flattened_dynamic_and_json_serialization 1 \
+    --query "SELECT toDateTime(0)::Dynamic AS d,
+                    toDateTime(0) AS plain,
+                    toDateTime(0, 'Europe/Berlin')::Dynamic AS berlin
+             FROM numbers(100) FORMAT Native" > "${USER_FILES_PATH}/${payload}"
+
+# Which thread serves a read is not fixed, so the pairs run several times over. Every read of a
+# time zone has to give that zone's rendering, and any other rendering shows up as an extra line.
+for _ in {1..8}; do
+    $CLICKHOUSE_CLIENT --query "
+SELECT 'dynamic tokyo', any(toString(d)) FROM file('${payload}', Native)
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 1, schema_inference_use_cache_for_file = 0;
+SELECT 'dynamic utc', any(toString(d)) FROM file('${payload}', Native)
+    SETTINGS session_timezone = 'UTC', max_threads = 1, schema_inference_use_cache_for_file = 0;
+
+-- \`plain\` is an ordinary DateTime column of the same file, reached through the same call and
+-- rendered by the same function, but its type is never looked up by name. It tracks the reading
+-- session whichever way the variant above behaves, so it shows that these two time zones do
+-- discriminate here.
+SELECT 'plain tokyo', any(toString(plain)) FROM file('${payload}', Native)
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 1, schema_inference_use_cache_for_file = 0;
+SELECT 'plain utc', any(toString(plain)) FROM file('${payload}', Native)
+    SETTINGS session_timezone = 'UTC', max_threads = 1, schema_inference_use_cache_for_file = 0;
+
+-- A variant that declares its own time zone keeps it under every reading session.
+SELECT 'berlin tokyo', any(toString(berlin)) FROM file('${payload}', Native)
+    SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 1, schema_inference_use_cache_for_file = 0;
+SELECT 'berlin utc', any(toString(berlin)) FROM file('${payload}', Native)
+    SETTINGS session_timezone = 'UTC', max_threads = 1, schema_inference_use_cache_for_file = 0;
+"
+done | LC_ALL=C sort -u
+
+rm -f "${USER_FILES_PATH:?}/${payload}"

--- a/tests/queries/0_stateless/05057_dynamic_datetime_timezone_native.sh
+++ b/tests/queries/0_stateless/05057_dynamic_datetime_timezone_native.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # The FLATTENED Dynamic serialization of the Native format lists its variant types by name, and the
 # name of a DateTime that declares no time zone carries none, so such a type has to be built again
-# for every read. Each pair below runs in one client invocation, so its second read runs where the
-# first one has already built that type.
+# for every read. Native can also encode those types as binary codes instead of names, so the
+# settings choosing between the two are pinned inside the queries, which the test runner cannot
+# override. Each pair below runs in one client invocation, so its second read runs where the first
+# one has already built that type.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -11,16 +13,20 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 mkdir -p "${USER_FILES_PATH}"
 payload=${CLICKHOUSE_TEST_UNIQUE_NAME}.native
 
-$CLICKHOUSE_CLIENT --output_format_native_use_flattened_dynamic_and_json_serialization 1 \
-    --query "SELECT toDateTime(0)::Dynamic AS d,
+$CLICKHOUSE_CLIENT --query "SELECT toDateTime(0)::Dynamic AS d,
                     toDateTime(0) AS plain,
                     toDateTime(0, 'Europe/Berlin')::Dynamic AS berlin
-             FROM numbers(100) FORMAT Native" > "${USER_FILES_PATH}/${payload}"
+             FROM numbers(100)
+             SETTINGS output_format_native_use_flattened_dynamic_and_json_serialization = 1,
+                      output_format_native_encode_types_in_binary_format = 0
+             FORMAT Native" > "${USER_FILES_PATH}/${payload}"
 
 # Which thread serves a read is not fixed, so the pairs run several times over. Every read of a
 # time zone has to give that zone's rendering, and any other rendering shows up as an extra line.
 for _ in {1..8}; do
     $CLICKHOUSE_CLIENT --query "
+SET input_format_native_decode_types_in_binary_format = 0;
+
 SELECT 'dynamic tokyo', any(toString(d)) FROM file('${payload}', Native)
     SETTINGS session_timezone = 'Asia/Tokyo', max_threads = 1, schema_inference_use_cache_for_file = 0;
 SELECT 'dynamic utc', any(toString(d)) FROM file('${payload}', Native)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results where a `DateTime` or `DateTime64` stored in a `Dynamic` or `JSON` column was rendered in the time zone of an unrelated earlier session instead of the reading one, for parts written with `dynamic_serialization_version` `v1` or `v2`.


### Description

On a freshly started server both selects return `1970-01-01 09:00:00`; the second must return `1970-01-01 00:00:00`.

```sql
CREATE TABLE dv (d Dynamic) ENGINE = MergeTree ORDER BY tuple()
    SETTINGS dynamic_serialization_version = 'v2';
INSERT INTO dv SELECT toDateTime(0)::Dynamic FROM numbers(1000) SETTINGS session_timezone = 'UTC';
SELECT any(toString(d)) FROM dv SETTINGS session_timezone = 'Asia/Tokyo';
SELECT any(toString(d)) FROM dv SETTINGS session_timezone = 'UTC';
```

No non-default setting is needed: the version comes from the part, not the table setting, and `dynamic_serialization_version` defaulted to `v2` from 2025-08-18 to 2025-12-18. Present on master and 26.3, 26.6, 26.7, 26.8.

`v1` and `v2` persist variant types as names, rebuilt on read. A bare `DateTime` name carries no time zone, so the rebuilt type captures the ambient one; because these two sites took it from a name-keyed, thread-local, process-lifetime cache, every later session got the instance built by whichever session read that name first. `v3` decodes types per read and is unaffected. This is not the captured-zone behaviour `04927` pins but a capture owned by an unrelated session: it varies with read order, leaks across tables, and disagrees with `v3` on identical data. `04231` and `04927` still pass unchanged.

The two sites now use the simple type cache: it serves 23 parameterless zone-free names and builds anything else, so `DateTime`, `DateTime64` and composites are rebuilt per read while common variants keep memoization. It runs once per column per part read for wide parts, per granule for compact parts, never per row. The second site decodes the `Native` FLATTENED type list, affected the same way and fixed with it.

`DateTime64` and `Nullable(DateTime)` (stored as plain `DateTime`) were also wrong and are fixed. `Array`, `Tuple` and `Map` of `DateTime`, and an explicitly zoned `DateTime`, were already correct: the lookup matches only a top-level `DateTime`. Text format output was already correct and is unchanged; the test asserts it under two zones as a guard. `JSON` dynamic paths rebuild variant types through this same function (`SerializationDynamicElement.cpp:106`), so the `Dynamic` test covers them.

No issue exists; found while building an unrelated time zone regression test.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117285&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117285](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117285+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
