### PR TITLE
Do not fuzz the stateful fixture load in the flaky check

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1059,9 +1059,9 @@ def main():
                         build_types[0] if is_bugfix_validation else args.options
                     ),
                     step_timeout=stateful_prep_step_timeout(info),
-                    # The flaky check is the only lane that arms ThreadFuzzer, and the
-                    # stateful fixture load is setup, not a test: no assertion depends on
-                    # how its statements interleave.
+                    # Of the lanes this job runs, only the flaky check arms
+                    # `ThreadFuzzer`, and the stateful fixture load is setup, not a
+                    # test: no assertion depends on how its statements interleave.
                     stop_thread_fuzzer=is_flaky_check,
                 ):
                     print(

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1059,6 +1059,10 @@ def main():
                         build_types[0] if is_bugfix_validation else args.options
                     ),
                     step_timeout=stateful_prep_step_timeout(info),
+                    # The flaky check is the only lane that arms ThreadFuzzer. Under a
+                    # sanitizer every signal delivery takes a per-thread slot, and the
+                    # fixture load runs more threads than there are slots.
+                    stop_thread_fuzzer=is_flaky_check,
                 ):
                     print(
                         "SETUP FAILURE: "

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -1059,9 +1059,9 @@ def main():
                         build_types[0] if is_bugfix_validation else args.options
                     ),
                     step_timeout=stateful_prep_step_timeout(info),
-                    # The flaky check is the only lane that arms ThreadFuzzer. Under a
-                    # sanitizer every signal delivery takes a per-thread slot, and the
-                    # fixture load runs more threads than there are slots.
+                    # The flaky check is the only lane that arms ThreadFuzzer, and the
+                    # stateful fixture load is setup, not a test: no assertion depends on
+                    # how its statements interleave.
                     stop_thread_fuzzer=is_flaky_check,
                 ):
                     print(

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -587,7 +587,8 @@ class ClickHouseProc:
         )
 
     def prepare_stateful_data(
-        self, with_s3_storage, is_db_replicated, build_type=None, step_timeout=None
+        self, with_s3_storage, is_db_replicated, build_type=None, step_timeout=None,
+        stop_thread_fuzzer=False,
     ):
         """`step_timeout` bounds each statement, in seconds; None means unbounded."""
         self.stateful_setup_error = None
@@ -620,6 +621,10 @@ set -o pipefail
 trap 'rc=$?; echo "prepare_stateful_data: command [$BASH_COMMAND] at line $LINENO failed with exit $rc" >&2' ERR
 
 MAX_EXECUTION_TIME=1800
+
+if [[ "$STOP_THREAD_FUZZER" == "1" ]]; then
+    $PREP_TIMEOUT clickhouse-client --query "SYSTEM STOP THREAD FUZZER"
+fi
 
 $PREP_TIMEOUT clickhouse-client --query "SHOW DATABASES"
 $PREP_TIMEOUT clickhouse-client --query "CREATE DATABASE datasets"
@@ -658,10 +663,15 @@ $PREP_TIMEOUT clickhouse-client --query "CREATE TABLE test.hits_parquet (Title S
 $PREP_TIMEOUT clickhouse-client --query "SHOW TABLES FROM test"
 $PREP_TIMEOUT clickhouse-client --query "SELECT count() FROM test.hits"
 $PREP_TIMEOUT clickhouse-client --query "SELECT count() FROM test.visits"
+
+if [[ "$STOP_THREAD_FUZZER" == "1" ]]; then
+    $PREP_TIMEOUT clickhouse-client --query "SYSTEM START THREAD FUZZER"
+fi
 """
         command = (
             f"PREP_TIMEOUT={shlex.quote(self.prep_timeout_prefix(step_timeout))}\n"
             f"MAX_INSERT_THREADS={max_insert_threads}\n"
+            f"STOP_THREAD_FUZZER={1 if stop_thread_fuzzer else 0}\n"
         ) + command
         if with_s3_storage:
             command = "USE_S3_STORAGE_FOR_MERGE_TREE=1\n" + command

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -587,7 +587,11 @@ class ClickHouseProc:
         )
 
     def prepare_stateful_data(
-        self, with_s3_storage, is_db_replicated, build_type=None, step_timeout=None,
+        self,
+        with_s3_storage,
+        is_db_replicated,
+        build_type=None,
+        step_timeout=None,
         stop_thread_fuzzer=False,
     ):
         """`step_timeout` bounds each statement, in seconds; None means unbounded."""


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110321#issuecomment-5471356428


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The stateful fixture preparation in the flaky check no longer runs with `ThreadFuzzer` armed.


### Description

@ alexey-milovidov asked me to investigate a `Stateless tests (amd_tsan, flaky check)` setup failure on #110321 and fix it separately ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110321&sha=2def28ac1fbdc8166d4e6c37c00ab830b4248148&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20flaky%20check%29)): `prepare_stateful_data` was terminated at its bound on `INSERT INTO test.hits_s3 SELECT * FROM test.hits`, so the job produced no signal. It recurred on #117831 ([report](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117831&sha=24803f871cdf465dac768070f6e1326256647773&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20flaky%20check%29)); 8 in 90 days, all in that lane.

Of the lanes that run `functional_tests.py`, only the flaky check arms `ThreadFuzzer`, and for the server's whole lifetime: the config is appended during INSTALL, so `THREAD_FUZZER_CPU_TIME_PERIOD_US=1000` is set before the server starts, the constructor self-arms a process-wide `setitimer(ITIMER_PROF)`, and nothing in this lane stops it. So the fixture load is fuzzed although nothing asserts on its interleaving, and pays 7.8x to 33x where it finishes (below). Under TSan there is no ceiling: each delivery takes one of 255 thread slots before dispatch, and one sleeping in the handler re-attaches one. In a wedged job's dump 576 of 684 threads sit in `SlotLock`, none in ClickHouse code; unfuzzed, the same TSan build runs it in 217 s.

This stops the fuzzer across `prepare_stateful_data` and starts it after, in the flaky check only, as `tests/docker_scripts/stress_runner.sh` already does before loading that table.

Validation: with the flag off the rendered script's argv log is byte-identical to master's; a mutant arm proves that check is not blind; the re-arm measures 3.00x, control 1.05x.

Not shown: the wedge did not reproduce locally (3 arms, 732-878 threads, fuzzer active, all completed), so the lane comparison is the attribution evidence; I do not claim the wedge fixed. This PR touches no test file, so the flaky lanes skip and its own CI never runs the new statements. `SYSTEM STOP THREAD FUZZER` leaves the SIGPROF timer armed; the stress lane runs that state and loads the same table in 91-155 s, so I left it.

<details><summary>Measurements</summary>

Cost of `INSERT INTO test.hits_s3 SELECT * FROM test.hits`, from the job logs of one commit (PR 117831, `24803f871cdf465dac768070f6e1326256647773`):

| build | fuzzer off (lane) | fuzzer on (flaky check) | tax |
|---|---|---|---|
| debug | 7 s (`amd_debug, parallel`) | 229 s | 33x |
| binary | 10 s (`amd_binary_excluded_from_llvm`) | 229 s | 23x |
| asan_ubsan | 98 s (`amd_asan_ubsan, distributed plan, parallel, selected tests`) | 762 s | 7.8x |
| msan | - | 296 s | - |
| tsan | 217 s (`amd_tsan, parallel, selected tests`), 291 s (`sequential, selected tests`) | never completes | >=14.5x |

The controlled pair is the 217 s lane against the flaky check: both are `m7i.8xlarge`, both report `test.hits` = 8,873,898 rows, and the statement and `max_insert_threads=4` are identical. The 291 s lane ran on an `m7i.2xlarge`, and the debug and binary rows compare different instance types, so read those as the size of the tax rather than as controls.

Occurrences: CIDB, 90 days, job-level rows of the flaky-check lanes (`test_name = ''`). 6 runs where the last recorded output is the preparation's own `tpcds` table listing, at 9013-9055 s (the whole job budget), plus the 2 bounded ones after #115585 at 4365 s and 4513 s. All 8 are `Stateless tests (amd_tsan, flaky check)`, and the same two predicates over every other `Stateless tests (%` lane return nothing.

</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117997&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/117997](https://github.com/search?q=head%3Async-upstream%2Fpr%2F117997+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1367` (included in `26.9` and later)
<!-- ch-version-info:end -->