### PR TITLE
Add a test that AI functions respect `remote_url_allow_hosts`

### DIFF
--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -391,3 +391,58 @@ def test_schema_inference(start_cluster):
     error = node7.query_and_get_error("desc url('http://test.com', 'TSVRaw')")
     assert "not allowed" in error
     assert error.find("ReadWriteBufferFromHTTPBase") == -1
+
+
+# The AI functions read their HTTP endpoint from a named collection, so `NAMED COLLECTION ADMIN`
+# alone must not let a user aim the server's HTTP client at a host the operator did not allow.
+# Nothing listens on port 1; the check runs before any connection, so no server is needed.
+AI_ENDPOINT = "http://localhost:1/v1/chat/completions"
+
+AI_QUERIES = [
+    "SELECT aiGenerate('x', map('credentials', 'ai_text'))",
+    "SELECT aiEmbed('x', 'test-model', map('credentials', 'ai_embed'))",
+    "SELECT aiSimilarity('x', 'y', 'test-model', map('credentials', 'ai_embed'))",
+]
+
+
+def create_ai_collections(node):
+    node.query(
+        f"CREATE NAMED COLLECTION IF NOT EXISTS ai_text AS provider = 'openai', "
+        f"endpoint = '{AI_ENDPOINT}', model = 'test-model', api_key = 'test-key'"
+    )
+    # An embedding collection must not define `model`: `aiEmbed` and `aiSimilarity` take it as an
+    # argument and reject a collection that declares it too.
+    node.query(
+        f"CREATE NAMED COLLECTION IF NOT EXISTS ai_embed AS provider = 'openai', "
+        f"endpoint = '{AI_ENDPOINT}', api_key = 'test-key'"
+    )
+
+
+def drop_ai_collections(node):
+    node.query("DROP NAMED COLLECTION IF EXISTS ai_text")
+    node.query("DROP NAMED COLLECTION IF EXISTS ai_embed")
+
+
+def test_ai_functions_host_filter(start_cluster):
+    # `node5` declares an empty `remote_url_allow_hosts` (allows nothing); `node4` declares none at
+    # all, so its filter stays uninitialized and allows everything. Same collections, same endpoint.
+    create_ai_collections(node4)
+    create_ai_collections(node5)
+    try:
+        for query in AI_QUERIES:
+            error = node5.query_and_get_error(
+                query, settings={"ai_function_max_retries": 0}
+            )
+            assert "UNACCEPTABLE_URL" in error, f"{query}: {error}"
+            # The check must run before the request, so the refusal carries no connection error.
+            assert "Connection refused" not in error, f"{query}: {error}"
+
+            # Control: without an allow-list the same call gets past the check and fails at the
+            # network instead. Without this arm, a filter that rejected everything would also pass.
+            error = node4.query_and_get_error(
+                query, settings={"ai_function_max_retries": 0}
+            )
+            assert "UNACCEPTABLE_URL" not in error, f"{query}: {error}"
+    finally:
+        drop_ai_collections(node4)
+        drop_ai_collections(node5)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/103779

AI functions (`aiGenerate`, `aiEmbed`, `aiSimilarity`, ...) read their HTTP endpoint from a named collection, so the endpoint is user-controlled. `FunctionBaseAI::resolveAIParams` already passes it through the server's `RemoteHostFilter`, and the docs promise it does ("Restricting endpoint hosts" in `ai-functions.mdx`), but that call has no test: none of the six existing AI tests mentions `remote_url_allow_hosts`, `UNACCEPTABLE_URL` or error code 491.

The check arrived in #103779, which added two checks but shipped a test (`04142_ai_functions_named_collection_access.sh`) for only the named-collection access one. A later refactor moved it out of `FunctionBaseAI::executeImpl` into `resolveAIParams`, now the single point covering all three call sites. It survived that move by luck, not by a test.

This PR adds `test_allowed_url_from_config/test.py::test_ai_functions_host_filter`, reusing two instances that module already has, which differ in exactly one thing: `node5` declares an empty `remote_url_allow_hosts` (allows nothing), `node4` declares none at all, so its filter stays uninitialized and allows everything. The same three queries run on both, one per `createAIProvider` call site (`FunctionBaseAI`, `aiEmbed`, `aiSimilarity`) - the only three, and none reaches a provider without passing `resolveAIParams`. On `node5` each query is refused with `UNACCEPTABLE_URL` and carries no connection error; on `node4` each gets past the check and fails at the socket. The second arm is a live mutation preview: remove the filter call and `node5` behaves like `node4`, so the test fails.

It is an integration test because `remote_url_allow_hosts` is a server setting with no per-query form, and the stateless configs never set it, which leaves the filter inert there.

No source change, and no backport: every supported release that has the file already carries the check. Severity is low - it needs a `NAMED COLLECTION` grant and AI functions enabled, and on a default install the option is unset and every host is allowed anyway.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117425&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117425](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117425+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
