### PR TITLE
Add priority ordering to continue-all-prs.sh

### DIFF
--- a/utils/continue-all-prs.sh
+++ b/utils/continue-all-prs.sh
@@ -13,6 +13,16 @@ set -euo pipefail
 # worker becomes free first, so the work is distributed evenly regardless of how
 # long each PR takes.
 #
+# PRs are processed in priority order within each round. First every PR carrying
+# the `blocker` label is processed; only once a full pass over them makes no
+# progress does the round move on to the PRs labeled `pr-critical-bugfix`, and
+# only once those likewise make no progress does it process the rest. As soon as
+# a priority makes progress the round stops there, and the next round starts over
+# from the `blocker` PRs, so the highest-priority work is always revisited first.
+# "Progress" means a PR was pushed, merged or closed; a PR that only needs a
+# human decision (NEEDS-ATTENTION) or that failed / timed out does not count as
+# progress, so a stuck PR never starves the lower priorities.
+#
 # Output is intentionally terse: one line when a PR is assigned to a worker, and
 # when it finishes a status line plus a one-to-two sentence summary of what was
 # done. The finish status is one of:
@@ -104,8 +114,10 @@ set -euo pipefail
 #   If colors look wrong, run with --color never.
 #
 # Advanced/testing:
-#   Set CONTINUE_ALL_PRS_PRS_FILE=<file> to read the PR list (lines of
-#   "<number>\t<title>") from a file instead of querying GitHub.
+#   Set CONTINUE_ALL_PRS_PRS_FILE=<file> to read the PR list from a file instead
+#   of querying GitHub. Each line is "<number>\t<title>", optionally followed by
+#   a third tab-separated column of comma-separated labels
+#   ("<number>\t<title>\t<label>,<label>,...") used to assign the priority tier.
 #   Set CONTINUE_ALL_PRS_MIN_FREE_GB=<integer> to override the minimum free
 #   disk space maintained by worktree cleanup (default: 100).
 
@@ -418,6 +430,10 @@ na_add()
       grep -qxF "$1" "$NAFILE" 2>/dev/null || echo "$1" >> "$NAFILE"
     } 7>>"$STATSLOCK"
 }
+
+# Record a PR that made real progress this priority pass. Reset by run_workers_on
+# before each pass; read afterwards to decide whether to advance priorities.
+action_add() { { flock 7; printf '%s\n' "$1" >> "$ACTION_FILE"; } 7>>"$STATSLOCK"; }
 
 # Pipe this script's stdout (banners + all worker lines) through the renderer,
 # which owns the real terminal. No-op if disabled or the renderer is missing.
@@ -878,6 +894,10 @@ STATSFILE="$LOGDIR/stats"
 STATSLOCK="$LOGDIR/stats.lock"
 NAFILE="$LOGDIR/needs-attention"
 CLEANUP_FAILURE_FILE="$LOGDIR/cleanup-failure"
+# PRs that made real progress (pushed / merged / closed) during the current
+# priority pass. A non-empty file after a pass means the round should stay on
+# this priority and not advance to a lower one.
+ACTION_FILE="$LOGDIR/action-taken"
 declare -a WORKER_PIDS=()
 
 stop_workers()
@@ -1205,6 +1225,10 @@ process_pr()
         *)               stats_add 0 1 0 0 0 0 0 0 ;;
     esac
     [[ "$outcome" == NEEDS-ATTENTION ]] && na_add "$number"
+    # Real progress (pushed / merged / closed) keeps the current priority tier
+    # active, so the round does not advance to a lower priority yet. NO-CHANGE,
+    # NEEDS-ATTENTION, FAILED and TIMEOUT are not progress and let it advance.
+    [[ "$mark" == "OK " ]] && action_add "$number"
 
     ts=$(date +%H:%M:%S)
     emit "$color" "$ts  $mark  worker $i  FINISHED  PR #$number  $title  --  $status"
@@ -1248,6 +1272,31 @@ worker()
     exec 9>&-
 }
 
+# Run the worker pool over the given newline-separated "<number>\t<title>" list,
+# blocking until every worker drains the queue. Resets the progress marker first;
+# a worker records a PR in $ACTION_FILE whenever it makes real progress (pushed /
+# merged / closed), so afterwards a non-empty $ACTION_FILE means the pass
+# advanced at least one PR.
+run_workers_on()
+{
+    local prs="$1" i
+    : > "$ACTION_FILE"
+    printf '%s\n' "$prs" > "$QUEUEFILE"
+
+    # Job control gives every asynchronous worker its own process group. This
+    # lets the interrupt trap terminate the worker and all of its descendants
+    # immediately instead of waiting for a running agent command to return.
+    set -m
+    WORKER_PIDS=()
+    for (( i = 0; i < WORKERS; i++ )); do
+        worker "$i" "${WT[i]}" &
+        WORKER_PIDS+=($!)
+    done
+    set +m
+    wait "${WORKER_PIDS[@]}" || true
+    WORKER_PIDS=()
+}
+
 # Return 0 (true) if a "related" PR looks abandoned: nobody other than me has
 # acted on it (pushed a commit, commented, or reviewed) since `cutoff`. If the
 # activity data can't be fetched, treat it as active (skip) - fail closed rather
@@ -1279,10 +1328,29 @@ load_excluded_authors()
     done < "$EXCLUDE_AUTHORS_FILE"
 }
 
+# Map a PR's comma-separated label list to its priority tier: 0 for `blocker`,
+# 1 for `pr-critical-bugfix`, 2 for everything else (blocker wins if both apply).
+pr_priority()
+{
+    case ",$1," in
+        *,blocker,*)            printf '0' ;;
+        *,pr-critical-bugfix,*) printf '1' ;;
+        *)                      printf '2' ;;
+    esac
+}
+
+# Emit the PR list as "<number>\t<priority>\t<title>" lines, oldest first. The
+# caller buckets them into priority tiers.
 fetch_prs()
 {
     if [[ -n "${CONTINUE_ALL_PRS_PRS_FILE:-}" ]]; then
-        cat "$CONTINUE_ALL_PRS_PRS_FILE"
+        # File lines are "<number>\t<title>" with an optional third
+        # "<label>,<label>,..." column used only to assign the priority tier.
+        local n t labels
+        while IFS=$'\t' read -r n t labels || [[ -n "$n" ]]; do
+            [[ -n "$n" ]] || continue
+            printf '%s\t%s\t%s\n' "$n" "$(pr_priority "$labels")" "$t"
+        done < "$CONTINUE_ALL_PRS_PRS_FILE"
         return 0
     fi
 
@@ -1318,29 +1386,33 @@ fetch_prs()
         add
         | map(select((.labels // []) | map(.name) | index("hold") | not))
         | group_by(.number)
-        | map({ number:    .[0].number,
-                title:     .[0].title,
-                author:    (.[0].author.login // ""),
-                updatedAt: (map(.updatedAt) | max),
-                always:    (any(.[]; .always)) })
+        | map(([.[].labels[]?.name] | unique) as $names
+              | { number:    .[0].number,
+                  title:     .[0].title,
+                  author:    (.[0].author.login // ""),
+                  updatedAt: (map(.updatedAt) | max),
+                  always:    (any(.[]; .always)),
+                  priority:  (if   ($names | index("blocker"))            then 0
+                              elif ($names | index("pr-critical-bugfix")) then 1
+                              else 2 end) })
         | sort_by(.updatedAt)
-        | .[] | [ .number, (.always | tostring), .author, .updatedAt, .title ] | @tsv' )
+        | .[] | [ .number, (.always | tostring), .author, .updatedAt, (.priority | tostring), .title ] | @tsv' )
 
-    local number always author updatedAt title
-    while IFS=$'\t' read -r number always author updatedAt title; do
+    local number always author updatedAt priority title
+    while IFS=$'\t' read -r number always author updatedAt priority title; do
         [[ -n "$number" ]] || continue
         if [[ "$always" == "true" ]]; then
             # mine / assigned to me -> always processed, regardless of author.
-            printf '%s\t%s\n' "$number" "$title"
+            printf '%s\t%s\t%s\n' "$number" "$priority" "$title"
             continue
         fi
         # related-only: skip if the author is excluded from --related updates.
         [[ -n "${EXCLUDED_AUTHOR[${author,,}]:-}" ]] && continue
         if [[ "$updatedAt" < "$cutoff" ]]; then
             # No activity by anyone (including me) in the window -> abandoned.
-            printf '%s\t%s\n' "$number" "$title"
+            printf '%s\t%s\t%s\n' "$number" "$priority" "$title"
         elif related_is_abandoned "$number" "$cutoff"; then
-            printf '%s\t%s\n' "$number" "$title"
+            printf '%s\t%s\t%s\n' "$number" "$priority" "$title"
         fi
     done <<< "$candidates"
 }
@@ -1357,6 +1429,10 @@ fi
 maybe_color_hint
 load_excluded_authors
 
+# Priority tiers processed highest-first each round (see the header comment).
+# Index i names priority i, as assigned by pr_priority / fetch_prs.
+PRIORITY_NAMES=("blocker" "pr-critical-bugfix" "other")
+
 modes=()
 (( MODE_MINE ))     && modes+=("mine")
 (( MODE_ASSIGNED )) && modes+=("assigned")
@@ -1369,6 +1445,7 @@ banner "Workers:         $WORKERS"
 banner "Worktree base:   ${WORKTREE_BASE}-{0..$((WORKERS - 1))}"
 [[ -n "$GH_USER" ]] && banner "GitHub user:     $GH_USER"
 banner "Selecting:       $MODES_DESC"
+banner "Priority order:  ${PRIORITY_NAMES[0]} > ${PRIORITY_NAMES[1]} > ${PRIORITY_NAMES[2]}"
 (( MODE_RELATED )) && (( ${#EXCLUDED_AUTHOR[@]} )) && banner "Excluded (related): ${!EXCLUDED_AUTHOR[*]}"
 banner "Per-PR timeout:  ${TIMEOUT}s (shared across up to ${MAX_CONTINUE} turns)"
 banner "ccache:          ${CCACHE_DIR} (max ${CCACHE_MAXSIZE})"
@@ -1428,38 +1505,43 @@ while true; do
     na_reset
     banner "===== Round ${ROUND}: fetching open PRs ====="
 
-    PRS="$(fetch_prs || true)"
+    PRS_RAW="$(fetch_prs || true)"
 
-    if [[ -z "$PRS" ]]; then
+    if [[ -z "$PRS_RAW" ]]; then
         banner "No open PRs found. Sleeping 60s before retrying..."
         (( ONCE )) && break
         sleep 60
         continue
     fi
 
-    COUNT=$(printf '%s\n' "$PRS" | grep -c . || true)
-    banner "Round ${ROUND}: ${COUNT} PR(s) to process across ${WORKERS} worker(s)"
+    TOTAL=$(printf '%s\n' "$PRS_RAW" | grep -c . || true)
+    banner "Round ${ROUND}: ${TOTAL} PR(s) across ${WORKERS} worker(s), by priority: ${PRIORITY_NAMES[0]} > ${PRIORITY_NAMES[1]} > ${PRIORITY_NAMES[2]}"
     echo ""
 
-    printf '%s\n' "$PRS" > "$QUEUEFILE"
+    # Process the PRs in priority tiers. Only advance to a lower priority once a
+    # full pass over the current one makes no progress; the moment a pass does
+    # make progress, stop the round so the next one revisits the top priority.
+    for prio in 0 1 2; do
+        tier_prs=$(printf '%s\n' "$PRS_RAW" \
+            | awk -F'\t' -v p="$prio" '$2 == p { t = $3; for (i = 4; i <= NF; ++i) t = t "\t" $i; print $1 "\t" t }')
+        tier_count=$(printf '%s\n' "$tier_prs" | grep -c . || true)
+        (( tier_count == 0 )) && continue
 
-    # Job control gives every asynchronous worker its own process group. This
-    # lets the interrupt trap terminate the worker and all of its descendants
-    # immediately instead of waiting for a running agent command to return.
-    set -m
-    WORKER_PIDS=()
-    for (( i = 0; i < WORKERS; i++ )); do
-        worker "$i" "${WT[i]}" &
-        WORKER_PIDS+=($!)
+        banner "Priority ${prio} (${PRIORITY_NAMES[prio]}): ${tier_count} PR(s)"
+        echo ""
+        run_workers_on "$tier_prs"
+
+        if [[ -s "$CLEANUP_FAILURE_FILE" ]]; then
+            banner "Worktree cleanup failed; stopping instead of retrying in another round"
+            exit 1
+        fi
+
+        if [[ -s "$ACTION_FILE" ]]; then
+            banner "Priority ${prio} (${PRIORITY_NAMES[prio]}) made progress; skipping lower priorities this round"
+            break
+        fi
+        banner "Priority ${prio} (${PRIORITY_NAMES[prio]}) needs no action; advancing to the next priority"
     done
-    set +m
-    wait "${WORKER_PIDS[@]}" || true
-    WORKER_PIDS=()
-
-    if [[ -s "$CLEANUP_FAILURE_FILE" ]]; then
-        banner "Worktree cleanup failed; stopping instead of retrying in another round"
-        exit 1
-    fi
 
     echo ""
     banner "===== Round ${ROUND} complete ====="

--- a/utils/tests/test_continue_all_prs_priority.sh
+++ b/utils/tests/test_continue_all_prs_priority.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exercises the priority ordering in continue-all-prs.sh:
+#   * PRs are processed highest-priority first (blocker > pr-critical-bugfix > rest);
+#   * the round advances to a lower priority only when the current one makes no
+#     progress;
+#   * as soon as a priority makes progress the round skips the lower priorities.
+#
+# GitHub is mocked (CONTINUE_ALL_PRS_PRS_FILE supplies the PR list with a labels
+# column, and a mock `gh`/`claude` on PATH stand in for the real tools). A PR
+# whose number is listed in MOCK_PUSHED reports a changed head after the run, so
+# it is classified PUSHED (progress); all others are NO-CHANGE.
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+mkdir -p "$repo/tmp"
+scratch=$(mktemp -d "$repo/tmp/test-continue-all-prs-priority.XXXXXX")
+bin="$scratch/bin"
+worktree_base="$scratch/worktree"
+pr_file="$scratch/prs"
+
+export CONTINUE_ALL_PRS_MIN_FREE_GB=1
+
+cleanup()
+{
+    git -C "$repo" worktree remove --force "${worktree_base}-0" 2>/dev/null || true
+    rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+mkdir -p "$bin"
+
+# One PR per priority tier: #101 blocker, #102 pr-critical-bugfix, #103 plain.
+printf '%s\n' \
+    $'101\tBlocker PR\tblocker' \
+    $'102\tCritical bugfix PR\tpr-critical-bugfix' \
+    $'103\tOrdinary PR\t' > "$pr_file"
+
+# Mock `gh pr view`: returns the head SHA before the run and a state tuple after.
+# A PR in MOCK_PUSHED gets a different "after" SHA, so the script sees a push.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [[ "${1:-}" == pr && "${2:-}" == view ]]; then' \
+    '    n="$3"' \
+    '    after="sha-$n"' \
+    '    case " ${MOCK_PUSHED:-} " in *" $n "*) after="sha-$n-new" ;; esac' \
+    '    if [[ "$*" == *state,mergeable* ]]; then' \
+    '        printf "OPEN\tMERGEABLE\tNONE\t%s\n" "$after"' \
+    '    else' \
+    '        printf "sha-%s\n" "$n"' \
+    '    fi' \
+    '    exit 0' \
+    'fi' \
+    'exit 0' > "$bin/gh"
+chmod +x "$bin/gh"
+
+# Mock `claude`: emits a single JSON result that signals completion immediately.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\n" "{\"result\":\"handled\n<<<CONTINUE-PR-DONE>>>\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0},\"total_cost_usd\":0}"' > "$bin/claude"
+chmod +x "$bin/claude"
+
+run()
+{
+    # run <log> [MOCK_PUSHED value]
+    local log="$1" pushed="${2:-}"
+    PATH="$bin:$PATH" CONTINUE_ALL_PRS_PRS_FILE="$pr_file" MOCK_PUSHED="$pushed" \
+        "$repo/utils/continue-all-prs.sh" --agent claude --timeout 60 --once \
+            --skip-submodules --no-status --worktree-base "$worktree_base" --color never \
+            > "$log" 2>&1
+}
+
+# The line number at which "ASSIGNED  PR #<n>" appears (empty if not processed).
+assigned_line() { grep -n "ASSIGNED  PR #$2" "$1" | head -n1 | cut -d: -f1; }
+
+# ---------------------------------------------------------------------------
+# 1. No progress anywhere: every priority is visited, in order, all PRs run.
+# ---------------------------------------------------------------------------
+run "$scratch/all.log"
+
+grep -q 'Priority 0 (blocker): 1 PR'            "$scratch/all.log"
+grep -q 'Priority 1 (pr-critical-bugfix): 1 PR' "$scratch/all.log"
+grep -q 'Priority 2 (other): 1 PR'              "$scratch/all.log"
+grep -q 'Priority 0 (blocker) needs no action; advancing'            "$scratch/all.log"
+grep -q 'Priority 1 (pr-critical-bugfix) needs no action; advancing' "$scratch/all.log"
+
+l101=$(assigned_line "$scratch/all.log" 101)
+l102=$(assigned_line "$scratch/all.log" 102)
+l103=$(assigned_line "$scratch/all.log" 103)
+[[ -n "$l101" && -n "$l102" && -n "$l103" ]] || { echo 'Expected all three PRs to run' >&2; exit 1; }
+(( l101 < l102 && l102 < l103 )) || { echo 'PRs were not processed in priority order' >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 2. Top priority makes progress: lower priorities are skipped this round.
+# ---------------------------------------------------------------------------
+run "$scratch/blocker-progress.log" 101
+
+grep -q 'Priority 0 (blocker) made progress; skipping lower priorities' "$scratch/blocker-progress.log"
+[[ -n "$(assigned_line "$scratch/blocker-progress.log" 101)" ]] || { echo 'Blocker PR should have run' >&2; exit 1; }
+if grep -q 'ASSIGNED  PR #102' "$scratch/blocker-progress.log" \
+    || grep -q 'ASSIGNED  PR #103' "$scratch/blocker-progress.log"; then
+    echo 'Lower-priority PRs must be skipped once the blocker made progress' >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Progress at the middle priority: the top advances, the rest is skipped.
+# ---------------------------------------------------------------------------
+run "$scratch/critical-progress.log" 102
+
+grep -q 'Priority 0 (blocker) needs no action; advancing'              "$scratch/critical-progress.log"
+grep -q 'Priority 1 (pr-critical-bugfix) made progress; skipping'      "$scratch/critical-progress.log"
+[[ -n "$(assigned_line "$scratch/critical-progress.log" 101)" ]] || { echo 'Blocker PR should have run' >&2; exit 1; }
+[[ -n "$(assigned_line "$scratch/critical-progress.log" 102)" ]] || { echo 'Critical-bugfix PR should have run' >&2; exit 1; }
+if grep -q 'ASSIGNED  PR #103' "$scratch/critical-progress.log"; then
+    echo 'The lowest priority must be skipped once the middle one made progress' >&2
+    exit 1
+fi
+
+echo 'test_continue_all_prs_priority: OK'


### PR DESCRIPTION
Process open PRs in priority tiers within each round of `continue-all-prs.sh`: first PRs labeled `blocker`, then PRs labeled `pr-critical-bugfix`, then the rest.

The round advances to a lower priority only when a full pass over the current one makes no progress. The moment a pass makes progress it stops, and the next round starts over from the top priority, so the highest-priority work is always revisited first. "Progress" means a PR was pushed, merged or closed; a PR that only needs a human decision (`NEEDS-ATTENTION`) or that failed / timed out does not count as progress, so a stuck PR never starves the lower priorities.

Motivation: keep the worker pool focused on the most important PRs instead of spreading effort evenly across everything.

Details:
- `fetch_prs` now emits a priority column derived from labels (`blocker` > `pr-critical-bugfix` > rest); the queue format workers consume is unchanged.
- The test-file path (`CONTINUE_ALL_PRS_PRS_FILE`) accepts an optional third tab-separated column of comma-separated labels for the tier; a plain `<number>\t<title>` line still works and lands in the lowest tier.
- Adds `utils/tests/test_continue_all_prs_priority.sh` (ordering, advancement when nothing progresses, and gating when a higher tier progresses). The existing test still passes.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Developer tooling only (`utils/continue-all-prs.sh`); no user-facing change.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117886&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117886](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117886+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.618` (included in `26.9` and later)
<!-- ch-version-info:end -->