### PR TITLE
Fix dictionary reload and unload ON CLUSTER database

### DIFF
--- a/src/Interpreters/AddDefaultDatabaseVisitor.h
+++ b/src/Interpreters/AddDefaultDatabaseVisitor.h
@@ -9,6 +9,7 @@
 #include <Parsers/ASTRefreshStrategy.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSubquery.h>
+#include <Parsers/ASTSystemQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSelectIntersectExceptQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
@@ -66,6 +67,7 @@ public:
         if (!tryVisitDynamicCast<ASTAlterQuery>(parent, ast) &&
             !tryVisitDynamicCast<ASTQueryWithTableAndOutput>(parent, ast) &&
             !tryVisitDynamicCast<ASTRenameQuery>(parent, ast) &&
+            !tryVisitDynamicCast<ASTSystemQuery>(parent, ast) &&
             !tryVisitDynamicCast<ASTFunction>(parent, ast))
         {}
     }
@@ -407,6 +409,21 @@ private:
             if (command_ast->to_database.empty())
                 command_ast->to_database = database_name;
         }
+    }
+
+    void visitDDL(ASTPtr & /* parent */, ASTSystemQuery & query, ASTPtr &) const
+    {
+        if (query.type != ASTSystemQuery::Type::RELOAD_DICTIONARY
+            && query.type != ASTSystemQuery::Type::UNLOAD_DICTIONARY)
+            return;
+
+        if (!query.table || query.database || only_replace_current_database_function)
+            return;
+
+        if (query.getTable().find('.') != String::npos)
+            return;
+
+        query.setDatabase(database_name);
     }
 
     void visitDDL(ASTPtr & parent, ASTFunction & function, ASTPtr & node) const

--- a/src/Interpreters/AddDefaultDatabaseVisitor.h
+++ b/src/Interpreters/AddDefaultDatabaseVisitor.h
@@ -420,9 +420,6 @@ private:
         if (!query.table || query.database || only_replace_current_database_function)
             return;
 
-        if (query.getTable().contains('.'))
-            return;
-
         query.setDatabase(database_name);
     }
 

--- a/src/Interpreters/AddDefaultDatabaseVisitor.h
+++ b/src/Interpreters/AddDefaultDatabaseVisitor.h
@@ -420,7 +420,7 @@ private:
         if (!query.table || query.database || only_replace_current_database_function)
             return;
 
-        if (query.getTable().find('.') != String::npos)
+        if (query.getTable().contains('.'))
             return;
 
         query.setDatabase(database_name);

--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -154,9 +154,21 @@ void ExternalDictionariesLoader::reloadDictionary(const std::string & dictionary
     loadOrReload(resolved_dictionary_name);
 }
 
+void ExternalDictionariesLoader::reloadDictionary(const QualifiedTableName & dictionary_name) const
+{
+    std::string resolved_dictionary_name = resolveDictionaryName(dictionary_name);
+    loadOrReload(resolved_dictionary_name);
+}
+
 bool ExternalDictionariesLoader::unloadDictionary(const std::string & dictionary_name, ContextPtr local_context) const
 {
     std::string resolved_dictionary_name = resolveDictionaryName(dictionary_name, local_context->getCurrentDatabase());
+    return unload(resolved_dictionary_name);
+}
+
+bool ExternalDictionariesLoader::unloadDictionary(const QualifiedTableName & dictionary_name) const
+{
+    std::string resolved_dictionary_name = resolveDictionaryName(dictionary_name);
     return unload(resolved_dictionary_name);
 }
 
@@ -245,6 +257,16 @@ std::string ExternalDictionariesLoader::resolveDictionaryName(const std::string 
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Dictionary ({}) not found", backQuote(dictionary_name));
 }
 
+std::string ExternalDictionariesLoader::resolveDictionaryName(const QualifiedTableName & dictionary_name) const
+{
+    std::string resolved_name = resolveDictionaryNameFromDatabaseCatalog(dictionary_name);
+
+    if (has(resolved_name))
+        return resolved_name;
+
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Dictionary ({}) not found", backQuote(dictionary_name.getFullName()));
+}
+
 std::string ExternalDictionariesLoader::resolveDictionaryNameFromDatabaseCatalog(const std::string & name, const std::string & current_database_name) const
 {
     /// If it's dictionary from Atomic database, then we need to convert qualified name to UUID.
@@ -266,11 +288,17 @@ std::string ExternalDictionariesLoader::resolveDictionaryNameFromDatabaseCatalog
             return res;
 
         qualified_name->database = current_database_name;
-        res = current_database_name + '.' + name;
     }
 
+    return resolveDictionaryNameFromDatabaseCatalog(*qualified_name);
+}
+
+std::string ExternalDictionariesLoader::resolveDictionaryNameFromDatabaseCatalog(const QualifiedTableName & name) const
+{
+    String res = name.getFullName();
+
     auto [db, table] = DatabaseCatalog::instance().tryGetDatabaseAndTable(
-        {qualified_name->database, qualified_name->table},
+        {name.database, name.table},
         const_pointer_cast<Context>(getContext()));
 
     if (!db)

--- a/src/Interpreters/ExternalDictionariesLoader.h
+++ b/src/Interpreters/ExternalDictionariesLoader.h
@@ -4,6 +4,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/ExternalLoader.h>
 #include <Common/quoteString.h>
+#include <Core/QualifiedTableName.h>
 
 #include <memory>
 
@@ -27,7 +28,11 @@ public:
 
     void reloadDictionary(const std::string & dictionary_name, ContextPtr context) const;
 
+    void reloadDictionary(const QualifiedTableName & dictionary_name) const;
+
     bool unloadDictionary(const std::string & dictionary_name, ContextPtr context) const;
+
+    bool unloadDictionary(const QualifiedTableName & dictionary_name) const;
 
     void unloadAllDictionaries() const;
 
@@ -71,8 +76,12 @@ protected:
 
     std::string resolveDictionaryName(const std::string & dictionary_name, const std::string & current_database_name) const;
 
+    std::string resolveDictionaryName(const QualifiedTableName & dictionary_name) const;
+
     /// Try convert qualified dictionary name to persistent UUID
     std::string resolveDictionaryNameFromDatabaseCatalog(const std::string & name, const std::string & current_database_name) const;
+
+    std::string resolveDictionaryNameFromDatabaseCatalog(const QualifiedTableName & name) const;
 
     friend class StorageSystemDictionaries;
     friend class DatabaseDictionary;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -348,12 +348,26 @@ void InterpreterSystemQuery::startStopActionInDatabase(StorageActionBlockType ac
 }
 
 
-static String getDictionaryNameForLoader(const ASTSystemQuery & query)
+static void reloadDictionaryFromSystemQuery(ExternalDictionariesLoader & loader, const ASTSystemQuery & query, ContextPtr context)
 {
-    if (!query.database)
-        return query.getTable();
+    if (query.database)
+    {
+        loader.reloadDictionary({query.getDatabase(), query.getTable()});
+        return;
+    }
 
-    return backQuoteIfNeed(query.getDatabase()) + "." + backQuoteIfNeed(query.getTable());
+    loader.reloadDictionary(query.getTable(), context);
+}
+
+static void unloadDictionaryFromSystemQuery(ExternalDictionariesLoader & loader, const ASTSystemQuery & query, ContextPtr context)
+{
+    if (query.database)
+    {
+        loader.unloadDictionary({query.getDatabase(), query.getTable()});
+        return;
+    }
+
+    loader.unloadDictionary(query.getTable(), context);
 }
 
 
@@ -782,8 +796,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            const String dictionary_name = getDictionaryNameForLoader(query);
-            external_dictionaries_loader.reloadDictionary(dictionary_name, getContext());
+            reloadDictionaryFromSystemQuery(external_dictionaries_loader, query, getContext());
 
             ExternalDictionariesLoader::resetAll();
             break;
@@ -803,8 +816,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            const String dictionary_name = getDictionaryNameForLoader(query);
-            external_dictionaries_loader.unloadDictionary(dictionary_name, getContext());
+            unloadDictionaryFromSystemQuery(external_dictionaries_loader, query, getContext());
             ExternalDictionariesLoader::resetAll();
             break;
         }

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -374,11 +374,12 @@ BlockIO InterpreterSystemQuery::execute()
     bool check_constraints = false;
     system_context->setCurrentProfile(getContext()->getSystemProfileName(), check_constraints);
 
-    auto dictionary_context = getContext();
-    if ((query.type == Type::RELOAD_DICTIONARY || query.type == Type::UNLOAD_DICTIONARY) && query.database)
+    String dictionary_name;
+    if (query.type == Type::RELOAD_DICTIONARY || query.type == Type::UNLOAD_DICTIONARY)
     {
-        dictionary_context = Context::createCopy(getContext());
-        dictionary_context->setCurrentDatabase(query.getDatabase());
+        dictionary_name = query.getTable();
+        if (query.database)
+            dictionary_name = backQuoteIfNeed(query.getDatabase()) + "." + backQuoteIfNeed(dictionary_name);
     }
 
     /// Make canonical query for simpler processing
@@ -780,7 +781,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            external_dictionaries_loader.reloadDictionary(query.getTable(), dictionary_context);
+            external_dictionaries_loader.reloadDictionary(dictionary_name, getContext());
 
             ExternalDictionariesLoader::resetAll();
             break;
@@ -800,7 +801,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            external_dictionaries_loader.unloadDictionary(query.getTable(), dictionary_context);
+            external_dictionaries_loader.unloadDictionary(dictionary_name, getContext());
             ExternalDictionariesLoader::resetAll();
             break;
         }

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -348,6 +348,15 @@ void InterpreterSystemQuery::startStopActionInDatabase(StorageActionBlockType ac
 }
 
 
+static String getDictionaryNameForLoader(const ASTSystemQuery & query)
+{
+    if (!query.database)
+        return query.getTable();
+
+    return backQuoteIfNeed(query.getDatabase()) + "." + backQuoteIfNeed(query.getTable());
+}
+
+
 InterpreterSystemQuery::InterpreterSystemQuery(const ASTPtr & query_ptr_, ContextMutablePtr context_)
         : WithMutableContext(context_), query_ptr(query_ptr_->clone()), log(getLogger("InterpreterSystemQuery"))
 {
@@ -373,14 +382,6 @@ BlockIO InterpreterSystemQuery::execute()
     /// some experimental settings)
     bool check_constraints = false;
     system_context->setCurrentProfile(getContext()->getSystemProfileName(), check_constraints);
-
-    String dictionary_name;
-    if (query.type == Type::RELOAD_DICTIONARY || query.type == Type::UNLOAD_DICTIONARY)
-    {
-        dictionary_name = query.getTable();
-        if (query.database)
-            dictionary_name = backQuoteIfNeed(query.getDatabase()) + "." + backQuoteIfNeed(dictionary_name);
-    }
 
     /// Make canonical query for simpler processing
     if (query.type != Type::RELOAD_DICTIONARY && query.type != Type::UNLOAD_DICTIONARY && query.table)
@@ -781,6 +782,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
+            const String dictionary_name = getDictionaryNameForLoader(query);
             external_dictionaries_loader.reloadDictionary(dictionary_name, getContext());
 
             ExternalDictionariesLoader::resetAll();
@@ -801,6 +803,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
+            const String dictionary_name = getDictionaryNameForLoader(query);
             external_dictionaries_loader.unloadDictionary(dictionary_name, getContext());
             ExternalDictionariesLoader::resetAll();
             break;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -374,13 +374,15 @@ BlockIO InterpreterSystemQuery::execute()
     bool check_constraints = false;
     system_context->setCurrentProfile(getContext()->getSystemProfileName(), check_constraints);
 
-    /// Make canonical query for simpler processing
-    if (query.type == Type::RELOAD_DICTIONARY || query.type == Type::UNLOAD_DICTIONARY)
+    auto dictionary_context = getContext();
+    if ((query.type == Type::RELOAD_DICTIONARY || query.type == Type::UNLOAD_DICTIONARY) && query.database)
     {
-        if (query.database)
-            query.setTable(query.getDatabase() + "." + query.getTable());
+        dictionary_context = Context::createCopy(getContext());
+        dictionary_context->setCurrentDatabase(query.getDatabase());
     }
-    else if (query.table)
+
+    /// Make canonical query for simpler processing
+    if (query.type != Type::RELOAD_DICTIONARY && query.type != Type::UNLOAD_DICTIONARY && query.table)
     {
         StorageID id_in_query(query.getDatabase(), query.getTable());
         /// `IF EXISTS` (currently parsed for `SYSTEM SYNC REPLICA`) must suppress
@@ -778,7 +780,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            external_dictionaries_loader.reloadDictionary(query.getTable(), getContext());
+            external_dictionaries_loader.reloadDictionary(query.getTable(), dictionary_context);
 
             ExternalDictionariesLoader::resetAll();
             break;
@@ -798,7 +800,7 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            external_dictionaries_loader.unloadDictionary(query.getTable(), getContext());
+            external_dictionaries_loader.unloadDictionary(query.getTable(), dictionary_context);
             ExternalDictionariesLoader::resetAll();
             break;
         }

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -79,7 +79,7 @@ static bool needsDefaultDatabaseForBareDictionaryOnCluster(const ASTPtr & query_
     if (!system_query->table || system_query->database)
         return false;
 
-    return system_query->getTable().find('.') == String::npos;
+    return !system_query->getTable().contains('.');
 }
 
 

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -66,6 +66,23 @@ bool isSupportedAlterTypeForOnClusterDDLQuery(int type)
 }
 
 
+static bool needsDefaultDatabaseForBareDictionaryOnCluster(const ASTPtr & query_ptr)
+{
+    const auto * system_query = query_ptr->as<ASTSystemQuery>();
+    if (!system_query)
+        return false;
+
+    if (system_query->type != ASTSystemQuery::Type::RELOAD_DICTIONARY
+        && system_query->type != ASTSystemQuery::Type::UNLOAD_DICTIONARY)
+        return false;
+
+    if (!system_query->table || system_query->database)
+        return false;
+
+    return system_query->getTable().find('.') == String::npos;
+}
+
+
 BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, const DDLQueryOnClusterParams & params)
 {
     OpenTelemetry::SpanHolder span(__FUNCTION__, OpenTelemetry::SpanKind::PRODUCER);
@@ -136,7 +153,8 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, 
     bool need_replace_current_database = std::any_of(
         access_to_check.begin(),
         access_to_check.end(),
-        [](const AccessRightsElement & elem) { return elem.isEmptyDatabase(); });
+        [](const AccessRightsElement & elem) { return elem.isEmptyDatabase(); })
+        || needsDefaultDatabaseForBareDictionaryOnCluster(query_ptr);
 
     bool use_local_default_database = false;
     const String & current_database = context->getCurrentDatabase();

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -79,7 +79,7 @@ static bool needsDefaultDatabaseForBareDictionaryOnCluster(const ASTPtr & query_
     if (!system_query->table || system_query->database)
         return false;
 
-    return !system_query->getTable().contains('.');
+    return true;
 }
 
 

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -54,18 +54,9 @@ namespace ErrorCodes
         if (ParserStringLiteral{}.parse(pos, ast, expected))
         {
             String name = ast->as<ASTLiteral &>().value.safeGet<String>();
-            /// The string literal may contain 'database.table', split it
-            /// to match what parseDatabaseAndTableAsAST would produce.
-            auto dot_pos = name.find('.');
-            if (dot_pos != String::npos)
-            {
-                res->setDatabase(name.substr(0, dot_pos));
-                res->setTable(name.substr(dot_pos + 1));
-            }
-            else
-            {
-                res->setTable(name);
-            }
+            /// A string literal carries a dictionary name verbatim. In particular,
+            /// a dot may be part of the dictionary name rather than a database separator.
+            res->setTable(name);
             parsed_table = true;
             children_already_added = true; /// setDatabase/setTable already push to children
         }

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -54,9 +54,18 @@ namespace ErrorCodes
         if (ParserStringLiteral{}.parse(pos, ast, expected))
         {
             String name = ast->as<ASTLiteral &>().value.safeGet<String>();
-            /// A string literal carries a dictionary name verbatim. In particular,
-            /// a dot may be part of the dictionary name rather than a database separator.
-            res->setTable(name);
+            /// A single dot preserves the established string-literal form for a
+            /// qualified dictionary name. Multiple dots are part of a bare dictionary name.
+            auto dot_pos = name.find('.');
+            if (dot_pos != String::npos && name.find('.', dot_pos + 1) == String::npos)
+            {
+                res->setDatabase(name.substr(0, dot_pos));
+                res->setTable(name.substr(dot_pos + 1));
+            }
+            else
+            {
+                res->setTable(name);
+            }
             parsed_table = true;
             children_already_added = true; /// setDatabase/setTable already push to children
         }

--- a/tests/integration/test_ddl_worker_stale_task_name/configs/dict.xml
+++ b/tests/integration/test_ddl_worker_stale_task_name/configs/dict.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <dictionary>
+        <database>default</database>
         <name>slow_dict_7</name>
         <source>
             <executable>

--- a/tests/integration/test_dictionary_ddl_on_cluster/configs/config.d/clusters.xml
+++ b/tests/integration/test_dictionary_ddl_on_cluster/configs/config.d/clusters.xml
@@ -24,5 +24,33 @@
             </replica>
         </shard>
     </cluster>
+    <one_node>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>ch1</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </one_node>
+    <workers_only>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>ch1</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </workers_only>
+    <workers_with_default_db>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>ch1</host>
+                <port>9000</port>
+                <default_database>issue_114322</default_database>
+            </replica>
+        </shard>
+    </workers_with_default_db>
 </remote_servers>
 </clickhouse>

--- a/tests/integration/test_dictionary_ddl_on_cluster/configs/dictionaries/issue_114322_xml_only.xml
+++ b/tests/integration/test_dictionary_ddl_on_cluster/configs/dictionaries/issue_114322_xml_only.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <dictionary>
+        <name>issue_114322_xml_only</name>
+        <source>
+            <null/>
+        </source>
+        <layout>
+            <flat/>
+        </layout>
+        <structure>
+            <id>
+                <name>id</name>
+            </id>
+            <attribute>
+                <name>value</name>
+                <type>String</type>
+                <null_value></null_value>
+            </attribute>
+        </structure>
+        <lifetime>0</lifetime>
+    </dictionary>
+</clickhouse>

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -314,6 +314,31 @@ def test_qualified_dictionary_on_cluster_keeps_explicit_database(
         drop_issue_114322_dictionaries()
 
 
+@pytest.mark.parametrize("command", ["RELOAD", "UNLOAD"])
+def test_qualified_dictionary_string_literal_on_cluster_keeps_explicit_database(
+    started_cluster, command
+):
+    try:
+        prepare_issue_114322_dictionaries()
+        if command == "RELOAD":
+            unload_issue_114322_dictionaries(ch1)
+            expected = "default\tLOADED\n{}\tNOT_LOADED\n".format(DICTIONARY_DB)
+        else:
+            reload_issue_114322_dictionaries(ch1)
+            expected = "default\tNOT_LOADED\n{}\tLOADED\n".format(DICTIONARY_DB)
+
+        coordinator.query(
+            "SYSTEM {} DICTIONARY 'default.{}' ON CLUSTER 'workers_only'".format(
+                command, DICTIONARY_NAME
+            ),
+            database=DICTIONARY_DB,
+        )
+
+        assert_issue_114322_dictionary_statuses(expected)
+    finally:
+        drop_issue_114322_dictionaries()
+
+
 def test_reload_xml_only_dictionary_on_cluster_uses_qualified_database_name(
     started_cluster,
 ):

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -262,7 +262,7 @@ def test_reload_dictionary_on_cluster_uses_initiator_database_without_default_de
         drop_issue_114322_dictionaries()
 
 
-def test_reload_dictionary_on_cluster_uses_initiator_database_for_quoted_dotted_name(
+def test_reload_dictionary_on_cluster_uses_initiator_database_for_dotted_string_literal_name(
     started_cluster,
 ):
     try:
@@ -280,7 +280,7 @@ def test_reload_dictionary_on_cluster_uses_initiator_database_for_quoted_dotted_
         )
 
         coordinator.query(
-            f"SYSTEM RELOAD DICTIONARY `{DOTTED_DICTIONARY_NAME}` ON CLUSTER 'workers_only'",
+            f"SYSTEM RELOAD DICTIONARY '{DOTTED_DICTIONARY_NAME}' ON CLUSTER 'workers_only'",
             database=DICTIONARY_DB,
         )
 

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -34,13 +34,17 @@ coordinator = cluster.add_instance(
 
 DICTIONARY_DB = "issue_114322"
 DICTIONARY_NAME = "issue_114322_dict"
+DOTTED_DICTIONARY_NAME = "issue_114322_dict.with.dot"
 XML_ONLY_DICTIONARY_NAME = "issue_114322_xml_only"
-DICTIONARY_STATUS_QUERY = """
+
+
+def get_issue_114322_dictionary_status_query(name=DICTIONARY_NAME):
+    return """
     SELECT database, status
     FROM system.dictionaries
     WHERE name = '{name}' AND database IN ('default', '{database}')
     ORDER BY database
-""".format(name=DICTIONARY_NAME, database=DICTIONARY_DB)
+""".format(name=name, database=DICTIONARY_DB)
 
 
 @pytest.fixture(scope="module")
@@ -131,6 +135,7 @@ def test_dictionary_ddl_on_cluster(started_cluster):
 def drop_issue_114322_dictionaries():
     for node in (ch1, coordinator):
         node.query(f"DROP DICTIONARY IF EXISTS default.{DICTIONARY_NAME}")
+        node.query(f"DROP DICTIONARY IF EXISTS default.`{DOTTED_DICTIONARY_NAME}`")
         node.query(f"DROP DATABASE IF EXISTS {DICTIONARY_DB} SYNC")
 
 
@@ -139,10 +144,10 @@ def create_issue_114322_database():
     coordinator.query(f"CREATE DATABASE IF NOT EXISTS {DICTIONARY_DB}")
 
 
-def create_issue_114322_dictionary(node, database):
+def create_issue_114322_dictionary(node, database, name=DICTIONARY_NAME):
     node.query(
         f"""
-        CREATE DICTIONARY {database}.{DICTIONARY_NAME} (k UInt64, v String)
+        CREATE DICTIONARY {database}.`{name}` (k UInt64, v String)
         PRIMARY KEY k
         SOURCE(NULL())
         LAYOUT(FLAT())
@@ -171,8 +176,10 @@ def prepare_issue_114322_dictionaries(include_default=True):
         create_issue_114322_dictionary(ch1, "default")
 
 
-def assert_issue_114322_dictionary_statuses(expected):
-    assert_eq_with_retry(ch1, DICTIONARY_STATUS_QUERY, expected)
+def assert_issue_114322_dictionary_statuses(expected, name=DICTIONARY_NAME):
+    assert_eq_with_retry(
+        ch1, get_issue_114322_dictionary_status_query(name), expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -251,6 +258,36 @@ def test_reload_dictionary_on_cluster_uses_initiator_database_without_default_de
         )
 
         assert_issue_114322_dictionary_statuses(f"{DICTIONARY_DB}\tLOADED\n")
+    finally:
+        drop_issue_114322_dictionaries()
+
+
+def test_reload_dictionary_on_cluster_uses_initiator_database_for_quoted_dotted_name(
+    started_cluster,
+):
+    try:
+        drop_issue_114322_dictionaries()
+        create_issue_114322_database()
+        create_issue_114322_dictionary(ch1, DICTIONARY_DB, DOTTED_DICTIONARY_NAME)
+        create_issue_114322_dictionary(ch1, "default", DOTTED_DICTIONARY_NAME)
+        ch1.query(
+            f"SYSTEM UNLOAD DICTIONARY {DICTIONARY_DB}.`{DOTTED_DICTIONARY_NAME}`"
+        )
+        ch1.query(f"SYSTEM UNLOAD DICTIONARY default.`{DOTTED_DICTIONARY_NAME}`")
+        assert_issue_114322_dictionary_statuses(
+            f"default\tNOT_LOADED\n{DICTIONARY_DB}\tNOT_LOADED\n",
+            DOTTED_DICTIONARY_NAME,
+        )
+
+        coordinator.query(
+            f"SYSTEM RELOAD DICTIONARY `{DOTTED_DICTIONARY_NAME}` ON CLUSTER 'workers_only'",
+            database=DICTIONARY_DB,
+        )
+
+        assert_issue_114322_dictionary_statuses(
+            f"default\tNOT_LOADED\n{DICTIONARY_DB}\tLOADED\n",
+            DOTTED_DICTIONARY_NAME,
+        )
     finally:
         drop_issue_114322_dictionaries()
 

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -2,11 +2,13 @@ import pytest
 
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 ch1 = cluster.add_instance(
     "ch1",
     main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+    dictionaries=["configs/dictionaries/issue_114322_xml_only.xml"],
     with_zookeeper=True,
 )
 ch2 = cluster.add_instance(
@@ -24,6 +26,21 @@ ch4 = cluster.add_instance(
     main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
     with_zookeeper=True,
 )
+coordinator = cluster.add_instance(
+    "coordinator",
+    main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+    with_zookeeper=True,
+)
+
+DICTIONARY_DB = "issue_114322"
+DICTIONARY_NAME = "issue_114322_dict"
+XML_ONLY_DICTIONARY_NAME = "issue_114322_xml_only"
+DICTIONARY_STATUS_QUERY = """
+    SELECT database, status
+    FROM system.dictionaries
+    WHERE name = '{name}' AND database IN ('default', '{database}')
+    ORDER BY database
+""".format(name=DICTIONARY_NAME, database=DICTIONARY_DB)
 
 
 @pytest.fixture(scope="module")
@@ -109,3 +126,191 @@ def test_dictionary_ddl_on_cluster(started_cluster):
     for node in [ch1, ch2, ch3, ch4]:
         with pytest.raises(QueryRuntimeException):
             node.query("SELECT dictGetString('default.somedict', 'value', toUInt64(1))")
+
+
+def drop_issue_114322_dictionaries():
+    for node in (ch1, coordinator):
+        node.query(f"DROP DICTIONARY IF EXISTS default.{DICTIONARY_NAME}")
+        node.query(f"DROP DATABASE IF EXISTS {DICTIONARY_DB} SYNC")
+
+
+def create_issue_114322_database():
+    ch1.query(f"CREATE DATABASE IF NOT EXISTS {DICTIONARY_DB}")
+    coordinator.query(f"CREATE DATABASE IF NOT EXISTS {DICTIONARY_DB}")
+
+
+def create_issue_114322_dictionary(node, database):
+    node.query(
+        f"""
+        CREATE DICTIONARY {database}.{DICTIONARY_NAME} (k UInt64, v String)
+        PRIMARY KEY k
+        SOURCE(NULL())
+        LAYOUT(FLAT())
+        LIFETIME(0)
+        """
+    )
+
+
+def unload_issue_114322_dictionaries(node, include_default=True):
+    node.query(f"SYSTEM UNLOAD DICTIONARY {DICTIONARY_DB}.{DICTIONARY_NAME}")
+    if include_default:
+        node.query(f"SYSTEM UNLOAD DICTIONARY default.{DICTIONARY_NAME}")
+
+
+def reload_issue_114322_dictionaries(node, include_default=True):
+    node.query(f"SYSTEM RELOAD DICTIONARY {DICTIONARY_DB}.{DICTIONARY_NAME}")
+    if include_default:
+        node.query(f"SYSTEM RELOAD DICTIONARY default.{DICTIONARY_NAME}")
+
+
+def prepare_issue_114322_dictionaries(include_default=True):
+    drop_issue_114322_dictionaries()
+    create_issue_114322_database()
+    create_issue_114322_dictionary(ch1, DICTIONARY_DB)
+    if include_default:
+        create_issue_114322_dictionary(ch1, "default")
+
+
+def assert_issue_114322_dictionary_statuses(expected):
+    assert_eq_with_retry(ch1, DICTIONARY_STATUS_QUERY, expected)
+
+
+@pytest.mark.parametrize(
+    "initiator, cluster_name",
+    [
+        pytest.param(ch1, "one_node", id="initiator_is_cluster_member"),
+        pytest.param(
+            coordinator, "workers_only", id="coordinator_is_not_cluster_member"
+        ),
+    ],
+)
+def test_reload_dictionary_on_cluster_uses_initiator_database_for_bare_name(
+    started_cluster, initiator, cluster_name
+):
+    try:
+        prepare_issue_114322_dictionaries()
+        unload_issue_114322_dictionaries(ch1)
+        assert_issue_114322_dictionary_statuses(
+            f"default\tNOT_LOADED\n{DICTIONARY_DB}\tNOT_LOADED\n"
+        )
+
+        initiator.query(
+            f"SYSTEM RELOAD DICTIONARY {DICTIONARY_NAME} ON CLUSTER '{cluster_name}'",
+            database=DICTIONARY_DB,
+        )
+
+        assert_issue_114322_dictionary_statuses(
+            f"default\tNOT_LOADED\n{DICTIONARY_DB}\tLOADED\n"
+        )
+    finally:
+        drop_issue_114322_dictionaries()
+
+
+@pytest.mark.parametrize(
+    "initiator, cluster_name",
+    [
+        pytest.param(ch1, "one_node", id="initiator_is_cluster_member"),
+        pytest.param(
+            coordinator, "workers_only", id="coordinator_is_not_cluster_member"
+        ),
+    ],
+)
+def test_unload_dictionary_on_cluster_uses_initiator_database_for_bare_name(
+    started_cluster, initiator, cluster_name
+):
+    try:
+        prepare_issue_114322_dictionaries()
+        reload_issue_114322_dictionaries(ch1)
+        assert_issue_114322_dictionary_statuses(
+            f"default\tLOADED\n{DICTIONARY_DB}\tLOADED\n"
+        )
+
+        initiator.query(
+            f"SYSTEM UNLOAD DICTIONARY {DICTIONARY_NAME} ON CLUSTER '{cluster_name}'",
+            database=DICTIONARY_DB,
+        )
+
+        assert_issue_114322_dictionary_statuses(
+            f"default\tLOADED\n{DICTIONARY_DB}\tNOT_LOADED\n"
+        )
+    finally:
+        drop_issue_114322_dictionaries()
+
+
+def test_reload_dictionary_on_cluster_uses_initiator_database_without_default_decoy(
+    started_cluster,
+):
+    try:
+        prepare_issue_114322_dictionaries(include_default=False)
+        unload_issue_114322_dictionaries(ch1, include_default=False)
+        assert_issue_114322_dictionary_statuses(f"{DICTIONARY_DB}\tNOT_LOADED\n")
+
+        coordinator.query(
+            f"SYSTEM RELOAD DICTIONARY {DICTIONARY_NAME} ON CLUSTER 'workers_only'",
+            database=DICTIONARY_DB,
+        )
+
+        assert_issue_114322_dictionary_statuses(f"{DICTIONARY_DB}\tLOADED\n")
+    finally:
+        drop_issue_114322_dictionaries()
+
+
+def test_qualified_dictionary_on_cluster_keeps_explicit_database(
+    started_cluster,
+):
+    try:
+        prepare_issue_114322_dictionaries()
+        unload_issue_114322_dictionaries(ch1)
+        assert_issue_114322_dictionary_statuses(
+            f"default\tNOT_LOADED\n{DICTIONARY_DB}\tNOT_LOADED\n"
+        )
+
+        coordinator.query(
+            f"SYSTEM RELOAD DICTIONARY default.{DICTIONARY_NAME} ON CLUSTER 'workers_only'",
+            database=DICTIONARY_DB,
+        )
+
+        assert_issue_114322_dictionary_statuses(
+            f"default\tLOADED\n{DICTIONARY_DB}\tNOT_LOADED\n"
+        )
+    finally:
+        drop_issue_114322_dictionaries()
+
+
+def test_reload_xml_only_dictionary_on_cluster_uses_qualified_database_name(
+    started_cluster,
+):
+    try:
+        drop_issue_114322_dictionaries()
+        create_issue_114322_database()
+
+        with pytest.raises(QueryRuntimeException) as exc:
+            coordinator.query(
+                f"SYSTEM RELOAD DICTIONARY {XML_ONLY_DICTIONARY_NAME} ON CLUSTER 'workers_only'",
+                database=DICTIONARY_DB,
+            )
+
+        exception = str(exc.value)
+        assert "Dictionary" in exception
+        assert f"{DICTIONARY_DB}.{XML_ONLY_DICTIONARY_NAME}" in exception
+        assert "BAD_ARGUMENTS" in exception or "Code: 36" in exception
+    finally:
+        drop_issue_114322_dictionaries()
+
+
+def test_reload_dictionary_on_cluster_uses_shard_default_database_when_configured(
+    started_cluster,
+):
+    try:
+        prepare_issue_114322_dictionaries(include_default=False)
+        unload_issue_114322_dictionaries(ch1, include_default=False)
+        assert_issue_114322_dictionary_statuses(f"{DICTIONARY_DB}\tNOT_LOADED\n")
+
+        coordinator.query(
+            f"SYSTEM RELOAD DICTIONARY {DICTIONARY_NAME} ON CLUSTER 'workers_with_default_db'",
+            database="default",
+        )
+
+        assert_issue_114322_dictionary_statuses(f"{DICTIONARY_DB}\tLOADED\n")
+    finally:
+        drop_issue_114322_dictionaries()

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -113,7 +113,7 @@ def test_dictionary_ddl_on_cluster(started_cluster):
     for num, node in enumerate([ch1, ch2, ch3, ch4]):
         node.query("ALTER TABLE sometbl UPDATE value = 'new_key' WHERE 1")
 
-    ch1.query("SYSTEM RELOAD DICTIONARY ON CLUSTER 'cluster' `default.somedict`")
+    ch1.query("SYSTEM RELOAD DICTIONARY ON CLUSTER 'cluster' default.somedict")
 
     for num, node in enumerate([ch1, ch2, ch3, ch4]):
         assert (

--- a/tests/integration/test_distributed_ddl_parallel/configs/dict.xml
+++ b/tests/integration/test_distributed_ddl_parallel/configs/dict.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <dictionary>
+        <database>default</database>
         <name>slow_dict_7</name>
         <source>
            <executable>
@@ -26,6 +27,7 @@
     </dictionary>
 
     <dictionary>
+        <database>default</database>
         <name>slow_dict_3</name>
         <source>
            <executable>


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/114322

`SYSTEM RELOAD DICTIONARY <bare-name> ON CLUSTER` and `SYSTEM UNLOAD DICTIONARY <bare-name> ON CLUSTER` could enqueue the dictionary name without the initiator's current database. Distributed DDL workers then resolved the bare name against their own default database, commonly `default`, so a command issued from another database could affect `default.<dictionary>` or silently do nothing.

This change makes those two `SYSTEM` dictionary commands participate in the same default-database rewrite path that existing table-like `ON CLUSTER` DDL already uses before serialization. The rewrite is limited to bare dictionary names, preserves explicitly qualified dictionary names, and keeps the existing `<default_database>` cluster carve-out where workers resolve the bare name against the shard default database.

The issue's coordinator-only initiator topology is covered: the initiating node can enqueue the distributed DDL task without hosting the dictionary locally. This avoids relying on `ExternalDictionariesLoader` local resolvability checks, and local non-`ON CLUSTER` dictionary resolution is unchanged.

The PR also documents the deliberate XML-only behavior change with a test. Since XML dictionaries are registered without a database, a bare XML dictionary name over `ON CLUSTER` is now qualified before queuing on normal clusters and therefore fails as a missing database dictionary instead of being resolved XML-first on the worker.

`@Manerone`, you mentioned I could ping you once there was something to review.

Tests:
- `python3 -m py_compile tests/integration/test_dictionary_ddl_on_cluster/test.py`
- `git diff --check -- src/Interpreters/AddDefaultDatabaseVisitor.h src/Interpreters/executeDDLQueryOnCluster.cpp tests/integration/test_dictionary_ddl_on_cluster`
- `ninja -C build clickhouse > build/build_issue_114322_dictionary_on_cluster.log 2>&1`
- Focused integration suite via the documented local workaround: `9 passed in 53.80s`

The official `python3 -m ci.praktika run "integration" --test test_dictionary_ddl_on_cluster` path was attempted first, but local Docker image pulling timed out before reaching test bodies.

### Changelog category (leave one):
- Bug Fix


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SYSTEM RELOAD DICTIONARY <bare-name> ON CLUSTER` and `SYSTEM UNLOAD DICTIONARY <bare-name> ON CLUSTER` so normal distributed DDL clusters resolve the bare dictionary name against the initiator's current database before queuing the task, matching existing table-like `ON CLUSTER` DDL behavior. Closes #114322.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117596&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117596](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117596+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1375` (included in `26.9` and later)
<!-- ch-version-info:end -->