### PR TITLE
CI: fix Bugfix validation master-build lookup for the new S3 prefix scheme

### DIFF
--- a/ci/jobs/scripts/bugfix_validation.py
+++ b/ci/jobs/scripts/bugfix_validation.py
@@ -1,5 +1,5 @@
 from ci.praktika.info import Info
-from ci.praktika.utils import Shell
+from ci.praktika.utils import Shell, Utils
 
 # Build types whose master-HEAD binaries the bugfix-validation runners download
 # from S3. The set must match the runner architecture: an x86 binary cannot be
@@ -30,9 +30,12 @@ def find_master_builds(build_types=None):
     """
     build_types = build_types if build_types is not None else BUGFIX_BUILD_TYPES
     commits = Info().get_kv_data("master_commits") or []
+    # Artifacts live under the normalized workflow name:
+    #   REFs/master/<sha>/<workflow>/build_<bt>/clickhouse
+    workflow = Utils.normalize_string("MasterCI")
     for sha in commits:
         urls = {
-            bt: f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/build_{bt}/clickhouse"
+            bt: f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/{workflow}/build_{bt}/clickhouse"
             for bt in build_types
         }
         if all(


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

Follow-up for https://github.com/ClickHouse/ClickHouse/pull/110081, which moved build artifacts under the normalized workflow name: `REFs/master/<sha>/masterci/build_<bt>/clickhouse`. `find_master_builds` in `ci/jobs/scripts/bugfix_validation.py` still probed the old `REFs/master/<sha>/build_<bt>/clickhouse` path. While the `master_commits` window still contained pre-change commits the probe kept finding old-layout builds, but once the window rolled past the layout change, every candidate returned 403 and both `Bugfix validation (functional tests)` jobs started failing on every pull request with:

```
AssertionError: Could not find master builds in S3
```

Example: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=116057&sha=6dbaa58acfc2c84f8f0da5956bb01700c8cc1216&name_0=PR (from https://github.com/ClickHouse/ClickHouse/pull/116057). I verified the last 30 master commits: `build_amd_asan_ubsan/clickhouse` is 403 on the old path and 200 under `masterci/` for all of them.

The same stale pattern also exists in `ci/jobs/parser_memory_check.py`, `ci/jobs/performance_tests.py`, and `ci/jobs/update_toolchain_dockerfile.py`; those are not touched here.

Caused by: https://github.com/ClickHouse/ClickHouse/pull/110081
Related: https://github.com/ClickHouse/ClickHouse/commit/83e3e3d2ae48bb61ba1a1521b85120cbbca52f85

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117580&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117580](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117580+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.503` (included in `26.9` and later)
<!-- ch-version-info:end -->