### PR TITLE
Include `tests/fuzz` inputs in the fuzzer job digests

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -577,6 +577,22 @@ class JobConfigs:
             parameter=BuildTypes.ARM_FUZZERS,
             provides=[],
             runs_on=RunnerLabels.ARM_LARGE,
+            # This is the only build that runs `tests/fuzz/build.sh`, which packs the
+            # fuzzer options and the dictionary into the artifact the nightly job runs
+            # from. Without them in the digest, a change that only tunes a `.options`
+            # file reuses a cached build and the nightly silently runs the old settings.
+            # `tests/queries/0_stateless` also feeds the seed corpus archives, but it is
+            # deliberately left out: it would rebuild the fuzzers on every test-only pull
+            # request, and the seeds are refreshed by any source change anyway.
+            digest_config=Job.CacheDigestConfig(
+                include_paths=build_digest_config.include_paths
+                + [
+                    "./tests/fuzz/build.sh",
+                    "./tests/fuzz/all.dict",
+                    "./tests/fuzz/*.options",
+                ],
+                with_git_submodules=True,
+            ),
         ),
     )
     # The standalone WebAssembly build of the SQL parser (utils/wasm-parser). It cross-compiles to
@@ -1860,7 +1876,12 @@ class JobConfigs:
         command="python3 ./ci/jobs/libfuzzer_test_check.py 'libFuzzer tests'",
         requires=[ArtifactNames.ARM_FUZZERS, ArtifactNames.FUZZERS_CORPUS],
         digest_config=Job.CacheDigestConfig(
-            include_paths=["./ci/jobs/libfuzzer_test_check.py"],
+            include_paths=[
+                "./ci/jobs/libfuzzer_test_check.py",
+                # Mounted from the repository and executed inside the container, so it
+                # does not reach the job through the build artifact.
+                "./tests/fuzz/runner.py",
+            ],
         ),
     )
     libfuzzer_corpus_minimization_job = Job.Config(
@@ -1872,7 +1893,12 @@ class JobConfigs:
         ),
         requires=[ArtifactNames.ARM_FUZZERS, ArtifactNames.FUZZERS_CORPUS],
         digest_config=Job.CacheDigestConfig(
-            include_paths=["./ci/jobs/libfuzzer_test_check.py"],
+            include_paths=[
+                "./ci/jobs/libfuzzer_test_check.py",
+                # Mounted from the repository and executed inside the container, so it
+                # does not reach the job through the build artifact.
+                "./tests/fuzz/runner.py",
+            ],
         ),
     )
     collect_clickhouse_profiles_jobs = Job.Config(

--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -25,6 +25,7 @@ class Job:
         requires: Optional[List[str]] = None
         timeout: Optional[int] = None
         command: Optional[str] = None
+        digest_config: Optional["Job.CacheDigestConfig"] = None
 
     @dataclass
     class Config:
@@ -137,6 +138,8 @@ class Job:
                     obj.runs_on = param_set.runs_on
                 if param_set.timeout:
                     obj.timeout = param_set.timeout
+                if param_set.digest_config:
+                    obj.digest_config = param_set.digest_config
                 if param_set.provides:
                     assert (
                         not obj.provides


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`tests/fuzz/build.sh` copies `tests/fuzz/*.options` and `all.dict` into the build output, and they reach the nightly job inside the `ARM_FUZZERS` artifact. None of them were in any job digest, so a change that only tuned a `.options` file left every digest untouched: praktika reused a cached build and the nightly kept running the old settings, silently. The same applies to `tests/fuzz/runner.py`, which the libFuzzer jobs mount from the repository and execute, so it never reaches them through the artifact either.

This was found while reviewing https://github.com/ClickHouse/ClickHouse/pull/117140, which adds a dictionary and HTTP timeout caps to `clickhouse_fuzzer.options`. That pull request happens to be safe, because it also deletes files under `./src` and so invalidates the build digest anyway — but a future options-only change would not be.

Only `Build (arm_fuzzers)` runs `tests/fuzz/build.sh`, so the paths go on that parameter set rather than into the shared `build_digest_config`, which would rebuild all two dozen build variants for files none of them package. `Job.ParamSet` gains a `digest_config` override for this, mirroring the existing `timeout` and `runs_on` overrides.

`tests/queries/0_stateless` also feeds the seed corpus archives and is deliberately left out: including it would rebuild the fuzzers on every test-only pull request, and the seeds are regenerated by any source change already.

Verified by computing the digests directly:

| changed file | `Build (arm_fuzzers)` | `libFuzzer tests` | `libFuzzer corpus minimization` | `Build (arm_tsan)` |
|---|---|---|---|---|
| `tests/fuzz/clickhouse_fuzzer.options` | affected | – | – | – |
| `tests/fuzz/all.dict` | affected | – | – | – |
| `tests/fuzz/build.sh` | affected | – | – | – |
| `tests/fuzz/runner.py` | – | affected | affected | – |
| `tests/queries/0_stateless/*.sql` | – | – | – | – |
| `src/Interpreters/Context.cpp` | affected | – | – | affected |

The last column is the control: the shared build digest is unchanged, so ordinary builds do not react to `tests/fuzz`.

Related: https://github.com/ClickHouse/ClickHouse/pull/117140

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdf1c756-0e14-4bd0-a2d2-35ba1abee018?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdf1c756-0e14-4bd0-a2d2-35ba1abee018&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117405&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117405](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117405+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
