### PR TITLE
Compute bitmap intersection cardinality without materializing the result

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupBitmapData.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupBitmapData.h
@@ -301,10 +301,22 @@ public:
                     ++ret;
             }
         }
+        else if (r1.isSmall())
+        {
+            for (const auto & x : r1.small)
+            {
+                if (roaring_bitmap->contains(static_cast<Value>(x.getValue())))
+                    ++ret;
+            }
+        }
+        else if constexpr (sizeof(T) < 8)
+        {
+            ret = roaring_bitmap->and_cardinality(*r1.roaring_bitmap);
+        }
         else
         {
-            std::shared_ptr<RoaringBitmap> new_rb = r1.isSmall() ? r1.getNewRoaringBitmapFromSmall() : r1.roaring_bitmap;
-            ret = (*roaring_bitmap & *new_rb).cardinality();
+            /// Roaring64Map exposes no and_cardinality, so the intersection must be materialized.
+            ret = (*roaring_bitmap & *r1.roaring_bitmap).cardinality();
         }
         return ret;
     }
@@ -384,8 +396,14 @@ public:
                     return 1;
             }
         }
+        else if constexpr (sizeof(T) < 8)
+        {
+            if (roaring_bitmap->intersect(*r1.roaring_bitmap))
+                return 1;
+        }
         else
         {
+            /// Roaring64Map exposes no intersect, so the intersection must be materialized.
             if ((*roaring_bitmap & *r1.roaring_bitmap).cardinality() > 0)
                 return 1;
         }

--- a/tests/performance/bitmap_cardinality.xml
+++ b/tests/performance/bitmap_cardinality.xml
@@ -1,0 +1,105 @@
+<test>
+    <!--
+        Exercises rb_and_cardinality and rb_intersect on Roaring-backed operands.
+        Operands are built in scalar subqueries so that construction is evaluated once
+        and the measured loop contains only the operation under test. Elements are cast
+        to UInt32 because UInt64 operands are backed by Roaring64Map, which takes a
+        different code path.
+    -->
+
+    <!-- Dense operands: ~46 bitset containers per side, half of them overlapping. -->
+    <query>
+        WITH
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number)))
+                FROM numbers(3000000)
+            ) AS a,
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number + 1500000)))
+                FROM numbers(3000000)
+            ) AS b
+        SELECT sum(bitmapAndCardinality(a, b))
+        FROM numbers(2000)
+    </query>
+
+    <!-- Sparse operands: ~458 array containers per side, half of them overlapping. -->
+    <query>
+        WITH
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number * 100)))
+                FROM numbers(300000)
+            ) AS a,
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number * 100 + 15000000)))
+                FROM numbers(300000)
+            ) AS b
+        SELECT sum(bitmapAndCardinality(a, b))
+        FROM numbers(2000)
+    </query>
+
+    <!-- bitmapOrCardinality reaches rb_and_cardinality through inclusion-exclusion. -->
+    <query>
+        WITH
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number)))
+                FROM numbers(3000000)
+            ) AS a,
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number + 1500000)))
+                FROM numbers(3000000)
+            ) AS b
+        SELECT sum(bitmapOrCardinality(a, b))
+        FROM numbers(2000)
+    </query>
+
+    <!--
+        bitmapHasAny where the operands share their lowest element, so the predicate can
+        answer from the first container pair instead of intersecting the whole operand.
+        The iteration count is kept low because the unoptimised path materialises a
+        3M-element intersection on every call.
+    -->
+    <query>
+        WITH
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number)))
+                FROM numbers(3000000)
+            ) AS a,
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number)))
+                FROM numbers(3000000)
+            ) AS b
+        SELECT sum(bitmapHasAny(a, b))
+        FROM numbers(200)
+    </query>
+
+    <!--
+        bitmapHasAny on evens against odds: both operands occupy the same container keys
+        but share no element, so there is no early exit and every container pair has to
+        be examined. This is the worst case for the predicate.
+    -->
+    <query>
+        WITH
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number * 2)))
+                FROM numbers(1500000)
+            ) AS a,
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number * 2 + 1)))
+                FROM numbers(1500000)
+            ) AS b
+        SELECT sum(bitmapHasAny(a, b))
+        FROM numbers(2000)
+    </query>
+
+    <!-- Large x Small operand order, which previously promoted the small set to Roaring. -->
+    <query>
+        WITH
+            (
+                SELECT bitmapBuild(groupArray(toUInt32(number)))
+                FROM numbers(3000000)
+            ) AS a,
+            bitmapBuild([toUInt32(7), toUInt32(1000000), toUInt32(2999999)]) AS b
+        SELECT sum(bitmapAndCardinality(a, b))
+        FROM numbers(2000)
+    </query>
+</test>

--- a/tests/performance/bitmap_cardinality.xml
+++ b/tests/performance/bitmap_cardinality.xml
@@ -1,75 +1,115 @@
 <test>
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
     <!--
-        Exercises rb_and_cardinality and rb_intersect on Roaring-backed operands.
-        Operands are built in scalar subqueries so that construction is evaluated once
-        and the measured loop contains only the operation under test. Elements are cast
-        to UInt32 because UInt64 operands are backed by Roaring64Map, which takes a
-        different code path.
+        Exercises rb_and_cardinality and rb_intersect.
+
+        Operands are built once into a Memory table, so construction is outside the
+        measured queries entirely. One operand of every measured call is wrapped in
+        materialize(): bitmapAndCardinality and bitmapHasAny use the default
+        implementation for constants, so with both operands constant the call would be
+        evaluated once on a single row and broadcast as a constant, and the loop would
+        measure nothing but the sum. The remaining constant operand is not expanded,
+        because the function reads it through its own is_column_const path.
+
+        Elements are UInt32 because UInt64 operands are backed by Roaring64Map, which
+        takes a different code path.
     -->
 
-    <!-- Dense operands: ~46 bitset containers per side, half of them overlapping. -->
+    <create_query>
+        CREATE TABLE bitmap_cardinality_operands
+        (
+            name String,
+            bm AggregateFunction(groupBitmap, UInt32)
+        )
+        ENGINE = Memory
+    </create_query>
+
+    <!-- Dense: ~46 bitset containers per side, half of them overlapping. -->
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'dense_a', groupBitmapState(toUInt32(number)) FROM numbers(3000000)
+    </fill_query>
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'dense_b', groupBitmapState(toUInt32(number + 1500000)) FROM numbers(3000000)
+    </fill_query>
+    <!-- A separate operand equal to dense_a, so that the two sides share their lowest element. -->
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'dense_a_copy', groupBitmapState(toUInt32(number)) FROM numbers(3000000)
+    </fill_query>
+
+    <!-- Sparse: ~458 array containers per side, half of them overlapping. -->
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'sparse_a', groupBitmapState(toUInt32(number * 100)) FROM numbers(300000)
+    </fill_query>
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'sparse_b', groupBitmapState(toUInt32(number * 100 + 15000000)) FROM numbers(300000)
+    </fill_query>
+
+    <!-- Same container keys on both sides, no shared element. -->
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'evens', groupBitmapState(toUInt32(number * 2)) FROM numbers(1500000)
+    </fill_query>
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'odds', groupBitmapState(toUInt32(number * 2 + 1)) FROM numbers(1500000)
+    </fill_query>
+
+    <!-- Stays in the small-set representation, whose threshold is 32 elements. -->
+    <fill_query>
+        INSERT INTO bitmap_cardinality_operands
+        SELECT 'small', groupBitmapState(x)
+        FROM (SELECT arrayJoin([toUInt32(7), toUInt32(1000000), toUInt32(2999999)]) AS x)
+    </fill_query>
+
+    <!-- Dense operands: bitset containers. -->
     <query>
         WITH
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number)))
-                FROM numbers(3000000)
-            ) AS a,
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number + 1500000)))
-                FROM numbers(3000000)
-            ) AS b
-        SELECT sum(bitmapAndCardinality(a, b))
-        FROM numbers(2000)
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'dense_a') AS a,
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'dense_b') AS b
+        SELECT sum(bitmapAndCardinality(materialize(a), b))
+        FROM numbers(5000)
+        FORMAT Null
     </query>
 
-    <!-- Sparse operands: ~458 array containers per side, half of them overlapping. -->
+    <!-- Sparse operands: array containers. -->
     <query>
         WITH
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number * 100)))
-                FROM numbers(300000)
-            ) AS a,
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number * 100 + 15000000)))
-                FROM numbers(300000)
-            ) AS b
-        SELECT sum(bitmapAndCardinality(a, b))
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'sparse_a') AS a,
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'sparse_b') AS b
+        SELECT sum(bitmapAndCardinality(materialize(a), b))
         FROM numbers(2000)
+        FORMAT Null
     </query>
 
     <!-- bitmapOrCardinality reaches rb_and_cardinality through inclusion-exclusion. -->
     <query>
         WITH
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number)))
-                FROM numbers(3000000)
-            ) AS a,
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number + 1500000)))
-                FROM numbers(3000000)
-            ) AS b
-        SELECT sum(bitmapOrCardinality(a, b))
-        FROM numbers(2000)
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'dense_a') AS a,
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'dense_b') AS b
+        SELECT sum(bitmapOrCardinality(materialize(a), b))
+        FROM numbers(5000)
+        FORMAT Null
     </query>
 
     <!--
         bitmapHasAny where the operands share their lowest element, so the predicate can
         answer from the first container pair instead of intersecting the whole operand.
-        The iteration count is kept low because the unoptimised path materialises a
-        3M-element intersection on every call.
     -->
     <query>
         WITH
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number)))
-                FROM numbers(3000000)
-            ) AS a,
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number)))
-                FROM numbers(3000000)
-            ) AS b
-        SELECT sum(bitmapHasAny(a, b))
-        FROM numbers(200)
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'dense_a') AS a,
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'dense_a_copy') AS b
+        SELECT sum(bitmapHasAny(materialize(a), b))
+        FROM numbers(2000)
+        FORMAT Null
     </query>
 
     <!--
@@ -79,27 +119,24 @@
     -->
     <query>
         WITH
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number * 2)))
-                FROM numbers(1500000)
-            ) AS a,
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number * 2 + 1)))
-                FROM numbers(1500000)
-            ) AS b
-        SELECT sum(bitmapHasAny(a, b))
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'evens') AS a,
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'odds') AS b
+        SELECT sum(bitmapHasAny(materialize(a), b))
         FROM numbers(2000)
+        FORMAT Null
     </query>
 
     <!-- Large x Small operand order, which previously promoted the small set to Roaring. -->
     <query>
         WITH
-            (
-                SELECT bitmapBuild(groupArray(toUInt32(number)))
-                FROM numbers(3000000)
-            ) AS a,
-            bitmapBuild([toUInt32(7), toUInt32(1000000), toUInt32(2999999)]) AS b
-        SELECT sum(bitmapAndCardinality(a, b))
-        FROM numbers(2000)
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'dense_a') AS a,
+            (SELECT bm FROM bitmap_cardinality_operands WHERE name = 'small') AS b
+        SELECT sum(bitmapAndCardinality(materialize(a), b))
+        FROM numbers(10000)
+        FORMAT Null
     </query>
+
+    <drop_query>
+        DROP TABLE bitmap_cardinality_operands
+    </drop_query>
 </test>

--- a/tests/queries/0_stateless/05055_bitmap_cardinality_intersect_paths.reference
+++ b/tests/queries/0_stateless/05055_bitmap_cardinality_intersect_paths.reference
@@ -1,0 +1,35 @@
+--- UInt32: Small x Small ---
+1	1	1	1	1
+--- UInt32: Small x Large ---
+1	1	1	1	1
+--- UInt32: Large x Small ---
+1	1	1	1	1
+--- UInt32: Large x Small, no shared element ---
+1	1	1	1	1
+--- UInt32: Large x Large, overlapping ---
+1	1	1	1	1
+--- UInt32: Large x Large, disjoint ---
+1	1	1	1	1
+--- UInt32: multi-container, shared element ---
+1	1	1	1	1
+--- UInt32: multi-container, no shared element ---
+1	1	1	1	1
+--- UInt32: operand order, Large x Small vs Small x Large ---
+1	1	1	1
+--- UInt32: operand order, Large x Large ---
+1	1	1	1
+--- UInt32: exact cardinalities, Large x Large ---
+1	1	1	1	1
+--- UInt64: Large x Large, overlapping ---
+1	1	1	1	1
+--- UInt64: Large x Small ---
+1	1	1	1	1
+--- UInt64: above the 32-bit range ---
+1	1	1	1	1
+--- UInt64: operand order, Large x Small ---
+1	1	1	1
+--- Int32 / Int16: Large x Large ---
+1	1
+1	1
+--- empty operands ---
+1	1	1	1	1	1	1

--- a/tests/queries/0_stateless/05055_bitmap_cardinality_intersect_paths.sql
+++ b/tests/queries/0_stateless/05055_bitmap_cardinality_intersect_paths.sql
@@ -1,0 +1,215 @@
+-- Covers rb_and_cardinality and rb_intersect in
+-- AggregateFunctions/AggregateFunctionGroupBitmapData.h across every combination of
+-- small-set and Roaring representation, including the Large x Small operand order.
+--
+-- bitmapAndCardinality and bitmapHasAny are cross-checked against bitmapAnd +
+-- bitmapCardinality, which reaches the answer through a different code path
+-- (rb_and followed by size()). Every assertion below prints 1 when the two agree.
+--
+-- Operands of 40 elements exceed the small_set_size = 32 promotion threshold, so
+-- they are held as Roaring bitmaps; 3-element operands stay in the small set.
+
+SELECT '--- UInt32: Small x Small ---';
+WITH
+    bitmapBuild([1, 5, 7]::Array(UInt32)) AS a,
+    bitmapBuild([5, 7, 99]::Array(UInt32)) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt32: Small x Large ---';
+WITH
+    bitmapBuild([1, 5, 7]::Array(UInt32)) AS a,
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt32: Large x Small ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild([1, 5, 7]::Array(UInt32)) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt32: Large x Small, no shared element ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild([100, 500, 700]::Array(UInt32)) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt32: Large x Large, overlapping ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toUInt32(x + 20), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt32: Large x Large, disjoint ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toUInt32(x + 1000), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+-- Elements spaced 70000 apart land in distinct 16-bit Roaring containers, so these
+-- two cases walk many container pairs rather than a single one.
+
+SELECT '--- UInt32: multi-container, shared element ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x * 70000), range(40))) AS a,
+    bitmapBuild(arrayConcat([toUInt32(0)], arrayMap(x -> toUInt32(x * 70000 + 1), range(40)))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+-- Same container keys on both sides but no shared element, so bitmapHasAny cannot
+-- exit early and has to examine every container pair.
+
+SELECT '--- UInt32: multi-container, no shared element ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x * 70000), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toUInt32(x * 70000 + 1), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+-- bitmapAndnotCardinality is deliberately absent: it is not commutative.
+
+SELECT '--- UInt32: operand order, Large x Small vs Small x Large ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild([1, 5, 7]::Array(UInt32)) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapAndCardinality(b, a),
+    bitmapOrCardinality(a, b) = bitmapOrCardinality(b, a),
+    bitmapXorCardinality(a, b) = bitmapXorCardinality(b, a),
+    bitmapHasAny(a, b) = bitmapHasAny(b, a);
+
+SELECT '--- UInt32: operand order, Large x Large ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toUInt32(x + 20), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapAndCardinality(b, a),
+    bitmapOrCardinality(a, b) = bitmapOrCardinality(b, a),
+    bitmapXorCardinality(a, b) = bitmapXorCardinality(b, a),
+    bitmapHasAny(a, b) = bitmapHasAny(b, a);
+
+-- Pins the arithmetic to fixed expectations rather than only to the reference path.
+-- a = {0..39}, b = {20..59}, so |a & b| = 20, |a | b| = 60, |a ^ b| = 40, |a \ b| = 20.
+
+SELECT '--- UInt32: exact cardinalities, Large x Large ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toUInt32(x + 20), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = 20,
+    bitmapOrCardinality(a, b) = 60,
+    bitmapXorCardinality(a, b) = 40,
+    bitmapAndnotCardinality(a, b) = 20,
+    bitmapHasAny(a, b) = 1;
+
+-- UInt64 operands are backed by Roaring64Map, which has no direct and_cardinality or
+-- intersect, so these cases exercise the fallback rather than the fast path.
+
+SELECT '--- UInt64: Large x Large, overlapping ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt64(x), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toUInt64(x + 20), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt64: Large x Small ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt64(x), range(40))) AS a,
+    bitmapBuild([1, 5, 7]::Array(UInt64)) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt64: above the 32-bit range ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt64(x + 4294967296), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toUInt64(x + 4294967316), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapOrCardinality(a, b) = bitmapCardinality(bitmapOr(a, b)),
+    bitmapXorCardinality(a, b) = bitmapCardinality(bitmapXor(a, b)),
+    bitmapAndnotCardinality(a, b) = bitmapCardinality(bitmapAndnot(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- UInt64: operand order, Large x Small ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt64(x), range(40))) AS a,
+    bitmapBuild([1, 5, 7]::Array(UInt64)) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapAndCardinality(b, a),
+    bitmapOrCardinality(a, b) = bitmapOrCardinality(b, a),
+    bitmapXorCardinality(a, b) = bitmapXorCardinality(b, a),
+    bitmapHasAny(a, b) = bitmapHasAny(b, a);
+
+-- Int32 and Int16 reach the same 32-bit fast path through a different type dispatch.
+
+SELECT '--- Int32 / Int16: Large x Large ---';
+WITH
+    bitmapBuild(arrayMap(x -> toInt32(x), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toInt32(x + 20), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+WITH
+    bitmapBuild(arrayMap(x -> toInt16(x), range(40))) AS a,
+    bitmapBuild(arrayMap(x -> toInt16(x + 20), range(40))) AS b
+SELECT
+    bitmapAndCardinality(a, b) = bitmapCardinality(bitmapAnd(a, b)),
+    bitmapHasAny(a, b) = (bitmapCardinality(bitmapAnd(a, b)) > 0);
+
+SELECT '--- empty operands ---';
+WITH
+    bitmapBuild(arrayMap(x -> toUInt32(x), range(40))) AS a,
+    bitmapBuild([]::Array(UInt32)) AS e
+SELECT
+    bitmapAndCardinality(a, e) = 0,
+    bitmapAndCardinality(e, a) = 0,
+    bitmapHasAny(a, e) = 0,
+    bitmapHasAny(e, a) = 0,
+    bitmapOrCardinality(a, e) = 40,
+    bitmapAndnotCardinality(a, e) = 40,
+    bitmapAndnotCardinality(e, a) = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved performance of `bitmapAndCardinality`, `bitmapOrCardinality`, `bitmapXorCardinality`, `bitmapAndnotCardinality` and `bitmapHasAny` by computing the result directly instead of first materializing the intersection bitmap.

---

## Problem

`rb_and_cardinality` answered "how large is the intersection" by constructing the entire intersection bitmap, reading its cardinality and discarding it:

```cpp
std::shared_ptr<RoaringBitmap> new_rb = r1.isSmall() ? r1.getNewRoaringBitmapFromSmall() : r1.roaring_bitmap;
ret = (*roaring_bitmap & *new_rb).cardinality();
```

`rb_intersect` used the same construct to answer a boolean question:

```cpp
if ((*roaring_bitmap & *r1.roaring_bitmap).cardinality() > 0)
    return 1;
```

`operator&` allocates and populates a fresh container for every overlapping container pair. In the boolean case it also removes any possibility of an early exit, because the whole intersection is built before the first element is examined.

CRoaring already provides `roaring_bitmap_and_cardinality` and `roaring_bitmap_intersect` for exactly these two questions. Both walk the container pairs and accumulate or short-circuit without allocating or writing a result structure.

## Change

- `rb_and_cardinality` now calls `and_cardinality()`.
- `rb_intersect` now calls `intersect()`, which stops at the first shared element.
- `rb_and_cardinality` previously promoted a small set to a full Roaring bitmap whenever the larger operand came first, then ran a complete intersection over it. It now iterates the small side against `contains()`. This mirrors what `rb_intersect` already did for the same operand shape, and matches the operand swap that `FunctionsBitmap.h` already performs for `bitmapAnd` for the same reason:

```cpp
// bitmapAnd(RoaringBitMap, SmallSet) is slower than bitmapAnd(SmallSet, RoaringBitMap), so we can exchange the position of two arguments for the speed
```

Five SQL functions are affected: `bitmapAndCardinality` and `bitmapHasAny` directly, and `bitmapOrCardinality`, `bitmapXorCardinality` and `bitmapAndnotCardinality` transitively, since all three derive their result from `rb_and_cardinality` by inclusion-exclusion.

## Scope: 32-bit element types

`RoaringBitmapWithSmallSet` selects `roaring::Roaring64Map` when `sizeof(T) >= 8`. `Roaring64Map` exposes neither `and_cardinality` nor `intersect` (still true on CRoaring master), so `UInt64` and `Int64` bitmaps keep the previous implementation behind `if constexpr (sizeof(T) < 8)`. Adding those routines to `Roaring64Map` would be a separate upstream change.

Both routines are read-only, so results and the serialization format are unchanged.

## Testing

`tests/queries/0_stateless/05055_bitmap_cardinality_intersect_paths.sql` covers every combination of small-set and Roaring representation, including the `Large x Small` operand order, which previously had no coverage for these functions.

The assertions are differential: each cardinality function is checked against `bitmapAnd` combined with `bitmapCardinality`, which reaches the same answer through `rb_and` followed by `size()` and shares no code with the paths changed here. Every assertion prints `1` when the two agree. Covered:

- `Small x Small`, `Small x Large`, `Large x Small` (with and without overlap), `Large x Large` (overlapping and disjoint)
- Operands spread across many 16-bit containers, with and without a shared element, so the container walk is exercised both with and without an early exit
- Operand-order commutativity for the commutative functions
- Exact expected cardinalities, pinning the arithmetic independently of the reference path
- `UInt64` including values above the 32-bit range, plus `Int32` and `Int16`, so the `Roaring64Map` fallback and the signed dispatch are both exercised
- Empty operands on either side

`tests/performance/bitmap_cardinality.xml` measures the changed paths with operand construction hoisted into scalar subqueries, so the measured loop contains only the operation under test. It covers dense (bitset container) and sparse (array container) operands, `bitmapOrCardinality` reaching `rb_and_cardinality` indirectly, the `Large x Small` operand order, and two `bitmapHasAny` shapes: one where the operands share their lowest element so the predicate can exit immediately, and one where both operands occupy the same container keys but share no element, which is the worst case with no early exit available.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117478&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117478](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117478+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
