### PR TITLE
Attach the correlated-subquery set builder below the materialized CTE steps

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -3,6 +3,7 @@
 #include <Processors/QueryPlan/CreatingSetsStep.h>
 #include <Processors/QueryPlan/Optimizations/Cascades/Optimizer.h>
 #include <Processors/QueryPlan/IQueryPlanStep.h>
+#include <Processors/QueryPlan/MaterializingCTEStep.h>
 #include <Processors/QueryPlan/MergingAggregatedStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
@@ -280,20 +281,38 @@ void optimizeTreeSecondPass(
             optimizeUnusedCommonSubplans(frame_node);
         });
 
-        /// A single builder above the root dominates every copy of a materialized subplan, so each set
-        /// is ready before any copy's `in()` is evaluated, regardless of join kind, join algorithm or
+        /// A single builder that dominates every copy of a materialized subplan makes each set ready
+        /// before any copy's `in()` is evaluated, regardless of join kind, join algorithm or
         /// scheduling. Every extracted set must be re-attached: a set with no builder left in the plan
         /// stays unbuilt, and `FunctionIn` then reports it as not ready.
         if (!materialized_sets.empty())
         {
+            /// Below every `DelayedMaterializingCTEsStep` on the spine, where
+            /// `addBuildSubqueriesForSetsStepIfNeeded` already puts the plan's own builder: a set whose
+            /// source reads a materialized CTE has to be built after it. Only single-child nodes are
+            /// descended, so every copy stays below the insertion point.
+            QueryPlan::Node * parent = nullptr;
+            QueryPlan::Node * child = &root;
+            for (auto * spine = &root; spine->children.size() == 1; spine = spine->children.front())
+                if (typeid_cast<DelayedMaterializingCTEsStep *>(spine->step.get()))
+                {
+                    parent = spine;
+                    child = spine->children.front();
+                }
+
             auto step = std::make_unique<DelayedCreatingSetsStep>(
-                root.step->getOutputHeader(),
+                child->step->getOutputHeader(),
                 std::move(materialized_sets),
                 optimization_settings.network_transfer_limits,
                 optimization_settings.prepared_sets_cache);
 
-            auto * child = &nodes.emplace_back(std::move(root));
-            root = QueryPlan::Node{std::move(step), {child}};
+            if (parent)
+                parent->children.front() = &nodes.emplace_back(QueryPlan::Node{std::move(step), {child}});
+            else
+            {
+                auto * old_root = &nodes.emplace_back(std::move(root));
+                root = QueryPlan::Node{std::move(step), {old_root}};
+            }
         }
     }
 

--- a/tests/queries/0_stateless/05029_correlated_subquery_materialized_in_set.reference
+++ b/tests/queries/0_stateless/05029_correlated_subquery_materialized_in_set.reference
@@ -75,3 +75,42 @@ FROM (EXPLAIN PLAN SELECT (SELECT x) FROM (SELECT arrayJoin([1, 2, 3]) AS x GROU
 SELECT countIf(explain LIKE '%CreatingSet (Create set for subquery)%') AS builders, countIf(explain LIKE '%DelayedCreatingSets%') AS placeholders, countIf(explain LIKE '%CreatingSets (Create sets before main query execution)%') AS set_gates
 FROM (EXPLAIN PLAN SELECT (SELECT x) FROM (SELECT arrayJoin([1, 2, 3]) AS x GROUP BY x, x IN (SELECT 2)) SETTINGS correlated_subqueries_use_in_memory_buffer = 0, correlated_subqueries_default_join_kind = 'left');
 1	0	1
+-- A set whose source reads a MATERIALIZED CTE must be built after the CTE is materialized. The set
+-- gate is attached over the whole plan, so it has to stay under the CTE gate.
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 0;
+1	0
+2	1
+3	0
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 1;
+1	0
+2	1
+3	0
+-- A non-right decorrelation join kind takes the same path with the buffer setting left at its default.
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) ORDER BY s
+SETTINGS correlated_subqueries_default_join_kind = 'left';
+1	0
+2	1
+3	0
+-- The same CTE read both inside the duplicated body and outside it: one writer, readers on both
+-- sides of the set gate.
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) AS t WHERE s IN (SELECT y FROM mat) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 0;
+2	1
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) AS t WHERE s IN (SELECT y FROM mat) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 1;
+2	1
+-- The ordering is structural: the CTE gate stays at the plan root, matched without a leading
+-- wildcard because only the root step is unindented, and the set gate sits under it.
+SELECT countIf(explain LIKE 'MaterializingCTEs%') AS cte_gate_at_root, countIf(explain LIKE '%CreatingSets (Create sets before main query execution)%') AS set_gates
+FROM (EXPLAIN PLAN WITH mat AS MATERIALIZED (SELECT 2 AS y) SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) SETTINGS correlated_subqueries_use_in_memory_buffer = 0);
+1	1
+SELECT countIf(explain LIKE 'MaterializingCTEs%') AS cte_gate_at_root, countIf(explain LIKE '%CreatingSets (Create sets before main query execution)%') AS set_gates
+FROM (EXPLAIN PLAN WITH mat AS MATERIALIZED (SELECT 2 AS y) SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) SETTINGS correlated_subqueries_use_in_memory_buffer = 1);
+1	1

--- a/tests/queries/0_stateless/05029_correlated_subquery_materialized_in_set.sql
+++ b/tests/queries/0_stateless/05029_correlated_subquery_materialized_in_set.sql
@@ -10,6 +10,7 @@
 
 SET enable_analyzer = 1;
 SET allow_experimental_correlated_subqueries = 1;
+SET enable_materialized_cte = 1;
 
 -- { echoOn }
 
@@ -65,5 +66,38 @@ FROM (EXPLAIN PLAN SELECT (SELECT x) FROM (SELECT arrayJoin([1, 2, 3]) AS x GROU
 
 SELECT countIf(explain LIKE '%CreatingSet (Create set for subquery)%') AS builders, countIf(explain LIKE '%DelayedCreatingSets%') AS placeholders, countIf(explain LIKE '%CreatingSets (Create sets before main query execution)%') AS set_gates
 FROM (EXPLAIN PLAN SELECT (SELECT x) FROM (SELECT arrayJoin([1, 2, 3]) AS x GROUP BY x, x IN (SELECT 2)) SETTINGS correlated_subqueries_use_in_memory_buffer = 0, correlated_subqueries_default_join_kind = 'left');
+
+-- A set whose source reads a MATERIALIZED CTE must be built after the CTE is materialized. The set
+-- gate is attached over the whole plan, so it has to stay under the CTE gate.
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 0;
+
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 1;
+
+-- A non-right decorrelation join kind takes the same path with the buffer setting left at its default.
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) ORDER BY s
+SETTINGS correlated_subqueries_default_join_kind = 'left';
+
+-- The same CTE read both inside the duplicated body and outside it: one writer, readers on both
+-- sides of the set gate.
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) AS t WHERE s IN (SELECT y FROM mat) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 0;
+
+WITH mat AS MATERIALIZED (SELECT 2 AS y)
+SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) AS t WHERE s IN (SELECT y FROM mat) ORDER BY s
+SETTINGS correlated_subqueries_use_in_memory_buffer = 1;
+
+-- The ordering is structural: the CTE gate stays at the plan root, matched without a leading
+-- wildcard because only the root step is unindented, and the set gate sits under it.
+SELECT countIf(explain LIKE 'MaterializingCTEs%') AS cte_gate_at_root, countIf(explain LIKE '%CreatingSets (Create sets before main query execution)%') AS set_gates
+FROM (EXPLAIN PLAN WITH mat AS MATERIALIZED (SELECT 2 AS y) SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) SETTINGS correlated_subqueries_use_in_memory_buffer = 0);
+
+SELECT countIf(explain LIKE 'MaterializingCTEs%') AS cte_gate_at_root, countIf(explain LIKE '%CreatingSets (Create sets before main query execution)%') AS set_gates
+FROM (EXPLAIN PLAN WITH mat AS MATERIALIZED (SELECT 2 AS y) SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1, 2, 3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) SETTINGS correlated_subqueries_use_in_memory_buffer = 1);
 
 -- { echoOff }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/115868
Related: https://github.com/ClickHouse/ClickHouse/issues/116343
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `Reading from materialized CTE ... DelayedPortsProcessor gate is missing` logical error when a correlated subquery's `IN` subquery reads a `MATERIALIZED` CTE and the decorrelated body is duplicated, which `correlated_subqueries_use_in_memory_buffer = 0` and `correlated_subqueries_default_join_kind = 'left'` each cause.


### Description

Reported by @ zlareb1 on https://github.com/ClickHouse/ClickHouse/pull/115868#issuecomment-5473051838. Related: https://github.com/ClickHouse/ClickHouse/issues/116343.

**What breaks.** With `enable_materialized_cte = 1`, a valid query is rejected with `Code: 49 ... DelayedPortsProcessor gate is missing in the query plan`:

```sql
WITH mat AS MATERIALIZED (SELECT 2 AS y)
SELECT * FROM (SELECT (SELECT x) AS s, m FROM (SELECT arrayJoin([1,2,3]) AS x, x IN (SELECT y FROM mat) AS m GROUP BY x, m)) ORDER BY s
SETTINGS correlated_subqueries_use_in_memory_buffer = 0;
```

**Root cause.** When a decorrelated body is duplicated, `optimizeTreeSecondPass` takes the `IN` sets out of the fragments and re-attaches one `DelayedCreatingSetsStep` above the plan root. With a top-level `MATERIALIZED` CTE, that root is the `DelayedMaterializingCTEsStep` chain, so the set builder lands above the CTE gate. Both steps schedule through `addPipelineBefore`, so the set plans run before the CTE writer, while `makePlansForSets` has already stripped the set plan's own gate on the premise that the outer gate dominates it. Its source then reads an unmaterialized `StorageMemory`.

**The change.** Attach the builder below every `DelayedMaterializingCTEsStep` on the plan's single-child spine, which is where `Planner.cpp` already puts the plan's own set builder. With no materialized CTE on the spine the behaviour is unchanged.

**Validation.** Both settings above reproduce the logical error before the fix and pass after it; the `buffer = 1` control is unchanged. Seven arms were added to `05029_correlated_subquery_materialized_in_set`, one a structural `EXPLAIN PLAN` arm pinning the CTE gate at the root. They abort a pre-fix debug server and pass 100/100 randomized runs after it. `make_distributed_plan = 1` clears the same flag and reaches the same hoist, but every shape measured under it is rejected before execution with `SUPPORT_IS_DISABLED`, identically with and without this change, so it gets no arm.

Different seam from #113489, which changes only the in-place set build, not the attachment point.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117311&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117311](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117311+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
