### PR TITLE
Keep the log export config of one perf server independent of the other

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -863,17 +863,29 @@ def create_log_export_configs():
         return True
     try:
         host, password = log_export.get_credentials()
-        for config_dir, binary in (
-            (perf_left_config, f"{perf_left}/clickhouse"),
-            (perf_right_config, f"{perf_right}/clickhouse"),
-        ):
+    except Exception:
+        # Best effort: a job that cannot export its system logs still runs.
+        traceback.print_exc()
+        return True
+    for config_dir, binary in (
+        (perf_left_config, f"{perf_left}/clickhouse"),
+        (perf_right_config, f"{perf_right}/clickhouse"),
+    ):
+        # Per server: the export of the one whose config cannot be written is
+        # the only one lost. The reference server runs an older build, and it
+        # is the one whose `system.settings` probe can fail; the patched server
+        # is the side the check reports on, and it keeps its export.
+        try:
             if not log_export.create_config(config_dir, host, password):
                 print(f"WARNING: Failed to write the log export config into [{config_dir}]")
                 continue
             write_ci_logs_sender_user(config_dir, binary)
-    except Exception:
-        # Best effort: a job that cannot export its system logs still runs.
-        traceback.print_exc()
+        except Exception:
+            traceback.print_exc()
+            print(
+                f"WARNING: Failed to configure the log export of the server in "
+                f"[{config_dir}], its system logs will not be exported"
+            )
     return True
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Documentation entry for user-facing changes
<!--- N/A -->

`create_log_export_configs` in the performance comparison job is meant to be best effort per server, but the outer `try` made the first failure abort the loop over both servers.

The probe in `write_ci_logs_sender_user` runs `clickhouse local --query "SELECT name FROM system.settings"` with `strict=True`, and it runs against the older reference build first. When that build cannot answer the probe, control jumped out of the loop and the patched server never got its generated `ci_logs_sender` profile either — so a reference-only export problem cost the check the system logs of the side it actually reports on.

The credential fetch stays outside the loop (without credentials there is nothing to write for either server); the per-server body now has its own `try`, so one server's failure only disables that server's export.

This addresses the remaining unresolved review finding on https://github.com/ClickHouse/ClickHouse/pull/116035, which was merged before it was applied.

Related: https://github.com/ClickHouse/ClickHouse/pull/116035

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117477&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117477](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117477+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.509` (included in `26.9` and later)
<!-- ch-version-info:end -->