### PR TITLE
CI: resolve the performance reference build under its workflow prefix

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -15,6 +15,7 @@ from threading import Thread
 
 import yaml
 
+from ci.defs.defs import S3_REPORT_BUCKET_HTTP_ENDPOINT
 from ci.jobs.scripts import log_export
 from ci.jobs.scripts.cidb_cluster import CIDBCluster
 from ci.jobs.scripts.dataset_download import download_and_extract_datasets
@@ -1447,6 +1448,14 @@ MASTER_RUN_INCOMPLETE = "incomplete"
 MASTER_WORKFLOW_RESULT_FILE = "result_masterci.json"
 
 
+def master_report_link(sha, file_name):
+    """Link to a report file published by `MasterCI` at master commit `sha`."""
+    prefix = _Environment.get_s3_prefix_static(
+        pr_number=0, branch="master", sha=sha, workflow_name="MasterCI"
+    )
+    return f"https://{S3_REPORT_BUCKET_HTTP_ENDPOINT}/{prefix}/{file_name}"
+
+
 def classify_missing_prev_master_run(job_name, sha):
     """Tell whether this job was ever scheduled at master commit `sha`, given
     that its `result_*.json` is missing there.
@@ -1472,10 +1481,7 @@ def classify_missing_prev_master_run(job_name, sha):
     or parsed. Those all stop the walk, and the caller falls back to the
     absolute gate for this one run - the next master run finds this run's own
     result and gets its delta back."""
-    link = (
-        "https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/"
-        f"{sha}/{MASTER_WORKFLOW_RESULT_FILE}"
-    )
+    link = master_report_link(sha, MASTER_WORKFLOW_RESULT_FILE)
     state, out = fetch_prev_master_result(link)
     if state == FETCH_MISSING:
         print(f"INFO: master commit {sha} has no {MASTER_WORKFLOW_RESULT_FILE}")
@@ -1529,7 +1535,7 @@ def find_prev_master_slower_count(job_name, commits, release_base_sha):
     before reaching the previous run that did measure this job."""
     result_file_name = f"result_{Utils.normalize_string(job_name)}.json"
     for sha in commits:
-        link = f"https://s3.amazonaws.com/clickhouse-test-reports/REFs/master/{sha}/{result_file_name}"
+        link = master_report_link(sha, result_file_name)
         state, out = fetch_prev_master_result(link)
         if state == FETCH_MISSING:
             if classify_missing_prev_master_run(job_name, sha) == MASTER_RUN_INCOMPLETE:

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -18,6 +18,7 @@ import yaml
 from ci.jobs.scripts import log_export
 from ci.jobs.scripts.cidb_cluster import CIDBCluster
 from ci.jobs.scripts.dataset_download import download_and_extract_datasets
+from ci.praktika._environment import _Environment
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.settings import Settings
@@ -1286,10 +1287,19 @@ def parse_args():
     return parser.parse_args()
 
 
+def master_build_link(sha, build_type):
+    """Ask praktika where `MasterCI` published the build of master commit `sha`,
+    so that a later change of the prefix layout is picked up here for free."""
+    prefix = _Environment.get_s3_prefix_static(
+        pr_number=0, branch="master", sha=sha, workflow_name="MasterCI"
+    )
+    return f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/{prefix}/{build_type}/clickhouse"
+
+
 def find_prev_build(info, build_type):
     commits = info.get_kv_data("master_track_commits_sha") or []
     for sha in commits:
-        link = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/{build_type}/clickhouse"
+        link = master_build_link(sha, build_type)
         if Shell.check(f"curl -sfI {link} > /dev/null"):
             return link
     return None
@@ -1299,7 +1309,7 @@ def find_base_release_build(info, build_type):
     commits = info.get_kv_data("release_branch_base_sha_with_predecessors") or []
     assert commits, "No commits found to fetch reference build"
     for sha in commits:
-        link = f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/{build_type}/clickhouse"
+        link = master_build_link(sha, build_type)
         if Shell.check(f"curl -sfI {link} > /dev/null"):
             return link
     return None
@@ -1768,9 +1778,7 @@ def main():
     if Utils.is_arm():
         if compare_against_master:
             link_for_ref_ch = find_prev_build(info, "build_arm_release")
-            if not link_for_ref_ch:
-                print("WARNING: No build found for master track commits, falling back to latest master build")
-                link_for_ref_ch = "https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/aarch64/clickhouse"
+            assert link_for_ref_ch, "reference clickhouse build has not been found"
         elif compare_against_release:
             link_for_ref_ch = find_base_release_build(info, "build_arm_release")
             assert link_for_ref_ch, "reference clickhouse build has not been found"
@@ -1779,9 +1787,7 @@ def main():
     elif Utils.is_amd():
         if compare_against_master:
             link_for_ref_ch = find_prev_build(info, "build_amd_release")
-            if not link_for_ref_ch:
-                print("WARNING: No build found for master track commits, falling back to latest master build")
-                link_for_ref_ch = "https://clickhouse-builds.s3.us-east-1.amazonaws.com/master/amd64/clickhouse"
+            assert link_for_ref_ch, "reference clickhouse build has not been found"
         elif compare_against_release:
             link_for_ref_ch = find_base_release_build(info, "build_amd_release")
             assert link_for_ref_ch, "reference clickhouse build has not been found"


### PR DESCRIPTION
`Performance Comparison` measures against a reference `clickhouse` built from master. `find_prev_build` and `find_base_release_build` in `ci/jobs/performance_tests.py` hand-spell that artifact's key as `REFs/master/<sha>/build_<type>/clickhouse`. Praktika builds it with `_Environment.get_s3_prefix_static`, which now appends the normalized workflow name unconditionally after `_should_include_workflow_name_in_s3_prefix` was deleted in #110081 (merged 2026-08-31). The artifact lives at `REFs/master/<sha>/masterci/build_<type>/clickhouse`.

The loop returns the first sha in `master_track_commits_sha` that resolves, so the failure was silent and had two phases.

Until 2026-09-02 13:55 every run pinned its "master head" reference to `2abd0f27` (2026-08-31 08:23), the last master commit built under the old layout, and every master change landed after it was reported as the pull request's own. On https://github.com/ClickHouse/ClickHouse/pull/117619, a `base58` change, 51 queries came back faster across 12 shards, 124 first-parent master commits of drift: `preliminary_distinct_abandoning #0` at 1.53x is #116508, merged inside that window, and `hashes`, `uniq_to_count`, `distinct_high_cardinality`, `promql_set_operator_presence_mask` and `wide_integer_division` are the same story.

From 13:56 the window slid past that commit, nothing resolved, and the job took its fallback: `WARNING: No build found for master track commits, falling back to latest master build`, then `master/aarch64/clickhouse`, a 185 MB stripped artifact from a different publishing job at an unrecorded sha, against the 1.2 GB CI build the comparison expects. Both the `master_head` pull request runs and the `MasterCI` runs that feed the dashboard baseline are affected.

So I ask praktika for the prefix rather than restating it, and drop the fallback. It is what turned a hard resolution failure into two days of quietly wrong numbers; an unresolved reference now asserts, as the `release_base` arm already did. `release_base` itself has not broken yet only because the release base shas predate the cutover, and it would have failed loudly rather than drifted.

Validation, calling the real function against the live 100-commit window: `build_arm_release` 0/100 resolve before the change and 58/100 after, first at depth 5; `build_amd_release` 0/100 and 52/100, first at depth 1.

The same cutover also broke the `release_base` delta gate in this file: `find_prev_master_slower_count` and `classify_missing_prev_master_run` read `REFs/master/<sha>/result_*.json` from the report bucket, which moved under `masterci/` too. Every predecessor now reads as missing, the walk classifies the whole tracking list as never scheduled, and the gate degrades to the absolute slower-count threshold. `result_masterci.json` resolves for none of the last 8 master commits under the old key and for 7 under the new one, the eighth having published no report at all. Second commit.

Caused by: https://github.com/ClickHouse/ClickHouse/pull/110081
Related: https://github.com/ClickHouse/ClickHouse/pull/117718
Related: https://github.com/ClickHouse/ClickHouse/pull/117701
Related: https://github.com/ClickHouse/ClickHouse/pull/117580

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the performance comparison measuring against a stale or unrelated reference binary after the CI S3 prefix change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117715&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117715](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117715+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.554` (included in `26.9` and later)
<!-- ch-version-info:end -->