### PR TITLE
Add `ci-coverage` label to force LLVM coverage jobs on tests-only PRs

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -181,7 +181,8 @@ _PIPELINE_NOTES = {
     ),
     Labels.CI_COVERAGE: (
         "Label `ci-coverage` forces coverage jobs and the `LLVM Coverage` merge job "
-        "to run even though the change does not affect the build."
+        "to run even though the change does not affect the build. The "
+        "`excluded_from_llvm` jobs stay skipped: they produce no coverage data."
     ),
 }
 
@@ -413,7 +414,15 @@ def should_skip_job(job_name):
         ):
             # The `ci-coverage` label overrides only this automatic skip: it lets
             # a tests-only PR still measure the coverage of the tests it adds.
+            # The `excluded_from_llvm` jobs stay skipped even then - they run on a
+            # plain build and produce no coverage data, and the tests they hold
+            # are covered by the regular (non-coverage) test jobs of the PR.
             if Labels.CI_COVERAGE in _info_cache.pr_labels:
+                if "excluded_from_llvm" in job_name:
+                    return (
+                        True,
+                        f"Skipped: '{Labels.CI_COVERAGE}' forces only the coverage jobs; this job produces no coverage data",
+                    )
                 _add_pipeline_note(Labels.CI_COVERAGE)
                 return False, ""
             return True, "Skipped: no build-affecting changes; coverage would be identical to master"

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -9,6 +9,7 @@ from ci.jobs.scripts.workflow_hooks.new_tests_check import (
 from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
 from ci.praktika.info import Info
 from ci.praktika.utils import Shell
+from ci.praktika.workflow import Workflow
 
 
 def only_docs(changed_files):
@@ -417,6 +418,10 @@ def should_skip_job(job_name):
             # The `excluded_from_llvm` jobs stay skipped even then - they run on a
             # plain build and produce no coverage data, and the tests they hold
             # are covered by the regular (non-coverage) test jobs of the PR.
+            # FILTER_HOOK_FORCE_JOB (rather than a plain neutral answer) also
+            # exempts the job from the later "filter not affected jobs" pass,
+            # which would otherwise drop it again when no changed file matches
+            # its digest_config (e.g. a docs-only PR).
             if Labels.CI_COVERAGE in _info_cache.pr_labels:
                 if "excluded_from_llvm" in job_name:
                     return (
@@ -424,7 +429,7 @@ def should_skip_job(job_name):
                         f"Skipped: '{Labels.CI_COVERAGE}' forces only the coverage jobs; this job produces no coverage data",
                     )
                 _add_pipeline_note(Labels.CI_COVERAGE)
-                return False, ""
+                return False, Workflow.FILTER_HOOK_FORCE_JOB
             return True, "Skipped: no build-affecting changes; coverage would be identical to master"
 
     if not _is_bugfix_pr() and "Bugfix" in job_name:

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -179,6 +179,10 @@ _PIPELINE_NOTES = {
         "Label `ci-macos` runs the Darwin (macOS) `Fast test` job, which is "
         "skipped by default in PRs."
     ),
+    Labels.CI_COVERAGE: (
+        "Label `ci-coverage` forces coverage jobs and the `LLVM Coverage` merge job "
+        "to run even though the change does not affect the build."
+    ),
 }
 
 
@@ -395,18 +399,24 @@ def should_skip_job(job_name):
         "llvm_coverage" in job_name
         or "excluded_from_llvm" in job_name
         or job_name == JobNames.LLVM_COVERAGE
-    ) and (
-        Labels.CI_NO_COVERAGE in _info_cache.pr_labels
-        or (
-            _info_cache.pr_number > 0
-            and not _has_build_digest_changes(_info_cache.get_changed_files() or [])
-            and not _has_coverage_pipeline_changes(_info_cache.get_changed_files() or [])
-        )
     ):
+        # The explicit `ci-no-coverage` label wins over everything, including the
+        # `ci-coverage` force label below - an explicit "skip" should never lose
+        # to a leftover force label.
         if Labels.CI_NO_COVERAGE in _info_cache.pr_labels:
             _add_pipeline_note(Labels.CI_NO_COVERAGE)
             return True, f"Skipped, labeled with '{Labels.CI_NO_COVERAGE}'"
-        return True, "Skipped: no build-affecting changes; coverage would be identical to master"
+        if (
+            _info_cache.pr_number > 0
+            and not _has_build_digest_changes(_info_cache.get_changed_files() or [])
+            and not _has_coverage_pipeline_changes(_info_cache.get_changed_files() or [])
+        ):
+            # The `ci-coverage` label overrides only this automatic skip: it lets
+            # a tests-only PR still measure the coverage of the tests it adds.
+            if Labels.CI_COVERAGE in _info_cache.pr_labels:
+                _add_pipeline_note(Labels.CI_COVERAGE)
+                return False, ""
+            return True, "Skipped: no build-affecting changes; coverage would be identical to master"
 
     if not _is_bugfix_pr() and "Bugfix" in job_name:
         # Don't skip if the corresponding test job file was changed

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -95,6 +95,9 @@ class Labels:
     # Gates the Darwin (macOS) "Fast test" job in PRs; it is skipped unless this
     # label is applied. See DARWIN_FAST_TEST_JOBS in filter_job.py.
     CI_MACOS = "ci-macos"
+    # Forces the LLVM coverage family to run on a PR where it would be
+    # auto-skipped as having no build-affecting changes (e.g. a tests-only PR).
+    CI_COVERAGE = "ci-coverage"
 
     # Gates the PromQL compliance dedicated job + PR comment (see promql_compliance_job.py).
     COMP_PROMQL = "comp-promql"

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -305,7 +305,9 @@ def _prepare_submodule_cache(workflow, workflow_config: RunConfig) -> Result:
     )
 
 
-def _filter_unaffected_jobs(jobs, workflow_config, changed_files, affected_dockers=()):
+def _filter_unaffected_jobs(
+    jobs, workflow_config, changed_files, affected_dockers=(), forced_jobs=()
+):
     """
     Update workflow_config.filtered_jobs for jobs unaffected by changed_files.
 
@@ -317,6 +319,11 @@ def _filter_unaffected_jobs(jobs, workflow_config, changed_files, affected_docke
     Fix 2 (Bug 3) — all_required_artifacts is propagated to a fixed point after
     the initial sweep.  When an unaffected job is rescued because an affected job
     requires it, that rescued job's own dependencies are also rescued.
+
+    Jobs in forced_jobs (force-included by a workflow filter hook returning
+    Workflow.FILTER_HOOK_FORCE_JOB) are treated as affected, so they run even
+    when no changed file matches their digest_config, and their dependencies
+    are kept alive through the usual rescue propagation.
     """
     affected_artifacts = []
     unaffected_jobs = {}  # name → job
@@ -330,7 +337,10 @@ def _filter_unaffected_jobs(jobs, workflow_config, changed_files, affected_docke
 
         is_affected = False
 
-        if any(dep in affected_artifacts for dep in job.requires):
+        if job.name in forced_jobs:
+            print(f"Job [{job.name}] is force-included by a workflow filter hook")
+            is_affected = True
+        elif any(dep in affected_artifacts for dep in job.requires):
             print(f"Job [{job.name}] requires affected artifacts")
             is_affected = True
         elif job.get_docker_image_name() in affected_dockers:
@@ -619,6 +629,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
             )
         )
 
+    force_jobs = set()
     if results[-1].is_ok() and workflow.workflow_filter_hooks:
         sw_ = Utils.Stopwatch()
         try:
@@ -639,6 +650,11 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
                             )
                             workflow_config.set_job_as_filtered(job.name, reason)
                             continue
+                        if reason == Workflow.FILTER_HOOK_FORCE_JOB:
+                            print(
+                                f"Job [{job.name}] set to forced by custom hook [{hook.__name__}] - exempt from filtering by changed files"
+                            )
+                            force_jobs.add(job.name)
             status = Result.Status.OK
             workflow_config.dump()
             info = ""
@@ -680,7 +696,11 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
                 print(f"Affected docker images [{all_affected_dockers}]")
 
             _filter_unaffected_jobs(
-                workflow.jobs, workflow_config, changed_files, all_affected_dockers
+                workflow.jobs,
+                workflow_config,
+                changed_files,
+                all_affected_dockers,
+                force_jobs,
             )
 
             workflow_config.dump()

--- a/ci/praktika/workflow.py
+++ b/ci/praktika/workflow.py
@@ -8,6 +8,13 @@ from .utils import Utils
 
 
 class Workflow:
+    # A workflow filter hook normally returns (True, reason) to skip a job or
+    # (False, "") to stay neutral. Returning (False, FILTER_HOOK_FORCE_JOB)
+    # force-includes the job: it is then exempt from the later "filter not
+    # affected jobs" pass, which would otherwise drop it when no changed file
+    # matches its digest_config.
+    FILTER_HOOK_FORCE_JOB = "force"
+
     class Event:
         PULL_REQUEST = "pull_request"
         PUSH = "push"


### PR DESCRIPTION
The LLVM coverage family (the coverage build, the `amd_llvm_coverage` test shards, the `excluded_from_llvm` jobs, and the `LLVM Coverage` merge job) is skipped automatically on PRs with no build-affecting changes. The reason: the coverage of the compiled binary would be identical to master. But sometimes the author of a tests-only PR wants to run the coverage pipeline anyway, for example to see the coverage of the tests the PR adds.

This PR adds a new `ci-coverage` label. It overrides only the automatic skip, symmetric to the existing `ci-no-coverage` label. The explicit `ci-no-coverage` label still wins if both labels are present. The `excluded_from_llvm` jobs stay skipped even with the label: they run on a plain (non-instrumented) build and produce no coverage data, and their tests already run in the regular test jobs of the PR. A note about the label's effect is added to the CI report, in the same way as for the other `ci-*` labels.

Bypassing `should_skip_job` alone is not enough: the later "Filter not affected jobs" pass would still drop the coverage jobs when no changed file matches their `digest_config` (e.g. a docs-only PR). So this PR also adds a generic praktika mechanism: a workflow filter hook can return `(False, Workflow.FILTER_HOOK_FORCE_JOB)` to force-include a job. Forced jobs are treated as affected in `_filter_unaffected_jobs`, and their dependencies are kept alive through the usual rescue propagation. The job cache is still respected: a digest-identical coverage build is reused, not rebuilt.

Validation note: this PR cannot exercise the new branch in its own CI. Its diff touches `filter_job.py`, which is in `_COVERAGE_PIPELINE_PATHS`, so the coverage family runs here regardless of the label. The contract was validated by an offline replay of the Config Workflow decision pipeline against the real PR job graph (real `should_skip_job`, real digest configs, real `_filter_unaffected_jobs`) with a pure tests-only diff (`tests/queries/0_stateless/09999_new_test.sql`): without the label all 25 coverage-family jobs are filtered; with the label 23 coverage jobs run and the 2 `excluded_from_llvm` jobs stay skipped. After the merge, the end-to-end behavior should be confirmed once with a real tests-only PR carrying the label.

The `ci-coverage` label does not exist in the repository label list yet. It must be created once: `gh label create ci-coverage --description "Force LLVM coverage jobs to run on a PR with no build-affecting changes (e.g. tests-only)" --color 8256D0`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.633` (included in `26.9` and later)
<!-- ch-version-info:end -->