### PR TITLE
Add a regression test for reading a cleared Nested member subcolumn

### DIFF
--- a/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.reference
+++ b/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.reference
@@ -1,3 +1,7 @@
+-- the fixture: one active Compact part
+Compact
+-- the fixture: the cleared member is absent from the part
+c0.c1
 -- the cleared member and its `size0` subcolumn read together
 [(0)]	1
 -- the same pair in the other order

--- a/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.reference
+++ b/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.reference
@@ -1,0 +1,6 @@
+-- the cleared member and its `size0` subcolumn read together
+[(0)]	1
+-- the same pair in the other order
+1	[(0)]
+-- the subcolumn alone was already correct and must stay so
+1

--- a/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.sql
+++ b/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.sql
@@ -1,0 +1,26 @@
+-- `ALTER TABLE ... CLEAR COLUMN` on a `Nested` `Tuple` member leaves the member absent from the
+-- mutated part while the table metadata still declares it. Reading the member together with one of
+-- its subcolumns then used to raise `Bad cast from type DB::ColumnVector<int> to DB::ColumnTuple` in
+-- `fillMissingColumns`: the synthesized `Nested` group took the member's element type from the
+-- subcolumn entry, which carries the metadata type rather than the type of the data the part
+-- supplies. `ALTER TABLE ... ADD COLUMN` leaves the member absent in the same way and reaches the
+-- same code path.
+-- The pinned settings keep the read on that path: it needs a Compact part
+-- (`min_bytes_for_wide_part` is randomized by the test runner) and shared `Nested` offsets.
+-- `[(0)]` below is the fixture's own guard: an unapplied mutation would read `[(10)]`.
+
+DROP TABLE IF EXISTS t_nested_cleared;
+CREATE TABLE t_nested_cleared (c0 Nested(c1 Int32, c2 Tuple(c3 Int32)))
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 10485760, min_rows_for_wide_part = 1048576, share_nested_offsets = 1;
+INSERT INTO t_nested_cleared (`c0.c1`, `c0.c2`) VALUES ([1], [(10)]);
+ALTER TABLE t_nested_cleared CLEAR COLUMN `c0.c2` SETTINGS mutations_sync = 2;
+
+SELECT '-- the cleared member and its `size0` subcolumn read together';
+SELECT `c0.c2`, `c0.c2`.size0 FROM t_nested_cleared;
+SELECT '-- the same pair in the other order';
+SELECT `c0.c2`.size0, `c0.c2` FROM t_nested_cleared;
+SELECT '-- the subcolumn alone was already correct and must stay so';
+SELECT `c0.c2`.size0 FROM t_nested_cleared;
+
+DROP TABLE t_nested_cleared;

--- a/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.sql
+++ b/tests/queries/0_stateless/05060_nested_member_subcolumn_cleared_column.sql
@@ -1,10 +1,6 @@
--- `ALTER TABLE ... CLEAR COLUMN` on a `Nested` `Tuple` member leaves the member absent from the
--- mutated part while the table metadata still declares it. Reading the member together with one of
--- its subcolumns then used to raise `Bad cast from type DB::ColumnVector<int> to DB::ColumnTuple` in
--- `fillMissingColumns`: the synthesized `Nested` group took the member's element type from the
--- subcolumn entry, which carries the metadata type rather than the type of the data the part
--- supplies. `ALTER TABLE ... ADD COLUMN` leaves the member absent in the same way and reaches the
--- same code path.
+-- `ALTER TABLE ... CLEAR COLUMN` leaves a `Nested` `Tuple` member absent from the mutated part while
+-- the metadata still declares it; reading it beside one of its subcolumns then raised a logical error
+-- in `fillMissingColumns`. `ALTER TABLE ... ADD COLUMN` leaves it absent the same way, same path.
 -- The pinned settings keep the read on that path: it needs a Compact part
 -- (`min_bytes_for_wide_part` is randomized by the test runner) and shared `Nested` offsets.
 -- `[(0)]` below is the fixture's own guard: an unapplied mutation would read `[(10)]`.
@@ -15,6 +11,14 @@ ENGINE = MergeTree ORDER BY tuple()
 SETTINGS min_bytes_for_wide_part = 10485760, min_rows_for_wide_part = 1048576, share_nested_offsets = 1;
 INSERT INTO t_nested_cleared (`c0.c1`, `c0.c2`) VALUES ([1], [(10)]);
 ALTER TABLE t_nested_cleared CLEAR COLUMN `c0.c2` SETTINGS mutations_sync = 2;
+
+SELECT '-- the fixture: one active Compact part';
+SELECT part_type FROM system.parts
+WHERE database = currentDatabase() AND table = 't_nested_cleared' AND active;
+SELECT '-- the fixture: the cleared member is absent from the part';
+SELECT column FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_nested_cleared' AND active
+AND column LIKE 'c0.%' ORDER BY column;
 
 SELECT '-- the cleared member and its `size0` subcolumn read together';
 SELECT `c0.c2`, `c0.c2`.size0 FROM t_nested_cleared;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/114082
Related: https://github.com/ClickHouse/ClickHouse/pull/113925
Related: https://github.com/ClickHouse/ClickHouse/pull/80263


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

`Stress test (amd_tsan)` on #80263 raised `Logical error: 'Bad cast from type DB::ColumnVector<int> to DB::ColumnTuple'` in `fillMissingColumns` (STID `3227-42db`), while a stress-mutated `04210_alter_clear_column_nested_tuple_89537` read the `size0` subcolumn of a `Nested` `Tuple` member after `ALTER TABLE ... CLEAR COLUMN`. Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=80263&sha=e51e5db5cd3d750a6fc19e90b38f2b67e1734862&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29

That defect is already fixed by #113925: `getSubcolumnsOfNested` now lets a plain entry's contribution replace a subcolumn entry's, so a synthesized `Nested` group no longer takes a member's element type from metadata when the part supplies something else. `CLEAR COLUMN` reaches that state by a different route than the test #113925 shipped: it leaves the member absent from the mutated part, where `MODIFY COLUMN` leaves it present with an older type. I said on #114082 and #113925 that I would add the `CLEAR COLUMN` case once that merged, so this is it. No source change.

Verified in both directions: with only #113925's preference branch reverted the new test fails; on master it passes. Coverage is not duplicated either. All 38 pre-existing stateless tests mentioning `CLEAR COLUMN` were run against that reverted build and none reddens because of it (33 pass; the 5 failures reproduce identically on master, for want of a ZooKeeper or Iceberg endpoint). That includes the nearest neighbours: `03742_test_flattened_crash` reads `size0` beside its parent on a part missing its `Nested` `Tuple` member, but gets there by `DROP COLUMN` + `ADD COLUMN`; and `04210` runs `OPTIMIZE TABLE ... FINAL` before every read, rewriting the part before the disagreement is observable.

The pinned settings keep the read on the failing path: it needs a Compact part, and `min_bytes_for_wide_part` is randomized by the test runner. The test also asserts that state (`part_type` and the part's own column list) rather than only setting it, so a rewritten part fails loudly instead of quietly losing coverage, as happened to `04210`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117966&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117966](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117966+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.666` (included in `26.9` and later)
<!-- ch-version-info:end -->