### PR TITLE
Support compression codecs for Tuple elements

### DIFF
--- a/src/DataTypes/DataTypeFactory.cpp
+++ b/src/DataTypes/DataTypeFactory.cpp
@@ -79,6 +79,17 @@ static DataTypePtr createEnumFromValues(const String & type_name, const std::vec
 /// Helper to create Tuple data type from ASTTupleDataType
 static DataTypePtr createTupleFromAST(const ASTTupleDataType * tuple_ast)
 {
+    /// Codecs of tuple elements are not part of the data type. They are accepted only in column
+    /// declarations of CREATE TABLE and ALTER TABLE queries, where they are extracted from the
+    /// type AST before this function is called (see extractSubcolumnCodecsFromTypeAST()).
+    for (const auto & codec : tuple_ast->element_codecs)
+    {
+        if (codec)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Codecs for Tuple elements can be specified only in a column declaration "
+                "of a CREATE TABLE or ALTER TABLE query");
+    }
+
     const auto arguments = tuple_ast->getArguments();
     if (!arguments || arguments->children.empty())
         return std::make_shared<DataTypeTuple>(DataTypes{});

--- a/src/DataTypes/DataTypeTuple.cpp
+++ b/src/DataTypes/DataTypeTuple.cpp
@@ -551,6 +551,28 @@ SELECT a.2 FROM named_tuples; -- by index
 └────────────────────┘
 ```
 
+## Compression codecs for Tuple elements {#compression-codecs-for-tuple-elements}
+
+When a column of a `MergeTree` family table is defined, every named tuple element can get its own
+[compression codec](/reference/statements/create/table#column_compression_codec). This is useful when the elements have
+different natures and need different codecs, for example timestamps and values of a time series:
+
+```sql
+CREATE TABLE series
+(
+    id UInt64,
+    samples Array(Tuple(
+        timestamp DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+        value Float64 CODEC(Gorilla, ZSTD(1))))
+)
+ENGINE = MergeTree ORDER BY id;
+```
+
+A codec of an element applies to the streams of the corresponding subcolumn (`samples.timestamp` and `samples.value`
+in the example above) instead of the codec of the whole column. Elements without a codec use the codec
+of the column as usual. Codecs of tuple elements can be specified only in column declarations of
+`CREATE TABLE` and `ALTER TABLE` queries.
+
 ## Comparison operations with Tuple {#comparison-operations-with-tuple}
 
 Two tuples are compared by sequentially comparing their elements from the left to the right. If first tuples element is greater (smaller) than the second tuples corresponding element, then the first tuple is greater (smaller) than the second, otherwise (both elements are equal), the next element is compared.

--- a/src/DataTypes/SubcolumnCodecs.cpp
+++ b/src/DataTypes/SubcolumnCodecs.cpp
@@ -1,0 +1,230 @@
+#include <DataTypes/SubcolumnCodecs.h>
+
+#include <Compression/CompressionFactory.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/dataTypeToAST.h>
+#include <Parsers/ASTDataType.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTTupleDataType.h>
+#include <Common/Exception.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+/// Type wrappers through which a tuple element keeps its subcolumn name,
+/// e.g. the subcolumn name of `x` in `Array(Tuple(x UInt64))` is just "x".
+bool isTransparentTypeWrapper(const String & type_name)
+{
+    return type_name == "Array"
+        || type_name == "Nullable"
+        || type_name == "LowCardinality"
+        || type_name == "SimpleAggregateFunction"
+        || type_name == "AggregateFunction";
+}
+
+/// Calls `visit_element(tuple, element_index, subcolumn_name)` for every named tuple element in the type AST.
+/// `subcolumn_name` is the full dotted path of the element relative to the column.
+template <typename Visitor>
+void visitTupleElements(IAST & ast, const String & prefix, const Visitor & visit_element)
+{
+    if (auto * tuple = ast.as<ASTTupleDataType>())
+    {
+        const auto arguments = tuple->getArguments();
+        if (!arguments)
+            return;
+
+        const auto & argument_children = arguments->as<ASTExpressionList &>().children;
+        for (size_t i = 0; i < argument_children.size(); ++i)
+        {
+            const String & element_name = (i < tuple->element_names.size()) ? tuple->element_names[i] : "";
+
+            if (element_name.empty())
+            {
+                if (i < tuple->element_codecs.size() && tuple->element_codecs[i])
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Codecs can be specified only for named Tuple elements");
+            }
+            else
+            {
+                visit_element(*tuple, i, prefix + element_name);
+            }
+
+            /// Elements of an unnamed tuple are addressed by their 1-based positions.
+            String child_prefix = prefix + (element_name.empty() ? std::to_string(i + 1) : element_name) + ".";
+            visitTupleElements(*argument_children[i], child_prefix, visit_element);
+        }
+        return;
+    }
+
+    if (const auto * data_type = ast.as<ASTDataType>())
+    {
+        const auto arguments = data_type->getArguments();
+        if (!arguments)
+            return;
+
+        auto & argument_children = arguments->as<ASTExpressionList &>().children;
+
+        if (data_type->name == "Map" && argument_children.size() == 2)
+        {
+            visitTupleElements(*argument_children[0], prefix + "keys.", visit_element);
+            visitTupleElements(*argument_children[1], prefix + "values.", visit_element);
+            return;
+        }
+
+        if (isTransparentTypeWrapper(data_type->name))
+        {
+            for (const auto & child : argument_children)
+                visitTupleElements(*child, prefix, visit_element);
+            return;
+        }
+
+        /// Codecs are not supported inside other types (Nested, Variant, JSON, ...) because
+        /// there is no way to map a tuple element to a subcolumn there.
+        for (const auto & child : argument_children)
+        {
+            if (child && typeASTHasSubcolumnCodecs(*child))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Codecs for Tuple elements are not supported inside type {}", data_type->name);
+        }
+    }
+}
+
+void clearEmptyElementCodecs(IAST & ast)
+{
+    if (auto * tuple = ast.as<ASTTupleDataType>())
+    {
+        bool all_empty = true;
+        for (const auto & codec : tuple->element_codecs)
+        {
+            if (codec)
+            {
+                all_empty = false;
+                break;
+            }
+        }
+        if (all_empty)
+            tuple->element_codecs.clear();
+    }
+
+    for (const auto & child : ast.children)
+        clearEmptyElementCodecs(*child);
+}
+
+}
+
+bool typeASTHasSubcolumnCodecs(const IAST & type_ast)
+{
+    if (const auto * tuple = type_ast.as<ASTTupleDataType>())
+    {
+        for (const auto & codec : tuple->element_codecs)
+            if (codec)
+                return true;
+    }
+
+    for (const auto & child : type_ast.children)
+        if (child && typeASTHasSubcolumnCodecs(*child))
+            return true;
+
+    return false;
+}
+
+ASTPtr extractSubcolumnCodecsFromTypeAST(const ASTPtr & type_ast, SubcolumnCodecs & out_codecs)
+{
+    if (!typeASTHasSubcolumnCodecs(*type_ast))
+        return type_ast;
+
+    ASTPtr cleaned = type_ast->clone();
+
+    visitTupleElements(*cleaned, "", [&](ASTTupleDataType & tuple, size_t element_index, const String & subcolumn_name)
+    {
+        if (element_index >= tuple.element_codecs.size() || !tuple.element_codecs[element_index])
+            return;
+
+        if (!out_codecs.emplace(subcolumn_name, std::move(tuple.element_codecs[element_index])).second)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Multiple codecs are specified for subcolumn {}", subcolumn_name);
+
+        tuple.element_codecs[element_index] = nullptr;
+    });
+
+    clearEmptyElementCodecs(*cleaned);
+    return cleaned;
+}
+
+ASTPtr typeASTWithoutSubcolumnCodecs(const ASTPtr & type_ast)
+{
+    SubcolumnCodecs ignored_codecs;
+    return extractSubcolumnCodecsFromTypeAST(type_ast, ignored_codecs);
+}
+
+void injectSubcolumnCodecsIntoTypeAST(IAST & type_ast, const SubcolumnCodecs & codecs)
+{
+    if (codecs.empty())
+        return;
+
+    size_t num_injected = 0;
+
+    visitTupleElements(type_ast, "", [&](ASTTupleDataType & tuple, size_t element_index, const String & subcolumn_name)
+    {
+        auto it = codecs.find(subcolumn_name);
+        if (it == codecs.end())
+            return;
+
+        if (tuple.element_codecs.empty())
+            tuple.element_codecs.resize(tuple.getArguments()->as<ASTExpressionList &>().children.size());
+
+        tuple.element_codecs[element_index] = it->second->clone();
+        ++num_injected;
+    });
+
+    if (num_injected != codecs.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Cannot put codecs of subcolumns back into the type AST {}: only {} of {} codecs matched tuple elements",
+            type_ast.formatForErrorMessage(), num_injected, codecs.size());
+}
+
+String getTypeNameWithSubcolumnCodecs(const DataTypePtr & type, const SubcolumnCodecs & codecs)
+{
+    if (codecs.empty())
+        return type->getName();
+
+    auto type_ast = dataTypeToAST(type);
+    injectSubcolumnCodecsIntoTypeAST(*type_ast, codecs);
+    return type_ast->formatWithSecretsOneLine();
+}
+
+void validateSubcolumnCodecs(
+    const String & column_name,
+    const DataTypePtr & column_type,
+    SubcolumnCodecs & codecs,
+    const CodecValidationSettings & validation_settings)
+{
+    for (auto & [subcolumn_name, codec] : codecs)
+    {
+        auto subcolumn_type = column_type->tryGetSubcolumnType(subcolumn_name);
+        if (!subcolumn_type)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Cannot specify codec for subcolumn {}: there is no such subcolumn in column {} of type {}",
+                subcolumn_name, column_name, column_type->getName());
+
+        codec = CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(codec, subcolumn_type, validation_settings);
+    }
+}
+
+SubcolumnCodecs cloneSubcolumnCodecs(const SubcolumnCodecs & codecs)
+{
+    SubcolumnCodecs res;
+    for (const auto & [subcolumn_name, codec] : codecs)
+        res.emplace(subcolumn_name, codec->clone());
+    return res;
+}
+
+}

--- a/src/DataTypes/SubcolumnCodecs.h
+++ b/src/DataTypes/SubcolumnCodecs.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Core/Types.h>
+#include <Parsers/IAST_fwd.h>
+
+#include <map>
+
+
+namespace DB
+{
+
+class IDataType;
+using DataTypePtr = std::shared_ptr<const IDataType>;
+struct CodecValidationSettings;
+
+/// Codecs declared for elements of a Tuple inside a column type, for example:
+///     CREATE TABLE t
+///     (
+///         samples Array(Tuple(
+///             timestamp DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+///             value Float64 CODEC(Gorilla, ZSTD(1))))
+///     ) ENGINE = MergeTree ...
+/// The key is the subcolumn name of the element relative to the column (as in `SELECT samples.timestamp`),
+/// e.g. "timestamp" or "a.b" for an element of a nested tuple.
+/// Such codecs are not part of the data type: they are extracted from the type AST when a column
+/// declaration is processed and stored in ColumnDescription::subcolumn_codecs. The MergeTree part
+/// writers use them for the streams of the corresponding subcolumns instead of the column-level codec.
+using SubcolumnCodecs = std::map<String, ASTPtr>;
+
+/// Whether the type AST contains codecs of tuple elements.
+bool typeASTHasSubcolumnCodecs(const IAST & type_ast);
+
+/// Collects codecs of tuple elements from the type AST into `out_codecs`, keyed by subcolumn name.
+/// Returns the type AST without the codecs: the original AST if it has none, or a cleaned clone
+/// (the original AST is never modified because it can be a part of a query which is formatted later).
+ASTPtr extractSubcolumnCodecsFromTypeAST(const ASTPtr & type_ast, SubcolumnCodecs & out_codecs);
+
+/// Same as extractSubcolumnCodecsFromTypeAST() but discards the codecs.
+ASTPtr typeASTWithoutSubcolumnCodecs(const ASTPtr & type_ast);
+
+/// Puts the codecs back into a type AST without codecs; the reverse of extractSubcolumnCodecsFromTypeAST().
+/// Used to format a column declaration for SHOW CREATE TABLE and for table metadata.
+void injectSubcolumnCodecsIntoTypeAST(IAST & type_ast, const SubcolumnCodecs & codecs);
+
+/// Returns the name of the type annotated with the codecs,
+/// e.g. "Array(Tuple(timestamp DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)), value Float64))".
+String getTypeNameWithSubcolumnCodecs(const DataTypePtr & type, const SubcolumnCodecs & codecs);
+
+/// Checks that every declared subcolumn exists in the column type and that its codec is applicable
+/// to the type of that subcolumn; replaces each codec with its validated preprocessed form.
+void validateSubcolumnCodecs(
+    const String & column_name,
+    const DataTypePtr & column_type,
+    SubcolumnCodecs & codecs,
+    const CodecValidationSettings & validation_settings);
+
+/// Deep copy: the codec ASTs are cloned.
+SubcolumnCodecs cloneSubcolumnCodecs(const SubcolumnCodecs & codecs);
+
+}

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -76,6 +76,7 @@
 #include <Access/Common/AccessRightsElement.h>
 
 #include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/SubcolumnCodecs.h>
 #include <DataTypes/dataTypeToAST.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeLowCardinality.h>
@@ -510,7 +511,11 @@ ASTPtr InterpreterCreateQuery::formatColumns(const ColumnsDescription & columns)
         ASTPtr column_declaration_ptr{column_declaration};
 
         column_declaration->name = column.name;
-        column_declaration->setType(dataTypeToAST(column.type));
+
+        auto type_ast = dataTypeToAST(column.type);
+        if (!column.subcolumn_codecs.empty())
+            injectSubcolumnCodecsIntoTypeAST(*type_ast, column.subcolumn_codecs);
+        column_declaration->setType(std::move(type_ast));
 
         if (column.default_desc.expression)
         {
@@ -595,7 +600,9 @@ DataTypePtr InterpreterCreateQuery::getColumnType(
         return std::make_shared<DataTypeUInt8>();
     }
 
-    DataTypePtr column_type = DataTypeFactory::instance().get(col_type);
+    /// Codecs of tuple elements are not part of the data type; getColumnsDescription() extracts
+    /// and stores them separately.
+    DataTypePtr column_type = DataTypeFactory::instance().get(typeASTWithoutSubcolumnCodecs(col_type));
 
     if (LoadingStrictnessLevel::ATTACH <= mode)
         setVersionToAggregateFunctions(column_type, true);
@@ -751,6 +758,14 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
             column.codec
                 = CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(codec, column.type, codec_validation_settings);
+        }
+
+        if (auto col_decl_type = col_decl.getType(); col_decl_type && typeASTHasSubcolumnCodecs(*col_decl_type))
+        {
+            if (col_decl.default_specifier == ColumnDefaultSpecifier::Alias)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
+            extractSubcolumnCodecsFromTypeAST(col_decl_type, column.subcolumn_codecs);
+            validateSubcolumnCodecs(column.name, column.type, column.subcolumn_codecs, codec_validation_settings);
         }
 
         if (auto statistics_desc = col_decl.getStatisticsDesc())

--- a/src/Parsers/ASTTupleDataType.cpp
+++ b/src/Parsers/ASTTupleDataType.cpp
@@ -32,7 +32,14 @@ ASTPtr ASTTupleDataType::clone() const
         res->children.emplace_back(arguments->clone());
     }
 
-    /// element_names vector is copied by the copy constructor
+    /// element_names vector is copied by the copy constructor.
+    /// element_codecs entries are shared after the copy constructor, so clone them.
+    for (auto & codec : res->element_codecs)
+    {
+        if (codec)
+            codec = codec->clone();
+    }
+
     return res;
 }
 
@@ -47,6 +54,15 @@ void ASTTupleDataType::updateTreeHashImpl(SipHash & hash_state, bool ignore_alia
     {
         hash_state.update(elem_name.size());
         hash_state.update(elem_name);
+    }
+
+    /// Hash element codecs
+    hash_state.update(element_codecs.size());
+    for (const auto & codec : element_codecs)
+    {
+        hash_state.update(codec != nullptr);
+        if (codec)
+            codec->updateTreeHashImpl(hash_state, ignore_aliases);
     }
 
     /// Hash child types via arguments
@@ -97,6 +113,12 @@ void ASTTupleDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & set
 
                 /// Print the type
                 arguments->children[i]->format(ostr, settings, state, frame);
+
+                if (i < element_codecs.size() && element_codecs[i])
+                {
+                    ostr << ' ';
+                    element_codecs[i]->format(ostr, settings, state, frame);
+                }
             }
         }
         else
@@ -113,6 +135,12 @@ void ASTTupleDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & set
 
                 /// Print the type
                 arguments->children[i]->format(ostr, settings, state, frame);
+
+                if (i < element_codecs.size() && element_codecs[i])
+                {
+                    ostr << ' ';
+                    element_codecs[i]->format(ostr, settings, state, frame);
+                }
             }
         }
 
@@ -126,6 +154,10 @@ void ASTTupleDataType::writeJSON(WriteBuffer & out) const
     w.writeString("name", name);
     if (auto args = getArguments())
         w.writeChild("arguments", args);
+
+    /// element_codecs are not serialized: a type AST inside a serialized query plan never carries them,
+    /// because they can appear only in column declarations of CREATE/ALTER TABLE queries, where they are
+    /// extracted from the type AST before the column type is created.
 
     /// Named-tuple field names live in `element_names`, not as AST children, so write them explicitly;
     /// the generic `ASTDataType::writeJSON` would drop them (turning `Tuple(a UInt8)` into `Tuple(UInt8)`).

--- a/src/Parsers/ASTTupleDataType.h
+++ b/src/Parsers/ASTTupleDataType.h
@@ -21,6 +21,14 @@ public:
     /// Validation happens in DataTypeFactory::createTupleFromAST().
     Strings element_names;
 
+    /// Optional codecs of elements: Tuple(x UInt64 CODEC(Delta, ZSTD), y String).
+    /// If non-empty, has the same size as arguments->children; an entry is nullptr for an element
+    /// without a codec. Codecs can be specified only for named elements.
+    /// A codec is not a part of the data type: such type declarations are allowed only for columns
+    /// of CREATE TABLE and ALTER TABLE queries, where the codecs are extracted from the type AST
+    /// before the type is created (see extractSubcolumnCodecsFromTypeAST()).
+    ASTs element_codecs;
+
     String getID(char delim) const override;
     ASTPtr clone() const override;
     void updateTreeHashImpl(SipHash & hash_state, bool ignore_aliases) const override;

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -391,7 +391,9 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         tuple_node->children.push_back(arguments);
 
         bool has_named_elements = false;
+        bool has_element_codecs = false;
         Strings element_names_tmp;
+        ASTs element_codecs_tmp;
         bool first_element = true;
 
         while (true)
@@ -415,12 +417,22 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             auto element_pos = pos;
             if (identifier_parser.parse(pos, identifier_node, expected) && type_parser.parse(pos, type_node, expected))
             {
-                /// Named element: name Type
+                /// Named element: name Type [CODEC(...)]
                 String elem_name;
                 tryGetIdentifierNameInto(identifier_node, elem_name);
                 element_names_tmp.push_back(elem_name);
                 arguments->children.push_back(type_node);
                 has_named_elements = true;
+
+                ASTPtr codec_node;
+                if (ParserKeyword(Keyword::CODEC).ignore(pos, expected))
+                {
+                    ParserCodec codec_parser;
+                    if (!codec_parser.parse(pos, codec_node, expected))
+                        return false;
+                    has_element_codecs = true;
+                }
+                element_codecs_tmp.push_back(std::move(codec_node));
             }
             else
             {
@@ -432,6 +444,7 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
                     /// The factory validates that all names are non-empty when element_names is set.
                     element_names_tmp.push_back("");
                     arguments->children.push_back(type_node);
+                    element_codecs_tmp.push_back(nullptr);
                 }
                 else
                 {
@@ -449,6 +462,12 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             {
                 element_names_tmp.shrink_to_fit();
                 tuple_node->element_names = std::move(element_names_tmp);
+            }
+            /// Only store element_codecs if any element has a codec
+            if (has_element_codecs)
+            {
+                element_codecs_tmp.shrink_to_fit();
+                tuple_node->element_codecs = std::move(element_codecs_tmp);
             }
             arguments->children.shrink_to_fit();
             node = tuple_node;

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -177,13 +177,15 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         command.column_name = ast_col_decl.name;
         if (ast_col_decl.getType())
         {
-            command.data_type = data_type_factory.get(ast_col_decl.getType());
+            command.data_type = data_type_factory.get(extractSubcolumnCodecsFromTypeAST(ast_col_decl.getType(), command.subcolumn_codecs));
             applyNullModifier(command.data_type, ast_col_decl.null_modifier);
             /// A stored column has to spell its state version out in the metadata the same way
             /// `CREATE TABLE` does (see `InterpreterCreateQuery::getColumnType`): an unversioned
             /// name in stored metadata denotes the layout from before the function became versioned.
             pinCurrentStateVersionToAggregateFunctions(command.data_type);
         }
+        if (!command.subcolumn_codecs.empty() && ast_col_decl.default_specifier == ColumnDefaultSpecifier::Alias)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
         if (ast_col_decl.getDefaultExpression())
         {
             command.default_kind = toColumnDefaultKind(ast_col_decl.default_specifier);
@@ -247,7 +249,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
 
         if (ast_col_decl.getType())
         {
-            command.data_type = data_type_factory.get(ast_col_decl.getType());
+            command.data_type = data_type_factory.get(extractSubcolumnCodecsFromTypeAST(ast_col_decl.getType(), command.subcolumn_codecs));
             applyNullModifier(command.data_type, ast_col_decl.null_modifier);
             /// Deliberately NOT pinning the current state version here, unlike ADD COLUMN above.
             /// `DataTypeAggregateFunction::equals` ignores the state version, so a version change is
@@ -694,6 +696,12 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context,
         if (codec)
             column.codec = CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(codec, data_type, CodecValidationSettings::trusted());
 
+        if (!subcolumn_codecs.empty())
+        {
+            column.subcolumn_codecs = cloneSubcolumnCodecs(subcolumn_codecs);
+            validateSubcolumnCodecs(column_name, data_type, column.subcolumn_codecs, CodecValidationSettings::trusted());
+        }
+
         column.ttl = ttl;
 
         if (!settings_changes.empty())
@@ -754,6 +762,7 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context,
             else if (to_remove == RemoveProperty::CODEC)
             {
                 column.codec.reset();
+                column.subcolumn_codecs.clear();
             }
             else if (to_remove == RemoveProperty::COMMENT)
             {
@@ -782,6 +791,13 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context,
                 if (data_type)
                 {
                     column.type = data_type;
+
+                    /// The new type declaration is authoritative for the codecs of tuple elements:
+                    /// they are replaced even when the new declaration has none.
+                    column.subcolumn_codecs = cloneSubcolumnCodecs(subcolumn_codecs);
+                    if (!column.subcolumn_codecs.empty())
+                        validateSubcolumnCodecs(column_name, data_type, column.subcolumn_codecs, CodecValidationSettings::trusted());
+
                     /// Update statistics data type to match the new column type
                     if (!column.statistics.empty())
                         column.statistics.data_type = data_type;
@@ -2091,6 +2107,12 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
                     codec_validation_settings);
             }
 
+            if (!command.subcolumn_codecs.empty())
+            {
+                auto subcolumn_codecs_copy = cloneSubcolumnCodecs(command.subcolumn_codecs);
+                validateSubcolumnCodecs(column_name, command.data_type, subcolumn_codecs_copy, codec_validation_settings);
+            }
+
             /// Advance the working snapshot with the exact columns apply() would materialize
             /// (flatten_nested expansion), not a synthetic top-level `n`, so a later command in the
             /// same ALTER that targets a real flattened child (e.g. RENAME COLUMN `n.b`) sees it.
@@ -2120,17 +2142,23 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
                     "Cannot modify column {} to ephemeral: it conflicts with a virtual column of the same name",
                     backQuote(column_name));
 
-            if (command.codec)
+            if (command.codec || !command.subcolumn_codecs.empty())
             {
                 /// `default_kind` is what the parser set: `validate` runs before `prepare`, which back-fills it from the table.
                 const bool becomes_physical = command.default_expression
                     && (command.default_kind == ColumnDefaultKind::Default || command.default_kind == ColumnDefaultKind::Materialized);
                 if (all_columns.hasAlias(column_name) && !becomes_physical)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot specify codec for column type ALIAS");
-                CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(
-                    command.codec,
-                    command.data_type,
-                    codec_validation_settings);
+                if (command.codec)
+                    CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(
+                        command.codec,
+                        command.data_type,
+                        codec_validation_settings);
+                if (!command.subcolumn_codecs.empty())
+                {
+                    auto subcolumn_codecs_copy = cloneSubcolumnCodecs(command.subcolumn_codecs);
+                    validateSubcolumnCodecs(column_name, command.data_type, subcolumn_codecs_copy, codec_validation_settings);
+                }
             }
             auto column_default = all_columns.getDefault(column_name);
             if (column_default)
@@ -2197,7 +2225,8 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
                         ErrorCodes::BAD_ARGUMENTS,
                         "Column {} doesn't have TTL, cannot remove it",
                         backQuote(column_name));
-                if (command.to_remove == AlterCommand::RemoveProperty::CODEC && column_from_table.codec == nullptr)
+                if (command.to_remove == AlterCommand::RemoveProperty::CODEC && column_from_table.codec == nullptr
+                    && column_from_table.subcolumn_codecs.empty())
                     throw Exception(
                         ErrorCodes::BAD_ARGUMENTS,
                         "Column {} doesn't have CODEC, cannot remove it",

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -155,6 +155,10 @@ struct AlterCommand
     /// For ADD and MODIFY
     ASTPtr codec = nullptr;
 
+    /// For ADD and MODIFY: codecs of tuple elements extracted from the column type declaration
+    /// (see SubcolumnCodecs.h).
+    SubcolumnCodecs subcolumn_codecs;
+
     /// For MODIFY SETTING or MODIFY COLUMN MODIFY SETTING
     SettingsChanges settings_changes;
 

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -106,6 +106,7 @@ ColumnDescription & ColumnDescription::operator=(const ColumnDescription & other
     default_desc = other.default_desc;
     comment = other.comment;
     codec = other.codec ? other.codec->clone() : nullptr;
+    subcolumn_codecs = cloneSubcolumnCodecs(other.subcolumn_codecs);
     settings = other.settings;
     ttl = other.ttl ? other.ttl->clone() : nullptr;
     statistics = other.statistics;
@@ -126,6 +127,9 @@ ColumnDescription & ColumnDescription::operator=(ColumnDescription && other) ///
     codec = other.codec ? other.codec->clone() : nullptr;
     other.codec.reset();
 
+    subcolumn_codecs = cloneSubcolumnCodecs(other.subcolumn_codecs);
+    other.subcolumn_codecs.clear();
+
     settings = std::move(other.settings);
 
     ttl = other.ttl ? other.ttl->clone() : nullptr;
@@ -140,11 +144,20 @@ bool ColumnDescription::operator==(const ColumnDescription & other) const
 {
     auto ast_to_str = [](const ASTPtr & ast) { return ast ? ast->formatWithSecretsOneLine() : String{}; };
 
+    auto subcolumn_codecs_equal = [&](const SubcolumnCodecs & lhs, const SubcolumnCodecs & rhs)
+    {
+        return std::ranges::equal(lhs, rhs, [&](const auto & lhs_elem, const auto & rhs_elem)
+        {
+            return lhs_elem.first == rhs_elem.first && ast_to_str(lhs_elem.second) == ast_to_str(rhs_elem.second);
+        });
+    };
+
     return name == other.name
         && type->equals(*other.type)
         && default_desc == other.default_desc
         && statistics == other.statistics
         && ast_to_str(codec) == ast_to_str(other.codec)
+        && subcolumn_codecs_equal(subcolumn_codecs, other.subcolumn_codecs)
         && settings == other.settings
         && ast_to_str(ttl) == ast_to_str(other.ttl);
 }
@@ -167,7 +180,10 @@ void ColumnDescription::writeText(WriteBuffer & buf, IAST::FormatState & state, 
 
     writeBackQuotedString(name, buf);
     writeChar(' ', buf);
-    writeEscapedString(type->getName(), buf);
+    if (subcolumn_codecs.empty())
+        writeEscapedString(type->getName(), buf);
+    else
+        writeEscapedString(getTypeNameWithSubcolumnCodecs(type, subcolumn_codecs), buf);
 
     if (default_desc.expression)
     {
@@ -226,7 +242,21 @@ void ColumnDescription::readText(ReadBuffer & buf)
 
     String type_string;
     readEscapedString(type_string, buf);
-    type = DataTypeFactory::instance().get(type_string);
+
+    subcolumn_codecs.clear();
+    if (type_string.find(" CODEC(") != String::npos)
+    {
+        /// The type name can be annotated with codecs of tuple elements (see getTypeNameWithSubcolumnCodecs()).
+        ParserDataType type_parser;
+        ASTPtr type_ast = parseQuery(type_parser, type_string, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+        type_ast = extractSubcolumnCodecsFromTypeAST(type_ast, subcolumn_codecs);
+        type = DataTypeFactory::instance().get(type_ast);
+        validateSubcolumnCodecs(name, type, subcolumn_codecs, CodecValidationSettings::trusted());
+    }
+    else
+    {
+        type = DataTypeFactory::instance().get(type_string);
+    }
 
     if (checkChar('\t', buf))
     {

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -4,6 +4,7 @@
 #include <Core/Names.h>
 #include <Core/NamesAndAliases.h>
 #include <Core/NamesAndTypes.h>
+#include <DataTypes/SubcolumnCodecs.h>
 #include <Interpreters/Context_fwd.h>
 #include <Storages/ColumnDefault.h>
 #include <Storages/StatisticsDescription.h>
@@ -101,6 +102,9 @@ struct ColumnDescription
     ColumnDefault default_desc;
     String comment;
     ASTPtr codec;
+    /// Codecs of tuple elements from the column type declaration, keyed by subcolumn name (see SubcolumnCodecs.h).
+    /// They take precedence over `codec` for the streams of the corresponding subcolumns.
+    SubcolumnCodecs subcolumn_codecs;
     SettingsChanges settings;
     ASTPtr ttl;
     ColumnStatisticsDescription statistics;

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
@@ -174,6 +174,30 @@ ASTPtr IMergeTreeDataPartWriter::getCodecDescOrDefault(const String & column_nam
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected column name: {}", column_name);
 }
 
+ASTPtr IMergeTreeDataPartWriter::getSubcolumnCodecDesc(const String & column_name, const ISerialization::SubstreamPath & substream_path) const
+{
+    const auto * column_desc = metadata_snapshot->columns.tryGet(column_name);
+    if (!column_desc || column_desc->subcolumn_codecs.empty())
+        return nullptr;
+
+    /// Look up the deepest declared subcolumn: a codec of tuple element `a` also applies to nested
+    /// streams of `a` (e.g. `a.size0`, or `a.b` when there is no more specific codec for `a.b`).
+    String subcolumn_name = ISerialization::getSubcolumnNameForStream(substream_path);
+    while (!subcolumn_name.empty())
+    {
+        auto it = column_desc->subcolumn_codecs.find(subcolumn_name);
+        if (it != column_desc->subcolumn_codecs.end())
+            return it->second;
+
+        auto pos = subcolumn_name.rfind('.');
+        if (pos == String::npos)
+            break;
+        subcolumn_name.resize(pos);
+    }
+
+    return nullptr;
+}
+
 bool IMergeTreeDataPartWriter::columnUsesDefaultCodec(const String & column_name) const
 {
     if (const auto * column_desc = metadata_snapshot->columns.tryGet(column_name))

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -85,6 +85,10 @@ protected:
 
     ASTPtr getCodecDescOrDefault(const String & column_name, CompressionCodecPtr default_codec) const;
 
+    /// Codec description declared for the given substream of the column (a codec of a tuple element,
+    /// see SubcolumnCodecs.h), or nullptr if there is none and the column-level codec should be used.
+    ASTPtr getSubcolumnCodecDesc(const String & column_name, const ISerialization::SubstreamPath & substream_path) const;
+
     /// True if `column_name` uses the default codec (no `CODEC` clause, or an explicit lone `CODEC(Default)`).
     bool columnUsesDefaultCodec(const String & column_name) const;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1054,20 +1054,32 @@ void MergeTreeData::checkProperties(
         {
             const auto column = new_metadata.columns.tryGetColumnDescription(
                 GetColumnsOptions(GetColumnsOptions::AllPhysical), name);
-            if (!column || !column->codec)
+            if (!column || (!column->codec && column->subcolumn_codecs.empty()))
                 continue;
 
             /// A codec applies to `Array(Float64)` through its float substream, not through the outer type,
             /// so lossiness is resolved per substream the way the part writer resolves it.
             bool is_lossy = false;
-            ISerialization::StreamCallback callback = [&](const auto & substream_path)
+            auto check_lossy = [&](const ASTPtr & codec_desc, const DataTypePtr & type_to_check)
             {
-                if (is_lossy || !ISerialization::isSpecialCompressionAllowed(substream_path))
-                    return;
-                is_lossy = CompressionCodecFactory::instance()
-                               .get(column->codec, substream_path.back().data.type.get())->isLossyCompression();
+                ISerialization::StreamCallback callback = [&](const auto & substream_path)
+                {
+                    if (is_lossy || !ISerialization::isSpecialCompressionAllowed(substream_path))
+                        return;
+                    is_lossy = CompressionCodecFactory::instance()
+                                   .get(codec_desc, substream_path.back().data.type.get())->isLossyCompression();
+                };
+                type_to_check->getDefaultSerialization()->enumerateStreams(callback, type_to_check);
             };
-            column->type->getDefaultSerialization()->enumerateStreams(callback, column->type);
+
+            if (column->codec)
+                check_lossy(column->codec, column->type);
+
+            for (const auto & [subcolumn_name, subcolumn_codec] : column->subcolumn_codecs)
+            {
+                if (auto subcolumn_type = column->type->tryGetSubcolumnType(subcolumn_name))
+                    check_lossy(subcolumn_codec, subcolumn_type);
+            }
 
             if (is_lossy)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -91,14 +91,23 @@ void MergeTreeDataPartWriterCompact::addStreams(const NameAndTypePair & name_and
         const auto & subtype = substream_path.back().data.type;
         CompressionCodecPtr compression_codec;
 
+        /// A codec of a tuple element takes precedence over the column-level codec for its streams.
+        ASTPtr stream_codec_desc = effective_codec_desc;
+        bool stream_uses_default_codec = column_uses_default_codec;
+        if (auto subcolumn_codec_desc = getSubcolumnCodecDesc(name_and_type.getNameInStorage(), substream_path))
+        {
+            stream_codec_desc = subcolumn_codec_desc;
+            stream_uses_default_codec = false;
+        }
+
         /// If we can use special codec than just get it
         if (ISerialization::isSpecialCompressionAllowed(substream_path))
         {
-            compression_codec = CompressionCodecFactory::instance().get(effective_codec_desc, subtype.get(), default_codec);
-            compression_codec = maybeAdaptiveDefaultCodec(column_uses_default_codec, subtype, compression_codec);
+            compression_codec = CompressionCodecFactory::instance().get(stream_codec_desc, subtype.get(), default_codec);
+            compression_codec = maybeAdaptiveDefaultCodec(stream_uses_default_codec, subtype, compression_codec);
         }
         else /// otherwise return only generic codecs and don't use info about data_type
-            compression_codec = CompressionCodecFactory::instance().get(effective_codec_desc, nullptr, default_codec, true);
+            compression_codec = CompressionCodecFactory::instance().get(stream_codec_desc, nullptr, default_codec, true);
 
         UInt64 codec_id = compression_codec->getHash();
         /// Codecs that need the vector dimension upfront (e.g. SZ3) keep per-stream state in the codec

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -226,14 +226,23 @@ void MergeTreeDataPartWriterWide::addStreams(
         const auto & subtype = substream_path.back().data.type;
         CompressionCodecPtr compression_codec;
 
+        /// A codec of a tuple element takes precedence over the column-level codec for its streams.
+        ASTPtr stream_codec_desc = effective_codec_desc;
+        bool stream_uses_default_codec = column_uses_default_codec;
+        if (auto subcolumn_codec_desc = getSubcolumnCodecDesc(name_and_type.getNameInStorage(), substream_path))
+        {
+            stream_codec_desc = subcolumn_codec_desc;
+            stream_uses_default_codec = false;
+        }
+
         /// If we can use special codec then just get it
         if (ISerialization::isSpecialCompressionAllowed(substream_path))
         {
-            compression_codec = CompressionCodecFactory::instance().get(effective_codec_desc, subtype.get(), default_codec);
-            compression_codec = maybeAdaptiveDefaultCodec(column_uses_default_codec, subtype, compression_codec);
+            compression_codec = CompressionCodecFactory::instance().get(stream_codec_desc, subtype.get(), default_codec);
+            compression_codec = maybeAdaptiveDefaultCodec(stream_uses_default_codec, subtype, compression_codec);
         }
         else /// otherwise return only generic codecs and don't use info about the` data_type
-            compression_codec = CompressionCodecFactory::instance().get(effective_codec_desc, nullptr, default_codec, true);
+            compression_codec = CompressionCodecFactory::instance().get(stream_codec_desc, nullptr, default_codec, true);
 
         /// No lossy codec is ever assigned to a structural substream (`Array` offsets, null map, ...): the
         /// only lossy codec, `SZ3`, is non-generic, and structural substreams take the generic-only branch

--- a/tests/queries/0_stateless/05054_tuple_element_codecs.reference
+++ b/tests/queries/0_stateless/05054_tuple_element_codecs.reference
@@ -1,0 +1,30 @@
+Create and show:
+CREATE TABLE default.ts_series\n(\n    `id` UInt64,\n    `samples` Array(Tuple(timestamp DateTime64(3, \'UTC\') CODEC(DoubleDelta, ZSTD(1)), value Float64 CODEC(Gorilla(8), ZSTD(1))))\n)\nENGINE = MergeTree\nORDER BY id\nSETTINGS index_granularity = 8192
+Data:
+1	[('2026-08-28 10:00:00.000',41.5),('2026-08-28 10:00:15.000',42)]
+2	[('2026-08-28 11:00:00.000',1)]
+After merge:
+1	[('2026-08-28 10:00:00.000',41.5),('2026-08-28 10:00:15.000',42)]
+2	[('2026-08-28 11:00:00.000',1)]
+After DETACH and ATTACH:
+CREATE TABLE default.ts_series\n(\n    `id` UInt64,\n    `samples` Array(Tuple(timestamp DateTime64(3, \'UTC\') CODEC(DoubleDelta, ZSTD(1)), value Float64 CODEC(Gorilla(8), ZSTD(1))))\n)\nENGINE = MergeTree\nORDER BY id\nSETTINGS index_granularity = 8192
+1	[('2026-08-28 10:00:00.000',41.5),('2026-08-28 10:00:15.000',42)]
+2	[('2026-08-28 11:00:00.000',1)]
+Codecs are applied per subcolumn:
+a	1	0
+b	0	1
+Compact part:
+[(1,'x'),(2,'y')]
+Compact
+ALTER:
+CREATE TABLE default.t_alter\n(\n    `x` UInt64,\n    `v` Array(Tuple(a UInt64 CODEC(Delta(8), ZSTD(1)), b UInt64))\n)\nENGINE = MergeTree\nORDER BY x\nSETTINGS index_granularity = 8192
+CREATE TABLE default.t_alter\n(\n    `x` UInt64,\n    `v` Array(Tuple(a UInt64 CODEC(LZ4HC(5)), b UInt64 CODEC(ZSTD(3))))\n)\nENGINE = MergeTree\nORDER BY x\nSETTINGS index_granularity = 8192
+CREATE TABLE default.t_alter\n(\n    `x` UInt64,\n    `v` Array(Tuple(a UInt64, b UInt64))\n)\nENGINE = MergeTree\nORDER BY x\nSETTINGS index_granularity = 8192
+1	[(10,20)]
+SimpleAggregateFunction storage:
+CREATE TABLE default.t_saf\n(\n    `id` UInt64,\n    `t` SimpleAggregateFunction(anyLast, Tuple(a UInt64 CODEC(Delta(8), ZSTD(1)), b Float64 CODEC(Gorilla(8), ZSTD(1))))\n)\nENGINE = AggregatingMergeTree\nORDER BY id\nSETTINGS index_granularity = 8192
+1	(1,1.5)
+Tuple inside Map:
+CREATE TABLE default.t_map\n(\n    `m` Map(String, Tuple(x UInt64 CODEC(ZSTD(1)), y UInt64))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+{'k':(1,2)}
+Errors:

--- a/tests/queries/0_stateless/05054_tuple_element_codecs.sql
+++ b/tests/queries/0_stateless/05054_tuple_element_codecs.sql
@@ -1,0 +1,118 @@
+SET print_pretty_type_names = 0;
+
+DROP TABLE IF EXISTS ts_series;
+DROP TABLE IF EXISTS t_check;
+DROP TABLE IF EXISTS t_compact;
+DROP TABLE IF EXISTS t_alter;
+DROP TABLE IF EXISTS t_saf;
+DROP TABLE IF EXISTS t_map;
+
+SELECT 'Create and show:';
+
+CREATE TABLE ts_series
+(
+    id UInt64,
+    samples Array(Tuple(
+        timestamp DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
+        value Float64 CODEC(Gorilla, ZSTD(1))))
+)
+ENGINE = MergeTree ORDER BY id;
+
+SHOW CREATE TABLE ts_series;
+
+INSERT INTO ts_series VALUES (1, [('2026-08-28 10:00:00.000', 41.5), ('2026-08-28 10:00:15.000', 42.)]);
+INSERT INTO ts_series VALUES (2, [('2026-08-28 11:00:00.000', 1.)]);
+
+SELECT 'Data:';
+SELECT id, samples FROM ts_series ORDER BY id;
+
+OPTIMIZE TABLE ts_series FINAL;
+SELECT 'After merge:';
+SELECT id, samples FROM ts_series ORDER BY id;
+
+DETACH TABLE ts_series;
+ATTACH TABLE ts_series;
+SELECT 'After DETACH and ATTACH:';
+SHOW CREATE TABLE ts_series;
+SELECT id, samples FROM ts_series ORDER BY id;
+
+SELECT 'Codecs are applied per subcolumn:';
+
+CREATE TABLE t_check
+(
+    v Array(Tuple(a UInt64 CODEC(ZSTD(1)), b UInt64)) CODEC(NONE)
+)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_check SELECT [(0, number)] FROM numbers(100000);
+
+SELECT name, compressed < (uncompressed / 10), compressed >= uncompressed
+FROM system.parts_columns
+ARRAY JOIN `subcolumns.names` AS name, `subcolumns.data_compressed_bytes` AS compressed, `subcolumns.data_uncompressed_bytes` AS uncompressed
+WHERE database = currentDatabase() AND table = 't_check' AND column = 'v' AND active AND name IN ('a', 'b')
+ORDER BY name;
+
+SELECT 'Compact part:';
+
+CREATE TABLE t_compact
+(
+    v Array(Tuple(a UInt64 CODEC(Delta, ZSTD(1)), b String))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_compact VALUES ([(1, 'x'), (2, 'y')]);
+SELECT v FROM t_compact;
+SELECT part_type FROM system.parts WHERE database = currentDatabase() AND table = 't_compact' AND active;
+
+SELECT 'ALTER:';
+
+CREATE TABLE t_alter (x UInt64) ENGINE = MergeTree ORDER BY x;
+ALTER TABLE t_alter ADD COLUMN v Array(Tuple(a UInt64 CODEC(Delta, ZSTD(1)), b UInt64));
+SHOW CREATE TABLE t_alter;
+INSERT INTO t_alter VALUES (1, [(10, 20)]);
+ALTER TABLE t_alter MODIFY COLUMN v Array(Tuple(a UInt64 CODEC(LZ4HC(5)), b UInt64 CODEC(ZSTD(3))));
+SHOW CREATE TABLE t_alter;
+ALTER TABLE t_alter MODIFY COLUMN v REMOVE CODEC;
+SHOW CREATE TABLE t_alter;
+SELECT x, v FROM t_alter;
+
+SELECT 'SimpleAggregateFunction storage:';
+
+CREATE TABLE t_saf
+(
+    id UInt64,
+    t SimpleAggregateFunction(anyLast, Tuple(a UInt64 CODEC(Delta, ZSTD(1)), b Float64 CODEC(Gorilla, ZSTD(1))))
+)
+ENGINE = AggregatingMergeTree ORDER BY id;
+
+SHOW CREATE TABLE t_saf;
+INSERT INTO t_saf VALUES (1, (1, 1.5));
+SELECT id, t FROM t_saf;
+
+SELECT 'Tuple inside Map:';
+
+CREATE TABLE t_map
+(
+    m Map(String, Tuple(x UInt64 CODEC(ZSTD(1)), y UInt64))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+SHOW CREATE TABLE t_map;
+INSERT INTO t_map VALUES ({'k': (1, 2)});
+SELECT m FROM t_map;
+
+SELECT 'Errors:';
+
+SELECT CAST((1, 2), 'Tuple(a UInt64 CODEC(LZ4), b UInt64)'); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE t_err (t Tuple(x UInt32 CODEC(Gorilla, ZSTD(1)))) ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+CREATE TABLE t_err (x UInt64, a Tuple(p UInt64 CODEC(LZ4)) ALIAS tuple(x)) ENGINE = MergeTree ORDER BY x; -- { serverError BAD_ARGUMENTS }
+CREATE TABLE t_err (n Nested(x UInt32 CODEC(LZ4))) ENGINE = MergeTree ORDER BY tuple(); -- { clientError SYNTAX_ERROR }
+CREATE TABLE t_err (t Tuple(UInt32 CODEC(LZ4))) ENGINE = MergeTree ORDER BY tuple(); -- { clientError SYNTAX_ERROR }
+
+DROP TABLE ts_series;
+DROP TABLE t_check;
+DROP TABLE t_compact;
+DROP TABLE t_alter;
+DROP TABLE t_saf;
+DROP TABLE t_map;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support compression codecs for Tuple elements.

For example,
```
CREATE TABLE series
(
    id UInt64,
    samples Array(Tuple(
        timestamp DateTime64(3, 'UTC') CODEC(DoubleDelta, ZSTD(1)),
        value Float64 CODEC(Gorilla, ZSTD(1))))
)
ENGINE = MergeTree ORDER BY id;
```

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117343&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117343](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117343+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
