### PR TITLE
CI: resolve the perf release_base reference build under the legacy S3 prefix

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1288,32 +1288,43 @@ def parse_args():
     return parser.parse_args()
 
 
-def master_build_link(sha, build_type):
-    """Ask praktika where `MasterCI` published the build of master commit `sha`,
-    so that a later change of the prefix layout is picked up here for free."""
+def master_build_links(sha, build_type):
+    """Links to the build of master commit `sha`, newest layout first.
+
+    Ask praktika where `MasterCI` publishes builds now, so that a later change
+    of the prefix layout is picked up here for free. Commits older than
+    https://github.com/ClickHouse/ClickHouse/pull/110081 (2026-09) published
+    their builds one level up, without the normalized workflow name, and the
+    `release_base` baseline stays pinned to such a commit until the next release
+    branch is cut - keep probing the legacy path until then."""
     prefix = _Environment.get_s3_prefix_static(
         pr_number=0, branch="master", sha=sha, workflow_name="MasterCI"
     )
-    return f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/{prefix}/{build_type}/clickhouse"
+    legacy_prefix = f"REFs/master/{sha}"
+    return [
+        f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/{p}/{build_type}/clickhouse"
+        for p in (prefix, legacy_prefix)
+    ]
+
+
+def find_master_build(commits, build_type):
+    for sha in commits:
+        for link in master_build_links(sha, build_type):
+            if Shell.check(f"curl -sfI {link} > /dev/null"):
+                return link
+    return None
 
 
 def find_prev_build(info, build_type):
-    commits = info.get_kv_data("master_track_commits_sha") or []
-    for sha in commits:
-        link = master_build_link(sha, build_type)
-        if Shell.check(f"curl -sfI {link} > /dev/null"):
-            return link
-    return None
+    return find_master_build(
+        info.get_kv_data("master_track_commits_sha") or [], build_type
+    )
 
 
 def find_base_release_build(info, build_type):
     commits = info.get_kv_data("release_branch_base_sha_with_predecessors") or []
     assert commits, "No commits found to fetch reference build"
-    for sha in commits:
-        link = master_build_link(sha, build_type)
-        if Shell.check(f"curl -sfI {link} > /dev/null"):
-            return link
-    return None
+    return find_master_build(commits, build_type)
 
 
 # The number of distinct "slower" queries that fails the whole performance


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110081
Related: https://github.com/ClickHouse/ClickHouse/pull/117766

Every `Performance Comparison (release_base)` shard on MasterCI fails with `AssertionError: reference clickhouse build has not been found`: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=da918ab89c172a82dd31fbe1239e6c8db8b71c60&name_0=MasterCI

The `release_base` comparison resolves its reference build at the release branch point, currently `94a1553123bb29dd8e3a3f85d7052322428a27bd` (2026-08-24). That commit published its builds before build artifacts moved under the normalized workflow name, so only the legacy path exists:

```
403 REFs/master/94a1553.../masterci/build_arm_release/clickhouse
200 REFs/master/94a1553.../build_arm_release/clickhouse
```

None of the 20 candidate predecessor commits has a build under either layout, so the lookup exhausts the list and the job fails. It would keep failing on every master commit until the next release branch is cut. The `master_head` mode is unaffected because it walks recent master commits, which are all published under the new layout.

Probe the legacy prefix as well, newest layout first.

### Changelog category (leave one):
- CI Fix or Improvement

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118125&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118125](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118125+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.740` (included in `26.9` and later)
<!-- ch-version-info:end -->