### PR TITLE
Do not declare a type for the sparse offsets stream

### DIFF
--- a/src/DataTypes/Serializations/SerializationSparse.cpp
+++ b/src/DataTypes/Serializations/SerializationSparse.cpp
@@ -290,7 +290,6 @@ void SerializationSparse::enumerateStreams(
 
     settings.path.push_back(Substream::SparseOffsets);
     auto offsets_data = SubstreamData(SerializationNumber<UInt64>::create())
-                            .withType(data.type ? std::make_shared<DataTypeUInt64>() : nullptr)
                             .withColumn(column_sparse ? column_sparse->getOffsetsPtr() : nullptr)
                             .withSerializationInfo(data.serialization_info);
 

--- a/src/DataTypes/Serializations/tests/gtest_sparse_serialization.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_sparse_serialization.cpp
@@ -1,0 +1,28 @@
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/Serializations/ISerialization.h>
+#include <DataTypes/Serializations/SerializationSparse.h>
+
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+TEST(SparseSerialization, OffsetsStreamHasNoType)
+{
+    auto type = std::make_shared<DataTypeUInt64>();
+    auto serialization = SerializationSparse::create(type->getDefaultSerialization());
+
+    bool offsets_have_type = true;
+    bool values_have_type = false;
+    serialization->enumerateStreams(
+        [&](const ISerialization::SubstreamPath & path)
+        {
+            if (path.back().type == ISerialization::Substream::SparseOffsets)
+                offsets_have_type = path.back().data.type != nullptr;
+            else if (path.back().type == ISerialization::Substream::Regular)
+                values_have_type = path.back().data.type != nullptr;
+        },
+        type);
+
+    EXPECT_FALSE(offsets_have_type);
+    EXPECT_TRUE(values_have_type);
+}


### PR DESCRIPTION
`SerializationSparse` writes its offsets as `VarUInt` [[1](https://github.com/ClickHouse/ClickHouse/blob/48a638b5f3a216b34bf61f6088ab9332957ad9ee/src/DataTypes/Serializations/SerializationSparse.cpp#L76)], but declared `UInt64` for that stream. The stream is not a subcolumn, so nothing reads the declaration. This PR removes it and adds a regression test.


 Motivation: adaptive codec selection (`enable_adaptive_codec_selection`) picks candidate codecs based on substream's declared type. With `UInt64` it tries `T64` codec, which never wins for the underlying `VarUInt`.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118048&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118048](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118048+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
