### PR TITLE
Run the docs examples check in the merge queue

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -250,9 +250,43 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_binary, flaky check)' --workflow "MergeQueueCI" --ci --timestamp
 
+  docs_examples:
+    runs-on: [self-hosted, amd-medium]
+    needs: [build_amd_binary, config_workflow, dockers_build_amd, dockers_build_arm]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'RG9jcyBleGFtcGxlcw==') }}
+    name: "Docs examples"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=.:./ci
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Docs examples' --workflow "MergeQueueCI" --ci --timestamp
+
   finish_workflow:
     runs-on: [self-hosted, arm-tiny]
-    needs: [build_amd_binary, config_workflow, dockers_build_amd, dockers_build_arm, fast_test, stateless_tests_amd_binary_flaky_check, style_check]
+    needs: [build_amd_binary, config_workflow, dockers_build_amd, dockers_build_arm, docs_examples, fast_test, stateless_tests_amd_binary_flaky_check, style_check]
     if: ${{ always() }}
     name: "Finish Workflow"
     outputs:

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1833,6 +1833,23 @@ class JobConfigs:
         run_in_docker="clickhouse/stateless-test",
         timeout=3600,
     )
+    # The merge-queue copy of `docs_examples_job`, which reruns the examples
+    # against the merge group state. The examples are extracted from the
+    # server's own registrations and run against a live server, so a pull
+    # request and a `master` commit that are each green on their own can still
+    # break them together: the pull request documents a function whose behavior
+    # a `master` commit then changes, or `master` fixes an example the pull
+    # request has just listed in `known_failures.txt`.
+    #
+    # The merge queue builds only the plain `amd_binary` flavor, so this copy
+    # runs against that binary on an amd runner instead of the `arm_release`
+    # build the pull request and master workflows use - the examples exercise
+    # server behavior, which is the same either way. The run takes ~1.5 minutes
+    # and reuses the build the queue already produces, so it finishes well
+    # inside the runtime of the fast test it runs alongside.
+    docs_examples_mq_job = docs_examples_job.set_requires(
+        ArtifactNames.CH_AMD_BINARY, reset=True
+    ).set_runs_on(RunnerLabels.FUNC_TESTER_AMD)
     sqlstorm_test_job = Job.Config(
         name=JobNames.SQL_STORM_TEST,
         runs_on=RunnerLabels.FUNC_TESTER_ARM,

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -510,20 +510,21 @@ def should_skip_merge_queue_job(job_name):
     """Config-time filter for the `MergeQueueCI` workflow.
 
     The merge queue runs a small, fixed set of jobs (style check, fast test, the
-    `amd_binary` build, and the stateless flaky check). Only the flaky check is
-    conditional: it reruns the PR's new/changed stateless tests as a drift guard,
-    so a PR that changes no stateless tests has nothing for it to do. Filter it
-    out here, at config time, so such a PR does not schedule the runner, restore
-    `CH_AMD_BINARY`, and enter the test container only to exit `SKIPPED`. This is
-    the merge-queue counterpart to the `flaky` branch of `should_skip_job`, kept
-    deliberately minimal so it cannot skip the build/style/fast-test jobs the
-    queue always needs. The skip condition matches the in-job selection in
-    `functional_tests.py` (both rely on `Targeting.get_changed_tests`), so the
-    early exit and the config-time skip never disagree. `get_changed_tests`
-    resolves data fixtures (a `.parquet`/`.tsv` under `tests/queries/0_stateless/`,
-    even one nested in a subdirectory) back to the tests that consume them, so a
-    fixture-only PR still reruns the affected test surface instead of being
-    skipped here as "no changed tests".
+    `amd_binary` build, the stateless flaky check, and the docs examples). Only
+    the flaky check is conditional: it reruns the PR's new/changed stateless
+    tests as a drift guard, so a PR that changes no stateless tests has nothing
+    for it to do. Filter it out here, at config time, so such a PR does not
+    schedule the runner, restore `CH_AMD_BINARY`, and enter the test container
+    only to exit `SKIPPED`. This is the merge-queue counterpart to the `flaky`
+    branch of `should_skip_job`, kept deliberately minimal so it cannot skip the
+    build/style/fast-test/docs-examples jobs the queue always needs. The skip
+    condition matches the in-job selection in `functional_tests.py` (both rely
+    on `Targeting.get_changed_tests`), so the early exit and the config-time
+    skip never disagree. `get_changed_tests` resolves data fixtures (a
+    `.parquet`/`.tsv` under `tests/queries/0_stateless/`, even one nested in a
+    subdirectory) back to the tests that consume them, so a fixture-only PR
+    still reruns the affected test surface instead of being skipped here as
+    "no changed tests".
     """
     global _info_cache
     if _info_cache is None:

--- a/ci/workflows/merge_queue.py
+++ b/ci/workflows/merge_queue.py
@@ -23,6 +23,11 @@ workflow = Workflow.Config(
         # after the PR's last CI run (e.g. a new randomized setting in
         # `tests/clickhouse-test`). Self-skips when the PR changes no tests.
         *JobConfigs.stateless_tests_flaky_mq_jobs,
+        # Reruns the documentation examples against the merge group state, so a
+        # pull request and a `master` commit that are each green on their own
+        # cannot break them together. Cheap enough to run unconditionally - see
+        # `JobConfigs.docs_examples_mq_job`.
+        JobConfigs.docs_examples_mq_job,
     ],
     artifacts=[
         *[

--- a/src/Functions/vectorFunctions.cpp
+++ b/src/Functions/vectorFunctions.cpp
@@ -2540,17 +2540,22 @@ Calculates the approximate [cosine distance](https://en.wikipedia.org/wiki/Cosin
             {"UInt"}}};
     FunctionDocumentation::ReturnedValue returned_value_cosine_distance_transposed
         = {"Returns the approximate cosine distance (one minus the cosine similarity). Always returns Float64.", {"Float64"}};
+    /// The example rounds the result, and the one of `cosineDistanceTransposedQuantized` below does the same, because the
+    /// unrounded value is not the same on every architecture: the cosine kernels normalize with a reciprocal square root
+    /// approximation, which SimSIMD implements per instruction set, so the result differs in its last digits between an
+    /// aarch64 and an x86_64 server (and between x86_64 servers of different capabilities, since the kernel is resolved from
+    /// the CPU at run time). The distance is documented as approximate anyway - the surplus digits carried no meaning.
     FunctionDocumentation::Examples examples_cosine_distance_transposed
         = {{"Basic usage",
             R"(
 CREATE TABLE qbit (id UInt32, vec QBit(Float64, 2)) ENGINE = Memory;
 INSERT INTO qbit VALUES (1, [0, 1]);
-SELECT cosineDistanceTransposed(vec, array(1, 2), 16) FROM qbit;
+SELECT round(cosineDistanceTransposed(vec, array(1, 2), 16), 6) FROM qbit;
 )",
             R"(
-┌─cosineDistanceTransposed(vec, [1, 2], 16)─┐
-│                       0.10557280905788935 │
-└───────────────────────────────────────────┘
+┌─round(cosineDistanceTransposed(vec, [1, 2], 16), 6)─┐
+│                                            0.105573 │
+└─────────────────────────────────────────────────────┘
             )"}};
     FunctionDocumentation::IntroducedIn introduced_in_cosine_distance_transposed = {26, 1};
     FunctionDocumentation::Category category_cosine_distance_transposed = FunctionDocumentation::Category::Distance;
@@ -2703,17 +2708,19 @@ SELECT L2DistanceTransposedQuantized(vec, [0.1, -0.5]::Array(Float32), 8) FROM q
            quantized_used_dims_argument};
     FunctionDocumentation::ReturnedValue returned_value_cosine_distance_transposed_quantized
         = {"Returns the approximate cosine distance (one minus the cosine similarity). Always returns `Float64`.", {"Float64"}};
+    /// Rounded for the reason given at the example of `cosineDistanceTransposed`: the last digits of a cosine distance are
+    /// architecture-dependent.
     FunctionDocumentation::Examples examples_cosine_distance_transposed_quantized
         = {{"Basic usage",
             R"(
 CREATE TABLE qbit (id UInt32, vec QBit(Int8, 2)) ENGINE = Memory;
 INSERT INTO qbit VALUES (1, arrayMap(x -> quantizeBFloat16ToInt8(x), [0.1, -0.5]::Array(BFloat16)));
-SELECT cosineDistanceTransposedQuantized(vec, [0.1, -0.5]::Array(Float32), 8) FROM qbit;
+SELECT round(cosineDistanceTransposedQuantized(vec, [0.1, -0.5]::Array(Float32), 8), 6) FROM qbit;
 )",
             R"(
-┌─cosineDistanceTransposedQuantized(vec, CAST('[0.1, -0.5]', 'Array(Float32)'), 8)─┐
-│                                                          0.000027192636379513857 │
-└──────────────────────────────────────────────────────────────────────────────────┘
+┌─round(cosineDistanceTransposedQuantized(vec, CAST('[0.1, -0.5]', 'Array(Float32)'), 8), 6)─┐
+│                                                                                   0.000027 │
+└────────────────────────────────────────────────────────────────────────────────────────────┘
             )"}};
     FunctionDocumentation documentation_cosine_distance_transposed_quantized
         = {description_cosine_distance_transposed_quantized,


### PR DESCRIPTION
The `Docs examples` job runs the SQL examples embedded in the documentation against a live server. The examples are extracted from the server's own registrations, so a pull request and a `master` commit that are each green on their own can still break them once merged: the pull request documents a function whose behavior a `master` commit then changes, or `master` fixes an example the pull request has just listed in `known_failures.txt`. The merge queue is where that kind of drift gets caught, so the check belongs there.

The merge queue builds only the plain `amd_binary` flavor, so the merge-queue copy of the job (`JobConfigs.docs_examples_mq_job`) requires `CH_AMD_BINARY` and runs on an amd runner instead of the `arm_release` build the pull request and master workflows use. The examples exercise server behavior, which is the same either way, and all the binary artifacts share the same self-extracting path, so the job script needed no change.

It is cheap enough to run unconditionally. Over the last two weeks:

| job | p50 | max |
| --- | --- | --- |
| `Docs examples` | 77s | 94s |
| `Build (amd_binary)` | 533s | 2256s |
| `Fast test` | 892s | 18074s |

It starts after the build the queue already produces and finishes long before the fast test, so it adds no wall-clock time to the queue.

One detail worth noting: praktika drops `requires` from the job digest but not `runs_on`, so this copy's digest never matches the pull request workflow's arm job and the merge queue always runs it cold. That is ~80 seconds, and largely moot anyway - the merge commit's build digest differs from the pull request head's whenever `master` has moved on any build path, which is most of the time.

The check found something on its first real run, which is a point in its favor and also what needed fixing here. The examples exercise server behavior, and that behavior is *almost* the same on either architecture: `cosineDistanceTransposed` and `cosineDistanceTransposedQuantized` printed different last digits under `amd_binary` than the `arm_release` build the pull request and master workflows document them from.

```
  Function/cosineDistanceTransposed#0  [output]  src/Functions/vectorFunctions.cpp
    documented response:
    - │                       0.10557280905788935 │
    actual response:
    + │                        0.1055728122669417 │
```

These two are the only ones of the six transposed distance examples that differ, and the reason is what sets these two functions apart from the other four: normalizing by `1 / (sqrt(a2) * sqrt(b2))`. `distanceTransposed.cpp` computes the distances with SimSIMD, whose cosine kernels normalize with a reciprocal square root approximation that is implemented per instruction set and resolved from the CPU at run time, so the last digits differ not only between aarch64 and x86_64 but potentially between x86_64 servers of different capabilities. The `L2DistanceTransposed` and `dotProductTransposed` examples, which do not normalize, agree exactly.

The second commit therefore rounds both examples to six decimal places - which absorbs the ~3e-9 divergence with about a hundredfold margin - and records in the source why they are rounded, so that the surplus digits do not come back. They never meant anything: both functions are documented as returning an *approximate* cosine distance, computed from `p` bits of each element. The generated documentation page is left to the documentation autogeneration workflow, which regenerates it from these `FunctionDocumentation` registrations.

Also updated the `should_skip_merge_queue_job` docstring, which enumerated the queue's fixed job set. The hook itself returns `False` for anything that is not the stateless flaky job, so no logic change was needed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117843&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117843](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117843+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.786` (included in `26.9` and later)
<!-- ch-version-info:end -->