### PR TITLE
PromQL: optimize empty by() grouping

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForAggregationOperator.cpp
@@ -14,9 +14,10 @@ ASTPtr transformGroupASTForAggregationOperator(
     bool drop_metric_name,
     bool & metric_name_dropped)
 {
-    if (!operator_node->by && !operator_node->without)
+    if ((!operator_node->by && !operator_node->without)
+        || (operator_node->by && operator_node->labels.empty()))
     {
-        /// No by/without: aggregate all series into one with no tags (group 0).
+        /// No grouping labels: aggregate all series into one with no tags (group 0).
         metric_name_dropped = true;
         return makeASTFunction("CAST", make_intrusive<ASTLiteral>(0u), make_intrusive<ASTLiteral>("UInt64"));
     }

--- a/tests/performance/promql_tags_transform.xml
+++ b/tests/performance/promql_tags_transform.xml
@@ -99,6 +99,8 @@
         FROM numbers_mt(200000)
     </fill_query>
 
+    <!-- Empty by() should use the constant empty group instead of transforming every input tag group. -->
+    <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'sum by() (foo)', 100) SETTINGS max_threads = 1 FORMAT Null</query>
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'sum by (namespace) (foo)', 100) FORMAT Null</query>
     <query>SELECT * FROM prometheusQuery('promql_tags_transform', 'foo / on(pod) bar', 100) FORMAT Null</query>
 

--- a/tests/queries/0_stateless/05059_promql_empty_by_group.reference
+++ b/tests/queries/0_stateless/05059_promql_empty_by_group.reference
@@ -1,0 +1,4 @@
+sum by() aggregates all series into one group
+1	3
+sum by() uses the constant empty group
+1

--- a/tests/queries/0_stateless/05059_promql_empty_by_group.reference
+++ b/tests/queries/0_stateless/05059_promql_empty_by_group.reference
@@ -2,3 +2,14 @@ sum by() aggregates all series into one group
 1	3
 sum by() uses the constant empty group
 1
+sum by() aggregates all series into one group with no tags
+[]	3
+quantile by() aggregates all series into one group with no tags
+[]	1.5
+topk by() selects over all series and keeps their own tags
+[('__name__','m'),('host','h2')]	2
+the group expression is the constant empty group, not timeSeriesRemoveAllTagsExcept
+sum by()	1
+quantile by()	1
+topk by()	1
+by (host), control	1

--- a/tests/queries/0_stateless/05059_promql_empty_by_group.sql
+++ b/tests/queries/0_stateless/05059_promql_empty_by_group.sql
@@ -1,0 +1,23 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: PromQL needs ANTLR4, which is disabled in the fast-test build.
+
+DROP TABLE IF EXISTS prometheus;
+
+SET session_timezone = 'UTC';
+SET allow_experimental_time_series_table = 1;
+
+CREATE TABLE prometheus ENGINE = TimeSeries;
+
+INSERT INTO prometheus (metric_name, tags, time_series) VALUES
+    ('m', map('host', 'h1'), [(toDateTime64(100, 3), 1)]),
+    ('m', map('host', 'h2'), [(toDateTime64(100, 3), 2)]);
+
+SELECT 'sum by() aggregates all series into one group';
+SELECT count() AS series_count, sum(value) AS value
+FROM prometheusQuery('prometheus', 'sum by() (m)', 100);
+
+SELECT 'sum by() uses the constant empty group';
+SELECT countIf(explain LIKE '%timeSeriesRemoveAllTagsExcept%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'sum by() (m)', 100));
+
+DROP TABLE prometheus;

--- a/tests/queries/0_stateless/05059_promql_empty_by_group.sql
+++ b/tests/queries/0_stateless/05059_promql_empty_by_group.sql
@@ -20,4 +20,29 @@ SELECT 'sum by() uses the constant empty group';
 SELECT countIf(explain LIKE '%timeSeriesRemoveAllTagsExcept%') = 0
 FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'sum by() (m)', 100));
 
+-- An empty `by()` always produces the single empty label set, and the empty set of tags is always group 0
+-- (see `ContextTimeSeriesTagsCollector::getGroupForNoTags`), so the group expression is the constant group 0
+-- instead of `timeSeriesRemoveAllTagsExcept(group, [])`. The transformation is shared by every kind of
+-- aggregation operator, so a one-argument operator, `quantile` and a limit operator are all checked here.
+SELECT 'sum by() aggregates all series into one group with no tags';
+SELECT tags, value FROM prometheusQuery('prometheus', 'sum by() (m)', 100);
+
+SELECT 'quantile by() aggregates all series into one group with no tags';
+SELECT tags, value FROM prometheusQuery('prometheus', 'quantile by () (0.5, m)', 100);
+
+SELECT 'topk by() selects over all series and keeps their own tags';
+SELECT tags, value FROM prometheusQuery('prometheus', 'topk(1, m) by ()', 100) ORDER BY tags;
+
+-- The `by (host)` query is a control: it must still transform the group, so the assertions above cannot
+-- pass just because the plan text stops mentioning the function for an unrelated reason.
+SELECT 'the group expression is the constant empty group, not timeSeriesRemoveAllTagsExcept';
+SELECT 'sum by()', countIf(explain LIKE '%timeSeriesRemoveAllTagsExcept%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'sum by() (m)', 100));
+SELECT 'quantile by()', countIf(explain LIKE '%timeSeriesRemoveAllTagsExcept%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'quantile by () (0.5, m)', 100));
+SELECT 'topk by()', countIf(explain LIKE '%timeSeriesRemoveAllTagsExcept%') = 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'topk(1, m) by ()', 100));
+SELECT 'by (host), control', countIf(explain LIKE '%timeSeriesRemoveAllTagsExcept%') > 0
+FROM (EXPLAIN SELECT * FROM prometheusQuery('prometheus', 'sum by (host) (m)', 100));
+
 DROP TABLE prometheus;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Use the constant empty group for PromQL aggregations with an empty `by()` modifier.

### Summary

`sum by() (m)` has one grouping key: the empty label set. ClickHouse already reserves group `0` for that set.

Today, an empty `by()` still lowers to `timeSeriesRemoveAllTagsExcept(group, [])`. That sends the input group through the tag collector for every series, even though every row maps to the same group `0`.

This patch adds a conditional fast path for `by()` with no labels. Other `by(...)`, `without(...)`, and unmodified aggregations keep their existing behavior.

The path is most useful for high-cardinality, generated PromQL queries. It removes one O(number of input series) tag transformation. It does not remove sample reads, vector-grid construction, or array aggregation, so the end-to-end speedup depends on the workload.

The shared helper covers the empty-`by()` grouping path for regular aggregations, `quantile`, and `topk`/`bottomk`/`limitk`.

### Performance workload

Extended the existing `tests/performance/promql_tags_transform.xml` fixture instead of adding another setup table. It already loads 200,000 TimeSeries rows and includes a non-empty `sum by (namespace)` aggregation as a control.

The new query runs `sum by() (foo)` with `max_threads = 1` and `FORMAT Null`, exercising the optimized empty-group path over the high-cardinality input. The reference and patched builds run the same setup and query, so CI can compare the end-to-end query time.

### Tests

- `tests/queries/0_stateless/05059_promql_empty_by_group.sql`
  - checks that `sum by()` still returns one series;
  - checks that the generated plan no longer uses `timeSeriesRemoveAllTagsExcept`.
- `tests/performance/promql_tags_transform.xml`
  - covers the empty `by()` query and keeps the existing non-empty `by` control.
- XML validation and `git diff --check`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118132&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118132](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118132+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1224` (included in `26.9` and later)
<!-- ch-version-info:end -->