### PR TITLE
Use simpler jemalloc fiber TLS mitigation

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -236,6 +236,7 @@ target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_PROF=1)
 if (ENABLE_JEMALLOC_UAF_SAN)
     target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_UAF_DETECTION)
 endif ()
+target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_EXPERIMENTAL_FIBER_SAFE_TLS)
 
 # jemalloc provides support two unwind flavors:
 # - JEMALLOC_PROF_LIBUNWIND - unw_backtrace() - gnu libunwind (compatible with llvm libunwind)


### PR DESCRIPTION
_This is only to run performance tests_

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use simpler jemalloc fiber TLS mitigation

Refs: https://github.com/ClickHouse/jemalloc/pull/11

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117369&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117369](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117369+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
