### PR TITLE
Reserve host memory for the CI runner agent in the stress and upgrade jobs

### DIFF
--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -16,6 +16,18 @@ from ci.praktika.utils import Shell, Utils
 RUNNER_MEMORY_RESERVE = 8 * 1024**3
 
 
+def container_memory_limit() -> int:
+    visible = Utils.physical_memory()
+    limit = visible - RUNNER_MEMORY_RESERVE
+    if limit <= 0:
+        raise RuntimeError(
+            f"Not enough RAM to run this job: {RUNNER_MEMORY_RESERVE} bytes are reserved for the "
+            f"runner agent outside the container and this host has {visible}. Docker refuses a "
+            f"negative --memory and reads 0 as no limit at all, so there is no safe cap to pass."
+        )
+    return limit
+
+
 def sanitize_test_result_line(line: str) -> str:
     # Drop bare CR in addition to escaping NUL. The writer escapes
     # `\0\t\n` into backslash forms (`escape_tsv_info`) but not `\r`,
@@ -172,7 +184,7 @@ def get_run_command(
         "--privileged "
         # azurite-rs (in-process Azure Blob Storage emulator) needs many fds under parallel load
         "--ulimit nofile=1048576:1048576 "
-        f"--memory={Utils.physical_memory() - RUNNER_MEMORY_RESERVE} "
+        f"--memory={container_memory_limit()} "
         # a static link, don't use S3_URL or S3_DOWNLOAD
         "-e S3_URL='https://s3.amazonaws.com/clickhouse-datasets' "
         "--tmpfs /tmp/clickhouse:mode=1777 "

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -12,6 +12,9 @@ from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.utils import Shell, Utils
 
+# The runner agent lives on the host, outside this container, so it is only safe if the container cannot take the whole box.
+RUNNER_MEMORY_RESERVE = 8 * 1024**3
+
 
 def sanitize_test_result_line(line: str) -> str:
     # Drop bare CR in addition to escaping NUL. The writer escapes
@@ -169,6 +172,7 @@ def get_run_command(
         "--privileged "
         # azurite-rs (in-process Azure Blob Storage emulator) needs many fds under parallel load
         "--ulimit nofile=1048576:1048576 "
+        f"--memory={Utils.physical_memory() - RUNNER_MEMORY_RESERVE} "
         # a static link, don't use S3_URL or S3_DOWNLOAD
         "-e S3_URL='https://s3.amazonaws.com/clickhouse-datasets' "
         "--tmpfs /tmp/clickhouse:mode=1777 "


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/116782
Related: https://github.com/ClickHouse/ClickHouse/issues/111892
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bound the stress test and upgrade check containers so a run cannot exhaust the CI runner host.

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/116782
Related: https://github.com/ClickHouse/ClickHouse/issues/111892

`Stress test (arm_asan_ubsan)` on #116485 published nothing: praktika reported `ERROR` with
`links=[]`, and CI DB holds **0** rows for it while the same commit carries 258,113 rows and nine
sibling variants that each reported.
[Report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116485&sha=a65b1fc6f1124c36c5ee6504ba840e5ea9ce2f98&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%29),
[job log](https://github.com/ClickHouse/ClickHouse/actions/runs/33670036751/job/100462891406).

`get_run_command` passes no `--memory`, and `common_stress_job_config` has no `run_in_docker`, so the
container is bounded only by the host. `configure_limits` sets
`max_server_memory_usage_to_ram_ratio=0.8` and calls that safe because "the total server memory usage
is capped to the memory usage of the whole cgroup", a cap this call site never creates. Its log shows
`total_mem=66198712320` (61.65 GiB of host RAM), so the server's ceiling was 49.32 GiB on a host that
also runs the agent. From 00:15:52Z its own trivial statements were refused with 241
(`SYSTEM STOP VIEWS`, a `LIMIT 1` read of `system.mutations`). Runner timestamps then jump 19m44s
while the lines arriving at the far end carry inner stamps from inside that gap: the process was
alive and only its output was not drained. GitHub then cancelled the job.

I add `--memory=Utils.physical_memory() - RUNNER_MEMORY_RESERVE`, in the shape and with the 8 GiB of
#116782. A kernel bound holds whatever the server, `gdb` and the clients do, and the launcher stays
on the host, so an in-container kill still publishes a result.

This is the single container call site for `Stress test (*)`, `Stress test (amd_cfi)` and
`Upgrade check (*)`: 35 job instances across five workflows.

Validated with these exact flags including `--privileged`, against a control with the cap removed and
nothing else changed; both arms are below. No `ci/defs/` change, so `praktika yaml` leaves
`.github/workflows/` unchanged.

Known and unchanged: `max_memory_usage_for_user` stays host-derived at 18.50 GiB, below the new
ceiling. The libFuzzer and vector-search containers are also uncapped, but I have no runner-loss
observation for either.

<details>
<summary>Memory envelope before and after, on the measured 61.65 GiB <code>*-medium</code> runner</summary>

| | before | after |
|---|---|---|
| container | unbounded (`memory.max` reads `max`) | 53.65 GiB, kernel-enforced |
| server ceiling (0.8 ratio, unchanged) | 49.32 GiB | 42.92 GiB |
| room for what the server does not track (`gdb`, clients, page tables) | whatever is spare | 10.73 GiB |
| left outside the container for the agent, dockerd and the kernel | whatever is spare, and the agent lost communication | 8.00 GiB, kernel-enforced |

The reserve is 8 GiB because #116782 measured 4.6 GiB of host headroom left at failure, and 4.6 was
not enough. The server's ceiling therefore drops 12.98%, so stress runs meet
`MEMORY_LIMIT_EXCEEDED` a little sooner, and an overshoot becomes an in-container kill: the job still
publishes its result, logs and cores instead of losing the runner and publishing nothing, and an OOM
is already an allowed outcome there (`stress_job.py:441`). Lowering the harness ratio instead was
tried on the stateless jobs and reverted the same day (#110293, #110572); that is a different
mechanism, and it would bound only the server rather than `gdb` and the clients sharing this cgroup.

Measured in the `clickhouse/stress-test` image with the job's own flags, differing only in
`--memory`. With the cap: `memory.max` reads the exact byte value passed, a plain 12 GiB allocation
is SIGKILLed by the kernel, and a query the server refuses reports a `maximum:` scaled from the cap
rather than from the host. Control, cap removed and nothing else changed: `memory.max` reads `max`,
the same 12 GiB allocation completes, and the same query passes a host-derived ceiling.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118057&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118057](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118057+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1363` (included in `26.9` and later)
<!-- ch-version-info:end -->