### PR TITLE
Do not schedule the unit bugfix validation when the functional or integration one owns the verdict

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -491,6 +491,19 @@ def should_skip_job(job_name):
     ):
         return True, "Skipped, no integration tests updates"
 
+    # When the PR carries a functional or integration test, `new_tests_check.check`
+    # decides the bug fix on the per-arch validators for those and returns before it
+    # reads the unit validator, so a merge-base unit build has no verdict to contribute.
+    if (
+        _is_bugfix_pr()
+        and job_name == JobNames.BUGFIX_VALIDATE_UT
+        and (
+            has_new_functional_tests(_info_cache.get_changed_files())
+            or has_new_integration_tests(_info_cache.get_changed_files())
+        )
+    ):
+        return True, "Skipped, the functional/integration bugfix validation owns the verdict"
+
     # skip AMD perf tests for non-performance update (ARM runs by default)
     if (
         " Performance Improvement" not in _info_cache.pr_body


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117894

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

On a bug-fix PR whose reproducer is an SQL or integration test, `Bugfix validation (unit tests)`
reports a red check the author cannot clear when the PR also touches a gtest file for scoping:

    Failed to reproduce the bug.
    Touched unit tests on the before-binary (must fail): fail: 0, passed: 1

Master's gtest suite is green, so such a file passes on the merge base by construction.

`new_tests_check.check` is mutually exclusive on the functional/integration-vs-rest axis by
design: it returns inside its `has_ft or has_it` branch (`new_tests_check.py:230-242`), so the
branch that reads the unit validator (`:251`) is unreachable whenever the PR carries such a test.
`filter_job.should_skip_job` already declines the functional arms when a PR changes no functional
test, and the integration arms likewise, but had none for the unit one. So it scheduled a
merge-base `unit_tests_dbms` build whose verdict nothing reads, and a `FAIL` there exits 1.

This adds the missing arm, reusing the predicates the consumer branches on.

Measured over 60 days of CI DB records:

* **9** false reds removed on 9 PRs (8 other contributors', 3 merged with the red on them)
* **~553** merge-base `unit_tests_dbms` builds no longer started
* **244** "Bug reproduced" reports, on 66 PRs, no longer emitted

Those 244 are genuine reproductions, but the gate never reads them and each such PR is validated by
its functional or integration arm. The 7 events on 4 PRs where the unit arm *is* the gate are
untouched.

The repo has no test harness for `ci/jobs/**`. Validation is a matrix calling `should_skip_job`
on the real base-diff file lists of 13 carrier PRs: 9 skip, and the 4 unit-only ones keep
refuting.

If you would rather it kept running and abstained, that variant is ~12 lines in
`ci/jobs/unit_tests_bugfix_validation_job.py`, at the cost of a cacheable non-`FAIL` record; your
call.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118108&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118108](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118108+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
