### PR TITLE
Feat(PromQL): Implement /api/v1/status/tsdb

### DIFF
--- a/docs/concepts/features/interfaces/prometheus.mdx
+++ b/docs/concepts/features/interfaces/prometheus.mdx
@@ -82,7 +82,7 @@ curl http://127.0.0.1:9363/metrics
 
 ## Prometheus HTTP API and PromQL {#prometheus-http-api-and-promql}
 
-ClickHouse implements the Prometheus HTTP API over a [`TimeSeries`](/reference/engines/table-engines/integrations/time-series) table. One handler serves remote write, remote read, instant PromQL queries, and range PromQL queries.
+ClickHouse implements the Prometheus HTTP API over a [`TimeSeries`](/reference/engines/table-engines/integrations/time-series) table. One handler serves remote write, remote read, instant PromQL queries, range PromQL queries, and metadata endpoints.
 
 ### Prerequisites {#prerequisites}
 
@@ -127,7 +127,10 @@ Configure one prefix-routed handler on the main ClickHouse HTTP port:
 | `/prometheus/api/v1/query_range` | Range PromQL queries |
 | `/prometheus/api/v1/format_query` | PromQL expression formatting |
 | `/prometheus/api/v1/series` | Series metadata |
+| `/prometheus/api/v1/labels` | Label names |
+| `/prometheus/api/v1/label/<name>/values` | Label values |
 | `/prometheus/api/v1/metadata` | Metric-family metadata |
+| `/prometheus/api/v1/status/tsdb` | TSDB cardinality statistics |
 
 The example omits `database` and `table` from the handler. Each request must provide the `table` query parameter (except for `/format_query`, which only parses the given PromQL expression and doesn't need a table). It can also provide `database`, use a qualified table name such as `prometheus.metrics`, or omit the database to use `default`. This allows one handler to serve multiple `TimeSeries` tables.
 
@@ -234,7 +237,9 @@ datasources:
 Grafana appends `/api/v1/query` or `/api/v1/query_range` to this base URL and adds `customQueryParameters` to each request.
 
 <Note>
-Only the query endpoints `/api/v1/query`, `/api/v1/query_range`, and `/api/v1/format_query` and the metadata endpoints `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values`, and `/api/v1/metadata` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. `/api/v1/labels` accepts the same parameters, with `match[]` being optional, and returns the sorted label names of the matched series (or of all series when no selectors are given). `/api/v1/label/<name>/values` accepts the same parameters as `/api/v1/labels` and returns the sorted values of one label, with `<name>` optionally using the Prometheus `U__...` escaping of label names that contain characters outside `[a-zA-Z0-9_]`. These endpoints cover what a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete.
+The query endpoints `/api/v1/query`, `/api/v1/query_range`, and `/api/v1/format_query` and the metadata endpoints `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values`, and `/api/v1/metadata` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. `/api/v1/labels` accepts the same parameters, with `match[]` being optional, and returns the sorted label names of the matched series (or of all series when no selectors are given). `/api/v1/label/<name>/values` accepts the same parameters as `/api/v1/labels` and returns the sorted values of one label, with `<name>` optionally using the Prometheus `U__...` escaping of label names that contain characters outside `[a-zA-Z0-9_]`. These metadata endpoints cover what a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete.
+
+The `/api/v1/status/tsdb` endpoint returns cardinality statistics for stored logical series. Its `limit` parameter defaults to 10 and applies independently to each statistics list, with a maximum of 10000. The `memoryInBytesByLabelName` values are approximations based on the encoded byte lengths of label names and values. Because ClickHouse does not use Prometheus head chunks, `chunkCount` is always zero and `numSeries` describes stored logical series. When the tags target stores time bounds, `minTime` and `maxTime` report the bounds of the stored TimeSeries data; otherwise they are zero.
 </Note>
 
 #### SQL entry points {#sql-entry-points}

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -58,12 +58,14 @@ public:
         const size_t old_size = buffer.size();
         buffer.resize(old_size + count);
         auto * __restrict appended = buffer.data() + old_size;
-        for (size_t i = 0; i < count; ++i)
-            appended[i] = {timestamps[i], values[i]};
-
         UInt8 in_order = old_size == 0 || appended[-1].first < timestamps[0];
+
+        appended[0] = {timestamps[0], values[0]};
         for (size_t i = 1; i < count; ++i)
+        {
+            appended[i] = {timestamps[i], values[i]};
             in_order &= static_cast<UInt8>(timestamps[i - 1] < timestamps[i]);
+        }
         sorted = sorted && in_order;
     }
 

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -424,7 +424,7 @@ public:
 };
 
 /// Handles the read-only query and metadata endpoints of the Prometheus HTTP API
-/// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata).
+/// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata, /api/v1/status/tsdb).
 class PrometheusRequestHandler::QueryImpl : public ImplWithContext
 {
 public:
@@ -464,6 +464,23 @@ public:
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                             "Invalid value of the 'limit' parameter: '{}', expected a non-negative integer",
                             limit_param);
+        return static_cast<UInt64>(parsed_limit);
+    }
+
+    /// Parses the optional `limit` parameter of /status/tsdb: 10 by default, with a maximum of 10000.
+    UInt64 getTSDBStatsLimitParam() const
+    {
+        String limit_param = params->get("limit", "");
+        if (limit_param.empty())
+            return 10;
+
+        Int64 parsed_limit = 0;
+        if (!tryParse(parsed_limit, limit_param.data(), limit_param.size()) || parsed_limit < 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Invalid value of the 'limit' parameter: '{}', expected a positive integer",
+                            limit_param);
+        if (parsed_limit > 10000)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The 'limit' parameter must not exceed 10000");
         return static_cast<UInt64>(parsed_limit);
     }
 
@@ -558,6 +575,11 @@ public:
                 UInt64 limit = getLimitParam();
 
                 protocol.getSeries(getOutputStream(response), match, start, end, limit, query_finish_callback);
+            }
+            else if (uri_path.ends_with("/status/tsdb"))
+            {
+                UInt64 limit = getTSDBStatsLimitParam();
+                protocol.getTSDBStats(getOutputStream(response), limit, query_finish_callback);
             }
             else if (uri_path.ends_with("/metadata"))
             {
@@ -731,7 +753,7 @@ private:
         if (path.ends_with("/read"))
             return read_impl;
 
-        /// All other /api/v1/* endpoints (query, query_range, series, labels, label/<name>/values, metadata)
+        /// All other /api/v1/* endpoints (query, query_range, series, labels, label/<name>/values, metadata, status/tsdb)
         /// are served by the Query implementation, which itself returns 404 for unknown paths.
         return query_impl;
     }

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -36,6 +36,7 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/DataTypeDateTime64.h>
@@ -43,8 +44,11 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
 
 #include <fmt/format.h>
+
+#include <vector>
 
 
 namespace DB
@@ -178,6 +182,35 @@ String unescapePrometheusLabelName(const String & name)
         pos = closing + 1;
     }
     return result;
+}
+
+/// Makes a "SELECT <expressions> FROM <table>" query.
+ASTPtr makeSelectFromTable(ASTs select_list, const StorageID & table_id)
+{
+    auto select_query = make_intrusive<ASTSelectQuery>();
+
+    auto select_list_exp = make_intrusive<ASTExpressionList>();
+    select_list_exp->children = std::move(select_list);
+    select_query->setExpression(ASTSelectQuery::Expression::SELECT, std::move(select_list_exp));
+
+    auto table_exp = make_intrusive<ASTTableExpression>();
+    table_exp->database_and_table_name = make_intrusive<ASTTableIdentifier>(table_id);
+    table_exp->children.push_back(table_exp->database_and_table_name);
+
+    auto table = make_intrusive<ASTTablesInSelectQueryElement>();
+    table->table_expression = table_exp;
+    table->children.push_back(std::move(table_exp));
+
+    auto tables = make_intrusive<ASTTablesInSelectQuery>();
+    tables->children.push_back(std::move(table));
+    select_query->setExpression(ASTSelectQuery::Expression::TABLES, std::move(tables));
+
+    auto select_with_union_query = make_intrusive<ASTSelectWithUnionQuery>();
+    auto list_of_selects = make_intrusive<ASTExpressionList>();
+    list_of_selects->children.push_back(std::move(select_query));
+    select_with_union_query->children.push_back(list_of_selects);
+    select_with_union_query->list_of_selects = std::move(list_of_selects);
+    return select_with_union_query;
 }
 }
 
@@ -1000,6 +1033,340 @@ void PrometheusHTTPProtocolAPI::getLabelsOrLabelValues(
     }
 
     /// Release the query slot early, flush the response and record QueryFinish.
+    finishExecutedQuery(io, query_finish_callback);
+}
+
+void PrometheusHTTPProtocolAPI::getTSDBStats(
+    WriteBuffer & response,
+    UInt64 limit,
+    QueryFinishCallback query_finish_callback)
+{
+    using PrometheusQueryToSQL::SQLSubquery;
+    using PrometheusQueryToSQL::SQLSubqueryType;
+    using PrometheusQueryToSQL::SelectQueryBuilder;
+
+    std::vector<SQLSubquery> subqueries;
+    auto add_subquery = [&](ASTPtr query, SQLSubqueryType type)
+    {
+        subqueries.emplace_back(SQLSubquery{subqueries.size(), std::move(query), type});
+        return subqueries.back().name;
+    };
+
+    /// Use the same logical label representation as /series and /labels. In particular, this
+    /// deduplicates unmerged tags rows and includes labels stored in dedicated tag columns.
+    auto series_ids_query = makeSeriesIDsQuery({R"({__name__!=""})"}, "", "");
+    auto labels_expression = makeASTFunction("timeSeriesIdToTags", make_intrusive<ASTIdentifier>("series_id"));
+    labels_expression->setAlias("labels");
+    auto canonical_series_query = makeSelectFromSubquery(
+        {std::move(labels_expression)}, std::move(series_ids_query), /* distinct = */ true, {});
+    const String canonical_series_name = add_subquery(std::move(canonical_series_query), SQLSubqueryType::MATERIALIZED_TABLE);
+
+    /// SELECT tupleElement(label, 1) AS label_name, tupleElement(label, 2) AS label_value
+    /// FROM (canonical_series) ARRAY JOIN labels AS label
+    SelectQueryBuilder label_pairs_builder;
+    label_pairs_builder.from_table = canonical_series_name;
+    auto label = makeASTFunction("arrayJoin", make_intrusive<ASTIdentifier>("labels"));
+    label->setAlias("label");
+    auto label_name = makeASTFunction("tupleElement", label, make_intrusive<ASTLiteral>(1u));
+    label_name->setAlias("label_name");
+    label_pairs_builder.select_list.push_back(std::move(label_name));
+    auto label_value = makeASTFunction(
+        "tupleElement", make_intrusive<ASTIdentifier>("label"), make_intrusive<ASTLiteral>(2u));
+    label_value->setAlias("label_value");
+    label_pairs_builder.select_list.push_back(std::move(label_value));
+    label_pairs_builder.where = makeASTFunction(
+        "notEquals",
+        makeASTFunction("tupleElement", make_intrusive<ASTIdentifier>("label"), make_intrusive<ASTLiteral>(2u)),
+        make_intrusive<ASTLiteral>(""));
+    const String label_pairs_name = add_subquery(label_pairs_builder.getSelectQuery(), SQLSubqueryType::TABLE);
+
+    /// One row per distinct logical (label name, label value) pair, with the number of series using it.
+    SelectQueryBuilder pair_counts_builder;
+    pair_counts_builder.from_table = label_pairs_name;
+    pair_counts_builder.select_list.push_back(make_intrusive<ASTIdentifier>("label_name"));
+    pair_counts_builder.select_list.push_back(make_intrusive<ASTIdentifier>("label_value"));
+    auto series_count = makeASTFunction("count");
+    series_count->setAlias("series_count");
+    pair_counts_builder.select_list.push_back(std::move(series_count));
+    pair_counts_builder.group_by.push_back(make_intrusive<ASTIdentifier>("label_name"));
+    pair_counts_builder.group_by.push_back(make_intrusive<ASTIdentifier>("label_value"));
+    const String pair_counts_name = add_subquery(pair_counts_builder.getSelectQuery(), SQLSubqueryType::MATERIALIZED_TABLE);
+
+    /// Aggregate label-name cardinality and the approximate memory required for the label pairs.
+    SelectQueryBuilder label_stats_builder;
+    label_stats_builder.from_table = pair_counts_name;
+    label_stats_builder.select_list.push_back(make_intrusive<ASTIdentifier>("label_name"));
+    auto label_value_count = makeASTFunction("count");
+    label_value_count->setAlias("label_value_count");
+    label_stats_builder.select_list.push_back(std::move(label_value_count));
+    /// This follows the default Prometheus labels representation: each string contributes its byte length
+    /// plus one byte for the encoded length (or four bytes for strings of length 255 and larger).
+    auto encoded_string_size = [](ASTPtr value)
+    {
+        auto length = makeASTFunction("length", std::move(value));
+        auto encoded_length = makeASTFunction(
+            "if",
+            makeASTFunction("less", length->clone(), make_intrusive<ASTLiteral>(255u)),
+            make_intrusive<ASTLiteral>(1u),
+            make_intrusive<ASTLiteral>(4u));
+        return makeASTFunction("plus", std::move(length), std::move(encoded_length));
+    };
+
+    auto label_size = makeASTFunction(
+        "plus",
+        encoded_string_size(make_intrusive<ASTIdentifier>("label_name")),
+        encoded_string_size(make_intrusive<ASTIdentifier>("label_value")));
+    auto memory_bytes = makeASTFunction(
+        "sum",
+        makeASTFunction(
+            "multiply",
+            std::move(label_size),
+            make_intrusive<ASTIdentifier>("series_count")));
+    memory_bytes->setAlias("memory_bytes");
+    label_stats_builder.select_list.push_back(std::move(memory_bytes));
+    label_stats_builder.group_by.push_back(make_intrusive<ASTIdentifier>("label_name"));
+    const String label_stats_name = add_subquery(label_stats_builder.getSelectQuery(), SQLSubqueryType::MATERIALIZED_TABLE);
+
+    /// Build one scalar CTE containing an array of {name, value} objects. The bitwise complement
+    /// makes groupArraySorted keep the largest values without materializing all statistics entries.
+    auto add_stats_array = [&](const String & source_name, ASTPtr name_expression, ASTPtr value_expression, ASTPtr where)
+    {
+        SelectQueryBuilder builder;
+        builder.from_table = source_name;
+        builder.where = std::move(where);
+
+        auto value_sort_key = makeASTFunction("bitNot", value_expression->clone());
+        auto value_name_tuple = makeASTFunction("tuple", std::move(value_sort_key), std::move(name_expression));
+        auto sorted = addParametersToAggregateFunction(
+            makeASTFunction("groupArraySorted", std::move(value_name_tuple)), make_intrusive<ASTLiteral>(limit));
+        auto stats = makeASTFunction(
+            "arrayMap",
+            makeASTLambda(
+                {"x"},
+                makeASTFunction(
+                    "tuple",
+                    makeASTFunction("tupleElement", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTLiteral>(2u)),
+                    makeASTFunction(
+                        "bitNot",
+                        makeASTFunction("tupleElement", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTLiteral>(1u))))),
+            std::move(sorted));
+        stats->setAlias("stats");
+        builder.select_list.push_back(std::move(stats));
+        return add_subquery(builder.getSelectQuery(), SQLSubqueryType::SCALAR);
+    };
+
+    const String metric_stats_name = add_stats_array(
+        pair_counts_name,
+        make_intrusive<ASTIdentifier>("label_value"),
+        make_intrusive<ASTIdentifier>("series_count"),
+        makeASTFunction("equals", make_intrusive<ASTIdentifier>("label_name"), make_intrusive<ASTLiteral>("__name__")));
+    const String label_value_stats_name = add_stats_array(
+        label_stats_name,
+        make_intrusive<ASTIdentifier>("label_name"),
+        make_intrusive<ASTIdentifier>("label_value_count"),
+        {});
+    const String memory_stats_name = add_stats_array(
+        label_stats_name,
+        make_intrusive<ASTIdentifier>("label_name"),
+        make_intrusive<ASTIdentifier>("memory_bytes"),
+        {});
+    const String pair_stats_name = add_stats_array(
+        pair_counts_name,
+        makeASTFunction(
+            "concat",
+            make_intrusive<ASTIdentifier>("label_name"),
+            make_intrusive<ASTLiteral>("="),
+            make_intrusive<ASTIdentifier>("label_value")),
+        make_intrusive<ASTIdentifier>("series_count"),
+        {});
+
+    SelectQueryBuilder series_count_builder;
+    series_count_builder.from_table = canonical_series_name;
+    auto logical_series_count = makeASTFunction("count");
+    logical_series_count->setAlias("num_series");
+    series_count_builder.select_list.push_back(std::move(logical_series_count));
+    const String logical_series_count_name = add_subquery(series_count_builder.getSelectQuery(), SQLSubqueryType::SCALAR);
+
+    /// TimeSeries has no Prometheus head block. Use stored per-series bounds when the tags target
+    /// exposes them, and leave them at zero for custom targets without those optional columns.
+    const auto tags_table_id = time_series_storage->getTargetTableID(ViewTarget::Tags, getContext());
+    const auto tags_table_metadata = time_series_storage->getTargetTable(ViewTarget::Tags, getContext())
+        ->getInMemoryMetadataPtr(getContext(), false);
+    const auto time_series_settings = time_series_storage->getStorageSettings();
+    const bool has_time_bounds = (*time_series_settings)[TimeSeriesSetting::store_min_time_and_max_time]
+        && tags_table_metadata->columns.has(TimeSeriesColumnNames::MinTime)
+        && tags_table_metadata->columns.has(TimeSeriesColumnNames::MaxTime);
+
+    std::optional<String> time_bounds_name;
+    if (has_time_bounds)
+    {
+        auto time_series_metadata = time_series_storage->getInMemoryMetadataPtr(getContext(), false);
+        auto timestamp_data_type = splitTimeSeriesType(time_series_metadata->columns.get(TimeSeriesColumnNames::TimeSeries).type).first;
+        UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
+
+        auto to_milliseconds = [&](const char * column_name, const char * aggregate_function)
+        {
+            const auto * column = tags_table_metadata->columns.tryGet(column_name);
+            chassert(column);
+
+            ASTPtr value = make_intrusive<ASTIdentifier>(column_name);
+            if (typeid_cast<const DataTypeAggregateFunction *>(column->type.get()))
+                value = makeASTFunction("finalizeAggregation", std::move(value));
+
+            return makeASTFunction(
+                "ifNull",
+                makeASTFunction(
+                    "toUnixTimestamp64Milli",
+                    makeASTFunction(
+                        "toDateTime64",
+                        makeASTFunction(aggregate_function, std::move(value)),
+                        make_intrusive<ASTLiteral>(timestamp_scale))),
+                make_intrusive<ASTLiteral>(Int64{0}));
+        };
+
+        auto bounds = makeASTFunction(
+            "tuple",
+            to_milliseconds(TimeSeriesColumnNames::MinTime, "min"),
+            to_milliseconds(TimeSeriesColumnNames::MaxTime, "max"));
+        bounds->setAlias("time_bounds");
+        auto bounds_query = makeSelectFromTable({std::move(bounds)}, tags_table_id);
+        time_bounds_name = add_subquery(std::move(bounds_query), SQLSubqueryType::SCALAR);
+    }
+
+    SelectQueryBuilder final_builder;
+    final_builder.from_table = pair_counts_name;
+    final_builder.with = std::move(subqueries);
+
+    auto num_label_pairs = makeASTFunction("count");
+    num_label_pairs->setAlias("num_label_pairs");
+    final_builder.select_list.push_back(std::move(num_label_pairs));
+
+    ASTPtr num_series = make_intrusive<ASTIdentifier>(logical_series_count_name);
+    num_series = makeASTFunction("assumeNotNull", std::move(num_series));
+    num_series->setAlias("num_series");
+    final_builder.select_list.push_back(std::move(num_series));
+
+    ASTPtr min_time;
+    ASTPtr max_time;
+    if (time_bounds_name)
+    {
+        auto time_bounds = makeASTFunction("assumeNotNull", make_intrusive<ASTIdentifier>(*time_bounds_name));
+        min_time = makeASTFunction("tupleElement", time_bounds->clone(), make_intrusive<ASTLiteral>(1u));
+        max_time = makeASTFunction("tupleElement", std::move(time_bounds), make_intrusive<ASTLiteral>(2u));
+    }
+    else
+    {
+        /// Keep the serialized SQL expressions as Int64. A bare numeric literal would be inferred as UInt8.
+        min_time = makeASTFunction("toInt64", make_intrusive<ASTLiteral>(0u));
+        max_time = makeASTFunction("toInt64", make_intrusive<ASTLiteral>(0u));
+    }
+    min_time->setAlias("min_time");
+    max_time->setAlias("max_time");
+    final_builder.select_list.push_back(std::move(min_time));
+    final_builder.select_list.push_back(std::move(max_time));
+
+    auto add_final_array = [&](const String & name, const char * alias)
+    {
+        auto expression = makeASTFunction("assumeNotNull", make_intrusive<ASTIdentifier>(name));
+        expression->setAlias(alias);
+        final_builder.select_list.push_back(std::move(expression));
+    };
+    add_final_array(metric_stats_name, "series_count_by_metric_name");
+    add_final_array(label_value_stats_name, "label_value_count_by_label_name");
+    add_final_array(memory_stats_name, "memory_in_bytes_by_label_name");
+    add_final_array(pair_stats_name, "series_count_by_label_value_pair");
+
+    auto sql_query = final_builder.getSelectQuery();
+    LOG_TRACE(log, "SQL query to execute:\n{}", sql_query->formatForLogging());
+
+    /// Functions timeSeriesStoreTags() and timeSeriesIdToTags() are supported by the analyzer only.
+    getContext()->setSetting("allow_experimental_analyzer", true);
+    if (!getContext()->getSettingsRef()[Setting::enable_materialized_cte].changed)
+        getContext()->setSetting("enable_materialized_cte", true);
+
+    auto [ast, io] = executeQuery(sql_query->formatWithSecretsOneLine(), getContext(), {}, QueryProcessingStage::Complete);
+
+    try
+    {
+        PullingAsyncPipelineExecutor executor(io.pipeline);
+
+        /// Pull the first non-empty block before writing the header so an early exception still produces the correct error response.
+        bool has_output = false;
+        Block block;
+        while (executor.pull(block))
+        {
+            if (block.rows() > 0)
+            {
+                has_output = true;
+                break;
+            }
+        }
+
+        if (!has_output)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "The Prometheus TSDB statistics query returned no rows");
+
+        auto materialize_column = [&](const char * column_name) -> const ColumnPtr &
+        {
+            auto & column = block.getByName(column_name).column;
+            column = column->convertToFullColumnIfConst();
+            return column;
+        };
+
+        const auto & num_series_column = typeid_cast<const ColumnUInt64 &>(*materialize_column("num_series")).getData();
+        const auto & num_label_pairs_column = typeid_cast<const ColumnUInt64 &>(*materialize_column("num_label_pairs")).getData();
+        const auto & min_time_column = typeid_cast<const ColumnInt64 &>(*materialize_column("min_time")).getData();
+        const auto & max_time_column = typeid_cast<const ColumnInt64 &>(*materialize_column("max_time")).getData();
+
+        writeString(R"({"status":"success","data":{"headStats":{"numSeries":)", response);
+        writeIntText(num_series_column[0], response);
+        writeString(R"(,"numLabelPairs":)", response);
+        writeIntText(num_label_pairs_column[0], response);
+        writeString(R"(,"chunkCount":0,"minTime":)", response);
+        writeIntText(min_time_column[0], response);
+        writeString(R"(,"maxTime":)", response);
+        writeIntText(max_time_column[0], response);
+        writeString(R"(,"seriesCountByMetricName":)", response);
+
+        auto write_stats_array = [&](const char * column_name)
+        {
+            const auto & array_column = typeid_cast<const ColumnArray &>(*materialize_column(column_name));
+            const auto & offsets = array_column.getOffsets();
+            const auto & tuple_column = typeid_cast<const ColumnTuple &>(array_column.getData());
+            const auto & name_column = tuple_column.getColumn(0);
+            const auto & value_column = typeid_cast<const ColumnUInt64 &>(tuple_column.getColumn(1)).getData();
+
+            writeString("[", response);
+            size_t end = offsets.empty() ? 0 : offsets[0];
+            for (size_t i = 0; i < end; ++i)
+            {
+                if (i)
+                    writeString(",", response);
+                writeString(R"({"name":)", response);
+                writeJSONString(name_column.getDataAt(i), response, format_settings);
+                writeString(R"(,"value":)", response);
+                writeIntText(value_column[i], response);
+                writeString("}", response);
+            }
+            writeString("]", response);
+        };
+
+        write_stats_array("series_count_by_metric_name");
+        writeString(R"(,"labelValueCountByLabelName":)", response);
+        write_stats_array("label_value_count_by_label_name");
+        writeString(R"(,"memoryInBytesByLabelName":)", response);
+        write_stats_array("memory_in_bytes_by_label_name");
+        writeString(R"(,"seriesCountByLabelValuePair":)", response);
+        write_stats_array("series_count_by_label_value_pair");
+        writeString("}}", response);
+
+        io.pipeline.finalizeWriteInQueryResultCache();
+    }
+    catch (...)
+    {
+        io.onException();
+        throw;
+    }
+
     finishExecutedQuery(io, query_finish_callback);
 }
 

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -1280,11 +1280,13 @@ void PrometheusHTTPProtocolAPI::getTSDBStats(
     LOG_TRACE(log, "SQL query to execute:\n{}", sql_query->formatForLogging());
 
     /// Functions timeSeriesStoreTags() and timeSeriesIdToTags() are supported by the analyzer only.
-    getContext()->setSetting("allow_experimental_analyzer", true);
+    auto query_context = Context::createCopy(getContext());
+    query_context->setSetting("allow_experimental_analyzer", true);
     if (!getContext()->getSettingsRef()[Setting::enable_materialized_cte].changed)
-        getContext()->setSetting("enable_materialized_cte", true);
+        query_context->setSetting("enable_materialized_cte", true);
+    query_context->setSetting("empty_result_for_aggregation_by_empty_set", false);
 
-    auto [ast, io] = executeQuery(sql_query->formatWithSecretsOneLine(), getContext(), {}, QueryProcessingStage::Complete);
+    auto [ast, io] = executeQuery(sql_query->formatWithSecretsOneLine(), query_context, {}, QueryProcessingStage::Complete);
 
     try
     {

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -1327,7 +1327,7 @@ void PrometheusHTTPProtocolAPI::getTSDBStats(
         writeIntText(min_time_column[0], response);
         writeString(R"(,"maxTime":)", response);
         writeIntText(max_time_column[0], response);
-        writeString(R"(,"seriesCountByMetricName":)", response);
+        writeString(R"(},"seriesCountByMetricName":)", response);
 
         auto write_stats_array = [&](const char * column_name)
         {

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -17,7 +17,7 @@ class PullingAsyncPipelineExecutor;
 enum class PrometheusQueryResultType;
 
 /// Helper class to support the query and metadata endpoints of the Prometheus HTTP API.
-/// Implements /api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata
+/// Implements /api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata, /api/v1/status/tsdb
 class PrometheusHTTPProtocolAPI : public WithMutableContext
 {
 public:
@@ -76,6 +76,12 @@ public:
         const Strings & match_params,
         const String & start_param,
         const String & end_param,
+        UInt64 limit,
+        QueryFinishCallback query_finish_callback = {});
+
+    /// Get TSDB cardinality statistics (/api/v1/status/tsdb), with each statistics category capped by `limit`.
+    void getTSDBStats(
+        WriteBuffer & response,
         UInt64 limit,
         QueryFinishCallback query_finish_callback = {});
 

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -35,7 +35,7 @@
                 </handler>
             </my_rule_4>
 
-            <!-- Query and metadata endpoints of the Prometheus HTTP API -->
+            <!-- Query and metadata endpoints of the Prometheus HTTP API, including /api/v1/status/tsdb. -->
             <my_rule_5>
                 <url>/api/v1/query</url>
                 <handler>
@@ -78,6 +78,20 @@
                     <table>default.prometheus</table>
                 </handler>
             </my_rule_13>
+            <my_rule_18>
+                <url>/api/v1/status/tsdb</url>
+                <handler>
+                    <type>query</type>
+                    <table>default.prometheus</table>
+                </handler>
+            </my_rule_18>
+            <my_rule_17>
+                <url>/empty/api/v1/status/tsdb</url>
+                <handler>
+                    <type>query</type>
+                    <table>default.prometheus_empty</table>
+                </handler>
+            </my_rule_17>
             <!-- A table which never gets any metrics metadata: /api/v1/metadata must return an empty result for it. -->
             <my_rule_14>
                 <url>/empty/api/v1/metadata</url>

--- a/tests/integration/test_prometheus_protocols/test_http_port.py
+++ b/tests/integration/test_prometheus_protocols/test_http_port.py
@@ -153,6 +153,20 @@ def test_main_http_prefixed_metadata_api():
     }
 
 
+def test_main_http_prefixed_tsdb_api():
+    timestamp = 1_700_001_225.0
+    metric_name = "main_http_prefixed_tsdb_target"
+
+    send_to_clickhouse([({"__name__": metric_name}, {timestamp: 14.0})])
+
+    url = f"http://{node.ip_address}:{MAIN_HTTP_PORT}/prometheus/api/v1/status/tsdb"
+    response = get_response_to_http_api(url)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"]["headStats"]["numSeries"] > 0
+
+
 def test_main_http_prefixed_label_values_api():
     timestamp = 1_700_001_275.0
     metric_name = "main_http_prefixed_label_values_target"

--- a/tests/integration/test_prometheus_protocols/test_tsdb_api.py
+++ b/tests/integration/test_prometheus_protocols/test_tsdb_api.py
@@ -1,0 +1,175 @@
+"""Tests for the Prometheus /api/v1/status/tsdb endpoint."""
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=["configs/allow_experimental_time_series_table.xml"],
+)
+
+
+def get_json_from_api(path):
+    response = requests.get(f"http://{node.ip_address}:9093{path}")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["status"] == "success", data
+    return data["data"]
+
+
+def get_bad_data_from_api(path):
+    response = requests.get(f"http://{node.ip_address}:9093{path}")
+    assert response.status_code == 400, response.text
+    data = response.json()
+    assert data["status"] == "error", data
+    assert data["errorType"] == "bad_data", data
+    return data
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    try:
+        cluster.start()
+        node.query(
+            "CREATE TABLE prometheus ENGINE=TimeSeries "
+            "SETTINGS tags_to_columns = {'host': 'host_column'}"
+        )
+        node.query("CREATE TABLE prometheus_empty ENGINE=TimeSeries")
+        node.query(
+            "CREATE TABLE prometheus_no_bounds ENGINE=TimeSeries "
+            "SETTINGS store_min_time_and_max_time = 0"
+        )
+
+        rows = [
+            "('cpu_usage', {'host': 'server1', 'region': 'eu'}, "
+            "[(toDateTime64(1000, 3), 0.5), (toDateTime64(1030, 3), 0.7)])",
+            "('cpu_usage', {'host': 'server2', 'region': 'us'}, "
+            "[(toDateTime64(1000, 3), 0.3), (toDateTime64(1030, 3), 0.5)])",
+            "('memory_usage', {'host': 'server1', 'region': 'eu'}, "
+            "[(toDateTime64(1000, 3), 0.8)])",
+            "('unicode_metric', {'city': 'é', 'region': 'eu'}, "
+            "[(toDateTime64(1000, 3), 1.0)])",
+        ]
+        for row in rows:
+            node.query(
+                "INSERT INTO prometheus (metric_name, tags, time_series) VALUES "
+                + row
+            )
+
+        # Insert one logical series again in a separate part. Physical duplicate metadata rows
+        # must not increase the Prometheus series or label cardinalities.
+        node.query(
+            "INSERT INTO prometheus (metric_name, tags, time_series) VALUES "
+            "('cpu_usage', {'host': 'server1', 'region': 'eu'}, "
+            "[(toDateTime64(1000, 3), 0.5), (toDateTime64(1030, 3), 0.7)])"
+        )
+        node.query(
+            "INSERT INTO prometheus_no_bounds (metric_name, tags, time_series) VALUES "
+            "('only_metric', {'job': 'api', 'empty': ''}, [(toDateTime64(1000, 3), 1.0)])"
+        )
+
+        assert_eq_with_retry(node, "SELECT count() > 0 FROM timeSeriesData(prometheus)", "1")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_tsdb_returns_all_statistics():
+    data = get_json_from_api("/api/v1/status/tsdb")
+
+    assert data["headStats"] == {
+        "numSeries": 4,
+        "numLabelPairs": 8,
+        "chunkCount": 0,
+        "minTime": 1_000_000,
+        "maxTime": 1_030_000,
+    }
+    assert data["seriesCountByMetricName"] == [
+        {"name": "cpu_usage", "value": 2},
+        {"name": "memory_usage", "value": 1},
+        {"name": "unicode_metric", "value": 1},
+    ]
+    assert data["labelValueCountByLabelName"] == [
+        {"name": "__name__", "value": 3},
+        {"name": "host", "value": 2},
+        {"name": "region", "value": 2},
+        {"name": "city", "value": 1},
+    ]
+    assert data["memoryInBytesByLabelName"] == [
+        {"name": "__name__", "value": 84},
+        {"name": "region", "value": 40},
+        {"name": "host", "value": 39},
+        {"name": "city", "value": 8},
+    ]
+    assert data["seriesCountByLabelValuePair"] == [
+        {"name": "region=eu", "value": 3},
+        {"name": "__name__=cpu_usage", "value": 2},
+        {"name": "host=server1", "value": 2},
+        {"name": "__name__=memory_usage", "value": 1},
+        {"name": "__name__=unicode_metric", "value": 1},
+        {"name": "city=é", "value": 1},
+        {"name": "host=server2", "value": 1},
+        {"name": "region=us", "value": 1},
+    ]
+
+
+def test_tsdb_limit_applies_independently_to_each_statistics_list():
+    data = get_json_from_api("/api/v1/status/tsdb?limit=1")
+
+    assert data["seriesCountByMetricName"] == [{"name": "cpu_usage", "value": 2}]
+    assert data["labelValueCountByLabelName"] == [{"name": "__name__", "value": 3}]
+    assert data["memoryInBytesByLabelName"] == [{"name": "__name__", "value": 84}]
+    assert data["seriesCountByLabelValuePair"] == [{"name": "region=eu", "value": 3}]
+
+
+@pytest.mark.parametrize("limit", ["0", "-1", "10001", "abc", "1.5"])
+def test_tsdb_rejects_invalid_limits(limit):
+    get_bad_data_from_api(f"/api/v1/status/tsdb?limit={limit}")
+
+
+def test_tsdb_accepts_maximum_limit():
+    data = get_json_from_api("/api/v1/status/tsdb?limit=10000")
+    assert len(data["seriesCountByLabelValuePair"]) == 8
+
+
+def test_tsdb_empty_table_returns_zero_statistics():
+    data = get_json_from_api("/empty/api/v1/status/tsdb")
+    assert data == {
+        "headStats": {
+            "numSeries": 0,
+            "numLabelPairs": 0,
+            "chunkCount": 0,
+            "minTime": 0,
+            "maxTime": 0,
+        },
+        "seriesCountByMetricName": [],
+        "labelValueCountByLabelName": [],
+        "memoryInBytesByLabelName": [],
+        "seriesCountByLabelValuePair": [],
+    }
+
+
+def test_tsdb_without_stored_time_bounds_still_returns_cardinality():
+    data = get_json_from_api("/no_bounds/api/v1/status/tsdb")
+    assert data["headStats"] == {
+        "numSeries": 1,
+        "numLabelPairs": 2,
+        "chunkCount": 0,
+        "minTime": 0,
+        "maxTime": 0,
+    }
+    assert data["seriesCountByMetricName"] == [{"name": "only_metric", "value": 1}]
+    assert data["labelValueCountByLabelName"] == [
+        {"name": "__name__", "value": 1},
+        {"name": "job", "value": 1},
+    ]
+    assert data["seriesCountByLabelValuePair"] == [
+        {"name": "__name__=only_metric", "value": 1},
+        {"name": "job=api", "value": 1},
+    ]

--- a/tests/integration/test_prometheus_protocols/test_tsdb_api.py
+++ b/tests/integration/test_prometheus_protocols/test_tsdb_api.py
@@ -155,6 +155,23 @@ def test_tsdb_empty_table_returns_zero_statistics():
     }
 
 
+def test_tsdb_empty_table_ignores_empty_result_for_aggregation_setting():
+    data = get_json_from_api(
+        "/empty/api/v1/status/tsdb?empty_result_for_aggregation_by_empty_set=1"
+    )
+    assert data["headStats"] == {
+        "numSeries": 0,
+        "numLabelPairs": 0,
+        "chunkCount": 0,
+        "minTime": 0,
+        "maxTime": 0,
+    }
+    assert data["seriesCountByMetricName"] == []
+    assert data["labelValueCountByLabelName"] == []
+    assert data["memoryInBytesByLabelName"] == []
+    assert data["seriesCountByLabelValuePair"] == []
+
+
 def test_tsdb_without_stored_time_bounds_still_returns_cardinality():
     data = get_json_from_api("/no_bounds/api/v1/status/tsdb")
     assert data["headStats"] == {


### PR DESCRIPTION
Related:
- https://github.com/ClickHouse/ClickHouse/issues/89553
- https://github.com/ClickHouse/ClickHouse/issues/57545

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Implement the `/api/v1/status/tsdb` endpoint of the Prometheus HTTP API for `TimeSeries` tables.

### Description

Adds `GET /api/v1/status/tsdb` for `TimeSeries` tables. The endpoint returns cardinality and time-range information for the stored logical series.

The response includes:

- `headStats` with the number of logical series, label pairs, `minTime`, `maxTime`, and `chunkCount`.
- `seriesCountByMetricName`.
- `labelValueCountByLabelName`.
- `memoryInBytesByLabelName`.
- `seriesCountByLabelValuePair`.

Implementation details:

- Reuses the same logical-series reconstruction as `/api/v1/series` and `/api/v1/labels`.
- Reads cardinality from the tags target, without scanning sample rows.
- Applies `limit` independently to each statistics list. It defaults to 10 and is capped at 10000.
- Uses stored `min_time` and `max_time` metadata when available.
- Returns `chunkCount: 0` because ClickHouse does not use Prometheus head chunks.
- Reports `memoryInBytesByLabelName` as an encoded label-size estimate, not an exact process-memory measurement.

### Tests

Added integration coverage for:

- normal responses and all statistics lists;
- empty tables;
- tables without stored time bounds;
- duplicate metadata rows;
- empty label values;
- default, maximum, and invalid `limit` values;
- the prefixed endpoint on the main HTTP port.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117787&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117787](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117787+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
