### PR TITLE
Optimize lazy algorithms for intersection and union of posting lists

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -375,6 +375,22 @@ void PostingListCursor::decodeBlock(size_t block_idx)
     index = 0;
 }
 
+/// Lower bound over decoded posting values. The target is usually close to `first`.
+/// Probe at offsets 1, 2, 4, ... and binary-search only the last interval.
+static const uint32_t * gallopingLowerBound(const uint32_t * first, const uint32_t * last, uint32_t target)
+{
+    const size_t size = static_cast<size_t>(last - first);
+    if (size == 0 || *first >= target)
+        return first;
+
+    size_t bound = 1;
+    while (bound < size && first[bound] < target)
+        bound *= 2;
+
+    /// first[bound / 2] < target, so the answer is in (bound / 2, bound], clamped to the range.
+    return std::lower_bound(first + bound / 2 + 1, first + std::min(bound + 1, size), target);
+}
+
 void PostingListCursor::advance(uint32_t target)
 {
     ++counters.advance_count;
@@ -384,7 +400,7 @@ void PostingListCursor::advance(uint32_t target)
 
     if (is_embedded)
     {
-        const auto * it = std::lower_bound(decoded_values_ptr, decoded_values_ptr + decoded_count, target);
+        const auto * it = gallopingLowerBound(decoded_values_ptr + index, decoded_values_ptr + decoded_count, target);
         if (it != decoded_values_ptr + decoded_count)
         {
             index = static_cast<size_t>(it - decoded_values_ptr);
@@ -427,7 +443,7 @@ bool PostingListCursor::advanceImpl(uint32_t target)
     /// If current block contains the target, search within it.
     if (decoded_count > 0 && target <= decoded_values_ptr[decoded_count - 1])
     {
-        const auto * it = std::lower_bound(decoded_values_ptr + index, decoded_values_ptr + decoded_count, target);
+        const auto * it = gallopingLowerBound(decoded_values_ptr + index, decoded_values_ptr + decoded_count, target);
         if (it != decoded_values_ptr + decoded_count)
         {
             index = static_cast<size_t>(it - decoded_values_ptr);
@@ -446,8 +462,8 @@ bool PostingListCursor::advanceImpl(uint32_t target)
     if (j != current_block || decoded_count == 0)
         decodeBlock(j);
 
-    /// Binary search within the decoded packed block.
-    const auto * found_it = std::lower_bound(decoded_values_ptr, decoded_values_ptr + decoded_count, target);
+    /// Search within the decoded packed block.
+    const auto * found_it = gallopingLowerBound(decoded_values_ptr, decoded_values_ptr + decoded_count, target);
     if (found_it != decoded_values_ptr + decoded_count)
     {
         index = static_cast<size_t>(found_it - decoded_values_ptr);
@@ -505,6 +521,7 @@ inline const uint32_t * findRowRangeEnd(const uint32_t * begin, const uint32_t *
     size_t exclusive_end = row_offset + num_rows;
     if (exclusive_end > std::numeric_limits<uint32_t>::max())
         return end;
+
     return std::lower_bound(begin, end, static_cast<uint32_t>(exclusive_end));
 }
 
@@ -684,8 +701,6 @@ void PostingListCursor::linearSegments(UInt8 * data, size_t row_offset, size_t n
 
         for (size_t block_idx = first_block_idx; block_idx < current_segment->block_count; ++block_idx)
         {
-            uint32_t block_last = block_last_row_ids[block_idx];
-
             if (block_idx > 0 && block_last_row_ids[block_idx - 1] == std::numeric_limits<uint32_t>::max())
             {
                 throw Exception(ErrorCodes::CORRUPTED_DATA,
@@ -693,11 +708,10 @@ void PostingListCursor::linearSegments(UInt8 * data, size_t row_offset, size_t n
                     "at block {}, computing block_first would overflow", block_idx);
             }
 
-            uint32_t block_first = (block_idx == 0)
-                ? static_cast<uint32_t>(seg_begin)
-                : (block_last_row_ids[block_idx - 1] + 1);
-
+            uint32_t block_first = (block_idx == 0) ? static_cast<uint32_t>(seg_begin) : (block_last_row_ids[block_idx - 1] + 1);
+            uint32_t block_last = block_last_row_ids[block_idx];
             chassert(block_last >= row_offset);
+
             if (block_first >= row_offset + num_rows)
                 break;
 
@@ -723,7 +737,7 @@ void PostingListCursor::linearSegments(UInt8 * data, size_t row_offset, size_t n
             if (block_idx != current_block || decoded_count == 0)
                 decodeBlock(block_idx);
 
-            const auto * begin_it = std::lower_bound(decoded_values_ptr, decoded_values_ptr + decoded_count, static_cast<uint32_t>(row_offset));
+            const auto * begin_it = gallopingLowerBound(decoded_values_ptr, decoded_values_ptr + decoded_count, static_cast<uint32_t>(row_offset));
             const auto * end_it = findRowRangeEnd(begin_it, decoded_values_ptr + decoded_count, row_offset, num_rows);
             size_t begin_idx = static_cast<size_t>(begin_it - decoded_values_ptr);
             size_t end_idx = static_cast<size_t>(end_it - decoded_values_ptr);
@@ -758,7 +772,7 @@ void PostingListCursor::linearEmbedded(UInt8 * data, size_t row_offset, size_t n
         }
     }
 
-    const auto * begin_it = std::lower_bound(decoded_values_ptr, decoded_values_ptr + decoded_count, static_cast<uint32_t>(row_offset));
+    const auto * begin_it = gallopingLowerBound(decoded_values_ptr, decoded_values_ptr + decoded_count, static_cast<uint32_t>(row_offset));
     const auto * end_it = findRowRangeEnd(begin_it, decoded_values_ptr + decoded_count, row_offset, num_rows);
     size_t begin_idx = static_cast<size_t>(begin_it - decoded_values_ptr);
     size_t end_idx = static_cast<size_t>(end_it - decoded_values_ptr);

--- a/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPostingListCursor.cpp
@@ -678,11 +678,15 @@ void PostingListCursor::linearSegments(UInt8 * data, size_t row_offset, size_t n
         }
 
         /// Decode all blocks in this segment that overlap with [row_offset, row_offset + num_rows).
-        for (size_t block_idx = 0; block_idx < current_segment->block_count; ++block_idx)
-        {
-            uint32_t block_last = current_segment->block_last_row_ids[block_idx];
+        const auto & block_last_row_ids = current_segment->block_last_row_ids;
+        const auto * first_block_it = std::lower_bound(block_last_row_ids.begin(), block_last_row_ids.end(), static_cast<uint32_t>(row_offset));
+        const size_t first_block_idx = static_cast<size_t>(first_block_it - block_last_row_ids.begin());
 
-            if (block_idx > 0 && current_segment->block_last_row_ids[block_idx - 1] == std::numeric_limits<uint32_t>::max())
+        for (size_t block_idx = first_block_idx; block_idx < current_segment->block_count; ++block_idx)
+        {
+            uint32_t block_last = block_last_row_ids[block_idx];
+
+            if (block_idx > 0 && block_last_row_ids[block_idx - 1] == std::numeric_limits<uint32_t>::max())
             {
                 throw Exception(ErrorCodes::CORRUPTED_DATA,
                     "Corrupted data in lazy posting list cursor: previous block_last_row_id is UInt32::max "
@@ -691,11 +695,9 @@ void PostingListCursor::linearSegments(UInt8 * data, size_t row_offset, size_t n
 
             uint32_t block_first = (block_idx == 0)
                 ? static_cast<uint32_t>(seg_begin)
-                : (current_segment->block_last_row_ids[block_idx - 1] + 1);
+                : (block_last_row_ids[block_idx - 1] + 1);
 
-            if (block_last < row_offset)
-                continue;
-
+            chassert(block_last >= row_offset);
             if (block_first >= row_offset + num_rows)
                 break;
 
@@ -717,7 +719,9 @@ void PostingListCursor::linearSegments(UInt8 * data, size_t row_offset, size_t n
                 }
             }
 
-            decodeBlock(block_idx);
+            /// A block that straddles two consecutive windows is still decoded from the previous call.
+            if (block_idx != current_block || decoded_count == 0)
+                decodeBlock(block_idx);
 
             const auto * begin_it = std::lower_bound(decoded_values_ptr, decoded_values_ptr + decoded_count, static_cast<uint32_t>(row_offset));
             const auto * end_it = findRowRangeEnd(begin_it, decoded_values_ptr + decoded_count, row_offset, num_rows);

--- a/tests/performance/text_index_lazy_wide_granule.xml
+++ b/tests/performance/text_index_lazy_wide_granule.xml
@@ -1,0 +1,51 @@
+<test>
+    <settings>
+        <use_skip_indexes_on_data_read>1</use_skip_indexes_on_data_read>
+        <query_plan_direct_read_from_text_index>1</query_plan_direct_read_from_text_index>
+        <query_plan_optimize_count_from_text_index>0</query_plan_optimize_count_from_text_index>
+        <use_query_condition_cache>0</use_query_condition_cache>
+        <text_index_posting_list_apply_mode>lazy</text_index_posting_list_apply_mode>
+    </settings>
+
+    <!-- One text-index granule per part: every posting list spans the whole part, so a dense token gets full
+         1M-posting segments (8192 packed blocks) that the lazy cursor applies granule by granule. -->
+    <create_query>
+        CREATE TABLE text_index_lazy_wide
+        (
+            id UInt64,
+            s String,
+            INDEX idx s TYPE text(tokenizer = splitByNonAlpha, posting_list_codec = 'bitpacking') GRANULARITY 100000000
+        )
+        ENGINE = MergeTree ORDER BY id
+    </create_query>
+
+    <!-- half: 50% of the rows, third: 33%, quarter: 25%, fifth: 20%, dense: 10%, medium: 6.7%, sparse: 2%;
+         dense and medium overlap on every 30th row. The tokens with density >= 0.2 make hasAllTokens pick the
+         brute-force intersection by default, so those queries exercise linearOr + linearAnd on long posting lists. -->
+    <fill_query>
+        INSERT INTO text_index_lazy_wide
+        SELECT number,
+            concat('common',
+                if(number % 2 = 0, ' half', ''),
+                if(number % 3 = 0, ' third', ''),
+                if(number % 4 = 0, ' quarter', ''),
+                if(number % 5 = 0, ' fifth', ''),
+                if(number % 10 = 0, ' dense', ''),
+                if(number % 15 = 0, ' medium', ''),
+                if(number % 50 = 7, ' sparse', ''),
+                ' filler', toString(number % 1000))
+        FROM numbers(50000000)
+        SETTINGS max_insert_threads = 8
+    </fill_query>
+    <fill_query>OPTIMIZE TABLE text_index_lazy_wide FINAL</fill_query>
+
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasToken(s, 'dense')</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasToken(s, 'half')</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAnyTokens(s, ['dense', 'medium', 'sparse'])</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAnyTokens(s, ['half', 'third', 'quarter', 'fifth'])</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['dense', 'medium']) SETTINGS text_index_lazy_intersection_density_threshold = 0</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['half', 'third', 'quarter'])</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['dense', 'medium'])</query>
+
+    <drop_query>DROP TABLE IF EXISTS text_index_lazy_wide</drop_query>
+</test>

--- a/tests/performance/text_index_lazy_wide_granule.xml
+++ b/tests/performance/text_index_lazy_wide_granule.xml
@@ -47,5 +47,14 @@
     <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['half', 'third', 'quarter'])</query>
     <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['dense', 'medium'])</query>
 
+    <!-- Leapfrog intersection on long posting lists: the density threshold of 1 forces it for tokens that would
+         otherwise take the brute-force path. `third` and `sparse` co-occur on a third of the sparse rows, so the
+         sparse cursor leads and the dense one jumps about 17 postings per advance. -->
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['half', 'third']) SETTINGS text_index_lazy_intersection_density_threshold = 1</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['half', 'third', 'quarter', 'fifth']) SETTINGS text_index_lazy_intersection_density_threshold = 1</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['third', 'sparse'])</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['half', 'third']) SETTINGS text_index_lazy_intersection_density_threshold = 1, max_threads = 4</query>
+    <query>SELECT count() FROM text_index_lazy_wide WHERE hasAllTokens(s, ['half', 'third', 'quarter', 'fifth']) SETTINGS text_index_lazy_intersection_density_threshold = 1, max_threads = 4</query>
+
     <drop_query>DROP TABLE IF EXISTS text_index_lazy_wide</drop_query>
 </test>

--- a/tests/queries/0_stateless/05059_text_index_lazy_multi_block_windows.reference
+++ b/tests/queries/0_stateless/05059_text_index_lazy_multi_block_windows.reference
@@ -1,0 +1,24 @@
+parts	1
+Ground truth (no index)
+third	66667	6666633333
+third in [100000, 120000)	6666	733256667
+any third seventh	85715	8571471429
+any even rare	100200	10019999800
+all third seventh	9524	952319046
+all even third	33334	3333366666
+all third rare	67	6699933
+all even third seventh	4762	476109522
+Lazy, leapfrog intersection
+third	66667	6666633333
+third in [100000, 120000)	6666	733256667
+any third seventh	85715	8571471429
+any even rare	100200	10019999800
+all third seventh	9524	952319046
+all even third	33334	3333366666
+all third rare	67	6699933
+all even third seventh	4762	476109522
+Lazy, brute-force intersection
+all third seventh	9524	952319046
+all even third	33334	3333366666
+all third rare	67	6699933
+all even third seventh	4762	476109522

--- a/tests/queries/0_stateless/05059_text_index_lazy_multi_block_windows.sql
+++ b/tests/queries/0_stateless/05059_text_index_lazy_multi_block_windows.sql
@@ -1,0 +1,75 @@
+-- The lazy posting-list cursor applies a token's postings to the output column one granule at a time
+-- (`linearOr` / `linearAnd`), reusing the cursor across the consecutive per-granule windows of a part.
+-- The posting lists below span many packed blocks (128 postings each) and many segments
+-- (`posting_list_block_size` postings each), and both block and segment boundaries straddle the
+-- 8192-row granule boundaries. Every lazy result is compared with a plain column scan.
+
+SET enable_full_text_index = 1;
+SET use_skip_indexes = 1;
+SET use_skip_indexes_on_data_read = 1;
+SET query_plan_direct_read_from_text_index = 1;
+SET query_plan_optimize_count_from_text_index = 0;
+SET use_query_condition_cache = 0;
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
+
+DROP TABLE IF EXISTS tab_lazy_windows;
+
+-- One index granule covers the whole part, so every posting list spans all 25 granules of the part.
+CREATE TABLE tab_lazy_windows
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = splitByNonAlpha, posting_list_codec = 'bitpacking', posting_list_block_size = 1024) GRANULARITY 100000000
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+
+--   third   : every 3rd row -> 66667 postings, 2730.67 per granule: packed blocks and segments straddle granule boundaries
+--   seventh : every 7th row -> 28572 postings
+--   even    : every 2nd row -> 100000 postings, exactly 32 packed blocks per granule: block boundaries coincide with granule boundaries
+--   rare    : 200 postings  -> embedded (single-block) postings
+INSERT INTO tab_lazy_windows
+SELECT number,
+    concat('base',
+        if(number % 3 = 0, ' third', ''),
+        if(number % 7 = 0, ' seventh', ''),
+        if(number % 2 = 0, ' even', ''),
+        if(number % 1000 = 999, ' rare', ''))
+FROM numbers(200000)
+SETTINGS max_insert_threads = 1, max_insert_block_size = 1000000, min_insert_block_size_rows = 1000000, min_insert_block_size_bytes = 0;
+
+SELECT 'parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 'tab_lazy_windows' AND active;
+
+SELECT 'Ground truth (no index)';
+SET use_skip_indexes = 0;
+SELECT 'third', count(), sum(id) FROM tab_lazy_windows WHERE hasToken(s, 'third');
+SELECT 'third in [100000, 120000)', count(), sum(id) FROM tab_lazy_windows WHERE id >= 100000 AND id < 120000 AND hasToken(s, 'third');
+SELECT 'any third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAnyTokens(s, ['third', 'seventh']);
+SELECT 'any even rare', count(), sum(id) FROM tab_lazy_windows WHERE hasAnyTokens(s, ['even', 'rare']);
+SELECT 'all third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['third', 'seventh']);
+SELECT 'all even third', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['even', 'third']);
+SELECT 'all third rare', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['third', 'rare']);
+SELECT 'all even third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['even', 'third', 'seventh']);
+
+SET use_skip_indexes = 1;
+SET text_index_posting_list_apply_mode = 'lazy';
+
+SELECT 'Lazy, leapfrog intersection';
+SET text_index_lazy_intersection_density_threshold = 1;
+SELECT 'third', count(), sum(id) FROM tab_lazy_windows WHERE hasToken(s, 'third');
+SELECT 'third in [100000, 120000)', count(), sum(id) FROM tab_lazy_windows WHERE id >= 100000 AND id < 120000 AND hasToken(s, 'third');
+SELECT 'any third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAnyTokens(s, ['third', 'seventh']);
+SELECT 'any even rare', count(), sum(id) FROM tab_lazy_windows WHERE hasAnyTokens(s, ['even', 'rare']);
+SELECT 'all third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['third', 'seventh']);
+SELECT 'all even third', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['even', 'third']);
+SELECT 'all third rare', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['third', 'rare']);
+SELECT 'all even third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['even', 'third', 'seventh']);
+
+SELECT 'Lazy, brute-force intersection';
+SET text_index_lazy_intersection_density_threshold = 0;
+SELECT 'all third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['third', 'seventh']);
+SELECT 'all even third', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['even', 'third']);
+SELECT 'all third rare', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['third', 'rare']);
+SELECT 'all even third seventh', count(), sum(id) FROM tab_lazy_windows WHERE hasAllTokens(s, ['even', 'third', 'seventh']);
+
+DROP TABLE tab_lazy_windows;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved performance of `hasToken`, `hasAnyTokens` and `hasAllTokens` queries with the text index in lazy posting list apply mode.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117905&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117905](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117905+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.722` (included in `26.9` and later)
<!-- ch-version-info:end -->