### PR TITLE
Do not claim injectivity for a function that collapses varying arguments to `Nothing`

### DIFF
--- a/src/Functions/IFunctionAdaptors.cpp
+++ b/src/Functions/IFunctionAdaptors.cpp
@@ -1,3 +1,5 @@
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunctionAdaptors.h>
 
@@ -14,6 +16,17 @@ ColumnPtr FunctionToExecutableFunctionAdaptor::executeDryRunImpl(const ColumnsWi
 {
     checkFunctionArgumentSizes(arguments, input_rows_count);
     return function->executeImplDryRun(arguments, result_type, input_rows_count);
+}
+
+bool FunctionToFunctionBaseAdaptor::isInjective(const ColumnsWithTypeAndName & sample_columns) const
+{
+    /// A result type admitting at most one value maps the whole argument domain onto that value, so
+    /// injectivity could only hold over a single-valued domain. The overload resolver produces such a
+    /// type by itself (a NULL constant argument, or a `Nothing` one), bypassing the implementation.
+    if (isNothing(removeNullable(getResultType())))
+        return false;
+
+    return function->isInjective(sample_columns);
 }
 
 }

--- a/src/Functions/IFunctionAdaptors.cpp
+++ b/src/Functions/IFunctionAdaptors.cpp
@@ -20,11 +20,19 @@ ColumnPtr FunctionToExecutableFunctionAdaptor::executeDryRunImpl(const ColumnsWi
 
 bool FunctionToFunctionBaseAdaptor::isInjective(const ColumnsWithTypeAndName & sample_columns) const
 {
-    /// A result type admitting at most one value maps the whole argument domain onto that value, so
-    /// injectivity could only hold over a single-valued domain. The overload resolver produces such a
-    /// type by itself (a NULL constant argument, or a `Nothing` one), bypassing the implementation.
+    /// A `Nothing` or `Nullable(Nothing)` result holds at most one value, so it maps the whole argument
+    /// domain onto that value. Injectivity then survives only over a domain that is itself at most one
+    /// tuple wide, and the overload resolver forms this result type without consulting `function`.
     if (isNothing(removeNullable(getResultType())))
-        return false;
+    {
+        /// The argument types decide how wide the domain is; an empty sample decides nothing.
+        if (sample_columns.empty())
+            return false;
+
+        for (const auto & argument : sample_columns)
+            if (!isNothing(removeNullable(argument.type)))
+                return false;
+    }
 
     return function->isInjective(sample_columns);
 }

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -87,7 +87,7 @@ public:
 
     bool isVolumeReducing() const override { return function->isVolumeReducing(); }
 
-    bool isInjective(const ColumnsWithTypeAndName & sample_columns) const override { return function->isInjective(sample_columns); }
+    bool isInjective(const ColumnsWithTypeAndName & sample_columns) const override;
 
     ComparisonOrderDomain getComparisonOrderDomain() const override
     {

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -2132,7 +2132,7 @@ struct FunctionsStressTestThread
             /// return false (conservative) because injectivity of the underlying function does not hold
             /// on the mixed-type domain, and the resolver lacks full type information before build().
             /// A result type admitting at most one value is skipped for the same reason: it is known
-            /// only after build(), and mapping a whole domain onto one value is not injective.
+            /// only after build(), so the resolver can still claim what the built function declines.
             if (!isAnyArgumentDynamicallyTyped(valid_args) && !isNothing(removeNullable(result_type)))
             {
                 stats.reportProblem(P_UNEXPECTED_ERROR, fmt::format("isInjective mismatch between IFunctionOverloadResolver ({}) and IFunctionBase ({}); {}", resolver_injective, injective, operation.describe()));

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -2131,7 +2131,9 @@ struct FunctionsStressTestThread
             /// Skip isInjective mismatch for Dynamic/Variant/Object types: the adaptors intentionally
             /// return false (conservative) because injectivity of the underlying function does not hold
             /// on the mixed-type domain, and the resolver lacks full type information before build().
-            if (!isAnyArgumentDynamicallyTyped(valid_args))
+            /// A result type admitting at most one value is skipped for the same reason: it is known
+            /// only after build(), and mapping a whole domain onto one value is not injective.
+            if (!isAnyArgumentDynamicallyTyped(valid_args) && !isNothing(removeNullable(result_type)))
             {
                 stats.reportProblem(P_UNEXPECTED_ERROR, fmt::format("isInjective mismatch between IFunctionOverloadResolver ({}) and IFunctionBase ({}); {}", resolver_injective, injective, operation.describe()));
             }

--- a/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.reference
+++ b/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.reference
@@ -16,6 +16,12 @@ SELECT toFixedString(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
 \N	7
 SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY toFixedString(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
 1
+-- The other collapse branch: an argument already typed `Nothing` collapses the result to bare
+-- `Nothing`, which no non-empty column can hold, so this branch is asserted on the query tree.
+SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))));
+1	1
+SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))) SETTINGS optimize_injective_functions_in_group_by = 0);
+1	1
 -- LIMIT BY must keep a single row.
 SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
 1

--- a/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.reference
+++ b/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.reference
@@ -3,39 +3,40 @@ SET enable_analyzer = 1;
 SET optimize_injective_functions_in_group_by = 1;
 SET optimize_injective_functions_in_limit_by = 1;
 SET optimize_truncate_order_by_after_group_by_keys = 1;
+-- The carrier is concatAssumeInjective: its injectivity claim is a user opt-in, so unlike a function's own false claim it cannot be removed to make this test pass vacuously.
 DROP TABLE IF EXISTS t_nothing_key;
 CREATE TABLE t_nothing_key (fs FixedString(2)) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_nothing_key VALUES ('aa'), ('aa'), ('aa'), ('bb'), ('bb'), ('cc'), ('cc');
 -- The resolver collapses the result type, so this expression is one constant NULL over all 7 rows.
-SELECT toTypeName(toFixedString(fs, NULL)) FROM t_nothing_key LIMIT 1;
+SELECT toTypeName(concatAssumeInjective(fs, NULL)) FROM t_nothing_key LIMIT 1;
 Nullable(Nothing)
-SELECT count() FROM (SELECT DISTINCT toFixedString(fs, NULL) FROM t_nothing_key);
+SELECT count() FROM (SELECT DISTINCT concatAssumeInjective(fs, NULL) FROM t_nothing_key);
 1
 -- GROUP BY must produce a single group holding every row.
-SELECT toFixedString(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
+SELECT concatAssumeInjective(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
 \N	7
-SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY toFixedString(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
+SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY concatAssumeInjective(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
 1
 -- The other collapse branch: an argument already typed `Nothing` collapses the result to bare
 -- `Nothing`, which no non-empty column can hold, so this branch is asserted on the query tree.
-SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))));
+SELECT countIf(explain ILIKE '%concatAssumeInjective%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY concatAssumeInjective(fs, assumeNotNull(materialize(NULL))));
 1	1
-SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))) SETTINGS optimize_injective_functions_in_group_by = 0);
+SELECT countIf(explain ILIKE '%concatAssumeInjective%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY concatAssumeInjective(fs, assumeNotNull(materialize(NULL))) SETTINGS optimize_injective_functions_in_group_by = 0);
 1	1
 -- LIMIT BY must keep a single row.
-SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
+SELECT count() FROM (SELECT concatAssumeInjective(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
 1
-SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k) SETTINGS optimize_injective_functions_in_limit_by = 0;
+SELECT count() FROM (SELECT concatAssumeInjective(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k) SETTINGS optimize_injective_functions_in_limit_by = 0;
 1
 -- ORDER BY must keep the fs DESC tiebreaker, because a constant leading expression does not cover the key.
-SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC);
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY concatAssumeInjective(fs, NULL), fs DESC);
 1	2
-SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC SETTINGS optimize_truncate_order_by_after_group_by_keys = 0);
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY concatAssumeInjective(fs, NULL), fs DESC SETTINGS optimize_truncate_order_by_after_group_by_keys = 0);
 1	2
--- A claim that does hold must still be used: widening a FixedString(2) is injective, so the key is
--- unwrapped and the redundant tiebreaker is still truncated.
-SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, 4));
+-- A claim that does hold must still be used: with a non-NULL argument the result type does not
+-- collapse, so the key is unwrapped and the redundant tiebreaker is still truncated.
+SELECT countIf(explain ILIKE '%concatAssumeInjective%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY concatAssumeInjective(fs, 'x'));
 0	1
-SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, 4), fs DESC);
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY concatAssumeInjective(fs, 'x'), fs DESC);
 0	1
 DROP TABLE t_nothing_key;

--- a/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.reference
+++ b/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.reference
@@ -1,0 +1,35 @@
+-- { echo }
+SET enable_analyzer = 1;
+SET optimize_injective_functions_in_group_by = 1;
+SET optimize_injective_functions_in_limit_by = 1;
+SET optimize_truncate_order_by_after_group_by_keys = 1;
+DROP TABLE IF EXISTS t_nothing_key;
+CREATE TABLE t_nothing_key (fs FixedString(2)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nothing_key VALUES ('aa'), ('aa'), ('aa'), ('bb'), ('bb'), ('cc'), ('cc');
+-- The resolver collapses the result type, so this expression is one constant NULL over all 7 rows.
+SELECT toTypeName(toFixedString(fs, NULL)) FROM t_nothing_key LIMIT 1;
+Nullable(Nothing)
+SELECT count() FROM (SELECT DISTINCT toFixedString(fs, NULL) FROM t_nothing_key);
+1
+-- GROUP BY must produce a single group holding every row.
+SELECT toFixedString(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
+\N	7
+SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY toFixedString(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
+1
+-- LIMIT BY must keep a single row.
+SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
+1
+SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k) SETTINGS optimize_injective_functions_in_limit_by = 0;
+1
+-- ORDER BY must keep the fs DESC tiebreaker, because a constant leading expression does not cover the key.
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC);
+1	2
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC SETTINGS optimize_truncate_order_by_after_group_by_keys = 0);
+1	2
+-- A claim that does hold must still be used: widening a FixedString(2) is injective, so the key is
+-- unwrapped and the redundant tiebreaker is still truncated.
+SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, 4));
+0	1
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, 4), fs DESC);
+0	1
+DROP TABLE t_nothing_key;

--- a/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.sql
+++ b/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.sql
@@ -1,0 +1,25 @@
+-- { echo }
+SET enable_analyzer = 1;
+SET optimize_injective_functions_in_group_by = 1;
+SET optimize_injective_functions_in_limit_by = 1;
+SET optimize_truncate_order_by_after_group_by_keys = 1;
+DROP TABLE IF EXISTS t_nothing_key;
+CREATE TABLE t_nothing_key (fs FixedString(2)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_nothing_key VALUES ('aa'), ('aa'), ('aa'), ('bb'), ('bb'), ('cc'), ('cc');
+-- The resolver collapses the result type, so this expression is one constant NULL over all 7 rows.
+SELECT toTypeName(toFixedString(fs, NULL)) FROM t_nothing_key LIMIT 1;
+SELECT count() FROM (SELECT DISTINCT toFixedString(fs, NULL) FROM t_nothing_key);
+-- GROUP BY must produce a single group holding every row.
+SELECT toFixedString(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
+SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY toFixedString(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
+-- LIMIT BY must keep a single row.
+SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
+SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k) SETTINGS optimize_injective_functions_in_limit_by = 0;
+-- ORDER BY must keep the fs DESC tiebreaker, because a constant leading expression does not cover the key.
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC);
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC SETTINGS optimize_truncate_order_by_after_group_by_keys = 0);
+-- A claim that does hold must still be used: widening a FixedString(2) is injective, so the key is
+-- unwrapped and the redundant tiebreaker is still truncated.
+SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, 4));
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, 4), fs DESC);
+DROP TABLE t_nothing_key;

--- a/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.sql
+++ b/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.sql
@@ -12,6 +12,10 @@ SELECT count() FROM (SELECT DISTINCT toFixedString(fs, NULL) FROM t_nothing_key)
 -- GROUP BY must produce a single group holding every row.
 SELECT toFixedString(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
 SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY toFixedString(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
+-- The other collapse branch: an argument already typed `Nothing` collapses the result to bare
+-- `Nothing`, which no non-empty column can hold, so this branch is asserted on the query tree.
+SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))));
+SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))) SETTINGS optimize_injective_functions_in_group_by = 0);
 -- LIMIT BY must keep a single row.
 SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
 SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k) SETTINGS optimize_injective_functions_in_limit_by = 0;

--- a/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.sql
+++ b/tests/queries/0_stateless/05090_injective_function_collapsed_to_nothing.sql
@@ -3,27 +3,28 @@ SET enable_analyzer = 1;
 SET optimize_injective_functions_in_group_by = 1;
 SET optimize_injective_functions_in_limit_by = 1;
 SET optimize_truncate_order_by_after_group_by_keys = 1;
+-- The carrier is concatAssumeInjective: its injectivity claim is a user opt-in, so unlike a function's own false claim it cannot be removed to make this test pass vacuously.
 DROP TABLE IF EXISTS t_nothing_key;
 CREATE TABLE t_nothing_key (fs FixedString(2)) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t_nothing_key VALUES ('aa'), ('aa'), ('aa'), ('bb'), ('bb'), ('cc'), ('cc');
 -- The resolver collapses the result type, so this expression is one constant NULL over all 7 rows.
-SELECT toTypeName(toFixedString(fs, NULL)) FROM t_nothing_key LIMIT 1;
-SELECT count() FROM (SELECT DISTINCT toFixedString(fs, NULL) FROM t_nothing_key);
+SELECT toTypeName(concatAssumeInjective(fs, NULL)) FROM t_nothing_key LIMIT 1;
+SELECT count() FROM (SELECT DISTINCT concatAssumeInjective(fs, NULL) FROM t_nothing_key);
 -- GROUP BY must produce a single group holding every row.
-SELECT toFixedString(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
-SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY toFixedString(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
+SELECT concatAssumeInjective(fs, NULL) AS k, count() FROM t_nothing_key GROUP BY k;
+SELECT count() FROM (SELECT 1 FROM t_nothing_key GROUP BY concatAssumeInjective(fs, NULL)) SETTINGS optimize_injective_functions_in_group_by = 0;
 -- The other collapse branch: an argument already typed `Nothing` collapses the result to bare
 -- `Nothing`, which no non-empty column can hold, so this branch is asserted on the query tree.
-SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))));
-SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, assumeNotNull(materialize(NULL))) SETTINGS optimize_injective_functions_in_group_by = 0);
+SELECT countIf(explain ILIKE '%concatAssumeInjective%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY concatAssumeInjective(fs, assumeNotNull(materialize(NULL))));
+SELECT countIf(explain ILIKE '%concatAssumeInjective%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY concatAssumeInjective(fs, assumeNotNull(materialize(NULL))) SETTINGS optimize_injective_functions_in_group_by = 0);
 -- LIMIT BY must keep a single row.
-SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
-SELECT count() FROM (SELECT toFixedString(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k) SETTINGS optimize_injective_functions_in_limit_by = 0;
+SELECT count() FROM (SELECT concatAssumeInjective(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k);
+SELECT count() FROM (SELECT concatAssumeInjective(fs, NULL) AS k FROM t_nothing_key LIMIT 1 BY k) SETTINGS optimize_injective_functions_in_limit_by = 0;
 -- ORDER BY must keep the fs DESC tiebreaker, because a constant leading expression does not cover the key.
-SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC);
-SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, NULL), fs DESC SETTINGS optimize_truncate_order_by_after_group_by_keys = 0);
--- A claim that does hold must still be used: widening a FixedString(2) is injective, so the key is
--- unwrapped and the redundant tiebreaker is still truncated.
-SELECT countIf(explain ILIKE '%toFixedString%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY toFixedString(fs, 4));
-SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY toFixedString(fs, 4), fs DESC);
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY concatAssumeInjective(fs, NULL), fs DESC);
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY concatAssumeInjective(fs, NULL), fs DESC SETTINGS optimize_truncate_order_by_after_group_by_keys = 0);
+-- A claim that does hold must still be used: with a non-NULL argument the result type does not
+-- collapse, so the key is unwrapped and the redundant tiebreaker is still truncated.
+SELECT countIf(explain ILIKE '%concatAssumeInjective%') AS unwrapped_fn_nodes, countIf(explain ILIKE '%GROUP BY%') AS group_by_sections FROM (EXPLAIN QUERY TREE SELECT count() FROM t_nothing_key GROUP BY concatAssumeInjective(fs, 'x'));
+SELECT countIf(explain ILIKE '%sort_direction: DESCENDING%') AS keeps_tiebreaker, countIf(explain ILIKE '%SORT id%') AS sort_nodes FROM (EXPLAIN QUERY TREE SELECT fs FROM t_nothing_key GROUP BY fs ORDER BY concatAssumeInjective(fs, 'x'), fs DESC);
 DROP TABLE t_nothing_key;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/117767
Related: https://github.com/ClickHouse/ClickHouse/pull/117197
Related: https://github.com/ClickHouse/ClickHouse/pull/117210
Related: https://github.com/ClickHouse/ClickHouse/pull/117238
Related: https://github.com/ClickHouse/ClickHouse/pull/117239
Related: https://github.com/ClickHouse/ClickHouse/pull/117357

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results when a `GROUP BY` or `LIMIT BY` key, or an `ORDER BY` expression, was a function call whose result type collapses to `Nullable(Nothing)` because an argument is a `NULL` constant, such as `concatAssumeInjective(s, NULL)`. Such a call was still treated as injective and replaced by its argument in the key, so `GROUP BY` and `LIMIT BY` produced one group or row per distinct argument value, and `optimize_truncate_order_by_after_group_by_keys` dropped a still-needed `ORDER BY` tiebreaker.

### Description

Reported for `UUIDStringToNum(<column>, NULL)`: `GROUP BY f(<column>, NULL)` silently returned one group per distinct *argument* value instead of a single group.

```sql
CREATE TABLE t (fs FixedString(2)) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES ('aa'),('aa'),('aa'),('bb'),('bb'),('cc'),('cc');
SELECT concatAssumeInjective(fs, NULL) AS k, count() FROM t GROUP BY k;
-- three rows, must be a single \N 7
```

The overload resolver replaces the result type before `getReturnTypeImpl` runs: `Nullable(Nothing)` when `useDefaultImplementationForNulls` meets a `NULL` constant argument, bare `Nothing` for a `Nothing` argument. The built function's `isInjective` still describes the un-collapsed function and answers `true`, so consumers rewrite `f(x)` to `x`. A function mapping its whole domain onto one value is injective only over a single-valued domain.

The fix answers `false` when the result type admits at most one value and an argument type admits more. With every argument type also single-valued the domain is one tuple wide, the claim holds, and the rewrite master's `04805_group_by_injective_function_of_constant` pins is kept. Declining is monotonically safe: the claim is a permission to rewrite, never an obligation.

The per-function fixes above do not close the class: they remove claims that are false in general, while `concatAssumeInjective` is a documented user opt-in that must be respected and still collapses for a `NULL` argument.

Residuals. At `enable_analyzer = 0` these still reproduce, unchanged here: that path asks `isInjective({})` with no arguments at all. #117238 plumbs them in, #117210 drops the reported carrier's claim. `Bugfix validation (unit tests)` is expected to report "failed to reproduce"; the reproducing test is the SQL one.
<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117894&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117894](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117894+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

