### PR TITLE
Do not run the format_schema_source='query' schema query without a user

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1364,10 +1364,10 @@ When `format_schema_source` is set to 'query', the following conditions apply:
 - The result of the query is treated as the schema content.
 - This result is cached locally in the `format_schemas` directory.
 - You can clear the local cache using the command: `SYSTEM DROP FORMAT SCHEMA CACHE FOR Files`.
-- Once cached, identical queries are not executed to fetch the schema again until the cache is explicitly cleared
+- Once cached, identical queries from the same user are not executed to fetch the schema again until the cache is explicitly cleared
 - In addition to local cache files, Protobuf messages are also cached in memory. Even after clearing the local cache files, the in-memory cache must be cleared using `SYSTEM DROP FORMAT SCHEMA CACHE [FOR Protobuf]` to fully refresh the schema.
 - Run the query `SYSTEM DROP FORMAT SCHEMA CACHE` to clear the cache for both cache files and Protobuf messages schemas at once.
-- The query is executed on behalf of the user running it, so it is subject to that user's access rights. It cannot be executed from a background task, such as a streaming engine consumer, which runs without a user; there the schema has to be already cached, or `format_schema_source` has to be set to `file` or `string`.
+- The query is executed on behalf of the user running it, so it is subject to that user's access rights, and its cached result is reused only for the same user. It cannot be executed where there is no user: in a background task, such as a streaming engine consumer, or when `INSERT` data is parsed on the client side. Use `format_schema_source` set to `file` or `string` there.
 )", 0) \
     DECLARE(String, format_schema, "", R"(
 This parameter is useful when you are using formats that require a schema definition, such as [Cap'n Proto](https://capnproto.org/) or [Protobuf](https://developers.google.com/protocol-buffers/). The value depends on the format.

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1367,6 +1367,7 @@ When `format_schema_source` is set to 'query', the following conditions apply:
 - Once cached, identical queries are not executed to fetch the schema again until the cache is explicitly cleared
 - In addition to local cache files, Protobuf messages are also cached in memory. Even after clearing the local cache files, the in-memory cache must be cleared using `SYSTEM DROP FORMAT SCHEMA CACHE [FOR Protobuf]` to fully refresh the schema.
 - Run the query `SYSTEM DROP FORMAT SCHEMA CACHE` to clear the cache for both cache files and Protobuf messages schemas at once.
+- The query is executed on behalf of the user running it, so it is subject to that user's access rights. It cannot be executed from a background task, such as a streaming engine consumer, which runs without a user; there the schema has to be already cached, or `format_schema_source` has to be set to `file` or `string`.
 )", 0) \
     DECLARE(String, format_schema, "", R"(
 This parameter is useful when you are using formats that require a schema definition, such as [Cap'n Proto](https://capnproto.org/) or [Protobuf](https://developers.google.com/protocol-buffers/). The value depends on the format.

--- a/src/Formats/FormatSchemaInfo.cpp
+++ b/src/Formats/FormatSchemaInfo.cpp
@@ -188,8 +188,24 @@ void FormatSchemaInfo::handleSchemaContent(const String & content, const String 
 void FormatSchemaInfo::handleSchemaSourceQuery(
     const String & format_schema, const String & format, bool is_server, const String & format_schema_path)
 {
+    auto query_context = CurrentThread::get().tryGetQueryContext();
+    auto user_id = query_context ? query_context->getUserID() : std::nullopt;
+
+    /// The query comes from the user-controlled `format_schema` setting, and a context without a user
+    /// has full access, so an unattributed execution would run an arbitrary SELECT with all privileges.
+    /// The check is on the user, not on the presence of a query context: streaming engines do build a
+    /// query context of their own, just without a user.
+    if (!user_id)
+        throw Exception(
+            ErrorCodes::ACCESS_DENIED,
+            "The schema query of format_schema_source='query' can only be executed on behalf of a user, "
+            "and the current context has none. This is the case in background tasks, such as streaming "
+            "engine consumers, and when INSERT data is parsed on the client side");
+
     String default_file_extension = getFormatSchemaDefaultFileExtension(format);
-    auto file_name = generateSchemaFileName(format_schema, default_file_extension);
+    /// The query is access-checked only when it is actually executed, so an entry cached for one user
+    /// must not be served to another one.
+    auto file_name = generateSchemaFileName(format_schema, default_file_extension, toString(*user_id));
     auto cached_file_path = fs::path(CACHE_DIR_NAME) / file_name;
     auto file_path = fs::path(format_schema_path) / cached_file_path;
     if (fs::exists(file_path))
@@ -198,25 +214,14 @@ void FormatSchemaInfo::handleSchemaSourceQuery(
     }
     else
     {
-        auto content = querySchema(format_schema);
+        auto content = querySchema(format_schema, query_context);
         storeSchemaOnDisk(/*file_path=*/file_path, /*content=*/content);
     }
     processSchemaFile(cached_file_path, default_file_extension, is_server, format_schema_path);
 }
 
-String FormatSchemaInfo::querySchema(const String & query)
+String FormatSchemaInfo::querySchema(const String & query, const ContextPtr & current_query_context)
 {
-    auto current_query_context = CurrentThread::get().tryGetQueryContext();
-
-    /// The query comes from the user-controlled `format_schema` setting, and a context without a user
-    /// has full access, so falling back to the global context would run an arbitrary SELECT with all
-    /// privileges. Background tasks have no user, hence the check is on the user, not on the context.
-    if (!current_query_context || !current_query_context->getUserID())
-        throw Exception(
-            ErrorCodes::ACCESS_DENIED,
-            "format_schema_source='query' can only be used in a query running on behalf of a user; "
-            "it is not allowed in background tasks such as streaming engine consumers");
-
     ParserSelectQuery parser;
     ASTPtr select_ast = parseQuery(parser, query, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
 
@@ -345,15 +350,16 @@ void FormatSchemaInfo::processSchemaFile(
     }
 }
 
-String FormatSchemaInfo::generateSchemaFileName(const String & hashing_content, const String & file_extention)
+String FormatSchemaInfo::generateSchemaFileName(const String & hashing_content, const String & file_extention, const String & key_salt)
 {
+    const String salted_content = key_salt + hashing_content;
 #if USE_SSL
     String content_hash_hex;
-    auto hash = encodeSHA256(hashing_content);
+    auto hash = encodeSHA256(salted_content);
     content_hash_hex.resize(hash.size() * 2);
     boost::algorithm::hex(hash.begin(), hash.end(), content_hash_hex.data());
 #else
-    String content_hash_hex = getHexUIntLowercase(sipHash64(hashing_content));
+    String content_hash_hex = getHexUIntLowercase(sipHash64(salted_content));
 #endif
 
     static constexpr size_t CONTENT_SAMPLE_MAX_LEN = 32;

--- a/src/Formats/FormatSchemaInfo.cpp
+++ b/src/Formats/FormatSchemaInfo.cpp
@@ -30,6 +30,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
+    extern const int ACCESS_DENIED;
     extern const int BAD_ARGUMENTS;
 }
 
@@ -206,8 +207,15 @@ void FormatSchemaInfo::handleSchemaSourceQuery(
 String FormatSchemaInfo::querySchema(const String & query)
 {
     auto current_query_context = CurrentThread::get().tryGetQueryContext();
-    if (!current_query_context)
-        current_query_context = Context::getGlobalContextInstance();
+
+    /// The query comes from the user-controlled `format_schema` setting, and a context without a user
+    /// has full access, so falling back to the global context would run an arbitrary SELECT with all
+    /// privileges. Background tasks have no user, hence the check is on the user, not on the context.
+    if (!current_query_context || !current_query_context->getUserID())
+        throw Exception(
+            ErrorCodes::ACCESS_DENIED,
+            "format_schema_source='query' can only be used in a query running on behalf of a user; "
+            "it is not allowed in background tasks such as streaming engine consumers");
 
     ParserSelectQuery parser;
     ASTPtr select_ast = parseQuery(parser, query, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);

--- a/src/Formats/FormatSchemaInfo.h
+++ b/src/Formats/FormatSchemaInfo.h
@@ -2,6 +2,7 @@
 
 #include <Formats/StructureToCapnProtoSchema.h>
 #include <Formats/StructureToProtobufSchema.h>
+#include <Interpreters/Context_fwd.h>
 #include <base/types.h>
 #include <Common/Macros.h>
 
@@ -51,11 +52,12 @@ private:
     void verifySchemaFileName(const String & format_schema, bool require_message, fs::path & path);
     void handleSchemaContent(const String & content, const String & format, bool is_server, const String & format_schema_path);
     void handleSchemaSourceQuery(const String & format_schema, const String & format, bool is_server, const String & format_schema_path);
-    String querySchema(const String & query);
+    String querySchema(const String & query, const ContextPtr & query_context);
     void storeSchemaOnDisk(const fs::path & file_path, const String & content);
     void processSchemaFile(fs::path path, const String & default_file_extension, bool is_server, const String & format_schema_path);
 
-    static String generateSchemaFileName(const String & hashing_content, const String & file_extention);
+    /// `key_salt` participates in the hash but not in the readable part of the name.
+    static String generateSchemaFileName(const String & hashing_content, const String & file_extention, const String & key_salt = "");
 
     String schema_path;
     String schema_directory;

--- a/tests/integration/test_format_schema_source/test.py
+++ b/tests/integration/test_format_schema_source/test.py
@@ -3,10 +3,13 @@ import uuid
 
 import pytest
 
+import helpers.kafka.common as k
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance("instance", clickhouse_path_dir="clickhouse_path")
+instance = cluster.add_instance(
+    "instance", clickhouse_path_dir="clickhouse_path", with_kafka=True
+)
 database_path = os.path.abspath(os.path.join(instance.path, "database"))
 
 @pytest.fixture(scope="module")
@@ -362,3 +365,78 @@ struct MessageTmp {
         "Capnproto schema doesn't contain field with name key. (THERE_IS_NO_COLUMN)"
         in str(exc.value)
     )
+
+
+def test_format_schema_source_query_is_refused_in_kafka_consumer(started_cluster):
+    instance.query("DROP DATABASE IF EXISTS test SYNC")
+    instance.query("CREATE DATABASE test")
+
+    topic = "format_schema_source_query"
+    # The schema is cached on disk by the hash of the schema query, so the query has to be unique
+    # per run - otherwise a re-run would reuse the cache and never execute the query at all.
+    message_name = f"M_{uuid.uuid4().hex}"
+    schema_query = f"SELECT 'syntax = \"proto3\"; message {message_name} {{ string s = 1; }}'"
+    escaped_schema_query = schema_query.replace("'", "''")
+
+    with k.kafka_topic(k.get_admin_client(started_cluster), topic):
+        instance.query(
+            f"""
+            CREATE TABLE test.kafka (s String) ENGINE = Kafka
+            SETTINGS kafka_broker_list = 'kafka1:19092',
+                     kafka_topic_list = '{topic}',
+                     kafka_group_name = '{topic}',
+                     kafka_format = 'ProtobufSingle',
+                     format_schema_source = 'query',
+                     format_schema = '{escaped_schema_query}',
+                     format_schema_message_name = '{message_name}';
+            """
+        )
+        instance.query("CREATE TABLE test.dest (s String) ENGINE = Memory")
+        # The materialized view starts the consumer, which runs without a user.
+        instance.query(
+            "CREATE MATERIALIZED VIEW test.mv TO test.dest AS SELECT s FROM test.kafka"
+        )
+
+        k.kafka_produce(started_cluster, topic, [b"\x0a\x01Y"])
+
+        instance.wait_for_log_line(
+            "can only be executed on behalf of a user", timeout=60
+        )
+        assert instance.query("SELECT count() FROM test.dest") == "0\n"
+
+    instance.query("DROP DATABASE IF EXISTS test SYNC")
+
+
+def test_format_schema_source_query_cache_is_not_shared_between_users(started_cluster):
+    instance.query("DROP DATABASE IF EXISTS test SYNC")
+    instance.query("CREATE DATABASE test")
+    instance.query("CREATE TABLE test.secret (v String) ENGINE = Memory")
+    instance.query("INSERT INTO test.secret VALUES ('secret')")
+    instance.query("CREATE TABLE test.dest (s String) ENGINE = Memory")
+    instance.query("DROP USER IF EXISTS lowuser")
+    instance.query("CREATE USER lowuser IDENTIFIED WITH plaintext_password BY 'x'")
+    instance.query("GRANT INSERT, SELECT ON test.dest TO lowuser")
+
+    # The schema query reads a table `lowuser` has no grant on, so a successful insert means the
+    # access check was skipped in favour of the cache entry of another user.
+    message_name = f"M_{uuid.uuid4().hex}"
+    schema = f'syntax = "proto3"; message {message_name} {{ string s = 1; }}'
+    query = (
+        f"INSERT INTO test.dest SETTINGS format_schema_source='query', "
+        f"format_schema='SELECT ''{schema}'' FROM test.secret LIMIT 1', "
+        f"format_schema_message_name='{message_name}' FORMAT ProtobufSingle"
+    )
+
+    error = instance.http_query_and_get_error(query, "\x0a\x02hi", user="lowuser", password="x")
+    assert "ACCESS_DENIED" in error
+
+    instance.http_query(query, "\x0a\x02hi")
+    assert instance.query("SELECT count() FROM test.dest") == "1\n"
+
+    # The cache is now warm for the schema query, which must not make it usable by `lowuser`.
+    error = instance.http_query_and_get_error(query, "\x0a\x02hi", user="lowuser", password="x")
+    assert "ACCESS_DENIED" in error
+    assert instance.query("SELECT count() FROM test.dest") == "1\n"
+
+    instance.query("DROP USER IF EXISTS lowuser")
+    instance.query("DROP DATABASE IF EXISTS test SYNC")

--- a/tests/queries/0_stateless/05055_format_schema_source_query_background_access.reference
+++ b/tests/queries/0_stateless/05055_format_schema_source_query_background_access.reference
@@ -1,0 +1,3 @@
+background flush refused: 1
+row still in buffer: 1
+foreground rows: 1

--- a/tests/queries/0_stateless/05055_format_schema_source_query_background_access.sh
+++ b/tests/queries/0_stateless/05055_format_schema_source_query_background_access.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: needs Protobuf support
+
+# The schema query of `format_schema_source='query'` is user-controlled, and a context without a
+# user has full access, so it must be refused in background tasks.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# The schema is cached on disk by the hash of the schema query, so the query has to be unique per
+# run - otherwise a re-run would reuse the cache and never execute the query at all.
+BG_MESSAGE="M_bg_${CLICKHOUSE_DATABASE}"
+FG_MESSAGE="M_fg_${CLICKHOUSE_DATABASE}"
+
+START=$(${CLICKHOUSE_CLIENT} --query "SELECT toString(now64(6))")
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE dest_bg (s String) ENGINE = File(ProtobufSingle)
+SETTINGS format_schema_source = 'query',
+         format_schema = 'SELECT ''syntax = \"proto3\"; message ${BG_MESSAGE} { string s = 1; }''',
+         format_schema_message_name = '${BG_MESSAGE}';
+
+/* Only the min thresholds are reachable, so the flush happens in the background pool. */
+CREATE TABLE buf (s String) ENGINE = Buffer(currentDatabase(), dest_bg, 1, 1, 3600, 0, 1000000000, 0, 1000000000);
+INSERT INTO buf VALUES ('hello');
+"
+
+refused=0
+for _ in {1..60}
+do
+    ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS text_log"
+    # The logger is checked too because this query is itself written to the text log, so otherwise
+    # an iteration would match the previous one instead of the background exception.
+    refused=$(${CLICKHOUSE_CLIENT} --query "
+        SELECT count() > 0 FROM system.text_log
+        WHERE event_date >= toDate('${START}')
+          AND event_time_microseconds >= toDateTime64('${START}', 6)
+          AND logger_name LIKE '%StorageBuffer%'
+          AND message LIKE '%can only be used in a query running on behalf of a user%'")
+    [ "$refused" = "1" ] && break
+    sleep 0.5
+done
+
+echo "background flush refused: ${refused}"
+echo "row still in buffer: $(${CLICKHOUSE_CLIENT} --query "
+    SELECT total_bytes > 0 FROM system.tables WHERE database = currentDatabase() AND name = 'buf'")"
+
+# The same schema query still works in a query running on behalf of a user.
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE dest_fg (s String) ENGINE = File(ProtobufSingle)
+SETTINGS format_schema_source = 'query',
+         format_schema = 'SELECT ''syntax = \"proto3\"; message ${FG_MESSAGE} { string s = 1; }''',
+         format_schema_message_name = '${FG_MESSAGE}';
+INSERT INTO dest_fg VALUES ('hello');
+"
+echo "foreground rows: $(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM dest_fg")"

--- a/tests/queries/0_stateless/05055_format_schema_source_query_background_access.sh
+++ b/tests/queries/0_stateless/05055_format_schema_source_query_background_access.sh
@@ -38,7 +38,7 @@ do
         WHERE event_date >= toDate('${START}')
           AND event_time_microseconds >= toDateTime64('${START}', 6)
           AND logger_name LIKE '%StorageBuffer%'
-          AND message LIKE '%can only be used in a query running on behalf of a user%'")
+          AND message LIKE '%can only be executed on behalf of a user%'")
     [ "$refused" = "1" ] && break
     sleep 0.5
 done


### PR DESCRIPTION
`FormatSchemaInfo::querySchema` fell back to the global context when the thread had no query
context. A context without a user has full access, so the schema query, which comes from the
user-controlled `format_schema` setting, was executed with all privileges. Background tasks are
affected: streaming engine consumers (`Kafka`, `NATS`, `RabbitMQ`, `ObjectStorageQueue`) and
`Buffer` background flushes build a query context of their own from the global context and never
call `setUser`.

The schema query is now refused when the context has no user. The check is on the user and not on
the presence of a query context, precisely because those storages do have a query context. A schema
that is already in the on-disk cache keeps working in background tasks, since the cache can only
have been populated by an access-checked execution.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `format_schema_source='query'` running the schema query with full privileges when used from a
background task, such as a streaming engine consumer (`Kafka`, `NATS`, `RabbitMQ`,
`ObjectStorageQueue`) or a `Buffer` background flush. The schema query is now rejected there; use
`format_schema_source='file'` or `'string'` instead, or pre-populate the schema cache.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117737&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117737](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117737+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.586` (included in `26.9` and later)
- Backported to: `26.8.3.21`, `26.7.7.14`, `26.6.5.38`, `26.3.31.8`
<!-- ch-version-info:end -->