### PR TITLE
Fix flaky test_zookeeper_fallback_session by freezing the client watermark instead of sampling it

### DIFF
--- a/tests/integration/test_zookeeper_fallback_session/test.py
+++ b/tests/integration/test_zookeeper_fallback_session/test.py
@@ -78,26 +78,8 @@ def get_zk_applied_zxid(cluster: ClickHouseCluster, zk_node):
     return None
 
 
-def get_max_client_zxid(nodes):
-    """Highest zxid any of `nodes` has already seen, or None if one is reconnecting.
-
-    `system.zookeeper_connection` has no row for a session that currently has no
-    connected host, so a read taken while a reconnect is in flight is not a
-    watermark and must not be mistaken for a low one.
-    """
-    seen = []
-    for node in nodes:
-        raw = node.query(
-            "select last_zxid_seen from system.zookeeper_connection"
-        ).strip()
-        if not raw:
-            return None
-        seen.append(int(raw))
-    return max(seen)
-
-
-def wait_zk_node_caught_up(cluster: ClickHouseCluster, zk_node, nodes, timeout=60):
-    """Wait until `zk_node` has applied everything `nodes` have already seen.
+def wait_zk_node_caught_up(cluster: ClickHouseCluster, zk_node, target_zxid, timeout=60):
+    """Wait until `zk_node` has applied everything up to `target_zxid`.
 
     A Keeper refuses a reconnecting client whose `last_zxid_seen` exceeds its
     own applied zxid, telling it to try another server, and the client falls
@@ -106,23 +88,17 @@ def wait_zk_node_caught_up(cluster: ClickHouseCluster, zk_node, nodes, timeout=6
     demoted for the rest of the test.
     """
     deadline = time.monotonic() + timeout
-    applied = client_zxid = None
+    applied = None
     while time.monotonic() < deadline:
         applied = get_zk_applied_zxid(cluster, zk_node)
-        # Read the clients after zk_node, so client_zxid is never older than
-        # applied. A Keeper's committed zxid only grows, so once this holds for
-        # such a pair it stays true for that pair.
-        client_zxid = get_max_client_zxid(nodes)
-        if applied is not None and client_zxid is not None and applied >= client_zxid:
+        if applied is not None and applied >= target_zxid:
             return
         time.sleep(0.2)
 
     raise AssertionError(
-        f"{zk_node} did not catch up within {timeout}s: it has applied "
-        f"{'unreadable (not serving requests?)' if applied is None else applied}"
-        f", while the clients have already seen "
-        f"{'unknown (reconnecting)' if client_zxid is None else client_zxid}. "
-        f"{zk_node} would refuse their sessions and they would fall back to "
+        f"{zk_node} did not reach zxid {target_zxid} within {timeout}s: it has "
+        f"applied {'unreadable (not serving requests?)' if applied is None else applied}. "
+        f"{zk_node} would refuse the nodes' sessions and they would fall back to "
         f"another Keeper."
     )
 
@@ -169,26 +145,30 @@ def test_fallback_session(started_cluster: ClickHouseCluster):
     for node in [node1, node2, node3]:
         assert_uses_zk_node(node, "zoo3")
 
-    # zoo1 is a Raft follower applying the tail of the log asynchronously, so
-    # it can be behind what the nodes saw through zoo3 and would refuse their
-    # new sessions. Waiting closes that catch-up window; the cluster keeps
-    # committing, so this narrows the race rather than removing it.
-    wait_zk_node_caught_up(started_cluster, "zoo1", [node1, node2, node3])
-
     with PartitionManager() as pm:
-        for node in started_cluster.instances.values():
-            pm.add_rule(
-                {
-                    "instance": node,
-                    "source": node.ip_address,
-                    "destination": cluster.get_instance_ip("zoo3"),
-                    "action": "REJECT --reject-with tcp-reset",
-                    "protocol": "tcp",
-                }
+        # Cut the nodes off every Keeper, not only the one they use, so that none of
+        # them can start a session anywhere while zoo1 catches up.
+        for node in [node1, node2, node3]:
+            pm.drop_instance_zk_connections(
+                node, action="REJECT --reject-with tcp-reset"
             )
 
+        # The rule stops only what a node sends, so a reply already on its way could
+        # still raise its `last_zxid_seen`. Finalizing joins the receiving thread,
+        # after which the value cannot move.
         for node in [node1, node2, node3]:
-            assert_uses_zk_node(node, "zoo1")
+            node.query("SYSTEM RECONNECT ZOOKEEPER")
+
+        # Every zxid the nodes can have seen came from zoo3, and zoo3 answers only
+        # from what it has applied, so its applied zxid bounds all of theirs. zoo1
+        # applies the tail of the log asynchronously and refuses a client that has
+        # seen more.
+        target_zxid = get_zk_applied_zxid(started_cluster, "zoo3")
+        assert target_zxid is not None, "zoo3 is not serving requests"
+        wait_zk_node_caught_up(started_cluster, "zoo1", target_zxid)
+
+    for node in [node1, node2, node3]:
+        assert_uses_zk_node(node, "zoo1")
 
     node1.query_with_retry("INSERT INTO simple VALUES ({0}, {0})".format(2))
     for node in [node2, node3]:

--- a/tests/integration/test_zookeeper_fallback_session/test.py
+++ b/tests/integration/test_zookeeper_fallback_session/test.py
@@ -118,7 +118,7 @@ def wait_zk_node_caught_up(cluster: ClickHouseCluster, zk_node, target_zxid, tim
     raise AssertionError(
         f"{zk_node} did not reach zxid {target_zxid} within {timeout}s: it has "
         f"applied {'unreadable (not serving requests?)' if applied is None else applied}. "
-        f"{zk_node} would refuse the nodes' sessions and they would fall back to "
+        f"{zk_node} could refuse the nodes' sessions and they would fall back to "
         f"another Keeper."
     )
 
@@ -179,10 +179,9 @@ def test_fallback_session(started_cluster: ClickHouseCluster):
         for node in [node1, node2, node3]:
             node.query("SYSTEM RECONNECT ZOOKEEPER")
 
-        # Every zxid the nodes can have seen came from zoo3, and zoo3 answers only
-        # from what it has applied, so its applied zxid bounds all of theirs. zoo1
-        # applies the tail of the log asynchronously and refuses a client that has
-        # seen more.
+        # zoo3 accepted these sessions and has answered every request since, so its
+        # applied zxid bounds what any of the nodes has seen. zoo1 applies the tail of
+        # the log asynchronously and refuses a client that has seen more.
         target_zxid = get_zk_applied_zxid(started_cluster, "zoo3")
         assert target_zxid is not None, "zoo3 is not serving requests"
         wait_zk_node_caught_up(started_cluster, "zoo1", target_zxid)
@@ -215,6 +214,15 @@ def test_fallback_session(started_cluster: ClickHouseCluster):
                 "select host, client_id from system.zookeeper_connection",
                 check_callback=lambda session: session.strip() != "",
             ).strip()
+
+    # `PartitionManager` logs a failed `iptables -D` and carries on, so a rule left
+    # behind would keep zoo1 the only reachable Keeper and satisfy the assertion below.
+    for node in [node1, node2, node3]:
+        rules = node.exec_in_container(
+            ["iptables", "--wait", "-S", "OUTPUT"], user="root"
+        )
+        for zk in ["zoo2", "zoo3"]:
+            assert cluster.get_instance_ip(zk) not in rules, rules
 
     # A node's `last_zxid_seen` was at or below what zoo1 had applied when it connected
     # to it, and everything it has seen since came from zoo1, so zoo1 cannot refuse the

--- a/tests/integration/test_zookeeper_fallback_session/test.py
+++ b/tests/integration/test_zookeeper_fallback_session/test.py
@@ -167,6 +167,36 @@ def test_fallback_session(started_cluster: ClickHouseCluster):
         assert target_zxid is not None, "zoo3 is not serving requests"
         wait_zk_node_caught_up(started_cluster, "zoo1", target_zxid)
 
+        # A session is established by walking the host list in order and stopping at
+        # the first Keeper that answers, so with several reachable the outcome depends
+        # on where a walk already is. Shutting zoo2 and zoo3 leaves only zoo1.
+        for node in [node1, node2, node3]:
+            for zk in ["zoo2", "zoo3"]:
+                pm.add_rule(
+                    {
+                        "instance": node,
+                        "source": node.ip_address,
+                        "destination": cluster.get_instance_ip(zk),
+                        "action": "REJECT --reject-with tcp-reset",
+                        "protocol": "tcp",
+                    }
+                )
+
+        for node in [node1, node2, node3]:
+            pm.restore_instance_zk_connections(
+                node, action="REJECT --reject-with tcp-reset"
+            )
+
+        for node in [node1, node2, node3]:
+            # Synchronisation, not the assertion: zoo1 is the only Keeper reachable.
+            assert_uses_zk_node(node, "zoo1")
+
+    # Every Keeper is reachable again, and every zxid these nodes have seen came from
+    # zoo1, so none of them is ahead of what zoo1 has applied and zoo1 cannot refuse
+    # their new sessions. `in_order` alone decides the host they land on.
+    for node in [node1, node2, node3]:
+        node.query("SYSTEM RECONNECT ZOOKEEPER")
+
     for node in [node1, node2, node3]:
         assert_uses_zk_node(node, "zoo1")
 

--- a/tests/integration/test_zookeeper_fallback_session/test.py
+++ b/tests/integration/test_zookeeper_fallback_session/test.py
@@ -57,6 +57,26 @@ def assert_uses_zk_node(node: ClickHouseInstance, zk_node):
     assert host.strip() == zk_node
 
 
+def assert_uses_new_zk_session(node: ClickHouseInstance, zk_node, previous):
+    """Wait until `node` holds a session other than `previous`, and on `zk_node`.
+
+    The host on its own would also be satisfied by `previous`, which was established
+    while zoo1 was the only Keeper reachable.
+    """
+
+    def check_callback(session):
+        session = session.strip()
+        return session != previous and session.split("\t")[0] == zk_node
+
+    session = node.query_with_retry(
+        "select host, client_id from system.zookeeper_connection",
+        check_callback=check_callback,
+    ).strip()
+
+    assert session != previous, f"{node.name} kept the session it had before the heal"
+    assert session.split("\t")[0] == zk_node, f"{node.name} is connected as {session!r}"
+
+
 def get_zk_applied_zxid(cluster: ClickHouseCluster, zk_node):
     """Last zxid applied by `zk_node` itself, or None if it cannot be read.
 
@@ -187,18 +207,23 @@ def test_fallback_session(started_cluster: ClickHouseCluster):
                 node, action="REJECT --reject-with tcp-reset"
             )
 
+        sessions = {}
         for node in [node1, node2, node3]:
             # Synchronisation, not the assertion: zoo1 is the only Keeper reachable.
             assert_uses_zk_node(node, "zoo1")
+            sessions[node.name] = node.query_with_retry(
+                "select host, client_id from system.zookeeper_connection",
+                check_callback=lambda session: session.strip() != "",
+            ).strip()
 
-    # Every Keeper is reachable again, and every zxid these nodes have seen came from
-    # zoo1, so none of them is ahead of what zoo1 has applied and zoo1 cannot refuse
-    # their new sessions. `in_order` alone decides the host they land on.
+    # A node's `last_zxid_seen` was at or below what zoo1 had applied when it connected
+    # to it, and everything it has seen since came from zoo1, so zoo1 cannot refuse the
+    # new sessions. `in_order` alone decides the host they land on.
     for node in [node1, node2, node3]:
         node.query("SYSTEM RECONNECT ZOOKEEPER")
 
     for node in [node1, node2, node3]:
-        assert_uses_zk_node(node, "zoo1")
+        assert_uses_new_zk_session(node, "zoo1", sessions[node.name])
 
     node1.query_with_retry("INSERT INTO simple VALUES ({0}, {0})".format(2))
     for node in [node2, node3]:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/66966
Related: https://github.com/ClickHouse/ClickHouse/pull/114055

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_fallback_session` breaks the nodes' zoo3 session and asserts that `in_order` balancing puts
them back on zoo1. A Keeper refuses a reconnecting client whose `last_zxid_seen` exceeds its own
applied zxid (`KeeperTCPHandler.cpp`, `Refusing session ...`), and
`GetPriorityForLoadBalancing::hasOptimalNode` returns `false` for `IN_ORDER`, so no reconnect task is
armed to undo it. If zoo1 is behind, the nodes land on zoo2 and stay.

#114055 sampled "zoo1 has caught up" before the cut, which cannot work: heartbeats alone raise
`last_zxid_seen`, so while the nodes are on zoo3 they keep advancing the quantity zoo1 must overtake.

This removes the movement instead of sampling it. The second partition cuts the nodes off EVERY
Keeper and finalizes their sessions with `SYSTEM RECONNECT ZOOKEEPER`, which joins the receiving
thread so `last_zxid_seen` can no longer advance; zoo3's applied zxid is then read once as a fixed
target bounding every zxid they can have seen, and the wait is retargeted to it. Releasing all three
Keepers at once would still let a reconnect walk that had already passed zoo1 settle on zoo2, so
zoo2 and zoo3 stay shut while the nodes are synchronised onto zoo1, and only then is everything
reachable and the sessions broken again for the assertion. Nothing they have seen exceeds zoo1's own
applied zxid, so zoo1 cannot refuse them and `in_order` alone decides the host.

Validated by cutting zoo1's Raft link inside its container, so it keeps serving clients but stops
applying. Under it the current test fails with `assert 'zoo2' == 'zoo1'` and the verbatim
refusal in zoo1's log, the fixed test passes with the watermark observed frozen, and weakening the
cut back to zoo3 alone reddens it again. The release race reproduces deterministically on the
previous revision, not on this one. 20 of 20 unforced runs pass, 40-50 s each.

<details>
<summary>The reds this fixes, the CI report, and the read-order measurement</summary>

```
File: test_zookeeper_fallback_session/test.py:176 - in test_fallback_session
    wait_zk_node_caught_up(started_cluster, "zoo1", [node1, node2, node3])
E   AssertionError: zoo1 did not catch up within 60s: it has applied 214, while the
    clients have already seen 215. zoo1 would refuse their sessions and they would
    fall back to another Keeper.
```

```sql
SELECT check_start_time, pull_request_number, check_name
FROM default.checks
WHERE test_name LIKE '%test_zookeeper_fallback_session%'
  AND test_status IN ('FAIL','ERROR') AND check_status != 'success'
  AND test_context_raw LIKE '%in test_fallback_session%'
  AND check_start_time > now() - INTERVAL 35 DAY
ORDER BY check_start_time DESC
```

```
2026-08-30 15:37:20  104424  Integration tests (amd_asan_ubsan, db disk, old analyzer, 5/6)
2026-08-09 00:22:59  113044  Integration tests (arm_binary, distributed plan, 4/4)
2026-08-08 19:42:46  113575  Integration tests (arm_binary, distributed plan, 3/4)
```

Three unrelated PRs. The 2026-08-30 row is the `:176` timeout above and post-dates #114055; the two
August rows are the `assert 'zoo2' == 'zoo1'` form and pre-date it. True master over 90 days: 0 of
12,195 rows.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104424&sha=832752fd4d22ac63a2eee5a92c6288833b7471a2&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29

`applied 214 / seen 215` is not a real lag. Taking the old check's two reads 250 times at its own
cadence on a healthy cluster, plus a third read of zoo1 after the client read: 47 rounds (18.8%)
failed the check, all 47 with `applied_before < client <= applied_after`, zero real lags, gap always
exactly 1. It could only pass in a quiet moment between its own two reads.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117976&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117976](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117976+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.680` (included in `26.9` and later)
<!-- ch-version-info:end -->