### PR TITLE
Docs: ODBC search ranking improvements

### DIFF
--- a/docs/reference/functions/table-functions/odbc.mdx
+++ b/docs/reference/functions/table-functions/odbc.mdx
@@ -2,7 +2,7 @@
 description: 'Returns the table that is connected via ODBC.'
 sidebarTitle: 'odbc'
 slug: /sql-reference/table-functions/odbc
-title: 'odbc'
+title: 'odbc table function'
 doc_type: 'reference'
 ---
 

--- a/src/TableFunctions/ITableFunctionXDBC.cpp
+++ b/src/TableFunctions/ITableFunctionXDBC.cpp
@@ -256,9 +256,9 @@ clickhouse-jdbc-bridge contains experimental codes and is no longer supported. I
 ClickHouse recommend using built-in table functions in ClickHouse which provide a better alternative for ad-hoc querying scenarios (Postgres, MySQL, MongoDB, etc).
 </Note>
 
-JDBC table function returns table that is connected via JDBC driver.
+The JDBC table function returns a table that is connected via the JDBC driver.
 
-This table function requires separate [clickhouse-jdbc-bridge](https://github.com/ClickHouse/clickhouse-jdbc-bridge) program to be running.
+This table function requires a separate [clickhouse-jdbc-bridge](https://github.com/ClickHouse/clickhouse-jdbc-bridge) program to be running.
 It supports Nullable types (based on DDL of remote table that is queried).
 
 ## Syntax {#syntax}
@@ -301,7 +301,7 @@ INNER JOIN jdbc('self?datasource_column', 'show databases') b ON a.Database = b.
 void registerTableFunctionODBC(TableFunctionFactory & factory)
 {
     factory.registerFunction<TableFunctionODBC>({.description = R"DOCS_MD(
-Returns table that is connected via [ODBC](https://en.wikipedia.org/wiki/Open_Database_Connectivity).
+The `odbc` table function returns a table that is connected via [ODBC](https://en.wikipedia.org/wiki/Open_Database_Connectivity).
 
 ## Syntax {#syntax}
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
A search for "ODBC" returns the table function first over the driver. The title of this page should be more specific.
Also makes a few minor language adjustments.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117741&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117741](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117741+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.577` (included in `26.9` and later)
<!-- ch-version-info:end -->