### PR TITLE
Do not re-probe a PromQL selector that is known not to match a whole metric

### DIFF
--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -593,7 +593,7 @@ namespace
     /// costs at most a missed optimization.
     ///
     /// An entry is retired after a fixed number of uses, so a selector that becomes whole-metric
-    /// again is re-probed within that many queries of its shape.
+    /// again is re-probed on the next query of its shape once the entry is exhausted.
     class WholeMetricProbeNegativeMemo
     {
     public:
@@ -630,9 +630,13 @@ namespace
         void rememberCounterexampleFound(const UInt128 & key)
         {
             std::lock_guard lock{mutex};
+            /// Never raises an existing count: a probe that completes late must not extend a reuse
+            /// window another query is already consuming.
+            if (remaining_uses.contains(key))
+                return;
             if (remaining_uses.size() >= MAX_ENTRIES)
                 remaining_uses.clear();
-            remaining_uses[key] = MAX_VERDICT_REUSES;
+            remaining_uses.emplace(key, MAX_VERDICT_REUSES);
         }
 
     private:

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -1,6 +1,8 @@
 #include <Storages/StorageTimeSeriesSelector.h>
 
 #include <Common/Exception.h>
+#include <Common/HashTable/Hash.h>
+#include <Common/SipHash.h>
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 #include <Columns/IColumn.h>
@@ -36,6 +38,9 @@
 #include <Storages/TimeSeries/TimeSeriesTagNames.h>
 #include <Storages/TimeSeries/splitTimeSeriesType.h>
 #include <Storages/TimeSeries/timeSeriesTypesToAST.h>
+
+#include <mutex>
+#include <unordered_map>
 
 
 namespace DB
@@ -579,6 +584,65 @@ namespace
             substituteMetricNameInPlace(child, metric_name_value);
     }
 
+    /// Remembers, per tags table and probe shape, that the probe of condition 4 below already found
+    /// a counterexample.
+    ///
+    /// Only that verdict is remembered, never its opposite: reusing it makes the caller return an
+    /// empty condition list, which adds no primary-key range and so can neither exclude a granule
+    /// nor reject a row. A remembered verdict therefore needs no invalidation, and a key collision
+    /// costs at most a missed optimization.
+    ///
+    /// An entry is retired after a fixed number of uses, so a selector that becomes whole-metric
+    /// again is re-probed within that many queries of its shape.
+    class WholeMetricProbeNegativeMemo
+    {
+    public:
+        static WholeMetricProbeNegativeMemo & instance()
+        {
+            static WholeMetricProbeNegativeMemo memo;
+            return memo;
+        }
+
+        static UInt128 makeKey(const StorageID & tags_table_id, const IASTHash & probe_shape_hash)
+        {
+            SipHash hash;
+            hash.update(tags_table_id.uuid);
+            hash.update(tags_table_id.database_name);
+            hash.update('\0');
+            hash.update(tags_table_id.table_name);
+            hash.update('\0');
+            hash.update(probe_shape_hash.low64);
+            hash.update(probe_shape_hash.high64);
+            return hash.get128();
+        }
+
+        bool tryUseCounterexampleFound(const UInt128 & key)
+        {
+            std::lock_guard lock{mutex};
+            auto it = remaining_uses.find(key);
+            if (it == remaining_uses.end())
+                return false;
+            if (--it->second == 0)
+                remaining_uses.erase(it);
+            return true;
+        }
+
+        void rememberCounterexampleFound(const UInt128 & key)
+        {
+            std::lock_guard lock{mutex};
+            if (remaining_uses.size() >= MAX_ENTRIES)
+                remaining_uses.clear();
+            remaining_uses[key] = MAX_VERDICT_REUSES;
+        }
+
+    private:
+        static constexpr size_t MAX_VERDICT_REUSES = 31;
+        static constexpr size_t MAX_ENTRIES = 16384;
+
+        std::mutex mutex;
+        std::unordered_map<UInt128, size_t, UInt128Hash> remaining_uses TSA_GUARDED_BY(mutex);
+    };
+
     /// Checks whether the selector can carry a primary-key range on the samples table's `id`
     /// column covering the whole metric, and makes the two range conditions if it can.
     ///
@@ -707,6 +771,15 @@ namespace
                     "or", makeASTFunction("not", makeASTForLogicalAnd(std::move(other_matcher_asts))), std::move(counterexample));
             }
 
+            const UInt128 memo_key
+                = WholeMetricProbeNegativeMemo::makeKey(tags_table_id, counterexample->getTreeHash(/*ignore_aliases=*/true));
+            if (WholeMetricProbeNegativeMemo::instance().tryUseCounterexampleFound(memo_key))
+            {
+                LOG_DEBUG(log, "Keeping the id set condition for index analysis: reusing a recent whole-metric probe result for metric {}",
+                          quoteString(metric_name));
+                return {};
+            }
+
             PrometheusQueryTree::MatcherList name_matcher_only{*name_matcher};
             ASTPtr probe_where = makeASTForLogicalAnd(
                 {makeWhereFilterForTagsTable(name_matcher_only, column_name_by_tag_name, min_time_to_filter_ids, max_time_to_filter_ids, timestamp_data_type),
@@ -749,7 +822,10 @@ namespace
                 while (executor.pull(block))
                 {
                     if (block.rows() > 0)
+                    {
+                        WholeMetricProbeNegativeMemo::instance().rememberCounterexampleFound(memo_key);
                         return {};
+                    }
                 }
             }
             catch (...)

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -775,8 +775,8 @@ namespace
                 = WholeMetricProbeNegativeMemo::makeKey(tags_table_id, counterexample->getTreeHash(/*ignore_aliases=*/true));
             if (WholeMetricProbeNegativeMemo::instance().tryUseCounterexampleFound(memo_key))
             {
-                LOG_DEBUG(log, "Keeping the id set condition for index analysis: reusing a recent whole-metric probe result for metric {}",
-                          quoteString(metric_name));
+                LOG_DEBUG(log, "Keeping the id set condition for index analysis: reusing a remembered whole-metric probe result for metric {} of tags table {}",
+                          quoteString(metric_name), tags_table_id.getNameForLogs());
                 return {};
             }
 

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
@@ -11,7 +11,7 @@ wide window falls back: 0
 a different shape on the same table still emits the range: 1
 narrow window reuses that verdict: 1
 reuse returns the same rows: 1
-probed again within 40 queries: 1
+probed again within 35 queries: 1
 plan builds that reused the verdict before the re-probe: 31
 rows unchanged after the verdict was retired: 1
 rows in the narrow window:

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
@@ -8,6 +8,7 @@ both series are returned:
 -- B. a reused verdict is retired after a bounded number of uses
 narrow window is whole-metric on its own probe: 1
 wide window falls back: 0
+a different shape on the same table still emits the range: 1
 narrow window reuses that verdict: 1
 reuse returns the same rows: 1
 probed again within 40 queries: 1
@@ -19,3 +20,4 @@ rows in the narrow window:
 -- C. reuse skips the probe's work, not just its emitted range
 reuse reads fewer marks than the probe: 1
 the reusing query still reads marks of its own: 1
+the same shape on a different table still emits the range: 1

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
@@ -10,9 +10,12 @@ narrow window is whole-metric on its own probe: 1
 wide window falls back: 0
 narrow window reuses that verdict: 1
 reuse returns the same rows: 1
-probed again within 200 queries: 1
-the verdict was reused at least once before that: 1
+probed again within 40 queries: 1
+plan builds that reused the verdict before the re-probe: 31
 rows unchanged after the verdict was retired: 1
 rows in the narrow window:
 1970-01-01 00:01:40.000	1
 1970-01-01 00:02:30.000	10
+-- C. reuse skips the probe's work, not just its emitted range
+reuse reads fewer marks than the probe: 1
+the reusing query still reads marks of its own: 1

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.reference
@@ -1,0 +1,18 @@
+-- A. the whole-metric verdict is not reused after an out-of-range series appears
+range emitted while the selector matches the whole metric: 1
+the two series have distinct first id components: 1
+range emitted after the out-of-range series appeared: 0
+both series are returned:
+1970-01-01 00:01:40.000	1
+1970-01-01 00:03:20.000	2
+-- B. a reused verdict is retired after a bounded number of uses
+narrow window is whole-metric on its own probe: 1
+wide window falls back: 0
+narrow window reuses that verdict: 1
+reuse returns the same rows: 1
+probed again within 200 queries: 1
+the verdict was reused at least once before that: 1
+rows unchanged after the verdict was retired: 1
+rows in the narrow window:
+1970-01-01 00:01:40.000	1
+1970-01-01 00:02:30.000	10

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
@@ -99,6 +99,10 @@ ROWS_FRESH=$(selector_rows ts_b "$NARROW_SELECTOR" 0 200)
 # The wide window makes the failing series time-eligible, so the probe finds a counterexample.
 echo "wide window falls back: $(has_id_range ts_b "$NARROW_SELECTOR" 0 1000)"
 
+# A different shape on the same table: the entry stored above is for the regex shape, so this
+# bare-metric selector must still probe and still emit the range.
+echo "a different shape on the same table still emits the range: $(has_id_range ts_b foo 0 200)"
+
 echo "narrow window reuses that verdict: $([ "$(has_id_range ts_b "$NARROW_SELECTOR" 0 200)" = 0 ] && echo 1 || echo 0)"
 echo "reuse returns the same rows: $([ "$(selector_rows ts_b "$NARROW_SELECTOR" 0 200)" = "$ROWS_FRESH" ] && echo 1 || echo 0)"
 
@@ -147,5 +151,10 @@ MARKS_REUSED=$(marks_of 05076_probe_2)
 echo "reuse reads fewer marks than the probe: $([ "$MARKS_PROBED" -gt "$MARKS_REUSED" ] && echo 1 || echo 0)"
 # Positive control: without it two zeros - a query that read nothing at all - would also pass above.
 echo "the reusing query still reads marks of its own: $([ "$MARKS_REUSED" -gt 0 ] && echo 1 || echo 0)"
+
+# The same shape on a different table: scenario C's entry is for ts_c, so the identical selector
+# on ts_b must still probe. In this window only the matching series is time-eligible, so its own
+# probe finds no counterexample and the range is emitted.
+echo "the same shape on a different table still emits the range: $(has_id_range ts_b 'foo{env="prod"}' 0 120)"
 
 $CH -q "DROP TABLE ts_c SYNC; DROP TABLE ts_b SYNC; DROP TABLE ts_a SYNC;"

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, long
 # no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+# long: scenario B observes one verdict use per plan build, so it needs as many plan builds as the
+# reuse bound, and a timeSeriesSelector plan build costs seconds on a sanitizer build.
 
 # `timeSeriesSelector` gates its whole-metric primary-key range on a probe query over the tags
 # table, and the probe's counterexample-found verdict is reused for a bounded number of later
@@ -107,8 +109,9 @@ echo "narrow window reuses that verdict: $([ "$(has_id_range ts_b "$NARROW_SELEC
 echo "reuse returns the same rows: $([ "$(selector_rows ts_b "$NARROW_SELECTOR" 0 200)" = "$ROWS_FRESH" ] && echo 1 || echo 0)"
 
 # Build the plan repeatedly in one call and find the first query that is probed again. A verdict
-# that never expires would keep every value at 0.
-MAX_USES=40
+# that never expires would keep every value at 0. Each iteration is a plan build, the dominant cost
+# here, so this stays just above the two uses already spent plus the reuse bound.
+MAX_USES=35
 VERDICTS=$($CH -q "$(for _ in $(seq 1 $MAX_USES); do has_id_range_query ts_b "$NARROW_SELECTOR" 0 200; done)" | tr -d '\n')
 REUSED_IN_LOOP=${VERDICTS%%1*}
 echo "probed again within $MAX_USES queries: $([ "$REUSED_IN_LOOP" != "$VERDICTS" ] && echo 1 || echo 0)"

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
@@ -23,7 +23,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-CH="${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table 1 --session_timezone UTC"
+# The test runner can enable the query result cache, and its key ignores `log_comment`. Every
+# scenario below needs a byte-identical query to answer differently the second time, which a cache
+# hit defeats. On `$CH` so it also covers statements a later scenario adds.
+CH="${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table 1 --session_timezone UTC --use_query_cache 0"
 
 # Scenario B counts statements to count verdict uses, which needs one plan build per statement. A
 # non-zero `automatic_parallel_replicas_mode` builds a second complete plan to decide whether

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+
+# `timeSeriesSelector` gates its whole-metric primary-key range on a probe query over the tags
+# table, and the probe's counterexample-found verdict is reused for a bounded number of later
+# queries of the same shape. Two properties of that reuse are checked here.
+#
+# A. The opposite verdict is never reused. A selector that matches the whole metric today stops
+#    matching it once a series is written with an id outside the metric's range; reusing the old
+#    verdict would keep emitting the range, which filters the out-of-range series out of the result.
+# B. A reused verdict is retired after a bounded number of uses, so a selector that becomes
+#    whole-metric again is probed again. The reuse key excludes the query's time bounds, so a
+#    narrowed window - whose own probe finds no counterexample - reuses the entry until it expires;
+#    that is what this scenario uses to make the retirement observable.
+#
+# The range conditions carry the max-UUID literal, which is how the emission is detected below.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CH="${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table 1 --session_timezone UTC"
+
+# Prints 1 if the built plan carries the whole-metric id range, 0 otherwise. Each call builds the
+# plan once, i.e. consumes exactly one probe verdict.
+has_id_range_query() {
+    echo "SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%'
+          FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
+                FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector($1, '$2', $3, $4)));"
+}
+
+has_id_range() {
+    $CH -q "$(has_id_range_query "$1" "$2" "$3" "$4")"
+}
+
+selector_rows() {
+    $CH -q "SELECT timestamp, value FROM timeSeriesSelector($1, '$2', $3, $4) ORDER BY value, timestamp;"
+}
+
+echo "-- A. the whole-metric verdict is not reused after an out-of-range series appears"
+
+$CH -q "
+DROP TABLE IF EXISTS ts_a SYNC;
+CREATE TABLE ts_a ENGINE = TimeSeries TAGS INNER COLUMNS (id Tuple(UInt64, UUID));
+INSERT INTO ts_a (metric_name, tags, time_series) VALUES ('foo', map('env', 'a'), [(toDateTime64(100, 3), 1.)]);
+"
+
+# The selector matches the whole metric, so the range is emitted. This verdict must not be reused.
+echo "range emitted while the selector matches the whole metric: $(has_id_range ts_a foo 0 1000)"
+
+# The setting overrides the tags-table `id` column DEFAULT, so this series gets an id whose first
+# component is not the metric's; resetting it restores the canonical generator, which is what the
+# probe requires before it runs at all.
+$CH -q "
+ALTER TABLE ts_a MODIFY SETTING id_generator = 'tuple(sipHash64(tags), reinterpretAsUUID(sipHash128(metric_name, tags)))';
+INSERT INTO ts_a (metric_name, tags, time_series) VALUES ('foo', map('env', 'b'), [(toDateTime64(200, 3), 2.)]);
+ALTER TABLE ts_a RESET SETTING id_generator;
+"
+
+echo "the two series have distinct first id components: $($CH -q "
+    SELECT uniqExact(tupleElement(id, 1)) = 2 FROM \`.inner_id.tags.$($CH -q "SELECT uuid FROM system.tables WHERE database = currentDatabase() AND name = 'ts_a'")\`;")"
+
+echo "range emitted after the out-of-range series appeared: $(has_id_range ts_a foo 0 1000)"
+echo "both series are returned:"
+selector_rows ts_a foo 0 1000
+
+echo "-- B. a reused verdict is retired after a bounded number of uses"
+
+$CH -q "
+DROP TABLE IF EXISTS ts_b SYNC;
+CREATE TABLE ts_b ENGINE = TimeSeries TAGS INNER COLUMNS (id Tuple(UInt64, UUID));
+INSERT INTO ts_b (metric_name, tags, time_series) VALUES
+    ('foo', map('env', 'prod'), [(toDateTime64(100, 3), 1.)]),
+    ('foo', map('env', 'dev'), [(toDateTime64(150, 3), 10.)]),
+    ('foo', map('env', 'stag'), [(toDateTime64(900, 3), 99.)]);
+"
+
+NARROW_SELECTOR='foo{env=~"prod|dev"}'
+
+# Sensitivity control: in the narrow window the series that fails the matcher is not time-eligible,
+# so this selector's own probe finds no counterexample and the range IS emitted. Without this the
+# rest of the scenario could not tell reuse from a genuinely non-whole-metric selector.
+echo "narrow window is whole-metric on its own probe: $(has_id_range ts_b "$NARROW_SELECTOR" 0 200)"
+
+ROWS_FRESH=$(selector_rows ts_b "$NARROW_SELECTOR" 0 200)
+
+# The wide window makes the failing series time-eligible, so the probe finds a counterexample.
+echo "wide window falls back: $(has_id_range ts_b "$NARROW_SELECTOR" 0 1000)"
+
+echo "narrow window reuses that verdict: $([ "$(has_id_range ts_b "$NARROW_SELECTOR" 0 200)" = 0 ] && echo 1 || echo 0)"
+echo "reuse returns the same rows: $([ "$(selector_rows ts_b "$NARROW_SELECTOR" 0 200)" = "$ROWS_FRESH" ] && echo 1 || echo 0)"
+
+# Build the plan repeatedly in one call and find the first query that is probed again. A verdict
+# that never expires would keep every value at 0.
+MAX_USES=200
+VERDICTS=$($CH -q "$(for _ in $(seq 1 $MAX_USES); do has_id_range_query ts_b "$NARROW_SELECTOR" 0 200; done)" | tr -d '\n')
+echo "probed again within $MAX_USES queries: $([ "${VERDICTS%%1*}" != "$VERDICTS" ] && echo 1 || echo 0)"
+echo "the verdict was reused at least once before that: $([ "${VERDICTS:0:1}" = 0 ] && echo 1 || echo 0)"
+echo "rows unchanged after the verdict was retired: $([ "$(selector_rows ts_b "$NARROW_SELECTOR" 0 200)" = "$ROWS_FRESH" ] && echo 1 || echo 0)"
+echo "rows in the narrow window:"
+echo "$ROWS_FRESH"
+
+$CH -q "DROP TABLE ts_b SYNC; DROP TABLE ts_a SYNC;"

--- a/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
+++ b/tests/queries/0_stateless/05076_time_series_selector_whole_metric_probe_memo.sh
@@ -4,7 +4,7 @@
 
 # `timeSeriesSelector` gates its whole-metric primary-key range on a probe query over the tags
 # table, and the probe's counterexample-found verdict is reused for a bounded number of later
-# queries of the same shape. Two properties of that reuse are checked here.
+# queries of the same shape. Three properties of that reuse are checked here.
 #
 # A. The opposite verdict is never reused. A selector that matches the whole metric today stops
 #    matching it once a series is written with an id outside the metric's range; reusing the old
@@ -13,6 +13,9 @@
 #    whole-metric again is probed again. The reuse key excludes the query's time bounds, so a
 #    narrowed window - whose own probe finds no counterexample - reuses the entry until it expires;
 #    that is what this scenario uses to make the retirement observable.
+# C. Reuse skips the probe query itself. A and B read the emitted plan, which is the same whether
+#    the probe ran or its result was reused, so on their own they would stay green for an
+#    implementation that probes and then discards the answer.
 #
 # The range conditions carry the max-UUID literal, which is how the emission is detected below.
 
@@ -22,12 +25,17 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 CH="${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table 1 --session_timezone UTC"
 
+# Scenario B counts statements to count verdict uses, which needs one plan build per statement. A
+# non-zero `automatic_parallel_replicas_mode` builds a second complete plan to decide whether
+# parallel replicas pay off, and that second build consumes a second use of the same verdict.
+ONE_PLAN_BUILD='SETTINGS automatic_parallel_replicas_mode = 0'
+
 # Prints 1 if the built plan carries the whole-metric id range, 0 otherwise. Each call builds the
 # plan once, i.e. consumes exactly one probe verdict.
 has_id_range_query() {
     echo "SELECT plan LIKE '%ffffffff-ffff-ffff-ffff-ffffffffffff%'
           FROM (SELECT arrayStringConcat(groupArray(explain), '\n') AS plan
-                FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector($1, '$2', $3, $4)));"
+                FROM (EXPLAIN actions = 1 SELECT sum(value) FROM timeSeriesSelector($1, '$2', $3, $4) $ONE_PLAN_BUILD));"
 }
 
 has_id_range() {
@@ -35,7 +43,7 @@ has_id_range() {
 }
 
 selector_rows() {
-    $CH -q "SELECT timestamp, value FROM timeSeriesSelector($1, '$2', $3, $4) ORDER BY value, timestamp;"
+    $CH -q "SELECT timestamp, value FROM timeSeriesSelector($1, '$2', $3, $4) ORDER BY value, timestamp $ONE_PLAN_BUILD;"
 }
 
 echo "-- A. the whole-metric verdict is not reused after an out-of-range series appears"
@@ -93,12 +101,48 @@ echo "reuse returns the same rows: $([ "$(selector_rows ts_b "$NARROW_SELECTOR" 
 
 # Build the plan repeatedly in one call and find the first query that is probed again. A verdict
 # that never expires would keep every value at 0.
-MAX_USES=200
+MAX_USES=40
 VERDICTS=$($CH -q "$(for _ in $(seq 1 $MAX_USES); do has_id_range_query ts_b "$NARROW_SELECTOR" 0 200; done)" | tr -d '\n')
-echo "probed again within $MAX_USES queries: $([ "${VERDICTS%%1*}" != "$VERDICTS" ] && echo 1 || echo 0)"
-echo "the verdict was reused at least once before that: $([ "${VERDICTS:0:1}" = 0 ] && echo 1 || echo 0)"
+REUSED_IN_LOOP=${VERDICTS%%1*}
+echo "probed again within $MAX_USES queries: $([ "$REUSED_IN_LOOP" != "$VERDICTS" ] && echo 1 || echo 0)"
+echo "plan builds that reused the verdict before the re-probe: $(( 2 + ${#REUSED_IN_LOOP} ))"
 echo "rows unchanged after the verdict was retired: $([ "$(selector_rows ts_b "$NARROW_SELECTOR" 0 200)" = "$ROWS_FRESH" ] && echo 1 || echo 0)"
 echo "rows in the narrow window:"
 echo "$ROWS_FRESH"
 
-$CH -q "DROP TABLE ts_b SYNC; DROP TABLE ts_a SYNC;"
+echo "-- C. reuse skips the probe's work, not just its emitted range"
+
+# Its own table, so this scenario cannot consume the reuse budget scenario B measures.
+$CH -q "
+DROP TABLE IF EXISTS ts_c SYNC;
+CREATE TABLE ts_c ENGINE = TimeSeries TAGS INNER COLUMNS (id Tuple(UInt64, UUID));
+INSERT INTO ts_c (metric_name, tags, time_series) VALUES
+    ('foo', map('env', 'prod'), [(toDateTime64(100, 3), 1.)]),
+    ('foo', map('env', 'dev'), [(toDateTime64(150, 3), 10.)]);
+"
+
+# The series that fails the matcher is time-eligible, so the probe finds a counterexample and both
+# queries fall back to the id set condition. The query text is identical and the data does not
+# change between them, so their plans and their own reads are identical and the whole difference in
+# marks is the probe's read of the tags table - which the second query must not repeat.
+for comment in 05076_probe_1 05076_probe_2; do
+    $CH --log_comment "$comment" -q \
+        "SELECT sum(value) FROM timeSeriesSelector(ts_c, 'foo{env=\"prod\"}', 0, 1000) FORMAT Null"
+done
+
+$CH -q "SYSTEM FLUSH LOGS query_log;"
+
+marks_of() {
+    $CH -q "SELECT ProfileEvents['SelectedMarks'] FROM system.query_log
+            WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND is_initial_query
+                  AND log_comment = '$1'
+            ORDER BY event_time_microseconds DESC LIMIT 1;"
+}
+MARKS_PROBED=$(marks_of 05076_probe_1)
+MARKS_REUSED=$(marks_of 05076_probe_2)
+
+echo "reuse reads fewer marks than the probe: $([ "$MARKS_PROBED" -gt "$MARKS_REUSED" ] && echo 1 || echo 0)"
+# Positive control: without it two zeros - a query that read nothing at all - would also pass above.
+echo "the reusing query still reads marks of its own: $([ "$MARKS_REUSED" -gt 0 ] && echo 1 || echo 0)"
+
+$CH -q "DROP TABLE ts_c SYNC; DROP TABLE ts_b SYNC; DROP TABLE ts_a SYNC;"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/117956

A PromQL instant selector over a `TimeSeries` table can carry a continuous primary-key range on the samples table's `id` when it matches a whole metric. The last gate is a `SELECT 1 ... LIMIT 1` probe on the tags table, which `tryMakeWholeMetricIDRangeConditions` builds and runs synchronously once per selector, mid-planning. When the selector does not match a whole metric the probe finds a counterexample and the function emits exactly the SQL that #114131 replaced, so a dashboard re-evaluating that selector every 15-30 s pays #114131's "~2-4 ms each" for nothing.

This remembers the counterexample-found verdict only, per tags table and probe shape, and reuses it for at most 31 further plan builds before probing again. A reused verdict returns an empty condition list, which adds no primary-key range and so can neither exclude a granule nor reject a row, and needs no invalidation. The opposite verdict is never remembered: it does change which granules are read, so reusing it after a series is written with an id outside the metric's range would drop that series' rows.

The whole price is those 31 plan builds without the range, paid by a selector that becomes whole-metric again and by a narrower window of the same selector - the key omits the query's time bounds, which is what lets a recording rule at `now()` hit the entry.

On a Debug build, 64 interleaved executions per side: for a non-firing selector the median plan build drops 9193 -> 4481 us as the probe's tags-table read disappears, `SelectedMarks` 38 instead of 46 on 61 of 63 executions and 46 on the two that re-probe, 32 apart. A whole-metric selector still probes: both exact counters at ratio 1.0000, results byte-identical either way. The 5.3-16.9% in the report measures a whole-metric selector, which this leaves alone.


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

A PromQL instant selector over a `TimeSeries` table that does not match a whole metric no longer re-runs, on every query, the tags-table probe that established that. The probe's result is reused for a bounded number of later queries of the same selector shape and re-checked after that, so a dashboard or recording rule repeatedly evaluating such a selector no longer pays for the probe during query planning. Only that result is ever remembered, so the optimization it gates is never applied on the strength of a remembered verdict. Query results are unchanged.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118116&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118116](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118116+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
