### PR TITLE
Docs: Skip private sync for documentation-only pull requests

### DIFF
--- a/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
+++ b/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
@@ -3,13 +3,34 @@ from ci.praktika.gh import GH
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 
+DOCS_ONLY_SYNC_STATUS_DESCRIPTION = "skipped: documentation-only change"
+RETAINED_DOCS_PATH_PREFIXES = (
+    "docs/changelogs/",
+    "docs/private-changelogs/",
+)
+
 # This status is a marker that the sync process can be started. We set it from
 # the `Code Review` job because that job always runs for PRs.
 
 
+def can_skip_sync(changed_files):
+    """Return whether all changes can wait for the periodic master sync."""
+    normalized_files = [
+        file.removeprefix(".").removeprefix("/") for file in changed_files or []
+    ]
+    return bool(normalized_files) and all(
+        file.startswith("docs/")
+        and not any(
+            file.startswith(prefix) for prefix in RETAINED_DOCS_PATH_PREFIXES
+        )
+        for file in normalized_files
+    )
+
+
 def main():
-    if Info().repo_name != "ClickHouse/ClickHouse":
-        print(f"Not applicable for repo [{Info().repo_name}], skipping")
+    info = Info()
+    if info.repo_name != "ClickHouse/ClickHouse":
+        print(f"Not applicable for repo [{info.repo_name}], skipping")
         return
 
     statuses = GH.get_commit_statuses()
@@ -24,12 +45,21 @@ def main():
         )
         return
 
-    GH.post_commit_status(
-        name=SYNC,
-        status=Result.Status.PENDING,
-        description="awaiting",
-        url="",
-    )
+    changed_files = info.get_changed_files()
+    if can_skip_sync(changed_files):
+        GH.post_commit_status(
+            name=SYNC,
+            status=Result.Status.OK,
+            description=DOCS_ONLY_SYNC_STATUS_DESCRIPTION,
+            url="",
+        )
+    else:
+        GH.post_commit_status(
+            name=SYNC,
+            status=Result.Status.PENDING,
+            description="awaiting",
+            url="",
+        )
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_set_sync_status_awaiting_hook.py
+++ b/ci/tests/test_set_sync_status_awaiting_hook.py
@@ -1,0 +1,103 @@
+import unittest
+from unittest.mock import patch
+
+from ci.jobs.scripts.job_hooks import set_sync_status_awaiting_hook as hook
+from ci.praktika.result import Result
+
+
+class FakeInfo:
+    repo_name = "ClickHouse/ClickHouse"
+
+    def __init__(self, changed_files):
+        self.changed_files = changed_files
+
+    def get_changed_files(self):
+        return self.changed_files
+
+
+class TestCanSkipSync(unittest.TestCase):
+    def test_docs_only_changes(self):
+        cases = [
+            ["docs/guides/example.mdx"],
+            ["docs/images/example.png", "docs/guides/example.mdx"],
+            ["./docs/guides/example.mdx"],
+            ["/docs/guides/example.mdx"],
+        ]
+        for changed_files in cases:
+            with self.subTest(changed_files=changed_files):
+                self.assertTrue(hook.can_skip_sync(changed_files))
+
+    def test_other_changes(self):
+        cases = [
+            None,
+            [],
+            ["README.md"],
+            ["src/example.cpp"],
+            ["docs/guides/example.mdx", "src/example.cpp"],
+            ["docs/changelogs/v26.8.md"],
+            ["docs/private-changelogs/v26.8.md"],
+            ["docs/old-page.mdx", "src/new-file.cpp"],
+        ]
+        for changed_files in cases:
+            with self.subTest(changed_files=changed_files):
+                self.assertFalse(hook.can_skip_sync(changed_files))
+
+
+class TestSetSyncStatusAwaitingHook(unittest.TestCase):
+    def run_hook(self, changed_files, statuses=None):
+        posted = []
+        with (
+            patch.object(hook, "Info", return_value=FakeInfo(changed_files)),
+            patch.object(hook.GH, "get_commit_statuses", return_value=statuses or {}),
+            patch.object(
+                hook.GH,
+                "post_commit_status",
+                side_effect=lambda **kwargs: posted.append(kwargs),
+            ),
+        ):
+            hook.main()
+        return posted
+
+    def test_docs_only_change_is_completed_without_requesting_sync(self):
+        self.assertEqual(
+            self.run_hook(["docs/guides/example.mdx"]),
+            [
+                {
+                    "name": hook.SYNC,
+                    "status": Result.Status.OK,
+                    "description": hook.DOCS_ONLY_SYNC_STATUS_DESCRIPTION,
+                    "url": "",
+                }
+            ],
+        )
+
+    def test_uncertain_or_non_docs_change_requests_sync(self):
+        for changed_files in (None, [], ["src/example.cpp"]):
+            with self.subTest(changed_files=changed_files):
+                self.assertEqual(
+                    self.run_hook(changed_files),
+                    [
+                        {
+                            "name": hook.SYNC,
+                            "status": Result.Status.PENDING,
+                            "description": "awaiting",
+                            "url": "",
+                        }
+                    ],
+                )
+
+    def test_existing_sync_status_is_not_replaced(self):
+        existing_status = hook.GH.CommitStatus(
+            state="pending", description="tests started", url="", context=hook.SYNC
+        )
+        self.assertEqual(
+            self.run_hook(
+                ["docs/guides/example.mdx"],
+                statuses={hook.SYNC: existing_status},
+            ),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Documentation-only pull requests currently wait for the private incremental-sync poller even though their changes are also carried by the periodic public-to-private master sync.

Use the existing `CH Inc sync` commit-status handshake to mark documentation-only changes as skipped immediately after `Code Review`. Changes under `docs/changelogs/` and `docs/private-changelogs/`, mixed pull requests, and cases where changed files cannot be determined continue through the normal per-PR sync path.

The private counterpart recognizes the explicit status marker after merge and avoids creating a deferred sync PR.

Related: https://github.com/ClickHouse/clickhouse-private/pull/72241

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry:
Not applicable

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117768&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117768](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117768+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
