### PR TITLE
CI: ignore unknown keys in Result.from_dict

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -477,6 +477,9 @@ class Result(MetaClasses.Serializable):
             sub_res = cls.from_dict(result_dict)
             sub_results.append(sub_res)
         obj["results"] = sub_results
+        # Ignore unknown keys to avoid NBC on field removal
+        known_fields = {f.name for f in dataclasses.fields(cls)}
+        obj = {k: v for k, v in obj.items() if k in known_fields}
         return Result(**obj)
 
     def update_duration(self):


### PR DESCRIPTION
Make `Result.from_dict` tolerant of unknown keys by filtering the deserialized dict down to the dataclass fields before constructing the `Result`.

This avoids a backward-compatibility break when a field is removed from `Result`: older serialized results that still carry the removed field can be deserialized instead of raising a `TypeError` for an unexpected keyword argument.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117312&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117312](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117312+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.441` (included in `26.9` and later)
<!-- ch-version-info:end -->