### PR TITLE
Fix logical error on TRUNCATE of a TimeSeries table in a Replicated database

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -879,7 +879,8 @@ AccessRightsElements InterpreterDropQuery::getRequiredAccessForDDLOnCluster() co
 }
 
 void InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind kind, ContextPtr global_context, ContextPtr current_context,
-                                            const StorageID & target_table_id, bool sync, bool ignore_sync_setting, bool need_ddl_guard)
+                                            const StorageID & target_table_id, bool sync, bool ignore_sync_setting, bool need_ddl_guard,
+                                            bool propagate_metadata_transaction)
 {
     auto ddl_guard = (need_ddl_guard ? DatabaseCatalog::instance().getDDLGuard(target_table_id.database_name, target_table_id.table_name, nullptr) : nullptr);
     if (DatabaseCatalog::instance().tryGetTable(target_table_id, current_context))
@@ -912,7 +913,8 @@ void InterpreterDropQuery::executeDropQuery(ASTDropQuery::Kind kind, ContextPtr 
             /// For Replicated database
             drop_context->setQueryKindReplicatedDatabaseInternal();
             drop_context->setQueryContext(std::const_pointer_cast<Context>(current_context));
-            drop_context->initZooKeeperMetadataTransaction(txn, true);
+            if (propagate_metadata_transaction)
+                drop_context->initZooKeeperMetadataTransaction(txn, true);
         }
         InterpreterDropQuery drop_interpreter(ast_drop_query, drop_context);
         drop_interpreter.execute();

--- a/src/Interpreters/InterpreterDropQuery.h
+++ b/src/Interpreters/InterpreterDropQuery.h
@@ -24,8 +24,15 @@ public:
     /// Drop table or database.
     BlockIO execute() override;
 
+    /// Runs `kind` on a table owned by another table, such as an inner table of a materialized view.
+    ///
+    /// A `Replicated` database has one ZooKeeper transaction per query and it can be consumed only once. Set
+    /// `propagate_metadata_transaction` to false when one query touches several owned tables: `TRUNCATE` of a `TimeSeries`
+    /// table truncates four inner tables, and the second one would fail. `DDLWorker` commits the transaction after the
+    /// query instead.
     static void executeDropQuery(ASTDropQuery::Kind kind, ContextPtr global_context, ContextPtr current_context,
-                                 const StorageID & target_table_id, bool sync, bool ignore_sync_setting = false, bool need_ddl_guard = false);
+                                 const StorageID & target_table_id, bool sync, bool ignore_sync_setting = false, bool need_ddl_guard = false,
+                                 bool propagate_metadata_transaction = true);
 
     bool supportsTransactions() const override;
 

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -363,8 +363,12 @@ void StorageTimeSeries::truncate(const ASTPtr &, const StorageMetadataPtr &, Con
         if (isInnerTable(target_kind))
         {
             auto inner_table_id = getTargetTableID(target_kind, local_context);
+            /// `propagate_metadata_transaction` is false because the transaction can only be consumed once, so the DDL worker
+            /// commits it after all the inner tables are truncated. If the server dies in between, the entry is executed
+            /// again, which is safe: TRUNCATE is idempotent.
             InterpreterDropQuery::executeDropQuery(
-                ASTDropQuery::Kind::Truncate, getContext(), local_context, inner_table_id, /* sync= */ true);
+                ASTDropQuery::Kind::Truncate, getContext(), local_context, inner_table_id, /* sync= */ true,
+                /* ignore_sync_setting= */ false, /* need_ddl_guard= */ false, /* propagate_metadata_transaction= */ false);
         }
     }
 }

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -287,6 +287,13 @@ class SharedEngineReplacer:
 
     OLD_SYNTAX_OR_ARGUMENTS_RE = r"Tree\(.*[0-9]+.*\)"
 
+    # `default_table_engine` names an engine family in a setting value rather than in an `ENGINE =`
+    # clause, so the mapping above never sees it. Tables generated from the setting (such as the inner
+    # tables of a `TimeSeries` table) need it rewritten too, or they stay replicated.
+    DEFAULT_TABLE_ENGINE_RE = (
+        r"(default_table_engine\s*=\s*'?)Replicated([a-zA-Z]*MergeTree'?)"
+    )
+
     CLUSTER_KEYWORDS = [
         "test_shard_localhost",
         "test_shard_localhost_secure",
@@ -448,6 +455,9 @@ class SharedEngineReplacer:
             return modified_statement
         return line
 
+    def _replace_default_table_engine(self, line):
+        return re.sub(self.DEFAULT_TABLE_ENGINE_RE, r"\1Shared\2", line)
+
     def _replace_database_engines(self, line):
         pattern = r"(CREATE DATABASE\s+(?:IF NOT EXISTS\s+)?(?:`[^`]*`|\S+))(\s*ENGINE\s*=\s*(Shared|Replicated|Atomic|Ordinary|Memory)(\(.*\))?)"
         if re.search(pattern, line, flags=re.IGNORECASE):
@@ -528,6 +538,8 @@ class SharedEngineReplacer:
                         ):
                             line = line.replace(engine_from, engine_to)
                             break
+
+                    line = self._replace_default_table_engine(line)
 
                 if args.shared_catalog_stress:
                     line = self._replace_data_engines(line)

--- a/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.reference
+++ b/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.reference
@@ -1,0 +1,3 @@
+replicated_inner_tables	4
+samples_before	1
+samples_after	0

--- a/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.sql
+++ b/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.sql
@@ -1,4 +1,5 @@
 -- Tags: zookeeper
+-- Tag zookeeper: the inner tables are argument-less replicated tables using the default replica path.
 
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} FORMAT Null;
 CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Replicated('/clickhouse/05060_time_series_truncate_in_replicated_database/{database}', 'shard1', 'replica1') FORMAT Null;
@@ -9,7 +10,9 @@ SET default_table_engine = 'ReplicatedMergeTree';
 
 CREATE TABLE ts ENGINE = TimeSeries FORMAT Null;
 
-SELECT 'replicated_inner_tables', count() FROM system.tables WHERE database = currentDatabase() AND engine LIKE 'Replicated%MergeTree';
+-- Both engine families count: Cloud runs rewrite the setting above to `SharedMergeTree`.
+SELECT 'replicated_inner_tables', count() FROM system.tables
+WHERE database = currentDatabase() AND (engine LIKE 'Replicated%MergeTree' OR engine LIKE 'Shared%MergeTree');
 
 INSERT INTO ts(metric_name, tags, time_series) VALUES ('m', map('a', 'b'), [(now64(3), 1)]);
 SELECT 'samples_before', count() FROM ts;

--- a/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.sql
+++ b/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.sql
@@ -1,0 +1,20 @@
+-- Tags: zookeeper
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} FORMAT Null;
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Replicated('/clickhouse/05060_time_series_truncate_in_replicated_database/{database}', 'shard1', 'replica1') FORMAT Null;
+USE {CLICKHOUSE_DATABASE_1:Identifier};
+
+SET allow_experimental_time_series_table = 1;
+SET default_table_engine = 'ReplicatedMergeTree';
+
+CREATE TABLE ts ENGINE = TimeSeries FORMAT Null;
+
+SELECT 'replicated_inner_tables', count() FROM system.tables WHERE database = currentDatabase() AND engine LIKE 'Replicated%MergeTree';
+
+INSERT INTO ts(metric_name, tags, time_series) VALUES ('m', map('a', 'b'), [(now64(3), 1)]);
+SELECT 'samples_before', count() FROM ts;
+
+TRUNCATE TABLE ts;
+SELECT 'samples_after', count() FROM ts;
+
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier} FORMAT Null;

--- a/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.sql
+++ b/tests/queries/0_stateless/05060_time_series_truncate_in_replicated_database.sql
@@ -14,7 +14,7 @@ SELECT 'replicated_inner_tables', count() FROM system.tables WHERE database = cu
 INSERT INTO ts(metric_name, tags, time_series) VALUES ('m', map('a', 'b'), [(now64(3), 1)]);
 SELECT 'samples_before', count() FROM ts;
 
-TRUNCATE TABLE ts;
+TRUNCATE TABLE ts FORMAT Null;
 SELECT 'samples_after', count() FROM ts;
 
 DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier} FORMAT Null;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117900
Related: https://github.com/ClickHouse/ClickHouse/issues/115965

`TRUNCATE TABLE` on a `TimeSeries` table inside a `Replicated` database failed with `LOGICAL_ERROR: Cannot add ZooKeeper operation because query is executed. It's a bug.`:

```sql
CREATE DATABASE d ENGINE = Replicated('/clickhouse/databases/d', 's1', 'r1');
SET allow_experimental_time_series_table = 1, default_table_engine = 'ReplicatedMergeTree';
CREATE TABLE d.ts ENGINE = TimeSeries;
TRUNCATE TABLE d.ts;  -- Code: 49
```

A distributed DDL entry carries one `ZooKeeperMetadataTransaction`, and it can be consumed only once: `moveOpsTo` drains the ops and marks the transaction executed. `StorageTimeSeries::truncate` truncates each inner table with a separate nested query and handed the same transaction to every one of them, so the first inner `ReplicatedMergeTree` consumed it in `dropAllPartsInPartitions` and the second one threw. It fired even on empty tables, because the ops always carry the `alter_partition_version` and `log` set requests.

The nested truncates no longer receive the transaction. `DDLWorker::tryExecuteQuery` already commits a transaction that the query left unexecuted, so the entry is now marked finished after every inner table is truncated instead of after the first one. If the server dies in between, the entry is executed again, which is safe because `TRUNCATE` is idempotent. Callers that touch a single owned table, such as `StorageMaterializedView::truncate`, keep propagating the transaction and are unchanged.

Not addressed here: the inner tables are still truncated in separate ZooKeeper transactions, so a concurrent reader can observe a partially truncated series. That window is not new, and closing it needs a single multi spanning all the inner tables.

In CI this showed up in stress tests, where `ignore_drop_queries_probability` rewrote the `DROP TABLE` of `05028_time_series_default_table_engine` into a `TRUNCATE`. It hit six unrelated pull requests within a day.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the logical error `Cannot add ZooKeeper operation because query is executed` when running `TRUNCATE TABLE` on a `TimeSeries` table in a `Replicated` database.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117902&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117902](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117902+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.801` (included in `26.9` and later)
<!-- ch-version-info:end -->