### PR TITLE
Keep the finished-stages drain test away from the parallel suite

### DIFF
--- a/tests/queries/0_stateless/05047_distributed_plan_finished_stages_drain.sql
+++ b/tests/queries/0_stateless/05047_distributed_plan_finished_stages_drain.sql
@@ -1,7 +1,8 @@
--- Tags: no-old-analyzer, no-flaky-check, no-asan, no-msan, no-tsan, no-ubsan, no-debug
--- no-flaky-check and the sanitizer exclusions: the check below is a wall-clock bound, so it
--- needs runs where machine time relates to real time; the flaky check runs many copies of this
--- test at once and sanitizer builds are an order of magnitude slower.
+-- Tags: no-old-analyzer, no-flaky-check, no-asan, no-msan, no-tsan, no-ubsan, no-debug, no-parallel
+-- no-flaky-check, no-parallel and the sanitizer exclusions: the check below is a wall-clock
+-- bound, so it needs runs where machine time relates to real time; the flaky check runs many
+-- copies of this test at once, the parallel suite runs it alongside the rest of the suite on
+-- one server, and sanitizer builds are an order of magnitude slower.
 
 -- The distributed plan driver must pop every already-finished stage at once: stages finish
 -- together at the end of the query, and a driver that takes one stage per poll interval turns


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/116987

`05047_distributed_plan_finished_stages_drain` closes with a wall-clock bound,
`max(query_duration_ms) < 3000`. The regression it catches costs a fixed ~4 seconds regardless of
hardware (`stage_poll_interval_ms = 100` in `ReadFromDistributedPlanSource.h` times ~40 stages), so an
absolute bound fits. But the `parallel` job passes `--no-sequential` and runs the rest of the suite
against one server, so that duration also absorbs neighbour load.

After the six exclusions already on the file, every remaining timing failure sits on one lane,
`Stateless tests (arm_binary, parallel)`, and none on `Fast test`. Two of the four are other
contributors' pull requests; the other two are mine, both after #116987 merged with its change present.

`no-parallel` **moves** the test into the matching `sequential` job rather than skipping it, so the
assertion keeps running. I read the tag as strictly necessary in the sense `AGENTS.md` asks for: the
test is already parallel-safe the usual way (`currentDatabase()`-scoped, no file I/O), so unique naming
is not the missing piece, and machine time is the one resource a test cannot scope. Widening the bound
would stop it discriminating the regression, and the deterministic alternative was offered here and
declined during review of #116987.

The signal is load-independent, so the quieter lane raises the margin rather than lowering it: over 14
days, across tests with comparable p50 (400-1200 ms, >= 100 passing runs), tail inflation p99.9/p50
averages **7.25** on `arm_binary, parallel` against **1.47** on `arm_binary, sequential`. This test has
never run on a `sequential` job, so that lane holds no history for it; the closest in-tree reference is
`01360_materialized_view_with_join_on_query_log`, which also asserts `query_duration_ms` under
`no-parallel`: 27258 runs there in 90 days, 0 failures.

Oracle, bound, query and `.reference` are byte-identical to master; the diff is the tag plus one comment
clause.

<details>
<summary>Remaining timing failures by lane, 90 days</summary>

Signature: reference `95 / 1` against stdout `95 / 0`, i.e. the bound returned 0. Excludes the
flaky-check rows, which are one cluster on 2026-08-28 pre-dating the file's own `no-flaky-check` tag,
and the `NO_SUCH_DATA_PART` rows on this test, which are a different signature with its own owner.

| check | runs | timing failures | on master | first | last |
| --- | --- | --- | --- | --- | --- |
| `Stateless tests (arm_binary, parallel)` | 3254 | 4 | 0 | 2026-08-28 22:08:20 | 2026-08-31 15:29:46 |
| `Fast test` | 1696 | 0 | 0 | - | - |

`Fast test` keeps running the test after this change (p50 290 ms, max 1690 ms, none above 3000 ms).
Locally the bound's own statistic moves from max 103 ms on an idle server to max 199 ms under 57
concurrent queries, with the result and `DistributedPlanLocalExecution` unchanged.

Most recent report:
https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117126&sha=1343529ab133f299e88306ccf7c009f235c5262c&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

</details>


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117397&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117397](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117397+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
