### PR TITLE
Require `SHOW COLUMNS` on an `Alias` target in `hasColumnInTable`

### DIFF
--- a/src/Functions/hasColumnInTable.cpp
+++ b/src/Functions/hasColumnInTable.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnConst.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Storages/IStorage.h>
+#include <Storages/StorageAlias.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 
@@ -15,6 +16,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
+    extern const int ACCESS_DENIED;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int UNKNOWN_TABLE;
 }
@@ -108,6 +110,13 @@ ColumnPtr FunctionHasColumnInTable::executeImpl(const ColumnsWithTypeAndName & a
     const StoragePtr & table = DatabaseCatalog::instance().getTable(
         {database_name, table_name},
         const_pointer_cast<Context>(getContext()));
+
+    /// An `Alias` reports the columns of its target, so seeing them takes the privilege on the target.
+    if (const auto * alias = table->as<StorageAlias>();
+        alias && !alias->isTargetTableGranted(getContext(), AccessType::SHOW_COLUMNS, {}))
+        throw Exception(ErrorCodes::ACCESS_DENIED, "Not enough privileges to check metadata exposed by {}",
+                        StorageID{database_name, table_name}.getNameForLogs());
+
     auto table_metadata = table->getInMemoryMetadataPtr(getContext(), false);
     bool has_column = table_metadata->getColumns().hasPhysical(column_name);
     bool has_alias_column = table_metadata->getColumns().hasAlias(column_name);

--- a/tests/queries/0_stateless/05055_has_column_in_table_alias_access_check.reference
+++ b/tests/queries/0_stateless/05055_has_column_in_table_alias_access_check.reference
@@ -1,0 +1,12 @@
+-- SHOW COLUMNS on the alias only: denied (existing column of the target)
+ACCESS_DENIED
+-- SHOW COLUMNS on the alias only: denied (non-existing column, no oracle)
+ACCESS_DENIED
+-- SHOW COLUMNS on the alias only: DESCRIBE is denied too
+ACCESS_DENIED
+-- SHOW COLUMNS on the target: existing column
+1
+-- SHOW COLUMNS on the target: non-existing column
+0
+-- SHOW COLUMNS on the target: DESCRIBE works too
+2

--- a/tests/queries/0_stateless/05055_has_column_in_table_alias_access_check.sh
+++ b/tests/queries/0_stateless/05055_has_column_in_table_alias_access_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# An `Alias` table reports its target's columns, so `hasColumnInTable` on the alias must require
+# `SHOW COLUMNS` on the target, exactly as `DESCRIBE` of the same alias does.
+# User and table names are scoped to ${CLICKHOUSE_DATABASE} so the test is parallel-safe.
+
+user="user_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user}"
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user} IDENTIFIED WITH plaintext_password BY 'password'"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON system.one TO ${user}"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${CLICKHOUSE_DATABASE}.secret (id UInt64, password String) ENGINE = MergeTree ORDER BY id"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${CLICKHOUSE_DATABASE}.secret_alias ENGINE = Alias('${CLICKHOUSE_DATABASE}', 'secret')"
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON ${CLICKHOUSE_DATABASE}.secret_alias TO ${user}"
+
+run_as_user() { ${CLICKHOUSE_CLIENT} --user "${user}" --password password "$@"; }
+
+echo "-- SHOW COLUMNS on the alias only: denied (existing column of the target)"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'secret_alias', 'password')" 2>&1 | grep -Fo "ACCESS_DENIED" | uniq
+echo "-- SHOW COLUMNS on the alias only: denied (non-existing column, no oracle)"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'secret_alias', 'not_a_column')" 2>&1 | grep -Fo "ACCESS_DENIED" | uniq
+echo "-- SHOW COLUMNS on the alias only: DESCRIBE is denied too"
+run_as_user --query "DESCRIBE ${CLICKHOUSE_DATABASE}.secret_alias" 2>&1 | grep -Fo "ACCESS_DENIED" | uniq
+
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON ${CLICKHOUSE_DATABASE}.secret TO ${user}"
+
+echo "-- SHOW COLUMNS on the target: existing column"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'secret_alias', 'password')"
+echo "-- SHOW COLUMNS on the target: non-existing column"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'secret_alias', 'not_a_column')"
+echo "-- SHOW COLUMNS on the target: DESCRIBE works too"
+run_as_user --query "DESCRIBE TABLE ${CLICKHOUSE_DATABASE}.secret_alias FORMAT TSV" | wc -l
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE ${CLICKHOUSE_DATABASE}.secret_alias"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE ${CLICKHOUSE_DATABASE}.secret"
+${CLICKHOUSE_CLIENT} --query "DROP USER ${user}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/108464
Related: https://github.com/ClickHouse/ClickHouse/pull/117572


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `hasColumnInTable` telling a user whether a column exists on the target of an `ENGINE = Alias` table when that user holds `SHOW COLUMNS` on the alias but not on its target. The function now requires that privilege on the target too, so it discloses no more than `DESCRIBE` of the same alias.

### Description

`hasColumnInTable` checks `SHOW COLUMNS` on the database and table name it is given, then reads that
storage's metadata. For an `ENGINE = Alias` row the metadata read returns the **target's** columns, so
a caller holding `SHOW COLUMNS` on the alias and nothing on the target got `1` for a column that exists
on the protected table and `0` for one that does not. Repeating the call enumerates the protected
table's columns by guessing, and the function was weaker than `DESCRIBE` of the very same alias, which
is denied.

The function's own documentation already states that it "requires the `SHOW COLUMNS` privilege on the
target table (the same grant needed by `DESCRIBE` and `SHOW CREATE TABLE`)". That was not true for an
`Alias`.

This adds the second-stage check the rest of the tree already uses, in the same shape as
`InterpreterDescribeQuery`, reusing the existing `StorageAlias::isTargetTableGranted`. It is +9/-0 in
one function. `alias` is `nullptr` for every other storage, so nothing but `Alias` is affected, and the
first-stage check stays on the raw names so denial still does not depend on the table existing. A
table-level `SELECT` grant on the target implies `SHOW COLUMNS` and keeps working; reads through an
alias are untouched.

Validated with a new stateless test that fails on the unmodified binary and passes with the fix (50/50
under 8-way self-concurrency), plus a sweep of the `Alias` and `hasColumnInTable` tests.

<details>
<summary>Measured, one-hop <code>Alias</code>: user holds <code>SHOW COLUMNS</code> on the alias only</summary>

| probe | before | after |
|---|---|---|
| `DESCRIBE nl.al` | `ACCESS_DENIED` | `ACCESS_DENIED` |
| `hasColumnInTable('nl', 'al', '<existing column of the target>')` | `1` | `ACCESS_DENIED` |
| `hasColumnInTable('nl', 'al', '<absent column>')` | `0` | `ACCESS_DENIED` |

After also granting `SHOW COLUMNS` on the target, all three succeed as before.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117621&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117621](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117621+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
