### PR TITLE
Don't run index analysis when formatting a parallel replicas plan fragment

### DIFF
--- a/src/Processors/QueryPlan/ReadFromParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/ReadFromParallelReplicas.cpp
@@ -77,10 +77,13 @@ namespace FailPoints
 
 namespace
 {
-/// Formats the fragment shipped to the replicas for display only. `actions` and `indexes` are off on
-/// purpose: they make `describeActions` and `describeIndexes` ask every MergeTree read for its analysis
-/// result, so formatting a string would run index analysis, which is expensive and can throw (for
-/// example when the analysis exceeds `max_rows_to_read`) even though nothing is being read yet.
+/// Formats the fragment for the step description. `actions` and `indexes` are off on purpose: they make
+/// `describeActions` and `describeIndexes` ask every MergeTree read for its analysis result, so building
+/// a description string would run index analysis, which is expensive and can throw (for example when the
+/// analysis exceeds `max_rows_to_read`) even though nothing is being read yet. Only the description is
+/// built this way: the dump passed to `RemoteQueryExecutor` reaches the replica as the query text, where
+/// it is hashed into `normalized_query_hash` and buckets `NORMALIZED_QUERY_HASH` quotas, so dropping the
+/// actions from it would collapse distinct fragments into one quota bucket.
 String dumpQueryPlanShape(const QueryPlan & query_plan)
 {
     WriteBufferFromOwnString buffer;
@@ -225,7 +228,7 @@ Pipe ReadFromParallelReplicasStep::createPipeForSingeReplica(
 
     auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(
         pool,
-        dumpQueryPlanShape(*query_plan),
+        dumpQueryPlan(*query_plan),
         out_header,
         context,
         getThrottler(context),

--- a/src/Processors/QueryPlan/ReadFromParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/ReadFromParallelReplicas.cpp
@@ -80,10 +80,7 @@ namespace
 /// Formats the fragment for the step description. `actions` and `indexes` are off on purpose: they make
 /// `describeActions` and `describeIndexes` ask every MergeTree read for its analysis result, so building
 /// a description string would run index analysis, which is expensive and can throw (for example when the
-/// analysis exceeds `max_rows_to_read`) even though nothing is being read yet. Only the description is
-/// built this way: the dump passed to `RemoteQueryExecutor` reaches the replica as the query text, where
-/// it is hashed into `normalized_query_hash` and buckets `NORMALIZED_QUERY_HASH` quotas, so dropping the
-/// actions from it would collapse distinct fragments into one quota bucket.
+/// analysis exceeds `max_rows_to_read`) even though nothing is being read yet.
 String dumpQueryPlanShape(const QueryPlan & query_plan)
 {
     WriteBufferFromOwnString buffer;

--- a/src/Processors/QueryPlan/ReadFromParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/ReadFromParallelReplicas.cpp
@@ -16,6 +16,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionsMiscellaneous.h>
 #include <Functions/IFunction.h>
+#include <IO/WriteBufferFromString.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -74,6 +75,20 @@ namespace FailPoints
     extern const char parallel_replicas_wait_for_unused_replicas[];
 }
 
+namespace
+{
+/// Formats the fragment shipped to the replicas for display only. `actions` and `indexes` are off on
+/// purpose: they make `describeActions` and `describeIndexes` ask every MergeTree read for its analysis
+/// result, so formatting a string would run index analysis, which is expensive and can throw (for
+/// example when the analysis exceeds `max_rows_to_read`) even though nothing is being read yet.
+String dumpQueryPlanShape(const QueryPlan & query_plan)
+{
+    WriteBufferFromOwnString buffer;
+    query_plan.explainPlan(buffer, ExplainPlanOptions{.header = true, .description = true, .actions = false, .indexes = false});
+    return buffer.str();
+}
+}
+
 ReadFromParallelReplicasStep::ReadFromParallelReplicasStep(
     std::shared_ptr<const QueryPlan> query_plan_,
     ClusterPtr cluster_,
@@ -107,7 +122,7 @@ ReadFromParallelReplicasStep::ReadFromParallelReplicasStep(
         replicas.push_back(pools_to_use[i]->getAddress());
     }
 
-    auto description = fmt::format("QueryPlan: {} Replicas: {}", dumpQueryPlan(*query_plan), fmt::join(replicas, ", "));
+    auto description = fmt::format("QueryPlan: {} Replicas: {}", dumpQueryPlanShape(*query_plan), fmt::join(replicas, ", "));
     setStepDescription(std::move(description), context->getSettingsRef()[Setting::query_plan_max_step_description_length]);
 }
 
@@ -210,7 +225,7 @@ Pipe ReadFromParallelReplicasStep::createPipeForSingeReplica(
 
     auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(
         pool,
-        dumpQueryPlan(*query_plan),
+        dumpQueryPlanShape(*query_plan),
         out_header,
         context,
         getThrottler(context),

--- a/tests/queries/0_stateless/05055_pr_plan_based_step_description_no_index_analysis.sql
+++ b/tests/queries/0_stateless/05055_pr_plan_based_step_description_no_index_analysis.sql
@@ -1,0 +1,27 @@
+-- The step description of a plan-based parallel replicas read is formatted with `actions` and
+-- `indexes` disabled: with them, `describeActions` and `describeIndexes` ask every MergeTree read of
+-- the shipped fragment for its analysis result, so index analysis ran while a description string was
+-- being built. That analysis is done without the query's filter pushed into the read, so it reports
+-- the whole table and a query with `max_rows_to_read` failed with `TOO_MANY_ROWS` even though the
+-- actual read is empty.
+
+DROP TABLE IF EXISTS t_pr_step_description;
+
+CREATE TABLE t_pr_step_description (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_pr_step_description SELECT number, number % 10 FROM numbers(100000);
+
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 1;
+SET parallel_replicas_for_non_replicated_merge_tree = 1;
+SET max_parallel_replicas = 3;
+SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
+SET parallel_replicas_plan_based = 1;
+-- Statistics-only mode: the plan with parallel replicas is built (so its step description is
+-- formatted) but never substituted for the local plan. This is the combination the functional tests
+-- randomize.
+SET automatic_parallel_replicas_mode = 2;
+SET max_rows_to_read = 1000;
+
+SELECT a, uniq(b) FROM t_pr_step_description WHERE 0 != 0 GROUP BY a;
+
+DROP TABLE t_pr_step_description;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.757` (included in `26.9` and later)
<!-- ch-version-info:end -->