### PR TITLE
Do not run the per-test coverage tests with continuous-mode profiling

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -657,7 +657,10 @@ def main():
         # %c enables continuous mode: counters are memory-mapped into the file,
         # so the profile is valid at every instant instead of being written only
         # by an interruptible exit-time dump (see integration_test_job.py).
-        os.environ["LLVM_PROFILE_FILE"] = f"ft-{batch_num}-%c%2m.profraw"
+        # It also releases the static counter section to the OS, and per-test coverage reads
+        # that section in the server process, so the two modes are mutually exclusive.
+        profile_pattern = "%2m" if is_per_test_coverage else "%c%2m"
+        os.environ["LLVM_PROFILE_FILE"] = f"ft-{batch_num}-{profile_pattern}.profraw"
         if is_per_test_coverage:
             runner_options += " --collect-per-test-coverage"
         else:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -6133,7 +6133,10 @@ ORDER BY (test_name, callee_offset)
         if selftest_rows == 0:
             raise Exception(
                 "Coverage self-test FAILED: coverage_log has 0 rows for _selftest — "
-                "coverage mapping is not working (binary built without WITH_COVERAGE_DEPTH?)"
+                "read the coverageDiag tuples printed above: zero name_refs means the "
+                "static counters were not updated (LLVM_PROFILE_FILE with %c relocates "
+                "counter updates out of that section); non-zero name_refs with zero "
+                "non_empty_file_regions means no coverage region resolved them"
             )
         print(f"Coverage self-test: coverage_log rows for _selftest = {selftest_rows} (OK)")
         # Validate that the coverage mapping parser produced no bogus line numbers.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->

Related: https://github.com/ClickHouse/ClickHouse/pull/115623
Related: https://github.com/ClickHouse/ClickHouse/pull/116834


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The `per_test_coverage` lane has been publishing zero test results. On every `NightlyCoverage`
run since 2026-08-29, all 8 shards of `Stateless tests (amd_llvm_coverage_per_test,
per_test_coverage, N/8)` report only a job-level error, `The test runner was terminated
unexpectedly`. The lane published about 14,200 per-test rows per day through 2026-08-27 and 0
per day since, so any real failure in it is currently invisible. Report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ac95bf3cf20cdb4f08660d2b7dd27f915cd5abd0&name_0=NightlyCoverage&name_1=Stateless%20tests%20%28amd_llvm_coverage_per_test%2C%20per_test_coverage%2C%202%2F8%29

Root cause. Coverage runs ask for LLVM continuous mode by putting `%c` in `LLVM_PROFILE_FILE`.
Continuous mode points the counter bias at the memory-mapped `.profraw` and then calls
`lprofReleaseMemoryPagesToOS` on the static `__llvm_prf_cnts` section. Per-test coverage does not
consume `.profraw` at all: `getCurrentCoveredNameRefs` in `base/base/coverage.cpp` reads that
static section inside the server process, so it sees only zeroes, `system.coverage_log` stays
empty, and the fail-closed self-test in `tests/clickhouse-test` raises before any test runs. The
self-test is doing its job; the configuration is wrong.

`ci/jobs/scripts/clickhouse_proc.py` already skips the server profile file for per-test coverage,
but `ci/jobs/functional_tests.py` set `LLVM_PROFILE_FILE` unconditionally in the job process and
the server inherits it through `os.environ`, so that guard never took effect. The `%c` arrived in
#115623, and ancestry matches the onset: the last green nightly, `708305557adf`, does not contain
it, and all three broken ones do.

This drops `%c` only for the per-test lane. The regular `amd_llvm_coverage` lane keeps
`ft-{batch_num}-%c%2m.profraw` byte for byte, because it does merge `.profraw` and does want a
profile that survives a kill. No compile flag changes: `-mllvm -runtime-counter-relocation` is
inert without `%c`, measured rather than assumed.

I also extended the self-test's diagnostic, which previously blamed only a missing
`WITH_COVERAGE_DEPTH`; that is the one cause not in play here, and why the real cause was
initially ruled out.

This lane is scheduled only by `ci/workflows/nightly_coverage.py`, so PR CI cannot exercise it;
it is validated locally instead.

<details>
<summary>Local validation (click to expand)</summary>

A per-test coverage build (`-DWITH_COVERAGE=ON -DWITH_COVERAGE_DEPTH=ON`, `clang-22`), running
`SELECT coverageDiag(); SYSTEM SET COVERAGE TEST '_selftest'; SELECT 1; SYSTEM SET COVERAGE TEST ''; SELECT coverageDiag();`

| `LLVM_PROFILE_FILE` | `coverageDiag` before | after |
|---|---|---|
| `ft-2-%c%2m.profraw` (before this change) | `[35,2839830,33,33,0,...]` | `[0,2839830,0,0,0,0]` |
| `ft-2-%2m.profraw` (after this change) | `[11038,2839830,10740,10740,0,...]` | `[7441,2839830,6962,6962,0,...]` |

The first row is what the failing nightly reports, `coverageDiag=[0,2839830,0,0,0,0]`; the second
matches the last healthy nightly. Tuple order is `(name_refs, map_size, matches,
non_empty_file_regions, zero_line_regions, first_file_len_and_line)`. `map_size` is identical
throughout, so `-fcoverage-mapping` and the mapping parser were never the problem; only the
counter-derived fields were affected.

Separately, a standalone program compiled with the same coverage flags reads 0 non-zero counters
out of its static section under `%c` and 8 out of 9 without it, and a control built without
`-mllvm -runtime-counter-relocation` reads them fine under both settings. With `%c` absent,
`__llvm_profile_reset_counters` also still clears the static section, which per-test attribution
depends on.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117288&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117288](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117288+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.604` (included in `26.9` and later)
<!-- ch-version-info:end -->