### PR TITLE
CI: fix the diff-coverage baseline lookup for the new S3 prefix scheme

### DIFF
--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -29,7 +29,10 @@ IFS=',' read -ra COMMITS <<< "${PREV_30_COMMITS}"
 FOUND=0
 FIRST_BASE_COMMIT=""
 for TEST_COMMIT in "${COMMITS[@]}"; do
-COVERAGE_URL="https://clickhouse-builds.s3.amazonaws.com/REFs/master/${TEST_COMMIT}/llvm_coverage/llvm_coverage.info"
+# Artifacts live under the normalized workflow name; the baseline coverage is
+# produced by the MasterCI workflow:
+#   REFs/master/<sha>/masterci/llvm_coverage/llvm_coverage.info
+COVERAGE_URL="https://clickhouse-builds.s3.amazonaws.com/REFs/master/${TEST_COMMIT}/masterci/llvm_coverage/llvm_coverage.info"
 echo "Checking coverage file for commit ${TEST_COMMIT}..."
 if wget --spider "${COVERAGE_URL}" 2>&1 | grep -q '200 OK'; then
 echo "Found coverage file at ${COVERAGE_URL}"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

Follow-up for https://github.com/ClickHouse/ClickHouse/pull/110081, which moved build artifacts under the normalized workflow name. The baseline `llvm_coverage.info` produced by master now lives at `REFs/master/<sha>/masterci/llvm_coverage/llvm_coverage.info`, but `generate_diff_coverage_report.sh` still probed the old path without the `masterci` segment. The lookup exhausted all 30 candidate master commits, so `Generate LLVM Coverage Diff Report` (and with it the `LLVM Coverage` job) fails on every pull request:

```
Checking coverage file for commit 552cef42a06e1ba24edf3b7c4e87ed60252231c1...
...
ERROR: Could not find baseline coverage file after checking 30 commits
```

Example: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117655&sha=c4e6648b2ccbbedf97a6d5bab32c8a8c9cf01c9d&name_0=PR&name_1=LLVM%20Coverage (from https://github.com/ClickHouse/ClickHouse/pull/117655). I verified recent master commits: the artifact is 403 on the old path and 200 under `masterci/` for all of them.

Same class of breakage as https://github.com/ClickHouse/ClickHouse/pull/117580 (`Bugfix validation`); the remaining stale paths in `ci/jobs/parser_memory_check.py`, `ci/jobs/performance_tests.py`, and `ci/jobs/update_toolchain_dockerfile.py` are still not touched here.

Caused by: https://github.com/ClickHouse/ClickHouse/pull/110081
Related: https://github.com/ClickHouse/ClickHouse/pull/117580

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117733&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117733](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117733+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.561` (included in `26.9` and later)
<!-- ch-version-info:end -->