### PR TITLE
Draw the `04936` ports from outside the ephemeral range

### DIFF
--- a/tests/queries/0_stateless/04936_keeper_handler_config_error.sh
+++ b/tests/queries/0_stateless/04936_keeper_handler_config_error.sh
@@ -35,9 +35,40 @@ trap cleanup EXIT
 # here is unique per concurrent copy of this test, so any derived port would be the same in every
 # copy, and probe-then-bind is a race those copies lose against each other. Collisions are detected
 # by binding, which is the only reliable test, so a retry always makes progress.
+#
+# What the retries cannot survive is a window where nearly everything is taken, and the local
+# ephemeral range is exactly that: it is where the kernel puts the source port of every outgoing
+# connection, a runner running the rest of the suite has tens of thousands of those at a time, and
+# each one that ends holds its port for another minute in `TIME_WAIT`. `SO_REUSEADDR` on the
+# listener does not get past them - the socket that opened the connection never set it - and the
+# raft listener binds the wildcard address, so a port taken on any interface is lost. The window is
+# therefore the larger of the two ranges the ephemeral one leaves free.
+read -r EPHEMERAL_LOW EPHEMERAL_HIGH <<< "$(cat /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)"
+: "${EPHEMERAL_LOW:=32768}" "${EPHEMERAL_HIGH:=60999}"
+
+if [ "$((EPHEMERAL_LOW - 1024))" -ge "$((65535 - EPHEMERAL_HIGH))" ]; then
+    PORT_WINDOW_LOW=1024
+    PORT_WINDOW_HIGH=$((EPHEMERAL_LOW - 1))
+else
+    PORT_WINDOW_LOW=$((EPHEMERAL_HIGH + 1))
+    PORT_WINDOW_HIGH=65535
+fi
+
+# Every slot has to fit all three ports, so the last one starts two below the top of the window.
+PORT_WINDOW_SLOTS=$(((PORT_WINDOW_HIGH - 2 - PORT_WINDOW_LOW) / 4 + 1))
+
+# A range configured to cover everything leaves a window of a single slot, and every retry would
+# then pick the port that has already been refused. Picking from all of the unprivileged ports is
+# no worse than what this replaces, and it still makes progress.
+if [ "$PORT_WINDOW_SLOTS" -lt 256 ]; then
+    PORT_WINDOW_LOW=1024
+    PORT_WINDOW_HIGH=65535
+    PORT_WINDOW_SLOTS=$(((PORT_WINDOW_HIGH - 2 - PORT_WINDOW_LOW) / 4 + 1))
+fi
+
 function pick_ports()
 {
-    PORT_BASE=$((32768 + RANDOM % 8000 * 4))
+    PORT_BASE=$((PORT_WINDOW_LOW + RANDOM % PORT_WINDOW_SLOTS * 4))
     PROM_PORT=$PORT_BASE
     KEEPER_PORT=$((PORT_BASE + 1))
     RAFT_PORT=$((PORT_BASE + 2))


### PR DESCRIPTION
`04936_keeper_handler_config_error` needs three free ports, and it picked them at random from
32768..64764, retrying on collision. That window is almost exactly the local ephemeral range: where
the kernel puts the source port of every outgoing connection. A runner running the rest of the
stateless suite holds tens of thousands of those at a time, and each connection that ends keeps its
port for another minute in `TIME_WAIT`. `SO_REUSEADDR` on the listener does not get past those,
because the socket that opened the connection never set it, and the raft listener binds the wildcard
address, so a port taken on any interface is lost.

That is enough for every one of the twenty retries to lose. On master the `--- valid` arm exhausted
all of them and reported `metrics endpoint: 000`, with `Cannot create interserver listener on port
33794 after trying both IPv6 and IPv4. (RAFT_ERROR)` behind it:

https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=9f66d3214a1847acb6cb16a55154e523fbc54dca&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

The same arms failed the same way on 2026-08-30, 2026-09-02 and 2026-09-03.

The ports are now drawn from the larger of the two ranges the ephemeral one leaves free - 1024..32767
with the Linux default - where nothing but a handful of fixed services lives, so a retry is enough
again. Measured on an otherwise quiet host, a random port in the ephemeral range is already
unavailable 3.7% of the time against 0.07% below it; on a loaded runner the first figure approaches 1.

Related: https://github.com/ClickHouse/ClickHouse/pull/117130

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118047&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118047](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118047+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.716` (included in `26.9` and later)
<!-- ch-version-info:end -->