### PR TITLE
Fix a lost row when a signed-zero constant is pushed through a transformed sorting key

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2382,28 +2382,114 @@ static bool isDeterministicTransformInjective(const ActionsDAG & dag, const Stri
     return dfs(output_node, dfs).injective;
 }
 
-/// Whether the value holds a floating-point zero at any depth. `-0.` and `+0.` compare equal while
-/// being distinct values, and they are the only such pair on a floating-point domain: every other pair
-/// of distinct bit patterns compares unequal, and a `NaN` equals nothing. `Field` has no `Float32`, so
-/// `Float32` and `BFloat16` values arrive here as `Float64`.
+/// Whether the type is, or contains at any depth, a dynamically typed one. Such a type compares values
+/// of different types as equal, so a constant in that domain does not determine which values it stands
+/// for.
+static bool hasDynamicallyTypedComponent(const DataTypePtr & type)
+{
+    bool result = false;
+    auto check = [&](const IDataType & child)
+    {
+        const WhichDataType which(child);
+        result = result || which.isDynamic() || which.isVariant() || which.isObject();
+    };
+
+    check(*type);
+    type->forEachChild(check);
+    return result;
+}
+
+
+/// Whether the value holds a floating-point zero at any depth.
+/// Iterative because `Field`s nest inside `Field`s and a recursive walk overflows the native stack.
 static bool fieldHoldsFloatZero(const Field & field)
 {
-    switch (field.getType())
+    absl::InlinedVector<const Field *, 16> pending{&field};
+
+    while (!pending.empty())
     {
-        case Field::Types::Float64:
-            return field.safeGet<Float64>() == 0;
-        case Field::Types::Array:
-            return std::ranges::any_of(field.safeGet<Array>(), fieldHoldsFloatZero);
-        case Field::Types::Tuple:
-            return std::ranges::any_of(field.safeGet<Tuple>(), fieldHoldsFloatZero);
-        case Field::Types::Map:
-            return std::ranges::any_of(field.safeGet<Map>(), fieldHoldsFloatZero);
-        case Field::Types::Object:
-            return std::ranges::any_of(
-                field.safeGet<Object>(), [](const auto & entry) { return fieldHoldsFloatZero(entry.second); });
-        default:
-            return false;
+        const Field * current = pending.back();
+        pending.pop_back();
+
+        switch (current->getType())
+        {
+            case Field::Types::Float64:
+                if (current->safeGet<Float64>() == 0)
+                    return true;
+                break;
+            case Field::Types::Array:
+                for (const Field & element : current->safeGet<Array>())
+                    pending.push_back(&element);
+                break;
+            case Field::Types::Tuple:
+                for (const Field & element : current->safeGet<Tuple>())
+                    pending.push_back(&element);
+                break;
+            case Field::Types::Map:
+                for (const Field & element : current->safeGet<Map>())
+                    pending.push_back(&element);
+                break;
+            case Field::Types::Object:
+                for (const auto & entry : current->safeGet<Object>())
+                    pending.push_back(&entry.second);
+                break;
+            default:
+                break;
+        }
     }
+
+    return false;
+}
+
+
+/// A predicate on a floating-point zero holds for both `-0.` and `+0.`, which are distinct values, so a
+/// key range built from one of them stands for the predicate only if the key transform sends both to key
+/// values the index compares as equal. `{-0., +0.}` is the only such pair on a floating-point domain:
+/// every other pair of distinct bit patterns compares unequal, and a `NaN` equals nothing. `Field` has
+/// no `Float32`, so `Float32` and `BFloat16` values arrive here as `Float64`.
+static bool keyTransformCanSeparateEqualValues(
+    const Field & value,
+    const DataTypePtr & value_type,
+    const String & input_name,
+    const DeterministicKeyTransformDag & dag)
+{
+    /// A stored `-0.` equals a `0` written as an integer in such a domain, so the constant does not
+    /// determine which values it stands for and no range can be built from it.
+    if (hasDynamicallyTypedComponent(dag.input_type))
+        return true;
+
+    const WhichDataType key_input_domain(removeNullable(removeLowCardinality(dag.input_type)));
+
+    /// The comparison reads the constant in the domain of the column the key expression consumes, and
+    /// that is where its equality class lives: `WHERE f = 0` over a `Float64` column compares two floats.
+    const Field key_input_value = tryConvertFieldToType(value, *dag.input_type, value_type.get());
+
+    /// A container holds one sign combination per zero inside it, so one sibling does not decide it.
+    if (key_input_value.getType() != Field::Types::Float64)
+        return fieldHoldsFloatZero(key_input_value);
+
+    const Float64 zero = key_input_value.safeGet<Float64>();
+    if (zero != 0)
+        return false;
+
+    /// Only a floating-point domain carries the other spelling, and only its columns accept a `Float64`
+    /// value, so anything else cannot be probed and is declined instead.
+    if (!key_input_domain.isFloat())
+        return true;
+
+    /// Both spellings go through in one column, in the transform's own input type, so neither the
+    /// conversion nor the transform can treat them differently.
+    auto probe_column = dag.input_type->createColumn();
+    probe_column->insert(Field(zero));
+    probe_column->insert(Field(-zero));
+
+    ColumnPtr transformed_column;
+    DataTypePtr transformed_type;
+    if (!applyDeterministicDagToColumn(
+            std::move(probe_column), dag.input_type, input_name, dag, transformed_column, transformed_type))
+        return true;
+
+    return !Range::equals((*transformed_column)[0], (*transformed_column)[1]);
 }
 
 bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
@@ -2447,12 +2533,6 @@ bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
     if (!extractDeterministicFunctionsDagFromKey(expr_name, info, out_key_column_num, out_key_column_type, dag))
         return false;
 
-    /// A key transform reads the bit pattern, so it can map `-0.` and `+0.` to two different key values
-    /// while the comparison feeding it treats them as one. A range built from one of them misses the
-    /// mark holding the other, so decline the atom instead.
-    if (fieldHoldsFloatZero(tryConvertFieldToType(out_value, *dag.input_type, out_type.get())))
-        return false;
-
     out_is_injective = isDeterministicTransformInjective(dag.actions->getActionsDAG(), expr_name, dag.output_name);
 
     ColumnPtr const_column = out_type->createColumnConst(1, out_value);
@@ -2475,6 +2555,11 @@ bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
     /// If the key transform produces NaN for the constant, the index cannot answer this predicate;
     /// fall back so the caller scans the granules.
     if (transformed_value.isNaN())
+        return false;
+
+    /// A point range built from one spelling of a floating-point zero misses the mark holding the other,
+    /// so the atom would be narrower than the predicate it stands for.
+    if (keyTransformCanSeparateEqualValues(out_value, out_type, expr_name, dag))
         return false;
 
     out_value = transformed_value;

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -33,6 +33,7 @@
 #include <Common/typeid_cast.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeFixedString.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnSet.h>
@@ -2382,16 +2383,19 @@ static bool isDeterministicTransformInjective(const ActionsDAG & dag, const Stri
     return dfs(output_node, dfs).injective;
 }
 
-/// Whether the type is, or contains at any depth, a dynamically typed one. Such a type holds values of
-/// several types at once and compares them across types.
+/// Whether the type holds values of several types at once and compares them across types.
+static bool isDynamicallyTypedDomain(const IDataType & type)
+{
+    const WhichDataType which(type);
+    return which.isDynamic() || which.isVariant() || which.isObject();
+}
+
+
+/// Whether the type is, or contains at any depth, a dynamically typed one.
 static bool hasDynamicallyTypedComponent(const DataTypePtr & type)
 {
     bool result = false;
-    auto check = [&](const IDataType & child)
-    {
-        const WhichDataType which(child);
-        result = result || which.isDynamic() || which.isVariant() || which.isObject();
-    };
+    auto check = [&](const IDataType & child) { result = result || isDynamicallyTypedDomain(child); };
 
     check(*type);
     type->forEachChild(check);
@@ -2408,43 +2412,85 @@ static bool fieldIsZeroWrittenInAnyType(const Field & field)
 }
 
 
-/// Whether the value holds a zero at any depth. `any_spelling_of_zero` widens that to a zero written in
-/// another numeric type, or as a string that parses as one, which a dynamically typed domain compares
-/// equal to a stored `-0.`.
+/// Whether the value holds, at any depth, a zero the member holding it compares equal to a stored `-0.`:
+/// under a dynamically typed member any spelling of a zero, elsewhere only a `Float64` zero, since no other
+/// type has two spellings of zero. A value that does not have the shape of its own type cannot be read.
 /// Iterative because `Field`s nest inside `Field`s and a recursive walk overflows the native stack.
-static bool fieldHoldsZero(const Field & field, bool any_spelling_of_zero)
+static bool fieldHoldsZeroConflatedWithNegativeZero(const Field & field, const DataTypePtr & type)
 {
-    absl::InlinedVector<const Field *, 16> pending{&field};
+    /// A null type marks a value under a dynamically typed member.
+    absl::InlinedVector<std::pair<const Field *, DataTypePtr>, 16> pending{{&field, type}};
 
     while (!pending.empty())
     {
-        const Field * current = pending.back();
+        const auto [current, current_type] = pending.back();
         pending.pop_back();
+
+        DataTypePtr member_type;
+        if (current_type)
+        {
+            member_type = removeNullable(removeLowCardinality(current_type));
+            if (isDynamicallyTypedDomain(*member_type))
+                member_type = nullptr;
+        }
 
         switch (current->getType())
         {
-            case Field::Types::Float64:
-                if (current->safeGet<Float64>() == 0)
-                    return true;
-                break;
             case Field::Types::Array:
+            {
+                const auto * array_type = member_type ? typeid_cast<const DataTypeArray *>(member_type.get()) : nullptr;
+                if (member_type && !array_type)
+                    return true;
                 for (const Field & element : current->safeGet<Array>())
-                    pending.push_back(&element);
+                    pending.emplace_back(&element, array_type ? array_type->getNestedType() : nullptr);
                 break;
+            }
             case Field::Types::Tuple:
-                for (const Field & element : current->safeGet<Tuple>())
-                    pending.push_back(&element);
+            {
+                const Tuple & elements = current->safeGet<Tuple>();
+                const auto * tuple_type = member_type ? typeid_cast<const DataTypeTuple *>(member_type.get()) : nullptr;
+                if (member_type && (!tuple_type || tuple_type->getElements().size() != elements.size()))
+                    return true;
+                for (size_t i = 0; i < elements.size(); ++i)
+                    pending.emplace_back(&elements[i], tuple_type ? tuple_type->getElement(i) : nullptr);
                 break;
+            }
             case Field::Types::Map:
-                for (const Field & element : current->safeGet<Map>())
-                    pending.push_back(&element);
+            {
+                const auto * map_type = member_type ? typeid_cast<const DataTypeMap *>(member_type.get()) : nullptr;
+                if (member_type && !map_type)
+                    return true;
+                for (const Field & entry : current->safeGet<Map>())
+                {
+                    if (!map_type)
+                    {
+                        pending.emplace_back(&entry, nullptr);
+                        continue;
+                    }
+                    /// An entry of a `Map` value is a key and a value in a tuple.
+                    if (entry.getType() != Field::Types::Tuple || entry.safeGet<Tuple>().size() != 2)
+                        return true;
+                    const Tuple & entry_elements = entry.safeGet<Tuple>();
+                    pending.emplace_back(&entry_elements[0], map_type->getKeyType());
+                    pending.emplace_back(&entry_elements[1], map_type->getValueType());
+                }
                 break;
+            }
             case Field::Types::Object:
+            {
+                if (member_type)
+                    return true;
                 for (const auto & entry : current->safeGet<Object>())
-                    pending.push_back(&entry.second);
+                    pending.emplace_back(&entry.second, nullptr);
                 break;
+            }
             default:
-                if (any_spelling_of_zero && fieldIsZeroWrittenInAnyType(*current))
+                if (member_type)
+                {
+                    if (current->getType() == Field::Types::Float64 && current->safeGet<Float64>() == 0)
+                        return true;
+                }
+                else if (fieldIsZeroWrittenInAnyType(*current))
                     return true;
                 break;
         }
@@ -2471,15 +2517,15 @@ static bool keyTransformCanSeparateEqualValues(
     /// that is where its equality class lives: `WHERE f = 0` over a `Float64` column compares two floats.
     const Field key_input_value = tryConvertFieldToType(value, *dag.input_type, value_type.get());
 
-    /// A stored `-0.` equals a zero written in any other type in such a domain, so every spelling of a
-    /// zero there stands for both zeros. A value that denotes no number stands for itself alone, and a
-    /// constant that does not reach the domain at all leaves nothing to reason about.
-    if (hasDynamicallyTypedComponent(dag.input_type))
-        return key_input_value.isNull() || fieldHoldsZero(key_input_value, /*any_spelling_of_zero=*/ true);
+    /// A constant that does not reach the domain at all leaves nothing to reason about, unless the domain
+    /// accepts values of any type, where a conversion that fails leaves the comparison unmodelled.
+    if (key_input_value.isNull())
+        return hasDynamicallyTypedComponent(dag.input_type);
 
-    /// A container holds one sign combination per zero inside it, so one sibling does not decide it.
-    if (key_input_value.getType() != Field::Types::Float64)
-        return fieldHoldsZero(key_input_value, /*any_spelling_of_zero=*/ false);
+    /// A container holds one sign combination per zero inside it, so one sibling does not decide it, and a
+    /// dynamically typed member reads every spelling of a zero as a number.
+    if (key_input_value.getType() != Field::Types::Float64 || hasDynamicallyTypedComponent(dag.input_type))
+        return fieldHoldsZeroConflatedWithNegativeZero(key_input_value, dag.input_type);
 
     const Float64 zero = key_input_value.safeGet<Float64>();
     if (zero != 0)

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2382,9 +2382,8 @@ static bool isDeterministicTransformInjective(const ActionsDAG & dag, const Stri
     return dfs(output_node, dfs).injective;
 }
 
-/// Whether the type is, or contains at any depth, a dynamically typed one. Such a type compares values
-/// of different types as equal, so a constant in that domain does not determine which values it stands
-/// for.
+/// Whether the type is, or contains at any depth, a dynamically typed one. Such a type holds values of
+/// several types at once and compares them across types.
 static bool hasDynamicallyTypedComponent(const DataTypePtr & type)
 {
     bool result = false;
@@ -2400,9 +2399,20 @@ static bool hasDynamicallyTypedComponent(const DataTypePtr & type)
 }
 
 
-/// Whether the value holds a floating-point zero at any depth.
+/// Whether the value is a number equal to zero, whatever type it is written in. A value that denotes no
+/// number at all converts to a null `Field`, and this conversion never throws.
+static bool fieldIsZeroWrittenInAnyType(const Field & field)
+{
+    const Field as_float = tryConvertFieldToType(field, DataTypeFloat64());
+    return !as_float.isNull() && as_float.safeGet<Float64>() == 0;
+}
+
+
+/// Whether the value holds a zero at any depth. `any_spelling_of_zero` widens that to a zero written in
+/// another numeric type, or as a string that parses as one, which a dynamically typed domain compares
+/// equal to a stored `-0.`.
 /// Iterative because `Field`s nest inside `Field`s and a recursive walk overflows the native stack.
-static bool fieldHoldsFloatZero(const Field & field)
+static bool fieldHoldsZero(const Field & field, bool any_spelling_of_zero)
 {
     absl::InlinedVector<const Field *, 16> pending{&field};
 
@@ -2434,6 +2444,8 @@ static bool fieldHoldsFloatZero(const Field & field)
                     pending.push_back(&entry.second);
                 break;
             default:
+                if (any_spelling_of_zero && fieldIsZeroWrittenInAnyType(*current))
+                    return true;
                 break;
         }
     }
@@ -2453,20 +2465,21 @@ static bool keyTransformCanSeparateEqualValues(
     const String & input_name,
     const DeterministicKeyTransformDag & dag)
 {
-    /// A stored `-0.` equals a `0` written as an integer in such a domain, so the constant does not
-    /// determine which values it stands for and no range can be built from it.
-    if (hasDynamicallyTypedComponent(dag.input_type))
-        return true;
-
     const WhichDataType key_input_domain(removeNullable(removeLowCardinality(dag.input_type)));
 
     /// The comparison reads the constant in the domain of the column the key expression consumes, and
     /// that is where its equality class lives: `WHERE f = 0` over a `Float64` column compares two floats.
     const Field key_input_value = tryConvertFieldToType(value, *dag.input_type, value_type.get());
 
+    /// A stored `-0.` equals a zero written in any other type in such a domain, so every spelling of a
+    /// zero there stands for both zeros. A value that denotes no number stands for itself alone, and a
+    /// constant that does not reach the domain at all leaves nothing to reason about.
+    if (hasDynamicallyTypedComponent(dag.input_type))
+        return key_input_value.isNull() || fieldHoldsZero(key_input_value, /*any_spelling_of_zero=*/ true);
+
     /// A container holds one sign combination per zero inside it, so one sibling does not decide it.
     if (key_input_value.getType() != Field::Types::Float64)
-        return fieldHoldsFloatZero(key_input_value);
+        return fieldHoldsZero(key_input_value, /*any_spelling_of_zero=*/ false);
 
     const Float64 zero = key_input_value.safeGet<Float64>();
     if (zero != 0)

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2382,6 +2382,30 @@ static bool isDeterministicTransformInjective(const ActionsDAG & dag, const Stri
     return dfs(output_node, dfs).injective;
 }
 
+/// Whether the value holds a floating-point zero at any depth. `-0.` and `+0.` compare equal while
+/// being distinct values, and they are the only such pair on a floating-point domain: every other pair
+/// of distinct bit patterns compares unequal, and a `NaN` equals nothing. `Field` has no `Float32`, so
+/// `Float32` and `BFloat16` values arrive here as `Float64`.
+static bool fieldHoldsFloatZero(const Field & field)
+{
+    switch (field.getType())
+    {
+        case Field::Types::Float64:
+            return field.safeGet<Float64>() == 0;
+        case Field::Types::Array:
+            return std::ranges::any_of(field.safeGet<Array>(), fieldHoldsFloatZero);
+        case Field::Types::Tuple:
+            return std::ranges::any_of(field.safeGet<Tuple>(), fieldHoldsFloatZero);
+        case Field::Types::Map:
+            return std::ranges::any_of(field.safeGet<Map>(), fieldHoldsFloatZero);
+        case Field::Types::Object:
+            return std::ranges::any_of(
+                field.safeGet<Object>(), [](const auto & entry) { return fieldHoldsFloatZero(entry.second); });
+        default:
+            return false;
+    }
+}
+
 bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
     const RPNBuilderTreeNode & node,
     const BuildInfo & info,
@@ -2421,6 +2445,12 @@ bool KeyCondition::canConstantBeWrappedByDeterministicFunctions(
     DeterministicKeyTransformDag dag;
 
     if (!extractDeterministicFunctionsDagFromKey(expr_name, info, out_key_column_num, out_key_column_type, dag))
+        return false;
+
+    /// A key transform reads the bit pattern, so it can map `-0.` and `+0.` to two different key values
+    /// while the comparison feeding it treats them as one. A range built from one of them misses the
+    /// mark holding the other, so decline the atom instead.
+    if (fieldHoldsFloatZero(tryConvertFieldToType(out_value, *dag.input_type, out_type.get())))
         return false;
 
     out_is_injective = isDeterministicTransformInjective(dag.actions->getActionsDAG(), expr_name, dag.output_name);

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2471,8 +2471,8 @@ static bool fieldHoldsZeroConflatedWithNegativeZero(const Field & field, const D
                     if (entry.getType() != Field::Types::Tuple || entry.safeGet<Tuple>().size() != 2)
                         return true;
                     const Tuple & entry_elements = entry.safeGet<Tuple>();
-                    pending.emplace_back(&entry_elements[0], map_type->getKeyType());
-                    pending.emplace_back(&entry_elements[1], map_type->getValueType());
+                    pending.emplace_back(entry_elements.data(), map_type->getKeyType());
+                    pending.emplace_back(entry_elements.data() + 1, map_type->getValueType());
                 }
                 break;
             }

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
@@ -26,3 +26,5 @@ dynamically typed domain	1
 dynamically typed domain, ground truth	1
 dynamically typed domain nested in a container	1
 dynamically typed domain nested in a container, ground truth	1
+variant domain	1
+variant domain, ground truth	1

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
@@ -28,3 +28,8 @@ dynamically typed domain nested in a container	1
 dynamically typed domain nested in a container, ground truth	1
 variant domain	1
 variant domain, ground truth	1
+zero written as a string	1
+zero written as a string, ground truth	1
+constant denoting no number	1
+constant denoting no number, ground truth	1
+constant denoting no number	Granules: 1/3

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
@@ -4,6 +4,8 @@ notEquals	0
 notEquals, ground truth	0
 zero inside a tuple constant	1
 zero inside a tuple constant, ground truth	1
+non-zero constant inside a tuple	1
+non-zero constant inside a tuple	Granules: 2/3
 non-zero constant	1
 non-zero constant	Granules: 2/3
 zero constant, transform keeps the values equal	1
@@ -13,6 +15,8 @@ isNotDistinctFrom	1
 isNotDistinctFrom, ground truth	1
 partition key	1
 partition key, ground truth	1
+partition key, non-zero constant	1
+partition key, non-zero constant, the pruner still gets the atom	1
 minmax index	1
 minmax index, ground truth	1
 minmax index, non-zero constant	1

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
@@ -9,3 +9,13 @@ non-zero constant	Granules: 2/3
 zero constant, transform keeps the values equal	1
 zero constant, transform keeps the values equal, ground truth	1
 zero constant, transform keeps the values equal	Granules: 1/3
+isNotDistinctFrom	1
+isNotDistinctFrom, ground truth	1
+partition key	1
+partition key, ground truth	1
+minmax index	1
+minmax index, ground truth	1
+dynamically typed domain	1
+dynamically typed domain, ground truth	1
+dynamically typed domain nested in a container	1
+dynamically typed domain nested in a container, ground truth	1

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
@@ -26,6 +26,11 @@ dynamically typed domain	1
 dynamically typed domain, ground truth	1
 dynamically typed domain nested in a container	1
 dynamically typed domain nested in a container, ground truth	1
+zero on the dynamically typed member	1
+zero on the dynamically typed member, ground truth	1
+zero on a fixed-typed member beside a dynamically typed one	1
+zero on a fixed-typed member beside a dynamically typed one, ground truth	1
+zero on a fixed-typed member beside a dynamically typed one	Granules: 1/3
 variant domain	1
 variant domain, ground truth	1
 zero written as a string	1

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
@@ -1,0 +1,11 @@
+equals	1
+equals, ground truth	1
+notEquals	0
+notEquals, ground truth	0
+zero inside a tuple constant	1
+zero inside a tuple constant, ground truth	1
+non-zero constant	1
+non-zero constant	Granules: 2/3
+zero constant, transform keeps the values equal	1
+zero constant, transform keeps the values equal, ground truth	1
+zero constant, transform keeps the values equal	Granules: 1/3

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.reference
@@ -15,6 +15,9 @@ partition key	1
 partition key, ground truth	1
 minmax index	1
 minmax index, ground truth	1
+minmax index, non-zero constant	1
+minmax index, non-zero constant, ground truth	1
+minmax index, non-zero constant	Granules: 1/3
 dynamically typed domain	1
 dynamically typed domain, ground truth	1
 dynamically typed domain nested in a container	1

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
@@ -1,0 +1,50 @@
+-- `-0.` and `+0.` compare equal but are distinct values, so a key transform that reads the bit pattern
+-- maps them to two key values while the comparison feeding it treats them as one. A point range built
+-- from one spelling must not prune the mark holding the other.
+
+DROP TABLE IF EXISTS t_signed_zero;
+CREATE TABLE t_signed_zero (f Float64) ENGINE = MergeTree ORDER BY toString(f)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero VALUES (-0);
+
+SELECT 'equals', count() FROM t_signed_zero WHERE f = 0;
+SELECT 'equals, ground truth', countIf(f = 0) FROM t_signed_zero;
+SELECT 'notEquals', count() FROM t_signed_zero WHERE f != 0;
+SELECT 'notEquals, ground truth', countIf(f != 0) FROM t_signed_zero;
+
+DROP TABLE IF EXISTS t_signed_zero_tuple;
+CREATE TABLE t_signed_zero_tuple (k Tuple(Float64, Float64)) ENGINE = MergeTree ORDER BY toString(k)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_tuple VALUES ((-0, 1));
+
+SELECT 'zero inside a tuple constant', count() FROM t_signed_zero_tuple WHERE k = (0., 1.);
+SELECT 'zero inside a tuple constant, ground truth', countIf(k = (0., 1.)) FROM t_signed_zero_tuple;
+
+-- A non-zero constant names a single value, so its range still prunes.
+DROP TABLE IF EXISTS t_signed_zero_nonzero;
+CREATE TABLE t_signed_zero_nonzero (f Float64) ENGINE = MergeTree ORDER BY toString(f)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_nonzero VALUES (1), (2), (3);
+
+SELECT 'non-zero constant', count() FROM t_signed_zero_nonzero WHERE f = 2;
+SELECT 'non-zero constant', extract(explain, 'Granules: \\d+/\\d+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_nonzero WHERE f = 2)
+WHERE match(explain, 'Granules: \\d+/\\d+');
+
+-- `negate` sends both spellings to key values the index compares as equal, so a zero constant keeps
+-- pruning there, and it still finds the row holding the other spelling.
+DROP TABLE IF EXISTS t_signed_zero_negate;
+CREATE TABLE t_signed_zero_negate (f Float64) ENGINE = MergeTree ORDER BY (-f)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_negate VALUES (-1), (-2), (-0);
+
+SELECT 'zero constant, transform keeps the values equal', count() FROM t_signed_zero_negate WHERE f = 0;
+SELECT 'zero constant, transform keeps the values equal, ground truth', countIf(f = 0) FROM t_signed_zero_negate;
+SELECT 'zero constant, transform keeps the values equal', extract(explain, 'Granules: \\d+/\\d+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_negate WHERE f = 0)
+WHERE match(explain, 'Granules: \\d+/\\d+');
+
+DROP TABLE t_signed_zero;
+DROP TABLE t_signed_zero_tuple;
+DROP TABLE t_signed_zero_nonzero;
+DROP TABLE t_signed_zero_negate;

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
@@ -9,8 +9,9 @@ INSERT INTO t_signed_zero VALUES (-0);
 
 SELECT 'equals', count() FROM t_signed_zero WHERE f = 0;
 SELECT 'equals, ground truth', countIf(f = 0) FROM t_signed_zero;
--- An implicit projection can answer this count from part metadata, and the metadata is what the
--- wrong range describes, so both projection settings stay at their defaults for this row.
+-- An implicit projection may answer this count from part metadata when key analysis reports the
+-- filter always-true for a part, which is what the wrong range does here, so both projection
+-- settings stay at their defaults for this row.
 SELECT 'notEquals', count() FROM t_signed_zero WHERE f != 0
 SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1;
 SELECT 'notEquals, ground truth', countIf(f != 0) FROM t_signed_zero;
@@ -22,6 +23,17 @@ INSERT INTO t_signed_zero_tuple VALUES ((-0, 1));
 
 SELECT 'zero inside a tuple constant', count() FROM t_signed_zero_tuple WHERE k = (0., 1.);
 SELECT 'zero inside a tuple constant, ground truth', countIf(k = (0., 1.)) FROM t_signed_zero_tuple;
+
+-- A container constant with no zero inside it names a single key value, so its range still prunes.
+DROP TABLE IF EXISTS t_signed_zero_tuple_control;
+CREATE TABLE t_signed_zero_tuple_control (k Tuple(Float64, Float64)) ENGINE = MergeTree ORDER BY toString(k)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_tuple_control VALUES ((1, 1)), ((2, 1)), ((3, 1));
+
+SELECT 'non-zero constant inside a tuple', count() FROM t_signed_zero_tuple_control WHERE k = (2., 1.);
+SELECT 'non-zero constant inside a tuple', extract(explain, 'Granules: \\d+/\\d+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_tuple_control WHERE k = (2., 1.))
+WHERE match(explain, 'Granules: \\d+/\\d+');
 
 -- A non-zero constant names a single value, so its range still prunes.
 DROP TABLE IF EXISTS t_signed_zero_nonzero;
@@ -65,6 +77,17 @@ INSERT INTO t_signed_zero_partition VALUES (-0);
 SELECT 'partition key', count() FROM t_signed_zero_partition WHERE f = 0;
 SELECT 'partition key, ground truth', countIf(f = 0) FROM t_signed_zero_partition;
 
+-- A non-zero constant names one partition value, so the atom still reaches the partition pruner.
+DROP TABLE IF EXISTS t_signed_zero_partition_control;
+CREATE TABLE t_signed_zero_partition_control (f Float64) ENGINE = MergeTree PARTITION BY toString(f) ORDER BY tuple()
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_partition_control VALUES (1), (2);
+
+SELECT 'partition key, non-zero constant', count() FROM t_signed_zero_partition_control WHERE f = 2;
+SELECT 'partition key, non-zero constant, the pruner still gets the atom', count()
+FROM (EXPLAIN indexes = 1 SELECT f FROM t_signed_zero_partition_control WHERE f = 2)
+WHERE explain ILIKE '%Condition:%toString(f)%';
+
 DROP TABLE IF EXISTS t_signed_zero_minmax;
 CREATE TABLE t_signed_zero_minmax (f Float64, INDEX idx toString(f) TYPE minmax GRANULARITY 1)
 ENGINE = MergeTree ORDER BY tuple()
@@ -107,10 +130,12 @@ SELECT 'dynamically typed domain nested in a container, ground truth', countIf(d
 
 DROP TABLE t_signed_zero;
 DROP TABLE t_signed_zero_tuple;
+DROP TABLE t_signed_zero_tuple_control;
 DROP TABLE t_signed_zero_nonzero;
 DROP TABLE t_signed_zero_negate;
 DROP TABLE t_signed_zero_not_distinct;
 DROP TABLE t_signed_zero_partition;
+DROP TABLE t_signed_zero_partition_control;
 DROP TABLE t_signed_zero_minmax;
 DROP TABLE t_signed_zero_minmax_control;
 DROP TABLE t_signed_zero_dynamic;

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
@@ -110,8 +110,8 @@ SELECT 'minmax index, non-zero constant', extract(explain, 'Granules: \\d+/\\d+'
 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_minmax_control WHERE f = 2)
 WHERE match(explain, 'Granules: \\d+/\\d+');
 
--- A dynamically typed domain compares values of different types as equal, so a constant there does not
--- name a single stored value and no range can be built from it, whatever the constant's own type is.
+-- A dynamically typed domain compares values of different types as equal, so a zero there stands for a
+-- stored `-0.` however it is written, including on an alternative holding no floating-point value.
 DROP TABLE IF EXISTS t_signed_zero_dynamic;
 CREATE TABLE t_signed_zero_dynamic (d Dynamic) ENGINE = MergeTree ORDER BY toString(d)
 SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
@@ -138,6 +138,28 @@ INSERT INTO t_signed_zero_variant VALUES (toFloat64('-0')::Variant(Float64, UInt
 SELECT 'variant domain', count() FROM t_signed_zero_variant WHERE v = toUInt64(0)::Variant(Float64, UInt64);
 SELECT 'variant domain, ground truth', countIf(v = toUInt64(0)::Variant(Float64, UInt64)) FROM t_signed_zero_variant;
 
+-- A string that parses as a zero is one of those spellings, and a comparison with it reads a stored
+-- `-0.` as a number.
+DROP TABLE IF EXISTS t_signed_zero_dynamic_string;
+CREATE TABLE t_signed_zero_dynamic_string (j JSON) ENGINE = MergeTree ORDER BY j.b::String
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_dynamic_string VALUES ('{"b":-0.0}');
+
+SELECT 'zero written as a string', count() FROM t_signed_zero_dynamic_string WHERE j.b = '0';
+SELECT 'zero written as a string, ground truth', countIf(j.b = '0') FROM t_signed_zero_dynamic_string;
+
+-- A constant that denotes no number stands for itself alone there, so its range still prunes.
+DROP TABLE IF EXISTS t_signed_zero_dynamic_control;
+CREATE TABLE t_signed_zero_dynamic_control (j JSON) ENGINE = MergeTree ORDER BY j.b::String
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_dynamic_control VALUES ('{"b":"str_0"}'), ('{"b":"str_1"}'), ('{"b":"str_2"}');
+
+SELECT 'constant denoting no number', count() FROM t_signed_zero_dynamic_control WHERE j.b = 'str_0';
+SELECT 'constant denoting no number, ground truth', countIf(j.b = 'str_0') FROM t_signed_zero_dynamic_control;
+SELECT 'constant denoting no number', extract(explain, 'Granules: \\d+/\\d+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_dynamic_control WHERE j.b = 'str_0')
+WHERE match(explain, 'Granules: \\d+/\\d+');
+
 DROP TABLE t_signed_zero;
 DROP TABLE t_signed_zero_tuple;
 DROP TABLE t_signed_zero_tuple_control;
@@ -151,3 +173,5 @@ DROP TABLE t_signed_zero_minmax_control;
 DROP TABLE t_signed_zero_dynamic;
 DROP TABLE t_signed_zero_dynamic_nested;
 DROP TABLE t_signed_zero_variant;
+DROP TABLE t_signed_zero_dynamic_string;
+DROP TABLE t_signed_zero_dynamic_control;

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
@@ -9,7 +9,10 @@ INSERT INTO t_signed_zero VALUES (-0);
 
 SELECT 'equals', count() FROM t_signed_zero WHERE f = 0;
 SELECT 'equals, ground truth', countIf(f = 0) FROM t_signed_zero;
-SELECT 'notEquals', count() FROM t_signed_zero WHERE f != 0;
+-- An implicit projection can answer this count from part metadata, and the metadata is what the
+-- wrong range describes, so both projection settings stay at their defaults for this row.
+SELECT 'notEquals', count() FROM t_signed_zero WHERE f != 0
+SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1;
 SELECT 'notEquals, ground truth', countIf(f != 0) FROM t_signed_zero;
 
 DROP TABLE IF EXISTS t_signed_zero_tuple;
@@ -71,6 +74,19 @@ INSERT INTO t_signed_zero_minmax VALUES (-0);
 SELECT 'minmax index', count() FROM t_signed_zero_minmax WHERE f = 0;
 SELECT 'minmax index, ground truth', countIf(f = 0) FROM t_signed_zero_minmax;
 
+-- A non-zero constant leaves the skip index a range to compare, so it still drops granules there.
+DROP TABLE IF EXISTS t_signed_zero_minmax_control;
+CREATE TABLE t_signed_zero_minmax_control (f Float64, INDEX idx toString(f) TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_minmax_control VALUES (1), (2), (3);
+
+SELECT 'minmax index, non-zero constant', count() FROM t_signed_zero_minmax_control WHERE f = 2;
+SELECT 'minmax index, non-zero constant, ground truth', countIf(f = 2) FROM t_signed_zero_minmax_control;
+SELECT 'minmax index, non-zero constant', extract(explain, 'Granules: \\d+/\\d+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_minmax_control WHERE f = 2)
+WHERE match(explain, 'Granules: \\d+/\\d+');
+
 -- A dynamically typed domain compares values of different types as equal, so a constant there does not
 -- name a single stored value and no range can be built from it, whatever the constant's own type is.
 DROP TABLE IF EXISTS t_signed_zero_dynamic;
@@ -96,5 +112,6 @@ DROP TABLE t_signed_zero_negate;
 DROP TABLE t_signed_zero_not_distinct;
 DROP TABLE t_signed_zero_partition;
 DROP TABLE t_signed_zero_minmax;
+DROP TABLE t_signed_zero_minmax_control;
 DROP TABLE t_signed_zero_dynamic;
 DROP TABLE t_signed_zero_dynamic_nested;

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
@@ -128,6 +128,33 @@ INSERT INTO t_signed_zero_dynamic_nested VALUES (tuple(-0.0::Float64));
 SELECT 'dynamically typed domain nested in a container', count() FROM t_signed_zero_dynamic_nested WHERE d = tuple(0);
 SELECT 'dynamically typed domain nested in a container, ground truth', countIf(d = tuple(0)) FROM t_signed_zero_dynamic_nested;
 
+-- A container can hold a dynamically typed member beside a fixed-typed one, and each member reads a zero
+-- inside it in its own domain.
+DROP TABLE IF EXISTS t_signed_zero_dynamic_sibling;
+CREATE TABLE t_signed_zero_dynamic_sibling (k Tuple(UInt64, Dynamic)) ENGINE = MergeTree ORDER BY toString(k)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_dynamic_sibling VALUES ((1, toFloat64('-0')::Dynamic));
+
+SELECT 'zero on the dynamically typed member', count() FROM t_signed_zero_dynamic_sibling
+WHERE k = (1, toUInt64(0))::Tuple(UInt64, Dynamic);
+SELECT 'zero on the dynamically typed member, ground truth',
+    countIf(k = (1, toUInt64(0))::Tuple(UInt64, Dynamic)) FROM t_signed_zero_dynamic_sibling;
+
+-- A fixed-typed member has one spelling of a zero, so a zero there still names a single key value.
+DROP TABLE IF EXISTS t_signed_zero_dynamic_sibling_control;
+CREATE TABLE t_signed_zero_dynamic_sibling_control (k Tuple(UInt64, Dynamic)) ENGINE = MergeTree ORDER BY toString(k)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_dynamic_sibling_control VALUES ((0, toUInt64(1))), ((0, toUInt64(2))), ((1, toUInt64(1)));
+
+SELECT 'zero on a fixed-typed member beside a dynamically typed one', count()
+FROM t_signed_zero_dynamic_sibling_control WHERE k = (0, toUInt64(1))::Tuple(UInt64, Dynamic);
+SELECT 'zero on a fixed-typed member beside a dynamically typed one, ground truth',
+    countIf(k = (0, toUInt64(1))::Tuple(UInt64, Dynamic)) FROM t_signed_zero_dynamic_sibling_control;
+SELECT 'zero on a fixed-typed member beside a dynamically typed one', extract(explain, 'Granules: \\d+/\\d+')
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_dynamic_sibling_control
+    WHERE k = (0, toUInt64(1))::Tuple(UInt64, Dynamic))
+WHERE match(explain, 'Granules: \\d+/\\d+');
+
 -- `Variant` is a second such domain, and a constant there can sit on the integer alternative, so it
 -- carries no floating-point value at all while still standing for a stored `-0.`.
 DROP TABLE IF EXISTS t_signed_zero_variant;
@@ -172,6 +199,8 @@ DROP TABLE t_signed_zero_minmax;
 DROP TABLE t_signed_zero_minmax_control;
 DROP TABLE t_signed_zero_dynamic;
 DROP TABLE t_signed_zero_dynamic_nested;
+DROP TABLE t_signed_zero_dynamic_sibling;
+DROP TABLE t_signed_zero_dynamic_sibling_control;
 DROP TABLE t_signed_zero_variant;
 DROP TABLE t_signed_zero_dynamic_string;
 DROP TABLE t_signed_zero_dynamic_control;

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
@@ -128,6 +128,16 @@ INSERT INTO t_signed_zero_dynamic_nested VALUES (tuple(-0.0::Float64));
 SELECT 'dynamically typed domain nested in a container', count() FROM t_signed_zero_dynamic_nested WHERE d = tuple(0);
 SELECT 'dynamically typed domain nested in a container, ground truth', countIf(d = tuple(0)) FROM t_signed_zero_dynamic_nested;
 
+-- `Variant` is a second such domain, and a constant there can sit on the integer alternative, so it
+-- carries no floating-point value at all while still standing for a stored `-0.`.
+DROP TABLE IF EXISTS t_signed_zero_variant;
+CREATE TABLE t_signed_zero_variant (v Variant(Float64, UInt64)) ENGINE = MergeTree ORDER BY toString(v)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_variant VALUES (toFloat64('-0')::Variant(Float64, UInt64));
+
+SELECT 'variant domain', count() FROM t_signed_zero_variant WHERE v = toUInt64(0)::Variant(Float64, UInt64);
+SELECT 'variant domain, ground truth', countIf(v = toUInt64(0)::Variant(Float64, UInt64)) FROM t_signed_zero_variant;
+
 DROP TABLE t_signed_zero;
 DROP TABLE t_signed_zero_tuple;
 DROP TABLE t_signed_zero_tuple_control;
@@ -140,3 +150,4 @@ DROP TABLE t_signed_zero_minmax;
 DROP TABLE t_signed_zero_minmax_control;
 DROP TABLE t_signed_zero_dynamic;
 DROP TABLE t_signed_zero_dynamic_nested;
+DROP TABLE t_signed_zero_variant;

--- a/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
+++ b/tests/queries/0_stateless/05055_key_condition_signed_zero_constant.sql
@@ -44,7 +44,57 @@ SELECT 'zero constant, transform keeps the values equal', extract(explain, 'Gran
 FROM (EXPLAIN indexes = 1 SELECT count() FROM t_signed_zero_negate WHERE f = 0)
 WHERE match(explain, 'Granules: \\d+/\\d+');
 
+-- `IS NOT DISTINCT FROM` builds the same atom, and the atom also feeds the partition pruner and a
+-- `minmax` skip index.
+DROP TABLE IF EXISTS t_signed_zero_not_distinct;
+CREATE TABLE t_signed_zero_not_distinct (f Float64) ENGINE = MergeTree ORDER BY toString(f)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_not_distinct VALUES (-0);
+
+SELECT 'isNotDistinctFrom', count() FROM t_signed_zero_not_distinct WHERE f IS NOT DISTINCT FROM 0;
+SELECT 'isNotDistinctFrom, ground truth', countIf(f IS NOT DISTINCT FROM 0) FROM t_signed_zero_not_distinct;
+
+DROP TABLE IF EXISTS t_signed_zero_partition;
+CREATE TABLE t_signed_zero_partition (f Float64) ENGINE = MergeTree PARTITION BY toString(f) ORDER BY tuple()
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_partition VALUES (-0);
+
+SELECT 'partition key', count() FROM t_signed_zero_partition WHERE f = 0;
+SELECT 'partition key, ground truth', countIf(f = 0) FROM t_signed_zero_partition;
+
+DROP TABLE IF EXISTS t_signed_zero_minmax;
+CREATE TABLE t_signed_zero_minmax (f Float64, INDEX idx toString(f) TYPE minmax GRANULARITY 1)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_minmax VALUES (-0);
+
+SELECT 'minmax index', count() FROM t_signed_zero_minmax WHERE f = 0;
+SELECT 'minmax index, ground truth', countIf(f = 0) FROM t_signed_zero_minmax;
+
+-- A dynamically typed domain compares values of different types as equal, so a constant there does not
+-- name a single stored value and no range can be built from it, whatever the constant's own type is.
+DROP TABLE IF EXISTS t_signed_zero_dynamic;
+CREATE TABLE t_signed_zero_dynamic (d Dynamic) ENGINE = MergeTree ORDER BY toString(d)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_dynamic VALUES (toFloat64('-0')::Dynamic);
+
+SELECT 'dynamically typed domain', count() FROM t_signed_zero_dynamic WHERE d = toUInt64(0)::Dynamic;
+SELECT 'dynamically typed domain, ground truth', countIf(d = toUInt64(0)::Dynamic) FROM t_signed_zero_dynamic;
+
+DROP TABLE IF EXISTS t_signed_zero_dynamic_nested;
+CREATE TABLE t_signed_zero_dynamic_nested (d Tuple(Dynamic)) ENGINE = MergeTree ORDER BY toString(d)
+SETTINGS index_granularity = 1, auto_statistics_types = '', add_minmax_index_for_numeric_columns = 0;
+INSERT INTO t_signed_zero_dynamic_nested VALUES (tuple(-0.0::Float64));
+
+SELECT 'dynamically typed domain nested in a container', count() FROM t_signed_zero_dynamic_nested WHERE d = tuple(0);
+SELECT 'dynamically typed domain nested in a container, ground truth', countIf(d = tuple(0)) FROM t_signed_zero_dynamic_nested;
+
 DROP TABLE t_signed_zero;
 DROP TABLE t_signed_zero_tuple;
 DROP TABLE t_signed_zero_nonzero;
 DROP TABLE t_signed_zero_negate;
+DROP TABLE t_signed_zero_not_distinct;
+DROP TABLE t_signed_zero_partition;
+DROP TABLE t_signed_zero_minmax;
+DROP TABLE t_signed_zero_dynamic;
+DROP TABLE t_signed_zero_dynamic_nested;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/117543
Related: https://github.com/ClickHouse/ClickHouse/pull/115970


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a lost row when a floating-point column is filtered with a zero constant and the sorting key, partition key or a `minmax` index applies a transform to that column, for example `ORDER BY toString(f)` with `WHERE f = 0`. `-0.0` and `0.0` compare equal but `toString` maps them to different key values, so the primary key dropped the granule holding the other spelling. Closes #117543.

### Description

A filter on a zero silently returned fewer rows than a full scan when the sorting key, partition key or a `minmax` index transformed the column `f`:

```sql
CREATE TABLE t (f Float64) ENGINE = MergeTree ORDER BY toString(f)
    SETTINGS index_granularity = 1;
INSERT INTO t VALUES (-0);
SELECT count() FROM t WHERE f = 0;   -- 0, expected 1
```

Root cause: over a transformed key, analysis pushes the constant through the transform and uses the result as a range. `-0.` and `+0.` compare equal but are distinct values, so a transform reading the bit pattern maps them apart, and a range built from one misses the mark holding the other. Exactness is not the lever: `ORDER BY cityHash64(f)` is already relaxed and still loses the row, because relaxing widens `can_be_false` while `equals` needs `can_be_true`.

The atom is now declined when the transform is measured to separate the constant's equality class: both spellings go through it in one column, compared with the index's own relation. Only a `Dynamic`, `Variant` or `JSON` member compares values across types, so a zero under such a member stands for a stored `-0.` in any spelling, a string that parses as one included, and is declined; a zero on a fixed-typed member beside it does not, nor does a constant denoting no number.

This covers `=`, `!=` and `isNotDistinctFrom`; the `IN` set index reaches key space through `tryPrepareSetIndexForIn` and is untouched.

Measured cost, in granules: a zero constant on a separating transform stops pruning (`1/125` to `125/125`), as does a key whose image cannot hold `-0.` (`2/65` to `65/65`). `ORDER BY (-f)` keeps them equal and prunes as before; that ships as a test. `LowCardinality(Float64)` is not fixed here (#116637): the column collapses the two spellings on insert while the index does not.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117611&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117611](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117611+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117611&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117611](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117611+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



