### PR TITLE
Disable `04669_window_partitions_independently` under MSan

### DIFF
--- a/tests/queries/0_stateless/04669_window_partitions_independently.sql
+++ b/tests/queries/0_stateless/04669_window_partitions_independently.sql
@@ -1,4 +1,5 @@
--- Tags: long, no-random-settings, no-random-merge-tree-settings
+-- Tags: long, no-msan, no-random-settings, no-random-merge-tree-settings
+-- no-msan: 16 scenarios with INSERT + EXPLAIN; the MSan slowdown blows past the test timeout
 -- no-random-settings, no-random-merge-tree-settings: Explain output may differ
 
 -- max_threads = 8: the cost heuristic requires partitions >= max_threads/2, and every positive case


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/100371
Related: https://github.com/ClickHouse/ClickHouse/pull/115050

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Tag `04669_window_partitions_independently` with `no-msan`: it exceeds the per-test timeout under Memory Sanitizer when metadata is in Keeper and data is on S3.

### Description

In the private sync run of #100371 this test was killed at `[ FAIL ] 600.16 sec. Reason: Timeout!` on `Stateless tests (amd_msan, distributed cache, meta in keeper, s3 storage, parallel, 2/3)` (job: https://github.com/ClickHouse/clickhouse-private/actions/runs/33556271270/job/100030241449). It has never timed out on public CI: 2044 executed runs on master since it merged, 0 failures. The public form of that shard peaks at 119 s of the 600 s budget (n=131) and the heaviest public shard of any kind at 152 s (n=1328), both MSan.

The test is statement-heavy and data-trivial: 16 scenarios, 16 `CREATE TABLE`, 30 `INSERT`, 32 `EXPLAIN`, largest insert `numbers_mt(480)`. Keeper metadata plus S3 data turns each into a network round trip, and MSan multiplies it again. Every assertion is an `EXPLAIN` line filter or a `cityHash64` equality, so it exercises query planning, not memory correctness.

This is the same change #115050 makes to 307 tests, including the sibling `04411_distinct_partitions_independently`. `04669` merged on 2026-08-24, after that PR's set was computed; under #115050's own criterion it is 1328 runs at 63.7 s mean, above the 60 s threshold. `a0c26d8ca5e65ca69a0b9115669d5ce45a8983ce` made the identical change to `04218_limit_by_partitions_independently` for the same private-configuration timeout.

`no-msan` is the smallest tag covering every arm observed failing: `no-s3-storage` covers them too but costs 3508 executed runs against 1493 over 30 days, and `no-distributed-cache` would be free yet misses the sibling's failing arm, which has none. ASan+UBSan, TSan, the s3-storage shards and four non-MSan flaky checks keep running the test, stress jobs ignore `no-<build>` tags, and `.reference` is byte-identical.

I found no open issue for it. `04669_creating_set_partitions_independently` averages 119.9 s under the same criterion and is in neither PR, but it has no master failures, so I left it alone. Happy to fold this into #115050 instead if you would rather keep it in one place; your call.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117833&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117833](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117833+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
