### PR TITLE
Serialize `SYSTEM RESTORE DATABASE REPLICA` against in-flight replicated DDL

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -232,6 +232,7 @@ static struct InitFiu
     PAUSEABLE(database_replicated_stop_entry_execution) \
     PAUSEABLE_ONCE(database_replicated_pause_after_reading_log_pointer) \
     PAUSEABLE_ONCE(database_replicated_pause_after_snapshot_identity_check) \
+    PAUSEABLE_ONCE(database_replicated_pause_before_initial_entry_execution) \
     REGULAR(remove_merge_tree_part_delay) \
     REGULAR(plain_object_storage_copy_temp_source_file_fail_on_file_move) \
     REGULAR(plain_object_storage_copy_temp_target_file_fail_on_file_move) \

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -859,14 +859,16 @@ bool DatabaseReplicated::waitForReplicaToProcessAllEntries(UInt64 timeout_ms, Sy
 {
     auto component_guard = Coordination::setCurrentComponent("DatabaseReplicated::waitForReplicaToProcessAllEntries");
     chassert(mode == SyncReplicaMode::DEFAULT || mode == SyncReplicaMode::STRICT);
+    std::shared_ptr<DatabaseReplicatedDDLWorker> worker;
     {
         std::lock_guard lock{ddl_worker_mutex};
         if (!ddl_worker || is_probably_dropped)
             return false;
+        worker = ddl_worker;
     }
 
     if (mode == SyncReplicaMode::DEFAULT)
-        return ddl_worker->waitForReplicaToProcessAllEntries(timeout_ms);
+        return worker->waitForReplicaToProcessAllEntries(timeout_ms);
 
     /// In STRICT mode the sync is satisfied as soon as our replication lag is within the
     /// max_replication_lag_to_enqueue threshold - we do not require every entry to be fully
@@ -878,7 +880,7 @@ bool DatabaseReplicated::waitForReplicaToProcessAllEntries(UInt64 timeout_ms, Sy
     Stopwatch elapsed;
     while (true)
     {
-        UInt32 our_log_ptr = ddl_worker->getLogPointer();
+        UInt32 our_log_ptr = worker->getLogPointer();
         UInt32 max_log_ptr = parse<UInt32>(getZooKeeper()->get(fs::path(zookeeper_path) / "max_log_ptr"));
         bool became_synced = our_log_ptr + db_settings[DatabaseReplicatedSetting::max_replication_lag_to_enqueue] >= max_log_ptr;
         if (became_synced)
@@ -892,7 +894,7 @@ bool DatabaseReplicated::waitForReplicaToProcessAllEntries(UInt64 timeout_ms, Sy
         /// processing (our_log_ptr == max_log_ptr) is strictly stronger than the STRICT
         /// threshold, so return immediately in that case; otherwise loop and re-check the
         /// threshold above, re-reading max_log_ptr, which might have advanced while we waited.
-        if (ddl_worker->waitForReplicaToProcessAllEntries(std::min(wait_step_ms, timeout_ms - elapsed_ms)))
+        if (worker->waitForReplicaToProcessAllEntries(std::min(wait_step_ms, timeout_ms - elapsed_ms)))
             return true;
     }
 }
@@ -1065,7 +1067,7 @@ void DatabaseReplicated::initDDLWorkerUnlocked()
     chassert(!is_probably_dropped.load());
     chassert(!ddl_worker_initialized.load());
 
-    ddl_worker = std::make_unique<DatabaseReplicatedDDLWorker>(this, getContext());
+    ddl_worker = std::make_shared<DatabaseReplicatedDDLWorker>(this, getContext());
     ddl_worker->startup();
     ddl_worker_initialized = true;
 }
@@ -1464,13 +1466,14 @@ BlockIO DatabaseReplicated::tryEnqueueReplicatedDDL(const ASTPtr & query, Contex
     if (is_readonly)
         throw Exception(ErrorCodes::NO_ZOOKEEPER, "Database is in readonly mode, because it cannot connect to ZooKeeper");
 
-    String host_fqdn_id;
+    std::shared_ptr<DatabaseReplicatedDDLWorker> worker;
     {
         std::lock_guard lock{ddl_worker_mutex};
         if (!ddl_worker || is_probably_dropped)
             throw Exception(ErrorCodes::DATABASE_REPLICATION_FAILED, "Database is not initialized or is being dropped");
-        host_fqdn_id = ddl_worker->getCommonHostID();
+        worker = ddl_worker;
     }
+    const String host_fqdn_id = worker->getCommonHostID();
 
     if (!flags.internal && query_context->isDDLOrOnClusterInternal())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "It's not initial query. ON CLUSTER is not allowed for Replicated database.");
@@ -1485,7 +1488,7 @@ BlockIO DatabaseReplicated::tryEnqueueReplicatedDDL(const ASTPtr & query, Contex
     entry.tracing_context = OpenTelemetry::CurrentContext();
     entry.initial_query_id = query_context->getClientInfo().initial_query_id;
     entry.is_backup_restore = flags.distributed_backup_restore;
-    String node_path = ddl_worker->tryEnqueueAndExecuteEntry(entry, query_context, flags.internal);
+    String node_path = worker->tryEnqueueAndExecuteEntry(entry, query_context, flags.internal);
 
     Strings hosts_to_wait;
     Strings unfiltered_hosts = getZooKeeper()->getChildren(zookeeper_path + "/replicas");
@@ -2653,7 +2656,7 @@ void DatabaseReplicated::commitAlterTable(const StorageID & table_id,
                                           const String & statement, ContextPtr query_context)
 {
     auto txn = query_context->getZooKeeperMetadataTransaction();
-    chassert(!ddl_worker || !ddl_worker->isCurrentlyActive() || txn);
+    chassert(txn || !ddl_worker || !ddl_worker->isCurrentlyActive());
     if (txn && txn->isInitialQuery())
     {
         String metadata_zk_path = zookeeper_path + "/metadata/" + escapeForFileName(table_id.table_name);

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -276,7 +276,7 @@ private:
     std::atomic_bool is_probably_dropped = false;
     std::atomic_bool is_recovering = false;
     std::atomic_bool ddl_worker_initialized = false;
-    std::unique_ptr<DatabaseReplicatedDDLWorker> ddl_worker;
+    std::shared_ptr<DatabaseReplicatedDDLWorker> ddl_worker;
     mutable std::mutex ddl_worker_mutex;
     UInt32 max_log_ptr_at_creation = 0;
 

--- a/src/Databases/DatabaseReplicatedWorker.cpp
+++ b/src/Databases/DatabaseReplicatedWorker.cpp
@@ -52,6 +52,7 @@ namespace FailPoints
     extern const char database_replicated_delay_recovery[];
     extern const char database_replicated_delay_entry_execution[];
     extern const char database_replicated_stop_entry_execution[];
+    extern const char database_replicated_pause_before_initial_entry_execution[];
 }
 
 
@@ -505,6 +506,8 @@ String DatabaseReplicatedDDLWorker::tryEnqueueAndExecuteEntry(DDLLogEntry & entr
 
     if (entry.parent_table_uuid.has_value() && !checkParentTableExists(entry.parent_table_uuid.value()))
         throw Exception(ErrorCodes::TABLE_IS_DROPPED, "Parent table doesn't exist");
+
+    FailPointInjection::pauseFailPoint(FailPoints::database_replicated_pause_before_initial_entry_execution);
 
     processTask(*task, zookeeper, internal_query);
 

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1395,6 +1395,8 @@ void InterpreterSystemQuery::restoreDatabaseReplica(ASTSystemQuery & query)
     const String database_name = query.getDatabase();
     getContext()->checkAccess(AccessType::SYSTEM_RESTORE_DATABASE_REPLICA, database_name);
 
+    auto ddl_guard = DatabaseCatalog::instance().getDDLGuard(database_name, "", nullptr);
+
     const auto db_ptr = DatabaseCatalog::instance().getDatabase(database_name);
 
     auto* replicated_db = dynamic_cast<DatabaseReplicated*>(db_ptr.get());
@@ -1402,6 +1404,11 @@ void InterpreterSystemQuery::restoreDatabaseReplica(ASTSystemQuery & query)
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Database {} is not Replicated", database_name);
     }
+
+    /// The restore replaces the database's DDL worker, so no query may be executing a replicated DDL
+    /// entry through it. Startup is awaited before the exclusive guard because it needs table guards.
+    db_ptr->waitDatabaseStarted();
+    auto db_guard = DatabaseCatalog::instance().getExclusiveDDLGuardForDatabase(database_name);
 
     replicated_db->restoreDatabaseInKeeper(getContext());
 

--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -1,5 +1,6 @@
 import random
 import string
+import threading
 import time
 
 import pytest
@@ -622,6 +623,306 @@ def test_failed_restore_db_replica_on_normal_replica(
 
     node_1.query(f"DROP DATABASE {exclusive_database_name} SYNC")
     node_2.query(f"DROP DATABASE {exclusive_database_name} SYNC")
+
+
+def test_restore_db_replica_waits_for_in_flight_ddl(
+    start_cluster,
+    exclusive_database_name,
+):
+    fail_point = "database_replicated_pause_before_initial_entry_execution"
+    seed_table = "seed_table"
+    parked_table = "parked_table"
+
+    # One replica only: the test deletes this replica's Keeper state to make the restore legal, and a
+    # second replica would change what the restore recovers from.
+    node_1.query(
+        f"""
+            CREATE DATABASE {exclusive_database_name}
+            ENGINE=Replicated("/clickhouse/{exclusive_database_name}", \'{{shard}}\', \'{{replica}}\')
+        """
+    )
+    create_table(node_1, f"{exclusive_database_name}.{seed_table}")
+
+    zk = cluster.get_kazoo_client("zoo1")
+    replica_path = f"/clickhouse/{exclusive_database_name}/replicas/shard1|replica1"
+
+    restore_query_id = f"restore_{generate_random_string(10)}"
+
+    finished = []
+    finished_lock = threading.Lock()
+    create_result = {}
+    restore_result = {}
+
+    def run_query(query, sink, label, query_id=None):
+        try:
+            node_1.query(query, query_id=query_id)
+            sink["ok"] = True
+        except Exception as ex:
+            sink["error"] = str(ex)
+        with finished_lock:
+            finished.append(label)
+
+    create_thread = threading.Thread(
+        target=run_query,
+        args=(
+            f"CREATE TABLE {exclusive_database_name}.{parked_table} (n UInt64) ENGINE = MergeTree ORDER BY n",
+            create_result,
+            "create",
+        ),
+    )
+    restore_thread = threading.Thread(
+        target=run_query,
+        args=(
+            f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}",
+            restore_result,
+            "restore",
+            restore_query_id,
+        ),
+    )
+
+    try:
+        node_1.query(f"SYSTEM ENABLE FAILPOINT {fail_point}")
+        create_thread.start()
+
+        # Blocks until the CREATE is parked inside tryEnqueueAndExecuteEntry, still holding
+        # the table-level DDLGuard that InterpreterCreateQuery took for it.
+        node_1.query(f"SYSTEM WAIT FAILPOINT {fail_point} PAUSE", timeout=60)
+
+        # A healthy database refuses the restore ("digest ... already exists"), so drop this
+        # replica's Keeper state first. /log survives, so the parked entry can still commit.
+        zk_rmr_with_retries(zk, replica_path)
+        assert zk.exists(replica_path) is None
+
+        restore_thread.start()
+
+        # The restore must start and then stay unfinished for as long as the entry is parked.
+        # Both halves are latched, so neither can be missed by a slow poll: once the restore
+        # finishes it stays finished, and once it recreates its Keeper node that node stays.
+        # Blocked on the guard it never finishes at all, so the window cannot be too short.
+        observed_running = False
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            with finished_lock:
+                assert "restore" not in finished, (
+                    "SYSTEM RESTORE DATABASE REPLICA finished while a replicated DDL entry"
+                    f" was still executing through the DDL worker it replaces: {restore_result}"
+                )
+            assert zk.exists(replica_path) is None, (
+                "SYSTEM RESTORE DATABASE REPLICA recreated the replica in Keeper while a"
+                " replicated DDL entry was still executing through the DDL worker it replaces"
+            )
+            if not observed_running:
+                observed_running = (
+                    node_1.query(
+                        "SELECT count() FROM system.processes"
+                        f" WHERE query_id = '{restore_query_id}'"
+                    ).strip()
+                    == "1"
+                )
+            time.sleep(0.2)
+
+        assert observed_running, (
+            "SYSTEM RESTORE DATABASE REPLICA was never observed running, so the window it"
+            f" is supposed to block in was never entered. finished={finished}"
+        )
+
+        node_1.query(f"SYSTEM DISABLE FAILPOINT {fail_point}")
+
+        create_thread.join(timeout=120)
+        restore_thread.join(timeout=120)
+        assert not create_thread.is_alive(), "the parked CREATE TABLE never returned"
+        assert not restore_thread.is_alive(), (
+            "SYSTEM RESTORE DATABASE REPLICA never returned after the entry was released;"
+            f" finished={finished}"
+        )
+
+        assert restore_result == {"ok": True}, f"restore failed: {restore_result}"
+        # The entry loses the race for the database lock the restore now holds exclusively,
+        # exactly as it does against the pre-existing guard in DROP DATABASE.
+        create_error = create_result.get("error", "")
+        assert (
+            "Code: 159" in create_error
+            and "Unable to acquire the database lock" in create_error
+        ), f"expected the parked entry to fail with TIMEOUT_EXCEEDED on the database lock, got: {create_result}"
+        assert node_1.query("SELECT 1").strip() == "1"
+        assert zk.exists(replica_path)
+        assert seed_table in get_tables_from_replicated(node_1, exclusive_database_name)
+    finally:
+        # Disable first, so a failed assertion above cannot leave a thread parked forever.
+        try:
+            node_1.query(f"SYSTEM DISABLE FAILPOINT {fail_point}")
+        except Exception as ex:
+            print(ex)
+        for thread in (create_thread, restore_thread):
+            if thread.ident is not None:
+                thread.join(timeout=120)
+        try:
+            node_1.query(f"DROP DATABASE IF EXISTS {exclusive_database_name} SYNC")
+        except Exception as ex:
+            print(ex)
+
+
+def test_restore_db_replica_waits_for_database_sync(
+    start_cluster,
+    exclusive_database_name,
+):
+    # SYSTEM SYNC DATABASE REPLICA holds the database-wide DDLGuard while it waits, and that guard
+    # does not imply the shared database lock, so a waiting sync isolates it from the exclusive
+    # lock the restore takes next.
+    fail_point = "database_replicated_stop_entry_execution"
+    remote_table = "remote_table"
+
+    prepare_db(exclusive_database_name)
+    for node in cluster_nodes:
+        node.query(f"SYSTEM SYNC DATABASE REPLICA {exclusive_database_name}")
+
+    zk = cluster.get_kazoo_client("zoo1")
+    digest_path = (
+        f"/clickhouse/{exclusive_database_name}/replicas/shard1|replica1/digest"
+    )
+
+    sync_query_id = f"sync_{generate_random_string(10)}"
+    restore_query_id = f"restore_{generate_random_string(10)}"
+
+    finished = []
+    finished_lock = threading.Lock()
+    sync_result = {}
+    restore_result = {}
+
+    def run_query(query, sink, label, query_id, settings=None):
+        try:
+            node_1.query(query, query_id=query_id, settings=settings)
+            sink["ok"] = True
+        except Exception as ex:
+            sink["error"] = str(ex)
+        with finished_lock:
+            finished.append(label)
+
+    sync_thread = threading.Thread(
+        target=run_query,
+        args=(
+            f"SYSTEM SYNC DATABASE REPLICA {exclusive_database_name}",
+            sync_result,
+            "sync",
+            sync_query_id,
+            {"receive_timeout": 120},
+        ),
+    )
+    restore_thread = threading.Thread(
+        target=run_query,
+        args=(
+            f"SYSTEM RESTORE DATABASE REPLICA {exclusive_database_name}",
+            restore_result,
+            "restore",
+            restore_query_id,
+        ),
+    )
+
+    try:
+        node_1.query(f"SYSTEM ENABLE FAILPOINT {fail_point}")
+
+        # The entry is enqueued from the other replica, so no query thread on node_1 holds a
+        # table-level DDLGuard: this failpoint parks node_1's own worker thread before it takes
+        # one. That is what makes the arm measure the database-wide guard and nothing else.
+        node_2.query(
+            f"CREATE TABLE {exclusive_database_name}.{remote_table} (n UInt32)"
+            " ENGINE = ReplicatedMergeTree ORDER BY n",
+            settings={
+                "distributed_ddl_task_timeout": 5,
+                "distributed_ddl_output_mode": "never_throw",
+            },
+        )
+        node_1.query(f"SYSTEM WAIT FAILPOINT {fail_point} PAUSE", timeout=60)
+
+        # node_1 is behind the log now, so the sync waits instead of returning at once.
+        sync_thread.start()
+        # `getDDLGuard(db, "")` is the first statement of `syncReplicatedDatabase`, and this
+        # line is logged after it and immediately before the wait, so seeing it for this query
+        # id proves the sync holds the guard.
+        sync_latch = (
+            f"{{{sync_query_id}}} <Trace> InterpreterSystemQuery: Synchronizing entries"
+        )
+        deadline = time.monotonic() + 60
+        while not node_1.contains_in_log(sync_latch):
+            assert time.monotonic() < deadline, (
+                f"SYSTEM SYNC DATABASE REPLICA never reached its wait: {sync_result}"
+            )
+            time.sleep(0.2)
+
+        digest_before_restore = zk.get(digest_path)[0]
+        restore_thread.start()
+
+        # Latched, as in the test above. The digest is the condition that fires: an unguarded
+        # restore rewrites it to force recovery, and only then reaches the worker reset, where it
+        # blocks on the parked thread - so "did not finish" alone would pass unguarded too. The
+        # sync half keeps the arm honest, because a sync that stopped waiting holds no guard.
+        observed_running = False
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline:
+            with finished_lock:
+                assert "sync" not in finished, (
+                    "SYSTEM SYNC DATABASE REPLICA stopped waiting before the window ended, so"
+                    f" this arm measured nothing: {sync_result}"
+                )
+                assert "restore" not in finished, (
+                    "SYSTEM RESTORE DATABASE REPLICA finished while SYSTEM SYNC DATABASE REPLICA"
+                    f" held the database guard: {restore_result}"
+                )
+            assert zk.get(digest_path)[0] == digest_before_restore, (
+                "SYSTEM RESTORE DATABASE REPLICA rewrote this replica's digest in Keeper during"
+                " the window in which SYSTEM SYNC DATABASE REPLICA was waiting"
+            )
+            if not observed_running:
+                observed_running = (
+                    node_1.query(
+                        "SELECT count() FROM system.processes"
+                        f" WHERE query_id = '{restore_query_id}'"
+                    ).strip()
+                    == "1"
+                )
+            time.sleep(0.2)
+
+        assert observed_running, (
+            "SYSTEM RESTORE DATABASE REPLICA was never observed running, so the window it"
+            f" is supposed to block in was never entered. finished={finished}"
+        )
+
+        node_1.query(f"SYSTEM DISABLE FAILPOINT {fail_point}")
+
+        sync_thread.join(timeout=180)
+        restore_thread.join(timeout=180)
+        assert not sync_thread.is_alive(), "SYSTEM SYNC DATABASE REPLICA never returned"
+        assert not restore_thread.is_alive(), (
+            "SYSTEM RESTORE DATABASE REPLICA never returned after the sync released the"
+            f" database guard; finished={finished}"
+        )
+
+        assert sync_result == {"ok": True}, f"sync failed: {sync_result}"
+        # Once released the restore reaches the same refusal it gives on any healthy replica, so
+        # it was delayed and not broken.
+        assert (
+            f"Replica node '/clickhouse/{exclusive_database_name}/replicas/shard1|replica1/digest'"
+            " in ZooKeeper already exists" in restore_result.get("error", "")
+        ), f"expected the restore to refuse a healthy replica, got: {restore_result}"
+        assert remote_table in get_tables_from_replicated(node_1, exclusive_database_name)
+    finally:
+        # Disable first, so a failed assertion above cannot leave a thread parked forever.
+        try:
+            node_1.query(f"SYSTEM DISABLE FAILPOINT {fail_point}")
+        except Exception as ex:
+            print(ex)
+        for thread in (sync_thread, restore_thread):
+            if thread.ident is not None:
+                thread.join(timeout=180)
+        for node in cluster_nodes:
+            try:
+                node.query(f"DROP DATABASE IF EXISTS {exclusive_database_name} SYNC")
+            except Exception as ex:
+                print(ex)
+
+    assert node_1.query(
+        f"SELECT count() FROM system.fail_points WHERE name = '{fail_point}' AND enabled"
+    ) == TSV([0])
 
 
 def test_restore_db_replica_on_cluster(


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes a use-after-free when `SYSTEM RESTORE DATABASE REPLICA` replaces the DDL worker of a `Replicated` database while another session is still executing a replicated DDL query through it. In debug and sanitizer builds the same window also produces a `Digest does not match` logical error.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/114819
Related: https://github.com/ClickHouse/ClickHouse/pull/117235#issuecomment-5473319334

Reported there by @ zlareb1.

**Root cause.** `tryEnqueueReplicatedDDL` reads `ddl_worker` under `ddl_worker_mutex`, releases the lock, then executes the entry through the raw pointer. `tryEnqueueAndExecuteEntry` runs `processTask` on the *calling client thread*, and `DDLWorker::shutdown` joins only the worker's own threads. `SYSTEM RESTORE DATABASE REPLICA` is the one database-lifecycle entrypoint that takes no DDL guard, so it destroys that worker while a client thread is inside a member function: a use-after-free in every build type. Since #118481 that happens at the top of `restoreDatabaseInKeeper`, before its first Keeper write, and again in `reinitializeDDLWorker`.

**Fix.** Take the two guards `DROP DATABASE` and `CREATE DATABASE` already take, in their order, across the restore. A table-level `DDLGuard` holds the same database mutex shared for its whole lifetime, and every `tryEnqueueReplicatedDDL` call site runs on a thread that holds one, so the restore cannot overlap an executing entry. `ddl_worker` also becomes a `shared_ptr`, with a local strong reference at both client-thread call sites, because `createTableRestoredFromBackup` waits on the worker from a `RestorerFromBackup` thread holding no DDL guard. `SYSTEM SYNC DATABASE REPLICA` and the backup-restore wait share those call sites and are fixed too.

**Behavior change.** A replicated DDL query concurrent with a restore fails with `TIMEOUT_EXCEEDED` on the database lock instead of racing; `DROP DATABASE` already does this on master (measured). It also serializes against `SYSTEM SYNC DATABASE REPLICA`, which takes the same guard.

**Two reported items I deliberately do not change**, reasoning in the thread: the `DatabaseReplicated::shutdown` half is not reachable (every live-server caller already holds that exclusive guard, and shutdown force-exits via `safeExit` while any connection remains), and the three digest assertions missing the `!ddl_worker ||` guard need none (not evaluated outside `DEBUG_OR_SANITIZER_BUILD`, no remaining unsynchronized read can observe a reset after this fix, and locking them deadlocks against `stopReplication`).

<details>
<summary>Validation and notes</summary>

Two new tests in `test_restore_db_replica/`. `test_restore_db_replica_waits_for_in_flight_ddl` parks a replicated `CREATE TABLE` at a new failpoint; oracle: while the entry is parked the restore must neither complete nor recreate its Keeper replica node, and once released the entry must fail with `Code: 159` on the database lock. `test_restore_db_replica_waits_for_database_sync` isolates the database-level guard: the entry is enqueued from the other replica, so no query thread there holds a table guard, and a waiting `SYSTEM SYNC DATABASE REPLICA` blocks the restore through that guard alone; oracle: the trace the restore logs when it stops this replica's DDL worker, before any Keeper write. Both oracles are latched.

| Test | Control removes | Fix | Control | Master + failpoints only |
|---|---|---|---|---|
| in-flight DDL | `getExclusiveDDLGuardForDatabase` | pass, 5/5 | **fail** | **fail** |
| database sync | `getDDLGuard(db, "")` | pass, 5/5 | **fail** | **fail** |

The last column is master plus the two failpoint hunks only.

`test_restore_db_replica/` full module: 15 passed. `test_replicated_database/` full: identical to unmodified master. Re-measured after the master merge: fix green, both controls red, module 15 passed.

`initializeReplication` calls `checkDigestValid` unconditionally, so one unsynchronized `ddl_worker` read is not debug-only; it runs on the worker's own main thread, which both reset sites join before assigning `nullptr`. The other five are `chassert` only.

Every strong reference is taken through a `DatabasePtr` its caller holds, so it never outlives the database; `~DDLWorker` joins if nothing else did.

Unlike `DROP DATABASE`, the restore joins the worker while holding the exclusive guard, so it cannot restart in between; the join is bounded because a starved table guard gives up after a second.

The backup-restore waiter has no independent test; parking it needs scaffolding.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117399&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117399](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117399+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

