### PR TITLE
Retry docker buildx on a registry status failure regardless of the request method

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -247,7 +247,9 @@ BUILDX_RETRIES = 2
 BUILDX_RETRY_ERRORS = [
     # Docker registry (docker.io / registry-1.docker.io)
     "failed to do request",
-    "unexpected status from HEAD request",
+    # One containerd error, formatted `unexpected status from <method> request to <url>:
+    # <status>`, so the method is an interpolated field and not part of the failure.
+    "unexpected status from ",
     "500 Internal Server Error",
     "502 Bad Gateway",
     "503 Service Unavailable",


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114975#issuecomment-5474152420
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Retry `docker buildx` when the registry answers with a non-2xx status for any request method, not only `HEAD`.

### Description

`Docker keeper image` failed resolving `alpine:latest` and `ubuntu:22.04` from Docker Hub with `httpReadSeeker: failed open: unexpected status from GET request to ...: 400 Bad Request`. The retry did not fire: `No retryable errors found, stopping retries`, `command failed after 1/2 attempt(s)`.

`BUILDX_RETRY_ERRORS` carried `unexpected status from HEAD request`, and its status-code entries are 429/5xx only, so nothing matched a 400 on a `GET`. The method is an interpolated field of one containerd format string, `unexpected status from %s request to %s: %s`, so pinning it covered only the method observed then. I replace it with the method-agnostic prefix, a strict superset of the entry it replaces, so nothing retried today stops being retried.

A second attempt would have worked: the failing leg died at metadata resolution after 951 s, while `head-alpine-arm64`, same platform and base images, resolved both fresh 9 s later.

Trade-off: the token also accepts a permanent 4xx. That is bounded by `BUILDX_RETRIES = 2`, is already the status quo for `HEAD`, and `buildx_timeout` already divides the job budget by 2 attempts. Allowlisting "transient" status codes is unsound here, since the observed 400 was itself transient.

Footprint over 45 days: 6 job runs across both docker image jobs and three workflows, none on master. The `Failed to fetch` apt-mirror class is a different, already-handled signature.

Validation: replaying the captured stderr through `Shell.run` reproduces the CI lines byte-for-byte, and reaches `2/2 attempt(s)` with the change; changing only `GET` to `HEAD` makes master's own list retry it. Permanent failures still fail fast.

`ci/praktika/docker.py` holds separate, deliberately narrower retry lists for other jobs; none matches this error, and CIDB shows no occurrence of it there. Its `merge_manifest` has no retries at all.

No related open issue found.

Related: https://github.com/ClickHouse/ClickHouse/pull/114975#issuecomment-5474152420
CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114975&sha=42581e0c27fdd48645f31bdb01747e2c06d8d98b&name_0=PR&name_1=Docker%20keeper%20image

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117301&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117301](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117301+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
