### PR TITLE
Fix two CI jobs left behind by the CIDB connection-secret rename

### DIFF
--- a/ci/jobs/collect_test_duration_statistics.py
+++ b/ci/jobs/collect_test_duration_statistics.py
@@ -50,13 +50,9 @@ if __name__ == "__main__":
     days = int(sys.argv[1]) if len(sys.argv) > 1 else DAYS
 
     info = Info()
-    url_secret = info.get_secret(Settings.SECRET_CI_DB_URL)
-    user_secret = info.get_secret(Settings.SECRET_CI_DB_USER)
-    passwd_secret = info.get_secret(Settings.SECRET_CI_DB_PASSWORD)
-    url, user, pwd = (
-        url_secret.join_with(user_secret).join_with(passwd_secret).get_value()
+    cidb = CIDB.from_connection_secret(
+        info.get_secret(Settings.SECRET_CI_DB_CONNECTION).get_value()
     )
-    cidb = CIDB(url=url, user=user, passwd=pwd)
 
     results = []
     statistics = {}

--- a/ci/jobs/revert_ci_regressions.py
+++ b/ci/jobs/revert_ci_regressions.py
@@ -2511,13 +2511,9 @@ def prepare(info: Info) -> bool:
 
 def connect() -> CIDB:
     info = Info()
-    url, user, password = (
-        info.get_secret(Settings.SECRET_CI_DB_URL)
-        .join_with(info.get_secret(Settings.SECRET_CI_DB_USER))
-        .join_with(info.get_secret(Settings.SECRET_CI_DB_PASSWORD))
-        .get_value()
+    return CIDB.from_connection_secret(
+        info.get_secret(Settings.SECRET_CI_DB_CONNECTION).get_value()
     )
-    return CIDB(url=url, user=user, passwd=password)
 
 
 def table_exists(cidb: CIDB, table: str) -> bool:


### PR DESCRIPTION
Caused by: https://github.com/ClickHouse/ClickHouse/pull/110081

`Settings.SECRET_CI_DB_URL`, `Settings.SECRET_CI_DB_USER` and `Settings.SECRET_CI_DB_PASSWORD` were replaced by a single `Settings.SECRET_CI_DB_CONNECTION` (a JSON blob with `url`, `user` and `password`) plus the `CIDB.from_connection_secret` helper. Two callers were not migrated, and both now die on startup with

```
AttributeError: '_Settings' object has no attribute 'SECRET_CI_DB_URL'
```

* `Revert CI regressions` in the `Hourly` workflow has failed on every run since 2026-08-31 09:05 UTC (last green run 08:05 UTC, the breaking change merged at 08:54 UTC). It crashes in `connect` before it reads anything, so since then no master failure has been investigated and no regression reverted, and nothing has been written to `checks_investigated` — its last row is from 2026-08-31 08:10:59 UTC.
* `Collect Test Duration Statistics` in the `NightlyStatistics` workflow has failed the same way since 2026-09-01 05:23 UTC.

The secret itself needs no change: `clickhouse-test-stat-connection` is already declared in `SECRETS`, which both workflows use.

I checked for other stragglers: a sweep of every `Settings.<NAME>` reference outside `ci/praktika` against the fields of the current `_Settings` and `ci/settings/settings.py` finds only these two files, and no other scheduled workflow or CIDB-reported check went from green to red at that merge.

Verified locally by stubbing the secret: `connect` now resolves `clickhouse-test-stat-connection` and builds a `CIDB` that sends no auth header for a `{"user": null, "password": null}` blob, matching the server-side `<no_password/>` ACL.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117582&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117582](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117582+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
