### PR TITLE
Remove the animation from the web terminal in the docs

### DIFF
--- a/docs/_site/customizations/webterminal.js
+++ b/docs/_site/customizations/webterminal.js
@@ -62,7 +62,7 @@
     style.textContent = ''
       + '#' + PANEL_ID + ' { position: fixed; left: 0; right: 0; bottom: 0; height: ' + BAR_HEIGHT + 'px;'
       + ' display: flex; flex-direction: column; background: #0d0d0d; color: #f3f4f6;'
-      + ' z-index: 2147483646; box-shadow: 0 -1px 0 #2a2a2a; transition: height 180ms ease; }'
+      + ' z-index: 2147483646; box-shadow: 0 -1px 0 #2a2a2a; }'
       + 'html.' + PAGE_LOCK_CLASS + ', html.' + PAGE_LOCK_CLASS + ' body { overflow: hidden !important; }'
       // The spacer puts the fixed tray into the page's layout. At the end of the document the
       // footer can scroll completely above the tray instead of ending underneath it.
@@ -81,7 +81,7 @@
       + '#' + IFRAME_ID + ' { display: block; width: calc(100% + 8px); max-width: none; height: 100%; border: none; background: #000;'
       + ' overscroll-behavior: contain; }'
       + '#' + RESIZER_ID + ' { position: absolute; top: -4px; left: 0; right: 0; height: 8px;'
-      + ' cursor: row-resize; user-select: none; opacity: 0; transition: opacity 120ms; }'
+      + ' cursor: row-resize; user-select: none; opacity: 0; }'
       + '#' + PANEL_ID + '.' + OPEN_CLASS + ' #' + RESIZER_ID + ':hover,'
       + ' #' + PANEL_ID + '.' + OPEN_CLASS + ' #' + RESIZER_ID + '.ch-webterminal-dragging { opacity: 1;'
       + ' background: linear-gradient(to bottom, transparent 3px, #faff69 3px, #faff69 5px, transparent 5px); }'
@@ -101,11 +101,10 @@
       + '#' + ACTION_ID + ' { display: flex; align-items: center; justify-content: center; width: ' + BAR_HEIGHT + 'px;'
       + ' border-left: 1px solid #2a2a2a; color: #a9adb7; }'
       + '#' + ACTION_ID + ':hover { color: #fff; background: #202020; }'
-      + '#' + ACTION_ID + ' svg { width: 16px; height: 16px; transition: transform 180ms ease; }'
+      + '#' + ACTION_ID + ' svg { width: 16px; height: 16px; }'
       + '#' + PANEL_ID + '.' + OPEN_CLASS + ' #' + ACTION_ID + ' svg { transform: rotate(180deg); }'
       + '@media (max-width: ' + (DESKTOP_MIN_WIDTH - 1) + 'px) { #' + PANEL_ID + ', #' + SPACER_ID + ' { display: none; }'
-      + ' #sidebar { bottom: 0 !important; } }'
-      + '@media (prefers-reduced-motion: reduce) { #' + PANEL_ID + ', #' + ACTION_ID + ' svg { transition: none; } }';
+      + ' #sidebar { bottom: 0 !important; } }';
     document.head.appendChild(style);
   }
 


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/117940

The web terminal tray in the documentation website was animated: the panel had `transition: height 180ms ease`, the chevron had `transition: transform 180ms ease` and the resizer had `transition: opacity 120ms`.

The height transition is the harmful one. While dragging the panel's top edge, every pointer move starts a new 180 ms animation, so the panel lags behind the pointer and the embedded terminal keeps being resized and re-fitted for 180 ms after the drag stops, which makes it flicker and re-render. Opening and collapsing the tray were slow for the same reason.

The original implementation in `play.html` has no transitions at all - the terminal panel appears and disappears instantly. This restores the same behaviour in the docs: all three transitions are removed. With no motion left, the `prefers-reduced-motion` override is no longer needed and is removed as well. The chevron still flips when the tray is open, it simply flips immediately.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117942&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117942](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117942+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.636` (included in `26.9` and later)
<!-- ch-version-info:end -->