### PR TITLE
Perf(TimeSeries): Fuse TimeSeries addMany copy and order check

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -58,12 +58,14 @@ public:
         const size_t old_size = buffer.size();
         buffer.resize(old_size + count);
         auto * __restrict appended = buffer.data() + old_size;
-        for (size_t i = 0; i < count; ++i)
-            appended[i] = {timestamps[i], values[i]};
-
         UInt8 in_order = old_size == 0 || appended[-1].first < timestamps[0];
+
+        appended[0] = {timestamps[0], values[0]};
         for (size_t i = 1; i < count; ++i)
+        {
+            appended[i] = {timestamps[i], values[i]};
             in_order &= static_cast<UInt8>(timestamps[i - 1] < timestamps[i]);
+        }
         sorted = sorted && in_order;
     }
 

--- a/tests/performance/timeseries_to_grid_addmany.xml
+++ b/tests/performance/timeseries_to_grid_addmany.xml
@@ -1,0 +1,31 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_aggregate_functions>1</allow_experimental_time_series_aggregate_functions>
+        <max_threads>1</max_threads>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <!--
+        Benchmarks the sorted batch path that calls AggregateFunctionTimeseriesSamples::addMany(). Each series
+        receives timestamps in ascending order at one-second intervals. With a 100-second grid step, a normal bucket
+        receives about 100 samples, so the copy and timestamp-order check run over the same batch.
+    -->
+
+    <create_query>
+        CREATE TABLE ts_addmany (id UInt16, timestamp DateTime, value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
+    </create_query>
+
+    <!-- 1000 series, 10000 sorted samples per series, 10M rows total. -->
+    <fill_query>
+        INSERT INTO ts_addmany
+        SELECT
+            (number % 1000)::UInt16 AS id,
+            toDateTime(intDiv(number, 1000)) AS timestamp,
+            (intDiv(number, 1000) % 1000)::Float64 AS value
+        FROM numbers(1000 * 10000)
+    </fill_query>
+
+    <query>SELECT id, timeSeriesRateToGrid(0, 10000, 100, 300)(timestamp, value) FROM ts_addmany GROUP BY id FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS ts_addmany</drop_query>
+</test>

--- a/tests/performance/timeseries_to_grid_addmany.xml
+++ b/tests/performance/timeseries_to_grid_addmany.xml
@@ -7,25 +7,25 @@
 
     <!--
         Benchmarks the sorted batch path that calls AggregateFunctionTimeseriesSamples::addMany(). Each series
-        receives timestamps in ascending order at one-second intervals. With a 100-second grid step, a normal bucket
-        receives about 100 samples, so the copy and timestamp-order check run over the same batch.
+        receives timestamps in ascending order at one-second intervals. With a 1000-second grid step, a normal bucket
+        receives about 1000 samples, so the copy and timestamp-order check run over the same large batch.
     -->
 
     <create_query>
         CREATE TABLE ts_addmany (id UInt16, timestamp DateTime, value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
     </create_query>
 
-    <!-- 1000 series, 10000 sorted samples per series, 10M rows total. -->
+    <!-- 1000 series, 50000 sorted samples per series, 50M rows total. -->
     <fill_query>
         INSERT INTO ts_addmany
         SELECT
             (number % 1000)::UInt16 AS id,
             toDateTime(intDiv(number, 1000)) AS timestamp,
             (intDiv(number, 1000) % 1000)::Float64 AS value
-        FROM numbers(1000 * 10000)
+        FROM numbers(1000 * 50000)
     </fill_query>
 
-    <query>SELECT id, timeSeriesRateToGrid(0, 10000, 100, 300)(timestamp, value) FROM ts_addmany GROUP BY id FORMAT Null</query>
+    <query>SELECT id, timeSeriesRateToGrid(0, 50000, 1000, 1000)(timestamp, value) FROM ts_addmany GROUP BY id FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS ts_addmany</drop_query>
 </test>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/57545

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fuse the TimeSeries sample copy and timestamp-order check in `addMany()` into one pass.

### Description

`AggregateFunctionTimeseriesSamples::addMany()` used to walk each incoming batch twice:

1. Copy every timestamp/value pair into the buffer.
2. Scan the timestamps again to check strict ordering.

This change writes each pair once and checks the adjacent timestamps in the same loop.

The existing behavior is preserved:

- Empty batches return before touching the input pointers.
- The boundary check between the previous buffer entry and the first new timestamp remains strict.
- Intra-batch timestamps must remain strictly increasing for the buffer to stay marked as sorted.
- Existing sorting and duplicate-timestamp handling is unchanged.

### Performance test

Added `tests/performance/timeseries_to_grid_addmany.xml`. It uses 1,000 series with 10,000 sorted samples per series. Samples arrive one second apart and the grid step is 100 seconds, so each populated bucket sends about 100 samples through `addMany()` at once.

The existing `tests/performance/timeseries_to_grid_bucketing.xml` also covers this sorted batch path in a larger mixed workload.

### Local microbenchmark

Focused microbenchmark on Apple arm64 with `clang++ -O3`, using the same `absl::InlinedVector` storage layout. Each result is nanoseconds per `addMany()` call over 1,000 batches and 10 repeats.

| Batch size | Before | Fused | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 4.91 ns | 4.40 ns | 1.12x |
| 4 | 9.01 ns | 7.03 ns | 1.28x |
| 16 | 24.80 ns | 21.35 ns | 1.16x |
| 64 | 104.89 ns | 81.72 ns | 1.28x |
| 256 | 401.63 ns | 330.55 ns | 1.22x |
| 1024 | 1672.65 ns | 1417.21 ns | 1.18x |
| 4096 | 7002.21 ns | 5966.90 ns | 1.17x |

### Tests

- Focused assertions for empty, single-sample, ordered, duplicate, and out-of-order batches.
- `git diff --check`.
- XML structure validation with Python.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118163&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118163](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118163+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->