### PR TITLE
Docs: fix Cloud quickstart link on installation pages

### DIFF
--- a/ci/jobs/scripts/docs/quickstarts_check.py
+++ b/ci/jobs/scripts/docs/quickstarts_check.py
@@ -37,7 +37,7 @@ guide):
 
 4. Install-page Cloud banner parity. The English and localized install pages
    must render the same recommended Cloud banner, attributed signup link, and
-   locale-preserving quickstart link under the canonical `/docs` mount.
+   locale-preserving quickstart link.
 
 5. Explorer links. Quickstart and sample-dataset cards must render the
    canonical `/docs` mount during server-side rendering in English and every
@@ -810,14 +810,6 @@ def check_install_cloud_banners(docs_root: Path) -> list:
         for locale in LOCALES
     ]
 
-    docs_base_helper = (
-        "export const withDocsBase = (href) => {\n"
-        "  if (!href || !href.startsWith('/')) return href;\n"
-        "  const base = typeof window === 'undefined' || "
-        "window.location.pathname.startsWith('/docs') ? '/docs' : '';\n"
-        "  return base + href;\n"
-        "};"
-    )
     errors = []
     for locale, page in pages:
         source = page.read_text(encoding="utf-8")
@@ -825,7 +817,6 @@ def check_install_cloud_banners(docs_root: Path) -> list:
         quickstart_href = "/get-started/setup/cloud"
         if locale:
             quickstart_href = f"/{locale}{quickstart_href}"
-        quickstart_anchor = f"href={{withDocsBase('{quickstart_href}')}}"
 
         if source.count('className="ch-install-cloud-card"') != 1:
             errors.append(
@@ -836,15 +827,10 @@ def check_install_cloud_banners(docs_root: Path) -> list:
                 f"{name}: expected one signup link attributed with "
                 "`loc=docs-install-page-banner`"
             )
-        if source.count(docs_base_helper) != 1:
+        if source.count(f'href="{quickstart_href}"') != 1:
             errors.append(
-                f"{name}: withDocsBase must default to the canonical `/docs` "
-                "mount during server-side rendering"
-            )
-        if source.count(quickstart_anchor) != 1:
-            errors.append(
-                f"{name}: expected one Cloud quickstart link that renders "
-                f"{f'/docs{quickstart_href}'!r} during server-side rendering"
+                f"{name}: expected one Cloud quickstart link to "
+                f"{quickstart_href!r}"
             )
         if '<Card title="ClickHouse Cloud"' in source:
             errors.append(

--- a/docs/ar/get-started/setup/install.mdx
+++ b/docs/ar/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: 'إرشادات التثبيت'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">موصى به</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       ابدأ مجانًا
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/ar/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/ar/get-started/setup/cloud">
       اقرأ البرنامج التعليمي للبدء السريع
     </a>
   </div>

--- a/docs/es/get-started/setup/install.mdx
+++ b/docs/es/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: 'Guía de instalación'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">Recomendado</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       Empieza gratis
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/es/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/es/get-started/setup/cloud">
       Lee el tutorial de inicio rápido
     </a>
   </div>

--- a/docs/fr/get-started/setup/install.mdx
+++ b/docs/fr/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: 'Instructions d’installation'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">Recommandé</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       Commencer gratuitement
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/fr/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/fr/get-started/setup/cloud">
       Lire le tutoriel de démarrage rapide
     </a>
   </div>

--- a/docs/get-started/setup/install.mdx
+++ b/docs/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: 'Installation instructions'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">Recommended</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       Get started free
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/get-started/setup/cloud">
       Read the quickstart tutorial
     </a>
   </div>

--- a/docs/ja/get-started/setup/install.mdx
+++ b/docs/ja/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: 'インストール手順'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">推奨</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       無料で始める
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/ja/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/ja/get-started/setup/cloud">
       クイックスタートチュートリアルを読む
     </a>
   </div>

--- a/docs/ko/get-started/setup/install.mdx
+++ b/docs/ko/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: '설치 안내'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">권장</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       무료로 시작하기
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/ko/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/ko/get-started/setup/cloud">
       빠른 시작 튜토리얼 읽기
     </a>
   </div>

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -80,10 +80,6 @@ exclude = [
   # The base-aware homepage MCP routes are computed at runtime in JSX. Lychee
   # reads the identifier in `href={href}` as a literal `{href}` path.
   "(?:%7B|\\{)href(?:%7D|\\})$",
-  # The install banner computes its origin-relative route with withDocsBase.
-  # The quickstart checker validates the actual English and localized targets;
-  # exclude only Lychee's encoded rendering of that JSX expression here.
-  "(?:%7B|\\{)withDocsBase\\(.*/get-started/setup/cloud.*\\)(?:%7D|\\})$",
   # Local and placeholder hosts used in setup instructions and connection
   # examples. They are not expected to resolve from the link checker.
   "^https?://localhost(?::[0-9]+)?(?:/|$)",

--- a/docs/pt-BR/get-started/setup/install.mdx
+++ b/docs/pt-BR/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: 'Instruções de instalação'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">Recomendado</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       Comece gratuitamente
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/pt-BR/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/pt-BR/get-started/setup/cloud">
       Leia o tutorial de início rápido
     </a>
   </div>

--- a/docs/ru/get-started/setup/install.mdx
+++ b/docs/ru/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: 'Инструкция по установке'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">Рекомендуется</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       Начать бесплатно
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/ru/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/ru/get-started/setup/cloud">
       Прочитать руководство по быстрому старту
     </a>
   </div>

--- a/docs/zh/get-started/setup/install.mdx
+++ b/docs/zh/get-started/setup/install.mdx
@@ -7,12 +7,6 @@ title: '安装指南'
 doc_type: 'guide'
 ---
 
-export const withDocsBase = (href) => {
-  if (!href || !href.startsWith('/')) return href;
-  const base = typeof window === 'undefined' || window.location.pathname.startsWith('/docs') ? '/docs' : '';
-  return base + href;
-};
-
 <div className="ch-install-cloud-card">
   <span className="ch-install-cloud-badge">推荐</span>
   <span className="ch-install-cloud-icon" aria-hidden="true"></span>
@@ -25,7 +19,7 @@ export const withDocsBase = (href) => {
     <a className="ch-install-cloud-cta" href="https://clickhouse.cloud/signUp?loc=docs-install-page-banner">
       免费开始使用
     </a>
-    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href={withDocsBase('/zh/get-started/setup/cloud')}>
+    <a className="ch-install-cloud-cta ch-install-cloud-cta-secondary" href="/zh/get-started/setup/cloud">
       阅读快速入门教程
     </a>
   </div>


### PR DESCRIPTION
The Cloud quickstart card added the docs mount twice, producing a `/docs/docs/...` URL and a 404. Restore the site-relative route so the docs host applies its mount exactly once.

Apply the same correction to localized installation cards, and keep the focused quickstart checker aligned with the rendered link.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118107&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118107](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118107+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.711` (included in `26.9` and later)
<!-- ch-version-info:end -->