### PR TITLE
Fix `bloom_filter` skip index serialization on big-endian

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -99,10 +99,11 @@ void MergeTreeIndexGranuleBloomFilter::deserializeBinary(ReadBuffer & istr, Merg
     for (auto & filter : bloom_filters)
     {
         filter->resize(bytes_size);
+        /// Big-endian granules hold whole `BloomFilter::UnderType` words, so only the payload size
+        /// differs there. The read itself is unconditional: guarding it too leaves the filter zeroed.
         if constexpr (std::endian::native == std::endian::big)
             read_size = filter->getFilter().size() * sizeof(BloomFilter::UnderType);
-        else
-            istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), read_size);
+        istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), read_size);
     }
 }
 
@@ -117,10 +118,10 @@ void MergeTreeIndexGranuleBloomFilter::serializeBinary(WriteBuffer & ostr) const
     size_t write_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
     for (const auto & bloom_filter : bloom_filters)
     {
+        /// Mirrors `deserializeBinary`: the size is byte-order dependent, the write is not.
         if constexpr (std::endian::native == std::endian::big)
             write_size = bloom_filter->getFilter().size() * sizeof(BloomFilter::UnderType);
-        else
-            ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), write_size);
+        ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), write_size);
     }
 }
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/118273

Fixes a bug where on big-endian platforms a query using a `bloom_filter` index silently
returns no rows for data that is present. Every release since v25.3.1 is affected.

Reproducer:
```sql
CREATE TABLE t (k UInt64, n UInt64, INDEX i n TYPE bloom_filter GRANULARITY 1)
ENGINE = MergeTree ORDER BY k SETTINGS index_granularity = 4;
INSERT INTO t SELECT number, number * 7 FROM numbers(64);
SELECT count() FROM t WHERE n = 49;
```

Expected result on s390x:

`1`

Actual result on s390x:

`0`

Cause:

`MergeTreeIndexGranuleBloomFilter::serializeBinary` and `deserializeBinary` guarded the
filter payload with `if constexpr (std::endian::native == std::endian::big) ... else`, so on
a big-endian platform the payload was neither written to the index granule nor read back
from it, and the filter stayed all zeros.

Side effects:

Little-endian platforms: none

Big-endian platforms: an index written before this change holds the header only, and the
fixed code cannot tell such a file from a correct one, so after upgrading a query reading it
raises `CANNOT_READ_ALL_DATA` or consumes the bytes of the following granule.

Remedy:

1. Until the index is rebuilt, a query can avoid it with `SETTINGS use_skip_indexes = 0`.
2. Rebuild every `bloom_filter` index written on a big-endian platform, or drop and re-add it:
```sql
ALTER TABLE <table> MATERIALIZE INDEX <index>;
```
3. Check that the index now holds its payload:
```sql
SELECT secondary_indices_uncompressed_bytes FROM system.parts
WHERE table = '<table>' AND active;
```

No new test: nothing is skipped on little-endian, so no test can observe the difference
there, and CI builds `Build (s390x)` with `-DENABLE_TESTS=0` and never runs the binary.

Tested on a real IBM z16 instead. The indexed query returns 1 instead of 0, and 22 of the 27
`bloom_filter` tests that failed on that machine now pass.

We are considering ClickHouse as the backend database for one of our mainframe products. We
have access to real z hardware, and we intend to keep reporting and fixing big-endian
related problems.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes `bloom_filter` skip indexes on big-endian platforms (s390x), where the index payload
is never written or read. A query using such an index returns no rows for data that is
present.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118164&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118164](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118164+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.841` (included in `26.9` and later)
<!-- ch-version-info:end -->