### PR TITLE
Bound the stress job's three dataset preparation INSERTs

### DIFF
--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -208,11 +208,41 @@ clickhouse-client --query "CREATE TABLE test.visits (CounterID UInt32,  StartDat
     ENGINE = CollapsingMergeTree(Sign) PARTITION BY toYYYYMM(StartDate) ORDER BY (CounterID, StartDate, intHash32(UserID), VisitID)
     SAMPLE BY intHash32(UserID) SETTINGS index_granularity = 8192, storage_policy='$TEMP_POLICY'"
 
+# `--max_execution_time` is enforced cooperatively: the deadline is raised out of band and ends the
+# query only where its threads observe it, so it does not bound a statement parked in blocking I/O.
+# Bound each INSERT in wall-clock time instead.
+PREP_MAX_EXECUTION_TIME=600
+PREP_STATEMENT_TIMEOUT=$((PREP_MAX_EXECUTION_TIME + 300))
+PREP_STDERR=/tmp/prep_statement.err
+
+function run_prep_statement()
+{
+    local rc=0
+    LC_ALL=C timeout --verbose --signal=TERM --kill-after=60 "$PREP_STATEMENT_TIMEOUT" "$@" \
+        2> "$PREP_STDERR" || rc=$?
+    cat "$PREP_STDERR" >&2
+
+    # An expiry is 124 with the TERM diagnostic, or 137 with the KILL one. Neither half identifies it
+    # alone: `clickhouse-client` exits with the server's error code, and a signal the wrapper merely
+    # forwarded exits 143 after printing the same TERM line.
+    case "$rc" in
+        124) grep -qF "sending signal TERM to command" "$PREP_STDERR" || return $rc ;;
+        137) grep -qF "sending signal KILL to command" "$PREP_STDERR" || return $rc ;;
+        *) return $rc ;;
+    esac
+
+    echo -e "Stateful data preparation statement exceeded ${PREP_STATEMENT_TIMEOUT}s (see gdb.log)$FAIL" >> /test_output/test_results.tsv
+    echo "thread apply all backtrace (on stateful prep bound)" >> /test_output/gdb.log
+    timeout --verbose --signal=TERM --kill-after=60 30m gdb -batch -ex 'thread apply all backtrace' -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log
+    clickhouse stop --force
+    exit 1
+}
+
 # Might fail in sanitizer runs, not very important
 set +e
-clickhouse-client --max_execution_time 600 --max_memory_usage 30G --max_memory_usage_for_user 30G --query "INSERT INTO test.hits_s3 SELECT * FROM datasets.hits_v1 SETTINGS enable_filesystem_cache_on_write_operations=0, max_insert_threads=16"
-clickhouse-client --max_execution_time 600 --max_memory_usage 30G --max_memory_usage_for_user 30G --query "INSERT INTO test.hits SELECT * FROM datasets.hits_v1 SETTINGS enable_filesystem_cache_on_write_operations=0, max_insert_threads=16"
-clickhouse-client --max_execution_time 600 --max_memory_usage 30G --max_memory_usage_for_user 30G --query "INSERT INTO test.visits SELECT * FROM datasets.visits_v1 SETTINGS enable_filesystem_cache_on_write_operations=0, max_insert_threads=16"
+run_prep_statement clickhouse-client --max_execution_time "$PREP_MAX_EXECUTION_TIME" --max_memory_usage 30G --max_memory_usage_for_user 30G --query "INSERT INTO test.hits_s3 SELECT * FROM datasets.hits_v1 SETTINGS enable_filesystem_cache_on_write_operations=0, max_insert_threads=16"
+run_prep_statement clickhouse-client --max_execution_time "$PREP_MAX_EXECUTION_TIME" --max_memory_usage 30G --max_memory_usage_for_user 30G --query "INSERT INTO test.hits SELECT * FROM datasets.hits_v1 SETTINGS enable_filesystem_cache_on_write_operations=0, max_insert_threads=16"
+run_prep_statement clickhouse-client --max_execution_time "$PREP_MAX_EXECUTION_TIME" --max_memory_usage 30G --max_memory_usage_for_user 30G --query "INSERT INTO test.visits SELECT * FROM datasets.visits_v1 SETTINGS enable_filesystem_cache_on_write_operations=0, max_insert_threads=16"
 
 clickhouse-client --query "DROP TABLE datasets.visits_v1 SYNC"
 clickhouse-client --query "DROP TABLE datasets.hits_v1 SYNC"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/117132
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bound the stress job's three `test.hits_s3` / `test.hits` / `test.visits` preparation `INSERT`s in wall-clock time, and dump the server's thread stacks when the bound fires.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/117132#issuecomment-5503683654
Failing job: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117132&sha=36daaa0b2b59eae8c3ddfbd72137c5235282cfb8&name_0=BackportPR&name_1=Stress%20test%20%28amd_tsan%29

`Stress test (amd_tsan)` burned its whole 10800 s budget inside dataset preparation, before any stress test ran, leaving zero test rows and no stacks. Job `99232249984`, under `azure_cache`: the `INSERT INTO test.hits_s3` traced, then 176 minutes of silence until praktika's `Timeout exceeded [10800]`.

Two causes.

1. The statement never returned. `--max_execution_time` is enforced cooperatively: `CancellationChecker` raises the deadline out of band, ending the query only where its threads observe it; a thread parked in blocking I/O never does. Which frame was parked is unknown: the `SIGTERM` left no stacks, so this PR does not touch `src/`.

2. It cost the whole budget because nothing bounded it in wall clock and nothing captured state. #115585 added that bound to `prepare_stateful_data`, but the stress job never calls it: `stress_job.py` runs `stress_runner.sh` instead.

Same mechanism: `timeout --verbose --signal=TERM --kill-after=60 900` per statement, the 600 s declared deadline plus 300 s of grace, against a worst measured 187 s. On a proven expiry it writes a named `FAIL` row, dumps the server's threads to `gdb.log`, force-stops and exits, mirroring `upgrade_runner.sh:161`.

An expiry needs the exit code AND `timeout`'s own diagnostic: `clickhouse-client` exits with the server's error code, so 124 is also an ordinary error, and a forwarded signal prints the same TERM line but exits 143. A 9-arm harness over the shipped helper covers both expiry shapes and five non-expiry ones, both directions.

Only those three are bounded. `create_tpch.sh` runs eight earlier `s3()` `INSERT`s, but they declare no deadline, so there is no unenforced limit to restore; bounding them is a separate change.

Behaviour change: a wedge becomes a named red with stacks, bounded by 900 s plus the 30 min dump, not an opaque 10800 s timeout with nothing to diagnose. Ordinary failures keep today's `set +e` behaviour.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117626&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117626](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117626+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117626&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117626](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117626+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
