### PR TITLE
Do not report a base-branch submodule move as a bugfix-validation failure

### DIFF
--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -695,16 +695,20 @@ def mark_reproduced(result):
     result.set_status(Result.Status.XFAIL)
 
 
-def finalize(results, info_lines, status="", do_not_cache=False):
+def finalize(results, info_lines, status=""):
     # `Result.create_from` derives the job status from the children and skips over
     # OK/SKIPPED/XFAIL ones, so a lone SKIPPED child yields a job status of OK. A caller
     # that needs the job itself to read SKIPPED has to pass `status` explicitly.
+    #
+    # No verdict here is cacheable: each reads the merge base, the PR's labels or the PR's
+    # changed-file set, and a digest hashes the checkout's files and submodule revisions
+    # only. The digest is kept because it also gates affectedness.
     Result.create_from(
         results=results,
         info=info_lines,
         with_info_from_results=True,
         status=status,
-    ).complete_job(do_not_cache=do_not_cache)
+    ).complete_job(do_not_cache=True)
 
 
 def main():
@@ -724,8 +728,6 @@ def main():
                 )
             ],
             "Skipped: not a bugfix PR.",
-            # A job digest hashes files and submodule revisions, never the PR's labels.
-            do_not_cache=True,
         )
         return
 
@@ -771,8 +773,6 @@ def main():
     # what the PR author wrote. See determine_merge_base.
     pr_sha = info.sha
     assert pr_sha, "Info.sha (PR head commit) is empty; cannot overlay the PR's test files"
-    # No digest input captures `merge_base` (a digest hashes the checkout's files and
-    # submodule revisions), so every verdict reached against it below sets `do_not_cache`.
     merge_base = determine_merge_base(info)
     print(f"PR head commit: {pr_sha}")
     print(f"merge-base: {merge_base}")
@@ -888,7 +888,6 @@ def main():
             "branch split, so the before-worktree cannot be populated at the merge-base "
             "submodule revisions.",
             status=Result.Status.SKIPPED,
-            do_not_cache=True,
         )
         return
 
@@ -969,7 +968,6 @@ def main():
                 "interface. Regression coverage is judged by the functional/integration "
                 "Bugfix validation jobs (enforced by new_tests_check.py when such tests "
                 "exist).",
-                do_not_cache=True,
             )
             return
         compile_result.set_status(Result.Status.ERROR)
@@ -1038,7 +1036,6 @@ def main():
             results,
             "Bug reproduced: at least one touched unit test fails/crashes on the "
             "before-binary (merge-base without the fix) and passes on the PR binary.",
-            do_not_cache=True,
         )
         return
 

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -769,6 +769,8 @@ def main():
     # what the PR author wrote. See determine_merge_base.
     pr_sha = info.sha
     assert pr_sha, "Info.sha (PR head commit) is empty; cannot overlay the PR's test files"
+    # No digest input captures `merge_base` (a digest hashes the checkout's files and
+    # submodule revisions), so every verdict reached against it below sets `do_not_cache`.
     merge_base = determine_merge_base(info)
     print(f"PR head commit: {pr_sha}")
     print(f"merge-base: {merge_base}")
@@ -868,8 +870,7 @@ def main():
             )
             return
         # Base-only motion is a function of the branch's age, not of anything the author
-        # can influence. It is also not cacheable: the verdict depends on the merge base,
-        # which no digest input captures.
+        # can influence.
         finalize(
             [
                 Result(
@@ -966,6 +967,7 @@ def main():
                 "interface. Regression coverage is judged by the functional/integration "
                 "Bugfix validation jobs (enforced by new_tests_check.py when such tests "
                 "exist).",
+                do_not_cache=True,
             )
             return
         compile_result.set_status(Result.Status.ERROR)
@@ -1034,6 +1036,7 @@ def main():
             results,
             "Bug reproduced: at least one touched unit test fails/crashes on the "
             "before-binary (merge-base without the fix) and passes on the PR binary.",
+            do_not_cache=True,
         )
         return
 

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -695,12 +695,16 @@ def mark_reproduced(result):
     result.set_status(Result.Status.XFAIL)
 
 
-def finalize(results, info_lines):
+def finalize(results, info_lines, status="", do_not_cache=False):
+    # `Result.create_from` derives the job status from the children and skips over
+    # OK/SKIPPED/XFAIL ones, so a lone SKIPPED child yields a job status of OK. A caller
+    # that needs the job itself to read SKIPPED has to pass `status` explicitly.
     Result.create_from(
         results=results,
         info=info_lines,
         with_info_from_results=True,
-    ).complete_job()
+        status=status,
+    ).complete_job(do_not_cache=do_not_cache)
 
 
 def main():
@@ -808,26 +812,78 @@ def main():
     ), "Failed to resolve the checkout HEAD; cannot verify submodule state"
     submodule_changes = get_submodule_state_changes(merge_base, checkout_head)
     if submodule_changes:
+        # `checkout_head` is the base+PR merge ref, so it carries the base tip's gitlinks
+        # too: a base-only bump after the branch split lands in the diff above with nothing
+        # contributed by the PR. `None` means the attribution itself could not be computed.
+        try:
+            pr_submodule_changes = get_submodule_state_changes(merge_base, pr_sha)
+        except Exception as e:
+            print(f"WARNING: failed to attribute the submodule difference: {e}")
+            pr_submodule_changes = None
+        changed = ", ".join(submodule_changes)
+        why_inconclusive = (
+            "The before-worktree can only be populated with the primary checkout's "
+            "submodule content, not the merge-base's, so building the before-binary "
+            "would validate against the wrong submodule code. This is "
+            "inconclusive — NOT a reproduction or a refutation."
+        )
+        if pr_submodule_changes is None:
+            finalize(
+                [
+                    Result(
+                        name="Bugfix validation (unit tests)",
+                        status=Result.Status.ERROR,
+                        info=(
+                            f"Submodule state differs between the merge-base and the "
+                            f"checkout ({changed}), and the diff that would attribute it "
+                            f"to the PR or to the base branch could not be computed. "
+                            f"{why_inconclusive}"
+                        ),
+                    )
+                ],
+                "Bugfix validation inconclusive: submodule state differs between the "
+                "merge-base and the checkout, and the change could not be attributed to "
+                "the PR or to the base branch.",
+            )
+            return
+        if pr_submodule_changes:
+            finalize(
+                [
+                    Result(
+                        name="Bugfix validation (unit tests)",
+                        status=Result.Status.ERROR,
+                        info=(
+                            f"The PR changes submodule state "
+                            f"({', '.join(pr_submodule_changes)}), so submodule state "
+                            f"differs between the merge-base and the checkout "
+                            f"({changed}). {why_inconclusive}"
+                        ),
+                    )
+                ],
+                "Bugfix validation inconclusive: the PR changes submodule state, and the "
+                "before-worktree cannot be populated at the merge-base submodule "
+                "revisions.",
+            )
+            return
+        # Base-only motion is a function of the branch's age, not of anything the author
+        # can influence. It is also not cacheable: the verdict depends on the merge base,
+        # which no digest input captures.
         finalize(
             [
                 Result(
                     name="Bugfix validation (unit tests)",
-                    status=Result.Status.ERROR,
+                    status=Result.Status.SKIPPED,
                     info=(
-                        "Submodule state differs between the merge-base and the "
-                        "checkout (" + ", ".join(submodule_changes) + ") — either the "
-                        "PR changes submodule state, or the base branch moved a "
-                        "submodule after the branch split. The before-worktree can "
-                        "only be populated with the primary checkout's submodule "
-                        "content, not the merge-base's, so building the before-binary "
-                        "would validate against the wrong submodule code. This is "
-                        "inconclusive — NOT a reproduction or a refutation."
+                        f"The base branch moved submodule state after the branch split "
+                        f"({changed}) and the PR changes none of it. {why_inconclusive}"
                     ),
                 )
             ],
-            "Bugfix validation inconclusive: submodule state differs between the "
-            "merge-base and the checkout, and the before-worktree cannot be populated "
-            "at the merge-base submodule revisions.",
+            "Bugfix validation skipped: the base branch moved a submodule after the "
+            "branch split, so the before-worktree cannot be populated at the merge-base "
+            "submodule revisions.",
+            status=Result.Status.SKIPPED,
+            do_not_cache=True,
         )
         return
 

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -809,9 +809,9 @@ def main():
     # which would otherwise leak base-tip contrib sources into the merge-base build.
     # Either way the "before" binary would be built against the wrong submodule content
     # (or miss a merge-base-only submodule entirely) and the validator could report a
-    # false reproduction or refutation. Never a validation either way: a PR-side or
-    # unattributable difference reports ERROR, base-only motion reports SKIPPED, and
-    # `is_success` counts neither.
+    # false reproduction or refutation. None of these outcomes counts as a validation: a
+    # PR-side or unattributable difference reports ERROR, base-only motion reports
+    # SKIPPED, and `is_success` counts neither.
     checkout_head = Shell.get_output("git rev-parse HEAD").strip()
     assert (
         checkout_head
@@ -831,7 +831,7 @@ def main():
             "The before-worktree can only be populated with the primary checkout's "
             "submodule content, not the merge-base's, so building the before-binary "
             "would validate against the wrong submodule code. This is "
-            "inconclusive — NOT a reproduction or a refutation."
+            "inconclusive, NOT a reproduction or a refutation."
         )
         if pr_submodule_changes is None:
             finalize(

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -724,6 +724,8 @@ def main():
                 )
             ],
             "Skipped: not a bugfix PR.",
+            # A job digest hashes files and submodule revisions, never the PR's labels.
+            do_not_cache=True,
         )
         return
 

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -805,7 +805,9 @@ def main():
     # which would otherwise leak base-tip contrib sources into the merge-base build.
     # Either way the "before" binary would be built against the wrong submodule content
     # (or miss a merge-base-only submodule entirely) and the validator could report a
-    # false reproduction or refutation. Inconclusive (ERROR), not a pass.
+    # false reproduction or refutation. Never a validation either way: a PR-side or
+    # unattributable difference reports ERROR, base-only motion reports SKIPPED, and
+    # `is_success` counts neither.
     checkout_head = Shell.get_output("git rev-parse HEAD").strip()
     assert (
         checkout_head

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1072,8 +1072,8 @@ class Result(MetaClasses.Serializable):
             self._add_job_summary_to_info()
         if do_not_block_pipeline_on_failure and not self.is_ok():
             self.ext["do_not_block_pipeline_on_failure"] = True
-        # Set by a job whose verdict depends on run-time state no digest input captures,
-        # where a success record would be reused by a later commit that hashes the same.
+        # A job sets this flag when its verdict depends on run-time state no digest input
+        # captures, so a later commit with the same digest must not reuse its success record.
         if do_not_cache:
             self.ext["do_not_cache"] = True
         if not disable_attached_files_sorting:

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1072,8 +1072,8 @@ class Result(MetaClasses.Serializable):
             self._add_job_summary_to_info()
         if do_not_block_pipeline_on_failure and not self.is_ok():
             self.ext["do_not_block_pipeline_on_failure"] = True
-        # For a job whose verdict depends on run-time state that no digest input captures,
-        # so a success record would be reused on a later commit that hashes the same.
+        # Set by a job whose verdict depends on run-time state no digest input captures,
+        # where a success record would be reused by a later commit that hashes the same.
         if do_not_cache:
             self.ext["do_not_cache"] = True
         if not disable_attached_files_sorting:

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1058,16 +1058,24 @@ class Result(MetaClasses.Serializable):
     def do_not_block_pipeline_on_failure(self):
         return self.ext.get("do_not_block_pipeline_on_failure", False)
 
+    def do_not_cache(self):
+        return self.ext.get("do_not_cache", False)
+
     def complete_job(
         self,
         with_job_summary_in_info=True,
         do_not_block_pipeline_on_failure=False,
         disable_attached_files_sorting=False,
+        do_not_cache=False,
     ):
         if with_job_summary_in_info:
             self._add_job_summary_to_info()
         if do_not_block_pipeline_on_failure and not self.is_ok():
             self.ext["do_not_block_pipeline_on_failure"] = True
+        # For a job whose verdict depends on run-time state that no digest input captures,
+        # so a success record would be reused on a later commit that hashes the same.
+        if do_not_cache:
+            self.ext["do_not_cache"] = True
         if not disable_attached_files_sorting:
             try:
                 # Normalize to string and sort by filename case-insensitively

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -1071,7 +1071,7 @@ class Runner:
         # always in the end
         if workflow.enable_cache:
             print("Run CI cache hook")
-            if result.is_ok():
+            if result.is_ok() and not result.do_not_cache():
                 CacheRunnerHooks.post_run(workflow, job)
 
         if workflow.enable_open_issues_check:


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111530

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`Bugfix validation (unit tests)` no longer reports a failure when the only submodule difference between the merge-base and the checkout came from the base branch.

### Description

The job reports `ERROR` when submodule state differs between merge-base and checkout, without deciding whether the PR or the base branch moved it. Only a PR-side move is the author's to fix.

praktika checks out the synthetic merge ref, so `HEAD` carries the base tip's pins: master's submodule motion since the split lands in that diff. Since 2026-08-04: 143 error rows, 70 pull requests, more than all other causes combined (87); latest 2026-09-03. Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116959&sha=40a2ee8c17b1f660a491bf088121e3cd1b428e51&name_0=PR&name_1=Bugfix%20validation%20%28unit%20tests%29

So compute the PR-side diff too. Empty means the base moved it, and the job reports `SKIPPED`; non-empty keeps `ERROR` and names the PR's paths; an uncomputable diff keeps `ERROR` (fail close). The sibling validators already spell a declined verdict `SKIPPED`: `is_ok` covers it (the job exits 0), `is_success` does not.

The praktika commit keeps that outcome out of the success cache, and every other verdict of this job with it: each one reads the merge base, the PR's labels or its changed-file set, none of which a digest hashes (`job_configs.py` cites PR 109229). The digest stays, because it also gates affectedness. The keyword is opt-in, so no job that omits it changes behaviour.

On #111530 you wrote that an inconclusive `ERROR` is honest, for a case that "should stay rare (recent merge-bases)". Drift is nonzero at one day of merge-base age, and a base refresh only postpones it (below). If you still prefer `ERROR`, say so and I will close this.

**Alternative, your call:** `digest_config=None` here, as on the functional and integration validators. That reaches the same place, but the digest is this job's only affectedness gate, so bugfix PRs touching none of its paths would then still schedule a large runner.

My branch has no drift, so this PR's CI cannot exercise the new arm.

<details>
<summary>How to reproduce both measurements</summary>

Paths a merge-base of a given age already differs in, against master `41b3bd68a3a31449af85a6d76eff3814db5b6b1c` (2026-09-03), counted exactly as the guard counts them:

```
D=7; B=$(git rev-list -1 --before="$D days ago" 41b3bd68a3a3)
git diff --raw --ignore-submodules=none $B 41b3bd68a3a3 -- contrib .gitmodules \
  | awk '$1==":160000"||$2=="160000"||$NF==".gitmodules"{print $NF}' | sort -u | wc -l
```

| merge-base age (days) | 1 | 2 | 4 | 7 | 14 | 30 |
|---|---|---|---|---|---|---|
| drifted paths | 2 | 5 | 5 | 9 | 8 | 24 |

Not monotonic, because a pin can move and move back. The guard fires as a function of branch age rather than of anything the PR did, and merging master clears it only until the next pin moves.

The row counts are `check_status = 'error'` (this job leaves `test_status` empty, so filtering on it returns zero) with `position(test_context_raw, 'Submodule state differs between the merge-base and the checkout') > 0`, on `play.clickhouse.com`.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117948&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117948](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117948+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->




<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1370` (included in `26.9` and later)
<!-- ch-version-info:end -->