### PR TITLE
Force the analyzer in `03707_autopr_unsupported_cases`

### DIFF
--- a/tests/queries/0_stateless/03707_autopr_unsupported_cases.sql
+++ b/tests/queries/0_stateless/03707_autopr_unsupported_cases.sql
@@ -8,6 +8,11 @@
 SET enable_parallel_replicas=1, automatic_parallel_replicas_mode=2, parallel_replicas_local_plan=1, parallel_replicas_index_analysis_only_on_coordinator=1,
     parallel_replicas_for_non_replicated_merge_tree=1, max_parallel_replicas=3, cluster_for_parallel_replicas='parallel_replicas';
 
+-- The optimization works on the query plan, which only the analyzer builds. `InterpreterSelectQuery`
+-- turns `enable_parallel_replicas` off when it sees this settings combination, so with the old
+-- analyzer every shape below - supported or not - would collect no statistics.
+SET enable_analyzer=1;
+
 CREATE TABLE t(number UInt64) ENGINE=MergeTree ORDER BY () AS SELECT * FROM numbers_mt(1e6);
 
 CREATE TABLE tt


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117364&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117364](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117364+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.464` (included in `26.9` and later)
<!-- ch-version-info:end -->