### PR TITLE
Fix flaky 04758_alter_modify_projection_settings_replicated

### DIFF
--- a/tests/queries/0_stateless/04758_alter_modify_projection_settings_replicated.sql
+++ b/tests/queries/0_stateless/04758_alter_modify_projection_settings_replicated.sql
@@ -19,7 +19,10 @@ CREATE TABLE t_modify_projection_r2
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_modify_projection', 'r2') ORDER BY k;
 
-ALTER TABLE t_modify_projection_r1 MODIFY PROJECTION p (SELECT v ORDER BY v) WITH SETTINGS (index_granularity = 128);
+-- `alter_sync = 2` waits for every replica to apply the new metadata version. `SYSTEM SYNC REPLICA`
+-- alone is not enough: on `SharedMergeTree` it refreshes parts and mutations, not the table structure.
+ALTER TABLE t_modify_projection_r1 MODIFY PROJECTION p (SELECT v ORDER BY v) WITH SETTINGS (index_granularity = 128)
+    SETTINGS alter_sync = 2;
 
 SYSTEM SYNC REPLICA t_modify_projection_r2;
 


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/clickhouse-private/issues/71837
Related: https://github.com/ClickHouse/ClickHouse/pull/113343

`04758_alter_modify_projection_settings_replicated` alters the projection settings on one replica and then reads the definition back from the other after `SYSTEM SYNC REPLICA`. That is a `ReplicatedMergeTree` guarantee only: there the metadata change is a replication queue entry, so draining the queue applies it.

On `SharedMergeTree` there is no such queue. `SYSTEM SYNC REPLICA` refreshes parts and mutations, and only *schedules* the background task that applies the table structure, so the following `SHOW CREATE TABLE` can still report the pre-alter `index_granularity`. `alter_sync` defaults to `1`, meaning the `ALTER` waits for the current replica only, so nothing waited for the second replica.

Waiting with `alter_sync = 2` blocks until every replica reports the new metadata version, which is correct for both engines and is the existing convention for metadata alters that must be visible elsewhere (for example `00988_constraints_replication_zookeeper_long.sql`).

This only ever failed in private CI, where `ReplicatedMergeTree` is replaced with `SharedMergeTree`: 27 failures between 2026-08-21 and 2026-08-31 across 27 distinct commits, 11 of them directly on `master`, and none in public CI.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117365&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117365](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117365+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.477` (included in `26.9` and later)
- Backported to: `26.8.3.4`
<!-- ch-version-info:end -->