### PR TITLE
Fix DeltaLake snapshot load hanging forever and blocking KILL QUERY

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -136,7 +136,7 @@
     M(ObjectStorageQueueMetadataCacheSizeBytes, "Size in bytes of ObjectStorageQueue metadata cache.") \
     M(ObjectStorageQueueMetadataCacheSizeElements, "Size in elements of ObjectStorageQueue metadata cache.") \
     M(DeltaLakeSnapshotCacheSizeElements, "Size in elements of DeltaLake snapshot cache.") \
-    M(DeltaLakeSnapshotLoadsStuck, "Number of delta-kernel snapshot loads that some query gave up waiting for (KILL QUERY or a timeout) and whose kernel call has not returned yet.") \
+    M(DeltaLakeSnapshotLoadsStuck, "Number of delta-kernel snapshot loads that every waiting query gave up on (KILL QUERY or a timeout) and whose kernel call has not returned yet.") \
     M(BackupsIOThreads, "Number of threads in the BackupsIO thread pool.") \
     M(BackupsIOThreadsActive, "Number of threads in the BackupsIO thread pool running a task.") \
     M(BackupsIOThreadsScheduled, "Number of queued or active jobs in the BackupsIO thread pool.") \

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -136,6 +136,7 @@
     M(ObjectStorageQueueMetadataCacheSizeBytes, "Size in bytes of ObjectStorageQueue metadata cache.") \
     M(ObjectStorageQueueMetadataCacheSizeElements, "Size in elements of ObjectStorageQueue metadata cache.") \
     M(DeltaLakeSnapshotCacheSizeElements, "Size in elements of DeltaLake snapshot cache.") \
+    M(DeltaLakeSnapshotLoadsStuck, "Number of delta-kernel snapshot load worker threads that were abandoned by their query (KILL QUERY or a timeout) and are still waiting for the kernel call to return.") \
     M(BackupsIOThreads, "Number of threads in the BackupsIO thread pool.") \
     M(BackupsIOThreadsActive, "Number of threads in the BackupsIO thread pool running a task.") \
     M(BackupsIOThreadsScheduled, "Number of queued or active jobs in the BackupsIO thread pool.") \

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -136,7 +136,7 @@
     M(ObjectStorageQueueMetadataCacheSizeBytes, "Size in bytes of ObjectStorageQueue metadata cache.") \
     M(ObjectStorageQueueMetadataCacheSizeElements, "Size in elements of ObjectStorageQueue metadata cache.") \
     M(DeltaLakeSnapshotCacheSizeElements, "Size in elements of DeltaLake snapshot cache.") \
-    M(DeltaLakeSnapshotLoadsStuck, "Number of delta-kernel snapshot load worker threads that were abandoned by their query (KILL QUERY or a timeout) and are still waiting for the kernel call to return.") \
+    M(DeltaLakeSnapshotLoadsStuck, "Number of delta-kernel snapshot loads that some query gave up waiting for (KILL QUERY or a timeout) and whose kernel call has not returned yet.") \
     M(BackupsIOThreads, "Number of threads in the BackupsIO thread pool.") \
     M(BackupsIOThreadsActive, "Number of threads in the BackupsIO thread pool running a task.") \
     M(BackupsIOThreadsScheduled, "Number of queued or active jobs in the BackupsIO thread pool.") \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -157,6 +157,7 @@ static struct InitFiu
     PAUSEABLE_ONCE(smt_select_sequential_consistency_before_keeper_fence) \
     PAUSEABLE_ONCE(smt_select_sequential_consistency_after_keeper_get) \
     PAUSEABLE_ONCE(delta_lake_metadata_iterate_pause) \
+    PAUSEABLE_ONCE(delta_kernel_snapshot_load_pause) \
     PAUSEABLE_ONCE(delta_lake_write_commit_pause) \
     PAUSEABLE_ONCE(query_metric_log_pause_before_finish) \
     PAUSEABLE_ONCE(replicated_table_remove_zk_before_get_children) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8062,6 +8062,11 @@ Start version of delta lake snapshot to read. Value -1 means to read latest vers
     DECLARE(Int64, delta_lake_snapshot_end_version, -1, R"(
 End version of delta lake snapshot to read. Value -1 means to read latest version (value 0 is a valid snapshot version).
 )", 0) \
+    DECLARE(Milliseconds, delta_lake_snapshot_load_timeout_ms, 600000, R"(
+Maximum time to wait for delta-kernel to load a snapshot of a Delta Lake table (listing and reading its `_delta_log`).
+The load runs on a separate thread and the query waits for it, so the wait is interrupted by `KILL QUERY` and `max_execution_time`,
+and fails with `TIMEOUT_EXCEEDED` once this timeout is exceeded. Value 0 means no timeout.
+)", 0) \
     DECLARE(Bool, delta_lake_throw_on_engine_predicate_error, false, R"(
 Enables throwing an exception if there was an error when analyzing scan predicate in delta-kernel.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -64,7 +64,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"iceberg_compaction_max_rows_in_data_file", std::numeric_limits<UInt64>::max(), std::numeric_limits<UInt64>::max(), "New setting for the max rows of an iceberg data file produced by compaction, separate from the insert-time limit."},
             {"iceberg_compaction_max_bytes_in_data_file", std::numeric_limits<UInt64>::max(), std::numeric_limits<UInt64>::max(), "New setting for the max bytes of an iceberg data file produced by compaction, separate from the insert-time limit."},
             {"optimize_mutations_with_partition_pruning", false, true, "New setting to automatically prune partitions for mutations based on WHERE clause"},
-            {"delta_lake_snapshot_load_timeout_ms", 600000, 600000, "New setting bounding how long a query waits for delta-kernel to load a Delta Lake table snapshot; the wait is also interrupted by `KILL QUERY` and `max_execution_time`."},
+            {"delta_lake_snapshot_load_timeout_ms", 0, 600000, "New setting bounding how long a query waits for delta-kernel to load a Delta Lake table snapshot; the wait is also interrupted by `KILL QUERY` and `max_execution_time`."},
         });
         addSettingsChanges(settings_changes_history, "26.8",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -64,6 +64,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"iceberg_compaction_max_rows_in_data_file", std::numeric_limits<UInt64>::max(), std::numeric_limits<UInt64>::max(), "New setting for the max rows of an iceberg data file produced by compaction, separate from the insert-time limit."},
             {"iceberg_compaction_max_bytes_in_data_file", std::numeric_limits<UInt64>::max(), std::numeric_limits<UInt64>::max(), "New setting for the max bytes of an iceberg data file produced by compaction, separate from the insert-time limit."},
             {"optimize_mutations_with_partition_pruning", false, true, "New setting to automatically prune partitions for mutations based on WHERE clause"},
+            {"delta_lake_snapshot_load_timeout_ms", 600000, 600000, "New setting bounding how long a query waits for delta-kernel to load a Delta Lake table snapshot; the wait is also interrupted by `KILL QUERY` and `max_execution_time`."},
         });
         addSettingsChanges(settings_changes_history, "26.8",
         {

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.h
@@ -139,6 +139,11 @@ public:
         return object_storage->getS3StorageClient();
     }
 
+    std::shared_ptr<const S3Settings> tryGetS3StorageSettings() const override
+    {
+        return object_storage->tryGetS3StorageSettings();
+    }
+
     std::shared_ptr<const S3::Client> tryGetS3StorageClient() override
     {
         return object_storage->tryGetS3StorageClient();

--- a/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h
@@ -233,6 +233,10 @@ using ObjectStorageIteratorPtr = std::shared_ptr<IObjectStorageIterator>;
 /// Base class for all object storages which implement some subset of ordinary filesystem operations.
 ///
 /// Examples of object storages are S3, Azure Blob Storage, HDFS.
+#if USE_AWS_S3
+struct S3Settings;
+#endif
+
 class IObjectStorage
 {
 public:
@@ -445,6 +449,11 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "This function is only implemented for S3ObjectStorage");
     }
     virtual std::shared_ptr<const S3::Client> tryGetS3StorageClient() { return nullptr; }
+
+    /// The live S3 settings of the storage (the ones applyNewSettings reapplies), or nullptr
+    /// when the storage is not backed by S3. For clients which build their own S3 client and
+    /// must follow the same settings as the storage's client (e.g. delta-kernel).
+    virtual std::shared_ptr<const S3Settings> tryGetS3StorageSettings() const { return nullptr; }
 #endif
 
     /// Invokes the catalog-vended credentials refresh callback (e.g. for Glue / Unity / REST

--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h
@@ -157,6 +157,7 @@ public:
 
     S3::URI getURI() const { return uri; }
     S3Settings getS3Settings() const { return *s3_settings.get(); }
+    std::shared_ptr<const S3Settings> tryGetS3StorageSettings() const override { return std::make_shared<const S3Settings>(*s3_settings.get()); }
 private:
     void removeObjectImpl(const StoredObject & object, bool if_exists);
     void removeObjectsImpl(const StoredObjects & objects, bool if_exists);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -2,6 +2,7 @@
 
 #if USE_DELTA_KERNEL_RS
 #include <Storages/ObjectStorage/S3/Configuration.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h>
 #include <Storages/ObjectStorage/Local/Configuration.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelUtils.h>
@@ -227,8 +228,20 @@ public:
         /// (`applyNewSettings`), so a query-level `SETTINGS s3_request_timeout_ms = ...` must
         /// reach the kernel client as well: the options captured on the query thread take
         /// precedence over the values captured when this helper was created.
-        const UInt64 effective_connect_timeout_ms = options.s3_connect_timeout_ms.value_or(connect_timeout_ms);
-        const UInt64 effective_request_timeout_ms = options.s3_request_timeout_ms.value_or(request_timeout_ms);
+        /// The fallbacks come from the object storage's live settings — `applyNewSettings`
+        /// reapplies config/endpoint settings on every update — rather than from the values
+        /// captured when this helper was created, so a reloaded configuration reaches the
+        /// kernel client the same way it reaches the server's own S3 client.
+        UInt64 fallback_connect_timeout_ms = connect_timeout_ms;
+        UInt64 fallback_request_timeout_ms = request_timeout_ms;
+        if (const auto * s3_object_storage = dynamic_cast<const DB::S3ObjectStorage *>(object_storage.get()))
+        {
+            const auto live_settings = s3_object_storage->getS3Settings();
+            fallback_connect_timeout_ms = live_settings.auth_settings[DB::S3AuthSetting::connect_timeout_ms];
+            fallback_request_timeout_ms = live_settings.auth_settings[DB::S3AuthSetting::request_timeout_ms];
+        }
+        const UInt64 effective_connect_timeout_ms = options.s3_connect_timeout_ms.value_or(fallback_connect_timeout_ms);
+        const UInt64 effective_request_timeout_ms = options.s3_request_timeout_ms.value_or(fallback_request_timeout_ms);
 
         if (effective_connect_timeout_ms)
             set_option("connect_timeout", fmt::format("{}ms", effective_connect_timeout_ms));

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -50,6 +50,20 @@ namespace DB::FailPoints
 namespace DeltaLake
 {
 
+KernelClientOptions KernelClientOptions::fromCurrentQuery()
+{
+    KernelClientOptions options;
+    if (auto query_context = DB::CurrentThread::tryGetQueryContext())
+    {
+        const auto & settings = query_context->getSettingsRef();
+        if (settings[DB::Setting::s3_connect_timeout_ms].changed)
+            options.s3_connect_timeout_ms = settings[DB::Setting::s3_connect_timeout_ms];
+        if (settings[DB::Setting::s3_request_timeout_ms].changed)
+            options.s3_request_timeout_ms = settings[DB::Setting::s3_request_timeout_ms];
+    }
+    return options;
+}
+
 namespace
 {
 
@@ -153,6 +167,11 @@ public:
 
     ffi::EngineBuilder * createBuilder() const override
     {
+        return createBuilderWithOptions(KernelClientOptions::fromCurrentQuery());
+    }
+
+    ffi::EngineBuilder * createBuilderWithOptions(const KernelClientOptions & options) const override
+    {
         ffi::EngineBuilder * builder = KernelUtils::unwrapResult(
             ffi::get_engine_builder(
                 KernelUtils::toDeltaString(table_location),
@@ -206,18 +225,10 @@ public:
         /// object_store's built-in defaults (30 s request / 5 s connect) stay in effect.
         /// The server's S3 client re-resolves these from the current query on every update
         /// (`applyNewSettings`), so a query-level `SETTINGS s3_request_timeout_ms = ...` must
-        /// reach the kernel client as well: prefer the current query's changed settings over
-        /// the values captured when this helper was created.
-        UInt64 effective_connect_timeout_ms = connect_timeout_ms;
-        UInt64 effective_request_timeout_ms = request_timeout_ms;
-        if (auto query_context = DB::CurrentThread::tryGetQueryContext())
-        {
-            const auto & settings = query_context->getSettingsRef();
-            if (settings[DB::Setting::s3_connect_timeout_ms].changed)
-                effective_connect_timeout_ms = settings[DB::Setting::s3_connect_timeout_ms];
-            if (settings[DB::Setting::s3_request_timeout_ms].changed)
-                effective_request_timeout_ms = settings[DB::Setting::s3_request_timeout_ms];
-        }
+        /// reach the kernel client as well: the options captured on the query thread take
+        /// precedence over the values captured when this helper was created.
+        const UInt64 effective_connect_timeout_ms = options.s3_connect_timeout_ms.value_or(connect_timeout_ms);
+        const UInt64 effective_request_timeout_ms = options.s3_request_timeout_ms.value_or(request_timeout_ms);
 
         if (effective_connect_timeout_ms)
             set_option("connect_timeout", fmt::format("{}ms", effective_connect_timeout_ms));

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -2,7 +2,7 @@
 
 #if USE_DELTA_KERNEL_RS
 #include <Storages/ObjectStorage/S3/Configuration.h>
-#include <Disks/DiskObjectStorage/ObjectStorages/S3/S3ObjectStorage.h>
+#include <IO/S3Settings.h>
 #include <Storages/ObjectStorage/Local/Configuration.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelUtils.h>
@@ -231,14 +231,14 @@ public:
         /// The fallbacks come from the object storage's live settings — `applyNewSettings`
         /// reapplies config/endpoint settings on every update — rather than from the values
         /// captured when this helper was created, so a reloaded configuration reaches the
-        /// kernel client the same way it reaches the server's own S3 client.
+        /// kernel client the same way it reaches the server's own S3 client. The accessor is
+        /// virtual, so wrappers such as CachedObjectStorage forward it to the S3 storage inside.
         UInt64 fallback_connect_timeout_ms = connect_timeout_ms;
         UInt64 fallback_request_timeout_ms = request_timeout_ms;
-        if (const auto * s3_object_storage = dynamic_cast<const DB::S3ObjectStorage *>(object_storage.get()))
+        if (const auto live_settings = object_storage->tryGetS3StorageSettings())
         {
-            const auto live_settings = s3_object_storage->getS3Settings();
-            fallback_connect_timeout_ms = live_settings.auth_settings[DB::S3AuthSetting::connect_timeout_ms];
-            fallback_request_timeout_ms = live_settings.auth_settings[DB::S3AuthSetting::request_timeout_ms];
+            fallback_connect_timeout_ms = live_settings->auth_settings[DB::S3AuthSetting::connect_timeout_ms];
+            fallback_request_timeout_ms = live_settings->auth_settings[DB::S3AuthSetting::request_timeout_ms];
         }
         const UInt64 effective_connect_timeout_ms = options.s3_connect_timeout_ms.value_or(fallback_connect_timeout_ms);
         const UInt64 effective_request_timeout_ms = options.s3_request_timeout_ms.value_or(fallback_request_timeout_ms);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -191,10 +191,24 @@ public:
         /// client settings do not reach. Give it the same per-request bounds as the server's
         /// S3 client (`s3_connect_timeout_ms` / `s3_request_timeout_ms`), so that a request the
         /// object store never answers fails instead of hanging.
+        /// A value of `0` means "no timeout" for the server's S3 client, but object_store cannot
+        /// be given an unbounded timeout through its string options (a literal `0` makes every
+        /// request time out immediately), so `0` intentionally leaves the option unset and
+        /// object_store's built-in defaults (30 s request / 5 s connect) stay in effect.
         if (connect_timeout_ms)
             set_option("connect_timeout", fmt::format("{}ms", connect_timeout_ms));
+        else
+            LOG_WARNING(
+                log,
+                "s3_connect_timeout_ms = 0 (no timeout) cannot be forwarded to the delta-kernel "
+                "object store client; its default connect timeout stays in effect");
         if (request_timeout_ms)
             set_option("timeout", fmt::format("{}ms", request_timeout_ms));
+        else
+            LOG_WARNING(
+                log,
+                "s3_request_timeout_ms = 0 (no timeout) cannot be forwarded to the delta-kernel "
+                "object store client; its default request timeout stays in effect");
 
         LOG_TRACE(
             log,

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -144,8 +144,13 @@ public:
         /// Re-fetch the live S3 client. `S3ObjectStorage::applyNewSettings` swaps the
         /// MultiVersion<S3::Client> when catalog / vended credentials rotate; a captured
         /// snapshot would keep returning the original session.
-        const auto & credentials = object_storage->getS3StorageClient()->getCredentials();
+        const auto client = object_storage->getS3StorageClient();
+        return fingerprintOf(client->getCredentials());
+    }
 
+    template <typename Credentials>
+    static DB::UInt128 fingerprintOf(const Credentials & credentials)
+    {
         SipHash hash;
         hash.update(credentials.GetAWSAccessKeyId());
         hash.update(credentials.GetAWSSecretKey());
@@ -168,10 +173,11 @@ public:
 
     ffi::EngineBuilder * createBuilder() const override
     {
-        return createBuilderWithOptions(KernelClientOptions::fromCurrentQuery());
+        DB::UInt128 credentials_fingerprint;
+        return createBuilderWithOptions(KernelClientOptions::fromCurrentQuery(), credentials_fingerprint);
     }
 
-    ffi::EngineBuilder * createBuilderWithOptions(const KernelClientOptions & options) const override
+    ffi::EngineBuilder * createBuilderWithOptions(const KernelClientOptions & options, DB::UInt128 & credentials_fingerprint) const override
     {
         ffi::EngineBuilder * builder = KernelUtils::unwrapResult(
             ffi::get_engine_builder(
@@ -185,8 +191,12 @@ public:
             setBuilderOption(builder, name, value);
         };
 
-        /// Read credentials from the *current* client — see `getCredentialsFingerprint`.
-        const auto & credentials = object_storage->getS3StorageClient()->getCredentials();
+        /// One snapshot of the live client for both the builder and the fingerprint: the client
+        /// may be swapped (applyNewSettings, a credentials refresh) between two reads, and the
+        /// fingerprint must describe the credentials the engine is actually built with.
+        const auto client = object_storage->getS3StorageClient();
+        const auto & credentials = client->getCredentials();
+        credentials_fingerprint = fingerprintOf(credentials);
         auto access_key_id = credentials.GetAWSAccessKeyId();
         auto secret_access_key = credentials.GetAWSSecretKey();
         auto token = credentials.GetSessionToken();

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -51,20 +51,6 @@ namespace DB::FailPoints
 namespace DeltaLake
 {
 
-KernelClientOptions KernelClientOptions::fromCurrentQuery()
-{
-    KernelClientOptions options;
-    if (auto query_context = DB::CurrentThread::tryGetQueryContext())
-    {
-        const auto & settings = query_context->getSettingsRef();
-        if (settings[DB::Setting::s3_connect_timeout_ms].changed)
-            options.s3_connect_timeout_ms = settings[DB::Setting::s3_connect_timeout_ms];
-        if (settings[DB::Setting::s3_request_timeout_ms].changed)
-            options.s3_request_timeout_ms = settings[DB::Setting::s3_request_timeout_ms];
-    }
-    return options;
-}
-
 namespace
 {
 
@@ -171,10 +157,34 @@ public:
         return object_storage->tryRefreshCredentialsViaCallback();
     }
 
+    KernelClientOptions resolveClientOptions() const override
+    {
+        /// Effective values, so that they can serve as the sharing key of a build: the storage's
+        /// live settings (reapplied by `applyNewSettings`; the accessor is virtual, so wrappers
+        /// such as CachedObjectStorage forward it to the S3 storage inside), overridden by what
+        /// the current query changed. The constructor-time values remain as the last resort.
+        UInt64 connect = connect_timeout_ms;
+        UInt64 request = request_timeout_ms;
+        if (const auto live_settings = object_storage->tryGetS3StorageSettings())
+        {
+            connect = live_settings->auth_settings[DB::S3AuthSetting::connect_timeout_ms];
+            request = live_settings->auth_settings[DB::S3AuthSetting::request_timeout_ms];
+        }
+        if (auto query_context = DB::CurrentThread::tryGetQueryContext())
+        {
+            const auto & settings = query_context->getSettingsRef();
+            if (settings[DB::Setting::s3_connect_timeout_ms].changed)
+                connect = settings[DB::Setting::s3_connect_timeout_ms];
+            if (settings[DB::Setting::s3_request_timeout_ms].changed)
+                request = settings[DB::Setting::s3_request_timeout_ms];
+        }
+        return KernelClientOptions{.s3_connect_timeout_ms = connect, .s3_request_timeout_ms = request};
+    }
+
     ffi::EngineBuilder * createBuilder() const override
     {
         DB::UInt128 credentials_fingerprint;
-        return createBuilderWithOptions(KernelClientOptions::fromCurrentQuery(), credentials_fingerprint);
+        return createBuilderWithOptions(resolveClientOptions(), credentials_fingerprint);
     }
 
     ffi::EngineBuilder * createBuilderWithOptions(const KernelClientOptions & options, DB::UInt128 & credentials_fingerprint) const override
@@ -238,20 +248,11 @@ public:
         /// (`applyNewSettings`), so a query-level `SETTINGS s3_request_timeout_ms = ...` must
         /// reach the kernel client as well: the options captured on the query thread take
         /// precedence over the values captured when this helper was created.
-        /// The fallbacks come from the object storage's live settings — `applyNewSettings`
-        /// reapplies config/endpoint settings on every update — rather than from the values
-        /// captured when this helper was created, so a reloaded configuration reaches the
-        /// kernel client the same way it reaches the server's own S3 client. The accessor is
-        /// virtual, so wrappers such as CachedObjectStorage forward it to the S3 storage inside.
-        UInt64 fallback_connect_timeout_ms = connect_timeout_ms;
-        UInt64 fallback_request_timeout_ms = request_timeout_ms;
-        if (const auto live_settings = object_storage->tryGetS3StorageSettings())
-        {
-            fallback_connect_timeout_ms = live_settings->auth_settings[DB::S3AuthSetting::connect_timeout_ms];
-            fallback_request_timeout_ms = live_settings->auth_settings[DB::S3AuthSetting::request_timeout_ms];
-        }
-        const UInt64 effective_connect_timeout_ms = options.s3_connect_timeout_ms.value_or(fallback_connect_timeout_ms);
-        const UInt64 effective_request_timeout_ms = options.s3_request_timeout_ms.value_or(fallback_request_timeout_ms);
+        /// `options` carry the effective values resolved by `resolveClientOptions` on the query
+        /// thread (the storage's live settings overridden by the query); the constructor-time
+        /// values only remain as a fallback for options which were not resolved through it.
+        const UInt64 effective_connect_timeout_ms = options.s3_connect_timeout_ms.value_or(connect_timeout_ms);
+        const UInt64 effective_request_timeout_ms = options.s3_request_timeout_ms.value_or(request_timeout_ms);
 
         if (effective_connect_timeout_ms)
             set_option("connect_timeout", fmt::format("{}ms", effective_connect_timeout_ms));

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -29,6 +29,8 @@ namespace DB::ErrorCodes
 namespace DB::S3AuthSetting
 {
     extern const S3AuthSettingsBool no_sign_request;
+    extern const S3AuthSettingsUInt64 connect_timeout_ms;
+    extern const S3AuthSettingsUInt64 request_timeout_ms;
 }
 
 namespace DB::FailPoints
@@ -105,6 +107,8 @@ public:
             url.addRegionToURI(region);
 
         no_sign = auth_settings[DB::S3AuthSetting::no_sign_request];
+        connect_timeout_ms = auth_settings[DB::S3AuthSetting::connect_timeout_ms];
+        request_timeout_ms = auth_settings[DB::S3AuthSetting::request_timeout_ms];
     }
 
     const std::string & getTableLocation() const override { return table_location; }
@@ -183,12 +187,23 @@ public:
             set_option("aws_endpoint", url.endpoint);
         }
 
+        /// The kernel talks to S3 through its own object_store client, which the server's S3
+        /// client settings do not reach. Give it the same per-request bounds as the server's
+        /// S3 client (`s3_connect_timeout_ms` / `s3_request_timeout_ms`), so that a request the
+        /// object store never answers fails instead of hanging.
+        if (connect_timeout_ms)
+            set_option("connect_timeout", fmt::format("{}ms", connect_timeout_ms));
+        if (request_timeout_ms)
+            set_option("timeout", fmt::format("{}ms", request_timeout_ms));
+
         LOG_TRACE(
             log,
             "Using endpoint: {}, uri: {}, region: {}, bucket: {}, no sign: {}, "
-            "has access_key_id: {}, has secret_access_key: {}, has token: {}",
+            "has access_key_id: {}, has secret_access_key: {}, has token: {}, "
+            "connect timeout: {} ms, request timeout: {} ms",
             url.endpoint, url.uri_str, region, url.bucket, no_sign,
-            !access_key_id.empty(), !secret_access_key.empty(), !token.empty());
+            !access_key_id.empty(), !secret_access_key.empty(), !token.empty(),
+            connect_timeout_ms, request_timeout_ms);
 
         return guard.release();
     }
@@ -201,6 +216,8 @@ private:
 
     std::string region;
     bool no_sign;
+    UInt64 connect_timeout_ms;
+    UInt64 request_timeout_ms;
 
     static std::string getTableLocation(const DB::S3::URI & url)
     {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -9,6 +9,9 @@
 #include <Common/SipHash.h>
 #include <Common/isValidUTF8.h>
 #include <Common/logger_useful.h>
+#include <Common/CurrentThread.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
 
 #if USE_AZURE_BLOB_STORAGE
 #include <Storages/ObjectStorage/Azure/Configuration.h>
@@ -31,6 +34,12 @@ namespace DB::S3AuthSetting
     extern const S3AuthSettingsBool no_sign_request;
     extern const S3AuthSettingsUInt64 connect_timeout_ms;
     extern const S3AuthSettingsUInt64 request_timeout_ms;
+}
+
+namespace DB::Setting
+{
+    extern const SettingsUInt64 s3_connect_timeout_ms;
+    extern const SettingsUInt64 s3_request_timeout_ms;
 }
 
 namespace DB::FailPoints
@@ -195,15 +204,30 @@ public:
         /// be given an unbounded timeout through its string options (a literal `0` makes every
         /// request time out immediately), so `0` intentionally leaves the option unset and
         /// object_store's built-in defaults (30 s request / 5 s connect) stay in effect.
-        if (connect_timeout_ms)
-            set_option("connect_timeout", fmt::format("{}ms", connect_timeout_ms));
+        /// The server's S3 client re-resolves these from the current query on every update
+        /// (`applyNewSettings`), so a query-level `SETTINGS s3_request_timeout_ms = ...` must
+        /// reach the kernel client as well: prefer the current query's changed settings over
+        /// the values captured when this helper was created.
+        UInt64 effective_connect_timeout_ms = connect_timeout_ms;
+        UInt64 effective_request_timeout_ms = request_timeout_ms;
+        if (auto query_context = DB::CurrentThread::tryGetQueryContext())
+        {
+            const auto & settings = query_context->getSettingsRef();
+            if (settings[DB::Setting::s3_connect_timeout_ms].changed)
+                effective_connect_timeout_ms = settings[DB::Setting::s3_connect_timeout_ms];
+            if (settings[DB::Setting::s3_request_timeout_ms].changed)
+                effective_request_timeout_ms = settings[DB::Setting::s3_request_timeout_ms];
+        }
+
+        if (effective_connect_timeout_ms)
+            set_option("connect_timeout", fmt::format("{}ms", effective_connect_timeout_ms));
         else
             LOG_WARNING(
                 log,
                 "s3_connect_timeout_ms = 0 (no timeout) cannot be forwarded to the delta-kernel "
                 "object store client; its default connect timeout stays in effect");
-        if (request_timeout_ms)
-            set_option("timeout", fmt::format("{}ms", request_timeout_ms));
+        if (effective_request_timeout_ms)
+            set_option("timeout", fmt::format("{}ms", effective_request_timeout_ms));
         else
             LOG_WARNING(
                 log,
@@ -217,7 +241,7 @@ public:
             "connect timeout: {} ms, request timeout: {} ms",
             url.endpoint, url.uri_str, region, url.bucket, no_sign,
             !access_key_id.empty(), !secret_access_key.empty(), !token.empty(),
-            connect_timeout_ms, request_timeout_ms);
+            effective_connect_timeout_ms, effective_request_timeout_ms);
 
         return guard.release();
     }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -36,6 +36,9 @@ struct KernelClientOptions
 
     /// Takes the settings changed in the current query, if there is one.
     static KernelClientOptions fromCurrentQuery();
+
+    /// Loads are shared only between queries with equal options.
+    bool operator==(const KernelClientOptions &) const = default;
 };
 
 /**

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -64,9 +64,15 @@ public:
     /// with object storage layer.
     virtual ffi::EngineBuilder * createBuilder() const = 0;
 
-    /// Same as createBuilder(), with client options captured on the query thread. The default
-    /// ignores them; helpers whose client depends on query settings override it.
-    virtual ffi::EngineBuilder * createBuilderWithOptions(const KernelClientOptions &) const { return createBuilder(); }
+    /// Same as createBuilder(), with client options captured on the query thread, and reporting
+    /// the fingerprint of the very credentials the builder was filled with (a helper's client
+    /// may be swapped at any time, so the two must come from one snapshot of it). The default
+    /// ignores the options; helpers whose client depends on query settings override it.
+    virtual ffi::EngineBuilder * createBuilderWithOptions(const KernelClientOptions &, DB::UInt128 & credentials_fingerprint) const
+    {
+        credentials_fingerprint = getCredentialsFingerprint();
+        return createBuilder();
+    }
 
     /// Hash of current credentials; override for providers with rotating sessions.
     virtual DB::UInt128 getCredentialsFingerprint() const { return {}; }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -26,18 +26,17 @@ struct ConnectionParams;
 namespace DeltaLake
 {
 
-/// Client options resolved on the query thread for one kernel engine build. The worker which
-/// performs the build runs under a neutral thread group and has no query context of its own,
-/// so anything taken from the query's settings must be captured beforehand.
+/// The effective client options of one kernel engine build, resolved on the query thread by
+/// IKernelHelper::resolveClientOptions (the worker which performs the build has no query
+/// context of its own). They are also the key under which an in-flight build may be shared:
+/// two queries share one only if the builder would be filled identically, so the values here
+/// are the effective ones — the storage's live settings overridden by the query — never a
+/// mere "the query changed this setting" bit.
 struct KernelClientOptions
 {
     std::optional<UInt64> s3_connect_timeout_ms;
     std::optional<UInt64> s3_request_timeout_ms;
 
-    /// Takes the settings changed in the current query, if there is one.
-    static KernelClientOptions fromCurrentQuery();
-
-    /// Loads are shared only between queries with equal options.
     bool operator==(const KernelClientOptions &) const = default;
 };
 
@@ -73,6 +72,11 @@ public:
         credentials_fingerprint = getCredentialsFingerprint();
         return createBuilder();
     }
+
+    /// The effective client options a build started by the current query would use (see
+    /// KernelClientOptions). Must be called on the query thread. Empty for helpers whose
+    /// client does not depend on query settings.
+    virtual KernelClientOptions resolveClientOptions() const { return {}; }
 
     /// Hash of current credentials; override for providers with rotating sessions.
     virtual DB::UInt128 getCredentialsFingerprint() const { return {}; }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -24,6 +24,18 @@ struct ConnectionParams;
 namespace DeltaLake
 {
 
+/// Client options resolved on the query thread for one kernel engine build. The worker which
+/// performs the build runs under a neutral thread group and has no query context of its own,
+/// so anything taken from the query's settings must be captured beforehand.
+struct KernelClientOptions
+{
+    std::optional<UInt64> s3_connect_timeout_ms;
+    std::optional<UInt64> s3_request_timeout_ms;
+
+    /// Takes the settings changed in the current query, if there is one.
+    static KernelClientOptions fromCurrentQuery();
+};
+
 /**
  * A helper class to manage different storage types,
  * their data location, authentication, connection.
@@ -46,6 +58,10 @@ public:
     /// delta-kernel-rs ffi api and performs all interactions
     /// with object storage layer.
     virtual ffi::EngineBuilder * createBuilder() const = 0;
+
+    /// Same as createBuilder(), with client options captured on the query thread. The default
+    /// ignores them; helpers whose client depends on query settings override it.
+    virtual ffi::EngineBuilder * createBuilderWithOptions(const KernelClientOptions &) const { return createBuilder(); }
 
     /// Hash of current credentials; override for providers with rotating sessions.
     virtual DB::UInt128 getCredentialsFingerprint() const { return {}; }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include <optional>
+
 namespace ffi
 {
 struct EngineBuilder;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -962,9 +962,9 @@ void TableSnapshot::initOrUpdateSnapshot() const
         log, "{}",
         kernel_snapshot_state ? "Rebuilding kernel snapshot state (credentials rotated)" : "Initializing snapshot");
 
-    /// Captured on the query thread; also part of the decision whether an in-flight build
-    /// may be shared, since this PR forwards query-level S3 timeouts into the kernel client.
-    const auto client_options = KernelClientOptions::fromCurrentQuery();
+    /// Resolved on the query thread; also the key deciding whether an in-flight build may be
+    /// shared, since query-level S3 timeouts are forwarded into the kernel client.
+    const auto client_options = helper->resolveClientOptions();
 
     for (size_t attempt = 0;; ++attempt)
     {
@@ -1228,7 +1228,7 @@ void TableSnapshot::markAbandoned(InflightSnapshotLoad & load, const IKernelHelp
 std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::loadKernelSnapshotState(
     KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log)
 {
-    auto load = startKernelSnapshotLoad(kernel_helper, version_to_build, KernelClientOptions::fromCurrentQuery());
+    auto load = startKernelSnapshotLoad(kernel_helper, version_to_build, kernel_helper->resolveClientOptions());
     try
     {
         waitForSnapshotLoad(*load, *kernel_helper);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -946,7 +946,7 @@ void TableSnapshot::initOrUpdateSnapshot() const
     std::unique_lock lock(mutex);
 
     /// Rebuild when credentials rotate so the engine never outlives its embedded STS token.
-    auto current_credentials_fingerprint = helper->getCredentialsFingerprint();
+    const auto current_credentials_fingerprint = helper->getCredentialsFingerprint();
     if (kernel_snapshot_state && !kernel_state_needs_rebuild
         && current_credentials_fingerprint == kernel_state_credentials_fingerprint)
         return;
@@ -1042,9 +1042,11 @@ void TableSnapshot::initOrUpdateSnapshot() const
         }
         catch (const DB::Exception & e)
         {
-            if (attempt > 0 || !tryRefreshAfterStaleTokenError(e, current_credentials_fingerprint, "snapshot init"))
+            /// Judged against the credentials the failed build actually used (recorded by the
+            /// worker), not against the helper's client as seen by whichever waiter handles the
+            /// failure: the client may have rotated while the shared load was in flight.
+            if (attempt > 0 || !tryRefreshAfterStaleTokenError(e, load->credentials_fingerprint, "snapshot init"))
                 throw;
-            current_credentials_fingerprint = helper->getCredentialsFingerprint();
             continue;
         }
         if (!is_current_load && kernel_snapshot_state)
@@ -1128,11 +1130,12 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
     auto load = std::make_shared<InflightSnapshotLoad>();
     load->client_options = client_options;
     auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
-        [kernel_helper, version_to_build, client_options]
+        [kernel_helper, version_to_build, client_options, load]
         {
             /// Simulates a kernel call which never returns (used by tests).
             DB::FailPointInjection::pauseFailPoint(DB::FailPoints::delta_kernel_snapshot_load_pause);
-            return std::make_shared<KernelSnapshotState>(*kernel_helper, version_to_build, client_options);
+            return std::make_shared<KernelSnapshotState>(
+                *kernel_helper, version_to_build, client_options, load->credentials_fingerprint);
         });
     load->future = task->get_future().share();
 
@@ -1249,7 +1252,10 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::getKernelSnap
 }
 
 TableSnapshot::KernelSnapshotState::KernelSnapshotState(
-    const IKernelHelper & helper_, std::optional<size_t> snapshot_version_, const KernelClientOptions & client_options_)
+    const IKernelHelper & helper_,
+    std::optional<size_t> snapshot_version_,
+    const KernelClientOptions & client_options_,
+    DB::UInt128 & used_credentials_fingerprint)
 {
     fiu_do_on(DB::FailPoints::delta_kernel_force_stale_token_error,
     {
@@ -1259,8 +1265,10 @@ TableSnapshot::KernelSnapshotState::KernelSnapshotState(
     });
 
     /// The fingerprint is taken inside the helper from the same client snapshot the builder is
-    /// filled with, so it describes the credentials this engine is actually built with.
+    /// filled with, so it describes the credentials this engine is actually built with. It is
+    /// published to the load right away, before the kernel calls below which may throw.
     auto * engine_builder = helper_.createBuilderWithOptions(client_options_, credentials_fingerprint);
+    used_credentials_fingerprint = credentials_fingerprint;
     engine = KernelUtils::unwrapResult(ffi::builder_build(engine_builder), "builder_build");
 
     using KernelSnapshotBuilder = KernelPointerWrapper<ffi::MutableFfiSnapshotBuilder, ffi::free_snapshot_builder>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -952,11 +952,11 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSn
     }
 
     auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
-        [helper = helper, version_to_build]
+        [kernel_helper = helper, version_to_build]
         {
             /// Simulates a kernel call which never returns (used by tests).
             DB::FailPointInjection::pauseFailPoint(DB::FailPoints::delta_kernel_snapshot_load_pause);
-            return std::make_shared<KernelSnapshotState>(*helper, version_to_build);
+            return std::make_shared<KernelSnapshotState>(*kernel_helper, version_to_build);
         });
     auto future = task->get_future();
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -41,6 +41,7 @@
 #include <fmt/ranges.h>
 #include <roaring/roaring.hh>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <future>
@@ -933,10 +934,12 @@ void TableSnapshot::initOrUpdateSnapshot() const
     for (size_t attempt = 0;; ++attempt)
     {
         /// One in-flight build is shared by every query which needs this snapshot: the first
-        /// waiter starts it, later waiters (and later queries, if every waiter gave up before
-        /// the kernel call returned) adopt it.
+        /// waiter starts it and later waiters adopt it. A load that some waiter already gave up
+        /// on is not adopted, though: it may be stuck for good, and adopting it would poison
+        /// this snapshot forever. A fresh (permit-bounded) load is started instead, so the
+        /// table recovers once the object store does; the stuck worker just drops its result.
         auto load = inflight_load;
-        if (!load)
+        if (!load || load->state.load() == InflightSnapshotLoad::State::Abandoned)
         {
             load = startKernelSnapshotLoad(helper, version_to_build);
             inflight_load = load;
@@ -984,10 +987,17 @@ namespace
     /// whether still serving waiters or already given up by them. The permit is reserved
     /// BEFORE the worker is launched (a post-facto counter would let any number of concurrent
     /// loads pass the check together) and released by the worker itself when the kernel call
-    /// returns, so stuck workers can never exceed this cap. The cap stays far above realistic
-    /// concurrent snapshot loads (builds are shared per table snapshot) and far below
-    /// `max_thread_pool_size` (default 10000), each stuck worker occupying one pool thread.
-    constexpr Int64 MAX_SNAPSHOT_LOAD_WORKERS = 128;
+    /// returns, so stuck workers can never exceed this cap.
+    /// Each stuck worker occupies one `GlobalThreadPool` thread, so the cap is derived from the
+    /// pool's actual size (`max_thread_pool_size`, configurable): a small share of it, at most
+    /// 128 (reached with the default pool of 10000), so that a dead object store can never
+    /// starve unrelated tasks even on installations with a small pool. Builds are shared per
+    /// table snapshot, so this stays far above realistic concurrent snapshot loads.
+    Int64 maxSnapshotLoadWorkers()
+    {
+        const auto pool_size = static_cast<Int64>(GlobalThreadPool::instance().getMaxThreads());
+        return std::clamp<Int64>(pool_size / 8, 1, 128);
+    }
     std::atomic<Int64> snapshot_load_worker_permits{0};
 }
 
@@ -1004,7 +1014,8 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
     /// waiter; it keeps the kernel handles alive and releases them when the kernel call returns.
 
     /// Reserve a permit before launching, so the bound holds under concurrency.
-    if (snapshot_load_worker_permits.fetch_add(1, std::memory_order_relaxed) >= MAX_SNAPSHOT_LOAD_WORKERS)
+    const Int64 max_workers = maxSnapshotLoadWorkers();
+    if (snapshot_load_worker_permits.fetch_add(1, std::memory_order_relaxed) >= max_workers)
     {
         snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
         throw DB::Exception(
@@ -1012,7 +1023,7 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
             "Refusing to load the snapshot of the Delta Lake table at {}: {} snapshot-load workers are "
             "already running or stuck inside delta-kernel ({} of them were given up by their queries, "
             "see the DeltaLakeSnapshotLoadsStuck metric); not starting another one until a worker returns",
-            kernel_helper->getTableLocation(), MAX_SNAPSHOT_LOAD_WORKERS,
+            kernel_helper->getTableLocation(), max_workers,
             CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck));
     }
 
@@ -1026,12 +1037,23 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
         });
     load->future = task->get_future().share();
 
+    /// The build is shared by unrelated queries, so it must not run under the starting query's
+    /// thread group: its `max_memory_usage`, quota and accounting would silently apply to every
+    /// waiter. Give the worker a neutral group derived from the global context instead.
+    DB::ThreadGroupPtr thread_group;
+    if (auto global_context = DB::Context::getGlobalContextInstance())
+    {
+        thread_group = std::make_shared<DB::ThreadGroup>(global_context, /* os_threads_nice_value */ 0);
+        thread_group->memory_tracker.setDescription("Delta Lake snapshot load");
+    }
+    else
+        thread_group = DB::CurrentThread::getGroup();
+
     try
     {
         ThreadFromGlobalPool thread(
-            [task, load, thread_group = DB::CurrentThread::getGroup()]
+            [task, load, thread_group]
             {
-                /// Attach to the query thread group to keep memory accounting and the query id in logs.
                 DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
                 (*task)();
                 /// If every waiter already gave up, undoing the stuck-load accounting is ours to do.
@@ -1095,7 +1117,7 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKern
                     "the worker thread keeps running until the kernel call returns "
                     "(stuck loads: {}, snapshot-load workers are capped at {})",
                     kernel_helper.getTableLocation(), watch.elapsedMilliseconds(),
-                    CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), MAX_SNAPSHOT_LOAD_WORKERS);
+                    CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), maxSnapshotLoadWorkers());
             }
             throw;
         }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -23,6 +23,7 @@
 #include <Common/setThreadName.h>
 #include <Common/Stopwatch.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/MemoryTracker.h>
 
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
@@ -1102,13 +1103,21 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
     load->future = task->get_future().share();
 
     /// The build is shared by unrelated queries, so it must not run under the starting query's
-    /// thread group: its `max_memory_usage`, quota and accounting would silently apply to every
-    /// waiter. Give the worker a neutral group derived from the global context instead.
+    /// own thread group: its `max_memory_usage` and accounting would silently apply to every
+    /// waiter. The worker gets a group of its own instead: built from the starting query's
+    /// context, so that the kernel's log lines (`DeltaKernelTracing` in `system.text_log`) stay
+    /// attributed to the query which started the load, as they were when the load ran on the
+    /// query thread — but through the raw constructor, which applies no per-query memory
+    /// limits, and with the memory accounted to the server total rather than to that query.
     DB::ThreadGroupPtr thread_group;
-    if (auto global_context = DB::Context::getGlobalContextInstance())
+    DB::ContextPtr group_context = DB::CurrentThread::tryGetQueryContext();
+    if (!group_context)
+        group_context = DB::Context::getGlobalContextInstance();
+    if (group_context)
     {
-        thread_group = std::make_shared<DB::ThreadGroup>(global_context, /* os_threads_nice_value */ 0);
+        thread_group = std::make_shared<DB::ThreadGroup>(group_context, /* os_threads_nice_value */ 0);
         thread_group->memory_tracker.setDescription("Delta Lake snapshot load");
+        thread_group->memory_tracker.setParent(&total_memory_tracker);
     }
     else
         thread_group = DB::CurrentThread::getGroup();

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -959,10 +959,11 @@ void TableSnapshot::initOrUpdateSnapshot() const
         if (inflight_load == load)
             inflight_load = nullptr;
 
+        std::shared_ptr<KernelSnapshotState> built;
         try
         {
             /// Rethrows the build error to every waiter if the build failed.
-            kernel_snapshot_state = load->future.get();
+            built = load->future.get();
         }
         catch (const DB::Exception & e)
         {
@@ -971,6 +972,20 @@ void TableSnapshot::initOrUpdateSnapshot() const
             current_credentials_fingerprint = helper->getCredentialsFingerprint();
             continue;
         }
+
+        /// A TableSnapshot never changes its version once one is installed. Two latest-version
+        /// loads on the same object (a fresh one started after the first was given up) may
+        /// resolve different versions; whichever completes second is stale and is ignored,
+        /// otherwise the cached object would flip between versions. Rebuilds after a
+        /// credentials refresh are pinned to the installed version, so they always pass.
+        if (kernel_snapshot_state && built->snapshot_version != kernel_snapshot_state->snapshot_version)
+        {
+            LOG_TRACE(
+                log, "Ignoring a stale snapshot load which resolved version {} after version {} was installed",
+                built->snapshot_version, kernel_snapshot_state->snapshot_version);
+            break;
+        }
+        kernel_snapshot_state = built;
         kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
         kernel_state_needs_rebuild = false;
         break;
@@ -989,15 +1004,16 @@ namespace
     /// loads pass the check together) and released by the worker itself when the kernel call
     /// returns, so stuck workers can never exceed this cap.
     /// Each stuck worker occupies one `GlobalThreadPool` thread, so the cap is derived from the
-    /// pool's actual size (`max_thread_pool_size`, configurable): a small share of it, at most
-    /// 128 (reached with the default pool of 10000), and always leaving at least two workers
-    /// free for unrelated tasks and for shutdown. On a pool too small for that the cap is 0:
-    /// snapshot loads then fail fast with a clear error instead of occupying the last worker.
-    /// Builds are shared per table snapshot, so this stays far above realistic concurrency.
+    /// pool's actual size (`max_thread_pool_size`, configurable): a share of it, at least one
+    /// worker and at most 128 (reached with the default pool of 10000), while always leaving
+    /// two workers free for unrelated tasks and for shutdown. Only a pool too small even for
+    /// that (`max_thread_pool_size <= 2`) gets a cap of 0, so that snapshot loads fail fast
+    /// with a clear error instead of occupying the last worker. Builds are shared per table
+    /// snapshot, so this stays far above realistic concurrency.
     Int64 maxSnapshotLoadWorkers()
     {
         const auto pool_size = static_cast<Int64>(GlobalThreadPool::instance().getMaxThreads());
-        return std::clamp<Int64>(std::min<Int64>(pool_size / 8, pool_size - 2), 0, 128);
+        return std::clamp<Int64>(std::min<Int64>(std::max<Int64>(pool_size / 8, 1), pool_size - 2), 0, 128);
     }
     std::atomic<Int64> snapshot_load_worker_permits{0};
 }
@@ -1033,6 +1049,13 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
             kernel_helper->getTableLocation(), max_workers,
             CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck));
     }
+    /// Everything below may throw (allocations, thread creation): release the permit unless it
+    /// was handed over to the worker, which releases it when the kernel call returns.
+    bool permit_transferred = false;
+    SCOPE_EXIT({
+        if (!permit_transferred)
+            snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
+    });
 
     auto load = std::make_shared<InflightSnapshotLoad>();
     auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
@@ -1056,27 +1079,20 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
     else
         thread_group = DB::CurrentThread::getGroup();
 
-    try
-    {
-        ThreadFromGlobalPool thread(
-            [task, load, thread_group]
-            {
-                DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
-                (*task)();
-                /// If every waiter already gave up, undoing the stuck-load accounting is ours to do.
-                if (load->state.exchange(InflightSnapshotLoad::State::Finished) == InflightSnapshotLoad::State::Abandoned)
-                    CurrentMetrics::sub(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
-                snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
-            });
-        /// Nobody joins the worker: waiters wait on the shared future with their own cancellation
-        /// checks, and the captured shared state keeps everything the worker needs alive.
-        thread.detach();
-    }
-    catch (...)
-    {
-        snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
-        throw;
-    }
+    ThreadFromGlobalPool thread(
+        [task, load, thread_group]
+        {
+            DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
+            (*task)();
+            /// If every waiter already gave up, undoing the stuck-load accounting is ours to do.
+            if (load->state.exchange(InflightSnapshotLoad::State::Finished) == InflightSnapshotLoad::State::Abandoned)
+                CurrentMetrics::sub(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
+            snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
+        });
+    /// Nobody joins the worker: waiters wait on the shared future with their own cancellation
+    /// checks, and the captured shared state keeps everything the worker needs alive.
+    thread.detach();
+    permit_transferred = true;
     return load;
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -990,13 +990,14 @@ namespace
     /// returns, so stuck workers can never exceed this cap.
     /// Each stuck worker occupies one `GlobalThreadPool` thread, so the cap is derived from the
     /// pool's actual size (`max_thread_pool_size`, configurable): a small share of it, at most
-    /// 128 (reached with the default pool of 10000), so that a dead object store can never
-    /// starve unrelated tasks even on installations with a small pool. Builds are shared per
-    /// table snapshot, so this stays far above realistic concurrent snapshot loads.
+    /// 128 (reached with the default pool of 10000), and always leaving at least two workers
+    /// free for unrelated tasks and for shutdown. On a pool too small for that the cap is 0:
+    /// snapshot loads then fail fast with a clear error instead of occupying the last worker.
+    /// Builds are shared per table snapshot, so this stays far above realistic concurrency.
     Int64 maxSnapshotLoadWorkers()
     {
         const auto pool_size = static_cast<Int64>(GlobalThreadPool::instance().getMaxThreads());
-        return std::clamp<Int64>(pool_size / 8, 1, 128);
+        return std::clamp<Int64>(std::min<Int64>(pool_size / 8, pool_size - 2), 0, 128);
     }
     std::atomic<Int64> snapshot_load_worker_permits{0};
 }
@@ -1015,6 +1016,12 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
 
     /// Reserve a permit before launching, so the bound holds under concurrency.
     const Int64 max_workers = maxSnapshotLoadWorkers();
+    if (max_workers == 0)
+        throw DB::Exception(
+            DB::ErrorCodes::CANNOT_SCHEDULE_TASK,
+            "Refusing to load the snapshot of the Delta Lake table at {}: the global thread pool is too small "
+            "(max_thread_pool_size = {}) to run a snapshot-load worker without starving other tasks",
+            kernel_helper->getTableLocation(), GlobalThreadPool::instance().getMaxThreads());
     if (snapshot_load_worker_permits.fetch_add(1, std::memory_order_relaxed) >= max_workers)
     {
         snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -1013,8 +1013,12 @@ void TableSnapshot::initOrUpdateSnapshot() const
         }
         catch (...)
         {
+            /// Unregistered — and, when this was the last waiter, marked as given up — in one
+            /// critical section with the `given_up` check above, so that neither transition can
+            /// be observed half-done by another query.
             lock.lock();
-            load->waiters.fetch_sub(1, std::memory_order_relaxed);
+            if (load->waiters.fetch_sub(1, std::memory_order_relaxed) == 1)
+                markAbandoned(*load, *helper, log);
             throw;
         }
         lock.lock();
@@ -1185,38 +1189,36 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKern
     Stopwatch watch;
     while (load.future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready)
     {
-        try
-        {
-            /// Throws if the query was killed or `max_execution_time` is exceeded.
-            if (process_list_element)
-                process_list_element->checkTimeLimit();
+        /// Throws if the query was killed or `max_execution_time` is exceeded. Giving up is
+        /// accounted for by the caller (see markAbandoned), under the snapshot's mutex.
+        if (process_list_element)
+            process_list_element->checkTimeLimit();
 
-            if (timeout_ms && watch.elapsedMilliseconds() >= timeout_ms)
-                throw DB::Exception(
-                    DB::ErrorCodes::TIMEOUT_EXCEEDED,
-                    "Timeout exceeded while loading the snapshot of the Delta Lake table at {}: "
-                    "waited {} ms, delta_lake_snapshot_load_timeout_ms is {} ms",
-                    kernel_helper.getTableLocation(), watch.elapsedMilliseconds(), timeout_ms);
-        }
-        catch (...)
-        {
-            /// This waiter gives up, but the build keeps running for the other waiters (and for
-            /// later queries, which adopt it through `inflight_load`). The first waiter to give
-            /// up counts the load as stuck; the worker undoes that when the kernel call returns.
-            auto expected = InflightSnapshotLoad::State::Running;
-            if (load.state.compare_exchange_strong(expected, InflightSnapshotLoad::State::Abandoned))
-            {
-                CurrentMetrics::add(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
-                LOG_WARNING(
-                    log,
-                    "Giving up waiting for the delta-kernel snapshot load of the table at {} after {} ms; "
-                    "the worker thread keeps running until the kernel call returns "
-                    "(stuck loads: {}, snapshot-load workers are capped at {})",
-                    kernel_helper.getTableLocation(), watch.elapsedMilliseconds(),
-                    CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), maxSnapshotLoadWorkers());
-            }
-            throw;
-        }
+        if (timeout_ms && watch.elapsedMilliseconds() >= timeout_ms)
+            throw DB::Exception(
+                DB::ErrorCodes::TIMEOUT_EXCEEDED,
+                "Timeout exceeded while loading the snapshot of the Delta Lake table at {}: "
+                "waited {} ms, delta_lake_snapshot_load_timeout_ms is {} ms",
+                kernel_helper.getTableLocation(), watch.elapsedMilliseconds(), timeout_ms);
+    }
+}
+
+void TableSnapshot::markAbandoned(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper, const LoggerPtr & log)
+{
+    /// The build keeps running: the worker delivers or drops its result when the kernel call
+    /// returns, and undoes the stuck-load count then. Callers which share the load call this
+    /// under `TableSnapshot::mutex`, in one critical section with the waiter count.
+    auto expected = InflightSnapshotLoad::State::Running;
+    if (load.state.compare_exchange_strong(expected, InflightSnapshotLoad::State::Abandoned))
+    {
+        CurrentMetrics::add(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
+        LOG_WARNING(
+            log,
+            "Giving up waiting for the delta-kernel snapshot load of the table at {}: no waiter is left; "
+            "the worker thread keeps running until the kernel call returns "
+            "(stuck loads: {}, snapshot-load workers are capped at {})",
+            kernel_helper.getTableLocation(),
+            CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), maxSnapshotLoadWorkers());
     }
 }
 
@@ -1224,7 +1226,16 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::loadKernelSna
     KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log)
 {
     auto load = startKernelSnapshotLoad(kernel_helper, version_to_build, KernelClientOptions::fromCurrentQuery());
-    waitForSnapshotLoad(*load, *kernel_helper, log);
+    try
+    {
+        waitForSnapshotLoad(*load, *kernel_helper, log);
+    }
+    catch (...)
+    {
+        /// A private, unshared load: nobody else waits, so give it up right here.
+        markAbandoned(*load, *kernel_helper, log);
+        throw;
+    }
     /// Rethrows the build error, if any.
     return load->future.get();
 }
@@ -1247,9 +1258,9 @@ TableSnapshot::KernelSnapshotState::KernelSnapshotState(
             "ExpiredToken: forced by delta_kernel_force_stale_token_error failpoint");
     });
 
-    /// Describes the credentials this engine is built with (the helper may rotate later).
-    credentials_fingerprint = helper_.getCredentialsFingerprint();
-    auto * engine_builder = helper_.createBuilderWithOptions(client_options_);
+    /// The fingerprint is taken inside the helper from the same client snapshot the builder is
+    /// filled with, so it describes the credentials this engine is actually built with.
+    auto * engine_builder = helper_.createBuilderWithOptions(client_options_, credentials_fingerprint);
     engine = KernelUtils::unwrapResult(ffi::builder_build(engine_builder), "builder_build");
 
     using KernelSnapshotBuilder = KernelPointerWrapper<ffi::MutableFfiSnapshotBuilder, ffi::free_snapshot_builder>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -955,9 +955,25 @@ void TableSnapshot::initOrUpdateSnapshot() const
         waitForSnapshotLoad(*load, *helper, log);
         lock.lock();
 
-        /// The build finished (successfully or not): it is no longer in flight.
-        if (inflight_load == load)
+        /// Only the load which is still registered as in flight may install its result. A load
+        /// that was given up on and superseded by a fresh one is stale whenever it completes,
+        /// before or after the fresh one: installing it could make the cached object resolve
+        /// to an older version, or flip between versions. Its waiters re-adopt the fresh load.
+        const bool is_current_load = (inflight_load == load);
+        if (is_current_load)
             inflight_load = nullptr;
+
+        if (!is_current_load)
+        {
+            if (kernel_snapshot_state)
+                break;  /// Installed by the fresh load (or by a sibling waiter of this one): keep it.
+            if (inflight_load)
+            {
+                LOG_TRACE(log, "Ignoring the completion of a superseded snapshot load; waiting for the current one");
+                continue;
+            }
+            /// Nothing newer exists any more (the fresh load failed): fall through and use this result.
+        }
 
         std::shared_ptr<KernelSnapshotState> built;
         try
@@ -971,19 +987,6 @@ void TableSnapshot::initOrUpdateSnapshot() const
                 throw;
             current_credentials_fingerprint = helper->getCredentialsFingerprint();
             continue;
-        }
-
-        /// A TableSnapshot never changes its version once one is installed. Two latest-version
-        /// loads on the same object (a fresh one started after the first was given up) may
-        /// resolve different versions; whichever completes second is stale and is ignored,
-        /// otherwise the cached object would flip between versions. Rebuilds after a
-        /// credentials refresh are pinned to the installed version, so they always pass.
-        if (kernel_snapshot_state && built->snapshot_version != kernel_snapshot_state->snapshot_version)
-        {
-            LOG_TRACE(
-                log, "Ignoring a stale snapshot load which resolved version {} after version {} was installed",
-                built->snapshot_version, kernel_snapshot_state->snapshot_version);
-            break;
         }
         kernel_snapshot_state = built;
         kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -718,30 +718,35 @@ size_t TableSnapshot::getVersionUnlocked() const
 
 TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStats() const
 {
-    if (snapshot_stats.has_value())
-        return snapshot_stats.value();
+    for (size_t attempt = 0;; ++attempt)
+    {
+        /// Builds the kernel state (or rebuilds it after a credentials refresh) through the
+        /// interruptible shared load, with the mutex released while waiting.
+        initOrUpdateSnapshot();
 
-    const auto pre_fingerprint = kernel_state_credentials_fingerprint;
-    try
-    {
-        snapshot_stats = getSnapshotStatsImpl();
+        std::lock_guard lock(mutex);
+        if (snapshot_stats.has_value())
+            return snapshot_stats.value();
+
+        const auto pre_fingerprint = kernel_state_credentials_fingerprint;
+        try
+        {
+            snapshot_stats = getSnapshotStatsImpl();
+        }
+        catch (const DB::Exception & e)
+        {
+            if (attempt > 0 || !tryRefreshAfterStaleTokenError(e, pre_fingerprint, "stats scan"))
+                throw;
+            /// Fresh credentials: let the next `initOrUpdateSnapshot` rebuild the engine (still
+            /// killable, mutex released) and re-run the stats scan against it.
+            kernel_state_needs_rebuild = true;
+            continue;
+        }
+        LOG_TEST(
+            log, "Updated statistics for snapshot version {}",
+            getVersionUnlocked());
+        return snapshot_stats.value();
     }
-    catch (const DB::Exception & e)
-    {
-        if (!tryRefreshAfterStaleTokenError(e, pre_fingerprint, "stats scan"))
-            throw;
-        /// Rebuild with the freshened credentials, then re-run the stats scan against the
-        /// new engine. This rare re-auth path builds synchronously while holding the mutex;
-        /// the assignment is direct so `kernel_snapshot_state` is never left null unlocked.
-        auto load = startKernelSnapshotLoad(kernel_snapshot_state->snapshot_version);
-        kernel_snapshot_state = load->future.get();
-        kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
-        snapshot_stats = getSnapshotStatsImpl();
-    }
-    LOG_TEST(
-        log, "Updated statistics for snapshot version {}",
-        getVersionUnlocked());
-    return snapshot_stats.value();
 }
 
 TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
@@ -866,15 +871,11 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
 
 std::optional<size_t> TableSnapshot::getTotalRows() const
 {
-    initOrUpdateSnapshot();
-    std::lock_guard lock(mutex);
     return getSnapshotStats().total_rows;
 }
 
 std::optional<size_t> TableSnapshot::getTotalBytes() const
 {
-    initOrUpdateSnapshot();
-    std::lock_guard lock(mutex);
     return getSnapshotStats().total_bytes;
 }
 
@@ -913,7 +914,8 @@ void TableSnapshot::initOrUpdateSnapshot() const
 
     /// Rebuild when credentials rotate so the engine never outlives its embedded STS token.
     auto current_credentials_fingerprint = helper->getCredentialsFingerprint();
-    if (kernel_snapshot_state && current_credentials_fingerprint == kernel_state_credentials_fingerprint)
+    if (kernel_snapshot_state && !kernel_state_needs_rebuild
+        && current_credentials_fingerprint == kernel_state_credentials_fingerprint)
         return;
 
     /// Pin rebuilds to the already-resolved version so cached latest snapshots don't drift.
@@ -966,6 +968,7 @@ void TableSnapshot::initOrUpdateSnapshot() const
             continue;
         }
         kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
+        kernel_state_needs_rebuild = false;
         break;
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -21,11 +21,13 @@
 #include <Common/ThreadGroupSwitcher.h>
 #include <Common/escapeForFileName.h>
 #include <Common/setThreadName.h>
+#include <Common/Stopwatch.h>
 
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/getSchemaFromSnapshot.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/PartitionPruner.h>
@@ -34,13 +36,18 @@
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/ExpressionVisitor.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/EnginePredicate.h>
 #include <delta_kernel_ffi.hpp>
+#include <base/scope_guard.h>
 #include <fmt/ranges.h>
 #include <roaring/roaring.hh>
+
+#include <chrono>
+#include <future>
 
 namespace DB::ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int DELTA_KERNEL_ERROR;
+    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace DB::Setting
@@ -49,6 +56,7 @@ namespace DB::Setting
     extern const SettingsInt64 delta_lake_snapshot_version;
     extern const SettingsBool delta_lake_throw_on_engine_predicate_error;
     extern const SettingsBool delta_lake_enable_engine_predicate;
+    extern const SettingsMilliseconds delta_lake_snapshot_load_timeout_ms;
 }
 
 namespace ProfileEvents
@@ -61,6 +69,7 @@ namespace ProfileEvents
 namespace DB::FailPoints
 {
     extern const char delta_kernel_force_stale_token_error[];
+    extern const char delta_kernel_snapshot_load_pause[];
 }
 
 namespace DeltaLake
@@ -904,19 +913,92 @@ void TableSnapshot::initOrUpdateSnapshot() const
 
     try
     {
-        kernel_snapshot_state = std::make_shared<KernelSnapshotState>(*helper, version_to_build);
+        kernel_snapshot_state = buildKernelSnapshotState(version_to_build);
     }
     catch (const DB::Exception & e)
     {
         if (!tryRefreshAfterStaleTokenError(e, current_credentials_fingerprint, "snapshot init"))
             throw;
-        kernel_snapshot_state = std::make_shared<KernelSnapshotState>(*helper, version_to_build);
+        kernel_snapshot_state = buildKernelSnapshotState(version_to_build);
     }
     kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
 
     LOG_TRACE(
         log, "Initialized snapshot. Snapshot version: {}",
         kernel_snapshot_state->snapshot_version);
+}
+
+std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSnapshotState(std::optional<size_t> version_to_build) const
+{
+    /// The kernel FFI is synchronous and has no cancellation hook: `snapshot_builder_build` reads
+    /// `_delta_log` through the kernel's own object store client and blocks on a channel fed by
+    /// the kernel's background executor. If the object store never answers, the call never
+    /// returns; a query stuck there could not be killed, was not bounded by any timeout and, when
+    /// executed by `DDLWorker`, blocked the whole distributed DDL queue
+    /// (https://github.com/ClickHouse/ClickHouse/issues/117280).
+    /// So the kernel call runs on a separate thread and the query waits for it here, re-checking
+    /// its status on every poll: `KILL QUERY`, `max_execution_time` and
+    /// `delta_lake_snapshot_load_timeout_ms` all abort the wait. An abandoned worker does not touch
+    /// `this`; it keeps the kernel handles alive and releases them when the kernel call returns.
+    DB::QueryStatusPtr process_list_element;
+    UInt64 timeout_ms = 0;
+    auto context = DB::CurrentThread::tryGetQueryContext();
+    if (!context)
+        context = DB::Context::getGlobalContextInstance();
+    if (context)
+    {
+        process_list_element = context->getProcessListElementSafe();
+        timeout_ms = context->getSettingsRef()[DB::Setting::delta_lake_snapshot_load_timeout_ms].totalMilliseconds();
+    }
+
+    auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
+        [helper = helper, version_to_build]
+        {
+            /// Simulates a kernel call which never returns (used by tests).
+            DB::FailPointInjection::pauseFailPoint(DB::FailPoints::delta_kernel_snapshot_load_pause);
+            return std::make_shared<KernelSnapshotState>(*helper, version_to_build);
+        });
+    auto future = task->get_future();
+
+    ThreadFromGlobalPool thread(
+        [task, thread_group = DB::CurrentThread::getGroup()]
+        {
+            /// Attach to the query thread group to keep memory accounting and the query id in logs.
+            DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
+            (*task)();
+        });
+
+    Stopwatch watch;
+    /// Leave the worker running if the wait below is aborted: `ThreadFromGlobalPool` aborts the
+    /// process when it is destroyed while still joinable.
+    SCOPE_EXIT({
+        if (thread.joinable())
+        {
+            LOG_WARNING(
+                log,
+                "Abandoning the delta-kernel snapshot load of the table at {} after {} ms; "
+                "the worker thread keeps running until the kernel call returns",
+                helper->getTableLocation(), watch.elapsedMilliseconds());
+            thread.detach();
+        }
+    });
+
+    while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready)
+    {
+        /// Throws if the query was killed or `max_execution_time` is exceeded.
+        if (process_list_element)
+            process_list_element->checkTimeLimit();
+
+        if (timeout_ms && watch.elapsedMilliseconds() >= timeout_ms)
+            throw DB::Exception(
+                DB::ErrorCodes::TIMEOUT_EXCEEDED,
+                "Timeout exceeded while loading the snapshot of the Delta Lake table at {}: "
+                "waited {} ms, delta_lake_snapshot_load_timeout_ms is {} ms",
+                helper->getTableLocation(), watch.elapsedMilliseconds(), timeout_ms);
+    }
+
+    thread.join();
+    return future.get();
 }
 
 std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::getKernelSnapshotState() const

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -731,7 +731,17 @@ bool TableSnapshot::isInitialized() const
 bool TableSnapshot::canShareInflightLoad(const KernelClientOptions & client_options) const
 {
     std::lock_guard lock(mutex);
-    return !inflight_load || inflight_load->client_options == client_options;
+    if (inflight_load)
+        return inflight_load->client_options == client_options;
+    if (reserved_client_options)
+        return *reserved_client_options == client_options;
+    return true;
+}
+
+void TableSnapshot::reserveClientOptions(const KernelClientOptions & client_options)
+{
+    std::lock_guard lock(mutex);
+    reserved_client_options = client_options;
 }
 
 size_t TableSnapshot::getVersionUnlocked() const
@@ -976,7 +986,12 @@ void TableSnapshot::initOrUpdateSnapshot() const
         /// versions and rebuilds ever start a second load on the same object.
         if (!load || (version_to_build.has_value() && (given_up || other_options)))
         {
-            load = startKernelSnapshotLoad(helper, version_to_build, client_options);
+            /// The first load of an object reserved by the metadata layer runs with the reserved
+            /// options (they equal this query's: other queries were turned away by then).
+            const auto load_options = (!kernel_snapshot_state && reserved_client_options)
+                ? *reserved_client_options
+                : client_options;
+            load = startKernelSnapshotLoad(helper, version_to_build, load_options);
             inflight_load = load;
         }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -721,6 +721,12 @@ bool TableSnapshot::isAbandonedWithoutWaiters() const
         && inflight_load->waiters.load() == 0;
 }
 
+bool TableSnapshot::isInitialized() const
+{
+    std::lock_guard lock(mutex);
+    return kernel_snapshot_state != nullptr;
+}
+
 bool TableSnapshot::canShareInflightLoad(const KernelClientOptions & client_options) const
 {
     std::lock_guard lock(mutex);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -980,6 +980,12 @@ void TableSnapshot::initOrUpdateSnapshot() const
             inflight_load = load;
         }
 
+        /// Registered as a waiter while still holding the mutex, so that a query evaluating
+        /// `given_up` above cannot observe this load as waited-for by nobody during the
+        /// unlock-to-wait handoff below.
+        load->waiters.fetch_add(1, std::memory_order_relaxed);
+        SCOPE_EXIT({ load->waiters.fetch_sub(1, std::memory_order_relaxed); });
+
         /// Wait for the build OUTSIDE the mutex, so that every waiter sits in its own polling
         /// loop with its own cancellation checks. With the wait under the mutex, sibling
         /// queries slept inside a plain lock and could not be killed while a load was stuck.
@@ -1151,9 +1157,6 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKern
         process_list_element = context->getProcessListElementSafe();
         timeout_ms = context->getSettingsRef()[DB::Setting::delta_lake_snapshot_load_timeout_ms].totalMilliseconds();
     }
-
-    load.waiters.fetch_add(1, std::memory_order_relaxed);
-    SCOPE_EXIT({ load.waiters.fetch_sub(1, std::memory_order_relaxed); });
 
     Stopwatch watch;
     while (load.future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready)

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -938,7 +938,7 @@ void TableSnapshot::initOrUpdateSnapshot() const
         auto load = inflight_load;
         if (!load)
         {
-            load = startKernelSnapshotLoad(helper, version_to_build, log);
+            load = startKernelSnapshotLoad(helper, version_to_build);
             inflight_load = load;
         }
 
@@ -992,7 +992,7 @@ namespace
 }
 
 std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelSnapshotLoad(
-    KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log)
+    KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build)
 {
     /// The kernel FFI is synchronous and has no cancellation hook: `snapshot_builder_build` reads
     /// `_delta_log` through the kernel's own object store client and blocks on a channel fed by
@@ -1105,7 +1105,7 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKern
 std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::loadKernelSnapshotState(
     KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log)
 {
-    auto load = startKernelSnapshotLoad(kernel_helper, version_to_build, log);
+    auto load = startKernelSnapshotLoad(kernel_helper, version_to_build);
     waitForSnapshotLoad(*load, *kernel_helper, log);
     /// Rethrows the build error, if any.
     return load->future.get();

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -283,7 +283,7 @@ public:
         /// apply on this scan thread too) rather than blocking in the kernel synchronously.
         kernel_snapshot_state = loadKernelSnapshotState(
             helper, std::optional<size_t>(kernel_snapshot_state->snapshot_version), log);
-        captured_credentials_fingerprint = post_fingerprint;
+        captured_credentials_fingerprint = kernel_snapshot_state->credentials_fingerprint;
         scan = KernelScan();
         scan_data_iterator = KernelScanDataIterator();
         return true;
@@ -721,6 +721,12 @@ bool TableSnapshot::isAbandonedWithoutWaiters() const
         && inflight_load->waiters.load() == 0;
 }
 
+bool TableSnapshot::canShareInflightLoad(const KernelClientOptions & client_options) const
+{
+    std::lock_guard lock(mutex);
+    return !inflight_load || inflight_load->client_options == client_options;
+}
+
 size_t TableSnapshot::getVersionUnlocked() const
 {
     return getKernelSnapshotState()->snapshot_version;
@@ -939,6 +945,10 @@ void TableSnapshot::initOrUpdateSnapshot() const
         log, "{}",
         kernel_snapshot_state ? "Rebuilding kernel snapshot state (credentials rotated)" : "Initializing snapshot");
 
+    /// Captured on the query thread; also part of the decision whether an in-flight build
+    /// may be shared, since this PR forwards query-level S3 timeouts into the kernel client.
+    const auto client_options = KernelClientOptions::fromCurrentQuery();
+
     for (size_t attempt = 0;; ++attempt)
     {
         /// One in-flight build is shared by every query which needs this snapshot: the first
@@ -953,9 +963,13 @@ void TableSnapshot::initOrUpdateSnapshot() const
         auto load = inflight_load;
         const bool given_up = load && load->state.load() == InflightSnapshotLoad::State::Abandoned
             && load->waiters.load() == 0;
-        if (!load || (given_up && version_to_build.has_value()))
+        const bool other_options = load && !(load->client_options == client_options);
+        /// For a first latest-version load the metadata layer already handed out a separate
+        /// object when the options differ (see canShareInflightLoad), so here only pinned
+        /// versions and rebuilds ever start a second load on the same object.
+        if (!load || (version_to_build.has_value() && (given_up || other_options)))
         {
-            load = startKernelSnapshotLoad(helper, version_to_build);
+            load = startKernelSnapshotLoad(helper, version_to_build, client_options);
             inflight_load = load;
         }
 
@@ -995,7 +1009,9 @@ void TableSnapshot::initOrUpdateSnapshot() const
         if (!is_current_load && kernel_snapshot_state)
             break;  /// Already installed by the registered load (or a sibling waiter): keep it.
         kernel_snapshot_state = built;
-        kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
+        /// The fingerprint of the credentials inside `built`, not of the helper's current client:
+        /// the client may have rotated while the load was in flight (or given up on).
+        kernel_state_credentials_fingerprint = built->credentials_fingerprint;
         kernel_state_needs_rebuild = false;
         break;
     }
@@ -1028,7 +1044,7 @@ namespace
 }
 
 std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelSnapshotLoad(
-    KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build)
+    KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const KernelClientOptions & client_options)
 {
     /// The kernel FFI is synchronous and has no cancellation hook: `snapshot_builder_build` reads
     /// `_delta_log` through the kernel's own object store client and blocks on a channel fed by
@@ -1066,11 +1082,10 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
             snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
     });
 
-    /// Captured here, on the query thread: the worker runs under a neutral thread group and
-    /// has no query context to take settings from.
-    const auto client_options = KernelClientOptions::fromCurrentQuery();
-
+    /// `client_options` were captured by the caller on the query thread: the worker runs under
+    /// a neutral thread group and has no query context to take settings from.
     auto load = std::make_shared<InflightSnapshotLoad>();
+    load->client_options = client_options;
     auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
         [kernel_helper, version_to_build, client_options]
         {
@@ -1166,7 +1181,7 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKern
 std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::loadKernelSnapshotState(
     KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log)
 {
-    auto load = startKernelSnapshotLoad(kernel_helper, version_to_build);
+    auto load = startKernelSnapshotLoad(kernel_helper, version_to_build, KernelClientOptions::fromCurrentQuery());
     waitForSnapshotLoad(*load, *kernel_helper, log);
     /// Rethrows the build error, if any.
     return load->future.get();
@@ -1190,6 +1205,8 @@ TableSnapshot::KernelSnapshotState::KernelSnapshotState(
             "ExpiredToken: forced by delta_kernel_force_stale_token_error failpoint");
     });
 
+    /// Describes the credentials this engine is built with (the helper may rotate later).
+    credentials_fingerprint = helper_.getCredentialsFingerprint();
     auto * engine_builder = helper_.createBuilderWithOptions(client_options_);
     engine = KernelUtils::unwrapResult(ffi::builder_build(engine_builder), "builder_build");
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -51,6 +51,7 @@ namespace DB::ErrorCodes
     extern const int DELTA_KERNEL_ERROR;
     extern const int TIMEOUT_EXCEEDED;
     extern const int CANNOT_SCHEDULE_TASK;
+    extern const int LOGICAL_ERROR;
 }
 
 namespace DB::Setting
@@ -705,7 +706,8 @@ TableSnapshot::TableSnapshot(
 
 size_t TableSnapshot::getVersion() const
 {
-    std::lock_guard lock(mutex);
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
     return getVersionUnlocked();
 }
 
@@ -714,7 +716,7 @@ size_t TableSnapshot::getVersionUnlocked() const
     return getKernelSnapshotState()->snapshot_version;
 }
 
-TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStats() const
+TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStats(std::unique_lock<std::mutex> & lock) const
 {
     if (snapshot_stats.has_value())
         return snapshot_stats.value();
@@ -731,7 +733,7 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStats() const
         /// Invalidate the cached engine so `initOrUpdateSnapshot` rebuilds with the
         /// freshened credentials, then re-run the stats scan against the new engine.
         kernel_snapshot_state.reset();
-        initOrUpdateSnapshot();
+        initOrUpdateSnapshot(lock);
         snapshot_stats = getSnapshotStatsImpl();
     }
     LOG_TEST(
@@ -862,14 +864,16 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
 
 std::optional<size_t> TableSnapshot::getTotalRows() const
 {
-    std::lock_guard lock(mutex);
-    return getSnapshotStats().total_rows;
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
+    return getSnapshotStats(lock).total_rows;
 }
 
 std::optional<size_t> TableSnapshot::getTotalBytes() const
 {
-    std::lock_guard lock(mutex);
-    return getSnapshotStats().total_bytes;
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
+    return getSnapshotStats(lock).total_bytes;
 }
 
 bool TableSnapshot::tryRefreshAfterStaleTokenError(
@@ -901,10 +905,10 @@ bool TableSnapshot::tryRefreshAfterStaleTokenError(
     return true;
 }
 
-void TableSnapshot::initOrUpdateSnapshot() const
+void TableSnapshot::initOrUpdateSnapshot(std::unique_lock<std::mutex> & lock) const
 {
     /// Rebuild when credentials rotate so the engine never outlives its embedded STS token.
-    const auto current_credentials_fingerprint = helper->getCredentialsFingerprint();
+    auto current_credentials_fingerprint = helper->getCredentialsFingerprint();
     if (kernel_snapshot_state && current_credentials_fingerprint == kernel_state_credentials_fingerprint)
         return;
 
@@ -919,17 +923,54 @@ void TableSnapshot::initOrUpdateSnapshot() const
         log, "{}",
         kernel_snapshot_state ? "Rebuilding kernel snapshot state (credentials rotated)" : "Initializing snapshot");
 
-    try
+    for (size_t attempt = 0;; ++attempt)
     {
-        kernel_snapshot_state = buildKernelSnapshotState(version_to_build);
-    }
-    catch (const DB::Exception & e)
-    {
-        if (!tryRefreshAfterStaleTokenError(e, current_credentials_fingerprint, "snapshot init"))
+        /// One in-flight build is shared by every query which needs this snapshot: the first
+        /// waiter starts it, later waiters (and later queries, if every waiter gave up before
+        /// the kernel call returned) adopt it.
+        auto load = inflight_load;
+        if (!load)
+        {
+            load = startKernelSnapshotLoad(version_to_build);
+            inflight_load = load;
+        }
+
+        /// Wait for the build OUTSIDE the mutex, so that every waiter sits in its own polling
+        /// loop with its own cancellation checks. With the wait under the mutex, sibling
+        /// queries slept inside a plain lock and could not be killed while a load was stuck.
+        lock.unlock();
+        try
+        {
+            waitForSnapshotLoad(*load);
+        }
+        catch (...)
+        {
+            /// This waiter was cancelled or timed out; the build keeps running and stays
+            /// installed in `inflight_load` for the other waiters and for later queries.
+            lock.lock();
             throw;
-        kernel_snapshot_state = buildKernelSnapshotState(version_to_build);
+        }
+        lock.lock();
+
+        /// The build finished (successfully or not): it is no longer in flight.
+        if (inflight_load == load)
+            inflight_load = nullptr;
+
+        try
+        {
+            /// Rethrows the build error to every waiter if the build failed.
+            kernel_snapshot_state = load->future.get();
+        }
+        catch (const DB::Exception & e)
+        {
+            if (attempt > 0 || !tryRefreshAfterStaleTokenError(e, current_credentials_fingerprint, "snapshot init"))
+                throw;
+            current_credentials_fingerprint = helper->getCredentialsFingerprint();
+            continue;
+        }
+        kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
+        break;
     }
-    kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
 
     LOG_TRACE(
         log, "Initialized snapshot. Snapshot version: {}",
@@ -938,24 +979,18 @@ void TableSnapshot::initOrUpdateSnapshot() const
 
 namespace
 {
-    /// Who is responsible for the stuck-worker bookkeeping when a snapshot-load wait is aborted.
-    /// The waiter and the worker race for the state with `exchange`: whoever loses the race
-    /// (sees the other side's value) performs the transition's bookkeeping.
-    enum class SnapshotLoadWorkerState
-    {
-        Running,
-        Finished,   /// Set by the worker when the kernel call returned.
-        Abandoned,  /// Set by the waiter when it gave up the wait (KILL QUERY or a timeout).
-    };
-
-    /// Hard cap on abandoned snapshot-load workers that are still stuck inside the kernel call.
-    /// Each of them occupies one `GlobalThreadPool` worker until the kernel returns, so without
-    /// a cap a dead object store retried in a loop would leak pool workers without bound and
-    /// could eventually exhaust `max_thread_pool_size`. At the cap, new loads fail fast instead.
-    constexpr Int64 MAX_STUCK_SNAPSHOT_LOAD_WORKERS = 16;
+    /// Bounds the number of snapshot-load worker threads that are alive at the same time,
+    /// whether still serving waiters or already given up by them. The permit is reserved
+    /// BEFORE the worker is launched (a post-facto counter would let any number of concurrent
+    /// loads pass the check together) and released by the worker itself when the kernel call
+    /// returns, so stuck workers can never exceed this cap. The cap stays far above realistic
+    /// concurrent snapshot loads (builds are shared per table snapshot) and far below
+    /// `max_thread_pool_size` (default 10000), each stuck worker occupying one pool thread.
+    constexpr Int64 MAX_SNAPSHOT_LOAD_WORKERS = 128;
+    std::atomic<Int64> snapshot_load_worker_permits{0};
 }
 
-std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSnapshotState(std::optional<size_t> version_to_build) const
+std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelSnapshotLoad(std::optional<size_t> version_to_build) const
 {
     /// The kernel FFI is synchronous and has no cancellation hook: `snapshot_builder_build` reads
     /// `_delta_log` through the kernel's own object store client and blocks on a channel fed by
@@ -963,21 +998,59 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSn
     /// returns; a query stuck there could not be killed, was not bounded by any timeout and, when
     /// executed by `DDLWorker`, blocked the whole distributed DDL queue
     /// (https://github.com/ClickHouse/ClickHouse/issues/117280).
-    /// So the kernel call runs on a separate thread and the query waits for it here, re-checking
-    /// its status on every poll: `KILL QUERY`, `max_execution_time` and
-    /// `delta_lake_snapshot_load_timeout_ms` all abort the wait. An abandoned worker does not touch
-    /// `this`; it keeps the kernel handles alive and releases them when the kernel call returns.
-    /// Stuck workers are counted by the `DeltaLakeSnapshotLoadsStuck` metric and bounded by
-    /// `MAX_STUCK_SNAPSHOT_LOAD_WORKERS`: at the cap, new loads fail fast instead of leaking
-    /// another `GlobalThreadPool` worker.
-    if (CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck) >= MAX_STUCK_SNAPSHOT_LOAD_WORKERS)
+    /// So the kernel call runs on a worker thread which never touches `this` and outlives any
+    /// waiter; it keeps the kernel handles alive and releases them when the kernel call returns.
+
+    /// Reserve a permit before launching, so the bound holds under concurrency.
+    if (snapshot_load_worker_permits.fetch_add(1, std::memory_order_relaxed) >= MAX_SNAPSHOT_LOAD_WORKERS)
+    {
+        snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
         throw DB::Exception(
             DB::ErrorCodes::CANNOT_SCHEDULE_TASK,
-            "Refusing to load the snapshot of the Delta Lake table at {}: {} previous snapshot loads were "
-            "abandoned and are still stuck inside delta-kernel (see the DeltaLakeSnapshotLoadsStuck metric); "
-            "not starting another worker until one of them returns",
-            helper->getTableLocation(), MAX_STUCK_SNAPSHOT_LOAD_WORKERS);
+            "Refusing to load the snapshot of the Delta Lake table at {}: {} snapshot-load workers are "
+            "already running or stuck inside delta-kernel ({} of them were given up by their queries, "
+            "see the DeltaLakeSnapshotLoadsStuck metric); not starting another one until a worker returns",
+            helper->getTableLocation(), MAX_SNAPSHOT_LOAD_WORKERS,
+            CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck));
+    }
 
+    auto load = std::make_shared<InflightSnapshotLoad>();
+    auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
+        [kernel_helper = helper, version_to_build]
+        {
+            /// Simulates a kernel call which never returns (used by tests).
+            DB::FailPointInjection::pauseFailPoint(DB::FailPoints::delta_kernel_snapshot_load_pause);
+            return std::make_shared<KernelSnapshotState>(*kernel_helper, version_to_build);
+        });
+    load->future = task->get_future().share();
+
+    try
+    {
+        ThreadFromGlobalPool thread(
+            [task, load, thread_group = DB::CurrentThread::getGroup()]
+            {
+                /// Attach to the query thread group to keep memory accounting and the query id in logs.
+                DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
+                (*task)();
+                /// If every waiter already gave up, undoing the stuck-load accounting is ours to do.
+                if (load->state.exchange(InflightSnapshotLoad::State::Finished) == InflightSnapshotLoad::State::Abandoned)
+                    CurrentMetrics::sub(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
+                snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
+            });
+        /// Nobody joins the worker: waiters wait on the shared future with their own cancellation
+        /// checks, and the captured shared state keeps everything the worker needs alive.
+        thread.detach();
+    }
+    catch (...)
+    {
+        snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
+        throw;
+    }
+    return load;
+}
+
+void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load) const
+{
     DB::QueryStatusPtr process_list_element;
     UInt64 timeout_ms = 0;
     auto context = DB::CurrentThread::tryGetQueryContext();
@@ -989,76 +1062,49 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSn
         timeout_ms = context->getSettingsRef()[DB::Setting::delta_lake_snapshot_load_timeout_ms].totalMilliseconds();
     }
 
-    auto worker_state = std::make_shared<std::atomic<SnapshotLoadWorkerState>>(SnapshotLoadWorkerState::Running);
-
-    auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
-        [kernel_helper = helper, version_to_build]
-        {
-            /// Simulates a kernel call which never returns (used by tests).
-            DB::FailPointInjection::pauseFailPoint(DB::FailPoints::delta_kernel_snapshot_load_pause);
-            return std::make_shared<KernelSnapshotState>(*kernel_helper, version_to_build);
-        });
-    auto future = task->get_future();
-
-    ThreadFromGlobalPool thread(
-        [task, worker_state, thread_group = DB::CurrentThread::getGroup()]
-        {
-            /// Attach to the query thread group to keep memory accounting and the query id in logs.
-            DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
-            (*task)();
-            /// If the waiter already gave up, undoing the stuck-worker accounting is ours to do.
-            if (worker_state->exchange(SnapshotLoadWorkerState::Finished) == SnapshotLoadWorkerState::Abandoned)
-                CurrentMetrics::sub(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
-        });
-
     Stopwatch watch;
-    /// Leave the worker running if the wait below is aborted: `ThreadFromGlobalPool` aborts the
-    /// process when it is destroyed while still joinable.
-    SCOPE_EXIT({
-        if (thread.joinable())
+    while (load.future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready)
+    {
+        try
         {
-            /// The wait was aborted (`KILL QUERY` or a timeout threw). If the worker finished in
-            /// the meantime, join it: nothing leaks and nothing has to be counted.
-            if (worker_state->exchange(SnapshotLoadWorkerState::Abandoned) == SnapshotLoadWorkerState::Finished)
-            {
-                thread.join();
-            }
-            else
+            /// Throws if the query was killed or `max_execution_time` is exceeded.
+            if (process_list_element)
+                process_list_element->checkTimeLimit();
+
+            if (timeout_ms && watch.elapsedMilliseconds() >= timeout_ms)
+                throw DB::Exception(
+                    DB::ErrorCodes::TIMEOUT_EXCEEDED,
+                    "Timeout exceeded while loading the snapshot of the Delta Lake table at {}: "
+                    "waited {} ms, delta_lake_snapshot_load_timeout_ms is {} ms",
+                    helper->getTableLocation(), watch.elapsedMilliseconds(), timeout_ms);
+        }
+        catch (...)
+        {
+            /// This waiter gives up, but the build keeps running for the other waiters (and for
+            /// later queries, which adopt it through `inflight_load`). The first waiter to give
+            /// up counts the load as stuck; the worker undoes that when the kernel call returns.
+            auto expected = InflightSnapshotLoad::State::Running;
+            if (load.state.compare_exchange_strong(expected, InflightSnapshotLoad::State::Abandoned))
             {
                 CurrentMetrics::add(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
                 LOG_WARNING(
                     log,
-                    "Abandoning the delta-kernel snapshot load of the table at {} after {} ms; "
+                    "Giving up waiting for the delta-kernel snapshot load of the table at {} after {} ms; "
                     "the worker thread keeps running until the kernel call returns "
-                    "(stuck workers: {}, new snapshot loads fail fast at {})",
+                    "(stuck loads: {}, snapshot-load workers are capped at {})",
                     helper->getTableLocation(), watch.elapsedMilliseconds(),
-                    CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), MAX_STUCK_SNAPSHOT_LOAD_WORKERS);
-                thread.detach();
+                    CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), MAX_SNAPSHOT_LOAD_WORKERS);
             }
+            throw;
         }
-    });
-
-    while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready)
-    {
-        /// Throws if the query was killed or `max_execution_time` is exceeded.
-        if (process_list_element)
-            process_list_element->checkTimeLimit();
-
-        if (timeout_ms && watch.elapsedMilliseconds() >= timeout_ms)
-            throw DB::Exception(
-                DB::ErrorCodes::TIMEOUT_EXCEEDED,
-                "Timeout exceeded while loading the snapshot of the Delta Lake table at {}: "
-                "waited {} ms, delta_lake_snapshot_load_timeout_ms is {} ms",
-                helper->getTableLocation(), watch.elapsedMilliseconds(), timeout_ms);
     }
-
-    thread.join();
-    return future.get();
 }
 
 std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::getKernelSnapshotState() const
 {
-    initOrUpdateSnapshot();
+    /// Built by `initOrUpdateSnapshot` at every public entry point before reaching here.
+    if (!kernel_snapshot_state)
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Kernel snapshot state is not initialized");
     return kernel_snapshot_state;
 }
 
@@ -1104,7 +1150,8 @@ DB::ObjectIterator TableSnapshot::iterate(
     DB::ContextPtr context)
 {
     const auto & settings = context->getSettingsRef();
-    std::lock_guard lock(mutex);
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
     initOrUpdateSchemaIfChanged();
     auto state = getKernelSnapshotState();
     auto update_stats_func = [self = shared_from_this(), version = state->snapshot_version, this]
@@ -1178,28 +1225,32 @@ void TableSnapshot::initOrUpdateSchemaIfChanged() const
 
 const DB::NamesAndTypesList & TableSnapshot::getTableSchema() const
 {
-    std::lock_guard lock(mutex);
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
     initOrUpdateSchemaIfChanged();
     return schema->table_schema;
 }
 
 const DB::NamesAndTypesList & TableSnapshot::getReadSchema() const
 {
-    std::lock_guard lock(mutex);
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
     initOrUpdateSchemaIfChanged();
     return schema->read_schema;
 }
 
 const DB::Names & TableSnapshot::getPartitionColumns() const
 {
-    std::lock_guard lock(mutex);
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
     initOrUpdateSchemaIfChanged();
     return schema->partition_columns;
 }
 
 const DB::NameToNameMap & TableSnapshot::getPhysicalNamesMap() const
 {
-    std::lock_guard lock(mutex);
+    std::unique_lock lock(mutex);
+    initOrUpdateSnapshot(lock);
     initOrUpdateSchemaIfChanged();
     return schema->physical_names_map;
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -713,6 +713,14 @@ size_t TableSnapshot::getVersion() const
     return getVersionUnlocked();
 }
 
+bool TableSnapshot::isAbandonedWithoutWaiters() const
+{
+    std::lock_guard lock(mutex);
+    return !kernel_snapshot_state && inflight_load
+        && inflight_load->state.load() == InflightSnapshotLoad::State::Abandoned
+        && inflight_load->waiters.load() == 0;
+}
+
 size_t TableSnapshot::getVersionUnlocked() const
 {
     return getKernelSnapshotState()->snapshot_version;
@@ -934,12 +942,18 @@ void TableSnapshot::initOrUpdateSnapshot() const
     for (size_t attempt = 0;; ++attempt)
     {
         /// One in-flight build is shared by every query which needs this snapshot: the first
-        /// waiter starts it and later waiters adopt it. A load that some waiter already gave up
-        /// on is not adopted, though: it may be stuck for good, and adopting it would poison
-        /// this snapshot forever. A fresh (permit-bounded) load is started instead, so the
-        /// table recovers once the object store does; the stuck worker just drops its result.
+        /// waiter starts it and later waiters adopt it — also when some waiter already gave up
+        /// on it, as long as another one is still waiting (a short-timeout query must not divert
+        /// healthy work). Only a load nobody waits for any more is considered dead: it may be
+        /// stuck for good, so a fresh (permit-bounded) load is started instead and the table
+        /// recovers once the object store does. That restart is only allowed for a pinned
+        /// version (or a rebuild of the installed one), whose result is the same version. A first
+        /// latest-version load is never repeated on this object, or it could resolve two
+        /// different versions: the metadata layer starts a fresh object in that case.
         auto load = inflight_load;
-        if (!load || load->state.load() == InflightSnapshotLoad::State::Abandoned)
+        const bool given_up = load && load->state.load() == InflightSnapshotLoad::State::Abandoned
+            && load->waiters.load() == 0;
+        if (!load || (given_up && version_to_build.has_value()))
         {
             load = startKernelSnapshotLoad(helper, version_to_build);
             inflight_load = load;
@@ -955,25 +969,15 @@ void TableSnapshot::initOrUpdateSnapshot() const
         waitForSnapshotLoad(*load, *helper, log);
         lock.lock();
 
-        /// Only the load which is still registered as in flight may install its result. A load
-        /// that was given up on and superseded by a fresh one is stale whenever it completes,
-        /// before or after the fresh one: installing it could make the cached object resolve
-        /// to an older version, or flip between versions. Its waiters re-adopt the fresh load.
+        /// The registered load installs its result. A superseded load (given up on by everyone,
+        /// then replaced by a fresh one for the same pinned version) may still install it while
+        /// nothing is installed yet, so that a waiter which stayed on healthy work completes from
+        /// it. Once a state is installed only the registered load may replace it — a rebuild
+        /// after a credentials refresh, pinned to the same version — so an object never changes
+        /// its version.
         const bool is_current_load = (inflight_load == load);
         if (is_current_load)
             inflight_load = nullptr;
-
-        if (!is_current_load)
-        {
-            if (kernel_snapshot_state)
-                break;  /// Installed by the fresh load (or by a sibling waiter of this one): keep it.
-            if (inflight_load)
-            {
-                LOG_TRACE(log, "Ignoring the completion of a superseded snapshot load; waiting for the current one");
-                continue;
-            }
-            /// Nothing newer exists any more (the fresh load failed): fall through and use this result.
-        }
 
         std::shared_ptr<KernelSnapshotState> built;
         try
@@ -988,6 +992,8 @@ void TableSnapshot::initOrUpdateSnapshot() const
             current_credentials_fingerprint = helper->getCredentialsFingerprint();
             continue;
         }
+        if (!is_current_load && kernel_snapshot_state)
+            break;  /// Already installed by the registered load (or a sibling waiter): keep it.
         kernel_snapshot_state = built;
         kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
         kernel_state_needs_rebuild = false;
@@ -1060,13 +1066,17 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
             snapshot_load_worker_permits.fetch_sub(1, std::memory_order_relaxed);
     });
 
+    /// Captured here, on the query thread: the worker runs under a neutral thread group and
+    /// has no query context to take settings from.
+    const auto client_options = KernelClientOptions::fromCurrentQuery();
+
     auto load = std::make_shared<InflightSnapshotLoad>();
     auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
-        [kernel_helper, version_to_build]
+        [kernel_helper, version_to_build, client_options]
         {
             /// Simulates a kernel call which never returns (used by tests).
             DB::FailPointInjection::pauseFailPoint(DB::FailPoints::delta_kernel_snapshot_load_pause);
-            return std::make_shared<KernelSnapshotState>(*kernel_helper, version_to_build);
+            return std::make_shared<KernelSnapshotState>(*kernel_helper, version_to_build, client_options);
         });
     load->future = task->get_future().share();
 
@@ -1111,6 +1121,9 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKern
         process_list_element = context->getProcessListElementSafe();
         timeout_ms = context->getSettingsRef()[DB::Setting::delta_lake_snapshot_load_timeout_ms].totalMilliseconds();
     }
+
+    load.waiters.fetch_add(1, std::memory_order_relaxed);
+    SCOPE_EXIT({ load.waiters.fetch_sub(1, std::memory_order_relaxed); });
 
     Stopwatch watch;
     while (load.future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready)
@@ -1167,7 +1180,8 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::getKernelSnap
     return kernel_snapshot_state;
 }
 
-TableSnapshot::KernelSnapshotState::KernelSnapshotState(const IKernelHelper & helper_, std::optional<size_t> snapshot_version_)
+TableSnapshot::KernelSnapshotState::KernelSnapshotState(
+    const IKernelHelper & helper_, std::optional<size_t> snapshot_version_, const KernelClientOptions & client_options_)
 {
     fiu_do_on(DB::FailPoints::delta_kernel_force_stale_token_error,
     {
@@ -1176,7 +1190,7 @@ TableSnapshot::KernelSnapshotState::KernelSnapshotState(const IKernelHelper & he
             "ExpiredToken: forced by delta_kernel_force_stale_token_error failpoint");
     });
 
-    auto * engine_builder = helper_.createBuilder();
+    auto * engine_builder = helper_.createBuilderWithOptions(client_options_);
     engine = KernelUtils::unwrapResult(ffi::builder_build(engine_builder), "builder_build");
 
     using KernelSnapshotBuilder = KernelPointerWrapper<ffi::MutableFfiSnapshotBuilder, ffi::free_snapshot_builder>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -980,21 +980,30 @@ void TableSnapshot::initOrUpdateSnapshot() const
             inflight_load = load;
         }
 
-        /// Registered as a waiter while still holding the mutex, so that a query evaluating
-        /// `given_up` above cannot observe this load as waited-for by nobody during the
-        /// unlock-to-wait handoff below.
+        /// Registered as a waiter while still holding the mutex — and unregistered under it
+        /// again below — so that a query evaluating `given_up` above never observes a waiter
+        /// which is already gone, nor misses one which is about to poll.
         load->waiters.fetch_add(1, std::memory_order_relaxed);
-        SCOPE_EXIT({ load->waiters.fetch_sub(1, std::memory_order_relaxed); });
 
         /// Wait for the build OUTSIDE the mutex, so that every waiter sits in its own polling
         /// loop with its own cancellation checks. With the wait under the mutex, sibling
         /// queries slept inside a plain lock and could not be killed while a load was stuck.
         lock.unlock();
-        /// This waiter may be cancelled or time out; if so it throws and the build keeps
-        /// running, staying installed in `inflight_load` for the other waiters and for later
-        /// queries. `lock` does not own the mutex here, so unwinding it does not unlock twice.
-        waitForSnapshotLoad(*load, *helper, log);
+        try
+        {
+            /// This waiter may be cancelled or time out; if so it throws and the build keeps
+            /// running, staying installed in `inflight_load` for the other waiters and for
+            /// later queries.
+            waitForSnapshotLoad(*load, *helper, log);
+        }
+        catch (...)
+        {
+            lock.lock();
+            load->waiters.fetch_sub(1, std::memory_order_relaxed);
+            throw;
+        }
         lock.lock();
+        load->waiters.fetch_sub(1, std::memory_order_relaxed);
 
         /// The registered load installs its result. A superseded load (given up on by everyone,
         /// then replaced by a fresh one for the same pinned version) may still install it while

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -1009,7 +1009,7 @@ void TableSnapshot::initOrUpdateSnapshot() const
             /// This waiter may be cancelled or time out; if so it throws and the build keeps
             /// running, staying installed in `inflight_load` for the other waiters and for
             /// later queries.
-            waitForSnapshotLoad(*load, *helper, log);
+            waitForSnapshotLoad(*load, *helper);
         }
         catch (...)
         {
@@ -1176,7 +1176,7 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
     return load;
 }
 
-void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper, const LoggerPtr & log)
+void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper)
 {
     DB::QueryStatusPtr process_list_element;
     UInt64 timeout_ms = 0;
@@ -1231,7 +1231,7 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::loadKernelSna
     auto load = startKernelSnapshotLoad(kernel_helper, version_to_build, KernelClientOptions::fromCurrentQuery());
     try
     {
-        waitForSnapshotLoad(*load, *kernel_helper, log);
+        waitForSnapshotLoad(*load, *kernel_helper);
     }
     catch (...)
     {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -278,9 +278,10 @@ public:
             "scan state (refreshed via callback: {}, fingerprint drifted: {}). Original error: {}",
             refreshed_via_callback, fingerprint_drifted, msg);
 
-        kernel_snapshot_state = std::make_shared<KernelSnapshotState>(
-            *helper,
-            std::optional<size_t>(kernel_snapshot_state->snapshot_version));
+        /// Rebuild through the interruptible load (permit-bounded, `KILL QUERY` and the timeouts
+        /// apply on this scan thread too) rather than blocking in the kernel synchronously.
+        kernel_snapshot_state = loadKernelSnapshotState(
+            helper, std::optional<size_t>(kernel_snapshot_state->snapshot_version), log);
         captured_credentials_fingerprint = post_fingerprint;
         scan = KernelScan();
         scan_data_iterator = KernelScanDataIterator();
@@ -937,7 +938,7 @@ void TableSnapshot::initOrUpdateSnapshot() const
         auto load = inflight_load;
         if (!load)
         {
-            load = startKernelSnapshotLoad(version_to_build);
+            load = startKernelSnapshotLoad(helper, version_to_build, log);
             inflight_load = load;
         }
 
@@ -948,7 +949,7 @@ void TableSnapshot::initOrUpdateSnapshot() const
         /// This waiter may be cancelled or time out; if so it throws and the build keeps
         /// running, staying installed in `inflight_load` for the other waiters and for later
         /// queries. `lock` does not own the mutex here, so unwinding it does not unlock twice.
-        waitForSnapshotLoad(*load);
+        waitForSnapshotLoad(*load, *helper, log);
         lock.lock();
 
         /// The build finished (successfully or not): it is no longer in flight.
@@ -990,7 +991,8 @@ namespace
     std::atomic<Int64> snapshot_load_worker_permits{0};
 }
 
-std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelSnapshotLoad(std::optional<size_t> version_to_build) const
+std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelSnapshotLoad(
+    KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log)
 {
     /// The kernel FFI is synchronous and has no cancellation hook: `snapshot_builder_build` reads
     /// `_delta_log` through the kernel's own object store client and blocks on a channel fed by
@@ -1010,13 +1012,13 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
             "Refusing to load the snapshot of the Delta Lake table at {}: {} snapshot-load workers are "
             "already running or stuck inside delta-kernel ({} of them were given up by their queries, "
             "see the DeltaLakeSnapshotLoadsStuck metric); not starting another one until a worker returns",
-            helper->getTableLocation(), MAX_SNAPSHOT_LOAD_WORKERS,
+            kernel_helper->getTableLocation(), MAX_SNAPSHOT_LOAD_WORKERS,
             CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck));
     }
 
     auto load = std::make_shared<InflightSnapshotLoad>();
     auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
-        [kernel_helper = helper, version_to_build]
+        [kernel_helper, version_to_build]
         {
             /// Simulates a kernel call which never returns (used by tests).
             DB::FailPointInjection::pauseFailPoint(DB::FailPoints::delta_kernel_snapshot_load_pause);
@@ -1049,7 +1051,7 @@ std::shared_ptr<TableSnapshot::InflightSnapshotLoad> TableSnapshot::startKernelS
     return load;
 }
 
-void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load) const
+void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper, const LoggerPtr & log)
 {
     DB::QueryStatusPtr process_list_element;
     UInt64 timeout_ms = 0;
@@ -1076,7 +1078,7 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load) const
                     DB::ErrorCodes::TIMEOUT_EXCEEDED,
                     "Timeout exceeded while loading the snapshot of the Delta Lake table at {}: "
                     "waited {} ms, delta_lake_snapshot_load_timeout_ms is {} ms",
-                    helper->getTableLocation(), watch.elapsedMilliseconds(), timeout_ms);
+                    kernel_helper.getTableLocation(), watch.elapsedMilliseconds(), timeout_ms);
         }
         catch (...)
         {
@@ -1092,12 +1094,21 @@ void TableSnapshot::waitForSnapshotLoad(InflightSnapshotLoad & load) const
                     "Giving up waiting for the delta-kernel snapshot load of the table at {} after {} ms; "
                     "the worker thread keeps running until the kernel call returns "
                     "(stuck loads: {}, snapshot-load workers are capped at {})",
-                    helper->getTableLocation(), watch.elapsedMilliseconds(),
+                    kernel_helper.getTableLocation(), watch.elapsedMilliseconds(),
                     CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), MAX_SNAPSHOT_LOAD_WORKERS);
             }
             throw;
         }
     }
+}
+
+std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::loadKernelSnapshotState(
+    KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log)
+{
+    auto load = startKernelSnapshotLoad(kernel_helper, version_to_build, log);
+    waitForSnapshotLoad(*load, *kernel_helper, log);
+    /// Rethrows the build error, if any.
+    return load->future.get();
 }
 
 std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::getKernelSnapshotState() const

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -706,8 +706,8 @@ TableSnapshot::TableSnapshot(
 
 size_t TableSnapshot::getVersion() const
 {
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
     return getVersionUnlocked();
 }
 
@@ -716,7 +716,7 @@ size_t TableSnapshot::getVersionUnlocked() const
     return getKernelSnapshotState()->snapshot_version;
 }
 
-TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStats(std::unique_lock<std::mutex> & lock) const
+TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStats() const
 {
     if (snapshot_stats.has_value())
         return snapshot_stats.value();
@@ -730,10 +730,12 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStats(std::unique_lock<st
     {
         if (!tryRefreshAfterStaleTokenError(e, pre_fingerprint, "stats scan"))
             throw;
-        /// Invalidate the cached engine so `initOrUpdateSnapshot` rebuilds with the
-        /// freshened credentials, then re-run the stats scan against the new engine.
-        kernel_snapshot_state.reset();
-        initOrUpdateSnapshot(lock);
+        /// Rebuild with the freshened credentials, then re-run the stats scan against the
+        /// new engine. This rare re-auth path builds synchronously while holding the mutex;
+        /// the assignment is direct so `kernel_snapshot_state` is never left null unlocked.
+        auto load = startKernelSnapshotLoad(kernel_snapshot_state->snapshot_version);
+        kernel_snapshot_state = load->future.get();
+        kernel_state_credentials_fingerprint = helper->getCredentialsFingerprint();
         snapshot_stats = getSnapshotStatsImpl();
     }
     LOG_TEST(
@@ -864,16 +866,16 @@ TableSnapshot::SnapshotStats TableSnapshot::getSnapshotStatsImpl() const
 
 std::optional<size_t> TableSnapshot::getTotalRows() const
 {
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
-    return getSnapshotStats(lock).total_rows;
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
+    return getSnapshotStats().total_rows;
 }
 
 std::optional<size_t> TableSnapshot::getTotalBytes() const
 {
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
-    return getSnapshotStats(lock).total_bytes;
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
+    return getSnapshotStats().total_bytes;
 }
 
 bool TableSnapshot::tryRefreshAfterStaleTokenError(
@@ -905,8 +907,10 @@ bool TableSnapshot::tryRefreshAfterStaleTokenError(
     return true;
 }
 
-void TableSnapshot::initOrUpdateSnapshot(std::unique_lock<std::mutex> & lock) const
+void TableSnapshot::initOrUpdateSnapshot() const
 {
+    std::unique_lock lock(mutex);
+
     /// Rebuild when credentials rotate so the engine never outlives its embedded STS token.
     auto current_credentials_fingerprint = helper->getCredentialsFingerprint();
     if (kernel_snapshot_state && current_credentials_fingerprint == kernel_state_credentials_fingerprint)
@@ -939,17 +943,10 @@ void TableSnapshot::initOrUpdateSnapshot(std::unique_lock<std::mutex> & lock) co
         /// loop with its own cancellation checks. With the wait under the mutex, sibling
         /// queries slept inside a plain lock and could not be killed while a load was stuck.
         lock.unlock();
-        try
-        {
-            waitForSnapshotLoad(*load);
-        }
-        catch (...)
-        {
-            /// This waiter was cancelled or timed out; the build keeps running and stays
-            /// installed in `inflight_load` for the other waiters and for later queries.
-            lock.lock();
-            throw;
-        }
+        /// This waiter may be cancelled or time out; if so it throws and the build keeps
+        /// running, staying installed in `inflight_load` for the other waiters and for later
+        /// queries. `lock` does not own the mutex here, so unwinding it does not unlock twice.
+        waitForSnapshotLoad(*load);
         lock.lock();
 
         /// The build finished (successfully or not): it is no longer in flight.
@@ -1150,8 +1147,8 @@ DB::ObjectIterator TableSnapshot::iterate(
     DB::ContextPtr context)
 {
     const auto & settings = context->getSettingsRef();
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
     initOrUpdateSchemaIfChanged();
     auto state = getKernelSnapshotState();
     auto update_stats_func = [self = shared_from_this(), version = state->snapshot_version, this]
@@ -1225,32 +1222,32 @@ void TableSnapshot::initOrUpdateSchemaIfChanged() const
 
 const DB::NamesAndTypesList & TableSnapshot::getTableSchema() const
 {
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
     initOrUpdateSchemaIfChanged();
     return schema->table_schema;
 }
 
 const DB::NamesAndTypesList & TableSnapshot::getReadSchema() const
 {
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
     initOrUpdateSchemaIfChanged();
     return schema->read_schema;
 }
 
 const DB::Names & TableSnapshot::getPartitionColumns() const
 {
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
     initOrUpdateSchemaIfChanged();
     return schema->partition_columns;
 }
 
 const DB::NameToNameMap & TableSnapshot::getPhysicalNamesMap() const
 {
-    std::unique_lock lock(mutex);
-    initOrUpdateSnapshot(lock);
+    initOrUpdateSnapshot();
+    std::lock_guard lock(mutex);
     initOrUpdateSchemaIfChanged();
     return schema->physical_names_map;
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -126,7 +126,7 @@ public:
         UpdateStatsFunc update_stats_func_,
         LoggerPtr log_)
         : kernel_snapshot_state(kernel_snapshot_state_)
-        , captured_credentials_fingerprint(helper_->getCredentialsFingerprint())
+        , captured_credentials_fingerprint(kernel_snapshot_state_->credentials_fingerprint)
         , helper(helper_)
         , read_schema(read_schema_)
         , expression_schema(table_schema_)

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -22,6 +22,7 @@
 #include <Common/escapeForFileName.h>
 #include <Common/setThreadName.h>
 #include <Common/Stopwatch.h>
+#include <Common/CurrentMetrics.h>
 
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteBufferFromString.h>
@@ -40,6 +41,7 @@
 #include <fmt/ranges.h>
 #include <roaring/roaring.hh>
 
+#include <atomic>
 #include <chrono>
 #include <future>
 
@@ -48,6 +50,7 @@ namespace DB::ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int DELTA_KERNEL_ERROR;
     extern const int TIMEOUT_EXCEEDED;
+    extern const int CANNOT_SCHEDULE_TASK;
 }
 
 namespace DB::Setting
@@ -70,6 +73,11 @@ namespace DB::FailPoints
 {
     extern const char delta_kernel_force_stale_token_error[];
     extern const char delta_kernel_snapshot_load_pause[];
+}
+
+namespace CurrentMetrics
+{
+    extern const Metric DeltaLakeSnapshotLoadsStuck;
 }
 
 namespace DeltaLake
@@ -928,6 +936,25 @@ void TableSnapshot::initOrUpdateSnapshot() const
         kernel_snapshot_state->snapshot_version);
 }
 
+namespace
+{
+    /// Who is responsible for the stuck-worker bookkeeping when a snapshot-load wait is aborted.
+    /// The waiter and the worker race for the state with `exchange`: whoever loses the race
+    /// (sees the other side's value) performs the transition's bookkeeping.
+    enum class SnapshotLoadWorkerState
+    {
+        Running,
+        Finished,   /// Set by the worker when the kernel call returned.
+        Abandoned,  /// Set by the waiter when it gave up the wait (KILL QUERY or a timeout).
+    };
+
+    /// Hard cap on abandoned snapshot-load workers that are still stuck inside the kernel call.
+    /// Each of them occupies one `GlobalThreadPool` worker until the kernel returns, so without
+    /// a cap a dead object store retried in a loop would leak pool workers without bound and
+    /// could eventually exhaust `max_thread_pool_size`. At the cap, new loads fail fast instead.
+    constexpr Int64 MAX_STUCK_SNAPSHOT_LOAD_WORKERS = 16;
+}
+
 std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSnapshotState(std::optional<size_t> version_to_build) const
 {
     /// The kernel FFI is synchronous and has no cancellation hook: `snapshot_builder_build` reads
@@ -940,6 +967,17 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSn
     /// its status on every poll: `KILL QUERY`, `max_execution_time` and
     /// `delta_lake_snapshot_load_timeout_ms` all abort the wait. An abandoned worker does not touch
     /// `this`; it keeps the kernel handles alive and releases them when the kernel call returns.
+    /// Stuck workers are counted by the `DeltaLakeSnapshotLoadsStuck` metric and bounded by
+    /// `MAX_STUCK_SNAPSHOT_LOAD_WORKERS`: at the cap, new loads fail fast instead of leaking
+    /// another `GlobalThreadPool` worker.
+    if (CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck) >= MAX_STUCK_SNAPSHOT_LOAD_WORKERS)
+        throw DB::Exception(
+            DB::ErrorCodes::CANNOT_SCHEDULE_TASK,
+            "Refusing to load the snapshot of the Delta Lake table at {}: {} previous snapshot loads were "
+            "abandoned and are still stuck inside delta-kernel (see the DeltaLakeSnapshotLoadsStuck metric); "
+            "not starting another worker until one of them returns",
+            helper->getTableLocation(), MAX_STUCK_SNAPSHOT_LOAD_WORKERS);
+
     DB::QueryStatusPtr process_list_element;
     UInt64 timeout_ms = 0;
     auto context = DB::CurrentThread::tryGetQueryContext();
@@ -951,6 +989,8 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSn
         timeout_ms = context->getSettingsRef()[DB::Setting::delta_lake_snapshot_load_timeout_ms].totalMilliseconds();
     }
 
+    auto worker_state = std::make_shared<std::atomic<SnapshotLoadWorkerState>>(SnapshotLoadWorkerState::Running);
+
     auto task = std::make_shared<std::packaged_task<std::shared_ptr<KernelSnapshotState>()>>(
         [kernel_helper = helper, version_to_build]
         {
@@ -961,11 +1001,14 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSn
     auto future = task->get_future();
 
     ThreadFromGlobalPool thread(
-        [task, thread_group = DB::CurrentThread::getGroup()]
+        [task, worker_state, thread_group = DB::CurrentThread::getGroup()]
         {
             /// Attach to the query thread group to keep memory accounting and the query id in logs.
             DB::ThreadGroupSwitcher switcher(thread_group, DB::ThreadName::DATALAKE_TABLE_SNAPSHOT);
             (*task)();
+            /// If the waiter already gave up, undoing the stuck-worker accounting is ours to do.
+            if (worker_state->exchange(SnapshotLoadWorkerState::Finished) == SnapshotLoadWorkerState::Abandoned)
+                CurrentMetrics::sub(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
         });
 
     Stopwatch watch;
@@ -974,12 +1017,24 @@ std::shared_ptr<TableSnapshot::KernelSnapshotState> TableSnapshot::buildKernelSn
     SCOPE_EXIT({
         if (thread.joinable())
         {
-            LOG_WARNING(
-                log,
-                "Abandoning the delta-kernel snapshot load of the table at {} after {} ms; "
-                "the worker thread keeps running until the kernel call returns",
-                helper->getTableLocation(), watch.elapsedMilliseconds());
-            thread.detach();
+            /// The wait was aborted (`KILL QUERY` or a timeout threw). If the worker finished in
+            /// the meantime, join it: nothing leaks and nothing has to be counted.
+            if (worker_state->exchange(SnapshotLoadWorkerState::Abandoned) == SnapshotLoadWorkerState::Finished)
+            {
+                thread.join();
+            }
+            else
+            {
+                CurrentMetrics::add(CurrentMetrics::DeltaLakeSnapshotLoadsStuck);
+                LOG_WARNING(
+                    log,
+                    "Abandoning the delta-kernel snapshot load of the table at {} after {} ms; "
+                    "the worker thread keeps running until the kernel call returns "
+                    "(stuck workers: {}, new snapshot loads fail fast at {})",
+                    helper->getTableLocation(), watch.elapsedMilliseconds(),
+                    CurrentMetrics::get(CurrentMetrics::DeltaLakeSnapshotLoadsStuck), MAX_STUCK_SNAPSHOT_LOAD_WORKERS);
+                thread.detach();
+            }
         }
     });
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -15,6 +15,10 @@
 #include <boost/noncopyable.hpp>
 #include "delta_kernel_ffi.hpp"
 
+#include <atomic>
+#include <future>
+#include <mutex>
+
 namespace DeltaLake
 {
 
@@ -90,6 +94,23 @@ private:
     mutable std::shared_ptr<KernelSnapshotState> kernel_snapshot_state;
     mutable DB::UInt128 kernel_state_credentials_fingerprint{};
 
+    /// One in-flight kernel snapshot build, shared between the worker thread that runs the
+    /// kernel call and every query waiting for its result. Waiters poll the future outside
+    /// `mutex`, each with its own cancellation checks.
+    struct InflightSnapshotLoad : private boost::noncopyable
+    {
+        enum class State
+        {
+            Running,
+            Finished,   /// Set by the worker when the kernel call returned.
+            Abandoned,  /// Set by the first waiter that gave up (KILL QUERY or a timeout).
+        };
+
+        std::shared_future<std::shared_ptr<KernelSnapshotState>> future;
+        std::atomic<State> state{State::Running};
+    };
+    mutable std::shared_ptr<InflightSnapshotLoad> inflight_load TSA_GUARDED_BY(mutex);
+
     struct SchemaInfo
     {
         /// Table logical schema
@@ -119,10 +140,13 @@ private:
 
     size_t getVersionUnlocked() const TSA_REQUIRES(mutex);
 
-    void initOrUpdateSnapshot() const TSA_REQUIRES(mutex);
+    /// Ensures `kernel_snapshot_state` is built and current. Temporarily releases `lock` while
+    /// waiting for an in-flight build, so every public entry point calls it first, before
+    /// anything guarded by `mutex` is read.
+    void initOrUpdateSnapshot(std::unique_lock<std::mutex> & lock) const TSA_NO_THREAD_SAFETY_ANALYSIS;
     void initOrUpdateSchemaIfChanged() const TSA_REQUIRES(mutex);
 
-    SnapshotStats getSnapshotStats() const TSA_REQUIRES(mutex);
+    SnapshotStats getSnapshotStats(std::unique_lock<std::mutex> & lock) const TSA_NO_THREAD_SAFETY_ANALYSIS;
     SnapshotStats getSnapshotStatsImpl() const TSA_REQUIRES(mutex);
 
     /// One-shot recovery from `DELTA_KERNEL_ERROR` with `ExpiredToken`/`InvalidToken`:
@@ -137,12 +161,17 @@ private:
 
     std::shared_ptr<KernelSnapshotState> getKernelSnapshotState() const TSA_REQUIRES(mutex);
 
-    /// Builds `KernelSnapshotState` on a separate thread and waits for it, re-checking the query
-    /// status while waiting. The kernel FFI is synchronous and has no cancellation hook, so this
-    /// is the only place where `KILL QUERY`, `max_execution_time` and
-    /// `delta_lake_snapshot_load_timeout_ms` can interrupt a snapshot load that is stuck inside
-    /// the kernel (for example, waiting for an object store which never answers).
-    std::shared_ptr<KernelSnapshotState> buildKernelSnapshotState(std::optional<size_t> version_to_build) const;
+    /// Starts a snapshot build on a worker thread, reserving one of the bounded worker permits
+    /// before the launch, and returns the shared in-flight state for waiters. Never blocks on
+    /// the kernel.
+    std::shared_ptr<InflightSnapshotLoad> startKernelSnapshotLoad(std::optional<size_t> version_to_build) const;
+
+    /// Waits for an in-flight build, re-checking the query status on every poll: `KILL QUERY`,
+    /// `max_execution_time` and `delta_lake_snapshot_load_timeout_ms` abort the wait for this
+    /// waiter only, while the build keeps running for the others. The kernel FFI is synchronous
+    /// and has no cancellation hook, so this polling wait is the only cancellation point of a
+    /// snapshot load (for example, one stuck on an object store which never answers).
+    void waitForSnapshotLoad(InflightSnapshotLoad & load) const;
 };
 
 using TableSnapshotPtr = std::shared_ptr<TableSnapshot>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -136,6 +136,13 @@ private:
         const char * context_for_log) const TSA_REQUIRES(mutex);
 
     std::shared_ptr<KernelSnapshotState> getKernelSnapshotState() const TSA_REQUIRES(mutex);
+
+    /// Builds `KernelSnapshotState` on a separate thread and waits for it, re-checking the query
+    /// status while waiting. The kernel FFI is synchronous and has no cancellation hook, so this
+    /// is the only place where `KILL QUERY`, `max_execution_time` and
+    /// `delta_lake_snapshot_load_timeout_ms` can interrupt a snapshot load that is stuck inside
+    /// the kernel (for example, waiting for an object store which never answers).
+    std::shared_ptr<KernelSnapshotState> buildKernelSnapshotState(std::optional<size_t> version_to_build) const;
 };
 
 using TableSnapshotPtr = std::shared_ptr<TableSnapshot>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -45,6 +45,9 @@ public:
     /// rather than reusing this one, so that one object never resolves two different versions.
     bool isAbandonedWithoutWaiters() const;
 
+    /// True once a kernel snapshot state is installed (the object is usable as a cache entry).
+    bool isInitialized() const;
+
     /// False when a build is in flight with client options different from `client_options`:
     /// this PR forwards query-level S3 timeouts, so such a query must not adopt that build.
     bool canShareInflightLoad(const KernelClientOptions & client_options) const;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -93,6 +93,9 @@ private:
     };
     mutable std::shared_ptr<KernelSnapshotState> kernel_snapshot_state;
     mutable DB::UInt128 kernel_state_credentials_fingerprint{};
+    /// Set after a credentials refresh whose fingerprint may not have changed, so that the next
+    /// `initOrUpdateSnapshot` rebuilds the engine anyway (without ever leaving the state null).
+    mutable bool kernel_state_needs_rebuild = false;
 
     /// One in-flight kernel snapshot build, shared between the worker thread that runs the
     /// kernel call and every query waiting for its result. Waiters poll the future outside
@@ -146,7 +149,9 @@ private:
     void initOrUpdateSnapshot() const TSA_NO_THREAD_SAFETY_ANALYSIS;
     void initOrUpdateSchemaIfChanged() const TSA_REQUIRES(mutex);
 
-    SnapshotStats getSnapshotStats() const TSA_REQUIRES(mutex);
+    /// Acquires `mutex` itself: a stale-credentials retry rebuilds the engine through
+    /// `initOrUpdateSnapshot` (killable, mutex released) instead of blocking under the lock.
+    SnapshotStats getSnapshotStats() const;
     SnapshotStats getSnapshotStatsImpl() const TSA_REQUIRES(mutex);
 
     /// One-shot recovery from `DELTA_KERNEL_ERROR` with `ExpiredToken`/`InvalidToken`:

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -40,6 +40,11 @@ public:
     /// Get snapshot version.
     size_t getVersion() const;
 
+    /// True when nothing is installed yet and the only load on this snapshot was given up on by
+    /// every waiter. The metadata layer then resolves the latest version through a fresh object
+    /// rather than reusing this one, so that one object never resolves two different versions.
+    bool isAbandonedWithoutWaiters() const;
+
     std::optional<size_t> getTotalRows() const;
     std::optional<size_t> getTotalBytes() const;
 
@@ -84,7 +89,8 @@ private:
 
     struct KernelSnapshotState : private boost::noncopyable
     {
-        KernelSnapshotState(const IKernelHelper & helper_, std::optional<size_t> snapshot_version_);
+        KernelSnapshotState(
+            const IKernelHelper & helper_, std::optional<size_t> snapshot_version_, const KernelClientOptions & client_options_);
 
         KernelExternEngine engine;
         KernelSnapshot snapshot;
@@ -111,6 +117,9 @@ private:
 
         std::shared_future<std::shared_ptr<KernelSnapshotState>> future;
         std::atomic<State> state{State::Running};
+        /// Queries currently waiting for this load. A load some waiter gave up on is still
+        /// healthy work for the others; only a load nobody waits for is considered dead.
+        std::atomic<Int64> waiters{0};
     };
     mutable std::shared_ptr<InflightSnapshotLoad> inflight_load TSA_GUARDED_BY(mutex);
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -45,6 +45,10 @@ public:
     /// rather than reusing this one, so that one object never resolves two different versions.
     bool isAbandonedWithoutWaiters() const;
 
+    /// False when a build is in flight with client options different from `client_options`:
+    /// this PR forwards query-level S3 timeouts, so such a query must not adopt that build.
+    bool canShareInflightLoad(const KernelClientOptions & client_options) const;
+
     std::optional<size_t> getTotalRows() const;
     std::optional<size_t> getTotalBytes() const;
 
@@ -96,6 +100,8 @@ private:
         KernelSnapshot snapshot;
         KernelScan scan;
         size_t snapshot_version;
+        /// Fingerprint of the credentials embedded into `engine`, taken when it was built.
+        DB::UInt128 credentials_fingerprint{};
     };
     mutable std::shared_ptr<KernelSnapshotState> kernel_snapshot_state;
     mutable DB::UInt128 kernel_state_credentials_fingerprint{};
@@ -120,6 +126,8 @@ private:
         /// Queries currently waiting for this load. A load some waiter gave up on is still
         /// healthy work for the others; only a load nobody waits for is considered dead.
         std::atomic<Int64> waiters{0};
+        /// Client options the build runs with; a query with different options does not share it.
+        KernelClientOptions client_options;
     };
     mutable std::shared_ptr<InflightSnapshotLoad> inflight_load TSA_GUARDED_BY(mutex);
 
@@ -179,7 +187,7 @@ private:
     /// before the launch, and returns the shared in-flight state for waiters. Never blocks on
     /// the kernel. Static, so that the scan iterator can rebuild through the same path.
     static std::shared_ptr<InflightSnapshotLoad> startKernelSnapshotLoad(
-        KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build);
+        KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const KernelClientOptions & client_options);
 
     /// Waits for an in-flight build, re-checking the query status on every poll: `KILL QUERY`,
     /// `max_execution_time` and `delta_lake_snapshot_load_timeout_ms` abort the wait for this

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -217,7 +217,7 @@ private:
     /// waiter only, while the build keeps running for the others. The kernel FFI is synchronous
     /// and has no cancellation hook, so this polling wait is the only cancellation point of a
     /// snapshot load (for example, one stuck on an object store which never answers).
-    static void waitForSnapshotLoad(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper, const LoggerPtr & log);
+    static void waitForSnapshotLoad(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper);
 
     /// Marks a load as given up by every waiter (counted in DeltaLakeSnapshotLoadsStuck until
     /// the worker returns). For a shared load this is called under `mutex`, together with the

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -100,8 +100,14 @@ private:
 
     struct KernelSnapshotState : private boost::noncopyable
     {
+        /// `used_credentials_fingerprint` receives the fingerprint of the credentials the engine
+        /// is built with as soon as they are known — before the kernel calls which may throw —
+        /// so that a failed build can still be judged against the credentials it actually used.
         KernelSnapshotState(
-            const IKernelHelper & helper_, std::optional<size_t> snapshot_version_, const KernelClientOptions & client_options_);
+            const IKernelHelper & helper_,
+            std::optional<size_t> snapshot_version_,
+            const KernelClientOptions & client_options_,
+            DB::UInt128 & used_credentials_fingerprint);
 
         KernelExternEngine engine;
         KernelSnapshot snapshot;
@@ -136,6 +142,11 @@ private:
         std::atomic<Int64> waiters{0};
         /// Client options the build runs with; a query with different options does not share it.
         KernelClientOptions client_options;
+        /// Fingerprint of the credentials the worker built (or tried to build) the engine with.
+        /// Written by the worker before the future becomes ready, so readers which observed the
+        /// ready future see it; the stale-token retry compares against it, not against whatever
+        /// the helper's client is by the time some waiter handles the failure.
+        DB::UInt128 credentials_fingerprint{};
     };
     mutable std::shared_ptr<InflightSnapshotLoad> inflight_load TSA_GUARDED_BY(mutex);
     /// Client options this object is meant to load with, recorded by the metadata layer before

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -168,15 +168,22 @@ private:
 
     /// Starts a snapshot build on a worker thread, reserving one of the bounded worker permits
     /// before the launch, and returns the shared in-flight state for waiters. Never blocks on
-    /// the kernel.
-    std::shared_ptr<InflightSnapshotLoad> startKernelSnapshotLoad(std::optional<size_t> version_to_build) const;
+    /// the kernel. Static, so that the scan iterator can rebuild through the same path.
+    static std::shared_ptr<InflightSnapshotLoad> startKernelSnapshotLoad(
+        KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log);
 
     /// Waits for an in-flight build, re-checking the query status on every poll: `KILL QUERY`,
     /// `max_execution_time` and `delta_lake_snapshot_load_timeout_ms` abort the wait for this
     /// waiter only, while the build keeps running for the others. The kernel FFI is synchronous
     /// and has no cancellation hook, so this polling wait is the only cancellation point of a
     /// snapshot load (for example, one stuck on an object store which never answers).
-    void waitForSnapshotLoad(InflightSnapshotLoad & load) const;
+    static void waitForSnapshotLoad(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper, const LoggerPtr & log);
+
+    /// Convenience for a single waiter: start, wait (interruptibly) and take the result.
+    /// Every `KernelSnapshotState` construction must go through this or the two helpers
+    /// above, so that no code path blocks in the kernel without a cancellation point.
+    static std::shared_ptr<KernelSnapshotState> loadKernelSnapshotState(
+        KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log);
 };
 
 using TableSnapshotPtr = std::shared_ptr<TableSnapshot>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -170,7 +170,7 @@ private:
     /// before the launch, and returns the shared in-flight state for waiters. Never blocks on
     /// the kernel. Static, so that the scan iterator can rebuild through the same path.
     static std::shared_ptr<InflightSnapshotLoad> startKernelSnapshotLoad(
-        KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build, const LoggerPtr & log);
+        KernelHelperPtr kernel_helper, std::optional<size_t> version_to_build);
 
     /// Waits for an in-flight build, re-checking the query status on every poll: `KILL QUERY`,
     /// `max_execution_time` and `delta_lake_snapshot_load_timeout_ms` abort the wait for this

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -48,9 +48,13 @@ public:
     /// True once a kernel snapshot state is installed (the object is usable as a cache entry).
     bool isInitialized() const;
 
-    /// False when a build is in flight with client options different from `client_options`:
-    /// this PR forwards query-level S3 timeouts, so such a query must not adopt that build.
+    /// False when a build is in flight — or reserved, before the first load started — with
+    /// client options different from `client_options`: query-level S3 timeouts are forwarded
+    /// into the build, so such a query must not adopt it.
     bool canShareInflightLoad(const KernelClientOptions & client_options) const;
+
+    /// Records the options the first load of this object must use (see canShareInflightLoad).
+    void reserveClientOptions(const KernelClientOptions & client_options);
 
     std::optional<size_t> getTotalRows() const;
     std::optional<size_t> getTotalBytes() const;
@@ -134,6 +138,10 @@ private:
         KernelClientOptions client_options;
     };
     mutable std::shared_ptr<InflightSnapshotLoad> inflight_load TSA_GUARDED_BY(mutex);
+    /// Client options this object is meant to load with, recorded by the metadata layer before
+    /// the object is published, so that a query with other options is turned away even before
+    /// the first load has started (see canShareInflightLoad).
+    mutable std::optional<KernelClientOptions> reserved_client_options TSA_GUARDED_BY(mutex);
 
     struct SchemaInfo
     {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -140,13 +140,13 @@ private:
 
     size_t getVersionUnlocked() const TSA_REQUIRES(mutex);
 
-    /// Ensures `kernel_snapshot_state` is built and current. Temporarily releases `lock` while
-    /// waiting for an in-flight build, so every public entry point calls it first, before
-    /// anything guarded by `mutex` is read.
-    void initOrUpdateSnapshot(std::unique_lock<std::mutex> & lock) const TSA_NO_THREAD_SAFETY_ANALYSIS;
+    /// Ensures `kernel_snapshot_state` is built and current. Acquires `mutex` itself and
+    /// releases it while waiting for the in-flight build, so it must be called WITHOUT the
+    /// lock held: every public entry point calls it first, then re-locks for its guarded reads.
+    void initOrUpdateSnapshot() const TSA_NO_THREAD_SAFETY_ANALYSIS;
     void initOrUpdateSchemaIfChanged() const TSA_REQUIRES(mutex);
 
-    SnapshotStats getSnapshotStats(std::unique_lock<std::mutex> & lock) const TSA_NO_THREAD_SAFETY_ANALYSIS;
+    SnapshotStats getSnapshotStats() const TSA_REQUIRES(mutex);
     SnapshotStats getSnapshotStatsImpl() const TSA_REQUIRES(mutex);
 
     /// One-shot recovery from `DELTA_KERNEL_ERROR` with `ExpiredToken`/`InvalidToken`:

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -208,6 +208,11 @@ private:
     /// snapshot load (for example, one stuck on an object store which never answers).
     static void waitForSnapshotLoad(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper, const LoggerPtr & log);
 
+    /// Marks a load as given up by every waiter (counted in DeltaLakeSnapshotLoadsStuck until
+    /// the worker returns). For a shared load this is called under `mutex`, together with the
+    /// waiter unregistration, so that `given_up` in initOrUpdateSnapshot never sees a half state.
+    static void markAbandoned(InflightSnapshotLoad & load, const IKernelHelper & kernel_helper, const LoggerPtr & log);
+
     /// Convenience for a single waiter: start, wait (interruptibly) and take the result.
     /// Every `KernelSnapshotState` construction must go through this or the two helpers
     /// above, so that no code path blocks in the kernel without a cancellation point.

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.h
@@ -126,8 +126,9 @@ private:
 
         std::shared_future<std::shared_ptr<KernelSnapshotState>> future;
         std::atomic<State> state{State::Running};
-        /// Queries currently waiting for this load. A load some waiter gave up on is still
-        /// healthy work for the others; only a load nobody waits for is considered dead.
+        /// Queries currently waiting for this load, registered under `TableSnapshot::mutex` at
+        /// adoption time. A load some waiter gave up on is still healthy work for the others;
+        /// only a load nobody waits for is considered dead.
         std::atomic<Int64> waiters{0};
         /// Client options the build runs with; a query with different options does not share it.
         KernelClientOptions client_options;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -157,7 +157,7 @@ getSnapshotVersion(const Settings & settings)
 DeltaLakeMetadataDeltaKernel::LatestSnapshot DeltaLakeMetadataDeltaKernel::resolveLatestSnapshot() const
 {
     DeltaLake::TableSnapshotPtr snapshot;
-    const auto client_options = DeltaLake::KernelClientOptions::fromCurrentQuery();
+    const auto client_options = kernel_helper->resolveClientOptions();
     {
         std::lock_guard lock(snapshots_mutex);
         /// Concurrent callers share one TableSnapshot, and with it one in-flight kernel build,

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -193,10 +193,18 @@ DeltaLakeMetadataDeltaKernel::LatestSnapshot DeltaLakeMetadataDeltaKernel::resol
     if (!latest_snapshot_version.has_value() || version >= latest_snapshot_version.value())
         latest_snapshot_version = version;
 
-    /// Replace rather than prefer an existing entry: a cached object for this version may be
-    /// poisoned by a still-stuck in-flight load, while this one has just loaded successfully.
-    snapshots.set(version, snapshot);
-    return LatestSnapshot{.snapshot = snapshot, .version = version, .created = true};
+    /// Keep an existing, initialized entry for this version (it carries cached schema and
+    /// statistics, and its credentials-rotation check must keep running against the state it
+    /// installed). Only an entry which never got a state — e.g. poisoned by a still-stuck
+    /// in-flight load — is replaced by this freshly loaded snapshot.
+    auto [cached, created] = snapshots.getOrSet(version, [&]() { return snapshot; });
+    if (!created && cached != snapshot && !cached->isInitialized())
+    {
+        snapshots.set(version, snapshot);
+        cached = snapshot;
+        created = true;
+    }
+    return LatestSnapshot{.snapshot = cached, .version = version, .created = created};
 }
 
 DeltaLake::TableSnapshotPtr

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -154,43 +154,52 @@ getSnapshotVersion(const Settings & settings)
 DeltaLake::TableSnapshotPtr
 DeltaLakeMetadataDeltaKernel::getTableSnapshot(std::optional<SnapshotVersion> version) const
 {
-    std::lock_guard lock(snapshots_mutex);
-
-    /// Fallback to latest_snapshot_version.
-    /// In case we needed a newer version - update() must
-    /// have been called to reload latest_snapshot_version.
-    std::optional<SnapshotVersion> result_snapshot_version = version.has_value()
-        ? version
-        : latest_snapshot_version;
-
-    auto snapshot_creator = [&]()
-    {
-        /// Constructor itself is lightweight.
-        return std::make_shared<DeltaLake::TableSnapshot>(
-            result_snapshot_version,
-            kernel_helper,
-            object_storage,
-            log);
-    };
-
     DeltaLake::TableSnapshotPtr snapshot;
     bool created = true;
-    if (result_snapshot_version.has_value())
+    std::optional<SnapshotVersion> result_snapshot_version;
     {
-        std::tie(snapshot, created) = snapshots.getOrSet(
-            result_snapshot_version.value(), std::move(snapshot_creator));
-    }
-    else
-    {
-        snapshot = snapshot_creator();
-        latest_snapshot_version = snapshot->getVersion();
-        snapshots.set(latest_snapshot_version.value(), snapshot);
+        std::lock_guard lock(snapshots_mutex);
+
+        /// Fallback to latest_snapshot_version.
+        /// In case we needed a newer version - update() must
+        /// have been called to reload latest_snapshot_version.
+        result_snapshot_version = version.has_value() ? version : latest_snapshot_version;
+
+        auto snapshot_creator = [&]()
+        {
+            /// Constructor itself is lightweight.
+            return std::make_shared<DeltaLake::TableSnapshot>(
+                result_snapshot_version,
+                kernel_helper,
+                object_storage,
+                log);
+        };
+
+        if (result_snapshot_version.has_value())
+            std::tie(snapshot, created) = snapshots.getOrSet(
+                result_snapshot_version.value(), std::move(snapshot_creator));
+        else
+            snapshot = snapshot_creator();
     }
 
-    LOG_TEST(
-        log, "Using snapshot version: {}, latest loaded snapshot version: {}, reused cached snapshot: {}",
-        result_snapshot_version.has_value() ? result_snapshot_version.value() : snapshot->getVersion(),
-        latestSnapshotVersionToStr(), !created);
+    if (!result_snapshot_version.has_value())
+    {
+        /// Resolving the latest version builds the kernel snapshot, which may block on object
+        /// storage. Never do that under `snapshots_mutex`: every other query on this table
+        /// would sleep inside the mutex, unreachable by `KILL QUERY` (#117431).
+        result_snapshot_version = snapshot->getVersion();
+
+        std::lock_guard lock(snapshots_mutex);
+        latest_snapshot_version = result_snapshot_version;
+        snapshots.set(result_snapshot_version.value(), snapshot);
+    }
+
+    {
+        std::lock_guard lock(snapshots_mutex);
+        LOG_TEST(
+            log, "Using snapshot version: {}, latest loaded snapshot version: {}, reused cached snapshot: {}",
+            result_snapshot_version.value(), latestSnapshotVersionToStr(), !created);
+    }
 
     return snapshot;
 }
@@ -252,14 +261,17 @@ void DeltaLakeMetadataDeltaKernel::update(const ContextPtr & context)
     const auto snapshot_version = getSnapshotVersion(context->getSettingsRef());
     if (!snapshot_version.has_value())
     {
-        std::lock_guard lock(snapshots_mutex);
         auto latest_snapshot = std::make_shared<DeltaLake::TableSnapshot>(
                 /* version */std::nullopt,
                 kernel_helper,
                 object_storage,
                 log);
 
+        /// Resolving the latest version builds the kernel snapshot, which may block on object
+        /// storage; keep it outside `snapshots_mutex` (see getTableSnapshot).
         size_t version = latest_snapshot->getVersion();
+
+        std::lock_guard lock(snapshots_mutex);
         snapshots.getOrSet(version, [&]() { return latest_snapshot; });
 
         LOG_TEST(

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -151,6 +151,43 @@ getSnapshotVersion(const Settings & settings)
         value);
 }
 
+DeltaLakeMetadataDeltaKernel::LatestSnapshot DeltaLakeMetadataDeltaKernel::resolveLatestSnapshot() const
+{
+    DeltaLake::TableSnapshotPtr snapshot;
+    {
+        std::lock_guard lock(snapshots_mutex);
+        /// Concurrent callers share one TableSnapshot, and with it one in-flight kernel build,
+        /// instead of each starting their own `snapshot_builder_build` for the same table.
+        if (!latest_snapshot_in_flight)
+        {
+            /// Constructor itself is lightweight.
+            latest_snapshot_in_flight = std::make_shared<DeltaLake::TableSnapshot>(
+                /* version */std::nullopt,
+                kernel_helper,
+                object_storage,
+                log);
+        }
+        snapshot = latest_snapshot_in_flight;
+    }
+
+    /// Resolving the version builds the kernel snapshot, which may block on object storage.
+    /// Never do that under `snapshots_mutex`: every other query on this table would sleep
+    /// inside the mutex, unreachable by `KILL QUERY`. On failure the shared object stays
+    /// in flight, so the next caller retries through it rather than starting a duplicate.
+    const SnapshotVersion version = snapshot->getVersion();
+
+    std::lock_guard lock(snapshots_mutex);
+    if (latest_snapshot_in_flight == snapshot)
+        latest_snapshot_in_flight = nullptr;
+
+    /// A slower resolution must not move "latest" backwards.
+    if (!latest_snapshot_version.has_value() || version >= latest_snapshot_version.value())
+        latest_snapshot_version = version;
+
+    auto [cached, created] = snapshots.getOrSet(version, [&]() { return snapshot; });
+    return LatestSnapshot{.snapshot = cached, .version = version, .created = created};
+}
+
 DeltaLake::TableSnapshotPtr
 DeltaLakeMetadataDeltaKernel::getTableSnapshot(std::optional<SnapshotVersion> version) const
 {
@@ -165,33 +202,28 @@ DeltaLakeMetadataDeltaKernel::getTableSnapshot(std::optional<SnapshotVersion> ve
         /// have been called to reload latest_snapshot_version.
         result_snapshot_version = version.has_value() ? version : latest_snapshot_version;
 
-        auto snapshot_creator = [&]()
-        {
-            /// Constructor itself is lightweight.
-            return std::make_shared<DeltaLake::TableSnapshot>(
-                result_snapshot_version,
-                kernel_helper,
-                object_storage,
-                log);
-        };
-
         if (result_snapshot_version.has_value())
+        {
             std::tie(snapshot, created) = snapshots.getOrSet(
-                result_snapshot_version.value(), std::move(snapshot_creator));
-        else
-            snapshot = snapshot_creator();
+                result_snapshot_version.value(),
+                [&]()
+                {
+                    /// Constructor itself is lightweight.
+                    return std::make_shared<DeltaLake::TableSnapshot>(
+                        result_snapshot_version,
+                        kernel_helper,
+                        object_storage,
+                        log);
+                });
+        }
     }
 
     if (!result_snapshot_version.has_value())
     {
-        /// Resolving the latest version builds the kernel snapshot, which may block on object
-        /// storage. Never do that under `snapshots_mutex`: every other query on this table
-        /// would sleep inside the mutex, unreachable by `KILL QUERY` (#117431).
-        result_snapshot_version = snapshot->getVersion();
-
-        std::lock_guard lock(snapshots_mutex);
-        latest_snapshot_version = result_snapshot_version;
-        snapshots.set(result_snapshot_version.value(), snapshot);
+        auto latest = resolveLatestSnapshot();
+        snapshot = latest.snapshot;
+        result_snapshot_version = latest.version;
+        created = latest.created;
     }
 
     {
@@ -261,24 +293,12 @@ void DeltaLakeMetadataDeltaKernel::update(const ContextPtr & context)
     const auto snapshot_version = getSnapshotVersion(context->getSettingsRef());
     if (!snapshot_version.has_value())
     {
-        auto latest_snapshot = std::make_shared<DeltaLake::TableSnapshot>(
-                /* version */std::nullopt,
-                kernel_helper,
-                object_storage,
-                log);
-
-        /// Resolving the latest version builds the kernel snapshot, which may block on object
-        /// storage; keep it outside `snapshots_mutex` (see getTableSnapshot).
-        size_t version = latest_snapshot->getVersion();
+        const auto latest = resolveLatestSnapshot();
 
         std::lock_guard lock(snapshots_mutex);
-        snapshots.getOrSet(version, [&]() { return latest_snapshot; });
-
         LOG_TEST(
-            log, "Updating latest snapshot version from {} to {}",
-            latestSnapshotVersionToStr(), version);
-
-        latest_snapshot_version = version;
+            log, "Updated latest snapshot version: resolved {}, published {}",
+            latest.version, latestSnapshotVersionToStr());
     }
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -157,13 +157,17 @@ getSnapshotVersion(const Settings & settings)
 DeltaLakeMetadataDeltaKernel::LatestSnapshot DeltaLakeMetadataDeltaKernel::resolveLatestSnapshot() const
 {
     DeltaLake::TableSnapshotPtr snapshot;
+    const auto client_options = DeltaLake::KernelClientOptions::fromCurrentQuery();
     {
         std::lock_guard lock(snapshots_mutex);
         /// Concurrent callers share one TableSnapshot, and with it one in-flight kernel build,
         /// instead of each starting their own `snapshot_builder_build` for the same table.
         /// A latest-version load is never repeated on one object (it could resolve a different
-        /// version), so once every waiter gave up on the shared one, a fresh object takes over.
-        if (!latest_snapshot_in_flight || latest_snapshot_in_flight->isAbandonedWithoutWaiters())
+        /// version), so once every waiter gave up on the shared one — or when this query's
+        /// client options differ from the ones the shared build runs with — a fresh object
+        /// takes over.
+        if (!latest_snapshot_in_flight || latest_snapshot_in_flight->isAbandonedWithoutWaiters()
+            || !latest_snapshot_in_flight->canShareInflightLoad(client_options))
         {
             /// Constructor itself is lightweight.
             latest_snapshot_in_flight = std::make_shared<DeltaLake::TableSnapshot>(

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -175,6 +175,9 @@ DeltaLakeMetadataDeltaKernel::LatestSnapshot DeltaLakeMetadataDeltaKernel::resol
                 kernel_helper,
                 object_storage,
                 log);
+            /// Reserved before publishing, so that a concurrent caller with other options does
+            /// not grab this object in the window before its first load has started.
+            latest_snapshot_in_flight->reserveClientOptions(client_options);
         }
         snapshot = latest_snapshot_in_flight;
     }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -38,6 +38,9 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
+    extern const int TIMEOUT_EXCEEDED;
+    extern const int QUERY_WAS_CANCELLED;
+    extern const int CANNOT_SCHEDULE_TASK;
 }
 
 namespace FailPoints
@@ -259,6 +262,18 @@ std::optional<size_t> DeltaLakeMetadataDeltaKernel::totalRows(ContextPtr context
     {
         return getTableSnapshot(snapshot_version)->getTotalRows();
     }
+    catch (const Exception & e)
+    {
+        /// Cancellation, the snapshot-load timeout and the worker cap are control flow, not
+        /// "statistics unavailable": swallowing them would make the query fall back to the read
+        /// path and wait through a second full snapshot load (#117431).
+        if (e.code() == ErrorCodes::TIMEOUT_EXCEEDED || e.code() == ErrorCodes::QUERY_WAS_CANCELLED
+            || e.code() == ErrorCodes::CANNOT_SCHEDULE_TASK)
+            throw;
+        DB::tryLogCurrentException(
+            log, "Failed to get total rows for Delta Lake table at location " + kernel_helper->getTableLocation());
+        return std::nullopt;
+    }
     catch (...)
     {
         DB::tryLogCurrentException(
@@ -281,6 +296,18 @@ std::optional<size_t> DeltaLakeMetadataDeltaKernel::totalBytes(ContextPtr contex
     try
     {
         return getTableSnapshot(snapshot_version)->getTotalBytes();
+    }
+    catch (const Exception & e)
+    {
+        /// Cancellation, the snapshot-load timeout and the worker cap are control flow, not
+        /// "statistics unavailable": swallowing them would make the query fall back to the read
+        /// path and wait through a second full snapshot load (#117431).
+        if (e.code() == ErrorCodes::TIMEOUT_EXCEEDED || e.code() == ErrorCodes::QUERY_WAS_CANCELLED
+            || e.code() == ErrorCodes::CANNOT_SCHEDULE_TASK)
+            throw;
+        DB::tryLogCurrentException(
+            log, "Failed to get total bytes for Delta Lake table at location " + kernel_helper->getTableLocation());
+        return std::nullopt;
     }
     catch (...)
     {

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -184,8 +184,10 @@ DeltaLakeMetadataDeltaKernel::LatestSnapshot DeltaLakeMetadataDeltaKernel::resol
     if (!latest_snapshot_version.has_value() || version >= latest_snapshot_version.value())
         latest_snapshot_version = version;
 
-    auto [cached, created] = snapshots.getOrSet(version, [&]() { return snapshot; });
-    return LatestSnapshot{.snapshot = cached, .version = version, .created = created};
+    /// Replace rather than prefer an existing entry: a cached object for this version may be
+    /// poisoned by a still-stuck in-flight load, while this one has just loaded successfully.
+    snapshots.set(version, snapshot);
+    return LatestSnapshot{.snapshot = snapshot, .version = version, .created = true};
 }
 
 DeltaLake::TableSnapshotPtr

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -161,7 +161,9 @@ DeltaLakeMetadataDeltaKernel::LatestSnapshot DeltaLakeMetadataDeltaKernel::resol
         std::lock_guard lock(snapshots_mutex);
         /// Concurrent callers share one TableSnapshot, and with it one in-flight kernel build,
         /// instead of each starting their own `snapshot_builder_build` for the same table.
-        if (!latest_snapshot_in_flight)
+        /// A latest-version load is never repeated on one object (it could resolve a different
+        /// version), so once every waiter gave up on the shared one, a fresh object takes over.
+        if (!latest_snapshot_in_flight || latest_snapshot_in_flight->isAbandonedWithoutWaiters())
         {
             /// Constructor itself is lightweight.
             latest_snapshot_in_flight = std::make_shared<DeltaLake::TableSnapshot>(

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.h
@@ -109,6 +109,9 @@ private:
     mutable TableSnapshotCache snapshots TSA_GUARDED_BY(snapshots_mutex);
     mutable std::mutex snapshots_mutex;
     mutable std::optional<SnapshotVersion> latest_snapshot_version;
+    /// Single-flight for "latest" resolution: concurrent callers share this one TableSnapshot
+    /// (and therefore its in-flight kernel build) until its version is published.
+    mutable DeltaLake::TableSnapshotPtr latest_snapshot_in_flight TSA_GUARDED_BY(snapshots_mutex);
 
     void logMetadataFiles(ContextPtr context) const;
 
@@ -117,6 +120,17 @@ private:
         std::optional<SnapshotVersion> version = std::nullopt) const;
 
     std::string latestSnapshotVersionToStr() const TSA_REQUIRES(snapshots_mutex);
+
+    struct LatestSnapshot
+    {
+        DeltaLake::TableSnapshotPtr snapshot;
+        SnapshotVersion version;
+        bool created;
+    };
+    /// Resolves the latest snapshot outside `snapshots_mutex` (the kernel build may block on
+    /// object storage and must stay killable), shared between concurrent callers, and
+    /// publishes `latest_snapshot_version` monotonically.
+    LatestSnapshot resolveLatestSnapshot() const;
 };
 
 }

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -6138,3 +6138,99 @@ def test_delta_kernel_retry_on_stale_token_via_catalog_callback(started_cluster)
         f"Expected the catalog-callback retry log line to fire for query {retry_query_id}, "
         f"found {retry_hits} hits — the stale-token retry path was not exercised."
     )
+
+
+SNAPSHOT_LOAD_PAUSE_FAILPOINT = "delta_kernel_snapshot_load_pause"
+
+
+def prepare_paused_snapshot_load(started_cluster, table_name):
+    """Writes a small Delta table to S3 and arms the failpoint that keeps the thread running the
+    delta-kernel snapshot load paused, simulating a kernel call which never returns.
+    Returns the engine arguments of the table."""
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    delta_path = f"/{table_name}"
+    write_delta_from_df(spark, spark.range(10).selectExpr("id as a"), delta_path)
+    default_upload_directory(started_cluster, "s3", delta_path, "")
+    instance.query(f"SYSTEM ENABLE FAILPOINT {SNAPSHOT_LOAD_PAUSE_FAILPOINT}")
+    return f"s3, filename = '{table_name}/', url = 'http://minio1:9001/{started_cluster.minio_bucket}/'"
+
+
+def release_paused_snapshot_load(instance):
+    # Wake up the paused worker thread, so it finishes the kernel call and frees its handles.
+    instance.query(f"SYSTEM NOTIFY FAILPOINT {SNAPSHOT_LOAD_PAUSE_FAILPOINT}")
+    instance.query(f"SYSTEM DISABLE FAILPOINT {SNAPSHOT_LOAD_PAUSE_FAILPOINT}")
+
+
+def test_kill_query_during_snapshot_load(started_cluster):
+    """A snapshot load stuck inside delta-kernel must not make the query unkillable:
+    KILL QUERY has to abort the waiting query although the kernel call has not returned yet."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    instance = started_cluster.instances["node1"]
+    TABLE_NAME = randomize_table_name("test_kill_query_during_snapshot_load")
+    engine_args = prepare_paused_snapshot_load(started_cluster, TABLE_NAME)
+    query_id = f"{TABLE_NAME}_kill"
+    executor = ThreadPoolExecutor(max_workers=2)
+    try:
+        wait_future = executor.submit(
+            lambda: instance.query(
+                f"SYSTEM WAIT FAILPOINT {SNAPSHOT_LOAD_PAUSE_FAILPOINT} PAUSE",
+                timeout=60,
+            )
+        )
+        query_future = executor.submit(
+            lambda: instance.query_and_get_error(
+                f"CREATE TABLE {TABLE_NAME} ENGINE = DeltaLake({engine_args})",
+                query_id=query_id,
+                timeout=120,
+            )
+        )
+        # The worker thread is paused inside the snapshot load and the query waits for it.
+        wait_future.result(timeout=60)
+        assert (
+            instance.query(
+                f"SELECT count() FROM system.processes WHERE query_id = '{query_id}'"
+            ).strip()
+            == "1"
+        )
+
+        instance.query(f"KILL QUERY WHERE query_id = '{query_id}' ASYNC")
+        error = query_future.result(timeout=60)
+        assert "QUERY_WAS_CANCELLED" in error, error
+    finally:
+        release_paused_snapshot_load(instance)
+        executor.shutdown(wait=False)
+
+    # The cancelled CREATE left nothing behind and the table is readable once the kernel answers.
+    assert instance.query(f"EXISTS TABLE {TABLE_NAME}").strip() == "0"
+    assert int(instance.query(f"SELECT count() FROM deltaLake({engine_args})")) == 10
+
+
+@pytest.mark.parametrize(
+    "settings, expected_error",
+    [
+        (
+            {"delta_lake_snapshot_load_timeout_ms": 1000},
+            "delta_lake_snapshot_load_timeout_ms",
+        ),
+        ({"max_execution_time": 1}, "TIMEOUT_EXCEEDED"),
+    ],
+)
+def test_snapshot_load_timeout(started_cluster, settings, expected_error):
+    """A snapshot load stuck inside delta-kernel is bounded by delta_lake_snapshot_load_timeout_ms
+    and by max_execution_time instead of blocking the query forever."""
+    instance = started_cluster.instances["node1"]
+    TABLE_NAME = randomize_table_name("test_snapshot_load_timeout")
+    engine_args = prepare_paused_snapshot_load(started_cluster, TABLE_NAME)
+    try:
+        error = instance.query_and_get_error(
+            f"SELECT count() FROM deltaLake({engine_args})",
+            settings=settings,
+            timeout=120,
+        )
+        assert "TIMEOUT_EXCEEDED" in error and expected_error in error, error
+    finally:
+        release_paused_snapshot_load(instance)
+
+    assert int(instance.query(f"SELECT count() FROM deltaLake({engine_args})")) == 10

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -6162,6 +6162,14 @@ def release_paused_snapshot_load(instance):
     instance.query(f"SYSTEM DISABLE FAILPOINT {SNAPSHOT_LOAD_PAUSE_FAILPOINT}")
 
 
+def get_stuck_snapshot_loads(instance):
+    return int(
+        instance.query(
+            "SELECT value FROM system.metrics WHERE metric = 'DeltaLakeSnapshotLoadsStuck'"
+        )
+    )
+
+
 def test_kill_query_during_snapshot_load(started_cluster):
     """A snapshot load stuck inside delta-kernel must not make the query unkillable:
     KILL QUERY has to abort the waiting query although the kernel call has not returned yet."""
@@ -6198,9 +6206,18 @@ def test_kill_query_during_snapshot_load(started_cluster):
         instance.query(f"KILL QUERY WHERE query_id = '{query_id}' ASYNC")
         error = query_future.result(timeout=60)
         assert "QUERY_WAS_CANCELLED" in error, error
+        # The abandoned worker is visible in system.metrics until the kernel call returns.
+        assert get_stuck_snapshot_loads(instance) == 1
     finally:
         release_paused_snapshot_load(instance)
         executor.shutdown(wait=False)
+
+    # Once the kernel call returns, the abandoned worker unregisters itself.
+    for _ in range(300):
+        if get_stuck_snapshot_loads(instance) == 0:
+            break
+        time.sleep(0.1)
+    assert get_stuck_snapshot_loads(instance) == 0
 
     # The cancelled CREATE left nothing behind and the table is readable once the kernel answers.
     assert instance.query(f"EXISTS TABLE {TABLE_NAME}").strip() == "0"

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -6086,6 +6086,57 @@ def test_delta_kernel_rebuild_on_credentials_rotation(started_cluster):
     )
 
 
+def test_delta_kernel_rebuild_on_credentials_rotation_read_path(started_cluster):
+    """Same rotation as above, but through the read path (`TableSnapshot::iterate()`) instead
+    of the trivial-count statistics path: the rebuild must happen before the scan iterator is
+    built, the iterator must scan with the rebuilt engine, and the rows must still come back.
+    """
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    minio_client = started_cluster.minio_client
+    bucket = started_cluster.minio_bucket
+    TABLE_NAME = randomize_table_name("test_delta_kernel_rebuild_on_rotation_read")
+
+    write_delta_from_df(
+        spark, generate_data(spark, 0, 100), f"/{TABLE_NAME}", mode="overwrite"
+    )
+    upload_directory(minio_client, bucket, f"/{TABLE_NAME}", "")
+    create_delta_table(instance, "s3", TABLE_NAME, started_cluster)
+
+    # `sum(a)` cannot be answered from statistics, so it goes through the scan iterator.
+    read_query = f"SELECT sum(a) FROM {TABLE_NAME}"
+    expected_sum = sum(range(100))
+
+    baseline_query_id = f"{TABLE_NAME}_baseline"
+    assert int(instance.query(read_query, query_id=baseline_query_id)) == expected_sum
+
+    instance.query("SYSTEM FLUSH LOGS")
+    rebuild_hits_pre = int(instance.query(
+        "SELECT count() FROM system.text_log "
+        f"WHERE query_id = '{baseline_query_id}' "
+        "  AND message ILIKE '%Rebuilding kernel snapshot state%'"
+    ).strip())
+    assert rebuild_hits_pre == 0, "First read should NOT trigger the credentials-rotation rebuild"
+
+    rotated_query_id = f"{TABLE_NAME}_rotated"
+    instance.query("SYSTEM ENABLE FAILPOINT delta_kernel_force_credentials_fingerprint_drift")
+    try:
+        assert int(instance.query(read_query, query_id=rotated_query_id)) == expected_sum
+    finally:
+        instance.query("SYSTEM DISABLE FAILPOINT delta_kernel_force_credentials_fingerprint_drift")
+
+    instance.query("SYSTEM FLUSH LOGS")
+    rebuild_hits = int(instance.query(
+        "SELECT count() FROM system.text_log "
+        f"WHERE query_id = '{rotated_query_id}' "
+        "  AND message ILIKE '%Rebuilding kernel snapshot state (credentials rotated)%'"
+    ).strip())
+    assert rebuild_hits >= 1, (
+        f"Expected the credentials-rotation rebuild to fire on the read path for query {rotated_query_id}, "
+        f"found {rebuild_hits} hits"
+    )
+
+
 def test_delta_kernel_retry_on_stale_token_via_catalog_callback(started_cluster):
     """Simulate delta-kernel reporting an `ExpiredToken` during snapshot init. The
     `delta_kernel_force_stale_token_error` failpoint throws the kernel error exactly

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -6251,3 +6251,74 @@ def test_snapshot_load_timeout(started_cluster, settings, expected_error):
         release_paused_snapshot_load(instance)
 
     assert int(instance.query(f"SELECT count() FROM deltaLake({engine_args})")) == 10
+
+
+def test_kill_waiter_on_shared_snapshot_load(started_cluster):
+    """Queries waiting for the SAME in-flight snapshot load must be independently killable:
+    killing one waiter leaves the build running, and the other waiter succeeds once the
+    kernel call returns."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    TABLE_NAME = randomize_table_name("test_kill_waiter_on_shared_snapshot_load")
+    delta_path = f"/{TABLE_NAME}"
+
+    write_delta_from_df(spark, spark.range(10).selectExpr("id as a"), delta_path)
+    default_upload_directory(started_cluster, "s3", delta_path, "")
+    engine_args = f"s3, filename = '{TABLE_NAME}/', url = 'http://minio1:9001/{started_cluster.minio_bucket}/'"
+    instance.query(f"CREATE TABLE {TABLE_NAME} ENGINE = DeltaLake({engine_args})")
+
+    # Advance the table to version 1, then pause every following snapshot load.
+    write_delta_from_df(
+        spark, spark.range(10, 30).selectExpr("id as a"), delta_path, mode="append"
+    )
+    default_upload_directory(started_cluster, "s3", delta_path, "")
+    instance.query(f"SYSTEM ENABLE FAILPOINT {SNAPSHOT_LOAD_PAUSE_FAILPOINT}")
+
+    # Both queries need the version-1 snapshot, which is loaded once and shared.
+    select = f"SELECT count() FROM {TABLE_NAME} SETTINGS delta_lake_snapshot_version = 1"
+    surviving_id = f"{TABLE_NAME}_surviving"
+    killed_id = f"{TABLE_NAME}_killed"
+    executor = ThreadPoolExecutor(max_workers=3)
+    try:
+        wait_future = executor.submit(
+            lambda: instance.query(
+                f"SYSTEM WAIT FAILPOINT {SNAPSHOT_LOAD_PAUSE_FAILPOINT} PAUSE", timeout=60
+            )
+        )
+        surviving_future = executor.submit(
+            lambda: instance.query(select, query_id=surviving_id, timeout=120)
+        )
+        wait_future.result(timeout=60)
+        killed_future = executor.submit(
+            lambda: instance.query_and_get_error(select, query_id=killed_id, timeout=120)
+        )
+        for _ in range(300):
+            if (
+                instance.query(
+                    f"SELECT count() FROM system.processes WHERE query_id IN ('{surviving_id}', '{killed_id}')"
+                ).strip()
+                == "2"
+            ):
+                break
+            time.sleep(0.1)
+
+        # The killed query is a plain waiter (the load was started by the first query);
+        # it must be cancellable although the kernel call has not returned yet.
+        instance.query(f"KILL QUERY WHERE query_id = '{killed_id}' ASYNC")
+        error = killed_future.result(timeout=60)
+        assert "QUERY_WAS_CANCELLED" in error, error
+        # The build keeps running and the first waiter is still waiting for it.
+        assert (
+            instance.query(
+                f"SELECT count() FROM system.processes WHERE query_id = '{surviving_id}'"
+            ).strip()
+            == "1"
+        )
+    finally:
+        release_paused_snapshot_load(instance)
+        executor.shutdown(wait=False)
+
+    assert surviving_future.result(timeout=60).strip() == "30"
+    instance.query(f"DROP TABLE {TABLE_NAME}")


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117280
Related: https://github.com/ClickHouse/ClickHouse/issues/47272
Related: https://github.com/ClickHouse/ClickHouse/issues/58479
Related: https://github.com/ClickHouse/ClickHouse/issues/117434
Related: https://github.com/ClickHouse/ClickHouse/issues/117435

`CREATE TABLE ... ENGINE = DeltaLake(...)`, and any other query that loads a Delta Lake snapshot, can block forever inside delta-kernel. The FFI is synchronous and has no cancellation hook: `snapshot_builder_build` reads `_delta_log` through the kernel's own object store client and blocks in `read_files` on a channel fed by the kernel's background executor, so if the object store never answers, the call never returns. In the reported case the statement was still running after 4,718 s, `KILL QUERY` had no cancellation point to hit, none of the `s3_*` timeouts applied because the kernel uses its own object store client, and since the statement was executed by `DDLWorker` with `distributed_ddl.pool_size = 1`, every subsequent `ON CLUSTER` DDL timed out behind it.

The kernel call itself cannot be cancelled, so the wait for it is made interruptible instead:

- `TableSnapshot` runs the kernel snapshot build on a worker thread and waits for it with its mutex released. Every query which needs the snapshot waits on one shared in-flight load (`InflightSnapshotLoad`) and polls with its own cancellation checks, so `KILL QUERY`, `max_execution_time` and the new setting `delta_lake_snapshot_load_timeout_ms` (default 10 minutes, `0` disables it) abort the wait for that query only, with `TIMEOUT_EXCEEDED` for the timeouts. A load is considered dead only once every waiter has given up on it (waiters are counted under the mutex); then a fresh, permit-bounded load is started for a pinned version, or a fresh object takes over for the latest version. `DeltaLakeMetadataDeltaKernel` resolves "latest" single-flight, outside `snapshots_mutex`, and publishes it monotonically; an installed snapshot state never changes its version.
- Workers are bounded by an atomic permit reserved before launch and derived from the global thread pool (`clamp(min(max(pool / 8, 1), pool - 2), 0, 128)`; a pool too small to keep two workers free refuses with `CANNOT_SCHEDULE_TASK`). They run under a thread group of their own, built from the starting query's context so the kernel's log lines keep the query id, but without that query's memory limits. `DeltaLakeSnapshotLoadsStuck` counts loads every waiter gave up on. `totalRows` / `totalBytes` propagate cancellation, the load timeout and the permit refusal instead of falling back to a second load.
- The S3 kernel helper builds the engine from the effective client options resolved on the query thread (`IKernelHelper::resolveClientOptions`: the object storage's live `s3_connect_timeout_ms` / `s3_request_timeout_ms`, read through a virtual accessor so cache wrappers are covered, overridden by the settings the query changed); those options are also the key under which an in-flight build may be shared. The credentials fingerprint stored with a state is that of the very client snapshot the builder was filled with, so credentials-rotation recovery judges the right engine.

The failpoint `delta_kernel_snapshot_load_pause` keeps the worker thread paused to simulate a kernel call which never returns. The new integration tests check that `KILL QUERY` cancels a `CREATE TABLE` stuck in the snapshot load, that `delta_lake_snapshot_load_timeout_ms` and `max_execution_time` fail the query with `TIMEOUT_EXCEEDED`, and that the table is readable again once the worker is released.

**Scope.** This PR deliberately covers only the snapshot load (`snapshot_builder_build` and every path that rebuilds `KernelSnapshotState`). The remaining un-cancellable kernel waits are tracked in #117434: the data-file scan on the iterator thread, the snapshot statistics scan (`getSnapshotStatsImpl`, still performed under `TableSnapshot::mutex`), CDF reads and writes. The Azure timeout forwarding is #117435. Keying the snapshot cache (and its engine) by per-query client options is deliberately not part of this fix either: a cached engine is shared as cached, and only the build a query starts uses that query's options.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `CREATE TABLE ... ENGINE = DeltaLake` and other Delta Lake snapshot loads hanging forever when the delta-kernel object store client never answers. The snapshot load can now be interrupted by `KILL QUERY` and `max_execution_time`, is bounded by the new setting `delta_lake_snapshot_load_timeout_ms` (default 10 minutes), and the kernel's S3 client honours non-zero `s3_connect_timeout_ms` / `s3_request_timeout_ms` when a snapshot engine is built (`0`, which object_store cannot express as "no timeout", keeps its built-in defaults and logs a warning). A query's own overrides apply to the build it starts; an engine already cached for a snapshot keeps the options it was built with. Abandoned snapshot loads are bounded and observable via the new `DeltaLakeSnapshotLoadsStuck` metric.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117431&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117431](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117431+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->





