### PR TITLE
Docs: correct the default piped output format of clickhousectl service query

### DIFF
--- a/docs/snippets/quickstarts/_cloud_quickstart_cli.mdx
+++ b/docs/snippets/quickstarts/_cloud_quickstart_cli.mdx
@@ -88,7 +88,7 @@ done
 `clickhousectl cloud service query` runs SQL over HTTP — no local `clickhouse` binary or service password required. The first call provisions a Query API endpoint and a service-scoped API key automatically:
 
 ```bash
-clickhousectl cloud service query --id "$CH_ID" --query "SHOW databases"
+clickhousectl cloud service query --id "$CH_ID" --json --query "SHOW databases"
 ```
 
 ```text
@@ -99,7 +99,7 @@ Provisioning Query API endpoint + key for service 'quickstart-ch'...
 {"name":"system"}
 ```
 
-Piped output defaults to `JSONEachRow`; pass `--format PrettyCompact` for table-formatted output instead.
+Output defaults to `PrettyCompact` on a terminal and `TabSeparated` when piped. `--json`, used above, selects `JSONEachRow`; for any other format, pass `--format` instead (`--json` and `--format` cannot be combined).
 
 ## Create a database and table {#create-database-and-table}
 
@@ -131,7 +131,7 @@ clickhousectl cloud service query --id "$CH_ID" \
 Verify it worked:
 
 ```bash
-clickhousectl cloud service query --id "$CH_ID" \
+clickhousectl cloud service query --id "$CH_ID" --json \
   --query "SELECT * FROM helloworld.my_first_table ORDER BY timestamp"
 ```
 
@@ -164,7 +164,7 @@ printf 'INSERT INTO helloworld.my_first_table FORMAT CSV\n' | cat - data.csv \
 Verify the new rows landed:
 
 ```bash
-clickhousectl cloud service query --id "$CH_ID" \
+clickhousectl cloud service query --id "$CH_ID" --json \
   --query "SELECT count() FROM helloworld.my_first_table"
 ```
 


### PR DESCRIPTION
The cloud CLI quickstart snippet (`docs/snippets/quickstarts/_cloud_quickstart_cli.mdx`) said "Piped output defaults to `JSONEachRow`; pass `--format PrettyCompact` for table-formatted output instead." That is wrong.

`clickhousectl cloud service query --help` says: "Default format: PrettyCompact on a TTY, TabSeparated when piped. `--json` selects JSONEachRow and cannot be combined with `--format`; an explicit `--format` takes precedence over agent auto-JSON."

Confirmed live on 2026-09-01 with `clickhousectl` 0.4.2 (same help text in 0.4.1): piping `cloud service query --query "SELECT 1, 'a'"` through `cat` prints tab-separated output, not JSON. The likely source of the confusion is that coding-agent environments auto-enable JSON output.

This corrects the sentence and adds `--json` to the three example commands whose output blocks show `JSONEachRow`, so the examples match the output shown. English snippet only; no other change.

Related: https://github.com/ClickHouse/ClickHouse/pull/116691

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117574&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117574](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117574+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.635` (included in `26.9` and later)
<!-- ch-version-info:end -->