### PR TITLE
Respect the direction of each sorting key column when reading in order for GROUP BY

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -726,9 +726,11 @@ InputOrder buildInputOrderFromUnorderedKeys(
     const FixedColumns & fixed_columns,
     const std::optional<ActionsDAG> & dag,
     const Names & unordered_keys,
-    const ActionsDAG & sorting_key_dag,
-    const Names & sorting_key_columns)
+    const KeyDescription & sorting_key)
 {
+    const auto & sorting_key_dag = sorting_key.expression->getActionsDAG();
+    const auto & sorting_key_columns = sorting_key.column_names;
+
     MatchedTrees::Matches matches;
     FixedColumns fixed_key_columns;
 
@@ -803,7 +805,14 @@ InputOrder buildInputOrderFromUnorderedKeys(
     {
         const auto & sorting_key_column = sorting_key_columns[next_sort_key];
 
-        /// Direction for current sort key.
+        /// A descending sorting key column (`ORDER BY (a, b DESC)`) means the value decreases as the
+        /// table is read forward, so the description must say `DESC` for it. Without this the
+        /// aggregation-in-order transform compared the keys in the wrong direction and merged every
+        /// row of a block into one group, returning one row per ascending prefix.
+        const int reverse_indicator
+            = (!sorting_key.reverse_flags.empty() && sorting_key.reverse_flags[next_sort_key]) ? -1 : 1;
+
+        /// Direction for current sort key, relative to the table order.
         int current_direction = 0;
         bool strict_monotonic = true;
         std::unordered_set<std::string_view>::iterator group_by_key_it;
@@ -886,15 +895,16 @@ InputOrder buildInputOrderFromUnorderedKeys(
             /// Prefix sort description for reading will be (negate(y) DESC, negate(x) DESC),
             /// Sort description for GROUP BY will be (negate(y) DESC, negate(x) DESC, z).
             //std::cerr << "---- adding " << std::string(*group_by_key_it) << std::endl;
-            sort_description.emplace_back(SortColumnDescription(std::string(*group_by_key_it), current_direction));
-            order_key_prefix_descr.emplace_back(SortColumnDescription(std::string(*group_by_key_it), current_direction));
+            const int value_direction = current_direction * reverse_indicator;
+            sort_description.emplace_back(SortColumnDescription(std::string(*group_by_key_it), value_direction));
+            order_key_prefix_descr.emplace_back(SortColumnDescription(std::string(*group_by_key_it), value_direction));
             not_matched_keys.erase(group_by_key_it);
         }
         else
         {
             /// If column is fixed, will read it in table order as well.
             //std::cerr << "---- adding " << sorting_key_column << std::endl;
-            order_key_prefix_descr.emplace_back(SortColumnDescription(sorting_key_column, 1));
+            order_key_prefix_descr.emplace_back(SortColumnDescription(sorting_key_column, reverse_indicator));
         }
 
         if (current_direction && !strict_monotonic)
@@ -1072,12 +1082,11 @@ InputOrder buildInputOrderFromUnorderedKeys(
     const Names & unordered_keys)
 {
     const auto & sorting_key = reading->getStorageMetadata()->getSortingKey();
-    const auto & sorting_key_columns = sorting_key.column_names;
 
     return buildInputOrderFromUnorderedKeys(
         fixed_columns,
         dag, unordered_keys,
-        sorting_key.expression->getActionsDAG(), sorting_key_columns);
+        sorting_key);
 }
 
 InputOrder buildInputOrderFromUnorderedKeys(
@@ -1087,12 +1096,11 @@ InputOrder buildInputOrderFromUnorderedKeys(
     const Names & unordered_keys)
 {
     const auto & sorting_key = reading->getStorageMetadata()->getSortingKey();
-    const auto & sorting_key_columns = sorting_key.column_names;
 
     return buildInputOrderFromUnorderedKeys(
         fixed_columns,
         dag, unordered_keys,
-        sorting_key.expression->getActionsDAG(), sorting_key_columns);
+        sorting_key);
 }
 
 InputOrder buildInputOrderFromUnorderedKeys(
@@ -1126,7 +1134,7 @@ InputOrder buildInputOrderFromUnorderedKeys(
         auto table_order_info = buildInputOrderFromUnorderedKeys(
             combined_fixed_columns,
             combined_dag, unordered_keys,
-            sorting_key.expression->getActionsDAG(), sorting_key_columns);
+            sorting_key);
 
         if (!table_order_info.input_order)
             return {};

--- a/tests/queries/0_stateless/04316_limit_by_in_order_reverse_key.reference
+++ b/tests/queries/0_stateless/04316_limit_by_in_order_reverse_key.reference
@@ -59,6 +59,8 @@ SELECT (SELECT groupArray((a, b)) FROM (SELECT a, b FROM (SELECT a, b FROM test_
 1
 DROP TABLE test_reverse_mixed;
 -- Merge engine over children whose sort keys disagree on direction (one ascending, one reverse).
+-- There is no single input order to describe both children, so the in-order LIMIT BY is not
+-- applied - only the plain one, which still produces the right rows (#111901).
 DROP TABLE IF EXISTS test_merge_mixed_dir_part_1;
 DROP TABLE IF EXISTS test_merge_mixed_dir_part_2;
 DROP TABLE IF EXISTS test_merge_mixed_dir_wrap;
@@ -69,7 +71,6 @@ INSERT INTO test_merge_mixed_dir_part_2 SELECT number % 20, number+1000 FROM num
 CREATE TABLE test_merge_mixed_dir_wrap AS test_merge_mixed_dir_part_1 ENGINE = Merge(currentDatabase(), '^test_merge_mixed_dir_part_[12]$');
 SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\1') FROM (EXPLAIN PIPELINE SELECT a FROM test_merge_mixed_dir_wrap LIMIT 1 BY a SETTINGS optimize_limit_by_in_order = 1) WHERE explain LIKE '%LimitBy%Transform%' OR explain LIKE '%MergingSortedTransform%';
 LimitByTransform
-LimitBySortedStreamTransform × 2
 SELECT count() = (SELECT uniqExact(a) FROM test_merge_mixed_dir_wrap) FROM (SELECT a FROM test_merge_mixed_dir_wrap LIMIT 1 BY a SETTINGS optimize_limit_by_in_order = 1);
 1
 DROP TABLE test_merge_mixed_dir_wrap;

--- a/tests/queries/0_stateless/04316_limit_by_in_order_reverse_key.sql
+++ b/tests/queries/0_stateless/04316_limit_by_in_order_reverse_key.sql
@@ -54,6 +54,8 @@ SELECT (SELECT groupArray((a, b)) FROM (SELECT a, b FROM (SELECT a, b FROM test_
 DROP TABLE test_reverse_mixed;
 
 -- Merge engine over children whose sort keys disagree on direction (one ascending, one reverse).
+-- There is no single input order to describe both children, so the in-order LIMIT BY is not
+-- applied - only the plain one, which still produces the right rows (#111901).
 DROP TABLE IF EXISTS test_merge_mixed_dir_part_1;
 DROP TABLE IF EXISTS test_merge_mixed_dir_part_2;
 DROP TABLE IF EXISTS test_merge_mixed_dir_wrap;

--- a/tests/queries/0_stateless/05105_aggregation_in_order_reverse_key.reference
+++ b/tests/queries/0_stateless/05105_aggregation_in_order_reverse_key.reference
@@ -1,0 +1,40 @@
+40
+40
+40
+0	0
+0	4
+0	7
+0	8
+0	11
+0	10	115
+1	10	125
+2	10	135
+3	10	145
+0	10	115
+1	10	125
+2	10	135
+3	10	145
+40
+40
+an all-ascending key is unaffected
+40
+40
+0	10
+1	10
+2	10
+3	10
+a fully descending key
+40
+40
+0	10
+1	10
+2	10
+3	10
+the optimization still engages, with the direction of each key column
+│  Order: a ASC, b DESC
+│  Order: a ASC
+reading in order over the same key stays correct
+0	16
+0	12
+0	8
+20

--- a/tests/queries/0_stateless/05105_aggregation_in_order_reverse_key.sql
+++ b/tests/queries/0_stateless/05105_aggregation_in_order_reverse_key.sql
@@ -1,0 +1,60 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/111901
+-- The aggregation-in-order analysis derived the sort description from the sorting key column names
+-- only, assuming every column ascending. With a descending sorting key column the description said
+-- the value increases along the table order while it decreases, so the transform merged rows into one
+-- group per ascending prefix and `GROUP BY` silently returned fewer rows.
+
+DROP TABLE IF EXISTS t_aio_reverse;
+CREATE TABLE t_aio_reverse (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a, b DESC);
+INSERT INTO t_aio_reverse SELECT number % 4, number FROM numbers(20);
+INSERT INTO t_aio_reverse SELECT number % 4, number + 7 FROM numbers(20);
+
+SELECT count() FROM (SELECT a, b FROM t_aio_reverse GROUP BY a, b);
+SELECT count() FROM (SELECT a, b FROM t_aio_reverse GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 1;
+SELECT count() FROM (SELECT a, b FROM t_aio_reverse GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 0;
+SELECT a, b FROM t_aio_reverse GROUP BY a, b ORDER BY a, b LIMIT 5 SETTINGS optimize_aggregation_in_order = 1;
+SELECT a, count(), sum(b) FROM t_aio_reverse GROUP BY a ORDER BY a SETTINGS optimize_aggregation_in_order = 1;
+SELECT a, count(), sum(b) FROM t_aio_reverse GROUP BY a ORDER BY a SETTINGS optimize_aggregation_in_order = 0;
+
+OPTIMIZE TABLE t_aio_reverse FINAL;
+SELECT count() FROM (SELECT a, b FROM t_aio_reverse GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 1;
+SELECT count() FROM (SELECT a, b FROM t_aio_reverse GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 0;
+DROP TABLE t_aio_reverse;
+
+SELECT 'an all-ascending key is unaffected';
+DROP TABLE IF EXISTS t_aio_asc;
+CREATE TABLE t_aio_asc (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a, b);
+INSERT INTO t_aio_asc SELECT number % 4, number FROM numbers(20);
+INSERT INTO t_aio_asc SELECT number % 4, number + 7 FROM numbers(20);
+SELECT count() FROM (SELECT a, b FROM t_aio_asc GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 1;
+SELECT count() FROM (SELECT a, b FROM t_aio_asc GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 0;
+SELECT a, count() FROM t_aio_asc GROUP BY a ORDER BY a SETTINGS optimize_aggregation_in_order = 1;
+DROP TABLE t_aio_asc;
+
+SELECT 'a fully descending key';
+DROP TABLE IF EXISTS t_aio_desc;
+CREATE TABLE t_aio_desc (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a DESC, b DESC);
+INSERT INTO t_aio_desc SELECT number % 4, number FROM numbers(20);
+INSERT INTO t_aio_desc SELECT number % 4, number + 7 FROM numbers(20);
+SELECT count() FROM (SELECT a, b FROM t_aio_desc GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 1;
+SELECT count() FROM (SELECT a, b FROM t_aio_desc GROUP BY a, b) SETTINGS optimize_aggregation_in_order = 0;
+SELECT a, count() FROM t_aio_desc GROUP BY a ORDER BY a SETTINGS optimize_aggregation_in_order = 1;
+DROP TABLE t_aio_desc;
+
+SELECT 'the optimization still engages, with the direction of each key column';
+DROP TABLE IF EXISTS t_aio_explain;
+CREATE TABLE t_aio_explain (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a, b DESC);
+INSERT INTO t_aio_explain SELECT number % 4, number FROM numbers(40);
+SELECT trimLeft(explain) FROM (EXPLAIN actions = 1 SELECT a, b, count() FROM t_aio_explain GROUP BY a, b
+    SETTINGS optimize_aggregation_in_order = 1) WHERE explain LIKE '%Order:%';
+SELECT trimLeft(explain) FROM (EXPLAIN actions = 1 SELECT a, count() FROM t_aio_explain GROUP BY a
+    SETTINGS optimize_aggregation_in_order = 1) WHERE explain LIKE '%Order:%';
+DROP TABLE t_aio_explain;
+
+SELECT 'reading in order over the same key stays correct';
+DROP TABLE IF EXISTS t_aio_read;
+CREATE TABLE t_aio_read (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a, b DESC);
+INSERT INTO t_aio_read SELECT number % 4, number FROM numbers(20);
+SELECT a, b FROM t_aio_read ORDER BY a, b DESC LIMIT 3 SETTINGS optimize_read_in_order = 1;
+SELECT count() FROM (SELECT DISTINCT a, b FROM t_aio_read) SETTINGS optimize_distinct_in_order = 1;
+DROP TABLE t_aio_read;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `optimize_aggregation_in_order` collapsing `GROUP BY` groups on a table with a descending sorting key column (`ORDER BY (a, b DESC)`), which silently returned one row per ascending prefix instead of one row per group.

### Documentation entry for user-facing changes

The analysis that matches `GROUP BY` keys against the sorting key derived its sort description from the key column names alone, so it described every column as ascending. With a descending sorting key column the value decreases as the table is read forward, and the aggregation-in-order transform, told the opposite, merged rows into one group per ascending prefix — `GROUP BY` silently returned fewer rows:

```sql
CREATE TABLE md (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY (a, b DESC);
INSERT INTO md SELECT number % 4, number FROM numbers(20);
INSERT INTO md SELECT number % 4, number + 7 FROM numbers(20);

SELECT count() FROM (SELECT a, b FROM md GROUP BY a, b);   -- 40
SELECT count() FROM (SELECT a, b FROM md GROUP BY a, b)
    SETTINGS optimize_aggregation_in_order = 1;            -- 8, and 4 after a merge
```

The sibling analysis for `ORDER BY` already reads `KeyDescription::reverse_flags` for exactly this reason, which is why `optimize_read_in_order` over the same table was correct. The unordered-keys analysis now takes the whole `KeyDescription` and applies the same flag, so the described direction is the one the data actually has: `Order: a ASC, b DESC`. The optimization still engages — it is the description that was wrong, not its applicability.

One consequence is recorded in `04316_limit_by_in_order_reverse_key`: a `Merge` table whose children disagree on key direction no longer has a single input order to describe them, so the in-order `LIMIT BY` is not applied to it. That combination only appeared to match while the reverse flag was ignored, and the rows it returns are unchanged.

Closes: https://github.com/ClickHouse/ClickHouse/issues/111901

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117622&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117622](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117622+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
