### PR TITLE
Add a functional test for invalid JSON shared-data bucket counts in Native

### DIFF
--- a/tests/queries/0_stateless/05059_json_native_invalid_shared_data_buckets.sql
+++ b/tests/queries/0_stateless/05059_json_native_invalid_shared_data_buckets.sql
@@ -1,0 +1,13 @@
+-- Crafted Native blocks whose V3 JSON structure prefix carries an invalid shared-data bucket count.
+-- The count sizes the per-bucket reader state directly, so it must be rejected before use.
+-- The structure is passed to `format` explicitly: otherwise schema inference wraps the error into
+-- CANNOT_EXTRACT_TABLE_STRUCTURE and hides the code the guard raises.
+
+-- buckets = 0
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e0400000000000000000100')); -- { serverError INCORRECT_DATA }
+-- buckets = SIZE_MAX
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e04000000000000000001ffffffffffffffffff01')); -- { serverError INCORRECT_DATA }
+-- buckets = 257, one past the maximum
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e040000000000000000018102')); -- { serverError INCORRECT_DATA }
+-- buckets = 256, the maximum, passes the guard and fails only on the truncated payload
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e040000000000000000018002')); -- { serverError CANNOT_READ_ALL_DATA, ATTEMPT_TO_READ_AFTER_EOF }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110590

Adds a stateless test covering the validation of the V3 `shared_data_buckets` count in a `JSON`/`Object` `Native` structure prefix. Until now this was only covered by the gtest `ObjectSerialization.InvalidNumberOfSharedDataBuckets`, which drives the serialization directly instead of going through the `Native` reader.

The test feeds crafted `Native` blocks through `format` and asserts the error code for every corner of the guard: `0`, `SIZE_MAX` and `257` are rejected as `INCORRECT_DATA`, while `256` - the maximum - passes the guard and fails only because the crafted block has no payload after the prefix.

The guard itself landed in https://github.com/ClickHouse/ClickHouse/pull/110590.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117739&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117739](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117739+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1587` (included in `26.9` and later)
<!-- ch-version-info:end -->