### PR TITLE
Fix internal errors on malformed `mergeTreeAnalyzeIndexes` and `generateRandom` arguments

### DIFF
--- a/src/Storages/checkAndGetLiteralArgument.cpp
+++ b/src/Storages/checkAndGetLiteralArgument.cpp
@@ -16,7 +16,8 @@ T checkAndGetLiteralArgument(const ASTPtr & arg, const String & arg_name)
 {
     if (arg)
     {
-        if (const auto * func = arg->as<const ASTFunction>(); func && func->name == "_CAST")
+        if (const auto * func = arg->as<const ASTFunction>();
+            func && func->name == "_CAST" && func->arguments && func->arguments->children.size() == 2)
             return T(checkAndGetLiteralArgument<T>(func->arguments->children.at(0), arg_name));
 
         if (arg->as<ASTLiteral>())

--- a/src/TableFunctions/TableFunctionGenerateRandom.cpp
+++ b/src/TableFunctions/TableFunctionGenerateRandom.cpp
@@ -90,7 +90,8 @@ void TableFunctionGenerateRandom::parseArguments(const ASTPtr & ast_function, Co
     for (const auto & arg : args)
     {
         const IAST * arg_raw = arg.get();
-        if (const auto * func = arg_raw->as<const ASTFunction>(); func && func->name == "_CAST")
+        if (const auto * func = arg_raw->as<const ASTFunction>();
+            func && func->name == "_CAST" && func->arguments && func->arguments->children.size() == 2)
             arg_raw = func->arguments->children.at(0).get();
 
         if (!arg_raw->as<const ASTLiteral>())

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -45,37 +45,58 @@ namespace ErrorCodes
 
 /// Both `['a', 'b']` and `array('a', 'b')` are parsed as `_CAST(['a', 'b'], 'Array(String)')` with analyzer.
 /// While for non-analyzer there is no _CAST
-static Strings extractParts(const ASTPtr & argument, const ContextPtr & context)
+static std::optional<Strings> tryExtractParts(const ASTPtr & argument, const ContextPtr & context)
 {
     ASTPtr array = argument;
     if (const auto * func = array->as<ASTFunction>())
     {
-        if (func->name == "_CAST" && func->arguments) /// _CAST([], 'Array(String)')
+        if (func->name == "_CAST" && func->arguments && func->arguments->children.size() == 2) /// _CAST([], 'Array(String)')
             array = func->arguments->children.at(0);
         else if (func->name == "array") /// array(ExpressionList)
             array = func->arguments;
         else
-            array = ASTPtr();
+            return {};
     }
 
-    if (array)
+    if (!array)
+        return {};
+
+    if (const auto * literal = array->as<ASTLiteral>())
     {
-        if (const auto * literal = array->as<ASTLiteral>())
-        {
-            Strings result;
-            for (const auto & element : literal->value.safeGet<Array>())
-                result.push_back(element.safeGet<String>());
-            return result;
-        }
+        if (literal->value.getType() != Field::Types::Array)
+            return {};
 
-        if (const auto * expr_list = array->as<ASTExpressionList>())
+        Strings result;
+        for (const auto & element : literal->value.safeGet<Array>())
         {
-            Strings result;
-            for (const auto & element : expr_list->children)
-                result.push_back(evaluateConstantExpressionAsLiteral(element, context)->as<ASTLiteral &>().value.safeGet<String>());
-            return result;
+            if (element.getType() != Field::Types::String)
+                return {};
+            result.push_back(element.safeGet<String>());
         }
+        return result;
     }
+
+    if (const auto * expr_list = array->as<ASTExpressionList>())
+    {
+        Strings result;
+        for (const auto & element : expr_list->children)
+        {
+            ASTPtr element_literal = evaluateConstantExpressionAsLiteral(element, context);
+            const Field & field = element_literal->as<ASTLiteral &>().value;
+            if (field.getType() != Field::Types::String)
+                return {};
+            result.push_back(field.safeGet<String>());
+        }
+        return result;
+    }
+
+    return {};
+}
+
+static Strings extractParts(const ASTPtr & argument, const ContextPtr & context)
+{
+    if (auto parts = tryExtractParts(argument, context))
+        return std::move(*parts);
 
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parts must be an array of strings, got: {}", argument->formatForLogging());
 }

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -3,6 +3,7 @@
 #include <Core/Types.h>
 #include <DataTypes/DataTypeString.h>
 #include <Core/NamesAndTypes.h>
+#include <Common/FieldVisitorConvertToNumber.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -239,20 +240,51 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsForOptimizations(const 
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
                 "vector_search_index_analysis requires 6 arguments");
 
-        Array field_array = vector_search_args[3].safeGet<Array>();
-        VectorWithMemoryTracking<Float64> reference_vector;
-        for (const auto & field_array_value : field_array)
+        auto get_string = [&](size_t index, std::string_view element_name)
         {
-            Float64 float64 = field_array_value.safeGet<Float64>();
-            reference_vector.push_back(float64);
+            const Field & element = vector_search_args[index];
+            if (element.getType() != Field::Types::String)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Element {} ({}) of argument 'args_array' of optimization 'vector_search_index_analysis' "
+                    "must be of type `String`, got type {}", index, element_name, element.getTypeName());
+            return element.safeGet<String>();
+        };
+
+        /// A `Field` stores a boolean as an integer, so the flags accept the same types as the limit.
+        auto get_integer = [&](size_t index, std::string_view element_name)
+        {
+            const Field & element = vector_search_args[index];
+            Field::Types::Which type = element.getType();
+            if (type != Field::Types::UInt64 && type != Field::Types::Int64 && type != Field::Types::Bool)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Element {} ({}) of argument 'args_array' of optimization 'vector_search_index_analysis' "
+                    "must be of an integer type, got type {}", index, element_name, element.getTypeName());
+            return element.safeGet<UInt64>();
+        };
+
+        const Field & reference_vector_field = vector_search_args[3];
+        if (reference_vector_field.getType() != Field::Types::Array)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Element 3 (search vector) of argument 'args_array' of optimization 'vector_search_index_analysis' "
+                "must be of type `Array`, got type {}", reference_vector_field.getTypeName());
+
+        VectorWithMemoryTracking<Float64> reference_vector;
+        for (const auto & field_array_value : reference_vector_field.safeGet<Array>())
+        {
+            Field::Types::Which type = field_array_value.getType();
+            if (type != Field::Types::Float64 && type != Field::Types::UInt64 && type != Field::Types::Int64)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Element 3 (search vector) of argument 'args_array' of optimization 'vector_search_index_analysis' "
+                    "must be an array of numbers, got an element of type {}", field_array_value.getTypeName());
+            reference_vector.push_back(applyVisitor(FieldVisitorConvertToNumber<Float64>(), field_array_value));
         }
 
-        vector_search_parameters = VectorSearchParameters{vector_search_args[0].safeGet<String>(), /// column
-            vector_search_args[1].safeGet<String>(), /// distance function
-            vector_search_args[2].safeGet<UInt64>(), /// limit
+        vector_search_parameters = VectorSearchParameters{get_string(0, "column"),
+            get_string(1, "distance function"),
+            get_integer(2, "limit"),
             reference_vector, /// search vector
-            static_cast<bool>(vector_search_args[4].safeGet<bool>()), /// additional filters
-            static_cast<bool>(vector_search_args[5].safeGet<bool>())}; /// return distances
+            static_cast<bool>(get_integer(4, "additional filters")),
+            static_cast<bool>(get_integer(5, "return distances"))};
     }
     else
     {

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -205,8 +205,15 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsForOptimizations(const 
     auto optimization = checkAndGetLiteralArgument<String>(args[start_index++], "extra_optimization");
     if (optimization == "vector_search_index_analysis")
     {
-        auto cast_node = args[start_index++]->children.at(0);
-        auto vector_search_args = evaluateConstantExpressionAsLiteral(cast_node->children.at(0), context)->as<ASTLiteral &>().value.safeGet<Array>();
+        const ASTPtr & args_array = args[start_index++];
+        /// Owns the literal that `args_field` and `vector_search_args` point into.
+        ASTPtr args_array_literal = evaluateConstantExpressionAsLiteral(args_array, context);
+        const Field & args_field = args_array_literal->as<ASTLiteral &>().value;
+        if (args_field.getType() != Field::Types::Array)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Argument 'args_array' of optimization 'vector_search_index_analysis' must be a constant expression "
+                "of type `Array`, got {} of type {}", args_array->formatForErrorMessage(), args_field.getTypeName());
+        const Array & vector_search_args = args_field.safeGet<Array>();
         if (vector_search_args.size() != 6)
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
                 "vector_search_index_analysis requires 6 arguments");

--- a/tests/queries/0_stateless/01256_negative_generate_random.sql
+++ b/tests/queries/0_stateless/01256_negative_generate_random.sql
@@ -2,3 +2,10 @@ SELECT * FROM generateRandom('i8', 1, 10, 10); -- { serverError SYNTAX_ERROR }
 SELECT * FROM generateRandom; -- { serverError UNKNOWN_TABLE }
 SELECT * FROM generateRandom('i8 UInt8', 1, 10, 10, 10, 10); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT * FROM generateRandom('', 1, 10, 10); -- { serverError SYNTAX_ERROR }
+-- `_CAST` takes a value and a type name; any other argument list is not a cast wrapper. The
+-- analyzer rejects such a `_CAST` while resolving it, so the code differs per analyzer.
+-- `LIMIT 1` bounds the query: `generateRandom` is an infinite source, so without it an argument that
+-- is wrongly accepted would be reported by a test timeout rather than by an unexpected success.
+SELECT * FROM generateRandom('i8 UInt8', _CAST()) LIMIT 1; -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM generateRandom('i8 UInt8', _CAST(1)) LIMIT 1; -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM generateRandom('i8 UInt8', _CAST(1, 'UInt64', 'extra')) LIMIT 1; -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
+++ b/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
@@ -18,6 +18,10 @@ SELECT * FROM mergeTreeAnalyzeIndexesUUID('00000000-0000-0000-0000-000000000001'
 -- A well-formed constant array is still accepted and reaches the arity check.
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', CAST([1, 2, 3] AS Array(UInt8))); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
+-- The heterogeneous array needs `Variant` as its common type. Pin the setting: the stress job
+-- randomizes `compatibility`, and a version below 26.1 restores this setting's old default of 0.
+SET use_variant_as_common_type = 1;
+
 -- A six-element array is decoded element by element, each with its own expected type. `data` has no
 -- parts, so the analysis itself returns nothing.
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, [1.0], false, false));

--- a/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
+++ b/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
@@ -15,6 +15,23 @@ SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_se
 -- parsed before the table is resolved, so the UUID does not have to exist.
 SELECT * FROM mergeTreeAnalyzeIndexesUUID('00000000-0000-0000-0000-000000000001', 1, [], 'vector_search_index_analysis', (SELECT tuple(1))); -- { serverError BAD_ARGUMENTS }
 
+-- `_CAST` takes a value and a type name. Any other argument list is not a cast wrapper, in the
+-- optimization name and in the parts array alike. The analyzer rejects such a `_CAST` while
+-- resolving it, so the code differs per analyzer.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], _CAST(), [1]); -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, _CAST()); -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, _CAST(['all_1_1_0'])); -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, _CAST(['all_1_1_0'], 'Array(String)', 'extra')); -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+
+-- A parts argument that is not an array, and arrays whose elements are not strings. The literal and
+-- the `array(...)` spellings reach different branches.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, _CAST(1, 'UInt8')); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, _CAST([1], 'Array(UInt8)')); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, array(1)); -- { serverError BAD_ARGUMENTS }
+
+-- A well-formed parts array is still accepted. `data` has no parts, so nothing is returned.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, array('all_1_1_0'));
+
 -- A well-formed constant array is still accepted and reaches the arity check.
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', CAST([1, 2, 3] AS Array(UInt8))); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
@@ -25,5 +42,12 @@ SET use_variant_as_common_type = 1;
 -- A six-element array is decoded element by element, each with its own expected type. `data` has no
 -- parts, so the analysis itself returns nothing.
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, [1.0], false, false));
+
+-- The same six-element array behind `_CAST` optimization names of one, two and three arguments.
+-- Everything except the name is valid here, so the two-argument name must be unwrapped and succeed
+-- while the other two must fail, rather than reaching a second accepted error code.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], _CAST('vector_search_index_analysis'), array('value', 'L2Distance', 1, [1.0], false, false)); -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], _CAST('vector_search_index_analysis', 'String'), array('value', 'L2Distance', 1, [1.0], false, false));
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], _CAST('vector_search_index_analysis', 'String', 'extra'), array('value', 'L2Distance', 1, [1.0], false, false)); -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 DROP TABLE data;

--- a/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
+++ b/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
@@ -1,6 +1,20 @@
+-- Arguments of the `vector_search_index_analysis` optimization are evaluated as expressions, so a
+-- malformed argument is rejected with `BAD_ARGUMENTS` instead of reaching `IAST::getColumnName`.
 DROP TABLE IF EXISTS data;
 CREATE TABLE data (key Int, value Int) ENGINE = MergeTree() ORDER BY key;
 
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', tuple(materialize(1))); -- { serverError BAD_ARGUMENTS }
+
+-- A subquery argument, which resolves to an expression list rather than a column.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', (SELECT tuple(1))); -- { serverError BAD_ARGUMENTS }
+
+-- An argument node with no children.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', 1); -- { serverError BAD_ARGUMENTS }
+
+-- `mergeTreeAnalyzeIndexesUUID` reaches the same code at a different argument index.
+SELECT * FROM mergeTreeAnalyzeIndexesUUID((SELECT toString(uuid) FROM system.tables WHERE database = currentDatabase() AND name = 'data'), 1, [], 'vector_search_index_analysis', (SELECT tuple(1))); -- { serverError BAD_ARGUMENTS }
+
+-- A well-formed constant array is still accepted and reaches the arity check.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', CAST([1, 2, 3] AS Array(UInt8))); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 DROP TABLE data;

--- a/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
+++ b/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
@@ -50,4 +50,21 @@ SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], _CAST('vec
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], _CAST('vector_search_index_analysis', 'String'), array('value', 'L2Distance', 1, [1.0], false, false));
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], _CAST('vector_search_index_analysis', 'String', 'extra'), array('value', 'L2Distance', 1, [1.0], false, false)); -- { serverError BAD_ARGUMENTS, NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
+-- Each element of a six-element array has its own expected type, and an element of the wrong type is
+-- reported as `BAD_ARGUMENTS` rather than as a failed `Field` access. The remaining five elements are
+-- valid in every case below, so an element that stopped being checked would return an empty result
+-- instead of a second accepted error code.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array(1, 'L2Distance', 1, [1.0], false, false)); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 1, 1, [1.0], false, false)); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 'one', [1.0], false, false)); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, 'one', false, false)); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, ['one'], false, false)); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, [1.0], 'no', false)); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, [1.0], false, 'no')); -- { serverError BAD_ARGUMENTS }
+
+-- A search vector of integers is accepted, as the optimization itself accepts one. A `Float64` with
+-- an integral value is formatted without a decimal point, so this is also the text the server sends
+-- to itself when it distributes the analysis of such a search vector.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, [1, 2, 3], false, false));
+
 DROP TABLE data;

--- a/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
+++ b/tests/queries/0_stateless/04070_mergetree_analyze_indexes_optimizations_no_crash.sql
@@ -11,10 +11,15 @@ SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_se
 -- An argument node with no children.
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', 1); -- { serverError BAD_ARGUMENTS }
 
--- `mergeTreeAnalyzeIndexesUUID` reaches the same code at a different argument index.
-SELECT * FROM mergeTreeAnalyzeIndexesUUID((SELECT toString(uuid) FROM system.tables WHERE database = currentDatabase() AND name = 'data'), 1, [], 'vector_search_index_analysis', (SELECT tuple(1))); -- { serverError BAD_ARGUMENTS }
+-- `mergeTreeAnalyzeIndexesUUID` reaches the same code at a different argument index. Arguments are
+-- parsed before the table is resolved, so the UUID does not have to exist.
+SELECT * FROM mergeTreeAnalyzeIndexesUUID('00000000-0000-0000-0000-000000000001', 1, [], 'vector_search_index_analysis', (SELECT tuple(1))); -- { serverError BAD_ARGUMENTS }
 
 -- A well-formed constant array is still accepted and reaches the arity check.
 SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', CAST([1, 2, 3] AS Array(UInt8))); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+
+-- A six-element array is decoded element by element, each with its own expected type. `data` has no
+-- parts, so the analysis itself returns nothing.
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [], 'vector_search_index_analysis', array('value', 'L2Distance', 1, [1.0], false, false));
 
 DROP TABLE data;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A malformed argument of `mergeTreeAnalyzeIndexes` or `generateRandom` is now rejected with `BAD_ARGUMENTS` instead of raising a logical error, a raw `std::out_of_range` or `BAD_GET`.


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/117610
Related: https://github.com/ClickHouse/ClickHouse/issues/97988

`checkAndGetLiteralArgument`, `extractParts` in `TableFunctionMergeTreeAnalyzeIndexes` and the argument loop in `TableFunctionGenerateRandom` each recognized the analyzer's `_CAST` wrapper by name alone, then read `func->arguments->children.at(0)`. `parseArgumentsForOptimizations` also walked two levels of raw AST by position instead of evaluating its `args_array`, and decoded every element of that array with a raw `safeGet`. Four user-visible consequences, each measured before and after in both analyzer modes:

- a bare literal `args_array` has no children, so `children.at(0)` escaped as `STD_EXCEPTION`; with `enable_analyzer = 0` a subquery there raised `Trying to get name of not a column: ExpressionList`, which aborts debug and sanitizer builds;
- an empty `_CAST()` in the optimization name or the parts array escaped as `STD_EXCEPTION` (reported by zlareb1 below);
- `_CAST(['part'])` in the parts array was accepted as a cast by the legacy interpreter and rejected by the analyzer, so the two paths disagreed on whether the query was valid;
- `BAD_GET` escaped for a parts argument that is not an array of strings, for an element of the wrong type in a well-formed `args_array`, and for an integral search vector, which the optimization producing that argument accepts.

`parseArgumentsForOptimizations` now evaluates the whole argument with the helper used for its other arguments, and checks the array and each element before reading it, naming the element and the type received. `_CAST` is recognized only with the two arguments it declares. `extractParts` validates the array and its element types. Every shape above now reports `BAD_ARGUMENTS`, or `NUMBER_OF_ARGUMENTS_DOESNT_MATCH` from the analyzer. Nothing accepted before is rejected now, and no assertion is weakened.

A `Float64` with an integral value is formatted without a decimal point, so the internal producer sends `[1, 2, 3]` for the search vector `1.0, 2.0, 3.0`. That text now works too, matching the analyzer.

<details>
<summary>CI provenance and failure breadth</summary>

Found by `AST fuzzer (amd_debug, targeted, old_compatibility)` on PR #117579, commit `7a6545576e6c6a5b34d14c28f0cb0f6116f2d5a6`, STID 2310-3c6a:

https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117579&sha=7a6545576e6c6a5b34d14c28f0cb0f6116f2d5a6&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29

```sql
SELECT check_name, pull_request_number, head_ref, count() AS hits
FROM default.checks
WHERE check_start_time > now() - INTERVAL 30 DAY
  AND test_context_raw LIKE '%Trying to get name of not a column%'
GROUP BY check_name, pull_request_number, head_ref
ORDER BY hits DESC
```

```
check_name                                              pull_request_number  head_ref                            hits
AST fuzzer (amd_debug, targeted)                        99509                merge_tree_queue_engine             2
AST fuzzer (amd_debug, targeted, old_compatibility)     117579               fix-join-use-nulls-predicate-inference  1
```

The two hits on #99509 are a different carrier of the same error string. There are no hits with `head_ref = 'master' AND pull_request_number = 0`, so this carrier has not fired on master.

Reproducer, no fuzzer needed:

```sql
CREATE TABLE data (key Int, value Int) ENGINE = MergeTree ORDER BY key;

-- at default settings
SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [],
                                      'vector_search_index_analysis', 1);

SET enable_analyzer = 0;
SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1, [],
                                      'vector_search_index_analysis', (SELECT tuple(1)));
```

Validated over 45 argument shapes per analyzer mode against the pristine binary and the fix,
plus 146 neighbouring tests whose verdicts are identical on both.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117628&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117628](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117628+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


