### PR TITLE
Give the integration tests' nested containers the budget they actually use

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -28,10 +28,19 @@ KEEPER_DIND_MEM = Utils.physical_memory() * 70 // 100
 INTEGRATION_DIND_ROOT_RESERVE = 1 * 1024**3
 # Everything not charged to `/docker`: pytest, its xdist workers, the post-teardown steps, and the
 # per-test subprocesses - `helpers/cluster.py` runs each node's `clickhouse-client` and
-# `helpers/iceberg_utils.py` runs Spark's `local` driver on the host, not in a container. That
-# scales with xdist concurrency, hence a share of the job limit; the floor keeps the smallest
-# supported host runnable and the cap keeps the container budget from losing a worker.
-INTEGRATION_DIND_INIT_RESERVE = min(max(LIMITED_MEM // 3, 8 * 1024**3), 16 * 1024**3)
+# `helpers/iceberg_utils.py` runs Spark's `local` driver on the host, not in a container.
+#
+# A flat floor rather than the third of the job limit this used to take, because the share was
+# claiming memory `/docker` cannot do without. Measured over 58 integration jobs on the 61.78 GiB
+# runner: `/docker` peaks at its cap in every single one, while `/init` peaks at 20.8 GiB
+# (median) against this reserve and `/dockerd` at 18.3 GiB against its 2 GiB one, and the job
+# cgroup never breaches - the two overruns are page cache (the log archiving here, the image
+# layers there) and reclaim gives them back. `/docker` is the opposite: read off a kernel OOM
+# report, its 40.35 GiB charge is anonymous memory against 753664 bytes of cache, so not one page
+# of it is reclaimable and its cap is the only one that binds. Sizing the unreclaimable leaf last
+# is what put `Container memory budget exceeded (/docker)` on nearly every run of the ASan+UBSan
+# shards.
+INTEGRATION_DIND_INIT_RESERVE = 8 * 1024**3
 # Holds dockerd, containerd and one containerd-shim per nested container, so it scales with
 # concurrency rather than staying at the daemon's own footprint. An absolute floor, never a
 # fraction of the job limit: too small and the daemons cannot boot at all.
@@ -46,9 +55,10 @@ INTEGRATION_NESTED_BUDGET = max(
     - INTEGRATION_DIND_DAEMON_RESERVE,
     0,
 )
-# `/init`'s ceiling, not its share: its peak is one test's host-side client fan-out, and its
-# charge is anon, so reclaim cannot meet a cap the way it can for `/docker`'s page cache. It
-# overlaps `/docker`, so this cap alone is within the job limit but the three together are not.
+# `/init`'s ceiling, not its share: its peak is one test's host-side client fan-out plus the page
+# cache of the logs it reads and archives, and neither is bounded by the reserve above. It
+# overlaps `/docker`, so this cap alone is within the job limit but the three together are not -
+# which is what lets the reserve shrink without `/init` losing any room it actually uses.
 INTEGRATION_DIND_INIT_LIMIT = max(
     LIMITED_MEM - INTEGRATION_DIND_ROOT_RESERVE - INTEGRATION_DIND_DAEMON_RESERVE,
     INTEGRATION_DIND_INIT_RESERVE,


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117202
Related: https://github.com/ClickHouse/ClickHouse/pull/112984

`Integration tests (amd_asan_ubsan, db disk, old analyzer, 6/6)` fails on master with `Container memory budget exceeded (/docker)` while every test in the batch passes - 15 of the 26 master runs after 2026-08-31 12:00:

https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=25dfbdb6c5dd3c0bd78c7134c14045ddb7647bcf&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29

`docker_in_docker.sh` splits the job's memory limit into three capped cgroup leaves and sizes `/docker` - the one that parents every nested test container - last, from whatever the other reserves leave. On the 61.78 GiB runner that is 40.78 GiB, and it is not enough. Across 58 collected job logs `/docker` peaked at **exactly its cap in all 58**, green runs included, so the leaf has no reclaim headroom at all and whether the kernel has to kill something is luck:

```
cgroup leaf /docker:  peak 40.78 GiB of 40.78 GiB cap (AT CAP - demand is at least this)
cgroup leaf /dockerd: peak 18.35 GiB of 42.78 GiB cap
cgroup leaf /init:    peak 21.58 GiB of 56.78 GiB cap
```

The partition rests on an assumption the kernel's own OOM report refutes. It gives `/init` a third of the job limit and `/docker` the remainder, on the grounds that `/init`'s charge is anonymous while `/docker` holds page cache that reclaim can give back. Read off the kill, `/docker` is the opposite:

```
memory: usage 42756008kB, limit 42756044kB
total_rss 43330654208      <- 40.35 GiB anonymous
total_cache 753664         <- 0.7 MB of page cache
```

`/init` and `/dockerd` are the ones running on cache - they peak 20 GiB above what the partition promises them (16 GiB and 2 GiB reserves) and the job cgroup still never breaches, because reclaim takes that back. The only leaf that cannot give anything back is the one being sized last.

So `/init` keeps the floor instead of the share, and `/docker` gets the 8 GiB that frees: 48.78 GiB against a measured peak of 40.35 GiB of servers plus the 3.4-4.3 GiB a shutdown `gdb` attach adds on top. `/init`'s own ceiling is unchanged - the reserve was never its cap - so this takes away none of the room it uses, and the worker plan derived from the budget stays at 3 workers (2 under `--dist=each`), so no job runs longer for this.

This is the remainder of the same overrun #117202 addressed. Serializing the shutdown `gdb` attaches removed the four-at-once pile-up and fixed shards 2/6 and 5/6 (0 occurrences since), but 6/6 still fails: there the servers alone reach 39.30 GiB across 34 processes, so a single 4 GiB attach no longer fits either, and half the kills there have no `gdb` in them at all - the victim is a `clickhouse` server.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117412&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117412](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117412+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.480` (included in `26.9` and later)
<!-- ch-version-info:end -->