### PR TITLE
Resolve the master `clickhouse-examples` binary under its workflow prefix

### DIFF
--- a/ci/jobs/parser_memory_check.py
+++ b/ci/jobs/parser_memory_check.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from ci.praktika._environment import _Environment
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.utils import Shell, Utils
@@ -70,7 +71,10 @@ def get_merge_base_profiler_url() -> str:
     for sha in commits:
         if not re.fullmatch(r"[0-9a-f]{40}", sha):
             continue
-        url = f"{MASTER_PROFILER_BASE_URL}/REFs/master/{sha}/build_arm_release/clickhouse-examples"
+        prefix = _Environment.get_s3_prefix_static(
+            pr_number=0, branch="master", sha=sha, workflow_name="MasterCI"
+        )
+        url = f"{MASTER_PROFILER_BASE_URL}/{prefix}/build_arm_release/clickhouse-examples"
         if Shell.check(f"curl -sfI '{url}' > /dev/null"):
             print(f"Using master binary from commit {sha[:12]}")
             return url


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Parser memory check` erroring on every pull request because it looked for the master `clickhouse-examples` build artifact under its pre-cutover S3 key.

### Description

`Parser memory check` errors in its `Resolve master binary` step before running anything, with ``No master `clickhouse-examples` artifact was found``. The first error started 2026-09-02 10:14:18Z; 58 runs across 57 pull requests had errored by 13:41:07Z. The job sets no `allow_failure`, so it blocks `Mergeable Check`.

`get_merge_base_profiler_url` hand-spelled the artifact key as `REFs/master/<sha>/build_arm_release/clickhouse-examples`. Praktika builds that key with `_Environment.get_s3_prefix_static`, which now appends the normalized workflow name unconditionally, after `_should_include_workflow_name_in_s3_prefix` was deleted in #110081 (merged 2026-08-31). That helper suppressed the segment for exactly the pr/main/master flows, which is why the hand-spelled key used to be correct. The artifact now lives at `REFs/master/<sha>/masterci/build_arm_release/clickhouse-examples`, matching the link `Build (arm_release)` records in its own `MasterCI` report.

The loop returns the first sha in `master_track_commits_sha` that resolves, and that window is 100 first-parent master commits, currently 1.99 days, its oldest already newer than the cutover. That is why the break arrived two days after that merge, why a run configured earlier can still be green, and why a legacy fallback would rescue nothing.

So I ask praktika for the prefix instead of restating it; a later prefix change then follows automatically. Merged sibling #117580 spells the segment by hand in `bugfix_validation`; say the word and I will match it in one line.

Validation, calling the real function against the live window: 0 of 100 shas resolve before the change, 54 after, first at depth 7. A master sha with no published build resolves on neither path. The job runs from this pull request's own tree, so it is its own end-to-end test.

Not fixed here: the same layout in `performance_tests.py`, `llvm_coverage_job.py`, `update_toolchain_dockerfile.py`, `generate_diff_coverage_report.sh`, `binary-builder/Dockerfile`, `retry_infra_failures.yml`, and `ci/CLAUDE.md`. Each reads a different workflow, so each needs its own segment.

No related open issue found.

Reported by @ bacek at https://github.com/ClickHouse/ClickHouse/pull/116552#issuecomment-5508709751
CI report: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=116552&sha=d5fa6652f262ce060c04c2206ec141660a43d597&name_0=PR&name_1=Parser%20memory%20check

Related: https://github.com/ClickHouse/ClickHouse/pull/116552

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117701&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117701](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117701+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
