### PR TITLE
ci: ignore uknown config directives for upgrade check (fixes upgrade check)

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -112,6 +112,12 @@ function configure()
     #
     /repo/tests/config/install.sh /etc/clickhouse-server /etc/clickhouse-client --no-keeper-inject-auth --no-remote-database-disk "$@"
 
+    # These jobs mix config drop-ins and binaries of different versions (the upgrade
+    # check boots the previous release with the current repo's configs) - an unknown
+    # config option is expected here and must not prevent the server from starting.
+    echo "<clickhouse><skip_check_for_incorrect_settings>1</skip_check_for_incorrect_settings></clickhouse>" \
+        > /etc/clickhouse-server/config.d/skip_check_for_incorrect_settings.xml
+
     # avoid too slow startup
     sudo cat /etc/clickhouse-server/config.d/keeper_port.xml \
       | sed "s|<snapshot_distance>100000</snapshot_distance>|<snapshot_distance>10000</snapshot_distance>|" \


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116903&sha=latest&name_0=PR&name_1=Upgrade+check+%28amd_release%29
Conflict between https://github.com/ClickHouse/ClickHouse/pull/112667 and #100332

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
ci: ignore uknown config directives for upgrade check

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117300&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117300](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117300+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.462` (included in `26.9` and later)
<!-- ch-version-info:end -->