### PR TITLE
Do not miss private stress test failures in `check_ci.py`

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -924,71 +924,70 @@ def main():
     # Process the sync PR result regardless of the "CH Inc sync" commit status as stress test failures are ignored by it.
     sync_known_failures = []
     sync_unknown_failures = []
-    if sync_status:
+    sync_status_text = (
+        f"{sync_status.state} - {sync_status.description}" if sync_status else "unknown"
+    )
+    print(
+        f"\n=== Processing Sync PR ({CheckStatuses.CH_INC_SYNC}: {sync_status_text}) ==="
+    )
+
+    # Check proxy connectivity before proceeding
+    process_sync = False
+    while True:
+        if Shell.check(
+            f"curl -sf --connect-timeout 5 {S3_PROXY_BASE_URL} -o /dev/null 2>&1"
+        ):
+            process_sync = True
+            break
         print(
-            f"\n=== Processing Sync PR ({CheckStatuses.CH_INC_SYNC}: "
-            f"{sync_status.state} - {sync_status.description}) ==="
+            f"WARNING: S3 proxy at {S3_PROXY_BASE_URL} is not reachable. "
+            "Connect to VPN/Tailscale to access sync PR results."
         )
+        answer = UserPrompt.select_from_menu(
+            [
+                ("Skip sync PR processing", "skip"),
+                ("Retry (after connecting to VPN)", "retry"),
+            ],
+            question="S3 proxy is not available",
+        )
+        if answer[1] == "skip":
+            print("Skipping sync PR processing")
+            break
 
-        # Check proxy connectivity before proceeding
-        process_sync = False
-        while True:
-            if Shell.check(
-                f"curl -sf --connect-timeout 5 {S3_PROXY_BASE_URL} -o /dev/null 2>&1"
-            ):
-                process_sync = True
-                break
-            print(
-                f"WARNING: S3 proxy at {S3_PROXY_BASE_URL} is not reachable. "
-                "Connect to VPN/Tailscale to access sync PR results."
+    if process_sync:
+        sync_pr_info = CommitStatusCheck.get_sync_pr_info(pr_number)
+        if sync_pr_info:
+            sync_pr_num, sync_sha = sync_pr_info
+            print(f"Sync PR: {SYNC_REPO}#{sync_pr_num} (sha: {sync_sha[:12]})")
+            sync_workflow_result = CommitStatusCheck.get_sync_pr_result(
+                sync_pr_num, sync_sha
             )
-            answer = UserPrompt.select_from_menu(
-                [
-                    ("Skip sync PR processing", "skip"),
-                    ("Retry (after connecting to VPN)", "retry"),
-                ],
-                question="S3 proxy is not available",
-            )
-            if answer[1] == "skip":
-                print("Skipping sync PR processing")
-                break
-
-        if process_sync:
-            sync_pr_info = CommitStatusCheck.get_sync_pr_info(pr_number)
-            if sync_pr_info:
-                sync_pr_num, sync_sha = sync_pr_info
-                print(
-                    f"Sync PR: {SYNC_REPO}#{sync_pr_num} (sha: {sync_sha[:12]})"
+            if sync_workflow_result:
+                sync_workflow_result = (
+                    sync_workflow_result.to_failed_results_with_flat_leaves()
                 )
-                sync_workflow_result = CommitStatusCheck.get_sync_pr_result(
-                    sync_pr_num, sync_sha
+                (
+                    sync_known_failures,
+                    sync_unknown_failures,
+                    sync_not_finished,
+                    _,
+                ) = process_workflow_failures(
+                    sync_workflow_result,
+                    SYNC_REPO,
+                    sync_pr_num,
+                    sync_sha,
+                    allow_infra_issues=create_infrastructure_issue,
                 )
-                if sync_workflow_result:
-                    sync_workflow_result = (
-                        sync_workflow_result.to_failed_results_with_flat_leaves()
-                    )
-                    (
-                        sync_known_failures,
-                        sync_unknown_failures,
-                        sync_not_finished,
-                        _,
-                    ) = process_workflow_failures(
-                        sync_workflow_result,
-                        SYNC_REPO,
-                        sync_pr_num,
-                        sync_sha,
-                        allow_infra_issues=create_infrastructure_issue,
-                    )
-                    print_failure_summary(
-                        sync_known_failures,
-                        sync_unknown_failures,
-                        sync_not_finished,
-                        label="Sync",
-                    )
-                else:
-                    print("WARNING: Could not fetch sync PR result - skipping")
+                print_failure_summary(
+                    sync_known_failures,
+                    sync_unknown_failures,
+                    sync_not_finished,
+                    label="Sync",
+                )
             else:
-                print("WARNING: Could not find sync PR - skipping")
+                print("WARNING: Could not fetch sync PR result - skipping")
+        else:
+            print("WARNING: Could not find sync PR - skipping")
 
     public_failed = known_failures or unknown_failures
     sync_failed = sync_known_failures or sync_unknown_failures
@@ -1001,8 +1000,7 @@ def main():
         if known_failures:
             summary += f" - {len(known_failures)} known failure{'s' if len(known_failures) != 1 else ''}\n"
         summary += " - all other public checks passed\n"
-        if sync_status:
-            summary += f" - Sync status: {sync_status.state}, description: {sync_status.description}\n"
+        summary += f" - Sync status: {sync_status_text}\n"
         if sync_failed:
             summary += f" - Sync failures: {len(sync_known_failures)} known, {len(sync_unknown_failures)} unknown\n"
     else:

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -990,30 +990,27 @@ def main():
             else:
                 print("WARNING: Could not find sync PR - skipping")
 
-    question = "CI status:\n"
-    if (
-        unknown_failures
-        or known_failures
-        or sync_known_failures
-        or sync_unknown_failures
-    ):
+    public_failed = known_failures or unknown_failures
+    sync_failed = sync_known_failures or sync_unknown_failures
+    if public_failed or sync_failed:
+        summary = "CI status:\n"
         if not_finished_jobs:
-            question += f" - {len(not_finished_jobs)} not finished job{'s' if len(not_finished_jobs) != 1 else ''}\n"
+            summary += f" - {len(not_finished_jobs)} not finished job{'s' if len(not_finished_jobs) != 1 else ''}\n"
         if unknown_failures:
-            question += f" - {len(unknown_failures)} unknown failure{'s' if len(unknown_failures) != 1 else ''}\n"
+            summary += f" - {len(unknown_failures)} unknown failure{'s' if len(unknown_failures) != 1 else ''}\n"
         if known_failures:
-            question += f" - {len(known_failures)} known failure{'s' if len(known_failures) != 1 else ''}\n"
-        question += " - all other public checks passed\n"
+            summary += f" - {len(known_failures)} known failure{'s' if len(known_failures) != 1 else ''}\n"
+        summary += " - all other public checks passed\n"
         if sync_status:
-            question += f" - Sync status: {sync_status.state}, description: {sync_status.description}\n"
-        if sync_known_failures or sync_unknown_failures:
-            question += f" - Sync failures: {len(sync_known_failures)} known, {len(sync_unknown_failures)} unknown\n"
+            summary += f" - Sync status: {sync_status.state}, description: {sync_status.description}\n"
+        if sync_failed:
+            summary += f" - Sync failures: {len(sync_known_failures)} known, {len(sync_unknown_failures)} unknown\n"
     else:
-        question = "All checks passed! Congratulations!\n"
+        summary = "All checks passed! Congratulations!\n"
+    print(f"\n{summary}")
 
-    if unknown_failures or known_failures:
-        question += "\nDo you want to update PR CI comment?"
-        if not UserPrompt.confirm(question):
+    if public_failed:
+        if not UserPrompt.confirm("Do you want to update PR CI comment?"):
             sys.exit(0)
 
         try:
@@ -1033,8 +1030,6 @@ def main():
         except Exception as e:
             print(f"ERROR: failed to post CI summary, ex: {e}")
             traceback.print_exc()
-    else:
-        print(f"\n{question}")
 
     if not UserPrompt.confirm(
         f"Add PR #{pr_number} to the merge queue (y - continue, n - exit)?"

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -580,7 +580,6 @@ class CommitStatusCheck:
         return Result.from_file("/tmp/result_sync_pr.json")
 
 
-issues_created = 0
 ci_start_time = None
 create_infrastructure_issue = False
 
@@ -909,18 +908,13 @@ def main():
     global ci_start_time
     ci_start_time = workflow_result.start_time
 
-    known_failures, unknown_failures, not_finished_jobs, new_issues_count = (
-        process_workflow_failures(
-            workflow_result,
-            PUBLIC_REPO,
-            pr_number,
-            head_sha,
-            allow_infra_issues=create_infrastructure_issue,
-        )
+    known_failures, unknown_failures, not_finished_jobs, _ = process_workflow_failures(
+        workflow_result,
+        PUBLIC_REPO,
+        pr_number,
+        head_sha,
+        allow_infra_issues=create_infrastructure_issue,
     )
-    pre_existing_issues_count = len(known_failures) - new_issues_count
-    global issues_created
-    issues_created += new_issues_count
 
     print_failure_summary(known_failures, unknown_failures, not_finished_jobs)
 
@@ -999,8 +993,7 @@ def main():
     question = "CI status:\n"
     if (
         unknown_failures
-        or issues_created > 0
-        or pre_existing_issues_count > 0
+        or known_failures
         or sync_known_failures
         or sync_unknown_failures
     ):

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -924,6 +924,8 @@ def main():
     # Process the sync PR result regardless of the "CH Inc sync" commit status as stress test failures are ignored by it.
     sync_known_failures = []
     sync_unknown_failures = []
+    sync_not_finished = []
+    sync_checked = False
     sync_status_text = (
         f"{sync_status.state} - {sync_status.description}" if sync_status else "unknown"
     )
@@ -978,6 +980,7 @@ def main():
                     sync_sha,
                     allow_infra_issues=create_infrastructure_issue,
                 )
+                sync_checked = True
                 print_failure_summary(
                     sync_known_failures,
                     sync_unknown_failures,
@@ -991,7 +994,7 @@ def main():
 
     public_failed = known_failures or unknown_failures
     sync_failed = sync_known_failures or sync_unknown_failures
-    if public_failed or sync_failed:
+    if public_failed or sync_failed or not_finished_jobs or sync_not_finished:
         summary = "CI status:\n"
         if not_finished_jobs:
             summary += f" - {len(not_finished_jobs)} not finished job{'s' if len(not_finished_jobs) != 1 else ''}\n"
@@ -1001,10 +1004,14 @@ def main():
             summary += f" - {len(known_failures)} known failure{'s' if len(known_failures) != 1 else ''}\n"
         summary += " - all other public checks passed\n"
         summary += f" - Sync status: {sync_status_text}\n"
+        if sync_not_finished:
+            summary += f" - Sync not finished: {len(sync_not_finished)} job{'s' if len(sync_not_finished) != 1 else ''}\n"
         if sync_failed:
             summary += f" - Sync failures: {len(sync_known_failures)} known, {len(sync_unknown_failures)} unknown\n"
-    else:
+    elif sync_checked:
         summary = "All checks passed! Congratulations!\n"
+    else:
+        summary = "All public checks passed, sync PR was not checked\n"
     print(f"\n{summary}")
 
     if public_failed:

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -927,15 +927,14 @@ def main():
     if is_master_commit:
         sys.exit(0)
 
-    # Process sync PR failures if sync CI failed with test failures
+    # Process the sync PR result regardless of the "CH Inc sync" commit status as stress test failures are ignored by it.
     sync_known_failures = []
     sync_unknown_failures = []
-    if (
-        sync_status
-        and sync_status.state == Result.GHStatus.FAILURE
-        and sync_status.description == "tests failed"
-    ):
-        print("\n=== Processing Sync PR (CH Inc sync) failures ===")
+    if sync_status:
+        print(
+            f"\n=== Processing Sync PR ({CheckStatuses.CH_INC_SYNC}: "
+            f"{sync_status.state} - {sync_status.description}) ==="
+        )
 
         # Check proxy connectivity before proceeding
         process_sync = False
@@ -998,15 +997,22 @@ def main():
                 print("WARNING: Could not find sync PR - skipping")
 
     question = "CI status:\n"
-    if unknown_failures or issues_created > 0 or pre_existing_issues_count > 0:
+    if (
+        unknown_failures
+        or issues_created > 0
+        or pre_existing_issues_count > 0
+        or sync_known_failures
+        or sync_unknown_failures
+    ):
         if not_finished_jobs:
             question += f" - {len(not_finished_jobs)} not finished job{'s' if len(not_finished_jobs) != 1 else ''}\n"
         if unknown_failures:
             question += f" - {len(unknown_failures)} unknown failure{'s' if len(unknown_failures) != 1 else ''}\n"
         if known_failures:
             question += f" - {len(known_failures)} known failure{'s' if len(known_failures) != 1 else ''}\n"
-        question += " - all other checks passed\n"
-        question += f" - Sync status: {sync_status.state}, description: {sync_status.description}\n"
+        question += " - all other public checks passed\n"
+        if sync_status:
+            question += f" - Sync status: {sync_status.state}, description: {sync_status.description}\n"
         if sync_known_failures or sync_unknown_failures:
             question += f" - Sync failures: {len(sync_known_failures)} known, {len(sync_unknown_failures)} unknown\n"
     else:
@@ -1034,6 +1040,8 @@ def main():
         except Exception as e:
             print(f"ERROR: failed to post CI summary, ex: {e}")
             traceback.print_exc()
+    else:
+        print(f"\n{question}")
 
     if not UserPrompt.confirm(
         f"Add PR #{pr_number} to the merge queue (y - continue, n - exit)?"


### PR DESCRIPTION
Now the sync PR result is processed regardless of the sync status and unmatched private-only failures are offered for issue creation.

Previously `check_ci.py` only looked at the private sync PR when the `CH Inc sync` status was `failure` with description `tests failed`. The private side turns the status green when only stress tests failed, so such findings were not offered for issue creation. Example: https://github.com/ClickHouse/ClickHouse/pull/117604.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`check_ci.py` now inspects the private sync PR even when its status is green, so stress test failures ignored by the sync job are offered for issue creation.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117887&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117887](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117887+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.616` (included in `26.9` and later)
<!-- ch-version-info:end -->