### PR TITLE
Fix the master-build lookup in bugfix validation after the S3 prefix change

### DIFF
--- a/ci/jobs/scripts/bugfix_validation.py
+++ b/ci/jobs/scripts/bugfix_validation.py
@@ -1,3 +1,4 @@
+from ci.praktika._environment import _Environment
 from ci.praktika.info import Info
 from ci.praktika.utils import Shell
 
@@ -31,8 +32,13 @@ def find_master_builds(build_types=None):
     build_types = build_types if build_types is not None else BUGFIX_BUILD_TYPES
     commits = Info().get_kv_data("master_commits") or []
     for sha in commits:
+        # The prefix has to come from the same function the artifact uploader
+        # uses, so that a reader and a writer cannot disagree about the layout.
+        prefix = _Environment.get_s3_prefix_static(
+            pr_number=0, branch="master", sha=sha, workflow_name="MasterCI"
+        )
         urls = {
-            bt: f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/build_{bt}/clickhouse"
+            bt: f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/{prefix}/build_{bt}/clickhouse"
             for bt in build_types
         }
         if all(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110081
Related: https://github.com/ClickHouse/ClickHouse/pull/117287
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Bugfix validation` failing to locate the reference master binaries in S3 after the artifact prefix gained a workflow-name segment.


### Description

`_Environment.get_s3_prefix_static` gained a trailing `/<normalized workflow name>` segment
in #110081, so a master build artifact now lives at
`REFs/master/<sha>/masterci/build_<type>/clickhouse`. `find_master_builds` still
hand-spelled the old `REFs/master/<sha>/build_<type>/clickhouse`, so every `curl -sfI` probe
404s and the function returns `None` for the x86 and the ARM build-type set alike. Both
callers then abort on `assert build_urls, "Could not find master builds in S3"`.

So all four per-arch `Bugfix validation` jobs fail before starting a server, and
`Finish Workflow` then fails its `new_tests_check.py` hook: every pull request carrying a
`Bug Fix` category is blocked on a required check while the bug it fixes is never measured.
CI DB shows 0 occurrences in the preceding 7 days, then onset at 2026-08-31 19:00 UTC rising
to 32 rows over 19 distinct pull requests by 23:00 UTC. The ~10h lag is `master_commits`
being a 50-entry (~12h) listing: failures began once the newest commit predating the change
aged out of it.

This takes the prefix from `_Environment.get_s3_prefix_static`, the same function the
uploader uses (`ci/praktika/runner.py:925`), instead of spelling it here a second time, so
this reader cannot drift from the writer again.

Validated credential-free against the links the uploader itself recorded in the MasterCI
report, not against a URL I built: on master tip all 8 relevant artifacts match the derived
prefix and 0 match the old one. Exercising `find_master_builds` with its two collaborators
stubbed and those recorded links as ground truth gives `None` before the change and the full
URL set after, on both arch sets, stable over 100 invocations, with an incomplete build set
still walked past. This PR is `CI Fix or Improvement`, so `Bugfix validation` is not
scheduled on it and I cannot self-validate in CI.

Related: https://github.com/ClickHouse/ClickHouse/pull/110081
Related: https://github.com/ClickHouse/ClickHouse/pull/117287

<details>
<summary>Other places that still hand-spell the old prefix (code read, not measured)</summary>

Same root cause, deliberately not in this PR, which restores a merge-gating check:

| file:line | producing workflow segment |
|---|---|
| `performance_tests.py:1280, 1290, 1454-1455, 1510` | `masterci` |
| `parser_memory_check.py:73` | `masterci` |
| `llvm_coverage_job.py:608-612, 706-707, 752-756` | `pr`, `masterci` |
| `scripts/generate_diff_coverage_report.sh:32` | `masterci` |
| `scripts/release_packages.py:38, 162` | `releasebranchci` |
| `scripts/create_release.py:642, 732-775` | `releasebranchci` |
| `.github/workflows/retry_infra_failures.yml:118` | `pr` |
| `update_toolchain_dockerfile.py:36-37` | `optimizetoolchain` |
| `docker/binary-builder/Dockerfile:55, 72` | `optimizetoolchain`, `optimizeclickhouse` |

CI DB is silent for all of them, but for the two reference-build lookups in
`performance_tests.py` that silence is not evidence of health. `find_prev_build` walks
`master_track_commits_sha`, 50 first-parent master commits, a longer window than the
`master_commits` listing above, and the release binaries carry `retention: long`, so it is
still reaching pre-change commits. Once it stops, its `None` is swallowed by the fixed
`.../master/<arch>/clickhouse` fallback at `performance_tests.py:1758-1774`: the MasterCI
commit-to-commit baseline silently stops being the previous commit, which is the
self-comparison `store_data.py:477-490` exists to prevent, and no failure row is produced.
`find_base_release_build` asserts instead. Neither performance job carries `allow_failure`.

The two `Dockerfile` sites are inert today: `TOOLCHAIN_COMMIT` is pinned to a pre-change
commit, and `CLICKHOUSE_PROFILES_COMMIT=none` never takes that branch. The
`retry_infra_failures.yml` one fails closed, so the retry silently never fires. Docs and
local helpers (`ci/CLAUDE.md:12`, `utils/auto-bisect/helpers/download.sh`) are stale too.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117433&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117433](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117433+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
