### PR TITLE
fabric workload documentation improvements

### DIFF
--- a/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
+++ b/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
@@ -107,7 +107,7 @@ The embedded SQL console lets you query your ClickHouse data without leaving Fab
 
 ### Saved queries {#saved-queries}
 
-Save any query with a name to reuse it later. Saved queries are stored with the item, so everyone in the workspace works from the same set.
+Save any query with a name to reuse it later. In public preview, saved queries are personal to each user; shared saved queries for collaboration are on the roadmap.
 
 ### Go further with ClickHouse SQL {#go-further-with-clickhouse-sql}
 
@@ -260,6 +260,42 @@ The ClickHouse workload is in public preview. The limitations below are the curr
 * **Removing or downgrading a user in Fabric does not revoke their ClickHouse access.** Because roles are only applied when a user opens a ClickHouse item, a user who is removed from the workspace or downgraded may retain their existing access on the ClickHouse Cloud side, and if they never open the item again that change never propagates at all. To revoke access immediately and reliably, remove the user from the organization in the ClickHouse Cloud console.
 * **Workspace-level access.** Everyone in the workspace can use its ClickHouse items. Granular, per-table permission sync from OneLake is currently not supported.
 * **Console SSO requires an email on your Entra profile.** ClickHouse Cloud users need an email address; if your Microsoft Entra profile has none set, signing in to the Cloud console will fail.
+
+## Troubleshooting {#troubleshooting}
+
+### Email verification fails when opening a ClickHouse item {#email-verification-fails}
+
+**Error codes:** `email_domain_unverified`, `email_domain_onmicrosoft`, `email_not_found`
+
+**Cause:** Provisioning a ClickHouse user requires an email address from a verified domain on the Microsoft Entra account. Personal or test tenants using a default `.onmicrosoft.com` domain without a verified custom domain cannot provide one, and neither can Entra profiles with no email attribute set.
+
+**Resolution:** Contact your Fabric administrator to confirm your Microsoft Entra profile has an email address on a verified custom domain, or use an account from a tenant with one. See [Managing custom domain names in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/users/domains-manage).
+
+### Cannot sign in to the ClickHouse Cloud console {#cannot-sign-in-to-the-clickhouse-cloud-console}
+
+**Cause:** ClickHouse Cloud users require an email address. Sign-in from the workload fails if the Entra profile has no email set, and first-time console sign-in sends a verification code, so the address must have a real inbox. The in-Fabric experience is unaffected; this only gates **Open in ClickHouse Cloud** and marketplace checkout.
+
+**Resolution:** Contact your Fabric administrator to add an email address with an active inbox to your Microsoft Entra profile, then retry.
+
+### Access denied when opening an item {#access-denied-when-opening-an-item}
+
+**Error code:** `item_access_denied`
+
+**Cause:** The signed-in user does not have access to the Fabric item, or a recent workspace role change has not been applied yet.
+
+**Resolution:** Confirm you are a member of the workspace with the right role. Role changes take effect the next time you open a ClickHouse item.
+
+### A sync fails partway or will not start {#a-sync-fails-partway-or-will-not-start}
+
+**Cause:** In trial organizations, OneLake reads use a token tied to the signed-in user. If it expires mid-sync, the sync fails.
+
+**Resolution:** Re-authenticate and run the sync again.
+
+### Item is stuck on "Setting up ClickHouse" or errors after previously working {#item-is-stuck-or-errors-after-previously-working}
+
+**Cause:** The underlying service was deleted directly in the ClickHouse Cloud console, which orphans the Fabric item. As noted in [known limitations](#service-management), this is unrecoverable.
+
+**Resolution:** Manage the item's lifecycle from Fabric. If the service was already deleted, create a new ClickHouse item.
 
 ## Reference {#reference}
 

--- a/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
+++ b/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
@@ -289,17 +289,7 @@ The ClickHouse workload is in public preview. The limitations below are the curr
 
 **Resolution:** Confirm you are a member of the workspace with the right role. Role changes take effect the next time you open a ClickHouse item.
 
-### A sync fails partway or will not start {#a-sync-fails-partway-or-will-not-start}
 
-**Cause:** In trial organizations, OneLake reads use a token tied to the signed-in user. If it expires mid-sync, the sync fails.
-
-**Resolution:** Re-authenticate and run the sync again.
-
-### Item is stuck on "Setting up ClickHouse" or errors after previously working {#item-is-stuck-or-errors-after-previously-working}
-
-**Cause:** The underlying service was deleted directly in the ClickHouse Cloud console, which orphans the Fabric item. As noted in [known limitations](#service-management), this is unrecoverable.
-
-**Resolution:** Manage the item's lifecycle from Fabric. If the service was already deleted, create a new ClickHouse item.
 
 ## Reference {#reference}
 

--- a/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
+++ b/docs/integrations/connectors/data-integrations/integrations/microsoft-fabric.mdx
@@ -265,15 +265,19 @@ The ClickHouse workload is in public preview. The limitations below are the curr
 
 ### Email verification fails when opening a ClickHouse item {#email-verification-fails}
 
-**Error codes:** `email_domain_unverified`, `email_domain_onmicrosoft`, `email_not_found`
+**Error codes:** `email_not_found`, `email_domain_unverified`
 
-**Cause:** Provisioning a ClickHouse user requires an email address from a verified domain on the Microsoft Entra account. Personal or test tenants using a default `.onmicrosoft.com` domain without a verified custom domain cannot provide one, and neither can Entra profiles with no email attribute set.
+**Cause:** Provisioning a ClickHouse user requires an email address from a verified domain on the Microsoft Entra account. Member accounts always qualify, including those in personal or test tenants that only have the default `.onmicrosoft.com` domain. These errors almost always mean you are signed in as a **guest (B2B) account**:
 
-**Resolution:** Contact your Fabric administrator to confirm your Microsoft Entra profile has an email address on a verified custom domain, or use an account from a tenant with one. See [Managing custom domain names in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/users/domains-manage).
+- `email_not_found` — your guest profile in this tenant has no email address set.
+- `email_domain_unverified` — your email belongs to your home tenant, which is not a
+  verified domain in the tenant you are using Fabric in.
+
+**Resolution:** Use a member account of the tenant, or contact your Fabric administrator to confirm your Microsoft Entra profile has an email address on one of the tenant's verified domains. See [Managing custom domain names in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/users/domains-manage).
 
 ### Cannot sign in to the ClickHouse Cloud console {#cannot-sign-in-to-the-clickhouse-cloud-console}
 
-**Cause:** ClickHouse Cloud users require an email address. Sign-in from the workload fails if the Entra profile has no email set, and first-time console sign-in sends a verification code, so the address must have a real inbox. The in-Fabric experience is unaffected; this only gates **Open in ClickHouse Cloud** and marketplace checkout.
+**Cause:** ClickHouse Cloud users require an email address. Sign-in from the workload fails if the Entra profile has no email set, and first-time console sign-in sends a verification code, so the address must have a real inbox. Default `.onmicrosoft.com` addresses often have no mailbox. The in-Fabric experience is unaffected; this only gates **Open in ClickHouse Cloud** and marketplace checkout.
 
 **Resolution:** Contact your Fabric administrator to add an email address with an active inbox to your Microsoft Entra profile, then retry.
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Documentation entry for user-facing changes

Part of https://github.com/ClickHouse/ClickHouse/issues/116380 (reference only — this does not close the issue).

Two improvements to the [ClickHouse for Microsoft Fabric](https://clickhouse.com/docs/integrations/microsoft-fabric) page. Branched off `master`. The page stays unlisted (`hidden: true` in frontmatter, untouched).

#### 1. Saved queries: correct an inaccurate claim

The **Saved queries** section claimed saved queries are stored with the item and shared workspace-wide. That is wrong for public preview — per the product decision, saved queries are **per-user with no sharing**. Anyone reading the old copy would expect a colleague to see their saved queries, and they will not.

```diff
-Save any query with a name to reuse it later. Saved queries are stored with the item, so everyone in the workspace works from the same set.
+Save any query with a name to reuse it later. In public preview, saved queries are personal to each user; shared saved queries for collaboration are on the roadmap.
```

Same length and tone as before, and the roadmap framing matches the rest of the page's preview language.

#### 2. New Troubleshooting section

Added `## Troubleshooting {#troubleshooting}` between **Known limitations** and **Reference**, covering the auth and provisioning error states users actually hit. Each entry is symptom heading → **Cause** → **Resolution**, following the convention already used on the [Fivetran troubleshooting page](/integrations/fivetran/troubleshooting). Literal error codes are shown as inline code so users can match what is on screen.

| Symptom | Error codes | Root cause |
|---|---|---|
| Email verification fails when opening a ClickHouse item | `email_domain_unverified`, `email_domain_onmicrosoft`, `email_not_found` | No email on a verified Entra custom domain (default `.onmicrosoft.com` tenants, or no email attribute) |
| Cannot sign in to the ClickHouse Cloud console | — | Cloud users require an email with a real inbox for the first-time verification code |
| Access denied when opening an item | `item_access_denied` | No access to the Fabric item, or a workspace role change not yet applied |
| A sync fails partway or will not start | — | In trial orgs, the OneLake read token is tied to the signed-in user and can expire mid-sync |
| Item stuck on "Setting up ClickHouse" or errors after previously working | — | Service deleted directly in the Cloud console, orphaning the Fabric item |

Two notes on scope:

- The console sign-in entry states explicitly that the in-Fabric experience is unaffected, and that this only gates **Open in ClickHouse Cloud** and marketplace checkout — so users do not read it as a total outage.
- The orphaned-item entry links to [known limitations](https://clickhouse.com/docs/integrations/microsoft-fabric#service-management) rather than restating that the state is unrecoverable in two places.

The email entry links Microsoft's [Managing custom domain names in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/users/domains-manage), since the fix is on the Entra side and generally needs a Fabric administrator.

#### Checks run locally

- `navigation_check.py` — passes; page stays unlisted, not re-added to the sidebar
- `snippet_component_imports_check.py` — 113 snippet files and 108 local image references OK
- `mint validate` — build validation passed
- `lychee_check.py --mode links` — 32,460 unique links, 0 errors (includes the new `#service-management` cross-link)
- External links on this page — the new `learn.microsoft.com` link returns 200 with no redirect. The three pre-existing `marketplace.microsoft.com` links return 403 to bots; unchanged by this PR, and the external check is a non-blocking warning in CI
- `mint dev` — page returns 200 and all six new anchors render with the expected IDs: `#troubleshooting`, `#email-verification-fails`, `#cannot-sign-in-to-the-clickhouse-cloud-console`, `#access-denied-when-opening-an-item`, `#a-sync-fails-partway-or-will-not-start`, `#item-is-stuck-or-errors-after-previously-working`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117807&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117807](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117807+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.620` (included in `26.9` and later)
<!-- ch-version-info:end -->