### PR TITLE
Materialize conflicting missing column markers during merges

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -695,6 +695,19 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     auto mutations_snapshot = global_ctx->data->getMutationsSnapshot(params);
     const auto & merge_tree_settings = global_ctx->data_settings;
 
+    /// Alter conversions must include patch parts before they are cached below. Patch application
+    /// uses these per-part conversions later in both horizontal and vertical merge readers.
+    if (!patch_parts.empty())
+    {
+        LOG_DEBUG(ctx->log, "Will apply {} patches up to version {}", patch_parts.size(), global_ctx->future_part->part_info.getMutationVersion());
+
+        for (const auto & patch : patch_parts)
+            LOG_TRACE(ctx->log, "Applying patch part {} with max data version {}", patch->name, patch->getPatchPartIndex().getMaxDataVersion());
+
+        auto & mutable_snapshot = const_cast<MergeTreeData::IMutationsSnapshot &>(*mutations_snapshot);
+        mutable_snapshot.addPatches(patch_parts);
+    }
+
     struct MissingColumnMergeState
     {
         SerializationInfoByName::MissingColumnInfo marker;
@@ -910,17 +923,6 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
             addMergingColumn(global_ctx, BlockOffsetColumn::name, BlockOffsetColumn::type);
         else
             addGatheringColumn(global_ctx, BlockOffsetColumn::name, BlockOffsetColumn::type);
-    }
-
-    if (!patch_parts.empty())
-    {
-        LOG_DEBUG(ctx->log, "Will apply {} patches up to version {}", patch_parts.size(), global_ctx->future_part->part_info.getMutationVersion());
-
-        for (const auto & patch : patch_parts)
-            LOG_TRACE(ctx->log, "Applying patch part {} with max data version {}", patch->name, patch->getPatchPartIndex().getMaxDataVersion());
-
-        auto & mutable_snapshot = const_cast<MergeTreeData::IMutationsSnapshot &>(*mutations_snapshot);
-        mutable_snapshot.addPatches(global_ctx->future_part->patch_parts);
     }
 
     if ((*merge_tree_settings)[MergeTreeSetting::materialize_statistics_on_merge])

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -693,6 +693,66 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     };
 
     auto mutations_snapshot = global_ctx->data->getMutationsSnapshot(params);
+    const auto & merge_tree_settings = global_ctx->data_settings;
+
+    struct MissingColumnMergeState
+    {
+        SerializationInfoByName::MissingColumnInfo marker;
+        size_t parts_with_marker = 0;
+        bool has_different_types = false;
+    };
+
+    std::map<String, MissingColumnMergeState> missing_column_states;
+    NameSet missing_columns_to_materialize;
+    size_t non_empty_parts = 0;
+    global_ctx->alter_conversions.reserve(global_ctx->future_part->parts.size());
+
+    for (const auto & part : global_ctx->future_part->parts)
+    {
+        auto conversions = MergeTreeData::getAlterConversionsForPart(part, mutations_snapshot, global_ctx->context
+#if CLICKHOUSE_CLOUD
+            , nullptr
+#endif
+            );
+
+        global_ctx->alter_conversions.push_back(conversions);
+        if (part->rows_count == 0)
+            continue;
+
+        ++non_empty_parts;
+        for (const auto & marker : part->getSerializationInfos().getMissingColumns())
+        {
+            String current_name = marker.name;
+            if (conversions->columnHasNewName(marker.name))
+                current_name = conversions->getColumnNewName(marker.name);
+
+            bool share_nested = (*merge_tree_settings)[MergeTreeSetting::share_nested_offsets];
+            if (conversions->isColumnDropped(marker.name, share_nested)
+                || conversions->isColumnDropped(current_name, share_nested))
+                continue;
+
+            auto [it, inserted] = missing_column_states.try_emplace(current_name);
+            auto & state = it->second;
+            if (inserted)
+            {
+                state.marker = marker;
+                state.marker.name = current_name;
+            }
+            else if (state.marker.type_name != marker.type_name)
+                state.has_different_types = true;
+            ++state.parts_with_marker;
+        }
+    }
+
+    /// A merged part has only one marker per column, so it can preserve omission only when every
+    /// source part that contributes rows represents the column with the same frozen type. If a
+    /// source part has a physical column, no marker, a dropped marker, or a marker of another type,
+    /// the merge must read each part with its own missing-column semantics and write the column.
+    for (const auto & [name, state] : missing_column_states)
+    {
+        if (state.has_different_types || state.parts_with_marker != non_empty_parts)
+            missing_columns_to_materialize.insert(name);
+    }
 
     /// Determine columns that are absent in all source parts—either fully expired or never written—and mark them as
     /// expired to avoid unnecessary reads or writes during merges.
@@ -766,6 +826,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
             if (!columns_present_in_parts.contains(storage_column.name)
                 && !columns_present_in_patch_parts.contains(storage_column.name)
                 && !renamed_column_targets.contains(storage_column.name)
+                && !missing_columns_to_materialize.contains(storage_column.name)
                 && !columns_desc.getDefault(storage_column.name))
                 global_ctx->new_data_part->expired_columns.emplace(storage_column.name);
         }
@@ -785,8 +846,6 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         global_ctx->merging_params.mode != MergeTreeData::MergingParams::Ordinary;
 
     prepareProjectionsToMergeAndRebuild();
-
-    const auto & merge_tree_settings = global_ctx->data_settings;
 
     /// Get list of skip indexes to exclude from merge
     std::unordered_set<String> exclude_index_names;
@@ -944,13 +1003,6 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     };
 
     SerializationInfoByName infos(global_ctx->storage_columns, info_settings);
-    global_ctx->alter_conversions.reserve(global_ctx->future_part->parts.size());
-
-    /// A source marker prevents the column from expiring during a normal merge,
-    /// so carrying its union reproduces the same lazy type-default materialization.
-    NameSet source_missing_column_names;
-    /// Resolve marker names to the merged schema.
-    std::map<String, SerializationInfoByName::MissingColumnInfo> source_missing_map;
     for (const auto & part : global_ctx->future_part->parts)
     {
         if (!info_settings.isAlwaysDefault())
@@ -966,52 +1018,19 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
 
             infos.add(part_infos);
         }
-
-        auto part_alter_conversions = MergeTreeData::getAlterConversionsForPart(part, mutations_snapshot, global_ctx->context
-#if CLICKHOUSE_CLOUD
-            , nullptr
-#endif
-            );
-
-        for (const auto & mc : part->getSerializationInfos().getMissingColumns())
-        {
-            String current_name = mc.name;
-            if (part_alter_conversions->columnHasNewName(mc.name))
-                current_name = part_alter_conversions->getColumnNewName(mc.name);
-
-            /// Pending DROP/CLEAR invalidates either spelling of the marker.
-            bool share_nested = (*merge_tree_settings)[MergeTreeSetting::share_nested_offsets];
-            if (part_alter_conversions->isColumnDropped(mc.name, share_nested)
-                || part_alter_conversions->isColumnDropped(current_name, share_nested))
-                continue;
-
-            source_missing_column_names.insert(current_name);
-            if (!source_missing_map.contains(current_name))
-            {
-                auto entry = mc;
-                entry.name = current_name;
-                source_missing_map.emplace(current_name, std::move(entry));
-            }
-        }
-
-        global_ctx->alter_conversions.push_back(std::move(part_alter_conversions));
     }
 
-    if (!source_missing_column_names.empty())
+    if (!missing_column_states.empty())
     {
         NameSet final_columns;
         for (const auto & column : global_ctx->storage_columns)
             final_columns.insert(column.name);
 
         SerializationInfoByName::MissingColumns merged_missing;
-        for (const auto & name : source_missing_column_names)
+        for (const auto & [name, state] : missing_column_states)
         {
-            if (!final_columns.contains(name))
-            {
-                auto it = source_missing_map.find(name);
-                if (it != source_missing_map.end())
-                    merged_missing.push_back(it->second);
-            }
+            if (!missing_columns_to_materialize.contains(name) && !final_columns.contains(name))
+                merged_missing.push_back(state.marker);
         }
 
         if (!merged_missing.empty())

--- a/tests/queries/0_stateless/04858_missing_column_marker_type_conflict.reference
+++ b/tests/queries/0_stateless/04858_missing_column_marker_type_conflict.reference
@@ -1,0 +1,36 @@
+different marker types before horizontal merge
+1	0	1
+2		0
+different marker types after horizontal merge
+1	0	1
+2		0
+b
+k
+payload
+different marker types before vertical merge
+1	0	1
+2		0
+different marker types after vertical merge
+1	0	1
+2		0
+Vertical
+b
+k
+payload
+same marker types stay omitted
+1	0
+2	0
+k
+marker and physical column are materialized
+1	0
+2	7
+b
+k
+marker and absent before merge
+1		0
+2	0	1
+marker and absent after merge
+1		0
+2	0	1
+b
+k

--- a/tests/queries/0_stateless/04858_missing_column_marker_type_conflict.sql
+++ b/tests/queries/0_stateless/04858_missing_column_marker_type_conflict.sql
@@ -1,4 +1,5 @@
--- Tags: no-random-settings, no-random-merge-tree-settings
+-- Tags: no-random-merge-tree-settings
+-- The test asserts horizontal/vertical merge selection and physical column materialization.
 
 DROP TABLE IF EXISTS t_missing_marker_conflict;
 

--- a/tests/queries/0_stateless/04858_missing_column_marker_type_conflict.sql
+++ b/tests/queries/0_stateless/04858_missing_column_marker_type_conflict.sql
@@ -1,0 +1,160 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings
+
+DROP TABLE IF EXISTS t_missing_marker_conflict;
+
+CREATE TABLE t_missing_marker_conflict
+(
+    k UInt64,
+    b UInt64,
+    payload String
+)
+ENGINE = MergeTree
+ORDER BY k
+SETTINGS skip_empty_columns_on_insert = 1,
+         serialization_info_version = 'with_missing_columns',
+         min_bytes_for_wide_part = 0,
+         min_rows_for_wide_part = 0,
+         enable_vertical_merge_algorithm = 0,
+         enable_block_number_column = 0,
+         enable_block_offset_column = 0;
+
+INSERT INTO t_missing_marker_conflict VALUES (1, 0, 'first');
+ALTER TABLE t_missing_marker_conflict DETACH PARTITION tuple();
+ALTER TABLE t_missing_marker_conflict MODIFY COLUMN b String;
+ALTER TABLE t_missing_marker_conflict ATTACH PARTITION tuple();
+INSERT INTO t_missing_marker_conflict VALUES (2, '', 'second');
+
+SELECT 'different marker types before horizontal merge';
+SELECT k, b, length(b) FROM t_missing_marker_conflict ORDER BY k;
+OPTIMIZE TABLE t_missing_marker_conflict FINAL;
+SELECT 'different marker types after horizontal merge';
+SELECT k, b, length(b) FROM t_missing_marker_conflict ORDER BY k;
+SELECT column FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_missing_marker_conflict' AND active
+ORDER BY column;
+
+DROP TABLE t_missing_marker_conflict;
+
+CREATE TABLE t_missing_marker_conflict
+(
+    k UInt64,
+    b UInt64,
+    payload String
+)
+ENGINE = MergeTree
+ORDER BY k
+SETTINGS skip_empty_columns_on_insert = 1,
+         serialization_info_version = 'with_missing_columns',
+         min_bytes_for_wide_part = 0,
+         min_rows_for_wide_part = 0,
+         enable_vertical_merge_algorithm = 1,
+         vertical_merge_algorithm_min_rows_to_activate = 0,
+         vertical_merge_algorithm_min_bytes_to_activate = 0,
+         vertical_merge_algorithm_min_columns_to_activate = 0,
+         enable_block_number_column = 0,
+         enable_block_offset_column = 0;
+
+INSERT INTO t_missing_marker_conflict VALUES (1, 0, 'first');
+ALTER TABLE t_missing_marker_conflict DETACH PARTITION tuple();
+ALTER TABLE t_missing_marker_conflict MODIFY COLUMN b String;
+ALTER TABLE t_missing_marker_conflict ATTACH PARTITION tuple();
+INSERT INTO t_missing_marker_conflict VALUES (2, '', 'second');
+
+SELECT 'different marker types before vertical merge';
+SELECT k, b, length(b) FROM t_missing_marker_conflict ORDER BY k;
+OPTIMIZE TABLE t_missing_marker_conflict FINAL;
+SELECT 'different marker types after vertical merge';
+SELECT k, b, length(b) FROM t_missing_marker_conflict ORDER BY k;
+SYSTEM FLUSH LOGS part_log;
+SELECT merge_algorithm FROM system.part_log
+WHERE database = currentDatabase() AND table = 't_missing_marker_conflict' AND event_type = 'MergeParts'
+ORDER BY event_time_microseconds DESC LIMIT 1;
+SELECT column FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_missing_marker_conflict' AND active
+ORDER BY column;
+
+DROP TABLE t_missing_marker_conflict;
+
+CREATE TABLE t_missing_marker_same
+(
+    k UInt64,
+    b UInt64
+)
+ENGINE = MergeTree
+ORDER BY k
+SETTINGS skip_empty_columns_on_insert = 1,
+         serialization_info_version = 'with_missing_columns',
+         min_bytes_for_wide_part = 0,
+         min_rows_for_wide_part = 0,
+         enable_vertical_merge_algorithm = 0,
+         enable_block_number_column = 0,
+         enable_block_offset_column = 0;
+
+INSERT INTO t_missing_marker_same VALUES (1, 0);
+INSERT INTO t_missing_marker_same VALUES (2, 0);
+OPTIMIZE TABLE t_missing_marker_same FINAL;
+
+SELECT 'same marker types stay omitted';
+SELECT k, b FROM t_missing_marker_same ORDER BY k;
+SELECT column FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_missing_marker_same' AND active
+ORDER BY column;
+
+DROP TABLE t_missing_marker_same;
+
+CREATE TABLE t_missing_marker_physical
+(
+    k UInt64,
+    b UInt64
+)
+ENGINE = MergeTree
+ORDER BY k
+SETTINGS skip_empty_columns_on_insert = 1,
+         serialization_info_version = 'with_missing_columns',
+         min_bytes_for_wide_part = 0,
+         min_rows_for_wide_part = 0,
+         enable_vertical_merge_algorithm = 0,
+         enable_block_number_column = 0,
+         enable_block_offset_column = 0;
+
+INSERT INTO t_missing_marker_physical VALUES (1, 0);
+INSERT INTO t_missing_marker_physical VALUES (2, 7);
+OPTIMIZE TABLE t_missing_marker_physical FINAL;
+
+SELECT 'marker and physical column are materialized';
+SELECT k, b FROM t_missing_marker_physical ORDER BY k;
+SELECT column FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_missing_marker_physical' AND active
+ORDER BY column;
+
+DROP TABLE t_missing_marker_physical;
+
+CREATE TABLE t_missing_marker_absent
+(
+    k UInt64
+)
+ENGINE = MergeTree
+ORDER BY k
+SETTINGS skip_empty_columns_on_insert = 1,
+         serialization_info_version = 'with_missing_columns',
+         min_bytes_for_wide_part = 0,
+         min_rows_for_wide_part = 0,
+         enable_vertical_merge_algorithm = 0,
+         enable_block_number_column = 0,
+         enable_block_offset_column = 0;
+
+INSERT INTO t_missing_marker_absent VALUES (1);
+ALTER TABLE t_missing_marker_absent ADD COLUMN b UInt64;
+INSERT INTO t_missing_marker_absent VALUES (2, 0);
+ALTER TABLE t_missing_marker_absent MODIFY COLUMN b String;
+
+SELECT 'marker and absent before merge';
+SELECT k, b, length(b) FROM t_missing_marker_absent ORDER BY k;
+OPTIMIZE TABLE t_missing_marker_absent FINAL;
+SELECT 'marker and absent after merge';
+SELECT k, b, length(b) FROM t_missing_marker_absent ORDER BY k;
+SELECT column FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_missing_marker_absent' AND active
+ORDER BY column;
+
+DROP TABLE t_missing_marker_absent;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117601

Parts may record the same omitted column with different frozen types. A merge cannot represent those rows with one marker, so it now materializes the column through each source part's normal read conversion. Uniform markers remain omitted.

Covers conflicting types in horizontal and vertical merges, plus uniform, physical, and unmarked source-part cases.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117926&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117926](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117926+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.904` (included in `26.9` and later)
<!-- ch-version-info:end -->