### PR TITLE
docs: remove private-preview badge from Managed Postgres migrations FAQ

### DIFF
--- a/docs/products/managed-postgres/migrations/faq.mdx
+++ b/docs/products/managed-postgres/migrations/faq.mdx
@@ -7,10 +7,6 @@ keywords: ['postgres', 'migration', 'faq', 'managed postgres', 'logical replicat
 doc_type: 'reference'
 ---
 
-import { PrivatePreviewBadge } from "/snippets/components/PrivatePreviewBadge/PrivatePreviewBadge.jsx";
-
-<PrivatePreviewBadge link="https://clickhouse.com/cloud/postgres" galaxyTrack={true} slug="migrations-faq" />
-
 Many questions about how Postgres replication works — including `TOAST` columns, replication slots, publications, schema changes, and data type mappings — are covered in the [ClickPipes for Postgres FAQ](/integrations/clickpipes/postgres/faq). The information there applies to ClickHouse Managed Postgres migrations as well.
 
 ### I'm seeing an "invalid input value for enum" error during replication {#invalid-enum-value}


### PR DESCRIPTION
The [Managed Postgres migrations FAQ](https://clickhouse.com/docs/products/managed-postgres/migrations/faq) still renders the "Private preview in ClickHouse Cloud" notice (`PrivatePreviewBadge`). This removes the badge import and component. Page content is unchanged.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117708&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117708](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117708+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.546` (included in `26.9` and later)
<!-- ch-version-info:end -->