### PR TITLE
Do not fail the stress test when a log grows while it is archived

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -19,6 +19,10 @@ from typing import List, Optional
 # Failpoint that delays every background mutation by a bounded random amount.
 MUTATION_DELAY_FAILPOINT = "mutate_task_random_sleep_in_prepare"
 
+# GNU `tar` exit statuses: 0 - success, 1 - some files differ (a file changed
+# or shrank while it was being read), 2 and above - a fatal error.
+TAR_EXIT_DIFFERS = 1
+
 
 class ServerDied(Exception):
     pass
@@ -715,11 +719,41 @@ def run_func_test(
 
 
 def compress_stress_logs(output_path: Path, files_prefix: str) -> None:
-    cmd = (
-        f"cd {output_path} && tar --zstd --create --file=stress_run_logs.tar.zst "
-        f"{files_prefix}* && rm {files_prefix}*"
+    """Archive the per-process `clickhouse-test` logs into a single file.
+
+    A log can still be growing while it is archived: when the global time
+    limit is reached, `clickhouse-test` force-kills its workers and exits,
+    but a worker - or a `clickhouse client` the worker spawned - can outlive
+    it and keep appending through the inherited stdout descriptor. `tar`
+    notices the size change and exits with `TAR_EXIT_DIFFERS`, which used to
+    fail the whole stress test job right before the hung check, even though
+    the archive itself is written and only the tail of one log is missing.
+    Only a fatal `tar` status is treated as a failure here.
+    """
+    archive = "stress_run_logs.tar.zst"
+    result = subprocess.run(
+        f"cd {output_path} && tar --zstd --create --file={archive} {files_prefix}*",
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
     )
-    check_output(cmd, shell=True)
+    if result.returncode == TAR_EXIT_DIFFERS:
+        logging.warning(
+            "Some logs changed while %s was being created: %s",
+            archive,
+            result.stderr.strip(),
+        )
+    elif result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to create {archive}, tar exit code {result.returncode}:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+    # Not chained after `tar` with `&&`: the logs have to be removed on the
+    # `TAR_EXIT_DIFFERS` path as well, otherwise they are uploaded twice.
+    for path in output_path.glob(f"{files_prefix}*"):
+        path.unlink()
 
 
 def call_with_retry(


### PR DESCRIPTION
The stress test job archives the per-process `clickhouse-test` logs with
`tar --zstd --create ... && rm ...` and treats any non-zero `tar` status as a
failure. GNU `tar` exits with status 1 (*some files differ*) when a file it is
reading changes size, and that happens routinely at the end of a stress run:
once the global time limit is reached, `clickhouse-test` force-kills its workers
and exits, but a worker - or a `clickhouse client` the worker spawned - can
outlive it and keep appending to the log through the inherited stdout
descriptor. Archival starts within milliseconds of the last tracked child
exiting, so it can catch the file still growing:

```
All processes finished
Compressing stress logs
tar: stress_test_run_2.txt: file changed as we read it
subprocess.CalledProcessError: Command 'cd /test_output && tar --zstd --create
--file=stress_run_logs.tar.zst stress_test_run_* && rm stress_test_run_*'
returned non-zero exit status 1.
```

The archive is written correctly in that case and only the tail of one log is
missing, but the job was reported as `Test script failed` and the hung check -
which runs right after - never happened. Because `rm` was chained after `tar`
with `&&`, the raw logs were also left behind and uploaded next to the archive.

`compress_stress_logs` now interprets the `tar` status: status 1 is logged as a
warning, a fatal status still fails, and the logs are removed from Python so the
cleanup is no longer tied to the `tar` status.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=100406&sha=b6afb25f427fa4527128eb025d0c4557e718b06d&name_0=PR&name_1=Stress%20test%20%28amd_msan%29

Related: https://github.com/ClickHouse/ClickHouse/pull/100406

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117592&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117592](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117592+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.568` (included in `26.9` and later)
<!-- ch-version-info:end -->