### PR TITLE
Count hash join matches even when the probe emits no right column

### DIFF
--- a/src/Interpreters/HashJoin/AddedColumns.cpp
+++ b/src/Interpreters/HashJoin/AddedColumns.cpp
@@ -442,6 +442,10 @@ void AddedColumns<true>::appendFromBlock(UInt64 ref_word, bool)
     {
         lazy_output.addRef(ref_word);
     }
+    else
+    {
+        lazy_output.countMatch(ref_word);
+    }
 }
 
 }

--- a/src/Interpreters/HashJoin/AddedColumns.h
+++ b/src/Interpreters/HashJoin/AddedColumns.h
@@ -111,6 +111,10 @@ struct LazyOutput
         hash_table_matches += rows;
     }
 
+    /// Ref-free counterpart of `addRef`: the match count is independent of ref retention, so it
+    /// stays exact for a probe that emits no right column and therefore keeps no refs.
+    void countMatch(UInt64 ref_word) { hash_table_matches += refWordRows(ref_word); }
+
     void addDefault()
     {
         row_refs.emplace_back(0);

--- a/tests/queries/0_stateless/04054_hash_join_with_row_store.reference
+++ b/tests/queries/0_stateless/04054_hash_join_with_row_store.reference
@@ -6,6 +6,15 @@ rs_disabled_by_planner	0
 --- Hash table matches feedback loop test ---
 rs_collect_runtime_stats	1
 rs_disabed_by_runtime_stats	0
+--- Hash table matches recorded by a probe that emits no right column ---
+rs_hash_1_warm	1
+rs_hash_2_no_emit_probe	0
+rs_hash_3_after_no_emit_probe	1
+rs_hash_4_row_store_off	0
+rs_par_1_warm	1
+rs_par_2_no_emit_probe	0
+rs_par_3_after_no_emit_probe	1
+rs_par_4_row_store_off	0
 --- INNER JOIN ---
 7	2024-01-01 00:00:07	7	0	0	0
 7	2024-01-01 00:00:07	7	\N	5	dup

--- a/tests/queries/0_stateless/04054_hash_join_with_row_store.reference
+++ b/tests/queries/0_stateless/04054_hash_join_with_row_store.reference
@@ -15,6 +15,13 @@ rs_par_1_warm	1
 rs_par_2_no_emit_probe	0
 rs_par_3_after_no_emit_probe	1
 rs_par_4_row_store_off	0
+--- Hash table matches counted per matched row, not per matched key ---
+rs_dup_hash_1_warm	1
+rs_dup_hash_2_no_emit_probe	0
+rs_dup_hash_3_after_no_emit_probe	1
+rs_dup_par_1_warm	1
+rs_dup_par_2_no_emit_probe	0
+rs_dup_par_3_after_no_emit_probe	1
 --- INNER JOIN ---
 7	2024-01-01 00:00:07	7	0	0	0
 7	2024-01-01 00:00:07	7	\N	5	dup

--- a/tests/queries/0_stateless/04054_hash_join_with_row_store.sql
+++ b/tests/queries/0_stateless/04054_hash_join_with_row_store.sql
@@ -147,6 +147,50 @@ ORDER BY log_comment;
 DROP TABLE right_wide_ph;
 DROP TABLE right_wide;
 
+SELECT '--- Hash table matches counted per matched row, not per matched key ---';
+
+-- A key carrying several right rows separates the number of matched rows from the number of matched
+-- keys, so these arms also pin which of the two is recorded. The right table holds 500 keys of 40
+-- rows over a 20000 row build side, and 5000 probe rows match 200000 right rows, so at ratio 2 the
+-- row store needs 40000 matches: a per-row count reaches it and a per-key count of 5000 does not.
+
+CREATE TABLE right_dup (k UInt64, v1 Int64, v2 UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO right_dup SELECT number % 500, number, number FROM numbers(20000);
+
+-- Separate table for `parallel_hash`: `join_algorithm` is not part of the match stats cache key.
+CREATE TABLE right_dup_ph (k UInt64, v1 Int64, v2 UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO right_dup_ph SELECT number % 500, number, number FROM numbers(20000);
+
+SELECT r.v1, r.v2 FROM (SELECT number % 500 AS k FROM numbers(5000)) p JOIN right_dup r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 0, log_comment = 'rs_dup_hash_1_warm';
+
+SELECT count() FROM (SELECT number % 500 AS k FROM numbers(5000)) p JOIN right_dup r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_dup_hash_2_no_emit_probe';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 500 AS k FROM numbers(5000)) p JOIN right_dup r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_dup_hash_3_after_no_emit_probe';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 500 AS k FROM numbers(5000)) p JOIN right_dup_ph r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'parallel_hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 0, log_comment = 'rs_dup_par_1_warm';
+
+SELECT count() FROM (SELECT number % 500 AS k FROM numbers(5000)) p JOIN right_dup_ph r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'parallel_hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_dup_par_2_no_emit_probe';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 500 AS k FROM numbers(5000)) p JOIN right_dup_ph r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'parallel_hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_dup_par_3_after_no_emit_probe';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT log_comment, ProfileEvents['JoinBuildRowStoreMicroseconds'] > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND event_date >= yesterday()
+  AND log_comment IN ('rs_dup_hash_1_warm', 'rs_dup_hash_2_no_emit_probe', 'rs_dup_hash_3_after_no_emit_probe',
+                      'rs_dup_par_1_warm', 'rs_dup_par_2_no_emit_probe', 'rs_dup_par_3_after_no_emit_probe')
+ORDER BY log_comment;
+
+DROP TABLE right_dup_ph;
+DROP TABLE right_dup;
+
 -- Keep the row store enabled regardless of cardinality estimates.
 SET min_rows_ratio_for_hash_join_row_store = 0;
 

--- a/tests/queries/0_stateless/04054_hash_join_with_row_store.sql
+++ b/tests/queries/0_stateless/04054_hash_join_with_row_store.sql
@@ -95,6 +95,58 @@ WHERE event_date >= yesterday() AND query_id IN (
     SELECT query_id FROM system.query_log
     WHERE current_database = currentDatabase() AND log_comment = 'rs_disabed_by_runtime_stats' AND type = 'QueryFinish');
 
+SELECT '--- Hash table matches recorded by a probe that emits no right column ---';
+
+-- A probe that emits no right column, such as `SELECT count()`, matches the same right rows as the
+-- full output query and must record the same number of matches. Otherwise it lowers the cached match
+-- count for the identical join, and the next full output run loses the row store.
+SET param__internal_join_table_stat_hints = '{}';
+
+CREATE TABLE right_wide (k UInt64, v1 Int64, v2 UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO right_wide SELECT number, number, number FROM numbers(20000);
+
+-- Separate table for `parallel_hash`: `join_algorithm` is not part of the match stats cache key.
+CREATE TABLE right_wide_ph (k UInt64, v1 Int64, v2 UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO right_wide_ph SELECT number, number, number FROM numbers(20000);
+
+SELECT r.v1, r.v2 FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 0, log_comment = 'rs_hash_1_warm';
+
+SELECT count() FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_hash_2_no_emit_probe';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_hash_3_after_no_emit_probe';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, enable_hash_join_row_store = 0, log_comment = 'rs_hash_4_row_store_off';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide_ph r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'parallel_hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 0, log_comment = 'rs_par_1_warm';
+
+SELECT count() FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide_ph r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'parallel_hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_par_2_no_emit_probe';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide_ph r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'parallel_hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, log_comment = 'rs_par_3_after_no_emit_probe';
+
+SELECT r.v1, r.v2 FROM (SELECT number % 20000 AS k FROM numbers(200000)) p JOIN right_wide_ph r ON p.k = r.k FORMAT Null
+SETTINGS join_algorithm = 'parallel_hash', query_plan_join_swap_table = 0, min_rows_ratio_for_hash_join_row_store = 2, enable_hash_join_row_store = 0, log_comment = 'rs_par_4_row_store_off';
+
+SYSTEM FLUSH LOGS query_log;
+
+-- The `_2_no_emit_probe` and `_4_row_store_off` rows read 0 and show the counter can report an
+-- unbuilt row store; the `_1_warm` and `_3_after_no_emit_probe` rows must read 1.
+SELECT log_comment, ProfileEvents['JoinBuildRowStoreMicroseconds'] > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND event_date >= yesterday()
+  AND log_comment IN ('rs_hash_1_warm', 'rs_hash_2_no_emit_probe', 'rs_hash_3_after_no_emit_probe', 'rs_hash_4_row_store_off',
+                      'rs_par_1_warm', 'rs_par_2_no_emit_probe', 'rs_par_3_after_no_emit_probe', 'rs_par_4_row_store_off')
+ORDER BY log_comment;
+
+DROP TABLE right_wide_ph;
+DROP TABLE right_wide;
+
 -- Keep the row store enabled regardless of cardinality estimates.
 SET min_rows_ratio_for_hash_join_row_store = 0;
 


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/117260
Related: https://github.com/ClickHouse/ClickHouse/pull/104884
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/117260
Related: https://github.com/ClickHouse/ClickHouse/pull/104884

`LazyOutput::hash_table_matches` was incremented only inside `addRef`, which
`AddedColumns<true>::appendFromBlock` calls behind `if (record_row_refs)`. That flag is false
whenever the probe emits no right-side column, so the counter tracked ref *retention* rather than
matching: `SELECT count()` over a join finished with 0 after matching millions of rows, published
that 0 to the match-stats cache under a projection-blind key, and the next full-output run of the
same join read it, failed `min_rows_ratio_for_hash_join_row_store`, and lost the row store. Affects
`hash` and `parallel_hash`.

I added `LazyOutput::countMatch`, a ref-free counterpart of `addRef`, plus an `else` on the
`record_row_refs` branch `appendFromBlock` already had. `addRef` is unchanged, so the ref-recording
path executes exactly the instructions it did before; only the no-emit path does extra work, one
`refWordRows` per matched key.

I did not take option 1 from the issue (skip the update when nothing was recorded):
`712df43e4674e05` deliberately removed the non-zero guard from both match writers, in the same commit
that made the output stats key discriminating, so a published 0 is meant to be a real observation.

`AddedColumns<false>` (`ANY`, `joinGet`) has the same coupling and is left alone, because it cannot
reach a row-store decision: `isRowStoreSupported` excludes `Any`, strictness is part of the cache
key, and `joinGet` never reaches `onProbePhaseFinish`. Measured inert on both builds.

`enable_hash_join_row_store` was added in 26.9 and is absent from 26.8, 26.7, 26.6 and 26.3, so no
stable release is affected and there is nothing to backport.

`04054_hash_join_with_row_store` gains the interleave the issue asks for, pinning row store engagement
via `ProfileEvents['JoinBuildRowStoreMicroseconds']` across warm / `count()` probe / full output, for
both algorithms on separate table pairs, over both unique right keys and a 40-rows-per-key fanout so
the arms pin matched rows rather than matched keys.

<details>
<summary>Validation</summary>

Measured at the publish site on instrumented base and fixed builds, same fixture and query pair:

| query | base | with this change |
|---|---|---|
| `SELECT b.v1, b.v2 FROM ... JOIN b ON ...` | `matches=200000` | `matches=200000` |
| `SELECT count() FROM ... JOIN b ON ...` | `matches=0` | `matches=200000` |

Swept 25 join shapes on both builds. Every shape that emits right columns is numerically unchanged,
including the residual-filter, `flag_per_row`, row-list, block-splitting and `parallel_hash` paths, so
nothing is double counted. Every no-emit shape now equals its full-output twin exactly, including a
post-filter count and a count over a key whose row list saturates the packed counter. `ANY` reads 0 on
both; ASOF and a LIMIT-truncated probe publish nothing on either.

Performance, medians over two independent batches of 30 runs per binary, `max_threads=1`:

| shape | base | with this change |
|---|---|---|
| no-emit, unique right keys (4M probes) | 96 / 98 ms | 97 / 92 ms |
| no-emit, saturated key (> `COUNT_SAT`) | 8790 ms | 8674 ms |
| full output, 4M rows emitted (unchanged path) | 366 ms | 370 ms |

The four full-output-after-probe arms read 0 on master and 1 with this change, while the ten control
arms read identically on both, so the assertion is not vacuous. The duplicate-key arms (500 keys of 40
rows) also pin *what* is counted: the no-emit probe publishes 200000 here, 0 on master and 5000 on a
mutant counting one per matched key rather than per matched row, so that mutant fails them while the
unique-key arms stay green. 80/80 passes with randomized settings, 32/32 self-parallel at `-j 16`;
12 individually injected settings all pass, and injecting `enable_hash_join_row_store=0` fails the
test, confirming the channel is live rather than inert.

</details>

#115605 and #115301 restructure this subsystem but touch neither file changed here.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117324&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117324](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117324+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
