### PR TITLE
Fix a column silently lost by a combined DROP COLUMN IF EXISTS and ADD COLUMN IF NOT EXISTS

### DIFF
--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -362,7 +362,7 @@ BlockIO runCommandSegments(CommandSegments & segments, const StoragePtr & table,
             if (auto * merge_tree = dynamic_cast<MergeTreeData *>(table.get()))
                 share_nested = (*merge_tree->getSettings())[MergeTreeSetting::share_nested_offsets];
 
-            alter_commands->prepare(*metadata_snapshot, share_nested);
+            alter_commands->prepare(*metadata_snapshot, context, share_nested);
             table->checkAlterIsPossible(*alter_commands, context);
             table->alter(*alter_commands, context, alter_lock);
         }

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1865,10 +1865,11 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
 }
 
 
-void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, bool share_nested_offsets)
+void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, ContextPtr context, bool share_nested_offsets)
 {
     auto columns = metadata.columns;
     std::unordered_set<String> columns_with_full_type_modify;
+    NameSet columns_added_by_this_alter;
 
     /// Used to tell whether a command restates the definition the table already has, so it must not
     /// depend on whether the redundant parentheses were written on one side and not on the other.
@@ -1900,11 +1901,10 @@ void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, bool share
                             "in a single ALTER query");
                     }
 
-                    /// `ADD ENUM VALUES` derives the resulting type by merging against the existing column, so
-                    /// the column must be present in the working snapshot. If it is not (e.g. the column is added
-                    /// by a preceding `ADD COLUMN` in the same statement, which does not advance the snapshot),
-                    /// fail explicitly instead of silently dropping the modification.
-                    if (!has_column)
+                    /// `ADD ENUM VALUES` derives the resulting type by merging against the type the column
+                    /// already has, so the column must predate this statement: one introduced by a preceding
+                    /// `ADD COLUMN` here has no such type to merge with.
+                    if (!has_column || columns_added_by_this_alter.contains(command.column_name))
                         throw Exception(
                             ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
                             "Cannot ADD ENUM VALUES to column {}: it does not exist in the table. Adding enum values to a "
@@ -2020,6 +2020,32 @@ void AlterCommands::prepare(const StorageInMemoryMetadata & metadata, bool share
         {
             if (ast_to_str(command.order_by) == ast_to_str(metadata.sorting_key.definition_ast))
                 command.ignore = true;
+        }
+
+        /// Advance the working snapshot exactly as `AlterCommand::apply` advances the metadata, so a
+        /// later command in the same statement decides `IF (NOT) EXISTS` against the state the
+        /// preceding commands produce rather than against the pre-statement columns.
+        if (!command.ignore)
+        {
+            if (command.type == AlterCommand::ADD_COLUMN)
+            {
+                for (auto & column : columnsAddedByAlter(columns, ColumnDescription(command.column_name, command.data_type),
+                                                         context, command.if_not_exists, share_nested_offsets))
+                {
+                    columns_added_by_this_alter.insert(column.name);
+                    columns.add(std::move(column));
+                }
+            }
+            else if (command.type == AlterCommand::DROP_COLUMN && !command.clear && !command.partition)
+            {
+                if (!command.if_exists || columns.has(command.column_name))
+                    columns.remove(command.column_name);
+            }
+            else if (command.type == AlterCommand::RENAME_COLUMN)
+            {
+                if (!command.if_exists || columns.has(command.column_name))
+                    columns.rename(command.column_name, command.rename_to);
+            }
         }
     }
 

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -231,7 +231,7 @@ public:
 
     /// Prepare alter commands. Set ignore flag to some of them and set some
     /// parts to commands from storage's metadata (for example, absent default)
-    void prepare(const StorageInMemoryMetadata & metadata, bool share_nested_offsets = true);
+    void prepare(const StorageInMemoryMetadata & metadata, ContextPtr context, bool share_nested_offsets = true);
 
     /// Apply all alter command in sequential order to storage metadata.
     /// Commands have to be prepared before apply.

--- a/tests/queries/0_stateless/01318_alter_add_column_exists.reference
+++ b/tests/queries/0_stateless/01318_alter_add_column_exists.reference
@@ -13,4 +13,10 @@ CREATE TABLE default.add_nested_sno0\n(\n    `key` UInt64,\n    `n.a` Array(UInt
 CREATE TABLE default.add_nested_mut\n(\n    `key` UInt64,\n    `n.a` UInt32,\n    `n2` String\n)\nENGINE = MergeTree\nORDER BY key\nSETTINGS share_nested_offsets = 0, index_granularity = 8192
 CREATE TABLE default.add_nested_exact_sno0\n(\n    `key` UInt64,\n    `n` String\n)\nENGINE = MergeTree\nORDER BY key\nSETTINGS share_nested_offsets = 0, index_granularity = 8192
 CREATE TABLE default.add_nested_rename_child\n(\n    `n.a` Array(UInt32),\n    `m` Array(String)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS share_nested_offsets = 0, index_granularity = 8192
-CREATE TABLE default.add_nested_cond_rename\n(\n    `n.a` Array(UInt32),\n    `n.b` Array(String)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS share_nested_offsets = 0, index_granularity = 8192
+CREATE TABLE default.add_nested_cond_rename\n(\n    `n.a` Array(UInt32),\n    `m` Array(String)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS share_nested_offsets = 0, index_granularity = 8192
+CREATE TABLE default.add_nested_absent_rename\n(\n    `n.a` Array(UInt32)\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS share_nested_offsets = 0, index_granularity = 8192
+CREATE TABLE default.replace_column_if_exists\n(\n    `key` UInt64,\n    `value1` String\n)\nENGINE = MergeTree\nORDER BY key\nSETTINGS index_granularity = 8192
+CREATE TABLE default.replace_only_column\n(\n    `value1` String\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.replace_only_column\n(\n    `value1` String,\n    `value2` UInt64\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
+CREATE TABLE default.add_then_rename_if_exists\n(\n    `key` UInt64,\n    `c` UInt64\n)\nENGINE = MergeTree\nORDER BY key\nSETTINGS index_granularity = 8192
+CREATE TABLE default.add_then_modify_if_exists\n(\n    `key` UInt64,\n    `b` String\n)\nENGINE = MergeTree\nORDER BY key\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01318_alter_add_column_exists.sql
+++ b/tests/queries/0_stateless/01318_alter_add_column_exists.sql
@@ -204,11 +204,9 @@ DROP TABLE IF EXISTS add_nested_rename_child;
 
 DROP TABLE IF EXISTS add_nested_cond_rename;
 
--- The mutation-planning replay (getMutationCommands -> tryConvertToMutationCommand) must not diverge from
--- the committed metadata when a later command is ignored by prepare(). With share_nested_offsets = 0 and
--- only `n.a`, `ADD COLUMN IF NOT EXISTS n Nested(a, b), RENAME COLUMN IF EXISTS n.b TO m` adds the missing
--- `n.b`; the RENAME is ignored because the prepare-time snapshot had no `n.b`. An ignored command reports
--- isRequireMutationStage() == false, so no RENAME_COLUMN mutation is queued and the final schema keeps `n.b`.
+-- A conditional command sees the columns the preceding commands of the same ALTER produce, so with
+-- share_nested_offsets = 0 and only `n.a`, `ADD COLUMN IF NOT EXISTS n Nested(a, b)` adds `n.b` and the
+-- following `RENAME COLUMN IF EXISTS n.b TO m` renames it, exactly as the unguarded spelling above does.
 CREATE TABLE add_nested_cond_rename
 (
     `n.a` Array(UInt32)
@@ -222,3 +220,98 @@ ALTER TABLE add_nested_cond_rename ADD COLUMN IF NOT EXISTS n Nested(a UInt32, b
 SHOW CREATE TABLE add_nested_cond_rename;
 
 DROP TABLE IF EXISTS add_nested_cond_rename;
+
+DROP TABLE IF EXISTS add_nested_absent_rename;
+
+-- The mutation-planning replay (getMutationCommands -> tryConvertToMutationCommand) must not diverge from
+-- the committed metadata when a later command is ignored by prepare(). Here `ADD COLUMN IF NOT EXISTS
+-- n Nested(a)` adds nothing and `n.b` never exists, so the RENAME is ignored: an ignored command requires
+-- no mutation stage, so no RENAME_COLUMN mutation is queued and the final schema keeps `n.a`.
+CREATE TABLE add_nested_absent_rename
+(
+    `n.a` Array(UInt32)
+)
+ENGINE = MergeTree()
+ORDER BY tuple()
+SETTINGS share_nested_offsets = 0;
+
+ALTER TABLE add_nested_absent_rename ADD COLUMN IF NOT EXISTS n Nested(a UInt32), RENAME COLUMN IF EXISTS `n.b` TO `m`;
+
+SHOW CREATE TABLE add_nested_absent_rename;
+
+DROP TABLE IF EXISTS add_nested_absent_rename;
+
+DROP TABLE IF EXISTS replace_column_if_exists;
+
+-- `DROP COLUMN IF EXISTS c, ADD COLUMN IF NOT EXISTS c <type>` is the idempotent way to give a column a new
+-- type: the add is judged against the columns after the drop, so `c` is re-added rather than treated as
+-- already present.
+CREATE TABLE replace_column_if_exists
+(
+    key UInt64,
+    value1 UInt64
+)
+ENGINE = MergeTree()
+ORDER BY key;
+
+ALTER TABLE replace_column_if_exists DROP COLUMN IF EXISTS value1, ADD COLUMN IF NOT EXISTS value1 String;
+
+SHOW CREATE TABLE replace_column_if_exists;
+
+DROP TABLE IF EXISTS replace_column_if_exists;
+
+DROP TABLE IF EXISTS replace_only_column;
+
+-- Replacing the table's only column keeps the table alterable: dropping the last column without re-adding it
+-- would leave metadata with no column list at all, which cannot be stored or loaded back.
+CREATE TABLE replace_only_column
+(
+    value1 UInt64
+)
+ENGINE = MergeTree()
+ORDER BY tuple();
+
+ALTER TABLE replace_only_column DROP COLUMN IF EXISTS value1, ADD COLUMN IF NOT EXISTS value1 String;
+
+SHOW CREATE TABLE replace_only_column;
+
+ALTER TABLE replace_only_column ADD COLUMN value2 UInt64;
+
+SHOW CREATE TABLE replace_only_column;
+
+-- Dropping the only column with nothing re-adding it is still refused.
+ALTER TABLE replace_only_column DROP COLUMN value1, DROP COLUMN value2; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE IF EXISTS replace_only_column;
+
+DROP TABLE IF EXISTS add_then_rename_if_exists;
+
+-- Mirror direction: a conditional RENAME of a column the same ALTER just added is applied, not skipped.
+CREATE TABLE add_then_rename_if_exists
+(
+    key UInt64
+)
+ENGINE = MergeTree()
+ORDER BY key;
+
+ALTER TABLE add_then_rename_if_exists ADD COLUMN b UInt64, RENAME COLUMN IF EXISTS b TO c;
+
+SHOW CREATE TABLE add_then_rename_if_exists;
+
+DROP TABLE IF EXISTS add_then_rename_if_exists;
+
+DROP TABLE IF EXISTS add_then_modify_if_exists;
+
+-- Same for a conditional MODIFY: the column the same ALTER just added exists by the time it runs.
+CREATE TABLE add_then_modify_if_exists
+(
+    key UInt64
+)
+ENGINE = MergeTree()
+ORDER BY key;
+
+ALTER TABLE add_then_modify_if_exists ADD COLUMN b UInt64, MODIFY COLUMN IF EXISTS b String;
+
+SHOW CREATE TABLE add_then_modify_if_exists;
+
+DROP TABLE IF EXISTS add_then_modify_if_exists;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `ALTER TABLE ... DROP COLUMN IF EXISTS c, ADD COLUMN IF NOT EXISTS c <type>` silently losing `c`: the column was dropped and never re-added. Inside a single `ALTER`, `IF EXISTS` and `IF NOT EXISTS` are now evaluated against the columns the preceding commands of the same statement produce. When the affected column was the table's only one, the table was left with no columns at all, which made every later `ALTER` fail with `Cannot alter table ... metadata doesn't have structure` and made the table impossible to load after a restart.


### Description

`AlterCommands::prepare` decides which commands are no-ops for the `IF (NOT) EXISTS` spellings, but it tested column presence against a snapshot taken once before the statement and never advanced it, while `AlterCommands::validate` and `AlterCommands::apply` both walk the command list sequentially. So for `DROP COLUMN IF EXISTS x, ADD COLUMN IF NOT EXISTS x String` prepare saw `x` in the pre-statement snapshot, marked the add redundant, and apply dropped `x` and skipped the re-add. The unguarded spelling `DROP COLUMN x, ADD COLUMN x String` was always correct; only the documented idempotent form was affected. Measured on master with 500 rows in the table: the column disappears, return code 0, no warning.

If `x` was the only column the result had zero columns, and the column list is written only when it is non-empty, so the stored metadata came out as `ATTACH TABLE _ UUID '...' ENGINE = MergeTree ORDER BY tuple()`. Every later `ALTER` then threw `LOGICAL_ERROR: Cannot alter table X metadata doesn't have structure`, which aborts the server in debug and sanitizer builds, and after a restart the table failed to load with `EMPTY_LIST_OF_COLUMNS_PASSED: Missing definition of columns`, making its data unreachable. That logical error is how this surfaced, in `AST fuzzer (amd_debug, targeted)`: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117320&sha=c2bbd70230105a47c417f6118a2f2d38d56d79e6&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29

The fix advances prepare's working snapshot for the commands that change column presence, mirroring `AlterCommand::apply` exactly and reusing `columnsAddedByAlter` so all three passes model the same schema. The rejection of `MODIFY COLUMN ... ADD ENUM VALUES` on a column created in the same statement is preserved deliberately. I did not guard the site that throws, because that would leave the silent column loss unfixed. A table already persisted with zero columns stays unloadable.

No related open issue found.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117593&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117593](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117593+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
