### PR TITLE
Mark the multi-threaded `groupArrayInsertAt` documentation example as unstable

### DIFF
--- a/tests/docs_examples/known_failures.txt
+++ b/tests/docs_examples/known_failures.txt
@@ -6,6 +6,7 @@
 # shows, and `unstable` means its output is random and any outcome is accepted.
 # An entry is not an excuse: fix the example and drop the line whenever you can.
 
+AggregateFunction/groupArrayInsertAt#3    unstable  # every thread inserts at the same position, and the documentation says the surviving value is undetermined
 AggregateFunction/groupArraySample#0      unstable  # the output is not the same on every run
 AggregateFunction/groupArraySample#2      unstable  # the output is not the same on every run
 AggregateFunction/kolmogorovSmirnovTest#0 unstable  # the output is not the same on every run


### PR DESCRIPTION
The `Docs examples` job fails at random on `AggregateFunction/groupArrayInsertAt#3`:

```sql
SELECT groupArrayInsertAt(number, 0) FROM numbers_mt(10) SETTINGS max_block_size = 1;
```

That example is the one demonstrating what happens when several threads insert at the same position, and the documentation of the function says it right above: "If a query is executed in multiple threads, the resulting value is an undetermined one of the inserted values". The example nevertheless pins the response to `[0]`, so the job fails whenever another thread wins the race - it observed `[1]`.

The example is worth keeping, because the undetermined result is the thing it illustrates, so it goes to `tests/docs_examples/known_failures.txt` as `unstable`, where any outcome is accepted, next to the other examples whose output is random.

Seen in https://s3.amazonaws.com/clickhouse-test-reports/PRs/117173/e9671f9b38e3773493460976980a62741a07cc91/docs_examples/docs_examples_report.html

Related: https://github.com/ClickHouse/ClickHouse/pull/117173

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117646&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117646](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117646+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
