### PR TITLE
Keep the derived Iceberg table root on the deserialization path

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h
@@ -54,6 +54,8 @@ class SettingsChanges;
 #define DATA_LAKE_STORAGE_RELATED_SETTINGS(DECLARE, ALIAS) \
     DECLARE(String, iceberg_metadata_file_path, "", R"(
 Explicit path to desired Iceberg metadata file, should be relative to path in object storage. Make sense for table function use case only.
+
+When the named file sits in a subdirectory of the queried path rather than in its own `metadata` directory, that subdirectory is the table's root, and the queried path also covers whatever else lives under it. The table is then read-only: `INSERT`, `ALTER`, mutations, `OPTIMIZE`, `expire_snapshots` and `remove_orphan_files` are refused, because they are scoped to the queried path and would reach outside the table. `DROP` keeps the data instead of deleting it, even with `iceberg_delete_data_on_drop` enabled.
 )", 0) \
     DECLARE(String, iceberg_metadata_table_uuid, "", R"(
 Explicit table UUID to read metadata for. Ignored if iceberg_metadata_file_path is set.

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -218,7 +218,6 @@ Iceberg::PersistentTableComponents IcebergMetadata::initializePersistentTableCom
         .table_uuid = table_uuid,
         .path_resolver = IcebergPathResolver(
             table_location, root_derivation.table_root, configuration->getTypeName(), configuration->getNamespace()),
-        .table_root_was_derived = root_derivation.relation == IcebergPathResolver::RootRelation::AdoptedDescendant,
     };
 }
 
@@ -686,7 +685,7 @@ void IcebergMetadata::mutate(
 
 void IcebergMetadata::checkTableRootIsQueriedPath(std::string_view operation) const
 {
-    if (!persistent_components.table_root_was_derived)
+    if (!persistent_components.tableRootWasDerived())
         return;
 
     throw Exception(
@@ -1545,7 +1544,7 @@ void IcebergMetadata::drop(ContextPtr context)
     {
         /// Skipped rather than refused: this runs after the table is already marked as dropped, so
         /// throwing here only makes `DatabaseCatalog` retry the drop forever.
-        if (persistent_components.table_root_was_derived)
+        if (persistent_components.tableRootWasDerived())
         {
             LOG_WARNING(
                 log,
@@ -1641,13 +1640,17 @@ DataLakeMetadataPtr IcebergMetadata::createWithDeserialization(
         .metadata_compression_method = metadata_compression_method,
         .table_path = standard_persistent_components.table_path,
         .table_uuid = standard_persistent_components.table_uuid,
+        /// The root has to come from the locally computed components: it is derived from where the
+        /// metadata document sits, which is not on the wire. Dropping it back to `table_path` here
+        /// would re-root every data and manifest key onto the queried path on this side only, which
+        /// is the very bug this derivation exists to fix, and would leave every operation scoped to
+        /// the queried path unrefused. `table_location` stays the deserialized one, because the
+        /// paths this resolver is asked to resolve are the ones the sender recorded against it.
         .path_resolver = IcebergPathResolver(
             table_location,
-            standard_persistent_components.table_path,
+            standard_persistent_components.path_resolver.getTableRoot(),
             configuration_ptr->getTypeName(),
-            configuration_ptr->getNamespace()),
-        /// Consistent with the resolver above, which is rooted at `table_path` itself.
-        .table_root_was_derived = false};
+            configuration_ptr->getNamespace())};
     auto metadata = std::make_unique<IcebergMetadata>(object_storage, configuration.lock(), std::move(deserialized_persistent_components), local_context);
     return metadata;
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h
@@ -3,6 +3,8 @@
 
 #if USE_AVRO
 
+#include <string_view>
+
 #include <IO/CompressionMethod.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h>
@@ -25,9 +27,23 @@ struct PersistentTableComponents
     const String table_path;
     const std::optional<String> table_uuid;
     const IcebergPathResolver path_resolver;
+
     /// True when the resolver works against a table root deeper than `table_path`. Operations scoped
     /// to `table_path` then reach outside this table, so they must refuse to run.
-    const bool table_root_was_derived;
+    ///
+    /// Derived from the resolver instead of being stored alongside it: a stored flag lets a
+    /// construction site hand the resolver a deeper root and still report `false`, and the
+    /// permissive value is the one aggregate initialization picks for an omitted member.
+    /// `IcebergPathResolver::deriveTableRoot` returns the queried path unchanged unless it adopted a
+    /// descendant of it, so the roots differ exactly when the derivation fired.
+    bool tableRootWasDerived() const
+    {
+        std::string_view queried = table_path;
+        /// The resolver trims trailing slashes off the root it was given; `table_path` keeps them.
+        while (!queried.empty() && queried.back() == '/')
+            queried.remove_suffix(1);
+        return std::string_view(path_resolver.getTableRoot()) != queried;
+    }
 
     /// Invalidate cached metadata for this table under both keys we may have used to cache it
     /// (`table_path` and `table_uuid`).

--- a/tests/integration/test_storage_iceberg_drop_derived_root/configs/users.d/iceberg.xml
+++ b/tests/integration/test_storage_iceberg_drop_derived_root/configs/users.d/iceberg.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- `IcebergMetadata::drop` runs in the background and reads this from the global
+                 context, so it cannot be set per query. -->
+            <iceberg_delete_data_on_drop>1</iceberg_delete_data_on_drop>
+            <allow_insert_into_iceberg>1</allow_insert_into_iceberg>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <password></password>
+            <profile>default</profile>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_storage_iceberg_drop_derived_root/test.py
+++ b/tests/integration/test_storage_iceberg_drop_derived_root/test.py
@@ -1,0 +1,98 @@
+"""
+`DROP` must not delete data when the Iceberg table root had to be derived from a metadata document
+deeper than the queried path: the queried path is then an ancestor of the table directory and covers
+whatever else lives under it, so deleting everything below it would take other tables with it.
+
+Covers the skip added by https://github.com/ClickHouse/ClickHouse/pull/117037. It cannot be a
+stateless test, because `StorageObjectStorage::drop` deliberately reads `iceberg_delete_data_on_drop`
+from the global context (the drop runs in the background), so the setting has to come from a profile.
+"""
+
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+USER_FILES = "/var/lib/clickhouse/user_files"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    cluster = ClickHouseCluster(__file__)
+    cluster.add_instance(
+        "node1",
+        user_configs=["configs/users.d/iceberg.xml"],
+        stay_alive=True,
+    )
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def list_files(instance, path):
+    return instance.exec_in_container(
+        ["bash", "-c", f"find {path} -type f 2>/dev/null | sort"], user="root"
+    ).strip()
+
+
+def test_drop_keeps_data_when_table_root_is_derived(started_cluster):
+    instance = started_cluster.instances["node1"]
+    prefix = f"{USER_FILES}/iceberg_drop_derived_{uuid.uuid4().hex}"
+    table = "t_derived_root"
+
+    # The real table lives one directory below the path the query will name.
+    instance.query(
+        f"CREATE TABLE t_real (x UInt32) ENGINE = IcebergLocal('{prefix}/tbl/sub/', 'Parquet')"
+    )
+    instance.query("INSERT INTO t_real VALUES (1), (2), (3)")
+    # Detached rather than dropped: dropping it would delete the very data this test is about.
+    instance.query("DETACH TABLE t_real")
+
+    # A neighbour of the table: reachable from the queried path, not part of the table.
+    instance.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"mkdir -p {prefix}/tbl/sibling && echo keep > {prefix}/tbl/sibling/keep.txt",
+        ],
+        user="root",
+    )
+
+    before = list_files(instance, f"{prefix}/tbl")
+    assert f"{prefix}/tbl/sibling/keep.txt" in before
+
+    instance.query(
+        f"""
+        CREATE TABLE {table} ENGINE = IcebergLocal('{prefix}/tbl/', 'Parquet')
+        SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json'
+        """
+    )
+
+    # Also proves the root really was derived: rooted at the queried path, every data key would
+    # lose its `sub/` component and the read would fail with a missing file.
+    assert instance.query(f"SELECT sum(x) FROM {table}").strip() == "6"
+
+    instance.query(f"DROP TABLE {table} SYNC")
+
+    assert list_files(instance, f"{prefix}/tbl") == before
+    assert instance.contains_in_log("Keeping the data of the Iceberg table at")
+
+
+def test_drop_deletes_data_when_table_root_is_the_queried_path(started_cluster):
+    """Control: the deletion the test above asserts against is live for an ordinary table."""
+    instance = started_cluster.instances["node1"]
+    prefix = f"{USER_FILES}/iceberg_drop_plain_{uuid.uuid4().hex}"
+
+    instance.query(
+        f"CREATE TABLE t_plain (x UInt32) ENGINE = IcebergLocal('{prefix}/tbl/', 'Parquet')"
+    )
+    instance.query("INSERT INTO t_plain VALUES (1), (2), (3)")
+    assert instance.query("SELECT sum(x) FROM t_plain").strip() == "6"
+    assert list_files(instance, f"{prefix}/tbl") != ""
+
+    instance.query("DROP TABLE t_plain SYNC")
+
+    assert list_files(instance, f"{prefix}/tbl") == ""


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117037
Related: https://github.com/ClickHouse/ClickHouse/issues/116985

### Description

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/117037, which fixed reads of an Iceberg table queried through a parent of its own directory by deriving the table root from where the metadata document actually sits, and refused write and maintenance operations while the root had to be derived.

`IcebergMetadata::createWithDeserialization` computed that derivation, by calling `initializePersistentTableComponents`, and then threw it away: it rebuilt the resolver at `table_path` and set `.table_root_was_derived = false`. On that path every data and manifest key is re-rooted onto the queried path again, which is exactly the 404 the derivation exists to prevent, and every operation scoped to the queried path is left unrefused. The original pull request recorded this as safe because the function has no callers. That is true of this repository only: `clickhouse-private` reaches it from `deserializeDataLakeConfiguration` in `DataLakeConfiguration.h` through `DataLakeSerde::deserialize`, which reconstructs the Iceberg read state on the receiving side. Today the divergence is masked because the sender ships already-resolved paths and the receiver short-circuits to the prepared iterator, so this is a latent inconsistency rather than an observable regression, but the receiver holds a resolver whose root is provably wrong for such a table and a refusal flag that is off.

Rather than fix the one construction site, the flag is now derived from the resolver instead of stored next to it. A stored `bool` lets a construction site hand the resolver a deeper root and still report `false`, and `false` is also what aggregate initialization picks for a member that a future construction site omits, so a flag whose whole purpose is to fail closed had a fail-open default. `deriveTableRoot` returns the queried path unchanged unless it adopted a descendant of it, so comparing the resolver's root against `table_path` reproduces the flag exactly and the two can no longer disagree. `PersistentTableComponents::tableRootWasDerived` trims trailing slashes off `table_path`, because the resolver trims them off the root it is given.

Two smaller items from the same review:

- The `iceberg_metadata_file_path` `DECLARE` doc string, which is the source of truth for the setting's generated documentation, did not mention that naming a metadata file in a subdirectory of the queried path now makes the table read-only and keeps the data on `DROP`.
- New integration test `test_storage_iceberg_drop_derived_root` for the `DROP` data-keep path. That is the most destructive site the refusals guard, since without the skip a `DROP` under `iceberg_delete_data_on_drop` deletes everything below the queried path including sibling tables, and it was the only guarded site with no test. It cannot be a stateless test, because `StorageObjectStorage::drop` deliberately reads the setting from the global context (the drop runs in the background), so it has to come from a profile. The test asserts the read through the pinned parent first, so it cannot pass unless the derivation really fired, and a control case pins that the deletion it asserts against is live for an ordinary table.

Not addressed here, because it lives in `clickhouse-private`: `IcebergMetadata::scheduleDataProcessingJob` and `isBackgroundExecutable` run the same compaction machinery that the foreground `OPTIMIZE` now refuses, without passing through `checkTableRootIsQueriedPath`. `Compaction.cpp` writes the new metadata document under `table_path` and the cleanup path deletes replaced data files, so a Cloud table with per-table `allow_experimental_iceberg_compaction` and a deeper `iceberg_metadata_file_path` pin would act outside the table in the background. Making `isBackgroundExecutable` return `false` when the root was derived covers the scheduler and the cleanup tasks at once. The Sync pull request for this change also has to apply the `createWithDeserialization` edit to the private copy of that function, which carries extra parameters.

`TableRootDerivation::relation` is now unused in production code and asserted only by the `deriveTableRoot` gtest. It is kept because it distinguishes `Same` from `Unknown`, which the derived flag cannot.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed reads of an Iceberg table queried through a parent of its own directory failing with a 404 (`S3_ERROR`) on distributed execution, where the table root derived from the metadata document named by `iceberg_metadata_file_path` was discarded and every data and manifest key was resolved against the queried path again. Operations that act outside such a table are now refused on that path too, consistently with a direct query.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117416&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117416](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117416+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
