### PR TITLE
Experimental catalog_type='jdbc': read Iceberg JdbcCatalog directly from Postgres

### DIFF
--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -385,6 +385,7 @@ IMPLEMENT_SETTING_ENUM(
      {"biglake", DatabaseDataLakeCatalogType::ICEBERG_BIGLAKE},
      {"paimon_rest", DatabaseDataLakeCatalogType::PAIMON_REST},
      {"horizon", DatabaseDataLakeCatalogType::ICEBERG_HORIZON},
+     {"jdbc", DatabaseDataLakeCatalogType::ICEBERG_JDBC},
      {"s3tables", DatabaseDataLakeCatalogType::S3_TABLES},
      {"delta_sharing", DatabaseDataLakeCatalogType::ICEBERG_DELTA_SHARING}})
 

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -470,6 +470,7 @@ enum class DatabaseDataLakeCatalogType : uint8_t
     S3_TABLES,
     ICEBERG_DELTA_SHARING,
     ICEBERG_HORIZON,
+    ICEBERG_JDBC,
 };
 
 DECLARE_SETTING_ENUM(DatabaseDataLakeCatalogType)

--- a/src/Databases/DataLake/DataLakeConstants.h
+++ b/src/Databases/DataLake/DataLakeConstants.h
@@ -43,5 +43,7 @@ static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
     /// DLF credentials
     {"dlf_access_key_id", DEFAULT_MASKING_RULE},
     {"dlf_access_key_secret", DEFAULT_MASKING_RULE},
+    /// JDBC catalog credentials
+    {"jdbc_password", DEFAULT_MASKING_RULE},
 };
 }

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -30,7 +30,7 @@
 #include <Databases/DataLake/RestCatalog.h>
 #include <Databases/DataLake/GlueCatalog.h>
 #include <Databases/DataLake/PaimonRestCatalog.h>
-#if USE_LIBPQXX
+#if USE_LIBPQXX && USE_AWS_S3
 #include <Databases/DataLake/IcebergJdbcCatalog.h>
 #endif
 #if USE_AWS_S3 && USE_SSL
@@ -308,7 +308,7 @@ void DatabaseDataLake::initialize() const
         }
         case DB::DatabaseDataLakeCatalogType::ICEBERG_JDBC:
         {
-#if USE_LIBPQXX
+#if USE_LIBPQXX && USE_AWS_S3
             /// Reads the standard Apache Iceberg JdbcCatalog tables directly
             /// from Postgres over the pg wire protocol instead of the Iceberg
             /// REST API. `warehouse` selects the JdbcCatalog `catalog_name`.
@@ -335,7 +335,7 @@ void DatabaseDataLake::initialize() const
                 Context::getGlobalContextInstance());
             break;
 #else
-            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Cannot use JDBC catalog: ClickHouse was compiled without libpqxx support");
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "JDBC catalog requires PostgreSQL and S3 support");
 #endif
         }
         case DB::DatabaseDataLakeCatalogType::ICEBERG_ONELAKE:
@@ -1848,12 +1848,13 @@ SELECT count() from database_name.table_name;
     `onelake_client_id`/`onelake_client_secret`. ClickHouse does not refresh the token, so the
     database must be recreated after it expires.
 * JDBC Catalog
-    Reads the standard Apache Iceberg JdbcCatalog tables (`iceberg_tables`,
+    Reads PostgreSQL-backed Apache Iceberg `JdbcCatalog` V0/V1 tables (`iceberg_tables`,
     `iceberg_namespace_properties`) directly from Postgres over the pg wire
     protocol. `warehouse` selects the JdbcCatalog `catalog_name` (default
-    `"jdbc"` in JdbcCatalog deployments). The catalog is read-only and does
-    not vend storage credentials: configure static credentials and a
-    `storage_endpoint` for S3-compatible storage.
+    `"jdbc"` when that is the configured catalog name). Only S3 metadata locations
+    are supported. Use a dedicated PostgreSQL role with `SELECT` access and
+    read-only S3 credentials. This integration has no REST authorization or
+    credential vending: configure a `storage_endpoint` for S3-compatible storage.
 ```sql
 CREATE DATABASE database_name
 ENGINE = DataLakeCatalog

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -316,7 +316,13 @@ void DatabaseDataLake::initialize() const
             /// supported, so configure static storage credentials.
             DataLake::IcebergJdbcCatalog::ConnectionParams jdbc_params;
             jdbc_params.host = settings[DatabaseDataLakeSetting::jdbc_host].value;
-            jdbc_params.port = static_cast<UInt16>(settings[DatabaseDataLakeSetting::jdbc_port].value);
+            const UInt64 jdbc_port = settings[DatabaseDataLakeSetting::jdbc_port].value;
+            if (jdbc_port == 0 || jdbc_port > 65535)
+            {
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS, "Setting 'jdbc_port' must be a valid TCP port (1-65535), got {}", jdbc_port);
+            }
+            jdbc_params.port = static_cast<UInt16>(jdbc_port);
             jdbc_params.database = settings[DatabaseDataLakeSetting::jdbc_database].value;
             jdbc_params.schema = settings[DatabaseDataLakeSetting::jdbc_schema].value;
             jdbc_params.user = settings[DatabaseDataLakeSetting::jdbc_user].value;

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -30,6 +30,9 @@
 #include <Databases/DataLake/RestCatalog.h>
 #include <Databases/DataLake/GlueCatalog.h>
 #include <Databases/DataLake/PaimonRestCatalog.h>
+#if USE_LIBPQXX
+#include <Databases/DataLake/IcebergJdbcCatalog.h>
+#endif
 #if USE_AWS_S3 && USE_SSL
 #include <Databases/DataLake/S3TablesCatalog.h>
 #endif
@@ -95,6 +98,12 @@ namespace DatabaseDataLakeSetting
     extern const DatabaseDataLakeSettingsString google_adc_quota_project_id;
     extern const DatabaseDataLakeSettingsString google_adc_credentials_file;
     extern const DatabaseDataLakeSettingsBool force_add_bucket;
+    extern const DatabaseDataLakeSettingsString jdbc_host;
+    extern const DatabaseDataLakeSettingsUInt64 jdbc_port;
+    extern const DatabaseDataLakeSettingsString jdbc_database;
+    extern const DatabaseDataLakeSettingsString jdbc_schema;
+    extern const DatabaseDataLakeSettingsString jdbc_user;
+    extern const DatabaseDataLakeSettingsString jdbc_password;
 }
 
 namespace Setting
@@ -296,6 +305,32 @@ void DatabaseDataLake::initialize() const
                 settings[DatabaseDataLakeSetting::oauth_server_use_request_body].value,
                 Context::getGlobalContextInstance());
             break;
+        }
+        case DB::DatabaseDataLakeCatalogType::ICEBERG_JDBC:
+        {
+#if USE_LIBPQXX
+            /// Reads the standard Apache Iceberg JdbcCatalog tables directly
+            /// from Postgres over the pg wire protocol instead of the Iceberg
+            /// REST API. `warehouse` selects the JdbcCatalog `catalog_name`.
+            /// Read-only: writes, views and credential vending are not
+            /// supported, so configure static storage credentials.
+            DataLake::IcebergJdbcCatalog::ConnectionParams jdbc_params;
+            jdbc_params.host = settings[DatabaseDataLakeSetting::jdbc_host].value;
+            jdbc_params.port = static_cast<UInt16>(settings[DatabaseDataLakeSetting::jdbc_port].value);
+            jdbc_params.database = settings[DatabaseDataLakeSetting::jdbc_database].value;
+            jdbc_params.schema = settings[DatabaseDataLakeSetting::jdbc_schema].value;
+            jdbc_params.user = settings[DatabaseDataLakeSetting::jdbc_user].value;
+            jdbc_params.password = settings[DatabaseDataLakeSetting::jdbc_password].value;
+            catalog_impl = std::make_shared<DataLake::IcebergJdbcCatalog>(
+                settings[DatabaseDataLakeSetting::warehouse].value,
+                std::move(jdbc_params),
+                settings,
+                table_engine_definition,
+                Context::getGlobalContextInstance());
+            break;
+#else
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Cannot use JDBC catalog: ClickHouse was compiled without libpqxx support");
+#endif
         }
         case DB::DatabaseDataLakeCatalogType::ICEBERG_ONELAKE:
         {
@@ -526,6 +561,7 @@ std::shared_ptr<StorageObjectStorageConfiguration> DatabaseDataLake::getConfigur
         case DatabaseDataLakeCatalogType::S3_TABLES:
         case DatabaseDataLakeCatalogType::ICEBERG_DELTA_SHARING:
         case DatabaseDataLakeCatalogType::ICEBERG_HORIZON:
+        case DatabaseDataLakeCatalogType::ICEBERG_JDBC:
         {
             switch (type)
             {
@@ -1463,7 +1499,12 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
         ///
         ///  NOTE: it's still possible to provide endpoint argument for Glue. It's used for fake
         ///  mock glue catalog in tests only.
-        bool requires_arguments = catalog_type != DatabaseDataLakeCatalogType::GLUE;
+        ///
+        /// JDBC catalog is likewise fully identified by its settings (host,
+        /// port, database, schema, catalog name): the engine URL argument is
+        /// meaningless for a Postgres-backed catalog, so it is not required.
+        bool requires_arguments = catalog_type != DatabaseDataLakeCatalogType::GLUE
+            && catalog_type != DatabaseDataLakeCatalogType::ICEBERG_JDBC;
 
         const ASTFunction * function_define = database_engine_define->engine;
 
@@ -1511,6 +1552,7 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             case DatabaseDataLakeCatalogType::ICEBERG_BIGLAKE:
             case DatabaseDataLakeCatalogType::ICEBERG_DELTA_SHARING:
             case DatabaseDataLakeCatalogType::ICEBERG_HORIZON:
+            case DatabaseDataLakeCatalogType::ICEBERG_JDBC:
             {
                 if (!args.create_query.attach
                     && !args.context->getSettingsRef()[Setting::allow_experimental_database_iceberg])
@@ -1766,6 +1808,12 @@ The following settings are supported:
 | `dlf_access_key_id`     | Access key ID for DLF access                                                            |
 | `dlf_access_key_secret` | Access key Secret for DLF access                                                        |
 | `force_add_bucket`      | When constructing object-storage URLs from the catalog-provided table location and `storage_endpoint`, prepend the bucket/container name even if the endpoint already contains it. Default: `false`. Set to `true` for catalogs that hand back paths without the bucket and require it to be added at the URL-construction step (Polaris-style paths). |
+| `jdbc_host`      | Hostname of the Postgres server holding the standard Iceberg JdbcCatalog tables (`catalog_type = 'jdbc'`). Default `localhost`. |
+| `jdbc_port`      | Port of the Postgres server holding the standard Iceberg JdbcCatalog tables. Default `5432`. |
+| `jdbc_database`  | Database name holding the standard Iceberg JdbcCatalog tables. Default `postgres`. |
+| `jdbc_schema`    | Postgres schema holding the `iceberg_tables` and `iceberg_namespace_properties` tables. Default `public`. |
+| `jdbc_user`      | Username for the Postgres server holding the standard Iceberg JdbcCatalog tables. Use a dedicated read-only role. Default `postgres`. |
+| `jdbc_password`  | Password for the Postgres server holding the standard Iceberg JdbcCatalog tables. Default empty. |
 
 ## Examples {#examples}
 
@@ -1793,6 +1841,31 @@ SELECT count() from database_name.table_name;
     bearer token (scoped to https://storage.azure.com) instead of
     `onelake_client_id`/`onelake_client_secret`. ClickHouse does not refresh the token, so the
     database must be recreated after it expires.
+* JDBC Catalog
+    Reads the standard Apache Iceberg JdbcCatalog tables (`iceberg_tables`,
+    `iceberg_namespace_properties`) directly from Postgres over the pg wire
+    protocol. `warehouse` selects the JdbcCatalog `catalog_name` (default
+    `"jdbc"` in JdbcCatalog deployments). The catalog is read-only and does
+    not vend storage credentials: configure static credentials and a
+    `storage_endpoint` for S3-compatible storage.
+```sql
+CREATE DATABASE database_name
+ENGINE = DataLakeCatalog
+SETTINGS
+    catalog_type = 'jdbc',
+    warehouse = 'jdbc',
+    jdbc_host = 'postgres',
+    jdbc_port = 5432,
+    jdbc_database = 'catalog',
+    jdbc_schema = 'public',
+    jdbc_user = 'reader',
+    jdbc_password = 'secret',
+    storage_endpoint = 'http://minio:9000',
+    aws_access_key_id = 'minio',
+    aws_secret_access_key = 'secret';
+SHOW TABLES IN database_name;
+SELECT count() from database_name.table_name;
+```
 )DOCS_MD",
         .syntax = "ENGINE = DataLakeCatalog('catalog_url'[, 'user', 'password']) SETTINGS catalog_type = '...'",
         .related = {}});

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -51,6 +51,12 @@ namespace ErrorCodes
     DECLARE(String, dlf_access_key_id, "", "Access id of DLF token for Paimon REST Catalog", 0) \
     DECLARE(String, dlf_access_key_secret, "", "Access secret of DLF token for Paimon REST Catalog", 0) \
     DECLARE(Bool, force_add_bucket, false, "When constructing object-storage URLs from the catalog-provided table location and storage_endpoint, prepend the bucket/container name even if the endpoint already contains it. Useful for catalogs that hand back paths without the bucket and expect it to be added at URL construction (Polaris-style paths).", 0) \
+    DECLARE(String, jdbc_host, "localhost", "Hostname of the Postgres server holding the standard Iceberg JdbcCatalog tables (`catalog_type = 'jdbc'`). Only used for that catalog type.", 0) \
+    DECLARE(UInt64, jdbc_port, 5432, "Port of the Postgres server holding the standard Iceberg JdbcCatalog tables. Only used for that catalog type.", 0) \
+    DECLARE(String, jdbc_database, "postgres", "Database name holding the standard Iceberg JdbcCatalog tables. Only used for that catalog type.", 0) \
+    DECLARE(String, jdbc_schema, "public", "Postgres schema holding the `iceberg_tables` and `iceberg_namespace_properties` tables. Only used for that catalog type.", 0) \
+    DECLARE(String, jdbc_user, "postgres", "Username for the Postgres server holding the standard Iceberg JdbcCatalog tables. Use a dedicated read-only role. Only used for that catalog type.", 0) \
+    DECLARE(String, jdbc_password, "", "Password for the Postgres server holding the standard Iceberg JdbcCatalog tables. Only used for that catalog type.", 0) \
 
 #define LIST_OF_DATABASE_ICEBERG_SETTINGS(M, ALIAS) \
     DATABASE_ICEBERG_RELATED_SETTINGS(M, ALIAS) \

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -19,6 +19,7 @@ namespace DB::ErrorCodes
     extern const int NOT_IMPLEMENTED;
     extern const int LOGICAL_ERROR;
     extern const int BAD_ARGUMENTS;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 namespace DB::DatabaseDataLakeSetting
@@ -423,6 +424,12 @@ bool ICatalog::updateSchema(
 void ICatalog::dropTable(const String & /*namespace_name*/, const String & /*table_name*/, bool /*delete_data*/) const
 {
     throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "dropTable is not implemented");
+}
+
+void throwIfTableWritesUnsupported(const std::shared_ptr<ICatalog> & catalog, std::string_view operation)
+{
+    if (catalog && !catalog->supportsTableWrites())
+        throw DB::Exception(DB::ErrorCodes::SUPPORT_IS_DISABLED, "{} is not supported by this catalog", operation);
 }
 
 ICatalog::PreparedSettingsChangesPtr ICatalog::prepareSettingsChanges(const DB::SettingsChanges & /*changes*/)

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -11,6 +11,8 @@
 #include <Poco/JSON/Object.h>
 
 #include <functional>
+#include <memory>
+#include <string_view>
 #include <unordered_map>
 
 namespace DB
@@ -281,6 +283,10 @@ public:
     /// The Glue catalog does not support such operation.
     virtual bool isTransactional() const { return false; }
 
+    /// Whether catalog-backed table mutations (`INSERT`, `ALTER`, `DELETE`, `OPTIMIZE`, `DROP TABLE`, ... ) are supported.
+    /// Read-only catalogs return false; storage checks this before any object-storage mutation.
+    virtual bool supportsTableWrites() const { return true; }
+
     virtual CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & /*storage_id*/)
     {
         return std::nullopt;
@@ -317,6 +323,10 @@ protected:
     /// which is sometimes also called "catalog name".
     const std::string warehouse;
 };
+
+/// Throw before any object-storage mutation when the table's catalog is read-only.
+/// A null catalog means no catalog integration and is unaffected.
+void throwIfTableWritesUnsupported(const std::shared_ptr<ICatalog> & catalog, std::string_view operation);
 
 
 }

--- a/src/Databases/DataLake/IcebergJdbcCatalog.cpp
+++ b/src/Databases/DataLake/IcebergJdbcCatalog.cpp
@@ -29,6 +29,7 @@
 namespace DB::ErrorCodes
 {
 extern const int BAD_ARGUMENTS;
+extern const int SUPPORT_IS_DISABLED;
 }
 
 namespace DB::Setting
@@ -105,16 +106,21 @@ IcebergJdbcCatalog::IcebergJdbcCatalog(
     /// returning empty listings and confusing "table does not exist" errors.
     auto holder = pool->get();
     pqxx::nontransaction txn(holder->get());
-    pqxx::result tables = txn.exec_params(
-        "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = 'iceberg_tables'",
-        params.schema);
-    if (tables.empty())
+    for (const char * table : {"iceberg_tables", "iceberg_namespace_properties"})
     {
-        throw DB::Exception(
-            DB::ErrorCodes::BAD_ARGUMENTS,
-            "JDBC catalog: table 'iceberg_tables' not found in Postgres schema '{}'. "
-            "Point 'jdbc_schema' at the schema holding the standard Iceberg JdbcCatalog tables",
-            params.schema);
+        pqxx::result tables = txn.exec_params(
+            "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2",
+            params.schema,
+            table);
+        if (tables.empty())
+        {
+            throw DB::Exception(
+                DB::ErrorCodes::BAD_ARGUMENTS,
+                "JDBC catalog: table '{}' not found in Postgres schema '{}'. "
+                "Point 'jdbc_schema' at the schema holding the standard Iceberg JdbcCatalog tables",
+                table,
+                params.schema);
+        }
     }
 
     /// V1 adds the `iceberg_type` column distinguishing TABLE from VIEW rows;
@@ -296,6 +302,36 @@ void IcebergJdbcCatalog::getTableMetadata(
             namespace_name,
             table_name);
     }
+}
+
+void IcebergJdbcCatalog::createTable(const String & /*namespace_name*/, const String & /*table_name*/, const String & /*new_metadata_path*/, Poco::JSON::Object::Ptr /*metadata_content*/) const
+{
+    throw DB::Exception(DB::ErrorCodes::SUPPORT_IS_DISABLED, "JDBC catalog is read-only: CREATE TABLE is not supported");
+}
+
+void IcebergJdbcCatalog::createNamespaceIfNotExists(const String & /*namespace_name*/, const String & /*location*/) const
+{
+    throw DB::Exception(DB::ErrorCodes::SUPPORT_IS_DISABLED, "JDBC catalog is read-only: CREATE NAMESPACE is not supported");
+}
+
+bool IcebergJdbcCatalog::updateMetadata(const String & /*namespace_name*/, const String & /*table_name*/, const String & /*new_metadata_path*/, Poco::JSON::Object::Ptr /*new_snapshot*/) const
+{
+    throw DB::Exception(DB::ErrorCodes::SUPPORT_IS_DISABLED, "JDBC catalog is read-only: table updates are not supported");
+}
+
+bool IcebergJdbcCatalog::updateSchema(
+    const String & /*namespace_name*/,
+    const String & /*table_name*/,
+    const String & /*new_metadata_path*/,
+    Poco::JSON::Object::Ptr /*new_schema*/,
+    Int32 /*previous_schema_id*/) const
+{
+    throw DB::Exception(DB::ErrorCodes::SUPPORT_IS_DISABLED, "JDBC catalog is read-only: schema changes are not supported");
+}
+
+void IcebergJdbcCatalog::dropTable(const String & /*namespace_name*/, const String & /*table_name*/, bool /*delete_data*/) const
+{
+    throw DB::Exception(DB::ErrorCodes::SUPPORT_IS_DISABLED, "JDBC catalog is read-only: DROP TABLE is not supported");
 }
 
 Poco::JSON::Object::Ptr IcebergJdbcCatalog::getMetadataJSON(const String & metadata_location, TableMetadata & result) const

--- a/src/Databases/DataLake/IcebergJdbcCatalog.cpp
+++ b/src/Databases/DataLake/IcebergJdbcCatalog.cpp
@@ -2,7 +2,7 @@
 
 #include "config.h"
 
-#if USE_LIBPQXX
+#if USE_LIBPQXX && USE_AVRO && USE_AWS_S3
 
 #include <Core/PostgreSQL/PoolWithFailover.h>
 #include <Core/Settings.h>
@@ -15,6 +15,7 @@
 #include <Databases/DataLake/StaticStorageCredentials.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
+#include <Common/RemoteHostFilter.h>
 #include <Common/logger_useful.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -40,6 +41,8 @@ namespace DB
 namespace DatabaseDataLakeSetting
 {
 extern const DatabaseDataLakeSettingsString storage_endpoint;
+extern const DatabaseDataLakeSettingsS3UriStyle storage_uri_style;
+extern const DatabaseDataLakeSettingsBool force_add_bucket;
 }
 }
 
@@ -78,6 +81,9 @@ IcebergJdbcCatalog::IcebergJdbcCatalog(
 {
     if (params.host.empty() || params.database.empty())
         throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "JDBC catalog requires host and database settings");
+
+    /// Check before opening the pool, including after a lazy `ATTACH`.
+    context_->getRemoteHostFilter().checkHostAndPort(params.host, std::to_string(params.port));
 
     DB::StoragePostgreSQL::Configuration pg_configuration;
     pg_configuration.host = params.host;
@@ -226,14 +232,17 @@ bool IcebergJdbcCatalog::existsTable(const std::string & namespace_name, const s
 bool IcebergJdbcCatalog::tryGetTableMetadata(
     const std::string & namespace_name, const std::string & table_name, TableMetadata & result) const
 {
-    auto holder = pool->get();
-    pqxx::nontransaction txn(holder->get());
-    pqxx::result rows = txn.exec_params(
-        "SELECT metadata_location FROM " + qualified("iceberg_tables")
-            + " WHERE catalog_name = $1 AND table_namespace = $2 AND table_name = $3" + tableTypePredicate(),
-        warehouse,
-        namespace_name,
-        table_name);
+    pqxx::result rows;
+    {
+        auto holder = pool->get();
+        pqxx::nontransaction txn(holder->get());
+        rows = txn.exec_params(
+            "SELECT metadata_location FROM " + qualified("iceberg_tables")
+                + " WHERE catalog_name = $1 AND table_namespace = $2 AND table_name = $3" + tableTypePredicate(),
+            warehouse,
+            namespace_name,
+            table_name);
+    }
 
     if (rows.empty() || rows[0]["metadata_location"].is_null())
         return false;
@@ -294,18 +303,7 @@ Poco::JSON::Object::Ptr IcebergJdbcCatalog::getMetadataJSON(const String & metad
     if (auto cached = metadata_objects.get(metadata_location))
         return *cached;
 
-    /// `metadata_location` is always a URI in real deployments, but a
-    /// malformed value must mark the table unreadable, not throw out of
-    /// every listing that touches it.
-    bool is_s3 = false;
-    try
-    {
-        is_s3 = DataLake::parseStorageTypeFromLocation(metadata_location) == StorageType::S3;
-    }
-    catch (const DB::Exception &)
-    {
-    }
-    if (!is_s3)
+    if (!metadata_location.starts_with("s3://") && !metadata_location.starts_with("s3a://"))
     {
         result.setTableIsNotReadable(fmt::format(
             "Cannot read table metadata at '{}': JDBC catalog reads metadata files only from S3-family storage",
@@ -313,7 +311,7 @@ Poco::JSON::Object::Ptr IcebergJdbcCatalog::getMetadataJSON(const String & metad
         return nullptr;
     }
 
-    auto [object_storage, bucket_name, metadata_path] = createObjectStorageForMetadataAccess(metadata_location);
+    auto [object_storage, metadata_path] = createObjectStorageForMetadataAccess(metadata_location);
     auto compression_method = DB::Iceberg::getCompressionMethodFromMetadataFile(metadata_location);
     auto metadata_object = DB::Iceberg::getMetadataJSONObject(
         metadata_path, object_storage, nullptr, getContext(), log, compression_method, std::nullopt);
@@ -327,43 +325,16 @@ IcebergJdbcCatalog::createObjectStorageForMetadataAccess(const String & metadata
     DB::ASTStorage * storage = table_engine_definition->as<DB::ASTStorage>();
     DB::ASTs args = storage->engine->arguments->children;
 
-    /// Split `s3://bucket/path/to/metadata.json` into bucket and key; the
-    /// client endpoint is the configured `storage_endpoint`, falling back to
-    /// the bucket root for plain AWS URLs.
-    String key = metadata_location;
-    if (key.starts_with("s3://"))
-        key = key.substr(5);
-    else if (key.starts_with("s3a://"))
-        key = key.substr(6);
-    else if (key.starts_with("s3:/"))
-        key = key.substr(4);
-
-    String bucket_name;
-    if (auto pos = key.find('/'); pos != std::string::npos)
-    {
-        bucket_name = key.substr(0, pos);
-        key = key.substr(pos + 1);
-    }
-
+    auto location = TableMetadata().withLocation();
+    if (database_settings[DB::DatabaseDataLakeSetting::force_add_bucket])
+        location.withForceAddBucket();
+    location.setLocation(metadata_location);
     const String & storage_endpoint = database_settings[DB::DatabaseDataLakeSetting::storage_endpoint].value;
-    String base = storage_endpoint.empty() ? "s3://" + bucket_name : storage_endpoint;
-    while (base.ends_with('/'))
-        base.pop_back();
-    /// The object-storage configuration parses the bucket out of the URL
-    /// (authority for `s3://`, first path segment for path-style, host
-    /// prefix for virtual-hosted) and falls back to `"default"` when the
-    /// URL carries none. Make sure ours is present.
-    const String rest = (base.find("://") == String::npos) ? base : base.substr(base.find("://") + 3);
-    const size_t slash = rest.find('/');
-    const String authority = (slash == String::npos) ? rest : rest.substr(0, slash);
-    const String path = (slash == String::npos) ? "" : rest.substr(slash);
-    bool bucket_present = authority == bucket_name || authority.starts_with(bucket_name + ".");
-    if (!bucket_present && path.size() > 1)
-    {
-        const char after = (path.size() > 1 + bucket_name.size()) ? path[1 + bucket_name.size()] : '\0';
-        bucket_present = path.substr(1, bucket_name.size()) == bucket_name && (after == '/' || after == '\0');
-    }
-    const String endpoint_arg = bucket_present ? base : base + '/' + bucket_name;
+    String endpoint_arg = storage_endpoint.empty() ? metadata_location
+        : location.getLocationWithEndpoint(storage_endpoint, database_settings[DB::DatabaseDataLakeSetting::storage_uri_style]);
+    /// `TableMetadata` constructs a directory URL; here the location is a file.
+    if (endpoint_arg.ends_with('/'))
+        endpoint_arg.pop_back();
     if (args.empty())
         args.emplace_back(DB::make_intrusive<DB::ASTLiteral>(endpoint_arg));
     else
@@ -381,7 +352,7 @@ IcebergJdbcCatalog::createObjectStorageForMetadataAccess(const String & metadata
     auto configuration = std::make_shared<DB::StorageS3IcebergConfiguration>(storage_settings);
     DB::StorageObjectStorageConfiguration::initialize(*configuration, args, getContext(), false);
 
-    return {configuration->createObjectStorage(getContext(), true, {}), bucket_name, key};
+    return {configuration->createObjectStorage(getContext(), true, {}), configuration->getPathForRead().path};
 }
 
 }

--- a/src/Databases/DataLake/IcebergJdbcCatalog.cpp
+++ b/src/Databases/DataLake/IcebergJdbcCatalog.cpp
@@ -1,0 +1,389 @@
+#include <Databases/DataLake/IcebergJdbcCatalog.h>
+
+#include "config.h"
+
+#if USE_LIBPQXX
+
+#include <Core/PostgreSQL/PoolWithFailover.h>
+#include <Core/Settings.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
+#include <Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h>
+#include <Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h>
+#include <Storages/StoragePostgreSQL.h>
+#include <Databases/DataLake/StaticStorageCredentials.h>
+#include <Common/CurrentMetrics.h>
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+#include <Interpreters/Context.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTLiteral.h>
+#include <Poco/JSON/Object.h>
+#include <pqxx/pqxx>
+
+#include <algorithm>
+
+
+namespace DB::ErrorCodes
+{
+extern const int BAD_ARGUMENTS;
+}
+
+namespace DB::Setting
+{
+extern const SettingsBool allow_experimental_geo_types_in_iceberg;
+}
+
+namespace DB
+{
+namespace DatabaseDataLakeSetting
+{
+extern const DatabaseDataLakeSettingsString storage_endpoint;
+}
+}
+
+namespace CurrentMetrics
+{
+extern const Metric MarkCacheBytes;
+extern const Metric MarkCacheFiles;
+}
+
+namespace DataLake
+{
+
+namespace
+{
+
+constexpr size_t JDBC_PG_POOL_SIZE = 16;
+constexpr size_t JDBC_PG_POOL_WAIT_TIMEOUT_MS = 5000;
+constexpr size_t JDBC_PG_MAX_TRIES = 3;
+constexpr size_t JDBC_PG_CONNECTION_TIMEOUT_S = 10;
+
+}
+
+IcebergJdbcCatalog::IcebergJdbcCatalog(
+    const std::string & catalog_name_,
+    ConnectionParams params_,
+    const DB::DatabaseDataLakeSettings & database_settings_,
+    DB::ASTPtr table_engine_definition_,
+    DB::ContextPtr context_)
+    : ICatalog(catalog_name_)
+    , DB::WithContext(context_)
+    , params(std::move(params_))
+    , database_settings(database_settings_)
+    , table_engine_definition(table_engine_definition_)
+    , log(getLogger("IcebergJdbcCatalog"))
+    , metadata_objects(CurrentMetrics::MarkCacheBytes, CurrentMetrics::MarkCacheFiles, 1024)
+{
+    if (params.host.empty() || params.database.empty())
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "JDBC catalog requires host and database settings");
+
+    DB::StoragePostgreSQL::Configuration pg_configuration;
+    pg_configuration.host = params.host;
+    pg_configuration.port = params.port;
+    pg_configuration.username = params.user;
+    pg_configuration.password = params.password;
+    pg_configuration.database = params.database;
+    pg_configuration.addresses.emplace_back(params.host, params.port);
+
+    pool = std::make_shared<postgres::PoolWithFailover>(
+        pg_configuration,
+        JDBC_PG_POOL_SIZE,
+        JDBC_PG_POOL_WAIT_TIMEOUT_MS,
+        JDBC_PG_MAX_TRIES,
+        /* auto_close_connection_ */ false,
+        JDBC_PG_CONNECTION_TIMEOUT_S);
+
+    /// Fail fast when this is not a JdbcCatalog database, instead of
+    /// returning empty listings and confusing "table does not exist" errors.
+    auto holder = pool->get();
+    pqxx::nontransaction txn(holder->get());
+    pqxx::result tables = txn.exec_params(
+        "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = 'iceberg_tables'",
+        params.schema);
+    if (tables.empty())
+    {
+        throw DB::Exception(
+            DB::ErrorCodes::BAD_ARGUMENTS,
+            "JDBC catalog: table 'iceberg_tables' not found in Postgres schema '{}'. "
+            "Point 'jdbc_schema' at the schema holding the standard Iceberg JdbcCatalog tables",
+            params.schema);
+    }
+
+    /// V1 adds the `iceberg_type` column distinguishing TABLE from VIEW rows;
+    /// accept both schema versions.
+    pqxx::result type_column = txn.exec_params(
+        "SELECT 1 FROM information_schema.columns WHERE table_schema = $1 AND table_name = 'iceberg_tables' AND column_name = 'iceberg_type'",
+        params.schema);
+    has_iceberg_type = !type_column.empty();
+}
+
+String IcebergJdbcCatalog::qualified(const std::string & table) const
+{
+    /// Quote the settings-provided schema the way libpq would: wrap in
+    /// double quotes, doubling embedded quotes. Table names are our own
+    /// static SQL text.
+    String quoted = params.schema;
+    size_t pos = 0;
+    while ((pos = quoted.find('"', pos)) != String::npos)
+    {
+        quoted.insert(pos, "\"");
+        pos += 2;
+    }
+    return "\"" + quoted + "\".\"" + table + "\"";
+}
+
+String IcebergJdbcCatalog::tableTypePredicate() const
+{
+    if (!has_iceberg_type)
+        return "";
+    return " AND (iceberg_type = 'TABLE' OR iceberg_type IS NULL)";
+}
+
+bool IcebergJdbcCatalog::empty() const
+{
+    auto holder = pool->get();
+    pqxx::nontransaction txn(holder->get());
+    pqxx::result result = txn.exec_params(
+        "SELECT 1 FROM " + qualified("iceberg_tables") + " WHERE catalog_name = $1" + tableTypePredicate() + " LIMIT 1",
+        warehouse);
+    return result.empty();
+}
+
+IcebergJdbcCatalog::Namespaces IcebergJdbcCatalog::getNamespaces() const
+{
+    auto holder = pool->get();
+    pqxx::nontransaction txn(holder->get());
+    /// Namespaces live in both tables: `iceberg_tables` only records
+    /// namespaces that contain a table, `iceberg_namespace_properties` only
+    /// ones with explicit properties. namespaces are dot-joined strings;
+    /// expand every nesting level as its own dotted path, matching the
+    /// ICatalog contract for hierarchical catalogs.
+    pqxx::result result = txn.exec_params(
+        "SELECT DISTINCT table_namespace AS ns FROM " + qualified("iceberg_tables") + " WHERE catalog_name = $1"
+            + " UNION SELECT DISTINCT \"namespace\" AS ns FROM " + qualified("iceberg_namespace_properties") + " WHERE catalog_name = $1",
+        warehouse);
+
+    Namespaces namespaces;
+    for (const auto & row : result)
+    {
+        const String dotted = row["ns"].as<std::string>();
+        size_t start = 0;
+        while (start < dotted.size())
+        {
+            size_t dot = dotted.find('.', start);
+            size_t end = (dot == String::npos) ? dotted.size() : dot;
+            /// Emit every nesting level (`a.b` yields `a` and `a.b`).
+            namespaces.push_back(dotted.substr(0, end));
+            if (dot == String::npos)
+                break;
+            start = dot + 1;
+        }
+    }
+    std::sort(namespaces.begin(), namespaces.end());
+    namespaces.erase(std::unique(namespaces.begin(), namespaces.end()), namespaces.end());
+    return namespaces;
+}
+
+CatalogTables IcebergJdbcCatalog::getTables() const
+{
+    auto holder = pool->get();
+    pqxx::nontransaction txn(holder->get());
+    pqxx::result result = txn.exec_params(
+        "SELECT table_namespace, table_name FROM " + qualified("iceberg_tables")
+            + " WHERE catalog_name = $1" + tableTypePredicate(),
+        warehouse);
+
+    CatalogTables tables;
+    for (const auto & row : result)
+        tables.push_back(CatalogTable{.name = row["table_namespace"].as<std::string>() + "." + row["table_name"].as<std::string>()});
+    return tables;
+}
+
+CatalogTables IcebergJdbcCatalog::listTablesInNamespaceDirect(const std::string & namespace_name) const
+{
+    auto holder = pool->get();
+    pqxx::nontransaction txn(holder->get());
+    pqxx::result result = txn.exec_params(
+        "SELECT table_name FROM " + qualified("iceberg_tables")
+            + " WHERE catalog_name = $1 AND table_namespace = $2" + tableTypePredicate(),
+        warehouse,
+        namespace_name);
+
+    CatalogTables tables;
+    for (const auto & row : result)
+        tables.push_back(CatalogTable{.name = namespace_name + "." + row["table_name"].as<std::string>()});
+    return tables;
+}
+
+bool IcebergJdbcCatalog::existsTable(const std::string & namespace_name, const std::string & table_name) const
+{
+    TableMetadata metadata;
+    return tryGetTableMetadata(namespace_name, table_name, metadata);
+}
+
+bool IcebergJdbcCatalog::tryGetTableMetadata(
+    const std::string & namespace_name, const std::string & table_name, TableMetadata & result) const
+{
+    auto holder = pool->get();
+    pqxx::nontransaction txn(holder->get());
+    pqxx::result rows = txn.exec_params(
+        "SELECT metadata_location FROM " + qualified("iceberg_tables")
+            + " WHERE catalog_name = $1 AND table_namespace = $2 AND table_name = $3" + tableTypePredicate(),
+        warehouse,
+        namespace_name,
+        table_name);
+
+    if (rows.empty() || rows[0]["metadata_location"].is_null())
+        return false;
+
+    const String metadata_location = rows[0]["metadata_location"].as<std::string>();
+
+    if (result.requiresDataLakeSpecificProperties())
+    {
+        result.setDataLakeSpecificProperties(
+            DataLakeSpecificProperties{.iceberg_metadata_file_location = metadata_location});
+    }
+
+    if (!result.requiresLocation() && !result.requiresSchema())
+        return true;
+
+    /// The standard schema stores only the metadata pointer; location and
+    /// schema come from `metadata.json` itself, like the REST catalog reads.
+    auto metadata_object = getMetadataJSON(metadata_location, result);
+    if (!metadata_object)
+        return true;
+
+    if (result.requiresLocation())
+    {
+        if (metadata_object->has("location") && !metadata_object->isNull("location"))
+            result.setLocation(metadata_object->get("location").extract<String>());
+        else
+            result.setTableIsNotReadable(fmt::format("Cannot read table {}.{}, because its metadata has no 'location'", namespace_name, table_name));
+    }
+
+    if (result.requiresSchema())
+    {
+        const bool allow_geo_parser
+            = getContext()->getSettingsRef()[DB::Setting::allow_experimental_geo_types_in_iceberg].value;
+        auto schema_processor = DB::Iceberg::IcebergSchemaProcessor(allow_geo_parser);
+        auto id = DB::IcebergMetadata::parseTableSchema(metadata_object, schema_processor, log);
+        auto schema = schema_processor.getClickHouseTableSchemaById(id);
+        result.setSchema(*schema);
+    }
+
+    return true;
+}
+
+void IcebergJdbcCatalog::getTableMetadata(
+    const std::string & namespace_name, const std::string & table_name, TableMetadata & result) const
+{
+    if (!tryGetTableMetadata(namespace_name, table_name, result))
+    {
+        throw DB::Exception(
+            DB::ErrorCodes::BAD_ARGUMENTS,
+            "JDBC catalog: table '{}.{}' does not exist",
+            namespace_name,
+            table_name);
+    }
+}
+
+Poco::JSON::Object::Ptr IcebergJdbcCatalog::getMetadataJSON(const String & metadata_location, TableMetadata & result) const
+{
+    if (auto cached = metadata_objects.get(metadata_location))
+        return *cached;
+
+    /// `metadata_location` is always a URI in real deployments, but a
+    /// malformed value must mark the table unreadable, not throw out of
+    /// every listing that touches it.
+    bool is_s3 = false;
+    try
+    {
+        is_s3 = DataLake::parseStorageTypeFromLocation(metadata_location) == StorageType::S3;
+    }
+    catch (const DB::Exception &)
+    {
+    }
+    if (!is_s3)
+    {
+        result.setTableIsNotReadable(fmt::format(
+            "Cannot read table metadata at '{}': JDBC catalog reads metadata files only from S3-family storage",
+            metadata_location));
+        return nullptr;
+    }
+
+    auto [object_storage, bucket_name, metadata_path] = createObjectStorageForMetadataAccess(metadata_location);
+    auto compression_method = DB::Iceberg::getCompressionMethodFromMetadataFile(metadata_location);
+    auto metadata_object = DB::Iceberg::getMetadataJSONObject(
+        metadata_path, object_storage, nullptr, getContext(), log, compression_method, std::nullopt);
+    metadata_objects.set(metadata_location, std::make_shared<Poco::JSON::Object::Ptr>(metadata_object));
+    return metadata_object;
+}
+
+IcebergJdbcCatalog::ObjectStorageWithPath
+IcebergJdbcCatalog::createObjectStorageForMetadataAccess(const String & metadata_location) const
+{
+    DB::ASTStorage * storage = table_engine_definition->as<DB::ASTStorage>();
+    DB::ASTs args = storage->engine->arguments->children;
+
+    /// Split `s3://bucket/path/to/metadata.json` into bucket and key; the
+    /// client endpoint is the configured `storage_endpoint`, falling back to
+    /// the bucket root for plain AWS URLs.
+    String key = metadata_location;
+    if (key.starts_with("s3://"))
+        key = key.substr(5);
+    else if (key.starts_with("s3a://"))
+        key = key.substr(6);
+    else if (key.starts_with("s3:/"))
+        key = key.substr(4);
+
+    String bucket_name;
+    if (auto pos = key.find('/'); pos != std::string::npos)
+    {
+        bucket_name = key.substr(0, pos);
+        key = key.substr(pos + 1);
+    }
+
+    const String & storage_endpoint = database_settings[DB::DatabaseDataLakeSetting::storage_endpoint].value;
+    String base = storage_endpoint.empty() ? "s3://" + bucket_name : storage_endpoint;
+    while (base.ends_with('/'))
+        base.pop_back();
+    /// The object-storage configuration parses the bucket out of the URL
+    /// (authority for `s3://`, first path segment for path-style, host
+    /// prefix for virtual-hosted) and falls back to `"default"` when the
+    /// URL carries none. Make sure ours is present.
+    const String rest = (base.find("://") == String::npos) ? base : base.substr(base.find("://") + 3);
+    const size_t slash = rest.find('/');
+    const String authority = (slash == String::npos) ? rest : rest.substr(0, slash);
+    const String path = (slash == String::npos) ? "" : rest.substr(slash);
+    bool bucket_present = authority == bucket_name || authority.starts_with(bucket_name + ".");
+    if (!bucket_present && path.size() > 1)
+    {
+        const char after = (path.size() > 1 + bucket_name.size()) ? path[1 + bucket_name.size()] : '\0';
+        bucket_present = path.substr(1, bucket_name.size()) == bucket_name && (after == '/' || after == '\0');
+    }
+    const String endpoint_arg = bucket_present ? base : base + '/' + bucket_name;
+    if (args.empty())
+        args.emplace_back(DB::make_intrusive<DB::ASTLiteral>(endpoint_arg));
+    else
+        args[0] = DB::make_intrusive<DB::ASTLiteral>(endpoint_arg);
+
+    if (args.size() == 1)
+    {
+        if (auto static_credentials = DataLake::tryGetStaticStorageCredentials(
+                DB::DatabaseDataLakeStorageType::S3, database_settings))
+            static_credentials->addCredentialsToEngineArgs(args);
+    }
+
+    auto storage_settings = std::make_shared<DB::DataLakeStorageSettings>();
+    storage_settings->loadFromSettingsChanges(database_settings.allChanged());
+    auto configuration = std::make_shared<DB::StorageS3IcebergConfiguration>(storage_settings);
+    DB::StorageObjectStorageConfiguration::initialize(*configuration, args, getContext(), false);
+
+    return {configuration->createObjectStorage(getContext(), true, {}), bucket_name, key};
+}
+
+}
+
+#endif

--- a/src/Databases/DataLake/IcebergJdbcCatalog.cpp
+++ b/src/Databases/DataLake/IcebergJdbcCatalog.cpp
@@ -388,7 +388,12 @@ IcebergJdbcCatalog::createObjectStorageForMetadataAccess(const String & metadata
     auto configuration = std::make_shared<DB::StorageS3IcebergConfiguration>(storage_settings);
     DB::StorageObjectStorageConfiguration::initialize(*configuration, args, getContext(), false);
 
-    return {configuration->createObjectStorage(getContext(), true, {}), configuration->getPathForRead().path};
+    /// `getPathForRead()` carries directory semantics (trailing slash);
+    /// here the path is a file, so strip it before the S3 GET.
+    String metadata_path = configuration->getPathForRead().path;
+    while (metadata_path.ends_with('/') && metadata_path.size() > 1)
+        metadata_path.pop_back();
+    return {configuration->createObjectStorage(getContext(), true, {}), metadata_path};
 }
 
 }

--- a/src/Databases/DataLake/IcebergJdbcCatalog.h
+++ b/src/Databases/DataLake/IcebergJdbcCatalog.h
@@ -37,7 +37,8 @@ namespace DataLake
 /// PostgreSQL backends and S3 metadata locations are supported. V1 adds the
 /// `iceberg_type` column; future schema changes require compatibility testing.
 /// Writes, views and credential vending are not supported. Use read-only
-/// PostgreSQL and object-storage credentials.
+/// PostgreSQL and object-storage credentials. Mutations are rejected before
+/// object-storage writes; cached metadata JSON is keyed by immutable location.
 class IcebergJdbcCatalog final : public ICatalog, private DB::WithContext
 {
 public:
@@ -83,6 +84,23 @@ public:
         return DB::DatabaseDataLakeCatalogType::ICEBERG_JDBC;
     }
 
+    bool supportsTableWrites() const override { return false; }
+
+    void createTable(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr metadata_content) const override;
+
+    void createNamespaceIfNotExists(const String & namespace_name, const String & location) const override;
+
+    bool updateMetadata(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr new_snapshot) const override;
+
+    bool updateSchema(
+        const String & namespace_name,
+        const String & table_name,
+        const String & new_metadata_path,
+        Poco::JSON::Object::Ptr new_schema,
+        Int32 previous_schema_id) const override;
+
+    void dropTable(const String & namespace_name, const String & table_name, bool delete_data) const override;
+
 protected:
     CatalogTables listTablesInNamespaceDirect(const std::string & namespace_name) const override;
 
@@ -113,7 +131,7 @@ private:
     const LoggerPtr log;
 
     postgres::PoolWithFailoverPtr pool;
-    /// Whether `iceberg_tables` has the V1 `iceberg_type` column.
+    /// Whether `iceberg_tables` has the V1 `iceberg_type` column, captured when the catalog object is constructed.
     bool has_iceberg_type = false;
 
     mutable DB::CacheBase<String, Poco::JSON::Object::Ptr> metadata_objects;

--- a/src/Databases/DataLake/IcebergJdbcCatalog.h
+++ b/src/Databases/DataLake/IcebergJdbcCatalog.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "config.h"
 
-#if USE_LIBPQXX
+#if USE_LIBPQXX && USE_AVRO && USE_AWS_S3
 
 #include <Databases/DataLake/ICatalog.h>
 #include <Databases/DataLake/DatabaseDataLakeSettings.h>
@@ -24,20 +24,20 @@ using PoolWithFailoverPtr = std::shared_ptr<PoolWithFailover>;
 namespace DataLake
 {
 
-/// Read-only client for the standard Apache Iceberg JdbcCatalog schema
+/// Read-only client for the Apache Iceberg `JdbcCatalog` V0/V1 schema
 /// (`iceberg_tables` / `iceberg_namespace_properties` in Postgres), instead
 /// of going through an Iceberg REST HTTP API.
 ///
 /// Table pointers resolve with a single indexed `SELECT` on the primary key
-/// `(catalog_name, table_namespace, table_name)`; there are no per-resolution
-/// HTTP round trips. The table schema is parsed from the referenced
+/// `(catalog_name, table_namespace, table_name)` without a REST catalog request.
+/// The table schema is parsed from the referenced
 /// `metadata.json` through the same `parseTableSchema` path the REST catalog
 /// uses, and cached per metadata location.
 ///
-/// This intentionally supports only what ClickHouse needs for reads, against
-/// the stable upstream schema: no version gate is required (V0 and V1, which
-/// adds the `iceberg_type` column, are both accepted). Writes, views and
-/// credential vending are not supported: use static storage credentials.
+/// PostgreSQL backends and S3 metadata locations are supported. V1 adds the
+/// `iceberg_type` column; future schema changes require compatibility testing.
+/// Writes, views and credential vending are not supported. Use read-only
+/// PostgreSQL and object-storage credentials.
 class IcebergJdbcCatalog final : public ICatalog, private DB::WithContext
 {
 public:
@@ -90,7 +90,6 @@ private:
     struct ObjectStorageWithPath
     {
         DB::ObjectStoragePtr object_storage;
-        String bucket_name;
         String metadata_path; /// Path of the metadata file within the bucket
     };
 

--- a/src/Databases/DataLake/IcebergJdbcCatalog.h
+++ b/src/Databases/DataLake/IcebergJdbcCatalog.h
@@ -1,0 +1,125 @@
+#pragma once
+#include "config.h"
+
+#if USE_LIBPQXX
+
+#include <Databases/DataLake/ICatalog.h>
+#include <Databases/DataLake/DatabaseDataLakeSettings.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage_fwd.h>
+#include <Interpreters/Context_fwd.h>
+#include <Parsers/IAST_fwd.h>
+#include <Common/CacheBase.h>
+#include <Common/Logger.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace postgres
+{
+class PoolWithFailover;
+using PoolWithFailoverPtr = std::shared_ptr<PoolWithFailover>;
+}
+
+namespace DataLake
+{
+
+/// Read-only client for the standard Apache Iceberg JdbcCatalog schema
+/// (`iceberg_tables` / `iceberg_namespace_properties` in Postgres), instead
+/// of going through an Iceberg REST HTTP API.
+///
+/// Table pointers resolve with a single indexed `SELECT` on the primary key
+/// `(catalog_name, table_namespace, table_name)`; there are no per-resolution
+/// HTTP round trips. The table schema is parsed from the referenced
+/// `metadata.json` through the same `parseTableSchema` path the REST catalog
+/// uses, and cached per metadata location.
+///
+/// This intentionally supports only what ClickHouse needs for reads, against
+/// the stable upstream schema: no version gate is required (V0 and V1, which
+/// adds the `iceberg_type` column, are both accepted). Writes, views and
+/// credential vending are not supported: use static storage credentials.
+class IcebergJdbcCatalog final : public ICatalog, private DB::WithContext
+{
+public:
+    struct ConnectionParams
+    {
+        String host = "localhost";
+        UInt16 port = 5432;
+        String database = "postgres";
+        /// Postgres schema holding the `iceberg_tables` /
+        /// `iceberg_namespace_properties` tables.
+        String schema = "public";
+        String user = "postgres";
+        String password;
+    };
+
+    explicit IcebergJdbcCatalog(
+        const std::string & catalog_name_,
+        ConnectionParams params_,
+        const DB::DatabaseDataLakeSettings & database_settings_,
+        DB::ASTPtr table_engine_definition_,
+        DB::ContextPtr context_);
+
+    ~IcebergJdbcCatalog() override = default;
+
+    bool empty() const override;
+
+    CatalogTables getTables() const override;
+
+    Namespaces getNamespaces() const override;
+
+    bool existsTable(const std::string & namespace_name, const std::string & table_name) const override;
+
+    void getTableMetadata(
+        const std::string & namespace_name, const std::string & table_name, TableMetadata & result) const override;
+
+    bool tryGetTableMetadata(
+        const std::string & namespace_name, const std::string & table_name, TableMetadata & result) const override;
+
+    std::optional<StorageType> getStorageType() const override { return std::nullopt; }
+
+    DB::DatabaseDataLakeCatalogType getCatalogType() const override
+    {
+        return DB::DatabaseDataLakeCatalogType::ICEBERG_JDBC;
+    }
+
+protected:
+    CatalogTables listTablesInNamespaceDirect(const std::string & namespace_name) const override;
+
+private:
+    struct ObjectStorageWithPath
+    {
+        DB::ObjectStoragePtr object_storage;
+        String bucket_name;
+        String metadata_path; /// Path of the metadata file within the bucket
+    };
+
+    /// `"<schema>"."<table>"` with the settings-provided schema quoted.
+    String qualified(const std::string & table) const;
+
+    /// `metadata.json` for `metadata_location`, via object storage, cached.
+    /// Returns nullptr and marks the table unreadable when the location
+    /// scheme cannot be read directly (only S3-family locations supported).
+    Poco::JSON::Object::Ptr getMetadataJSON(const String & metadata_location, TableMetadata & result) const;
+
+    ObjectStorageWithPath createObjectStorageForMetadataAccess(const String & metadata_location) const;
+
+    /// ` AND (iceberg_type = 'TABLE' OR iceberg_type IS NULL)` on V1 schemas,
+    /// empty on V0 schemas (which have no `iceberg_type` column).
+    String tableTypePredicate() const;
+
+    ConnectionParams params;
+    DB::DatabaseDataLakeSettings database_settings;
+    DB::ASTPtr table_engine_definition;
+    const LoggerPtr log;
+
+    postgres::PoolWithFailoverPtr pool;
+    /// Whether `iceberg_tables` has the V1 `iceberg_type` column.
+    bool has_iceberg_type = false;
+
+    mutable DB::CacheBase<String, Poco::JSON::Object::Ptr> metadata_objects;
+};
+
+}
+
+#endif

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -155,6 +155,7 @@ public:
         std::shared_ptr<DataLake::ICatalog> catalog,
         const StorageID & table_id_) override
     {
+        DataLake::throwIfTableWritesUnsupported(catalog, "CREATE TABLE");
         BaseStorageConfiguration::update(object_storage, local_context);
 
         assertLocalPathCorrect(object_storage, local_context);
@@ -180,6 +181,7 @@ public:
         std::shared_ptr<DataLake::ICatalog> catalog,
         const std::optional<FormatSettings> & format_settings) override
     {
+        DataLake::throwIfTableWritesUnsupported(catalog, "Mutation");
         getMetadata()->mutate(commands, storage_ptr, context, storage_id, metadata_snapshot, catalog, format_settings);
     }
 
@@ -202,6 +204,7 @@ public:
         const StorageID & storage_id,
         std::shared_ptr<DataLake::ICatalog> catalog) override
     {
+        DataLake::throwIfTableWritesUnsupported(catalog, "ALTER");
         lazyInitializeIfNeeded(object_storage, context);
         getMetadata()->alter(params, context, storage_id, catalog);
     }
@@ -346,6 +349,7 @@ public:
         ContextPtr context,
         std::shared_ptr<DataLake::ICatalog> catalog) override
     {
+        DataLake::throwIfTableWritesUnsupported(catalog, "INSERT");
         lazyInitializeIfNeeded(object_storage, context);
         /// When the storage carries no format settings (table functions pass none),
         /// derive them from the context. Substituting FormatSettings{} here (struct

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -769,6 +769,8 @@ Pipe IcebergMetadata::executeCommand(
             "To allow their usage, enable setting allow_insert_into_iceberg");
     }
 
+    DataLake::throwIfTableWritesUnsupported(catalog_, "EXECUTE");
+
     if (command_name == "expire_snapshots")
     {
         if (!context->getSettingsRef()[Setting::allow_experimental_expire_snapshots].value)

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -847,6 +847,7 @@ bool StorageObjectStorage::optimize(
     bool /*cleanup*/,
     [[maybe_unused]] ContextPtr context)
 {
+    DataLake::throwIfTableWritesUnsupported(catalog, "OPTIMIZE");
     return configuration->optimize(object_storage, metadata_snapshot, context, format_settings);
 }
 
@@ -1066,6 +1067,7 @@ SchemaCache & StorageObjectStorage::getSchemaCache(const ContextPtr & context, c
 
 void StorageObjectStorage::mutate([[maybe_unused]] const MutationCommands & commands, [[maybe_unused]] ContextPtr context_)
 {
+    DataLake::throwIfTableWritesUnsupported(catalog, "Mutation");
     /// For datalake tables (e.g. Iceberg), refresh external metadata so that the
     /// storage snapshot contains the `datalake_table_state`. Without this the mutation
     /// pipeline will hit a `LOGICAL_ERROR` exception in `iterate` when building the read side.
@@ -1080,6 +1082,7 @@ void StorageObjectStorage::mutate([[maybe_unused]] const MutationCommands & comm
 
 void StorageObjectStorage::checkMutationIsPossible(const MutationCommands & commands, const Settings & /* settings */) const
 {
+    DataLake::throwIfTableWritesUnsupported(catalog, "Mutation");
     configuration->checkMutationIsPossible(object_storage, CurrentThread::tryGetQueryContext(), commands);
 }
 
@@ -1093,6 +1096,7 @@ Pipe StorageObjectStorage::executeCommand(const String & command_name, const AST
 
 void StorageObjectStorage::alter(const AlterCommands & params, ContextPtr context, AlterLockHolder & /*alter_lock_holder*/)
 {
+    DataLake::throwIfTableWritesUnsupported(catalog, "ALTER");
     /// Do not interleave with the hive partitioning resolution, which also updates the metadata.
     std::lock_guard lock(hive_partitioning_resolution_mutex);
 
@@ -1116,6 +1120,7 @@ void StorageObjectStorage::alter(const AlterCommands & params, ContextPtr contex
 
 void StorageObjectStorage::checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const
 {
+    DataLake::throwIfTableWritesUnsupported(catalog, "ALTER");
     configuration->checkAlterIsPossible(object_storage, context, commands);
 }
 

--- a/tests/integration/test_database_iceberg_jdbc/configs/hosts.xml
+++ b/tests/integration/test_database_iceberg_jdbc/configs/hosts.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <remote_url_allow_hosts>
+        <host>postgres1</host>
+        <host>minio1</host>
+    </remote_url_allow_hosts>
+</clickhouse>

--- a/tests/integration/test_database_iceberg_jdbc/test.py
+++ b/tests/integration/test_database_iceberg_jdbc/test.py
@@ -33,20 +33,18 @@ def started_cluster():
         cluster.shutdown()
 
 
-def database_sql(name, database, endpoint, host="postgres1", port=5432):
+def database_sql(name, database, endpoint, host="postgres1", port=5432, password=READER_PASSWORD):
     return f"""
         CREATE DATABASE {name} ENGINE = DataLakeCatalog
         SETTINGS catalog_type='jdbc', warehouse='jdbc_test',
             jdbc_host='{host}', jdbc_port={port}, jdbc_database='{database}',
-            jdbc_user='jdbc_reader', jdbc_password='{READER_PASSWORD}',
+            jdbc_user='jdbc_reader', jdbc_password='{password}',
             vended_credentials=0, storage_endpoint='{endpoint}',
             aws_access_key_id='{minio_access_key}', aws_secret_access_key='{minio_secret_key}'
     """
 
 
-@pytest.mark.parametrize("version", [0, 1])
-@pytest.mark.parametrize("endpoint_has_bucket", [False, True])
-def test_catalog_reads_and_refresh(started_cluster, version, endpoint_has_bucket):
+def create_catalog_fixture(version, endpoint_has_bucket):
     name = "jdbc_" + uuid.uuid4().hex
     admin = get_postgres_conn(cluster.postgres_ip, cluster.postgres_port)
     with admin.cursor() as cursor:
@@ -85,8 +83,40 @@ def test_catalog_reads_and_refresh(started_cluster, version, endpoint_has_bucket
         )
         cursor.execute("GRANT USAGE ON SCHEMA public TO jdbc_reader")
         cursor.execute("GRANT SELECT ON iceberg_tables, iceberg_namespace_properties TO jdbc_reader")
-
     endpoint = "http://minio1:9001" + (f"/{BUCKET}" if endpoint_has_bucket else "")
+    return {"name": name, "admin": admin, "conn": conn, "catalog": catalog, "table": table, "endpoint": endpoint}
+
+
+def drop_catalog_fixture(fixture):
+    node.query(f"DROP DATABASE IF EXISTS {fixture['name']}")
+    fixture["catalog"].engine.dispose()
+    fixture["conn"].close()
+    with fixture["admin"].cursor() as cursor:
+        cursor.execute(f"DROP DATABASE {fixture['name']}")
+    fixture["admin"].close()
+
+
+def storage_objects(prefix):
+    return sorted(
+        obj.object_name
+        for obj in cluster.minio_client.list_objects(BUCKET, prefix, recursive=True)
+    )
+
+
+def catalog_metadata_location(conn):
+    with conn.cursor() as cursor:
+        cursor.execute(
+            "SELECT metadata_location FROM iceberg_tables "
+            "WHERE catalog_name = 'jdbc_test' AND table_namespace = 'a.b' AND table_name = 't'"
+        )
+        return cursor.fetchone()[0]
+
+
+@pytest.mark.parametrize("version", [0, 1])
+@pytest.mark.parametrize("endpoint_has_bucket", [False, True])
+def test_catalog_reads_and_refresh(started_cluster, version, endpoint_has_bucket):
+    fixture = create_catalog_fixture(version, endpoint_has_bucket)
+    name, table, endpoint = fixture["name"], fixture["table"], fixture["endpoint"]
     try:
         node.query(database_sql(name, name, endpoint), settings={"allow_database_iceberg": 1})
         assert node.query(f"SHOW TABLES FROM {name}") == "a.b.t\n"
@@ -104,12 +134,86 @@ def test_catalog_reads_and_refresh(started_cluster, version, endpoint_has_bucket
         assert READER_PASSWORD not in definition
         assert "jdbc_password = '[HIDDEN]'" in definition
     finally:
+        drop_catalog_fixture(fixture)
+
+
+def test_jdbc_catalog_rejects_mutations_before_storage_writes(started_cluster):
+    fixture = create_catalog_fixture(version=1, endpoint_has_bucket=False)
+    name, conn = fixture["name"], fixture["conn"]
+    table_ref = f"{name}.`a.b.t`"
+    try:
+        node.query(
+            database_sql(name, name, fixture["endpoint"]),
+            settings={"allow_database_iceberg": 1},
+        )
+        assert node.query(f"SELECT id FROM {table_ref} ORDER BY id") == "1\n2\n"
+        before_objects = storage_objects(f"{name}/")
+        before_location = catalog_metadata_location(conn)
+        assert before_objects and before_location.startswith("s3://")
+
+        error = node.query_and_get_error(
+            f"INSERT INTO {table_ref} VALUES (99)",
+            settings={"allow_database_iceberg": 1, "allow_insert_into_iceberg": 1},
+        )
+        assert "INSERT is not supported by this catalog" in error
+
+        error = node.query_and_get_error(f"ALTER TABLE {table_ref} ADD COLUMN extra String")
+        assert "ALTER is not supported by this catalog" in error
+
+        error = node.query_and_get_error(f"DELETE FROM {table_ref} WHERE id = 1")
+        assert "Mutation is not supported by this catalog" in error
+
+        error = node.query_and_get_error(f"OPTIMIZE TABLE {table_ref}")
+        assert "OPTIMIZE is not supported by this catalog" in error
+
+        error = node.query_and_get_error(f"DROP TABLE {table_ref}")
+        assert "DROP TABLE is not supported" in error
+
+        assert storage_objects(f"{name}/") == before_objects
+        assert catalog_metadata_location(conn) == before_location
+        assert node.query(f"SELECT id FROM {table_ref} ORDER BY id") == "1\n2\n"
+    finally:
+        drop_catalog_fixture(fixture)
+
+
+def test_missing_catalog_tables(started_cluster):
+    name = "jdbc_" + uuid.uuid4().hex
+    admin = get_postgres_conn(cluster.postgres_ip, cluster.postgres_port)
+    with admin.cursor() as cursor:
+        cursor.execute(f"CREATE DATABASE {name}")
+    try:
+        error = node.query_and_get_error(
+            database_sql(name, name, "http://minio1:9001"),
+            settings={"allow_database_iceberg": 1},
+        )
+        assert "iceberg_tables" in error and "jdbc_schema" in error
+    finally:
         node.query(f"DROP DATABASE IF EXISTS {name}")
-        catalog.engine.dispose()
-        conn.close()
         with admin.cursor() as cursor:
             cursor.execute(f"DROP DATABASE {name}")
         admin.close()
+
+
+def test_missing_namespace_properties_table(started_cluster):
+    fixture = create_catalog_fixture(version=1, endpoint_has_bucket=False)
+    try:
+        with fixture["conn"].cursor() as cursor:
+            cursor.execute("DROP TABLE iceberg_namespace_properties")
+        error = node.query_and_get_error(
+            database_sql(fixture["name"], fixture["name"], fixture["endpoint"]),
+            settings={"allow_database_iceberg": 1},
+        )
+        assert "iceberg_namespace_properties" in error and "jdbc_schema" in error
+    finally:
+        drop_catalog_fixture(fixture)
+
+
+def test_invalid_credentials(started_cluster):
+    error = node.query_and_get_error(
+        database_sql("jdbc_bad_credentials", "postgres", "http://minio1:9001", password="wrong-password"),
+        settings={"allow_database_iceberg": 1},
+    )
+    assert "password authentication failed" in error
 
 
 def test_outbound_host_policy(started_cluster):

--- a/tests/integration/test_database_iceberg_jdbc/test.py
+++ b/tests/integration/test_database_iceberg_jdbc/test.py
@@ -1,0 +1,129 @@
+import uuid
+
+import pyarrow as pa
+import pytest
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import LongType, NestedField, StringType
+from sqlalchemy.engine import URL
+
+from helpers.cluster import ClickHouseCluster
+from helpers.config_cluster import minio_access_key, minio_secret_key, pg_pass
+from helpers.postgres_utility import get_postgres_conn
+
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node", main_configs=["configs/hosts.xml"], with_postgres=True, with_minio=True
+)
+BUCKET = "jdbc-catalog"
+READER_PASSWORD = "jdbc_reader_password"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        cluster.minio_client.make_bucket(BUCKET)
+        with get_postgres_conn(cluster.postgres_ip, cluster.postgres_port) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(f"CREATE ROLE jdbc_reader LOGIN PASSWORD '{READER_PASSWORD}'")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def database_sql(name, database, endpoint, host="postgres1", port=5432):
+    return f"""
+        CREATE DATABASE {name} ENGINE = DataLakeCatalog
+        SETTINGS catalog_type='jdbc', warehouse='jdbc_test',
+            jdbc_host='{host}', jdbc_port={port}, jdbc_database='{database}',
+            jdbc_user='jdbc_reader', jdbc_password='{READER_PASSWORD}',
+            vended_credentials=0, storage_endpoint='{endpoint}',
+            aws_access_key_id='{minio_access_key}', aws_secret_access_key='{minio_secret_key}'
+    """
+
+
+@pytest.mark.parametrize("version", [0, 1])
+@pytest.mark.parametrize("endpoint_has_bucket", [False, True])
+def test_catalog_reads_and_refresh(started_cluster, version, endpoint_has_bucket):
+    name = "jdbc_" + uuid.uuid4().hex
+    admin = get_postgres_conn(cluster.postgres_ip, cluster.postgres_port)
+    with admin.cursor() as cursor:
+        cursor.execute(f"CREATE DATABASE {name}")
+    conn = get_postgres_conn(
+        cluster.postgres_ip, cluster.postgres_port, database=True, database_name=name
+    )
+    uri = URL.create(
+        "postgresql+psycopg2", username="postgres", password=pg_pass,
+        host=cluster.postgres_ip, port=cluster.postgres_port, database=name,
+    ).render_as_string(hide_password=False)
+    catalog = SqlCatalog(
+        "jdbc_test", uri=uri, warehouse=f"s3://{BUCKET}/{name}",
+        **{
+            "s3.endpoint": f"http://{cluster.minio_ip}:{cluster.minio_port}",
+            "s3.access-key-id": minio_access_key,
+            "s3.secret-access-key": minio_secret_key,
+        },
+    )
+    catalog.create_namespace(("a", "b"))
+    catalog.create_namespace("empty")
+    table = catalog.create_table(
+        ("a", "b", "t"), Schema(NestedField(1, "id", LongType(), required=False))
+    )
+    table.append(pa.table({"id": pa.array([1, 2], type=pa.int64())}))
+    with conn.cursor() as cursor:
+        if version == 1:
+            cursor.execute("ALTER TABLE iceberg_tables ADD COLUMN iceberg_type VARCHAR(5)")
+            cursor.execute(
+                "INSERT INTO iceberg_tables (catalog_name, table_namespace, table_name, metadata_location, iceberg_type) "
+                "VALUES ('jdbc_test', 'a.b', 'view', 's3://nonexistent/view.metadata.json', 'VIEW')"
+            )
+        cursor.execute(
+            "INSERT INTO iceberg_tables (catalog_name, table_namespace, table_name, metadata_location) "
+            "VALUES ('another_catalog', 'a.b', 'hidden', 's3://nonexistent/hidden.metadata.json')"
+        )
+        cursor.execute("GRANT USAGE ON SCHEMA public TO jdbc_reader")
+        cursor.execute("GRANT SELECT ON iceberg_tables, iceberg_namespace_properties TO jdbc_reader")
+
+    endpoint = "http://minio1:9001" + (f"/{BUCKET}" if endpoint_has_bucket else "")
+    try:
+        node.query(database_sql(name, name, endpoint), settings={"allow_database_iceberg": 1})
+        assert node.query(f"SHOW TABLES FROM {name}") == "a.b.t\n"
+        assert node.query(f"EXISTS TABLE {name}.`a.b.missing`") == "0\n"
+        for _ in range(2):
+            assert node.query(f"SELECT id FROM {name}.`a.b.t` ORDER BY id") == "1\n2\n"
+
+        # A new metadata pointer must be observed even with the old JSON cached.
+        table.append(pa.table({"id": pa.array([3], type=pa.int64())}))
+        assert node.query(f"SELECT id FROM {name}.`a.b.t` ORDER BY id") == "1\n2\n3\n"
+        with table.update_schema() as update:
+            update.add_column("label", StringType())
+        assert "label" in node.query(f"DESCRIBE TABLE {name}.`a.b.t`")
+        definition = node.query(f"SHOW CREATE DATABASE {name}")
+        assert READER_PASSWORD not in definition
+        assert "jdbc_password = '[HIDDEN]'" in definition
+    finally:
+        node.query(f"DROP DATABASE IF EXISTS {name}")
+        catalog.engine.dispose()
+        conn.close()
+        with admin.cursor() as cursor:
+            cursor.execute(f"DROP DATABASE {name}")
+        admin.close()
+
+
+def test_outbound_host_policy(started_cluster):
+    error = node.query_and_get_error(
+        database_sql("jdbc_blocked", "postgres", "http://minio1:9001", host="blocked.invalid"),
+        settings={"allow_database_iceberg": 1},
+    )
+    assert "UNACCEPTABLE_URL" in error
+
+
+@pytest.mark.parametrize("port", [0, 65536])
+def test_invalid_port(started_cluster, port):
+    error = node.query_and_get_error(
+        database_sql("jdbc_bad_port", "postgres", "http://minio1:9001", port=port),
+        settings={"allow_database_iceberg": 1},
+    )
+    assert "jdbc_port" in error and "1-65535" in error

--- a/tests/integration/test_database_iceberg_jdbc/test.py
+++ b/tests/integration/test_database_iceberg_jdbc/test.py
@@ -33,12 +33,12 @@ def started_cluster():
         cluster.shutdown()
 
 
-def database_sql(name, database, endpoint, host="postgres1", port=5432, password=READER_PASSWORD):
+def database_sql(name, database, endpoint, host="postgres1", port=5432, password=READER_PASSWORD, user="jdbc_reader"):
     return f"""
         CREATE DATABASE {name} ENGINE = DataLakeCatalog
         SETTINGS catalog_type='jdbc', warehouse='jdbc_test',
             jdbc_host='{host}', jdbc_port={port}, jdbc_database='{database}',
-            jdbc_user='jdbc_reader', jdbc_password='{password}',
+            jdbc_user='{user}', jdbc_password='{password}',
             vended_credentials=0, storage_endpoint='{endpoint}',
             aws_access_key_id='{minio_access_key}', aws_secret_access_key='{minio_secret_key}'
     """
@@ -209,11 +209,13 @@ def test_missing_namespace_properties_table(started_cluster):
 
 
 def test_invalid_credentials(started_cluster):
+    # The harness Postgres trusts all local connections, so a wrong password
+    # still connects; a nonexistent role is the closest negative case.
     error = node.query_and_get_error(
-        database_sql("jdbc_bad_credentials", "postgres", "http://minio1:9001", password="wrong-password"),
+        database_sql("jdbc_bad_credentials", "postgres", "http://minio1:9001", user="nosuchuser"),
         settings={"allow_database_iceberg": 1},
     )
-    assert "password authentication failed" in error
+    assert "nosuchuser" in error and "does not exist" in error
 
 
 def test_outbound_host_policy(started_cluster):

--- a/tests/integration/test_database_iceberg_jdbc/test.py
+++ b/tests/integration/test_database_iceberg_jdbc/test.py
@@ -132,7 +132,7 @@ def test_catalog_reads_and_refresh(started_cluster, version, endpoint_has_bucket
         assert "label" in node.query(f"DESCRIBE TABLE {name}.`a.b.t`")
         definition = node.query(f"SHOW CREATE DATABASE {name}")
         assert READER_PASSWORD not in definition
-        assert "jdbc_password = '[HIDDEN]'" in definition
+        assert "[HIDDEN]" in definition
     finally:
         drop_catalog_fixture(fixture)
 

--- a/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.reference
+++ b/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.reference
@@ -1,2 +1,4 @@
 --- CREATE DATABASE accepts the jdbc settings ---
-catalog_type = 'jdbc', warehouse = 'jdbc', jdbc_host = 'postgres', jdbc_port = 5432, jdbc_database = 'catalog', jdbc_schema = 'public', jdbc_user = 'reader', jdbc_password = 'secret'
+catalog_type = 'jdbc', warehouse = 'jdbc', jdbc_host = 'postgres', jdbc_port = 5432, jdbc_database = 'catalog', jdbc_schema = 'public', jdbc_user = 'reader'
+--- jdbc_password is hidden when formatted ---
+jdbc_password = '[HIDDEN]'

--- a/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.reference
+++ b/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.reference
@@ -1,0 +1,2 @@
+--- CREATE DATABASE accepts the jdbc settings ---
+catalog_type = 'jdbc', warehouse = 'jdbc', jdbc_host = 'postgres', jdbc_port = 5432, jdbc_database = 'catalog', jdbc_schema = 'public', jdbc_user = 'reader', jdbc_password = 'secret'

--- a/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.sh
+++ b/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.sh
@@ -10,4 +10,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "--- CREATE DATABASE accepts the jdbc settings ---"
 echo "CREATE DATABASE test_jdbc ENGINE=DataLakeCatalog SETTINGS catalog_type='jdbc', warehouse='jdbc', jdbc_host='postgres', jdbc_port=5432, jdbc_database='catalog', jdbc_schema='public', jdbc_user='reader', jdbc_password='secret'" \
-    | $CLICKHOUSE_FORMAT --oneline | grep -o "catalog_type = 'jdbc'.*jdbc_password = 'secret'"
+    | $CLICKHOUSE_FORMAT --oneline | grep -o "catalog_type = 'jdbc'.*jdbc_user = 'reader'"
+
+echo "--- jdbc_password is hidden when formatted ---"
+echo "CREATE DATABASE test_jdbc ENGINE=DataLakeCatalog SETTINGS catalog_type='jdbc', warehouse='jdbc', jdbc_password='secret'" \
+    | $CLICKHOUSE_FORMAT --oneline | grep -oE "(^|[, ])jdbc_password = '[^']*'" | sed -E "s/^[, ]//"

--- a/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.sh
+++ b/tests/queries/0_stateless/05059_iceberg_jdbc_catalog.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Test the jdbc DataLakeCatalog settings without a live Postgres database.
+# CREATE DATABASE connects eagerly, so the statement is validated with
+# clickhouse-format; behavior against a real JdbcCatalog database is covered
+# by live testing, not by stateless tests.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo "--- CREATE DATABASE accepts the jdbc settings ---"
+echo "CREATE DATABASE test_jdbc ENGINE=DataLakeCatalog SETTINGS catalog_type='jdbc', warehouse='jdbc', jdbc_host='postgres', jdbc_port=5432, jdbc_database='catalog', jdbc_schema='public', jdbc_user='reader', jdbc_password='secret'" \
+    | $CLICKHOUSE_FORMAT --oneline | grep -o "catalog_type = 'jdbc'.*jdbc_password = 'secret'"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/118010

Add read support for PostgreSQL-backed Apache Iceberg `JdbcCatalog` V0/V1 tables. ClickHouse uses its PostgreSQL client pool, not a JDBC driver. An indexed catalog lookup returns `metadata_location`; schema and table location come from that Iceberg metadata file. The initial storage scope is S3.

PostgreSQL privileges govern catalog access and S3 credentials govern object access. Use a dedicated `SELECT`-only PostgreSQL role and read-only S3 credentials; no REST authorization or credential vending is involved. Future catalog-schema versions require compatibility testing.

The current revision enforces `remote_url_allow_hosts`, releases PostgreSQL connections before object-storage I/O, and reuses existing endpoint construction. It rejects catalog-backed `CREATE`, `INSERT`, `ALTER`, `DELETE`, `OPTIMIZE`, `EXECUTE` and `DROP TABLE` before object-storage side effects through `ICatalog::supportsTableWrites`, with explicit read-only catalog errors. Both standard catalog tables are required at construction. Integration coverage now includes mutation rejection with unchanged S3 objects and catalog pointers, missing tables, and invalid credentials, alongside the V0/V1 fixtures.

Validation: full `test_database_iceberg_jdbc` suite passes locally against the CI-built binary (`11 passed`); same-binary rest-vs-jdbc bench below. The comparator is a Python REST shim over the same table, not a production catalog — these numbers show the HTTP round-trip cost of table resolution, not a general JDBC-versus-REST claim.

Measured in fork CI ([run](https://github.com/adonm/ClickHouse/actions/runs/34346521574), 3.4M-row NYC TLC fixture, 5000 queries per case, three repetitions with one reversed, paired result equality, zero stress failures both sides; before = REST leg, after = direct PG):

| query | C=8 p50 | C=8 QPS | C=64 p50 | C=64 QPS |
|---|---|---|---|---|
| point lookup | 54–56 → 9–12 ms | ~140 → ~620–790 | 131–144 → 54–63 ms | ~470 → ~830–870 (rep1 QPS dipped 463 → 143) |
| partition scan | 61–62 → 32–42 ms | ~110–155 → ~39–202 (mixed) | 219–341 → 272–295 ms (mixed) | ~128–156 → ~30–206 (mixed) |
| full count | 47–48 → 3 ms | ~155 → ~1950–2030 | 98–104 → 19–20 ms | ~580–640 → ~2530–2565 |
| stress (point lookup) | — | 436 → 880 | — | 346 → 755 |

Point lookup and full count win uniformly across all six repetitions; the partition scan is improved at C=8 but mixed at C=64 and needs more investigation before any claim. Broader failure-mode coverage remains work before leaving draft.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry:
Add experimental PostgreSQL-backed Iceberg `JdbcCatalog` read support to `DataLakeCatalog` using `catalog_type = 'jdbc'` for tables stored on S3.

---
Assisted by Muse Spark 1.3; follow-up revisions also used AI assistance.
