### PR TITLE
 AST fuzzer oracle: gate non-deterministic constructs found by fuzzing

### DIFF
--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -744,6 +744,29 @@ bool hasWithFillAnywhere(const ASTPtr & ast)
     return false;
 }
 
+/// True if any SELECT anywhere in the query uses `GROUP BY ... WITH TOTALS`
+/// (also `ROLLUP` / `CUBE` / `GROUPING SETS`). These synthesise a subtotal /
+/// grand-total row that is a global aggregate, not a per-input-row value, so it
+/// is not distributive over the WHERE/HAVING partition split the metamorphic
+/// oracles perform: re-scanning the source in each partition recomputes the
+/// totals over a subset (or drops them), so the totals row legitimately differs.
+/// The per-oracle guards already reject a TOP-LEVEL `group_by_with_totals`, but a
+/// modifier hidden in a CTE or subquery (whose outer query the oracle rewrites)
+/// slips past them, so gate it recursively at the top of `check`.
+bool hasGroupByTotalsModifierAnywhere(const ASTPtr & ast)
+{
+    if (!ast)
+        return false;
+    if (const auto * select = ast->as<ASTSelectQuery>())
+        if (select->group_by_with_totals || select->group_by_with_rollup
+            || select->group_by_with_cube || select->group_by_with_grouping_sets)
+            return true;
+    for (const auto & child : ast->children)
+        if (hasGroupByTotalsModifierAnywhere(child))
+            return true;
+    return false;
+}
+
 /// True if any table expression in the query uses `FINAL`. FINAL's dedup is
 /// global over the table's row versions and is NOT distributive over a WHERE
 /// predicate: the TLP rewrites split rows into `p` / `NOT p` / `p IS NULL`
@@ -2507,6 +2530,12 @@ bool QueryOracleChecker::check(const ASTPtr & query_ast, const ContextMutablePtr
     if (hasWithFillAnywhere(query_ast))
     {
         LOG_TRACE(logger, "Oracle skip: ORDER BY ... WITH FILL (synthesises order-dependent rows)");
+        return false;
+    }
+
+    if (hasGroupByTotalsModifierAnywhere(query_ast))
+    {
+        LOG_TRACE(logger, "Oracle skip: WITH TOTALS / ROLLUP / CUBE / GROUPING SETS (subtotal row is not distributive over partitions)");
         return false;
     }
 

--- a/src/Interpreters/QueryOracleChecker.cpp
+++ b/src/Interpreters/QueryOracleChecker.cpp
@@ -88,6 +88,15 @@ const std::unordered_set<String> non_deterministic_functions = {
     /// that moves or negates it (TLP partitions, NoREC `countIf`) changes
     /// the result legitimately.
     "indexHint",
+    /// These expose the physical storage layout of a `JSON`/`Dynamic` column —
+    /// which paths are stored as dedicated dynamic subcolumns versus spilled into
+    /// the shared-data blob. That split is decided per part/block at write time
+    /// under `max_dynamic_paths`/`max_dynamic_types`, not part of the logical
+    /// value, so a rewrite that re-materialises the column (subquery wrap, DQP
+    /// reblocking) legitimately reports a different dynamic/shared assignment.
+    "JSONDynamicPaths", "JSONDynamicPathsWithTypes",
+    "JSONSharedDataPaths", "JSONSharedDataPathsWithTypes",
+    "isDynamicElementInSharedData",
     /// `viewExplain` (the table function behind `SELECT ... FROM (EXPLAIN ...)`)
     /// returns the query plan as rows. The plan text legitimately changes when
     /// DQP toggles an optimizer setting, so comparing such results is comparing
@@ -104,6 +113,13 @@ const std::unordered_set<String> non_deterministic_functions = {
     "anyRespectNulls", "anyLastRespectNulls",
     "first_value", "last_value",
     "topK", "topKWeighted",
+    /// `approx_top_k` / `approx_top_sum` (alias `approx_top_count`) use the same
+    /// bounded Filtered-Space-Saving structure as `topK`: merging the partial
+    /// states from the TLP UNION-ALL partition split drops different candidates
+    /// than a single pass over the whole input, so the approximate result
+    /// legitimately differs. `stripAggregateCombinators` maps the `*State`/
+    /// `*Merge` forms back to these base names.
+    "approx_top_k", "approx_top_sum", "approx_top_count",
     "uniqHLL12", "uniqCombined", "uniqCombined64", "uniqTheta",
     /// Approximate quantile/median functions: State/Merge gives different results
     /// than direct computation due to approximate merging algorithms. Block both
@@ -753,15 +769,22 @@ bool usesFinalAnywhere(const ASTPtr & ast)
 /// implementation-defined, so which right-side row a left row pairs with can
 /// change between plans — observed as a `Subquery wrap` false mismatch.
 /// Checked recursively: an ASOF join in any subquery taints the whole query.
-bool hasAsofJoinAnywhere(const ASTPtr & ast)
+/// Joins whose result is not stable across plan rewrites: `ASOF` picks the
+/// latest matching row (tie-breaking is plan-dependent), and `ANY` / old
+/// `RightAny` pick an arbitrary matching row from the right table, so which row
+/// survives the join can differ between the reference and the rewrite even at a
+/// fixed setting. `SEMI` / `ANTI` / `ALL` are deterministic and stay eligible.
+bool hasNonDeterministicJoinAnywhere(const ASTPtr & ast)
 {
     if (!ast)
         return false;
     if (const auto * join = ast->as<ASTTableJoin>())
-        if (join->strictness == JoinStrictness::Asof)
+        if (join->strictness == JoinStrictness::Asof
+            || join->strictness == JoinStrictness::Any
+            || join->strictness == JoinStrictness::RightAny)
             return true;
     for (const auto & child : ast->children)
-        if (hasAsofJoinAnywhere(child))
+        if (hasNonDeterministicJoinAnywhere(child))
             return true;
     return false;
 }
@@ -895,7 +918,15 @@ bool referencesNonDeterministicDatabase(const ASTSelectQuery & select, const Str
 /// throws is treated conservatively as "distributed" (fail closed): we cannot
 /// prove the table is safe, so we skip the query rather than risk a false
 /// `AST_FUZZER_ORACLE_MISMATCH`.
-bool referencesDistributedTableAnywhere(const ASTPtr & ast, const ContextPtr & context)
+/// Engines whose read is not stable across the oracle's repeated reads or plan
+/// rewrites: `Distributed` routes to remote shards (on the test clusters that
+/// all point at localhost a row is read once per shard, so reference vs rewrite
+/// can route/dedup differently), and `Buffer` splits rows between an in-memory
+/// buffer and the backing table with a background flush thread, so two reads
+/// can legitimately return different rows.
+const std::unordered_set<String> non_deterministic_table_engines = {"Distributed", "Buffer"};
+
+bool referencesNonDeterministicEngineAnywhere(const ASTPtr & ast, const ContextPtr & context)
 {
     if (!ast)
         return false;
@@ -907,20 +938,20 @@ bool referencesDistributedTableAnywhere(const ASTPtr & ast, const ContextPtr & c
         try
         {
             auto storage = DatabaseCatalog::instance().tryGetTable({database, table_id->shortName()}, context);
-            if (storage && storage->getName() == "Distributed")
+            if (storage && non_deterministic_table_engines.contains(storage->getName()))
                 return true;
         }
         catch (...)
         {
             /// Ok: fail closed. If the table cannot be resolved we cannot prove it
-            /// is not `Distributed`, so treat it as distributed (unsafe) and skip
-            /// the query rather than risk a false oracle mismatch. Deliberately not
+            /// is not one of these engines, so treat it as unsafe and skip the
+            /// query rather than risk a false oracle mismatch. Deliberately not
             /// logged: this runs per-AST-node on a hot path.
             return true;
         }
     }
     for (const auto & child : ast->children)
-        if (referencesDistributedTableAnywhere(child, context))
+        if (referencesNonDeterministicEngineAnywhere(child, context))
             return true;
     return false;
 }
@@ -2467,9 +2498,9 @@ bool QueryOracleChecker::check(const ASTPtr & query_ast, const ContextMutablePtr
         }
     }
 
-    if (hasAsofJoinAnywhere(query_ast))
+    if (hasNonDeterministicJoinAnywhere(query_ast))
     {
-        LOG_TRACE(logger, "Oracle skip: ASOF JOIN (tie-breaking is plan-dependent)");
+        LOG_TRACE(logger, "Oracle skip: ASOF / ANY JOIN (picks an arbitrary/plan-dependent matching row)");
         return false;
     }
 
@@ -2485,14 +2516,12 @@ bool QueryOracleChecker::check(const ASTPtr & query_ast, const ContextMutablePtr
         return false;
     }
 
-    /// `Distributed` tables route to remote shards (here, test clusters whose
-    /// replicas all point at localhost), so a row is read once per shard and
-    /// the reference vs rewrite can route/dedup differently — the oracle can't
-    /// validate the result. Resolve each referenced table's engine (including
-    /// tables hidden inside subqueries / CTEs) and skip.
-    if (referencesDistributedTableAnywhere(query_ast, context))
+    /// Resolve each referenced table's engine (including tables hidden inside
+    /// subqueries / CTEs) and skip when any of them reads non-deterministically
+    /// across the oracle's repeated reads — see `non_deterministic_table_engines`.
+    if (referencesNonDeterministicEngineAnywhere(query_ast, context))
     {
-        LOG_TRACE(logger, "Oracle skip: query reads from a Distributed table");
+        LOG_TRACE(logger, "Oracle skip: query reads from a Distributed or Buffer table");
         return false;
     }
 


### PR DESCRIPTION
Live fuzzing of master surfaced several classes of false AST-fuzzer oracle mismatch —
each a construct whose result is not stable across the oracle's metamorphic rewrites,
so the reference and the rewrite legitimately differ. This gates them so the oracle
stops reporting them as mismatches (each verified with a 60–100-run zero-mismatch soak,
while an eligible control query still exercises the oracle):

* `approx_top_k` / `approx_top_sum` (alias `approx_top_count`) use the same bounded
  Filtered-Space-Saving structure as `topK`: merging the partial states from the TLP
  UNION-ALL partition split drops different candidates than a single pass, so the
  approximate result differs. Added to `non_deterministic_functions`.
* `Buffer`-engine tables split rows between an in-memory buffer and the backing table
  with a background flush, so two reads can return different rows. Generalised the
  `Distributed` gate to a `non_deterministic_table_engines` set covering both.
* `ANY` / `RightAny` joins pick an arbitrary matching right row, so which row survives
  is plan-dependent. Generalised the ASOF-join gate to also cover them.
* `JSONDynamicPaths` / `JSONSharedDataPaths(WithTypes)` / `isDynamicElementInSharedData`
  expose the physical dynamic-vs-shared storage split of a JSON column (decided per
  part/block under `max_dynamic_paths`), not the logical value; a rewrite that
  re-materialises the column reports a different split. Gated.
* `WITH TOTALS` / `ROLLUP` / `CUBE` / `GROUPING SETS` synthesise a subtotal/grand-total
  row that is a global aggregate, not distributive over the WHERE/HAVING partition
  split. The per-oracle guards only rejected a top-level modifier; a new recursive
  `hasGroupByTotalsModifierAnywhere` gate also catches one hidden in a CTE/subquery.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Related: https://github.com/ClickHouse/ClickHouse/pull/99980

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117347&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117347](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117347+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
