### PR TITLE
Run global coverage analysis in `LLVM Coverage` for PRs with no C++ changes

### DIFF
--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -571,6 +571,42 @@ if __name__ == "__main__":
             if diff_res.is_ok():
                 diff_res.info = _diff_msg
 
+        # When the PR changes no coverable C/C++ source file (a tests-only PR
+        # forced with the `ci-coverage` label, or a CI-scripts-only PR touching
+        # the coverage pipeline), the compiled binary is identical to master and
+        # the per-changed-line analysis above has no input. The global comparison
+        # against the master baseline is still meaningful: added tests show up as
+        # newly covered lines. base_llvm_coverage.info is already on disk in this
+        # outcome - the diff script downloads it before classifying the outcome.
+        _global_comparison_ok = False
+        if _diff_outcome == DiffOutcome.NO_CPP_CHANGES:
+            _baseline_info_file = Path(TEMP_DIR) / "base_llvm_coverage.info"
+            _current_info_file = Path(TEMP_DIR) / "llvm_coverage.info"
+            if _baseline_info_file.exists() and _current_info_file.exists():
+                (b_line_cov, b_line_hit, b_line_total), \
+                (b_function_cov, b_func_hit, b_func_total), \
+                (b_branch_cov, b_branch_hit, b_branch_total) = get_lcov_summary(
+                    str(_baseline_info_file)
+                )
+                (c_line_cov, c_line_hit, c_line_total), \
+                (c_function_cov, c_func_hit, c_func_total), \
+                (c_branch_cov, c_branch_hit, c_branch_total) = get_lcov_summary(
+                    str(_current_info_file)
+                )
+                delta = c_line_cov - b_line_cov
+                print(f"Baseline coverage : {b_line_cov:.2f}%")
+                print(f"Current coverage  : {c_line_cov:.2f}%")
+                print(f"Delta             : {delta:+.2f}%")
+                # No degradation gate here: the binary is unchanged, so a drop
+                # can only be baseline noise (flaky tests, async code), never a
+                # regression this PR could have introduced.
+                _global_comparison_ok = True
+            else:
+                print(
+                    "NOTE: baseline or current tracefile is missing, "
+                    "skipping the global coverage comparison"
+                )
+
         results.append(diff_res)
 
         # Generate report for changed blocks only
@@ -624,6 +660,50 @@ if __name__ == "__main__":
             print_res.files.append(_print_log)
         results.append(print_res)
 
+        # Line-level transitions vs the master baseline, the tests-only PR
+        # counterpart of the uncovered-code analysis above. Runs only in the
+        # NO_CPP_CHANGES outcome with both tracefiles present.
+        _newly_covered_stats = None
+        _newly_covered_log = (
+            f"{TEMP_DIR}{Utils.normalize_string('Newly Covered Lines')}.log"
+        )
+        if _global_comparison_ok:
+            from ci.jobs.scripts.newly_covered_lines import generate_report
+
+            _sw = Utils.Stopwatch()
+            try:
+                _newly_covered_stats = generate_report(
+                    current_info=str(_current_info_file),
+                    baseline_info=str(_baseline_info_file),
+                    output_path=_newly_covered_log,
+                )
+                _newly_info = (
+                    f"{_newly_covered_stats['newly_covered']} newly covered lines in "
+                    f"{_newly_covered_stats['newly_covered_files']} files, "
+                    f"{_newly_covered_stats['lost_coverage']} lines lost coverage"
+                )
+                print(f"Newly covered lines analysis: {_newly_info}")
+                newly_res = Result.create_from(
+                    name="Newly Covered Lines",
+                    status=Result.Status.OK,
+                    info=_newly_info,
+                    stopwatch=_sw,
+                )
+                newly_res.files.append(_newly_covered_log)
+            except Exception as e:
+                # A tooling failure reddens the job, same as a Print Uncovered
+                # Code failure would; the comment JSON below simply omits the
+                # newly-covered numbers.
+                print(f"ERROR: newly covered lines analysis failed: {e}")
+                _newly_covered_stats = None
+                newly_res = Result.create_from(
+                    name="Newly Covered Lines",
+                    status=Result.Status.FAIL,
+                    info=f"analysis failed: {e}",
+                    stopwatch=_sw,
+                )
+            results.append(newly_res)
+
         if not is_local_run:
             # Construct S3 artifact URLs from the known upload path structure:
             #   HTML files/assets → https://<endpoint>/<s3_prefix>/<normalize(job)>/<normalize(sub_result)>/<rel_path>
@@ -638,12 +718,12 @@ if __name__ == "__main__":
             _changed_lines_covered = print_res.ext.get("changed_lines_covered", 0)
             _changed_lines_cov = print_res.ext.get("changed_lines_cov", 0.0)
 
-            # Only write the full coverage numbers when the diff HTML report was
-            # generated; there are no numbers to report in any other outcome.
-            # Tests-only PRs never reach this job at all - the coverage family is
-            # auto-skipped for them (see filter_job.py) since the compiled binary,
-            # and therefore coverage, cannot have moved.
-            _has_coverage_data = _diff_ran
+            # Full coverage numbers exist in two outcomes: the diff HTML report
+            # was generated (C++ changed), or the global comparison ran (the
+            # NO_CPP_CHANGES outcome: a tests-only PR forced with `ci-coverage`,
+            # or a CI-scripts-only PR touching the coverage pipeline - see
+            # filter_job.py). The other outcomes have no numbers to report.
+            _has_coverage_data = _diff_ran or _global_comparison_ok
             if not _has_coverage_data:
                 print(coverage_comment_message(_diff_outcome))
                 # The hook renders this marker as a stale-numbers warning in the
@@ -657,6 +737,19 @@ if __name__ == "__main__":
                         f,
                     )
             else:
+                _newly_covered_info = ""
+                _newly_covered_url = ""
+                if _newly_covered_stats is not None:
+                    _newly_covered_info = (
+                        f"+{_newly_covered_stats['newly_covered']} lines in "
+                        f"{_newly_covered_stats['newly_covered_files']} files "
+                        f"(-{_newly_covered_stats['lost_coverage']} lines lost coverage)"
+                    )
+                    _newly_covered_url = (
+                        f"{_s3_base}/llvm_coverage/"
+                        f"{Utils.normalize_string('Newly Covered Lines')}/"
+                        f"{Path(_newly_covered_log).name}"
+                    )
                 _comment_data = {
                     # GitHub comment fields
                     "b_line_cov": b_line_cov,
@@ -686,6 +779,10 @@ if __name__ == "__main__":
                     # actually ran (i.e. C/C++ source files changed). For tests-only PRs
                     # the log doesn't exist on S3, so don't surface a 404 link.
                     "uncovered_code_url": uncovered_code_url if _diff_inputs_exist else "",
+                    # Filled only in the NO_CPP_CHANGES outcome, the counterpart
+                    # of the changed-lines fields above.
+                    "newly_covered_info": _newly_covered_info,
+                    "newly_covered_url": _newly_covered_url,
                     # CIDB fields
                     "check_start_time": datetime.now(timezone.utc).strftime(
                         "%Y-%m-%d %H:%M:%S"

--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -73,10 +73,10 @@ export REPO_NAME
 #    BASE_COMMIT (the actual PR merge base) so we only see files the PR itself
 #    changed. Using FIRST_BASE_COMMIT here would pull in unrelated master commits
 #    from the gap between FIRST_BASE_COMMIT and BASE_COMMIT — a src/Foo.cpp edit
-#    from that gap would appear in patterns, set _diff_ran=True, and then cause
-#    llvm_coverage_job.py to parse it into _changed_paths, flipping
-#    _binary_unchanged=False and suppressing the newly-covered analysis even
-#    though the PR binary is genuinely unchanged.
+#    from that gap would appear in patterns and turn a genuine no_cpp_changes
+#    outcome into report_generated, suppressing the global newly-covered
+#    analysis llvm_coverage_job.py runs for tests-only PRs even though the PR
+#    binary is genuinely unchanged.
 #
 # `gh` reports a failure as a bare "gh: Not Found (HTTP 404)" naming no resource,
 # so each endpoint is echoed before it is requested.

--- a/ci/jobs/scripts/job_hooks/llvm_coverage_hook.py
+++ b/ci/jobs/scripts/job_hooks/llvm_coverage_hook.py
@@ -124,6 +124,10 @@ def check():
         pr_changed_lines_info = d.get("pr_changed_lines_info", "")
         diff_url = d.get("diff_url", "")
         uncovered_code_url = d.get("uncovered_code_url", "")
+        # Set only for PRs with no coverable C/C++ changes (tests-only PRs forced
+        # with `ci-coverage`): the global transitions against the master baseline.
+        newly_covered_info = d.get("newly_covered_info", "")
+        newly_covered_url = d.get("newly_covered_url", "")
 
         if info.pr_number > 0:
             # The "Measured on commit" line attributes the numbers: when a later
@@ -144,6 +148,11 @@ def check():
                 if uncovered_code_url:
                     changed_line += f" · [Uncovered code]({uncovered_code_url})"
                 body += changed_line + "\n"
+            if newly_covered_info:
+                newly_line = f"\n**Newly covered:** {newly_covered_info}"
+                if newly_covered_url:
+                    newly_line += f" · [Details]({newly_covered_url})"
+                body += newly_line + "\n"
             links = []
             if coverage_report_url := d.get("coverage_report_url", ""):
                 links.append(f"[Full report]({coverage_report_url})")

--- a/ci/jobs/scripts/newly_covered_lines.py
+++ b/ci/jobs/scripts/newly_covered_lines.py
@@ -1,0 +1,147 @@
+"""Compare two lcov tracefiles line by line and report coverage transitions.
+
+Used by the `LLVM Coverage` job for PRs that change no coverable C/C++ source
+file (a tests-only PR forced with the `ci-coverage` label, or a CI-scripts-only
+PR that touches the coverage pipeline). The compiled binary is then identical
+to the master baseline, so the per-changed-line differential report has no
+input - but the global comparison is exactly what such a PR wants to see:
+which lines had zero hits on master and are executed now (what the new tests
+add), and which lines lost coverage (baseline noise or removed/disabled tests).
+
+Only `SF:`/`DA:` records are consulted. A line is compared only when both
+tracefiles instrument it; with an identical binary the instrumented line sets
+match, so lines present on one side only are reported as a diagnostic count
+rather than as coverage transitions.
+"""
+
+from pathlib import Path
+
+# SF paths embed the runner's workspace (/home/<user>/actions-runner/_work/
+# ClickHouse/ClickHouse/src/...), which differs between the runs that produced
+# the two tracefiles. Everything after the repo checkout directory is stable.
+_REPO_MARKER = "/ClickHouse/ClickHouse/"
+
+# Caps keeping the text report readable; totals are always exact.
+MAX_FILES_LISTED = 100
+MAX_RANGES_PER_FILE = 30
+
+
+def normalize_source_path(path: str) -> str:
+    pos = path.rfind(_REPO_MARKER)
+    if pos != -1:
+        return path[pos + len(_REPO_MARKER):]
+    return path
+
+
+def parse_tracefile(path: str) -> dict[str, dict[int, int]]:
+    """Return {normalized source file: {line: hit count}}.
+
+    lcov merge output holds one block per file, but blocks for the same file
+    (e.g. after path normalization) are folded by summing counts - the same
+    semantics lcov itself uses when merging tracefiles.
+    """
+    coverage: dict[str, dict[int, int]] = {}
+    current: dict[int, int] | None = None
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if line.startswith("SF:"):
+                current = coverage.setdefault(normalize_source_path(line[3:]), {})
+            elif line.startswith("DA:") and current is not None:
+                # DA:<line>,<count>[,<checksum>]
+                fields = line[3:].split(",")
+                lineno = int(fields[0])
+                # llvm-cov may emit huge counts in scientific notation.
+                count = int(float(fields[1]))
+                current[lineno] = current.get(lineno, 0) + count
+            elif line == "end_of_record":
+                current = None
+    return coverage
+
+
+def compress_line_ranges(lines: list[int]) -> str:
+    """[1, 2, 3, 7, 9, 10] -> "1-3, 7, 9-10", capped at MAX_RANGES_PER_FILE."""
+    ranges: list[str] = []
+    start = prev = lines[0]
+    for lineno in lines[1:]:
+        if lineno == prev + 1:
+            prev = lineno
+            continue
+        ranges.append(str(start) if start == prev else f"{start}-{prev}")
+        start = prev = lineno
+    ranges.append(str(start) if start == prev else f"{start}-{prev}")
+    if len(ranges) > MAX_RANGES_PER_FILE:
+        ranges = ranges[:MAX_RANGES_PER_FILE] + ["..."]
+    return ", ".join(ranges)
+
+
+def _render_transitions(title: str, per_file: dict[str, list[int]], out: list[str]) -> None:
+    total = sum(len(v) for v in per_file.values())
+    out.append(f"{title}: {total} lines in {len(per_file)} files")
+    ordered = sorted(per_file.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    for source_file, lines in ordered[:MAX_FILES_LISTED]:
+        out.append(f"  {len(lines):<7} {source_file}: {compress_line_ranges(sorted(lines))}")
+    if len(ordered) > MAX_FILES_LISTED:
+        out.append(f"  ... and {len(ordered) - MAX_FILES_LISTED} more files")
+    out.append("")
+
+
+def generate_report(current_info: str, baseline_info: str, output_path: str) -> dict:
+    """Write the transitions report to output_path and return the totals.
+
+    Returns {"newly_covered": N, "newly_covered_files": F,
+             "lost_coverage": M, "lost_coverage_files": G,
+             "one_sided_lines": K}.
+    """
+    baseline = parse_tracefile(baseline_info)
+    current = parse_tracefile(current_info)
+
+    newly_covered: dict[str, list[int]] = {}
+    lost_coverage: dict[str, list[int]] = {}
+    one_sided_lines = 0
+
+    for source_file, current_lines in current.items():
+        baseline_lines = baseline.get(source_file)
+        if baseline_lines is None:
+            one_sided_lines += len(current_lines)
+            continue
+        for lineno, count in current_lines.items():
+            base_count = baseline_lines.get(lineno)
+            if base_count is None:
+                one_sided_lines += 1
+            elif base_count == 0 and count > 0:
+                newly_covered.setdefault(source_file, []).append(lineno)
+            elif base_count > 0 and count == 0:
+                lost_coverage.setdefault(source_file, []).append(lineno)
+
+    for source_file, baseline_lines in baseline.items():
+        current_lines = current.get(source_file)
+        if current_lines is None:
+            one_sided_lines += len(baseline_lines)
+        else:
+            one_sided_lines += len(baseline_lines.keys() - current_lines.keys())
+
+    out: list[str] = [
+        "Line coverage transitions against the master baseline",
+        f"Baseline tracefile: {baseline_info}",
+        f"Current tracefile : {current_info}",
+        "",
+    ]
+    _render_transitions("Newly covered (0 hits on master, >0 hits now)", newly_covered, out)
+    _render_transitions("Lost coverage (>0 hits on master, 0 hits now)", lost_coverage, out)
+    if one_sided_lines:
+        out.append(
+            f"Diagnostic: {one_sided_lines} instrumented lines are present in only "
+            "one tracefile. With an identical binary this indicates path "
+            "normalization or instrumentation drift; these lines are not counted "
+            "as transitions."
+        )
+    Path(output_path).write_text("\n".join(out) + "\n", encoding="utf-8")
+
+    return {
+        "newly_covered": sum(len(v) for v in newly_covered.values()),
+        "newly_covered_files": len(newly_covered),
+        "lost_coverage": sum(len(v) for v in lost_coverage.values()),
+        "lost_coverage_files": len(lost_coverage),
+        "one_sided_lines": one_sided_lines,
+    }

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -119,6 +119,7 @@ _COVERAGE_PIPELINE_PATHS = (
     "ci/jobs/scripts/merge_llvm_coverage.sh",
     "ci/jobs/scripts/generate_diff_coverage_report.sh",
     "ci/jobs/scripts/print_uncovered_code.py",
+    "ci/jobs/scripts/newly_covered_lines.py",
     "ci/jobs/scripts/dedup_lcov_instantiations.py",
     "ci/jobs/scripts/job_hooks/llvm_coverage_hook.py",
     "ci/jobs/scripts/workflow_hooks/filter_job.py",


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/117866
Related: https://github.com/ClickHouse/ClickHouse/pull/117922

On a tests-only PR forced with the `ci-coverage` label (or a CI-scripts-only PR that touches the coverage pipeline), the `LLVM Coverage` job merged the shard profiles and generated the full report, but the whole comparison against master bailed with `no_cpp_changes`: no differential report, no uncovered-code analysis, no PR comment, no CI DB row. Observed on https://s3.amazonaws.com/clickhouse-test-reports/PRs/117922/687dc08d3f9fbc0a8fe6f97fef3ee953598b60a9/pr/llvm_coverage/job.log.

The per-changed-line analysis is indeed impossible there: the PR changes no coverable C/C++ line. But the global comparison is possible and is exactly what such a PR wants: the binary is identical to master, so any difference in hit counts is what the new tests add. In the `no_cpp_changes` outcome the job now:

- compares total line/function/branch coverage against the master baseline (`base_llvm_coverage.info` is already downloaded in this outcome);
- runs a new `Newly Covered Lines` analysis (`ci/jobs/scripts/newly_covered_lines.py`): lines with 0 hits on master and >0 hits now, lines that lost coverage, and a one-sided-lines diagnostic, with the per-file report attached as a log artifact;
- posts the PR comment and the CI DB row with these numbers; the comment shows a "Newly covered" line in place of the "Changed lines" one.

There is no degradation gate in this mode: with an unchanged binary, a coverage drop can only be baseline noise, never a regression of the PR.

Validation on the real tracefiles from the PR https://github.com/ClickHouse/ClickHouse/pull/117922 run (both 438 MB): the analysis takes 1.9 s and 190 MB RSS, and reports 1303 newly covered lines in 252 files - topped by `SubstituteColumnOptimizer.cpp` (+158), `AggregateFunctionDistinctDynamicTypes.cpp` (+42), `OptimizeIfChains.cpp` (+34), `MatcherNode.cpp` (+31), `ArithmeticOperationsInAgrFuncOptimize.cpp` (+28) - exactly the files the 12 new tests of that PR target.

This PR touches the coverage pipeline scripts, so its own CI runs the coverage family and exercises the new code path (its diff contains no coverable C++, so the job lands in `no_cpp_changes`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118051&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118051](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118051+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
