### PR TITLE
Add ClickHouse Wizard tips to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_question.yaml
+++ b/.github/ISSUE_TEMPLATE/10_question.yaml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        > Make sure to check documentation https://clickhouse.com/docs/ first. If the question is concise and probably has a short answer, asking it in [community Slack](https://join.slack.com/t/clickhousedb/shared_invite/zt-1gh9ds7f4-PgDhJAaF8ad5RbWBAAjzFg) is probably the fastest way to find the answer. For more complicated questions, consider asking them on StackOverflow with "clickhouse" tag https://stackoverflow.com/questions/tagged/clickhouse
+        > Make sure to check documentation https://clickhouse.com/docs/ first. Try the [ClickHouse Wizard](https://wizard.clickhouse.com/) for answers grounded in existing ClickHouse issues and pull requests. If the question is concise and probably has a short answer, asking it in [community Slack](https://join.slack.com/t/clickhousedb/shared_invite/zt-1gh9ds7f4-PgDhJAaF8ad5RbWBAAjzFg) is probably the fastest way to find the answer. For more complicated questions, consider asking them on StackOverflow with "clickhouse" tag https://stackoverflow.com/questions/tagged/clickhouse
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/20_feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/20_feature-request.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related feature requests and implementations before filing.
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/30_unexpected-behaviour.yaml
+++ b/.github/ISSUE_TEMPLATE/30_unexpected-behaviour.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related reports and explanations before filing.
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/35_incomplete_implementation.yaml
+++ b/.github/ISSUE_TEMPLATE/35_incomplete_implementation.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related issues and implementation work before filing.
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/45_usability-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/45_usability-issue.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related usability requests and improvements before filing.
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/50_build-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/50_build-issue.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > Make sure that `git diff` result is empty and you've just pulled fresh master. Try cleaning up cmake cache. Just in case, official build instructions are published here: https://clickhouse.com/docs/en/development/build/
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related build issues and fixes before filing.
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/60_documentation-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/60_documentation-issue.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > Thanks for helping us improve the documentation! Please describe what's wrong, missing, or unclear below. If you opened this from the "Raise issue" button on the docs site, the page you were viewing is filled in for you; otherwise, please add a link to the affected page.
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related documentation issues and changes before filing.
   - type: input
     id: page
     attributes:

--- a/.github/ISSUE_TEMPLATE/70_performance-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/70_performance-issue.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related performance issues and optimizations before filing.
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/80_backward-compatibility.yaml
+++ b/.github/ISSUE_TEMPLATE/80_backward-compatibility.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related compatibility issues and changes before filing.
   - type: textarea
     attributes:
       label: Company or project name

--- a/.github/ISSUE_TEMPLATE/85_bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/85_bug-report.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > Please make sure that the version you're using is still supported (you can find the list [here](https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions)).
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related bug reports and fixes before filing.
         > You have to provide the following information whenever possible.
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/90_fuzzing-report.yaml
+++ b/.github/ISSUE_TEMPLATE/90_fuzzing-report.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related fuzzing reports and fixes before filing.
   - type: textarea
     attributes:
       label: Describe the bug

--- a/.github/ISSUE_TEMPLATE/95_sanitizer-report.yaml
+++ b/.github/ISSUE_TEMPLATE/95_sanitizer-report.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > (you don't have to strictly follow this form)
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related sanitizer reports and fixes before filing.
   - type: textarea
     attributes:
       label: Describe the bug

--- a/.github/ISSUE_TEMPLATE/96_installation-issues.yaml
+++ b/.github/ISSUE_TEMPLATE/96_installation-issues.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         > **I have tried the following solutions**: https://clickhouse.com/docs/en/faq/troubleshooting/#troubleshooting-installation-errors
+        > Ask the [ClickHouse Wizard](https://wizard.clickhouse.com/) about related installation issues and fixes before filing.
   - type: textarea
     attributes:
       label: Company or project name


### PR DESCRIPTION
Encourage reporters to ask the ClickHouse Wizard about related issues and pull requests before filing. The wording is tailored to each issue type.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117946&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117946](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117946+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.646` (included in `26.9` and later)
<!-- ch-version-info:end -->