### PR TITLE
Prometheus HTTP API: implement /api/v1/status/buildinfo

### DIFF
--- a/docs/concepts/features/interfaces/prometheus.mdx
+++ b/docs/concepts/features/interfaces/prometheus.mdx
@@ -128,8 +128,9 @@ Configure one prefix-routed handler on the main ClickHouse HTTP port:
 | `/prometheus/api/v1/format_query` | PromQL expression formatting |
 | `/prometheus/api/v1/series` | Series metadata |
 | `/prometheus/api/v1/metadata` | Metric-family metadata |
+| `/prometheus/api/v1/status/buildinfo` | ClickHouse version and commit hash |
 
-The example omits `database` and `table` from the handler. Each request must provide the `table` query parameter (except for `/format_query`, which only parses the given PromQL expression and doesn't need a table). It can also provide `database`, use a qualified table name such as `prometheus.metrics`, or omit the database to use `default`. This allows one handler to serve multiple `TimeSeries` tables.
+The example omits `database` and `table` from the handler. Each request must provide the `table` query parameter (except for `/format_query`, which only parses the given PromQL expression, and `/status/buildinfo`, which describes the server; neither needs a table). It can also provide `database`, use a qualified table name such as `prometheus.metrics`, or omit the database to use `default`. This allows one handler to serve multiple `TimeSeries` tables.
 
 To use one fixed table for every request, configure it in the handler:
 
@@ -234,7 +235,7 @@ datasources:
 Grafana appends `/api/v1/query` or `/api/v1/query_range` to this base URL and adds `customQueryParameters` to each request.
 
 <Note>
-Only the query endpoints `/api/v1/query`, `/api/v1/query_range`, and `/api/v1/format_query` and the metadata endpoints `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values`, and `/api/v1/metadata` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. `/api/v1/labels` accepts the same parameters, with `match[]` being optional, and returns the sorted label names of the matched series (or of all series when no selectors are given). `/api/v1/label/<name>/values` accepts the same parameters as `/api/v1/labels` and returns the sorted values of one label, with `<name>` optionally using the Prometheus `U__...` escaping of label names that contain characters outside `[a-zA-Z0-9_]`. These endpoints cover what a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete.
+Only the query endpoints `/api/v1/query`, `/api/v1/query_range`, and `/api/v1/format_query`, the metadata endpoints `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values`, and `/api/v1/metadata`, and the status endpoint `/api/v1/status/buildinfo` are implemented. `/api/v1/series` requires at least one `match[]` series selector, supports the optional `start`, `end`, and `limit` parameters, and returns the union of the series matched by each selector. `/api/v1/labels` accepts the same parameters, with `match[]` being optional, and returns the sorted label names of the matched series (or of all series when no selectors are given). `/api/v1/label/<name>/values` accepts the same parameters as `/api/v1/labels` and returns the sorted values of one label, with `<name>` optionally using the Prometheus `U__...` escaping of label names that contain characters outside `[a-zA-Z0-9_]`. These endpoints cover what a Grafana Prometheus datasource uses for label browsing, template variables, and query-builder autocomplete. `/api/v1/status/buildinfo`, which Grafana calls to identify the backend, returns the ClickHouse server version as `version` and its commit hash as `revision`; the remaining Prometheus-specific fields are empty. Keep in mind that the backend is a ClickHouse instance, not a Prometheus server: for complete build information, query the [`system.build_options`](/reference/system-tables/build_options) table.
 </Note>
 
 #### SQL entry points {#sql-entry-points}

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -35,11 +35,14 @@
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Core/Settings.h>
+#include <Common/config_version.h>
 #include <Parsers/Prometheus/PrometheusQueryTree.h>
 #include <Storages/TimeSeries/PrometheusRemoteReadProtocol.h>
 #include <Storages/TimeSeries/PrometheusRemoteWriteProtocol.h>
 #include <Storages/TimeSeries/PrometheusHTTPProtocolAPI.h>
 
+
+extern const char * GIT_HASH;
 
 namespace DB
 {
@@ -422,8 +425,8 @@ public:
     }
 };
 
-/// Handles the read-only query and metadata endpoints of the Prometheus HTTP API
-/// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata).
+/// Handles the read-only query, metadata and status endpoints of the Prometheus HTTP API
+/// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata, /api/v1/status/buildinfo).
 class PrometheusRequestHandler::QueryImpl : public ImplWithContext
 {
 public:
@@ -488,6 +491,13 @@ public:
                 /// The format_query endpoint only parses and reformats the given PromQL expression,
                 /// so it doesn't need the TimeSeries table.
                 formatQuery(getOutputStream(response), params->get("query", ""));
+                return;
+            }
+
+            if (uri_path.ends_with("/status/buildinfo"))
+            {
+                /// The buildinfo endpoint describes the server itself, so it doesn't need the TimeSeries table either.
+                writeBuildInfo(getOutputStream(response));
                 return;
             }
 
@@ -631,6 +641,19 @@ private:
         writeChar('}', out);
     }
 
+    /// Handles the status/buildinfo endpoint, which clients such as Grafana use to identify the backend.
+    /// It reports the ClickHouse version and commit hash in the shape of the Prometheus response; the other
+    /// fields describe a Prometheus build and are left empty. For the full build information of this
+    /// ClickHouse instance, query the `system.build_options` table.
+    static void writeBuildInfo(WriteBuffer & out)
+    {
+        writeString(R"({"status":"success","data":{"version":)", out);
+        writeJSONString(VERSION_STRING, out, FormatSettings{});
+        writeString(R"(,"revision":)", out);
+        writeJSONString(GIT_HASH, out, FormatSettings{});
+        writeString(R"(,"branch":"","buildUser":"","buildDate":"","goVersion":""}})", out);
+    }
+
     /// Parses an optional integer parameter of the metadata endpoint; an absent parameter defaults to -1 (no limit).
     Int64 getMetadataLimitParam(const String & name) const
     {
@@ -724,7 +747,7 @@ private:
         if (path.ends_with("/read"))
             return read_impl;
 
-        /// All other /api/v1/* endpoints (query, query_range, series, labels, label/<name>/values, metadata)
+        /// All other /api/v1/* endpoints (query, query_range, series, labels, label/<name>/values, metadata, status/buildinfo)
         /// are served by the Query implementation, which itself returns 404 for unknown paths.
         return query_impl;
     }

--- a/src/Server/PrometheusRequestHandlerConfig.h
+++ b/src/Server/PrometheusRequestHandlerConfig.h
@@ -20,8 +20,8 @@ struct PrometheusRequestHandlerConfig
         /// Handles all Prometheus "/api/v1" protocols including Query, Write, Read.
         APIv1,
 
-        /// Handles the read-only query and metadata endpoints of the Prometheus HTTP API
-        /// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata),
+        /// Handles the read-only query, metadata and status endpoints of the Prometheus HTTP API
+        /// (/api/v1/query, /api/v1/query_range, /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values, /api/v1/metadata, /api/v1/status/buildinfo),
         /// i.e. everything under "/api/v1" except remote write and remote read.
         Query,
 

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -121,6 +121,14 @@
                 </handler>
             </my_rule_16>
 
+            <!-- The status/buildinfo endpoint describes the server, so its handler needs no table. -->
+            <my_rule_17>
+                <url>/api/v1/status/buildinfo</url>
+                <handler>
+                    <type>query</type>
+                </handler>
+            </my_rule_17>
+
             <!-- Table without min_time/max_time columns: /api/v1/series must ignore the time range for it. -->
             <my_rule_12>
                 <url_prefix>/no_bounds</url_prefix>

--- a/tests/integration/test_prometheus_protocols/test_buildinfo_api.py
+++ b/tests/integration/test_prometheus_protocols/test_buildinfo_api.py
@@ -1,0 +1,49 @@
+"""Tests for the Prometheus /api/v1/status/buildinfo endpoint."""
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+# The endpoint describes the server, so no TimeSeries table is created:
+# the test also verifies that the endpoint works without one.
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+)
+
+
+def buildinfo_url():
+    return f"http://{node.ip_address}:9093/api/v1/status/buildinfo"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    try:
+        cluster.start()
+        # cluster.start() waits for the native TCP port only; the Prometheus
+        # protocols port can start accepting connections slightly later.
+        cluster.wait_for_url(buildinfo_url())
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_buildinfo():
+    response = requests.get(buildinfo_url())
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "status": "success",
+        "data": {
+            "version": node.query("SELECT version()").strip(),
+            "revision": node.query(
+                "SELECT value FROM system.build_options WHERE name = 'GIT_HASH'"
+            ).strip(),
+            "branch": "",
+            "buildUser": "",
+            "buildDate": "",
+            "goVersion": "",
+        },
+    }


### PR DESCRIPTION
Grafana calls `/api/v1/status/buildinfo` to identify a Prometheus-compatible backend. The `query` and `prometheus_api_v1` handlers now answer it with the ClickHouse version and commit hash in the Prometheus response shape, without resolving a `TimeSeries` table. The remaining Prometheus-specific fields are left empty; note that the backend is a ClickHouse instance, and the full build information is available in `system.build_options`.

Condensed reimplementation of https://github.com/ClickHouse/ClickHouse/pull/117591
Related: https://github.com/ClickHouse/ClickHouse/issues/89553

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Implement the `/api/v1/status/buildinfo` endpoint of the Prometheus HTTP API, which reports the ClickHouse version and commit hash so that clients such as Grafana can identify the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118079&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118079](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118079+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
