### PR TITLE
Compute toHour and toMinute arithmetically in time zones where the calendar is not needed

### DIFF
--- a/src/Common/DateLUTImpl.cpp
+++ b/src/Common/DateLUTImpl.cpp
@@ -97,8 +97,7 @@ DateLUTImpl::DateLUTImpl(std::string_view time_zone_) // NOLINT(cppcoreguideline
     offset_minute_of_hour_is_constant_during_epoch = true;
 
     /// The UTC time of day at which a local day begins: 66600 for `Asia/Kolkata`, whose +05:30 puts local
-    /// midnight at 18:30 the day before. The two flags above assert that every epoch day begins at it, which
-    /// is what lets its complements below stand in for the offset.
+    /// midnight at 18:30 the day before.
     const Time utc_time_of_day_at_local_midnight = ((-offset_at_start_of_epoch) % 86400 + 86400) % 86400;
     hour_of_day_offset_addend = 86400 - utc_time_of_day_at_local_midnight;
     minute_of_hour_offset_addend = 3600 - utc_time_of_day_at_local_midnight % 3600;

--- a/src/Common/DateLUTImpl.cpp
+++ b/src/Common/DateLUTImpl.cpp
@@ -93,6 +93,14 @@ DateLUTImpl::DateLUTImpl(std::string_view time_zone_) // NOLINT(cppcoreguideline
     offset_is_whole_number_of_hours_during_epoch = true;
     offset_is_whole_number_of_minutes_during_epoch = true;
     offset_is_fixed = true;
+    offset_is_fixed_during_epoch = true;
+    offset_minute_of_hour_is_constant_during_epoch = true;
+
+    /// Time-of-day part of the UTC offset at the start of the epoch; the two flags above assert that every
+    /// epoch day agrees with it, which is what lets the addends below stand in for the offset itself.
+    const Time epoch_offset_time_of_day = ((-offset_at_start_of_epoch) % 86400 + 86400) % 86400;
+    hour_of_day_offset_addend = 86400 - epoch_offset_time_of_day;
+    minute_of_hour_offset_addend = 3600 - epoch_offset_time_of_day % 3600;
 
     cctz::civil_day date = lut_start;
     cctz::time_point<cctz::seconds> start_of_day_time_point_if_no_transitions = lookupTz(tz, date);
@@ -165,6 +173,22 @@ DateLUTImpl::DateLUTImpl(std::string_view time_zone_) // NOLINT(cppcoreguideline
 
         if (offset_is_whole_number_of_minutes_during_epoch && start_of_day > 0 && start_of_day % 60)
             offset_is_whole_number_of_minutes_during_epoch = false;
+
+        /// The epoch-scoped flags are derived from the local days that can contain a non-negative time point;
+        /// west of UTC that day starts before the epoch.
+        if (start_of_day > -86400)
+        {
+            Time time_of_day = start_of_day % 86400;
+            if (time_of_day < 0)
+                time_of_day += 86400;
+
+            if (values.amount_of_offset_change_value != 0 || (i != 0 && values.date - lut[i - 1].date != 86400))
+                offset_is_fixed_during_epoch = false;
+
+            if (time_of_day % 60 != 0 || time_of_day % 3600 != epoch_offset_time_of_day % 3600
+                || values.amount_of_offset_change() % 3600 != 0)
+                offset_minute_of_hour_is_constant_during_epoch = false;
+        }
 
         /// An offset change at midnight makes consecutive days start more or less than 86400 seconds apart;
         /// a change at any other time is recorded in amount_of_offset_change_value of the affected day.

--- a/src/Common/DateLUTImpl.cpp
+++ b/src/Common/DateLUTImpl.cpp
@@ -96,11 +96,12 @@ DateLUTImpl::DateLUTImpl(std::string_view time_zone_) // NOLINT(cppcoreguideline
     offset_is_fixed_during_epoch = true;
     offset_minute_of_hour_is_constant_during_epoch = true;
 
-    /// Time-of-day part of the UTC offset at the start of the epoch; the two flags above assert that every
-    /// epoch day agrees with it, which is what lets the addends below stand in for the offset itself.
-    const Time epoch_offset_time_of_day = ((-offset_at_start_of_epoch) % 86400 + 86400) % 86400;
-    hour_of_day_offset_addend = 86400 - epoch_offset_time_of_day;
-    minute_of_hour_offset_addend = 3600 - epoch_offset_time_of_day % 3600;
+    /// The UTC time of day at which a local day begins: 66600 for `Asia/Kolkata`, whose +05:30 puts local
+    /// midnight at 18:30 the day before. The two flags above assert that every epoch day begins at it, which
+    /// is what lets its complements below stand in for the offset.
+    const Time utc_time_of_day_at_local_midnight = ((-offset_at_start_of_epoch) % 86400 + 86400) % 86400;
+    hour_of_day_offset_addend = 86400 - utc_time_of_day_at_local_midnight;
+    minute_of_hour_offset_addend = 3600 - utc_time_of_day_at_local_midnight % 3600;
 
     cctz::civil_day date = lut_start;
     cctz::time_point<cctz::seconds> start_of_day_time_point_if_no_transitions = lookupTz(tz, date);
@@ -185,7 +186,7 @@ DateLUTImpl::DateLUTImpl(std::string_view time_zone_) // NOLINT(cppcoreguideline
             if (values.amount_of_offset_change_value != 0 || (i != 0 && values.date - lut[i - 1].date != 86400))
                 offset_is_fixed_during_epoch = false;
 
-            if (time_of_day % 60 != 0 || time_of_day % 3600 != epoch_offset_time_of_day % 3600
+            if (time_of_day % 60 != 0 || time_of_day % 3600 != utc_time_of_day_at_local_midnight % 3600
                 || values.amount_of_offset_change() % 3600 != 0)
                 offset_minute_of_hour_is_constant_during_epoch = false;
         }

--- a/src/Common/DateLUTImpl.h
+++ b/src/Common/DateLUTImpl.h
@@ -244,6 +244,16 @@ private:
     bool offset_is_whole_number_of_minutes_during_epoch;
     bool offset_is_fixed;
 
+    /// Epoch-scoped: `offset_is_fixed` above covers the whole lookup table and so excludes zones that merely
+    /// stopped changing their offset before 1970. The minute variant is weaker - a whole number of minutes,
+    /// changing only by whole hours - which is what makes the minute independent of the offset.
+    bool offset_is_fixed_during_epoch;
+    bool offset_minute_of_hour_is_constant_during_epoch;
+    /// Added before the division in `toHour` / `toMinute`: one extra whole day (hour) shifts the quotient by
+    /// exactly one cycle, so the result modulo 24 (60) is unchanged, and the dividend stays non-negative.
+    Time hour_of_day_offset_addend;
+    Time minute_of_hour_offset_addend;
+
     /// Time zone name.
     std::string time_zone;
 
@@ -859,6 +869,9 @@ public:
         if (unlikely(isOutOfLUTRange(t)))
             return static_cast<unsigned>(toDateTimeComponentsOutOfRange(t).time.hour);
 
+        if (t >= 0 && offset_is_fixed_during_epoch)
+            return static_cast<unsigned>(((t + hour_of_day_offset_addend) / 3600) % 24);
+
         const LUTIndex index = findIndexInRange(t);
 
         Time time = t - lut[index].date;
@@ -935,8 +948,12 @@ public:
         if (t >= 0 && offset_is_whole_number_of_hours_during_epoch)
             return (t / 60) % 60;
 
-        /// To consider the DST changing situation within this day
-        /// also make the special timezones with no whole hour offset such as 'Australia/Lord_Howe' been taken into account.
+        if (t >= 0 && offset_minute_of_hour_is_constant_during_epoch)
+            return static_cast<unsigned>(((t + minute_of_hour_offset_addend) / 60) % 60);
+
+        /// The zones reaching here are the ones whose minute-of-hour offset is not constant during the epoch,
+        /// such as `Australia/Lord_Howe` (a 30-minute DST step) and `Asia/Kathmandu` (a sub-hour offset that
+        /// moved in 1986), so the offset change within the day has to be applied explicitly.
 
         LUTIndex index = findIndexInRange(t);
         UInt32 time = static_cast<UInt32>(t - lut[index].date);

--- a/tests/performance/to_hour_to_minute_epoch_offset.xml
+++ b/tests/performance/to_hour_to_minute_epoch_offset.xml
@@ -1,0 +1,16 @@
+<test>
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <!-- A zone whose UTC offset never changes after 1970-01-01 has a constant hour and
+         minute component of that offset, so toHour and toMinute are pure arithmetic there.
+         Asia/Istanbul observed DST during that period and Asia/Kolkata is a fixed +05:30,
+         which is why the two zones behave differently for the same accessor. -->
+
+    <query>SELECT sum(toHour(t, 'UTC')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
+    <query>SELECT sum(toMinute(t, 'Asia/Kolkata')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
+
+    <query>SELECT sum(toHour(t, 'Asia/Istanbul')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
+    <query>SELECT sum(toMinute(t, 'UTC')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
+</test>

--- a/tests/performance/to_hour_to_minute_epoch_offset.xml
+++ b/tests/performance/to_hour_to_minute_epoch_offset.xml
@@ -3,14 +3,15 @@
         <max_threads>1</max_threads>
     </settings>
 
-    <!-- A zone whose UTC offset never changes after 1970-01-01 has a constant hour and
-         minute component of that offset, so toHour and toMinute are pure arithmetic there.
-         Asia/Istanbul observed DST during that period and Asia/Kolkata is a fixed +05:30,
-         which is why the two zones behave differently for the same accessor. -->
+    <!-- `UTC` never changes its offset at all; `Asia/Kolkata` is a fixed +05:30 since 1945, but had
+         both an LMT offset and DST before that; `Pacific/Chatham` steps its +12:45 offset by a whole
+         hour for DST every year, so its minute of the hour is constant while its hour is not. Those
+         three properties are what decide, per accessor, whether the calendar table has to be read. -->
 
     <query>SELECT sum(toHour(t, 'UTC')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
-    <query>SELECT sum(toMinute(t, 'Asia/Kolkata')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
+    <query>SELECT sum(toHour(t, 'Asia/Kolkata')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
+    <query>SELECT sum(toMinute(t, 'Pacific/Chatham')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
 
-    <query>SELECT sum(toHour(t, 'Asia/Istanbul')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
+    <query>SELECT sum(toHour(t, 'Pacific/Chatham')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
     <query>SELECT sum(toMinute(t, 'UTC')) FROM (SELECT toDateTime(1600000000 + number % 50000000, 'UTC') AS t FROM numbers(50000000))</query>
 </test>

--- a/tests/queries/0_stateless/05073_to_hour_to_minute_epoch_offset_fast_path.reference
+++ b/tests/queries/0_stateless/05073_to_hour_to_minute_epoch_offset_fast_path.reference
@@ -1,0 +1,16 @@
+Africa/Monrovia	0	72399	0	0
+Africa/Monrovia	1	150401	0	0
+America/St_Johns	0	72399	0	0
+America/St_Johns	1	150401	0	0
+Asia/Kathmandu	0	72399	0	0
+Asia/Kathmandu	1	150401	0	0
+Asia/Kolkata	0	72399	0	0
+Asia/Kolkata	1	150401	0	0
+Australia/Lord_Howe	0	72399	0	0
+Australia/Lord_Howe	1	150401	0	0
+Europe/Berlin	0	72399	0	0
+Europe/Berlin	1	150401	0	0
+Pacific/Chatham	0	72399	0	0
+Pacific/Chatham	1	150401	0	0
+UTC	0	72399	0	0
+UTC	1	150401	0	0

--- a/tests/queries/0_stateless/05073_to_hour_to_minute_epoch_offset_fast_path.sql
+++ b/tests/queries/0_stateless/05073_to_hour_to_minute_epoch_offset_fast_path.sql
@@ -1,0 +1,61 @@
+-- Tests the arithmetic fast paths of toHour and toMinute. toHour takes one in time zones whose UTC offset
+-- does not change from the epoch onwards; toMinute takes one in time zones that keep a constant minute-of-hour
+-- (a whole number of minutes, changing only by whole hours). Other zones, negative times and times outside the
+-- lookup table keep the calendar path.
+--
+-- Oracle is toString(), which renders hour and minute through toDateTimeComponents, a different code path.
+-- Do not use formatDateTime('%H'): it calls the same ToHourImpl, so it would compare the fast path to itself.
+-- n is printed so that a generator producing no rows cannot pass as "no mismatches".
+
+SELECT * FROM (
+    WITH ts AS (
+        -- epoch sweep: stride coprime with 86400, so every hour and minute residue occurs; spans 1970..2046
+        SELECT toInt64(number) * 39989 AS t FROM numbers(60000)
+        -- every second around the epoch, covering the local day that contains t = 0 in every zone
+        UNION ALL SELECT toInt64(number) - 50400 FROM numbers(136800)
+        -- before the epoch: the fast paths must not apply
+        UNION ALL SELECT -toInt64(number) * 39989 FROM numbers(20000)
+        -- outside the lookup table: the cctz escape path must not be affected
+        UNION ALL SELECT arrayJoin([-2209000000, 10413800000, 16725303245]) + toInt64(number) * 97 FROM numbers(2000)
+    )
+    -- both fast paths, whole-hour offset
+    SELECT 'UTC' AS zone, t >= 0 AS epoch, count() AS n,
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))) AS bad_hour,
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2))) AS bad_minute
+    FROM (SELECT t, toDateTime64(t, 0, 'UTC') AS dt, toString(dt) AS s FROM ts) GROUP BY epoch
+    -- both fast paths, +05:30 offset
+    UNION ALL SELECT 'Asia/Kolkata', t >= 0, count(),
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))),
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2)))
+    FROM (SELECT t, toDateTime64(t, 0, 'Asia/Kolkata') AS dt, toString(dt) AS s FROM ts) GROUP BY t >= 0
+    -- minute fast, hour on the calendar path: +12:45 with a whole-hour DST step
+    UNION ALL SELECT 'Pacific/Chatham', t >= 0, count(),
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))),
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2)))
+    FROM (SELECT t, toDateTime64(t, 0, 'Pacific/Chatham') AS dt, toString(dt) AS s FROM ts) GROUP BY t >= 0
+    -- minute fast, hour on the calendar path, west of UTC
+    UNION ALL SELECT 'America/St_Johns', t >= 0, count(),
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))),
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2)))
+    FROM (SELECT t, toDateTime64(t, 0, 'America/St_Johns') AS dt, toString(dt) AS s FROM ts) GROUP BY t >= 0
+    -- minute already fast before this change, hour on the calendar path
+    UNION ALL SELECT 'Europe/Berlin', t >= 0, count(),
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))),
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2)))
+    FROM (SELECT t, toDateTime64(t, 0, 'Europe/Berlin') AS dt, toString(dt) AS s FROM ts) GROUP BY t >= 0
+    -- neither fast path: 30-minute DST step
+    UNION ALL SELECT 'Australia/Lord_Howe', t >= 0, count(),
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))),
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2)))
+    FROM (SELECT t, toDateTime64(t, 0, 'Australia/Lord_Howe') AS dt, toString(dt) AS s FROM ts) GROUP BY t >= 0
+    -- neither fast path: sub-hour offset that moved in 1986
+    UNION ALL SELECT 'Asia/Kathmandu', t >= 0, count(),
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))),
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2)))
+    FROM (SELECT t, toDateTime64(t, 0, 'Asia/Kathmandu') AS dt, toString(dt) AS s FROM ts) GROUP BY t >= 0
+    -- neither fast path: sub-minute offset until 1972, inside the epoch
+    UNION ALL SELECT 'Africa/Monrovia', t >= 0, count(),
+           countIf(toHour(dt) != toUInt8(substring(s, 12, 2))),
+           countIf(toMinute(dt) != toUInt8(substring(s, 15, 2)))
+    FROM (SELECT t, toDateTime64(t, 0, 'Africa/Monrovia') AS dt, toString(dt) AS s FROM ts) GROUP BY t >= 0
+) ORDER BY zone, epoch;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/117512   (auto-closes the issue when this PR is merged into the default branch)
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`toHour` and `toMinute` no longer walk the calendar lookup table in time zones where the result is pure arithmetic. `toHour` gets an arithmetic path in every zone whose UTC offset does not change after 1970 (including `UTC` and `Asia/Kolkata`), and `toMinute` gets one in zones that merely keep a constant minute-of-hour, such as `Asia/Kolkata`, `Pacific/Chatham` and `America/St_Johns`, which the previous whole-hour-offset condition excluded. Results are unchanged.

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/117512
Reported and analysed by @ snelheidai.

`toHour` had no time-zone fast path at all, so every call resolved a lookup-table index and applied a DST correction per row, including in `UTC`. `toMinute` had one, but gated on the offset being a whole number of *hours*, so every sub-hour zone fell through to the same walk.

Both quantities depend only on `t` in a large class of zones: if the UTC offset never changes after the epoch, every epoch day is 86400 s long and the hour is `floor((t + off) / 3600) mod 24`; if the offset merely keeps a constant minute-of-hour, it cancels out of the minute. Master expressed neither property. `offset_is_fixed` covers the whole table from 1900, so it is false for `Asia/Kolkata` (+05:53:20 LMT, 1941-45 DST); the whole-hours flag is neither sufficient for the hour (`Asia/Istanbul` is whole-hour and had DST until 2016) nor necessary (`Asia/Kolkata` is fixed but not whole-hour).

So this adds two epoch-scoped flags and two precomputed addends, derived in the constructor's existing pass over the table, and one branch each in `toHour` and `toMinute`. The existing whole-hours branch is kept ahead of the new one: the two are derived over different windows, so collapsing them could change which zones are accepted. Both paths stay behind `isOutOfLUTRange` and are gated on `t >= 0`. The hour gate is conservative, not tight: master's fixed-offset condition also rejects the two zones whose only post-1970 change is exactly one whole day (`Pacific/Fakaofo`, `Pacific/Kwajalein`), where the hour is unaffected. Accepting those 3 zone files needs a second definition of a fixed offset.

Not addressed here, pre-existing: a `Time`/`Time64` seconds-of-day value would be wrong on these paths, as it already would be on the existing `toMinute` and `toSecond` fast paths; `isAcceptableFirstArgument` makes it unreachable today.

<details><summary>Which zones change, and how this was validated</summary>

Of 598 shipped zones, **184** get the new `toHour` path; for `toMinute`, 556 were already fast, **18** newly are (`America/St_Johns`, `Asia/Kolkata`, `Asia/Kabul`, `Pacific/Chatham`, ... ) and **24** keep the calendar path (`Africa/Monrovia`, `Asia/Kathmandu`, `Australia/Lord_Howe`, ... ). Cross-checked against a classification derived from the in-tree tzdata with `zdump`, without ClickHouse: all five counts and both zone lists agree exactly.

Results are byte-identical to master:

- `unit_tests_dbms --gtest_filter='*DateLUT*'`: 7799 tests pass, comparing `toHour` and `toMinute` against **cctz** for every embedded zone across six time ranges including `PreEpoch`.
- An A/B differential against a pristine master build over **all 598 zones** x 222,800 timestamps each (epoch sweep, every second of the local day containing `t = 0`, pre-epoch, out-of-lookup-table) = 133 M evaluations per binary: per-zone hashes identical.
- New test `05073_to_hour_to_minute_epoch_offset_fast_path`, one zone per gate outcome, checked against `toString` (a different code path) rather than `formatDateTime('%H')`, which would call the code under test. Its `.reference` was generated on pristine master. 100/100 with randomised settings.

`tests/performance/to_hour_to_minute_epoch_offset.xml` measures it. `date_time_long.xml` covers the same functions, but expands to 172 queries of which the job measures 10 at random, so none of those rows was drawn here. Master medians from `perf.py` against two servers of one `amd_release` build (1 thread, 50M rows): `toHour` 162 ms in `UTC` and 164 ms in `Asia/Kolkata`, `toMinute` 165 ms in `Pacific/Chatham`, against 98 ms for `toMinute` in `UTC`, already arithmetic. The first three should reach that 98 ms; `toHour` in `Pacific/Chatham` and `toMinute` in `UTC` should not move. One build, two paths, not an A/B: separately linked binaries differ by more than the effect.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117562&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117562](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117562+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117562&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117562](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117562+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->




<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.843` (included in `26.9` and later)
<!-- ch-version-info:end -->