### PR TITLE
Fail image builds at the apt index fetch so the apt mirror fallback can fire

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -25,7 +25,9 @@ ARG apt_ports_archive="http://ports.ubuntu.com"
 RUN sed -i -e "s|http://archive.ubuntu.com|${apt_archive}|g" -e "s|http://ports.ubuntu.com|${apt_ports_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
-    && apt-get update \
+    # `apt-get update` reports a failed repository index fetch as a warning and exits 0,
+    # proceeding with a stale or absent index; `--error-on=any` fails there, not in the install.
+    && apt-get update --error-on=any \
     && apt-get install --yes --no-install-recommends \
         ca-certificates \
         wget \
@@ -94,7 +96,7 @@ RUN if [ -n "${single_binary_location_url}" ]; then \
 
 # Fall back to installation from the ClickHouse repository.
 RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
-    ; apt-get update \
+    ; apt-get update --error-on=any \
     && apt-get install --yes --no-install-recommends dirmngr gnupg2 \
     && mkdir -p /etc/apt/sources.list.d \
     && GNUPGHOME=$(mktemp -d) \
@@ -113,7 +115,7 @@ RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
     && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
     && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \
     && echo "installing from repository: ${REPOSITORY}" \
-    && apt-get update \
+    && apt-get update --error-on=any \
     && for package in ${PACKAGES}; do \
         packages="${packages} ${package}=${VERSION}" \
     ; done \

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -31,7 +31,9 @@ ARG apt_ports_archive="http://ports.ubuntu.com"
 RUN sed -i -e "s|http://archive.ubuntu.com|${apt_archive}|g" -e "s|http://ports.ubuntu.com|${apt_ports_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
-    && apt-get update \
+    # `apt-get update` reports a failed repository index fetch as a warning and exits 0,
+    # proceeding with a stale or absent index; `--error-on=any` fails there, not in the install.
+    && apt-get update --error-on=any \
     && apt-get install --yes --no-install-recommends \
         ca-certificates \
         wget \
@@ -101,7 +103,7 @@ RUN if [ -n "${single_binary_location_url}" ]; then \
 
 # Fall back to installation from the ClickHouse repository.
 RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
-    ; apt-get update \
+    ; apt-get update --error-on=any \
     && apt-get install --yes --no-install-recommends dirmngr gnupg2 \
     && mkdir -p /etc/apt/sources.list.d \
     && GNUPGHOME=$(mktemp -d) \
@@ -120,7 +122,7 @@ RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
     && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
     && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \
     && echo "installing from repository: ${REPOSITORY}" \
-    && apt-get update \
+    && apt-get update --error-on=any \
     && for package in ${PACKAGES}; do \
         packages="${packages} ${package}=${VERSION}" \
     ; done \

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -20,7 +20,9 @@ ARG apt_ports_archive="http://ports.ubuntu.com"
 RUN sed -i -e "s|http://archive.ubuntu.com|${apt_archive}|g" -e "s|http://ports.ubuntu.com|${apt_ports_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
-    && apt-get update \
+    # `apt-get update` reports a failed repository index fetch as a warning and exits 0,
+    # proceeding with a stale or absent index; `--error-on=any` fails there, not in the install.
+    && apt-get update --error-on=any \
     && apt-get install --yes --no-install-recommends \
         busybox \
         ca-certificates \
@@ -110,7 +112,7 @@ RUN if [ -n "${single_binary_location_url}" ]; then \
 # A fallback to installation from ClickHouse repository
 # It works unless the clickhouse binary already exists
 RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
-    ; apt-get update \
+    ; apt-get update --error-on=any \
     && apt-get install --yes --no-install-recommends \
         dirmngr \
         gnupg2 \
@@ -131,7 +133,7 @@ RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
     && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
     && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \
     && echo "installing from repository: ${REPOSITORY}" \
-    && apt-get update \
+    && apt-get update --error-on=any \
     && for package in ${PACKAGES}; do \
         packages="${packages} ${package}=${VERSION}" \
     ; done \


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Make a failed apt package index refresh fatal in the server and keeper image builds, so a broken apt mirror is reported as a mirror failure instead of an unsatisfiable dependency.

### Description

`Docker server image` and `Docker keeper image` go red on an apt-mirror outage without ever
rebuilding against Canonical, even though that fallback is merged and its token defect
(#116444) is fixed on this base.

The producer is the cause, not the classifier. `apt-get update` does not treat a failed index
fetch as fatal: it warns, exits 0 and proceeds with a stale or absent index, so the `RUN` chain
continues into `apt-get install`, which dies on an unsatisfiable dependency. buildx fences only
that resolution error, so `is_apt_mirror_failure` finds no mirror token at `E:` severity and
`should_try_next_mirror` returns False; the lines that do carry the tokens are `W:` and sit
above the fence. `--error-on=any` promotes them to `E:` and stops the chain before the install,
which is the shape the merged classifier already recognises. Nothing in `ci/` changes.

Validated per Dockerfile against a local 503 server, both shapes: the pristine tree reproduces
the CI failure byte-for-byte with `should_try_next_mirror` False; with the flag it is True.
Both arms still fail the build, so this changes the classification, not the outcome. A full
`ch-builder` build against the real mirrors still succeeds, exercising all three sites.

Two disclosures. 4 of the 9 sites lie outside the `#docker-official-library` region, so the
published Dockerfiles become strict too, with no fallback behind them; I read that as wanted
for a release image, but say so if you want it confined. And a build that today survives a
transient failure on a stale index will now fail at the fetch, then take the retries and the
Canonical rebuild.

Not changed here: the `ci/docker/` sites have the same behaviour and no fallback; `26.8` still
carries the pre-#116444 `BUILDX_SOLVE_ERROR`, which needs a `v26.8-must-backport` label on
#116444.

No related open issue found. CI report:
https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=117612&sha=641c9b6831e3c49cc505ac66eed049c46b1f4a4d&name_0=PR&name_1=Docker%20server%20image

Related: https://github.com/ClickHouse/ClickHouse/pull/116444
Related: https://github.com/ClickHouse/ClickHouse/pull/117578

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118023&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118023](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118023+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1364` (included in `26.9` and later)
<!-- ch-version-info:end -->