### PR TITLE
Add support for queries with `LIMIT` and `OFFSET` to automatic parallel replicas

### DIFF
--- a/src/Processors/QueryPlan/FractionalLimitStep.cpp
+++ b/src/Processors/QueryPlan/FractionalLimitStep.cpp
@@ -10,6 +10,7 @@
 #include <Processors/QueryPlan/QueryPlanFormat.h>
 #include <Processors/QueryPlan/QueryPlanStepRegistry.h>
 #include <Processors/QueryPlan/Serialization.h>
+#include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Common/JSONBuilder.h>
 
@@ -53,6 +54,10 @@ void FractionalLimitStep::transformPipeline(QueryPipelineBuilder & pipeline, con
         pipeline.getSharedHeader(), limit_fraction, offset_fraction, offset, pipeline.getNumStreams(), with_ties, description);
 
     pipeline.addTransform(std::move(transform));
+
+    if (dataflow_cache_updater)
+        pipeline.addSimpleTransform([&](const SharedHeader & header)
+                                    { return std::make_shared<RuntimeDataflowStatisticsCollector>(header, dataflow_cache_updater); });
 }
 
 void FractionalLimitStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/FractionalLimitStep.h
+++ b/src/Processors/QueryPlan/FractionalLimitStep.h
@@ -36,6 +36,13 @@ public:
 
     bool hasCorrelatedExpressions() const override { return false; }
 
+    /// A fractional limit is resolved against the whole query result (the transform must see every row
+    /// to know what the fraction is), so `apply_prelimit` never pushes it to the shard and it is
+    /// evaluated on the initiator. Reporting support keeps `considerEnablingParallelReplicas` from
+    /// rejecting the whole plan; `transformPipeline` still attaches a collector so that a boundary here
+    /// would be measured rather than cached as `output_bytes = 0`.
+    bool supportsDataflowStatisticsCollection() const override { return true; }
+
 private:
     void updateOutputHeader() override { output_header = input_headers.front(); }
 

--- a/src/Processors/QueryPlan/FractionalLimitStep.h
+++ b/src/Processors/QueryPlan/FractionalLimitStep.h
@@ -36,11 +36,8 @@ public:
 
     bool hasCorrelatedExpressions() const override { return false; }
 
-    /// A fractional limit is resolved against the whole query result (the transform must see every row
-    /// to know what the fraction is), so `apply_prelimit` never pushes it to the shard and it is
-    /// evaluated on the initiator. Reporting support keeps `considerEnablingParallelReplicas` from
-    /// rejecting the whole plan; `transformPipeline` still attaches a collector so that a boundary here
-    /// would be measured rather than cached as `output_bytes = 0`.
+    /// The fraction is resolved against the whole result, so `apply_prelimit` never pushes this to a
+    /// shard and it runs on the initiator.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/FractionalOffsetStep.cpp
+++ b/src/Processors/QueryPlan/FractionalOffsetStep.cpp
@@ -8,6 +8,7 @@
 #include <Processors/QueryPlan/QueryPlanFormat.h>
 #include <Processors/QueryPlan/QueryPlanStepRegistry.h>
 #include <Processors/QueryPlan/Serialization.h>
+#include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <base/types.h>
 #include <Common/JSONBuilder.h>
@@ -41,6 +42,10 @@ void FractionalOffsetStep::transformPipeline(QueryPipelineBuilder & pipeline, co
     auto transform = std::make_shared<FractionalOffsetTransform>(pipeline.getHeader(), fractional_offset, pipeline.getNumStreams());
 
     pipeline.addTransform(std::move(transform));
+
+    if (dataflow_cache_updater)
+        pipeline.addSimpleTransform([&](const SharedHeader & header)
+                                    { return std::make_shared<RuntimeDataflowStatisticsCollector>(header, dataflow_cache_updater); });
 }
 
 void FractionalOffsetStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/FractionalOffsetStep.h
+++ b/src/Processors/QueryPlan/FractionalOffsetStep.h
@@ -24,10 +24,7 @@ public:
 
     static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
-    /// A fractional `OFFSET` is resolved against the whole query result, so it is evaluated on the
-    /// initiator. Reporting support keeps `considerEnablingParallelReplicas` from rejecting the whole
-    /// plan (its check is a whole-plan gate); `transformPipeline` still attaches a collector so that a
-    /// boundary here would be measured rather than cached as `output_bytes = 0`.
+    /// Like `FractionalLimitStep`: the fraction is resolved against the whole result.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/FractionalOffsetStep.h
+++ b/src/Processors/QueryPlan/FractionalOffsetStep.h
@@ -24,6 +24,12 @@ public:
 
     static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
+    /// A fractional `OFFSET` is resolved against the whole query result, so it is evaluated on the
+    /// initiator. Reporting support keeps `considerEnablingParallelReplicas` from rejecting the whole
+    /// plan (its check is a whole-plan gate); `transformPipeline` still attaches a collector so that a
+    /// boundary here would be measured rather than cached as `output_bytes = 0`.
+    bool supportsDataflowStatisticsCollection() const override { return true; }
+
 private:
     void updateOutputHeader() override { output_header = input_headers.front(); }
 

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -133,6 +133,11 @@ public:
     /// `buildOrderedSetInplace`, and trigger `Trying to execute PLACEHOLDER action`.
     virtual bool hasCorrelatedExpressions() const;
 
+    /// `considerEnablingParallelReplicas` gates on the whole plan: one step returning false rejects it
+    /// and no statistics are collected. A step that returns true must also attach a
+    /// `RuntimeDataflowStatisticsCollector` in `transformPipeline` when `dataflow_cache_updater` is set,
+    /// otherwise, should it end up at the replica-output boundary, the cached `output_bytes` stays 0 and
+    /// the transfer to the initiator is priced at zero.
     virtual bool supportsDataflowStatisticsCollection() const { return false; }
 
     void setRuntimeDataflowStatisticsCacheUpdater(RuntimeDataflowStatisticsCacheUpdaterPtr updater);

--- a/src/Processors/QueryPlan/LimitStep.h
+++ b/src/Processors/QueryPlan/LimitStep.h
@@ -48,6 +48,11 @@ public:
 
     bool hasCorrelatedExpressions() const override { return false; }
 
+    /// `transformPipeline` hands the updater to the `LimitTransform`, which records the post-limit
+    /// output. Note that a `Limit` at the replica-output boundary is a shard limit, so its output is
+    /// replicated rather than partitioned: every replica emits up to `limit` rows and ships all of them
+    /// to the initiator. `considerEnablingParallelReplicas` accounts for that when pricing the network
+    /// term.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/LimitStep.h
+++ b/src/Processors/QueryPlan/LimitStep.h
@@ -48,11 +48,8 @@ public:
 
     bool hasCorrelatedExpressions() const override { return false; }
 
-    /// `transformPipeline` hands the updater to the `LimitTransform`, which records the post-limit
-    /// output. Note that a `Limit` at the replica-output boundary is a shard limit, so its output is
-    /// replicated rather than partitioned: every replica emits up to `limit` rows and ships all of them
-    /// to the initiator. `considerEnablingParallelReplicas` accounts for that when pricing the network
-    /// term, for this step and for a top-N `SortingStep` alike.
+    /// A `Limit` at the replica-output boundary is a shard limit, so its output is replicated, not
+    /// partitioned: every replica emits up to `limit` rows and ships all of them.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/LimitStep.h
+++ b/src/Processors/QueryPlan/LimitStep.h
@@ -52,7 +52,7 @@ public:
     /// output. Note that a `Limit` at the replica-output boundary is a shard limit, so its output is
     /// replicated rather than partitioned: every replica emits up to `limit` rows and ships all of them
     /// to the initiator. `considerEnablingParallelReplicas` accounts for that when pricing the network
-    /// term.
+    /// term, for this step and for a top-N `SortingStep` alike.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/NegativeLimitStep.cpp
+++ b/src/Processors/QueryPlan/NegativeLimitStep.cpp
@@ -6,6 +6,7 @@
 #include <Processors/QueryPlan/QueryPlanFormat.h>
 #include <Processors/QueryPlan/QueryPlanStepRegistry.h>
 #include <Processors/QueryPlan/Serialization.h>
+#include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Common/JSONBuilder.h>
 
@@ -52,6 +53,10 @@ void NegativeLimitStep::transformPipeline(QueryPipelineBuilder & pipeline, const
         transform->markAsShardLimit();
 
     pipeline.addTransform(std::move(transform));
+
+    if (dataflow_cache_updater)
+        pipeline.addSimpleTransform([&](const SharedHeader & header)
+                                    { return std::make_shared<RuntimeDataflowStatisticsCollector>(header, dataflow_cache_updater); });
 }
 
 void NegativeLimitStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/NegativeLimitStep.h
+++ b/src/Processors/QueryPlan/NegativeLimitStep.h
@@ -33,16 +33,9 @@ public:
 
     bool hasCorrelatedExpressions() const override { return false; }
 
-    /// Unlike the other variants this one can be pushed to the shard: `addPreliminaryLimitStep` calls
-    /// `markAsShardLimit` on it, and `apply_prelimit` does not exclude a negative limit. So it may end
-    /// up at the replica-output boundary, which is precisely why `transformPipeline` attaches a
-    /// collector - reporting support without one would cache `output_bytes = 0` and price the transfer
-    /// to the initiator at zero.
-    ///
-    /// `LIMIT -n` returns the *last* `n` rows, so a shard `NegativeLimit` is a bounded top-N taken from
-    /// the tail: every replica keeps its own last `n` rows and ships all of them, and the initiator
-    /// takes the last `n` of the merged result. Its output is therefore replicated rather than
-    /// partitioned, and `considerEnablingParallelReplicas` prices it like `LimitStep`.
+    /// `LIMIT -n` returns the *last* `n` rows, and `addPreliminaryLimitStep` can push it to the shard, so
+    /// this step can be the replica-output boundary. It is a top-N taken from the tail, so like
+    /// `LimitStep` its output is replicated: every replica ships its own last `n` rows.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/NegativeLimitStep.h
+++ b/src/Processors/QueryPlan/NegativeLimitStep.h
@@ -33,6 +33,18 @@ public:
 
     bool hasCorrelatedExpressions() const override { return false; }
 
+    /// Unlike the other variants this one can be pushed to the shard: `addPreliminaryLimitStep` calls
+    /// `markAsShardLimit` on it, and `apply_prelimit` does not exclude a negative limit. So it may end
+    /// up at the replica-output boundary, which is precisely why `transformPipeline` attaches a
+    /// collector - reporting support without one would cache `output_bytes = 0` and price the transfer
+    /// to the initiator at zero.
+    ///
+    /// `LIMIT -n` returns the *last* `n` rows, so a shard `NegativeLimit` is a bounded top-N taken from
+    /// the tail: every replica keeps its own last `n` rows and ships all of them, and the initiator
+    /// takes the last `n` of the merged result. Its output is therefore replicated rather than
+    /// partitioned, and `considerEnablingParallelReplicas` prices it like `LimitStep`.
+    bool supportsDataflowStatisticsCollection() const override { return true; }
+
 private:
     void updateOutputHeader() override
     {

--- a/src/Processors/QueryPlan/NegativeOffsetStep.cpp
+++ b/src/Processors/QueryPlan/NegativeOffsetStep.cpp
@@ -5,6 +5,7 @@
 #include <Processors/QueryPlan/QueryPlanFormat.h>
 #include <Processors/QueryPlan/QueryPlanStepRegistry.h>
 #include <Processors/QueryPlan/Serialization.h>
+#include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Common/JSONBuilder.h>
 
@@ -37,6 +38,10 @@ void NegativeOffsetStep::transformPipeline(QueryPipelineBuilder & pipeline, cons
     auto transform = std::make_shared<NegativeOffsetTransform>(pipeline.getHeader(), offset, pipeline.getNumStreams());
 
     pipeline.addTransform(std::move(transform));
+
+    if (dataflow_cache_updater)
+        pipeline.addSimpleTransform([&](const SharedHeader & header)
+                                    { return std::make_shared<RuntimeDataflowStatisticsCollector>(header, dataflow_cache_updater); });
 }
 
 void NegativeOffsetStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/NegativeOffsetStep.h
+++ b/src/Processors/QueryPlan/NegativeOffsetStep.h
@@ -23,6 +23,13 @@ public:
 
     static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
+    /// A negative `OFFSET` skips rows of the entire query result, not of each shard, so like
+    /// `OffsetStep` this step is evaluated on the initiator and a plan carrying one is otherwise as
+    /// simple as any other. Reporting support keeps `considerEnablingParallelReplicas` from rejecting
+    /// the whole plan (its check is a whole-plan gate). `transformPipeline` still attaches a collector,
+    /// so that a boundary here would be measured rather than cached as `output_bytes = 0`.
+    bool supportsDataflowStatisticsCollection() const override { return true; }
+
 private:
     void updateOutputHeader() override { output_header = input_headers.front(); }
 

--- a/src/Processors/QueryPlan/NegativeOffsetStep.h
+++ b/src/Processors/QueryPlan/NegativeOffsetStep.h
@@ -23,11 +23,7 @@ public:
 
     static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
-    /// A negative `OFFSET` skips rows of the entire query result, not of each shard, so like
-    /// `OffsetStep` this step is evaluated on the initiator and a plan carrying one is otherwise as
-    /// simple as any other. Reporting support keeps `considerEnablingParallelReplicas` from rejecting
-    /// the whole plan (its check is a whole-plan gate). `transformPipeline` still attaches a collector,
-    /// so that a boundary here would be measured rather than cached as `output_bytes = 0`.
+    /// Like `OffsetStep`: a negative `OFFSET` applies to the whole result, so it runs on the initiator.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/OffsetStep.cpp
+++ b/src/Processors/QueryPlan/OffsetStep.cpp
@@ -2,6 +2,7 @@
 #include <Processors/QueryPlan/OffsetStep.h>
 #include <Processors/QueryPlan/QueryPlanFormat.h>
 #include <Processors/QueryPlan/QueryPlanStepRegistry.h>
+#include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 #include <Processors/QueryPlan/Serialization.h>
 #include <Processors/OffsetTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
@@ -38,6 +39,10 @@ void OffsetStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQ
             pipeline.getHeader(), offset, pipeline.getNumStreams());
 
     pipeline.addTransform(std::move(transform));
+
+    if (dataflow_cache_updater)
+        pipeline.addSimpleTransform([&](const SharedHeader & header)
+                                    { return std::make_shared<RuntimeDataflowStatisticsCollector>(header, dataflow_cache_updater); });
 }
 
 void OffsetStep::describeActions(FormatSettings & settings) const

--- a/src/Processors/QueryPlan/OffsetStep.h
+++ b/src/Processors/QueryPlan/OffsetStep.h
@@ -25,21 +25,9 @@ public:
 
     QueryPlanStepPtr clone() const override;
 
-    /// `considerEnablingParallelReplicas` uses this predicate as a whole-plan gate: a single
-    /// unsupported step rejects the plan outright and no statistics are collected at all. Reporting
-    /// support here is what lets a plan carrying an `OffsetStep` be considered for automatic parallel
-    /// replicas at all - `SELECT ... ORDER BY k OFFSET n`, or the shard-side `OFFSET` that
-    /// `addPreliminaryLimitStep` emits underneath a negative limit.
-    ///
-    /// `OFFSET` skips rows of the entire query result rather than of each shard, and there is no way to
-    /// evaluate it per replica (splitting the offset between them would skip a different set of rows),
-    /// so a bare one is applied on the initiator. Where the planner does place an `OffsetStep` on the
-    /// shard it sits under a `NegativeLimitStep`, never as the topmost replica step, so this step is
-    /// not expected to be the replica-output boundary itself.
-    ///
-    /// `transformPipeline` still attaches a `RuntimeDataflowStatisticsCollector` when instrumented,
-    /// because an uninstrumented boundary fails open: it would cache `output_bytes = 0`, i.e. price the
-    /// network transfer to the initiator at zero. Measuring the post-offset output instead fails close.
+    /// `OFFSET` skips a prefix of the whole result and cannot be evaluated per replica, so it runs on
+    /// the initiator; where the planner does put one on a shard (under a negative limit) it is never the
+    /// topmost replica step.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/OffsetStep.h
+++ b/src/Processors/QueryPlan/OffsetStep.h
@@ -25,6 +25,20 @@ public:
 
     QueryPlanStepPtr clone() const override;
 
+    /// `considerEnablingParallelReplicas` uses this predicate as a whole-plan gate: a single
+    /// unsupported step rejects the plan outright and no statistics are collected at all. `OFFSET`
+    /// means skipping rows of the entire query result rather than of each shard, so the planner never
+    /// pushes it below the replica boundary (see `apply_offset` in `Planner::buildQueryPlanIfNeeded`),
+    /// and a plan carrying one is otherwise as simple as any other. Reporting support here is what lets
+    /// `SELECT ... ORDER BY k OFFSET n` (an `OFFSET` without a `LIMIT`, the only shape that produces a
+    /// bare `OffsetStep`) be considered for automatic parallel replicas at all.
+    ///
+    /// `transformPipeline` still attaches a `RuntimeDataflowStatisticsCollector` when instrumented.
+    /// Being the replica-output boundary should be unreachable per the paragraph above, but an
+    /// uninstrumented boundary fails open: it would cache `output_bytes = 0`, i.e. price the network
+    /// transfer to the initiator at zero. Measuring the post-offset output instead fails close.
+    bool supportsDataflowStatisticsCollection() const override { return true; }
+
 private:
     void updateOutputHeader() override
     {

--- a/src/Processors/QueryPlan/OffsetStep.h
+++ b/src/Processors/QueryPlan/OffsetStep.h
@@ -26,17 +26,20 @@ public:
     QueryPlanStepPtr clone() const override;
 
     /// `considerEnablingParallelReplicas` uses this predicate as a whole-plan gate: a single
-    /// unsupported step rejects the plan outright and no statistics are collected at all. `OFFSET`
-    /// means skipping rows of the entire query result rather than of each shard, so the planner never
-    /// pushes it below the replica boundary (see `apply_offset` in `Planner::buildQueryPlanIfNeeded`),
-    /// and a plan carrying one is otherwise as simple as any other. Reporting support here is what lets
-    /// `SELECT ... ORDER BY k OFFSET n` (an `OFFSET` without a `LIMIT`, the only shape that produces a
-    /// bare `OffsetStep`) be considered for automatic parallel replicas at all.
+    /// unsupported step rejects the plan outright and no statistics are collected at all. Reporting
+    /// support here is what lets a plan carrying an `OffsetStep` be considered for automatic parallel
+    /// replicas at all - `SELECT ... ORDER BY k OFFSET n`, or the shard-side `OFFSET` that
+    /// `addPreliminaryLimitStep` emits underneath a negative limit.
     ///
-    /// `transformPipeline` still attaches a `RuntimeDataflowStatisticsCollector` when instrumented.
-    /// Being the replica-output boundary should be unreachable per the paragraph above, but an
-    /// uninstrumented boundary fails open: it would cache `output_bytes = 0`, i.e. price the network
-    /// transfer to the initiator at zero. Measuring the post-offset output instead fails close.
+    /// `OFFSET` skips rows of the entire query result rather than of each shard, and there is no way to
+    /// evaluate it per replica (splitting the offset between them would skip a different set of rows),
+    /// so a bare one is applied on the initiator. Where the planner does place an `OffsetStep` on the
+    /// shard it sits under a `NegativeLimitStep`, never as the topmost replica step, so this step is
+    /// not expected to be the replica-output boundary itself.
+    ///
+    /// `transformPipeline` still attaches a `RuntimeDataflowStatisticsCollector` when instrumented,
+    /// because an uninstrumented boundary fails open: it would cache `output_bytes = 0`, i.e. price the
+    /// network transfer to the initiator at zero. Measuring the post-offset output instead fails close.
     bool supportsDataflowStatisticsCollection() const override { return true; }
 
 private:

--- a/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
@@ -10,6 +10,7 @@
 #include <Processors/QueryPlan/JoinLazyColumnsStep.h>
 #include <Processors/QueryPlan/JoinStep.h>
 #include <Processors/QueryPlan/LimitStep.h>
+#include <Processors/QueryPlan/NegativeLimitStep.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/ReadFromParallelReplicas.h>
 #include <Processors/QueryPlan/ReadFromRemote.h>
@@ -411,13 +412,15 @@ void considerEnablingParallelReplicas(
             ///
             /// It does not hold for a boundary that keeps a bounded top-N *per replica*, because there
             /// every replica emits up to `n` rows and ships all of them, so each one sends the whole
-            /// `output_bytes` the single-node plan produced. That covers a shard `LIMIT n` and equally a
-            /// top-N `Sorting` (a sort carrying a limit keeps the local top `limit` rows on each node -
-            /// see `SortingStep::is_partial_top_n`), so both must skip the division. Dividing anyway
-            /// underestimates the cost of the parallel-replicas plan by a factor of `num_replicas`.
+            /// `output_bytes` the single-node plan produced. That covers a shard `LIMIT n`, a shard
+            /// `LIMIT -n` (which returns the *last* `n` rows, i.e. a top-N taken from the tail), and
+            /// equally a top-N `Sorting` (a sort carrying a limit keeps the local top `limit` rows on
+            /// each node - see `SortingStep::is_partial_top_n`), so all of them must skip the division.
+            /// Dividing anyway underestimates the parallel-replicas plan by a factor of `num_replicas`.
             const auto * boundary_step = corresponding_node_in_single_replica_plan->step.get();
             const auto * boundary_sorting_step = typeid_cast<const SortingStep *>(boundary_step);
             const bool output_is_replicated = typeid_cast<const LimitStep *>(boundary_step)
+                || typeid_cast<const NegativeLimitStep *>(boundary_step)
                 || (boundary_sorting_step && boundary_sorting_step->getLimit() != 0);
             const size_t output_replicas_divisor = output_is_replicated ? 1 : num_replicas;
             const auto local_plan_cost_estimation = stats->input_bytes / std::min<size_t>(max_threads, effective_max_reading_threads);

--- a/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
@@ -404,19 +404,11 @@ void considerEnablingParallelReplicas(
                 ? stats->input_bytes / optimization_settings.min_bytes_per_task_for_reading + 1
                 : SIZE_MAX;
             const auto num_replicas = optimization_settings.max_parallel_replicas;
-            /// `output_bytes` is what the boundary step produced on a single node, and the network term
-            /// below is what one replica ships to the initiator. Dividing by `num_replicas` assumes the
-            /// replicas partition that output between them, which holds for a boundary whose output is a
-            /// share of the rows: `Aggregating` (each replica aggregates its own share) or a plain
-            /// `Sorting`.
-            ///
-            /// It does not hold for a boundary that keeps a bounded top-N *per replica*, because there
-            /// every replica emits up to `n` rows and ships all of them, so each one sends the whole
-            /// `output_bytes` the single-node plan produced. That covers a shard `LIMIT n`, a shard
-            /// `LIMIT -n` (which returns the *last* `n` rows, i.e. a top-N taken from the tail), and
-            /// equally a top-N `Sorting` (a sort carrying a limit keeps the local top `limit` rows on
-            /// each node - see `SortingStep::is_partial_top_n`), so all of them must skip the division.
-            /// Dividing anyway underestimates the parallel-replicas plan by a factor of `num_replicas`.
+            /// Dividing `output_bytes` by `num_replicas` assumes the replicas partition the output
+            /// between them, as they do for `Aggregating` or a plain `Sorting`. A boundary that keeps a
+            /// bounded top-N per replica instead makes every replica ship the whole `output_bytes`:
+            /// `LIMIT n`, `LIMIT -n` (the last `n` rows) and a `Sorting` carrying a limit. Dividing
+            /// those underestimates the parallel-replicas plan by a factor of `num_replicas`.
             const auto * boundary_step = corresponding_node_in_single_replica_plan->step.get();
             const auto * boundary_sorting_step = typeid_cast<const SortingStep *>(boundary_step);
             const bool output_is_replicated = typeid_cast<const LimitStep *>(boundary_step)

--- a/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
@@ -10,10 +10,10 @@
 #include <Processors/QueryPlan/JoinLazyColumnsStep.h>
 #include <Processors/QueryPlan/JoinStep.h>
 #include <Processors/QueryPlan/LimitStep.h>
-#include <Processors/QueryPlan/OffsetStep.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/ReadFromParallelReplicas.h>
 #include <Processors/QueryPlan/ReadFromRemote.h>
+#include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
@@ -405,14 +405,20 @@ void considerEnablingParallelReplicas(
             const auto num_replicas = optimization_settings.max_parallel_replicas;
             /// `output_bytes` is what the boundary step produced on a single node, and the network term
             /// below is what one replica ships to the initiator. Dividing by `num_replicas` assumes the
-            /// replicas partition that output between them, which holds for `Aggregating` (each replica
-            /// aggregates its own share of the rows) and `Sorting`. It does not hold for a row-limiting
-            /// boundary: a shard `LIMIT n` makes *every* replica emit up to `n` rows, so each of them
-            /// ships the full `output_bytes` and the network term must not be divided. Dividing anyway
-            /// would underestimate the cost of the parallel-replicas plan by a factor of `num_replicas`.
+            /// replicas partition that output between them, which holds for a boundary whose output is a
+            /// share of the rows: `Aggregating` (each replica aggregates its own share), a plain
+            /// `Sorting`, or an `Offset` (each replica would emit its share less the skipped rows).
+            ///
+            /// It does not hold for a boundary that keeps a bounded top-N *per replica*, because there
+            /// every replica emits up to `n` rows and ships all of them, so each one sends the whole
+            /// `output_bytes` the single-node plan produced. That covers a shard `LIMIT n` and equally a
+            /// top-N `Sorting` (a sort carrying a limit keeps the local top `limit` rows on each node -
+            /// see `SortingStep::is_partial_top_n`), so both must skip the division. Dividing anyway
+            /// underestimates the cost of the parallel-replicas plan by a factor of `num_replicas`.
             const auto * boundary_step = corresponding_node_in_single_replica_plan->step.get();
-            const bool output_is_replicated
-                = typeid_cast<const LimitStep *>(boundary_step) || typeid_cast<const OffsetStep *>(boundary_step);
+            const auto * boundary_sorting_step = typeid_cast<const SortingStep *>(boundary_step);
+            const bool output_is_replicated = typeid_cast<const LimitStep *>(boundary_step)
+                || (boundary_sorting_step && boundary_sorting_step->getLimit() != 0);
             const size_t output_replicas_divisor = output_is_replicated ? 1 : num_replicas;
             const auto local_plan_cost_estimation = stats->input_bytes / std::min<size_t>(max_threads, effective_max_reading_threads);
             const auto replicas_plan_cost_estimation

--- a/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
@@ -9,6 +9,8 @@
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/JoinLazyColumnsStep.h>
 #include <Processors/QueryPlan/JoinStep.h>
+#include <Processors/QueryPlan/LimitStep.h>
+#include <Processors/QueryPlan/OffsetStep.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/ReadFromParallelReplicas.h>
 #include <Processors/QueryPlan/ReadFromRemote.h>
@@ -401,9 +403,20 @@ void considerEnablingParallelReplicas(
                 ? stats->input_bytes / optimization_settings.min_bytes_per_task_for_reading + 1
                 : SIZE_MAX;
             const auto num_replicas = optimization_settings.max_parallel_replicas;
+            /// `output_bytes` is what the boundary step produced on a single node, and the network term
+            /// below is what one replica ships to the initiator. Dividing by `num_replicas` assumes the
+            /// replicas partition that output between them, which holds for `Aggregating` (each replica
+            /// aggregates its own share of the rows) and `Sorting`. It does not hold for a row-limiting
+            /// boundary: a shard `LIMIT n` makes *every* replica emit up to `n` rows, so each of them
+            /// ships the full `output_bytes` and the network term must not be divided. Dividing anyway
+            /// would underestimate the cost of the parallel-replicas plan by a factor of `num_replicas`.
+            const auto * boundary_step = corresponding_node_in_single_replica_plan->step.get();
+            const bool output_is_replicated
+                = typeid_cast<const LimitStep *>(boundary_step) || typeid_cast<const OffsetStep *>(boundary_step);
+            const size_t output_replicas_divisor = output_is_replicated ? 1 : num_replicas;
             const auto local_plan_cost_estimation = stats->input_bytes / std::min<size_t>(max_threads, effective_max_reading_threads);
             const auto replicas_plan_cost_estimation
-                = (stats->input_bytes / std::min<size_t>(max_threads * num_replicas, effective_max_reading_threads)) + stats->output_bytes / num_replicas;
+                = (stats->input_bytes / std::min<size_t>(max_threads * num_replicas, effective_max_reading_threads)) + stats->output_bytes / output_replicas_divisor;
             LOG_DEBUG(
                 getLogger("optimizeTree"),
                 "The applied formula: {} / {} ? ({} / {} + {} / {}) ≡ {} ? {}",
@@ -412,7 +425,7 @@ void considerEnablingParallelReplicas(
                 stats->input_bytes,
                 std::min<size_t>(max_threads * num_replicas, effective_max_reading_threads),
                 stats->output_bytes,
-                num_replicas,
+                output_replicas_divisor,
                 local_plan_cost_estimation,
                 replicas_plan_cost_estimation);
             if (local_plan_cost_estimation > replicas_plan_cost_estimation)

--- a/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
@@ -407,8 +407,8 @@ void considerEnablingParallelReplicas(
             /// `output_bytes` is what the boundary step produced on a single node, and the network term
             /// below is what one replica ships to the initiator. Dividing by `num_replicas` assumes the
             /// replicas partition that output between them, which holds for a boundary whose output is a
-            /// share of the rows: `Aggregating` (each replica aggregates its own share), a plain
-            /// `Sorting`, or an `Offset` (each replica would emit its share less the skipped rows).
+            /// share of the rows: `Aggregating` (each replica aggregates its own share) or a plain
+            /// `Sorting`.
             ///
             /// It does not hold for a boundary that keeps a bounded top-N *per replica*, because there
             /// every replica emits up to `n` rows and ships all of them, so each one sends the whole

--- a/tests/queries/0_stateless/05055_autopr_limit_offset.reference
+++ b/tests/queries/0_stateless/05055_autopr_limit_offset.reference
@@ -3,3 +3,7 @@ input_stats_collected	output_stats_collected
 log_comment	stats_collected	pr_used
 05055_autopr_limit_query_0	1	0
 05055_autopr_limit_query_1	0	0
+log_comment	input_stats_collected	output_stats_collected
+05055_autopr_fractional	1	1
+05055_autopr_negative_limit	1	1
+05055_autopr_negative_offset	1	1

--- a/tests/queries/0_stateless/05055_autopr_limit_offset.reference
+++ b/tests/queries/0_stateless/05055_autopr_limit_offset.reference
@@ -1,0 +1,5 @@
+input_stats_collected	output_stats_collected
+1	1
+log_comment	stats_collected	pr_used
+05055_autopr_limit_query_0	1	0
+05055_autopr_limit_query_1	0	0

--- a/tests/queries/0_stateless/05055_autopr_limit_offset.sql
+++ b/tests/queries/0_stateless/05055_autopr_limit_offset.sql
@@ -12,48 +12,28 @@ SET enable_analyzer=1;
 SET max_threads=4;
 SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
 SET automatic_parallel_replicas_min_bytes_per_replica=0;
--- Keep `effective_max_reading_threads` from becoming the binding cap, so that the comparison below is
--- decided by the network term rather than by the reading term.
+-- Keep `effective_max_reading_threads` from capping, so the comparison is decided by the network term.
 SET merge_tree_min_bytes_per_task_for_remote_reading=65536;
 
--- `value` is incompressible, which makes the two byte estimators agree: the input side scales the read
--- bytes by the part's compressed/uncompressed ratio, the output side by a sampled serialization, and
--- both land near the raw size. The ratio between input and output bytes is what the check below rests on.
+-- `value` is incompressible so the input and output byte estimators agree; the check rests on their ratio.
 INSERT INTO t SELECT number, rand64() FROM numbers(1e6) SETTINGS max_insert_threads = 1;
--- Collapse to a single part. The comparison below rests on the ratio between the estimated input and
--- output bytes, so the input estimate has to be stable. Every part rounds the read of its tail up to a
--- whole granule, so with several parts (or a merge landing mid-test) the read reports more rows than
--- the table holds and the estimated input bytes grow by up to ~1.9x - enough to flip the comparison.
+-- Single part, so the input estimate is stable: every part rounds its tail read up to a whole granule,
+-- and with several of them the estimate grows enough to flip the comparison.
 OPTIMIZE TABLE t FINAL;
 
--- A bare `OFFSET` (no `LIMIT`). The replica-output boundary is the `Sorting` step below the `Union`;
--- the `Offset` step itself is computed on the initiator, because OFFSET means skipping rows of the
--- entire query result rather than of each shard. Statistics must be collected: before `OffsetStep`
--- reported support, the plan was rejected by the "simple enough" gate and nothing was recorded.
+-- A bare `OFFSET`: the boundary is the `Sorting` below the `Union`, the `Offset` runs on the initiator.
 SELECT value FROM t ORDER BY value OFFSET 100 FORMAT Null SETTINGS log_comment='05055_autopr_offset_query';
 
--- `ORDER BY ... LIMIT n`: the replica-output boundary is the shard `Limit` above the `Sorting`, which
--- records the post-limit output. Query 0 collects the statistics (the cache is empty), query 1 makes
--- the decision with them.
---
--- The limit is chosen so that output_bytes is ~0.3 of input_bytes, which is the band where the divisor
--- decides. With max_threads=4 and max_parallel_replicas=3:
---   local    = I/4                = 0.25 I
---   replicas = I/12 + O/1         = 0.38 I   -> local is cheaper, parallel replicas NOT enabled
--- Treating the limited output as partitioned (the previous `O/3`) gives 0.18 I and enables parallel
--- replicas for a query that does not benefit from them. The decision flips only once O leaves the band
--- (I/6, I/2), i.e. not before O moves by 1.7x in either direction, so the check is not knife-edge.
+-- The boundary is the shard `Limit`. Query 0 collects the statistics, query 1 decides with them.
+-- The limit puts O at ~0.3 of I, inside the band (I/6, I/2) where the divisor decides the outcome:
+-- local I/4 beats replicas I/12 + O, but would lose to I/12 + O/3 if the output were treated as
+-- partitioned. O has to move by 1.7x either way before the decision flips.
 SELECT value FROM t ORDER BY value LIMIT 300000 FORMAT Null SETTINGS log_comment='05055_autopr_limit_query_0';
 SELECT value FROM t ORDER BY value LIMIT 300000 FORMAT Null SETTINGS log_comment='05055_autopr_limit_query_1';
 
--- The negative and fractional variants of LIMIT/OFFSET are separate steps, and the gate rejects a plan
--- for any one of them that does not report support. `LIMIT -n` returns the last `n` rows, and unlike the
--- offset variants it can be pushed to the shard (`addPreliminaryLimitStep` marks it as a shard limit), so
--- it can be the replica-output boundary itself - which is why it carries a collector and is priced as
--- replicated, exactly like `LIMIT n`.
--- `automatic_parallel_replicas_mode=2` forces the statistics to be recollected on every run. Without it
--- the two shapes whose boundary is the `Sorting` step would reuse the entry the bare-OFFSET query above
--- already cached under the same plan hash, and would record nothing - which says nothing about the gate.
+-- The negative and fractional variants are separate steps, each of which can reject the whole plan.
+-- `LIMIT -3` is the one that can be the boundary itself. Mode 2 forces recollection: otherwise the two
+-- `Sorting`-boundary shapes would reuse the entry the bare-OFFSET query cached under the same hash.
 SELECT value FROM t ORDER BY value LIMIT -3 FORMAT Null SETTINGS automatic_parallel_replicas_mode=2, log_comment='05055_autopr_negative_limit';
 SELECT value FROM t ORDER BY value OFFSET -5 FORMAT Null SETTINGS automatic_parallel_replicas_mode=2, log_comment='05055_autopr_negative_offset';
 SELECT value FROM t ORDER BY value LIMIT 0.3 OFFSET 0.2 FORMAT Null SETTINGS automatic_parallel_replicas_mode=2, log_comment='05055_autopr_fractional';
@@ -62,8 +42,7 @@ SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=0;
 
 SYSTEM FLUSH LOGS query_log;
 
--- The plan with a bare `OFFSET` passes the gate now, so statistics are collected at the `Sorting`
--- boundary: both input and output bytes are recorded.
+-- The bare-`OFFSET` plan passes the gate, so both input and output bytes are recorded.
 SELECT
     ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 AS input_stats_collected,
     ProfileEvents['RuntimeDataflowStatisticsOutputBytes'] > 0 AS output_stats_collected
@@ -71,17 +50,15 @@ FROM system.query_log
 WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment = '05055_autopr_offset_query') AND (type = 'QueryFinish')
 FORMAT TSVWithNames;
 
--- Query 0 collects the statistics for the `Limit` boundary; query 1 reuses them and must decide against
--- parallel replicas, because every replica would ship its own `LIMIT 300000` worth of rows.
+-- Query 1 reuses query 0's statistics and must decide against parallel replicas, because every replica
+-- would ship its own `LIMIT 300000` worth of rows.
 SELECT log_comment, ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 AS stats_collected, ProfileEvents['ParallelReplicasUsedCount'] > 0 AS pr_used
 FROM system.query_log
 WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment LIKE '05055_autopr_limit_query_%') AND (type = 'QueryFinish')
 ORDER BY log_comment
 FORMAT TSVWithNames;
 
--- All three sibling shapes now pass the "simple enough" gate and collect statistics. Before they
--- reported support the plan was rejected outright with `Unsupported steps: NegativeLimit_...`,
--- `NegativeOffset_...` or `FractionalLimit_...` and nothing was recorded.
+-- All three sibling shapes pass the gate and collect statistics.
 SELECT log_comment,
        ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 AS input_stats_collected,
        ProfileEvents['RuntimeDataflowStatisticsOutputBytes'] > 0 AS output_stats_collected

--- a/tests/queries/0_stateless/05055_autopr_limit_offset.sql
+++ b/tests/queries/0_stateless/05055_autopr_limit_offset.sql
@@ -1,0 +1,82 @@
+-- Verify how query plans containing `Limit` and `Offset` steps interact with the automatic parallel
+-- replicas optimization.
+--
+-- 1. `OffsetStep` did not support dataflow statistics collection, and since
+--    `considerEnablingParallelReplicas` uses that predicate as a whole-plan gate, any plan carrying a
+--    bare `OffsetStep` was rejected outright (`optimizeTree: Some steps in the plan don't support
+--    dataflow statistics collection ... Unsupported steps: Offset_...`) and no statistics were
+--    gathered. `LIMIT n OFFSET m` is unaffected - the planner folds it into a single `LimitStep` - so
+--    only an `OFFSET` without a `LIMIT` produces such a plan.
+--
+-- 2. The cost model divides the boundary's `output_bytes` by the number of replicas, which assumes the
+--    replicas partition that output between them. A row-limiting boundary is replicated instead: a
+--    shard `LIMIT n` makes every replica emit up to `n` rows, so each of them ships the full
+--    `output_bytes`. Dividing anyway underestimated the parallel-replicas plan by `max_parallel_replicas`.
+
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t(key UInt64, value UInt64) ENGINE = MergeTree ORDER BY key;
+
+SET enable_parallel_replicas=1, automatic_parallel_replicas_mode=1, parallel_replicas_local_plan=1, parallel_replicas_index_analysis_only_on_coordinator=1,
+    parallel_replicas_for_non_replicated_merge_tree=1, max_parallel_replicas=3, cluster_for_parallel_replicas='test_cluster_one_shard_three_replicas_localhost';
+
+SET enable_analyzer=1;
+SET max_threads=4;
+SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
+SET automatic_parallel_replicas_min_bytes_per_replica=0;
+-- Keep `effective_max_reading_threads` from becoming the binding cap, so that the comparison below is
+-- decided by the network term rather than by the reading term.
+SET merge_tree_min_bytes_per_task_for_remote_reading=65536;
+
+-- `value` is incompressible, which makes the two byte estimators agree: the input side scales the read
+-- bytes by the part's compressed/uncompressed ratio, the output side by a sampled serialization, and
+-- both land near the raw size. The ratio between input and output bytes is what the check below rests on.
+INSERT INTO t SELECT number, rand64() FROM numbers(1e6) SETTINGS max_insert_threads = 1;
+-- Collapse to a single part. The comparison below rests on the ratio between the estimated input and
+-- output bytes, so the input estimate has to be stable. Every part rounds the read of its tail up to a
+-- whole granule, so with several parts (or a merge landing mid-test) the read reports more rows than
+-- the table holds and the estimated input bytes grow by up to ~1.9x - enough to flip the comparison.
+OPTIMIZE TABLE t FINAL;
+
+-- A bare `OFFSET` (no `LIMIT`). The replica-output boundary is the `Sorting` step below the `Union`;
+-- the `Offset` step itself is computed on the initiator, because OFFSET means skipping rows of the
+-- entire query result rather than of each shard. Statistics must be collected: before `OffsetStep`
+-- reported support, the plan was rejected by the "simple enough" gate and nothing was recorded.
+SELECT value FROM t ORDER BY value OFFSET 100 FORMAT Null SETTINGS log_comment='05055_autopr_offset_query';
+
+-- `ORDER BY ... LIMIT n`: the replica-output boundary is the shard `Limit` above the `Sorting`, which
+-- records the post-limit output. Query 0 collects the statistics (the cache is empty), query 1 makes
+-- the decision with them.
+--
+-- The limit is chosen so that output_bytes is ~0.3 of input_bytes, which is the band where the divisor
+-- decides. With max_threads=4 and max_parallel_replicas=3:
+--   local    = I/4                = 0.25 I
+--   replicas = I/12 + O/1         = 0.38 I   -> local is cheaper, parallel replicas NOT enabled
+-- Treating the limited output as partitioned (the previous `O/3`) gives 0.18 I and enables parallel
+-- replicas for a query that does not benefit from them. The decision flips only once O leaves the band
+-- (I/6, I/2), i.e. not before O moves by 1.7x in either direction, so the check is not knife-edge.
+SELECT value FROM t ORDER BY value LIMIT 300000 FORMAT Null SETTINGS log_comment='05055_autopr_limit_query_0';
+SELECT value FROM t ORDER BY value LIMIT 300000 FORMAT Null SETTINGS log_comment='05055_autopr_limit_query_1';
+
+SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=0;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- The plan with a bare `OFFSET` passes the gate now, so statistics are collected at the `Sorting`
+-- boundary: both input and output bytes are recorded.
+SELECT
+    ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 AS input_stats_collected,
+    ProfileEvents['RuntimeDataflowStatisticsOutputBytes'] > 0 AS output_stats_collected
+FROM system.query_log
+WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment = '05055_autopr_offset_query') AND (type = 'QueryFinish')
+FORMAT TSVWithNames;
+
+-- Query 0 collects the statistics for the `Limit` boundary; query 1 reuses them and must decide against
+-- parallel replicas, because every replica would ship its own `LIMIT 300000` worth of rows.
+SELECT log_comment, ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 AS stats_collected, ProfileEvents['ParallelReplicasUsedCount'] > 0 AS pr_used
+FROM system.query_log
+WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment LIKE '05055_autopr_limit_query_%') AND (type = 'QueryFinish')
+ORDER BY log_comment
+FORMAT TSVWithNames;
+
+DROP TABLE t;

--- a/tests/queries/0_stateless/05055_autopr_limit_offset.sql
+++ b/tests/queries/0_stateless/05055_autopr_limit_offset.sql
@@ -58,6 +58,18 @@ SELECT value FROM t ORDER BY value OFFSET 100 FORMAT Null SETTINGS log_comment='
 SELECT value FROM t ORDER BY value LIMIT 300000 FORMAT Null SETTINGS log_comment='05055_autopr_limit_query_0';
 SELECT value FROM t ORDER BY value LIMIT 300000 FORMAT Null SETTINGS log_comment='05055_autopr_limit_query_1';
 
+-- The negative and fractional variants of LIMIT/OFFSET are separate steps, and the gate rejects a plan
+-- for any one of them that does not report support. `LIMIT -n` returns the last `n` rows, and unlike the
+-- offset variants it can be pushed to the shard (`addPreliminaryLimitStep` marks it as a shard limit), so
+-- it can be the replica-output boundary itself - which is why it carries a collector and is priced as
+-- replicated, exactly like `LIMIT n`.
+-- `automatic_parallel_replicas_mode=2` forces the statistics to be recollected on every run. Without it
+-- the two shapes whose boundary is the `Sorting` step would reuse the entry the bare-OFFSET query above
+-- already cached under the same plan hash, and would record nothing - which says nothing about the gate.
+SELECT value FROM t ORDER BY value LIMIT -3 FORMAT Null SETTINGS automatic_parallel_replicas_mode=2, log_comment='05055_autopr_negative_limit';
+SELECT value FROM t ORDER BY value OFFSET -5 FORMAT Null SETTINGS automatic_parallel_replicas_mode=2, log_comment='05055_autopr_negative_offset';
+SELECT value FROM t ORDER BY value LIMIT 0.3 OFFSET 0.2 FORMAT Null SETTINGS automatic_parallel_replicas_mode=2, log_comment='05055_autopr_fractional';
+
 SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=0;
 
 SYSTEM FLUSH LOGS query_log;
@@ -76,6 +88,17 @@ FORMAT TSVWithNames;
 SELECT log_comment, ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 AS stats_collected, ProfileEvents['ParallelReplicasUsedCount'] > 0 AS pr_used
 FROM system.query_log
 WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment LIKE '05055_autopr_limit_query_%') AND (type = 'QueryFinish')
+ORDER BY log_comment
+FORMAT TSVWithNames;
+
+-- All three sibling shapes now pass the "simple enough" gate and collect statistics. Before they
+-- reported support the plan was rejected outright with `Unsupported steps: NegativeLimit_...`,
+-- `NegativeOffset_...` or `FractionalLimit_...` and nothing was recorded.
+SELECT log_comment,
+       ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 AS input_stats_collected,
+       ProfileEvents['RuntimeDataflowStatisticsOutputBytes'] > 0 AS output_stats_collected
+FROM system.query_log
+WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment IN ('05055_autopr_negative_limit', '05055_autopr_negative_offset', '05055_autopr_fractional')) AND (type = 'QueryFinish')
 ORDER BY log_comment
 FORMAT TSVWithNames;
 

--- a/tests/queries/0_stateless/05055_autopr_limit_offset.sql
+++ b/tests/queries/0_stateless/05055_autopr_limit_offset.sql
@@ -1,17 +1,5 @@
 -- Verify how query plans containing `Limit` and `Offset` steps interact with the automatic parallel
 -- replicas optimization.
---
--- 1. `OffsetStep` did not support dataflow statistics collection, and since
---    `considerEnablingParallelReplicas` uses that predicate as a whole-plan gate, any plan carrying a
---    bare `OffsetStep` was rejected outright (`optimizeTree: Some steps in the plan don't support
---    dataflow statistics collection ... Unsupported steps: Offset_...`) and no statistics were
---    gathered. `LIMIT n OFFSET m` is unaffected - the planner folds it into a single `LimitStep` - so
---    only an `OFFSET` without a `LIMIT` produces such a plan.
---
--- 2. The cost model divides the boundary's `output_bytes` by the number of replicas, which assumes the
---    replicas partition that output between them. A row-limiting boundary is replicated instead: a
---    shard `LIMIT n` makes every replica emit up to `n` rows, so each of them ships the full
---    `output_bytes`. Dividing anyway underestimated the parallel-replicas plan by `max_parallel_replicas`.
 
 DROP TABLE IF EXISTS t;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support dataflow statistics collection for `Limit` and `Offset` steps.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117402&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117402](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117402+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
