### PR TITLE
Log a warning when the MATERIALIZED CTE keyword is ignored because enable_materialized_cte is disabled

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -1329,14 +1329,25 @@ IdentifierResolveResult QueryAnalyzer::tryResolveIdentifierFromCTE(
     auto * union_node = cte_node->as<UnionNode>();
 
     bool is_materialized_cte = (query_node && query_node->isMaterialized()) || (union_node && union_node->isMaterialized());
-    if (is_materialized_cte && scope.context->getSettingsRef()[Setting::enable_materialized_cte])
+    if (is_materialized_cte)
     {
-        /// Create a TableNode with StorageDummy as placeholder. The subquery stays unresolved.
-        /// Resolution and real storage creation happen later in resolveQueryJoinTreeNode.
-        auto table_node = std::make_shared<TableNode>(full_name, cte_node, scope.context);
-        table_node->setAlias(full_name);
+        if (scope.context->getSettingsRef()[Setting::enable_materialized_cte])
+        {
+            /// Create a TableNode with StorageDummy as placeholder. The subquery stays unresolved.
+            /// Resolution and real storage creation happen later in resolveQueryJoinTreeNode.
+            auto table_node = std::make_shared<TableNode>(full_name, cte_node, scope.context);
+            table_node->setAlias(full_name);
 
-        cte_node = table_node;
+            cte_node = table_node;
+        }
+        else
+        {
+            LOG_WARNING(
+                getLogger("QueryAnalyzer"),
+                "CTE '{}' is declared as MATERIALIZED, but the setting 'enable_materialized_cte' is disabled: "
+                "the MATERIALIZED keyword is ignored and the CTE is inlined at each reference",
+                full_name);
+        }
     }
 
     return { .resolved_identifier = cte_node, .resolve_place = IdentifierResolvePlace::CTE };

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5598,7 +5598,7 @@ Propagate WITH statements to UNION queries and all subqueries
 )", 0) \
     DECLARE(Bool, enable_materialized_cte, false, R"(
 Enable materialized common table expressions (`WITH <name> AS MATERIALIZED (<subquery>)`).
-When enabled, a CTE declared as `MATERIALIZED` is executed once, stored in a temporary table, and all references read from that table.
+When enabled, a CTE declared as `MATERIALIZED` that is referenced more than once is executed once, stored in a temporary table, and all references read from that table. A CTE referenced only once is inlined as an ordinary CTE to avoid the overhead.
 When disabled, the `MATERIALIZED` keyword is ignored: the CTE is inlined at each reference like an ordinary CTE, and a warning is logged.
 )", EXPERIMENTAL) \
     DECLARE(Bool, analyzer_inline_views, false, R"(

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5597,7 +5597,9 @@ Allow to execute alters which affects not only tables metadata, but also data on
 Propagate WITH statements to UNION queries and all subqueries
 )", 0) \
     DECLARE(Bool, enable_materialized_cte, false, R"(
-Enable materialized common table expressions, it will be preferred over enable_global_with_statement
+Enable materialized common table expressions (`WITH <name> AS MATERIALIZED (<subquery>)`).
+When enabled, a CTE declared as `MATERIALIZED` is executed once, stored in a temporary table, and all references read from that table.
+When disabled, the `MATERIALIZED` keyword is ignored: the CTE is inlined at each reference like an ordinary CTE, and a warning is logged.
 )", EXPERIMENTAL) \
     DECLARE(Bool, analyzer_inline_views, false, R"(
 When enabled, the analyzer substitutes ordinary (non-materialized, non-parameterized) views with their defining subqueries, enabling cross-boundary optimizations such as predicate pushdown and column pruning.

--- a/src/Parsers/ParserWithElement.cpp
+++ b/src/Parsers/ParserWithElement.cpp
@@ -147,6 +147,7 @@ This is especially useful when the same CTE is referenced multiple times in a qu
 <Note>
 Materialized CTEs are an **experimental** feature.
 They require the [analyzer](/guides/clickhouse/performance-and-monitoring/analyzer) and the setting `enable_materialized_cte` to be enabled.
+If the setting is disabled, the `MATERIALIZED` keyword is ignored: the CTE is inlined at each reference like an ordinary CTE, and a warning is logged.
 </Note>
 
 ### Syntax {#materialized-common-table-expressions-syntax}
@@ -254,7 +255,7 @@ SELECT count() FROM b AS l LEFT SEMI JOIN b AS r ON l.uid = r.uid;
 
 ### Restrictions {#materialized-cte-restrictions}
 
-- **Experimental setting required**: The setting `enable_materialized_cte` must be enabled.
+- **Experimental setting required**: The setting `enable_materialized_cte` must be enabled. If it is disabled, the `MATERIALIZED` keyword is ignored: the CTE is inlined at each reference like an ordinary CTE, and a warning is logged.
 - **Analyzer required**: Materialized CTEs only work with the [analyzer](/guides/clickhouse/performance-and-monitoring/analyzer) enabled (`enable_analyzer = 1`).
 - **Not supported with `RECURSIVE`**: Combining `MATERIALIZED` and `RECURSIVE` keywords is not allowed and results in an `UNSUPPORTED_METHOD` exception.
 - **Correlated CTEs are forbidden**: A materialized CTE cannot reference columns from outer query scopes.

--- a/tests/queries/0_stateless/04561_materialized_cte_totals_gate.sh
+++ b/tests/queries/0_stateless/04561_materialized_cte_totals_gate.sh
@@ -13,7 +13,11 @@ explain_insert() {
         DROP TABLE IF EXISTS t_04561_plan SYNC;
         CREATE TABLE t_04561_plan (id UInt64) ENGINE = Memory;
     "
+    # With the setting disabled the analyzer warns that MATERIALIZED is ignored; keep it out of stderr.
+    local quiet_logs=''
+    [ "$1" = 0 ] && quiet_logs="SET send_logs_level = 'error';"
     $CLICKHOUSE_CLIENT --enable_analyzer 1 --enable_materialized_cte "$1" -q "
+        $quiet_logs
         EXPLAIN PIPELINE INSERT INTO t_04561_plan
             WITH a AS MATERIALIZED (SELECT number AS id FROM numbers(10))
             SELECT id FROM a WHERE id IN (SELECT id FROM a) GROUP BY id WITH TOTALS;

--- a/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
+++ b/tests/queries/0_stateless/04816_promql_shared_subqueries_materialized.sql
@@ -53,12 +53,17 @@ INSERT INTO prometheus (metric_name, tags, time_series) VALUES
 SELECT '-- or, range';
 SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10) ORDER BY tags;
 SELECT '-- or, range: identical result with materialization disabled';
+-- the analyzer warns that MATERIALIZED is ignored with the setting disabled
+SET send_logs_level = 'error';
 SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10) ORDER BY tags SETTINGS enable_materialized_cte = 0;
+SET send_logs_level = 'warning';
 
 SELECT '-- topk(2), range';
 SELECT * FROM prometheusQueryRange('prometheus', 'topk(2, last_over_time(m[10]))', 100, 130, 10) ORDER BY tags;
 SELECT '-- topk(2), range: identical result with materialization disabled';
+SET send_logs_level = 'error';
 SELECT * FROM prometheusQueryRange('prometheus', 'topk(2, last_over_time(m[10]))', 100, 130, 10) ORDER BY tags SETTINGS enable_materialized_cte = 0;
+SET send_logs_level = 'warning';
 
 SELECT '-- sparse or preserves both sides at different steps';
 SELECT count() AS series_count, sum(length(time_series)) AS sample_count
@@ -134,9 +139,11 @@ FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'topk(2, last_ove
 
 SELECT '-- explicitly disabling the setting restores the inlined plan: the left side of `or` is read twice again';
 SET enable_materialized_cte = 0;
+SET send_logs_level = 'error';
 SELECT countIf(explain LIKE '%ReadFromMergeTree%samples_table%') AS samples_table_reads,
        countIf(explain LIKE '%MaterializingCTEs%') > 0 AS uses_materialized_cte
 FROM (EXPLAIN SELECT * FROM prometheusQueryRange('prometheus', 'last_over_time(m[10]) or last_over_time(n[10])', 100, 130, 10));
+SET send_logs_level = 'warning';
 
 DROP TABLE prometheus;
 DROP TABLE tags_table;


### PR DESCRIPTION
When `enable_materialized_cte` is disabled (the default), a CTE declared as `WITH name AS MATERIALIZED (...)` is silently inlined at each reference like an ordinary CTE. Nothing in the query result, the plan, or the logs indicated that the keyword had no effect, so a user who forgot to enable the setting had no way to notice.

`QueryAnalyzer::tryResolveIdentifierFromCTE` is the only place the setting is consulted for `SELECT` queries. It now logs a warning for every reference to a `MATERIALIZED` CTE that is resolved with the setting disabled:

```
<Warning> QueryAnalyzer: CTE 'cte' is declared as MATERIALIZED, but the setting 'enable_materialized_cte' is disabled: the MATERIALIZED keyword is ignored and the CTE is inlined at each reference
```

The message reaches the server log and clients that run with `send_logs_level` set to `warning` or lower. The description of `enable_materialized_cte` and the embedded documentation of `WITH` in `ParserWithElement.cpp` now describe both states of the setting (the `docs/` pages are regenerated from these sources by the autogeneration workflow and are not edited here).

Two existing tests deliberately run `MATERIALIZED` CTEs with the setting disabled (`04561_materialized_cte_totals_gate`, `04816_promql_shared_subqueries_materialized`); those statements now run with `send_logs_level = 'error'` so the expected warning does not appear as unexpected stderr. No new test asserts on the log message itself. Other paths were already loud or intentional: `WITH RECURSIVE ... AS MATERIALIZED` throws `UNSUPPORTED_METHOD` regardless of the setting, `StorageInput` already explains the hint semantics in its error text, and the PromQL storages force-enable the setting unless the user changed it explicitly.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A warning is now logged when a CTE is declared as `MATERIALIZED` but the setting `enable_materialized_cte` is disabled, in which case the keyword is ignored and the CTE is inlined at each reference. Previously the keyword was silently ignored.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118032&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118032](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118032+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

