### PR TITLE
Fix Keeper aborting when memory pressure blocks eviction to object storage

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -4127,6 +4127,11 @@ void Changelog::appendCompletionThread()
 
 void Changelog::writeThread()
 {
+    /// The only consumer of an exception escaping this thread is the catch-all below, which calls
+    /// `std::terminate`. Rotation allocates (the file buffer, and the zstd buffer when logs are
+    /// compressed), so under memory pressure a refused allocation kills the process outright.
+    LockMemoryExceptionInThread blocker{VariableContext::Global};
+
     WriteOperation write_operation;
     bool batch_append_ok = true;
     size_t pending_appends = 0;
@@ -4646,6 +4651,11 @@ Changelog::~Changelog()
 
 void Changelog::backgroundChangelogOperationsThread()
 {
+    /// A failed removal here is stored and rethrown by `writeAt`, whose only handling is
+    /// `std::terminate`. A blocker on the write thread cannot help: the exception is created here,
+    /// and suppression applies where an exception is raised, not where it is rethrown.
+    LockMemoryExceptionInThread blocker{VariableContext::Global};
+
     ChangelogFileOperationPtr changelog_operation;
     while (changelog_operation_queue.pop(changelog_operation))
     {

--- a/src/Coordination/KeeperCommon.cpp
+++ b/src/Coordination/KeeperCommon.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include <Common/Exception.h>
+#include <Common/LockMemoryExceptionInThread.h>
 #include <Common/logger_useful.h>
 #include <Common/SipHash.h>
 #include <Common/ZooKeeper/IKeeper.h>
@@ -72,6 +73,11 @@ void moveFileBetweenDisks(
     LoggerPtr logger,
     const KeeperContextPtr & keeper_context)
 {
+    /// This is the only work that frees the local disk, and the Raft write path that fills it is
+    /// itself exempt from memory limit exceptions. Refusing the mover under memory pressure turns
+    /// that pressure into a full disk and a fail-stop abort, so it is exempt too.
+    LockMemoryExceptionInThread blocker{VariableContext::Global};
+
     LOG_TRACE(logger, "Moving {} to {} from disk {} to disk {}", path_from, path_to, disk_from->getName(), disk_to->getName());
     /// we use empty file with prefix tmp_ to detect incomplete copies
     /// if a copy is complete we don't care from which disk we use the same file

--- a/src/Coordination/tests/gtest_coordination_disk_move.cpp
+++ b/src/Coordination/tests/gtest_coordination_disk_move.cpp
@@ -1,0 +1,84 @@
+#include "config.h"
+
+#if USE_NURAFT
+
+#include <filesystem>
+#include <thread>
+
+#include <Coordination/CoordinationSettings.h>
+#include <Coordination/KeeperCommon.h>
+#include <Coordination/KeeperContext.h>
+
+#include <Disks/DiskLocal.h>
+#include <Disks/IDisk.h>
+
+#include <IO/WriteBufferFromFileBase.h>
+#include <IO/WriteHelpers.h>
+
+#include <Common/MemoryTracker.h>
+#include <Common/ThreadStatus.h>
+#include <Common/logger_useful.h>
+#include <Common/scope_guard_safe.h>
+
+#include <gtest/gtest.h>
+
+namespace DB::CoordinationSetting
+{
+    extern const CoordinationSettingsUInt64 disk_move_retries_during_init;
+    extern const CoordinationSettingsUInt64 disk_move_retries_wait_ms;
+}
+
+namespace fs = std::filesystem;
+
+/// Moving a finished changelog or snapshot to the object storage disk is the only thing that frees
+/// Keeper's local log disk. The Raft write path is exempt from memory limit exceptions and keeps
+/// producing files regardless of memory pressure, so a mover that the memory tracker can refuse
+/// turns memory pressure into a full local disk, a failing `fallocate` and a NuRaft fail-stop.
+TEST(KeeperDiskMove, MoveIsNotRefusedByTheMemoryTracker)
+{
+    const std::string test_dir = "./keeper_disk_move_test";
+    fs::remove_all(test_dir);
+    fs::create_directories(test_dir + "/from");
+    fs::create_directories(test_dir + "/to");
+    SCOPE_EXIT_SAFE(fs::remove_all(test_dir));
+
+    auto settings = std::make_shared<DB::CoordinationSettings>();
+    /// The retry loop is bounded only in `Phase::INIT`, which is what a fresh context is in. Give up
+    /// after the first failure so that a refused move fails this test instead of retrying forever.
+    (*settings)[DB::CoordinationSetting::disk_move_retries_during_init] = 1;
+    (*settings)[DB::CoordinationSetting::disk_move_retries_wait_ms] = 1;
+    auto keeper_context = std::make_shared<DB::KeeperContext>(/*standalone_keeper_=*/true, settings);
+
+    DB::DiskPtr disk_from = std::make_shared<DB::DiskLocal>("From", test_dir + "/from");
+    DB::DiskPtr disk_to = std::make_shared<DB::DiskLocal>("To", test_dir + "/to");
+
+    {
+        auto buf = disk_from->writeFile("changelog.bin", DB::DBMS_DEFAULT_BUFFER_SIZE, DB::WriteMode::Rewrite, {});
+        DB::writeString(std::string(1024 * 1024, 'x'), *buf);
+        buf->finalize();
+    }
+
+    /// `getMemoryTracker` only reaches `total_memory_tracker` once the main thread status exists.
+    DB::MainThreadStatus::getInstance();
+    auto log = getLogger("KeeperDiskMoveTest");
+
+    /// The move runs on a thread with no `ThreadStatus`, so every allocation goes straight to
+    /// `total_memory_tracker` instead of being batched into this thread's untracked memory, and a
+    /// hard limit below the amount already tracked refuses all of them - the incident's state, where
+    /// RSS stayed above the limit for over an hour.
+    std::thread mover(
+        [&]
+        {
+            const Int64 previous_hard_limit = total_memory_tracker.getHardLimit();
+            SCOPE_EXIT_SAFE(total_memory_tracker.setHardLimit(previous_hard_limit));
+            total_memory_tracker.setHardLimit(1);
+
+            DB::moveFileBetweenDisks(disk_from, "changelog.bin", disk_to, "changelog.bin", {}, log, keeper_context);
+        });
+    mover.join();
+
+    EXPECT_TRUE(disk_to->existsFile("changelog.bin"));
+    EXPECT_FALSE(disk_from->existsFile("changelog.bin"));
+}
+
+#endif


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/109460

## Problem

Keeper aborts because its local log disk fills up. Preallocating the next changelog fails with `ENOSPC`, NuRaft treats a failed log append as unrecoverable and stops the server, and the process takes `SIGABRT`:

```
23:14:22 Fatal  Failed to allocate enough space on disk for logs
23:14:22 Fatal  log appending failed, stop this server
23:14:22 Fatal  5.0. inlined from src/Coordination/KeeperStateManager.cpp:343: DB::KeeperStateManager::system_exit(int)
23:14:22 Fatal  5. contrib/NuRaft/src/handle_append_entries.cxx:1561: nuraft::raft_server::notify_log_append_completion(bool)
23:14:22 Fatal  6.0. inlined from src/Coordination/Changelog.cpp:2244: DB::Changelog::appendCompletionThread()
23:14:22 Fatal  (version 26.4.1.1909 …) (from thread 720) Received signal 6 (internal)
23:14:22 Fatal  Signal description: Aborted
```

The abort itself is correct — appending Raft entries to a full disk would break crash consistency. The problem is that the disk was allowed to fill in the first place, and it did so deterministically: for ~65 minutes beforehand every attempt to free space failed, at ~120 failures per minute per pod, and this ended the same way on multiple pods.

## Root cause

Keeper appends to a changelog on a local disk and moves finished changelogs and snapshots to object storage. That move is the only thing that frees the local disk — and it was the only Keeper path still subject to memory limit exceptions. Above the memory limit its write buffers are refused:

```
23:13:30 Error  While moving file changelog_4453896440_4453996439.bin to disk s3_keeper_log_disk and running
                'copying file': Code: 241. DB::Exception: (total) memory limit exceeded: would use 59.43 GiB
                (attempt to allocate chunk of 6.13 MiB), current RSS: 69.45 GiB, maximum: 63.00 GiB:
                While writing to ForkWriteBuf…
23:13:30 Error  While moving file snapshot_4453552321.bin.zstd to disk s3_keeper_snapshot_disk and running
                'copying file': Code: 241. …
23:13:31 Error  … same two, once per second, until the abort
```

and `moveFileBetweenDisks` retries them forever (`src/Coordination/KeeperCommon.cpp`):

```cpp
    auto run_with_retries = [&](const auto & op, std::string_view operation_description)
    {
        ...
            catch (...)
            {
                tryLogCurrentException(logger, fmt::format("While moving file {} to disk {} ...", ...));
                std::this_thread::sleep_for(retries_sleep);          // 1 s, then round again
            }
        } while (!keeper_context->isShutdownCalled());               // unbounded outside Phase::INIT
    };

    if (!run_with_retries([&] { auto buf = disk_to->writeFile(tmp_file_name); buf->finalize(); },
                          "creating temporary file"))                // allocates, so it can be refused
        return;
```

Meanwhile Raft keeps producing new local files. Several sites in `src/Coordination` already take `LockMemoryExceptionInThread{VariableContext::Global}` — `KeeperServer` commit / `append_entries_in_bg` / asio workers / apply, `KeeperStateMachine::pre_commit`, `Storage/BackgroundWork` — on the grounds that failing an allocation there is worse than overshooting the limit. Those cover the NuRaft threads and the in-memory apply; the durable changelog write is queued to `Changelog::writeThread`, which was not covered (see the fix below).

So the loop closes, with positive feedback and no backpressure:

```
memory limit reached → moves refused, retried forever → Raft (exempt) keeps writing
                     → local disk fills → ENOSPC → NuRaft fail-stop → abort
```

The one activity that would relieve the pressure is the one that gets refused. Note this requires a global hard limit to exist, which the standalone `clickhouse-keeper` binary never installs (see the comment in `programs/keeper/Keeper.cpp`); it applies to Keeper running from the server binary with `keeper_server.standalone_keeper=true`, where `max_server_memory_usage` becomes the tracker's hard limit.

## Fix

Exempt the mover too, which covers all three callers — the background changelog move, the snapshot move, and the moves done during initialization:

```cpp
 void moveFileBetweenDisks(...)
 {
+    /// This is the only work that frees the local disk, and the Raft write path that fills it is
+    /// itself exempt from memory limit exceptions. Refusing the mover under memory pressure turns
+    /// that pressure into a full disk and a fail-stop abort, so it is exempt too.
+    LockMemoryExceptionInThread blocker{VariableContext::Global};
+
     LOG_TRACE(logger, "Moving {} to {} from disk {} to disk {}", ...);
```

Letting the move run drains the local disk instead of filling it. `LockMemoryExceptionInThread` only suppresses the tracker's own exception; a real allocation failure still propagates.

Two more threads need the same treatment, because otherwise this relocates the abort rather than removing it. Once the disk stops filling, the node survives a memory event indefinitely and keeps rotating changelogs throughout it — so a path that was previously bounded by the hour-long march to `ENOSPC` becomes unbounded:

- **`Changelog::writeThread`** — where the durable write actually happens. `appendRecord` has no try/catch, so a rotation through `setFile`, whose own catch rethrows, lands in the thread's catch-all: `tryLogCurrentException(log, "Write thread failed, aborting"); std::terminate();`. Note the contrast inside `appendRecord`: running out of disk space is handled deliberately (returns `false`, the batch is marked failed, NuRaft decides), while a refused allocation escapes as an exception with no return value, no NuRaft and no retry. A rotation allocates the file buffer plus, with `compress_logs`, the zstd buffer — one to two MiB.
- **`Changelog::backgroundChangelogOperationsThread`** — a failed removal is stored and rethrown by `writeAt`, which terminates. Exempting the write thread does not cover it: the exception is created on the background thread, and suppression applies where an exception is raised, not where it is rethrown. `setError` has two call sites, both in that thread's removal catch blocks, and `getError` one consumer — that `std::terminate` — so the failure is unconditionally fatal.

Regression test: `KeeperDiskMove.MoveIsNotRefusedByTheMemoryTracker` in `src/Coordination/tests/gtest_coordination_disk_move.cpp`, covering the mover. The two thread-entry exemptions have no separate test: both are long-lived threads carrying a `ThreadStatus`, so whether an allocation reaches the tracker depends on when the 4 MiB untracked-memory batch flushes, which is inherently racy, and the one way to force it deterministically — fault injection — does not travel the tracker path the blocker actually suppresses, so such a test would pass without exercising the mechanism.

## Notes

<details>
<summary>How far the exemption can push memory past the limit</summary>

Bounded, not proportional to the file being moved.

- **~350 MiB per `WriteBufferFromS3`** — the current buffer plus at most `max_inflight_parts_for_one_file` (20) part buffers of `min_upload_part_size` (16 MiB), which `TaskTracker` blocks on rather than exceeding. The part size only grows after a single object passes ~8 GiB.
- **× enabled object storage locations** (`ForkWriteBuffer` fan-out).
- **× at most two concurrent moves** — changelog moves are serialized on one `background_changelog_operations_thread`, and the snapshot move runs one at a time. The log above shows exactly that pair.

So roughly **700 MiB per location** worst case. The common case is far below it: a changelog is capped by `max_log_file_size`, and at or below `max_single_part_upload_size` it is a single-part upload — one 32 MiB buffer, no parts in flight.

For scale, the process above was sustaining an RSS of 69.45 GiB against a 63.00 GiB limit — 6.45 GiB over — for ~65 minutes without being killed, because the tracker limit is not the cgroup ceiling. The permitted overshoot is an order of magnitude below the gap it was already running in.
</details>

<details>
<summary>Why the S3 part-upload thread pool needs no separate coverage</summary>

`LockMemoryExceptionInThread` is `FiberLocal`, so it does not reach the part uploads that `S3ObjectStorage::writeObject` schedules on `REMOTE_FS_WRITE_THREAD_POOL`. Those do not need it:

- Only explicit `CurrentMemoryTracker::alloc` calls — ClickHouse's `Allocator`, so `Memory<>` buffers — honour the limit unconditionally. The throwing `operator new` goes through `CurrentMemoryTracker::allocThrow`, gated on `min_allocation_size_to_throw_on_memory_limit`, which cannot refuse anything under its default of `0`.
- The only `Allocator` allocation in the S3 write path is `WriteBufferFromS3::allocateBuffer`, reached from `nextImpl` on the caller thread — which this fix covers. The pooled task only issues `UploadPart` on an already-filled buffer.

This matches what was actually refused: every refusal captured during the incident was multi-MiB (6.13 MiB ×85, 5.00 MiB ×9, 5.43 and 4.64 MiB ×1), named against `ForkWriteBuf` as in the log above. Not one small-chunk refusal among them, which is what you would expect with `operator new` refusals disabled.
</details>

<details>
<summary>Test details</summary>

The test performs a move with the global hard limit set below the tracked amount and asserts the file arrives on the destination disk and leaves the source disk. Without the fix it fails with `Code: 241` raised from `DiskLocal::writeFile` inside `moveFileBetweenDisks`, leaving the file on the source disk; with the fix it passes.

Two details are forced by the code under test: the retry count is pinned to one so the unfixed case fails instead of retrying forever, and the move runs on a thread without a `ThreadStatus` so allocations reach the global tracker directly instead of being batched into untracked memory.
</details>

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed Keeper aborting when memory usage stays near the limit: moving finished changelogs and snapshots to object storage was refused, so the local log disk filled up.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117983&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117983](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117983+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.708` (included in `26.9` and later)
- Backported to: `26.8.3.54`
<!-- ch-version-info:end -->