### PR TITLE
Return retryable HTTP 503 on remote-write async insert flush timeout

### DIFF
--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -688,6 +688,7 @@
     M(1014, TRANSACTION_ROLLBACK_PARTIAL_FAILURE) \
     M(1015, FILE_CHANGED_DURING_READ) \
     M(1016, TABLE_SIZE_LIMIT_EXCEEDED) \
+    M(1017, ASYNC_INSERT_FLUSH_TIMEOUT) \
     /* See END */
 
 #ifdef APPLY_FOR_EXTERNAL_ERROR_CODES
@@ -704,7 +705,7 @@ namespace ErrorCodes
     APPLY_FOR_ERROR_CODES(M)
 #undef M
 
-    constexpr ErrorCode END = 1016;
+    constexpr ErrorCode END = 1017;
 
 #if !defined(CLICKHOUSE_PARSER_MINIMAL_BUILD)
     /** One `ErrorPairHolder` per error code, each holding two `Error` structs - the last message,

--- a/src/Server/HTTP/exceptionCodeToHTTPStatus.cpp
+++ b/src/Server/HTTP/exceptionCodeToHTTPStatus.cpp
@@ -65,6 +65,7 @@ namespace ErrorCodes
     extern const int HTTP_LENGTH_REQUIRED;
 
     extern const int TIMEOUT_EXCEEDED;
+    extern const int ASYNC_INSERT_FLUSH_TIMEOUT;
 
     extern const int UNSUPPORTED_MEDIA_TYPE;
 }
@@ -129,6 +130,10 @@ Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int exception_code
     if (exception_code == ErrorCodes::TIMEOUT_EXCEEDED)
     {
         return HTTPResponse::HTTP_REQUEST_TIMEOUT;
+    }
+    if (exception_code == ErrorCodes::ASYNC_INSERT_FLUSH_TIMEOUT)
+    {
+        return HTTPResponse::HTTP_SERVICE_UNAVAILABLE;
     }
     if (exception_code == ErrorCodes::CANNOT_SCHEDULE_TASK)
     {

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -41,10 +41,10 @@ namespace Setting
 
 namespace ErrorCodes
 {
+    extern const int ASYNC_INSERT_FLUSH_TIMEOUT;
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TIME_SERIES_TAGS;
     extern const int LOGICAL_ERROR;
-    extern const int TIMEOUT_EXCEEDED;
 }
 
 namespace
@@ -262,9 +262,12 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
 
             io.resetPipeline(/*cancel=*/ true);
 
+            /// `ASYNC_INSERT_FLUSH_TIMEOUT` is returned to the client as HTTP 503: the remote-write protocol
+            /// treats 4xx statuses (other than 429) as permanent failures and drops the data without a retry,
+            /// while the data here is still in the queue and its fate is unknown, so the status must be retryable.
             const auto timeout_ms = context->getSettingsRef()[Setting::wait_for_async_insert_timeout].totalMilliseconds();
             if (result.future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::timeout)
-                throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
+                throw Exception(ErrorCodes::ASYNC_INSERT_FLUSH_TIMEOUT, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
 
             const auto progress = result.future.get();
             if (auto process_list_element = context->getProcessListElement())

--- a/tests/integration/test_prometheus_protocols/test_async_insert.py
+++ b/tests/integration/test_prometheus_protocols/test_async_insert.py
@@ -1,9 +1,11 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 from .prometheus_test_utils import (
     convert_metrics_metadata_to_protobuf,
     convert_time_series_to_protobuf,
+    execute_query_via_http_api,
     get_response_to_remote_write,
     send_protobuf_to_remote_write,
 )
@@ -107,3 +109,36 @@ def test_async_insert_no_acknowledgement_on_failure():
     assert not response.ok
     assert "VIOLATED_CONSTRAINT" in response.text
     assert node.query("SELECT count() FROM samples") == "0\n"
+
+
+def test_async_insert_flush_timeout_returns_503():
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+
+    # With a zero wait timeout and a 3-second flush deadline the wait always times out
+    # before the flush happens.
+    time_series = [({"__name__": "timeout_metric"}, {1724112000: 1.5})]
+    response = get_response_to_remote_write(
+        node.ip_address,
+        9093,
+        "/write?async_insert=1&wait_for_async_insert_timeout=0"
+        "&async_insert_use_adaptive_busy_timeout=0&async_insert_busy_timeout_max_ms=3000",
+        convert_time_series_to_protobuf(time_series),
+    )
+
+    # The remote-write spec makes senders drop data on 4xx statuses (other than 429),
+    # so the wait timeout must map to a retryable 503, not 408.
+    assert response.status_code == 503
+    assert "Wait for asynchronous insert timeout" in response.text
+
+    # The data stays in the server's asynchronous insert queue and is flushed later.
+    assert_eq_with_retry(
+        node, "SELECT count() FROM timeSeriesSamples(prometheus)", "1", retry_count=60
+    )
+
+    # A PromQL instant query at the sample's timestamp returns the flushed data.
+    assert execute_query_via_http_api(
+        node.ip_address, 9093, "/api/v1/query", "timeout_metric", timestamp=1724112000
+    ) == (
+        '{"resultType": "vector", "result": '
+        '[{"metric": {"__name__": "timeout_metric"}, "value": [1724112000, "1.5"]}]}'
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Return retryable `503 Service Unavailable` on remote-write async insert flush timeout.

Earlier it returned `HTTP 408 Request Timeout`, which was bad because Prometheus Remote Write compatible senders retry write requests only on HTTP 5xx responses (and sometimes HTTP 429) ([docs](https://prometheus.io/docs/specs/prw/remote_write_spec/#retries--backoff)) so `HTTP 408` was not retryable

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117632&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117632](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117632+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.588` (included in `26.9` and later)
<!-- ch-version-info:end -->