### PR TITLE
Move Stateless Worker distributed-plan settings to the private-preview tier

### DIFF
--- a/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
+++ b/ci/jobs/scripts/docs/autogenerate/autogenerate_docs.py
@@ -199,7 +199,7 @@ SETTINGS_GENERATORS = [
         # Run after the split settings families so both `--write` and `--check`
         # resolve links from their freshly generated routing metadata.
         "name": "beta-and-experimental",
-        "sql": ["beta-settings.sql", "experimental-settings.sql"],
+        "sql": ["beta-settings.sql", "experimental-settings.sql", "private-preview-settings.sql"],
         "outfile": "experimental-beta-settings.md",
         "dest": "docs/about-us/beta-and-experimental-features.md",
         "method": "markers",

--- a/ci/jobs/scripts/docs/autogenerate/sql/private-preview-settings.sql
+++ b/ci/jobs/scripts/docs/autogenerate/sql/private-preview-settings.sql
@@ -1,0 +1,36 @@
+-- First write the header
+SELECT '\n\n## Private preview settings {#private-preview-settings}\n\n| Name | Default |\n|------|--------|'
+INTO OUTFILE 'experimental-beta-settings.md' APPEND
+FORMAT TSVRaw;
+
+-- Then append the table content
+WITH
+    private_preview_session_settings AS
+        (
+            SELECT
+                format('[{}](/operations/settings/settings#{})', name, name) AS Name,
+                format('`{}`', default) AS Default
+FROM system.settings
+WHERE tier = 'PrivatePreview' AND alias_for=''
+    ),
+    private_preview_mergetree_settings AS
+    (
+SELECT
+    format('[{}](/operations/settings/merge-tree-settings#{})', name, name) AS Name,
+    format('`{}`', default) AS Default
+FROM system.merge_tree_settings
+WHERE tier = 'PrivatePreview'
+    ),
+    combined AS
+    (
+SELECT *
+FROM private_preview_session_settings
+UNION ALL
+SELECT *
+FROM private_preview_mergetree_settings
+ORDER BY Name ASC
+    )
+SELECT concat('| ', Name, ' | ', Default, ' |')
+FROM combined
+    INTO OUTFILE 'experimental-beta-settings.md' APPEND
+FORMAT TSVRaw;

--- a/ci/jobs/scripts/docs/autogenerate/sql/session-settings.sql
+++ b/ci/jobs/scripts/docs/autogenerate/sql/session-settings.sql
@@ -67,7 +67,7 @@ WITH
         format('## {}{}{}{}{}{}{}{}\n\n',
         name,
         ' {#'||name||'} \n\n',
-        multiIf(tier == 'Experimental', '<ExperimentalBadge/>\n\n', tier == 'Beta', '<BetaBadge/>\n\n', ''),
+        multiIf(tier == 'Experimental', '<ExperimentalBadge/>\n\n', tier == 'Beta', '<BetaBadge/>\n\n', tier == 'PrivatePreview', '<PrivatePreviewBadge/>\n\n', ''),
         if(description LIKE '%Only has an effect in ClickHouse Cloud%', '<CloudOnlyBadge/>\n\n', ''),
         if(sa.aliases IS NOT NULL AND length(sa.aliases) > 0,
            '**Aliases**: ' || arrayStringConcat(arrayMap(x -> '`' || x || '`', sa.aliases), ', ') || '\n\n',
@@ -98,6 +98,7 @@ doc_type: ''reference''
 
 import ExperimentalBadge from \'@theme/badges/ExperimentalBadge\';
 import BetaBadge from \'@theme/badges/BetaBadge\';
+import PrivatePreviewBadge from \'@theme/badges/PrivatePreviewBadge\';
 import CloudOnlyBadge from \'@theme/badges/CloudOnlyBadge\';
 import SettingsInfoBlock from \'@theme/SettingsInfoBlock/SettingsInfoBlock\';
 import VersionHistory from \'@theme/VersionHistory/VersionHistory\';

--- a/docs/reference/settings/beta-and-experimental-features.mdx
+++ b/docs/reference/settings/beta-and-experimental-features.mdx
@@ -8,11 +8,11 @@ doc_type: 'reference'
 
 Because ClickHouse is open-source, it receives many contributions not only from ClickHouse employees but also from the community. These contributions are often developed at different speeds; certain features may require a lengthy prototyping phase or more time for sufficient community feedback and iteration to be considered generally available (GA).
 
-Due to the uncertainty of when features are classified as generally available, we delineate features into two categories: **Beta** and **Experimental**.
+Due to the uncertainty of when features are classified as generally available, we delineate features into three categories: **Beta**, **Experimental**, and **Private preview**.
 
-**Beta** features are officially supported by the ClickHouse team. **Experimental** features are early prototypes driven by either the ClickHouse team or the community and aren't officially supported.
+**Beta** features are officially supported by the ClickHouse team. **Experimental** features are early prototypes driven by either the ClickHouse team or the community and aren't officially supported. **Private preview** features are on a clear path to general availability but still have limited applicability and are not recommended for production use.
 
-The sections below explicitly describe the properties of **Beta** and **Experimental** features:
+The sections below explicitly describe the properties of **Beta**, **Experimental**, and **Private preview** features:
 
 ## Beta features {#beta-features}
 
@@ -38,6 +38,14 @@ Note: please be sure to be using a current version of the ClickHouse [compatibil
 - Can't be enabled in the cloud
 
 Please note: no additional experimental features are allowed to be enabled in ClickHouse Cloud other than those listed above as Beta.
+
+## Private preview features {#private-preview-features}
+
+- On a clear path to general availability (GA)
+- Applicability is still limited
+- Not recommended for production use
+- Functionality may change in the future
+- Need to be deliberately enabled
 
 {/* The inner content of the tags below are replaced at build time with a table generated from source
      Please don't modify or remove the tags

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -9048,7 +9048,7 @@ Enabling it automatically adjusts settings that control features not supported b
 - `use_skip_indexes_on_data_read = 0`;
 - `compile_expressions = 0`;
 - `query_plan_direct_read_from_text_index = 0`.
-)", EXPERIMENTAL) \
+)", PRIVATE_PREVIEW) \
     DECLARE(Bool, distributed_plan_execute_locally, false, R"(
 Run all tasks of a distributed query plan locally. Useful for testing and debugging.
 )", EXPERIMENTAL) \
@@ -9065,10 +9065,10 @@ Removes unnecessary exchanges in distributed query plan. Disable it for debuggin
 )", 0) \
     DECLARE(UInt64, distributed_plan_workers_num, 0, R"(
 How many stateless workers will be used to execute this query. Zero disables stateless-worker leasing for distributed plans.
-)", EXPERIMENTAL) \
+)", PRIVATE_PREVIEW) \
     DECLARE(UInt64, distributed_plan_workers_provisioning_timeout_ms, 10000, R"(
 Total wall-clock time, in milliseconds, a query may spend provisioning stateless workers before execution: leasing them from the discovery service and verifying they are reachable. The query blocks up to this budget for the leased workers to become ready; when it elapses the query proceeds with the workers verified so far, or fails if none became available. Zero waits only for the initial lease-and-verify pass (no retries).
-)", EXPERIMENTAL) \
+)", PRIVATE_PREVIEW) \
     DECLARE(String, distributed_plan_force_exchange_kind, "", R"(
 Force specified kind of Exchange operators between distributed query stages.
 
@@ -9092,7 +9092,7 @@ order. Only shapes where no exchange survives between the read and the sort are 
 )", EXPERIMENTAL) \
     DECLARE(Bool, distributed_plan_prefer_replicas_over_workers, false, R"(
 Serialize the distributed query plan for execution at replicas.
-)", EXPERIMENTAL) \
+)", PRIVATE_PREVIEW) \
     DECLARE(Bool, allow_experimental_ytsaurus_table_engine, false, R"(
 Experimental table engine for integration with YTsaurus.
 )", EXPERIMENTAL) \

--- a/tests/integration/test_allow_feature_tier/test.py
+++ b/tests/integration/test_allow_feature_tier/test.py
@@ -53,6 +53,7 @@ EXPERIMENTAL_SETTING = (
     "allow_experimental_time_series_table"  # also in configs/users.d/users.xml
 )
 BETA_SETTING = "allow_experimental_lightweight_update"
+PRIVATE_PREVIEW_SETTING = "distributed_plan_workers_num"
 
 # A `MergeTree` setting is written by its bare name in a table's own `SETTINGS` or `ALTER ... MODIFY
 # SETTING`, and with a `merge_tree_` prefix in a profile, user or session `SETTINGS` clause.
@@ -88,6 +89,7 @@ MERGE_TREE_FORBIDDEN_DEFAULT_MIN = 16384
 
 EXPERIMENTAL_BLOCKED = "Changes to EXPERIMENTAL settings are disabled"
 BETA_BLOCKED = "Changes to BETA settings are disabled"
+PRIVATE_PREVIEW_BLOCKED = "Changes to PRIVATE PREVIEW settings are disabled"
 
 
 @pytest.fixture(scope="module")
@@ -161,6 +163,64 @@ def test_allow_feature_tier_in_general_settings(start_cluster):
     output, error = instance.query_and_get_answer_with_error(query_with_beta_setting)
     assert output == ""
     assert BETA_BLOCKED in error
+
+    # Leave the server as it was
+    instance.replace_in_config(feature_tier_path, "3", "0")
+    instance.query("SYSTEM RELOAD CONFIG")
+    assert "0" == get_current_tier_value(instance)
+
+
+def test_allow_feature_tier_in_private_preview_settings(start_cluster):
+    query_with_private_preview_setting = (
+        f"SELECT 1 SETTINGS {PRIVATE_PREVIEW_SETTING}=1"
+    )
+    query_with_experimental_setting = f"SELECT 1 SETTINGS {EXPERIMENTAL_SETTING}=1"
+
+    assert "0" == get_current_tier_value(instance)
+    output, error = instance.query_and_get_answer_with_error(
+        query_with_private_preview_setting
+    )
+    assert error == ""
+    assert "1" == output.strip()
+
+    # Disable experimental settings; private preview is still allowed
+    instance.replace_in_config(feature_tier_path, "0", "1")
+    instance.query("SYSTEM RELOAD CONFIG")
+    assert "1" == get_current_tier_value(instance)
+
+    output, error = instance.query_and_get_answer_with_error(
+        query_with_private_preview_setting
+    )
+    assert error == ""
+    assert "1" == output.strip()
+
+    output, error = instance.query_and_get_answer_with_error(
+        query_with_experimental_setting
+    )
+    assert output == ""
+    assert EXPERIMENTAL_BLOCKED in error
+
+    # Disable private preview settings too
+    instance.replace_in_config(feature_tier_path, "1", "2")
+    instance.query("SYSTEM RELOAD CONFIG")
+    assert "2" == get_current_tier_value(instance)
+
+    output, error = instance.query_and_get_answer_with_error(
+        query_with_private_preview_setting
+    )
+    assert output == ""
+    assert PRIVATE_PREVIEW_BLOCKED in error
+
+    # Disable beta settings as well; private preview stays blocked
+    instance.replace_in_config(feature_tier_path, "2", "3")
+    instance.query("SYSTEM RELOAD CONFIG")
+    assert "3" == get_current_tier_value(instance)
+
+    output, error = instance.query_and_get_answer_with_error(
+        query_with_private_preview_setting
+    )
+    assert output == ""
+    assert PRIVATE_PREVIEW_BLOCKED in error
 
     # Leave the server as it was
     instance.replace_in_config(feature_tier_path, "3", "0")

--- a/tests/queries/0_stateless/03257_setting_tiers.sql
+++ b/tests/queries/0_stateless/03257_setting_tiers.sql
@@ -1,7 +1,7 @@
 SELECT count() > 0 FROM system.settings WHERE tier = 'Production';
 SELECT count() > 0 FROM system.settings WHERE tier = 'Beta';
 SELECT count() > 0 FROM system.settings WHERE tier = 'Experimental';
-SELECT count() == 0 FROM system.settings WHERE tier = 'PrivatePreview';
+SELECT count() > 0 FROM system.settings WHERE tier = 'PrivatePreview';
 SELECT count() > 0 FROM system.settings WHERE tier = 'Obsolete';
 SELECT count() == countIf(tier IN ['Production', 'Beta', 'PrivatePreview', 'Experimental', 'Obsolete']) FROM system.settings;
 

--- a/tests/queries/0_stateless/05046_distributed_plan_private_preview_tier.reference
+++ b/tests/queries/0_stateless/05046_distributed_plan_private_preview_tier.reference
@@ -1,0 +1,5 @@
+distributed_plan_prefer_replicas_over_workers	PrivatePreview
+distributed_plan_workers_num	PrivatePreview
+distributed_plan_workers_provisioning_timeout_ms	PrivatePreview
+make_distributed_plan	PrivatePreview
+0

--- a/tests/queries/0_stateless/05046_distributed_plan_private_preview_tier.sql
+++ b/tests/queries/0_stateless/05046_distributed_plan_private_preview_tier.sql
@@ -1,0 +1,19 @@
+-- The distributed-plan settings a query needs to run on stateless workers are in the
+-- PRIVATE_PREVIEW tier (not EXPERIMENTAL). Assert the exact names and tiers so a
+-- regression that promotes only some of them, or leaves them experimental, is caught.
+
+SELECT name, tier FROM system.settings
+WHERE name IN (
+    'make_distributed_plan',
+    'distributed_plan_workers_num',
+    'distributed_plan_workers_provisioning_timeout_ms',
+    'distributed_plan_prefer_replicas_over_workers')
+ORDER BY name;
+
+-- None of them remain in the Experimental tier.
+SELECT count() FROM system.settings
+WHERE tier = 'Experimental' AND name IN (
+    'make_distributed_plan',
+    'distributed_plan_workers_num',
+    'distributed_plan_workers_provisioning_timeout_ms',
+    'distributed_plan_prefer_replicas_over_workers');


### PR DESCRIPTION
The four settings that put a query on Stateless Workers move from `EXPERIMENTAL` to `PRIVATE_PREVIEW`: `make_distributed_plan`, `distributed_plan_workers_num`, `distributed_plan_workers_provisioning_timeout_ms`, `distributed_plan_prefer_replicas_over_workers`. The feature is on a clear path to GA, but applicability is limited and production use is not recommended.

They are the first settings in that tier, so `03257_setting_tiers` now expects a non-empty set, the docs page gains a Private preview section, and `allow_feature_tier = 1` accepts them where it rejects experimental.

The docs autogenerator knew only the Beta and Experimental tiers, so it gains a private-preview settings table and badge. The generated regions themselves are left to the nightly job.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118098&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118098](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118098+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->




<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.884` (included in `26.9` and later)
<!-- ch-version-info:end -->