### PR TITLE
CI log parser: recognize AST Fuzzer oracle mismatch and any <Fatal>

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -28,6 +28,11 @@ class FuzzerLogParser:
     # of any kind, so keep every failure-carrying pattern listed here.
     ERROR_PATTERNS = [
         (
+            "AST Fuzzer oracle mismatch",
+            "is_oracle_mismatch",
+            r"AST Fuzzer oracle mismatch detected.*",
+        ),
+        (
             "Sanitizer",
             "is_sanitizer_error",
             SANITIZER_ERROR_PATTERN,
@@ -193,6 +198,7 @@ class FuzzerLogParser:
         is_killed_by_signal = False
         is_segfault = False
         is_memory_limit_exceeded = False
+        is_oracle_mismatch = False
 
         error_output = None
         matched_pattern = None
@@ -234,9 +240,28 @@ class FuzzerLogParser:
                     is_segfault = True
                 elif flag_name == "is_memory_limit_exceeded":
                     is_memory_limit_exceeded = True
+                elif flag_name == "is_oracle_mismatch":
+                    is_oracle_mismatch = True
                 break
 
         if not error_output:
+            # None of the specific patterns matched, but the server may still have
+            # logged a <Fatal> message the parser does not classify (e.g. a new
+            # fuzzer oracle). Surface that message so the report shows what actually
+            # happened, and only fall back to "Unknown error" when there is no
+            # <Fatal> at all.
+            generic_fatal = self.get_generic_fatal()
+            if generic_fatal:
+                fatal_lines = generic_fatal.splitlines()
+                result_name = fatal_lines[0].removesuffix(".")
+                stack_trace = self.get_stack_trace()
+                stack_trace_id = self.get_stack_trace_id(stack_trace)
+                if stack_trace_id:
+                    result_name += f" (STID: {stack_trace_id})"
+                info = f"Error:\n{generic_fatal}\n"
+                if stack_trace:
+                    info += "---\n\nStack trace:\n" + stack_trace + "\n"
+                return result_name, info, files
             return (
                 self.UNKNOWN_ERROR,
                 "Lost connection to server. See the logs.\n",
@@ -316,6 +341,18 @@ class FuzzerLogParser:
             result_name += f" (STID: {stack_trace_id})"
         elif is_memory_limit_exceeded:
             result_name = "Server unresponsive: memory limit exceeded"
+        elif is_oracle_mismatch:
+            # The oracle kind (e.g. "TLP Aggregate") is logged on a line of the
+            # form "<kind> oracle mismatch!" after the "Fuzzed query:" line. Fold
+            # it into the failure name so distinct oracles group separately in CI
+            # DB, while a missing kind still yields a stable generic name. The
+            # "Fuzzed query:" line captured in `error_output` is kept as the info.
+            result_name = "AST Fuzzer oracle mismatch"
+            for line in error_lines:
+                match = re.search(r"(\w[\w ]*?) oracle mismatch!", line)
+                if match and "AST Fuzzer" not in match.group(1):
+                    result_name = f"AST Fuzzer oracle mismatch: {match.group(1).strip()}"
+                    break
         elif is_sanitizer_error:
             stack_trace = self.get_sanitizer_stack_trace()
             if not stack_trace:
@@ -417,6 +454,33 @@ class FuzzerLogParser:
             info += stack_trace + "\n"
 
         return result_name, info, files
+
+    def get_generic_fatal(self):
+        # Fallback used when no specific pattern matched but the server still
+        # logged a <Fatal> message. Return the message (with a few following
+        # lines of context) with the "<Fatal> " prefix stripped, so the report
+        # shows the real message instead of a bare "Unknown error". Returns None
+        # when there is no <Fatal> line to surface.
+        if not self.server_log:
+            return None
+        output = Shell.get_output(
+            f"rg --text -A 10 -o '<Fatal> .*' {self.server_log} | head -n10"
+        ).strip()
+        if not output:
+            return None
+        lines = output.splitlines()
+        marker = "<Fatal> "
+        marker_pos = lines[0].find(marker)
+        if marker_pos != -1:
+            lines[0] = lines[0][marker_pos + len(marker) :]
+        # Stop at the next server log line so an unrelated later message is not
+        # folded into this one.
+        for i, line in enumerate(lines):
+            if i > 0 and "] {" in line and "} <" in line:
+                lines = lines[:i]
+                break
+        message = "\n".join(lines).strip()
+        return message or None
 
     def get_sanitizer_stack_trace(self):
         # Extract the full sanitizer report: description, all stack traces,

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -342,14 +342,18 @@ class FuzzerLogParser:
         elif is_memory_limit_exceeded:
             result_name = "Server unresponsive: memory limit exceeded"
         elif is_oracle_mismatch:
-            # The oracle kind (e.g. "TLP Aggregate") is logged on a line of the
+            # The oracle kind is logged by `QueryOracleChecker` on a line of the
             # form "<kind> oracle mismatch!" after the "Fuzzed query:" line. Fold
             # it into the failure name so distinct oracles group separately in CI
             # DB, while a missing kind still yields a stable generic name. The
             # "Fuzzed query:" line captured in `error_output` is kept as the info.
+            # The kind may carry a parenthesized, but still fixed, label - e.g.
+            # "Identity WHERE (p AND 1)" or "Identity WHERE (NOT(NOT p))" - so
+            # allow parentheses in the capture; variable trailers like DQP's
+            # "Setting: <name>" come after the "!" and are excluded.
             result_name = "AST Fuzzer oracle mismatch"
             for line in error_lines:
-                match = re.search(r"(\w[\w ]*?) oracle mismatch!", line)
+                match = re.search(r"(\w[\w ()]*?) oracle mismatch!", line)
                 if match and "AST Fuzzer" not in match.group(1):
                     result_name = f"AST Fuzzer oracle mismatch: {match.group(1).strip()}"
                     break

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -472,16 +472,24 @@ class FuzzerLogParser:
 
         return result_name, info, files
 
+    # A real server log line has its level in the structured prefix
+    # "[ <thread> ] {<query_id>} <Level>". Anchoring the generic-fatal search to
+    # this prefix avoids matching a "<Fatal>" substring quoted inside query text
+    # or a comment on an ordinary <Debug>/<Error> line (the query id has no "}").
+    GENERIC_FATAL_PATTERN = r"\[ \d+ \] \{[^}]*\} <Fatal> .*"
+
     def get_generic_fatal(self):
         # Fallback used when no specific pattern matched but the server still
         # logged a <Fatal> message. Return the message (with a few following
-        # lines of context) with the "<Fatal> " prefix stripped, so the report
-        # shows the real message instead of a bare "Unknown error". Returns None
-        # when there is no <Fatal> line to surface.
+        # lines of context) with the log prefix up to and including "<Fatal> "
+        # stripped, so the report shows the real message instead of a bare
+        # "Unknown error". Returns None when there is no <Fatal> record to
+        # surface. The match is anchored to the log-level field so a "<Fatal>"
+        # substring inside quoted query text is not mistaken for a failure.
         if not self.server_log:
             return None
         output = Shell.get_output(
-            f"rg --text -A 10 -o '<Fatal> .*' {self.server_log} | head -n10"
+            f"rg --text -A 10 -o '{self.GENERIC_FATAL_PATTERN}' {self.server_log} | head -n10"
         ).strip()
         if not output:
             return None

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -28,14 +28,19 @@ class FuzzerLogParser:
     # of any kind, so keep every failure-carrying pattern listed here.
     ERROR_PATTERNS = [
         (
-            "AST Fuzzer oracle mismatch",
-            "is_oracle_mismatch",
-            r"AST Fuzzer oracle mismatch detected.*",
-        ),
-        (
             "Sanitizer",
             "is_sanitizer_error",
             SANITIZER_ERROR_PATTERN,
+        ),
+        # After Sanitizer: a sanitizer report (memory safety, highest signal) must
+        # win over an oracle mismatch when both are present, since `parse_failure`
+        # stops at the first matching class. Kept ahead of the generic server-log
+        # patterns below so an unrelated `Logical error` from another test in the
+        # same run's aggregated server log does not steal the oracle classification.
+        (
+            "AST Fuzzer oracle mismatch",
+            "is_oracle_mismatch",
+            r"AST Fuzzer oracle mismatch detected.*",
         ),
         ("Logical error", "is_logical_error", r"Logical error.*"),
         (

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -107,6 +107,12 @@ class FuzzerLogParser:
         self.fuzzer_log = fuzzer_log
         self.stderr_log = stderr_log
         self.stack_trace_str = stack_trace_str
+        # Set by `parse_failure` when the result came from the generic <Fatal>
+        # fallback rather than a specific pattern. It is a lower-confidence signal
+        # than a known classification: a caller scanning several logs (e.g.
+        # `stress_job.py` across replicas) should keep looking for a specific
+        # failure and only settle for a generic fatal if nothing better is found.
+        self.is_generic_fatal = False
 
     @staticmethod
     def extract_format_string(line):
@@ -204,6 +210,7 @@ class FuzzerLogParser:
         is_segfault = False
         is_memory_limit_exceeded = False
         is_oracle_mismatch = False
+        self.is_generic_fatal = False
 
         error_output = None
         matched_pattern = None
@@ -257,6 +264,7 @@ class FuzzerLogParser:
             # <Fatal> at all.
             generic_fatal = self.get_generic_fatal()
             if generic_fatal:
+                self.is_generic_fatal = True
                 fatal_lines = generic_fatal.splitlines()
                 result_name = fatal_lines[0].removesuffix(".")
                 stack_trace = self.get_stack_trace()

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -363,7 +363,13 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                 )
             )
         else:
+            # Three priority tiers across replicas: a specific classification
+            # (sanitizer, logical error, ...) wins outright; a generic <Fatal>
+            # fallback is preferred over "Unknown error" but must not preempt a
+            # higher-signal specific failure on another replica, so keep scanning
+            # after one; "Unknown error" is the last resort.
             definitive_result = None
+            generic_fatal_result = None
             fallback_result = None
 
             for replica_name, server_log_file, stderr_log in replica_log_pairs:
@@ -378,11 +384,15 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                     if stderr_log.exists():
                         file_pair_info += f", {stderr_log.name}"
                     description = f"{file_pair_info}\n{description}"
-                    if name != FuzzerLogParser.UNKNOWN_ERROR:
+                    if name == FuzzerLogParser.UNKNOWN_ERROR:
+                        if fallback_result is None:
+                            fallback_result = (name, description, files)
+                    elif log_parser.is_generic_fatal:
+                        if generic_fatal_result is None:
+                            generic_fatal_result = (name, description, files)
+                    else:
                         definitive_result = (name, description, files)
                         break
-                    if fallback_result is None:
-                        fallback_result = (name, description, files)
                 except Exception as e:
                     print(
                         f"ERROR: Failed to parse failure logs for {replica_name} "
@@ -390,7 +400,7 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                         f"Server logs should still be collected."
                     )
 
-            result = definitive_result or fallback_result
+            result = definitive_result or generic_fatal_result or fallback_result
             if result:
                 name, description, files = result
                 failed_results.append(

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -245,6 +245,66 @@ def process_results(
     return test_results, additional_files
 
 
+def select_replica_failures(
+    replica_log_pairs: List[Tuple[str, Path, Path]],
+) -> List[Tuple[str, str, List[str]]]:
+    """Pick the failures to report from every replica's (server, stderr) log pair.
+
+    A failure on one replica must not hide a (possibly higher-signal) failure on
+    another, so every pair is scanned - never breaking early. All specific
+    classifications (sanitizer, logical error, oracle mismatch, ...) are
+    collected and every distinct one is returned. A generic `<Fatal>` fallback
+    and "Unknown error" are lower-confidence signals used only when no replica
+    yielded a specific classification.
+
+    Returns a list of `(name, description, files)` tuples: all distinct specific
+    findings; otherwise a single generic-fatal finding; otherwise a single
+    "Unknown error" finding; otherwise an empty list (nothing parsed at all).
+    """
+    specific_results: List[Tuple[str, str, List[str]]] = []
+    seen_specific_names = set()
+    generic_fatal_result = None
+    fallback_result = None
+
+    for replica_name, server_log_file, stderr_log in replica_log_pairs:
+        log_parser = FuzzerLogParser(
+            server_log=server_log_file,
+            stderr_log=str(stderr_log) if stderr_log.exists() else "",
+            fuzzer_log="",
+        )
+        try:
+            name, description, files = log_parser.parse_failure()
+            file_pair_info = f"Log files: {server_log_file.name}"
+            if stderr_log.exists():
+                file_pair_info += f", {stderr_log.name}"
+            description = f"{file_pair_info}\n{description}"
+            if name == FuzzerLogParser.UNKNOWN_ERROR:
+                if fallback_result is None:
+                    fallback_result = (name, description, files)
+            elif log_parser.is_generic_fatal:
+                if generic_fatal_result is None:
+                    generic_fatal_result = (name, description, files)
+            elif name not in seen_specific_names:
+                # The same failure often surfaces on several replicas (shared
+                # storage / replication); report each distinct classification once.
+                seen_specific_names.add(name)
+                specific_results.append((name, description, files))
+        except Exception as e:
+            print(
+                f"ERROR: Failed to parse failure logs for {replica_name} "
+                f"({server_log_file.name}): {e}\n"
+                f"Server logs should still be collected."
+            )
+
+    if specific_results:
+        return specific_results
+    if generic_fatal_result:
+        return [generic_fatal_result]
+    if fallback_result:
+        return [fallback_result]
+    return []
+
+
 def run_stress_test(upgrade_check: bool = False) -> None:
     info = Info()
     logging.basicConfig(level=logging.INFO)
@@ -363,54 +423,17 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                 )
             )
         else:
-            # Three priority tiers across replicas: a specific classification
-            # (sanitizer, logical error, ...) wins outright; a generic <Fatal>
-            # fallback is preferred over "Unknown error" but must not preempt a
-            # higher-signal specific failure on another replica, so keep scanning
-            # after one; "Unknown error" is the last resort.
-            definitive_result = None
-            generic_fatal_result = None
-            fallback_result = None
-
-            for replica_name, server_log_file, stderr_log in replica_log_pairs:
-                log_parser = FuzzerLogParser(
-                    server_log=server_log_file,
-                    stderr_log=str(stderr_log) if stderr_log.exists() else "",
-                    fuzzer_log="",
-                )
-                try:
-                    name, description, files = log_parser.parse_failure()
-                    file_pair_info = f"Log files: {server_log_file.name}"
-                    if stderr_log.exists():
-                        file_pair_info += f", {stderr_log.name}"
-                    description = f"{file_pair_info}\n{description}"
-                    if name == FuzzerLogParser.UNKNOWN_ERROR:
-                        if fallback_result is None:
-                            fallback_result = (name, description, files)
-                    elif log_parser.is_generic_fatal:
-                        if generic_fatal_result is None:
-                            generic_fatal_result = (name, description, files)
-                    else:
-                        definitive_result = (name, description, files)
-                        break
-                except Exception as e:
-                    print(
-                        f"ERROR: Failed to parse failure logs for {replica_name} "
-                        f"({server_log_file.name}): {e}\n"
-                        f"Server logs should still be collected."
+            results = select_replica_failures(replica_log_pairs)
+            if results:
+                for name, description, files in results:
+                    failed_results.append(
+                        Result.create_from(
+                            name=name,
+                            info=description,
+                            status=Result.Status.FAIL,
+                            files=files,
+                        )
                     )
-
-            result = definitive_result or generic_fatal_result or fallback_result
-            if result:
-                name, description, files = result
-                failed_results.append(
-                    Result.create_from(
-                        name=name,
-                        info=description,
-                        status=Result.Status.FAIL,
-                        files=files,
-                    )
-                )
             else:
                 failed_results.append(
                     Result.create_from(

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -11,6 +11,8 @@ though the message was right there in the log.
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from ci.jobs.scripts.log_parser import FuzzerLogParser
@@ -44,6 +46,48 @@ def test_parse_ast_fuzzer_oracle_mismatch(tmp_path):
     assert "AST Fuzzer oracle mismatch detected!" in info
     assert "Fuzzed query: SELECT g, count(), min(v), approx_top_k(v)" in info
     assert files == []
+
+
+# Every oracle-kind message emitted by `QueryOracleChecker` (src/Interpreters/
+# QueryOracleChecker.cpp), mapped to the kind the parser should extract. The
+# "Identity WHERE (...)" and DQP "Setting: <name>" variants are the tricky ones:
+# the kind carries a parenthesized label, and DQP appends a variable trailer
+# after the "!" that must be excluded.
+_ORACLE_KIND_CASES = [
+    ("TLP WHERE oracle mismatch!", "TLP WHERE"),
+    ("NoREC oracle mismatch!", "NoREC"),
+    ("TLP DISTINCT oracle mismatch!", "TLP DISTINCT"),
+    ("TLP GROUP BY oracle mismatch!", "TLP GROUP BY"),
+    ("TLP HAVING oracle mismatch!", "TLP HAVING"),
+    ("DQP oracle mismatch! Setting: allow_experimental_analyzer", "DQP"),
+    ("TLP Aggregate oracle mismatch!", "TLP Aggregate"),
+    ("Identity WHERE (NOT(NOT p)) oracle mismatch!", "Identity WHERE (NOT(NOT p))"),
+    ("Identity WHERE (p AND 1) oracle mismatch!", "Identity WHERE (p AND 1)"),
+    ("Identity WHERE (p OR 0) oracle mismatch!", "Identity WHERE (p OR 0)"),
+    ("Subquery wrap oracle mismatch!", "Subquery wrap"),
+]
+
+
+@pytest.mark.parametrize("oracle_line, expected_kind", _ORACLE_KIND_CASES)
+def test_oracle_kind_extraction(tmp_path, oracle_line, expected_kind):
+    # Each oracle kind must group under its own name, including the parenthesized
+    # "Identity WHERE (...)" variants that a word-only capture would have missed.
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(
+        "2026.09.04 00:44:57.972626 [ 1068 ] {q} <Fatal> ASTFuzzer: "
+        "AST Fuzzer oracle mismatch detected!\n"
+        "Fuzzed query: SELECT 1\n"
+        f"{oracle_line}\n"
+        "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    result_name, _, _ = parser.parse_failure()
+
+    assert result_name == f"AST Fuzzer oracle mismatch: {expected_kind}"
 
 
 def test_parse_ast_fuzzer_oracle_mismatch_unknown_kind(tmp_path):

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -1,0 +1,133 @@
+"""
+Tests for `FuzzerLogParser` (ci/jobs/scripts/log_parser.py).
+
+The synthetic server logs below reproduce the exact line format emitted by the
+server, in particular the AST Fuzzer oracle mismatch `<Fatal>` message logged by
+`executeQuery` (src/Interpreters/executeQuery.cpp). Before the parser learned to
+recognize it, such a `<Fatal>` produced a bare "Unknown error" in the report even
+though the message was right there in the log.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.log_parser import FuzzerLogParser
+
+# The real message: "<Fatal> ASTFuzzer: AST Fuzzer oracle mismatch detected!"
+# followed by the reproducer query and the oracle-specific message.
+_ORACLE_MISMATCH_LOG = """\
+2026.09.04 00:44:57.900000 [ 1068 ] {7af77722-1ba2-40a2-aa08-54e577a54015} <Debug> executeQuery: (from 127.0.0.1) SELECT g, count(), min(v), approx_top_k(v) FROM oracle_tlp_agg_counter WHERE v > 50 GROUP BY g ORDER BY g ASC (stage: Complete)
+2026.09.04 00:44:57.972626 [ 1068 ] {7af77722-1ba2-40a2-aa08-54e577a54015} <Fatal> ASTFuzzer: AST Fuzzer oracle mismatch detected!
+Fuzzed query: SELECT g, count(), min(v), approx_top_k(v) FROM oracle_tlp_agg_counter WHERE v > 50 GROUP BY g ORDER BY g ASC
+TLP Aggregate oracle mismatch!
+Original result had 3 rows, partitioned result had 4 rows
+2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down
+"""
+
+
+def test_parse_ast_fuzzer_oracle_mismatch(tmp_path):
+    # The oracle kind ("TLP Aggregate") is folded into the failure name so that
+    # distinct oracles group separately in CI DB, and the reproducer query is
+    # kept in the info.
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(_ORACLE_MISMATCH_LOG, encoding="utf-8")
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    result_name, info, files = parser.parse_failure()
+
+    assert result_name == "AST Fuzzer oracle mismatch: TLP Aggregate"
+    assert result_name != FuzzerLogParser.UNKNOWN_ERROR
+    assert "AST Fuzzer oracle mismatch detected!" in info
+    assert "Fuzzed query: SELECT g, count(), min(v), approx_top_k(v)" in info
+    assert files == []
+
+
+def test_parse_ast_fuzzer_oracle_mismatch_unknown_kind(tmp_path):
+    # If no "<kind> oracle mismatch!" line is present, the name stays generic but
+    # still classified (not "Unknown error").
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(
+        "2026.09.04 00:44:57.972626 [ 1068 ] {q} <Fatal> ASTFuzzer: "
+        "AST Fuzzer oracle mismatch detected!\n"
+        "Fuzzed query: SELECT 1\n"
+        "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    result_name, info, files = parser.parse_failure()
+
+    assert result_name == "AST Fuzzer oracle mismatch"
+    assert "Fuzzed query: SELECT 1" in info
+
+
+def test_generic_fatal_fallback_surfaces_message(tmp_path):
+    # An unrecognized <Fatal> message (no specific pattern matches) is surfaced
+    # verbatim instead of being reported as a bare "Unknown error".
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(
+        "2026.09.04 00:44:57.900000 [ 1068 ] {q} <Debug> executeQuery: SELECT 1\n"
+        "2026.09.04 00:44:57.972626 [ 1068 ] {q} <Fatal> SomeNewComponent: "
+        "Brand new fatal condition nobody parses yet\n"
+        "Extra detail line about the failure\n"
+        "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    result_name, info, files = parser.parse_failure()
+
+    assert result_name != FuzzerLogParser.UNKNOWN_ERROR
+    assert result_name == (
+        "SomeNewComponent: Brand new fatal condition nobody parses yet"
+    )
+    assert "Extra detail line about the failure" in info
+    # The "<Fatal> " prefix and the following unrelated log line are not folded in.
+    assert "<Fatal>" not in result_name
+    assert "Application: shutting down" not in info
+
+
+def test_unknown_error_when_no_fatal(tmp_path):
+    # With neither a specific pattern nor any <Fatal> message, the parser still
+    # falls back to "Unknown error".
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(
+        "2026.09.04 00:44:57.900000 [ 1068 ] {q} <Debug> executeQuery: SELECT 1\n"
+        "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    result_name, info, _ = parser.parse_failure()
+
+    assert result_name == FuzzerLogParser.UNKNOWN_ERROR
+    assert "Lost connection to server" in info
+
+
+def test_specific_pattern_wins_over_generic_fatal(tmp_path):
+    # A logical error is a <Fatal> too; the specific pattern must classify it
+    # rather than the generic fallback treating it as an opaque message.
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(
+        "2026.09.04 00:44:57.972626 [ 1068 ] {q} <Fatal> : Logical error: "
+        "'Bad cast from type A to type B'.\n"
+        "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    result_name, _, _ = parser.parse_failure()
+
+    assert result_name.startswith("Logical error")

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -162,6 +162,9 @@ def test_generic_fatal_fallback_surfaces_message(tmp_path):
     # The "<Fatal> " prefix and the following unrelated log line are not folded in.
     assert "<Fatal>" not in result_name
     assert "Application: shutting down" not in info
+    # This is a lower-confidence result: callers scanning several logs must be able
+    # to tell it apart from a specific classification.
+    assert parser.is_generic_fatal is True
 
 
 def test_unknown_error_when_no_fatal(tmp_path):
@@ -181,6 +184,22 @@ def test_unknown_error_when_no_fatal(tmp_path):
 
     assert result_name == FuzzerLogParser.UNKNOWN_ERROR
     assert "Lost connection to server" in info
+    assert parser.is_generic_fatal is False
+
+
+def test_generic_fatal_flag_not_set_for_specific_classification(tmp_path):
+    # A specific classification (here an oracle mismatch) must not be flagged as a
+    # generic fatal, so `stress_job.py` treats it as a definitive, higher-priority
+    # result than a generic <Fatal> on another replica.
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(_ORACLE_MISMATCH_LOG, encoding="utf-8")
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    parser.parse_failure()
+
+    assert parser.is_generic_fatal is False
 
 
 def test_specific_pattern_wins_over_generic_fatal(tmp_path):

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -90,6 +90,31 @@ def test_oracle_kind_extraction(tmp_path, oracle_line, expected_kind):
     assert result_name == f"AST Fuzzer oracle mismatch: {expected_kind}"
 
 
+def test_sanitizer_wins_over_oracle_mismatch(tmp_path):
+    # When both a server-side oracle mismatch and a sanitizer report are present,
+    # the higher-signal sanitizer failure must be reported, not the oracle
+    # mismatch. `parse_failure` stops at the first matching pattern, so Sanitizer
+    # must stay ahead of the oracle pattern in ERROR_PATTERNS.
+    server_log = tmp_path / "clickhouse-server.err.log"
+    stderr_log = tmp_path / "stderr.log"
+    server_log.write_text(_ORACLE_MISMATCH_LOG, encoding="utf-8")
+    stderr_log.write_text(
+        "==1234==ERROR: AddressSanitizer: heap-use-after-free on address 0x1\n"
+        "    #0 0x55b9b8db9bc7 in DB::Foo::bar() src/Foo.cpp:10:5\n"
+        "SUMMARY: AddressSanitizer: heap-use-after-free src/Foo.cpp:10:5\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log=str(stderr_log), fuzzer_log=""
+    )
+    result_name, info, _ = parser.parse_failure()
+
+    assert result_name.startswith("AddressSanitizer")
+    assert "oracle mismatch" not in result_name
+    assert "heap-use-after-free" in info
+
+
 def test_parse_ast_fuzzer_oracle_mismatch_unknown_kind(tmp_path):
     # If no "<kind> oracle mismatch!" line is present, the name stays generic but
     # still classified (not "Unknown error").

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -167,6 +167,28 @@ def test_generic_fatal_fallback_surfaces_message(tmp_path):
     assert parser.is_generic_fatal is True
 
 
+def test_quoted_fatal_in_query_text_is_not_a_generic_fatal(tmp_path):
+    # A "<Fatal>" substring quoted inside query text (or a comment) on an ordinary
+    # <Debug>/<Error> line must not be mistaken for a fatal record: the generic
+    # fallback is anchored to the "[ <tid> ] {<qid>} <Fatal>" log-level prefix.
+    server_log = tmp_path / "clickhouse-server.err.log"
+    server_log.write_text(
+        "2026.09.04 00:44:57.900000 [ 1068 ] {q} <Debug> executeQuery: "
+        "(from 127.0.0.1) SELECT '<Fatal> not an error' (stage: Complete)\n"
+        "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log), stderr_log="", fuzzer_log=""
+    )
+    result_name, info, _ = parser.parse_failure()
+
+    assert result_name == FuzzerLogParser.UNKNOWN_ERROR
+    assert parser.is_generic_fatal is False
+    assert "not an error" not in result_name
+
+
 def test_unknown_error_when_no_fatal(tmp_path):
     # With neither a specific pattern nor any <Fatal> message, the parser still
     # falls back to "Unknown error".

--- a/ci/tests/test_stress_job.py
+++ b/ci/tests/test_stress_job.py
@@ -1,0 +1,124 @@
+"""
+Tests for `select_replica_failures` (ci/jobs/stress_job.py).
+
+The stress job pairs each replica's server log with its stderr log and must not
+let a failure on one replica hide a (possibly higher-signal) failure on another:
+every pair is scanned, all distinct specific classifications are reported, and a
+generic `<Fatal>` / "Unknown error" is used only when nothing specific was found.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.log_parser import FuzzerLogParser
+from ci.jobs.stress_job import select_replica_failures
+
+_ORACLE_MISMATCH_LOG = (
+    "2026.09.04 00:44:57.972626 [ 1068 ] {q} <Fatal> ASTFuzzer: "
+    "AST Fuzzer oracle mismatch detected!\n"
+    "Fuzzed query: SELECT g FROM t GROUP BY g\n"
+    "TLP Aggregate oracle mismatch!\n"
+    "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n"
+)
+_ASAN_STDERR = (
+    "==1234==ERROR: AddressSanitizer: heap-use-after-free on address 0x1\n"
+    "    #0 0x55b9b8db9bc7 in DB::Foo::bar() src/Foo.cpp:10:5\n"
+    "SUMMARY: AddressSanitizer: heap-use-after-free src/Foo.cpp:10:5\n"
+)
+_GENERIC_FATAL_LOG = (
+    "2026.09.04 00:44:57.972626 [ 1068 ] {q} <Fatal> SomeComponent: "
+    "transient generic fatal\n"
+    "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n"
+)
+_UNKNOWN_LOG = (
+    "2026.09.04 00:44:57.900000 [ 1068 ] {q} <Debug> executeQuery: SELECT 1\n"
+    "2026.09.04 00:44:58.000000 [ 1068 ] {} <Information> Application: shutting down\n"
+)
+
+
+def _pair(tmp_path, replica, server_text=None, stderr_text=None):
+    # Build one (replica_name, server_log, stderr_log) pair. Missing logs are
+    # non-existent Paths, matching what the job passes when a file is absent.
+    server_log = tmp_path / f"clickhouse-server-{replica}.err.log"
+    stderr_log = tmp_path / f"stderr-{replica}.log"
+    if server_text is not None:
+        server_log.write_text(server_text, encoding="utf-8")
+    if stderr_text is not None:
+        stderr_log.write_text(stderr_text, encoding="utf-8")
+    return (replica, server_log, stderr_log)
+
+
+def test_specific_failure_on_second_replica_not_hidden_by_first(tmp_path):
+    # Main replica has an oracle mismatch, sc1 has an ASan report. Both are
+    # specific classifications and must both be reported - crucially the ASan
+    # report on the second replica is not suppressed by the first.
+    pairs = [
+        _pair(tmp_path, "main", server_text=_ORACLE_MISMATCH_LOG),
+        _pair(tmp_path, "sc1", server_text=_UNKNOWN_LOG, stderr_text=_ASAN_STDERR),
+    ]
+
+    results = select_replica_failures(pairs)
+    names = [name for name, _, _ in results]
+
+    assert any(n.startswith("AST Fuzzer oracle mismatch") for n in names), names
+    assert any(n.startswith("AddressSanitizer") for n in names), names
+    assert len(results) == 2
+
+
+def test_generic_fatal_does_not_suppress_sanitizer_on_second_replica(tmp_path):
+    # Main replica has only a generic <Fatal>, sc1 has an ASan report. The
+    # specific sanitizer failure wins; the generic fatal is dropped.
+    pairs = [
+        _pair(tmp_path, "main", server_text=_GENERIC_FATAL_LOG),
+        _pair(tmp_path, "sc1", server_text=_UNKNOWN_LOG, stderr_text=_ASAN_STDERR),
+    ]
+
+    results = select_replica_failures(pairs)
+    names = [name for name, _, _ in results]
+
+    assert len(results) == 1
+    assert names[0].startswith("AddressSanitizer")
+    assert "transient generic fatal" not in names[0]
+
+
+def test_same_specific_failure_across_replicas_reported_once(tmp_path):
+    # Replicated setups surface the same failure on several replicas; report a
+    # given specific classification only once.
+    pairs = [
+        _pair(tmp_path, "main", server_text=_ORACLE_MISMATCH_LOG),
+        _pair(tmp_path, "sc1", server_text=_ORACLE_MISMATCH_LOG),
+    ]
+
+    results = select_replica_failures(pairs)
+
+    assert len(results) == 1
+    assert results[0][0].startswith("AST Fuzzer oracle mismatch")
+
+
+def test_generic_fatal_used_when_no_specific_failure(tmp_path):
+    # No replica has a specific classification: the generic <Fatal> is reported
+    # (once) rather than "Unknown error".
+    pairs = [
+        _pair(tmp_path, "main", server_text=_GENERIC_FATAL_LOG),
+        _pair(tmp_path, "sc1", server_text=_UNKNOWN_LOG),
+    ]
+
+    results = select_replica_failures(pairs)
+
+    assert len(results) == 1
+    assert results[0][0] == "SomeComponent: transient generic fatal"
+
+
+def test_unknown_error_when_nothing_classified(tmp_path):
+    # Neither specific nor generic fatal anywhere: a single "Unknown error".
+    pairs = [
+        _pair(tmp_path, "main", server_text=_UNKNOWN_LOG),
+        _pair(tmp_path, "sc1", server_text=_UNKNOWN_LOG),
+    ]
+
+    results = select_replica_failures(pairs)
+
+    assert len(results) == 1
+    assert results[0][0] == FuzzerLogParser.UNKNOWN_ERROR


### PR DESCRIPTION
The AST Fuzzer oracle runs inside regular functional tests. On a mismatch the server logs a `<Fatal> ASTFuzzer: AST Fuzzer oracle mismatch detected!` message (in `executeQuery`), but `FuzzerLogParser` (`ci/jobs/scripts/log_parser.py`) had no pattern for it. So `parse_failure` fell through to "Unknown error" and the report showed a bare *"Fatal error: this job has unknown error"* even though the real reason and the reproducer query were right there in the server log.

This change:

- Adds an `AST Fuzzer oracle mismatch` pattern, checked first, folding the oracle kind (e.g. `TLP Aggregate`) into the failure name so distinct oracles group separately in CI DB, keeping the fuzzed query in the info.
- Adds a generic `<Fatal>` fallback: when no specific pattern matches, surface the first `<Fatal>` message (its context, with the `<Fatal> ` prefix stripped) instead of "Unknown error"; only fall back to "Unknown error" when there is no `<Fatal>` at all. This makes future unclassified fatals visible too.
- Adds `ci/tests/test_log_parser.py` covering the oracle mismatch (with and without a recognizable oracle kind), the generic fatal fallback, the no-fatal "Unknown error" case, and specific-pattern precedence.

Verified against the real `clickhouse-server.err.log` from the CI report below: the parser now reports `AST Fuzzer oracle mismatch: TLP Aggregate` with the reproducer, instead of "Unknown error".

Related: https://github.com/ClickHouse/ClickHouse/pull/72199

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118056&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118056](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118056+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1113` (included in `26.9` and later)
<!-- ch-version-info:end -->