### PR TITLE
Fix one-minute shutdown delay after writing an access entity to disk

### DIFF
--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -351,7 +351,7 @@ void DiskAccessStorage::listsWritingThreadFunc()
         /// the following timeout.
         const auto timeout = std::chrono::minutes(1);
         SCOPE_EXIT({ lists_writing_thread_is_waiting = false; });
-        if (lists_writing_thread_should_exit.wait_for(lock, timeout) != std::cv_status::timeout)
+        if (lists_writing_thread_should_exit.wait_for(lock, timeout, [this] { return lists_writing_thread_must_exit; }))
             return; /// The destructor requires us to exit.
     }
 
@@ -363,6 +363,11 @@ void DiskAccessStorage::stopListsWritingThread()
 {
     if (lists_writing_thread && lists_writing_thread->joinable())
     {
+        {
+            /// `mutex` has to be released before `join`: `listsWritingThreadFunc` acquires it.
+            std::lock_guard lock{mutex};
+            lists_writing_thread_must_exit = true;
+        }
         lists_writing_thread_should_exit.notify_one();
         lists_writing_thread->join();
     }

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -99,6 +99,10 @@ private:
 
     bool lists_writing_thread_is_waiting = false;
 
+    /// Written under `mutex`, so an exit request made before `listsWritingThreadFunc` starts waiting
+    /// is still visible to the predicate of that wait.
+    bool lists_writing_thread_must_exit = false;
+
     std::atomic<bool> readonly;
     std::atomic<bool> backup_allowed;
     mutable std::mutex mutex;

--- a/src/Access/tests/gtest_disk_access_storage.cpp
+++ b/src/Access/tests/gtest_disk_access_storage.cpp
@@ -90,9 +90,8 @@ TEST(DiskAccessStorageShutdown, DoesNotWaitOutTheListsWritingTimeout)
     AccessChangesNotifier notifier;
 
     /// Shutting down right after the insert races the request to stop the background lists-writing
-    /// thread against that thread starting to wait for the request, and which one wins varies per
-    /// pass, hence the repetition. Writing the lists takes milliseconds, while the thread's batching
-    /// timeout is a minute.
+    /// thread against that thread starting to wait for it, and neither order is guaranteed, hence
+    /// the repetition. Writing the lists takes milliseconds, while the batching timeout is a minute.
     for (size_t iteration = 0; iteration != 20; ++iteration)
     {
         Poco::TemporaryFile temp_dir;

--- a/src/Access/tests/gtest_disk_access_storage.cpp
+++ b/src/Access/tests/gtest_disk_access_storage.cpp
@@ -87,27 +87,34 @@ TEST(DiskAccessStorageRecovery, RebuildRemovesOlderDuplicates)
 
 TEST(DiskAccessStorageShutdown, DoesNotWaitOutTheListsWritingTimeout)
 {
-    Poco::TemporaryFile temp_dir;
-    temp_dir.createDirectories();
-    String dir = temp_dir.path() + "/";
-
     AccessChangesNotifier notifier;
-    DiskAccessStorage storage("test_disk", dir, notifier, /*readonly_=*/false, /*allow_backup_=*/false);
 
-    auto user = std::make_shared<User>();
-    user->setName("alice");
-    storage.insert(user);
+    /// Shutting down right after the insert races the request to stop the background lists-writing
+    /// thread against that thread starting to wait for the request, and which one wins varies per
+    /// pass, hence the repetition. Writing the lists takes milliseconds, while the thread's batching
+    /// timeout is a minute.
+    for (size_t iteration = 0; iteration != 20; ++iteration)
+    {
+        Poco::TemporaryFile temp_dir;
+        temp_dir.createDirectories();
+        String dir = temp_dir.path() + "/";
 
-    /// Shutting down right after the insert is the interleaving in which the request to stop the
-    /// background lists-writing thread is made before that thread starts waiting for it. Writing
-    /// the lists takes milliseconds, while the thread's batching timeout is a minute.
-    auto started = std::chrono::steady_clock::now();
-    storage.shutdown();
-    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started).count();
+        DiskAccessStorage storage("test_disk", dir, notifier, /*readonly_=*/false, /*allow_backup_=*/false);
 
-    EXPECT_LT(elapsed_ms, 20000) << "shutdown() took " << elapsed_ms << " ms";
+        auto user = std::make_shared<User>();
+        user->setName("alice");
+        storage.insert(user);
 
-    /// The lists are on disk once `shutdown` returns, whichever thread wrote them.
-    EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(dir) / "need_rebuild_lists.mark"));
-    EXPECT_TRUE(std::filesystem::exists(std::filesystem::path(dir) / "users.list"));
+        auto started = std::chrono::steady_clock::now();
+        storage.shutdown();
+        auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started).count();
+
+        ASSERT_LT(elapsed_ms, 20000) << "shutdown() took " << elapsed_ms << " ms on iteration " << iteration;
+
+        /// With the marker absent the reopened storage reads the `.list` files instead of rebuilding
+        /// from the `<id>.sql` files, so it resolves `alice` only if `users.list` really names her.
+        EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(dir) / "need_rebuild_lists.mark"));
+        DiskAccessStorage reopened("test_disk", dir, notifier, /*readonly_=*/false, /*allow_backup_=*/false);
+        ASSERT_TRUE(reopened.find<User>("alice").has_value()) << "iteration " << iteration;
+    }
 }

--- a/src/Access/tests/gtest_disk_access_storage.cpp
+++ b/src/Access/tests/gtest_disk_access_storage.cpp
@@ -84,3 +84,30 @@ TEST(DiskAccessStorageRecovery, RebuildRemovesOlderDuplicates)
     ASSERT_TRUE(resolved.has_value());
     EXPECT_EQ(*resolved, id_b);
 }
+
+TEST(DiskAccessStorageShutdown, DoesNotWaitOutTheListsWritingTimeout)
+{
+    Poco::TemporaryFile temp_dir;
+    temp_dir.createDirectories();
+    String dir = temp_dir.path() + "/";
+
+    AccessChangesNotifier notifier;
+    DiskAccessStorage storage("test_disk", dir, notifier, /*readonly_=*/false, /*allow_backup_=*/false);
+
+    auto user = std::make_shared<User>();
+    user->setName("alice");
+    storage.insert(user);
+
+    /// Shutting down right after the insert is the interleaving in which the request to stop the
+    /// background lists-writing thread is made before that thread starts waiting for it. Writing
+    /// the lists takes milliseconds, while the thread's batching timeout is a minute.
+    auto started = std::chrono::steady_clock::now();
+    storage.shutdown();
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started).count();
+
+    EXPECT_LT(elapsed_ms, 20000) << "shutdown() took " << elapsed_ms << " ms";
+
+    /// The lists are on disk once `shutdown` returns, whichever thread wrote them.
+    EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(dir) / "need_rebuild_lists.mark"));
+    EXPECT_TRUE(std::filesystem::exists(std::filesystem::path(dir) / "users.list"));
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a lost wakeup in the `local_directory` access storage that could make `clickhouse-local` and `clickhouse-server` take an extra minute to exit when creating, dropping or renaming an access entity (a user, role, settings profile, row policy, quota or masking policy) was the last operation before shutdown.

### Description

`DiskAccessStorage` writes its `.list` files from a background thread that first waits up to a minute, so that several list updates can be batched. `stopListsWritingThread` asked that thread to exit by calling `notify_one` on `lists_writing_thread_should_exit`, holding no lock and recording nothing. If the thread had not reached its `wait_for` yet, the notification was dropped, the thread waited out the whole minute, and `join` held shutdown open for it. `clickhouse-local` reaches this most easily, because the DDL is usually the last thing the process does, so shutdown starts about a millisecond after the thread is created.

I now record the request in a `mutex`-guarded flag before notifying, and pass the `wait_for` the predicate that reads it. The same line previously let a spurious wakeup return early and skip `writeLists`, which this also settles.

`CREATE` and `DROP` always schedule a list write and `ALTER` does when it renames, so every access entity type reaches this through the single `scheduleWriteLists`. The constructor and `SYSTEM RELOAD USERS` write the lists inline and start no thread. The code is from 2020.

In CI it appears as `04902_access_entity_map_setting_round_trip` being killed at the 60 s per-test cap in `Fast test`, which drops the rest of the matrix: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=116793&sha=a1ada61eaceb3825f95652b597d18c8920b07f5e&name_0=PR&name_1=Fast%20test

Validation: the new unit test fails on master with `shutdown() took 60000 ms` and passes 400 iterations with the fix, the slowest `shutdown` taking 1 ms. End to end, 6144 `clickhouse-local` invocations at 32-way concurrency with default settings gave 5 runs over 55 s before the fix and 0 after, with nothing between 30 s and 55 s in either arm.

A shell test cannot force this interleaving: the one setting that makes it deterministic (`--max_thread_pool_size=1`) makes that single pool thread the bottleneck for the rest of shutdown, so it stalls with the fix too.

<details>
<summary>The same stall is already visible in CI as a slow pass (click to expand)</summary>

```sql
SELECT countIf(test_duration_ms BETWEEN 6000 AND 29999) AS d_6_30s,
       countIf(test_duration_ms BETWEEN 30000 AND 54999) AS d_30_55s,
       countIf(test_duration_ms BETWEEN 55000 AND 85000) AS d_55_85s,
       count() AS total
FROM default.checks
WHERE test_name = '04902_access_entity_map_setting_round_trip'
  AND test_status = 'OK' AND check_start_time > now() - INTERVAL 7 DAY
  AND check_name IN (
    SELECT check_name FROM default.checks
    WHERE test_name = '04902_access_entity_map_setting_round_trip'
      AND test_status = 'OK' AND check_start_time > now() - INTERVAL 7 DAY
    GROUP BY check_name HAVING quantile(0.9)(test_duration_ms) < 25000);

d_6_30s  d_30_55s  d_55_85s  total
14541    0         44        24946
```

In the suites whose per-test timeout is far above 60 s, the same event is recorded as a slow `OK`:
44 runs at baseline plus a minute, and not a single run in the whole 30 s to 55 s band. Load
produces a continuum; one fixed timeout produces a gap and a cluster. For `Fast test` itself the
same 7 days give 4268 passing runs with p50 2760 ms, p90 3310 ms and a maximum of 5960 ms, so the
two 60 s failures are ten times the slowest pass ever observed.
</details>

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118099&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118099](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118099+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
