### PR TITLE
illumos: misc portability fixes.

### DIFF
--- a/base/base/openpty.h
+++ b/base/base/openpty.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sys/ioctl.h>
+#include <termios.h>
 
 
 /// Portable replacement for libc's `openpty` using POSIX `posix_openpt`/`grantpt`/`unlockpt`.

--- a/base/poco/Foundation/src/FPEnvironment_SUN.cpp
+++ b/base/poco/Foundation/src/FPEnvironment_SUN.cpp
@@ -50,7 +50,7 @@ FPEnvironmentImpl& FPEnvironmentImpl::operator = (const FPEnvironmentImpl& env)
 
 bool FPEnvironmentImpl::isInfiniteImpl(float value)
 {
-	int cls = fpclass(value);
+	int cls = fpclass(static_cast<double>(value));
 	return cls == FP_PINF || cls == FP_NINF;
 }
 
@@ -95,7 +95,7 @@ float FPEnvironmentImpl::copySignImpl(float target, float source)
 
 double FPEnvironmentImpl::copySignImpl(double target, double source)
 {
-	return (float) copysign(target, source);
+	return copysign(target, source);
 }
 
 

--- a/cmake/sunos/default_libs.cmake
+++ b/cmake/sunos/default_libs.cmake
@@ -13,7 +13,10 @@ set (DEFAULT_LIBS "-nodefaultlibs")
 # (no toolchain file in contrib/compiler-rt-cmake/), so we use -lgcc_s.
 set (BUILTINS_LIBRARY "-lgcc_s")
 
-set (DEFAULT_LIBS "${DEFAULT_LIBS} ${BUILTINS_LIBRARY} -lc -lm -lrt -lpthread -ldl -lsocket -lnsl -lsendfile -lproc -lumem")
+# On linux/darwin, we use lld, which isn't sensitive to the order of
+# dependencies. On illumos, we use ld, which is. Set `-z rescan-now` so that we
+# don't have to explicitly manage the dependency graph in DEPENDS.
+set (DEFAULT_LIBS "${DEFAULT_LIBS} -Wl,-z,rescan-now ${BUILTINS_LIBRARY} -lc -lm -lrt -lpthread -ldl -lsocket -lnsl -lsendfile -lproc -lumem")
 
 message(STATUS "Default libraries: ${DEFAULT_LIBS}")
 

--- a/src/Common/StackTrace.h
+++ b/src/Common/StackTrace.h
@@ -29,6 +29,14 @@
 #   define _XOPEN_SOURCE 700
 #endif
 #include <ucontext.h>
+
+#if defined(OS_SUNOS)
+/** illumos regset.h includes unprefixed macros for i386 gregset_t indices. These macros aren't used
+  * in ClickHouse, and conflict with `ProgressOption::ERR` and the `FS` namespace.
+  */
+#undef ERR
+#undef FS
+#endif
 #endif
 
 /** The stack trace of the throw that created an exception, recorded inside the `std::exception`


### PR DESCRIPTION
* Include termios.h in openpty.h. Under linux and darwin, ioctl.h provides `winsize`. Under illumos, it doesn't. For portability, explicitly include termios.h.
* Fix macro pollution in StackTrace.h. Under illumos, regset.h defines a set of unprefixed gregset_t index macros (ERR, FS, etc.). ClickHouse only uses the analogous prefixed macros (REG_ERR, REG_FS, etc.), so we conditionally undef the conflicting macros.
* Fix illumos-specific double/float cast errors in FPEnvironment, so that we don't widen or truncate inappropriately.

Part of #23777.

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->
---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117363&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117363](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117363+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.506` (included in `26.9` and later)
<!-- ch-version-info:end -->