### PR TITLE
Fix `Not-ready Set` when `additional_result_filter` contains an `IN` subquery

### DIFF
--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2138,7 +2138,8 @@ void addBuildSubqueriesForMaterializedCTEsIfNeeded(
 void addAdditionalFilterStepIfNeeded(QueryPlan & query_plan,
     const QueryNode & query_node,
     const SelectQueryOptions & select_query_options,
-    PlannerContextPtr & planner_context
+    PlannerContextPtr & planner_context,
+    UsefulSets & useful_sets
 )
 {
     if (select_query_options.subquery_depth != 0)
@@ -2196,6 +2197,7 @@ void addAdditionalFilterStepIfNeeded(QueryPlan & query_plan,
         filter_info.column_name,
         filter_info.do_remove_column);
     filter_step->setStepDescription("additional result filter");
+    appendSetsFromActionsDAG(filter_step->getExpression(), useful_sets);
     query_plan.addStep(std::move(filter_step));
 }
 
@@ -3040,7 +3042,7 @@ void Planner::buildPlanForQueryNode()
         }
 
         // For additional_result_filter setting
-        addAdditionalFilterStepIfNeeded(query_plan, query_node, select_query_options, planner_context);
+        addAdditionalFilterStepIfNeeded(query_plan, query_node, select_query_options, planner_context, useful_sets);
     }
 
     const auto & client_info = query_context->getClientInfo();

--- a/tests/queries/0_stateless/02346_additional_filters.reference
+++ b/tests/queries/0_stateless/02346_additional_filters.reference
@@ -276,3 +276,4 @@ select * from table_1 order by x settings additional_result_filter='x in (select
 2	bb
 select count() as c from table_1 settings additional_result_filter='c in (select 4)', enable_analyzer=1;
 4
+select count() as c from table_1 settings additional_result_filter='c in (select 3)', enable_analyzer=1;

--- a/tests/queries/0_stateless/02346_additional_filters.reference
+++ b/tests/queries/0_stateless/02346_additional_filters.reference
@@ -271,3 +271,6 @@ select * from (select x + 1 as a, y from table_1 union all select x as a, y from
 4	ccc
 4	dddd
 5	dddd
+select * from table_1 order by x settings additional_result_filter='x in (select number from numbers(3))';
+1	a
+2	bb

--- a/tests/queries/0_stateless/02346_additional_filters.reference
+++ b/tests/queries/0_stateless/02346_additional_filters.reference
@@ -274,3 +274,5 @@ select * from (select x + 1 as a, y from table_1 union all select x as a, y from
 select * from table_1 order by x settings additional_result_filter='x in (select number from numbers(3))';
 1	a
 2	bb
+select count() as c from table_1 settings additional_result_filter='c in (select 4)', enable_analyzer=1;
+4

--- a/tests/queries/0_stateless/02346_additional_filters.sql
+++ b/tests/queries/0_stateless/02346_additional_filters.sql
@@ -105,3 +105,4 @@ select * from (select x + 1 as a, y from table_1 union all select x as a, y from
 
 select * from table_1 order by x settings additional_result_filter='x in (select number from numbers(3))';
 select count() as c from table_1 settings additional_result_filter='c in (select 4)', enable_analyzer=1;
+select count() as c from table_1 settings additional_result_filter='c in (select 3)', enable_analyzer=1;

--- a/tests/queries/0_stateless/02346_additional_filters.sql
+++ b/tests/queries/0_stateless/02346_additional_filters.sql
@@ -102,3 +102,5 @@ select x + 1 from table_1 settings additional_result_filter='`plus(x, 1)` != 2';
 
 select * from (select x + 1 as a, y from table_1 union all select x as a, y from table_1) order by a, y settings additional_result_filter='a = 3';
 select * from (select x + 1 as a, y from table_1 union all select x as a, y from table_1) order by a, y settings additional_result_filter='a != 3';
+
+select * from table_1 order by x settings additional_result_filter='x in (select number from numbers(3))';

--- a/tests/queries/0_stateless/02346_additional_filters.sql
+++ b/tests/queries/0_stateless/02346_additional_filters.sql
@@ -104,3 +104,4 @@ select * from (select x + 1 as a, y from table_1 union all select x as a, y from
 select * from (select x + 1 as a, y from table_1 union all select x as a, y from table_1) order by a, y settings additional_result_filter='a != 3';
 
 select * from table_1 order by x settings additional_result_filter='x in (select number from numbers(3))';
+select count() as c from table_1 settings additional_result_filter='c in (select 4)', enable_analyzer=1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/107619
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the exception `Not-ready Set is passed as the second argument for function 'in'` when the `additional_result_filter` setting contains an `IN` subquery. Such a query now applies the filter instead of failing.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/107619

A `SELECT` whose `additional_result_filter` predicate contains an `IN` subquery fails with the exception `Not-ready Set is passed as the second argument for function 'in'` (`Code: 49`), and aborts the server in debug and sanitizer builds:

```sql
SELECT number FROM numbers(10)
SETTINGS additional_result_filter = 'number IN (SELECT number FROM numbers(3))';
```

A `FutureSetFromSubquery` only gets a source plan from `addBuildSubqueriesForSetsStepIfNeeded`, which drops every registered subquery absent from `useful_sets`. `addAdditionalFilterStepIfNeeded` was the only step-creation site that never added its own sets to that list, although `buildFilterInfo` registers the predicate's subquery in the real `PreparedSets`, so the "additional result filter" `FilterStep` executed `in` against a set that was never built. This appends the step's sets, exactly as `addFilterStep` and four other sites already do. Only queries setting `additional_result_filter` change behaviour, from failing to working. The omission is present on 26.3, 26.6, 26.7 and 26.8.

Validated on a debug build: the query above aborts the server on the base commit and returns the correctly filtered rows with the fix; `02346_additional_filters` passes 50 randomized, 50 self-parallel and 90 old analyzer randomized runs.

This fixes one carrier of the signature. It does not close the [`BuzzHouse (amd_debug)` report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=81944&sha=ffc0f9f1a77cdf31ae4da591059665e6036a7441&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29) at `ffc0f9f1a77c`, whose query sets no `additional_result_filter`, nor the object storage or one-block system table carriers. The old analyzer has the same omission in `IInterpreterUnionOrSelectQuery::addAdditionalPostFilter` and is unchanged here; it shows up whenever the predicate cannot be pushed into the reading step, which otherwise builds the sets of the filters pushed into it, for example a filter on an aggregate alias such as `additional_result_filter = 'c IN (SELECT 4)'` over `SELECT count() AS c`. The parallel replicas custom key filter also misses the append, but fixing it there needs its own change: the custom key is re-applied to the set subquery's own table expression, so the exception becomes `TOO_DEEP_SUBQUERIES`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117719&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117719](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117719+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

