### PR TITLE
Fail close on TOTP in SCRAM SHA-256 authentication

### DIFF
--- a/src/Access/Authentication.cpp
+++ b/src/Access/Authentication.cpp
@@ -117,6 +117,13 @@ namespace
         if (authentication_method.getType() != AuthenticationType::SCRAM_SHA256_PASSWORD)
             return false;
 
+        /// The SCRAM client proof is derived from the password alone, so it cannot carry or verify
+        /// a one-time password. Accepting it would let the client skip the second factor.
+        /// The PostgreSQL frontend refuses to run the SCRAM exchange for such users (see `getScramSalt`);
+        /// this check keeps the bypass closed for any other producer of SCRAM credentials.
+        if (authentication_method.getOneTimePassword())
+            return false;
+
         const auto & client_proof = scram_sha256_credentials->getClientProof();
         const auto & auth_message = scram_sha256_credentials->getAuthMessage();
         const auto & password = authentication_method.getPasswordHashBinary();

--- a/src/Core/PostgreSQLProtocol.h
+++ b/src/Core/PostgreSQLProtocol.h
@@ -1638,7 +1638,12 @@ class ScrambleSHA256Auth : public AuthenticationMethod
                     /// Methods verified against an external system never take part in the combination.
                     if (!authenticationTypeIsVerifiedLocally(type))
                         continue;
-                    if (type == AuthenticationType::SCRAM_SHA256_PASSWORD && auth_method.getSalt() == *live_scram_salt)
+                    /// A same-salt `scram_sha256_password` method can be matched by the proof, unless it carries
+                    /// a second factor: a SCRAM proof cannot verify a one-time password, so such a method (only an
+                    /// expired one can reach this point, a live one is refused by the first pass) would drop out of
+                    /// the combination instead of shortening the session lifetime.
+                    if (type == AuthenticationType::SCRAM_SHA256_PASSWORD && auth_method.getSalt() == *live_scram_salt
+                        && !auth_method.getOneTimePassword())
                         continue;
 
                     unsupported_configuration = true;

--- a/tests/integration/test_totp_auth/config/postgresql.xml
+++ b/tests/integration/test_totp_auth/config/postgresql.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <postgresql_port>9005</postgresql_port>
+</clickhouse>

--- a/tests/integration/test_totp_auth/test_totp.py
+++ b/tests/integration/test_totp_auth/test_totp.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import hmac
 import os
-import random
 import re
 import struct
 import time
@@ -14,7 +13,12 @@ from helpers.cluster import ClickHouseCluster
 from helpers.uclient import client, prompt
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-TOTP_SECRET = base64.b32encode(random.randbytes(random.randint(3, 64))).decode()
+# The secret must be deterministic: the flaky check runs this file on several pytest-xdist
+# workers in parallel, and `create_config` writes the shared `config/users.xml`, so all
+# workers must produce identical content. A random secret makes the last writer win and
+# the other workers' clusters reject codes generated for their own secrets.
+# The length is not a multiple of 5 bytes, so the base32 form exercises `=` padding.
+TOTP_SECRET = base64.b32encode(hashlib.sha256(b"test_totp_auth").digest()[:19]).decode()
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
@@ -38,7 +42,7 @@ def get_one_time_password(
     secret, interval=30, digits=6, sha_version=hashlib.sha1, timepoint=None
 ):
     key = base64.b32decode(secret, casefold=True)
-    time_step = int(timepoint or time.time() / interval)
+    time_step = int((timepoint or time.time()) / interval)
     msg = struct.pack(">Q", time_step)
     hmac_hash = hmac.new(key, msg, sha_version).digest()
     offset = hmac_hash[-1] & 0x0F

--- a/tests/integration/test_totp_auth/test_totp.py
+++ b/tests/integration/test_totp_auth/test_totp.py
@@ -7,6 +7,7 @@ import re
 import struct
 import time
 
+import psycopg2
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -18,6 +19,7 @@ TOTP_SECRET = base64.b32encode(random.randbytes(random.randint(3, 64))).decode()
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
+    main_configs=["config/postgresql.xml"],
     user_configs=["config/users.xml"],
 )
 
@@ -46,6 +48,8 @@ def get_one_time_password(
 
 
 def create_config(totp_secret):
+    # `password_scram_sha256_hex` stores the salted password with an empty salt.
+    scram_hex = hashlib.pbkdf2_hmac("sha256", b"abacaba", b"", 4096).hex()
     config = f"""
 <clickhouse>
     <profiles>
@@ -69,6 +73,22 @@ def create_config(totp_secret):
             <profile>default</profile>
             <quota>default</quota>
         </totuser>
+
+        <totuser_scram>
+            <password_scram_sha256_hex>{scram_hex}</password_scram_sha256_hex>
+            <time_based_one_time_password>
+                <secret>{totp_secret}</secret>
+                <period>60</period>
+                <digits>9</digits>
+                <algorithm>SHA256</algorithm>
+            </time_based_one_time_password>
+
+            <networks replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </totuser_scram>
 
         <totuser_no_password>
             <no_password></no_password>
@@ -228,6 +248,45 @@ def test_interactive_totp_authentication(started_cluster):
         command=f"{client_command} --password wrongpwd+{get_totp_for_config()}"
     ) as c:
         c.expect(expected_error)
+
+
+def test_postgresql_protocol_requires_totp(started_cluster):
+    """The PostgreSQL protocol must enforce TOTP. A SCRAM proof is derived from the password
+    alone and cannot carry a one-time password, so the server refuses the SCRAM exchange for
+    a `scram_sha256_password` user with TOTP. For cleartext password authentication the client
+    appends the TOTP to the password."""
+
+    def connect(user, password):
+        return psycopg2.connect(
+            host=node.ip_address,
+            port=9005,
+            user=user,
+            password=password,
+            dbname="default",
+        )
+
+    # A SCRAM user with TOTP must be refused: the exchange cannot verify the second factor.
+    with pytest.raises(psycopg2.OperationalError, match="not supported"):
+        connect("totuser_scram", "abacaba")
+
+    with pytest.raises(psycopg2.OperationalError, match="not supported"):
+        connect("totuser_scram", f"abacaba+{get_totp_for_config()}")
+
+    # Cleartext password authentication enforces the second factor.
+    # The message is intentionally generic and does not reveal the reason.
+    with pytest.raises(psycopg2.OperationalError, match="Invalid user or password"):
+        connect("totuser", "aa+bb")
+
+    with pytest.raises(psycopg2.OperationalError, match="Invalid user or password"):
+        connect("totuser", "aa+bb+000000000")
+
+    conn = connect("totuser", f"aa+bb+{get_totp_for_config()}")
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT currentUser()")
+        assert cursor.fetchall() == [("totuser",)]
+    finally:
+        conn.close()
 
 
 def test_one_time_only_no_password(started_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Harden SCRAM SHA-256 authentication for users with a time-based one-time password: the credential check now fails closed when a second factor is configured, since a SCRAM client proof is derived from the password alone and cannot carry or verify a one-time password.

The SCRAM client proof is derived from the password alone, so it cannot carry or verify a one-time password. `checkScramSHA256Authentication` ignored the configured TOTP secret and verified only the proof. The PostgreSQL frontend already refuses to run the SCRAM exchange for a `scram_sha256_password` method with a second factor (see `getScramSalt`), so this was not reachable — but the check itself must not depend on every producer of `ScramSHA256Credentials` pre-filtering such users. It now fails closed when a one-time password is configured.

Accordingly, the ambiguous-credentials pass in `getScramSalt` no longer exempts a same-salt `scram_sha256_password` method that carries a second factor (only an expired one can reach that point): the proof can no longer be checked against it, so it would silently drop out of the fail-close `GRANTS`/`VALID UNTIL` combination instead of shortening the session lifetime. Such a configuration is refused as unsupported instead.

Added an integration test for TOTP over the PostgreSQL protocol: a `scram_sha256_password` user with TOTP is refused as an unsupported configuration, and cleartext password authentication enforces the second factor (`password+TOTP`).

Related: https://github.com/ClickHouse/ClickHouse/pull/117407

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117408&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117408](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117408+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
