### PR TITLE
Fix automatic parallel replicas being skipped for a query-level `SETTINGS` clause

### DIFF
--- a/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
+++ b/src/Interpreters/InterpreterSelectQueryAnalyzer.cpp
@@ -12,6 +12,7 @@
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/stripQuerySettings.h>
 
 #include <DataTypes/DataTypesNumber.h>
 
@@ -38,6 +39,9 @@
 
 #include <Poco/Logger.h>
 #include <Common/logger_useful.h>
+
+#include <array>
+#include <string_view>
 
 namespace ProfileEvents
 {
@@ -200,6 +204,19 @@ QueryPlanPtr buildQueryPlanForAutomaticParallelReplicas(
     ctx->setSetting("automatic_parallel_replicas_mode", Field{0});
     // We don't want to analyze primaty key at all, see `query_plan_optimize_primary_key` below.
     ctx->setSetting("force_primary_key", false);
+    /// Setting them on the context is not enough: the nested interpreter re-applies the query's own
+    /// `SETTINGS` clause on top of the context it is handed (`QueryTreeBuilder::buildSelectExpression`),
+    /// which would put `automatic_parallel_replicas_mode` back and make `buildContext` clear
+    /// `enable_parallel_replicas` for the nested build. The nested plan would then contain no read from
+    /// the other replicas and the optimization would give up. Settings written after `FORMAT` land on
+    /// `ASTQueryWithOutput` and are not re-applied, which is why the very same query used to be
+    /// optimized or not depending on where its `SETTINGS` clause was written. Drop the overridden
+    /// settings from the (cloned) AST so that the overrides above actually hold.
+    static constexpr std::array settings_overridden_for_this_plan{
+        std::string_view{"automatic_parallel_replicas_mode"},
+        std::string_view{"force_primary_key"},
+    };
+    removeSettingsFromQuery(ast, settings_overridden_for_this_plan);
     InterpreterSelectQueryAnalyzer interpreter(ast, ctx, select_options, std::forward<Args>(interpreter_args)...);
     auto plan = std::move(interpreter).extractQueryPlan();
     auto optimization_settings = QueryPlanOptimizationSettings(ctx);

--- a/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
@@ -325,11 +325,19 @@ void considerEnablingParallelReplicas(
 
     auto plan_with_parallel_replicas = optimization_settings.query_plan_with_parallel_replicas_builder();
     if (!plan_with_parallel_replicas)
+    {
+        LOG_DEBUG(getLogger("optimizeTree"), "Cannot build a plan with parallel replicas. Skipping optimization");
         return;
+    }
 
     const auto * final_node_in_replica_plan = findTopNodeOfReplicasPlan(plan_with_parallel_replicas->getRootNode());
     if (!final_node_in_replica_plan)
+    {
+        LOG_DEBUG(
+            getLogger("optimizeTree"),
+            "The plan built with parallel replicas contains no read from the other replicas. Skipping optimization");
         return;
+    }
     LOG_DEBUG(getLogger("optimizeTree"), "Top node of replicas plan: {}", final_node_in_replica_plan->step->getName());
 
     const auto [corresponding_node_in_single_replica_plan, single_replica_plan_node_hash]

--- a/tests/queries/0_stateless/05059_autopr_settings_in_select_settings_clause.reference
+++ b/tests/queries/0_stateless/05059_autopr_settings_in_select_settings_clause.reference
@@ -1,0 +1,3 @@
+query	stats_collected	pr_used
+05059_autopr_select_settings_query_0	1	0
+05059_autopr_select_settings_query_1	0	1

--- a/tests/queries/0_stateless/05059_autopr_settings_in_select_settings_clause.sql
+++ b/tests/queries/0_stateless/05059_autopr_settings_in_select_settings_clause.sql
@@ -1,0 +1,61 @@
+-- Tags: no-sanitizers
+-- no-sanitizers: needs enough data and small blocks to collect statistics and make parallel replicas
+--                cost-beneficial, which is too slow under sanitizers (as for 05024).
+
+-- Automatic parallel replicas must work the same no matter how the query receives its settings. A
+-- query carrying `automatic_parallel_replicas_mode` in its own `SETTINGS` clause used to silently run
+-- without parallel replicas: the plan builder disables the heuristic on the context it hands to the
+-- nested interpreter (that plan is meant to be one with enforced parallel replicas), but the nested
+-- interpreter re-applied the clause on top of it, so the nested plan came back with no read from the
+-- other replicas and the optimization gave up. Settings written after `FORMAT` are not re-applied,
+-- which is why the same query worked when its `SETTINGS` clause was written there.
+
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t(WatchID UInt64, ClientIP UInt32, ResolutionWidth UInt16) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity=128;
+
+SET enable_parallel_replicas=1, parallel_replicas_local_plan=1,
+    parallel_replicas_for_non_replicated_merge_tree=1, max_parallel_replicas=3, cluster_for_parallel_replicas='parallel_replicas';
+
+SET enable_analyzer=1;
+
+-- max_block_size is set explicitly to ensure enough blocks will be fed to the statistics collector
+SET max_threads=4, max_block_size=128;
+
+-- May disable the usage of parallel replicas
+SET automatic_parallel_replicas_min_bytes_per_replica=0;
+SET merge_tree_min_bytes_per_task_for_remote_reading=0;
+
+-- External aggregation is not supported at the moment, i.e., no statistics will be reported
+SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
+
+-- Merge the partial aggregation results of the replicas without `GroupingAggregatedTransform`: the
+-- memory efficient merging rarely hits `Logical error: 'Bucket N is pushed twice'`
+-- (https://github.com/ClickHouse/ClickHouse/issues/115663), which has nothing to do with what this
+-- test checks - the decision of automatic parallel replicas, not how the partial results are merged.
+SET distributed_aggregation_memory_efficient=0;
+
+INSERT INTO t SELECT number % 1000, number % 500, number % 200 FROM numbers(5e5);
+
+-- `automatic_parallel_replicas_mode` is passed in the query's own `SETTINGS` clause, which is the whole
+-- point of the test: everything else is passed out of band, exactly as in 05024.
+
+-- Query 0: empty cache, collect statistics, no parallel replicas yet
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10
+    SETTINGS automatic_parallel_replicas_mode=1, log_comment='05059_autopr_select_settings_query_0' FORMAT Null;
+
+-- Query 1: the same replica sub-plan, statistics are already collected, parallel replicas are enabled
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10
+    SETTINGS automatic_parallel_replicas_mode=1, log_comment='05059_autopr_select_settings_query_1' FORMAT Null;
+
+SET enable_parallel_replicas=0;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT log_comment query, ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 stats_collected, ProfileEvents['ParallelReplicasUsedCount'] > 0 pr_used
+FROM system.query_log
+WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment LIKE '05059_autopr_select_settings_query_%') AND (type = 'QueryFinish')
+ORDER BY log_comment
+FORMAT TSVWithNames;
+
+DROP TABLE t;

--- a/tests/queries/0_stateless/05059_autopr_settings_in_select_settings_clause.sql
+++ b/tests/queries/0_stateless/05059_autopr_settings_in_select_settings_clause.sql
@@ -29,12 +29,6 @@ SET merge_tree_min_bytes_per_task_for_remote_reading=0;
 -- External aggregation is not supported at the moment, i.e., no statistics will be reported
 SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
 
--- Merge the partial aggregation results of the replicas without `GroupingAggregatedTransform`: the
--- memory efficient merging rarely hits `Logical error: 'Bucket N is pushed twice'`
--- (https://github.com/ClickHouse/ClickHouse/issues/115663), which has nothing to do with what this
--- test checks - the decision of automatic parallel replicas, not how the partial results are merged.
-SET distributed_aggregation_memory_efficient=0;
-
 INSERT INTO t SELECT number % 1000, number % 500, number % 200 FROM numbers(5e5);
 
 -- `automatic_parallel_replicas_mode` is passed in the query's own `SETTINGS` clause, which is the whole


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117950&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117950](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117950+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
