### PR TITLE
illumos: add process memory metrics.

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -1303,7 +1303,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
         "The difference in time the thread for calculation of the asynchronous metrics was scheduled to wake up and the time it was in fact, woken up."
         " A proxy-indicator of overall system latency and responsiveness." };
 
-#if defined(OS_LINUX) || defined(OS_FREEBSD)
+#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_SUNOS)
     MemoryStatisticsOS::Data memory_statistics_data = memory_stat.get();
 #endif
 
@@ -1498,7 +1498,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
 #endif
 
     /// Process process memory usage according to OS
-#if defined(OS_LINUX) || defined(OS_FREEBSD)
+#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_SUNOS)
     {
         MemoryStatisticsOS::Data & data = memory_statistics_data;
 
@@ -1524,18 +1524,20 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
             "When userspace page cache is disabled, this value equals MemoryResident."
         };
 
-#if !defined(OS_FREEBSD)
+#if !defined(OS_FREEBSD) && !defined(OS_SUNOS)
         new_values["MemoryShared"] = { data.shared,
             "The amount of memory used by the server process, that is also shared by another processes, in bytes."
             " ClickHouse does not use shared memory, but some memory can be labeled by OS as shared for its own reasons."
             " This metric does not make a lot of sense to watch, and it exists only for completeness reasons."};
 #endif
+#if !defined(OS_SUNOS)
         new_values["MemoryCode"] = { data.code,
             "The amount of virtual memory mapped for the pages of machine code of the server process, in bytes." };
         new_values["MemoryDataAndStack"] = { data.data_and_stack,
             "The amount of virtual memory mapped for the use of stack and for the allocated memory, in bytes."
             " It is unspecified whether it includes the per-thread stacks and most of the allocated memory, that is allocated with the 'mmap' system call."
             " This metric exists only for completeness reasons. I recommend to use the `MemoryResident` metric for monitoring."};
+#endif
 
         if (update_rss)
             MemoryTracker::updateRSS(data.resident);

--- a/src/Common/AsynchronousMetrics.h
+++ b/src/Common/AsynchronousMetrics.h
@@ -160,7 +160,7 @@ private:
     /// Values store the result of the last update prepared for reading.
     AsynchronousMetricValues values TSA_GUARDED_BY(values_mutex);
 
-#if defined(OS_LINUX) || defined(OS_FREEBSD)
+#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_SUNOS)
     MemoryStatisticsOS memory_stat TSA_GUARDED_BY(data_mutex);
 #endif
 

--- a/src/Common/MemoryStatisticsOS.cpp
+++ b/src/Common/MemoryStatisticsOS.cpp
@@ -1,10 +1,13 @@
-#if defined(OS_LINUX) || defined(OS_FREEBSD)
+#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_SUNOS)
 
 #include <sys/types.h>
 #include <sys/stat.h>
 #if defined(OS_FREEBSD)
 #include <sys/sysctl.h>
 #include <sys/user.h>
+#endif
+#if defined(OS_SUNOS)
+#include <procfs.h>
 #endif
 #include <fcntl.h>
 #include <unistd.h>
@@ -22,15 +25,16 @@
 namespace DB
 {
 
-#if defined(OS_LINUX)
-
 namespace ErrorCodes
 {
     extern const int FILE_DOESNT_EXIST;
     extern const int CANNOT_OPEN_FILE;
     extern const int CANNOT_READ_FROM_FILE_DESCRIPTOR;
     extern const int CANNOT_CLOSE_FILE;
+    extern const int SYSTEM_ERROR;
 }
+
+#if defined(OS_LINUX)
 
 static constexpr auto filename = "/proc/self/statm";
 
@@ -113,11 +117,6 @@ MemoryStatisticsOS::Data MemoryStatisticsOS::get() const
 
 #if defined(OS_FREEBSD)
 
-namespace ErrorCodes
-{
-    extern const int SYSTEM_ERROR;
-}
-
 MemoryStatisticsOS::MemoryStatisticsOS()
 {
     pagesize = static_cast<size_t>(::getPageSize());
@@ -150,6 +149,66 @@ MemoryStatisticsOS::Data MemoryStatisticsOS::get() const
     data.resident = kp.ki_rssize * pagesize;
     data.code = kp.ki_tsize * pagesize;
     data.data_and_stack = (kp.ki_dsize + kp.ki_ssize) * pagesize;
+
+    return data;
+}
+
+#endif
+
+#if defined(OS_SUNOS)
+
+static constexpr auto filename = "/proc/self/psinfo";
+
+MemoryStatisticsOS::MemoryStatisticsOS()
+{
+    psinfo_fd = ::open(filename, O_RDONLY | O_CLOEXEC);
+
+    if (-1 == psinfo_fd)
+        ErrnoException::throwFromPath(
+            errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE, filename, "Cannot open file {}", filename);
+}
+
+MemoryStatisticsOS::~MemoryStatisticsOS()
+{
+    if (0 != ::close(psinfo_fd))
+    {
+        try
+        {
+            ErrnoException::throwFromPath(
+                ErrorCodes::CANNOT_CLOSE_FILE, filename, "File descriptor for '{}' could not be closed", filename);
+        }
+        catch (const ErrnoException &)
+        {
+            DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+}
+
+MemoryStatisticsOS::Data MemoryStatisticsOS::get() const
+{
+    psinfo_t info{};
+    ssize_t bytes_read;
+
+    do
+    {
+        bytes_read = ::pread(psinfo_fd, &info, sizeof(info), 0);
+    } while (bytes_read == -1 && errno == EINTR);
+
+    if (bytes_read == -1)
+        ErrnoException::throwFromPath(
+            ErrorCodes::CANNOT_READ_FROM_FILE_DESCRIPTOR, filename, "Cannot read from file {}", filename);
+
+    if (static_cast<size_t>(bytes_read) != sizeof(info))
+        throw DB::Exception(
+            ErrorCodes::CANNOT_READ_FROM_FILE_DESCRIPTOR,
+            "Cannot read from file {}: expected {} bytes, got {}",
+            filename,
+            sizeof(info),
+            bytes_read);
+
+    Data data{};
+    data.virt = static_cast<uint64_t>(info.pr_size) * 1024;
+    data.resident = static_cast<uint64_t>(info.pr_rssize) * 1024;
 
     return data;
 }

--- a/src/Common/MemoryStatisticsOS.h
+++ b/src/Common/MemoryStatisticsOS.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(OS_LINUX) || defined(OS_FREEBSD)
+#if defined(OS_LINUX) || defined(OS_FREEBSD) || defined(OS_SUNOS)
 #include <cstdint>
 #if defined(OS_FREEBSD)
 #include <unistd.h>
@@ -46,6 +46,9 @@ private:
 #if defined(OS_FREEBSD)
     size_t pagesize;
     pid_t self;
+#endif
+#if defined(OS_SUNOS)
+    int psinfo_fd;
 #endif
 };
 


### PR DESCRIPTION
illumos doesn't implement /proc/self/statm, so in order to support memory metrics on illumos, we read /proc/self/psinfo instead. Note that this provides only the MemoryVirtual and MemoryResident metrics, and not the additional metrics supported on linux.

Adapted from
https://github.com/oxidecomputer/garbage-compactor/blob/master/clickhouse/patches/0021-Enable-memory-stats-on-illumos.patch; h/t @citrus-it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117757&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117757](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117757+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1209` (included in `26.9` and later)
<!-- ch-version-info:end -->