### PR TITLE
Pin background Iceberg compaction off in 05048_iceberg_metadata_deeper_than_table_path

### DIFF
--- a/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
+++ b/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
@@ -14,8 +14,8 @@ DIR="05048_iceberg_deeper/${CLICKHOUSE_TEST_UNIQUE_NAME}"
 NC="--use_iceberg_metadata_files_cache 0"
 
 # Background Iceberg compaction, which the cloud build runs off a member flag rather than a
-# query setting, would rewrite and lock the metadata these arms read. The table functions have
-# no table definition to store the per-table setting in, so it is pinned for every query too.
+# query setting, would rewrite and lock the metadata these arms read. It is pinned off on every
+# carrier: stored per table, inline per table function, and query-level for everything else.
 CLICKHOUSE_CLIENT="${CLICKHOUSE_CLIENT} --allow_experimental_iceberg_compaction 0"
 
 # t1: metadata `location` is an absolute path (the default).
@@ -29,13 +29,16 @@ ${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
 
 echo -n 'A control  '
 ${CLICKHOUSE_CLIENT} $NC -q "
-    SELECT groupArray(x) FROM (SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t1/sub') ORDER BY x)"
+    SELECT groupArray(x) FROM (
+        SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t1/sub',
+            SETTINGS allow_experimental_iceberg_compaction = 0) ORDER BY x)"
 
 echo -n 'B absolute '
 ${CLICKHOUSE_CLIENT} $NC -q "
     SELECT groupArray(x) FROM (
         SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t1',
-            SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json') ORDER BY x)"
+            SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json',
+                allow_experimental_iceberg_compaction = 0) ORDER BY x)"
 
 # t2: metadata `location` is a full URI.
 ${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 --write_full_path_in_iceberg_metadata 1 -q "
@@ -50,7 +53,8 @@ echo -n 'C full-uri '
 ${CLICKHOUSE_CLIENT} $NC -q "
     SELECT groupArray(x) FROM (
         SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t2',
-            SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json') ORDER BY x)"
+            SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json',
+                allow_experimental_iceberg_compaction = 0) ORDER BY x)"
 
 # t3: `location` names a directory DEEPER than the one the metadata document sits in, so the
 # document's own position is the only sound source for the table root. Re-rooting at the queried
@@ -87,7 +91,9 @@ print(json.dumps(m))
 
 echo -n 'D kept     '
 ${CLICKHOUSE_CLIENT} $NC -q "
-    SELECT groupArray(x) FROM (SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t3') ORDER BY x)"
+    SELECT groupArray(x) FROM (
+        SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t3',
+            SETTINGS allow_experimental_iceberg_compaction = 0) ORDER BY x)"
 
 # Every operation scoped to the queried path would reach the sibling tables under it, so all of
 # them are refused while the table root had to be derived. One arm per refusing site.
@@ -144,7 +150,8 @@ echo -n 'L kept     '
 ${CLICKHOUSE_CLIENT} $NC -q "
     SELECT groupArray(x) FROM (
         SELECT x FROM icebergS3(s3_conn, filename = '${DIR}/t4',
-            SETTINGS iceberg_metadata_file_path = 'archive/metadata/v2.metadata.json') ORDER BY x)"
+            SETTINGS iceberg_metadata_file_path = 'archive/metadata/v2.metadata.json',
+                allow_experimental_iceberg_compaction = 0) ORDER BY x)"
 
 ${CLICKHOUSE_CLIENT} $NC -q "
     DROP TABLE IF EXISTS t4_arch_05048;

--- a/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
+++ b/tests/queries/0_stateless/05048_iceberg_metadata_deeper_than_table_path.sh
@@ -13,10 +13,16 @@ DIR="05048_iceberg_deeper/${CLICKHOUSE_TEST_UNIQUE_NAME}"
 # The Iceberg metadata files cache would serve the copy read while the table was created.
 NC="--use_iceberg_metadata_files_cache 0"
 
+# Background Iceberg compaction, which the cloud build runs off a member flag rather than a
+# query setting, would rewrite and lock the metadata these arms read. The table functions have
+# no table definition to store the per-table setting in, so it is pinned for every query too.
+CLICKHOUSE_CLIENT="${CLICKHOUSE_CLIENT} --allow_experimental_iceberg_compaction 0"
+
 # t1: metadata `location` is an absolute path (the default).
 ${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
     DROP TABLE IF EXISTS t1_05048;
-    CREATE TABLE t1_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t1/sub');
+    CREATE TABLE t1_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t1/sub')
+    SETTINGS allow_experimental_iceberg_compaction = 0;
     INSERT INTO t1_05048 VALUES (1, 'a'), (2, 'b'), (3, 'c');
     DROP TABLE t1_05048;
 "
@@ -34,7 +40,8 @@ ${CLICKHOUSE_CLIENT} $NC -q "
 # t2: metadata `location` is a full URI.
 ${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 --write_full_path_in_iceberg_metadata 1 -q "
     DROP TABLE IF EXISTS t2_05048;
-    CREATE TABLE t2_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t2/sub');
+    CREATE TABLE t2_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t2/sub')
+    SETTINGS allow_experimental_iceberg_compaction = 0;
     INSERT INTO t2_05048 VALUES (1, 'a'), (2, 'b'), (3, 'c');
     DROP TABLE t2_05048;
 "
@@ -50,7 +57,8 @@ ${CLICKHOUSE_CLIENT} $NC -q "
 # path must be kept here.
 ${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
     DROP TABLE IF EXISTS t3_05048;
-    CREATE TABLE t3_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t3');
+    CREATE TABLE t3_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t3')
+    SETTINGS allow_experimental_iceberg_compaction = 0;
     INSERT INTO t3_05048 VALUES (7, 'd'), (8, 'e');
     DROP TABLE t3_05048;
 "
@@ -86,7 +94,7 @@ ${CLICKHOUSE_CLIENT} $NC -q "
 ${CLICKHOUSE_CLIENT} $NC -q "
     DROP TABLE IF EXISTS t1_deep_05048;
     CREATE TABLE t1_deep_05048 ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t1')
-    SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json';
+    SETTINGS iceberg_metadata_file_path = 'sub/metadata/v2.metadata.json', allow_experimental_iceberg_compaction = 0;
 "
 echo -n 'E insert   '
 ${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 -q "
@@ -120,7 +128,8 @@ ${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 --allow_iceb
 # disagree and the table root must NOT be derived. Reads and writes stay as they are.
 ${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
     DROP TABLE IF EXISTS t4_05048;
-    CREATE TABLE t4_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t4');
+    CREATE TABLE t4_05048 (x UInt32, s String) ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t4')
+    SETTINGS allow_experimental_iceberg_compaction = 0;
     INSERT INTO t4_05048 VALUES (5, 'g'), (6, 'h');
     DROP TABLE t4_05048;
 "
@@ -140,7 +149,7 @@ ${CLICKHOUSE_CLIENT} $NC -q "
 ${CLICKHOUSE_CLIENT} $NC -q "
     DROP TABLE IF EXISTS t4_arch_05048;
     CREATE TABLE t4_arch_05048 ENGINE = IcebergS3(s3_conn, filename = '${DIR}/t4')
-    SETTINGS iceberg_metadata_file_path = 'archive/metadata/v2.metadata.json';
+    SETTINGS iceberg_metadata_file_path = 'archive/metadata/v2.metadata.json', allow_experimental_iceberg_compaction = 0;
 "
 echo -n 'M write    '
 if ${CLICKHOUSE_CLIENT} $NC --allow_experimental_insert_into_iceberg 1 -q "


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/96978
Related: https://github.com/ClickHouse/ClickHouse/pull/117037
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/96978
Related: https://github.com/ClickHouse/ClickHouse/pull/117037

`Stress test (amd_debug, SharedCatalog, meta in keeper)` on the ClickHouse Inc sync pull request
logs a background failure naming this test's own directories:

```
BackgroundJobsAssignee::threadFunc(): Code: 499 ... S3_ERROR No such key
  while reading key: .../t4/metadata/compaction.lock
```

No public build can produce that read, so I claim no reproducer. `isBackgroundExecutable` has no
override, so the assignee never starts, and `IcebergMetadata::optimize` reaches the background
generator only inside `#if CLICKHOUSE_CLOUD`, off a member that does not exist here. CIDB
has no test context mentioning `compaction.lock` from 2026-06-04 to 2026-09-02, and from
2026-08-03 to 2026-09-02 this test is green in every public lane (8454 `OK`, 0 `FAIL`). No public
CI report URL exists: the run is on the private sync pull request.

The test arms machinery it never meant to exercise. It creates six Iceberg tables
and calls `icebergS3` five times; both paths run `StorageObjectStorage::startup`, so all
eleven can start a compactor on a root the test keeps mutating. Three share the `t4` root named in
the error. The key sits under `t4/metadata/` rather than `t4/archive/metadata/` because
`iceberg_metadata_file_path` only moves where the document is read from; the table root, and with
it the lock, stays the queried path.

So I pin compaction off on all three carriers: the stored setting on the six `CREATE TABLE`
statements, the same setting inline in the `SETTINGS` clause of the five `icebergS3` calls, and
the query-level flag on the client. @ PedroTadim used the stored pin in
`05045_iceberg_manifest_partition_arity` (`e6d78702ea0875c`). An inline value lands where a stored
one would: `TableFunctionObjectStorage::parseArguments` loads that clause into the
`DataLakeStorageSettings` object the configuration returns from `getDataLakeSettings`. The
`.reference` is unchanged, all thirteen arms still produce it byte for byte.

Whether the cloud side should tolerate an absent lock object is a separate question, on code I
cannot see.


<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117685&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117685](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117685+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.574` (included in `26.9` and later)
- Backported to: `26.8.3.53`
<!-- ch-version-info:end -->