### PR TITLE
Patch PSC changelog entry

### DIFF
--- a/docs/resources/changelogs/cloud/2026.mdx
+++ b/docs/resources/changelogs/cloud/2026.mdx
@@ -21,9 +21,9 @@ This week expands ClickHouse Cloud's global reach with new AWS regions in Taipei
 
 ClickHouse Cloud is now available in AWS Taipei (`ap-east-2`) and AWS Malaysia (`ap-southeast-5`). Both are set up as Private Regions with ClickPipes support. See the [supported regions documentation](/cloud/reference/supported-regions) and [Private Region considerations](/cloud/reference/supported-regions#private-regions) for details.
 
-### Private Service Connect supports Global Access {#private-service-connect-supports-global-access}
+### ClickPipes: Private Service Connect supports Global Access {#private-service-connect-supports-global-access}
 
-Private Service Connect (PSC) on GCP now supports Global Access. When enabled, clients in other GCP regions within the same VPC can connect to the PSC endpoint, including from regions not natively supported in ClickHouse Cloud, such as `asia-northeast3` (Seoul). The ClickHouse Cloud service and PSC endpoint must remain in the same GCP region.
+ClickPipes now supports Global Access for **cross-region** private connections using Private Service Connect (PSC). When enabled, ClickPipes can connect to a PSC endpoint in a different region than the GCP region where the service is running, including regions not natively supported in ClickHouse Cloud (_e.g._ `asia-northeast3` (Seoul)).
 
 ### Switch between SAML organizations {#switch-between-saml-organizations}
 


### PR DESCRIPTION
Mintlify must have allucinated this entry based on the internal feature release post; it contradicts itself and is mixing up global access support in ClickHouse Cloud and ClickPipes. This entry is meant to be exclusively about PSC support in ClickPipes.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117842&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117842](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117842+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
