### PR TITLE
Fix wrong results from cross-type equi-key filter push-down, and enable it for a plain INNER JOIN

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -3596,11 +3596,9 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     auto right_stream_push_down_conjunctions = getConjunctionNodes(predicate, right_stream_allowed_nodes, false);
     auto both_streams_push_down_conjunctions = getConjunctionNodes(predicate, both_streams_allowed_nodes, false);
 
-    /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so
-    /// it must read no more than that column's value: `isConstant` and `toColumnTypeName` answer differently
-    /// for the same value depending on constness, and a replacement can be constant where the input is not.
-    /// A lambda body describes every argument of its call: the ones it does not capture arrive as its
-    /// formal parameters.
+    /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so it
+    /// must read no more than that column's value: a replacement can be constant where the input is not.
+    /// A lambda body reads the call's arguments too: the ones it does not capture arrive as formal parameters.
     static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
     auto call_reads_representation = [](const Node * node)
     {

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -3540,6 +3540,43 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     auto right_stream_push_down_conjunctions = getConjunctionNodes(predicate, right_stream_allowed_nodes, false);
     auto both_streams_push_down_conjunctions = getConjunctionNodes(predicate, both_streams_allowed_nodes, false);
 
+    /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so
+    /// it must read no more than that column's value: `isConstant` and `toColumnTypeName` answer differently
+    /// for the same value depending on constness, and a replacement can be constant where the input is not.
+    auto reads_replaced_input_representation = [&](const Node * conjunct)
+    {
+        std::vector<std::pair<const Node *, bool>> to_visit{{conjunct, false}};
+        std::unordered_set<const Node *> visited_reading_value;
+        std::unordered_set<const Node *> visited_reading_representation;
+        while (!to_visit.empty())
+        {
+            auto [node, reads_representation] = to_visit.back();
+            to_visit.pop_back();
+
+            reads_representation |= !node->isDeterministic();
+            auto & visited = reads_representation ? visited_reading_representation : visited_reading_value;
+            if (!visited.insert(node).second)
+                continue;
+
+            if (reads_representation && node->type == ActionType::INPUT && both_streams_allowed_nodes.contains(node))
+                return true;
+
+            for (const auto * child : node->children)
+                to_visit.emplace_back(child, reads_representation);
+        }
+        return false;
+    };
+
+    NodeRawConstPtrs both_streams_value_only_conjunctions;
+    for (const auto * conjunct : both_streams_push_down_conjunctions.allowed)
+    {
+        if (reads_replaced_input_representation(conjunct))
+            both_streams_push_down_conjunctions.rejected.push_back(conjunct);
+        else
+            both_streams_value_only_conjunctions.push_back(conjunct);
+    }
+    both_streams_push_down_conjunctions.allowed = std::move(both_streams_value_only_conjunctions);
+
     /// getConjunctionNodes() classifies a conjunct as pushable to a side when all of its inputs are
     /// allowed inputs of that side. A conjunct with no inputs (a pure constant such as a literal `1`
     /// or a folded `NULL`) satisfies this trivially, so it is classified as pushable to EVERY side,

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -3599,18 +3599,6 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so
     /// it must read no more than that column's value: `isConstant` and `toColumnTypeName` answer differently
     /// for the same value depending on constness, and a replacement can be constant where the input is not.
-    static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
-    /// A higher-order function hands its remaining arguments to the lambda as its formal parameters, so a
-    /// body reading a representation describes every argument of the call, not only the captures below it.
-    auto call_reads_representation = [](const Node * node)
-    {
-        if (hasUnsafeHiddenLambdaBody(*node, is_representation_read))
-            return true;
-        for (const auto * argument : node->children)
-            if (hasUnsafeHiddenLambdaBody(*argument, is_representation_read))
-                return true;
-        return false;
-    };
     auto reads_replaced_input_representation = [&](const Node * conjunct)
     {
         std::vector<std::pair<const Node *, bool>> to_visit{{conjunct, false}};
@@ -3621,7 +3609,7 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
             auto [node, reads_representation] = to_visit.back();
             to_visit.pop_back();
 
-            reads_representation |= !node->isDeterministic() || call_reads_representation(node);
+            reads_representation |= !node->isDeterministic();
             auto & visited = reads_representation ? visited_reading_representation : visited_reading_value;
             if (!visited.insert(node).second)
                 continue;
@@ -3635,10 +3623,32 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
         return false;
     };
 
+    /// `getConjunctionNodes` already refuses a conjunct that is not stable within the query, but it reads
+    /// only the visible functions. A both-streams conjunct is evaluated once per side and dropped from the
+    /// post-join filter, so a body hidden from that check would be drawn twice and the two draws compared.
+    static constexpr auto is_unstable_within_query
+        = [](const IFunctionBase & function) { return !function.isDeterministicInScopeOfQuery(); };
+    auto hides_unstable_lambda_body = [](const Node * conjunct)
+    {
+        std::vector<const Node *> to_visit{conjunct};
+        std::unordered_set<const Node *> visited;
+        while (!to_visit.empty())
+        {
+            const auto * node = to_visit.back();
+            to_visit.pop_back();
+            if (!visited.insert(node).second)
+                continue;
+            if (hasUnsafeHiddenLambdaBody(*node, is_unstable_within_query))
+                return true;
+            to_visit.insert(to_visit.end(), node->children.begin(), node->children.end());
+        }
+        return false;
+    };
+
     NodeRawConstPtrs both_streams_value_only_conjunctions;
     for (const auto * conjunct : both_streams_push_down_conjunctions.allowed)
     {
-        if (reads_replaced_input_representation(conjunct))
+        if (reads_replaced_input_representation(conjunct) || hides_unstable_lambda_body(conjunct))
             both_streams_push_down_conjunctions.rejected.push_back(conjunct);
         else
             both_streams_value_only_conjunctions.push_back(conjunct);

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -3599,6 +3599,19 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so
     /// it must read no more than that column's value: `isConstant` and `toColumnTypeName` answer differently
     /// for the same value depending on constness, and a replacement can be constant where the input is not.
+    /// A lambda keeps its body out of the walk below, and a higher-order function hands its remaining
+    /// arguments to that body as its formal parameters, so a body reading a representation describes every
+    /// argument of the call and not only the captures below the node holding it.
+    static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
+    auto call_reads_representation = [](const Node * node)
+    {
+        if (hasUnsafeHiddenLambdaBody(*node, is_representation_read))
+            return true;
+        for (const auto * argument : node->children)
+            if (hasUnsafeHiddenLambdaBody(*argument, is_representation_read))
+                return true;
+        return false;
+    };
     auto reads_replaced_input_representation = [&](const Node * conjunct)
     {
         std::vector<std::pair<const Node *, bool>> to_visit{{conjunct, false}};
@@ -3609,7 +3622,7 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
             auto [node, reads_representation] = to_visit.back();
             to_visit.pop_back();
 
-            reads_representation |= !node->isDeterministic();
+            reads_representation |= !node->isDeterministic() || call_reads_representation(node);
             auto & visited = reads_representation ? visited_reading_representation : visited_reading_value;
             if (!visited.insert(node).second)
                 continue;
@@ -3626,8 +3639,8 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     /// `getConjunctionNodes` already refuses a conjunct that is not stable within the query, but it reads
     /// only the visible functions. A both-streams conjunct is evaluated once per side and dropped from the
     /// post-join filter, so a body hidden from that check would be drawn twice and the two draws compared.
-    static constexpr auto is_unstable_within_query
-        = [](const IFunctionBase & function) { return !function.isDeterministicInScopeOfQuery(); };
+    static constexpr auto is_unstable_within_query = [](const IFunctionBase & function)
+    { return function.isStateful() || !function.isDeterministicInScopeOfQuery(); };
     auto hides_unstable_lambda_body = [](const Node * conjunct)
     {
         std::vector<const Node *> to_visit{conjunct};

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -2205,6 +2205,58 @@ bool ActionsDAG::hasNonDeterministic() const
     return false;
 }
 
+namespace
+{
+
+bool dagHasUnsafeFunction(const ActionsDAG & dag, bool (*is_unsafe)(const IFunctionBase &))
+{
+    for (const auto & node : dag.getNodes())
+    {
+        if (node.type == ActionsDAG::ActionType::FUNCTION && is_unsafe(*node.function_base))
+            return true;
+        if (ActionsDAG::hasUnsafeHiddenLambdaBody(node, is_unsafe))
+            return true;
+    }
+
+    return false;
+}
+
+/// A lambda that captures only constants is itself folded to a constant, which holds the lambda object
+/// rather than a computed value: the body still runs, and its captures can hold further lambdas.
+bool foldedLambdaHasUnsafeFunction(const IColumn & column, bool (*is_unsafe)(const IFunctionBase &))
+{
+    const auto * column_function = typeid_cast<const ColumnFunction *>(&column);
+    if (!column_function)
+        return false;
+
+    const auto * expression = typeid_cast<const FunctionExpression *>(column_function->getFunction().get());
+    if (expression && dagHasUnsafeFunction(expression->getAcionsDAG(), is_unsafe))
+        return true;
+
+    for (const auto & captured : column_function->getCapturedColumns())
+        if (const auto * captured_constant = typeid_cast<const ColumnConst *>(captured.column.get()))
+            if (foldedLambdaHasUnsafeFunction(captured_constant->getDataColumn(), is_unsafe))
+                return true;
+
+    return false;
+}
+
+}
+
+bool ActionsDAG::hasUnsafeHiddenLambdaBody(const Node & node, bool (*is_unsafe)(const IFunctionBase &))
+{
+    if (node.type == ActionType::FUNCTION)
+    {
+        const auto * function_capture = typeid_cast<const FunctionCapture *>(node.function_base.get());
+        return function_capture && dagHasUnsafeFunction(function_capture->getAcionsDAG(), is_unsafe);
+    }
+
+    if (node.type == ActionType::COLUMN && node.column)
+        return foldedLambdaHasUnsafeFunction(node.column->getDataColumn(), is_unsafe);
+
+    return false;
+}
+
 bool ActionsDAG::hasInputNameShadowedByComputedNode() const
 {
     std::unordered_set<std::string_view> input_names;
@@ -3543,6 +3595,7 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so
     /// it must read no more than that column's value: `isConstant` and `toColumnTypeName` answer differently
     /// for the same value depending on constness, and a replacement can be constant where the input is not.
+    static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
     auto reads_replaced_input_representation = [&](const Node * conjunct)
     {
         std::vector<std::pair<const Node *, bool>> to_visit{{conjunct, false}};
@@ -3553,7 +3606,7 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
             auto [node, reads_representation] = to_visit.back();
             to_visit.pop_back();
 
-            reads_representation |= !node->isDeterministic();
+            reads_representation |= !node->isDeterministic() || hasUnsafeHiddenLambdaBody(*node, is_representation_read);
             auto & visited = reads_representation ? visited_reading_representation : visited_reading_value;
             if (!visited.insert(node).second)
                 continue;

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -3599,9 +3599,8 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so
     /// it must read no more than that column's value: `isConstant` and `toColumnTypeName` answer differently
     /// for the same value depending on constness, and a replacement can be constant where the input is not.
-    /// A lambda keeps its body out of the walk below, and a higher-order function hands its remaining
-    /// arguments to that body as its formal parameters, so a body reading a representation describes every
-    /// argument of the call and not only the captures below the node holding it.
+    /// A lambda body describes every argument of its call: the ones it does not capture arrive as its
+    /// formal parameters.
     static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
     auto call_reads_representation = [](const Node * node)
     {
@@ -3636,9 +3635,7 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
         return false;
     };
 
-    /// `getConjunctionNodes` already refuses a conjunct that is not stable within the query, but it reads
-    /// only the visible functions. A both-streams conjunct is evaluated once per side and dropped from the
-    /// post-join filter, so a body hidden from that check would be drawn twice and the two draws compared.
+    /// `getConjunctionNodes` asserts stability within the query over the visible functions only.
     static constexpr auto is_unstable_within_query = [](const IFunctionBase & function)
     { return function.isStateful() || !function.isDeterministicInScopeOfQuery(); };
     auto hides_unstable_lambda_body = [](const Node * conjunct)

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -2245,14 +2245,18 @@ bool foldedLambdaHasUnsafeFunction(const IColumn & column, bool (*is_unsafe)(con
 
 bool ActionsDAG::hasUnsafeHiddenLambdaBody(const Node & node, bool (*is_unsafe)(const IFunctionBase &))
 {
-    if (node.type == ActionType::FUNCTION)
+    const Node * lambda = &node;
+    while (lambda->type == ActionType::ALIAS)
+        lambda = lambda->children.front();
+
+    if (lambda->type == ActionType::FUNCTION)
     {
-        const auto * function_capture = typeid_cast<const FunctionCapture *>(node.function_base.get());
+        const auto * function_capture = typeid_cast<const FunctionCapture *>(lambda->function_base.get());
         return function_capture && dagHasUnsafeFunction(function_capture->getAcionsDAG(), is_unsafe);
     }
 
-    if (node.type == ActionType::COLUMN && node.column)
-        return foldedLambdaHasUnsafeFunction(node.column->getDataColumn(), is_unsafe);
+    if (lambda->type == ActionType::COLUMN && lambda->column)
+        return foldedLambdaHasUnsafeFunction(lambda->column->getDataColumn(), is_unsafe);
 
     return false;
 }
@@ -3596,6 +3600,17 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     /// it must read no more than that column's value: `isConstant` and `toColumnTypeName` answer differently
     /// for the same value depending on constness, and a replacement can be constant where the input is not.
     static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
+    /// A higher-order function hands its remaining arguments to the lambda as its formal parameters, so a
+    /// body reading a representation describes every argument of the call, not only the captures below it.
+    auto call_reads_representation = [](const Node * node)
+    {
+        if (hasUnsafeHiddenLambdaBody(*node, is_representation_read))
+            return true;
+        for (const auto * argument : node->children)
+            if (hasUnsafeHiddenLambdaBody(*argument, is_representation_read))
+                return true;
+        return false;
+    };
     auto reads_replaced_input_representation = [&](const Node * conjunct)
     {
         std::vector<std::pair<const Node *, bool>> to_visit{{conjunct, false}};
@@ -3606,7 +3621,7 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
             auto [node, reads_representation] = to_visit.back();
             to_visit.pop_back();
 
-            reads_representation |= !node->isDeterministic() || hasUnsafeHiddenLambdaBody(*node, is_representation_read);
+            reads_representation |= !node->isDeterministic() || call_reads_representation(node);
             auto & visited = reads_representation ? visited_reading_representation : visited_reading_value;
             if (!visited.insert(node).second)
                 continue;

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -2208,7 +2208,7 @@ bool ActionsDAG::hasNonDeterministic() const
 namespace
 {
 
-bool dagHasUnsafeFunction(const ActionsDAG & dag, bool (*is_unsafe)(const IFunctionBase &))
+bool dagHasUnsafeFunction(const ActionsDAG & dag, const std::function<bool(const IFunctionBase &)> & is_unsafe)
 {
     for (const auto & node : dag.getNodes())
     {
@@ -2223,7 +2223,7 @@ bool dagHasUnsafeFunction(const ActionsDAG & dag, bool (*is_unsafe)(const IFunct
 
 /// A lambda that captures only constants is itself folded to a constant, which holds the lambda object
 /// rather than a computed value: the body still runs, and its captures can hold further lambdas.
-bool foldedLambdaHasUnsafeFunction(const IColumn & column, bool (*is_unsafe)(const IFunctionBase &))
+bool foldedLambdaHasUnsafeFunction(const IColumn & column, const std::function<bool(const IFunctionBase &)> & is_unsafe)
 {
     const auto * column_function = typeid_cast<const ColumnFunction *>(&column);
     if (!column_function)
@@ -2243,7 +2243,7 @@ bool foldedLambdaHasUnsafeFunction(const IColumn & column, bool (*is_unsafe)(con
 
 }
 
-bool ActionsDAG::hasUnsafeHiddenLambdaBody(const Node & node, bool (*is_unsafe)(const IFunctionBase &))
+bool ActionsDAG::hasUnsafeHiddenLambdaBody(const Node & node, const std::function<bool(const IFunctionBase &)> & is_unsafe)
 {
     const Node * lambda = &node;
     while (lambda->type == ActionType::ALIAS)

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -3553,7 +3553,8 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     const Block & right_stream_header,
     const Names & equivalent_columns_to_push_down,
     const std::unordered_map<std::string, ColumnWithTypeAndName> & equivalent_left_stream_column_to_right_stream_column,
-    const std::unordered_map<std::string, ColumnWithTypeAndName> & equivalent_right_stream_column_to_left_stream_column)
+    const std::unordered_map<std::string, ColumnWithTypeAndName> & equivalent_right_stream_column_to_left_stream_column,
+    const NameSet & cross_type_equivalent_columns)
 {
     Node * predicate = const_cast<Node *>(tryFindInOutputs(filter_name));
     if (!predicate)
@@ -3596,72 +3597,83 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     auto right_stream_push_down_conjunctions = getConjunctionNodes(predicate, right_stream_allowed_nodes, false);
     auto both_streams_push_down_conjunctions = getConjunctionNodes(predicate, both_streams_allowed_nodes, false);
 
-    /// A both-streams conjunct has its equivalent inputs replaced by the opposite side's column below, so it
-    /// must read no more than that column's value: a replacement can be constant where the input is not.
-    /// A lambda body reads the call's arguments too: the ones it does not capture arrive as formal parameters.
-    static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
-    auto call_reads_representation = [](const Node * node)
+    /// A cross-type equivalent input is replaced below by a cast of the opposite side's key rather than
+    /// renamed to an equal-typed column, so it can be constant where the input is not and is computed a
+    /// second time: a conjunct reading one must read only its value, the same way in both evaluations.
+    std::unordered_set<const Node *> cross_type_allowed_nodes;
+    for (const auto * node : both_streams_allowed_nodes)
+        if (cross_type_equivalent_columns.contains(node->result_name))
+            cross_type_allowed_nodes.insert(node);
+
+    if (!cross_type_allowed_nodes.empty())
     {
-        if (hasUnsafeHiddenLambdaBody(*node, is_representation_read))
-            return true;
-        for (const auto * argument : node->children)
-            if (hasUnsafeHiddenLambdaBody(*argument, is_representation_read))
-                return true;
-        return false;
-    };
-    auto reads_replaced_input_representation = [&](const Node * conjunct)
-    {
-        std::vector<std::pair<const Node *, bool>> to_visit{{conjunct, false}};
-        std::unordered_set<const Node *> visited_reading_value;
-        std::unordered_set<const Node *> visited_reading_representation;
-        while (!to_visit.empty())
+        /// A lambda body reads the call's arguments too: the ones it does not capture arrive as formal parameters.
+        static constexpr auto is_representation_read = [](const IFunctionBase & function) { return !function.isDeterministic(); };
+        auto call_reads_representation = [](const Node * node)
         {
-            auto [node, reads_representation] = to_visit.back();
-            to_visit.pop_back();
-
-            reads_representation |= !node->isDeterministic() || call_reads_representation(node);
-            auto & visited = reads_representation ? visited_reading_representation : visited_reading_value;
-            if (!visited.insert(node).second)
-                continue;
-
-            if (reads_representation && node->type == ActionType::INPUT && both_streams_allowed_nodes.contains(node))
+            if (hasUnsafeHiddenLambdaBody(*node, is_representation_read))
                 return true;
-
-            for (const auto * child : node->children)
-                to_visit.emplace_back(child, reads_representation);
-        }
-        return false;
-    };
-
-    /// `getConjunctionNodes` asserts stability within the query over the visible functions only.
-    static constexpr auto is_unstable_within_query = [](const IFunctionBase & function)
-    { return function.isStateful() || !function.isDeterministicInScopeOfQuery(); };
-    auto hides_unstable_lambda_body = [](const Node * conjunct)
-    {
-        std::vector<const Node *> to_visit{conjunct};
-        std::unordered_set<const Node *> visited;
-        while (!to_visit.empty())
+            for (const auto * argument : node->children)
+                if (hasUnsafeHiddenLambdaBody(*argument, is_representation_read))
+                    return true;
+            return false;
+        };
+        auto reads_replaced_input_representation = [&](const Node * conjunct)
         {
-            const auto * node = to_visit.back();
-            to_visit.pop_back();
-            if (!visited.insert(node).second)
-                continue;
-            if (hasUnsafeHiddenLambdaBody(*node, is_unstable_within_query))
-                return true;
-            to_visit.insert(to_visit.end(), node->children.begin(), node->children.end());
-        }
-        return false;
-    };
+            std::vector<std::pair<const Node *, bool>> to_visit{{conjunct, false}};
+            std::unordered_set<const Node *> visited_reading_value;
+            std::unordered_set<const Node *> visited_reading_representation;
+            while (!to_visit.empty())
+            {
+                auto [node, reads_representation] = to_visit.back();
+                to_visit.pop_back();
 
-    NodeRawConstPtrs both_streams_value_only_conjunctions;
-    for (const auto * conjunct : both_streams_push_down_conjunctions.allowed)
-    {
-        if (reads_replaced_input_representation(conjunct) || hides_unstable_lambda_body(conjunct))
-            both_streams_push_down_conjunctions.rejected.push_back(conjunct);
-        else
-            both_streams_value_only_conjunctions.push_back(conjunct);
+                reads_representation |= !node->isDeterministic() || call_reads_representation(node);
+                auto & visited = reads_representation ? visited_reading_representation : visited_reading_value;
+                if (!visited.insert(node).second)
+                    continue;
+
+                if (reads_representation && node->type == ActionType::INPUT && cross_type_allowed_nodes.contains(node))
+                    return true;
+
+                for (const auto * child : node->children)
+                    to_visit.emplace_back(child, reads_representation);
+            }
+            return false;
+        };
+
+        /// `getConjunctionNodes` asserts stability within the query over the visible functions only.
+        static constexpr auto is_unstable_within_query = [](const IFunctionBase & function)
+        { return function.isStateful() || !function.isDeterministicInScopeOfQuery(); };
+        auto hides_unstable_lambda_body_over_replaced_input = [&](const Node * conjunct)
+        {
+            bool hides_unstable_body = false;
+            bool reads_replaced_input = false;
+            std::vector<const Node *> to_visit{conjunct};
+            std::unordered_set<const Node *> visited;
+            while (!to_visit.empty())
+            {
+                const auto * node = to_visit.back();
+                to_visit.pop_back();
+                if (!visited.insert(node).second)
+                    continue;
+                hides_unstable_body |= hasUnsafeHiddenLambdaBody(*node, is_unstable_within_query);
+                reads_replaced_input |= cross_type_allowed_nodes.contains(node);
+                to_visit.insert(to_visit.end(), node->children.begin(), node->children.end());
+            }
+            return hides_unstable_body && reads_replaced_input;
+        };
+
+        NodeRawConstPtrs both_streams_value_only_conjunctions;
+        for (const auto * conjunct : both_streams_push_down_conjunctions.allowed)
+        {
+            if (reads_replaced_input_representation(conjunct) || hides_unstable_lambda_body_over_replaced_input(conjunct))
+                both_streams_push_down_conjunctions.rejected.push_back(conjunct);
+            else
+                both_streams_value_only_conjunctions.push_back(conjunct);
+        }
+        both_streams_push_down_conjunctions.allowed = std::move(both_streams_value_only_conjunctions);
     }
-    both_streams_push_down_conjunctions.allowed = std::move(both_streams_value_only_conjunctions);
 
     /// getConjunctionNodes() classifies a conjunct as pushable to a side when all of its inputs are
     /// allowed inputs of that side. A conjunct with no inputs (a pure constant such as a literal `1`

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -305,6 +305,10 @@ public:
     bool trivial() const noexcept; /// If actions has no functions or array join.
     void assertDeterministic() const; /// Throw if not isDeterministic.
     bool hasNonDeterministic() const;
+    /// A lambda keeps its body in an inner DAG that neither `getNodes()` nor a walk over `Node::children`
+    /// reaches, while the node holding it reports the `IFunctionBase` determinism defaults whatever the body
+    /// does. True when a body hidden below `node`, at any lambda depth, has a function `is_unsafe` accepts.
+    static bool hasUnsafeHiddenLambdaBody(const Node & node, bool (*is_unsafe)(const IFunctionBase &));
     /// A computed node reuses an input's name (`CAST(x, ...) AS x`). Names then can't identify carriers.
     bool hasInputNameShadowedByComputedNode() const;
 

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -523,6 +523,8 @@ public:
       * to left and right streams.
       * @param equivalent_left_stream_column_to_right_stream_column - equivalent left stream column name to right stream column map.
       * @param equivalent_right_stream_column_to_left_stream_column - equivalent right stream column name to left stream column map.
+      * @param cross_type_equivalent_columns - the equivalent columns whose replacement is a cast of the opposite side's
+      * key rather than a rename of an equal-typed column.
       */
     ActionsForJOINFilterPushDown splitActionsForJOINFilterPushDown(
         const std::string & filter_name,
@@ -533,7 +535,8 @@ public:
         const Block & right_stream_header,
         const Names & equivalent_columns_to_push_down,
         const std::unordered_map<std::string, ColumnWithTypeAndName> & equivalent_left_stream_column_to_right_stream_column,
-        const std::unordered_map<std::string, ColumnWithTypeAndName> & equivalent_right_stream_column_to_left_stream_column);
+        const std::unordered_map<std::string, ColumnWithTypeAndName> & equivalent_right_stream_column_to_left_stream_column,
+        const NameSet & cross_type_equivalent_columns);
 
     /** Build filter dag from multiple filter dags.
       *

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -308,7 +309,7 @@ public:
     /// A lambda keeps its body in an inner DAG that neither `getNodes()` nor a walk over `Node::children`
     /// reaches, while the node holding it reports the `IFunctionBase` determinism defaults whatever the body
     /// does. True when a body hidden below `node`, at any lambda depth, has a function `is_unsafe` accepts.
-    static bool hasUnsafeHiddenLambdaBody(const Node & node, bool (*is_unsafe)(const IFunctionBase &));
+    static bool hasUnsafeHiddenLambdaBody(const Node & node, const std::function<bool(const IFunctionBase &)> & is_unsafe);
     /// A computed node reuses an input's name (`CAST(x, ...) AS x`). Names then can't identify carriers.
     bool hasInputNameShadowedByComputedNode() const;
 

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -768,10 +768,10 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             if (!replaced || !replaced->type->equals(*supertype))
                 return;
 
-            /// A float key can be join-equal while bit-different: `-0.0` and `+0.0` are equal to the comparison
-            /// a merge-based algorithm joins on, so a bit-sensitive predicate disagrees between the two sides.
-            /// The supertype is what the JOIN compares in, and a nested float is no different. A float inside
-            /// `Dynamic` or `JSON` is not described by the static type at all, so those are declined outright.
+            /// A float key can be join-equal while bit-different: `-0.0` and `+0.0` are equal to the comparison a merge-based
+            /// algorithm joins on, so a bit-sensitive predicate disagrees between the two sides. The supertype is what the JOIN
+            /// compares in, and a nested float is no different. A `Dynamic` or `JSON` supertype describes neither the runtime
+            /// contents nor the representation, and a predicate can read either, so both are declined outright.
             bool supertype_is_unsafe = false;
             auto check_type = [&](const IDataType & type)
             { supertype_is_unsafe |= isFloat(type) || isDynamic(type) || isObject(type); };

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -873,6 +873,34 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         }
     }
 
+    /// A name substituted for the opposite side's key must not feed a function that reads more than the
+    /// value: `isConstant` and `toColumnTypeName` return different results for the same value depending
+    /// on constness, and a substituted key can be constant where the replaced one is not.
+    std::unordered_set<std::string_view> representation_sensitive_inputs;
+    for (const auto & node : filter->getExpression().getNodes())
+    {
+        if (node.type != ActionsDAG::ActionType::FUNCTION || node.function_base->isDeterministic())
+            continue;
+
+        std::vector<const ActionsDAG::Node *> to_visit{&node};
+        std::unordered_set<const ActionsDAG::Node *> visited;
+        while (!to_visit.empty())
+        {
+            const auto * current = to_visit.back();
+            to_visit.pop_back();
+            if (!visited.insert(current).second)
+                continue;
+            if (current->type == ActionsDAG::ActionType::INPUT)
+                representation_sensitive_inputs.insert(current->result_name);
+            for (const auto * argument : current->children)
+                to_visit.push_back(argument);
+        }
+    }
+
+    if (!representation_sensitive_inputs.empty())
+        std::erase_if(equivalent_columns_to_push_down,
+            [&](const String & name) { return representation_sensitive_inputs.contains(name); });
+
     const bool is_filter_column_const_before = isFilterColumnConst(*filter);
 
     /// Capture the original constant column value before push-down modifies the expression DAG.

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -738,7 +738,8 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
     std::vector<CrossTypeReplacement> cross_type_replacements_for_left_stream;
     std::vector<CrossTypeReplacement> cross_type_replacements_for_right_stream;
 
-    /// Availability is applied per map below, so a pair registered for a side that cannot take the filter is inert.
+    /// The map keyed by a name of one side is applied to the filter pushed to the other side, while the
+    /// flag admitting its keys is the one of that name's own side, so a pair it rejects stays inert below.
     if (logical_join)
     {
         const auto & join_output_header = *join_header;
@@ -766,6 +767,15 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             const auto * replaced = join_output_header.findByName(replaced_name);
             if (!replaced || !replaced->type->equals(*supertype))
                 return;
+
+            /// The pushed-down filter computes this key and the JOIN computes it again, so a key that is
+            /// not stable within the query would be compared against two different values.
+            const auto source_dag = JoinExpressionActions::getSubDAG(source);
+            for (const auto & node : source_dag.getNodes())
+            {
+                if (node.type == ActionsDAG::ActionType::FUNCTION && !node.function_base->isDeterministicInScopeOfQuery())
+                    return;
+            }
 
             /// The side that already has the supertype is not cast by the JOIN either.
             if (source.getType()->equals(*supertype))

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -738,9 +738,8 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
     std::vector<CrossTypeReplacement> cross_type_replacements_for_left_stream;
     std::vector<CrossTypeReplacement> cross_type_replacements_for_right_stream;
 
-    if (logical_join
-        && (!left_stream_filter_push_down_input_columns_available
-            || !right_stream_filter_push_down_input_columns_available))
+    /// Availability is applied per map below, so a pair registered for a side that cannot take the filter is inert.
+    if (logical_join)
     {
         const auto & join_output_header = *join_header;
 

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -770,12 +770,14 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
 
             /// A float key can be join-equal while bit-different: `-0.0` and `+0.0` are equal to the comparison
             /// a merge-based algorithm joins on, so a bit-sensitive predicate disagrees between the two sides.
-            /// The supertype is what the JOIN compares in, and a nested float is no different.
-            bool supertype_has_float = false;
-            auto check_float = [&](const IDataType & type) { supertype_has_float |= isFloat(type); };
-            check_float(*supertype);
-            supertype->forEachChild(check_float);
-            if (supertype_has_float)
+            /// The supertype is what the JOIN compares in, and a nested float is no different. A float inside
+            /// `Dynamic` or `JSON` is not described by the static type at all, so those are declined outright.
+            bool supertype_is_unsafe = false;
+            auto check_type = [&](const IDataType & type)
+            { supertype_is_unsafe |= isFloat(type) || isDynamic(type) || isObject(type); };
+            check_type(*supertype);
+            supertype->forEachChild(check_type);
+            if (supertype_is_unsafe)
                 return;
 
             /// The pushed-down filter computes this key and the JOIN computes it again, so the key must return

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -783,17 +783,22 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             /// The pushed-down filter computes this key and the JOIN computes it again, so the key must return
             /// the same value twice within one query and must not change the number of rows. This pass already
             /// requires both properties of the filters it pushes.
+            static constexpr auto changes_between_evaluations = [](const IFunctionBase & function)
+            { return function.isStateful() || !function.isDeterministicInScopeOfQuery(); };
             const auto source_dag = JoinExpressionActions::getSubDAG(source);
             for (const auto & node : source_dag.getNodes())
             {
                 if (node.type == ActionsDAG::ActionType::FUNCTION)
                 {
-                    if (node.function_base->isStateful() || !node.function_base->isDeterministicInScopeOfQuery())
+                    if (changes_between_evaluations(*node.function_base))
                         return;
                 }
                 else if (node.type != ActionsDAG::ActionType::INPUT
                     && node.type != ActionsDAG::ActionType::COLUMN
                     && node.type != ActionsDAG::ActionType::ALIAS)
+                    return;
+
+                if (ActionsDAG::hasUnsafeHiddenLambdaBody(node, changes_between_evaluations))
                     return;
             }
 

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -768,12 +768,20 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             if (!replaced || !replaced->type->equals(*supertype))
                 return;
 
-            /// The pushed-down filter computes this key and the JOIN computes it again, so a key that is
-            /// not stable within the query would be compared against two different values.
+            /// The pushed-down filter computes this key and the JOIN computes it again, so the key must return
+            /// the same value twice within one query and must not change the number of rows. The pass requires
+            /// the same two of the filter it pushes.
             const auto source_dag = JoinExpressionActions::getSubDAG(source);
             for (const auto & node : source_dag.getNodes())
             {
-                if (node.type == ActionsDAG::ActionType::FUNCTION && !node.function_base->isDeterministicInScopeOfQuery())
+                if (node.type == ActionsDAG::ActionType::FUNCTION)
+                {
+                    if (node.function_base->isStateful() || !node.function_base->isDeterministicInScopeOfQuery())
+                        return;
+                }
+                else if (node.type != ActionsDAG::ActionType::INPUT
+                    && node.type != ActionsDAG::ActionType::COLUMN
+                    && node.type != ActionsDAG::ActionType::ALIAS)
                     return;
             }
 

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -768,9 +768,19 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             if (!replaced || !replaced->type->equals(*supertype))
                 return;
 
+            /// A float key can be join-equal while bit-different: `-0.0` and `+0.0` are equal to the comparison
+            /// a merge-based algorithm joins on, so a bit-sensitive predicate disagrees between the two sides.
+            /// The supertype is what the JOIN compares in, and a nested float is no different.
+            bool supertype_has_float = false;
+            auto check_float = [&](const IDataType & type) { supertype_has_float |= isFloat(type); };
+            check_float(*supertype);
+            supertype->forEachChild(check_float);
+            if (supertype_has_float)
+                return;
+
             /// The pushed-down filter computes this key and the JOIN computes it again, so the key must return
-            /// the same value twice within one query and must not change the number of rows. The pass requires
-            /// the same two of the filter it pushes.
+            /// the same value twice within one query and must not change the number of rows. This pass already
+            /// requires both properties of the filters it pushes.
             const auto source_dag = JoinExpressionActions::getSubDAG(source);
             for (const auto & node : source_dag.getNodes())
             {

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -873,34 +873,6 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         }
     }
 
-    /// A name substituted for the opposite side's key must not feed a function that reads more than the
-    /// value: `isConstant` and `toColumnTypeName` return different results for the same value depending
-    /// on constness, and a substituted key can be constant where the replaced one is not.
-    std::unordered_set<std::string_view> representation_sensitive_inputs;
-    for (const auto & node : filter->getExpression().getNodes())
-    {
-        if (node.type != ActionsDAG::ActionType::FUNCTION || node.function_base->isDeterministic())
-            continue;
-
-        std::vector<const ActionsDAG::Node *> to_visit{&node};
-        std::unordered_set<const ActionsDAG::Node *> visited;
-        while (!to_visit.empty())
-        {
-            const auto * current = to_visit.back();
-            to_visit.pop_back();
-            if (!visited.insert(current).second)
-                continue;
-            if (current->type == ActionsDAG::ActionType::INPUT)
-                representation_sensitive_inputs.insert(current->result_name);
-            for (const auto * argument : current->children)
-                to_visit.push_back(argument);
-        }
-    }
-
-    if (!representation_sensitive_inputs.empty())
-        std::erase_if(equivalent_columns_to_push_down,
-            [&](const String & name) { return representation_sensitive_inputs.contains(name); });
-
     const bool is_filter_column_const_before = isFilterColumnConst(*filter);
 
     /// Capture the original constant column value before push-down modifies the expression DAG.

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -737,6 +737,8 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
     };
     std::vector<CrossTypeReplacement> cross_type_replacements_for_left_stream;
     std::vector<CrossTypeReplacement> cross_type_replacements_for_right_stream;
+    /// Names substituted by a cast of the opposite side's key, as opposed to the equal-typed renames above.
+    NameSet cross_type_equivalent_columns;
 
     /// The map keyed by a name of one side is applied to the filter pushed to the other side, while the
     /// flag admitting its keys is the one of that name's own side, so a pair it rejects stays inert below.
@@ -801,6 +803,8 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
                 if (ActionsDAG::hasUnsafeHiddenLambdaBody(node, changes_between_evaluations))
                     return;
             }
+
+            cross_type_equivalent_columns.insert(replaced_name);
 
             /// The side that already has the supertype is not cast by the JOIN either.
             if (source.getType()->equals(*supertype))
@@ -894,7 +898,8 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         *right_stream_input_header,
         equivalent_columns_to_push_down,
         equivalent_left_stream_column_to_right_stream_column,
-        equivalent_right_stream_column_to_left_stream_column);
+        equivalent_right_stream_column_to_left_stream_column,
+        cross_type_equivalent_columns);
 
     if (is_filter_column_const_before && !join_filter_push_down_actions.is_filter_const_after_all_push_downs)
     {

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -64,6 +64,10 @@ INNER JOIN ON, conjunct with a deterministic lambda body over the equi-key: the 
 1
 INNER JOIN ON, conjunct whose lambda body reads the equi-key representation: the conjunct is not pushed
 1
+INNER JOIN ON, deterministic lambda body over the equi-key passed as the formal parameter: pushed
+1
+INNER JOIN ON, lambda body reading the formal parameter representation: the conjunct is not pushed
+1
 INNER JOIN ON, cross-type equi-key: result
 2020-06-01
 2020-06-02

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -48,3 +48,13 @@ FULL JOIN USING, cross-type: neither MergeTree prunes granules
 1
 FULL JOIN USING, cross-type, join_use_nulls: neither MergeTree prunes granules
 1
+INNER JOIN ON, cross-type equi-key, predicate on the wider key: right MergeTree prunes granules
+1
+INNER JOIN ON, cross-type equi-key, wider key on the right: left MergeTree prunes granules
+1
+INNER JOIN ON, matched types: right MergeTree prunes granules
+1
+INNER JOIN ON, cross-type equi-key: result
+2020-06-01
+2020-06-02
+2020-06-03

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -74,3 +74,5 @@ INNER JOIN ON, cross-type equi-key with a float inside a Dynamic: result
 0	-0
 INNER JOIN ON, cross-type equi-key with a JSON path in shared data on one side: result
 {"x":1}	{"x":1}
+INNER JOIN ON, cross-type equi-key under a predicate reading constness: result
+0

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -72,3 +72,5 @@ INNER JOIN ON, cross-type equi-key with a nested float: result
 [0]	[-0]
 INNER JOIN ON, cross-type equi-key with a float inside a Dynamic: result
 0	-0
+INNER JOIN ON, cross-type equi-key with a JSON path in shared data on one side: result
+{"x":1}	{"x":1}

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -56,6 +56,14 @@ INNER JOIN ON, matched types: right MergeTree prunes granules
 1
 INNER JOIN ON, cross-type equi-key beside a predicate reading constness: right MergeTree prunes granules
 1
+INNER JOIN ON, cross-type equi-key with a deterministic lambda body: the key reaches the right input
+1
+INNER JOIN ON, cross-type equi-key whose lambda body is not stable within the query: the key does not
+1
+INNER JOIN ON, conjunct with a deterministic lambda body over the equi-key: the conjunct is pushed
+1
+INNER JOIN ON, conjunct whose lambda body reads the equi-key representation: the conjunct is not pushed
+1
 INNER JOIN ON, cross-type equi-key: result
 2020-06-01
 2020-06-02

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -61,3 +61,8 @@ INNER JOIN ON, cross-type equi-key: result
 INNER JOIN ON, cross-type equi-key that is not stable within the query: result
 5
 6
+INNER JOIN ON, cross-type equi-key that changes the number of rows: result
+5
+5
+6
+6

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -70,3 +70,5 @@ LEFT JOIN ON, cross-type float equi-key: result
 0	-0
 INNER JOIN ON, cross-type equi-key with a nested float: result
 [0]	[-0]
+INNER JOIN ON, cross-type equi-key with a float inside a Dynamic: result
+0	-0

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -66,3 +66,7 @@ INNER JOIN ON, cross-type equi-key that changes the number of rows: result
 5
 6
 6
+INNER JOIN ON, cross-type float equi-key: result
+0	-0
+INNER JOIN ON, cross-type equi-key with a nested float: result
+[0]	[-0]

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -86,3 +86,5 @@ INNER JOIN ON, cross-type equi-key with a JSON path in shared data on one side: 
 {"x":1}	{"x":1}
 INNER JOIN ON, cross-type equi-key under a predicate reading constness: result
 0
+INNER JOIN ON, equi-key under a predicate reading constness inside a lambda body: result
+0

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -58,3 +58,6 @@ INNER JOIN ON, cross-type equi-key: result
 2020-06-01
 2020-06-02
 2020-06-03
+INNER JOIN ON, cross-type equi-key that is not stable within the query: result
+5
+6

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -66,7 +66,7 @@ INNER JOIN ON, cross-type equi-key that changes the number of rows: result
 5
 6
 6
-INNER JOIN ON, cross-type float equi-key: result
+LEFT JOIN ON, cross-type float equi-key: result
 0	-0
 INNER JOIN ON, cross-type equi-key with a nested float: result
 [0]	[-0]

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -60,13 +60,9 @@ INNER JOIN ON, cross-type equi-key with a deterministic lambda body: the key rea
 1
 INNER JOIN ON, cross-type equi-key whose lambda body is not stable within the query: the key does not
 1
-INNER JOIN ON, conjunct with a deterministic lambda body over the equi-key: the conjunct is pushed
+INNER JOIN ON, conjunct with a deterministic lambda body beside the equi-key: the conjunct is pushed
 1
-INNER JOIN ON, conjunct whose lambda body reads the equi-key representation: the conjunct is not pushed
-1
-INNER JOIN ON, deterministic lambda body over the equi-key passed as the formal parameter: pushed
-1
-INNER JOIN ON, lambda body reading the formal parameter representation: the conjunct is not pushed
+INNER JOIN ON, conjunct with an unstable lambda body beside the equi-key: the conjunct is not pushed
 1
 INNER JOIN ON, cross-type equi-key: result
 2020-06-01

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -54,6 +54,8 @@ INNER JOIN ON, cross-type equi-key, wider key on the right: left MergeTree prune
 1
 INNER JOIN ON, matched types: right MergeTree prunes granules
 1
+INNER JOIN ON, cross-type equi-key beside a predicate reading constness: right MergeTree prunes granules
+1
 INNER JOIN ON, cross-type equi-key: result
 2020-06-01
 2020-06-02

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -54,6 +54,10 @@ INNER JOIN ON, cross-type equi-key, wider key on the right: left MergeTree prune
 1
 INNER JOIN ON, matched types: right MergeTree prunes granules
 1
+INNER JOIN USING, cross-type equi-key: right MergeTree prunes granules
+1
+INNER JOIN ON <=>, cross-type equi-key: right MergeTree prunes granules
+1
 INNER JOIN ON, cross-type equi-key beside a predicate reading constness: right MergeTree prunes granules
 1
 INNER JOIN ON, cross-type equi-key with a deterministic lambda body: the key reaches the right input

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -88,3 +88,7 @@ INNER JOIN ON, cross-type equi-key under a predicate reading constness: result
 0
 INNER JOIN ON, equi-key under a predicate reading constness inside a lambda body: result
 0
+INNER JOIN ON, cross-type LowCardinality equi-key above a grouped input, join_use_nulls: grouped MergeTree prunes granules
+1
+INNER JOIN ON, cross-type LowCardinality equi-key above a grouped input, join_use_nulls: result
+20

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -70,6 +70,10 @@ INNER JOIN ON, cross-type equi-key whose lambda body holds per-query state: the 
 1
 INNER JOIN ON, conjunct whose lambda body holds per-query state beside the equi-key: the conjunct is not pushed
 1
+INNER JOIN ON, conjunct whose lambda body reads the value of a formal bound to the equi-key: the conjunct is pushed
+1
+INNER JOIN ON, conjunct whose lambda body reads the representation of a formal bound to the equi-key: it is not
+1
 INNER JOIN ON, cross-type equi-key: result
 2020-06-01
 2020-06-02

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.reference
@@ -64,6 +64,12 @@ INNER JOIN ON, conjunct with a deterministic lambda body beside the equi-key: th
 1
 INNER JOIN ON, conjunct with an unstable lambda body beside the equi-key: the conjunct is not pushed
 1
+INNER JOIN ON, cross-type equi-key holding per-query state: the key does not reach the right input
+1
+INNER JOIN ON, cross-type equi-key whose lambda body holds per-query state: the key does not either
+1
+INNER JOIN ON, conjunct whose lambda body holds per-query state beside the equi-key: the conjunct is not pushed
+1
 INNER JOIN ON, cross-type equi-key: result
 2020-06-01
 2020-06-02

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -276,6 +276,25 @@ SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
       AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 );
 
+-- The key can also reach the body as the lambda's formal parameter rather than as a capture, which the two
+-- arms above do not cover: the call passes it in from a sibling argument.
+
+SELECT 'INNER JOIN ON, deterministic lambda body over the equi-key passed as the formal parameter: pushed';
+SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 1 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE arrayExists(y -> y > toDate32('1900-01-01'), [l.a])
+      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
+SELECT 'INNER JOIN ON, lambda body reading the formal parameter representation: the conjunct is not pushed';
+SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE arrayExists(y -> isConstant(y) = 0, [l.a])
+      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
 SELECT 'INNER JOIN ON, cross-type equi-key: result';
 SELECT r.b FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
 WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -316,3 +316,21 @@ SETTINGS join_algorithm = 'full_sorting_merge';
 DROP TABLE inner_af64;
 DROP TABLE inner_af32;
 
+-- `Dynamic` does not describe its runtime alternatives in the static type, so a float inside one is invisible
+-- to a walk over the type and the type is declined outright. A `Dynamic` join key is rejected unless
+-- `allow_dynamic_type_in_join_keys` is set, so the arm sets it next to the algorithm at query level.
+
+DROP TABLE IF EXISTS inner_dyn;
+DROP TABLE IF EXISTS inner_dyn_f32;
+CREATE TABLE inner_dyn     (a Dynamic) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE inner_dyn_f32 (x Float32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO inner_dyn     VALUES (toFloat32(0.0)), (toFloat32(3.5));
+INSERT INTO inner_dyn_f32 VALUES (-0.0), (3.5);
+
+SELECT 'INNER JOIN ON, cross-type equi-key with a float inside a Dynamic: result';
+SELECT l.a, r.x FROM inner_dyn AS l INNER JOIN inner_dyn_f32 AS r ON l.a = r.x
+WHERE reinterpretAsUInt32(assumeNotNull(dynamicElement(l.a, 'Float32'))) = 0 ORDER BY r.x
+SETTINGS allow_dynamic_type_in_join_keys = 1, join_algorithm = 'full_sorting_merge';
+
+DROP TABLE inner_dyn;
+DROP TABLE inner_dyn_f32;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -418,4 +418,11 @@ SELECT 'INNER JOIN ON, cross-type equi-key under a predicate reading constness: 
 SELECT l.a FROM inner_ic_wide AS l INNER JOIN (SELECT toInt32(0) AS b) AS r ON l.a = r.b
 WHERE isConstant(l.a) = 0 ORDER BY 1;
 
+-- Reading it from inside a lambda body is the same predicate: the formal parameter comes from a constant
+-- array here, so the substituted key is constant on both sides of `if` and the whole read turns constant.
+
+SELECT 'INNER JOIN ON, equi-key under a predicate reading constness inside a lambda body: result';
+SELECT l.a FROM inner_ic_wide AS l INNER JOIN (SELECT toInt32(0) AS b) AS r ON l.a = r.b
+WHERE arrayExists(y -> isConstant(if(y, l.a, l.a)) = 0, [1]) ORDER BY 1;
+
 DROP TABLE inner_ic_wide;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -241,6 +241,41 @@ SELECT count() > 0 FROM (
     WHERE isConstant(l.a) = 0 AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 ) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
 
+-- A lambda keeps its body in an inner expression that a walk over the outer nodes never reaches, so both
+-- properties above are asserted twice: once where the body satisfies them and once where it hides a
+-- violation. `% 1` keeps `rand` from changing the key's value, leaving the body as the only difference,
+-- and the two spellings render identically in the plan, so only the pushed filter tells them apart.
+
+SELECT 'INNER JOIN ON, cross-type equi-key with a deterministic lambda body: the key reaches the right input';
+SELECT countIf(explain ILIKE '%Filter column%arrayMax%') = 1 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = arrayMax(arrayMap(z -> z, [r.b]))
+    WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
+SELECT 'INNER JOIN ON, cross-type equi-key whose lambda body is not stable within the query: the key does not';
+SELECT countIf(explain ILIKE '%Filter column%arrayMax%') = 0 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = arrayMax(arrayMap(z -> z + (rand(z) % 1), [r.b]))
+    WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
+SELECT 'INNER JOIN ON, conjunct with a deterministic lambda body over the equi-key: the conjunct is pushed';
+SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 1 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE arrayExists(y -> l.a + y > toDate32('1900-01-01'), [1])
+      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
+SELECT 'INNER JOIN ON, conjunct whose lambda body reads the equi-key representation: the conjunct is not pushed';
+SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE arrayExists(y -> isConstant(l.a + y) = 0, [1])
+      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
 SELECT 'INNER JOIN ON, cross-type equi-key: result';
 SELECT r.b FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
 WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -334,3 +334,23 @@ SETTINGS allow_dynamic_type_in_join_keys = 1, join_algorithm = 'full_sorting_mer
 
 DROP TABLE inner_dyn;
 DROP TABLE inner_dyn_f32;
+
+-- Which `JSON` paths get their own subcolumn is a property of the column, not of the type: two earlier
+-- rows fill both dynamic slots on the left, so its `x` lands in shared data while the right column keeps
+-- `x` dynamic. What disagrees between the sides is `JSONDynamicPaths`, which reads that placement rather
+-- than the value; the values themselves are equal under every join comparison, so unlike the float arms
+-- above this one needs no algorithm pinned.
+
+DROP TABLE IF EXISTS inner_json_shared;
+DROP TABLE IF EXISTS inner_json_dyn;
+CREATE TABLE inner_json_shared (a JSON(max_dynamic_paths = 2)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE inner_json_dyn    (x JSON(max_dynamic_paths = 1)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO inner_json_shared VALUES ('{"p":1}'), ('{"q":1}'), ('{"x":1}');
+INSERT INTO inner_json_dyn VALUES ('{"x":1}');
+
+SELECT 'INNER JOIN ON, cross-type equi-key with a JSON path in shared data on one side: result';
+SELECT l.a, r.x FROM inner_json_shared AS l INNER JOIN inner_json_dyn AS r ON l.a = r.x
+WHERE NOT has(JSONDynamicPaths(l.a), 'x') ORDER BY 1;
+
+DROP TABLE inner_json_shared;
+DROP TABLE inner_json_dyn;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -260,38 +260,24 @@ SELECT countIf(explain ILIKE '%Filter column%arrayMax%') = 0 FROM (
     WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 );
 
-SELECT 'INNER JOIN ON, conjunct with a deterministic lambda body over the equi-key: the conjunct is pushed';
+-- A both-streams conjunct is evaluated once per side and dropped from the post-join filter, so an unstable
+-- body would be drawn twice and the two draws compared. The body sits beside the key here rather than above
+-- it, which is the position the conjunct's own walk cannot reach. `% 1` keeps the conjunct true for every
+-- row, and the array is materialized because a constant one folds the whole call away before the plan.
+
+SELECT 'INNER JOIN ON, conjunct with a deterministic lambda body beside the equi-key: the conjunct is pushed';
 SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 1 FROM (
     EXPLAIN PLAN actions = 1
     SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
-    WHERE arrayExists(y -> l.a + y > toDate32('1900-01-01'), [1])
+    WHERE arrayExists(y -> y % 1 = 0, materialize([1])) = (l.a > toDate32('1900-01-01'))
       AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 );
 
-SELECT 'INNER JOIN ON, conjunct whose lambda body reads the equi-key representation: the conjunct is not pushed';
+SELECT 'INNER JOIN ON, conjunct with an unstable lambda body beside the equi-key: the conjunct is not pushed';
 SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
     EXPLAIN PLAN actions = 1
     SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
-    WHERE arrayExists(y -> isConstant(l.a + y) = 0, [1])
-      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
-);
-
--- The key can also reach the body as the lambda's formal parameter rather than as a capture, which the two
--- arms above do not cover: the call passes it in from a sibling argument.
-
-SELECT 'INNER JOIN ON, deterministic lambda body over the equi-key passed as the formal parameter: pushed';
-SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 1 FROM (
-    EXPLAIN PLAN actions = 1
-    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
-    WHERE arrayExists(y -> y > toDate32('1900-01-01'), [l.a])
-      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
-);
-
-SELECT 'INNER JOIN ON, lambda body reading the formal parameter representation: the conjunct is not pushed';
-SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
-    EXPLAIN PLAN actions = 1
-    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
-    WHERE arrayExists(y -> isConstant(y) = 0, [l.a])
+    WHERE arrayExists(y -> rand(y) % 1 = 0, materialize([1])) = (l.a > toDate32('1900-01-01'))
       AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 );
 

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -230,6 +230,17 @@ SELECT count() > 0 FROM (
     WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 ) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
 
+-- Only a conjunct that reads the representation of a substituted key is unsafe, so a safe conjunct on
+-- that same key still reaches the opposite input when the two sit side by side. `isConstant` is true for
+-- every row of this read, so it constrains nothing and the granule counts describe the range alone.
+
+SELECT 'INNER JOIN ON, cross-type equi-key beside a predicate reading constness: right MergeTree prunes granules';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN indexes = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE isConstant(l.a) = 0 AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
+
 SELECT 'INNER JOIN ON, cross-type equi-key: result';
 SELECT r.b FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
 WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -277,3 +277,39 @@ WHERE l.a BETWEEN 5 AND 6 ORDER BY 1;
 
 DROP TABLE inner_aj_wide;
 DROP TABLE inner_aj_narrow;
+
+-- A float key can be join-equal while bit-different: `-0.0` and `+0.0` are equal to the comparison a
+-- merge-based algorithm joins on, so substituting one side's key for the other would let a bit-sensitive
+-- predicate drop a matching row. A nested float is no different, and `Array` is used for the second shape
+-- because the wrapper-stripping predicates that cover `Nullable` do not look inside it. `join_algorithm` is
+-- pinned at query level because the hash algorithms hash the key bitwise and never match the pair at all.
+
+DROP TABLE IF EXISTS inner_f64;
+DROP TABLE IF EXISTS inner_f32;
+CREATE TABLE inner_f64 (a Float64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE inner_f32 (x Float32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO inner_f64 VALUES (0.0), (3.5);
+INSERT INTO inner_f32 VALUES (-0.0), (3.5);
+
+SELECT 'INNER JOIN ON, cross-type float equi-key: result';
+SELECT l.a, r.x FROM inner_f64 AS l INNER JOIN inner_f32 AS r ON l.a = r.x
+WHERE reinterpretAsUInt64(l.a) = 0 ORDER BY 1
+SETTINGS join_algorithm = 'full_sorting_merge';
+
+DROP TABLE inner_f64;
+DROP TABLE inner_f32;
+
+DROP TABLE IF EXISTS inner_af64;
+DROP TABLE IF EXISTS inner_af32;
+CREATE TABLE inner_af64 (a Array(Float64)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE inner_af32 (x Array(Float32)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO inner_af64 VALUES ([0.0]), ([3.5]);
+INSERT INTO inner_af32 VALUES ([-0.0]), ([3.5]);
+
+SELECT 'INNER JOIN ON, cross-type equi-key with a nested float: result';
+SELECT l.a, r.x FROM inner_af64 AS l INNER JOIN inner_af32 AS r ON l.a = r.x
+WHERE reinterpretAsUInt64(l.a[1]) = 0 ORDER BY 1
+SETTINGS join_algorithm = 'full_sorting_merge';
+
+DROP TABLE inner_af64;
+DROP TABLE inner_af32;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -354,3 +354,17 @@ WHERE NOT has(JSONDynamicPaths(l.a), 'x') ORDER BY 1;
 
 DROP TABLE inner_json_shared;
 DROP TABLE inner_json_dyn;
+
+-- A substituted key must not feed a predicate that reads representation rather than value: `isConstant`
+-- answers differently for the same value depending on constness, and the narrower key here is constant
+-- while the wider key it replaces is not, so pushing the predicate would drop the matching row.
+
+DROP TABLE IF EXISTS inner_ic_wide;
+CREATE TABLE inner_ic_wide (a Int64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO inner_ic_wide VALUES (0);
+
+SELECT 'INNER JOIN ON, cross-type equi-key under a predicate reading constness: result';
+SELECT l.a FROM inner_ic_wide AS l INNER JOIN (SELECT toInt32(0) AS b) AS r ON l.a = r.b
+WHERE isConstant(l.a) = 0 ORDER BY 1;
+
+DROP TABLE inner_ic_wide;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -237,3 +237,24 @@ WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;
 DROP TABLE inner_d32;
 DROP TABLE inner_d;
 DROP TABLE inner_d32_key;
+
+-- A key that is not stable within the query is not substitutable: the pushed-down filter computes it and
+-- the JOIN computes it again, so the two comparisons would see different values and matching rows would
+-- be dropped. `* 0` keeps the value at the row number while making the key an expression of the right
+-- input, and `max_threads` is pinned because `rowNumberInAllBlocks` numbers each stream from zero.
+
+DROP TABLE IF EXISTS inner_nd_wide;
+DROP TABLE IF EXISTS inner_nd_narrow;
+CREATE TABLE inner_nd_wide   (a Int64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE inner_nd_narrow (x Int32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO inner_nd_wide   SELECT number FROM numbers(10);
+INSERT INTO inner_nd_narrow SELECT number FROM numbers(10);
+
+SELECT 'INNER JOIN ON, cross-type equi-key that is not stable within the query: result';
+SELECT l.a FROM inner_nd_wide AS l INNER JOIN inner_nd_narrow AS r
+    ON l.a = toInt32(rowNumberInAllBlocks() + r.x * 0)
+WHERE l.a BETWEEN 5 AND 6 ORDER BY 1
+SETTINGS max_threads = 1;
+
+DROP TABLE inner_nd_wide;
+DROP TABLE inner_nd_narrow;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -283,21 +283,23 @@ DROP TABLE inner_aj_narrow;
 -- predicate drop a matching row. A nested float is no different, and `Array` is used for the second shape
 -- because the wrapper-stripping predicates that cover `Nullable` do not look inside it. `join_algorithm` is
 -- pinned at query level because the hash algorithms hash the key bitwise and never match the pair at all.
+-- The flat shape uses `LEFT JOIN`, whose cross-type registration is older than the plain `INNER` one, so
+-- there a dropped right row surfaces as a defaulted `r.x`; the nested shape stays on `INNER`.
 
-DROP TABLE IF EXISTS inner_f64;
-DROP TABLE IF EXISTS inner_f32;
-CREATE TABLE inner_f64 (a Float64) ENGINE = MergeTree ORDER BY tuple();
-CREATE TABLE inner_f32 (x Float32) ENGINE = MergeTree ORDER BY tuple();
-INSERT INTO inner_f64 VALUES (0.0), (3.5);
-INSERT INTO inner_f32 VALUES (-0.0), (3.5);
+DROP TABLE IF EXISTS left_f64;
+DROP TABLE IF EXISTS left_f32;
+CREATE TABLE left_f64 (a Float64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE left_f32 (x Float32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO left_f64 VALUES (0.0), (3.5);
+INSERT INTO left_f32 VALUES (-0.0), (3.5);
 
-SELECT 'INNER JOIN ON, cross-type float equi-key: result';
-SELECT l.a, r.x FROM inner_f64 AS l INNER JOIN inner_f32 AS r ON l.a = r.x
+SELECT 'LEFT JOIN ON, cross-type float equi-key: result';
+SELECT l.a, r.x FROM left_f64 AS l LEFT JOIN left_f32 AS r ON l.a = r.x
 WHERE reinterpretAsUInt64(l.a) = 0 ORDER BY 1
 SETTINGS join_algorithm = 'full_sorting_merge';
 
-DROP TABLE inner_f64;
-DROP TABLE inner_f32;
+DROP TABLE left_f64;
+DROP TABLE left_f32;
 
 DROP TABLE IF EXISTS inner_af64;
 DROP TABLE IF EXISTS inner_af32;
@@ -313,3 +315,4 @@ SETTINGS join_algorithm = 'full_sorting_merge';
 
 DROP TABLE inner_af64;
 DROP TABLE inner_af32;
+

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -231,8 +231,8 @@ SELECT count() > 0 FROM (
 ) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
 
 -- Only a conjunct that reads the representation of a substituted key is unsafe, so a safe conjunct on
--- that same key still reaches the opposite input when the two sit side by side. `isConstant` is true for
--- every row of this read, so it constrains nothing and the granule counts describe the range alone.
+-- that same key still reaches the opposite input when the two sit side by side. `isConstant(l.a) = 0`
+-- holds for every row of this read, so it constrains nothing and the granule counts describe the range.
 
 SELECT 'INNER JOIN ON, cross-type equi-key beside a predicate reading constness: right MergeTree prunes granules';
 SELECT count() > 0 FROM (

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -258,3 +258,22 @@ SETTINGS max_threads = 1;
 
 DROP TABLE inner_nd_wide;
 DROP TABLE inner_nd_narrow;
+
+-- A key that changes the number of rows is not substitutable either: the pushed-down filter expands the
+-- rows and the JOIN expands them again, so a match is reported once per extra copy. The array repeats its
+-- element so that the second expansion changes the result and not just an intermediate row count.
+
+DROP TABLE IF EXISTS inner_aj_wide;
+DROP TABLE IF EXISTS inner_aj_narrow;
+CREATE TABLE inner_aj_wide   (a Int64) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE inner_aj_narrow (x Int32) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO inner_aj_wide   SELECT number FROM numbers(10);
+INSERT INTO inner_aj_narrow SELECT number FROM numbers(10);
+
+SELECT 'INNER JOIN ON, cross-type equi-key that changes the number of rows: result';
+SELECT l.a FROM inner_aj_wide AS l INNER JOIN inner_aj_narrow AS r
+    ON l.a = toInt32(arrayJoin([r.x, r.x]))
+WHERE l.a BETWEEN 5 AND 6 ORDER BY 1;
+
+DROP TABLE inner_aj_wide;
+DROP TABLE inner_aj_narrow;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -3,8 +3,8 @@
 -- replicas replace, and the `RIGHT JOIN` shapes below hit the unrelated logical error of
 -- https://github.com/ClickHouse/ClickHouse/issues/113292 there.
 
--- Equi-key `WHERE` predicates must reach the left `MergeTree` input of a `RIGHT JOIN` as an index
--- condition, including when the two `USING` keys differ in type.
+-- Equi-key `WHERE` predicates must reach the opposite `MergeTree` input of a `RIGHT JOIN` or a plain
+-- `INNER JOIN` as an index condition, including when the two join keys differ in type.
 --
 -- Analyzer only. Under `enable_analyzer = 0` a `USING` key is renamed to `<table>.<key>` in the right
 -- input header while the `JOIN` output keeps the bare name, so the equivalence maps are keyed by a name
@@ -190,3 +190,50 @@ SET join_use_nulls = 0;
 
 DROP TABLE mt_u32;
 DROP TABLE mt_i32;
+
+-- A plain `INNER JOIN` leaves both inputs open to a pushed-down filter, so a cross-type equi-key must
+-- reach the opposite input there too. The side ordered by `tuple()` can never prune, so a read that
+-- prunes granules is unambiguously the other one; the assertion compares the two granule counts rather
+-- than matching a literal total, which depends on the part layout.
+
+DROP TABLE IF EXISTS inner_d32;
+DROP TABLE IF EXISTS inner_d;
+DROP TABLE IF EXISTS inner_d32_key;
+CREATE TABLE inner_d32     (a Date32) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+CREATE TABLE inner_d       (b Date)   ENGINE = MergeTree ORDER BY b
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+CREATE TABLE inner_d32_key (a Date32) ENGINE = MergeTree ORDER BY a
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+INSERT INTO inner_d32     SELECT toDate32('2020-01-01') + number FROM numbers(40000);
+INSERT INTO inner_d       SELECT toDate('2020-01-01')   + number FROM numbers(40000);
+INSERT INTO inner_d32_key SELECT toDate32('2020-01-01') + number FROM numbers(40000);
+
+SELECT 'INNER JOIN ON, cross-type equi-key, predicate on the wider key: right MergeTree prunes granules';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN indexes = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
+
+SELECT 'INNER JOIN ON, cross-type equi-key, wider key on the right: left MergeTree prunes granules';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN indexes = 1
+    SELECT count() FROM inner_d AS l INNER JOIN inner_d32 AS r ON l.b = r.a
+    WHERE r.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
+
+SELECT 'INNER JOIN ON, matched types: right MergeTree prunes granules';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN indexes = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d32_key AS r ON l.a = r.a
+    WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
+
+SELECT 'INNER JOIN ON, cross-type equi-key: result';
+SELECT r.b FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;
+
+DROP TABLE inner_d32;
+DROP TABLE inner_d;
+DROP TABLE inner_d32_key;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -309,6 +309,27 @@ SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
       AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 );
 
+-- A body reads the arguments the call does not capture as well, since those arrive as its formal
+-- parameters, and the key then sits beside the lambda rather than inside it. What the body does with a
+-- formal is what decides: reading its value leaves the conjunct pushable, reading its representation does
+-- not, and both spellings render alike, so only the pushed filter separates them.
+
+SELECT 'INNER JOIN ON, conjunct whose lambda body reads the value of a formal bound to the equi-key: the conjunct is pushed';
+SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 1 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE arrayExists(y -> y > toDate32('1900-01-01'), [l.a]) = (l.a > toDate32('1900-01-01'))
+      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
+SELECT 'INNER JOIN ON, conjunct whose lambda body reads the representation of a formal bound to the equi-key: it is not';
+SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE arrayExists(y -> isConstant(y) = 0, [l.a]) = (l.a > toDate32('1900-01-01'))
+      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
 SELECT 'INNER JOIN ON, cross-type equi-key: result';
 SELECT r.b FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
 WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -199,15 +199,19 @@ DROP TABLE mt_i32;
 DROP TABLE IF EXISTS inner_d32;
 DROP TABLE IF EXISTS inner_d;
 DROP TABLE IF EXISTS inner_d32_key;
+DROP TABLE IF EXISTS inner_d_key;
 CREATE TABLE inner_d32     (a Date32) ENGINE = MergeTree ORDER BY tuple()
     SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 CREATE TABLE inner_d       (b Date)   ENGINE = MergeTree ORDER BY b
     SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 CREATE TABLE inner_d32_key (a Date32) ENGINE = MergeTree ORDER BY a
     SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+CREATE TABLE inner_d_key   (a Date)   ENGINE = MergeTree ORDER BY a
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 INSERT INTO inner_d32     SELECT toDate32('2020-01-01') + number FROM numbers(40000);
 INSERT INTO inner_d       SELECT toDate('2020-01-01')   + number FROM numbers(40000);
 INSERT INTO inner_d32_key SELECT toDate32('2020-01-01') + number FROM numbers(40000);
+INSERT INTO inner_d_key   SELECT toDate('2020-01-01')   + number FROM numbers(40000);
 
 SELECT 'INNER JOIN ON, cross-type equi-key, predicate on the wider key: right MergeTree prunes granules';
 SELECT count() > 0 FROM (
@@ -227,6 +231,24 @@ SELECT 'INNER JOIN ON, matched types: right MergeTree prunes granules';
 SELECT count() > 0 FROM (
     EXPLAIN PLAN indexes = 1
     SELECT count() FROM inner_d32 AS l INNER JOIN inner_d32_key AS r ON l.a = r.a
+    WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
+
+-- `USING` and `<=>` carry an equi-key just as `ON ... =` does, and the substitution is keyed by the key's
+-- own name on each side. A `USING` key holds the same name on both sides, which the `ON l.a = r.b` arms
+-- above cannot exercise, so each carrier is asserted on the same shape.
+
+SELECT 'INNER JOIN USING, cross-type equi-key: right MergeTree prunes granules';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN indexes = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d_key AS r USING (a)
+    WHERE a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
+
+SELECT 'INNER JOIN ON <=>, cross-type equi-key: right MergeTree prunes granules';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN indexes = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a <=> r.b
     WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 ) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
 
@@ -337,6 +359,7 @@ WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;
 DROP TABLE inner_d32;
 DROP TABLE inner_d;
 DROP TABLE inner_d32_key;
+DROP TABLE inner_d_key;
 
 -- A key that is not stable within the query is not substitutable: the pushed-down filter computes it and
 -- the JOIN computes it again, so the two comparisons would see different values and matching rows would

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -426,3 +426,46 @@ SELECT l.a FROM inner_ic_wide AS l INNER JOIN (SELECT toInt32(0) AS b) AS r ON l
 WHERE arrayExists(y -> isConstant(if(y, l.a, l.a)) = 0, [1]) ORDER BY 1;
 
 DROP TABLE inner_ic_wide;
+
+-- The predicate inferred for the opposite key travels on past the `JOIN`, so it also reaches a
+-- `MergeTree` read that sits below an `Aggregating` step whose grouping keys carry the filter column.
+-- `LowCardinality(String)` against `String` is a cross-type pair whose least supertype is `String`, and
+-- an `INNER JOIN` widens neither key in its output, so `join_use_nulls` leaves the substitution
+-- admissible. The target rows sort after every other key value, so the granules the rest of the grouped
+-- input contributes are the ones the assertion sees dropped.
+
+DROP TABLE IF EXISTS inner_lc_grouped;
+DROP TABLE IF EXISTS inner_str_probe;
+CREATE TABLE inner_lc_grouped (org LowCardinality(String), sub String, ts UInt64) ENGINE = MergeTree ORDER BY (org, sub)
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+CREATE TABLE inner_str_probe (org String, sub String, rev Float64) ENGINE = MergeTree ORDER BY (org, sub)
+    SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
+INSERT INTO inner_lc_grouped SELECT toString(number % 400), toString(number), number FROM numbers(40000);
+INSERT INTO inner_lc_grouped SELECT 'TARGET', toString(number), number FROM numbers(20);
+INSERT INTO inner_str_probe SELECT 'TARGET', toString(number), 1 FROM numbers(20);
+
+SET join_use_nulls = 1;
+
+SELECT 'INNER JOIN ON, cross-type LowCardinality equi-key above a grouped input, join_use_nulls: grouped MergeTree prunes granules';
+SELECT count() > 0 FROM (
+    EXPLAIN PLAN indexes = 1
+    SELECT sum(t.rev) FROM (
+        SELECT f.org AS org, f.rev AS rev FROM inner_str_probe AS f
+        INNER JOIN (SELECT org, sub, max(ts) AS m FROM inner_lc_grouped GROUP BY org, sub) AS c
+            ON c.org = f.org AND c.sub = f.sub
+    ) AS t
+    WHERE t.org = 'TARGET'
+) WHERE toUInt64OrZero(extract(explain, 'Granules: ([0-9]+)/')) < toUInt64OrZero(extract(explain, 'Granules: [0-9]+/([0-9]+)'));
+
+SELECT 'INNER JOIN ON, cross-type LowCardinality equi-key above a grouped input, join_use_nulls: result';
+SELECT sum(t.rev) FROM (
+    SELECT f.org AS org, f.rev AS rev FROM inner_str_probe AS f
+    INNER JOIN (SELECT org, sub, max(ts) AS m FROM inner_lc_grouped GROUP BY org, sub) AS c
+        ON c.org = f.org AND c.sub = f.sub
+) AS t
+WHERE t.org = 'TARGET';
+
+SET join_use_nulls = 0;
+
+DROP TABLE inner_lc_grouped;
+DROP TABLE inner_str_probe;

--- a/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
+++ b/tests/queries/0_stateless/04117_join_equi_key_filter_pushdown_right_full.sql
@@ -281,6 +281,34 @@ SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
       AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
 );
 
+-- Stability within the query is two properties and a function can fail only the second:
+-- `timeSeriesStoreTags` returns its first argument unchanged while declaring itself stateful, so it
+-- separates statefulness from the non-determinism `rand` carries above. Its value is the same on every
+-- evaluation, so only the plan tells these keys apart from a substitutable one.
+
+SELECT 'INNER JOIN ON, cross-type equi-key holding per-query state: the key does not reach the right input';
+SELECT countIf(explain ILIKE '%Filter column%timeSeriesStoreTags%') = 0 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = timeSeriesStoreTags(r.b, map('n', 'v'))
+    WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
+SELECT 'INNER JOIN ON, cross-type equi-key whose lambda body holds per-query state: the key does not either';
+SELECT countIf(explain ILIKE '%Filter column%arrayMax%') = 0 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r
+        ON l.a = arrayMax(arrayMap(z -> timeSeriesStoreTags(z, map('n', 'v')), [r.b]))
+    WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
+SELECT 'INNER JOIN ON, conjunct whose lambda body holds per-query state beside the equi-key: the conjunct is not pushed';
+SELECT countIf(explain ILIKE '%arrayExists%CAST(b AS Date32)%') = 0 FROM (
+    EXPLAIN PLAN actions = 1
+    SELECT count() FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
+    WHERE arrayExists(y -> timeSeriesStoreTags(y, map('n', 'v')) % 1 = 0, materialize([1])) = (l.a > toDate32('1900-01-01'))
+      AND l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03')
+);
+
 SELECT 'INNER JOIN ON, cross-type equi-key: result';
 SELECT r.b FROM inner_d32 AS l INNER JOIN inner_d AS r ON l.a = r.b
 WHERE l.a BETWEEN toDate32('2020-06-01') AND toDate32('2020-06-03') ORDER BY 1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/116395

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results in five cases where a `WHERE` predicate on a join key was pushed to the other side of a `JOIN` whose two keys have different types. Such a key is no longer substituted when the keys' common type is a float, because `-0.0` and `+0.0` are join-equal but differ bit for bit; nor when it is `Dynamic` or `JSON`, whose runtime contents the static type does not describe; nor when the key is unstable within the query or changes the row count; nor in a conjunct that reads a column's representation rather than its value, as `isConstant` and `toColumnTypeName` do, including when such a read or an unstable function is hidden inside a lambda body. Separately, with `enable_analyzer = 1`, a predicate on the wider of two differently typed join keys is now also used as an index condition on the other table of a plain `INNER JOIN`, so it is read through its primary key instead of in full; previously only `ANY INNER JOIN`, `LEFT JOIN` and `RIGHT JOIN` got this.


### Description
@ fm4v asked for this in https://github.com/ClickHouse/ClickHouse/issues/116395#issuecomment-5426479774. #103478 fixed his `LEFT JOIN` arm; the `INNER JOIN` arm remains.

Root cause. The cross-type equi-key producer was gated on one side being unavailable for push-down, which a plain `INNER JOIN` never is, so both maps stayed empty. The gate was redundant: availability is applied per map below, as the equal-type registration above it always has.

Widening it put unsound cases in reach, so the substitution now declines the five kinds above. The declines also apply to `LEFT`/`RIGHT`/`ANY INNER`, so the float one fixes wrong results already released there: on 26.8.2.7 and 26.6.4.55, `Float64 +0.0 LEFT JOIN Float32 -0.0` under `full_sorting_merge` returns `r.x` as `0`, not the matched `-0`, and is correct with push-down off. Only that decline reproduces on a release.

At 1M rows per side, `Date32` against `Date`, `dim` goes from 122/122 granules to 1/122, reading 1,008,192 rows not 2,000,000, same result.

Not fixed here: key pairs with no least supertype, a predicate on the narrower key, cross-type keys that
`join_use_nulls` widens in the join output, which an `OUTER` join does and a plain `INNER JOIN` does
not, and the unstable-key and row-count exposures on the equal-type equi-key path,
which predate this change and come from a different producer,
`buildEquialentSetsForJoinStepLogical`. The declines above now do read a lambda body reached through `FunctionCapture`, but `getConjunctionNodes` itself still judges only the functions it can see, so the other push-down paths keep that gap; my open #112700 addresses it.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117973&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117973](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117973+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->





<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1543` (included in `26.9` and later)
<!-- ch-version-info:end -->