### PR TITLE
Report the fatal message the CI failure scan found instead of a lost connection

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -171,6 +171,7 @@ common_ft_job_config = Job.Config(
         include_paths=[
             "./ci/jobs/functional_tests.py",
             "./ci/jobs/scripts/clickhouse_proc.py",
+            "./ci/jobs/scripts/log_parser.py",
             "./ci/jobs/scripts/server_cleanup.py",
             "./ci/jobs/scripts/functional_tests_results.py",
             "./ci/jobs/scripts/log_export.py",

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -18,6 +18,16 @@ class FuzzerLogParser:
         ", Stack trace (when copying this message, always include the lines below):"
     )
     MAX_INLINE_REPRODUCE_COMMANDS = 20
+    UNRECOGNIZED_FATAL_CONTEXT_LINES = 10
+    # ClickHouse log line: "2024.01.15 12:34:56.789 [ 123 ] {id} <Level>"
+    CLICKHOUSE_LOG_LINE_PATTERN = re.compile(
+        r"\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.\d+\s+\["
+    )
+    # A whole `<Fatal>` record start: query text logged at other levels can itself
+    # contain `<Fatal>`, so matching the level alone picks the wrong record.
+    FATAL_RECORD_PATTERN = (
+        r"^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.\d+\s+\[ \d+ \]\s+\{[^}]*\}\s+<Fatal>"
+    )
     SANITIZER_ERROR_PATTERN = (
         r"(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:.*|"
         r".*[a-zA-Z]+Sanitizer: CHECK failed:.*"
@@ -186,6 +196,28 @@ class FuzzerLogParser:
                 return ""
         return ""
 
+    def find_unrecognized_fatal(self):
+        # `LOG_FATAL` writes multi-line messages, so the matched line alone can omit the
+        # reason; the lines after it belong to this record only until the next record
+        # starts, and the matched line is itself a record - hence the scan starts at 1.
+        for log_file, pattern in (
+            (self.server_log, self.FATAL_RECORD_PATTERN),
+            (self.stderr_log, r"\w+Sanitizer:"),
+        ):
+            if not log_file:
+                continue
+            output = Shell.get_output(
+                f"rg --text -m1 -A {self.UNRECOGNIZED_FATAL_CONTEXT_LINES}"
+                f" '{pattern}' {log_file}"
+            )
+            if output:
+                lines = output.splitlines()
+                for i, line in enumerate(lines[1:], start=1):
+                    if self.CLICKHOUSE_LOG_LINE_PATTERN.match(line):
+                        return "\n".join(lines[:i])
+                return output
+        return ""
+
     def parse_failure(self):
         files = []
         is_logical_error = False
@@ -237,6 +269,16 @@ class FuzzerLogParser:
                 break
 
         if not error_output:
+            # The name stays `UNKNOWN_ERROR`: `stress_job` treats any other name as a
+            # definitive failure and stops looking at the remaining replicas, and
+            # `revert_ci_regressions` matches this exact string.
+            unrecognized_fatal = self.find_unrecognized_fatal()
+            if unrecognized_fatal:
+                return (
+                    self.UNKNOWN_ERROR,
+                    f"Unrecognized fatal message:\n{unrecognized_fatal}\n",
+                    files,
+                )
             return (
                 self.UNKNOWN_ERROR,
                 "Lost connection to server. See the logs.\n",
@@ -429,10 +471,7 @@ class FuzzerLogParser:
                 r"\b\w+Sanitizer: CHECK failed:|: runtime error: "
             )
             summary_pattern = re.compile(r"SUMMARY: \w+Sanitizer:")
-            # ClickHouse log line: "2024.01.15 12:34:56.789 [ 123 ] {id} <Level>"
-            clickhouse_log_line = re.compile(
-                r"\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}\.\d+\s+\["
-            )
+            clickhouse_log_line = self.CLICKHOUSE_LOG_LINE_PATTERN
 
             with open(log_file, "r", errors="replace") as file:
                 all_lines = file.readlines()

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -91,6 +91,9 @@ AWS_PROFILE = "default"
 #       )
 # LIMIT 100;
 TEST_FAILURE_PATTERNS = [
+    # Order is precedence: the first entry found in the output wins, so the specific
+    # ones belong above the generic tokens a log excerpt can also contain.
+    "Unrecognized fatal message:",
     # Common Functional tests failures
     "Timeout",
     "having stderror",


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/114923#issuecomment-5509539841
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
When a CI job's post-run log scan finds a `<Fatal>` record matching none of the known error patterns, the report now quotes that record instead of claiming `Lost connection to server`.


### Description

`ClickHouseProc.check_fatal_messages_in_logs` scans a finished job's logs for a `<Fatal>` record or a sanitizer report and only then calls `FuzzerLogParser.parse_failure` to name the failure. If none of the seven `ERROR_PATTERNS` matches, `parse_failure` discarded that record and returned a fixed description, `Lost connection to server. See the logs.` - a cause that was never observed.

`cidb.py` stores that description as `test_context_raw` and builds its failure filters from it, so the one distinguishing fact was destroyed where it is recorded. Measured 2026-09-02: all 23 `Unknown error` rows of the last 30 days - 15 check flavours, 4 job families, 3 on `master` - carry one of only two byte-identical descriptions, both claiming a lost connection.

On the run below, `Stateless tests (amd_debug, sequential)` reported `Failed: 0, Passed: 958` and still went red as `Unknown error` / lost connection, while its log held the real reason: an `ASTFuzzer` oracle mismatch naming the query.

This keeps the fallback and the row name `UNKNOWN_ERROR` - `stress_job` treats any other name as definitive when choosing between replica logs, and `revert_ci_regressions` matches it exactly - and puts the triggering record in the description, bounded so it cannot absorb the following record.

`log_parser.py` is also added to the `Stateless tests` cache digest, without which this fix is a cache hit on the family holding 11 of those rows; that line is severable. The new prefix is registered first in `TEST_FAILURE_PATTERNS`, where list order is precedence.

When no fatal record is found the text still reads `Lost connection to server`, which now means exactly that. Validated with a throwaway harness instead of a committed test, per `.claude/CLAUDE.md`: 39 arms, including the real logs below.

Failing run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=114923&sha=c23eaf1ff970637c31078d51ed4996d1cc710cec&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20sequential%29

Related: https://github.com/ClickHouse/ClickHouse/pull/114923#issuecomment-5509539841 - @ alexey-milovidov asked me to investigate this red and send the fix as a separate pull request.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117714&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117714](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117714+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
