### PR TITLE
Complete an interrupted part removal when loading outdated parts

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -211,6 +211,7 @@ static struct InitFiu
     PAUSEABLE(async_insert_flush_pause_in_executor) \
     PAUSEABLE(system_replicas_schedule_requests_pause) \
     PAUSEABLE(stop_moving_part_before_swap_with_active) \
+    PAUSEABLE(merge_tree_commit_pause_before_removing_covered_parts) \
     REGULAR(replicated_merge_tree_all_replicas_stale) \
     REGULAR(zero_copy_lock_zk_fail_before_op) \
     REGULAR(zero_copy_lock_zk_fail_after_op) \

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -11044,8 +11044,6 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
         /// For transactional operations, MergeTreeTransaction rollback handles unlocking.
         DataPartsVector locked_parts_to_cleanup;
 
-        FailPointInjection::pauseFailPoint(FailPoints::merge_tree_commit_pause_before_removing_covered_parts);
-
         for (const auto & part : precommitted_parts)
         {
             DataPartPtr covering_part;
@@ -11075,6 +11073,9 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
             /// If there's a covering part, the precommitted part will be marked as obsolete in NOEXCEPT_SCOPE below.
             if (!covering_part)
             {
+                if (!covered_parts.empty())
+                    FailPointInjection::pauseFailPoint(FailPoints::merge_tree_commit_pause_before_removing_covered_parts);
+
                 MergeTreeTransaction::addNewPartAndRemoveCovered(data.shared_from_this(), part, covered_parts, txn);
                 /// Track successfully locked parts for cleanup in case a later iteration fails.
                 if (!txn)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -447,6 +447,10 @@ namespace FailPoints
     /// transient error (e.g. temporary disk unavailability). Used to test that the refresh task
     /// reschedules itself after such an error instead of stopping permanently.
     extern const char merge_tree_refresh_parts_throw_once[];
+    /// Pauses a commit after the covering parts are durable and before the covered parts are stamped
+    /// with their removal TID. Killing the server here leaves the on-disk state those two writes are
+    /// not atomic against.
+    extern const char merge_tree_commit_pause_before_removing_covered_parts[];
 }
 
 static String getPartNameFromAST(const ASTPtr & partition)
@@ -2520,6 +2524,43 @@ static void preparePartForRemoval(const MergeTreeMutableDataPartPtr & part)
     }
 }
 
+/// A part covered by an `Active` part has been removed even when its removal TID is not on disk: the
+/// covering part's directory is made durable before `MergeTreeTransaction::addNewPartAndRemoveCovered`
+/// stores the TID, and the two are separate writes. Storing it here writes what a finished commit writes.
+static void completeRemovalOfCoveredPart(
+    const MergeTreeMutableDataPartPtr & part,
+    bool covering_part_is_non_transactional,
+    const String & covering_part_name,
+    const LoggerPtr & log)
+{
+    auto current_version_info = part->version->getInfo();
+
+    /// `Tx::NonTransactionalTID` asserts that the removal was visible from the beginning of time, so it
+    /// is the truthful marker only when the removal was never recorded, the creation was committed by a
+    /// real transaction, and the covering part was itself created without one. Anything else is either
+    /// already handled elsewhere or corrupt metadata, and must keep reaching the check above.
+    if (current_version_info.isRemoved())
+        return;
+
+    if (!current_version_info.isCreated() || current_version_info.creation_tid.isNonTransactional()
+        || current_version_info.creation_tid.local_tid <= Tx::MaxReservedLocalTID)
+        return;
+
+    if (!covering_part_is_non_transactional)
+        return;
+
+    LOG_WARNING(
+        log,
+        "Part {} is covered by {}, which was created without a transaction, but its removal TID was not stored: {}. "
+        "Completing the interrupted removal",
+        part->name,
+        covering_part_name,
+        current_version_info.toString(/*one_line=*/true));
+
+    TransactionInfoContext transaction_context{part->storage.getStorageID(), part->name};
+    part->version->setAndStoreNonTransactionalRemovalTID(transaction_context);
+}
+
 static constexpr size_t loading_parts_initial_backoff_ms = 100;
 static constexpr size_t loading_parts_max_backoff_ms = 5000;
 static constexpr size_t loading_parts_max_tries = 3;
@@ -2572,7 +2613,9 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
     const String & part_name,
     const DiskPtr & part_disk_ptr,
     MergeTreeDataPartState to_state,
-    DB::SharedMutex & part_loading_mutex)
+    DB::SharedMutex & part_loading_mutex,
+    bool covering_part_is_non_transactional,
+    const String & covering_part_name)
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeData::loadDataPart");
     LOG_TRACE(log, "Loading {} part {} from disk {}", magic_enum::enum_name(to_state), part_name, part_disk_ptr->getName());
@@ -2669,6 +2712,10 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
         }
     }
 
+    /// Before publication: a background merge started by `startup` also stamps removal TIDs, and it can
+    /// see this part as soon as it is in `data_parts_indexes`.
+    completeRemovalOfCoveredPart(res.part, covering_part_is_non_transactional, covering_part_name, log.load());
+
     res.part->setState(to_state);
 
     DataPartIteratorByInfo it;
@@ -2714,7 +2761,9 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     DB::SharedMutex & part_loading_mutex,
     size_t initial_backoff_ms,
     size_t max_backoff_ms,
-    size_t max_tries)
+    size_t max_tries,
+    bool covering_part_is_non_transactional,
+    const String & covering_part_name)
 {
     auto handle_exception = [&, this](std::exception_ptr exception_ptr, size_t try_no)
     {
@@ -2733,7 +2782,9 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     {
         try
         {
-            return loadDataPart(part_info, part_name, part_disk_ptr, to_state, part_loading_mutex);
+            return loadDataPart(
+                part_info, part_name, part_disk_ptr, to_state, part_loading_mutex,
+                covering_part_is_non_transactional, covering_part_name);
         }
         catch (...)
         {
@@ -2804,6 +2855,29 @@ std::vector<MergeTreeData::LoadPartResult> MergeTreeData::loadDataPartsFromDisk(
 
                 part->is_loaded = true;
                 bool is_active_part = res.part->getState() == DataPartState::Active;
+
+                /// This part covers its whole subtree and, being `Active`, is the part whose existence
+                /// accounts for those rows. Record how it was created while its metadata is in memory:
+                /// a part that did not load `Active` hands its children back to the queue below instead,
+                /// so whichever descendant does load `Active` is the one that records this.
+                if (is_active_part && !part->children.empty())
+                {
+                    auto covering_info = res.part->version->getInfo();
+                    bool non_transactional = covering_info.creation_tid == Tx::NonTransactionalTID
+                        && covering_info.creation_csn == Tx::NonTransactionalCSN;
+
+                    std::function<void(const PartLoadingTree::NodePtr &)> mark_subtree
+                        = [&](const PartLoadingTree::NodePtr & node)
+                    {
+                        node->covering_part_is_non_transactional = non_transactional;
+                        node->covering_part_name = res.part->name;
+                        for (const auto & [_, child] : node->children)
+                            mark_subtree(child);
+                    };
+
+                    for (const auto & [_, node] : part->children)
+                        mark_subtree(node);
+                }
 
                 /// If part is broken or duplicate or should be removed according to transaction
                 /// and it has any covered parts then try to load them to replace this part.
@@ -3559,7 +3633,8 @@ try
             auto res = loadDataPartWithRetries(
                 my_part->info, my_part->name, my_part->disk,
                 DataPartState::Outdated, data_parts_mutex, loading_parts_initial_backoff_ms,
-                loading_parts_max_backoff_ms, loading_parts_max_tries);
+                loading_parts_max_backoff_ms, loading_parts_max_tries,
+                my_part->covering_part_is_non_transactional, my_part->covering_part_name);
 
             ++num_loaded_parts;
             if (res.is_broken)
@@ -10968,6 +11043,8 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
         /// Track covered parts locked by non-transactional operations for cleanup on failure.
         /// For transactional operations, MergeTreeTransaction rollback handles unlocking.
         DataPartsVector locked_parts_to_cleanup;
+
+        FailPointInjection::pauseFailPoint(FailPoints::merge_tree_commit_pause_before_removing_covered_parts);
 
         for (const auto & part : precommitted_parts)
         {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2614,8 +2614,7 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
     const DiskPtr & part_disk_ptr,
     MergeTreeDataPartState to_state,
     DB::SharedMutex & part_loading_mutex,
-    bool covering_part_is_non_transactional,
-    const String & covering_part_name)
+    const PartLoadingTree::NodePtr & part_loading_node)
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeData::loadDataPart");
     LOG_TRACE(log, "Loading {} part {} from disk {}", magic_enum::enum_name(to_state), part_name, part_disk_ptr->getName());
@@ -2714,7 +2713,10 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
 
     /// Before publication: a background merge started by `startup` also stamps removal TIDs, and it can
     /// see this part as soon as it is in `data_parts_indexes`.
-    completeRemovalOfCoveredPart(res.part, covering_part_is_non_transactional, covering_part_name, log.load());
+    if (part_loading_node)
+        completeRemovalOfCoveredPart(
+            res.part, part_loading_node->covering_part_is_non_transactional, part_loading_node->covering_part_name,
+            log.load());
 
     res.part->setState(to_state);
 
@@ -2762,8 +2764,7 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     size_t initial_backoff_ms,
     size_t max_backoff_ms,
     size_t max_tries,
-    bool covering_part_is_non_transactional,
-    const String & covering_part_name)
+    const PartLoadingTree::NodePtr & part_loading_node)
 {
     auto handle_exception = [&, this](std::exception_ptr exception_ptr, size_t try_no)
     {
@@ -2782,9 +2783,7 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     {
         try
         {
-            return loadDataPart(
-                part_info, part_name, part_disk_ptr, to_state, part_loading_mutex,
-                covering_part_is_non_transactional, covering_part_name);
+            return loadDataPart(part_info, part_name, part_disk_ptr, to_state, part_loading_mutex, part_loading_node);
         }
         catch (...)
         {
@@ -3633,8 +3632,7 @@ try
             auto res = loadDataPartWithRetries(
                 my_part->info, my_part->name, my_part->disk,
                 DataPartState::Outdated, data_parts_mutex, loading_parts_initial_backoff_ms,
-                loading_parts_max_backoff_ms, loading_parts_max_tries,
-                my_part->covering_part_is_non_transactional, my_part->covering_part_name);
+                loading_parts_max_backoff_ms, loading_parts_max_tries, my_part);
 
             ++num_loaded_parts;
             if (res.is_broken)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2612,9 +2612,9 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
     const MergeTreePartInfo & part_info,
     const String & part_name,
     const DiskPtr & part_disk_ptr,
+    const PartLoadingTree::NodePtr & part_loading_node,
     MergeTreeDataPartState to_state,
-    DB::SharedMutex & part_loading_mutex,
-    const PartLoadingTree::NodePtr & part_loading_node)
+    DB::SharedMutex & part_loading_mutex)
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeData::loadDataPart");
     LOG_TRACE(log, "Loading {} part {} from disk {}", magic_enum::enum_name(to_state), part_name, part_disk_ptr->getName());
@@ -2759,12 +2759,12 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     const MergeTreePartInfo & part_info,
     const String & part_name,
     const DiskPtr & part_disk_ptr,
+    const PartLoadingTree::NodePtr & part_loading_node,
     MergeTreeDataPartState to_state,
     DB::SharedMutex & part_loading_mutex,
     size_t initial_backoff_ms,
     size_t max_backoff_ms,
-    size_t max_tries,
-    const PartLoadingTree::NodePtr & part_loading_node)
+    size_t max_tries)
 {
     auto handle_exception = [&, this](std::exception_ptr exception_ptr, size_t try_no)
     {
@@ -2783,7 +2783,7 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPartWithRetries(
     {
         try
         {
-            return loadDataPart(part_info, part_name, part_disk_ptr, to_state, part_loading_mutex, part_loading_node);
+            return loadDataPart(part_info, part_name, part_disk_ptr, part_loading_node, to_state, part_loading_mutex);
         }
         catch (...)
         {
@@ -2848,7 +2848,7 @@ std::vector<MergeTreeData::LoadPartResult> MergeTreeData::loadDataPartsFromDisk(
                 /// Pass a separate mutex to guard the set of parts, because this lambda
                 /// is called concurrently but with already locked @data_parts_mutex.
                 auto res = loadDataPartWithRetries(
-                    part->info, part->name, part->disk,
+                    part->info, part->name, part->disk, /*part_loading_node=*/nullptr,
                     DataPartState::Active, part_loading_mutex, loading_parts_initial_backoff_ms,
                     loading_parts_max_backoff_ms, loading_parts_max_tries);
 
@@ -3404,7 +3404,7 @@ void MergeTreeData::refreshDataPartsOnce(UInt64 interval_milliseconds)
     for (const auto & my_part : parts_to_add)
     {
         auto res = loadDataPartWithRetries(
-            my_part->info, my_part->name, my_part->disk,
+            my_part->info, my_part->name, my_part->disk, /*part_loading_node=*/nullptr,
             DataPartState::PreActive, data_parts_mutex, loading_parts_initial_backoff_ms,
             loading_parts_max_backoff_ms, loading_parts_max_tries);
 
@@ -3630,9 +3630,9 @@ try
             auto blocker_for_runner_thread = CannotAllocateThreadFaultInjector::blockFaultInjections();
 
             auto res = loadDataPartWithRetries(
-                my_part->info, my_part->name, my_part->disk,
+                my_part->info, my_part->name, my_part->disk, my_part,
                 DataPartState::Outdated, data_parts_mutex, loading_parts_initial_backoff_ms,
-                loading_parts_max_backoff_ms, loading_parts_max_tries, my_part);
+                loading_parts_max_backoff_ms, loading_parts_max_tries);
 
             ++num_loaded_parts;
             if (res.is_broken)

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -2045,6 +2045,10 @@ protected:
             const DiskPtr disk;
 
             bool is_loaded = false;
+            /// Set from the ancestor that loaded `Active` and therefore covers this part. Copied by value
+            /// because the tree does not outlive active parts loading and the cover may be replaced by a merge.
+            bool covering_part_is_non_transactional = false;
+            String covering_part_name;
             std::map<MergeTreePartInfo, std::shared_ptr<Node>> children;
         };
 
@@ -2276,7 +2280,9 @@ private:
         const String & part_name,
         const DiskPtr & part_disk_ptr,
         MergeTreeDataPartState to_state,
-        DB::SharedMutex & part_loading_mutex);
+        DB::SharedMutex & part_loading_mutex,
+        bool covering_part_is_non_transactional = false,
+        const String & covering_part_name = {});
 
     LoadPartResult loadDataPartWithRetries(
         const MergeTreePartInfo & part_info,
@@ -2286,7 +2292,9 @@ private:
         DB::SharedMutex & part_loading_mutex,
         size_t backoff_ms,
         size_t max_backoff_ms,
-        size_t max_tries);
+        size_t max_tries,
+        bool covering_part_is_non_transactional = false,
+        const String & covering_part_name = {});
 
     /// Create zero-copy exclusive lock for part and disk. Useful for coordination of
     /// distributed operations which can lead to data duplication. Implemented only in ReplicatedMergeTree.

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -2045,8 +2045,8 @@ protected:
             const DiskPtr disk;
 
             bool is_loaded = false;
-            /// Set from the ancestor that loaded `Active` and therefore covers this part. Copied by value
-            /// because the tree does not outlive active parts loading and the cover may be replaced by a merge.
+            /// Set from the ancestor that loaded `Active` and therefore covers this part. Stored by
+            /// value rather than as a part pointer, because a merge may replace the cover during startup.
             bool covering_part_is_non_transactional = false;
             String covering_part_name;
             std::map<MergeTreePartInfo, std::shared_ptr<Node>> children;
@@ -2281,8 +2281,7 @@ private:
         const DiskPtr & part_disk_ptr,
         MergeTreeDataPartState to_state,
         DB::SharedMutex & part_loading_mutex,
-        bool covering_part_is_non_transactional = false,
-        const String & covering_part_name = {});
+        const PartLoadingTree::NodePtr & part_loading_node = nullptr);
 
     LoadPartResult loadDataPartWithRetries(
         const MergeTreePartInfo & part_info,
@@ -2293,8 +2292,7 @@ private:
         size_t backoff_ms,
         size_t max_backoff_ms,
         size_t max_tries,
-        bool covering_part_is_non_transactional = false,
-        const String & covering_part_name = {});
+        const PartLoadingTree::NodePtr & part_loading_node = nullptr);
 
     /// Create zero-copy exclusive lock for part and disk. Useful for coordination of
     /// distributed operations which can lead to data duplication. Implemented only in ReplicatedMergeTree.

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -2279,20 +2279,20 @@ private:
         const MergeTreePartInfo & part_info,
         const String & part_name,
         const DiskPtr & part_disk_ptr,
+        const PartLoadingTree::NodePtr & part_loading_node,
         MergeTreeDataPartState to_state,
-        DB::SharedMutex & part_loading_mutex,
-        const PartLoadingTree::NodePtr & part_loading_node = nullptr);
+        DB::SharedMutex & part_loading_mutex);
 
     LoadPartResult loadDataPartWithRetries(
         const MergeTreePartInfo & part_info,
         const String & part_name,
         const DiskPtr & part_disk_ptr,
+        const PartLoadingTree::NodePtr & part_loading_node,
         MergeTreeDataPartState to_state,
         DB::SharedMutex & part_loading_mutex,
         size_t backoff_ms,
         size_t max_backoff_ms,
-        size_t max_tries,
-        const PartLoadingTree::NodePtr & part_loading_node = nullptr);
+        size_t max_tries);
 
     /// Create zero-copy exclusive lock for part and disk. Useful for coordination of
     /// distributed operations which can lead to data duplication. Implemented only in ReplicatedMergeTree.

--- a/tests/integration/test_transactions/test.py
+++ b/tests/integration/test_transactions/test.py
@@ -440,9 +440,9 @@ def test_recover_removal_tid_of_part_covered_by_non_txn_part(start_cluster):
         "CREATE TABLE mt4 (n int, m int) ENGINE=MergeTree ORDER BY n PARTITION BY n % 2"
         " SETTINGS remove_empty_parts = 0, old_parts_lifetime = 3600"
     )
-    # The failpoint is global and background merges commit through the very same function, so a merge
-    # could consume the pause while DROP PARTITION is still waiting for merges to stop.
-    node.query("SYSTEM STOP MERGES mt4")
+    # The failpoint is global: any commit that removes covered parts pauses at it, so a merge of any
+    # table would satisfy the wait below and the SIGKILL would then capture a different operation.
+    node.query("SYSTEM STOP MERGES")
 
     # Each committed transaction leaves one part with a real creation_tid, a committed creation_csn
     # and an empty removal_tid.  Partition 0 (even n) is dropped below, partition 1 is the control.

--- a/tests/integration/test_transactions/test.py
+++ b/tests/integration/test_transactions/test.py
@@ -1,3 +1,5 @@
+import concurrent.futures
+
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -419,6 +421,103 @@ def test_rollback_unfinished_on_restart2(start_cluster):
     )
 
     node.query("DROP TABLE IF EXISTS mt2 SYNC")
+
+
+FAILPOINT = "merge_tree_commit_pause_before_removing_covered_parts"
+
+
+def test_recover_removal_tid_of_part_covered_by_non_txn_part(start_cluster):
+    """
+    A non-transactional DROP PARTITION makes its empty covering part durable before it stores the
+    removal TID of the parts it covers, and the two are separate writes.  Killing the server in
+    between leaves an Outdated part whose creation was committed by a transaction but whose removal
+    was never recorded; before the fix, loading it aborted the server on every subsequent start.
+
+    Refer: https://github.com/ClickHouse/ClickHouse/issues/71136
+    """
+    node.query("DROP TABLE IF EXISTS mt4 SYNC")
+    node.query(
+        "CREATE TABLE mt4 (n int, m int) ENGINE=MergeTree ORDER BY n PARTITION BY n % 2"
+        " SETTINGS remove_empty_parts = 0, old_parts_lifetime = 3600"
+    )
+    # The failpoint is global and background merges commit through the very same function, so a merge
+    # could consume the pause while DROP PARTITION is still waiting for merges to stop.
+    node.query("SYSTEM STOP MERGES mt4")
+
+    # Each committed transaction leaves one part with a real creation_tid, a committed creation_csn
+    # and an empty removal_tid.  Partition 0 (even n) is dropped below, partition 1 is the control.
+    for k in range(1, 5):
+        tx(k, "BEGIN TRANSACTION")
+        tx(k, f"INSERT INTO mt4 VALUES({k},{k})")
+        tx(k, "COMMIT")
+
+    node.query(f"SYSTEM ENABLE FAILPOINT {FAILPOINT}")
+    # A mistyped name would otherwise only surface as BAD_ARGUMENTS on the waiting thread below.
+    assert (
+        node.query(
+            f"SELECT count() FROM system.fail_points WHERE name = '{FAILPOINT}' AND enabled"
+        ).strip()
+        == "1"
+    ), f"failpoint {FAILPOINT} is not enabled"
+
+    # DROP PARTITION never returns: it renames the empty covering part into place and then blocks at
+    # the failpoint, holding the parts lock.  The executor must outlive the assertion, because
+    # shutdown(wait=True) would block forever on a worker parked in the wait.
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+    drop_future = pool.submit(node.query, "ALTER TABLE mt4 DROP PARTITION 0")
+    wait_future = pool.submit(node.query, f"SYSTEM WAIT FAILPOINT {FAILPOINT} PAUSE")
+
+    done, _ = concurrent.futures.wait([wait_future], timeout=60)
+    if not done:
+        pool.shutdown(wait=False, cancel_futures=True)
+        assert False, f"failpoint {FAILPOINT} not triggered within 60 s"
+    wait_future.result()
+    assert not drop_future.done(), "DROP PARTITION returned, so the commit was not paused"
+
+    # SIGKILL: the paused thread never rolls back, so the on-disk state is exactly the window state.
+    node.restart_clickhouse(kill=True)
+    pool.shutdown(wait=False, cancel_futures=True)
+    node.query("SYSTEM WAIT LOADING PARTS mt4")
+
+    assert node.query("SELECT n FROM mt4 ORDER BY n") == "1\n3\n"
+
+    empty_tid = "(0,0,'00000000-0000-0000-0000-000000000000')"
+    non_txn_tid = "(1,1,'00000000-0000-0000-0000-000000000000')"
+
+    # The empty covering parts survived the kill and were created without a transaction: DROP PARTITION
+    # covers each dropped part with one empty part of the same block range at the next level.  They are
+    # what makes the removal below a fact, and a non-transactional marker the truthful record of it.
+    covers = node.query(
+        "SELECT name FROM system.parts"
+        " WHERE database='default' AND table='mt4' AND active=1"
+        f"   AND creation_tid = {non_txn_tid} AND creation_csn = 1"
+        " ORDER BY name"
+    ).strip()
+    assert covers == "0_2_2_1\n0_4_4_1", f"unexpected covering parts: {covers}"
+
+    # The removal is now recorded exactly as a finished commit would have recorded it.  This is what
+    # distinguishes completing the removal from silencing the error.
+    recovered = node.query(
+        "SELECT name FROM system.parts"
+        " WHERE database='default' AND table='mt4' AND active=0"
+        f"   AND removal_tid = {non_txn_tid} AND removal_csn = 1"
+        " ORDER BY name"
+    ).strip()
+    assert recovered == "0_2_2_0\n0_4_4_0", f"unexpected recovered parts: {recovered}"
+
+    # In-range control: the partition-1 parts carry the same committed-creation / unrecorded-removal
+    # payload as the victims but are not covered, so they must be untouched.  Only a part covered by an
+    # active part gets a removal marker, so this is what shows the fix is not a blanket stamp.
+    control = node.query(
+        "SELECT name FROM system.parts"
+        " WHERE database='default' AND table='mt4' AND active=1"
+        f"   AND creation_tid != {non_txn_tid} AND creation_csn > 1"
+        f"   AND removal_tid = {empty_tid} AND removal_csn = 0"
+        " ORDER BY name"
+    ).strip()
+    assert control == "1_1_1_0\n1_3_3_0", f"unexpected control parts: {control}"
+
+    node.query("DROP TABLE IF EXISTS mt4 SYNC")
 
 
 def test_mutate_transaction_involved_parts(start_cluster):

--- a/tests/integration/test_transactions/test.py
+++ b/tests/integration/test_transactions/test.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
@@ -451,32 +452,52 @@ def test_recover_removal_tid_of_part_covered_by_non_txn_part(start_cluster):
         tx(k, f"INSERT INTO mt4 VALUES({k},{k})")
         tx(k, "COMMIT")
 
+    # `SYSTEM STOP MERGES` only installs the merge blockers: a merge already past its last
+    # cancellation check still commits, and any merge does remove covered parts, so it would
+    # satisfy the wait below instead of the DROP.  A merge holds its `system.merges` entry until
+    # after that commit, so an empty `system.merges` is what makes the DROP the only consumer.
+    assert_eq_with_retry(
+        node, "SELECT count() FROM system.merges", "0", retry_count=60, sleep_time=1
+    )
+
     node.query(f"SYSTEM ENABLE FAILPOINT {FAILPOINT}")
-    # A mistyped name would otherwise only surface as BAD_ARGUMENTS on the waiting thread below.
-    assert (
-        node.query(
-            f"SELECT count() FROM system.fail_points WHERE name = '{FAILPOINT}' AND enabled"
-        ).strip()
-        == "1"
-    ), f"failpoint {FAILPOINT} is not enabled"
 
     # DROP PARTITION never returns: it renames the empty covering part into place and then blocks at
     # the failpoint, holding the parts lock.  The executor must outlive the assertion, because
     # shutdown(wait=True) would block forever on a worker parked in the wait.
     pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
-    drop_future = pool.submit(node.query, "ALTER TABLE mt4 DROP PARTITION 0")
-    wait_future = pool.submit(node.query, f"SYSTEM WAIT FAILPOINT {FAILPOINT} PAUSE")
+    try:
+        # A mistyped name would otherwise only surface as BAD_ARGUMENTS on the waiting thread below.
+        assert (
+            node.query(
+                f"SELECT count() FROM system.fail_points WHERE name = '{FAILPOINT}' AND enabled"
+            ).strip()
+            == "1"
+        ), f"failpoint {FAILPOINT} is not enabled"
 
-    done, _ = concurrent.futures.wait([wait_future], timeout=60)
-    if not done:
+        drop_future = pool.submit(node.query, "ALTER TABLE mt4 DROP PARTITION 0")
+        wait_future = pool.submit(node.query, f"SYSTEM WAIT FAILPOINT {FAILPOINT} PAUSE")
+
+        done, _ = concurrent.futures.wait([wait_future], timeout=60)
+        if not done:
+            assert False, f"failpoint {FAILPOINT} not triggered within 60 s"
+        wait_future.result()
+        assert not drop_future.done(), "DROP PARTITION returned, so the commit was not paused"
+        assert (
+            node.query("SELECT count() FROM system.merges").strip() == "0"
+        ), "a merge is parked at the failpoint, so the paused commit is not the DROP's"
+
+        # SIGKILL: the paused thread never rolls back, so the on-disk state is exactly the window state.
+        node.restart_clickhouse(kill=True)
+    finally:
+        # Only the kill clears the armed failpoint and the merge stop, so a failure before it would
+        # leave every later commit that removes covered parts parked at the failpoint for the rest
+        # of the module.  Disabling also resumes a thread already parked, and is a no-op once the
+        # restart has cleared it.
+        node.query_and_get_answer_with_error(f"SYSTEM DISABLE FAILPOINT {FAILPOINT}")
+        node.query_and_get_answer_with_error("SYSTEM START MERGES")
         pool.shutdown(wait=False, cancel_futures=True)
-        assert False, f"failpoint {FAILPOINT} not triggered within 60 s"
-    wait_future.result()
-    assert not drop_future.done(), "DROP PARTITION returned, so the commit was not paused"
 
-    # SIGKILL: the paused thread never rolls back, so the on-disk state is exactly the window state.
-    node.restart_clickhouse(kill=True)
-    pool.shutdown(wait=False, cancel_futures=True)
     node.query("SYSTEM WAIT LOADING PARTS mt4")
 
     assert node.query("SELECT n FROM mt4 ORDER BY n") == "1\n3\n"

--- a/tests/integration/test_transactions/test.py
+++ b/tests/integration/test_transactions/test.py
@@ -463,8 +463,7 @@ def test_recover_removal_tid_of_part_covered_by_non_txn_part(start_cluster):
     node.query(f"SYSTEM ENABLE FAILPOINT {FAILPOINT}")
 
     # DROP PARTITION never returns: it renames the empty covering part into place and then blocks at
-    # the failpoint, holding the parts lock.  The executor must outlive the assertion, because
-    # shutdown(wait=True) would block forever on a worker parked in the wait.
+    # the failpoint, holding the parts lock.
     pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
     try:
         # A mistyped name would otherwise only surface as BAD_ARGUMENTS on the waiting thread below.
@@ -496,7 +495,9 @@ def test_recover_removal_tid_of_part_covered_by_non_txn_part(start_cluster):
         # restart has cleared it.
         node.query_and_get_answer_with_error(f"SYSTEM DISABLE FAILPOINT {FAILPOINT}")
         node.query_and_get_answer_with_error("SYSTEM START MERGES")
-        pool.shutdown(wait=False, cancel_futures=True)
+        # The disable above releases the parked commit and the wait, so joining is bounded, and the
+        # module-scoped node must be handed on with no DROP PARTITION still in flight on `mt4`.
+        pool.shutdown(wait=True, cancel_futures=True)
 
     node.query("SYSTEM WAIT LOADING PARTS mt4")
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/71136


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the server failing to start after a non-transactional `DROP PARTITION`, `DROP PART`, `TRUNCATE` or `MOVE PARTITION TO TABLE` was interrupted by an abrupt process stop: a covered part could be left with no removal TID, and loading it raised `Data part ... is Outdated ... but does not have removal tid`, which terminates startup and recurred on every later start. Such a removal is now completed while the part is loaded.

### Description

Requested by @ alexey-milovidov: https://github.com/ClickHouse/ClickHouse/pull/106231#issuecomment-5144254170 (private `Stress test (amd_tsan, meta in keeper)`, STID 2429-2239).
Public sighting: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=115916&sha=86f83f64ecd36a085371e943194ab3f64d098fdb&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29

**Root cause.** `renameAndCommitEmptyParts` makes the empty covering part durable, and only then `addNewPartAndRemoveCovered` stores the covered parts' removal TID: two durable writes with no atomicity between them. A stop in between leaves the covered part with a committed creation CSN and no removal TID. On restart it is `Outdated` by block range alone, `preparePartForRemoval` rejects that pair as impossible, and the exception reaches a handler that terminates the server. Being on disk, it recurs every start.

**The change.** In `loadDataPart`, before the part is published, complete the removal for exactly that shape: the removal was never recorded, the creation was committed by a real transaction, and the covering ancestor that loaded `Active` was created without one. That ancestor's classification is snapshotted by value as it loads, so no later merge can change the answer. Anything else falls through to today's behaviour, and `preparePartForRemoval` is untouched. The covering part accounts for the covered rows, so the removal is a fact, and the metadata written is byte-identical to a finished commit's: it is the same call.

**This is not the struck-out option in #71136:** the assertion is not relaxed, and the producer-side store added there is present and issued on every path (details below).

**Validation.** New integration test beside #81734's own regression test, using a new pauseable failpoint plus `SIGKILL` to make the window deterministic. Without the fix the server does not start and logs the reported message and stack; with it the restart succeeds and the recovered parts carry `removal_tid = (1,1,...)`, `removal_csn = 1`. 20/20 repeats.

<details>
<summary>Disclosed coverage limitation and adjacent findings</summary>

Why the load side: storing the TID first would instead lose data (a stop between the store and the rename leaves the covered part marked removed with no cover on disk, so its rows vanish), the two writes cannot be made atomic because they target different parts' storages, and no producer code runs after an abrupt stop.

On #71136 @ tuanpach struck through "remove the assertion" and fixed the producer in #81734, adding the then-missing store. That store exists today on every path, so there is no write left to add; what remains is process death between two writes that are not atomic with respect to each other, which no producer-side change can close.

The cover conditions have no reddening mutation arm by construction: every part reaching the helper is covered, so a case where deleting the cover predicate changes an assertion would need a second victim covered by a *transactional* cover, whose correct behaviour on the fixed build is that the server still terminates. They are justified fail-closed instead: they can only narrow what is touched, and anything rejected lands on the unchanged `preparePartForRemoval` throw.

The producer set is structural, not a closed list: any `MergeTreeData::Transaction` committed with no transaction while its covered parts were created by committed transactions. Background merges are *not* in it, since `MergeTreeDataMergerMutator` rejects a non-transactional merge once transactions are enabled.

Two adjacent issues found en route and deliberately left alone: `locked_parts_to_cleanup` in `Transaction::commit` is written and never read, which is the subject of open #115442; and `loadMetadata` discards a coexisting `txn_version.txt.tmp` instead of using it, so an interrupted metadata rewrite is silently rolled back (latent, and excluded as the cause here).

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117793&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117793](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117793+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
