### PR TITLE
Revert "Revert "Fix ALTER of a TimeSeries table dropping the other settings""

### DIFF
--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -168,6 +168,11 @@ StorageTimeSeries::StorageTimeSeries(
         *normalized_create_query->columns_list->columns, local_context, mode);
     storage_metadata.setColumns(normalized_columns);
 
+    /// The metadata must carry the whole `SETTINGS` clause because a settings alter changes that clause
+    /// and the result replaces the one in the create query.
+    if (normalized_create_query->storage && normalized_create_query->storage->settings)
+        storage_metadata.setSettingsChanges(normalized_create_query->storage->settings->clone());
+
     if (!comment.empty())
         storage_metadata.setComment(comment);
     storage_metadata.setVirtuals(createVirtuals());
@@ -524,7 +529,7 @@ void StorageTimeSeries::alter(const AlterCommands & params, ContextPtr local_con
     {
         chassert(new_metadata.settings_changes);
         /// Round-trip through `TimeSeriesSettings` to validate the names/values and
-        /// to drop entries that equal to the defaults.
+        /// to write them back in a canonical form.
         new_settings = std::make_unique<TimeSeriesSettings>();
         new_settings->applyChanges(new_metadata.settings_changes->as<const ASTSetQuery &>().changes);
         checkTimeSeriesSettings(*new_settings);
@@ -1176,6 +1181,7 @@ Two settings can be changed after `CREATE`:
 ```sql
 ALTER TABLE my_table MODIFY SETTING id_generator = 'sipHash64(tags)';
 ALTER TABLE my_table MODIFY SETTING filter_by_min_time_and_max_time = 0;
+ALTER TABLE my_table RESET SETTING filter_by_min_time_and_max_time;
 ```
 
 Note that changing `id_generator` while data is already in the tags table can produce different IDs for the same metric+tag combination — old rows keep their old IDs, new rows use the new generator.

--- a/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.reference
+++ b/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.reference
@@ -1,0 +1,15 @@
+-- the `SETTINGS` clause after `CREATE`
+['filter_by_min_time_and_max_time','recent_samples_ttl_seconds','samples_index_granularity','store_min_time_and_max_time','tags_to_columns']
+-- `MODIFY SETTING` adds the altered setting and keeps the other ones
+['filter_by_min_time_and_max_time','id_generator','recent_samples_ttl_seconds','samples_index_granularity','store_min_time_and_max_time','tags_to_columns']
+-- `tags_to_columns` survives the alter, so the dedicated column is still filled
+m1	j1
+m2	j2
+-- the settings are kept in the metadata too, so they still apply after a reload
+['filter_by_min_time_and_max_time','id_generator','recent_samples_ttl_seconds','samples_index_granularity','store_min_time_and_max_time','tags_to_columns']
+m1	j1
+m2	j2
+m3	j3
+-- `MODIFY SETTING` sees the other settings, so a conflicting value is rejected
+-- `RESET SETTING` removes only the reset setting
+['id_generator','recent_samples_ttl_seconds','samples_index_granularity','store_min_time_and_max_time','tags_to_columns']

--- a/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.sql
+++ b/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.sql
@@ -1,5 +1,7 @@
--- Tags: no-replicated-database
+-- Tags: no-replicated-database, no-parallel-replicas
 -- Tag no-replicated-database: plain `DETACH TABLE` is not allowed there, only `DETACH TABLE PERMANENTLY`.
+-- Tag no-parallel-replicas: the initiator sends the argument of `timeSeriesTags` to the replicas unqualified,
+-- so they look the table up in the `default` database, see https://github.com/ClickHouse/ClickHouse/issues/118130.
 
 SET allow_experimental_time_series_table = 1;
 

--- a/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.sql
+++ b/tests/queries/0_stateless/05057_time_series_alter_setting_keeps_other_settings.sql
@@ -1,0 +1,47 @@
+-- Tags: no-replicated-database
+-- Tag no-replicated-database: plain `DETACH TABLE` is not allowed there, only `DETACH TABLE PERMANENTLY`.
+
+SET allow_experimental_time_series_table = 1;
+
+DROP TABLE IF EXISTS ts;
+
+CREATE TABLE ts ENGINE = TimeSeries
+SETTINGS tags_to_columns = {'job': 'job'}, store_min_time_and_max_time = 0,
+         filter_by_min_time_and_max_time = 0, samples_index_granularity = 1024;
+
+INSERT INTO ts (metric_name, tags, time_series) VALUES ('m1', {'job': 'j1'}, [(1, 1.)]);
+
+-- The tests below print the names of the settings kept in the outer `SETTINGS` clause of the create
+-- query. That clause is the first line starting with `SETTINGS` of the formatted create query - the rest
+-- of the query describes the inner target tables and depends on the build configuration. The values are
+-- left out, they are checked through the behaviour of the table instead.
+SELECT '-- the `SETTINGS` clause after `CREATE`';
+SELECT arraySort(extractAll(arrayFirst(line -> line LIKE 'SETTINGS %', splitByChar('\n', formatQuery(create_table_query))), '([a-z_]+) = '))
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts';
+
+SELECT '-- `MODIFY SETTING` adds the altered setting and keeps the other ones';
+ALTER TABLE ts MODIFY SETTING id_generator = 'tuple(sipHash64(metric_name), toLowCardinality(reinterpretAsUUID(sipHash128(tags))))';
+SELECT arraySort(extractAll(arrayFirst(line -> line LIKE 'SETTINGS %', splitByChar('\n', formatQuery(create_table_query))), '([a-z_]+) = '))
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts';
+
+SELECT '-- `tags_to_columns` survives the alter, so the dedicated column is still filled';
+INSERT INTO ts (metric_name, tags, time_series) VALUES ('m2', {'job': 'j2'}, [(2, 2.)]);
+SELECT metric_name, job FROM timeSeriesTags(ts) ORDER BY metric_name;
+
+SELECT '-- the settings are kept in the metadata too, so they still apply after a reload';
+DETACH TABLE ts;
+ATTACH TABLE ts;
+SELECT arraySort(extractAll(arrayFirst(line -> line LIKE 'SETTINGS %', splitByChar('\n', formatQuery(create_table_query))), '([a-z_]+) = '))
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts';
+INSERT INTO ts (metric_name, tags, time_series) VALUES ('m3', {'job': 'j3'}, [(3, 3.)]);
+SELECT metric_name, job FROM timeSeriesTags(ts) ORDER BY metric_name;
+
+SELECT '-- `MODIFY SETTING` sees the other settings, so a conflicting value is rejected';
+ALTER TABLE ts MODIFY SETTING filter_by_min_time_and_max_time = 1; -- { serverError INVALID_SETTING_VALUE }
+
+SELECT '-- `RESET SETTING` removes only the reset setting';
+ALTER TABLE ts RESET SETTING filter_by_min_time_and_max_time;
+SELECT arraySort(extractAll(arrayFirst(line -> line LIKE 'SETTINGS %', splitByChar('\n', formatQuery(create_table_query))), '([a-z_]+) = '))
+FROM system.tables WHERE database = currentDatabase() AND name = 'ts';
+
+DROP TABLE ts;


### PR DESCRIPTION
Re-lands https://github.com/ClickHouse/ClickHouse/pull/117693, which was reverted by https://github.com/ClickHouse/ClickHouse/pull/118118 because the stateless test it added failed in `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)`.

`StorageTimeSeries` did not keep the outer `SETTINGS` clause in its metadata, so a settings alter rebuilt the clause from the altered entry alone and dropped every other setting: after `ALTER TABLE ts MODIFY SETTING id_generator = ...`, an `INSERT` fails with `No such column min_time in table ...` because `store_min_time_and_max_time = 0` is gone, and `tags_to_columns` stops filling the dedicated columns.

The test failure is unrelated to that fix. The initiator converts a table node to a fully qualified `database.table`, but the argument of a table function is sent to the replicas as it was written, and the connection to a parallel replica carries no default database, so a replica looks `timeSeriesTags(ts)` up as `default.ts` and throws `UNKNOWN_TABLE`. With the default `parallel_replicas_local_plan = 1` the local replica usually takes all the mark ranges before the remote ones parse the query, which is why only that one job saw it. Qualifying the argument is not a way out either: the two-argument form then returns one copy of every row per replica, because no replica announces its parts to the coordinator when the read goes through a table function. The test is tagged `no-parallel-replicas` and both defects are reported separately.

Related: https://github.com/ClickHouse/ClickHouse/issues/118130
Related: https://github.com/ClickHouse/ClickHouse/pull/117693
Related: https://github.com/ClickHouse/ClickHouse/pull/118118

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `ALTER` of a `TimeSeries` table dropping the other settings.
