### PR TITLE
Docs: Fix documentation MCP contextual menu link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,7 @@
       "download-pdf",
       {
         "description": "Setup instructions for the ClickHouse documentation MCP server",
-        "href": "https://clickhouse.com/docs",
+        "href": "https://clickhouse.com/docs/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server",
         "icon": "/images/icons/icon-mcp.svg",
         "title": "Set up the ClickHouse documentation MCP server"
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,7 @@
       "download-pdf",
       {
         "description": "Setup instructions for the ClickHouse documentation MCP server",
-        "href": "/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server",
+        "href": "https://clickhouse.com/docs",
         "icon": "/images/icons/icon-mcp.svg",
         "title": "Set up the ClickHouse documentation MCP server"
       }


### PR DESCRIPTION
Point the documentation MCP shortcut in the contextual menu to the dedicated setup guide at `https://clickhouse.com/docs/resources/support-center/knowledge-base/setup-installation/set-up-clickhouse-documentation-mcp-server`. The previous root-relative target omitted the `/docs` deployment prefix and opened a `404` page.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the documentation MCP shortcut in the contextual menu so it opens the dedicated setup guide instead of a `404` page.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117638&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117638](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117638+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.538` (included in `26.9` and later)
<!-- ch-version-info:end -->