### PR TITLE
Do not prune a comparison of a value that carries its own type

### DIFF
--- a/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
+++ b/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
@@ -438,6 +438,22 @@ static ValueComparisonResult invertComparisonResult(ValueComparisonResult result
     }
 }
 
+/// `IColumn::compareAt` orders a value that carries its own type by that type's place in the
+/// name-sorted alternative list before it looks at the value, while this analysis orders a `Field` by
+/// its own type tag; for `Variant(Float64, Int64)` the two are reversed.
+static bool comparisonOrdersTypeBeforeValue(const DataTypePtr & type)
+{
+    /// `hasDynamicStructure` reaches `Dynamic` and `JSON` at any depth, including a `JSON` with no
+    /// declared path, which is the only thing `forEachChild` walks for it. It is false for a `Variant`
+    /// of static alternatives, which `ColumnVariant::compareAt` still orders by discriminator.
+    if (type->hasDynamicStructure() || isVariant(type))
+        return true;
+
+    bool found = false;
+    type->forEachChild([&](const IDataType & child) { found = found || isVariant(child); });
+    return found;
+}
+
 /// Try to convert a constant to the expression's (column) type using strict (lossless) conversion.
 /// Returns the converted Field if successful, or std::nullopt if the conversion is lossy or fails.
 static std::optional<Field> tryConvertToColumnType(const ConstantNode * constant_node, const DataTypePtr & expr_type)
@@ -911,6 +927,16 @@ static AddComparisonFilterResult addComparisonFilter(
     /// Step 1: convert the constant to the column's type for uniform comparison.
     const auto & raw_type = expression->getResultType();
     auto expr_type = removeLowCardinality(raw_type);
+
+    /// The order this analysis puts such a value in is not the order the comparison applies to it, so
+    /// the condition's position relative to the others carries no information. Either operand decides:
+    /// a comparison is evaluated at the least common supertype, which is self-typed iff an operand is.
+    if (comparisonOrdersTypeBeforeValue(raw_type)
+        || comparisonOrdersTypeBeforeValue(new_filter.constant_node->getResultType()))
+    {
+        filter_map[expression].opaque_filters.push_back(std::move(new_filter));
+        return AddComparisonFilterResult::ADDED;
+    }
 
     new_filter.converted_value = tryConvertToColumnType(new_filter.constant_node, expr_type);
 

--- a/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
+++ b/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
@@ -911,6 +911,13 @@ static AddComparisonFilterResult addComparisonFilter(
     bool enable_pruning,
     const ContextPtr & context)
 {
+    /// The order this analysis puts such a value in is not the order the comparison applies to it, so
+    /// the condition's position relative to the others carries no information. Either operand decides:
+    /// a comparison is evaluated at the least common supertype, which is self-typed iff an operand is.
+    new_filter.orders_type_before_value
+        = comparisonOrdersTypeBeforeValue(expression->getResultType())
+        || comparisonOrdersTypeBeforeValue(new_filter.constant_node->getResultType());
+
     /// Pruning disabled — just store the filter without analysis.
     if (!enable_pruning)
     {
@@ -931,13 +938,8 @@ static AddComparisonFilterResult addComparisonFilter(
     const auto & raw_type = expression->getResultType();
     auto expr_type = removeLowCardinality(raw_type);
 
-    /// The order this analysis puts such a value in is not the order the comparison applies to it, so
-    /// the condition's position relative to the others carries no information. Either operand decides:
-    /// a comparison is evaluated at the least common supertype, which is self-typed iff an operand is.
-    if (comparisonOrdersTypeBeforeValue(raw_type)
-        || comparisonOrdersTypeBeforeValue(new_filter.constant_node->getResultType()))
+    if (new_filter.orders_type_before_value)
     {
-        new_filter.orders_type_before_value = true;
         filter_map[expression].opaque_filters.push_back(std::move(new_filter));
         return AddComparisonFilterResult::ADDED;
     }

--- a/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
+++ b/src/Analyzer/Passes/LogicalExpressionOptimizerPass.cpp
@@ -394,6 +394,9 @@ struct ComparisonFilterInfo
     /// Set when folding changed `function` or the constant: the node must be rebuilt on emission,
     /// so that the tightened predicate reaches downstream analysis.
     bool modified = false;
+    /// A merge into `notIn` rebuilds the constant from a `Field`, which carries no discriminator, so a
+    /// comparison whose operand order comes from the discriminator stays a plain comparison.
+    bool orders_type_before_value = false;
 };
 
 /// A `Bool` column constant may be stored as `Types::Bool` (strict conversion) or as an integer
@@ -934,6 +937,7 @@ static AddComparisonFilterResult addComparisonFilter(
     if (comparisonOrdersTypeBeforeValue(raw_type)
         || comparisonOrdersTypeBeforeValue(new_filter.constant_node->getResultType()))
     {
+        new_filter.orders_type_before_value = true;
         filter_map[expression].opaque_filters.push_back(std::move(new_filter));
         return AddComparisonFilterResult::ADDED;
     }
@@ -2072,7 +2076,7 @@ private:
 
             for (auto & filter : filters.opaque_filters)
             {
-                if (filter.function == ComparisonFunction::NOT_EQUALS)
+                if (filter.function == ComparisonFunction::NOT_EQUALS && !filter.orders_type_before_value)
                     not_equals_infos.push_back(&filter);
                 else
                     all_operands.emplace_back(filter.original_index, std::move(filter.original_node));

--- a/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.reference
+++ b/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.reference
@@ -9,3 +9,13 @@ array(variant), chain pruned	0
 array(variant), chain kept	0
 shared field, chain pruned	0
 shared field, chain kept	0
+self-typed constant, excluding bound alone	0
+self-typed constant, chain pruned	0
+self-typed constant, chain kept	0
+shared field 3-chain, chain kept	0
+shared field 3-chain, excluding constant first	0
+shared field 3-chain, excluding constant second	0
+plan, self-typed range conjuncts kept	2
+plan, ordinary range conjuncts pruned	1
+plan, self-typed notIn merges	0
+plan, ordinary notIn merges	1

--- a/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.reference
+++ b/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.reference
@@ -1,0 +1,11 @@
+json, excluding bound alone	0
+json, chain pruned	0
+json, chain kept	0
+array(dynamic), excluding bound alone	0
+array(dynamic), chain pruned	0
+array(dynamic), chain kept	0
+array(variant), excluding bound alone	0
+array(variant), chain pruned	0
+array(variant), chain kept	0
+shared field, chain pruned	0
+shared field, chain kept	0

--- a/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.reference
+++ b/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.reference
@@ -15,7 +15,13 @@ self-typed constant, chain kept	0
 shared field 3-chain, chain kept	0
 shared field 3-chain, excluding constant first	0
 shared field 3-chain, excluding constant second	0
+shared field 3-chain, merge armed with pruning off	0
+top-level variant, chain pruned	0
 plan, self-typed range conjuncts kept	2
 plan, ordinary range conjuncts pruned	1
 plan, self-typed notIn merges	0
 plan, ordinary notIn merges	1
+plan, self-typed notIn skipped with pruning off	0
+plan, ordinary notIn merges with pruning off	1
+plan, top-level variant range conjuncts kept	2
+plan, ordinary scalar range conjuncts pruned	1

--- a/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
+++ b/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
@@ -1,7 +1,5 @@
--- `optimize_redundant_comparisons` ordered an `AND` chain's constants by their `Field` type tag, while
--- a `Variant`, `Dynamic` or `JSON` value is compared by its own type's place in the name-sorted
--- alternative list first, so pruning the bound the pass judged looser dropped the one that excludes
--- the row.
+-- Pins that `optimize_redundant_comparisons` and the `notEquals` -> `notIn` merge both decline a
+-- comparison of a value that carries its own type.
 --
 -- Every arm pins `optimize_redundant_comparisons` (the setting under test) and
 -- `optimize_and_compare_chain` (randomized by the test runner, and its call site enables pruning
@@ -15,6 +13,7 @@ DROP TABLE IF EXISTS t_redundant_array_dynamic;
 DROP TABLE IF EXISTS t_redundant_array_variant;
 DROP TABLE IF EXISTS t_redundant_variant_shared_field;
 DROP TABLE IF EXISTS t_redundant_plain;
+DROP TABLE IF EXISTS t_redundant_variant_top;
 
 -- A top-level `JSON` comparison resolves to a plain `UInt8`, so the nullable-result screen does not
 -- hold it aside; a top-level `Variant` or `Dynamic` resolves to `Nullable(UInt8)` and is held aside.
@@ -94,6 +93,19 @@ SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, opt
 SELECT 'shared field 3-chain, excluding constant second', count() FROM t_redundant_variant_shared_field
 WHERE a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [1::UInt64]::Array(Variant(Date, UInt64)) AND a != [5::UInt64]::Array(Variant(Date, UInt64))
 SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3;
+-- The merge is not gated by `optimize_redundant_comparisons`, so the chain reaches it with pruning off.
+SELECT 'shared field 3-chain, merge armed with pruning off', count() FROM t_redundant_variant_shared_field
+WHERE a != [1::UInt64]::Array(Variant(Date, UInt64)) AND a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [5::UInt64]::Array(Variant(Date, UInt64))
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3;
+
+-- With `use_variant_default_implementation_for_comparisons = 0` a top-level `Variant` comparison
+-- resolves to plain `UInt8`, so the nullable-result screen does not hold it aside. Every `Float64`
+-- alternative sorts before every `Int64` one whatever the values are, so the two orders disagree here.
+CREATE TABLE t_redundant_variant_top (id UInt32, b Variant(Float64, Int64), f Float64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_redundant_variant_top VALUES (1, 9e9::Float64, 9e9);
+SELECT 'top-level variant, chain pruned', count() FROM t_redundant_variant_top
+WHERE b >= 5.0::Float64::Variant(Float64, Int64) AND b >= 2::Int64::Variant(Float64, Int64)
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, use_variant_default_implementation_for_comparisons = 0;
 
 -- Plan oracles. The counts above are all `0`, so they alone cannot tell a working guard from a pass
 -- that never ran; each assertion below is paired with the same shape on an ordinary type, which is
@@ -118,9 +130,30 @@ SELECT 'plan, ordinary notIn merges', count() FROM
      WHERE a != [1::UInt64] AND a != [2::UInt64] AND a != [3::UInt64]
      SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3)
 WHERE explain ILIKE '%function_name: notIn,%';
+SELECT 'plan, self-typed notIn skipped with pruning off', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_variant_shared_field
+     WHERE a != [1::UInt64]::Array(Variant(Date, UInt64)) AND a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [5::UInt64]::Array(Variant(Date, UInt64))
+     SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3)
+WHERE explain ILIKE '%function_name: notIn,%';
+SELECT 'plan, ordinary notIn merges with pruning off', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_plain
+     WHERE a != [1::UInt64] AND a != [2::UInt64] AND a != [3::UInt64]
+     SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3)
+WHERE explain ILIKE '%function_name: notIn,%';
+SELECT 'plan, top-level variant range conjuncts kept', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_variant_top
+     WHERE b >= 5.0::Float64::Variant(Float64, Int64) AND b >= 2::Int64::Variant(Float64, Int64)
+     SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, use_variant_default_implementation_for_comparisons = 0)
+WHERE explain ILIKE '%function_name: greaterOrEquals,%';
+SELECT 'plan, ordinary scalar range conjuncts pruned', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_variant_top
+     WHERE f >= 5.0 AND f >= 2
+     SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1)
+WHERE explain ILIKE '%function_name: greaterOrEquals,%';
 
 DROP TABLE t_redundant_json;
 DROP TABLE t_redundant_array_dynamic;
 DROP TABLE t_redundant_array_variant;
 DROP TABLE t_redundant_variant_shared_field;
 DROP TABLE t_redundant_plain;
+DROP TABLE t_redundant_variant_top;

--- a/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
+++ b/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
@@ -1,18 +1,20 @@
--- `optimize_redundant_comparisons` prunes the conditions of an `AND` chain by ordering the two
--- constants' `Field` values by their own type tag. A `Variant`, `Dynamic` or `JSON` value carries its
--- own type, and `IColumn::compareAt` orders such a value by that type's place in the name-sorted
--- alternative list before it looks at the value. For `Variant(Float64, Int64)` the two orders are
--- reversed, so the bound the analysis judged looser is the one that actually excludes the row, and
--- pruning it returned a row the `WHERE` clause excludes.
+-- `optimize_redundant_comparisons` ordered an `AND` chain's constants by their `Field` type tag, while
+-- a `Variant`, `Dynamic` or `JSON` value is compared by its own type's place in the name-sorted
+-- alternative list first, so pruning the bound the pass judged looser dropped the one that excludes
+-- the row.
 --
 -- Every arm pins `optimize_redundant_comparisons` (the setting under test) and
 -- `optimize_and_compare_chain` (randomized by the test runner, and its call site enables pruning
 -- unconditionally), so no arm depends on the randomization.
 
+-- The pass runs only under the analyzer, and `EXPLAIN QUERY TREE` requires it.
+SET enable_analyzer = 1;
+
 DROP TABLE IF EXISTS t_redundant_json;
 DROP TABLE IF EXISTS t_redundant_array_dynamic;
 DROP TABLE IF EXISTS t_redundant_array_variant;
 DROP TABLE IF EXISTS t_redundant_variant_shared_field;
+DROP TABLE IF EXISTS t_redundant_plain;
 
 -- A top-level `JSON` comparison resolves to a plain `UInt8`, so the nullable-result screen does not
 -- hold it aside; a top-level `Variant` or `Dynamic` resolves to `Nullable(UInt8)` and is held aside.
@@ -66,7 +68,59 @@ SELECT 'shared field, chain kept', count() FROM t_redundant_variant_shared_field
 WHERE a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [1::UInt64]::Array(Variant(Date, UInt64))
 SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
 
+-- Only the constant carries its own type here: `Array(UInt64)` is an ordinary type, and the
+-- comparison is evaluated at the self-typed supertype, where `UInt64` sorts before `UInt8` by name.
+CREATE TABLE t_redundant_plain (id UInt32, a Array(UInt64)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_redundant_plain VALUES (1, [1]);
+SELECT 'self-typed constant, excluding bound alone', count() FROM t_redundant_plain
+WHERE a >= [1::UInt8]::Array(Dynamic)
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+SELECT 'self-typed constant, chain pruned', count() FROM t_redundant_plain
+WHERE a >= [toDate(5)]::Array(Dynamic) AND a >= [1::UInt8]::Array(Dynamic)
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1;
+SELECT 'self-typed constant, chain kept', count() FROM t_redundant_plain
+WHERE a >= [toDate(5)]::Array(Dynamic) AND a >= [1::UInt8]::Array(Dynamic)
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+
+-- A chain long enough to be merged into `notIn`, which rebuilds its constant from a `Field` and so
+-- cannot carry a discriminator. Both constant orders are pinned: which of the two the duplicate-key
+-- map happens to keep decides the answer without the guard.
+SELECT 'shared field 3-chain, chain kept', count() FROM t_redundant_variant_shared_field
+WHERE a != [1::UInt64]::Array(Variant(Date, UInt64)) AND a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [5::UInt64]::Array(Variant(Date, UInt64))
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 100;
+SELECT 'shared field 3-chain, excluding constant first', count() FROM t_redundant_variant_shared_field
+WHERE a != [1::UInt64]::Array(Variant(Date, UInt64)) AND a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [5::UInt64]::Array(Variant(Date, UInt64))
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3;
+SELECT 'shared field 3-chain, excluding constant second', count() FROM t_redundant_variant_shared_field
+WHERE a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [1::UInt64]::Array(Variant(Date, UInt64)) AND a != [5::UInt64]::Array(Variant(Date, UInt64))
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3;
+
+-- Plan oracles. The counts above are all `0`, so they alone cannot tell a working guard from a pass
+-- that never ran; each assertion below is paired with the same shape on an ordinary type, which is
+-- what fails if the optimization stops firing altogether.
+SELECT 'plan, self-typed range conjuncts kept', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_array_dynamic
+     WHERE a >= [1.0::Float64]::Array(Dynamic) AND a >= [2::Int64]::Array(Dynamic)
+     SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1)
+WHERE explain ILIKE '%function_name: greaterOrEquals,%';
+SELECT 'plan, ordinary range conjuncts pruned', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_plain
+     WHERE a >= [1::UInt64] AND a >= [2::UInt64]
+     SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1)
+WHERE explain ILIKE '%function_name: greaterOrEquals,%';
+SELECT 'plan, self-typed notIn merges', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_variant_shared_field
+     WHERE a != [1::UInt64]::Array(Variant(Date, UInt64)) AND a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [5::UInt64]::Array(Variant(Date, UInt64))
+     SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3)
+WHERE explain ILIKE '%function_name: notIn,%';
+SELECT 'plan, ordinary notIn merges', count() FROM
+    (EXPLAIN QUERY TREE SELECT count() FROM t_redundant_plain
+     WHERE a != [1::UInt64] AND a != [2::UInt64] AND a != [3::UInt64]
+     SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1, optimize_min_inequality_conjunction_chain_length = 3)
+WHERE explain ILIKE '%function_name: notIn,%';
+
 DROP TABLE t_redundant_json;
 DROP TABLE t_redundant_array_dynamic;
 DROP TABLE t_redundant_array_variant;
 DROP TABLE t_redundant_variant_shared_field;
+DROP TABLE t_redundant_plain;

--- a/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
+++ b/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
@@ -1,0 +1,72 @@
+-- `optimize_redundant_comparisons` prunes the conditions of an `AND` chain by ordering the two
+-- constants' `Field` values by their own type tag. A `Variant`, `Dynamic` or `JSON` value carries its
+-- own type, and `IColumn::compareAt` orders such a value by that type's place in the name-sorted
+-- alternative list before it looks at the value. For `Variant(Float64, Int64)` the two orders are
+-- reversed, so the bound the analysis judged looser is the one that actually excludes the row, and
+-- pruning it returned a row the `WHERE` clause excludes.
+--
+-- Every arm pins `optimize_redundant_comparisons` (the setting under test) and
+-- `optimize_and_compare_chain` (randomized by the test runner, and its call site enables pruning
+-- unconditionally), so no arm depends on the randomization.
+
+DROP TABLE IF EXISTS t_redundant_json;
+DROP TABLE IF EXISTS t_redundant_array_dynamic;
+DROP TABLE IF EXISTS t_redundant_array_variant;
+DROP TABLE IF EXISTS t_redundant_variant_shared_field;
+
+-- A top-level `JSON` comparison resolves to a plain `UInt8`, so the nullable-result screen does not
+-- hold it aside; a top-level `Variant` or `Dynamic` resolves to `Nullable(UInt8)` and is held aside.
+CREATE TABLE t_redundant_json (id UInt32, j JSON) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_redundant_json VALUES (1, '{"k":1.0}');
+SELECT 'json, excluding bound alone', count() FROM t_redundant_json
+WHERE j >= '{"k":2}'::JSON
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+SELECT 'json, chain pruned', count() FROM t_redundant_json
+WHERE j >= '{"k":1.0}'::JSON AND j >= '{"k":2}'::JSON
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1;
+SELECT 'json, chain kept', count() FROM t_redundant_json
+WHERE j >= '{"k":1.0}'::JSON AND j >= '{"k":2}'::JSON
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+
+-- A `Dynamic` reached through a container: the elements are compared by `compareAt`.
+CREATE TABLE t_redundant_array_dynamic (id UInt32, a Array(Dynamic)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_redundant_array_dynamic VALUES (1, [1.0::Float64]);
+SELECT 'array(dynamic), excluding bound alone', count() FROM t_redundant_array_dynamic
+WHERE a >= [2::Int64]::Array(Dynamic)
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+SELECT 'array(dynamic), chain pruned', count() FROM t_redundant_array_dynamic
+WHERE a >= [1.0::Float64]::Array(Dynamic) AND a >= [2::Int64]::Array(Dynamic)
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1;
+SELECT 'array(dynamic), chain kept', count() FROM t_redundant_array_dynamic
+WHERE a >= [1.0::Float64]::Array(Dynamic) AND a >= [2::Int64]::Array(Dynamic)
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+
+-- A `Variant` of static alternatives has no dynamic structure, and `Variant(Float64, Int64)` is the
+-- pair whose name order and `Field` tag order are reversed.
+CREATE TABLE t_redundant_array_variant (id UInt32, a Array(Variant(Float64, Int64))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_redundant_array_variant VALUES (1, [1.0::Float64]);
+SELECT 'array(variant), excluding bound alone', count() FROM t_redundant_array_variant
+WHERE a >= [2::Int64]::Array(Variant(Float64, Int64))
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+SELECT 'array(variant), chain pruned', count() FROM t_redundant_array_variant
+WHERE a >= [1.0::Float64]::Array(Variant(Float64, Int64)) AND a >= [2::Int64]::Array(Variant(Float64, Int64))
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1;
+SELECT 'array(variant), chain kept', count() FROM t_redundant_array_variant
+WHERE a >= [1.0::Float64]::Array(Variant(Float64, Int64)) AND a >= [2::Int64]::Array(Variant(Float64, Int64))
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+
+-- `Date` and `UInt64` are one `Field` type, so the two `notEquals` constants below are one key in the
+-- map that drops exact duplicates, while `compareAt` separates them by discriminator.
+CREATE TABLE t_redundant_variant_shared_field (id UInt32, a Array(Variant(Date, UInt64))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_redundant_variant_shared_field VALUES (1, [1::UInt64]);
+SELECT 'shared field, chain pruned', count() FROM t_redundant_variant_shared_field
+WHERE a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [1::UInt64]::Array(Variant(Date, UInt64))
+SETTINGS optimize_redundant_comparisons = 1, optimize_and_compare_chain = 1;
+SELECT 'shared field, chain kept', count() FROM t_redundant_variant_shared_field
+WHERE a != [toDate(1)]::Array(Variant(Date, UInt64)) AND a != [1::UInt64]::Array(Variant(Date, UInt64))
+SETTINGS optimize_redundant_comparisons = 0, optimize_and_compare_chain = 1;
+
+DROP TABLE t_redundant_json;
+DROP TABLE t_redundant_array_dynamic;
+DROP TABLE t_redundant_array_variant;
+DROP TABLE t_redundant_variant_shared_field;

--- a/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
+++ b/tests/queries/0_stateless/05103_redundant_comparisons_dynamically_typed.sql
@@ -1,9 +1,18 @@
+-- Tags: no-parallel-replicas
+--
 -- Pins that `optimize_redundant_comparisons` and the `notEquals` -> `notIn` merge both decline a
 -- comparison of a value that carries its own type.
 --
 -- Every arm pins `optimize_redundant_comparisons` (the setting under test) and
 -- `optimize_and_compare_chain` (randomized by the test runner, and its call site enables pruning
 -- unconditionally), so no arm depends on the randomization.
+--
+-- `no-parallel-replicas`: a `Variant` nested inside a container does not survive the query-text
+-- round trip to a secondary server. The folded `Field` prints as a bare literal, which re-parses as
+-- a different type, and the internal `_CAST` back to the `Variant` then refuses it. #111136 fixed
+-- that for a scalar `Variant` constant and records the nested case as not covered; the
+-- `Array(Variant(...))` arms here need exactly the nested form. Independent of the pass under test:
+-- it reproduces on master with `optimize_redundant_comparisons = 0`.
 
 -- The pass runs only under the analyzer, and `EXPLAIN QUERY TREE` requires it.
 SET enable_analyzer = 1;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/113470
Related: https://github.com/ClickHouse/ClickHouse/pull/117595
Related: https://github.com/ClickHouse/ClickHouse/issues/116852
Related: https://github.com/ClickHouse/ClickHouse/pull/117293


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results when an `AND` chain compares a value that carries its own type: a `Variant`, `Dynamic` or `JSON`, at any depth. Such a value is compared by its type's position in the name-sorted alternative list before its value, which is neither the order `optimize_redundant_comparisons` (enabled by default since 26.7) prunes with nor an order a `NOT IN` set can hold, so a bound that excludes a row could be dropped and the row returned. That merge is not gated by the setting.

### Description

`optimize_redundant_comparisons` prunes a comparison implied by another on the same expression, ordering the constants' `Field` values by type tag. A `Variant`, `Dynamic` or `JSON` value carries its own type, and `IColumn::compareAt` orders it by that type's place in the name-sorted alternative list before the value. For `Variant(Float64, Int64)` the two orders are reversed, so the bound judged looser is the one that excludes the row. A `Field` cannot carry the discriminator, so the screen is on the type: pruning, folding and the `notIn` merge are declined when either operand is or contains one.

At pure defaults, on `Array(Dynamic)` holding `[1.0::Float64]`, `a >= [1.0::Float64]::Array(Dynamic) AND a >= [2::Int64]::Array(Dynamic)` answered 1 where the second bound alone answers 0; `Array(JSON)`, `Array(Variant(Float64, Int64))` and top-level `JSON` behave the same. `Date` and `UInt64` are one `Field` type, so the duplicate-`notEquals` map also dropped one of two different conditions on `Array(Variant(Date, UInt64))`; keeping both can push the chain past `optimize_min_inequality_conjunction_chain_length`, where the `notIn` set has the same blind spot. That merge is not gated by the setting: it answered 1 for one constant order at defaults and for both with the setting off; all answer 0 now.

Where the two orders agree (`Variant(Int64, String)`) or the `JSON` is fully typed, a sound fold is forgone, on answers that were already correct. #117595 asserts one such fold survives, so whichever merges second updates that arm. This subsumes #113470, which screens only `Variant` and only the expression side; it can be closed as superseded.

Pre-existing: the `OR`-side `equals`-to-`IN` rewrite, never fed by this pass, rebuilds its constants from `Field`s with no screen and drops a row at defaults. A different mechanism, so it gets its own PR; the `accurateEquals` divergence there is separate again (#116852, #117293).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117637&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117637](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117637+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

