### PR TITLE
Cap the integration tests' `/docker` cgroup leaf at a ceiling, not at its share

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -20,8 +20,9 @@ LIMITED_MEM = Utils.physical_memory() - 2 * 1024**3
 KEEPER_DIND_MEM = Utils.physical_memory() * 70 // 100
 
 # Integration tests run a nested Docker daemon, so `docker_in_docker.sh` splits the job's
-# `--memory` into capped cgroup leaves. `/init`'s cap is a ceiling rather than a share, so the
-# caps can sum above the job limit.
+# `--memory` into capped cgroup leaves. Every leaf's cap is a ceiling rather than a share, so the
+# caps can sum above the job limit: the reserves below are what the leaves owe each other, and the
+# job's own `--memory` is what actually bounds their total.
 
 # Not a leaf: headroom for the pages faulted before delegation, which stay charged to the
 # cgroup root and can be neither migrated nor reclaimed (measured up to ~147 MiB).
@@ -45,6 +46,20 @@ INTEGRATION_NESTED_BUDGET = max(
     - INTEGRATION_DIND_INIT_RESERVE
     - INTEGRATION_DIND_DAEMON_RESERVE,
     0,
+)
+# `/docker`'s ceiling, not its share, for the same reason the other two leaves have one: the leaf
+# holds the nested servers' page cache as well as their anon memory, so its charge runs far above
+# the footprint the budget models. Capping it at its own share is what a run measures: with the cap
+# at the share, the leaf sat AT CAP in nearly every run of every shard and was OOM-killed in 17% to
+# 47% of the runs of three of them, while the job as a whole peaked ~12 GiB below its own limit.
+# The share stays what it was, because it is also the worker-concurrency budget; only the cap moves.
+# This makes the overlap with `/init` mutual, where before only `/init` could borrow: what protects
+# the harness now is that the memory `/docker` borrows is page cache, which reclaim takes back
+# before it touches anon, and a borrow that outgrows even that breaches the job's own cgroup - a
+# breach `job_cgroup_oom` reports rather than one that reads as a clean run.
+INTEGRATION_NESTED_LIMIT = max(
+    LIMITED_MEM - INTEGRATION_DIND_ROOT_RESERVE - INTEGRATION_DIND_DAEMON_RESERVE,
+    INTEGRATION_NESTED_BUDGET,
 )
 # `/init`'s ceiling, not its share: its peak is one test's host-side client fan-out, and its
 # charge is anon, so reclaim cannot meet a cap the way it can for `/docker`'s page cache. It
@@ -70,6 +85,7 @@ integration_dind_env = (
     f"+--env=CI_DIND_DAEMON_RESERVE={INTEGRATION_DIND_DAEMON_RESERVE}"
     f"+--env=CI_DIND_DAEMON_LIMIT={INTEGRATION_DIND_DAEMON_LIMIT}"
     f"+--env=CI_DIND_NESTED_BUDGET={INTEGRATION_NESTED_BUDGET}"
+    f"+--env=CI_DIND_NESTED_LIMIT={INTEGRATION_NESTED_LIMIT}"
 )
 
 BINARY_DOCKER_COMMAND = (

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -128,11 +128,13 @@ _SHELL_INT_MAX = 2**63 - 1
 def nested_budget_gb(env=None, physical_memory=None) -> int:
     """Memory the nested test containers may collectively use, in GiB.
 
-    `CI_DIND_NESTED_BUDGET` is the cap `docker_in_docker.sh` puts on the cgroup that parents
-    them, so deriving worker concurrency from it keeps scheduling and containment on the same
-    number. `Utils.physical_memory` reports HOST memory, which those containers do not get:
-    on the 61.78 GiB runner it budgets 3 x 20 = 60 GiB for a `--dist=each` run inside a
-    40 GiB cap. Runs without the variable (local, or a job that sets no memory limit) keep
+    `CI_DIND_NESTED_BUDGET` is the share of the job limit that the cgroup parenting them owes the
+    other leaves nothing for, so deriving worker concurrency from it keeps scheduling and
+    containment on the same number. Its `memory.max` is `CI_DIND_NESTED_LIMIT`, a ceiling that
+    overlaps the other leaves, so scheduling to the ceiling would size every job to memory only an
+    otherwise idle run has. `Utils.physical_memory` reports HOST memory, which those containers do
+    not get: on the 61.78 GiB runner it budgets 3 x 20 = 60 GiB for a `--dist=each` run inside a
+    40 GiB share. Runs without the variable (local, or a job that sets no memory limit) keep
     deriving it from host memory, which is what they do today.
     """
     env = os.environ if env is None else env
@@ -286,11 +288,11 @@ def print_leaf_peak_usage(env, cgroup_root=DIND_CGROUP_ROOT) -> Dict[str, int]:
         return {}
     peaks = leaf_peak_usage(cgroup_root=cgroup_root)
     caps = {
-        # The cap that was written, which for `/init` and `/dockerd` is not their share of the
-        # budget. Falling back to the reserve would understate the cap and print a false AT CAP.
+        # The cap that was written, which for no leaf is its share of the budget. Falling back to
+        # the reserve would understate the cap and print a false AT CAP.
         "init": env.get("CI_DIND_INIT_LIMIT") or env.get("CI_DIND_INIT_RESERVE"),
         "dockerd": env.get("CI_DIND_DAEMON_LIMIT") or env.get("CI_DIND_DAEMON_RESERVE"),
-        "docker": env.get("CI_DIND_NESTED_BUDGET"),
+        "docker": env.get("CI_DIND_NESTED_LIMIT") or env.get("CI_DIND_NESTED_BUDGET"),
     }
     for leaf, peak in sorted(peaks.items()):
         cap = caps.get(leaf)

--- a/ci/jobs/scripts/docker_in_docker.sh
+++ b/ci/jobs/scripts/docker_in_docker.sh
@@ -24,7 +24,7 @@ echo '{
 }' | dd of=/etc/docker/daemon.json
 
 # Split the job's `--memory` into three capped leaves (harness, daemon, nested containers), so an
-# overrun hits a leaf. The RESERVES partition the limit and are validated below; `/init` is then
+# overrun hits a leaf. The RESERVES partition the limit and are validated below; every leaf is then
 # capped at its ceiling instead, so the written caps can sum above it and the job cgroup can breach.
 # Requested-then-required: a caller that asks for containment gets a refusal, not a daemon.
 # BEGIN: cgroup containment
@@ -40,7 +40,7 @@ if [ "${CI_DIND_REQUIRE_CGROUP_CONTAINMENT:-0}" = 1 ]; then
 
     for var in CI_DIND_JOB_MEM CI_DIND_ROOT_RESERVE CI_DIND_INIT_RESERVE \
                CI_DIND_INIT_LIMIT CI_DIND_DAEMON_RESERVE CI_DIND_DAEMON_LIMIT \
-               CI_DIND_NESTED_BUDGET; do
+               CI_DIND_NESTED_BUDGET CI_DIND_NESTED_LIMIT; do
         case "${!var:-}" in
             "" | *[!0-9]*) refuse "\$$var is [${!var:-}], expected a byte count" ;;
         esac
@@ -90,7 +90,8 @@ CI_DIND_REQUIRE_CGROUP_CONTAINMENT to run uncontained"
     # Each reserve is bounded by the job limit before they are summed: the sum is signed 64-bit,
     # so a value near its top wraps negative and passes the total check below.
     for var in CI_DIND_ROOT_RESERVE CI_DIND_INIT_RESERVE CI_DIND_DAEMON_RESERVE \
-               CI_DIND_NESTED_BUDGET CI_DIND_INIT_LIMIT CI_DIND_DAEMON_LIMIT; do
+               CI_DIND_NESTED_BUDGET CI_DIND_INIT_LIMIT CI_DIND_DAEMON_LIMIT \
+               CI_DIND_NESTED_LIMIT; do
         [ "${!var}" -le "$CI_DIND_JOB_MEM" ] || \
             refuse "\$$var is [${!var}] bytes, above the job limit of $CI_DIND_JOB_MEM"
     done
@@ -119,6 +120,15 @@ totals $init_headroom, above the job limit of $CI_DIND_JOB_MEM"
         refuse "the daemon limit of $CI_DIND_DAEMON_LIMIT bytes plus the root and init reserves \
 totals $daemon_headroom, above the job limit of $CI_DIND_JOB_MEM"
 
+    # `/docker`'s cap is a ceiling for the same reason, so it is bounded the same way: at least the
+    # share the harness schedules workers against, and still leaving the leaves it does not overlap.
+    [ "$CI_DIND_NESTED_LIMIT" -ge "$CI_DIND_NESTED_BUDGET" ] || \
+        refuse "the nested limit is [$CI_DIND_NESTED_LIMIT] bytes, below the nested budget of [$CI_DIND_NESTED_BUDGET]"
+    nested_headroom=$(( CI_DIND_NESTED_LIMIT + CI_DIND_ROOT_RESERVE + CI_DIND_DAEMON_RESERVE ))
+    [ "$nested_headroom" -le "$CI_DIND_JOB_MEM" ] || \
+        refuse "the nested limit of $CI_DIND_NESTED_LIMIT bytes plus the root and daemon reserves \
+totals $nested_headroom, above the job limit of $CI_DIND_JOB_MEM"
+
     mkdir -p "$leaf_root/init" "$leaf_root/dockerd" "$leaf_root/docker"
 
     if [ "$cgroup_version" = 2 ]; then
@@ -144,7 +154,7 @@ totals $daemon_headroom, above the job limit of $CI_DIND_JOB_MEM"
     # limit is measured to survive that only in this order.
     echo "$CI_DIND_INIT_LIMIT"     > "$leaf_root/init/$limit_file"    || refuse "capping [$leaf_root/init] failed"
     echo "$CI_DIND_DAEMON_LIMIT"   > "$leaf_root/dockerd/$limit_file" || refuse "capping [$leaf_root/dockerd] failed"
-    echo "$CI_DIND_NESTED_BUDGET"  > "$leaf_root/docker/$limit_file"  || refuse "capping [$leaf_root/docker] failed"
+    echo "$CI_DIND_NESTED_LIMIT"   > "$leaf_root/docker/$limit_file"  || refuse "capping [$leaf_root/docker] failed"
 
     # A memory cap alone bounds resident pages, so a leaf can still exceed its advertised budget
     # by swapping. v1 spells this `memory.memsw.limit_in_bytes` and counts memory+swap against one
@@ -161,7 +171,7 @@ totals $daemon_headroom, above the job limit of $CI_DIND_JOB_MEM"
         case $leaf in
             init)    bytes=$CI_DIND_INIT_LIMIT ;;
             dockerd) bytes=$CI_DIND_DAEMON_LIMIT ;;
-            docker)  bytes=$CI_DIND_NESTED_BUDGET ;;
+            docker)  bytes=$CI_DIND_NESTED_LIMIT ;;
         esac
         if [ "$cgroup_version" = 1 ]; then
             swap_file=memory.memsw.limit_in_bytes
@@ -198,7 +208,7 @@ totals $daemon_headroom, above the job limit of $CI_DIND_JOB_MEM"
 
     echo "docker_in_docker.sh: cgroup containment active (cgroup v$cgroup_version):" \
          "init=$CI_DIND_INIT_LIMIT dockerd=$CI_DIND_DAEMON_LIMIT" \
-         "docker=$CI_DIND_NESTED_BUDGET within $CI_DIND_JOB_MEM"
+         "docker=$CI_DIND_NESTED_LIMIT (budget $CI_DIND_NESTED_BUDGET) within $CI_DIND_JOB_MEM"
 fi
 # END: cgroup containment
 


### PR DESCRIPTION
The integration tests run a nested Docker daemon whose cgroup is split into three capped leaves — `/init` (the harness), `/dockerd` (the daemons) and `/docker` (the nested test containers). `/docker` was the only leaf whose `memory.max` was its *share* of the job limit rather than a *ceiling* overlapping the other leaves, and that share does not hold what the leaf actually charges: besides the nested servers' anon memory it holds every byte they write, as page cache. The leaf therefore ran at its cap continuously, and the kernel OOM-killed a `clickhouse` server whenever reclaim could not keep up with writeback.

Measured on master, one day after the reporting for this condition became reliable: `/docker` reached the 40.78 GiB cap in nearly every run of every `amd_asan_ubsan, db disk, old analyzer` shard — including shards that passed — and the kill turned into `Container memory budget exceeded (/docker)` in 47.3% of the runs of shard 6/6, 26.9% of 5/6 and 17.0% of 2/6, plus a smaller number of `amd_tsan` and `amd_llvm_coverage` runs. In the reported run the leaf was killed three times at 40.78 GiB of 40.78 GiB while `/dockerd` sat at 18.36 GiB of 42.78 GiB and `/init` at 21.98 GiB of 56.78 GiB, and the job as a whole peaked at 47.14 GiB against its own 59.78 GiB limit — about 12 GiB the partition held back from the only leaf that had a use for it. The `test_s3_plain_rewritable` failure in the same report (`Connection refused` during `OPTIMIZE TABLE test FINAL`) is one of those killed servers.

`/docker` now gets `CI_DIND_NESTED_LIMIT`, the same ceiling `/init` has, while `CI_DIND_NESTED_BUDGET` stays its share and keeps sizing xdist concurrency, so the worker count is unchanged. Containment is unaffected — it comes from `--cgroupns=private`, and the job's own `--memory` still bounds the leaves together. The overlap with `/init` becomes mutual, where before only `/init` could borrow; what protects the harness is that the memory `/docker` borrows is page cache, which reclaim takes back before it touches anon, and a borrow that outgrows even that breaches the job's own cgroup, which `job_cgroup_oom` already reports.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=25dfbdb6c5dd3c0bd78c7134c14045ddb7647bcf&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29

Caused by: https://github.com/ClickHouse/ClickHouse/pull/112984

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117411&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117411](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117411+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
