### PR TITLE
Start each path and substream in a new compressed block in JSON advanced shared data

### DIFF
--- a/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
+++ b/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
@@ -377,6 +377,10 @@ void SerializationObjectSharedData::serializeBinaryBulkWithMultipleStreams(
                 dynamic_serialization->serializeBinaryBulkStateSuffix(data_serialization_settings, path_state);
             }
 
+            /// Close the last path's block so it isn't merged with the following metadata streams (in
+            /// Compact parts they reuse the same compressed stream).
+            data_stream->next();
+
             /// End ObjectSharedDataData stream.
             settings.path.pop_back();
 

--- a/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
+++ b/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
@@ -358,6 +358,9 @@ void SerializationObjectSharedData::serializeBinaryBulkWithMultipleStreams(
                 paths_substreams_marks.emplace_back();
                 data_serialization_settings.getter = [&](const SubstreamPath & substream_path) -> WriteBuffer *
                 {
+                    /// Start each substream in a new compressed block so a selective read (one path or one
+                    /// subcolumn of a path) doesn't decompress blocks shared with the path's other substreams.
+                    data_stream->next();
                     /// Add new substream and its mark for current path.
                     paths_substreams.back().push_back(ISerialization::getFileNameForStream(NameAndTypePair("", dynamic_type), substream_path, stream_file_name_settings));
                     paths_substreams_marks.back().push_back(settings.stream_mark_getter(settings.path));
@@ -365,6 +368,8 @@ void SerializationObjectSharedData::serializeBinaryBulkWithMultipleStreams(
                 };
 
                 SerializeBinaryBulkStatePtr path_state;
+                /// Close the previous path's last substream block so this path's mark starts on a block boundary.
+                data_stream->next();
                 /// Remember the mark of ObjectSharedDataData stream for this path before writing any data.
                 paths_marks.push_back(settings.stream_mark_getter(settings.path));
                 dynamic_serialization->serializeBinaryBulkStatePrefix(*path_column, data_serialization_settings, path_state);

--- a/tests/performance/json_advanced_shared_data_read_paths.xml
+++ b/tests/performance/json_advanced_shared_data_read_paths.xml
@@ -1,0 +1,32 @@
+<test>
+    <!-- Reading an individual path (or a nested path) from JSON advanced shared data. The advanced
+         serializer now starts each path/substream in its own compressed block, so a selective read
+         decompresses only that path's data instead of the whole bucket it shares with other paths. -->
+    <create_query>
+        create table json_advanced_shared_data_top (json JSON(max_dynamic_paths=0))
+        engine=MergeTree order by tuple()
+        settings min_bytes_for_wide_part=0, min_rows_for_wide_part=0,
+                 object_shared_data_serialization_version='advanced',
+                 object_shared_data_serialization_version_for_zero_level_parts='advanced',
+                 object_shared_data_buckets_for_wide_part=1
+    </create_query>
+    <create_query>
+        create table json_advanced_shared_data_nested (json JSON(max_dynamic_paths=0))
+        engine=MergeTree order by tuple()
+        settings min_bytes_for_wide_part=0, min_rows_for_wide_part=0,
+                 object_shared_data_serialization_version='advanced',
+                 object_shared_data_serialization_version_for_zero_level_parts='advanced',
+                 object_shared_data_buckets_for_wide_part=1
+    </create_query>
+
+    <!-- top-level: a tiny path 'small' next to a large path 'big' in the same bucket -->
+    <fill_query>insert into json_advanced_shared_data_top select map('small', toString(number % 100), 'big', hex(randomString(4000))) from numbers(1000000)</fill_query>
+    <!-- nested: one Array(JSON) path 'items' whose objects have a large 'big' and a tiny 'small' -->
+    <fill_query>insert into json_advanced_shared_data_nested select '{"items":[' || arrayStringConcat(arrayMap(i -> '{"big":"' || hex(randomString(1000)) || '","small":"' || toString(i) || '"}', range(4)), ',') || ']}' from numbers(1000000)</fill_query>
+
+    <query>select json.small from json_advanced_shared_data_top format Null</query>
+    <query>select json.items[].small from json_advanced_shared_data_nested format Null</query>
+
+    <drop_query>drop table if exists json_advanced_shared_data_top</drop_query>
+    <drop_query>drop table if exists json_advanced_shared_data_nested</drop_query>
+</test>

--- a/tests/performance/json_advanced_shared_data_read_paths.xml
+++ b/tests/performance/json_advanced_shared_data_read_paths.xml
@@ -22,7 +22,8 @@
     <!-- top-level: a tiny path 'small' next to a large path 'big' in the same bucket -->
     <fill_query>insert into json_advanced_shared_data_top select map('small', toString(number % 100), 'big', hex(randomString(4000))) from numbers(1000000)</fill_query>
     <!-- nested: one Array(JSON) path 'items' whose objects have a large 'big' and a tiny 'small' -->
-    <fill_query>insert into json_advanced_shared_data_nested select '{"items":[' || arrayStringConcat(arrayMap(i -> '{"big":"' || hex(randomString(1000)) || '","small":"' || toString(i) || '"}', range(4)), ',') || ']}' from numbers(1000000)</fill_query>
+    <!-- Braces are doubled because perf.py expands every query through Python's string formatter. -->
+    <fill_query>insert into json_advanced_shared_data_nested select '{{"items":[' || arrayStringConcat(arrayMap(i -> '{{"big":"' || hex(randomString(1000)) || '","small":"' || toString(i) || '"}}', range(4)), ',') || ']}}' from numbers(1000000)</fill_query>
 
     <query>select json.small from json_advanced_shared_data_top format Null</query>
     <query>select json.items[].small from json_advanced_shared_data_nested format Null</query>

--- a/tests/performance/json_advanced_shared_data_read_paths.xml
+++ b/tests/performance/json_advanced_shared_data_read_paths.xml
@@ -20,10 +20,10 @@
     </create_query>
 
     <!-- top-level: a tiny path 'small' next to a large path 'big' in the same bucket -->
-    <fill_query>insert into json_advanced_shared_data_top select map('small', toString(number % 100), 'big', hex(randomString(4000))) from numbers(1000000)</fill_query>
+    <fill_query>insert into json_advanced_shared_data_top select map('small', toString(number % 100), 'big', hex(randomString(500))) from numbers(1000000)</fill_query>
     <!-- nested: one Array(JSON) path 'items' whose objects have a large 'big' and a tiny 'small' -->
     <!-- Braces are doubled because perf.py expands every query through Python's string formatter. -->
-    <fill_query>insert into json_advanced_shared_data_nested select '{{"items":[' || arrayStringConcat(arrayMap(i -> '{{"big":"' || hex(randomString(1000)) || '","small":"' || toString(i) || '"}}', range(4)), ',') || ']}}' from numbers(1000000)</fill_query>
+    <fill_query>insert into json_advanced_shared_data_nested select '{{"items":[' || arrayStringConcat(arrayMap(i -> '{{"big":"' || hex(randomString(200)) || '","small":"' || toString(i) || '"}}', range(4)), ',') || ']}}' from numbers(1000000)</fill_query>
 
     <query>select json.small from json_advanced_shared_data_top format Null</query>
     <query>select json.items[].small from json_advanced_shared_data_nested format Null</query>


### PR DESCRIPTION
The `ADVANCED` shared data serialization writes the data of all flattened paths into a single `ObjectSharedDataData` stream and remembers a mark per path and per substream. Those marks could point into the middle of a compressed block, so reading a single path — or a single subcolumn of a path — had to decompress blocks shared with unrelated paths and substreams, and the wasted decompression grew with the number of paths sharing a bucket.

This flushes the data stream before each path and before each of its substreams, so every remembered mark starts on a compressed block boundary and a selective read decompresses only the data it asked for. Only the MergeTree write path is affected: the code throws when `stream_mark_getter` is not set, so the `Native` format and its specification are unchanged.

Added `tests/performance/json_advanced_shared_data_read_paths.xml`, covering a selective read of a tiny top-level path next to a large one in the same bucket, and of a subcolumn of a nested `Array(JSON)` path.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved performance of reading individual paths and subcolumns from `JSON` columns that use the `advanced` shared data serialization. Each path and substream now starts in its own compressed block, so a selective read no longer decompresses data belonging to other paths.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118154&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118154](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118154+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.982` (included in `26.9` and later)
<!-- ch-version-info:end -->