### PR TITLE
Make the toYYYYMM documentation example independent of the current date

### DIFF
--- a/src/Functions/toYYYYMM.cpp
+++ b/src/Functions/toYYYYMM.cpp
@@ -26,13 +26,13 @@ toYYYYMM(datetime[, timezone])
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns a UInt32 number containing the year and month number (YYYY * 100 + MM).", {"UInt32"}};
     FunctionDocumentation::Examples examples = {
-        {"Convert current date to YYYYMM format", R"(
-SELECT toYYYYMM(now(), 'US/Eastern')
+        {"Convert a date and time to YYYYMM format in another time zone", R"(
+SELECT toYYYYMM(toDateTime('2026-01-01 03:04:05', 'UTC'), 'US/Eastern')
         )",
         R"(
-┌─toYYYYMM(now(), 'US/Eastern')─┐
-│                        202608 │
-└───────────────────────────────┘
+┌─toYYYYMM(toDateTime('2026-01-01 03:04:05', 'UTC'), 'US/Eastern')─┐
+│                                                           202512 │
+└──────────────────────────────────────────────────────────────────┘
         )"}
     };
     FunctionDocumentation::IntroducedIn introduced_in = {1, 1};


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The documented example of `toYYYYMM` no longer depends on the current date.


### Description

`Docs examples` has been red on every PR since 2026-09-01 04:00 UTC.

`src/Functions/toYYYYMM.cpp` documented an example whose query reads the clock while its expected
output is a hardcoded literal:

```sql
SELECT toYYYYMM(now(), 'US/Eastern')   -- documented: 202608
```

`tests/docs_examples/runner.py` compares the documented response to the server output verbatim, so
`202608` held only while the current month in `US/Eastern` was August 2026. At 2026-09-01 04:00 UTC
that timezone rolled into September, the query began returning `202609`, and the comparison has
failed on every run since: in CIDB the `Documentation examples` sub-result went from 400 OK / 6 FAIL
in the preceding 24 hours to 0 OK / 12 FAIL afterwards, across 12 unrelated PRs. It entered the
baseline as passing on 2026-08-02 because it was true that day, so this is a latent time bomb:
bumping the number would only move the failure to 2026-10-01.

The fix makes the example clock-independent with the idiom its siblings already use (`toYYYYMMDD`,
`toYYYYMMDDhhmmss`, `toYear`, `toMonth`, `toQuarter` and `toDayOfMonth` all pin a fixed
`toDateTime` literal):

```sql
SELECT toYYYYMM(toDateTime('2026-01-01 03:04:05', 'UTC'), 'US/Eastern')   -- 202512
```

That input is `2025-12-31 22:04:05` in `US/Eastern`, so the timezone argument now visibly moves the
result down a month and a year; with `now` its effect was invisible on all but one day a month. The
expected output is a byte-exact capture from a real run.

I left the generated `docs/**` pages carrying the same stale value alone: they sit inside
autogenerated regions that `ci/jobs/docs_autogen_nightly.py` regenerates from this source.

The example fails 3/3 runs without this change and passes 6/6 with it, and altering one digit of the
new expected value turns it red again. Of all 2223 documented examples this was the only one pairing
a clock-reading query with a hardcoded response and no known-failures entry.

Failing report:
https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117427&sha=a27d7145482ec43f1f88038913acc7398113e78e&name_0=PR&name_1=Docs%20examples

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117459&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117459](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117459+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.487` (included in `26.9` and later)
<!-- ch-version-info:end -->