### PR TITLE
Fix TOTP bypass in MySQL protocol authentication

### DIFF
--- a/src/Access/Authentication.cpp
+++ b/src/Access/Authentication.cpp
@@ -140,6 +140,13 @@ namespace
         const MySQLNative41Credentials * mysql_credentials,
         const AuthenticationData & authentication_method)
     {
+        /// The Native41 auth response is a hash of the password alone, so it cannot carry a one-time password.
+        /// Accepting it would let the client skip the second factor. `MySQLHandler` switches such users
+        /// to the `Sha256Password` plugin, which transmits the actual password string with the one-time
+        /// password appended, verified via the `BasicCredentials` path.
+        if (authentication_method.getOneTimePassword())
+            return false;
+
         switch (authentication_method.getType())
         {
             case AuthenticationType::PLAINTEXT_PASSWORD:

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -362,6 +362,19 @@ std::unordered_set<AuthenticationType> Session::getAuthenticationTypesOrLogInFai
     }
 }
 
+bool Session::userHasSecondFactor(const String & user_name) const
+{
+    const auto user_to_query = global_context->getAccessControl().read<User>(user_name);
+
+    for (const auto & authentication_method : user_to_query->authentication_methods)
+    {
+        if (authentication_method.getOneTimePassword())
+            return true;
+    }
+
+    return false;
+}
+
 void Session::authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const std::optional<Poco::Net::SocketAddress> & connection_address, const Strings & external_roles_)
 {
     authenticate(BasicCredentials{user_name, password}, address, connection_address, external_roles_);

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -52,6 +52,9 @@ public:
     /// Same as getAuthenticationType, but adds LoginFailure event in case of error.
     std::unordered_set<AuthenticationType> getAuthenticationTypesOrLogInFailure(const String & user_name) const;
 
+    /// Whether any of the user's authentication methods requires a one-time password as a second factor.
+    bool userHasSecondFactor(const String & user_name) const;
+
     /// Sets the current user, checks the credentials and that the specified address is allowed to connect from.
     /// The function throws an exception if there is no such user or password is wrong.
     void authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address, const std::optional<Poco::Net::SocketAddress> & connection_address = {}, const Strings & external_roles_ = {});

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -757,6 +757,14 @@ void MySQLHandler::authenticate(const String & user_name, const String & auth_pl
             }
         }
 
+        // The Native41 auth response is a hash of the password alone and cannot carry a one-time password,
+        // so for users with a second factor the plugin transmitting the actual password string is required:
+        // the client appends the one-time password to the password, like 'password+123456'.
+        if (session->userHasSecondFactor(user_name))
+        {
+            authPluginSSL();
+        }
+
         std::optional<String> auth_response = auth_plugin_name == auth_plugin->getName() ? std::make_optional<String>(initial_auth_response) : std::nullopt;
         auth_plugin->authenticate(user_name, *session, auth_response, packet_endpoint, secure_connection, socket().peerAddress());
     }

--- a/tests/integration/test_totp_auth/config/mysql.xml
+++ b/tests/integration/test_totp_auth/config/mysql.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <mysql_port>9004</mysql_port>
+</clickhouse>

--- a/tests/integration/test_totp_auth/test_totp.py
+++ b/tests/integration/test_totp_auth/test_totp.py
@@ -7,6 +7,7 @@ import re
 import struct
 import time
 
+import pymysql
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -18,6 +19,7 @@ TOTP_SECRET = base64.b32encode(random.randbytes(random.randint(3, 64))).decode()
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
+    main_configs=["config/mysql.xml"],
     user_configs=["config/users.xml"],
 )
 
@@ -69,6 +71,23 @@ def create_config(totp_secret):
             <profile>default</profile>
             <quota>default</quota>
         </totuser>
+
+        <totuser_double_sha1>
+            <!-- Double SHA1 of 'abacaba' -->
+            <password_double_sha1_hex>e395796d6546b1b65db9d665cd43f0e858dd4303</password_double_sha1_hex>
+            <time_based_one_time_password>
+                <secret>{totp_secret}</secret>
+                <period>60</period>
+                <digits>9</digits>
+                <algorithm>SHA256</algorithm>
+            </time_based_one_time_password>
+
+            <networks replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </totuser_double_sha1>
 
         <totuser_no_password>
             <no_password></no_password>
@@ -228,6 +247,40 @@ def test_interactive_totp_authentication(started_cluster):
         command=f"{client_command} --password wrongpwd+{get_totp_for_config()}"
     ) as c:
         c.expect(expected_error)
+
+
+def test_mysql_protocol_requires_totp(started_cluster):
+    """The MySQL protocol must enforce TOTP: the `mysql_native_password` auth response is a hash
+    of the password alone and cannot carry a one-time password, so the server switches such
+    users to the `sha256_password` plugin and the client appends the TOTP to the password."""
+
+    def connect(user, password):
+        return pymysql.connections.Connection(
+            host=node.ip_address,
+            user=user,
+            password=password,
+            database="default",
+            port=9004,
+        )
+
+    for user, password in (("totuser", "aa+bb"), ("totuser_double_sha1", "abacaba")):
+        # The correct password alone must not authenticate: the second factor is required.
+        # The message is intentionally generic; only the error code tells the reason.
+        with pytest.raises(pymysql.err.MySQLError) as exc_info:
+            connect(user, password)
+        assert exc_info.value.args[0] == 767  # REQUIRED_SECOND_FACTOR
+
+        # A wrong one-time password must not authenticate.
+        with pytest.raises(pymysql.err.MySQLError, match="Authentication failed"):
+            connect(user, password + "+000000000")
+
+        conn = connect(user, f"{password}+{get_totp_for_config()}")
+        try:
+            cursor = conn.cursor()
+            cursor.execute("SELECT currentUser()")
+            assert cursor.fetchall() == ((user,),)
+        finally:
+            conn.close()
 
 
 def test_one_time_only_no_password(started_cluster):

--- a/tests/integration/test_totp_auth/test_totp.py
+++ b/tests/integration/test_totp_auth/test_totp.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import hmac
 import os
-import random
 import re
 import struct
 import time
@@ -14,7 +13,12 @@ from helpers.cluster import ClickHouseCluster
 from helpers.uclient import client, prompt
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-TOTP_SECRET = base64.b32encode(random.randbytes(random.randint(3, 64))).decode()
+# The secret must be deterministic: the flaky check runs this file on several pytest-xdist
+# workers in parallel, and `create_config` writes the shared `config/users.xml`, so all
+# workers must produce identical content. A random secret makes the last writer win and
+# the other workers' clusters reject codes generated for their own secrets.
+# The length is not a multiple of 5 bytes, so the base32 form exercises `=` padding.
+TOTP_SECRET = base64.b32encode(hashlib.sha256(b"test_totp_auth").digest()[:19]).decode()
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
@@ -38,7 +42,7 @@ def get_one_time_password(
     secret, interval=30, digits=6, sha_version=hashlib.sha1, timepoint=None
 ):
     key = base64.b32decode(secret, casefold=True)
-    time_step = int(timepoint or time.time() / interval)
+    time_step = int((timepoint or time.time()) / interval)
     msg = struct.pack(">Q", time_step)
     hmac_hash = hmac.new(key, msg, sha_version).digest()
     offset = hmac_hash[-1] & 0x0F


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a second-factor bypass in the MySQL protocol: a user configured with `plaintext_password` or `double_sha1_password` plus a time-based one-time password could authenticate with the password alone, because the `mysql_native_password` auth response was verified without checking the TOTP. Such users are now switched to the `sha256_password` plugin and must append the one-time password to the password, like `password+123456`.

The `mysql_native_password` auth response is a hash of the password alone, so it cannot carry a one-time password. `checkMySQLAuthentication` verified only the password scramble and ignored the configured TOTP secret, so the second factor was silently skipped over the MySQL protocol.

Now `checkMySQLAuthentication` fails closed when a one-time password is configured, and `MySQLHandler` switches such users to the `sha256_password` plugin, which transmits the actual password string; the one-time password is appended to it and enforced via the `BasicCredentials` path, the same as for the native and HTTP protocols.

Added an integration test covering both `plaintext_password` and `double_sha1_password` users with TOTP over the MySQL protocol (password alone → `REQUIRED_SECOND_FACTOR`, wrong TOTP → authentication failure, `password+TOTP` → success).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117407&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117407](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117407+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
