### PR TITLE
Fix `CREATE TABLE ... AS` dropping the settings of a TimeSeries table

### DIFF
--- a/src/Common/SettingsChanges.cpp
+++ b/src/Common/SettingsChanges.cpp
@@ -65,6 +65,15 @@ bool SettingsChanges::insertSetting(std::string_view name, const Field & value)
     return true;
 }
 
+bool SettingsChanges::removeSetting(std::string_view name)
+{
+    auto it = std::find_if(begin(), end(), [&name](const SettingChange & change) { return change.name == name; });
+    if (it == end())
+        return false;
+    erase(it);
+    return true;
+}
+
 void SettingsChanges::setSetting(std::string_view name, const Field & value)
 {
     if (auto * setting_value = tryGet(name))
@@ -73,13 +82,18 @@ void SettingsChanges::setSetting(std::string_view name, const Field & value)
         insertSetting(name, value);
 }
 
-bool SettingsChanges::removeSetting(std::string_view name)
+void SettingsChanges::setSetting(const SettingChange & change)
 {
-    auto it = std::find_if(begin(), end(), [&name](const SettingChange & change) { return change.name == name; });
-    if (it == end())
-        return false;
-    erase(it);
-    return true;
+    if (auto * existing_change = tryGetChange(change.name))
+        *existing_change = change;
+    else
+        push_back(change);
+}
+
+void SettingsChanges::setSettings(const SettingsChanges & other)
+{
+    for (const auto & change : other)
+        setSetting(change);
 }
 
 String SettingsChanges::namesToString() const

--- a/src/Common/SettingsChanges.h
+++ b/src/Common/SettingsChanges.h
@@ -44,10 +44,16 @@ public:
 
     /// Inserts element if doesn't exists and returns true, otherwise just returns false
     bool insertSetting(std::string_view name, const Field & value);
-    /// Sets element to value, inserts if doesn't exist
-    void setSetting(std::string_view name, const Field & value);
+
     /// If element exists - removes it and returns true, otherwise returns false
     bool removeSetting(std::string_view name);
+
+    /// Sets element to value, inserts if doesn't exist
+    void setSetting(std::string_view name, const Field & value);
+    void setSetting(const SettingChange & change);
+
+    /// Applies `other` on top of these changes with `setSetting`.
+    void setSettings(const SettingsChanges & other);
 
     String namesToString() const;
 };

--- a/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
+++ b/src/Storages/TimeSeries/normalizeTimeSeriesDefinition.cpp
@@ -1172,13 +1172,22 @@ namespace
             as_create_query = normalized;
         }
 
-        /// Copy settings from the other table.
-        if (as_create_query->storage && as_create_query->storage->settings
-            && (!create_query.storage || !create_query.storage->settings))
+        /// Copy settings from the other table. Settings are merged by name: a setting written in this query wins.
+        if (as_create_query->storage && as_create_query->storage->settings)
         {
             if (!create_query.storage)
                 create_query.set(create_query.storage, make_intrusive<ASTStorage>());
-            create_query.storage->set(create_query.storage->settings, as_create_query->storage->settings->clone());
+
+            auto merged_settings = boost::static_pointer_cast<ASTSetQuery>(as_create_query->storage->settings->clone());
+            if (create_query.storage->settings)
+            {
+                /// A `name = DEFAULT` reset is a mention of the setting too, so the value of the other table
+                /// is not inherited for it. The reset itself is not kept: an absent setting means the default.
+                for (const auto & name : create_query.storage->settings->default_settings)
+                    merged_settings->changes.removeSetting(name);
+                merged_settings->changes.setSettings(create_query.storage->settings->changes);
+            }
+            create_query.storage->set(create_query.storage->settings, merged_settings);
         }
 
         /// Copy outer column from the other table.

--- a/tests/queries/0_stateless/05059_time_series_create_as_keeps_settings.reference
+++ b/tests/queries/0_stateless/05059_time_series_create_as_keeps_settings.reference
@@ -1,0 +1,14 @@
+-- `AS` without a `SETTINGS` clause: `job` comes from the copied `tags_to_columns`,
+-- and there is no `min_time`/`max_time` because the copied `store_min_time_and_max_time` is 0
+`id` Tuple(UInt64, LowCardinality(UUID)) DEFAULT tuple(sipHash64(metric_name), toLowCardinality(reinterpretAsUUID(sipHash128(tags)))), `metric_name` LowCardinality(String), `job` String, `tags` Map(LowCardinality(String), String)
+-- `AS` with a `SETTINGS` clause: the written `store_min_time_and_max_time` overrides the copied one so
+-- `min_time`/`max_time` appear, the written `aggregate_min_time_and_max_time` is added so they are not
+-- aggregated, and `tags_to_columns` is still copied from `ts_src`
+`id` Tuple(UInt64, LowCardinality(UUID)) DEFAULT tuple(sipHash64(metric_name), toLowCardinality(reinterpretAsUUID(sipHash128(tags)))), `metric_name` LowCardinality(String), `job` String, `tags` Map(LowCardinality(String), String), `min_time` Nullable(DateTime64(3)), `max_time` Nullable(DateTime64(3))
+-- the copied `tags_to_columns` fills the dedicated column
+m1	j1
+-- `AS` with a reset: the copied `store_min_time_and_max_time = 0` is not inherited, so the setting
+-- gets its default value and `min_time`/`max_time` appear, while `tags_to_columns` is still copied
+`id` Tuple(UInt64, LowCardinality(UUID)) DEFAULT tuple(sipHash64(metric_name), toLowCardinality(reinterpretAsUUID(sipHash128(tags)))), `metric_name` LowCardinality(String), `job` String, `tags` Map(LowCardinality(String), String), `min_time` Nullable(DateTime64(3)), `max_time` Nullable(DateTime64(3))
+-- a written value wins over a reset of the same setting, so there is no `min_time`/`max_time`
+`id` Tuple(UInt64, LowCardinality(UUID)) DEFAULT tuple(sipHash64(metric_name), toLowCardinality(reinterpretAsUUID(sipHash128(tags)))), `metric_name` LowCardinality(String), `job` String, `tags` Map(LowCardinality(String), String)

--- a/tests/queries/0_stateless/05059_time_series_create_as_keeps_settings.sql
+++ b/tests/queries/0_stateless/05059_time_series_create_as_keeps_settings.sql
@@ -1,0 +1,54 @@
+-- The clause `AS <other_table>` copies the settings of the other table. A `SETTINGS` clause written
+-- in the query itself doesn't replace them: the settings are merged by name, so a written setting
+-- overrides the copied one, a written setting the other table doesn't have is added, and the rest
+-- of the other table's settings are still copied. A setting written as `name = DEFAULT` is a mention
+-- of that setting too, so the value of the other table is not copied for it.
+
+SET allow_experimental_time_series_table = 1;
+
+DROP TABLE IF EXISTS ts_src;
+DROP TABLE IF EXISTS ts_copy;
+DROP TABLE IF EXISTS ts_derived;
+
+CREATE TABLE ts_src ENGINE = TimeSeries
+SETTINGS tags_to_columns = {'job': 'job'}, store_min_time_and_max_time = 0;
+
+SELECT '-- `AS` without a `SETTINGS` clause: `job` comes from the copied `tags_to_columns`,';
+SELECT '-- and there is no `min_time`/`max_time` because the copied `store_min_time_and_max_time` is 0';
+CREATE TABLE ts_copy AS ts_src ENGINE = TimeSeries;
+SELECT extract(create_table_query, 'TAGS INNER COLUMNS \((.*?)\) TAGS INNER ENGINE')
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts_copy';
+
+SELECT '-- `AS` with a `SETTINGS` clause: the written `store_min_time_and_max_time` overrides the copied one so';
+SELECT '-- `min_time`/`max_time` appear, the written `aggregate_min_time_and_max_time` is added so they are not';
+SELECT '-- aggregated, and `tags_to_columns` is still copied from `ts_src`';
+CREATE TABLE ts_derived AS ts_src ENGINE = TimeSeries
+SETTINGS store_min_time_and_max_time = 1, aggregate_min_time_and_max_time = 0;
+SELECT extract(create_table_query, 'TAGS INNER COLUMNS \((.*?)\) TAGS INNER ENGINE')
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts_derived';
+
+-- The `job` column comes with the copied inner columns anyway, so check that it's actually filled -
+-- that needs the `tags_to_columns` setting. The database is passed explicitly because with parallel
+-- replicas the query can go to a replica where the current database is different.
+SELECT '-- the copied `tags_to_columns` fills the dedicated column';
+INSERT INTO ts_derived (metric_name, tags, time_series) VALUES ('m1', {'job': 'j1'}, [(1, 1.)]);
+SELECT metric_name, job FROM timeSeriesTags({CLICKHOUSE_DATABASE:String}, 'ts_derived') ORDER BY metric_name;
+DROP TABLE ts_derived;
+
+SELECT '-- `AS` with a reset: the copied `store_min_time_and_max_time = 0` is not inherited, so the setting';
+SELECT '-- gets its default value and `min_time`/`max_time` appear, while `tags_to_columns` is still copied';
+CREATE TABLE ts_derived AS ts_src ENGINE = TimeSeries
+SETTINGS aggregate_min_time_and_max_time = 0, store_min_time_and_max_time = DEFAULT;
+SELECT extract(create_table_query, 'TAGS INNER COLUMNS \((.*?)\) TAGS INNER ENGINE')
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts_derived';
+DROP TABLE ts_derived;
+
+SELECT '-- a written value wins over a reset of the same setting, so there is no `min_time`/`max_time`';
+CREATE TABLE ts_derived AS ts_src ENGINE = TimeSeries
+SETTINGS store_min_time_and_max_time = 0, store_min_time_and_max_time = DEFAULT;
+SELECT extract(create_table_query, 'TAGS INNER COLUMNS \((.*?)\) TAGS INNER ENGINE')
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts_derived';
+
+DROP TABLE ts_derived;
+DROP TABLE ts_copy;
+DROP TABLE ts_src;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `CREATE TABLE ... AS` dropping the settings of a TimeSeries table

Earlier `CREATE TABLE t1 AS t2 SETTINGS x = 1` kept setting `x = 1` in `t1` but skipped all the settings from `t2`.
Now the settings are merged. 

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117839&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117839](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117839+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
