### PR TITLE
Backport #110590 to 26.3: Validate the JSON/Object shared-data bucket count read from a stream

### DIFF
--- a/src/Core/MergeTreeSerializationEnums.h
+++ b/src/Core/MergeTreeSerializationEnums.h
@@ -57,5 +57,14 @@ enum class MergeTreeMapBucketsStrategy : uint8_t
     LINEAR = 2,
 };
 
+/// The maximum number of buckets in the shared data of a `JSON` / `Object` column
+/// (`MAP_WITH_BUCKETS` / `ADVANCED` shared-data serialization). Legitimate bucket counts are written
+/// from the small MergeTree settings `object_shared_data_buckets_for_compact_part` /
+/// `object_shared_data_buckets_for_wide_part`, both non-zero and capped at this value, so a bucket
+/// count read from a stream that is outside `1 .. MAX_OBJECT_SHARED_DATA_BUCKETS` can only be data
+/// corruption. This constant is the single source of truth for both the writer-side setting bound
+/// and the reader-side validation.
+inline constexpr uint64_t MAX_OBJECT_SHARED_DATA_BUCKETS = 256;
+
 
 }

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -8,6 +8,7 @@
 
 
 #include <Columns/ColumnObject.h>
+#include <Core/MergeTreeSerializationEnums.h>
 #include <DataTypes/DataTypeObject.h>
 #include <DataTypes/DataTypeArray.h>
 #include <IO/ReadBufferFromString.h>
@@ -25,6 +26,20 @@ namespace ErrorCodes
     extern const int INCORRECT_DATA;
     extern const int LOGICAL_ERROR;
     extern const int TOO_LARGE_ARRAY_SIZE;
+}
+
+namespace
+{
+
+void throwIfInvalidNumberOfBuckets(size_t num_buckets)
+{
+    if (num_buckets == 0 || num_buckets > MAX_OBJECT_SHARED_DATA_BUCKETS)
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "JSON/Object column has an invalid number of shared data buckets: {} (must be in the range [1, {}])",
+            num_buckets, MAX_OBJECT_SHARED_DATA_BUCKETS);
+}
+
 }
 
 SerializationObject::SerializationObject(
@@ -697,6 +712,7 @@ ISerialization::DeserializeBinaryBulkStatePtr SerializationObject::deserializeOb
                     || structure_state->shared_data_serialization_version.value == SerializationObjectSharedData::SerializationVersion::ADVANCED)
                 {
                     readVarUInt(structure_state->shared_data_buckets, *structure_stream);
+                    throwIfInvalidNumberOfBuckets(structure_state->shared_data_buckets);
                 }
             }
 

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -5,6 +5,7 @@
 #include <Core/BaseSettingsFwdMacrosImpl.h>
 #include <Core/BaseSettingsProgramOptions.h>
 #include <Core/MergeSelectorAlgorithm.h>
+#include <Core/MergeTreeSerializationEnums.h>
 #include <Core/SettingsChangesHistory.h>
 #include <Disks/DiskFromAST.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -2449,22 +2450,24 @@ void MergeTreeSettingsImpl::sanityCheck(size_t background_pool_tasks, bool allow
             map_buckets_coefficient.value);
     }
 
-    if (object_shared_data_buckets_for_compact_part > max_allowed_buckets)
+    /// The reader validates the on-wire bucket count against the same bound
+    /// (`MAX_OBJECT_SHARED_DATA_BUCKETS`), so keep this cap and that guard in sync via the constant.
+    if (object_shared_data_buckets_for_compact_part > MAX_OBJECT_SHARED_DATA_BUCKETS)
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
             "The value of object_shared_data_buckets_for_compact_part setting ({}) exceeds the maximum allowed value of {}",
             object_shared_data_buckets_for_compact_part.value,
-            max_allowed_buckets);
+            MAX_OBJECT_SHARED_DATA_BUCKETS);
     }
 
-    if (object_shared_data_buckets_for_wide_part > max_allowed_buckets)
+    if (object_shared_data_buckets_for_wide_part > MAX_OBJECT_SHARED_DATA_BUCKETS)
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
             "The value of object_shared_data_buckets_for_wide_part setting ({}) exceeds the maximum allowed value of {}",
             object_shared_data_buckets_for_wide_part.value,
-            max_allowed_buckets);
+            MAX_OBJECT_SHARED_DATA_BUCKETS);
     }
 
     if (zero_copy_merge_mutation_min_parts_size_sleep_before_lock != 0

--- a/tests/queries/0_stateless/05059_json_native_invalid_shared_data_buckets.sql
+++ b/tests/queries/0_stateless/05059_json_native_invalid_shared_data_buckets.sql
@@ -1,0 +1,13 @@
+-- Crafted Native blocks whose V3 JSON structure prefix carries an invalid shared-data bucket count.
+-- The count sizes the per-bucket reader state directly, so it must be rejected before use.
+-- The structure is passed to `format` explicitly: otherwise schema inference wraps the error into
+-- CANNOT_EXTRACT_TABLE_STRUCTURE and hides the code the guard raises.
+
+-- buckets = 0
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e0400000000000000000100')); -- { serverError INCORRECT_DATA }
+-- buckets = SIZE_MAX
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e04000000000000000001ffffffffffffffffff01')); -- { serverError INCORRECT_DATA }
+-- buckets = 257, one past the maximum
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e040000000000000000018102')); -- { serverError INCORRECT_DATA }
+-- buckets = 256, the maximum, passes the guard and fails only on the truncated payload
+SELECT count() FROM format('Native', 'j JSON', unhex('0101016a044a534f4e040000000000000000018002')); -- { serverError CANNOT_READ_ALL_DATA, ATTEMPT_TO_READ_AFTER_EOF }


### PR DESCRIPTION
Manual backport to `26.3` of the shared-data bucket count validation added in https://github.com/ClickHouse/ClickHouse/pull/110590 (commit `73641c7f1d1`), plus a stateless test for it.

Not a cherry-pick: that commit is an incremental rename of an earlier `throwIfTooManyBuckets` introduced by two predecessor commits which also change the path-count handling and `SerializationDynamic`, and neither of those is backported here.

Related: https://github.com/ClickHouse/ClickHouse/pull/117739
Related: https://github.com/ClickHouse/ClickHouse/pull/117743


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.30.7`
<!-- ch-version-info:end -->