### PR TITLE
Reference math functions from std:: for portability.

### DIFF
--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -627,6 +627,7 @@ struct integer<Bits, Signed>::_impl
         // Calculate remainder: t - floor(alpha) * max_int
         // On platforms with >64-bit mantissa, round the multiplication to 64-bit precision
         // to match x86's 80-bit extended behavior
+        using std::floor;
         T remainder_subtrahend = floor(alpha) * static_cast<T>(max_int);
 #if (LDBL_MANT_DIG > 64)
         if constexpr (std::is_same_v<T, FromDoubleIntermediateType>)

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -27,7 +27,7 @@ struct L1Norm
     template <typename ResultType>
     static ResultType accumulate(ResultType result, ResultType value, const ConstParams &)
     {
-        return result + fabs(value);
+        return result + std::fabs(value);
     }
 
     template <typename ResultType>
@@ -64,7 +64,7 @@ struct L2Norm
     template <typename ResultType>
     static ResultType finalize(ResultType result, const ConstParams &)
     {
-        return sqrt(result);
+        return std::sqrt(result);
     }
 };
 
@@ -93,7 +93,7 @@ struct LpNorm
     template <typename ResultType>
     static ResultType accumulate(ResultType result, ResultType value, const ConstParams & params)
     {
-        return result + static_cast<ResultType>(std::pow(fabs(value), params.power));
+        return result + static_cast<ResultType>(std::pow(std::fabs(value), params.power));
     }
 
     template <typename ResultType>
@@ -118,13 +118,13 @@ struct LinfNorm
     template <typename ResultType>
     static ResultType accumulate(ResultType result, ResultType value, const ConstParams &)
     {
-        return fmax(result, fabs(value));
+        return std::fmax(result, std::fabs(value));
     }
 
     template <typename ResultType>
     static ResultType combine(ResultType result, ResultType other_result, const ConstParams &)
     {
-        return fmax(result, other_result);
+        return std::fmax(result, other_result);
     }
 
     template <typename ResultType>


### PR DESCRIPTION
As of
https://github.com/illumos/illumos-gate/commit/6d0c9b7f4a0d505fb904e57818c83b7d852c6119, illumos makes math function overloads like sqrt, fabs, etc., available in the std namespace, but no longer aliases them into the global namespace. To allow ClickHouse to compile on recent illumos versions, qualify relevant math functions with std::.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117884&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117884](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117884+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.675` (included in `26.9` and later)
<!-- ch-version-info:end -->