### PR TITLE
Docs: state that a row policy's `TO` clause matches enabled roles, and complete the `AS` formula

### DIFF
--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -446,7 +446,7 @@ row_is_visible = (one or more of the permissive policies that apply to the user 
                  (all of the restrictive policies that apply to the user have non-zero conditions)
 ```
 
-By default, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row. Disabling the server setting `users_without_row_policies_can_read_rows` reverses that: a user with no permissive policy then sees no rows.
+By default, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row. Disabling the server setting `users_without_row_policies_can_read_rows` reverses that for a table that some policy covers: a user to whom no permissive policy applies sees no rows of it. A table that no policy covers is not filtered either way.
 
 For example, the following policies:
 

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -446,7 +446,7 @@ row_is_visible = (one or more of the permissive policies that apply to the user 
                  (all of the restrictive policies that apply to the user have non-zero conditions)
 ```
 
-By default, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row. Disabling the server setting `users_without_row_policies_can_read_rows` reverses that for a table that some policy covers: a user to whom no permissive policy applies sees no rows of it. A table that no policy covers is not filtered either way.
+By default, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row.
 
 For example, the following policies:
 

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -446,7 +446,7 @@ row_is_visible = (one or more of the conditions from the permissive policies tha
                  (all of the conditions from the restrictive policies that apply to the current user and their enabled roles are non-zero)
 ```
 
-If no permissive condition applies, the first condition has no effect and only the restrictive policies decide, because `access_control_improvements.users_without_row_policies_can_read_rows` is enabled by default. A user to whom none of a table's policies apply therefore sees every row in it, unless `access_control_improvements.throw_on_unmatched_row_policies` is enabled, which throws an exception instead.
+If no permissive condition applies, the first condition has no effect and only the restrictive policies decide, because `access_control_improvements.users_without_row_policies_can_read_rows` is enabled by default. A user to whom no condition applies therefore sees every row, and `access_control_improvements.throw_on_unmatched_row_policies`, disabled by default, raises an exception instead when the table does have conditions and none of them apply.
 
 For example, the following policies:
 

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -420,7 +420,7 @@ In the `TO` section you can provide a list of users and roles this policy should
 
 Keyword `ALL` means all the ClickHouse users, including current user. Keyword `ALL EXCEPT` allows excluding some users from the all users list, for example, `CREATE ROW POLICY ... TO ALL EXCEPT accountant, john@localhost`
 
-Roles named in the `TO` section, including those after `ALL EXCEPT`, are matched against the roles enabled in the current session, not against every role granted to the user, so `SET ROLE` can change which policies apply.
+Roles named in the `TO` section, including those after `ALL EXCEPT`, are matched against the current user's enabled roles ([`system.enabled_roles`](/reference/system-tables/enabled_roles)), not against every role granted to the user, so [`SET ROLE`](/reference/statements/set-role) can change which policies apply.
 
 ## AS Clause {#as-clause}
 

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -340,7 +340,7 @@ CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE] policy_name [, ...]
     [ON CLUSTER cluster_name]
     ON { [db.]table | db.* }
     [IN access_storage_type]
-    [FOR SELECT] USING condition
+    [[FOR SELECT] USING {condition | NONE}]
     [AS {PERMISSIVE | RESTRICTIVE}]
     [TO {role1 [, role2 ...] | ALL | ALL EXCEPT role1 [, role2 ...]}]
 
@@ -349,7 +349,7 @@ CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE] policy_name
     [ON CLUSTER cluster_name]
     ON { [db.]table | db.* } [, ...]
     [IN access_storage_type]
-    [FOR SELECT] USING condition
+    [[FOR SELECT] USING {condition | NONE}]
     [AS {PERMISSIVE | RESTRICTIVE}]
     [TO {role1 [, role2 ...] | ALL | ALL EXCEPT role1 [, role2 ...]}]
 
@@ -358,7 +358,7 @@ CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE]
     policy_name ON { [db.]table | db.* } [, policy_name ON { [db.]table | db.* } ...]
     [ON CLUSTER cluster_name]
     [IN access_storage_type]
-    [FOR SELECT] USING condition
+    [[FOR SELECT] USING {condition | NONE}]
     [AS {PERMISSIVE | RESTRICTIVE}]
     [TO {role1 [, role2 ...] | ALL | ALL EXCEPT role1 [, role2 ...]}]
 ```
@@ -442,11 +442,11 @@ A policy can be defined as restrictive as an alternative. Restrictive policies a
 Here is the general formula:
 
 ```text
-row_is_visible = (one or more of the permissive policies that apply to the user have non-zero conditions) AND
-                 (all of the restrictive policies that apply to the user have non-zero conditions)
+row_is_visible = (one or more of the conditions from the permissive policies that apply to the user are non-zero) AND
+                 (all of the conditions from the restrictive policies that apply to the user are non-zero)
 ```
 
-With the default server configuration, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row.
+With the default server configuration, if no permissive condition applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row.
 
 For example, the following policies:
 
@@ -503,7 +503,7 @@ CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE] policy_name [, ...]
     [ON CLUSTER cluster_name]
     ON { [db.]table | db.* } [, ...]
     [IN access_storage_type]
-    [FOR SELECT] USING condition
+    [[FOR SELECT] USING {condition | NONE}]
     [AS {PERMISSIVE | RESTRICTIVE}]
     [TO {role1 [, role2 ...] | ALL | ALL EXCEPT role1 [, role2 ...]}]
 )",

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -442,11 +442,11 @@ A policy can be defined as restrictive as an alternative. Restrictive policies a
 Here is the general formula:
 
 ```text
-row_is_visible = (one or more of the conditions from the permissive policies that apply to the user are non-zero) AND
-                 (all of the conditions from the restrictive policies that apply to the user are non-zero)
+row_is_visible = (one or more of the conditions from the permissive policies that apply to the current user and their enabled roles are non-zero) AND
+                 (all of the conditions from the restrictive policies that apply to the current user and their enabled roles are non-zero)
 ```
 
-With the default server configuration, if no permissive condition applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row.
+If no permissive condition applies, the first condition has no effect and only the restrictive policies decide, because `access_control_improvements.users_without_row_policies_can_read_rows` is enabled by default. A user to whom none of a table's policies apply therefore sees every row in it, unless `access_control_improvements.throw_on_unmatched_row_policies` is enabled, which throws an exception instead.
 
 For example, the following policies:
 

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -446,6 +446,8 @@ row_is_visible = (one or more of the permissive policies that apply to the user 
                  (all of the restrictive policies that apply to the user have non-zero conditions)
 ```
 
+By default, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row. Disabling the server setting `users_without_row_policies_can_read_rows` reverses that: a user with no permissive policy then sees no rows.
+
 For example, the following policies:
 
 ```sql

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -420,6 +420,8 @@ In the `TO` section you can provide a list of users and roles this policy should
 
 Keyword `ALL` means all the ClickHouse users, including current user. Keyword `ALL EXCEPT` allows excluding some users from the all users list, for example, `CREATE ROW POLICY ... TO ALL EXCEPT accountant, john@localhost`
 
+Roles named in the `TO` section, including those after `ALL EXCEPT`, are matched against the roles enabled in the current session, not against every role granted to the user, so `SET ROLE` can change which policies apply.
+
 ## AS Clause {#as-clause}
 
 It's allowed to have more than one policy enabled on the same table for the same user at one time. So we need a way to combine the conditions from multiple policies.
@@ -440,8 +442,8 @@ A policy can be defined as restrictive as an alternative. Restrictive policies a
 Here is the general formula:
 
 ```text
-row_is_visible = (one or more of the permissive policies' conditions are non-zero) AND
-                 (all of the restrictive policies's conditions are non-zero)
+row_is_visible = (one or more of the permissive policies that apply to the user have non-zero conditions) AND
+                 (all of the restrictive policies that apply to the user have non-zero conditions)
 ```
 
 For example, the following policies:

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -446,7 +446,7 @@ row_is_visible = (one or more of the permissive policies that apply to the user 
                  (all of the restrictive policies that apply to the user have non-zero conditions)
 ```
 
-By default, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row.
+With the default server configuration, if no permissive policy applies to the user, the first condition is not applied and only the restrictive policies decide, so a user to whom no policy applies at all sees every row.
 
 For example, the following policies:
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/68601

The `CREATE ROW POLICY` reference documentation was incomplete in four ways that together made the expectation in the linked issue look correct.

1. The `TO` clause never mentioned role enablement, so `ALL EXCEPT foo_a` reads as a claim about the user ("has `foo_a` granted") while the server tests the session ("has `foo_a` enabled"). That is why `SET ROLE` changes which policies apply, and it holds for the inclusion list and the `ALL EXCEPT` list alike.

2. The visibility formula ranged over "the permissive policies", so read literally it promised that every permissive policy on the table is combined with `OR` for every user. The "for the same user" qualifier is present two paragraphs earlier and was dropped from the formula.

3. The formula predicted no rows where the server shows every row, because a policy is valid with no condition and the filter mixer ignores it. It now ranges over the conditions the applicable policies contribute, and the sentence after it covers the case where they contribute none. Measured on stock defaults: a user whose only permissive policy carries no condition sees every row, and so does one whose only restrictive policy carries no condition.

4. The four `CREATE` synopses contradicted point 3 by making the filter clause mandatory and omitting `NONE`. The `ALTER` synopses in the same registration already spell it `[USING {condition | NONE}]`.

On the issue I promised two wording changes. Points 3 and 4 go beyond that, and I will drop them on request.

The text lives in the statement's structured documentation in `src/`, the source of truth for the `AUTOGENERATED` region of the generated page, so nothing under `docs/` is in this diff and the nightly autogeneration workflow carries it into the page. It also removes a `policies's` typo.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117624&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117624](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117624+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
