### PR TITLE
Clamp `wait_for_async_insert_timeout` in the Prometheus remote-write protocol

### DIFF
--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -8,6 +8,7 @@
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnTuple.h>
 #include <Common/logger_useful.h>
+#include <Common/saturatedDuration.h>
 #include <Core/DecimalFunctions.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypeArray.h>
@@ -265,9 +266,9 @@ void insertBlock(Block block, StorageTimeSeries & storage, const ContextMutableP
             /// `ASYNC_INSERT_FLUSH_TIMEOUT` is returned to the client as HTTP 503: the remote-write protocol
             /// treats 4xx statuses (other than 429) as permanent failures and drops the data without a retry,
             /// while the data here is still in the queue and its fate is unknown, so the status must be retryable.
-            const auto timeout_ms = context->getSettingsRef()[Setting::wait_for_async_insert_timeout].totalMilliseconds();
-            if (result.future.wait_for(std::chrono::milliseconds(timeout_ms)) == std::future_status::timeout)
-                throw Exception(ErrorCodes::ASYNC_INSERT_FLUSH_TIMEOUT, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout_ms);
+            const auto timeout = saturatedMilliseconds(context->getSettingsRef()[Setting::wait_for_async_insert_timeout].totalMilliseconds());
+            if (result.future.wait_for(timeout) == std::future_status::timeout)
+                throw Exception(ErrorCodes::ASYNC_INSERT_FLUSH_TIMEOUT, "Wait for asynchronous insert timeout ({} ms) exceeded", timeout.count());
 
             const auto progress = result.future.get();
             if (auto process_list_element = context->getProcessListElement())

--- a/tests/integration/test_prometheus_protocols/test_async_insert.py
+++ b/tests/integration/test_prometheus_protocols/test_async_insert.py
@@ -142,3 +142,42 @@ def test_async_insert_flush_timeout_returns_503():
         '{"resultType": "vector", "result": '
         '[{"metric": {"__name__": "timeout_metric"}, "value": [1724112000, "1.5"]}]}'
     )
+
+
+def test_async_insert_flush_timeout_is_clamped():
+    node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+
+    def remote_write(metric_name, wait_for_async_insert_timeout):
+        # A 3-second flush deadline: a wait shorter than that times out, a longer one does not.
+        return get_response_to_remote_write(
+            node.ip_address,
+            9093,
+            f"/write?async_insert=1&wait_for_async_insert_timeout={wait_for_async_insert_timeout}"
+            "&async_insert_use_adaptive_busy_timeout=0&async_insert_busy_timeout_max_ms=3000",
+            convert_time_series_to_protobuf(
+                [({"__name__": metric_name}, {1724112000: 1.5})]
+            ),
+        )
+
+    # 1e10 seconds is accepted by the setting but overflows the millisecond-to-nanosecond
+    # conversion that wait_for() performs; capped at one year it outlasts the flush.
+    response = remote_write("clamped_pos_metric", 10000000000)
+    assert response.status_code == 204
+    # No retry here: the acknowledgement means the wait outlasted the flush.
+    assert node.query("SELECT count() FROM timeSeriesSamples(prometheus)") == "1\n"
+
+    # -1e10 seconds overflows the same conversion in the other direction. A negative timeout
+    # means "already expired", so the wait returns immediately.
+    response = remote_write("clamped_neg_metric", -10000000000)
+    assert response.status_code == 503
+    assert "Wait for asynchronous insert timeout (0 ms) exceeded" in response.text
+
+    # An in-range timeout is used as given, so the reported number is the one that applied.
+    response = remote_write("in_range_metric", 0.001)
+    assert response.status_code == 503
+    assert "Wait for asynchronous insert timeout (1 ms) exceeded" in response.text
+
+    # A timed-out wait keeps the data in the queue, so every sample arrives after the flush.
+    assert_eq_with_retry(
+        node, "SELECT count() FROM timeSeriesSamples(prometheus)", "3", retry_count=60
+    )

--- a/tests/integration/test_prometheus_protocols/test_async_insert.py
+++ b/tests/integration/test_prometheus_protocols/test_async_insert.py
@@ -160,7 +160,7 @@ def test_async_insert_flush_timeout_is_clamped():
         )
 
     # 1e10 seconds is accepted by the setting but overflows the millisecond-to-nanosecond
-    # conversion that wait_for() performs; capped at one year it outlasts the flush.
+    # conversion that `wait_for` performs; capped at one year it outlasts the flush.
     response = remote_write("clamped_pos_metric", 10000000000)
     assert response.status_code == 204
     # No retry here: the acknowledgement means the wait outlasted the flush.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a signed integer overflow reachable by writing to a `TimeSeries` table over the Prometheus remote-write protocol with `async_insert` enabled and `wait_for_async_insert_timeout` set to a large magnitude. The setting was passed to `std::future::wait_for` unclamped, so the millisecond to nanosecond conversion overflowed and the wait deadline became undefined, making the server either time out immediately or acknowledge the write after an undefined wait. The timeout is now clamped with `saturatedMilliseconds`, the helper the setting's two other consumers already use: the wait is capped at one year, a negative timeout is treated as already expired, and the `ASYNC_INSERT_FLUSH_TIMEOUT` message reports the timeout that was actually applied.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/117974

`wait_for_async_insert_timeout` is a `Seconds` setting whose validator only rejects values whose microsecond product leaves `Int64`, so any magnitude up to about `9.22e12` seconds is legal, negatives included. `PrometheusRemoteWriteProtocol.cpp` handed that raw millisecond count to `std::future::wait_for`, which libc++ turns into `wait_until(steady_clock::now() + d)` in nanoseconds. The millisecond to nanosecond multiply overflows `Int64` above about `9.22e9` seconds, which is undefined behaviour: the combined ASan+UBSan build uses `-fno-sanitize-recover=all` and aborts the server, and an ordinary build silently wraps the deadline.

The setting has three consumers. `executeQuery.cpp` and `TCPHandler.cpp` already clamp with `saturatedMilliseconds`; this was the missed third, added after the other two were fixed.

Measured, over HTTP with a 3 second flush deadline: at `+1e10` seconds the wrapped deadline lands in the past and the request fails with 503 instead of 204; at `-1e10` seconds it wraps positive and the request returns 204 after waiting on an undefined deadline. With the clamp, the first returns 204 and the second returns 503 immediately, and an in-range control of 1 ms still reports its own value.

Deliberately unchanged: unlike both other consumers, this site does not consult `wait_for_async_insert` and waits unconditionally, which is intentional for remote-write durability.

Provenance and residual: @ tiandiwonder found this while sweeping the wait primitives in `src/` and handed over two sites in https://github.com/ClickHouse/ClickHouse/pull/117974#issuecomment-5533853464. This pull request takes the first. The other, `OvercommitTracker.cpp` with `memory_usage_overcommit_max_wait_microseconds`, needs a microsecond-typed clamp that is not on master yet and follows separately.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118040&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118040](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118040+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.753` (included in `26.9` and later)
<!-- ch-version-info:end -->