### PR TITLE
Skip Darwin fast test in PRs unless labeled ci-macos

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -61,6 +61,11 @@ FUNCTIONAL_TEST_FLAKY_CHECK_JOBS = [
     "Stateless tests (amd_binary, flaky check)",
 ]
 
+# The Darwin (macOS) "Fast test" jobs, resolved to their parametrized names
+# (e.g. "Fast test (arm_darwin)"). They run on scarce self-hosted macOS runners,
+# so in PRs they are skipped unless the PR carries the `ci-macos` label.
+DARWIN_FAST_TEST_JOBS = [j.name for j in JobConfigs.darwin_fast_test_jobs]
+
 # Must match ci.workflows.pull_request.KEEPER_STRESS_PR_NAME
 KEEPER_STRESS_PR_NAME = "Keeper Stress Tests (PR)"
 
@@ -166,6 +171,10 @@ _PIPELINE_NOTES = {
     Labels.CI_NO_COVERAGE: (
         "Label `ci-no-coverage` skips coverage jobs and the `LLVM Coverage` merge job."
     ),
+    Labels.CI_MACOS: (
+        "Label `ci-macos` runs the Darwin (macOS) `Fast test` job, which is "
+        "skipped by default in PRs."
+    ),
 }
 
 
@@ -261,6 +270,16 @@ def should_skip_job(job_name):
                 "Skipped, no changes in src/Coordination, tests/stress/keeper, or keeper_stress_job.py",
             )
         return False, ""
+
+    # The Darwin (macOS) fast test runs on scarce self-hosted macOS runners, so
+    # in PRs it runs only when explicitly requested via the `ci-macos` label.
+    # Master has no such job, so this gate is a no-op there.
+    if (
+        job_name in DARWIN_FAST_TEST_JOBS
+        and _info_cache.pr_number
+        and Labels.CI_MACOS not in _info_cache.pr_labels
+    ):
+        return True, f"Skipped, not labeled with '{Labels.CI_MACOS}'"
 
     if (
         Labels.CI_BUILD in _info_cache.pr_labels

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -92,6 +92,9 @@ class Labels:
     CI_FUNCTIONAL = "ci-functional-test"
     CI_TOOLCHAIN = "ci-toolchain"
     CI_NO_COVERAGE = "ci-no-coverage"
+    # Gates the Darwin (macOS) "Fast test" job in PRs; it is skipped unless this
+    # label is applied. See DARWIN_FAST_TEST_JOBS in filter_job.py.
+    CI_MACOS = "ci-macos"
 
     # Gates the PromQL compliance dedicated job + PR comment (see promql_compliance_job.py).
     COMP_PROMQL = "comp-promql"


### PR DESCRIPTION
Skip the Darwin (macOS) `Fast test` job in pull requests unless the PR carries the new `ci-macos` label. The job runs on scarce self-hosted macOS runners, so gating it keeps them free for PRs that actually need macOS coverage. This mirrors the existing label-gated jobs such as `ci-toolchain`.

- Adds the `ci-macos` label constant (`Labels.CI_MACOS`).
- `should_skip_job` skips the Darwin fast test job(s) when the PR is missing the `ci-macos` label; guarded on `pr_number` so it is a no-op on master (which has no such job).
- Adds a pipeline note explaining the label.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117295&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117295](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117295+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
