### PR TITLE
Fix "Cannot write to finalized buffer" in MergeTreeDeduplicationLog::rotate

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -242,6 +242,23 @@ void MergeTreeDeduplicationLog::rotateAndDropIfNeeded()
     }
 }
 
+void MergeTreeDeduplicationLog::rotateAndDropIfNeededAfterWrite()
+{
+    /// The records are already written and applied to the in-memory map, so failing here would
+    /// report an operation that has actually succeeded as failed. For an insert this means that the
+    /// block IDs stay published for a part that never became active, and a retry of the insert
+    /// would be wrongly deduplicated. Rotation is only housekeeping, and it is retried on the next
+    /// operation, because `rotate` leaves the state untouched when it fails.
+    try
+    {
+        rotateAndDropIfNeeded();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__, "Error while rotating MergeTree deduplication log in " + logs_dir + ", will retry on the next operation");
+    }
+}
+
 std::vector<MergeTreeDeduplicationLog::AddPartResult> MergeTreeDeduplicationLog::addPart(const std::vector<std::string> & block_ids, const MergeTreePartInfo & part_info)
 {
     std::lock_guard lock(state_mutex);
@@ -289,8 +306,8 @@ std::vector<MergeTreeDeduplicationLog::AddPartResult> MergeTreeDeduplicationLog:
         /// Add to deduplication map
         deduplication_map.insert(record.block_id, part_info);
     }
-    /// Rotate and drop old logs if needed
-    rotateAndDropIfNeeded();
+
+    rotateAndDropIfNeededAfterWrite();
 
     return {};
 }
@@ -335,8 +352,7 @@ void MergeTreeDeduplicationLog::dropPart(const MergeTreePartInfo & drop_part_inf
             /// Remove block_id from in-memory table
             deduplication_map.erase(record.block_id);
 
-            /// Rotate and drop old logs if needed
-            rotateAndDropIfNeeded();
+            rotateAndDropIfNeededAfterWrite();
         }
         else
         {

--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.cpp
@@ -169,27 +169,32 @@ void MergeTreeDeduplicationLog::rotate()
     if (deduplication_window == 0)
         return;
 
-    try
+    /// Open the new log before finalizing the current one. If opening fails, nothing has changed
+    /// and `current_writer` still points to a live buffer, so the log stays usable.
+    /// Otherwise, `current_writer` would be left finalized and the next write to it would fail
+    /// with the logical error "Cannot write to finalized buffer".
+    size_t new_log_number = current_log_number + 1;
+    MergeTreeDeduplicationLogNameDescription new_log_description{getLogPath(logs_dir, new_log_number), 0};
+    auto new_writer = disk->writeFile(new_log_description.path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
+    existing_logs.emplace(new_log_number, new_log_description);
+
+    /// Nothing below can throw.
+    if (current_writer)
     {
-        if (current_writer)
+        try
         {
             current_writer->finalize();
             current_writer->sync();
         }
-    } catch (...)
-    {
-        tryLogCurrentException(__PRETTY_FUNCTION__, "Error while writing MergeTree deduplication log on path " + existing_logs[current_log_number].path + ", lost recods: " + DB::toString(existing_logs[current_log_number].entries_count));
-        if (current_writer)
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__, "Error while writing MergeTree deduplication log on path " + existing_logs[current_log_number].path + ", lost records: " + DB::toString(existing_logs[current_log_number].entries_count));
             current_writer->cancel();
-        current_writer = nullptr;
+        }
     }
 
-    current_log_number++;
-    auto new_path = getLogPath(logs_dir, current_log_number);
-    MergeTreeDeduplicationLogNameDescription log_description{new_path, 0};
-    existing_logs.emplace(current_log_number, log_description);
-
-    current_writer = disk->writeFile(log_description.path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
+    current_log_number = new_log_number;
+    current_writer = std::move(new_writer);
 }
 
 void MergeTreeDeduplicationLog::dropOutdatedLogs()

--- a/src/Storages/MergeTree/MergeTreeDeduplicationLog.h
+++ b/src/Storages/MergeTree/MergeTreeDeduplicationLog.h
@@ -201,6 +201,9 @@ private:
     /// Execute both previous methods if needed
     void rotateAndDropIfNeeded();
 
+    /// The same after writing records, when a failure must not be reported as a failure of the operation
+    void rotateAndDropIfNeededAfterWrite();
+
     /// Load single log from disk. In case of corruption throws exceptions
     size_t loadSingleLog(const std::string & path);
 };

--- a/src/Storages/MergeTree/tests/gtest_merge_tree_deduplication_log.cpp
+++ b/src/Storages/MergeTree/tests/gtest_merge_tree_deduplication_log.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include <Disks/DiskLocal.h>
+#include <Storages/MergeTree/MergeTreeDeduplicationLog.h>
+#include <Storages/MergeTree/MergeTreePartInfo.h>
+#include <Common/Exception.h>
+
+#include <unistd.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int FAULT_INJECTED;
+}
+
+namespace
+{
+
+/// A local disk that fails a chosen `writeFile` call, simulating a transient I/O error.
+class DiskFailingOnNthWriteFile : public DiskLocal
+{
+public:
+    DiskFailingOnNthWriteFile(const String & path_, size_t fail_on_call_)
+        : DiskLocal("faulty", path_), fail_on_call(fail_on_call_)
+    {
+    }
+
+    std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & path, size_t buf_size, WriteMode mode, const WriteSettings & settings) override
+    {
+        if (++calls == fail_on_call)
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure while opening {}", path);
+        return DiskLocal::writeFile(path, buf_size, mode, settings);
+    }
+
+private:
+    size_t calls = 0;
+    const size_t fail_on_call;
+};
+
+}
+
+/// A failure while opening the next log file during rotation must leave the log usable.
+/// Before the fix, `rotate` had already finalized the current writer at that point, so the next
+/// write to the deduplication log failed with the logical error "Cannot write to finalized buffer".
+TEST(MergeTreeDeduplicationLog, RotationFailureKeepsLogUsable)
+{
+    const auto disk_path = std::filesystem::temp_directory_path() / ("clickhouse_gtest_dedup_log_" + std::to_string(getpid()));
+    std::filesystem::remove_all(disk_path);
+    std::filesystem::create_directories(disk_path);
+
+    /// The first `writeFile` opens the first log during `load`. The second one is the rotation
+    /// after `rotate_interval` (two times the window) records were written, and it fails.
+    auto disk = std::make_shared<DiskFailingOnNthWriteFile>(disk_path.string() + "/", 2);
+
+    const MergeTreeDataFormatVersion format_version = MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING;
+    auto part = [&](const String & name) { return MergeTreePartInfo::fromPartName(name, format_version); };
+
+    {
+        MergeTreeDeduplicationLog log("dedup_logs", /*deduplication_window=*/ 2, format_version, disk);
+        log.load();
+
+        log.addPart({"block1"}, part("all_1_1_0"));
+        log.addPart({"block2"}, part("all_2_2_0"));
+        log.addPart({"block3"}, part("all_3_3_0"));
+
+        /// The fourth record triggers the rotation, whose `writeFile` fails.
+        EXPECT_THROW(log.addPart({"block4"}, part("all_4_4_0")), Exception);
+
+        /// The log must still accept records, both drops and adds, and the next rotation must succeed.
+        EXPECT_NO_THROW(log.dropPart(part("all_4_4_0")));
+        EXPECT_TRUE(log.addPart({"block5"}, part("all_5_5_0")).empty());
+        EXPECT_FALSE(log.addPart({"block3"}, part("all_6_6_0")).empty());
+        EXPECT_FALSE(log.addPart({"block5"}, part("all_6_6_0")).empty());
+    }
+
+    /// The records written after the failed rotation must have reached the disk.
+    {
+        MergeTreeDeduplicationLog log("dedup_logs", /*deduplication_window=*/ 2, format_version, disk);
+        log.load();
+
+        EXPECT_FALSE(log.addPart({"block3"}, part("all_6_6_0")).empty());
+        EXPECT_FALSE(log.addPart({"block5"}, part("all_6_6_0")).empty());
+        EXPECT_TRUE(log.addPart({"block4"}, part("all_6_6_0")).empty());
+    }
+
+    std::filesystem::remove_all(disk_path);
+}

--- a/src/Storages/MergeTree/tests/gtest_merge_tree_deduplication_log.cpp
+++ b/src/Storages/MergeTree/tests/gtest_merge_tree_deduplication_log.cpp
@@ -42,9 +42,10 @@ private:
 
 }
 
-/// A failure while opening the next log file during rotation must leave the log usable.
-/// Before the fix, `rotate` had already finalized the current writer at that point, so the next
-/// write to the deduplication log failed with the logical error "Cannot write to finalized buffer".
+/// A failure while opening the next log file during rotation must neither fail the operation that
+/// triggered the rotation, nor leave the log unusable. Before the fix, the operation failed although
+/// its records were already written, and `rotate` had already finalized the current writer, so the
+/// next write to the deduplication log failed with the logical error "Cannot write to finalized buffer".
 TEST(MergeTreeDeduplicationLog, RotationFailureKeepsLogUsable)
 {
     const auto disk_path = std::filesystem::temp_directory_path() / ("clickhouse_gtest_dedup_log_" + std::to_string(getpid()));
@@ -66,14 +67,16 @@ TEST(MergeTreeDeduplicationLog, RotationFailureKeepsLogUsable)
         log.addPart({"block2"}, part("all_2_2_0"));
         log.addPart({"block3"}, part("all_3_3_0"));
 
-        /// The fourth record triggers the rotation, whose `writeFile` fails.
-        EXPECT_THROW(log.addPart({"block4"}, part("all_4_4_0")), Exception);
+        /// The fourth record triggers the rotation, whose `writeFile` fails. The insert must succeed anyway.
+        EXPECT_TRUE(log.addPart({"block4"}, part("all_4_4_0")).empty());
+        EXPECT_FALSE(log.addPart({"block4"}, part("all_5_5_0")).empty());
 
         /// The log must still accept records, both drops and adds, and the next rotation must succeed.
         EXPECT_NO_THROW(log.dropPart(part("all_4_4_0")));
-        EXPECT_TRUE(log.addPart({"block5"}, part("all_5_5_0")).empty());
-        EXPECT_FALSE(log.addPart({"block3"}, part("all_6_6_0")).empty());
-        EXPECT_FALSE(log.addPart({"block5"}, part("all_6_6_0")).empty());
+        EXPECT_TRUE(log.addPart({"block4"}, part("all_5_5_0")).empty());
+        EXPECT_TRUE(log.addPart({"block5"}, part("all_6_6_0")).empty());
+        EXPECT_FALSE(log.addPart({"block4"}, part("all_7_7_0")).empty());
+        EXPECT_FALSE(log.addPart({"block5"}, part("all_7_7_0")).empty());
     }
 
     /// The records written after the failed rotation must have reached the disk.
@@ -81,9 +84,9 @@ TEST(MergeTreeDeduplicationLog, RotationFailureKeepsLogUsable)
         MergeTreeDeduplicationLog log("dedup_logs", /*deduplication_window=*/ 2, format_version, disk);
         log.load();
 
-        EXPECT_FALSE(log.addPart({"block3"}, part("all_6_6_0")).empty());
-        EXPECT_FALSE(log.addPart({"block5"}, part("all_6_6_0")).empty());
-        EXPECT_TRUE(log.addPart({"block4"}, part("all_6_6_0")).empty());
+        EXPECT_FALSE(log.addPart({"block4"}, part("all_7_7_0")).empty());
+        EXPECT_FALSE(log.addPart({"block5"}, part("all_7_7_0")).empty());
+        EXPECT_TRUE(log.addPart({"block3"}, part("all_7_7_0")).empty());
     }
 
     std::filesystem::remove_all(disk_path);


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110429

Fixes a server abort with the logical error `Cannot write to finalized buffer` hit by the stress test.

`MergeTreeDeduplicationLog::rotate` finalized the writer of the current log and only then opened the writer for the next log. When opening the next log threw (a transient I/O error, or, in the CI failure, a memory-tracker fault injection hitting the `WriteBufferFromS3` allocation), `current_writer` was left pointing at a finalized buffer, and the next write to the deduplication log failed with the logical error. In the CI failure that write came from the background `MergeTreeCleanupThread` calling `dropPart`.

Now `rotate` opens the writer for the next log before touching any state. If that throws, the current writer is still live and the log stays usable. Only after the new writer is ready, the old one is finalized and swapped out; nothing after that point can throw.

In addition, a failure of the rotation that follows `addPart` or `dropPart` no longer fails the operation. Its records are already written and applied to the in-memory map at that point, so reporting the failure would make the insert fail after its block IDs were published, and a retry of the insert would be wrongly deduplicated against a part that never became active. Rotation is housekeeping; the failure is logged and the rotation is retried on the next operation.

This is a minimal reimplementation of https://github.com/ClickHouse/ClickHouse/pull/110429, which grew far beyond the original defect.

A unit test injects a failure into the `writeFile` call of the rotation and checks that the insert which triggered it succeeds, that the log keeps accepting records and rotates successfully afterwards, and that the records written around the failed rotation are replayed on reload.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a63a425c48d3123d28bef2ad60511c9fc0583468&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20amd_tsan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a logical error `Cannot write to finalized buffer` (an abort in debug and sanitizer builds) in the non-replicated `MergeTree` deduplication log when opening the next log file during rotation failed, for example after a transient I/O error on the deduplication log's disk. Such a failure no longer fails the insert that triggered the rotation, so a retry of that insert is not wrongly deduplicated.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118089&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118089](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118089+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
