### PR TITLE
Fix complex types schema evolution typos

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
@@ -168,7 +168,7 @@ std::vector<std::vector<size_t>> IIcebergSchemaTransform::traverseAllPaths(const
                         current_path.pop_back();
                         continue;
                     }
-                    auto next_val = std::get<Map>(current_value)[i];
+                    auto next_val = std::get<Map>(current_value)[i].safeGet<Tuple>()[1];
 
                     Tuple tmp_node_tuple;
                     Array tmp_node_array;
@@ -679,7 +679,8 @@ void ExecutableEvolutionFunction::pushNewNode(
         auto old_subfields = old_node->getObject("type")->getObject("element");
 
         if (current_path)
-            current_path->push_back({"", "", TransformType::ARRAY});
+            current_path->push_back(
+                {old_node->getValue<std::string>("name"), new_node->getValue<std::string>("name"), TransformType::STRUCT});
 
         walk_stack.push(
             {makeArrayFromObject(old_subfields),
@@ -694,7 +695,8 @@ void ExecutableEvolutionFunction::pushNewNode(
         auto subfields = new_node->getObject("type")->getObject("value");
         auto old_subfields = old_node->getObject("type")->getObject("value");
         if (current_path)
-            current_path->push_back({"", "", TransformType::MAP});
+            current_path->push_back(
+                {old_node->getValue<std::string>("name"), new_node->getValue<std::string>("name"), TransformType::STRUCT});
 
         walk_stack.push(
             {makeArrayFromObject(old_subfields),

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
@@ -9,7 +9,6 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.h>
 #include <base/defines.h>
-#include <Common/typeid_cast.h>
 #include <Poco/JSON/Array.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Stringifier.h>
@@ -22,7 +21,6 @@ namespace DB
 namespace ErrorCodes
 {
 extern const int BAD_ARGUMENTS;
-extern const int LOGICAL_ERROR;
 }
 
 namespace Iceberg
@@ -63,95 +61,6 @@ public:
 
     std::vector<size_t> permutation;
 };
-
-namespace
-{
-
-const DataTypeTuple & getTupleType(const DataTypePtr & type)
-{
-    const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get());
-    if (!tuple_type)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR,
-            "Expected Tuple while resolving an Iceberg schema evolution path, got {}",
-            type->getName());
-    return *tuple_type;
-}
-
-size_t getElementIndexInTuple(const DataTypeTuple & tuple_type, const String & element_name)
-{
-    const auto & element_names = tuple_type.getElementNames();
-    for (size_t i = 0; i < element_names.size(); ++i)
-    {
-        if (element_names[i] == element_name)
-            return i;
-    }
-    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in data", element_name);
-}
-
-DataTypePtr getArrayElementType(const DataTypePtr & type)
-{
-    const auto * array_type = typeid_cast<const DataTypeArray *>(type.get());
-    if (!array_type)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR,
-            "Expected Array while resolving an Iceberg schema evolution path, got {}",
-            type->getName());
-    return array_type->getNestedType();
-}
-
-DataTypePtr getMapValueType(const DataTypePtr & type)
-{
-    const auto * map_type = typeid_cast<const DataTypeMap *>(type.get());
-    if (!map_type)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR,
-            "Expected Map while resolving an Iceberg schema evolution path, got {}",
-            type->getName());
-    DataTypePtr key_value_type = getArrayElementType(map_type->getNestedType());
-    return getTupleType(key_value_type).getElement(1);
-}
-
-std::vector<int> resolveSchemaPath(
-    const std::vector<IcebergChangeSchemaOperation::Edge> & path, DataTypePtr & type, bool use_new_names)
-{
-    std::vector<int> index_path;
-    index_path.reserve(path.size());
-
-    for (const auto & edge : path)
-    {
-        switch (edge.parent_type)
-        {
-            case TransformType::STRUCT:
-            {
-                const String & element_name = use_new_names ? edge.new_path : edge.path;
-                const auto & tuple_type = getTupleType(type);
-                size_t element_index = getElementIndexInTuple(tuple_type, element_name);
-                DataTypePtr element_type = tuple_type.getElement(element_index);
-
-                index_path.push_back(static_cast<int>(element_index));
-                type = std::move(element_type);
-                break;
-            }
-            case TransformType::ARRAY:
-            {
-                index_path.push_back(-1);
-                type = getArrayElementType(type);
-                break;
-            }
-            case TransformType::MAP:
-            {
-                index_path.push_back(-1);
-                type = getMapValueType(type);
-                break;
-            }
-        }
-    }
-
-    return index_path;
-}
-
-}
 
 IIcebergSchemaTransform::IIcebergSchemaTransform(std::vector<IcebergChangeSchemaOperation::Edge> path_)
     : path(path_)
@@ -436,17 +345,60 @@ public:
         : IIcebergSchemaTransform(operation_.getPath())
         , operation(operation_)
     {
-        index_path = resolveSchemaPath(operation_.getPath(), old_type, false);
+        for (const auto & path : operation_.getPath())
+        {
+            switch (path.parent_type)
+            {
+                case TransformType::STRUCT:
+                {
+                    auto current_types = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElements();
+                    auto element_names = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElementNames();
 
-        const auto & element_names = getTupleType(old_type).getElementNames();
+                    size_t result_index = current_types.size();
+                    for (size_t i = 0; i < current_types.size(); ++i)
+                    {
+                        if (element_names[i] == path.path)
+                        {
+                            result_index = i;
+                            break;
+                        }
+                    }
+                    if (result_index == current_types.size())
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in data", path.path);
 
-        index_to_delete = element_names.size();
-        for (size_t i = 0; i < element_names.size(); ++i)
+                    index_path.push_back(static_cast<Int32>(result_index));
+                    old_type = current_types[result_index];
+                    break;
+                }
+                case TransformType::ARRAY:
+                {
+                    index_path.push_back(-1);
+                    old_type = std::static_pointer_cast<const DataTypeArray>(old_type)->getNestedType();
+                    break;
+                }
+                case TransformType::MAP:
+                {
+                    index_path.push_back(-1);
+                    old_type = std::static_pointer_cast<const DataTypeTuple>(
+                                   std::static_pointer_cast<const DataTypeArray>(
+                                       std::static_pointer_cast<const DataTypeMap>(old_type)->getNestedType())
+                                       ->getNestedType())
+                                   ->getElement(1);
+                    break;
+                }
+            }
+        }
+
+        auto current_types = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElements();
+        auto element_names = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElementNames();
+
+        index_to_delete = current_types.size();
+        for (size_t i = 0; i < current_types.size(); ++i)
         {
             if (element_names[permutation[i]] == operation.field_name)
                 index_to_delete = i;
         }
-        if (index_to_delete == element_names.size())
+        if (index_to_delete == current_types.size())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find field {} in data", operation.field_name);
     }
 
@@ -466,12 +418,75 @@ public:
         : IIcebergSchemaTransform(operation_.getPath())
         , operation(operation_)
     {
-        index_path = resolveSchemaPath(operation_.getPath(), old_type, false);
-        resolveSchemaPath(operation_.getPath(), type, true);
+        for (const auto & path : operation_.getPath())
+        {
+            switch (path.parent_type)
+            {
+                case TransformType::STRUCT:
+                {
+                    auto old_current_types = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElements();
+                    auto old_element_names = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElementNames();
 
-        const auto & tuple_type = getTupleType(type);
-        current_types = tuple_type.getElements();
-        const auto & element_names = tuple_type.getElementNames();
+                    size_t old_result_index = old_current_types.size();
+                    for (size_t i = 0; i < old_current_types.size(); ++i)
+                    {
+                        if (old_element_names[i] == path.path)
+                        {
+                            old_result_index = i;
+                            break;
+                        }
+                    }
+                    if (old_result_index == old_current_types.size())
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in old data", path.path);
+
+                    index_path.push_back(static_cast<Int32>(old_result_index));
+                    old_type = old_current_types[old_result_index];
+
+                    current_types = std::static_pointer_cast<const DataTypeTuple>(type)->getElements();
+                    auto element_names = std::static_pointer_cast<const DataTypeTuple>(type)->getElementNames();
+
+                    size_t result_index = current_types.size();
+                    for (size_t i = 0; i < current_types.size(); ++i)
+                    {
+                        if (element_names[i] == path.new_path)
+                        {
+                            result_index = i;
+                            break;
+                        }
+                    }
+                    if (result_index == current_types.size())
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in new data", path.new_path);
+
+                    type = current_types[result_index];
+                    break;
+                }
+                case TransformType::ARRAY:
+                {
+                    index_path.push_back(-1);
+                    old_type = std::static_pointer_cast<const DataTypeArray>(old_type)->getNestedType();
+                    type = std::static_pointer_cast<const DataTypeArray>(type)->getNestedType();
+                    break;
+                }
+                case TransformType::MAP:
+                {
+                    index_path.push_back(-1);
+                    old_type = std::static_pointer_cast<const DataTypeTuple>(
+                                   std::static_pointer_cast<const DataTypeArray>(
+                                       std::static_pointer_cast<const DataTypeMap>(old_type)->getNestedType())
+                                       ->getNestedType())
+                                   ->getElement(1);
+                    type = std::static_pointer_cast<const DataTypeTuple>(
+                               std::static_pointer_cast<const DataTypeArray>(
+                                   std::static_pointer_cast<const DataTypeMap>(type)->getNestedType())
+                                   ->getNestedType())
+                               ->getElement(1);
+                    break;
+                }
+            }
+        }
+
+        current_types = std::static_pointer_cast<const DataTypeTuple>(type)->getElements();
+        auto element_names = std::static_pointer_cast<const DataTypeTuple>(type)->getElementNames();
 
         index_to_insert = current_types.size();
         for (size_t i = 0; i < current_types.size(); ++i)
@@ -502,7 +517,49 @@ public:
         : IIcebergSchemaTransform(operation_.getPath())
         , operation(operation_)
     {
-        index_path = resolveSchemaPath(operation_.getPath(), type, false);
+        for (const auto & path : operation_.getPath())
+        {
+            switch (path.parent_type)
+            {
+                case TransformType::STRUCT:
+                {
+                    current_types = std::static_pointer_cast<const DataTypeTuple>(type)->getElements();
+                    auto element_names = std::static_pointer_cast<const DataTypeTuple>(type)->getElementNames();
+
+                    size_t result_index = current_types.size();
+                    for (size_t i = 0; i < current_types.size(); ++i)
+                    {
+                        if (element_names[i] == path.path)
+                        {
+                            result_index = i;
+                            break;
+                        }
+                    }
+                    if (result_index == current_types.size())
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in data", path.path);
+
+                    index_path.push_back(static_cast<Int32>(result_index));
+                    type = current_types[result_index];
+                    break;
+                }
+                case TransformType::ARRAY:
+                {
+                    index_path.push_back(-1);
+                    type = std::static_pointer_cast<const DataTypeArray>(type)->getNestedType();
+                    break;
+                }
+                case TransformType::MAP:
+                {
+                    index_path.push_back(-1);
+                    type = std::static_pointer_cast<const DataTypeTuple>(
+                               std::static_pointer_cast<const DataTypeArray>(
+                                   std::static_pointer_cast<const DataTypeMap>(type)->getNestedType())
+                                   ->getNestedType())
+                               ->getElement(1);
+                    break;
+                }
+            }
+        }
     }
 
     void transformChildNode(Tuple & initial_node) override
@@ -515,6 +572,7 @@ public:
 
 private:
     IcebergReorderingOperation operation;
+    DataTypes current_types;
 };
 
 ColumnPtr ExecutableEvolutionFunction::executeImpl(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
@@ -9,6 +9,7 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.h>
 #include <base/defines.h>
+#include <Common/typeid_cast.h>
 #include <Poco/JSON/Array.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Stringifier.h>
@@ -21,6 +22,7 @@ namespace DB
 namespace ErrorCodes
 {
 extern const int BAD_ARGUMENTS;
+extern const int LOGICAL_ERROR;
 }
 
 namespace Iceberg
@@ -61,6 +63,95 @@ public:
 
     std::vector<size_t> permutation;
 };
+
+namespace
+{
+
+const DataTypeTuple & getTupleType(const DataTypePtr & type)
+{
+    const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get());
+    if (!tuple_type)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Expected Tuple while resolving an Iceberg schema evolution path, got {}",
+            type->getName());
+    return *tuple_type;
+}
+
+size_t getElementIndexInTuple(const DataTypeTuple & tuple_type, const String & element_name)
+{
+    const auto & element_names = tuple_type.getElementNames();
+    for (size_t i = 0; i < element_names.size(); ++i)
+    {
+        if (element_names[i] == element_name)
+            return i;
+    }
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in data", element_name);
+}
+
+DataTypePtr getArrayElementType(const DataTypePtr & type)
+{
+    const auto * array_type = typeid_cast<const DataTypeArray *>(type.get());
+    if (!array_type)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Expected Array while resolving an Iceberg schema evolution path, got {}",
+            type->getName());
+    return array_type->getNestedType();
+}
+
+DataTypePtr getMapValueType(const DataTypePtr & type)
+{
+    const auto * map_type = typeid_cast<const DataTypeMap *>(type.get());
+    if (!map_type)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Expected Map while resolving an Iceberg schema evolution path, got {}",
+            type->getName());
+    DataTypePtr key_value_type = getArrayElementType(map_type->getNestedType());
+    return getTupleType(key_value_type).getElement(1);
+}
+
+std::vector<int> resolveSchemaPath(
+    const std::vector<IcebergChangeSchemaOperation::Edge> & path, DataTypePtr & type, bool use_new_names)
+{
+    std::vector<int> index_path;
+    index_path.reserve(path.size());
+
+    for (const auto & edge : path)
+    {
+        switch (edge.parent_type)
+        {
+            case TransformType::STRUCT:
+            {
+                const String & element_name = use_new_names ? edge.new_path : edge.path;
+                const auto & tuple_type = getTupleType(type);
+                size_t element_index = getElementIndexInTuple(tuple_type, element_name);
+                DataTypePtr element_type = tuple_type.getElement(element_index);
+
+                index_path.push_back(static_cast<int>(element_index));
+                type = std::move(element_type);
+                break;
+            }
+            case TransformType::ARRAY:
+            {
+                index_path.push_back(-1);
+                type = getArrayElementType(type);
+                break;
+            }
+            case TransformType::MAP:
+            {
+                index_path.push_back(-1);
+                type = getMapValueType(type);
+                break;
+            }
+        }
+    }
+
+    return index_path;
+}
+
+}
 
 IIcebergSchemaTransform::IIcebergSchemaTransform(std::vector<IcebergChangeSchemaOperation::Edge> path_)
     : path(path_)
@@ -345,60 +436,17 @@ public:
         : IIcebergSchemaTransform(operation_.getPath())
         , operation(operation_)
     {
-        for (const auto & path : operation_.getPath())
-        {
-            switch (path.parent_type)
-            {
-                case TransformType::STRUCT:
-                {
-                    auto current_types = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElements();
-                    auto element_names = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElementNames();
+        index_path = resolveSchemaPath(operation_.getPath(), old_type, false);
 
-                    size_t result_index = current_types.size();
-                    for (size_t i = 0; i < current_types.size(); ++i)
-                    {
-                        if (element_names[i] == path.path)
-                        {
-                            result_index = i;
-                            break;
-                        }
-                    }
-                    if (result_index == current_types.size())
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in data", path.path);
+        const auto & element_names = getTupleType(old_type).getElementNames();
 
-                    index_path.push_back(static_cast<Int32>(result_index));
-                    old_type = current_types[result_index];
-                    break;
-                }
-                case TransformType::ARRAY:
-                {
-                    index_path.push_back(-1);
-                    old_type = std::static_pointer_cast<const DataTypeArray>(old_type)->getNestedType();
-                    break;
-                }
-                case TransformType::MAP:
-                {
-                    index_path.push_back(-1);
-                    old_type = std::static_pointer_cast<const DataTypeTuple>(
-                                   std::static_pointer_cast<const DataTypeArray>(
-                                       std::static_pointer_cast<const DataTypeMap>(old_type)->getNestedType())
-                                       ->getNestedType())
-                                   ->getElement(1);
-                    break;
-                }
-            }
-        }
-
-        auto current_types = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElements();
-        auto element_names = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElementNames();
-
-        index_to_delete = current_types.size();
-        for (size_t i = 0; i < current_types.size(); ++i)
+        index_to_delete = element_names.size();
+        for (size_t i = 0; i < element_names.size(); ++i)
         {
             if (element_names[permutation[i]] == operation.field_name)
                 index_to_delete = i;
         }
-        if (index_to_delete == current_types.size())
+        if (index_to_delete == element_names.size())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find field {} in data", operation.field_name);
     }
 
@@ -418,75 +466,12 @@ public:
         : IIcebergSchemaTransform(operation_.getPath())
         , operation(operation_)
     {
-        for (const auto & path : operation_.getPath())
-        {
-            switch (path.parent_type)
-            {
-                case TransformType::STRUCT:
-                {
-                    auto old_current_types = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElements();
-                    auto old_element_names = std::static_pointer_cast<const DataTypeTuple>(old_type)->getElementNames();
+        index_path = resolveSchemaPath(operation_.getPath(), old_type, false);
+        resolveSchemaPath(operation_.getPath(), type, true);
 
-                    size_t old_result_index = old_current_types.size();
-                    for (size_t i = 0; i < old_current_types.size(); ++i)
-                    {
-                        if (old_element_names[i] == path.path)
-                        {
-                            old_result_index = i;
-                            break;
-                        }
-                    }
-                    if (old_result_index == old_current_types.size())
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in old data", path.path);
-
-                    index_path.push_back(static_cast<Int32>(old_result_index));
-                    old_type = old_current_types[old_result_index];
-
-                    current_types = std::static_pointer_cast<const DataTypeTuple>(type)->getElements();
-                    auto element_names = std::static_pointer_cast<const DataTypeTuple>(type)->getElementNames();
-
-                    size_t result_index = current_types.size();
-                    for (size_t i = 0; i < current_types.size(); ++i)
-                    {
-                        if (element_names[i] == path.new_path)
-                        {
-                            result_index = i;
-                            break;
-                        }
-                    }
-                    if (result_index == current_types.size())
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in new data", path.new_path);
-
-                    type = current_types[result_index];
-                    break;
-                }
-                case TransformType::ARRAY:
-                {
-                    index_path.push_back(-1);
-                    old_type = std::static_pointer_cast<const DataTypeArray>(old_type)->getNestedType();
-                    type = std::static_pointer_cast<const DataTypeArray>(type)->getNestedType();
-                    break;
-                }
-                case TransformType::MAP:
-                {
-                    index_path.push_back(-1);
-                    old_type = std::static_pointer_cast<const DataTypeTuple>(
-                                   std::static_pointer_cast<const DataTypeArray>(
-                                       std::static_pointer_cast<const DataTypeMap>(old_type)->getNestedType())
-                                       ->getNestedType())
-                                   ->getElement(1);
-                    type = std::static_pointer_cast<const DataTypeTuple>(
-                               std::static_pointer_cast<const DataTypeArray>(
-                                   std::static_pointer_cast<const DataTypeMap>(type)->getNestedType())
-                                   ->getNestedType())
-                               ->getElement(1);
-                    break;
-                }
-            }
-        }
-
-        current_types = std::static_pointer_cast<const DataTypeTuple>(type)->getElements();
-        auto element_names = std::static_pointer_cast<const DataTypeTuple>(type)->getElementNames();
+        const auto & tuple_type = getTupleType(type);
+        current_types = tuple_type.getElements();
+        const auto & element_names = tuple_type.getElementNames();
 
         index_to_insert = current_types.size();
         for (size_t i = 0; i < current_types.size(); ++i)
@@ -517,49 +502,7 @@ public:
         : IIcebergSchemaTransform(operation_.getPath())
         , operation(operation_)
     {
-        for (const auto & path : operation_.getPath())
-        {
-            switch (path.parent_type)
-            {
-                case TransformType::STRUCT:
-                {
-                    current_types = std::static_pointer_cast<const DataTypeTuple>(type)->getElements();
-                    auto element_names = std::static_pointer_cast<const DataTypeTuple>(type)->getElementNames();
-
-                    size_t result_index = current_types.size();
-                    for (size_t i = 0; i < current_types.size(); ++i)
-                    {
-                        if (element_names[i] == path.path)
-                        {
-                            result_index = i;
-                            break;
-                        }
-                    }
-                    if (result_index == current_types.size())
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Can not find path {} in data", path.path);
-
-                    index_path.push_back(static_cast<Int32>(result_index));
-                    type = current_types[result_index];
-                    break;
-                }
-                case TransformType::ARRAY:
-                {
-                    index_path.push_back(-1);
-                    type = std::static_pointer_cast<const DataTypeArray>(type)->getNestedType();
-                    break;
-                }
-                case TransformType::MAP:
-                {
-                    index_path.push_back(-1);
-                    type = std::static_pointer_cast<const DataTypeTuple>(
-                               std::static_pointer_cast<const DataTypeArray>(
-                                   std::static_pointer_cast<const DataTypeMap>(type)->getNestedType())
-                                   ->getNestedType())
-                               ->getElement(1);
-                    break;
-                }
-            }
-        }
+        index_path = resolveSchemaPath(operation_.getPath(), type, false);
     }
 
     void transformChildNode(Tuple & initial_node) override
@@ -572,7 +515,6 @@ public:
 
 private:
     IcebergReorderingOperation operation;
-    DataTypes current_types;
 };
 
 ColumnPtr ExecutableEvolutionFunction::executeImpl(

--- a/tests/integration/test_storage_iceberg_schema_evolution/test_nested_containers_evolved.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/test_nested_containers_evolved.py
@@ -1,0 +1,252 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    default_upload_directory,
+    get_uuid_str,
+    get_creation_expression,
+    check_schema_and_data
+)
+
+
+def make_query_executor(started_cluster, storage_type, table_name):
+    spark = started_cluster.spark_session
+
+    def execute_spark_query(query: str):
+        spark.sql(query)
+        default_upload_directory(
+            started_cluster,
+            storage_type,
+            f"/iceberg_data/default/{table_name}/",
+            f"/iceberg_data/default/{table_name}/",
+        )
+
+    return execute_spark_query
+
+
+@pytest.mark.parametrize("storage_type", ["local"])
+def test_map_of_arrays_evolved(started_cluster_iceberg_schema_evolution, storage_type):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    TABLE_NAME = "test_map_of_arrays_evolved_" + storage_type + "_" + get_uuid_str()
+    execute_spark_query = make_query_executor(
+        started_cluster_iceberg_schema_evolution, storage_type, TABLE_NAME
+    )
+
+    execute_spark_query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                entries MAP<INT, ARRAY<STRUCT<a: INT, b: STRING>>>
+            )
+            USING iceberg
+            OPTIONS ('format-version'='2')
+        """
+    )
+    execute_spark_query(
+        f"INSERT INTO {TABLE_NAME} VALUES (MAP(1, ARRAY(named_struct('a', 10, 'b', 'hello'))))"
+    )
+
+    table_function = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_schema_evolution, table_function=True
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['entries', 'Map(Int32, Array(Tuple(\\n    a Nullable(Int32),\\n    b Nullable(String))))'],
+        ],
+        [
+            ["{1:[(10,'hello')]}"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN entries.value.element.c INT")
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ALTER COLUMN entries.value.element.c FIRST")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['entries', 'Map(Int32, Array(Tuple(\\n    c Nullable(Int32),\\n    a Nullable(Int32),\\n    b Nullable(String))))'],
+        ],
+        [
+            ["{1:[(NULL,10,'hello')]}"],
+        ],
+    )
+
+
+@pytest.mark.parametrize("storage_type", ["local"])
+def test_struct_with_doubly_nested_array_evolved(
+    started_cluster_iceberg_schema_evolution, storage_type
+):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    TABLE_NAME = (
+        "test_struct_with_doubly_nested_array_evolved_" + storage_type + "_" + get_uuid_str()
+    )
+    execute_spark_query = make_query_executor(
+        started_cluster_iceberg_schema_evolution, storage_type, TABLE_NAME
+    )
+
+    execute_spark_query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                top STRUCT<
+                    lvl1: ARRAY<STRUCT<
+                        lvl2: ARRAY<STRUCT<
+                            a: INT,
+                            b: STRING
+                        >>
+                    >>
+                >
+            )
+            USING iceberg
+            OPTIONS ('format-version'='2')
+        """
+    )
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES
+                (named_struct('lvl1', ARRAY(named_struct('lvl2', ARRAY(named_struct('a', 1, 'b', 'x'))))));
+        """
+    )
+
+    table_function = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_schema_evolution, table_function=True
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['top', 'Tuple(\\n    lvl1 Array(Tuple(\\n        lvl2 Array(Tuple(\\n            a Nullable(Int32),\\n            b Nullable(String))))))'],
+        ],
+        [
+            ["([([(1,'x')])])"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN top.lvl1.element.lvl2.element.c INT")
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ALTER COLUMN top.lvl1.element.lvl2.element.c FIRST")
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} DROP COLUMN top.lvl1.element.lvl2.element.b")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['top', 'Tuple(\\n    lvl1 Array(Tuple(\\n        lvl2 Array(Tuple(\\n            c Nullable(Int32),\\n            a Nullable(Int32))))))'],
+        ],
+        [
+            ["([([(NULL,1)])])"],
+        ],
+    )
+
+
+@pytest.mark.parametrize("storage_type", ["local"])
+def test_struct_with_sibling_arrays_evolved(
+    started_cluster_iceberg_schema_evolution, storage_type
+):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    TABLE_NAME = (
+        "test_struct_with_sibling_arrays_evolved_" + storage_type + "_" + get_uuid_str()
+    )
+    execute_spark_query = make_query_executor(
+        started_cluster_iceberg_schema_evolution, storage_type, TABLE_NAME
+    )
+
+    execute_spark_query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                top STRUCT<
+                    x: ARRAY<STRUCT<a: INT>>,
+                    y: ARRAY<STRUCT<b: INT>>
+                >
+            )
+            USING iceberg
+            OPTIONS ('format-version'='2')
+        """
+    )
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES
+                (named_struct('x', ARRAY(named_struct('a', 1)), 'y', ARRAY(named_struct('b', 2))));
+        """
+    )
+
+    table_function = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_schema_evolution, table_function=True
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN top.x.element.c INT")
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN top.y.element.d INT")
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ALTER COLUMN top.x.element.c FIRST")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['top', 'Tuple(\\n    x Array(Tuple(\\n        c Nullable(Int32),\\n        a Nullable(Int32))),\\n    y Array(Tuple(\\n        b Nullable(Int32),\\n        d Nullable(Int32))))'],
+        ],
+        [
+            ["([(NULL,1)],[(2,NULL)])"],
+        ],
+    )
+
+
+@pytest.mark.parametrize("storage_type", ["local"])
+def test_struct_with_primitive_array_sibling_evolved(
+    started_cluster_iceberg_schema_evolution, storage_type
+):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    TABLE_NAME = (
+        "test_struct_with_primitive_array_sibling_evolved_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+    execute_spark_query = make_query_executor(
+        started_cluster_iceberg_schema_evolution, storage_type, TABLE_NAME
+    )
+
+    execute_spark_query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                top STRUCT<
+                    nums: ARRAY<INT>,
+                    items: ARRAY<STRUCT<a: INT, b: STRING>>
+                >
+            )
+            USING iceberg
+            OPTIONS ('format-version'='2')
+        """
+    )
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES
+                (named_struct('nums', ARRAY(1, 2), 'items', ARRAY(named_struct('a', 1, 'b', 'x')))),
+                (named_struct('nums', CAST(ARRAY() AS ARRAY<INT>), 'items', CAST(ARRAY() AS ARRAY<STRUCT<a: INT, b: STRING>>))),
+                (named_struct('nums', ARRAY(3), 'items', ARRAY(named_struct('a', 2, 'b', 'y'), named_struct('a', 3, 'b', 'z'))));
+        """
+    )
+
+    table_function = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_schema_evolution, table_function=True
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN top.items.element.c INT")
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ALTER COLUMN top.items.element.c FIRST")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['top', 'Tuple(\\n    nums Array(Nullable(Int32)),\\n    items Array(Tuple(\\n        c Nullable(Int32),\\n        a Nullable(Int32),\\n        b Nullable(String))))'],
+        ],
+        [
+            ["([],[])"],
+            ["([1,2],[(NULL,1,'x')])"],
+            ["([3],[(NULL,2,'y'),(NULL,3,'z')])"],
+        ],
+    )

--- a/tests/integration/test_storage_iceberg_schema_evolution/test_struct_with_nested_array_evolved.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/test_struct_with_nested_array_evolved.py
@@ -1,0 +1,138 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    default_upload_directory,
+    get_uuid_str,
+    get_creation_expression,
+    check_schema_and_data
+)
+
+
+@pytest.mark.parametrize("format_version", ["1", "2"])
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_struct_with_nested_array_evolved(
+    started_cluster_iceberg_schema_evolution, format_version, storage_type
+):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    spark = started_cluster_iceberg_schema_evolution.spark_session
+    TABLE_NAME = (
+        "test_struct_with_nested_array_evolved_"
+        + format_version
+        + "_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    def execute_spark_query(query: str):
+        spark.sql(query)
+        default_upload_directory(
+            started_cluster_iceberg_schema_evolution,
+            storage_type,
+            f"/iceberg_data/default/{TABLE_NAME}/",
+            f"/iceberg_data/default/{TABLE_NAME}/",
+        )
+        return
+
+    execute_spark_query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                outer STRUCT<
+                    items: ARRAY<STRUCT<
+                        a: INT,
+                        b: STRING
+                    >>
+                >
+            )
+            USING iceberg
+            OPTIONS ('format-version'='{format_version}')
+        """
+    )
+
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES
+                (named_struct('items', ARRAY(named_struct('a', 1, 'b', 'hello'), named_struct('a', 2, 'b', 'world'))));
+        """
+    )
+
+    table_function = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_schema_evolution, table_function=True
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    items Array(Tuple(\\n        a Nullable(Int32),\\n        b Nullable(String))))'],
+        ],
+        [
+            ["([(1,'hello'),(2,'world')])"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN outer.items.element.c INT")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    items Array(Tuple(\\n        a Nullable(Int32),\\n        b Nullable(String),\\n        c Nullable(Int32))))'],
+        ],
+        [
+            ["([(1,'hello',NULL),(2,'world',NULL)])"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ALTER COLUMN outer.items.element.c FIRST")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    items Array(Tuple(\\n        c Nullable(Int32),\\n        a Nullable(Int32),\\n        b Nullable(String))))'],
+        ],
+        [
+            ["([(NULL,1,'hello'),(NULL,2,'world')])"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} RENAME COLUMN outer.items.element.a TO renamed_a")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    items Array(Tuple(\\n        c Nullable(Int32),\\n        renamed_a Nullable(Int32),\\n        b Nullable(String))))'],
+        ],
+        [
+            ["([(NULL,1,'hello'),(NULL,2,'world')])"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} DROP COLUMN outer.items.element.b")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    items Array(Tuple(\\n        c Nullable(Int32),\\n        renamed_a Nullable(Int32))))'],
+        ],
+        [
+            ["([(NULL,1),(NULL,2)])"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} RENAME COLUMN outer.items TO renamed_items")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    renamed_items Array(Tuple(\\n        c Nullable(Int32),\\n        renamed_a Nullable(Int32))))'],
+        ],
+        [
+            ["([(NULL,1),(NULL,2)])"],
+        ],
+    )

--- a/tests/integration/test_storage_iceberg_schema_evolution/test_struct_with_nested_map_evolved.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/test_struct_with_nested_map_evolved.py
@@ -1,0 +1,112 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    default_upload_directory,
+    get_uuid_str,
+    get_creation_expression,
+    check_schema_and_data
+)
+
+
+@pytest.mark.parametrize("format_version", ["1", "2"])
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_struct_with_nested_map_evolved(
+    started_cluster_iceberg_schema_evolution, format_version, storage_type
+):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    spark = started_cluster_iceberg_schema_evolution.spark_session
+    TABLE_NAME = (
+        "test_struct_with_nested_map_evolved_"
+        + format_version
+        + "_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    def execute_spark_query(query: str):
+        spark.sql(query)
+        default_upload_directory(
+            started_cluster_iceberg_schema_evolution,
+            storage_type,
+            f"/iceberg_data/default/{TABLE_NAME}/",
+            f"/iceberg_data/default/{TABLE_NAME}/",
+        )
+        return
+
+    execute_spark_query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                outer STRUCT<
+                    entries: MAP<INT, STRUCT<
+                        a: INT,
+                        b: STRING
+                    >>
+                >
+            )
+            USING iceberg
+            OPTIONS ('format-version'='{format_version}')
+        """
+    )
+
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES
+                (named_struct('entries', MAP(1, named_struct('a', 10, 'b', 'hello'))));
+        """
+    )
+
+    table_function = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_schema_evolution, table_function=True
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    entries Map(Int32, Tuple(\\n        a Nullable(Int32),\\n        b Nullable(String))))'],
+        ],
+        [
+            ["({1:(10,'hello')})"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN outer.entries.value.c INT")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    entries Map(Int32, Tuple(\\n        a Nullable(Int32),\\n        b Nullable(String),\\n        c Nullable(Int32))))'],
+        ],
+        [
+            ["({1:(10,'hello',NULL)})"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ALTER COLUMN outer.entries.value.c FIRST")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    entries Map(Int32, Tuple(\\n        c Nullable(Int32),\\n        a Nullable(Int32),\\n        b Nullable(String))))'],
+        ],
+        [
+            ["({1:(NULL,10,'hello')})"],
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} DROP COLUMN outer.entries.value.b")
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['outer', 'Tuple(\\n    entries Map(Int32, Tuple(\\n        c Nullable(Int32),\\n        a Nullable(Int32))))'],
+        ],
+        [
+            ["({1:(NULL,10)})"],
+        ],
+    )

--- a/tests/queries/0_stateless/05077_iceberg_equality_delete_nullability_mismatch.reference
+++ b/tests/queries/0_stateless/05077_iceberg_equality_delete_nullability_mismatch.reference
@@ -1,0 +1,5 @@
+bar
+world
+2	world
+4	bar
+2

--- a/tests/queries/0_stateless/05077_iceberg_equality_delete_nullability_mismatch.sh
+++ b/tests/queries/0_stateless/05077_iceberg_equality_delete_nullability_mismatch.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# Tag no-replicated-database: IcebergLocal is non-replicated.
+
+# The table has a required `data` column, while the equality delete file declares the same column
+# as optional. The set for the `notIn` filter used to be built with the table-schema type and then
+# filled from the delete file columns of a different type (a column type confusion), which crashed
+# the server in `ColumnString::insertRangeFrom`.
+# The fixture is described in data_minio/deletes_db/README.md (`eq_deletes_required_table`).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+LAKE_DIR="${CLICKHOUSE_USER_FILES_UNIQUE}/eq_deletes_required_table"
+rm -rf "${CLICKHOUSE_USER_FILES_UNIQUE}"
+mkdir -p "${CLICKHOUSE_USER_FILES_UNIQUE}"
+cp -r "${CUR_DIR}/data_minio/deletes_db/eq_deletes_required_table" "${LAKE_DIR}"
+
+${CLICKHOUSE_CLIENT} --query "SELECT data FROM icebergLocal('${LAKE_DIR}/') ORDER BY data"
+${CLICKHOUSE_CLIENT} --query "SELECT id, data FROM icebergLocal('${LAKE_DIR}/') ORDER BY id"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM icebergLocal('${LAKE_DIR}/')"
+
+rm -rf "${CLICKHOUSE_USER_FILES_UNIQUE}"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix complex types schema evolution typos

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118127&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118127](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118127+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.8.3.42`, `26.7.7.75`, `26.6.5.106`, `26.3.33.47`
<!-- ch-version-info:end -->