### PR TITLE
Analyzer: convert a GROUP BY key referenced from a window function to Nullable under group_by_use_nulls

### DIFF
--- a/src/Analyzer/Resolve/ExpressionsStack.h
+++ b/src/Analyzer/Resolve/ExpressionsStack.h
@@ -74,13 +74,13 @@ public:
         return alias_name_to_expressions.contains(alias);
     }
 
-    /** Returns true if the stack contains an aggregate, window, or `grouping` function.
+    /** Returns true if the stack contains an aggregate or `grouping` function.
       *
       * It is used to decide whether an expression equal to a GROUP BY key must be converted
-      * to Nullable when `group_by_use_nulls` is enabled. Arguments of aggregate and window
-      * functions are computed before the nullability is applied to the keys, and arguments
-      * of the `grouping` function only identify GROUP BY keys and are compared with them
-      * in their original form by `GroupingFunctionsResolvePass`.
+      * to Nullable when `group_by_use_nulls` is enabled. Arguments of aggregate functions are
+      * computed before the nullability is applied to the keys, and arguments of the `grouping`
+      * function only identify GROUP BY keys and are compared with them in their original form
+      * by `GroupingFunctionsResolvePass`.
       */
     bool hasAggregateOrGroupingFunction() const
     {
@@ -141,8 +141,16 @@ private:
     {
         /// The parser always lowercases the `grouping` function name (see `getFunctionLayer`
         /// in `ExpressionListParsers.cpp`), so the exact comparison is enough.
-        return AggregateFunctionFactory::instance().isAggregateFunctionName(function.getFunctionName())
-            || function.getFunctionName() == "grouping";
+        if (function.getFunctionName() == "grouping")
+            return true;
+
+        /// A window function is evaluated after aggregation, so both its arguments and its window
+        /// specification observe the GROUP BY keys already converted to Nullable. `isWindowFunction`
+        /// tests only for the window child, so it holds before the function is resolved.
+        if (function.isWindowFunction())
+            return false;
+
+        return AggregateFunctionFactory::instance().isAggregateFunctionName(function.getFunctionName());
     }
 
     QueryTreeNodes expressions;

--- a/src/Analyzer/Resolve/ExpressionsStack.h
+++ b/src/Analyzer/Resolve/ExpressionsStack.h
@@ -139,18 +139,13 @@ public:
 private:
     static bool isAggregateOrGroupingFunction(const FunctionNode & function)
     {
+        /// A window function is evaluated after aggregation: its arguments and window specification see GROUP BY keys
+        /// already converted to Nullable. `isWindowFunction` tests only the window child, so it holds before resolution.
         /// The parser always lowercases the `grouping` function name (see `getFunctionLayer`
         /// in `ExpressionListParsers.cpp`), so the exact comparison is enough.
-        if (function.getFunctionName() == "grouping")
-            return true;
-
-        /// A window function is evaluated after aggregation, so both its arguments and its window
-        /// specification observe the GROUP BY keys already converted to Nullable. `isWindowFunction`
-        /// tests only for the window child, so it holds before the function is resolved.
-        if (function.isWindowFunction())
-            return false;
-
-        return AggregateFunctionFactory::instance().isAggregateFunctionName(function.getFunctionName());
+        return (AggregateFunctionFactory::instance().isAggregateFunctionName(function.getFunctionName())
+                && !function.isWindowFunction())
+            || function.getFunctionName() == "grouping";
     }
 
     QueryTreeNodes expressions;

--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -379,10 +379,9 @@ std::optional<WindowAnalysisResult> analyzeWindow(
         }
     }
 
-    /// When `group_by_use_nulls = 1` with CUBE/ROLLUP/GROUPING SETS, GROUP BY keys become Nullable
-    /// in the data flowing into window functions. But the aggregate function was created during analysis
-    /// with the original (non-nullable) argument types. We need to re-create the aggregate function
-    /// with the actual (nullable) argument types so that the Null combinator is properly applied.
+    /// A window function's aggregate is created during analysis from the argument types known then.
+    /// When an argument's actual type differs by the time the window step runs, the aggregate must be
+    /// re-created with that type for the `Null` combinator to be applied.
     for (auto & window_description : window_descriptions)
     {
         for (auto & window_function : window_description.window_functions)

--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -379,9 +379,9 @@ std::optional<WindowAnalysisResult> analyzeWindow(
         }
     }
 
-    /// A window function's aggregate is created during analysis from the argument types known then.
-    /// When an argument's actual type differs by the time the window step runs, the aggregate must be
-    /// re-created with that type for the `Null` combinator to be applied.
+    /// A window function's aggregate is created during analysis and keeps the argument types known then,
+    /// so an argument whose actual type differs when the window step runs needs the aggregate re-created
+    /// with that type.
     for (auto & window_description : window_descriptions)
     {
         for (auto & window_function : window_description.window_functions)

--- a/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.reference
+++ b/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.reference
@@ -36,6 +36,10 @@ b	1
 a	1	1
 b	1	1
 \N	1	2
+-- the resolved type of a window aggregate over the key, on a query that was already accepted
+a	Nullable(String)
+b	Nullable(String)
+\N	Nullable(String)
 -- WITH TOTALS, where `group_by_use_nulls` does not reach the key today
 a	1
 b	1

--- a/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.reference
+++ b/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.reference
@@ -1,0 +1,59 @@
+-- window PARTITION BY over a ROLLUP key, and the key is Nullable inside the window
+a	Nullable(String)	1
+b	Nullable(String)	1
+\N	Nullable(String)	1
+-- the window really partitions: one row number per group, three without PARTITION BY
+1
+3
+-- window ORDER BY over a ROLLUP key
+a	1
+b	2
+\N	3
+-- the key as the argument of a window aggregate
+a
+a
+a
+-- the key in both the argument and the partition
+a
+b
+\N
+-- other window function names
+a	1	1	1	\N
+b	1	1	1	\N
+\N	1	1	1	\N
+-- HAVING beside the window
+a	1
+b	1
+-- QUALIFY
+a	1
+b	1
+\N	1
+-- WITH CUBE
+a	1
+b	1
+\N	1
+-- GROUPING SETS
+a	1	1
+b	1	1
+\N	1	2
+-- WITH TOTALS, where `group_by_use_nulls` does not reach the key today
+a	1
+b	1
+
+	1
+-- a named window, which resolves outside the window function and already worked
+a	1
+b	1
+\N	1
+-- `grouping` keeps comparing its argument in the original form
+a	0	1
+b	0	1
+\N	1	1
+-- a nested aggregate in the window specification keeps its own argument unconverted
+a	1
+b	1
+\N	1
+-- without `group_by_use_nulls`
+	1
+a	1
+b	1

--- a/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.reference
+++ b/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.reference
@@ -40,6 +40,15 @@ b	1	1
 a	Nullable(String)
 b	Nullable(String)
 \N	Nullable(String)
+-- an aggregate parameter folded from the key type now matches the same expression outside the window
+2	2
+2	2
+2	2
+-- a frame offset folded from the key type now matches the named window, which always folded it this way
+1	1
+2	2
+3	3
+-- and a frame offset that is only constant while the key is not Nullable is rejected, as under a named window
 -- WITH TOTALS, where `group_by_use_nulls` does not reach the key today
 a	1
 b	1

--- a/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
+++ b/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
@@ -1,0 +1,79 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/118070
+-- https://github.com/ClickHouse/ClickHouse/issues/103393
+-- A GROUP BY key referenced from a window function was not converted to Nullable under
+-- `group_by_use_nulls`, while the validator compared it against the Nullable key set, so
+-- every query below except the guards was rejected with NOT_AN_AGGREGATE.
+
+SET enable_analyzer = 1;
+SET group_by_use_nulls = 1;
+
+SELECT '-- window PARTITION BY over a ROLLUP key, and the key is Nullable inside the window';
+SELECT k, toTypeName(k) AS t, rank() OVER (PARTITION BY k) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- the window really partitions: one row number per group, three without PARTITION BY';
+SELECT countDistinct(r) FROM
+    (SELECT row_number() OVER (PARTITION BY k) AS r
+     FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP);
+SELECT countDistinct(r) FROM
+    (SELECT row_number() OVER () AS r
+     FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP);
+
+SELECT '-- window ORDER BY over a ROLLUP key';
+SELECT k, rank() OVER (ORDER BY k) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- the key as the argument of a window aggregate';
+SELECT min(k) OVER () AS m
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- the key in both the argument and the partition';
+SELECT min(k) OVER (PARTITION BY k) AS m
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- other window function names';
+SELECT k,
+    row_number() OVER (PARTITION BY k) AS a,
+    dense_rank() OVER (PARTITION BY k) AS b,
+    count() OVER (PARTITION BY k) AS c,
+    lagInFrame(k) OVER (PARTITION BY k ORDER BY k) AS d
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- HAVING beside the window';
+SELECT k, rank() OVER (PARTITION BY k) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP HAVING k IS NOT NULL ORDER BY ALL;
+
+SELECT '-- QUALIFY';
+SELECT k, rank() OVER (PARTITION BY k) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP QUALIFY r = 1 ORDER BY ALL;
+
+SELECT '-- WITH CUBE';
+SELECT k, rank() OVER (PARTITION BY k) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH CUBE ORDER BY ALL;
+
+SELECT '-- GROUPING SETS';
+SELECT k, rank() OVER (PARTITION BY k) AS r, count() AS c
+FROM values('k String', ('a'), ('b')) GROUP BY GROUPING SETS ((k), ()) ORDER BY ALL;
+
+-- Guards below: these already worked and must keep working unchanged.
+
+SELECT '-- WITH TOTALS, where `group_by_use_nulls` does not reach the key today';
+SELECT k, rank() OVER (PARTITION BY k) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH TOTALS ORDER BY ALL;
+
+SELECT '-- a named window, which resolves outside the window function and already worked';
+SELECT k, row_number() OVER w AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP WINDOW w AS (PARTITION BY k) ORDER BY ALL;
+
+SELECT '-- `grouping` keeps comparing its argument in the original form';
+SELECT k, grouping(k) AS g, rank() OVER (PARTITION BY grouping(k)) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- a nested aggregate in the window specification keeps its own argument unconverted';
+SELECT k, rank() OVER (PARTITION BY min(k)) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- without `group_by_use_nulls`';
+SELECT k, rank() OVER (PARTITION BY k) AS r
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL
+SETTINGS group_by_use_nulls = 0;

--- a/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
+++ b/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
@@ -55,6 +55,10 @@ SELECT '-- GROUPING SETS';
 SELECT k, rank() OVER (PARTITION BY k) AS r, count() AS c
 FROM values('k String', ('a'), ('b')) GROUP BY GROUPING SETS ((k), ()) ORDER BY ALL;
 
+SELECT '-- the resolved type of a window aggregate over the key, on a query that was already accepted';
+SELECT k, toTypeName(min(k) OVER ()) AS t
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
 -- Guards below: these already worked and must keep working unchanged.
 
 SELECT '-- WITH TOTALS, where `group_by_use_nulls` does not reach the key today';

--- a/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
+++ b/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
@@ -1,8 +1,8 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/118070
 -- https://github.com/ClickHouse/ClickHouse/issues/103393
 -- A GROUP BY key referenced from a window function was not converted to Nullable under
--- `group_by_use_nulls`, while the validator compared it against the Nullable key set, so
--- every query below except the guards was rejected with NOT_AN_AGGREGATE.
+-- `group_by_use_nulls`, while the validator compared it against the Nullable key set, so the
+-- reproducer queries below were rejected with NOT_AN_AGGREGATE.
 
 SET enable_analyzer = 1;
 SET group_by_use_nulls = 1;

--- a/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
+++ b/tests/queries/0_stateless/05076_window_function_group_by_use_nulls_not_an_aggregate.sql
@@ -59,6 +59,21 @@ SELECT '-- the resolved type of a window aggregate over the key, on a query that
 SELECT k, toTypeName(min(k) OVER ()) AS t
 FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
 
+SELECT '-- an aggregate parameter folded from the key type now matches the same expression outside the window';
+SELECT length(groupArray(toUInt8(isNullable(k)) + 1)(42) OVER ()) AS folded_parameter,
+    toUInt8(isNullable(k)) + 1 AS outside_the_window
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP ORDER BY ALL;
+
+SELECT '-- a frame offset folded from the key type now matches the named window, which always folded it this way';
+SELECT count() OVER (ORDER BY 1 ROWS BETWEEN length(toTypeName(k)) - 5 PRECEDING AND CURRENT ROW) AS inline_frame,
+    count() OVER w AS named_frame
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP
+WINDOW w AS (ORDER BY 1 ROWS BETWEEN length(toTypeName(k)) - 5 PRECEDING AND CURRENT ROW) ORDER BY ALL;
+
+SELECT '-- and a frame offset that is only constant while the key is not Nullable is rejected, as under a named window';
+SELECT count() OVER (ORDER BY 1 ROWS BETWEEN toUInt8(k IS NULL) PRECEDING AND CURRENT ROW)
+FROM values('k String', ('a'), ('b')) GROUP BY k WITH ROLLUP; -- { serverError BAD_ARGUMENTS }
+
 -- Guards below: these already worked and must keep working unchanged.
 
 SELECT '-- WITH TOTALS, where `group_by_use_nulls` does not reach the key today';


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/118070
Closes: https://github.com/ClickHouse/ClickHouse/issues/103393

A `GROUP BY` key referenced from a window function was not converted to `Nullable` under `group_by_use_nulls`, so the query was rejected with `NOT_AN_AGGREGATE`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `NOT_AN_AGGREGATE` being thrown for a `GROUP BY` key referenced from a window function when `group_by_use_nulls` is enabled together with `ROLLUP`, `CUBE` or `GROUPING SETS`, as in `SELECT rank() OVER (PARTITION BY k) FROM t GROUP BY k WITH ROLLUP`. Inside an inline window specification the key now has the same `Nullable` type it already had under a named `WINDOW` clause, which also changes a constant folded from that type, such as a `toTypeName(k)` frame offset.

### Description

Every window function name is registered in the aggregate function factory, and `ExpressionsStack::isAggregateOrGroupingFunction` classified by name only, so a window function incremented the counter that marks resolution as pre-aggregation, and the node stays on that stack for its whole resolution: the promotion was suppressed for its arguments and its window specification alike. `validateAggregates` builds its key set with `convertToNullable` and descends into window children, so the unpromoted reference matched no key.

A window function is evaluated after aggregation, so this suppression is wrong for it. Two other places agree: the planner puts its arguments, `PARTITION BY` and `ORDER BY` into `before_window_actions`, after the aggregation step, and a named `WINDOW` clause resolves the same specification with an empty stack.

The accessor has two callers, both gating this promotion, so nothing outside `group_by_use_nulls` changes. `grouping` stays outside the window guard and is still classified by name, so it keeps comparing its argument in the original form.

Four shapes that master already accepts change their answer, and tests pin all four. `toTypeName(min(k) OVER ())` now reports `Nullable(String)`, which is what the planner already executed. The promotion also reaches the children resolved at analysis time, so a constant folded from the key's type folds against `Nullable(...)`:

- `groupArray(toUInt8(isNullable(k)) + 1)(42) OVER ()` gives `[42,42]`, the value that expression already reports outside the window;
- `ROWS BETWEEN length(toTypeName(k)) - 5 PRECEDING` counts `1,2,3`;
- `ROWS BETWEEN toUInt8(k IS NULL) PRECEDING` is rejected with `BAD_ARGUMENTS`, having been constant only while the key was not `Nullable`.

For the two frame offsets a named `WINDOW` clause is the oracle: master already answers `1,2,3` and already rejects the second one, so only the inline spelling disagreed.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118173&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118173](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118173+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
