### PR TITLE
Mask secrets in the `Settings` map of `system.query_log` and `system.processes`

### DIFF
--- a/src/Common/maskURIPassword.h
+++ b/src/Common/maskURIPassword.h
@@ -116,6 +116,28 @@ inline bool maskURIUserinfo(std::string & url)
     return true;
 }
 
+/// Whether the text is one whole URL: it opens with a scheme and holds no whitespace, which a URL cannot contain.
+inline bool isOneWholeURL(std::string_view text)
+{
+    static constexpr std::string_view SEPARATOR = "://";
+
+    auto is_letter = [](char c) { return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'); };
+    auto is_letter_or_digit = [&](char c) { return is_letter(c) || ('0' <= c && c <= '9'); };
+
+    if (text.empty() || !is_letter(text[0]))
+        return false;
+
+    size_t scheme_end = 1;
+    while (scheme_end < text.length()
+           && (is_letter_or_digit(text[scheme_end]) || text[scheme_end] == '+' || text[scheme_end] == '.' || text[scheme_end] == '-'))
+        ++scheme_end;
+
+    if (text.compare(scheme_end, SEPARATOR.length(), SEPARATOR) != 0)
+        return false;
+
+    return text.find_first_of(" \t\n\v\f\r") == std::string_view::npos;
+}
+
 /** Mask the values of the query parameters that carry credentials in a presigned URL, so that
   * `...?X-Amz-Signature=abc&foo=1` becomes `...?X-Amz-Signature=[HIDDEN]&foo=1`. Every occurrence
   * is masked. Returns whether anything was masked.

--- a/src/Common/maskURIPassword.h
+++ b/src/Common/maskURIPassword.h
@@ -56,15 +56,16 @@ inline bool maskURIPassword(std::string * uri)
             continue;
 
         /// `[^:]*:` - the colon that opens the password.
+        /// A later iteration searches from a not-smaller position, so a miss here can never become a match.
         size_t password_begin = uri->find(':', separator + SEPARATOR.length());
         if (password_begin == std::string::npos)
-            continue;
+            break;
         ++password_begin;
 
         /// `[^@]*@` - the at sign that closes it.
         size_t password_end = uri->find('@', password_begin);
         if (password_end == std::string::npos)
-            continue;
+            break;
 
         uri->replace(password_begin, password_end - password_begin, "[HIDDEN]");
         return true;

--- a/src/Common/maskURIPassword.h
+++ b/src/Common/maskURIPassword.h
@@ -153,32 +153,45 @@ inline bool maskPresignedURLParameters(std::string & url)
         return false;
     };
 
+    static constexpr std::string_view REPLACEMENT = "[HIDDEN]";
+
     bool masked = false;
+    std::string result;
+    size_t copied = 0;
     for (size_t position = url.find_first_of("?&"); position != std::string::npos;
          position = url.find_first_of("?&", position + 1))
     {
         size_t name_begin = position + 1;
-        size_t equal_sign = url.find('=', name_begin);
-        if (equal_sign == std::string::npos)
+        /// None of the names above contains a separator, so the scan for '=' stops at the first one.
+        size_t name_end = url.find_first_of("=?&", name_begin);
+        if (name_end == std::string::npos)
             break;
+        if (url[name_end] != '=')
+            continue;
 
-        if (!is_secret_parameter(std::string_view(url).substr(name_begin, equal_sign - name_begin)))
+        if (!is_secret_parameter(std::string_view(url).substr(name_begin, name_end - name_begin)))
             continue;
 
         /// `[^&#]*` - the value.
-        size_t value_begin = equal_sign + 1;
+        size_t value_begin = name_end + 1;
         size_t value_end = url.find_first_of("&#", value_begin);
         if (value_end == std::string::npos)
             value_end = url.length();
 
-        static constexpr std::string_view REPLACEMENT = "[HIDDEN]";
-        url.replace(value_begin, value_end - value_begin, REPLACEMENT);
+        result.append(url, copied, value_begin - copied);
+        result.append(REPLACEMENT);
+        copied = value_end;
         masked = true;
-        /// Continue after the replacement, not inside it.
-        position = value_begin + REPLACEMENT.length() - 1;
+        /// Continue after the value, not inside it.
+        position = value_end - 1;
     }
 
-    return masked;
+    if (!masked)
+        return false;
+
+    result.append(url, copied, std::string::npos);
+    url = std::move(result);
+    return true;
 }
 
 }

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -20,6 +20,7 @@
 #include <Storages/System/MutableColumnsAndConstraints.h>
 #include <base/types.h>
 #include <Common/NamePrompter.h>
+#include <Common/maskURIPassword.h>
 #include <Common/typeid_cast.h>
 
 #include <boost/program_options.hpp>
@@ -9386,6 +9387,18 @@ void SettingsImpl::loadSettingsFromConfig(const String & path, const Poco::Util:
     }
 }
 
+/// Both settings maps below are display-only, so a secret is hidden in them as ASTSetQuery hides it in the query text.
+static String maskedCustomSettingValue(const SettingFieldCustom & field)
+{
+    CustomType custom;
+    if (field.value.tryGet<CustomType>(custom) && custom.isSecret())
+        return custom.toString(/* show_secrets */ false);
+
+    String value = field.toString();
+    maskURIPassword(&value);
+    return value;
+}
+
 void SettingsImpl::dumpToMapColumn(IColumn * column, bool changed_only)
 {
     if (!column)
@@ -9409,6 +9422,7 @@ void SettingsImpl::dumpToMapColumn(IColumn * column, bool changed_only)
 
         const auto & name = accessor.getName(i);
         auto value = accessor.getValueString(*this, i);
+        maskURIPassword(&value);
         key_column.insertData(name.data(), name.size());
         value_column.insertData(value.data(), value.size());
         ++size;
@@ -9422,7 +9436,7 @@ void SettingsImpl::dumpToMapColumn(IColumn * column, bool changed_only)
             continue;
 
         const auto & name = custom.first;
-        auto value = setting_field.toString();
+        auto value = maskedCustomSettingValue(setting_field);
         key_column.insertData(name.data(), name.size());
         value_column.insertData(value.data(), value.size());
         ++size;
@@ -9437,12 +9451,18 @@ std::map<String, String> SettingsImpl::changedToMap() const
 
     const auto & accessor = Traits::Accessor::instance();
     for (size_t i = 0; i < accessor.size(); ++i)
-        if (accessor.isValueChanged(*this, i))
-            result.emplace(accessor.getName(i), accessor.getValueString(*this, i));
+    {
+        if (!accessor.isValueChanged(*this, i))
+            continue;
+
+        String value = accessor.getValueString(*this, i);
+        maskURIPassword(&value);
+        result.emplace(accessor.getName(i), std::move(value));
+    }
 
     for (const auto & custom : custom_settings_map)
         if (custom.second.changed)
-            result.emplace(custom.first, custom.second.toString());
+            result.emplace(custom.first, maskedCustomSettingValue(custom.second));
 
     return result;
 }

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -9387,6 +9387,65 @@ void SettingsImpl::loadSettingsFromConfig(const String & path, const Poco::Util:
     }
 }
 
+static void maskURLCredentials(String & text)
+{
+    maskURIPassword(&text);
+    /// A presigned parameter with nothing after it runs to the end of the text, so only a whole URL is sound to scan.
+    if (isOneWholeURL(text))
+        maskPresignedURLParameters(text);
+}
+
+/// A serialized composite is not a URL and its punctuation closes the value, so its leaves are masked instead.
+static void maskURLCredentialsInLeaves(Field & field)
+{
+    switch (field.getType())
+    {
+        case Field::Types::String:
+            maskURLCredentials(field.safeGet<String>());
+            return;
+        case Field::Types::Array:
+            for (Field & element : field.safeGet<Array>())
+                maskURLCredentialsInLeaves(element);
+            return;
+        case Field::Types::Tuple:
+            for (Field & element : field.safeGet<Tuple>())
+                maskURLCredentialsInLeaves(element);
+            return;
+        case Field::Types::Map:
+            for (Field & element : field.safeGet<Map>())
+                maskURLCredentialsInLeaves(element);
+            return;
+        case Field::Types::Object:
+            for (auto & element : field.safeGet<Object>())
+                maskURLCredentialsInLeaves(element.second);
+            return;
+        case Field::Types::AggregateFunctionState:
+        {
+            AggregateFunctionStateData & state = field.safeGet<AggregateFunctionStateData>();
+            maskURLCredentials(state.name);
+            maskURLCredentials(state.data);
+            return;
+        }
+        default:
+            return;
+    }
+}
+
+static String maskedSettingValue(const SettingsTraits::Accessor & accessor, const SettingsImpl & settings, size_t index)
+{
+    if (accessor.getTypeName(index) == "Map")
+    {
+        Field field = accessor.getValue(settings, index);
+        maskURLCredentialsInLeaves(field);
+        /// Re-serialized through the setting's own type, so an unmasked value stays byte-identical.
+        return accessor.valueToStringUtil(index, field);
+    }
+
+    String value = accessor.getValueString(settings, index);
+    maskURLCredentials(value);
+    return value;
+}
+
 /// Both settings maps below are display-only, so a secret is hidden in them as ASTSetQuery hides it in the query text.
 static String maskedCustomSettingValue(const SettingFieldCustom & field)
 {
@@ -9394,9 +9453,9 @@ static String maskedCustomSettingValue(const SettingFieldCustom & field)
     if (field.value.tryGet<CustomType>(custom) && custom.isSecret())
         return custom.toString(/* show_secrets */ false);
 
-    String value = field.toString();
-    maskURIPassword(&value);
-    return value;
+    Field masked = field.value;
+    maskURLCredentialsInLeaves(masked);
+    return masked.dump();
 }
 
 void SettingsImpl::dumpToMapColumn(IColumn * column, bool changed_only)
@@ -9421,8 +9480,7 @@ void SettingsImpl::dumpToMapColumn(IColumn * column, bool changed_only)
             continue;
 
         const auto & name = accessor.getName(i);
-        auto value = accessor.getValueString(*this, i);
-        maskURIPassword(&value);
+        auto value = maskedSettingValue(accessor, *this, i);
         key_column.insertData(name.data(), name.size());
         value_column.insertData(value.data(), value.size());
         ++size;
@@ -9455,8 +9513,7 @@ std::map<String, String> SettingsImpl::changedToMap() const
         if (!accessor.isValueChanged(*this, i))
             continue;
 
-        String value = accessor.getValueString(*this, i);
-        maskURIPassword(&value);
+        String value = maskedSettingValue(accessor, *this, i);
         result.emplace(accessor.getName(i), std::move(value));
     }
 

--- a/src/Core/tests/gtest_settings_map_secret_mask.cpp
+++ b/src/Core/tests/gtest_settings_map_secret_mask.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <Core/Field.h>
+#include <Core/Settings.h>
+
+/// These `Field` shapes reach a custom setting only over the native wire format, so no stateless test can build a carrier.
+
+using namespace DB;
+
+namespace
+{
+
+const String PRESIGNED = "https://bucket/k?X-Amz-Signature=SIG_CANARY&list-type=2";
+const String PRESIGNED_MASKED = "https://bucket/k?X-Amz-Signature=[HIDDEN]&list-type=2";
+const String USERINFO = "http://user:PW_CANARY@host/p";
+const String USERINFO_MASKED = "http://user:[HIDDEN]@host/p";
+
+String mapped(const Field & value)
+{
+    Settings settings;
+    settings.setCustom("SQL_gtest_mask", value);
+    return settings.changedToMap().at("SQL_gtest_mask");
+}
+
+}
+
+TEST(SettingsMapSecretMask, MasksTheLeavesOfAnArray)
+{
+    EXPECT_EQ(
+        mapped(Array{PRESIGNED, USERINFO, String{"keep-me"}}),
+        Field(Array{PRESIGNED_MASKED, USERINFO_MASKED, String{"keep-me"}}).dump());
+}
+
+TEST(SettingsMapSecretMask, MasksTheLeavesOfAnObject)
+{
+    EXPECT_EQ(
+        mapped(Object{{"endpoint", PRESIGNED}, {"region", "eu-west-1"}}),
+        Field(Object{{"endpoint", PRESIGNED_MASKED}, {"region", "eu-west-1"}}).dump());
+}
+
+TEST(SettingsMapSecretMask, MasksBothMembersOfAnAggregateFunctionState)
+{
+    EXPECT_EQ(
+        mapped(AggregateFunctionStateData{PRESIGNED, USERINFO}),
+        Field(AggregateFunctionStateData{PRESIGNED_MASKED, USERINFO_MASKED}).dump());
+}
+
+TEST(SettingsMapSecretMask, LeavesAValueWithoutACredentialUnchanged)
+{
+    Field plain = Array{String{"https://bucket/k?list-type=2"}, String{"no credential here"}};
+    EXPECT_EQ(mapped(plain), plain.dump());
+}

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
@@ -1,0 +1,10 @@
+query_log, URI password
+http://leakuser:[HIDDEN]@registry.invalid:8080/subjects
+query_log, no credential
+http://registry.invalid:8080/subjects
+processes, URI password
+http://leakuser:[HIDDEN]@registry.invalid:8080/subjects
+processes, custom settings (plain, disk)
+\'no-secret-here\'	disk(type = \'s3\', endpoint = \'[HIDDEN]\', access_key_id = \'[HIDDEN]\', secret_access_key = \'[HIDDEN]\')
+query_log, custom settings (plain, disk)
+\'no-secret-here\'	disk(type = \'s3\', endpoint = \'[HIDDEN]\', access_key_id = \'[HIDDEN]\', secret_access_key = \'[HIDDEN]\')

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
@@ -12,3 +12,7 @@ query_log, String setting with a URI password
 http://baseuser:[HIDDEN]@base.invalid/dir/
 processes, String setting with a URI password
 http://baseuser:[HIDDEN]@base.invalid/dir/
+processes, custom setting with a URI password
+\'http://customuser:[HIDDEN]@custom.invalid/p\'
+query_log, custom setting with a URI password
+\'http://customuser:[HIDDEN]@custom.invalid/p\'

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
@@ -16,3 +16,21 @@ processes, custom setting with a URI password
 \'http://customuser:[HIDDEN]@custom.invalid/p\'
 query_log, custom setting with a URI password
 \'http://customuser:[HIDDEN]@custom.invalid/p\'
+query_log, presigned URL parameters
+https://bucket.s3.amazonaws.com/k?X-Amz-Credential=[HIDDEN]&X-Amz-Signature=[HIDDEN]&list-type=2
+processes, presigned URL parameters
+https://bucket.s3.amazonaws.com/k?X-Amz-Credential=[HIDDEN]&X-Amz-Signature=[HIDDEN]&list-type=2
+processes, free text after the URL
+https://b/k?X-Amz-Signature=FREE_TAIL_CANARY_6a4c and then some trailing words
+processes, free text before the URL
+note=https://b/k?X-Amz-Signature=FREE_HEAD_CANARY_7d5b
+processes, custom setting ending in a credential
+\'https://bucket.s3.amazonaws.com/k?list-type=2&X-Amz-Signature=[HIDDEN]\'
+processes, custom setting with a nested credential
+Map_(Tuple_(\'endpoint\', \'https://bucket.s3.amazonaws.com/n?list-type=2&X-Amz-Signature=[HIDDEN]\'), Tuple_(\'region\', \'eu-west-1\'))
+processes, Map setting with presigned URL parameters
+{\'Location\':\'https://bucket/k?X-Amz-Signature=[HIDDEN]\',\'X-Kept\':\'yes\'}
+processes, query parameters that are not credentials
+https://bucket.s3.amazonaws.com/k?list-type=2&prefix=a/b
+processes, a credential followed by a comma
+https://b/k?X-Amz-Signature=[HIDDEN]

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.reference
@@ -8,3 +8,7 @@ processes, custom settings (plain, disk)
 \'no-secret-here\'	disk(type = \'s3\', endpoint = \'[HIDDEN]\', access_key_id = \'[HIDDEN]\', secret_access_key = \'[HIDDEN]\')
 query_log, custom settings (plain, disk)
 \'no-secret-here\'	disk(type = \'s3\', endpoint = \'[HIDDEN]\', access_key_id = \'[HIDDEN]\', secret_access_key = \'[HIDDEN]\')
+query_log, String setting with a URI password
+http://baseuser:[HIDDEN]@base.invalid/dir/
+processes, String setting with a URI password
+http://baseuser:[HIDDEN]@base.invalid/dir/

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+SECRET_URL="http://leakuser:AVRO_LEAK_CANARY_9f3a2b@registry.invalid:8080/subjects"
+PLAIN_URL="http://registry.invalid:8080/subjects"
+SECRET_DISK="disk(type = 's3', endpoint = 'http://localhost:9000/x', access_key_id = 'AK_LEAK_CANARY', secret_access_key = 'SK_LEAK_CANARY')"
+
+# A query_log entry is written after the response is sent, so wait for it to appear.
+# An empty result after the last attempt is printed as is and fails the test.
+read_query_log() {
+    local result=""
+    for _ in {1..100}; do
+        $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+        result=$($CLICKHOUSE_CLIENT -q "
+            SELECT $1 FROM system.query_log
+            WHERE current_database = currentDatabase() AND log_comment = '$2'
+              AND type = 'QueryFinish' AND event_date >= yesterday()
+            ORDER BY event_time_microseconds DESC LIMIT 1")
+        [ -n "$result" ] && break
+        sleep 0.3
+    done
+    echo "$result"
+}
+
+# The password is hidden while scheme, user, host, port and path survive.
+echo 'query_log, URI password'
+$CLICKHOUSE_CLIENT -q "SELECT 1 FORMAT Null SETTINGS log_comment = 'settings_map_mask_uri', format_avro_schema_registry_url = '$SECRET_URL'"
+read_query_log "Settings['format_avro_schema_registry_url']" settings_map_mask_uri
+
+# A value that carries no credential is passed through unchanged.
+echo 'query_log, no credential'
+$CLICKHOUSE_CLIENT -q "SELECT 1 FORMAT Null SETTINGS log_comment = 'settings_map_mask_plain', format_avro_schema_registry_url = '$PLAIN_URL'"
+read_query_log "Settings['format_avro_schema_registry_url']" settings_map_mask_plain
+
+echo 'processes, URI password'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['format_avro_schema_registry_url'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS format_avro_schema_registry_url = '$SECRET_URL'"
+
+# A custom setting holding a disk definition is only reachable over an HTTP session:
+# the native protocol ships it as a Field dump, which cannot be restored.
+SESSION="05054_$CLICKHOUSE_DATABASE"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}&session_timeout=60" \
+    --data-binary "SET SQL_05054_plain = 'no-secret-here', SQL_05054_disk = $SECRET_DISK"
+
+echo 'processes, custom settings (plain, disk)'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary "
+    SELECT Settings['SQL_05054_plain'], Settings['SQL_05054_disk'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS log_comment = 'settings_map_mask_disk'"
+
+echo 'query_log, custom settings (plain, disk)'
+read_query_log "Settings['SQL_05054_plain'], Settings['SQL_05054_disk']" settings_map_mask_disk

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
@@ -8,6 +8,7 @@ SECRET_URL="http://leakuser:AVRO_LEAK_CANARY_9f3a2b@registry.invalid:8080/subjec
 PLAIN_URL="http://registry.invalid:8080/subjects"
 SECRET_DISK="disk(type = 's3', endpoint = 'http://localhost:9000/x', access_key_id = 'AK_LEAK_CANARY', secret_access_key = 'SK_LEAK_CANARY')"
 SECRET_BASE="http://baseuser:URL_BASE_LEAK_CANARY_4c1e7d@base.invalid/dir/"
+SECRET_CUSTOM="http://customuser:CUSTOM_URI_LEAK_CANARY_7b2e91@custom.invalid/p"
 
 # A query_log entry is written after the response is sent, so wait for it to appear.
 # An empty result after the last attempt is printed as is and fails the test.
@@ -45,7 +46,7 @@ $CLICKHOUSE_CLIENT -q "
 # the native protocol ships it as a Field dump, which cannot be restored.
 SESSION="05054_$CLICKHOUSE_DATABASE"
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}&session_timeout=60" \
-    --data-binary "SET SQL_05054_plain = 'no-secret-here', SQL_05054_disk = $SECRET_DISK"
+    --data-binary "SET SQL_05054_plain = 'no-secret-here', SQL_05054_disk = $SECRET_DISK, SQL_05054_uri = '$SECRET_CUSTOM'"
 
 echo 'processes, custom settings (plain, disk)'
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary "
@@ -64,3 +65,12 @@ echo 'processes, String setting with a URI password'
 $CLICKHOUSE_CLIENT -q "
     SELECT Settings['url_base'] FROM system.processes
     WHERE query_id = queryID() SETTINGS url_base = '$SECRET_BASE'"
+
+# A custom setting holding a plain String is not a secret CustomType, so only its value shape reaches it.
+echo 'processes, custom setting with a URI password'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary "
+    SELECT Settings['SQL_05054_uri'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS log_comment = 'settings_map_mask_custom_uri'"
+
+echo 'query_log, custom setting with a URI password'
+read_query_log "Settings['SQL_05054_uri']" settings_map_mask_custom_uri

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
@@ -9,6 +9,14 @@ PLAIN_URL="http://registry.invalid:8080/subjects"
 SECRET_DISK="disk(type = 's3', endpoint = 'http://localhost:9000/x', access_key_id = 'AK_LEAK_CANARY', secret_access_key = 'SK_LEAK_CANARY')"
 SECRET_BASE="http://baseuser:URL_BASE_LEAK_CANARY_4c1e7d@base.invalid/dir/"
 SECRET_CUSTOM="http://customuser:CUSTOM_URI_LEAK_CANARY_7b2e91@custom.invalid/p"
+PRESIGNED="https://bucket.s3.amazonaws.com/k?X-Amz-Credential=PRESIGN_ID_CANARY_1a2b&X-Amz-Signature=PRESIGN_SIG_CANARY_9d4e&list-type=2"
+PLAIN_QUERY="https://bucket.s3.amazonaws.com/k?list-type=2&prefix=a/b"
+TEXT_AFTER_URL="https://b/k?X-Amz-Signature=FREE_TAIL_CANARY_6a4c and then some trailing words"
+TEXT_BEFORE_URL="note=https://b/k?X-Amz-Signature=FREE_HEAD_CANARY_7d5b"
+CREDENTIAL_THEN_COMMA="https://b/k?X-Amz-Signature=COMMA_TAIL_CANARY_3c8f,request=42"
+PRESIGNED_LAST="https://bucket.s3.amazonaws.com/k?list-type=2&X-Amz-Signature=PRESIGN_TAIL_CANARY_3f81"
+PRESIGNED_NESTED="https://bucket.s3.amazonaws.com/n?list-type=2&X-Amz-Signature=PRESIGN_NEST_CANARY_2b7a"
+PRESIGNED_MAP="https://bucket/k?X-Amz-Signature=PRESIGN_MAP_CANARY_5c7d"
 
 # A query_log entry is written after the response is sent, so wait for it to appear.
 # An empty result after the last attempt is printed as is and fails the test.
@@ -74,3 +82,55 @@ ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary "
 
 echo 'query_log, custom setting with a URI password'
 read_query_log "Settings['SQL_05054_uri']" settings_map_mask_custom_uri
+
+# A presigned URL carries its credential in query parameters instead of the userinfo.
+echo 'query_log, presigned URL parameters'
+$CLICKHOUSE_CLIENT -q "SELECT 1 FORMAT Null SETTINGS log_comment = 'settings_map_mask_presigned', s3_base = '$PRESIGNED'"
+read_query_log "Settings['s3_base']" settings_map_mask_presigned
+
+echo 'processes, presigned URL parameters'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['s3_base'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS s3_base = '$PRESIGNED'"
+
+# A presigned parameter value runs to the end of the text, so free text is left alone. One arm per
+# half of that precondition, so removing either half reddens exactly one of them.
+echo 'processes, free text after the URL'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['log_comment'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS log_comment = '$TEXT_AFTER_URL'"
+
+echo 'processes, free text before the URL'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['log_comment'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS log_comment = '$TEXT_BEFORE_URL'"
+
+# A custom setting is shown as a Field dump, so the quotes and brackets around a masked leaf have to survive.
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary \
+    "SET SQL_05054_tail = '$PRESIGNED_LAST', SQL_05054_nested = {'endpoint':'$PRESIGNED_NESTED','region':'eu-west-1'}"
+
+echo 'processes, custom setting ending in a credential'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary "
+    SELECT Settings['SQL_05054_tail'] FROM system.processes WHERE query_id = queryID()"
+
+echo 'processes, custom setting with a nested credential'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary "
+    SELECT Settings['SQL_05054_nested'] FROM system.processes WHERE query_id = queryID()"
+
+# A Map setting serializes to more than one value, so the entry after the credential has to survive.
+echo 'processes, Map setting with presigned URL parameters'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['http_response_headers'] FROM system.processes WHERE query_id = queryID()
+    SETTINGS http_response_headers = {'Location':'$PRESIGNED_MAP','X-Kept':'yes'}"
+
+# Query parameters that name no credential are passed through unchanged.
+echo 'processes, query parameters that are not credentials'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['s3_base'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS s3_base = '$PLAIN_QUERY'"
+
+# A parameter value ends at the next '&' or '#', so a comma belongs to the credential it follows.
+echo 'processes, a credential followed by a comma'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['log_comment'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS log_comment = '$CREDENTIAL_THEN_COMMA'"

--- a/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
+++ b/tests/queries/0_stateless/05054_settings_map_secret_mask.sh
@@ -7,6 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SECRET_URL="http://leakuser:AVRO_LEAK_CANARY_9f3a2b@registry.invalid:8080/subjects"
 PLAIN_URL="http://registry.invalid:8080/subjects"
 SECRET_DISK="disk(type = 's3', endpoint = 'http://localhost:9000/x', access_key_id = 'AK_LEAK_CANARY', secret_access_key = 'SK_LEAK_CANARY')"
+SECRET_BASE="http://baseuser:URL_BASE_LEAK_CANARY_4c1e7d@base.invalid/dir/"
 
 # A query_log entry is written after the response is sent, so wait for it to appear.
 # An empty result after the last attempt is printed as is and fails the test.
@@ -53,3 +54,13 @@ ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&session_id=${SESSION}" --data-binary "
 
 echo 'query_log, custom settings (plain, disk)'
 read_query_log "Settings['SQL_05054_plain'], Settings['SQL_05054_disk']" settings_map_mask_disk
+
+# url_base is DECLARE(String, ...), so it is only reached by masking on the value shape.
+echo 'query_log, String setting with a URI password'
+$CLICKHOUSE_CLIENT -q "SELECT 1 FORMAT Null SETTINGS log_comment = 'settings_map_mask_url_base', url_base = '$SECRET_BASE'"
+read_query_log "Settings['url_base']" settings_map_mask_url_base
+
+echo 'processes, String setting with a URI password'
+$CLICKHOUSE_CLIENT -q "
+    SELECT Settings['url_base'] FROM system.processes
+    WHERE query_id = queryID() SETTINGS url_base = '$SECRET_BASE'"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Mask credentials in the `Settings` map column of `system.query_log` and `system.processes`. A URI password in a setting such as `format_avro_schema_registry_url` or `url_base`, the `X-Amz-*` parameters of a presigned URL in a setting such as `s3_base`, and a `disk(...)` definition in a custom setting were stored there in plaintext, so a user holding only `SELECT(Settings) ON system.query_log` or `SELECT ON system.processes` could read another user's credential.


### Description

Requested by @ nikitamikhaylov; the report is not public, so there is no issue to link.

`SettingsImpl::dumpToMapColumn` and `changedToMap` insert every changed setting's value raw, and three classes carry a credential there:

- a URI password: `format_avro_schema_registry_url` is `DECLARE(URI, ...)` and `url_base` is `DECLARE(String, ...)`, so the match is on the value shape, not a setting name.
- a presigned URL, whose credential sits in the query parameters: `s3_base` is documented to hold that form and reached the map with `X-Amz-Signature=...` verbatim.
- a custom setting: `SettingFieldCustom::toString` is `Field::dump`, so `SET SQL_d = disk(type = 's3', secret_access_key = '...')` reached it (the shipped `config.xml` enables `SQL_`).

All four loops now use the two scans `FunctionSecretArgumentsFinder` already applies to an S3 URL, plus `custom.toString(/* show_secrets */ false)` when `isSecret()` holds. A presigned parameter value ends only at `&` or `#`, so that scan is sound only on a value that is one whole URL: a scheme, and no whitespace. Anything else is masked in the String leaves of its `Field`, which keeps a custom setting's quotes and a `Map` setting's later entries intact. These maps are display only (four callers, all log elements); the settings wire format and the query-result-cache key are untouched. The first commit makes the parameter scan linear, which the settings path makes reachable per logged query.

Known limits:

- the `query` column is name-gated by `ASTSetQuery::hasSecretParts`, so `SET s3_base = '<presigned>'` still shows verbatim in its own row; making that predicate value-shaped would change "is this query secret?" for every query.
- `system.session_log.settings`, `system.opentelemetry_span_log.attribute` and `system.settings_profile_elements.value` render values unmasked through three other renderers, and `log_comment` has its own unmasked column.
- masking is unconditional, since these functions have no `Context`, and a secret custom setting shows masked AST text rather than a `CustomType_('AST', ...)` dump.
