### PR TITLE
Restore pooling of non-poolable serializations in DataTypesCache

### DIFF
--- a/src/DataTypes/DataTypesCache.cpp
+++ b/src/DataTypes/DataTypesCache.cpp
@@ -129,13 +129,7 @@ SerializationPtr DataTypesCache::getSerialization(const String & type_name)
     if (const auto * elem = getSimpleDataTypesCache().findByName(type_name))
         return elem->serialization;
 
-    const auto & element = getCacheElement(type_name);
-    if (element.serialization)
-        return element.serialization;
-
-    /// The default serialization of this type is non-poolable (see getCacheElement),
-    /// so it must be rebuilt fresh for every use.
-    return element.type->getDefaultSerialization();
+    return getCacheElement(type_name).serialization;
 }
 
 SerializationPtr DataTypesCache::getSerialization(const String & type_name, const DataTypePtr & type)
@@ -144,13 +138,7 @@ SerializationPtr DataTypesCache::getSerialization(const String & type_name, cons
     if (const auto * elem = getSimpleDataTypesCache().findByName(type_name))
         return elem->serialization;
 
-    const auto & element = getCacheElement(type_name, &type);
-    if (element.serialization)
-        return element.serialization;
-
-    /// The default serialization of this type is non-poolable (see getCacheElement),
-    /// so it must be rebuilt fresh for every use.
-    return element.type->getDefaultSerialization();
+    return getCacheElement(type_name, &type).serialization;
 }
 
 void DataTypesCache::clearIfQueryContextChanged()
@@ -195,18 +183,7 @@ const DataTypesCache::Element & DataTypesCache::getCacheElement(const String & t
         cache.clear();
 
     auto type = known_type ? *known_type : DataTypeFactory::instance().get(type_name);
-    auto serialization = type->getDefaultSerialization();
-
-    /// A serialization with `supportsPooling() == false` must not be shared across uses:
-    /// it keeps mutable per-use state (e.g. SerializationJSON accumulates caches inside its
-    /// extraction tree; the property propagates through wrapper serializations of composite
-    /// types). The type itself is an immutable value object and is safe to cache, so cache
-    /// only the type and leave the serialization null; getSerialization rebuilds a fresh
-    /// serialization on every lookup for such types.
-    if (!serialization->supportsPooling())
-        serialization = nullptr;
-
-    it = cache.emplace(type_name, Element{type, std::move(serialization)}).first;
+    it = cache.emplace(type_name, Element{type, type->getDefaultSerialization()}).first;
     return it->second;
 }
 

--- a/src/DataTypes/DataTypesCache.h
+++ b/src/DataTypes/DataTypesCache.h
@@ -80,11 +80,20 @@ const SimpleDataTypesCache & getSimpleDataTypesCache();
 /// documented example is exactly the timezone case this cache already invalidates
 /// on). Reuse *within* one query is already an established, trusted pattern for the
 /// very same object (see ColumnDynamic's per-column `serialization_cache`, used
-/// throughout its binary insert/deserialize paths). One narrower gap is accepted:
-/// `DataTypeObject::doGetSerialization` also reads `allow_simdjson` at construction,
-/// which this cache does not track, so a client session that flips it in place keeps
-/// the previously-built parser until invalidated for another reason; this only
-/// selects between two semantically equivalent JSON parsers, not a correctness issue.
+/// throughout its binary insert/deserialize paths).
+///
+/// IMPORTANT: this safety only holds for the ways SerializationJSON is currently used
+/// through this cache (type resolution, binary serialization, and text *output*) - none
+/// of which touch the mutable extraction-tree caches or the parser choice. A cached
+/// serialization from here must never be used for *text deserialization*: that path is
+/// exactly what SerializationJSON::create's "do NOT pool" comment is about, and two
+/// gaps this cache does not track would then matter. First, `DataTypeObject::doGetSerialization`
+/// reads `allow_simdjson` at construction; a client session that flips it in place would
+/// keep the previously-built parser, and rapidjson (`RAPIDJSON_PARSE_DEFAULT_FLAGS` lacks
+/// `kParseFullPrecisionFlag`) is not a drop-in replacement for simdjson's parsing the way
+/// it is for output - it can round Float64 differently and has no nesting-depth cap. Second,
+/// the extraction tree's caches would then legitimately accumulate per-query state and need
+/// the same cross-query invalidation this cache does not extend to their internals.
 class DataTypesCache
 {
 public:

--- a/src/DataTypes/DataTypesCache.h
+++ b/src/DataTypes/DataTypesCache.h
@@ -73,13 +73,18 @@ const SimpleDataTypesCache & getSimpleDataTypesCache();
 /// does this between queries of one session); otherwise a stale entry produces
 /// wrong results (e.g. DateTime values rendered in another query's timezone).
 ///
-/// Serializations with `supportsPooling() == false` (e.g. SerializationJSON, which
-/// holds mutable per-use state, see the comment in SerializationJSON::create) are
-/// never cached at all, not even within one query: for them only the type is cached
-/// and a fresh serialization is built on every lookup. Note that query-scoped
-/// invalidation alone would not be enough for them anyway: clickhouse-client keeps
-/// one client context attached to the client thread for the whole session, so
-/// consecutive client queries can share one "query scope".
+/// This scoping is also what makes it safe to pool serializations with
+/// `supportsPooling() == false` here, e.g. SerializationJSON: its own contract
+/// (see the comment in SerializationJSON::create) forbids sharing *across queries*,
+/// because its extraction tree accumulates mutable, context-dependent state (its
+/// documented example is exactly the timezone case this cache already invalidates
+/// on). Reuse *within* one query is already an established, trusted pattern for the
+/// very same object (see ColumnDynamic's per-column `serialization_cache`, used
+/// throughout its binary insert/deserialize paths). One narrower gap is accepted:
+/// `DataTypeObject::doGetSerialization` also reads `allow_simdjson` at construction,
+/// which this cache does not track, so a client session that flips it in place keeps
+/// the previously-built parser until invalidated for another reason; this only
+/// selects between two semantically equivalent JSON parsers, not a correctness issue.
 class DataTypesCache
 {
 public:
@@ -101,9 +106,6 @@ private:
     struct Element
     {
         DataTypePtr type;
-        /// Null if the default serialization of `type` has `supportsPooling() == false`:
-        /// such serializations keep mutable per-use state and must be rebuilt for every use
-        /// instead of being served from the cache.
         SerializationPtr serialization;
     };
 

--- a/src/DataTypes/tests/gtest_data_types_cache.cpp
+++ b/src/DataTypes/tests/gtest_data_types_cache.cpp
@@ -114,7 +114,7 @@ TEST(DataTypesCache, InvalidatesNonPoolableSerializationsAcrossQueries)
     ResetCurrentThreadGuard reset_current_thread;
     ThreadStatus thread_status;
 
-    ISerialization * first_serialization_ptr = nullptr;
+    const ISerialization * first_serialization_ptr = nullptr;
     {
         auto query_context = makeQueryContext("data_types_cache_test_non_poolable_query_1", "UTC");
         auto query_scope = QueryScope::create(query_context);

--- a/src/DataTypes/tests/gtest_data_types_cache.cpp
+++ b/src/DataTypes/tests/gtest_data_types_cache.cpp
@@ -86,26 +86,49 @@ TEST(DataTypesCache, InvalidatedOnQueryContextChange)
     }
 }
 
-TEST(DataTypesCache, DoesNotPoolNonPoolableSerializations)
+TEST(DataTypesCache, PoolsNonPoolableSerializationsWithinOneQuery)
 {
     ResetCurrentThreadGuard reset_current_thread;
     ThreadStatus thread_status;
 
-    auto query_context = makeQueryContext("data_types_cache_test_non_poolable", "UTC");
+    auto query_context = makeQueryContext("data_types_cache_test_non_poolable_same_query", "UTC");
     auto query_scope = QueryScope::create(query_context);
 
-    /// The JSON type itself is an immutable value object and is safe to cache...
+    /// SerializationJSON has supportsPooling() == false (it holds mutable per-use state in
+    /// its extraction tree, see the comment in SerializationJSON::create), but its contract
+    /// only forbids reuse *across queries*: within one query, on one thread, pooling one
+    /// instance across many lookups (and hence many rows) is the same trusted pattern
+    /// ColumnDynamic's per-column serialization_cache already relies on.
     auto first_type = getDataTypesCache().getType("JSON");
     auto second_type = getDataTypesCache().getType("JSON");
     ASSERT_EQ(first_type.get(), second_type.get());
 
-    /// ...but SerializationJSON holds mutable per-use state (`supportsPooling() == false`,
-    /// see the comment in SerializationJSON::create), so even within one query the cache
-    /// must build a fresh serialization on every lookup instead of pooling one instance.
     auto first_serialization = getDataTypesCache().getSerialization("JSON");
     auto second_serialization = getDataTypesCache().getSerialization("JSON");
     ASSERT_FALSE(first_serialization->supportsPooling());
-    ASSERT_NE(first_serialization.get(), second_serialization.get());
+    ASSERT_EQ(first_serialization.get(), second_serialization.get());
+}
+
+TEST(DataTypesCache, InvalidatesNonPoolableSerializationsAcrossQueries)
+{
+    ResetCurrentThreadGuard reset_current_thread;
+    ThreadStatus thread_status;
+
+    ISerialization * first_serialization_ptr = nullptr;
+    {
+        auto query_context = makeQueryContext("data_types_cache_test_non_poolable_query_1", "UTC");
+        auto query_scope = QueryScope::create(query_context);
+        first_serialization_ptr = getDataTypesCache().getSerialization("JSON").get();
+    }
+
+    /// A new query on the same thread must not be served the previous query's pooled
+    /// SerializationJSON instance: pooling supportsPooling() == false serializations is
+    /// only safe because the cache is cleared on every query-context change.
+    {
+        auto query_context = makeQueryContext("data_types_cache_test_non_poolable_query_2", "UTC");
+        auto query_scope = QueryScope::create(query_context);
+        ASSERT_NE(getDataTypesCache().getSerialization("JSON").get(), first_serialization_ptr);
+    }
 }
 
 TEST(DataTypesCache, InvalidatedOnSessionTimezoneChangeWithinOneContext)

--- a/src/DataTypes/tests/gtest_data_types_cache.cpp
+++ b/src/DataTypes/tests/gtest_data_types_cache.cpp
@@ -114,11 +114,15 @@ TEST(DataTypesCache, InvalidatesNonPoolableSerializationsAcrossQueries)
     ResetCurrentThreadGuard reset_current_thread;
     ThreadStatus thread_status;
 
-    const ISerialization * first_serialization_ptr = nullptr;
+    /// Kept alive (not just its raw address) across both query scopes: if only the address
+    /// were recorded, the first cache entry could be destroyed once its query scope ends,
+    /// and an unrelated later allocation could reuse the same address, making the comparison
+    /// below pass even when invalidation was actually broken.
+    SerializationPtr first_serialization;
     {
         auto query_context = makeQueryContext("data_types_cache_test_non_poolable_query_1", "UTC");
         auto query_scope = QueryScope::create(query_context);
-        first_serialization_ptr = getDataTypesCache().getSerialization("JSON").get();
+        first_serialization = getDataTypesCache().getSerialization("JSON");
     }
 
     /// A new query on the same thread must not be served the previous query's pooled
@@ -127,7 +131,7 @@ TEST(DataTypesCache, InvalidatesNonPoolableSerializationsAcrossQueries)
     {
         auto query_context = makeQueryContext("data_types_cache_test_non_poolable_query_2", "UTC");
         auto query_scope = QueryScope::create(query_context);
-        ASSERT_NE(getDataTypesCache().getSerialization("JSON").get(), first_serialization_ptr);
+        ASSERT_NE(getDataTypesCache().getSerialization("JSON").get(), first_serialization.get());
     }
 }
 

--- a/tests/performance/json_to_string.xml
+++ b/tests/performance/json_to_string.xml
@@ -5,6 +5,9 @@
     <create_query>
         CREATE TABLE json_to_string_shared_data (id UInt64, payload JSON(max_dynamic_paths=0)) ENGINE = MergeTree ORDER BY id
     </create_query>
+    <create_query>
+        CREATE TABLE json_to_string_dynamic (id UInt64, payload Dynamic) ENGINE = MergeTree ORDER BY id
+    </create_query>
 
     <fill_query>
         INSERT INTO json_to_string
@@ -22,12 +25,18 @@
         FROM numbers(500000)
     </fill_query>
     <fill_query>INSERT INTO json_to_string_shared_data SELECT * FROM json_to_string</fill_query>
+    <fill_query>INSERT INTO json_to_string_dynamic SELECT * FROM json_to_string</fill_query>
     <fill_query>OPTIMIZE TABLE json_to_string FINAL</fill_query>
     <fill_query>OPTIMIZE TABLE json_to_string_shared_data FINAL</fill_query>
+    <fill_query>OPTIMIZE TABLE json_to_string_dynamic FINAL</fill_query>
 
     <query>SELECT sum(length(toString(payload))) FROM json_to_string</query>
     <query>SELECT sum(length(toString(payload))) FROM json_to_string_shared_data</query>
+    <!-- Dynamic(JSON): exercises SerializationDynamic's text fast path resolving a
+         non-poolable SerializationJSON through DataTypesCache, not just plain JSON. -->
+    <query>SELECT sum(length(toString(payload))) FROM json_to_string_dynamic</query>
 
     <drop_query>DROP TABLE IF EXISTS json_to_string</drop_query>
     <drop_query>DROP TABLE IF EXISTS json_to_string_shared_data</drop_query>
+    <drop_query>DROP TABLE IF EXISTS json_to_string_dynamic</drop_query>
 </test>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/115852

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/115852, which merged before a last review comment was addressed: https://github.com/ClickHouse/ClickHouse/pull/115852#discussion_r3908158608

That PR's `DataTypesCache` fix made `getCacheElement` skip caching the serialization for types with `supportsPooling() == false` (e.g. `SerializationJSON`), to avoid a correctness bug where a query-context-dependent serialization (like `DateTime`'s baked-in `session_timezone`) could leak across queries on the same long-lived server thread. That was more conservative than necessary, and it reintroduced the exact performance regression the original PR fixed, but narrowed to `Dynamic(JSON)`: `SerializationDynamic`'s text fast path was rebuilding a fresh `SerializationJSON` on every row again.

`supportsPooling()`'s contract, and `SerializationJSON`'s own documented failure mode, are specifically about reuse *across queries* (its documented example is exactly the timezone case). `DataTypesCache` already prevents that: it's thread-local, and is cleared on every query-context change and on `session_timezone` mutation (added by the same earlier PR). Reuse *within* one query is an already-established, trusted pattern for the very same objects, via `ColumnDynamic`'s own per-column `serialization_cache`.

I considered instead routing the text-serialization path through that per-column cache directly (as one reviewer suggested), but a `ColumnDynamic` instance is not always exclusive to one query: `StorageMemory` and the query result cache can hand the very same column instance to concurrently-running queries, and that cache has no invalidation hook at all, so pooling from the read side there would both race and reintroduce cross-query staleness. The thread-local cache with query/timezone-scoped invalidation is the safe place for this.

Also extends the perf test added by the original PR with a `Dynamic` column holding `JSON` values (the previously-unproven path), and replaces the gtest asserting non-pooling with one asserting pooling within a query plus invalidation across queries.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Internal follow-up correcting an implementation detail from an unreleased change; no user-visible behavior change beyond restoring the intended performance characteristics of https://github.com/ClickHouse/ClickHouse/pull/115852 for `Dynamic(JSON)` text output.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117655&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117655](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117655+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.560` (included in `26.9` and later)
- Backported to: `26.8.3.17`, `26.7.7.13`, `26.6.5.94`
<!-- ch-version-info:end -->