### PR TITLE
Do not require privileges on the temporary table of CREATE OR REPLACE

### DIFF
--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -485,7 +485,8 @@ BlockIO InterpreterAlterQuery::executeToTable(const ASTAlterQuery & alter)
         return executeDDLQueryOnCluster(query_ptr, getContext(), params);
     }
 
-    getContext()->checkAccess(getRequiredAccess(table));
+    if (!skip_access_check)
+        getContext()->checkAccess(getRequiredAccess(table));
 
     if (!table_id)
         throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database {} does not exist", backQuoteIfNeed(alter.getDatabase()));

--- a/src/Interpreters/InterpreterAlterQuery.h
+++ b/src/Interpreters/InterpreterAlterQuery.h
@@ -39,6 +39,13 @@ public:
 
     bool supportsTransactions() const override { return true; }
 
+    /// Skip this query's own access check. Set only for the internal `ATTACH PARTITION` that fills the
+    /// temporary table of a `CREATE OR REPLACE TABLE ... CLONE AS` (see `fillTableIfNeeded`): the query
+    /// addresses a random `_tmp_replace_*` name that no grant can cover, and the caller has already
+    /// authorized the very same access -- `getRequiredAccessForCommand` -- against the user-visible name
+    /// the table is published under. Never set this for a user-visible target table.
+    void setSkipAccessCheck(bool skip) { skip_access_check = skip; }
+
 private:
     AccessRightsElements getRequiredAccess(const StoragePtr & storage) const;
 
@@ -47,6 +54,7 @@ private:
     BlockIO executeToDatabase(const ASTAlterQuery & alter);
 
     ASTPtr query_ptr;
+    bool skip_access_check = false;
 };
 
 }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2650,8 +2650,8 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
     /// with a full-access context derived from the global context -- mirroring how inner tables of a
     /// materialized view are dropped (see `InterpreterDropQuery::executeDropQuery`). Settings and any
     /// Replicated-database ZooKeeper transaction are propagated so the operations behave and replicate
-    /// correctly. This is used only for the plain-create case; REPLACE keeps running as the user (its
-    /// required access already includes DROP).
+    /// correctly. This is used only for the plain-create case; REPLACE keeps running as the user, whose
+    /// query context its publishing rename has to reach (see the rename below).
     ///
     /// `bypass_size_guard` additionally zeroes `max_table_size_to_drop` / `max_partition_size_to_drop`. The
     /// size guard is meaningful only for user-visible tables; a populated-then-abandoned temporary table can
@@ -2797,6 +2797,12 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
         ast_drop->is_dictionary = create.is_dictionary;
         ast_drop->setDatabase(create.getDatabase());
         ast_drop->kind = ASTDropQuery::Drop;
+        /// Every DROP issued through this AST addresses the internal temporary name, which no grant can
+        /// cover: on the failure path it is the temporary table this call created, and after a successful
+        /// EXCHANGE it is the replaced table, whose drop `pre_swap_check` below already authorized against
+        /// its own user-visible name and kind. Authorizing the random name could only produce a spurious
+        /// `ACCESS_DENIED`, so skip the check.
+        ast_drop->no_access_check = true;
     }
 
     /// The populating INSERT SELECT runs against the internal temporary table, so its (random) name is
@@ -2828,16 +2834,17 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
         /// If table has dependencies - add them to the graph
         addTableDependencies(create, query_ptr, getContext());
 
-        /// For a plain `CREATE TABLE ... AS SELECT` the populate below runs against the internal temporary
-        /// table, so `InterpreterInsertQuery` would authorize `INSERT` on the random `_tmp_replace_*` name
-        /// rather than the final name. That would regress table-scoped grants: before this PR the plain-create
-        /// path checked `INSERT` on the final name directly, so `CREATE TABLE` + `INSERT ON db.dst` (not a
-        /// wildcard grant) was sufficient. To preserve that contract, authorize `INSERT` on the final name up
-        /// front -- as the user, over the columns that will be inserted -- and then skip the redundant
-        /// target-`INSERT` check on the temporary name inside the populate. The source `SELECT` access is
-        /// still checked by the populate as the user. REPLACE keeps its prior behavior: it never required
-        /// `INSERT` on the final name (only DROP/CREATE), so it does not get the up-front check or the skip.
-        if (is_plain_create && create.isCreateQueryWithImmediateInsertSelect())
+        /// The populate below runs against the internal temporary table, so `InterpreterInsertQuery` would
+        /// authorize `INSERT` on the random `_tmp_replace_*` name rather than the final name -- a privilege
+        /// no grant can express (issue #90919) and one the user does not need. Authorize `INSERT` on the
+        /// final name up front instead -- as the user, over the columns that will be inserted -- and then
+        /// skip the redundant target-`INSERT` check on the temporary name inside the populate. The source
+        /// `SELECT` access is still checked by the populate as the user. This is the same contract as
+        /// populating the final table directly: both a plain `CREATE TABLE ... AS SELECT` (which on a
+        /// non-Atomic database still inserts into the final name) and a plain
+        /// `CREATE MATERIALIZED VIEW ... POPULATE` require `INSERT` on the final name, so a table-scoped
+        /// `CREATE TABLE` + `INSERT ON db.dst` grant is sufficient here too.
+        if (create.isCreateQueryWithImmediateInsertSelect())
         {
             auto temp_table = DatabaseCatalog::instance().getTable(
                 StorageID{create.getDatabase(), create.getTable(), create.uuid}, current_context);
@@ -2850,7 +2857,7 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
         /// Try fill temporary table. Note: POPULATE here uses the legacy, non-atomic population - the
         /// atomic path is only wired into the plain CREATE flow, not the create-or-replace flow (which
         /// populates a temporary table and then atomically swaps it in via EXCHANGE/RENAME).
-        BlockIO fill_io = fillTableIfNeeded(create, /*skip_target_insert_access_check=*/is_plain_create);
+        BlockIO fill_io = fillTableIfNeeded(create, /*published_table_name=*/table_to_replace_name);
         /// For queries like 'CREATE OR REPLACE TABLE ... AS SELECT * INSERT' might take a long time,
         /// passing this callback allows tcp sessions to send progress, stats and logs.
         /// It prevents getting socket timeout as well.
@@ -2902,9 +2909,20 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
         /// If it throws, no rename happens and the catch block below drops the temp. For a plain create the
         /// rename publishes an internal temporary table under the final name, so it runs with a full-access
         /// context (the user is not required to hold RENAME/DROP on the temporary table); REPLACE keeps
-        /// running as the user.
+        /// running as the user, because the rename has to invalidate this query's storage cache for the
+        /// swapped names, and that cache lives on the user's query context (see the `dropStorageCacheEntry`
+        /// calls in `InterpreterRenameQuery::executeToTables` and issue #108726).
+        ///
+        /// The access check of the rename itself is skipped either way: it authorizes `SELECT` and
+        /// `DROP TABLE` on the name it renames from -- the random `_tmp_replace_*` name here, which no grant
+        /// can cover (issue #90919) -- and `CREATE TABLE` and `INSERT` on the name it renames to, which for a
+        /// replaced view or dictionary are not even the grants of its kind. The privileges that matter are
+        /// checked against user-visible names instead: `CREATE`/`DROP` on the final name up front (see
+        /// `getRequiredAccess`) and `DROP` of the replaced table's own kind in `pre_swap_check` below, which
+        /// still runs as the user.
         ContextPtr rename_context = is_plain_create ? ContextPtr{make_internal_context(/*bypass_size_guard=*/false)} : current_context;
         InterpreterRenameQuery interpreter_rename{ast_rename, rename_context};
+        interpreter_rename.setSkipAccessCheck(true);
         interpreter_rename.setPreSwapCheck(
             [&current_context](const StorageID & to_drop_id)
             {
@@ -2947,9 +2965,6 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
             /// kind than the new one (e.g. a dictionary replaced by a view), so the drop must match its kind.
             if (auto replaced = DatabaseCatalog::instance().tryGetTable(StorageID{create.getDatabase(), create.getTable()}, current_context))
                 ast_drop->is_dictionary = replaced->isDictionary();
-            /// `pre_swap_check` already authorized this drop against the replaced table's real name.
-            /// The temporary name cannot be covered by grants, so skip the access check on it.
-            ast_drop->no_access_check = true;
             /// `pre_swap_check` also gated the size; bypass to avoid double-consuming
             /// the `force_drop_table` flag inside `Context::checkCanBeDropped`.
             auto drop_context = make_drop_context(/*bypass_size_guard=*/true);
@@ -2972,11 +2987,11 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
     catch (...)
     {
         /// Drop the temp table we just created if it was not renamed to the target name.
-        /// Bypassing the size guard is safe here: the temp name is unique to this call. For a plain create
-        /// use a full-access context (also size-guard-bypassed): the user is not required to hold DROP on the
-        /// internal temporary table (its cleanup must not turn a denied source SELECT into an ACCESS_DENIED on
-        /// the temporary table), and the cleanup must succeed even after the temporary table has grown past
-        /// `max_table_size_to_drop`, or a late failure would strand it.
+        /// Bypassing the size guard is safe here: the temp name is unique to this call, and the cleanup must
+        /// succeed even after the temporary table has grown past `max_table_size_to_drop`, or a late failure
+        /// would strand it. The user is not required to hold DROP on the internal temporary table either --
+        /// its cleanup must not turn a denied source SELECT into an ACCESS_DENIED on the temporary name --
+        /// which is what `ast_drop->no_access_check` above is for.
         if (created && !renamed)
         {
             auto drop_context = is_plain_create ? make_internal_context(/*bypass_size_guard=*/true) : make_drop_context(/*bypass_size_guard=*/true);
@@ -3029,8 +3044,14 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTemporaryTable(ASTCreateQuery &
     return fillTableIfNeeded(create);
 }
 
-BlockIO InterpreterCreateQuery::fillTableIfNeeded(const ASTCreateQuery & create, bool skip_target_insert_access_check)
+BlockIO InterpreterCreateQuery::fillTableIfNeeded(const ASTCreateQuery & create, const String & published_table_name)
 {
+    /// A non-empty `published_table_name` means `create.getTable()` is the internal temporary name of
+    /// `doCreateOrReplaceTable` and the table will be published under `published_table_name`. The fills
+    /// below then write into a name no grant can cover (issue #90919), so their target-side access is
+    /// authorized against the user-visible name the table will be published under instead.
+    const bool target_is_temporary = !published_table_name.empty();
+
     /// If the query is a CREATE SELECT, insert the data into the table.
     if (create.isCreateQueryWithImmediateInsertSelect())
     {
@@ -3045,7 +3066,8 @@ BlockIO InterpreterCreateQuery::fillTableIfNeeded(const ASTCreateQuery & create,
             /* no_squash */ false,
             /* no_destination */ false,
             /* async_isnert */ false);
-        interpreter.setSkipTargetInsertAccessCheck(skip_target_insert_access_check);
+        /// The caller authorized `INSERT` on `published_table_name` before the populate.
+        interpreter.setSkipTargetInsertAccessCheck(target_is_temporary);
         return interpreter.execute();
     }
 
@@ -3084,7 +3106,20 @@ BlockIO InterpreterCreateQuery::fillTableIfNeeded(const ASTCreateQuery & create,
         /// that executeTrivialBlockIO cannot handle.
         auto alter_context = Context::createCopy(getContext());
         alter_context->setSetting("alter_partition_verbose_result", Field(false));
-        return InterpreterAlterQuery(query, alter_context).execute();
+        InterpreterAlterQuery interpreter_alter{query, alter_context};
+        if (target_is_temporary)
+        {
+            /// The attach addresses the internal temporary table, so `InterpreterAlterQuery` would authorize
+            /// `ALTER DELETE` and `INSERT` on its random `_tmp_replace_*` name -- a privilege no grant can
+            /// express (issue #90919) and one the user does not need. Authorize the very same access against
+            /// the name the table will be published under instead, as the user, and skip the interpreter's
+            /// own check on the temporary name. A `CREATE TABLE ... CLONE AS` that populates the final table
+            /// directly requires exactly these grants, so the contract is the same either way.
+            getContext()->checkAccess(InterpreterAlterQuery::getRequiredAccessForCommand(
+                *command, create.getDatabase(), published_table_name, /*row_exists_is_lightweight_marker=*/false));
+            interpreter_alter.setSkipAccessCheck(true);
+        }
+        return interpreter_alter.execute();
     }
 
     return {};

--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -119,8 +119,11 @@ private:
     /// Converts the "*MergeTree" table engine to "Replicated*MergeTree" or "Shared*MergeTree" if the corresponding settings are enabled.
     void convertTableEngineForCloud(ASTStorage & table_engine, TableProperties & properties) const;
 #endif
-    /// Inserts data in created table if it's CREATE ... SELECT
-    BlockIO fillTableIfNeeded(const ASTCreateQuery & create, bool skip_target_insert_access_check = false);
+    /// Inserts data in created table if it's CREATE ... SELECT (or attaches the source partitions if it's
+    /// CREATE ... CLONE AS). `published_table_name`, when not empty, is the user-visible name the table
+    /// being filled will be published under: the table itself carries the internal `_tmp_replace_*` name of
+    /// `doCreateOrReplaceTable`, so the fill is authorized against `published_table_name` instead.
+    BlockIO fillTableIfNeeded(const ASTCreateQuery & create, const String & published_table_name = {});
 
     /// Whether this CREATE MATERIALIZED VIEW ... POPULATE should be populated atomically: the feature
     /// setting is enabled and the query is an immediate INSERT SELECT into a non-window, non-clone view.

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -45,7 +45,8 @@ BlockIO InterpreterRenameQuery::execute()
         return executeDDLQueryOnCluster(query_ptr, getContext(), params);
     }
 
-    getContext()->checkAccess(getRequiredAccess(rename.database ? RenameType::RenameDatabase : RenameType::RenameTable));
+    if (!skip_access_check)
+        getContext()->checkAccess(getRequiredAccess(rename.database ? RenameType::RenameDatabase : RenameType::RenameTable));
 
     String current_database = getContext()->getCurrentDatabase();
 

--- a/src/Interpreters/InterpreterRenameQuery.h
+++ b/src/Interpreters/InterpreterRenameQuery.h
@@ -71,6 +71,14 @@ public:
 
     void setPreSwapCheck(PreSwapCheck check) { pre_swap_check = std::move(check); }
 
+    /// Skip this query's own access check. Set only for the internal publishing rename of
+    /// `doCreateOrReplaceTable`: it renames from a random `_tmp_replace_*` name that no grant can
+    /// cover, and `getRequiredAccess` would also ask for `CREATE TABLE`/`INSERT` on the final name,
+    /// which are not the grants of a view's or a dictionary's kind. The caller authorizes the
+    /// privileges that matter against the user-visible names instead (see `getRequiredAccess` of
+    /// `InterpreterCreateQuery` and the pre-swap check above). Never set this for a user rename.
+    void setSkipAccessCheck(bool skip) { skip_access_check = skip; }
+
     void extendQueryLogElemImpl(QueryLogElement & elem, const ASTPtr & ast, ContextPtr) const override;
 
     bool renamedInsteadOfExchange() const { return renamed_instead_of_exchange; }
@@ -89,6 +97,7 @@ private:
 
     ASTPtr query_ptr;
     bool renamed_instead_of_exchange{false};
+    bool skip_access_check{false};
     PreSwapCheck pre_swap_check;
 };
 

--- a/tests/queries/0_stateless/05060_create_or_replace_scoped_grants.reference
+++ b/tests/queries/0_stateless/05060_create_or_replace_scoped_grants.reference
@@ -1,0 +1,26 @@
+-- [CREATE TABLE, DROP TABLE ON db.t] replacing an existing table must succeed:
+succeeded
+2
+-- [CREATE TABLE, DROP TABLE ON db.t_new] creating a table that does not exist yet must succeed:
+succeeded
+1
+-- [CREATE TABLE, DROP TABLE ON db.t_replace] bare REPLACE TABLE must succeed:
+succeeded
+2
+-- [CREATE VIEW, DROP VIEW ON db.v] replacing a view must need no table grants:
+succeeded
+2
+-- [CREATE TABLE, DROP TABLE, INSERT ON db.t_populated] replacing with a populating SELECT must succeed:
+succeeded
+3
+-- [no DROP TABLE grant] replacing an existing table must be denied:
+ACCESS_DENIED
+-- [no DROP VIEW grant] replacing an existing view must be denied:
+ACCESS_DENIED
+-- [no INSERT grant] a populating replace must be denied:
+ACCESS_DENIED
+-- the denied queries left the replaced objects untouched and no temporary table behind:
+1
+1
+0
+0

--- a/tests/queries/0_stateless/05060_create_or_replace_scoped_grants.sh
+++ b/tests/queries/0_stateless/05060_create_or_replace_scoped_grants.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# `CREATE OR REPLACE` builds the new table under an internal `_tmp_replace_*` name and publishes it with a
+# RENAME/EXCHANGE. That name is random, so no grant can ever cover it: everything the user is authorized for
+# must be authorized against the user-visible names. Table-scoped grants on the final name (plus `SELECT` on
+# the sources) must therefore be sufficient, and the grants required must be those of the object's own kind:
+# replacing a view must not demand `CREATE TABLE` / `INSERT` on the view.
+# https://github.com/ClickHouse/ClickHouse/issues/90919
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+granted="granted_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+nogrant="nogrant_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} --query "
+DROP USER IF EXISTS ${granted}, ${nogrant};
+CREATE USER ${granted} IDENTIFIED WITH plaintext_password BY '${granted}';
+CREATE USER ${nogrant} IDENTIFIED WITH plaintext_password BY '${nogrant}';
+GRANT TABLE ENGINE ON MergeTree TO ${granted}, ${nogrant};
+
+CREATE TABLE src (a Int32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO src VALUES (1), (2), (3);
+CREATE TABLE t (a Int32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t_replace (a Int32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t_populated (a Int32) ENGINE = MergeTree ORDER BY a;
+CREATE VIEW v AS SELECT 1 AS x;
+CREATE TABLE t_denied (a Int32) ENGINE = MergeTree ORDER BY a;
+CREATE VIEW v_denied AS SELECT 1 AS x;
+
+-- Table-scoped grants only: none of them can cover the internal \`_tmp_replace_*\` name.
+GRANT SELECT ON ${db}.src TO ${granted};
+GRANT CREATE TABLE, DROP TABLE ON ${db}.t TO ${granted};
+GRANT CREATE TABLE, DROP TABLE ON ${db}.t_replace TO ${granted};
+GRANT CREATE TABLE, DROP TABLE ON ${db}.t_new TO ${granted};
+GRANT CREATE TABLE, DROP TABLE, INSERT ON ${db}.t_populated TO ${granted};
+GRANT CREATE VIEW, DROP VIEW ON ${db}.v TO ${granted};
+
+-- The same, minus the privilege each denied query below is supposed to be stopped by.
+GRANT SELECT ON ${db}.src TO ${nogrant};
+GRANT CREATE TABLE ON ${db}.t_denied TO ${nogrant};
+GRANT CREATE TABLE, DROP TABLE ON ${db}.t_no_insert TO ${nogrant};
+GRANT CREATE VIEW ON ${db}.v_denied TO ${nogrant};
+"
+
+granted_client=(${CLICKHOUSE_CLIENT} --user "${granted}" --password "${granted}")
+nogrant_client=(${CLICKHOUSE_CLIENT} --user "${nogrant}" --password "${nogrant}")
+
+run_granted() {
+    local output
+    if output=$("${granted_client[@]}" --query "$1" 2>&1); then echo "succeeded"; else echo "FAILED: ${output}"; fi
+}
+
+echo "-- [CREATE TABLE, DROP TABLE ON db.t] replacing an existing table must succeed:"
+run_granted "CREATE OR REPLACE TABLE ${db}.t (a Int32, b String) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.columns WHERE database = '${db}' AND table = 't'"
+
+echo "-- [CREATE TABLE, DROP TABLE ON db.t_new] creating a table that does not exist yet must succeed:"
+run_granted "CREATE OR REPLACE TABLE ${db}.t_new (a Int32) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} --query "EXISTS TABLE ${db}.t_new"
+
+echo "-- [CREATE TABLE, DROP TABLE ON db.t_replace] bare REPLACE TABLE must succeed:"
+run_granted "REPLACE TABLE ${db}.t_replace (a Int32, b String) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.columns WHERE database = '${db}' AND table = 't_replace'"
+
+echo "-- [CREATE VIEW, DROP VIEW ON db.v] replacing a view must need no table grants:"
+run_granted "CREATE OR REPLACE VIEW ${db}.v AS SELECT 2 AS x"
+${CLICKHOUSE_CLIENT} --query "SELECT x FROM ${db}.v"
+
+echo "-- [CREATE TABLE, DROP TABLE, INSERT ON db.t_populated] replacing with a populating SELECT must succeed:"
+run_granted "CREATE OR REPLACE TABLE ${db}.t_populated ENGINE = MergeTree ORDER BY a AS SELECT a FROM ${db}.src"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${db}.t_populated"
+
+echo "-- [no DROP TABLE grant] replacing an existing table must be denied:"
+"${nogrant_client[@]}" --query "CREATE OR REPLACE TABLE ${db}.t_denied (a Int32, b String) ENGINE = MergeTree ORDER BY a" 2>&1 | grep -Fo ACCESS_DENIED | uniq
+echo "-- [no DROP VIEW grant] replacing an existing view must be denied:"
+"${nogrant_client[@]}" --query "CREATE OR REPLACE VIEW ${db}.v_denied AS SELECT 2 AS x" 2>&1 | grep -Fo ACCESS_DENIED | uniq
+echo "-- [no INSERT grant] a populating replace must be denied:"
+"${nogrant_client[@]}" --query "CREATE OR REPLACE TABLE ${db}.t_no_insert ENGINE = MergeTree ORDER BY a AS SELECT a FROM ${db}.src" 2>&1 | grep -Fo ACCESS_DENIED | uniq
+
+echo "-- the denied queries left the replaced objects untouched and no temporary table behind:"
+${CLICKHOUSE_CLIENT} --query "
+SELECT count() FROM system.columns WHERE database = '${db}' AND table = 't_denied';
+SELECT x FROM ${db}.v_denied;
+EXISTS TABLE ${db}.t_no_insert;
+SELECT count() FROM system.tables WHERE database = '${db}' AND startsWith(name, '_tmp_replace_');
+"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER ${granted}, ${nogrant}"

--- a/tests/queries/0_stateless/05061_create_or_replace_clone_as_scoped_grants.reference
+++ b/tests/queries/0_stateless/05061_create_or_replace_clone_as_scoped_grants.reference
@@ -1,0 +1,10 @@
+-- [SELECT on the source, ALTER DELETE and INSERT on the target] the clone must succeed:
+succeeded
+1
+2
+3
+-- [no ALTER DELETE or INSERT on the target] the clone must be denied:
+ACCESS_DENIED
+-- the denied clone left the table empty and no temporary table behind:
+0
+0

--- a/tests/queries/0_stateless/05061_create_or_replace_clone_as_scoped_grants.sh
+++ b/tests/queries/0_stateless/05061_create_or_replace_clone_as_scoped_grants.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# `CREATE OR REPLACE TABLE ... CLONE AS` attaches the source partitions to an internal `_tmp_replace_*`
+# table before publishing it under the final name. The random temporary name cannot be covered by any grant,
+# so the attach must be authorized against the name the table is published under: `ALTER DELETE` and `INSERT`
+# on the final name plus `SELECT` on the source -- exactly what a plain `CREATE TABLE ... CLONE AS` requires.
+# https://github.com/ClickHouse/ClickHouse/issues/90919
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+granted="granted_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+nogrant="nogrant_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} --query "
+DROP USER IF EXISTS ${granted}, ${nogrant};
+CREATE USER ${granted} IDENTIFIED WITH plaintext_password BY '${granted}';
+CREATE USER ${nogrant} IDENTIFIED WITH plaintext_password BY '${nogrant}';
+GRANT TABLE ENGINE ON MergeTree TO ${granted}, ${nogrant};
+
+CREATE TABLE src (a Int32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO src VALUES (1), (2), (3);
+CREATE TABLE cloned (a Int32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE cloned_denied (a Int32) ENGINE = MergeTree ORDER BY a;
+
+-- Table-scoped grants only: none of them can cover the internal \`_tmp_replace_*\` name.
+GRANT SELECT ON ${db}.src TO ${granted}, ${nogrant};
+GRANT CREATE TABLE, DROP TABLE, INSERT, ALTER DELETE ON ${db}.cloned TO ${granted};
+-- Everything except the target-side grants the attach needs.
+GRANT CREATE TABLE, DROP TABLE ON ${db}.cloned_denied TO ${nogrant};
+"
+
+echo "-- [SELECT on the source, ALTER DELETE and INSERT on the target] the clone must succeed:"
+if output=$(${CLICKHOUSE_CLIENT} --user "${granted}" --password "${granted}" \
+    --query "CREATE OR REPLACE TABLE ${db}.cloned CLONE AS ${db}.src ENGINE = MergeTree ORDER BY a" 2>&1)
+then echo "succeeded"; else echo "FAILED: ${output}"; fi
+${CLICKHOUSE_CLIENT} --query "SELECT a FROM ${db}.cloned ORDER BY a"
+
+echo "-- [no ALTER DELETE or INSERT on the target] the clone must be denied:"
+${CLICKHOUSE_CLIENT} --user "${nogrant}" --password "${nogrant}" \
+    --query "CREATE OR REPLACE TABLE ${db}.cloned_denied CLONE AS ${db}.src ENGINE = MergeTree ORDER BY a" 2>&1 | grep -Fo ACCESS_DENIED | uniq
+
+echo "-- the denied clone left the table empty and no temporary table behind:"
+${CLICKHOUSE_CLIENT} --query "
+SELECT count() FROM ${db}.cloned_denied;
+SELECT count() FROM system.tables WHERE database = '${db}' AND startsWith(name, '_tmp_replace_');
+"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER ${granted}, ${nogrant}"


### PR DESCRIPTION
`CREATE OR REPLACE TABLE` / `VIEW` / `DICTIONARY` and `REPLACE TABLE` build the new object under an internal
name (`_tmp_replace_<hash>_<random>`) and publish it with a `RENAME`/`EXCHANGE`. Several steps of that
machinery were authorized against the internal name: the publishing rename asked for `SELECT` and
`DROP TABLE` on it, the populating `INSERT SELECT` asked for `INSERT` on it, the `CLONE AS` attach asked for
`ALTER DELETE` and `INSERT` on it, and the cleanup `DROP` of a failed replace asked for `DROP TABLE` on it.
The name is random, so no grant can ever cover it, and the statement failed for anyone without wildcard
grants over the whole database:

```
Code: 497. DB::Exception: foo: Not enough privileges. To execute this query, it's necessary to have
the grant SELECT, DROP TABLE ON default._tmp_replace_61cef65d835f4faf_iftufikx6620edcb. (ACCESS_DENIED)
```

The same rename also asked for `CREATE TABLE` and `INSERT` on the final name, which are not the grants of the
object's kind, so replacing a view demanded `INSERT, CREATE TABLE ON default.the_view`. And because the
cleanup `DROP` was denied too, a failed replace left its temporary table behind (`Cannot DROP temporary
table: ... it's necessary to have the grant DROP TABLE ON default._tmp_replace_*`).

Now every privilege is checked against a user-visible name, and the internal steps on the temporary name are
not authorized against it:

- the publishing rename and the drops of the temporary name skip their own access check;
- `CREATE`/`DROP` of the object's own kind on the final name is checked up front, as before, and `DROP` of the
  replaced object's kind is checked on its real name right before the swap, as before;
- `INSERT` on the final name is checked, as the user, before a populating `AS SELECT`, and `SELECT` on the
  sources is still checked by the populate itself;
- `CLONE AS` checks `SELECT` on the source and `ALTER DELETE`/`INSERT` on the final name, as the user.

So `CREATE OR REPLACE` now needs exactly the grants of the plain statement it is equivalent to, plus the
`DROP` of what it replaces, and table-scoped grants are enough.

One case becomes stricter rather than looser: a populating `CREATE OR REPLACE TABLE ... AS SELECT` now
requires `INSERT` on the final name. Previously it required `INSERT` on the temporary name, so users who
worked around this bug by granting on the `_tmp_replace*` prefix (instead of on the table) need the grant on
the table. Without that check `CREATE TABLE` + `DROP TABLE` alone would let a user write arbitrary data into
a table they cannot `INSERT` into.

The publishing rename of a REPLACE keeps running as the user rather than under an internal context: it has to
invalidate the storage cache of the user's query context for the names it swapped, which is what keeps the
replaced materialized view subscribed to its source (issue #108726, covered by
`04492_create_or_replace_materialized_view_populate_keeps_subscription`).

Tests `05060_create_or_replace_scoped_grants` and `05061_create_or_replace_clone_as_scoped_grants` cover the
table, view, `AS SELECT` and `CLONE AS` forms with table-scoped grants, and check that a user missing `DROP`,
`INSERT` or the source `SELECT` is still denied and leaves no temporary table behind.

Closes: https://github.com/ClickHouse/ClickHouse/issues/90919

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `CREATE OR REPLACE TABLE`/`VIEW`/`DICTIONARY` and `REPLACE TABLE` requiring privileges on the internal
temporary table they create (`_tmp_replace_*`). Its name is random, so no grant could cover it and the query
failed with `ACCESS_DENIED` unless the user held wildcard grants on the whole database. The required
privileges are now checked against the user-visible names only: replacing an object needs the `CREATE` and
`DROP` grants of its own kind, plus `INSERT` on it when the statement populates it.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117967&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117967](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117967+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.808` (included in `26.9` and later)
<!-- ch-version-info:end -->