### PR TITLE
Feat(PromQL): Implement /api/v1/status/buildinfo

### DIFF
--- a/docs/concepts/features/interfaces/prometheus.mdx
+++ b/docs/concepts/features/interfaces/prometheus.mdx
@@ -82,7 +82,7 @@ curl http://127.0.0.1:9363/metrics
 
 ## Prometheus HTTP API and PromQL {#prometheus-http-api-and-promql}
 
-ClickHouse implements the Prometheus HTTP API over a [`TimeSeries`](/reference/engines/table-engines/integrations/time-series) table. One handler serves remote write, remote read, instant PromQL queries, and range PromQL queries.
+ClickHouse implements the Prometheus HTTP API over a [`TimeSeries`](/reference/engines/table-engines/integrations/time-series) table. One handler serves remote write, remote read, instant PromQL queries, range PromQL queries, and backend build information.
 
 ### Prerequisites {#prerequisites}
 
@@ -127,9 +127,11 @@ Configure one prefix-routed handler on the main ClickHouse HTTP port:
 | `/prometheus/api/v1/query_range` | Range PromQL queries |
 | `/prometheus/api/v1/format_query` | PromQL expression formatting |
 | `/prometheus/api/v1/series` | Series metadata |
+| `/prometheus/api/v1/labels` | Label names |
 | `/prometheus/api/v1/metadata` | Metric-family metadata |
+| `/prometheus/api/v1/status/buildinfo` | ClickHouse version and revision |
 
-The example omits `database` and `table` from the handler. Each request must provide the `table` query parameter (except for `/format_query`, which only parses the given PromQL expression and doesn't need a table). It can also provide `database`, use a qualified table name such as `prometheus.metrics`, or omit the database to use `default`. This allows one handler to serve multiple `TimeSeries` tables.
+The example omits `database` and `table` from the handler. All Prometheus API requests except `/api/v1/format_query` and `/api/v1/status/buildinfo` must provide the `table` query parameter. The `/api/v1/format_query` endpoint only parses the given PromQL expression, and the `/api/v1/status/buildinfo` endpoint returns backend identity information; neither needs a table. A request can also provide `database`, use a qualified table name such as `prometheus.metrics`, or omit the database to use `default`. This allows one handler to serve multiple `TimeSeries` tables.
 
 To use one fixed table for every request, configure it in the handler:
 
@@ -148,7 +150,7 @@ Routing and handler settings:
 | Name | Default | Description |
 |---|---|---|
 | `url_prefix` | none | Rule filter that matches every request path that starts with the configured prefix. |
-| `table` | none | The name of a `TimeSeries` table. When omitted, the request must provide the `table` query parameter. The configured name can include a database. |
+| `table` | none | The name of a `TimeSeries` table. When omitted, all Prometheus API requests except `/api/v1/status/buildinfo` must provide the `table` query parameter. The configured name can include a database. |
 | `database` | none | The database containing the table. A request can provide it as a query parameter. When omitted, ClickHouse uses a database from a qualified `table` value or falls back to `default`. |
 
 ### Ingest metrics with remote write {#remote-write}
@@ -234,7 +236,7 @@ datasources:
 Grafana appends `/api/v1/query` or `/api/v1/query_range` to this base URL and adds `customQueryParameters` to each request.
 
 <Note>
-Only the query endpoints `/api/v1/query`, `/api/v1/query_range`, and `/api/v1/format_query` and the metadata endpoints `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values`, and `/api/v1/metadata` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. `/api/v1/labels` accepts the same parameters, with `match[]` being optional, and returns the sorted label names of the matched series (or of all series when no selectors are given). `/api/v1/label/<name>/values` accepts the same parameters as `/api/v1/labels` and returns the sorted values of one label, with `<name>` optionally using the Prometheus `U__...` escaping of label names that contain characters outside `[a-zA-Z0-9_]`. These endpoints cover what a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete.
+The query endpoints `/api/v1/query`, `/api/v1/query_range`, and `/api/v1/format_query`, the metadata endpoints `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values`, and `/api/v1/metadata`, and the backend identity endpoint `/api/v1/status/buildinfo` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. `/api/v1/labels` accepts the same parameters, with `match[]` being optional, and returns the sorted label names of the matched series (or of all series when no selectors are given). `/api/v1/label/<name>/values` accepts the same parameters as `/api/v1/labels` and returns the sorted values of one label, with `<name>` optionally using the Prometheus `U__...` escaping of label names that contain characters outside `[a-zA-Z0-9_]`. These endpoints cover what a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete. The `/api/v1/status/buildinfo` endpoint returns the ClickHouse version and source revision, intentionally omits Mimir-specific `features`, and does not require a `TimeSeries` table. Write PromQL expressions in code mode instead of the query builder.
 </Note>
 
 #### SQL entry points {#sql-entry-points}

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -36,13 +36,29 @@
 #include <IO/WriteHelpers.h>
 #include <Core/Settings.h>
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
+#include <Common/config_version.h>
 #include <Storages/TimeSeries/PrometheusRemoteReadProtocol.h>
 #include <Storages/TimeSeries/PrometheusRemoteWriteProtocol.h>
 #include <Storages/TimeSeries/PrometheusHTTPProtocolAPI.h>
 
 
+extern const char * GIT_HASH;
+
 namespace DB
 {
+
+namespace
+{
+void writePrometheusBuildInfo(WriteBuffer & out)
+{
+    const FormatSettings format_settings;
+    writeString(R"({"status":"success","data":{"version":)", out);
+    writeJSONString(VERSION_STRING, out, format_settings);
+    writeString(R"(,"revision":)", out);
+    writeJSONString(GIT_HASH, out, format_settings);
+    writeString(R"(,"branch":"","buildUser":"","buildDate":"","goVersion":""}})", out);
+}
+}
 
 namespace Setting
 {
@@ -422,8 +438,8 @@ public:
     }
 };
 
-/// Handles the read-only query and metadata endpoints of the Prometheus HTTP API
-/// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata).
+/// Handles the read-only query, metadata, and build information endpoints of the Prometheus HTTP API
+/// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata, /api/v1/status/buildinfo).
 class PrometheusRequestHandler::QueryImpl : public ImplWithContext
 {
 public:
@@ -482,6 +498,26 @@ public:
             /// Use the decoded path without the query string (matching APIv1Impl::getImpl) so a
             /// percent-encoded label name in ".../label/<name>/values" is read correctly.
             const String uri_path = Poco::URI(uri).getPath();
+
+            /// The build information endpoint identifies the backend and does not need a TimeSeries table.
+            const size_t api_v1_path_start = uri_path.find("/api/v1");
+            const bool is_build_info_endpoint = api_v1_path_start != String::npos
+                && uri_path.find("/api/v1", api_v1_path_start + 1) == String::npos
+                && uri_path.substr(api_v1_path_start) == "/api/v1/status/buildinfo";
+            if (is_build_info_endpoint)
+            {
+                if (request.getMethod() != Poco::Net::HTTPRequest::HTTP_GET
+                    && request.getMethod() != Poco::Net::HTTPRequest::HTTP_HEAD)
+                {
+                    response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_METHOD_NOT_ALLOWED);
+                    response.set("Allow", "GET, HEAD");
+                    writeString(R"({"status":"error","errorType":"method_not_allowed","error":"Method not allowed"})", getOutputStream(response));
+                    return;
+                }
+
+                writePrometheusBuildInfo(getOutputStream(response));
+                return;
+            }
 
             if (uri_path.ends_with("/format_query"))
             {
@@ -724,7 +760,7 @@ private:
         if (path.ends_with("/read"))
             return read_impl;
 
-        /// All other /api/v1/* endpoints (query, query_range, series, labels, label/<name>/values, metadata)
+        /// All other /api/v1/* endpoints (query, query_range, series, labels, label/<name>/values, metadata, status/buildinfo)
         /// are served by the Query implementation, which itself returns 404 for unknown paths.
         return query_impl;
     }

--- a/src/Server/PrometheusRequestHandlerConfig.h
+++ b/src/Server/PrometheusRequestHandlerConfig.h
@@ -20,8 +20,8 @@ struct PrometheusRequestHandlerConfig
         /// Handles all Prometheus "/api/v1" protocols including Query, Write, Read.
         APIv1,
 
-        /// Handles the read-only query and metadata endpoints of the Prometheus HTTP API
-        /// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata),
+        /// Handles the read-only query, metadata, and build information endpoints of the Prometheus HTTP API
+        /// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata, /api/v1/status/buildinfo),
         /// i.e. everything under "/api/v1" except remote write and remote read.
         Query,
 

--- a/tests/integration/test_prometheus_protocols/configs/http_port.xml
+++ b/tests/integration/test_prometheus_protocols/configs/http_port.xml
@@ -8,6 +8,12 @@
             </handler>
         </rule>
         <rule>
+            <url_prefix>/prometheus_no_table/api/v1</url_prefix>
+            <handler>
+                <type>prometheus_api_v1</type>
+            </handler>
+        </rule>
+        <rule>
             <url>/api/v1/write</url>
             <handler>
                 <type>prometheus_write</type>

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -94,6 +94,12 @@
                     <table>default.prometheus_multi</table>
                 </handler>
             </my_rule_15>
+            <my_rule_17>
+                <url>/api/v1/status/buildinfo</url>
+                <handler>
+                    <type>query</type>
+                </handler>
+            </my_rule_17>
 
             <my_rule_10>
                 <!-- This handler sets no database and no table, so both database and table names

--- a/tests/integration/test_prometheus_protocols/test_buildinfo_api.py
+++ b/tests/integration/test_prometheus_protocols/test_buildinfo_api.py
@@ -1,0 +1,74 @@
+"""Tests for the Prometheus /api/v1/status/buildinfo endpoint."""
+
+import time
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+)
+
+
+def wait_for_prometheus_handlers(timeout=120):
+    # cluster.start() waits for the native TCP port, and the Prometheus protocols port
+    # can start accepting connections slightly later, so poll it before running the tests.
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            requests.get(
+                f"http://{node.ip_address}:9093/api/v1/status/buildinfo",
+                timeout=5,
+            )
+            return
+        except requests.exceptions.ConnectionError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.5)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    try:
+        cluster.start()
+        wait_for_prometheus_handlers()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_buildinfo_returns_clickhouse_identity_without_table():
+    response = requests.get(f"http://{node.ip_address}:9093/api/v1/status/buildinfo")
+    assert response.status_code == 200, response.text
+
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"] == {
+        "version": node.query("SELECT version()").strip(),
+        "revision": node.query(
+            "SELECT value FROM system.build_options WHERE name = 'GIT_HASH'"
+        ).strip(),
+        "branch": "",
+        "buildUser": "",
+        "buildDate": "",
+        "goVersion": "",
+    }
+    assert "features" not in data["data"]
+
+
+def test_buildinfo_supports_head_request():
+    response = requests.head(f"http://{node.ip_address}:9093/api/v1/status/buildinfo")
+    assert response.status_code == 200, response.text
+    assert response.content == b""
+
+
+def test_buildinfo_rejects_unsupported_methods():
+    response = requests.post(f"http://{node.ip_address}:9093/api/v1/status/buildinfo")
+    assert response.status_code == 405, response.text
+    assert response.headers["Allow"] == "GET, HEAD"

--- a/tests/integration/test_prometheus_protocols/test_http_port.py
+++ b/tests/integration/test_prometheus_protocols/test_http_port.py
@@ -129,6 +129,36 @@ def test_main_http_prefixed_query_range_api():
     assert metric_name in data
 
 
+def test_main_http_prefixed_buildinfo_api_without_table():
+    url = (
+        f"http://{node.ip_address}:{MAIN_HTTP_PORT}"
+        "/prometheus_no_table/api/v1/status/buildinfo"
+    )
+    response = get_response_to_http_api(url)
+    assert response.status_code == 200, response.text
+
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"]["version"] == node.query("SELECT version()").strip()
+    assert data["data"]["revision"] == node.query(
+        "SELECT value FROM system.build_options WHERE name = 'GIT_HASH'"
+    ).strip()
+    assert data["data"]["branch"] == ""
+    assert data["data"]["buildUser"] == ""
+    assert data["data"]["buildDate"] == ""
+    assert data["data"]["goVersion"] == ""
+    assert "features" not in data["data"]
+
+
+def test_main_http_prefixed_buildinfo_does_not_match_nested_path():
+    url = (
+        f"http://{node.ip_address}:{MAIN_HTTP_PORT}"
+        "/prometheus/api/v1/extra/api/v1/status/buildinfo"
+    )
+    response = get_response_to_http_api(url)
+    assert response.status_code == 404, response.text
+
+
 def test_main_http_prefixed_metadata_api():
     metric_name = "main_http_prefixed_metadata_target"
     help_text = "Metadata routed through the main HTTP port"


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/status/buildinfo` to the ClickHouse Prometheus HTTP API.

Grafana uses this endpoint to identify and classify Prometheus-compatible backends. It is a backend identity endpoint, not a list of supported endpoints.

- **Returns** the ClickHouse version and source revision in the Prometheus response shape.
- **Omits** the Mimir-specific `features` field.
- **Works** without resolving a `TimeSeries` table.

## What changed

- Added buildinfo handling to the query handler and the combined `prometheus_api_v1` handler.
- Handles buildinfo before the table lookup.
- Supports `GET` and `HEAD`; other methods return `405` with an `Allow` header.
- Updated the Prometheus API documentation.

## Tests

- Dedicated handler with no table.
- Prefixed APIv1 handler on the main HTTP port.
- Response shape, version, revision, and missing `features`.
- `GET`, `HEAD`, and unsupported methods.
- Nested-path routing.

## Scope

This is a small compatibility endpoint. It does not add endpoint discovery or change the existing query, series, labels, or metadata implementations.

## Related

Related to #89553, the broader Prometheus HTTP Query API tracking item.

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Add the Prometheus buildinfo endpoint for ClickHouse version and revision discovery.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117591&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117591](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117591+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
