### PR TITLE
Collect the full diagnostics when a stateless job fails during setup

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1502,7 +1502,10 @@ def main():
     # The collect-logs gate must see the run's real outcome, or a bugfix
     # validation job that reproduced a crash would attach neither its cores nor
     # its full logs.
-    test_run_failed = bool(test_result) and not test_result.is_ok()
+    # A setup failure never reaches the test stage, so `test_result` stays None
+    # and a predicate reading it alone sees "nothing failed".
+    setup_failed = test_result is None and not res
+    test_run_failed = (bool(test_result) and not test_result.is_ok()) or setup_failed
 
     # invert result status for bugfix validation
     bugfix_validation_no_repro = False

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1,4 +1,5 @@
 import glob
+import io
 import os
 import platform
 import shlex
@@ -32,6 +33,7 @@ class ClickHouseProc:
     KAFKA_LOG = f"{temp_dir}/kafka.log"
     LOGS_SAVER_CLIENT_OPTIONS = "--max_memory_usage 10G --max_threads 1 --max_rows_to_read=0 --max_result_rows 0 --max_result_bytes 0 --max_bytes_to_read 0 --max_execution_time 0 --max_execution_time_leaf 0 --max_estimated_execution_time 0"
     DMESG_LOG = f"{temp_dir}/dmesg.log"
+    DMESG_AT_COLLECT_LOG = f"{temp_dir}/dmesg.at-collect.log"
     # TODO: run servers in  dedicated wds to keep trash localised
     WD0 = f"{temp_dir}/ft_wd0"
     WD1 = f"{temp_dir}/ft_wd1"
@@ -544,6 +546,30 @@ class ClickHouseProc:
     # Grace period between the TERM the bound sends and the KILL that follows,
     # so a client that ignores TERM is still bounded.
     PREP_STEP_KILL_AFTER_S = 60
+    # TERM deadline for one all-thread backtrace capture (seconds).
+    STACK_CAPTURE_TIMEOUT_S = 300
+
+    def _capture_server_stacks(self, tag):
+        """Write an all-thread backtrace of each running server into `log_dir`.
+
+        A wedged server cannot report its own threads: `system.stack_trace`
+        needs a responsive server and the fault handler needs the machinery the
+        wedge has already stopped. An external debugger needs neither.
+        """
+        for pid in (self.pid_0, self.pid_1, self.pid_2):
+            if not pid:
+                continue
+            # gdb exits 0 even when the attach is refused, so its stderr goes
+            # into the same file: the artifact explains its own emptiness.
+            out = f"{self.log_dir}/{tag}-stacks-{pid}.log"
+            Shell.check(
+                f"timeout --verbose --signal=TERM"
+                f" --kill-after={self.PREP_STEP_KILL_AFTER_S}"
+                f" {self.STACK_CAPTURE_TIMEOUT_S}"
+                f" gdb -batch -ex 'thread apply all backtrace' -p {pid}"
+                f" > {out} 2>&1",
+                verbose=True,
+            )
 
     @classmethod
     def prep_timeout_prefix(cls, step_timeout):
@@ -578,6 +604,10 @@ class ClickHouseProc:
         is_sanitizer = any(
             san in sanitizer_source for san in ("asan", "tsan", "msan", "ubsan")
         )
+        # Attaching a debugger to an ASan build disables LeakSanitizer, so the
+        # capture below is skipped there. Both in-tree ubsan build names contain
+        # "asan"; the alternative only covers names outside this repository's defs.
+        is_asan = any(san in sanitizer_source for san in ("asan", "ubsan"))
         max_insert_threads = 4 if is_sanitizer else 16
         command = """
 set -e
@@ -643,17 +673,25 @@ $PREP_TIMEOUT clickhouse-client --query "SELECT count() FROM test.visits"
         log_file = f"{temp_dir}/prepare_stateful_data.log"
         rc = Shell.run(command, log_file=log_file, verbose=True)
         if rc != 0:
-            tail = ""
+            log_text = ""
             try:
                 with open(log_file, errors="ignore") as f:
-                    tail = "".join(f.readlines()[-15:]).strip()
+                    log_text = f.read()
             except OSError:
                 pass
+            tail = "".join(io.StringIO(log_text).readlines()[-15:]).strip()
             self.stateful_setup_error = (
                 f"stateful data prep failed (exit {rc})"
                 + (f": {tail}" if tail else "")
             )
             print(f"ERROR: {self.stateful_setup_error}")
+            if self._timeout_wrapper_expired(rc, log_text):
+                if is_asan:
+                    print(
+                        "Cannot collect C stacktraces under ASan: debugger attach is disabled."
+                    )
+                else:
+                    self._capture_server_stacks("stateful-prep")
         return rc == 0
 
     def insert_system_zookeeper_config(self):
@@ -813,8 +851,20 @@ $PREP_TIMEOUT clickhouse-client --query "SELECT count() FROM test.visits"
                     res.append(self.AZURITE_LOG)
                 if Path(self.KAFKA_LOG).exists():
                     res.append(self.KAFKA_LOG)
-                if Path(self.DMESG_LOG).exists():
-                    res.append(self.DMESG_LOG)
+                # `start` clears the ring buffer, so a dump after it holds only
+                # this server generation; before `start` it can hold earlier
+                # host lines. The OOM check grades the file it writes.
+                dmesg_target = (
+                    self.DMESG_AT_COLLECT_LOG
+                    if Path(self.DMESG_LOG).exists()
+                    else self.DMESG_LOG
+                )
+                if not Shell.check(f"dmesg > {dmesg_target}", verbose=True):
+                    print("WARNING: dmesg not enabled")
+                    Path(dmesg_target).unlink(missing_ok=True)
+                for dmesg_log in (self.DMESG_LOG, self.DMESG_AT_COLLECT_LOG):
+                    if Path(dmesg_log).exists():
+                        res.append(dmesg_log)
                 if Path(self.CH_LOCAL_ERR_LOG).exists():
                     res.append(self.CH_LOCAL_ERR_LOG)
                 if Path(self.CH_LOCAL_LOG).exists():
@@ -1153,12 +1203,17 @@ $PREP_TIMEOUT clickhouse-client --query "SELECT count() FROM test.visits"
     # after --kill-after; it proves a 137 came from the wrapper itself rather
     # than from an external/OOM SIGKILL of `clickhouse local`.
     _TIMEOUT_KILL_DIAG = "sending signal KILL to command"
+    # The same, for the initial SIGTERM. 124 is also the ClickHouse error code
+    # `INCORRECT_ELEMENT_OF_SET`, so the code alone proves nothing. Quote-free
+    # on purpose: `timeout` quotes the command name locale-dependently.
+    _TIMEOUT_TERM_DIAG = "sending signal TERM to command"
 
     def _timeout_wrapper_expired(self, res, stderr):
-        # 124: the child died on timeout's initial SIGTERM - always an expiry.
-        # 137 (128+9): any SIGKILL death; trust it as an expiry only when
-        # timeout's own KILL diagnostic is present in stderr.
-        return res == 124 or (res == 137 and self._TIMEOUT_KILL_DIAG in stderr)
+        # Both codes are ambiguous on their own (137 is any SIGKILL death), so
+        # each is trusted only alongside timeout's own diagnostic.
+        return (res == 124 and self._TIMEOUT_TERM_DIAG in stderr) or (
+            res == 137 and self._TIMEOUT_KILL_DIAG in stderr
+        )
 
     def _annotate_timeout(self, res, stderr):
         # Prepend the "timed out" annotation only to proven wrapper expiries,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110321#issuecomment-5471356428
Related: https://github.com/ClickHouse/ClickHouse/pull/115585


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A stateless job that fails during setup now uploads the same diagnostics as one that fails during tests.


### Description

`Stateless tests (amd_tsan, flaky check)` on #110321 failed before any test ran:
`prepare_stateful_data` hit its per-statement bound on
`INSERT INTO test.hits_s3 SELECT * FROM test.hits`
([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110321&sha=2def28ac1fbdc8166d4e6c37c00ab830b4248148&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20flaky%20check%29)).
Its diagnostics were then discarded. `@ alexey-milovidov` asked me for a separate PR.

`functional_tests.py` assigns `test_result` only inside the test stage, so a setup failure
leaves it `None`, `test_run_failed` reads `False`, and `prepare_logs` runs with `all=False` -
dropping cores, system-table dumps, the SeaweedFS log, dmesg and Keeper logs, for exactly
the runs that cannot explain themselves. Here `job.log` logs `send TRAP signal to generate core
file` and `Collect logs` in the same second. The shape covers 45+ stateless runs in 30 days.
#115585 got such a job to reach `Collect logs`; this makes it collect.

Four changes, all under `ci/`:

- capture `gdb -batch -ex 'thread apply all backtrace'` into the log directory when a prep
  statement hits its bound; skipped on ASan lanes, where the attach disables LeakSanitizer;
- require `timeout`'s own TERM diagnostic before trusting exit 124, which is also the
  error code `INCORRECT_ELEMENT_OF_SET`;
- count a setup failure as a failure in the artifact-collection predicate;
- run `dmesg` in the full-collection path, where nothing did: a setup failure gains
  `dmesg.log`, and a run whose OOM check already graded one gains `dmesg.at-collect.log`
  beside it, because `start` clears the buffer per server generation.

Green runs are unchanged.

**This does not fix the hang**; it makes the next occurrence diagnosable. Also not
fixed: the fatal-log scan still skips setup failures; a failure before `start` dumps an
uncleared ring buffer; `stop_server` still waits 10 s after `SIGTRAP`, so a core may not
survive; the gdb attach is argued from container flags, not measured in-container; ASan lanes
get no stacks. `#109745` edits the same function without overlap.

<details><summary>The hang this PR does not fix</summary>

Measured from the job's own `clickhouse-server.log`. The INSERT
(`22411ddf-da0f-4f93-90b6-c4a06af00f93`) progresses normally for 35.4 s, writing blocks and
completing S3 uploads at 8.00 GiB of tracked memory against an 85.25 GiB cap. Then the server
emits nothing at all for 62.0 min, from any of the 186 threads that had ever logged, and the
last line of the log is an unfinished `SystemLog (system.query_metric_log): Flushing system
log`. Of 18 system logs, only `metric_log` and `query_metric_log` have an unmatched
`Flushing`. `--max_execution_time 1800` never fired, so the query threads were blocked rather
than slow; `SYSTEM FLUSH LOGS` afterwards returned `Code: 209 SOCKET_TIMEOUT` after the full
300 s receive timeout; `SIGTERM` was ignored for 300 s. TERM landed at exactly +3150 s, the
bound from #115585, to the second.

Truncation is ruled out: the file ends on a complete line at 3.43 MB with no `.zst` sibling,
and jobs at the same commit uploaded 59.7 MB and 9.96 MB logs spanning their full durations.
Same-commit, same-binary controls for the identical statement: `amd_tsan parallel` 133 s,
`amd_tsan sequential` 277 s, `amd_asan_ubsan flaky check` 789 s, against >3150 s here.

A merely slow INSERT logs continuously. A server that answers no new query is globally
blocked, and naming the mechanism needs a thread stack, which no occurrence has produced -
7 in 90 days, none with a core or a `fatal.log`. That is what this PR adds.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117294&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117294](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117294+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
