### PR TITLE
Fix DPsize join reordering silently dropping single-table ON-clause filters

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinOrderDPSize.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrderDPSize.cpp
@@ -112,9 +112,9 @@ DPJoinEntryPtr DPSizeJoinOrderOptimizer::solve()
                         continue;
 
                     auto applicable_edge = getApplicableExpressions(query_graph, left->relations, right->relations);
-                    /// Only leave the edges that connect left and right.
-                    /// DPsize also includes non-connecting predicates (single-table filters) at the earliest
-                    /// stage (component_size == 2), unlike DPhyp which handles them separately via the hyperedge graph.
+                    /// Keep the edges that connect left and right, plus non-connecting single-table filters
+                    /// and constants, which DPsize attaches at the join that introduces their relation
+                    /// (unlike DPhyp, which handles them separately via the hyperedge graph).
                     std::vector<JoinActionRef *> edge;
                     for (auto & edge_it : applicable_edge)
                     {
@@ -123,14 +123,35 @@ DPJoinEntryPtr DPSizeJoinOrderOptimizer::solve()
                             LOG_TEST(log, "Adding predicate connecting {} and {} : {}", left->dump(), right->dump(), edge_it->dump());
                             edge.push_back(edge_it);
                         }
-                        else if ((edge_it->fromLeft() || edge_it->fromRight() || edge_it->fromNone()) && component_size == 2)
-                        {
-                            LOG_TEST(log, "Adding early non-connecting predicate for {} and {} : {}", left->dump(), right->dump(), edge_it->dump());
-                            edge.push_back(edge_it);
-                        }
                         else
                         {
-                            LOG_TEST(log, "Skipping non-connecting predicate for {} and {} : {}", left->dump(), right->dump(), edge_it->dump());
+                            /// Non-connecting predicate. A single-table filter (references exactly one
+                            /// relation) or a constant (references none) must still be applied; a predicate
+                            /// spanning two or more relations was already applied in a sub-join and is skipped.
+                            ///
+                            /// Attach a single-table filter at the join that introduces its relation (the
+                            /// side equal to that relation) so it filters as low as possible, and a constant
+                            /// at the earliest (component_size == 2) join. Two earlier conditions each
+                            /// silently dropped the predicate, changing the query result:
+                            ///   - `component_size == 2` drops the filter whenever its relation is introduced
+                            ///     against an already-multi-relation component (that step has size > 2).
+                            ///   - `fromLeft() || fromRight() || fromNone()` drops it for any single-table
+                            ///     filter on a relation whose id is >= 2, because `fromLeft`/`fromRight` test
+                            ///     relation ids 0 and 1 specifically (they describe the two inputs of a binary
+                            ///     join step, not "references a single relation").
+                            auto filter_rel = edge_it->getSourceRelations().getSingleBit();
+                            bool relation_introduced = filter_rel.has_value()
+                                && (left->relations.getSingleBit() == filter_rel || right->relations.getSingleBit() == filter_rel);
+                            bool constant_at_earliest_join = edge_it->fromNone() && component_size == 2;
+                            if (relation_introduced || constant_at_earliest_join)
+                            {
+                                LOG_TEST(log, "Adding non-connecting predicate for {} and {} : {}", left->dump(), right->dump(), edge_it->dump());
+                                edge.push_back(edge_it);
+                            }
+                            else
+                            {
+                                LOG_TEST(log, "Skipping non-connecting predicate for {} and {} : {}", left->dump(), right->dump(), edge_it->dump());
+                            }
                         }
                     }
 

--- a/tests/queries/0_stateless/05076_join_order_single_table_filter_placement.reference
+++ b/tests/queries/0_stateless/05076_join_order_single_table_filter_placement.reference
@@ -1,0 +1,12 @@
+filter deep relation greedy:
+0	Join_2_Value_0	0	Join_3_Value_0	0	Join_1_Value_0
+filter deep relation dpsize:
+0	Join_2_Value_0	0	Join_3_Value_0	0	Join_1_Value_0
+four way filter last greedy:
+0	0	0	0	Join_4_Value_0
+four way filter last dpsize:
+0	0	0	0	Join_4_Value_0
+two filters greedy:
+0	0	0
+two filters dpsize:
+0	0	0

--- a/tests/queries/0_stateless/05076_join_order_single_table_filter_placement.sql
+++ b/tests/queries/0_stateless/05076_join_order_single_table_filter_placement.sql
@@ -1,0 +1,88 @@
+-- Tests that a join-order algorithm keeps single-table filter predicates that live in a join's ON
+-- clause (e.g. `... JOIN t ON t.a = u.a AND t.b = 'x'`). The algorithm must attach such a predicate
+-- at the join that introduces its relation. Two earlier placement bugs silently dropped the
+-- predicate, letting extra rows through:
+--   1. attaching only at two-relation joins dropped it when the relation was introduced against an
+--      already-multi-relation subplan (e.g. `(t2 JOIN t3) JOIN t1`);
+--   2. gating on fromLeft()/fromRight() dropped it for any filter on a relation whose id is >= 2,
+--      because those helpers test relation ids 0 and 1 specifically.
+-- For each shape we print the result with the 'greedy' algorithm (the reference, which places the
+-- predicate correctly) and with 'dpsize'; the two must be identical row-for-row.
+--
+-- `query_plan_enable_optimizations = 0` is required to expose the bug and does NOT disable join
+-- reordering (that is controlled by `query_plan_optimize_join_order_algorithm`). It disables the
+-- general plan-optimization passes, notably filter push-down; with push-down enabled the
+-- single-table filter is applied independently of the join and masks the dropped ON-clause
+-- conjunct, so the wrong-result would not surface.
+--
+-- All joins are INNER: DPsize only reorders Inner joins (it bails out on outer joins), so an
+-- outer-join shape would fall back instead of exercising this path.
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+
+CREATE TABLE t1 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t2 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t3 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t4 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t1 VALUES (0, 'Join_1_Value_0'), (1, 'Join_1_Value_1'), (2, 'Join_1_Value_2');
+INSERT INTO t2 VALUES (0, 'Join_2_Value_0'), (1, 'Join_2_Value_1'), (3, 'Join_2_Value_3');
+INSERT INTO t3 VALUES (0, 'Join_3_Value_0'), (1, 'Join_3_Value_1'), (4, 'Join_3_Value_4');
+INSERT INTO t4 VALUES (0, 'Join_4_Value_0'), (1, 'Join_4_Value_1'), (5, 'Join_4_Value_5');
+
+SET enable_analyzer = 1;
+
+-- Filter on a relation that is introduced last, against an already-joined subplan (relation id >= 2).
+SELECT 'filter deep relation greedy:';
+SELECT t2.id, t2.value, t3.id, t3.value, t1.id, t1.value
+FROM t2 INNER JOIN t3 ON t2.id = t3.id
+INNER JOIN t1 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0' ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'greedy',
+         query_plan_enable_optimizations = 0;
+
+SELECT 'filter deep relation dpsize:';
+SELECT t2.id, t2.value, t3.id, t3.value, t1.id, t1.value
+FROM t2 INNER JOIN t3 ON t2.id = t3.id
+INNER JOIN t1 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0' ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize',
+         query_plan_enable_optimizations = 0;
+
+-- Four-way all-inner chain with the filter on the last relation (id = 3).
+SELECT 'four way filter last greedy:';
+SELECT t1.id, t2.id, t3.id, t4.id, t4.value
+FROM t1 INNER JOIN t2 ON t1.id = t2.id
+INNER JOIN t3 ON t2.id = t3.id
+INNER JOIN t4 ON t3.id = t4.id AND t4.value = 'Join_4_Value_0' ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'greedy',
+         query_plan_enable_optimizations = 0;
+
+SELECT 'four way filter last dpsize:';
+SELECT t1.id, t2.id, t3.id, t4.id, t4.value
+FROM t1 INNER JOIN t2 ON t1.id = t2.id
+INNER JOIN t3 ON t2.id = t3.id
+INNER JOIN t4 ON t3.id = t4.id AND t4.value = 'Join_4_Value_0' ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize',
+         query_plan_enable_optimizations = 0;
+
+-- Two single-table filters on different relations.
+SELECT 'two filters greedy:';
+SELECT t1.id, t2.id, t3.id
+FROM t1 INNER JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0'
+INNER JOIN t3 ON t2.id = t3.id AND t3.value = 'Join_3_Value_0' ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'greedy',
+         query_plan_enable_optimizations = 0;
+
+SELECT 'two filters dpsize:';
+SELECT t1.id, t2.id, t3.id
+FROM t1 INNER JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0'
+INNER JOIN t3 ON t2.id = t3.id AND t3.value = 'Join_3_Value_0' ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsize',
+         query_plan_enable_optimizations = 0;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP TABLE t4;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/111898
Related: https://github.com/ClickHouse/ClickHouse/pull/114629
Fixes: https://github.com/ClickHouse/ClickHouse/issues/116818

The `dpsize` join-order algorithm silently dropped single-table filter and constant predicates that live in a `JOIN ... ON` clause (e.g. `t1.value = 'x'`), returning extra rows. `greedy` places them correctly and was unaffected.

In the non-connecting-predicate branch of the DPsize enumeration, the placement condition `(fromLeft() || fromRight() || fromNone()) && component_size == 2` dropped such a predicate in two cases:

- `component_size == 2` dropped it whenever its relation was introduced against an already-multi-relation component (e.g. `(t2 JOIN t3) JOIN t1`), a step whose size is greater than two.
- `fromLeft() || fromRight()` dropped it for any single-table filter on a relation whose id is >= 2, because those helpers test relation ids 0 and 1 specifically (they describe the two inputs of a binary join step, not "references a single relation").

The predicate is now attached at the join that introduces its relation (the side equal to that relation), and pure constants at the earliest two-relation join. This mirrors the same fix for DPsub in #114629.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed `dpsize` join-order optimization (`query_plan_optimize_join_order_algorithm = 'dpsize'`) silently dropping single-table filter conditions from a `JOIN ... ON` clause, which could return extra rows.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118126&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118126](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118126+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.750` (included in `26.9` and later)
<!-- ch-version-info:end -->