### PR TITLE
Reduce template instantiation bloat in the largest translation units

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionsArgMinArgMax.cpp
+++ b/src/AggregateFunctions/AggregateFunctionsArgMinArgMax.cpp
@@ -85,6 +85,43 @@ static_assert(
     sizeof(AggregateFunctionArgMinMaxDataGeneric<Int8>) <= 2 * SingleValueDataBase::MAX_STORAGE_SIZE,
     "Incorrect size of AggregateFunctionArgMinMaxData struct");
 
+/// The validation and throw paths are outlined into non-template functions: they would otherwise
+/// be duplicated (together with the exception-message formatting) into the constructor and
+/// `deserialize` of every one of the hundreds of template instantiations below.
+NO_INLINE void validateArgMinMaxValueType(const DataTypePtr & type_val, const String & function_name)
+{
+    if (!type_val->isComparable())
+        throw Exception(
+            ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+            "Illegal type {} of second argument of aggregate function {} because the values of that data type are not comparable",
+            type_val->getName(),
+            function_name);
+
+    auto check_not_dynamic_or_variant = [&](const IDataType & type)
+    {
+        if (isDynamic(type) || isVariant(type))
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of argument of aggregate function {} because the values of that data type can contain values with "
+                "different data types. Consider using typed subcolumns or cast column to a specific data type{}",
+                type_val->getName(),
+                function_name,
+                getNumericVariantSupertypeHint(type.getPtr()));
+    };
+    check_not_dynamic_or_variant(*type_val);
+    type_val->forEachChild(check_not_dynamic_or_variant);
+}
+
+[[noreturn]] NO_INLINE void throwArgMinMaxInvalidDeserializedState(const String & function_name, bool has_value, bool has_result)
+{
+    throw Exception(
+        ErrorCodes::INCORRECT_DATA,
+        "Invalid state of the aggregate function {}: has_value ({}) != has_result ({})",
+        function_name,
+        has_value,
+        has_result);
+}
+
 /// Returns the first arg value found for the minimum/maximum value. Example: argMin(arg, value).
 /// When return_both is true, returns tuple (arg, value). Example: argAndMin(arg, value).
 template <typename Data, bool isMin>
@@ -112,26 +149,7 @@ public:
         , result_type_index(WhichDataType(this->argument_types[0]).idx)
         , return_both(return_both_)
     {
-        if (!type_val->isComparable())
-            throw Exception(
-                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                "Illegal type {} of second argument of aggregate function {} because the values of that data type are not comparable",
-                type_val->getName(),
-                getName());
-
-        auto check_not_dynamic_or_variant = [&](const IDataType & type)
-        {
-            if (isDynamic(type) || isVariant(type))
-                throw Exception(
-                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "Illegal type {} of argument of aggregate function {} because the values of that data type can contain values with "
-                    "different data types. Consider using typed subcolumns or cast column to a specific data type{}",
-                    this->type_val->getName(),
-                    getName(),
-                    getNumericVariantSupertypeHint(type.getPtr()));
-        };
-        check_not_dynamic_or_variant(*this->type_val);
-        this->type_val->forEachChild(check_not_dynamic_or_variant);
+        validateArgMinMaxValueType(type_val, getName());
     }
 
     static DataTypePtr createResultType(const DataTypes & argument_types_, bool return_both_)
@@ -270,12 +288,7 @@ public:
         this->data(place).result().read(buf, *serialization_res, data_type_res, arena);
         this->data(place).value().read(buf, *serialization_val, data_type_val, arena);
         if (unlikely(this->data(place).value().has() != this->data(place).result().has()))
-            throw Exception(
-                ErrorCodes::INCORRECT_DATA,
-                "Invalid state of the aggregate function {}: has_value ({}) != has_result ({})",
-                getName(),
-                this->data(place).value().has(),
-                this->data(place).result().has());
+            throwArgMinMaxInvalidDeserializedState(getName(), this->data(place).value().has(), this->data(place).result().has());
     }
 
     bool allocatesMemoryInArena() const override

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -3,10 +3,7 @@
 namespace DB
 {
 
-template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ false, /* sharded= */ false >;
-template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ false, /* sharded= */ true  >;
-
-template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ false, /* sharded= */ false >;
-template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ false, /* sharded= */ true  >;
+template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ false>;
+template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ false>;
 
 }

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -225,23 +225,32 @@ private:
 
     /// Sharding is a runtime property (`SHARDS` layout parameter), not a template parameter:
     /// making it a template parameter would instantiate the whole dictionary twice.
+    /// The per-key lookup loops still dispatch on it once per call (via the `sharded_`
+    /// template parameter below), so that the non-sharded fast path keeps a constant
+    /// shard index and the hash+modulo does not get inlined into the loop body.
     bool sharded() const { return configuration.shards > 1; }
 
+    template <bool sharded_>
     UInt64 getShard(UInt64 key) const
     {
-        if (!sharded())
+        if constexpr (!sharded_)
             return 0;
         /// NOTE: function here should not match with the DefaultHash<> since
         /// it used for the HashMap/sparse_hash_map.
         return intHashCRC32(key) % configuration.shards;
     }
 
+    template <bool sharded_>
     UInt64 getShard(std::string_view key) const
     {
-        if (!sharded())
+        if constexpr (!sharded_)
             return 0;
         return StringViewHash()(key) % configuration.shards;
     }
+
+    UInt64 getShard(UInt64 key) const { return sharded() ? getShard<true>(key) : 0; }
+
+    UInt64 getShard(std::string_view key) const { return sharded() ? getShard<true>(key) : 0; }
 
     template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>
     void getItemsImpl(
@@ -250,7 +259,22 @@ private:
         ValueSetter && set_value,
         DefaultValueExtractor & default_value_extractor) const;
 
+    template <typename AttributeType, bool is_nullable, bool sharded_, typename ValueSetter, typename DefaultValueExtractor>
+    void getItemsImpl(
+        const Attribute & attribute,
+        DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
+        ValueSetter && set_value,
+        DefaultValueExtractor & default_value_extractor) const;
+
     template <typename AttributeType, bool is_nullable, typename ValueSetter, typename NullAndDefaultSetter>
+    void getItemsShortCircuitImpl(
+        const Attribute & attribute,
+        DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
+        ValueSetter && set_value,
+        NullAndDefaultSetter && set_null_and_default,
+        IColumn::Filter & default_mask) const;
+
+    template <typename AttributeType, bool is_nullable, bool sharded_, typename ValueSetter, typename NullAndDefaultSetter>
     void getItemsShortCircuitImpl(
         const Attribute & attribute,
         DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
@@ -646,14 +670,22 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::hasKeys(const Co
 
     if (unlikely(attributes.empty()))
     {
-        for (size_t requested_key_index = 0; requested_key_index < keys_size; ++requested_key_index)
+        auto has_keys = [&]<bool sharded_>()
         {
-            auto key = extractor.extractCurrentKey();
-            const auto & container = no_attributes_containers[getShard(key)];
-            out[requested_key_index] = container.find(key) != container.end();
-            keys_found += out[requested_key_index];
-            extractor.rollbackCurrentKey();
-        }
+            for (size_t requested_key_index = 0; requested_key_index < keys_size; ++requested_key_index)
+            {
+                auto key = extractor.extractCurrentKey();
+                const auto & container = no_attributes_containers[getShard<sharded_>(key)];
+                out[requested_key_index] = container.find(key) != container.end();
+                keys_found += out[requested_key_index];
+                extractor.rollbackCurrentKey();
+            }
+        };
+
+        if (sharded())
+            has_keys.template operator()<true>();
+        else
+            has_keys.template operator()<false>();
 
         query_count.fetch_add(keys_size, std::memory_order_relaxed);
         found_count.fetch_add(keys_found, std::memory_order_relaxed);
@@ -665,20 +697,28 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::hasKeys(const Co
 
     getAttributeContainers(0 /*attribute_index*/, [&](const auto & containers)
     {
-        for (size_t requested_key_index = 0; requested_key_index < keys_size; ++requested_key_index)
+        auto has_keys = [&]<bool sharded_>()
         {
-            auto key = extractor.extractCurrentKey();
-            auto shard = getShard(key);
-            const auto & container = containers[shard];
+            for (size_t requested_key_index = 0; requested_key_index < keys_size; ++requested_key_index)
+            {
+                auto key = extractor.extractCurrentKey();
+                auto shard = getShard<sharded_>(key);
+                const auto & container = containers[shard];
 
-            out[requested_key_index] = container.find(key) != container.end();
-            if (is_attribute_nullable && !out[requested_key_index])
-                out[requested_key_index] = (*attribute.is_nullable_sets)[shard].find(key) != nullptr;
+                out[requested_key_index] = container.find(key) != container.end();
+                if (is_attribute_nullable && !out[requested_key_index])
+                    out[requested_key_index] = (*attribute.is_nullable_sets)[shard].find(key) != nullptr;
 
-            keys_found += out[requested_key_index];
+                keys_found += out[requested_key_index];
 
-            extractor.rollbackCurrentKey();
-        }
+                extractor.rollbackCurrentKey();
+            }
+        };
+
+        if (sharded())
+            has_keys.template operator()<true>();
+        else
+            has_keys.template operator()<false>();
     });
 
     query_count.fetch_add(keys_size, std::memory_order_relaxed);
@@ -707,39 +747,45 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr 
 
         const CollectionsHolder<UInt64> & child_key_to_parent_key_maps = std::get<CollectionsHolder<UInt64>>(hierarchical_attribute.containers);
 
-        auto is_key_valid_func = [&](auto & hierarchy_key)
-        {
-            auto shard = getShard(hierarchy_key);
-
-            if (unlikely(hierarchical_attribute.is_nullable_sets) && (*hierarchical_attribute.is_nullable_sets)[shard].find(hierarchy_key))
-                return true;
-
-            const auto & map = child_key_to_parent_key_maps[shard];
-            return map.find(hierarchy_key) != map.end();
-        };
-
         size_t keys_found = 0;
 
-        auto get_parent_func = [&](auto & hierarchy_key)
+        auto get_hierarchy = [&]<bool sharded_>()
         {
-            std::optional<UInt64> result;
+            auto is_key_valid_func = [&](auto & hierarchy_key)
+            {
+                auto shard = getShard<sharded_>(hierarchy_key);
 
-            const auto & map = child_key_to_parent_key_maps[getShard(hierarchy_key)];
-            auto it = map.find(hierarchy_key);
-            if (it == map.end())
+                if (unlikely(hierarchical_attribute.is_nullable_sets) && (*hierarchical_attribute.is_nullable_sets)[shard].find(hierarchy_key))
+                    return true;
+
+                const auto & map = child_key_to_parent_key_maps[shard];
+                return map.find(hierarchy_key) != map.end();
+            };
+
+            auto get_parent_func = [&](auto & hierarchy_key)
+            {
+                std::optional<UInt64> result;
+
+                const auto & map = child_key_to_parent_key_maps[getShard<sharded_>(hierarchy_key)];
+                auto it = map.find(hierarchy_key);
+                if (it == map.end())
+                    return result;
+
+                UInt64 parent_key = getValueFromCell(it);
+                if (null_value && *null_value == parent_key)
+                    return result;
+
+                result = parent_key;
+                keys_found += 1;
+
                 return result;
+            };
 
-            UInt64 parent_key = getValueFromCell(it);
-            if (null_value && *null_value == parent_key)
-                return result;
-
-            result = parent_key;
-            keys_found += 1;
-
-            return result;
+            return getKeysHierarchyArray(keys, is_key_valid_func, get_parent_func);
         };
 
-        auto dictionary_hierarchy_array = getKeysHierarchyArray(keys, is_key_valid_func, get_parent_func);
+        auto dictionary_hierarchy_array
+            = sharded() ? get_hierarchy.template operator()<true>() : get_hierarchy.template operator()<false>();
 
         query_count.fetch_add(keys.size(), std::memory_order_relaxed);
         found_count.fetch_add(keys_found, std::memory_order_relaxed);
@@ -781,39 +827,44 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::isInHierarchy(
 
         const CollectionsHolder<UInt64> & child_key_to_parent_key_maps = std::get<CollectionsHolder<UInt64>>(hierarchical_attribute.containers);
 
-        auto is_key_valid_func = [&](auto & hierarchy_key)
-        {
-            auto shard = getShard(hierarchy_key);
-
-            if (unlikely(hierarchical_attribute.is_nullable_sets) && (*hierarchical_attribute.is_nullable_sets)[shard].find(hierarchy_key))
-                return true;
-
-            const auto & map = child_key_to_parent_key_maps[shard];
-            return map.find(hierarchy_key) != map.end();
-        };
-
         size_t keys_found = 0;
 
-        auto get_parent_key_func = [&](auto & hierarchy_key)
+        auto is_in_hierarchy = [&]<bool sharded_>()
         {
-            std::optional<UInt64> result;
+            auto is_key_valid_func = [&](auto & hierarchy_key)
+            {
+                auto shard = getShard<sharded_>(hierarchy_key);
 
-            const auto & map = child_key_to_parent_key_maps[getShard(hierarchy_key)];
-            auto it = map.find(hierarchy_key);
-            if (it == map.end())
+                if (unlikely(hierarchical_attribute.is_nullable_sets) && (*hierarchical_attribute.is_nullable_sets)[shard].find(hierarchy_key))
+                    return true;
+
+                const auto & map = child_key_to_parent_key_maps[shard];
+                return map.find(hierarchy_key) != map.end();
+            };
+
+            auto get_parent_key_func = [&](auto & hierarchy_key)
+            {
+                std::optional<UInt64> result;
+
+                const auto & map = child_key_to_parent_key_maps[getShard<sharded_>(hierarchy_key)];
+                auto it = map.find(hierarchy_key);
+                if (it == map.end())
+                    return result;
+
+                UInt64 parent_key = getValueFromCell(it);
+                if (null_value && *null_value == parent_key)
+                    return result;
+
+                result = parent_key;
+                keys_found += 1;
+
                 return result;
+            };
 
-            UInt64 parent_key = getValueFromCell(it);
-            if (null_value && *null_value == parent_key)
-                return result;
-
-            result = parent_key;
-            keys_found += 1;
-
-            return result;
+            return getKeysIsInHierarchyColumn(keys, keys_in, is_key_valid_func, get_parent_key_func);
         };
 
-        auto result = getKeysIsInHierarchyColumn(keys, keys_in, is_key_valid_func, get_parent_key_func);
+        auto result = sharded() ? is_in_hierarchy.template operator()<true>() : is_in_hierarchy.template operator()<false>();
 
         query_count.fetch_add(keys.size(), std::memory_order_relaxed);
         found_count.fetch_add(keys_found, std::memory_order_relaxed);
@@ -1134,6 +1185,22 @@ void HashedDictionary<dictionary_key_type, sparse>::getItemsImpl(
     ValueSetter && set_value,
     DefaultValueExtractor & default_value_extractor) const
 {
+    if (sharded())
+        getItemsImpl<AttributeType, is_nullable, true>(
+            attribute, keys_extractor, std::forward<ValueSetter>(set_value), default_value_extractor);
+    else
+        getItemsImpl<AttributeType, is_nullable, false>(
+            attribute, keys_extractor, std::forward<ValueSetter>(set_value), default_value_extractor);
+}
+
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+template <typename AttributeType, bool is_nullable, bool sharded_, typename ValueSetter, typename DefaultValueExtractor>
+void HashedDictionary<dictionary_key_type, sparse>::getItemsImpl(
+    const Attribute & attribute,
+    DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
+    ValueSetter && set_value,
+    DefaultValueExtractor & default_value_extractor) const
+{
     const auto & attribute_containers = std::get<CollectionsHolder<AttributeType>>(attribute.containers);
     const size_t keys_size = keys_extractor.getKeysSize();
 
@@ -1142,7 +1209,7 @@ void HashedDictionary<dictionary_key_type, sparse>::getItemsImpl(
     for (size_t key_index = 0; key_index < keys_size; ++key_index)
     {
         auto key = keys_extractor.extractCurrentKey();
-        auto shard = getShard(key);
+        auto shard = getShard<sharded_>(key);
 
         const auto & container = attribute_containers[shard];
         const auto it = container.find(key);
@@ -1181,6 +1248,23 @@ void HashedDictionary<dictionary_key_type, sparse>::getItemsShortCircuitImpl(
     NullAndDefaultSetter && set_null_and_default,
     IColumn::Filter & default_mask) const
 {
+    if (sharded())
+        getItemsShortCircuitImpl<AttributeType, is_nullable, true>(
+            attribute, keys_extractor, std::forward<ValueSetter>(set_value), std::forward<NullAndDefaultSetter>(set_null_and_default), default_mask);
+    else
+        getItemsShortCircuitImpl<AttributeType, is_nullable, false>(
+            attribute, keys_extractor, std::forward<ValueSetter>(set_value), std::forward<NullAndDefaultSetter>(set_null_and_default), default_mask);
+}
+
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+template <typename AttributeType, bool is_nullable, bool sharded_, typename ValueSetter, typename NullAndDefaultSetter>
+void HashedDictionary<dictionary_key_type, sparse>::getItemsShortCircuitImpl(
+    const Attribute & attribute,
+    DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
+    ValueSetter && set_value,
+    NullAndDefaultSetter && set_null_and_default,
+    IColumn::Filter & default_mask) const
+{
     const auto & attribute_containers = std::get<CollectionsHolder<AttributeType>>(attribute.containers);
     const size_t keys_size = keys_extractor.getKeysSize();
     default_mask.resize(keys_size);
@@ -1189,7 +1273,7 @@ void HashedDictionary<dictionary_key_type, sparse>::getItemsShortCircuitImpl(
     for (size_t key_index = 0; key_index < keys_size; ++key_index)
     {
         auto key = keys_extractor.extractCurrentKey();
-        auto shard = getShard(key);
+        auto shard = getShard<sharded_>(key);
 
         const auto & container = attribute_containers[shard];
         const auto it = container.find(key);

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -69,11 +69,11 @@ struct HashedDictionaryConfiguration
     const std::chrono::seconds load_timeout{0};
 };
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+template <DictionaryKeyType dictionary_key_type, bool sparse>
 class HashedDictionary final : public IDictionary
 {
-    using DictionaryParallelLoaderType = HashedDictionaryParallelLoader<dictionary_key_type, HashedDictionary<dictionary_key_type, sparse, sharded>>;
-    friend class HashedDictionaryParallelLoader<dictionary_key_type, HashedDictionary<dictionary_key_type, sparse, sharded>>;
+    using DictionaryParallelLoaderType = HashedDictionaryParallelLoader<dictionary_key_type, HashedDictionary<dictionary_key_type, sparse>>;
+    friend class HashedDictionaryParallelLoader<dictionary_key_type, HashedDictionary<dictionary_key_type, sparse>>;
 
 public:
     using KeyType = std::conditional_t<dictionary_key_type == DictionaryKeyType::Simple, UInt64, std::string_view>;
@@ -118,7 +118,7 @@ public:
 
     std::shared_ptr<IExternalLoadable> clone() const override
     {
-        return std::make_shared<HashedDictionary<dictionary_key_type, sparse, sharded>>(
+        return std::make_shared<HashedDictionary<dictionary_key_type, sparse>>(
             getDictionaryID(),
             dict_struct,
             source_ptr->clone(),
@@ -223,9 +223,13 @@ private:
 
     void calculateBytesAllocated();
 
+    /// Sharding is a runtime property (`SHARDS` layout parameter), not a template parameter:
+    /// making it a template parameter would instantiate the whole dictionary twice.
+    bool sharded() const { return configuration.shards > 1; }
+
     UInt64 getShard(UInt64 key) const
     {
-        if constexpr (!sharded)
+        if (!sharded())
             return 0;
         /// NOTE: function here should not match with the DefaultHash<> since
         /// it used for the HashMap/sparse_hash_map.
@@ -234,7 +238,7 @@ private:
 
     UInt64 getShard(std::string_view key) const
     {
-        if constexpr (!sharded)
+        if (!sharded())
             return 0;
         return StringViewHash()(key) % configuration.shards;
     }
@@ -284,20 +288,16 @@ private:
 };
 
 /// hashed
-extern template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ false, /* sharded= */ false >;
-extern template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ false, /* sharded= */ true  >;
-extern template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ false, /* sharded= */ false >;
-extern template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ false, /* sharded= */ true  >;
+extern template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ false>;
+extern template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ false>;
 
 /// sparse_hashed
-extern template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ true, /* sharded= */ false >;
-extern template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ true, /* sharded= */ true  >;
-extern template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ true, /* sharded= */ false >;
-extern template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ true, /* sharded= */ true  >;
+extern template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ true>;
+extern template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ true>;
 
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-HashedDictionary<dictionary_key_type, sparse, sharded>::HashedDictionary(
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+HashedDictionary<dictionary_key_type, sparse>::HashedDictionary(
     const StorageID & dict_id_,
     const DictionaryStructure & dict_struct_,
     DictionarySourcePtr source_ptr_,
@@ -316,14 +316,14 @@ HashedDictionary<dictionary_key_type, sparse, sharded>::HashedDictionary(
     calculateBytesAllocated();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-HashedDictionary<dictionary_key_type, sparse, sharded>::~HashedDictionary()
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+HashedDictionary<dictionary_key_type, sparse>::~HashedDictionary()
 {
     /// Do a regular sequential destroy in case of non sharded dictionary
     ///
     /// Note, that even in non-sharded dictionaries you can have multiple hash
     /// tables, since each attribute is stored in a separate hash table.
-    if constexpr (!sharded)
+    if (!sharded())
         return;
 
     size_t shards = std::max<size_t>(configuration.shards, 1);
@@ -379,8 +379,8 @@ HashedDictionary<dictionary_key_type, sparse, sharded>::~HashedDictionary()
     LOG_TRACE(log, "Hash tables for dictionary {} destroyed", dictionary_name);
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getColumn(
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getColumn(
     const std::string & attribute_name,
     const DataTypePtr & attribute_type,
     const Columns & key_columns,
@@ -628,8 +628,8 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getColumn(
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse, sharded>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
 {
     if (dictionary_key_type == DictionaryKeyType::Complex)
         dict_struct.validateKeyTypes(key_types);
@@ -687,8 +687,8 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse, sharded>::hasKeys
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getHierarchy(ColumnPtr key_column [[maybe_unused]], const DataTypePtr &) const
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr key_column [[maybe_unused]], const DataTypePtr &) const
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
@@ -752,8 +752,8 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getHierarchy(C
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse, sharded>::isInHierarchy(
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::isInHierarchy(
     ColumnPtr key_column [[maybe_unused]],
     ColumnPtr in_key_column [[maybe_unused]],
     const DataTypePtr &) const
@@ -824,8 +824,8 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse, sharded>::isInHie
         return nullptr;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-DictionaryHierarchyParentToChildIndexPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getHierarchicalIndex() const
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+DictionaryHierarchyParentToChildIndexPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchicalIndex() const
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
@@ -859,8 +859,8 @@ DictionaryHierarchyParentToChildIndexPtr HashedDictionary<dictionary_key_type, s
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getDescendants(
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getDescendants(
     ColumnPtr key_column [[maybe_unused]],
     const DataTypePtr &,
     size_t level [[maybe_unused]],
@@ -885,8 +885,8 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getDescendants
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+void HashedDictionary<dictionary_key_type, sparse>::createAttributes()
 {
     const auto size = dict_struct.attributes.size();
     attributes.reserve(size);
@@ -942,8 +942,8 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
         arena = std::make_unique<Arena>();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+void HashedDictionary<dictionary_key_type, sparse>::updateData()
 {
     /// NOTE: updateData() does not preallocation since it may increase memory usage.
     BlockIO io = source_ptr->loadUpdatedAll();
@@ -994,8 +994,8 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, UInt64 shard)
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+void HashedDictionary<dictionary_key_type, sparse>::blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, UInt64 shard)
 {
     size_t skip_keys_size_offset = dict_struct.getKeysSize();
     size_t new_element_count = 0;
@@ -1096,14 +1096,14 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::blockToAttributes(c
     element_count += new_element_count;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::resize(size_t added_rows)
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+void HashedDictionary<dictionary_key_type, sparse>::resize(size_t added_rows)
 {
     if (unlikely(!added_rows))
         return;
 
     /// In multi shards configuration it is pointless.
-    if constexpr (sharded)
+    if (sharded())
         return;
 
     size_t attributes_size = attributes.size();
@@ -1126,9 +1126,9 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::resize(size_t added
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+template <DictionaryKeyType dictionary_key_type, bool sparse>
 template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::getItemsImpl(
+void HashedDictionary<dictionary_key_type, sparse>::getItemsImpl(
     const Attribute & attribute,
     DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
     ValueSetter && set_value,
@@ -1172,9 +1172,9 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::getItemsImpl(
     found_count.fetch_add(keys_found, std::memory_order_relaxed);
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+template <DictionaryKeyType dictionary_key_type, bool sparse>
 template <typename AttributeType, bool is_nullable, typename ValueSetter, typename NullAndDefaultSetter>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::getItemsShortCircuitImpl(
+void HashedDictionary<dictionary_key_type, sparse>::getItemsShortCircuitImpl(
     const Attribute & attribute,
     DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
     ValueSetter && set_value,
@@ -1222,13 +1222,13 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::getItemsShortCircui
     found_count.fetch_add(keys_found, std::memory_order_relaxed);
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::loadData()
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+void HashedDictionary<dictionary_key_type, sparse>::loadData()
 {
     if (!source_ptr->hasUpdateField())
     {
         std::optional<DictionaryParallelLoaderType> parallel_loader;
-        if constexpr (sharded)
+        if (sharded())
             parallel_loader.emplace(*this);
 
         BlockIO io = source_ptr->loadAll();
@@ -1264,8 +1264,8 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::loadData()
             getFullName());
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::buildHierarchyParentToChildIndexIfNeeded()
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+void HashedDictionary<dictionary_key_type, sparse>::buildHierarchyParentToChildIndexIfNeeded()
 {
     if (!dict_struct.hierarchical_attribute_index)
         return;
@@ -1274,8 +1274,8 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::buildHierarchyParen
         hierarchical_index = getHierarchicalIndex();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::calculateBytesAllocated()
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+void HashedDictionary<dictionary_key_type, sparse>::calculateBytesAllocated()
 {
     size_t attributes_size = attributes.size();
     bytes_allocated += attributes_size * sizeof(attributes.front());
@@ -1334,8 +1334,8 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::calculateBytesAlloc
         bytes_allocated += arena->allocatedBytes();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-Pipe HashedDictionary<dictionary_key_type, sparse, sharded>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
+template <DictionaryKeyType dictionary_key_type, bool sparse>
+Pipe HashedDictionary<dictionary_key_type, sparse>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
 {
     PaddedPODArray<HashedDictionary::KeyType> keys;
 
@@ -1398,9 +1398,9 @@ Pipe HashedDictionary<dictionary_key_type, sparse, sharded>::read(const Names & 
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+template <DictionaryKeyType dictionary_key_type, bool sparse>
 template <typename GetContainersFunc>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::getAttributeContainers(size_t attribute_index, GetContainersFunc && get_containers_func)
+void HashedDictionary<dictionary_key_type, sparse>::getAttributeContainers(size_t attribute_index, GetContainersFunc && get_containers_func)
 {
     chassert(attribute_index < attributes.size());
 
@@ -1419,9 +1419,9 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::getAttributeContain
     callOnDictionaryAttributeType(attribute.type, type_call);
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+template <DictionaryKeyType dictionary_key_type, bool sparse>
 template <typename GetContainersFunc>
-void HashedDictionary<dictionary_key_type, sparse, sharded>::getAttributeContainers(size_t attribute_index, GetContainersFunc && get_containers_func) const
+void HashedDictionary<dictionary_key_type, sparse>::getAttributeContainers(size_t attribute_index, GetContainersFunc && get_containers_func) const
 {
     const_cast<std::decay_t<decltype(*this)> *>(this)->getAttributeContainers(attribute_index, [&](auto & attribute_containers)
     {

--- a/src/Dictionaries/HashedDictionaryParallelLoader.h
+++ b/src/Dictionaries/HashedDictionaryParallelLoader.h
@@ -27,7 +27,7 @@ namespace CurrentMetrics
 namespace DB
 {
 
-template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded> class HashedDictionary;
+template <DictionaryKeyType dictionary_key_type, bool sparse> class HashedDictionary;
 
 namespace ErrorCodes
 {

--- a/src/Dictionaries/SparseHashedDictionary.cpp
+++ b/src/Dictionaries/SparseHashedDictionary.cpp
@@ -3,10 +3,7 @@
 namespace DB
 {
 
-template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ true, /* sharded= */ false >;
-template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ true, /* sharded= */ true  >;
-
-template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ true, /* sharded= */ false >;
-template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ true, /* sharded= */ true  >;
+template class HashedDictionary<DictionaryKeyType::Simple, /* sparse= */ true>;
+template class HashedDictionary<DictionaryKeyType::Complex, /* sparse= */ true>;
 
 }

--- a/src/Dictionaries/registerHashedDictionary.cpp
+++ b/src/Dictionaries/registerHashedDictionary.cpp
@@ -92,33 +92,16 @@ void registerDictionaryHashed(DictionaryFactory & factory)
         if (dictionary_key_type == DictionaryKeyType::Simple)
         {
             if (sparse)
-            {
-                if (shards > 1)
-                    return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, true, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
-                return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, true, false>>(
+                return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, true>>(
                     dict_id, dict_struct, std::move(source_ptr), configuration);
-            }
-
-            if (shards > 1)
-                return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, false, true>>(
-                    dict_id, dict_struct, std::move(source_ptr), configuration);
-            return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, false, false>>(
+            return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, false>>(
                 dict_id, dict_struct, std::move(source_ptr), configuration);
         }
 
         if (sparse)
-        {
-            if (shards > 1)
-                return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, true, true>>(
-                    dict_id, dict_struct, std::move(source_ptr), configuration);
-            return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, true, false>>(
+            return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, true>>(
                 dict_id, dict_struct, std::move(source_ptr), configuration);
-        }
-
-        if (shards > 1)
-            return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, false, true>>(
-                dict_id, dict_struct, std::move(source_ptr), configuration);
-        return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, false, false>>(
+        return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, false>>(
             dict_id, dict_struct, std::move(source_ptr), configuration);
     };
 

--- a/src/Functions/FunctionBinaryArithmetic.h
+++ b/src/Functions/FunctionBinaryArithmetic.h
@@ -858,7 +858,7 @@ private:
 using namespace traits_;
 using namespace impl_;
 
-template <template <typename, typename> class Op, typename Name, bool valid_on_default_arguments = true, bool valid_on_float_arguments = true, bool division_by_nullable = false>
+template <template <typename, typename> class Op, typename Name, bool valid_on_default_arguments = true, bool valid_on_float_arguments = true>
 class FunctionBinaryArithmetic : public IFunction, WithContext
 {
     static constexpr bool is_plus = IsOperation<Op>::plus;
@@ -875,6 +875,12 @@ class FunctionBinaryArithmetic : public IFunction, WithContext
     static constexpr bool is_int_div_or_null = IsOperation<Op>::int_div_or_null;
 
     bool check_decimal_overflow = true;
+
+    /// Whether the operation is a division with a Nullable denominator (needs the division-by-zero
+    /// protection in executeImpl2). Decided by the overload resolver from the original argument
+    /// types. A runtime flag instead of a template parameter: making it a template parameter would
+    /// instantiate the entire class twice for every division-like operation.
+    bool division_by_nullable = false;
 
     /// Date/Time overflow behavior, captured from the query context at construction time so that
     /// executeImpl does not have to consult the context (which may have been destroyed by the time a
@@ -2252,14 +2258,15 @@ class FunctionBinaryArithmetic : public IFunction, WithContext
 public:
     static constexpr auto name = Name::name;
     static FunctionPtr create(ContextPtr context_) { return std::make_shared<FunctionBinaryArithmetic>(context_); }
-    static FunctionPtr create(ContextPtr context_, const DataTypePtr & left_type, const DataTypePtr & right_type)
+    static FunctionPtr create(ContextPtr context_, const DataTypePtr & left_type, const DataTypePtr & right_type, bool division_by_nullable_ = false)
     {
-        return std::make_shared<FunctionBinaryArithmetic>(context_, left_type, right_type);
+        return std::make_shared<FunctionBinaryArithmetic>(context_, left_type, right_type, division_by_nullable_);
     }
 
-    explicit FunctionBinaryArithmetic(ContextPtr context_, const DataTypePtr & left_type = nullptr, const DataTypePtr & right_type = nullptr)
+    explicit FunctionBinaryArithmetic(ContextPtr context_, const DataTypePtr & left_type = nullptr, const DataTypePtr & right_type = nullptr, bool division_by_nullable_ = false)
     :   WithContext(context_),
         check_decimal_overflow(decimalCheckArithmeticOverflow(context_)),
+        division_by_nullable(division_by_nullable_),
         date_time_overflow_behavior(getDateTimeOverflowBehavior(context_))
     {
         /// Resolve the context-dependent builders for the interval/tuple special cases now, while the
@@ -2273,10 +2280,10 @@ public:
         /// same way here to resolve exactly the builders executeImpl would.
         if (left_type && right_type)
         {
-            auto normalize = [](DataTypePtr type)
+            auto normalize = [this](DataTypePtr type)
             {
                 type = recursiveRemoveLowCardinality(type);
-                if constexpr (!division_by_nullable && !is_division_or_null)
+                if (!division_by_nullable && !is_division_or_null)
                     type = removeNullable(type);
                 return type;
             };
@@ -3675,28 +3682,30 @@ ColumnPtr executeStringInteger(const ColumnsWithTypeAndName & arguments, const A
 };
 
 
-template <template <typename, typename> class Op, typename Name, bool valid_on_default_arguments = true, bool valid_on_float_arguments = true, bool division_by_nullable = false>
-class FunctionBinaryArithmeticWithConstants final : public FunctionBinaryArithmetic<Op, Name, valid_on_default_arguments, valid_on_float_arguments, division_by_nullable>
+template <template <typename, typename> class Op, typename Name, bool valid_on_default_arguments = true, bool valid_on_float_arguments = true>
+class FunctionBinaryArithmeticWithConstants final : public FunctionBinaryArithmetic<Op, Name, valid_on_default_arguments, valid_on_float_arguments>
 {
 public:
-    using Base = FunctionBinaryArithmetic<Op, Name, valid_on_default_arguments, valid_on_float_arguments, division_by_nullable>;
+    using Base = FunctionBinaryArithmetic<Op, Name, valid_on_default_arguments, valid_on_float_arguments>;
     using Monotonicity = typename Base::Monotonicity;
 
     static FunctionPtr create(
         const ColumnWithTypeAndName & left_,
         const ColumnWithTypeAndName & right_,
         const DataTypePtr & return_type_,
-        ContextPtr context_)
+        ContextPtr context_,
+        bool division_by_nullable_ = false)
     {
-        return std::make_shared<FunctionBinaryArithmeticWithConstants>(left_, right_, return_type_, context_);
+        return std::make_shared<FunctionBinaryArithmeticWithConstants>(left_, right_, return_type_, context_, division_by_nullable_);
     }
 
     FunctionBinaryArithmeticWithConstants(
         const ColumnWithTypeAndName & left_,
         const ColumnWithTypeAndName & right_,
         const DataTypePtr & return_type_,
-        ContextPtr context_)
-        : Base(context_, left_.type, right_.type), left(left_), right(right_), return_type(return_type_)
+        ContextPtr context_,
+        bool division_by_nullable_ = false)
+        : Base(context_, left_.type, right_.type, division_by_nullable_), left(left_), right(right_), return_type(return_type_)
     {
     }
 
@@ -4237,9 +4246,6 @@ public:
     FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
     {
         /// Only division-like operations can have division_by_nullable=true.
-        /// Using if constexpr avoids instantiating FunctionBinaryArithmetic<..., true> and
-        /// FunctionBinaryArithmeticWithConstants<..., true> for all other operations,
-        /// significantly reducing template bloat.
         static constexpr bool can_have_division_by_nullable =
             IsOperation<Op>::int_div || IsOperation<Op>::modulo || IsOperation<Op>::positive_modulo || IsOperation<Op>::div_floating;
 
@@ -4267,22 +4273,11 @@ public:
             && ((arguments[0].column && isColumnConst(*arguments[0].column))
                 || (arguments[1].column && isColumnConst(*arguments[1].column))))
         {
-            if constexpr (can_have_division_by_nullable)
-            {
-                if (division_by_nullable)
-                    return make_adaptor(FunctionBinaryArithmeticWithConstants<Op, Name, valid_on_default_arguments, valid_on_float_arguments, true>::create(
-                        arguments[0], arguments[1], return_type, context));
-            }
-            return make_adaptor(FunctionBinaryArithmeticWithConstants<Op, Name, valid_on_default_arguments, valid_on_float_arguments, false>::create(
-                arguments[0], arguments[1], return_type, context));
+            return make_adaptor(FunctionBinaryArithmeticWithConstants<Op, Name, valid_on_default_arguments, valid_on_float_arguments>::create(
+                arguments[0], arguments[1], return_type, context, division_by_nullable));
         }
 
-        if constexpr (can_have_division_by_nullable)
-        {
-            if (division_by_nullable)
-                return make_adaptor(FunctionBinaryArithmetic<Op, Name, valid_on_default_arguments, valid_on_float_arguments, true>::create(context, arguments[0].type, arguments[1].type));
-        }
-        return make_adaptor(FunctionBinaryArithmetic<Op, Name, valid_on_default_arguments, valid_on_float_arguments, false>::create(context, arguments[0].type, arguments[1].type));
+        return make_adaptor(FunctionBinaryArithmetic<Op, Name, valid_on_default_arguments, valid_on_float_arguments>::create(context, arguments[0].type, arguments[1].type, division_by_nullable));
     }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override

--- a/src/Functions/array/arrayDistance.cpp
+++ b/src/Functions/array/arrayDistance.cpp
@@ -807,6 +807,26 @@ public:
 
 
 private:
+    /// Mirror of the getLeastSupertype-based mapping in getReturnTypeImpl: the result is Float32
+    /// iff both operand types are representable in Float32 (small ints, BFloat16, Float32) and at
+    /// least one of them is a small float (otherwise the supertype is an integer type, which maps
+    /// to Float64). For every (left, right) pair exactly one ResultType is reachable, so guarding
+    /// the kernel instantiations with this predicate halves the number of instantiations.
+    template <typename T>
+    static constexpr bool is_small_float = std::is_same_v<T, BFloat16> || std::is_same_v<T, Float32>;
+
+    template <typename T>
+    static constexpr bool fits_float32 = is_small_float<T>
+        || std::is_same_v<T, UInt8> || std::is_same_v<T, UInt16> || std::is_same_v<T, Int8> || std::is_same_v<T, Int16>;
+
+    template <typename ResultType, typename FirstArgType, typename SecondArgType>
+    static constexpr bool isReachableResultType()
+    {
+        constexpr bool is_float32_result = fits_float32<FirstArgType> && fits_float32<SecondArgType>
+            && (is_small_float<FirstArgType> || is_small_float<SecondArgType>);
+        return std::is_same_v<ResultType, Float32> == is_float32_result;
+    }
+
     template <typename ResultType>
     ColumnPtr executeWithResultType(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const
     {
@@ -841,7 +861,13 @@ private:
         {
         #define ON_TYPE(type) \
             case TypeIndex::type: \
-                return executeWithResultTypeAndLeftTypeAndRightType<ResultType, LeftType, type>(arguments[0].column, arguments[1].column, input_rows_count, arguments); \
+                if constexpr (isReachableResultType<ResultType, LeftType, type>()) \
+                    return executeWithResultTypeAndLeftTypeAndRightType<ResultType, LeftType, type>(arguments[0].column, arguments[1].column, input_rows_count, arguments); \
+                else \
+                    throw Exception( \
+                        ErrorCodes::LOGICAL_ERROR, \
+                        "Result type {} of function {} is impossible for operand types {} and {}", \
+                        TypeName<ResultType>, getName(), TypeName<LeftType>, TypeName<type>); \
                 break;
 
             SUPPORTED_TYPES(ON_TYPE)

--- a/src/Functions/equals.cpp
+++ b/src/Functions/equals.cpp
@@ -8,6 +8,8 @@ namespace DB
 {
 
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
+/// Used through `FunctionIsNotDistinctFrom` in `executeArrayLexicographic`; instantiated in isNotDistinctFrom.cpp.
+extern template class FunctionComparison<EqualsOp, NameEquals, true>;
 
 REGISTER_FUNCTION(Equals)
 {

--- a/src/Functions/isDistinctFrom.cpp
+++ b/src/Functions/isDistinctFrom.cpp
@@ -9,6 +9,8 @@ namespace DB
 
 /// avoid second copy
 extern template class FunctionComparison<EqualsOp, NameEquals, true>;
+/// The null-safe comparison falls back to the plain one for tuples; instantiated in notEquals.cpp.
+extern template class FunctionComparison<NotEqualsOp, NameNotEquals>;
 
 REGISTER_FUNCTION(IsDistinctFrom)
 {

--- a/src/Functions/isNotDistinctFrom.cpp
+++ b/src/Functions/isNotDistinctFrom.cpp
@@ -5,6 +5,9 @@
 namespace DB
 {
 
+/// The null-safe comparison falls back to the plain one for tuples; instantiated in equals.cpp.
+extern template class FunctionComparison<EqualsOp, NameEquals>;
+
 REGISTER_FUNCTION(IsNotDistinctFrom)
 {
     FunctionDocumentation::Description description = R"(

--- a/src/Functions/notEquals.cpp
+++ b/src/Functions/notEquals.cpp
@@ -9,6 +9,8 @@ namespace DB
 using FunctionNotEquals = FunctionComparison<NotEqualsOp, NameNotEquals>;
 using FunctionEquals = FunctionComparison<EqualsOp, NameEquals>;
 extern template class FunctionComparison<EqualsOp, NameEquals>;
+/// Used through `FunctionIsNotDistinctFrom` in `executeArrayLexicographic`; instantiated in isNotDistinctFrom.cpp.
+extern template class FunctionComparison<EqualsOp, NameEquals, true>;
 
 REGISTER_FUNCTION(NotEquals)
 {


### PR DESCRIPTION
Removes several sources of redundant template instantiations found by analyzing per-symbol composition of the largest object files.

- Complete `extern template` coverage in the comparison family: `equals`/`notEquals` implicitly instantiated a second full `EqualsOp` kernel family via `FunctionIsNotDistinctFrom`, and the null-safe comparisons re-instantiated the plain ones for tuples. `notEquals.cpp.o` 17.2 → 9.3 MiB, the other three ~11.7 → ~9.3 MiB.
- Make `division_by_nullable` a runtime flag of `FunctionBinaryArithmetic` instead of a template parameter: it is decided at runtime in `buildImpl` and duplicated the whole class per bool (1132 of 1136 true/false symbol pairs in `modulo.cpp.o` were byte-identical). `modulo.cpp.o` 27.5 → 18.5 MiB, `divide.cpp.o` 15.3 → 10.6 MiB, `intDiv.cpp.o` 16.1 → 11.6 MiB.
- Make `sharded` a runtime property of `HashedDictionary` (`configuration.shards > 1`): it was consulted only in a few `if constexpr` branches. `HashedDictionary.cpp.o` 9.9 → 6.7 MiB, `SparseHashedDictionary.cpp.o` 12.0 → 8.9 MiB.
- Do not instantiate unreachable `arrayDistance` kernels: only one of `Float32`/`Float64` is reachable per operand type pair; a `constexpr` mirror of the supertype mapping (verified against `getLeastSupertype` for all 121 pairs) prunes the other half. `arrayDistance.cpp.o` 23.4 → 12.6 MiB.
- Outline the formatted throws of `argMin`/`argMax` (763 inlined exception-allocation sites). `AggregateFunctionsArgMinArgMax.cpp.o` 12.5 → 11.3 MiB.

Total: ~48 MiB less object files and correspondingly less compile time. The final binary is unchanged — the duplicated symbols were weak and already deduplicated by the linker. No behavior changes; verified against the existing `arrayDistance` stateless tests and `clickhouse-local` checks for nullable-denominator division, null-safe comparisons, `argMin`/`argMax`, and all hashed dictionary layouts with and without `SHARDS`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduced compile time and object file sizes by removing redundant template instantiations in comparison functions, binary arithmetic, `arrayDistance`, hashed dictionaries, and `argMin`/`argMax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117540&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117540](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117540+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.783` (included in `26.9` and later)
<!-- ch-version-info:end -->