### PR TITLE
Allow HTTP authentication responses to set session roles

### DIFF
--- a/docs/concepts/features/security/external-authenticators/http.mdx
+++ b/docs/concepts/features/security/external-authenticators/http.mdx
@@ -111,11 +111,11 @@ An HTTP authentication server can return optional session settings, roles, and a
     "reader",
     "analyst"
   ],
-  "valid_until": 1788192000
+  "valid_until": 1893456000
 }
 ```
 
-Each field is optional and is parsed independently. If the response body is not a valid JSON object, ClickHouse ignores all optional response metadata. A malformed field does not prevent ClickHouse from keeping metadata parsed successfully from the other fields.
+`1893456000` is 2030-01-01 00:00:00 UTC. Each field is optional and is parsed independently. If the response body is not a valid JSON object, ClickHouse ignores all optional response metadata. Malformed `settings` do not prevent ClickHouse from keeping metadata parsed successfully from the other fields.
 
 #### Session settings {#passing-session-settings}
 
@@ -123,10 +123,10 @@ The `settings` object contains key-value pairs that ClickHouse applies as sessio
 
 #### Roles {#roles}
 
-The `roles` array contains local ClickHouse role names. ClickHouse ignores names that do not identify an existing role. Returned roles are attached only to the authenticated session and are not persisted as grants for the user. Each successful authentication replaces the roles returned by the previous authentication, including when reauthenticating a named HTTP session.
+The `roles` array contains local ClickHouse role names. If the field is present, it must be an array of strings and every name must identify an existing role; otherwise, ClickHouse rejects authentication. Returned roles are attached only to the authenticated session and are not persisted as grants for the user. When ClickHouse creates a session, settings profiles attached to returned roles apply to it. Each successful authentication replaces the roles returned by the previous authentication, including when reauthenticating a named HTTP session.
 
 #### `valid_until` {#valid-until}
 
-The optional `valid_until` value is an absolute Unix timestamp in seconds. If it is absent, the authentication server adds no expiry deadline. A supplied deadline that has already expired rejects authentication. If the user's ClickHouse authentication method also has `VALID UNTIL`, the earlier deadline applies.
+The optional `valid_until` value is an absolute Unix timestamp in seconds. If it is absent, the authentication server adds no expiry deadline. If present, it must be an integer timestamp; malformed values and deadlines that have already expired reject authentication. If the user's ClickHouse authentication method also has `VALID UNTIL`, the earlier deadline applies.
 
 ClickHouse checks the deadline before subsequent queries. A query that starts before the deadline is not canceled solely because the deadline passes while it is running.

--- a/docs/concepts/features/security/external-authenticators/http.mdx
+++ b/docs/concepts/features/security/external-authenticators/http.mdx
@@ -98,6 +98,35 @@ CREATE USER my_user IDENTIFIED WITH HTTP SERVER 'basic_server' SCHEME 'Basic'
 CREATE USER my_user IDENTIFIED WITH HTTP SERVER 'basic_server'
 ```
 
-### Passing session settings {#passing-session-settings}
+### Returning session metadata {#returning-session-metadata}
 
-If a response body from HTTP authentication server has JSON format and contains `settings` sub-object, ClickHouse will try parse its key: value pairs as string values and set them as session settings for authenticated user's current session. If parsing is failed, a response body from server will be ignored.
+An HTTP authentication server can return optional session settings, roles, and an authentication expiry in a JSON response body:
+
+```json
+{
+  "settings": {
+    "max_threads": 4
+  },
+  "roles": [
+    "reader",
+    "analyst"
+  ],
+  "valid_until": 1788192000
+}
+```
+
+Each field is optional and is parsed independently. If the response body is not a valid JSON object, ClickHouse ignores all optional response metadata. A malformed field does not prevent ClickHouse from keeping metadata parsed successfully from the other fields.
+
+#### Session settings {#passing-session-settings}
+
+The `settings` object contains key-value pairs that ClickHouse applies as session settings for the authenticated user's current session.
+
+#### Roles {#roles}
+
+The `roles` array contains local ClickHouse role names. ClickHouse ignores names that do not identify an existing role. Returned roles are attached only to the authenticated session and are not persisted as grants for the user. Each successful authentication replaces the roles returned by the previous authentication, including when reauthenticating a named HTTP session.
+
+#### `valid_until` {#valid-until}
+
+The optional `valid_until` value is an absolute Unix timestamp in seconds. If it is absent, the authentication server adds no expiry deadline. A supplied deadline that has already expired rejects authentication. If the user's ClickHouse authentication method also has `VALID UNTIL`, the earlier deadline applies.
+
+ClickHouse checks the deadline before subsequent queries. A query that starts before the deadline is not canceled solely because the deadline passes while it is running.

--- a/src/Access/Authentication.cpp
+++ b/src/Access/Authentication.cpp
@@ -179,7 +179,9 @@ namespace
         const AuthenticationData & authentication_method,
         const ExternalAuthenticators & external_authenticators,
         const ClientInfo & client_info,
-        SettingsChanges & settings)
+        SettingsChanges & settings,
+        Strings & external_role_names,
+        std::optional<time_t> & valid_until)
     {
         const auto & provided_password = basic_credentials->getPassword();
         const auto & otp_secret = authentication_method.getOneTimePassword();
@@ -253,7 +255,12 @@ namespace
                 if (authentication_method.getHTTPAuthenticationScheme() == HTTPAuthenticationScheme::BASIC)
                 {
                     return external_authenticators.checkHTTPBasicCredentials(
-                        authentication_method.getHTTPAuthenticationServerName(), *basic_credentials, client_info, settings) ?
+                        authentication_method.getHTTPAuthenticationServerName(),
+                        *basic_credentials,
+                        client_info,
+                        settings,
+                        external_role_names,
+                        valid_until) ?
                         on_success : Authentication::CredentialsCheckResult::Fail;
                 }
                 break;
@@ -360,7 +367,9 @@ Authentication::CredentialsCheckResult Authentication::areCredentialsValid(
     const AuthenticationData & authentication_method,
     const ExternalAuthenticators & external_authenticators,
     const ClientInfo & client_info,
-    SettingsChanges & settings)
+    SettingsChanges & settings,
+    Strings & external_role_names,
+    std::optional<time_t> & valid_until)
 {
     if (!credentials.isReady())
         return CredentialsCheckResult::Fail;
@@ -379,7 +388,14 @@ Authentication::CredentialsCheckResult Authentication::areCredentialsValid(
 
     if (const auto * basic_credentials = typeid_cast<const BasicCredentials *>(&credentials))
     {
-        return checkBasicAuthentication(basic_credentials, authentication_method, external_authenticators, client_info, settings);
+        return checkBasicAuthentication(
+            basic_credentials,
+            authentication_method,
+            external_authenticators,
+            client_info,
+            settings,
+            external_role_names,
+            valid_until);
     }
 
     if (const auto * scram_shh256_credentials = typeid_cast<const ScramSHA256Credentials *>(&credentials))

--- a/src/Access/Authentication.h
+++ b/src/Access/Authentication.h
@@ -5,6 +5,9 @@
 #include <Interpreters/ClientInfo.h>
 #include <base/types.h>
 
+#include <ctime>
+#include <optional>
+
 
 namespace DB
 {
@@ -29,14 +32,16 @@ struct Authentication
     };
 
     /// Checks the credentials (passwords, readiness, etc.)
-    /// If necessary, makes a request to external authenticators and fills in the session settings if they were
-    /// returned by the authentication server
+    /// If necessary, makes a request to external authenticators and fills in the session settings, external role names,
+    /// and authentication expiry if they were returned by the authentication server.
     static CredentialsCheckResult areCredentialsValid(
         const Credentials & credentials,
         const AuthenticationData & authentication_method,
         const ExternalAuthenticators & external_authenticators,
         const ClientInfo & client_info,
-        SettingsChanges & settings);
+        SettingsChanges & settings,
+        Strings & external_role_names,
+        std::optional<time_t> & valid_until);
 
     // A signaling class used to communicate requirements for credentials.
     template <typename CredentialsType>

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -572,22 +572,23 @@ bool ExternalAuthenticators::checkHTTPBasicCredentials(
     auto params = getHTTPAuthenticationParams(server);
     HTTPBasicAuthClient<SettingsAuthResponseParser> client(params);
 
-    auto [is_ok, settings_from_auth_server, roles_from_auth_server, valid_until_from_auth_server]
-        = client.authenticate(credentials.getUserName(), credentials.getPassword(), client_info.http_headers);
+    auto response = client.authenticate(credentials.getUserName(), credentials.getPassword(), client_info.http_headers);
 
-    if (!is_ok)
+    if (!response.is_ok
+        || response.roles_status == SettingsAuthResponseParser::MetadataStatus::Invalid
+        || response.valid_until_status == SettingsAuthResponseParser::MetadataStatus::Invalid)
         return false;
 
-    if (valid_until_from_auth_server)
+    if (response.valid_until)
     {
         const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-        if (now > *valid_until_from_auth_server)
+        if (now > *response.valid_until)
             return false;
     }
 
-    std::ranges::move(settings_from_auth_server, std::back_inserter(settings));
-    std::ranges::move(roles_from_auth_server, std::back_inserter(external_role_names));
-    valid_until = valid_until_from_auth_server;
+    std::ranges::move(response.settings, std::back_inserter(settings));
+    std::ranges::move(response.roles, std::back_inserter(external_role_names));
+    valid_until = response.valid_until;
     return true;
 }
 }

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -562,16 +562,32 @@ HTTPAuthClientParams ExternalAuthenticators::getHTTPAuthenticationParams(const S
 }
 
 bool ExternalAuthenticators::checkHTTPBasicCredentials(
-    const String & server, const BasicCredentials & credentials, const ClientInfo & client_info, SettingsChanges & settings) const
+    const String & server,
+    const BasicCredentials & credentials,
+    const ClientInfo & client_info,
+    SettingsChanges & settings,
+    Strings & external_role_names,
+    std::optional<time_t> & valid_until) const
 {
     auto params = getHTTPAuthenticationParams(server);
     HTTPBasicAuthClient<SettingsAuthResponseParser> client(params);
 
-    auto [is_ok, settings_from_auth_server] = client.authenticate(credentials.getUserName(), credentials.getPassword(), client_info.http_headers);
+    auto [is_ok, settings_from_auth_server, roles_from_auth_server, valid_until_from_auth_server]
+        = client.authenticate(credentials.getUserName(), credentials.getPassword(), client_info.http_headers);
 
-    if (is_ok)
-        std::ranges::move(settings_from_auth_server, std::back_inserter(settings));
+    if (!is_ok)
+        return false;
 
-    return is_ok;
+    if (valid_until_from_auth_server)
+    {
+        const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+        if (now > *valid_until_from_auth_server)
+            return false;
+    }
+
+    std::ranges::move(settings_from_auth_server, std::back_inserter(settings));
+    std::ranges::move(roles_from_auth_server, std::back_inserter(external_role_names));
+    valid_until = valid_until_from_auth_server;
+    return true;
 }
 }

--- a/src/Access/ExternalAuthenticators.h
+++ b/src/Access/ExternalAuthenticators.h
@@ -43,7 +43,13 @@ public:
     bool checkLDAPCredentials(const String & server, const BasicCredentials & credentials,
         const LDAPClient::RoleSearchParamsList * role_search_params = nullptr, LDAPClient::SearchResultsList * role_search_results = nullptr) const;
     bool checkKerberosCredentials(const String & realm, const GSSAcceptorContext & credentials) const;
-    bool checkHTTPBasicCredentials(const String & server, const BasicCredentials & credentials, const ClientInfo & client_info, SettingsChanges & settings) const;
+    bool checkHTTPBasicCredentials(
+        const String & server,
+        const BasicCredentials & credentials,
+        const ClientInfo & client_info,
+        SettingsChanges & settings,
+        Strings & external_role_names,
+        std::optional<time_t> & valid_until) const;
 
     GSSAcceptorContext::Params getKerberosParams() const;
 

--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -641,6 +641,8 @@ Authentication::CredentialsCheckResult areCredentialsValid(
     const ExternalAuthenticators & external_authenticators,
     const ClientInfo & client_info,
     SettingsChanges & settings,
+    Strings & external_role_names,
+    std::optional<time_t> & external_valid_until,
     bool check_valid_until = true);
 
 /// A `NO_PASSWORD` or `PLAINTEXT_PASSWORD` method is ignored entirely when the corresponding server setting disables it
@@ -677,6 +679,7 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
 
             bool need_second_factor = false;
             const AuthenticationData * matched_authentication_method = nullptr;
+            std::optional<time_t> matched_external_valid_until;
             for (const auto & auth_method : user->authentication_methods)
             {
                 auto auth_type = auth_method.getType();
@@ -686,10 +689,24 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
                     continue;
                 }
 
-                auto cred_check_result = areCredentialsValid(user->getName(), auth_method, credentials, external_authenticators, client_info, auth_result.settings);
+                SettingsChanges attempt_settings;
+                Strings attempt_external_role_names;
+                std::optional<time_t> attempt_external_valid_until;
+                auto cred_check_result = areCredentialsValid(
+                    user->getName(),
+                    auth_method,
+                    credentials,
+                    external_authenticators,
+                    client_info,
+                    attempt_settings,
+                    attempt_external_role_names,
+                    attempt_external_valid_until);
                 if (cred_check_result == Authentication::CredentialsCheckResult::Success)
                 {
                     matched_authentication_method = &auth_method;
+                    auth_result.settings = std::move(attempt_settings);
+                    auth_result.external_role_names = std::move(attempt_external_role_names);
+                    matched_external_valid_until = attempt_external_valid_until;
                     break;
                 }
                 if (cred_check_result == Authentication::CredentialsCheckResult::NeedSecondFactor)
@@ -707,6 +724,8 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
                     auth_result.authentication_data = *matched_authentication_method;
                     auth_result.authentication_data.setGrants({});
                     auth_result.authentication_data.setValidUntil(0);
+                    auth_result.settings.clear();
+                    auth_result.external_role_names.clear();
                     return auth_result;
                 }
 
@@ -734,6 +753,9 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
                     combined_grants.emplace(matched_authentication_method->getGrants());
                 bool another_method_restricts_grants = false;
                 time_t combined_valid_until = matched_authentication_method->getValidUntil();
+                if (matched_external_valid_until
+                    && (combined_valid_until == 0 || *matched_external_valid_until < combined_valid_until))
+                    combined_valid_until = *matched_external_valid_until;
 
                 for (const auto & other_method : user->authentication_methods)
                 {
@@ -753,7 +775,18 @@ std::optional<AuthResult> IAccessStorage::authenticateImpl(
                         continue;
 
                     SettingsChanges discarded_settings;
-                    if (areCredentialsValid(user->getName(), other_method, credentials, external_authenticators, client_info, discarded_settings, /* check_valid_until = */ false)
+                    Strings discarded_external_role_names;
+                    std::optional<time_t> discarded_external_valid_until;
+                    if (areCredentialsValid(
+                            user->getName(),
+                            other_method,
+                            credentials,
+                            external_authenticators,
+                            client_info,
+                            discarded_settings,
+                            discarded_external_role_names,
+                            discarded_external_valid_until,
+                            /* check_valid_until = */ false)
                         != Authentication::CredentialsCheckResult::Success)
                         continue;
 
@@ -819,6 +852,8 @@ Authentication::CredentialsCheckResult areCredentialsValid(
     const ExternalAuthenticators & external_authenticators,
     const ClientInfo & client_info,
     SettingsChanges & settings,
+    Strings & external_role_names,
+    std::optional<time_t> & external_valid_until,
     bool check_valid_until)
 {
     if (!credentials.isReady())
@@ -839,7 +874,14 @@ Authentication::CredentialsCheckResult areCredentialsValid(
         }
     }
 
-    return Authentication::areCredentialsValid(credentials, authentication_method, external_authenticators, client_info, settings);
+    return Authentication::areCredentialsValid(
+        credentials,
+        authentication_method,
+        external_authenticators,
+        client_info,
+        settings,
+        external_role_names,
+        external_valid_until);
 }
 
 bool IAccessStorage::isAddressAllowed(const User & user, const Poco::Net::IPAddress & address) const

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -33,6 +33,8 @@ struct AuthResult
     UUID user_id;
     /// Session settings received from authentication server (if any)
     SettingsChanges settings{};
+    /// Role names returned by an external authentication server for this authentication.
+    Strings external_role_names{};
     AuthenticationData authentication_data {};
     /// Username determined by the access storage during authentication,
     /// should be treated as the authenticated user name

--- a/src/Access/SettingsAuthResponseParser.cpp
+++ b/src/Access/SettingsAuthResponseParser.cpp
@@ -1,13 +1,22 @@
 #include <Access/SettingsAuthResponseParser.h>
 
 #include <Access/resolveSetting.h>
+#include <Common/Exception.h>
 #include <IO/HTTPCommon.h>
 
+#include <Poco/JSON/Array.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
 
+#include <utility>
+
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int INCORRECT_DATA;
+}
 
 SettingsAuthResponseParser::Result
 SettingsAuthResponseParser::parse(const Poco::Net::HTTPResponse & response, std::istream * body_stream) const
@@ -21,23 +30,82 @@ SettingsAuthResponseParser::parse(const Poco::Net::HTTPResponse & response, std:
     if (!body_stream)
         return result;
 
-    Poco::JSON::Parser parser;
-    Poco::JSON::Object::Ptr parsed_body;
+    Poco::JSON::Object::Ptr obj;
 
     try
     {
+        Poco::JSON::Parser parser;
         Poco::Dynamic::Var json = parser.parse(*body_stream);
-        const Poco::JSON::Object::Ptr & obj = json.extract<Poco::JSON::Object::Ptr>();
-        Poco::JSON::Object::Ptr settings_obj = obj->getObject(settings_key);
-
-        if (settings_obj)
-            for (const auto & [key, value] : *settings_obj)
-                result.settings.emplace_back(key, settingStringToValueUtil(key, value));
+        obj = json.extract<Poco::JSON::Object::Ptr>();
     }
     catch (...)
     {
-        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse settings from authentication response. Skip it.");
+        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse authentication response body. Skip optional response metadata.");
+        return result;
     }
+
+    try
+    {
+        if (auto settings_obj = obj->getObject(settings_key))
+        {
+            /// Append directly to preserve the existing behavior where settings parsed before a later
+            /// conversion failure remain in the result.
+            for (const auto & [key, value] : *settings_obj)
+                result.settings.emplace_back(key, settingStringToValueUtil(key, value));
+        }
+    }
+    catch (...)
+    {
+        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse settings from authentication response. Skip them.");
+    }
+
+    try
+    {
+        if (obj->has(roles_key))
+        {
+            if (!obj->isArray(roles_key))
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Expected `roles` in authentication response to be an array");
+
+            auto roles_array = obj->getArray(roles_key);
+            Strings parsed_roles;
+            parsed_roles.reserve(roles_array->size());
+
+            for (const auto & value : *roles_array)
+            {
+                if (!value.isString())
+                    throw Exception(ErrorCodes::INCORRECT_DATA, "Expected every `roles` element in authentication response to be a string");
+
+                parsed_roles.emplace_back(value.extract<String>());
+            }
+
+            result.roles = std::move(parsed_roles);
+        }
+    }
+    catch (...)
+    {
+        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse roles from authentication response. Skip them.");
+    }
+
+    try
+    {
+        if (obj->has(valid_until_key))
+        {
+            const auto value = obj->get(valid_until_key);
+            if (!value.isInteger() || value.isBoolean())
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Expected `valid_until` in authentication response to be an integer");
+
+            const Int64 timestamp = value.convert<Int64>();
+            if (!std::in_range<time_t>(timestamp))
+                throw Exception(ErrorCodes::INCORRECT_DATA, "The `valid_until` value in authentication response is outside the `time_t` range");
+
+            result.valid_until = static_cast<time_t>(timestamp);
+        }
+    }
+    catch (...)
+    {
+        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse valid_until from authentication response. Skip it.");
+    }
+
     return result;
 }
 

--- a/src/Access/SettingsAuthResponseParser.cpp
+++ b/src/Access/SettingsAuthResponseParser.cpp
@@ -79,11 +79,13 @@ SettingsAuthResponseParser::parse(const Poco::Net::HTTPResponse & response, std:
             }
 
             result.roles = std::move(parsed_roles);
+            result.roles_status = MetadataStatus::Valid;
         }
     }
     catch (...)
     {
-        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse roles from authentication response. Skip them.");
+        result.roles_status = MetadataStatus::Invalid;
+        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse roles from authentication response.");
     }
 
     try
@@ -99,11 +101,13 @@ SettingsAuthResponseParser::parse(const Poco::Net::HTTPResponse & response, std:
                 throw Exception(ErrorCodes::INCORRECT_DATA, "The `valid_until` value in authentication response is outside the `time_t` range");
 
             result.valid_until = static_cast<time_t>(timestamp);
+            result.valid_until_status = MetadataStatus::Valid;
         }
     }
     catch (...)
     {
-        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse valid_until from authentication response. Skip it.");
+        result.valid_until_status = MetadataStatus::Invalid;
+        LOG_INFO(getLogger("HTTPAuthentication"), "Failed to parse valid_until from authentication response.");
     }
 
     return result;

--- a/src/Access/SettingsAuthResponseParser.h
+++ b/src/Access/SettingsAuthResponseParser.h
@@ -21,12 +21,21 @@ class SettingsAuthResponseParser
     static constexpr auto valid_until_key = "valid_until";
 
 public:
+    enum class MetadataStatus : uint8_t
+    {
+        Absent,
+        Valid,
+        Invalid,
+    };
+
     struct Result
     {
         bool is_ok = false;
         SettingsChanges settings;
         Strings roles;
+        MetadataStatus roles_status = MetadataStatus::Absent;
         std::optional<time_t> valid_until;
+        MetadataStatus valid_until_status = MetadataStatus::Absent;
     };
 
     Result parse(const Poco::Net::HTTPResponse & response, std::istream * body_stream) const;

--- a/src/Access/SettingsAuthResponseParser.h
+++ b/src/Access/SettingsAuthResponseParser.h
@@ -1,7 +1,10 @@
 #pragma once
 #include <Common/SettingsChanges.h>
+#include <base/types.h>
 
+#include <ctime>
 #include <istream>
+#include <optional>
 
 namespace Poco::Net
 {
@@ -10,16 +13,20 @@ class HTTPResponse;
 
 namespace DB
 {
-/// Class for parsing authentication response containing session settings
+/// Class for parsing optional metadata returned by an HTTP authentication server.
 class SettingsAuthResponseParser
 {
     static constexpr auto settings_key = "settings";
+    static constexpr auto roles_key = "roles";
+    static constexpr auto valid_until_key = "valid_until";
 
 public:
     struct Result
     {
         bool is_ok = false;
         SettingsChanges settings;
+        Strings roles;
+        std::optional<time_t> valid_until;
     };
 
     Result parse(const Poco::Net::HTTPResponse & response, std::istream * body_stream) const;

--- a/src/Access/tests/gtest_settings_auth_response_parser.cpp
+++ b/src/Access/tests/gtest_settings_auth_response_parser.cpp
@@ -38,8 +38,10 @@ TEST(SettingsAuthResponseParser, ParsesIndependentMetadataFields)
     EXPECT_EQ(result.settings[0].name, "auth_num");
     EXPECT_EQ(result.settings[0].value.safeGet<UInt64>(), 15u);
     EXPECT_EQ(result.roles, Strings({"reader", "analyst"}));
+    EXPECT_EQ(result.roles_status, SettingsAuthResponseParser::MetadataStatus::Valid);
     ASSERT_TRUE(result.valid_until.has_value());
     EXPECT_EQ(*result.valid_until, static_cast<time_t>(1788192000));
+    EXPECT_EQ(result.valid_until_status, SettingsAuthResponseParser::MetadataStatus::Valid);
 }
 
 TEST(SettingsAuthResponseParser, NonOKStatusRejectsWithoutParsingMetadata)
@@ -51,7 +53,9 @@ TEST(SettingsAuthResponseParser, NonOKStatusRejectsWithoutParsingMetadata)
     EXPECT_FALSE(result.is_ok);
     EXPECT_TRUE(result.settings.empty());
     EXPECT_TRUE(result.roles.empty());
+    EXPECT_EQ(result.roles_status, SettingsAuthResponseParser::MetadataStatus::Absent);
     EXPECT_FALSE(result.valid_until.has_value());
+    EXPECT_EQ(result.valid_until_status, SettingsAuthResponseParser::MetadataStatus::Absent);
 }
 
 TEST(SettingsAuthResponseParser, InvalidRootKeepsSuccessfulHTTPStatusAndIgnoresMetadata)
@@ -61,7 +65,9 @@ TEST(SettingsAuthResponseParser, InvalidRootKeepsSuccessfulHTTPStatusAndIgnoresM
     EXPECT_TRUE(result.is_ok);
     EXPECT_TRUE(result.settings.empty());
     EXPECT_TRUE(result.roles.empty());
+    EXPECT_EQ(result.roles_status, SettingsAuthResponseParser::MetadataStatus::Absent);
     EXPECT_FALSE(result.valid_until.has_value());
+    EXPECT_EQ(result.valid_until_status, SettingsAuthResponseParser::MetadataStatus::Absent);
 }
 
 TEST(SettingsAuthResponseParser, PreservesSettingsParsedBeforeConversionFailure)
@@ -80,10 +86,12 @@ TEST(SettingsAuthResponseParser, PreservesSettingsParsedBeforeConversionFailure)
     EXPECT_EQ(result.settings[0].name, "auth_a_valid");
     EXPECT_EQ(result.settings[0].value.safeGet<UInt64>(), 15u);
     EXPECT_EQ(result.roles, Strings({"reader"}));
+    EXPECT_EQ(result.roles_status, SettingsAuthResponseParser::MetadataStatus::Valid);
     EXPECT_EQ(result.valid_until, static_cast<time_t>(1788192000));
+    EXPECT_EQ(result.valid_until_status, SettingsAuthResponseParser::MetadataStatus::Valid);
 }
 
-TEST(SettingsAuthResponseParser, MalformedRolesAreIgnoredAtomically)
+TEST(SettingsAuthResponseParser, MalformedRolesAreInvalidAtomically)
 {
     for (const auto & roles : {R"("reader")", R"(["reader", 123])", R"(["reader", true])"})
     {
@@ -93,11 +101,13 @@ TEST(SettingsAuthResponseParser, MalformedRolesAreIgnoredAtomically)
         ASSERT_TRUE(result.is_ok);
         ASSERT_EQ(result.settings.size(), 1u);
         EXPECT_TRUE(result.roles.empty());
+        EXPECT_EQ(result.roles_status, SettingsAuthResponseParser::MetadataStatus::Invalid);
         EXPECT_EQ(result.valid_until, static_cast<time_t>(1788192000));
+        EXPECT_EQ(result.valid_until_status, SettingsAuthResponseParser::MetadataStatus::Valid);
     }
 }
 
-TEST(SettingsAuthResponseParser, MalformedValidUntilIsIgnoredIndependently)
+TEST(SettingsAuthResponseParser, MalformedValidUntilIsInvalidIndependently)
 {
     for (const auto & valid_until : {R"("not-a-timestamp")", "true", "1.5", "9223372036854775808"})
     {
@@ -107,7 +117,9 @@ TEST(SettingsAuthResponseParser, MalformedValidUntilIsIgnoredIndependently)
         ASSERT_TRUE(result.is_ok);
         ASSERT_EQ(result.settings.size(), 1u);
         EXPECT_EQ(result.roles, Strings({"reader"}));
+        EXPECT_EQ(result.roles_status, SettingsAuthResponseParser::MetadataStatus::Valid);
         EXPECT_FALSE(result.valid_until.has_value());
+        EXPECT_EQ(result.valid_until_status, SettingsAuthResponseParser::MetadataStatus::Invalid);
     }
 }
 
@@ -116,6 +128,8 @@ TEST(SettingsAuthResponseParser, ExplicitZeroValidUntilIsPreserved)
     const auto result = parseResponse(R"({"valid_until":0})");
 
     ASSERT_TRUE(result.is_ok);
+    EXPECT_EQ(result.roles_status, SettingsAuthResponseParser::MetadataStatus::Absent);
     ASSERT_TRUE(result.valid_until.has_value());
     EXPECT_EQ(*result.valid_until, 0);
+    EXPECT_EQ(result.valid_until_status, SettingsAuthResponseParser::MetadataStatus::Valid);
 }

--- a/src/Access/tests/gtest_settings_auth_response_parser.cpp
+++ b/src/Access/tests/gtest_settings_auth_response_parser.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <Access/SettingsAuthResponseParser.h>
+
+#include <Poco/Net/HTTPResponse.h>
+
+#include <fmt/format.h>
+
+#include <sstream>
+
+using namespace DB;
+
+namespace
+{
+
+SettingsAuthResponseParser::Result parseResponse(
+    const String & body,
+    Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_OK)
+{
+    Poco::Net::HTTPResponse response;
+    response.setStatus(status);
+    std::istringstream body_stream(body); // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    return SettingsAuthResponseParser{}.parse(response, &body_stream);
+}
+
+}
+
+TEST(SettingsAuthResponseParser, ParsesIndependentMetadataFields)
+{
+    const auto result = parseResponse(R"({
+        "settings": {"auth_num": "UInt64_15"},
+        "roles": ["reader", "analyst"],
+        "valid_until": 1788192000
+    })");
+
+    ASSERT_TRUE(result.is_ok);
+    ASSERT_EQ(result.settings.size(), 1u);
+    EXPECT_EQ(result.settings[0].name, "auth_num");
+    EXPECT_EQ(result.settings[0].value.safeGet<UInt64>(), 15u);
+    EXPECT_EQ(result.roles, Strings({"reader", "analyst"}));
+    ASSERT_TRUE(result.valid_until.has_value());
+    EXPECT_EQ(*result.valid_until, static_cast<time_t>(1788192000));
+}
+
+TEST(SettingsAuthResponseParser, NonOKStatusRejectsWithoutParsingMetadata)
+{
+    const auto result = parseResponse(
+        R"({"settings":{"auth_num":"UInt64_15"},"roles":["reader"],"valid_until":1788192000})",
+        Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED);
+
+    EXPECT_FALSE(result.is_ok);
+    EXPECT_TRUE(result.settings.empty());
+    EXPECT_TRUE(result.roles.empty());
+    EXPECT_FALSE(result.valid_until.has_value());
+}
+
+TEST(SettingsAuthResponseParser, InvalidRootKeepsSuccessfulHTTPStatusAndIgnoresMetadata)
+{
+    const auto result = parseResponse("not JSON");
+
+    EXPECT_TRUE(result.is_ok);
+    EXPECT_TRUE(result.settings.empty());
+    EXPECT_TRUE(result.roles.empty());
+    EXPECT_FALSE(result.valid_until.has_value());
+}
+
+TEST(SettingsAuthResponseParser, PreservesSettingsParsedBeforeConversionFailure)
+{
+    const auto result = parseResponse(R"({
+        "settings": {
+            "auth_a_valid": "UInt64_15",
+            "auth_z_invalid": "UInt64_not-a-number"
+        },
+        "roles": ["reader"],
+        "valid_until": 1788192000
+    })");
+
+    ASSERT_TRUE(result.is_ok);
+    ASSERT_EQ(result.settings.size(), 1u);
+    EXPECT_EQ(result.settings[0].name, "auth_a_valid");
+    EXPECT_EQ(result.settings[0].value.safeGet<UInt64>(), 15u);
+    EXPECT_EQ(result.roles, Strings({"reader"}));
+    EXPECT_EQ(result.valid_until, static_cast<time_t>(1788192000));
+}
+
+TEST(SettingsAuthResponseParser, MalformedRolesAreIgnoredAtomically)
+{
+    for (const auto & roles : {R"("reader")", R"(["reader", 123])", R"(["reader", true])"})
+    {
+        const auto result = parseResponse(fmt::format(
+            R"({{"settings":{{"auth_num":"UInt64_15"}},"roles":{},"valid_until":1788192000}})", roles));
+
+        ASSERT_TRUE(result.is_ok);
+        ASSERT_EQ(result.settings.size(), 1u);
+        EXPECT_TRUE(result.roles.empty());
+        EXPECT_EQ(result.valid_until, static_cast<time_t>(1788192000));
+    }
+}
+
+TEST(SettingsAuthResponseParser, MalformedValidUntilIsIgnoredIndependently)
+{
+    for (const auto & valid_until : {R"("not-a-timestamp")", "true", "1.5", "9223372036854775808"})
+    {
+        const auto result = parseResponse(fmt::format(
+            R"({{"settings":{{"auth_num":"UInt64_15"}},"roles":["reader"],"valid_until":{}}})", valid_until));
+
+        ASSERT_TRUE(result.is_ok);
+        ASSERT_EQ(result.settings.size(), 1u);
+        EXPECT_EQ(result.roles, Strings({"reader"}));
+        EXPECT_FALSE(result.valid_until.has_value());
+    }
+}
+
+TEST(SettingsAuthResponseParser, ExplicitZeroValidUntilIsPreserved)
+{
+    const auto result = parseResponse(R"({"valid_until":0})");
+
+    ASSERT_TRUE(result.is_ok);
+    ASSERT_TRUE(result.valid_until.has_value());
+    EXPECT_EQ(*result.valid_until, 0);
+}

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2218,7 +2218,12 @@ void Context::setUser(const UUID & user_id_, const std::vector<UUID> & external_
     auto user = access_control.read<User>(user_id_);
 
     auto default_roles = user->granted_roles.findGranted(user->default_roles);
-    auto enabled_roles = access_control.getEnabledRolesInfo(default_roles, {});
+    /// External roles are part of the authenticated session's enabled roles. Include them when
+    /// calculating login settings too, so profiles assigned to externally authenticated roles
+    /// are applied consistently with their access rights and row policies.
+    auto current_roles = default_roles;
+    current_roles.insert(current_roles.end(), external_roles_.begin(), external_roles_.end());
+    auto enabled_roles = access_control.getEnabledRolesInfo(current_roles, {});
     auto enabled_profiles = access_control.getEnabledSettingsInfo(user_id_, user->settings, enabled_roles->enabled_roles, enabled_roles->settings_from_enabled_roles);
     const auto & database = user->default_database;
     if (!database.empty())

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2282,7 +2282,8 @@ void Context::setCurrentRolesWithLock(const std::vector<UUID> & new_current_role
 
 void Context::setExternalRolesWithLock(const std::vector<UUID> & new_external_roles, const std::lock_guard<ContextSharedMutex> &)
 {
-    // External roles are roles received from another node; current roles is a collection of roles that were assigned locally.
+    // External roles are attached by an external authenticator or received from another node;
+    // current roles is a collection of roles that were assigned locally.
     // Replace them unconditionally (rather than append) so that switching the principal via `setUser` clears any external
     // roles carried over from a previous principal on the same or a copied context. `ContextData`'s copy constructor now
     // preserves `external_roles`, so without this reset a context authenticated with pushed roles would keep them after
@@ -2293,6 +2294,12 @@ void Context::setExternalRolesWithLock(const std::vector<UUID> & new_external_ro
     else
         external_roles = std::make_shared<std::vector<UUID>>(new_external_roles);
     need_recalculate_access = true;
+}
+
+void Context::setExternalRoles(const std::vector<UUID> & external_roles_)
+{
+    std::lock_guard lock(mutex);
+    setExternalRolesWithLock(external_roles_, lock);
 }
 
 void Context::setAuthenticationGrantsWithLock(const std::shared_ptr<const AccessRightsElements> & authentication_grants_, const std::lock_guard<ContextSharedMutex> &)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -939,6 +939,9 @@ public:
     void setAuthenticationValidUntil(time_t authentication_valid_until_);
     time_t getAuthenticationValidUntil() const;
 
+    /// Replaces external roles attached to the current authenticated session.
+    void setExternalRoles(const std::vector<UUID> & external_roles_);
+
     std::optional<UUID> getUserID() const;
     String getUserName() const;
 
@@ -947,7 +950,8 @@ public:
     void setCurrentRoles(const RolesOrUsersSet & new_current_roles, bool check_grants = true);
     void setCurrentRolesDefault();
     std::vector<UUID> getCurrentRoles() const;
-    /// The external (pushed) roles received from another node over the interserver protocol.
+    /// Roles attached externally to the authenticated session, including roles returned by an
+    /// external authenticator and roles pushed from another node over the interserver protocol.
     /// Deferred executors that re-create a context for the same session (asynchronous insert flush,
     /// the `QueryRunner` invoker) must carry these over and re-apply them via `setUser`, otherwise a
     /// role that exists only as an external role fails revalidation with `SET_NON_GRANTED_ROLE`.

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -389,12 +389,15 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
         user_id = auth_result.user_id;
         user_authenticated_with = auth_result.authentication_data;
         settings_from_auth_server = auth_result.settings;
+        auto & access_control = global_context->getAccessControl();
+        external_roles = access_control.find<Role>(auth_result.external_role_names);
         LOG_DEBUG(log, "{} Authenticated with global context as user {}",
                 toString(auth_id), toString(*user_id));
 
         if (!external_roles_.empty() && global_context->getSettingsRef()[Setting::push_external_roles_in_interserver_queries])
         {
-            external_roles = global_context->getAccessControl().find<Role>(external_roles_);
+            auto pushed_external_roles = access_control.find<Role>(external_roles_);
+            external_roles.insert(external_roles.end(), pushed_external_roles.begin(), pushed_external_roles.end());
 
             LOG_DEBUG(log, "User {} has external_roles applied: [{}] ({})",
                       toString(*user_id), fmt::join(external_roles_, ", "), external_roles_.size());
@@ -666,6 +669,9 @@ ContextMutablePtr Session::makeSessionContext(const String & session_name_, std:
         /// The per-method expiry follows the same reasoning: the reused context must fail closed on the
         /// expiry of the method used by this connection, not the one that originally created the session.
         new_session_context->setAuthenticationValidUntil(getAuthenticationValidUntil());
+        /// Returned roles are authentication-specific too, and an empty set must clear roles returned
+        /// by the authentication that previously attached to this named session.
+        new_session_context->setExternalRoles(external_roles);
 
         // Always get setting from profile
         // profile can be changed by ALTER PROFILE during single session

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -391,6 +391,11 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
         settings_from_auth_server = auth_result.settings;
         auto & access_control = global_context->getAccessControl();
         external_roles = access_control.find<Role>(auth_result.external_role_names);
+        if (external_roles.size() != auth_result.external_role_names.size())
+        {
+            throw Exception(ErrorCodes::ACCESS_DENIED,
+                "Some roles returned by the HTTP authentication server are unknown: [{}]", fmt::join(auth_result.external_role_names, ", "));
+        }
         LOG_DEBUG(log, "{} Authenticated with global context as user {}",
                 toString(auth_id), toString(*user_id));
 
@@ -675,7 +680,8 @@ ContextMutablePtr Session::makeSessionContext(const String & session_name_, std:
 
         // Always get setting from profile
         // profile can be changed by ALTER PROFILE during single session
-        auto settings = access->getDefaultSettings();
+        // Recalculate access after replacing external roles, because profiles can be assigned to them.
+        auto settings = new_session_context->getAccess()->getDefaultSettings();
         const Field * max_session_for_user_field = settings.tryGet("max_sessions_for_user");
         if (max_session_for_user_field)
             max_sessions_for_user = max_session_for_user_field->safeGet<UInt64>();

--- a/src/Interpreters/tests/gtest_context_external_roles.cpp
+++ b/src/Interpreters/tests/gtest_context_external_roles.cpp
@@ -2,7 +2,9 @@
 
 #include <Access/AccessControl.h>
 #include <Access/Role.h>
+#include <Access/SettingsProfile.h>
 #include <Access/User.h>
+#include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Common/Exception.h>
 #include <Common/tests/gtest_global_context.h>
@@ -14,6 +16,11 @@ using namespace DB;
 namespace DB::ErrorCodes
 {
     extern const int SET_NON_GRANTED_ROLE;
+}
+
+namespace DB::Setting
+{
+    extern const SettingsMaxThreads max_threads;
 }
 
 namespace
@@ -127,4 +134,36 @@ TEST(ContextExternalRoles, SetUserClearsStaleExternalRolesOnUserSwitch)
     /// The stale external role must be gone; otherwise the target user would silently keep it enabled.
     EXPECT_TRUE(session_context->getExternalRoles().empty());
     EXPECT_FALSE(contains(session_context->getCurrentRoles(), role_id));
+}
+
+/// Roles returned by an external authenticator participate in the authenticated session in the
+/// same way as the user's default roles. In particular, settings profiles assigned to such a role
+/// must be applied while initializing the session context.
+TEST(ContextExternalRoles, SetUserAppliesSettingsProfilesFromExternalRoles)
+{
+    auto context = getMutableContext().context;
+    auto & access_control = context->getAccessControl();
+    access_control.addMemoryStorage("gtest_external_roles_profiles_memory", /*allow_backup_=*/ false);
+
+    auto user = std::make_shared<User>();
+    user->setName("gtest_external_roles_profiles_user");
+    UUID user_id = access_control.insert(user);
+
+    auto role = std::make_shared<Role>();
+    role->setName("gtest_external_roles_profiles_role");
+    UUID role_id = access_control.insert(role);
+
+    auto profile = std::make_shared<SettingsProfile>();
+    profile->setName("gtest_external_roles_profiles_profile");
+    profile->to_roles = RolesOrUsersSet(role_id);
+    profile->elements.emplace_back();
+    profile->elements.back().setting_name = "max_threads";
+    profile->elements.back().value = Field(UInt64{1});
+    access_control.insert(profile);
+
+    auto session_context = Context::createCopy(context);
+    session_context->makeQueryContext();
+    session_context->setUser(user_id, /*external_roles=*/ {role_id});
+
+    EXPECT_EQ(session_context->getSettingsRef()[Setting::max_threads], 1);
 }

--- a/tests/integration/test_external_http_authenticator/configs/cluster.xml
+++ b/tests/integration/test_external_http_authenticator/configs/cluster.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <remote_servers>
+        <external_roles_cluster>
+            <secret>external_roles_test_secret</secret>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </external_roles_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_external_http_authenticator/http_auth_server.py
+++ b/tests/integration/test_external_http_authenticator/http_auth_server.py
@@ -1,6 +1,7 @@
 import base64
 import http.server
 import json
+import time
 from typing import List
 
 GOOD_PASSWORD = "good_password"
@@ -9,7 +10,63 @@ USER_RESPONSES = {
     "test_user_2": {},
     "test_user_3": "",
     "test_user_4": "not json string",
+    "role_user": {"roles": ["http_reader"]},
+    "multi_role_user": {"roles": ["role_a", "role_b"]},
+    "unknown_role_user": {"roles": ["http_reader", "role_that_does_not_exist"]},
+    "no_roles_user": {},
+    "malformed_roles_type_user": {
+        "settings": {"auth_num": "UInt64_15"},
+        "roles": "http_reader",
+    },
+    "malformed_roles_number_user": {
+        "settings": {"auth_num": "UInt64_15"},
+        "roles": ["http_reader", 123],
+    },
+    "malformed_roles_bool_user": {
+        "settings": {"auth_num": "UInt64_15"},
+        "roles": ["http_reader", True],
+    },
+    "partial_settings_user": {
+        "settings": {
+            "auth_a_valid": "UInt64_15",
+            "auth_z_invalid": "UInt64_not-a-number",
+        },
+        "roles": ["http_reader"],
+    },
+    "malformed_settings_user": {
+        "settings": {"auth_num": "UInt64_not-a-number"},
+        "roles": ["http_reader"],
+    },
+    "expiry_zero_user": {"valid_until": 0},
+    "expiry_string_user": {
+        "settings": {"auth_num": "UInt64_15"},
+        "roles": ["http_reader"],
+        "valid_until": "not-a-timestamp",
+    },
+    "expiry_bool_user": {"roles": ["http_reader"], "valid_until": True},
+    "expiry_fraction_user": {"roles": ["http_reader"], "valid_until": 1.5},
+    "expiry_out_of_range_user": {
+        "roles": ["http_reader"],
+        "valid_until": 9223372036854775808,
+    },
+    "interserver_user": {"roles": ["helper_reader"]},
+    "interserver_unknown_user": {"roles": ["initiator_only_role"]},
 }
+
+
+def get_response(user: str, request: http.server.BaseHTTPRequestHandler):
+    if user == "expiry_future_user":
+        return {"valid_until": int(time.time()) + 15}
+    if user == "expiry_past_user":
+        return {"roles": ["http_reader"], "valid_until": int(time.time()) - 30}
+    if user == "expiry_later_user":
+        return {"valid_until": int(time.time()) + 60}
+    if user == "named_session_user":
+        if request.headers.get("Custom-Header") == "roles-reader":
+            return {"roles": ["named_session_reader"]}
+        if request.headers.get("Custom-Header") == "roles-none":
+            return {"roles": []}
+    return USER_RESPONSES.get(user)
 
 
 class RequestHandler(http.server.BaseHTTPRequestHandler):
@@ -26,7 +83,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
 
     def do_ACCESS_GRANTED(self, user: str) -> None:
         self.send_response(http.HTTPStatus.OK)
-        response = USER_RESPONSES.get(user)
+        response = get_response(user, self)
 
         if isinstance(response, dict):
             body = json.dumps(response)

--- a/tests/integration/test_external_http_authenticator/http_auth_server.py
+++ b/tests/integration/test_external_http_authenticator/http_auth_server.py
@@ -38,19 +38,13 @@ USER_RESPONSES = {
         "roles": ["http_reader"],
     },
     "expiry_zero_user": {"valid_until": 0},
-    "expiry_string_user": {
-        "settings": {"auth_num": "UInt64_15"},
-        "roles": ["http_reader"],
-        "valid_until": "not-a-timestamp",
-    },
-    "expiry_bool_user": {"roles": ["http_reader"], "valid_until": True},
-    "expiry_fraction_user": {"roles": ["http_reader"], "valid_until": 1.5},
-    "expiry_out_of_range_user": {
-        "roles": ["http_reader"],
-        "valid_until": 9223372036854775808,
-    },
+    "expiry_string_user": {"valid_until": "not-a-timestamp"},
+    "expiry_bool_user": {"valid_until": True},
+    "expiry_fraction_user": {"valid_until": 1.5},
+    "expiry_out_of_range_user": {"valid_until": 9223372036854775808},
     "interserver_user": {"roles": ["helper_reader"]},
     "interserver_unknown_user": {"roles": ["initiator_only_role"]},
+    "external_role_settings_user": {"roles": ["external_role_with_profile"]},
 }
 
 
@@ -66,6 +60,11 @@ def get_response(user: str, request: http.server.BaseHTTPRequestHandler):
             return {"roles": ["named_session_reader"]}
         if request.headers.get("Custom-Header") == "roles-none":
             return {"roles": []}
+    if user == "named_session_limits_user":
+        if request.headers.get("Custom-Header") == "roles-unlimited":
+            return {"roles": ["named_session_unlimited"]}
+        if request.headers.get("Custom-Header") == "roles-limited":
+            return {"roles": ["named_session_limited"]}
     return USER_RESPONSES.get(user)
 
 

--- a/tests/integration/test_external_http_authenticator/test.py
+++ b/tests/integration/test_external_http_authenticator/test.py
@@ -1,6 +1,8 @@
 import json
 import os
+import shlex
 import typing
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -10,21 +12,28 @@ from helpers.test_tools import wait_condition
 from .http_auth_server import GOOD_PASSWORD, USER_RESPONSES
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance(
-    "node",
-    main_configs=["configs/config.xml"],
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.xml", "configs/cluster.xml"],
     user_configs=["configs/users.xml"],
 )
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.xml", "configs/cluster.xml"],
+    user_configs=["configs/users.xml"],
+)
+instance = node1
+nodes = [node1, node2]
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def run_echo_server():
-    instance.copy_file_to_container(
+def run_echo_server(node):
+    node.copy_file_to_container(
         os.path.join(SCRIPT_DIR, "http_auth_server.py"),
         "/http_auth_server.py",
     )
 
-    instance.exec_in_container(
+    node.exec_in_container(
         [
             "bash",
             "-c",
@@ -35,7 +44,7 @@ def run_echo_server():
     )
 
     def check_server() -> str:
-        return instance.exec_in_container(
+        return node.exec_in_container(
             ["curl", "-s", "http://localhost:8000/health"],
             nothrow=True,
         )
@@ -52,7 +61,8 @@ def run_echo_server():
 def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
     try:
         cluster.start()
-        run_echo_server()
+        for node in nodes:
+            run_echo_server(node)
         yield cluster
     finally:
         cluster.shutdown()
@@ -116,7 +126,8 @@ def test_header_failed(started_cluster: ClickHouseCluster):
 
 
 def test_session_settings_from_auth_response(started_cluster: ClickHouseCluster):
-    for user, response in USER_RESPONSES.items():
+    for user in ["test_user_1", "test_user_2", "test_user_3", "test_user_4"]:
+        response = USER_RESPONSES[user]
         query_id = f"test_query_{user}"
         assert (
             instance.query(
@@ -139,3 +150,244 @@ def test_session_settings_from_auth_response(started_cluster: ClickHouseCluster)
         if isinstance(response, dict):
             for key, value in response.get("settings", {}).items():
                 assert query_settings.get(key) == value
+
+
+def create_http_user(node, user, valid_until=None):
+    node.query(f"DROP USER IF EXISTS {user}")
+    query = (
+        f"CREATE USER {user} IDENTIFIED WITH HTTP SERVER 'basic_server' SCHEME 'BASIC'"
+    )
+    if valid_until is not None:
+        query += f" VALID UNTIL '{valid_until}'"
+    node.query(query)
+
+
+def query_as(user, query):
+    return node1.query(query, user=user, password=GOOD_PASSWORD)
+
+
+def query_error_as(user, query):
+    return node1.query_and_get_error(query, user=user, password=GOOD_PASSWORD)
+
+
+def ensure_http_reader_objects():
+    node1.query("CREATE TABLE IF NOT EXISTS http_auth_role_test (x UInt8) ENGINE=Memory")
+    node1.query("CREATE ROLE IF NOT EXISTS http_reader")
+    node1.query("GRANT SELECT ON http_auth_role_test TO http_reader")
+
+
+def test_roles_grant_session_access_and_are_not_persisted(started_cluster):
+    node1.query("DROP TABLE IF EXISTS http_auth_role_test")
+    node1.query("DROP ROLE IF EXISTS http_reader")
+    node1.query("CREATE TABLE http_auth_role_test (x UInt8) ENGINE=Memory")
+    node1.query("INSERT INTO http_auth_role_test VALUES (42)")
+    node1.query("CREATE ROLE http_reader")
+    node1.query("GRANT SELECT ON http_auth_role_test TO http_reader")
+    create_http_user(node1, "role_user")
+
+    assert query_as("role_user", "SELECT x FROM http_auth_role_test") == "42\n"
+    assert "http_reader" not in node1.query("SHOW GRANTS FOR role_user")
+
+
+def test_multiple_and_unknown_roles(started_cluster):
+    ensure_http_reader_objects()
+    node1.query("DROP TABLE IF EXISTS role_a_test")
+    node1.query("DROP TABLE IF EXISTS role_b_test")
+    node1.query("DROP ROLE IF EXISTS role_a")
+    node1.query("DROP ROLE IF EXISTS role_b")
+    node1.query("CREATE TABLE role_a_test (x UInt8) ENGINE=Memory")
+    node1.query("CREATE TABLE role_b_test (x UInt8) ENGINE=Memory")
+    node1.query("CREATE ROLE role_a")
+    node1.query("CREATE ROLE role_b")
+    node1.query("GRANT SELECT ON role_a_test TO role_a")
+    node1.query("GRANT SELECT ON role_b_test TO role_b")
+    create_http_user(node1, "multi_role_user")
+
+    assert query_as("multi_role_user", "SELECT count() FROM role_a_test") == "0\n"
+    assert query_as("multi_role_user", "SELECT count() FROM role_b_test") == "0\n"
+
+    create_http_user(node1, "unknown_role_user")
+    query_as("unknown_role_user", "SELECT count() FROM http_auth_role_test")
+    assert (
+        node1.query(
+            "SELECT count() FROM system.roles WHERE name = 'role_that_does_not_exist'"
+        )
+        == "0\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        "malformed_roles_type_user",
+        "malformed_roles_number_user",
+        "malformed_roles_bool_user",
+    ],
+)
+def test_malformed_roles_keep_settings_and_apply_no_partial_roles(started_cluster, user):
+    ensure_http_reader_objects()
+    create_http_user(node1, user)
+    assert query_as(user, "SELECT getSetting('auth_num')") == "15\n"
+    assert "Not enough privileges" in query_error_as(user, "SELECT x FROM http_auth_role_test")
+    assert node1.contains_in_log(
+        "Failed to parse roles from authentication response. Skip them."
+    )
+
+
+def test_partial_settings_and_roles_are_independent(started_cluster):
+    ensure_http_reader_objects()
+    create_http_user(node1, "partial_settings_user")
+    assert query_as("partial_settings_user", "SELECT getSetting('auth_a_valid')") == "15\n"
+    query_as("partial_settings_user", "SELECT count() FROM http_auth_role_test")
+
+    create_http_user(node1, "malformed_settings_user")
+    query_as("malformed_settings_user", "SELECT count() FROM http_auth_role_test")
+    assert node1.contains_in_log(
+        "Failed to parse settings from authentication response. Skip them."
+    )
+
+
+def test_http_interface_receives_roles_and_named_session_refreshes_them(started_cluster):
+    node1.query("DROP TABLE IF EXISTS named_session_test")
+    node1.query("DROP ROLE IF EXISTS named_session_reader")
+    node1.query("CREATE TABLE named_session_test (x UInt8) ENGINE=Memory")
+    node1.query("INSERT INTO named_session_test VALUES (7)")
+    node1.query("CREATE ROLE named_session_reader")
+    node1.query("GRANT SELECT ON named_session_test TO named_session_reader")
+    create_http_user(node1, "named_session_user")
+
+    url = "http://localhost:8123/?session_id=external-roles-refresh"
+    first = node1.exec_in_container(
+        [
+            "curl",
+            "-sS",
+            "-u",
+            f"named_session_user:{GOOD_PASSWORD}",
+            "-H",
+            "Custom-Header: roles-reader",
+            "--data-binary",
+            "SELECT x FROM named_session_test",
+            url,
+        ]
+    )
+    assert first == "7\n"
+
+    second = node1.exec_in_container(
+        [
+            "curl",
+            "-sS",
+            "-u",
+            f"named_session_user:{GOOD_PASSWORD}",
+            "-H",
+            "Custom-Header: roles-none",
+            "--data-binary",
+            "SELECT x FROM named_session_test",
+            url,
+        ],
+        nothrow=True,
+    )
+    assert "Not enough privileges" in second
+
+
+def test_expired_and_zero_deadlines_reject_authentication(started_cluster):
+    for user in ["expiry_past_user", "expiry_zero_user"]:
+        create_http_user(node1, user)
+        assert "Authentication failed" in query_error_as(user, "SELECT 1")
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        "expiry_string_user",
+        "expiry_bool_user",
+        "expiry_fraction_user",
+        "expiry_out_of_range_user",
+    ],
+)
+def test_malformed_deadlines_do_not_discard_roles_or_settings(started_cluster, user):
+    ensure_http_reader_objects()
+    create_http_user(node1, user)
+    query_as(user, "SELECT count() FROM http_auth_role_test")
+    if user == "expiry_string_user":
+        assert query_as(user, "SELECT getSetting('auth_num')") == "15\n"
+    assert node1.contains_in_log(
+        "Failed to parse valid_until from authentication response. Skip it."
+    )
+
+
+def run_expiring_native_session(user):
+    command = (
+        "/usr/bin/clickhouse client --user "
+        + shlex.quote(user)
+        + " --password "
+        + shlex.quote(GOOD_PASSWORD)
+        + " --multiquery --query "
+        + shlex.quote(
+            "SELECT 1; "
+            "SELECT sleep(17) SETTINGS function_sleep_max_microseconds_per_block = 17000000; "
+            "SELECT 2;"
+        )
+        + " 2>&1"
+    )
+    return node1.exec_in_container(["bash", "-c", command], nothrow=True)
+
+
+def test_helper_deadline_expires_a_persistent_native_session(started_cluster):
+    create_http_user(node1, "expiry_future_user", "2099-01-01 00:00:00")
+    output = run_expiring_native_session("expiry_future_user")
+    assert output.startswith("1\n0\n")
+    assert "Authentication method used has expired" in output
+
+
+def test_local_deadline_cannot_be_extended_by_helper(started_cluster):
+    local_deadline = datetime.now(timezone.utc) + timedelta(seconds=15)
+    create_http_user(
+        node1,
+        "expiry_later_user",
+        local_deadline.strftime("%Y-%m-%d %H:%M:%S UTC"),
+    )
+    output = run_expiring_native_session("expiry_later_user")
+    assert output.startswith("1\n0\n")
+    assert "Authentication method used has expired" in output
+
+
+def test_external_roles_are_forwarded_with_other_current_roles(started_cluster):
+    for node in nodes:
+        node.query("DROP TABLE IF EXISTS interserver_roles_test")
+        node.query("DROP ROLE IF EXISTS helper_reader")
+        node.query("DROP ROLE IF EXISTS initiator_reader")
+        node.query("CREATE TABLE interserver_roles_test (a UInt8, b UInt8) ENGINE=Memory")
+        node.query("INSERT INTO interserver_roles_test VALUES (1, 2)")
+        node.query("CREATE ROLE helper_reader")
+        node.query("CREATE ROLE initiator_reader")
+        node.query("GRANT SELECT ON interserver_roles_test TO helper_reader")
+        node.query("GRANT SHOW COLUMNS ON interserver_roles_test TO initiator_reader")
+        create_http_user(node, "interserver_user")
+
+    node1.query("GRANT initiator_reader TO interserver_user")
+    node1.query("ALTER USER interserver_user DEFAULT ROLE initiator_reader")
+    node1.query("GRANT READ ON REMOTE TO interserver_user")
+    assert query_as(
+        "interserver_user",
+        "SELECT sum(a), sum(b) FROM clusterAllReplicas("
+        "'external_roles_cluster', default.interserver_roles_test) "
+        "SETTINGS push_external_roles_in_interserver_queries=1",
+    ) == "2\t4\n"
+
+
+def test_unknown_forwarded_role_fails_closed(started_cluster):
+    node1.query("DROP ROLE IF EXISTS initiator_only_role")
+    node2.query("DROP ROLE IF EXISTS initiator_only_role")
+    node1.query("CREATE ROLE initiator_only_role")
+    node1.query("GRANT SELECT ON system.one TO initiator_only_role")
+    for node in nodes:
+        create_http_user(node, "interserver_unknown_user")
+    node1.query("GRANT READ ON REMOTE TO interserver_unknown_user")
+
+    error = query_error_as(
+        "interserver_unknown_user",
+        "SELECT count() FROM clusterAllReplicas("
+        "'external_roles_cluster', system.one) "
+        "SETTINGS push_external_roles_in_interserver_queries=1",
+    )
+    assert "Not all of the initiator's current roles are known on this node" in error

--- a/tests/integration/test_external_http_authenticator/test.py
+++ b/tests/integration/test_external_http_authenticator/test.py
@@ -189,7 +189,7 @@ def test_roles_grant_session_access_and_are_not_persisted(started_cluster):
     assert "http_reader" not in node1.query("SHOW GRANTS FOR role_user")
 
 
-def test_multiple_and_unknown_roles(started_cluster):
+def test_multiple_roles(started_cluster):
     ensure_http_reader_objects()
     node1.query("DROP TABLE IF EXISTS role_a_test")
     node1.query("DROP TABLE IF EXISTS role_b_test")
@@ -206,8 +206,13 @@ def test_multiple_and_unknown_roles(started_cluster):
     assert query_as("multi_role_user", "SELECT count() FROM role_a_test") == "0\n"
     assert query_as("multi_role_user", "SELECT count() FROM role_b_test") == "0\n"
 
+
+def test_unknown_roles_reject_authentication(started_cluster):
+    ensure_http_reader_objects()
     create_http_user(node1, "unknown_role_user")
-    query_as("unknown_role_user", "SELECT count() FROM http_auth_role_test")
+    assert "Some roles returned by the HTTP authentication server are unknown" in query_error_as(
+        "unknown_role_user", "SELECT count() FROM http_auth_role_test"
+    )
     assert (
         node1.query(
             "SELECT count() FROM system.roles WHERE name = 'role_that_does_not_exist'"
@@ -224,14 +229,9 @@ def test_multiple_and_unknown_roles(started_cluster):
         "malformed_roles_bool_user",
     ],
 )
-def test_malformed_roles_keep_settings_and_apply_no_partial_roles(started_cluster, user):
-    ensure_http_reader_objects()
+def test_malformed_roles_reject_authentication(started_cluster, user):
     create_http_user(node1, user)
-    assert query_as(user, "SELECT getSetting('auth_num')") == "15\n"
-    assert "Not enough privileges" in query_error_as(user, "SELECT x FROM http_auth_role_test")
-    assert node1.contains_in_log(
-        "Failed to parse roles from authentication response. Skip them."
-    )
+    assert "Authentication failed" in query_error_as(user, "SELECT 1")
 
 
 def test_partial_settings_and_roles_are_independent(started_cluster):
@@ -289,6 +289,87 @@ def test_http_interface_receives_roles_and_named_session_refreshes_them(started_
     assert "Not enough privileges" in second
 
 
+def test_external_role_settings_profile_applies_to_fresh_session(started_cluster):
+    node1.query("DROP USER IF EXISTS external_role_settings_user")
+    node1.query("DROP SETTINGS PROFILE IF EXISTS external_role_with_profile_settings")
+    node1.query("DROP ROLE IF EXISTS external_role_with_profile")
+    node1.query("CREATE ROLE external_role_with_profile")
+    node1.query(
+        "CREATE SETTINGS PROFILE external_role_with_profile_settings "
+        "SETTINGS max_threads = 1 TO external_role_with_profile"
+    )
+    create_http_user(node1, "external_role_settings_user")
+
+    assert (
+        query_as("external_role_settings_user", "SELECT getSetting('max_threads')")
+        == "1\n"
+    )
+
+
+def test_named_session_reauthentication_refreshes_role_derived_session_limit(started_cluster):
+    node1.query("DROP USER IF EXISTS named_session_limits_user")
+    node1.query("DROP SETTINGS PROFILE IF EXISTS named_session_unlimited_settings")
+    node1.query("DROP SETTINGS PROFILE IF EXISTS named_session_limited_settings")
+    node1.query("DROP ROLE IF EXISTS named_session_unlimited")
+    node1.query("DROP ROLE IF EXISTS named_session_limited")
+    node1.query("CREATE ROLE named_session_unlimited")
+    node1.query("CREATE ROLE named_session_limited")
+    node1.query(
+        "CREATE SETTINGS PROFILE named_session_unlimited_settings "
+        "SETTINGS max_sessions_for_user = 0 TO named_session_unlimited"
+    )
+    node1.query(
+        "CREATE SETTINGS PROFILE named_session_limited_settings "
+        "SETTINGS max_sessions_for_user = 1 TO named_session_limited"
+    )
+    create_http_user(node1, "named_session_limits_user")
+
+    def query_named_session(
+        session_id, role_header, query, detach=False, nothrow=False
+    ):
+        return node1.exec_in_container(
+            [
+                "curl",
+                "-sS",
+                "-u",
+                f"named_session_limits_user:{GOOD_PASSWORD}",
+                "-H",
+                f"Custom-Header: {role_header}",
+                "--data-binary",
+                query,
+                f"http://localhost:8123/?session_id={session_id}",
+            ],
+            detach=detach,
+            nothrow=nothrow,
+        )
+
+    assert (
+        query_named_session("external-role-limit-a", "roles-unlimited", "SELECT 1")
+        == "1\n"
+    )
+
+    query_named_session(
+        "external-role-limit-b",
+        "roles-unlimited",
+        "SELECT sleep(10) SETTINGS function_sleep_max_microseconds_per_block = 10000000",
+        detach=True,
+    )
+    wait_condition(
+        lambda: node1.query(
+            "SELECT count() FROM system.processes "
+            "WHERE user = 'named_session_limits_user'"
+        ),
+        lambda response: response == "1\n",
+        max_attempts=20,
+        delay=0.5,
+    )
+
+    error = query_named_session(
+        "external-role-limit-a", "roles-limited", "SELECT 1", nothrow=True
+    )
+    assert "has overflown session count 1" in error
+
+
 def test_expired_and_zero_deadlines_reject_authentication(started_cluster):
     for user in ["expiry_past_user", "expiry_zero_user"]:
         create_http_user(node1, user)
@@ -304,15 +385,9 @@ def test_expired_and_zero_deadlines_reject_authentication(started_cluster):
         "expiry_out_of_range_user",
     ],
 )
-def test_malformed_deadlines_do_not_discard_roles_or_settings(started_cluster, user):
-    ensure_http_reader_objects()
+def test_malformed_deadlines_reject_authentication(started_cluster, user):
     create_http_user(node1, user)
-    query_as(user, "SELECT count() FROM http_auth_role_test")
-    if user == "expiry_string_user":
-        assert query_as(user, "SELECT getSetting('auth_num')") == "15\n"
-    assert node1.contains_in_log(
-        "Failed to parse valid_until from authentication response. Skip it."
-    )
+    assert "Authentication failed" in query_error_as(user, "SELECT 1")
 
 
 def run_expiring_native_session(user):
@@ -353,15 +428,18 @@ def test_local_deadline_cannot_be_extended_by_helper(started_cluster):
 
 def test_external_roles_are_forwarded_with_other_current_roles(started_cluster):
     for node in nodes:
-        node.query("DROP TABLE IF EXISTS interserver_roles_test")
+        node.query("DROP TABLE IF EXISTS interserver_helper_roles_test")
+        node.query("DROP TABLE IF EXISTS interserver_initiator_roles_test")
         node.query("DROP ROLE IF EXISTS helper_reader")
         node.query("DROP ROLE IF EXISTS initiator_reader")
-        node.query("CREATE TABLE interserver_roles_test (a UInt8, b UInt8) ENGINE=Memory")
-        node.query("INSERT INTO interserver_roles_test VALUES (1, 2)")
+        node.query("CREATE TABLE interserver_helper_roles_test (x UInt8) ENGINE=Memory")
+        node.query("CREATE TABLE interserver_initiator_roles_test (y UInt8) ENGINE=Memory")
+        node.query("INSERT INTO interserver_helper_roles_test VALUES (1)")
+        node.query("INSERT INTO interserver_initiator_roles_test VALUES (2)")
         node.query("CREATE ROLE helper_reader")
         node.query("CREATE ROLE initiator_reader")
-        node.query("GRANT SELECT ON interserver_roles_test TO helper_reader")
-        node.query("GRANT SHOW COLUMNS ON interserver_roles_test TO initiator_reader")
+        node.query("GRANT SELECT ON interserver_helper_roles_test TO helper_reader")
+        node.query("GRANT SELECT ON interserver_initiator_roles_test TO initiator_reader")
         create_http_user(node, "interserver_user")
 
     node1.query("GRANT initiator_reader TO interserver_user")
@@ -369,10 +447,12 @@ def test_external_roles_are_forwarded_with_other_current_roles(started_cluster):
     node1.query("GRANT READ ON REMOTE TO interserver_user")
     assert query_as(
         "interserver_user",
-        "SELECT sum(a), sum(b) FROM clusterAllReplicas("
-        "'external_roles_cluster', default.interserver_roles_test) "
+        "SELECT sum(x) FROM clusterAllReplicas("
+        "'external_roles_cluster', default.interserver_helper_roles_test) "
+        "UNION ALL SELECT sum(y) FROM clusterAllReplicas("
+        "'external_roles_cluster', default.interserver_initiator_roles_test) "
         "SETTINGS push_external_roles_in_interserver_queries=1",
-    ) == "2\t4\n"
+    ) == "2\n4\n"
 
 
 def test_unknown_forwarded_role_fails_closed(started_cluster):


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117337

Allow an HTTP authentication server to return session-only roles and an optional `valid_until` deadline alongside existing session settings. Roles are resolved locally, refreshed for named HTTP sessions, participate in interserver role propagation, and apply their settings profiles. The deadline is folded into the normal authentication lifetime, so the earlier helper or local `VALID UNTIL` wins.

For security, malformed supplied `roles` or `valid_until` metadata, and unresolved returned roles, reject authentication rather than silently widening the session's access or lifetime.

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- HTTP authentication servers can return session roles and an authentication expiry in their JSON response.