### PR TITLE
Tear down an integration test's cluster when its module ends, not at session end

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -88,6 +88,12 @@ for i in "${ROOT_PATH}"/tests/integration/test_*; do FILE="${i}/__init__.py"; [ 
 # ClickHouse-owned images with ${VAR:-latest} pattern are excluded since the variable is set in CI.
 find "${ROOT_PATH}/tests/integration/compose" -name '*.yml' -print0 | xargs -0 grep -P 'image:\s*\S+:latest\s*$' | grep -v '\${\|clickhouse/' && echo "Docker compose files should use pinned versions instead of :latest for third-party images"
 
+# A leaf test file cannot share a fixture with another file, so a session-scoped fixture there only
+# defers its teardown to the end of the pytest session, keeping the cluster's containers and their
+# memory for the rest of the job. tests/integration/conftest.py is where session scope belongs.
+grep -rlE --include='test*.py' "scope[[:space:]]*=[[:space:]]*['\"]session['\"]" "${ROOT_PATH}"/tests/integration/test_*/ \
+    && echo "Integration test fixtures should be module-scoped, not session-scoped"
+
 # Check for executable bit on non-executable files
 git ls-files -s $ROOT_PATH/{src,base,programs,utils,tests,docs,cmake} | \
     awk '$1 != "120000" && $1 != "100644" { print $4 }' | grep -E '\.(cpp|h|sql|j2|xml|reference|txt|md)$' && echo "These files should not be executable."

--- a/tests/integration/test_distributed_over_distributed/test.py
+++ b/tests/integration/test_distributed_over_distributed/test.py
@@ -41,7 +41,7 @@ ENGINE = Distributed('test_cluster', default, distributed_table);
 INSERT_SQL_TEMPLATE = "INSERT INTO base_table VALUES ('{node_id}', {key}, {value})"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()

--- a/tests/integration/test_refreshable_mat_view/test.py
+++ b/tests/integration/test_refreshable_mat_view/test.py
@@ -30,7 +30,7 @@ node2 = cluster.add_instance(
 )
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def started_cluster():
     try:
         cluster.start()

--- a/tests/integration/test_refreshable_mat_view_replicated/test.py
+++ b/tests/integration/test_refreshable_mat_view_replicated/test.py
@@ -34,7 +34,7 @@ node2 = cluster.add_instance(
 nodes = [node, node2]
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def started_cluster():
     try:
         cluster.start()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117412
Related: https://github.com/ClickHouse/ClickHouse/pull/113107


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Integration tests (amd_asan_ubsan, db disk, old analyzer, 6/6)` still reports `Container memory budget exceeded (/docker)` with every test in the job passing, on this PR's own base, a master tree that carries #117412. The run cited on #113107 predates it. At 17:35 UTC on 2026-09-01 that one shard is 192 of 197 such rows fleet-wide.

https://github.com/ClickHouse/ClickHouse/actions/runs/33296819525/job/99262785281
https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=8627fa22f01595b16121a0d6100ef243475c778c&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29

Three test files declare their cluster fixture `scope="session"` instead of `scope="module"`: `test_refreshable_mat_view` and `test_refreshable_mat_view_replicated`, both on this shard, and `test_distributed_over_distributed`. A leaf pytest file cannot share a fixture, so session scope only defers `cluster.shutdown()` to the end of the xdist worker's session. Their servers, Keepers, MinIO and proxies stay resident for the rest of the ~105 minute job, holding 12.4-15.2 GiB, 26-37% of the `/docker` leaf's whole anonymous budget. `worker_plan` cannot see them: with `ncpu: 16` the CPU half binds at 3 workers, so it models `3 * 11 = 33 GiB` at any budget. A fixed tax, not a share, so 8 GiB more cap raised the ceiling without reaching demand.

Only 3 of 1120 leaf test files use session scope; in `conftest.py` it is correct, so the new `various_checks.sh` check is scoped to `test_*/test*.py`.

Module and session scope give a fixture the same lifetime across one file's tests, so no coverage is lost. Replaying docker lifecycle events over four consecutive modules, peak concurrent containers drop from 13 across 4 projects to 5 across 1, and each fixed module's last `destroy` moves from 48-286 s after the next module's first `create` to 2 s before it. All three modules, 126 tests, gave identical outcomes on the unchanged and changed trees and over 5 repeats.

Not addressed here: the shutdown `gdb` attach is the second contributor, resident at 70 of 154 kernel OOM snapshots at 4.8-7.7 GiB RSS.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117564&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117564](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117564+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117564&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117564](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117564+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.599` (included in `26.9` and later)
<!-- ch-version-info:end -->