### PR TITLE
Fix width of `timeSeriesPrometheusValueToString` doc example table (breaks "Docs examples" check)

### DIFF
--- a/src/Functions/TimeSeries/timeSeriesPrometheusValueToString.cpp
+++ b/src/Functions/TimeSeries/timeSeriesPrometheusValueToString.cpp
@@ -168,8 +168,8 @@ SELECT timeSeriesPrometheusValueToString(toFloat64(1e-7))
         )",
             R"(
 ┌─timeSeriesPrometheusValueToString(toFloat64(1e-7))─┐
-│ 0.0000001                                           │
-└─────────────────────────────────────────────────────┘
+│ 0.0000001                                          │
+└────────────────────────────────────────────────────┘
         )"}};
     FunctionDocumentation::IntroducedIn introduced_in = {26, 8};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::TimeSeries;


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=116085&sha=latest&name_0=PR&name_1=Docs+examples
Conflicts of https://github.com/ClickHouse/ClickHouse/pull/116085 (cc @nikitamikhaylov ) and #113024 (@alexey-milovidov )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117827&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117827](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117827+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.578` (included in `26.9` and later)
<!-- ch-version-info:end -->