### PR TITLE
Require `DROP DATABASE` for `TRUNCATE` of a database over `ON CLUSTER`

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -852,10 +852,9 @@ AccessRightsElements InterpreterDropQuery::getRequiredAccessForDDLOnCluster() co
 
     if (!drop.table)
     {
-        if (drop.kind == ASTDropQuery::Kind::Detach)
-            required_access.emplace_back(AccessType::DROP_DATABASE, drop.getDatabase());
-        else if (drop.kind == ASTDropQuery::Kind::Drop)
-            required_access.emplace_back(AccessType::DROP_DATABASE, drop.getDatabase());
+        /// `DROP`, `DETACH` and `TRUNCATE` of a database are all authorized by `DROP DATABASE`,
+        /// which is the single privilege `executeToDatabaseImpl` requires for each of them.
+        required_access.emplace_back(AccessType::DROP_DATABASE, drop.getDatabase());
     }
     else if (drop.is_dictionary)
     {

--- a/tests/queries/0_stateless/05076_truncate_database_on_cluster_access.reference
+++ b/tests/queries/0_stateless/05076_truncate_database_on_cluster_access.reference
@@ -1,0 +1,11 @@
+-- TRUNCATE DATABASE ON CLUSTER, without DROP DATABASE
+necessary to have the grant DROP DATABASE
+1
+-- TRUNCATE ALL TABLES FROM ON CLUSTER, without DROP DATABASE
+necessary to have the grant DROP DATABASE
+3
+-- TRUNCATE DATABASE ON CLUSTER, with DROP DATABASE but readonly
+Cannot execute query in readonly mode
+1
+-- TRUNCATE DATABASE ON CLUSTER, with DROP DATABASE
+0

--- a/tests/queries/0_stateless/05076_truncate_database_on_cluster_access.sh
+++ b/tests/queries/0_stateless/05076_truncate_database_on_cluster_access.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# TRUNCATE of a database is authorized by `DROP DATABASE`, the same privilege the local spelling
+# requires. The `ON CLUSTER` form is checked on the initiator before the task is queued, so a
+# refused statement leaves the database untouched.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+CLUSTER="test_shard_localhost"
+# Users are server-global, so their names carry the test database to keep this test safe against a
+# concurrent copy of itself.
+DB="db_05076_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+READER="reader_05076_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+OWNER="owner_05076_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+function cleanup()
+{
+    ${CLICKHOUSE_CLIENT} -mq "
+        DROP DATABASE IF EXISTS ${DB} SYNC;
+        DROP USER IF EXISTS ${READER}, ${OWNER};
+    "
+}
+cleanup
+trap cleanup EXIT
+
+${CLICKHOUSE_CLIENT} -mq "
+    CREATE USER ${READER} IDENTIFIED WITH no_password;
+    CREATE USER ${OWNER} IDENTIFIED WITH no_password;
+    GRANT CLUSTER ON *.* TO ${READER}, ${OWNER};
+"
+
+function fixture()
+{
+    ${CLICKHOUSE_CLIENT} -mq "
+        DROP DATABASE IF EXISTS ${DB} SYNC;
+        CREATE DATABASE ${DB};
+        CREATE TABLE ${DB}.t (x UInt32) ENGINE = MergeTree ORDER BY x;
+        INSERT INTO ${DB}.t VALUES (1), (2), (3);
+        GRANT SELECT ON ${DB}.* TO ${READER};
+        GRANT DROP DATABASE ON ${DB}.* TO ${OWNER};
+    "
+}
+
+# The message names the privilege that was required, so a check that asks for a different one is
+# caught here and not only by the outcome.
+echo "-- TRUNCATE DATABASE ON CLUSTER, without DROP DATABASE"
+fixture
+${CLICKHOUSE_CLIENT} --user "${READER}" --query "TRUNCATE DATABASE ${DB} ON CLUSTER ${CLUSTER}" 2>&1 |
+    grep -m1 -o -F "necessary to have the grant DROP DATABASE"
+${CLICKHOUSE_CLIENT} --query "EXISTS TABLE ${DB}.t"
+
+# The second parse shape of the same statement: it names tables, so it empties them instead of
+# dropping them. It reaches the same authorization branch.
+echo "-- TRUNCATE ALL TABLES FROM ON CLUSTER, without DROP DATABASE"
+fixture
+${CLICKHOUSE_CLIENT} --user "${READER}" --query "TRUNCATE ALL TABLES FROM ${DB} ON CLUSTER ${CLUSTER}" 2>&1 |
+    grep -m1 -o -F "necessary to have the grant DROP DATABASE"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM ${DB}.t"
+
+# `readonly` is passed on the command line so that it is applied together with the settings the test
+# harness already sends: constraints are checked against the value in force before the query, so
+# both are accepted and the statement itself runs readonly. A user-level `readonly = 1` would reject
+# those settings first, and this assertion would then hold without the statement ever being
+# authorized.
+echo "-- TRUNCATE DATABASE ON CLUSTER, with DROP DATABASE but readonly"
+fixture
+${CLICKHOUSE_CLIENT} --user "${OWNER}" --readonly 1 --query "TRUNCATE DATABASE ${DB} ON CLUSTER ${CLUSTER}" 2>&1 |
+    grep -m1 -o -F "Cannot execute query in readonly mode"
+${CLICKHOUSE_CLIENT} --query "EXISTS TABLE ${DB}.t"
+
+# `DROP DATABASE` is enough on its own: a check that required anything besides it would refuse here.
+echo "-- TRUNCATE DATABASE ON CLUSTER, with DROP DATABASE"
+fixture
+${CLICKHOUSE_CLIENT} --user "${OWNER}" --distributed_ddl_output_mode none --query "TRUNCATE DATABASE ${DB} ON CLUSTER ${CLUSTER}"
+${CLICKHOUSE_CLIENT} --query "EXISTS TABLE ${DB}.t"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`TRUNCATE DATABASE ... ON CLUSTER` and `TRUNCATE [ALL] TABLES FROM ... ON CLUSTER` ran without checking any privilege: a user holding only `SELECT` and `CLUSTER` could destroy every table in a database, and `readonly = 1` did not prevent it. Both now require `DROP DATABASE`, the privilege the non-cluster spellings have always required.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/114011

`InterpreterDropQuery::getRequiredAccessForDDLOnCluster` handled only `Kind::Detach` and `Kind::Drop` in its `!drop.table` branch, with no terminal `else`, so `Kind::Truncate` returned an empty `AccessRightsElements` and `executeDDLQueryOnCluster` checked only `AccessType::CLUSTER` before queueing the DDL.

`CLUSTER` is declared `GLOBAL` and is in neither `not_readonly_flags` nor `ddl_flags`, so that one empty list removed three gates: the privilege check, `readonly` and `allow_ddl`. The blast radius is `DROP`-equivalent rather than `TRUNCATE`-equivalent, because `executeToDatabaseImpl` maps a bare `TRUNCATE DATABASE` to `Kind::Drop` per table. Present in released stable; probed at `v26.8.2.7-lts`.

The branch is now unconditional rather than gaining a fourth `else if`: the local path authorizes all three kinds with one `DROP DATABASE` check, `AccessType.h` documents the privilege as allowing `{DROP|DETACH|TRUNCATE} DATABASE`, and a future kind now over-requires and fails closed.

Measured on a server with real users: all six spellings reaching the branch are refused without the privilege and allowed with it; no other arm changes behaviour.

A query that succeeds today starts failing; that is the fix: the non-cluster spelling has always required `DROP DATABASE`, so anyone relying on the `ON CLUSTER` form relies on this bug.

Left alone deliberately: the `is_dictionary` arm still handles only `Detach` and `Drop`, but `TRUNCATE DICTIONARY` is refused on every host before any access check, leaving only a doomed DDL-queue entry. `KILL TRANSACTION`, `KILL PART_MOVE_TO_SHARD`, `SYSTEM {START,STOP} THREAD FUZZER` and `SYSTEM RESET COVERAGE` skip their `ON CLUSTER` check the same way.

Not closed here: the local database path also checks each object after the database check, while the `ON CLUSTER` worker runs as the initiator only when `distributed_ddl_use_initial_user_and_roles` is enabled (default off). Identical for `DROP DATABASE` and `DETACH DATABASE ... ON CLUSTER`, which this PR does not touch, so this narrows the reachable set rather than closing that gap; converging needs the worker to run as the initiator.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118155&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118155](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118155+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.814` (included in `26.9` and later)
- Backported to: `26.8.3.50`, `26.7.7.36`, `26.6.5.62`, `26.3.33.36`
<!-- ch-version-info:end -->