### PR TITLE
Do not move AI functions to PREWHERE

### DIFF
--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -59,6 +59,7 @@ public:
     bool isDeterministicInScopeOfQuery() const override { return false; }
     bool isSuitableForConstantFolding() const override { return false; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+    bool isExpensive() const override { return true; }
     /// Handle Nullable cols explicitly, since setting this to true may call functions with arbitrary input values
     bool useDefaultImplementationForNulls() const override { return false; }
     bool useDefaultImplementationForConstants() const override { return false; }

--- a/src/Functions/FunctionsMiscellaneous.h
+++ b/src/Functions/FunctionsMiscellaneous.h
@@ -292,6 +292,18 @@ public:
         return true;
     }
 
+    /// Expensive if any function in the inner DAG is, so a higher-order function carrying an
+    /// expensive call in its lambda body is not mistaken for a cheap condition.
+    bool isExpensive() const override
+    {
+        for (const auto & inner_node : expression_actions->getActionsDAG().getNodes())
+        {
+            if (inner_node.type == ActionsDAG::ActionType::FUNCTION && inner_node.function_base->isExpensive())
+                return true;
+        }
+        return false;
+    }
+
     const DataTypes & getArgumentTypes() const override { return capture->captured_types; }
     const DataTypePtr & getResultType() const override { return return_type; }
 

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -211,6 +211,13 @@ public:
       */
     virtual bool isVolumeReducing() const { return false; }
 
+    /** Returns true if the function costs far more than reading its arguments, e.g. one network
+      * request per row. `MergeTreeWhereOptimizer` does not move such a condition to `PREWHERE`,
+      * where it would be evaluated on every row read rather than only on the rows that survive
+      * the cheaper conditions.
+      */
+    virtual bool isExpensive() const { return false; }
+
     /** Returns true if this is a spatial predicate for which bbox-disjoint pruning is safe.
       * Specifically: if the bounding boxes of the geometry arguments are disjoint,
       * the function is guaranteed to return 0/false for all such rows.
@@ -649,6 +656,8 @@ public:
     virtual bool isStateful() const { return false; }
     /// See `IFunctionBase::isVolumeReducing`.
     virtual bool isVolumeReducing() const { return false; }
+    /// See `IFunctionBase::isExpensive`.
+    virtual bool isExpensive() const { return false; }
     virtual bool isSpatialPredicate() const { return false; }
 
     using ShortCircuitSettings = IFunctionBase::ShortCircuitSettings;

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -87,6 +87,8 @@ public:
 
     bool isVolumeReducing() const override { return function->isVolumeReducing(); }
 
+    bool isExpensive() const override { return function->isExpensive(); }
+
     bool isInjective(const ColumnsWithTypeAndName & sample_columns) const override { return function->isInjective(sample_columns); }
 
     ComparisonOrderDomain getComparisonOrderDomain() const override

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -78,6 +78,7 @@ public:
 
     bool isSuitableForConstantFolding() const override { return false; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+    bool isExpensive() const override { return true; }
 
     /// Handle Nullable cols explicitly, since setting this to true may call func with arbitrary input values
     bool useDefaultImplementationForNulls() const override { return false; }

--- a/src/Functions/aiSimilarity.cpp
+++ b/src/Functions/aiSimilarity.cpp
@@ -102,6 +102,7 @@ public:
 
     bool isSuitableForConstantFolding() const override { return false; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+    bool isExpensive() const override { return true; }
 
     /// Handle Nullable cols explicitly, since setting this to true may call func with arbitrary input values
     bool useDefaultImplementationForNulls() const override { return false; }

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -841,9 +841,8 @@ bool MergeTreeWhereOptimizer::cannotBeMoved(const RPNBuilderTreeNode & node, con
         if (functionIsGlobalInOperator(function_name))
             return true;
 
-        /// Disallow expensive functions, e.g. AI functions issuing one request per row. The cost
-        /// model below prices a condition by the size of the columns it reads, which says nothing
-        /// about such a function, and in PREWHERE it would run on every row read.
+        /// Some functions are expensive in ways the optimizer cannot see, e.g. an LLM call.
+        /// Disallow these functions from being moved to PREWHERE.
         if (auto function_base = function_node.getFunctionBase(); function_base && function_base->isExpensive())
             return true;
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -841,6 +841,12 @@ bool MergeTreeWhereOptimizer::cannotBeMoved(const RPNBuilderTreeNode & node, con
         if (functionIsGlobalInOperator(function_name))
             return true;
 
+        /// Disallow expensive functions, e.g. AI functions issuing one request per row. The cost
+        /// model below prices a condition by the size of the columns it reads, which says nothing
+        /// about such a function, and in PREWHERE it would run on every row read.
+        if (auto function_base = function_node.getFunctionBase(); function_base && function_base->isExpensive())
+            return true;
+
         size_t arguments_size = function_node.getArgumentsSize();
         for (size_t i = 0; i < arguments_size; ++i)
         {

--- a/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.reference
+++ b/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.reference
@@ -1,6 +1,10 @@
-cheap condition first
-0	1
-AI condition first
-0	1
-AI condition alone
-0
+aiGenerate	0	1
+aiClassify	0	1
+aiExtract	0	1
+aiTranslate	0	1
+aiFilter	0	1
+aiRedact	0	1
+aiEmbed	0	1
+aiSimilarity	0	1
+AI condition written first	0	1
+AI condition alone	0

--- a/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.reference
+++ b/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.reference
@@ -7,4 +7,5 @@ aiRedact	0	1
 aiEmbed	0	1
 aiSimilarity	0	1
 AI condition written first	0	1
+AI inside a lambda	0	1
 AI condition alone	0

--- a/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.reference
+++ b/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.reference
@@ -1,0 +1,6 @@
+cheap condition first
+0	1
+AI condition first
+0	1
+AI condition alone
+0

--- a/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
+++ b/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
@@ -9,7 +9,12 @@
 --
 -- `MergeTreeWhereOptimizer` prices a condition by the size of the columns it
 -- reads, which cannot express that cost, so `isExpensive` keeps such a condition
--- out. Only EXPLAIN is used here, so no HTTP call is ever made.
+-- out. Every AI function is listed here: `aiEmbed` and `aiSimilarity` do not
+-- share a base class with the rest, so a new function can miss the trait.
+--
+-- Only EXPLAIN is used, so no HTTP call is ever made. Each case reports whether
+-- the AI function reached PREWHERE (must be 0) and whether the cheap condition
+-- still did (must be 1).
 -- =============================================================================
 
 DROP TABLE IF EXISTS tab;
@@ -23,36 +28,45 @@ CREATE NAMED COLLECTION ai_creds AS
     model = 'test-model',
     api_key = 'test-key';
 
-SELECT 'cheap condition first';
-SELECT
-    countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aifilter%') AS ai_in_prewhere,
-    countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
-FROM (
-    EXPLAIN indexes = 1
-    SELECT count() FROM tab
-    WHERE flag = 1 AND aiFilter(text, 'matches', map('credentials', 'ai_creds'))
-);
+DROP NAMED COLLECTION IF EXISTS ai_vec_creds;
+CREATE NAMED COLLECTION ai_vec_creds AS
+    provider = 'openai',
+    endpoint = 'http://localhost:1/v1/embeddings',
+    api_key = 'test-key';
+
+SELECT 'aiGenerate' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aigenerate%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiGenerate(text, map('credentials', 'ai_creds')) != '');
+
+SELECT 'aiClassify' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aiclassify%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiClassify(text, ['a', 'b'], map('credentials', 'ai_creds')) = 'a');
+
+SELECT 'aiExtract' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aiextract%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiExtract(text, 'the topic', map('credentials', 'ai_creds')) != '');
+
+SELECT 'aiTranslate' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aitranslate%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiTranslate(text, 'French', map('credentials', 'ai_creds')) != '');
+
+SELECT 'aiFilter' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aifilter%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiFilter(text, 'matches', map('credentials', 'ai_creds')));
+
+SELECT 'aiRedact' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%airedact%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiRedact(text, ['email'], map('credentials', 'ai_creds')) != '');
+
+SELECT 'aiEmbed' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aiembed%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND length(aiEmbed(text, 'test-model', map('credentials', 'ai_vec_creds'))) != 0);
+
+SELECT 'aiSimilarity' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aisimilarity%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiSimilarity(text, 'reference', 'test-model', map('credentials', 'ai_vec_creds')) != 0);
 
 -- The optimizer sorts conditions by its own cost estimate, so the AI condition must
 -- stay out of PREWHERE however the query is written.
-SELECT 'AI condition first';
-SELECT
-    countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aifilter%') AS ai_in_prewhere,
-    countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
-FROM (
-    EXPLAIN indexes = 1
-    SELECT count() FROM tab
-    WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds')) AND flag = 1
-);
+SELECT 'AI condition written first' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aifilter%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds')) AND flag = 1);
 
 -- With no other condition there is nothing to move, so there is no PREWHERE at all.
-SELECT 'AI condition alone';
-SELECT countIf(explain ILIKE '%prewhere%') AS prewhere_steps
-FROM (
-    EXPLAIN indexes = 1
-    SELECT count() FROM tab
-    WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds'))
-);
+SELECT 'AI condition alone' AS fn, countIf(explain ILIKE '%prewhere%') AS prewhere_lines
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds')));
 
 DROP NAMED COLLECTION ai_creds;
+DROP NAMED COLLECTION ai_vec_creds;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
+++ b/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
@@ -72,6 +72,12 @@ FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiSimilarit
 SELECT 'AI condition written first' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aifilter%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
 FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds')) AND flag = 1);
 
+-- A lambda body is not among the condition's children, so the capture has to report the
+-- trait on behalf of the AI call it carries. EXPLAIN prints the lambda as `Capture[...]`
+-- without the inner name, hence matching the higher-order function instead.
+SELECT 'AI inside a lambda' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%arrayexists%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND arrayExists(x -> aiFilter(x, 'matches', map('credentials', 'ai_creds')), [text]));
+
 -- With no other condition there is nothing to move, so there is no PREWHERE at all.
 SELECT 'AI condition alone' AS fn, countIf(explain ILIKE '%prewhere%') AS prewhere_lines
 FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds')));

--- a/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
+++ b/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
@@ -34,6 +34,15 @@ CREATE NAMED COLLECTION ai_vec_creds AS
     endpoint = 'http://localhost:1/v1/embeddings',
     api_key = 'test-key';
 
+-- The assertions describe the outcome of the WHERE-to-PREWHERE move, so the settings that
+-- decide whether it runs at all are pinned rather than left to test randomization. On the
+-- legacy analyzer the move happens in `InterpreterSelectQuery` instead, where the condition
+-- carries no resolved function to ask, and the AI function is still moved.
+SET optimize_move_to_prewhere = 1;
+SET query_plan_enable_optimizations = 1;
+SET query_plan_optimize_prewhere = 1;
+SET enable_analyzer = 1;
+
 SELECT 'aiGenerate' AS fn, countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aigenerate%') AS in_prewhere, countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
 FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE flag = 1 AND aiGenerate(text, map('credentials', 'ai_creds')) != '');
 

--- a/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
+++ b/tests/queries/0_stateless/05059_ai_functions_not_moved_to_prewhere.sql
@@ -1,0 +1,58 @@
+-- Tags: no-parallel, no-replicated-database
+-- no-parallel: creates and drops a global named collection
+-- no-replicated-database: named collections are server-global, not database-scoped
+
+-- =============================================================================
+-- An AI function issues one request per row, so it must not be moved to PREWHERE:
+-- PREWHERE conditions are evaluated on every row read, while a condition left in
+-- WHERE only sees the rows that survived the cheaper conditions.
+--
+-- `MergeTreeWhereOptimizer` prices a condition by the size of the columns it
+-- reads, which cannot express that cost, so `isExpensive` keeps such a condition
+-- out. Only EXPLAIN is used here, so no HTTP call is ever made.
+-- =============================================================================
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (flag UInt8, text String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab SELECT number % 2, 'row ' || toString(number) FROM numbers(16);
+
+DROP NAMED COLLECTION IF EXISTS ai_creds;
+CREATE NAMED COLLECTION ai_creds AS
+    provider = 'openai',
+    endpoint = 'http://localhost:1/v1/chat/completions',
+    model = 'test-model',
+    api_key = 'test-key';
+
+SELECT 'cheap condition first';
+SELECT
+    countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aifilter%') AS ai_in_prewhere,
+    countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab
+    WHERE flag = 1 AND aiFilter(text, 'matches', map('credentials', 'ai_creds'))
+);
+
+-- The optimizer sorts conditions by its own cost estimate, so the AI condition must
+-- stay out of PREWHERE however the query is written.
+SELECT 'AI condition first';
+SELECT
+    countIf(explain ILIKE '%prewhere%' AND explain ILIKE '%aifilter%') AS ai_in_prewhere,
+    countIf(explain ILIKE '%prewhere%') > 0 AS cheap_in_prewhere
+FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab
+    WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds')) AND flag = 1
+);
+
+-- With no other condition there is nothing to move, so there is no PREWHERE at all.
+SELECT 'AI condition alone';
+SELECT countIf(explain ILIKE '%prewhere%') AS prewhere_steps
+FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab
+    WHERE aiFilter(text, 'matches', map('credentials', 'ai_creds'))
+);
+
+DROP NAMED COLLECTION ai_creds;
+DROP TABLE tab;


### PR DESCRIPTION
Disallow moving the AI functions to PREWHERE to avoid running them before cheaper predicates. Note that a user can still force the AI functions with an explicit PREWHERE clause.

A new virtual function `isExpensive()` is added to the IFunction classes, defaults to `false`, and is checked during the PREWHERE optimization. All AI functions set this to `true`.

There is an alternative to this new virtual function, we could just filter on function name in src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp. However this is not as pretty and relies on adding new AI functions in another place. With the implementation in this PR new AI functions that inherit from FunctionBaseAI will instead get this behavior by default.

The old analyzer (`enable_analyzer = 0`) keeps the old behavior (in some specific cases) I didn't feel it was necessary to implement it there since it is off by default and (AFAIK) being phased out.

Note: this isExpensive flag can also be used by non-AI functions.

cc @ayakovlev-clickhouse @rschu1ze 

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not move AI functions (aiGenerate, aiClassify, aiExtract, aiTranslate, aiFilter, aiRedact, aiEmbed, aiSimilarity) to PREWHERE to avoid expensive API calls that would be filtered out by cheaper predicates.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117802&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117802](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117802+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
