### PR TITLE
Restore a clean quota config on every exit path in `test_quota`

### DIFF
--- a/tests/integration/test_quota/test.py
+++ b/tests/integration/test_quota/test.py
@@ -454,85 +454,87 @@ def test_tracking_quota():
 def test_exceed_quota():
     # Change quota, now the limits are tiny so we will exceed the quota.
     copy_quota_xml("tiny_limits.xml")
-    check_system_quotas(
-        [
+    try:
+        check_system_quotas(
             [
-                "myQuota",
-                "e651da9c-a748-8703-061a-7e5e5096dae7",
-                "users_xml",
-                "['user_name']",
-                "[31556952]",
-                0,
-                "['default']",
-                "[]",
+                [
+                    "myQuota",
+                    "e651da9c-a748-8703-061a-7e5e5096dae7",
+                    "users_xml",
+                    "['user_name']",
+                    "[31556952]",
+                    0,
+                    "['default']",
+                    "[]",
+                ]
             ]
-        ]
-    )
-    system_quota_limits(
-        [["myQuota", 31556952, 0, 1, 1, 1, 1, 1, "\\N", 1, "\\N", "\\N", "\\N", "1"]]
-    )
-    system_quota_usage(
-        [
+        )
+        system_quota_limits(
+            [["myQuota", 31556952, 0, 1, 1, 1, 1, 1, "\\N", 1, "\\N", "\\N", "\\N", "1"]]
+        )
+        system_quota_usage(
             [
-                "myQuota",
-                "default",
-                31556952,
-                0,
-                1,
-                0,
-                1,
-                0,
-                1,
-                0,
-                1,
-                0,
-                1,
-                0,
-                "\\N",
-                0,
-                1,
-                0,
-                "\\N",
-                "\\N",
-                "1",
+                [
+                    "myQuota",
+                    "default",
+                    31556952,
+                    0,
+                    1,
+                    0,
+                    1,
+                    0,
+                    1,
+                    0,
+                    1,
+                    0,
+                    1,
+                    0,
+                    "\\N",
+                    0,
+                    1,
+                    0,
+                    "\\N",
+                    "\\N",
+                    "1",
+                ]
             ]
-        ]
-    )
+        )
 
-    assert re.search(
-        "Quota.*has been exceeded",
-        instance.query_and_get_error("SELECT * from test_table"),
-    )
-    system_quota_usage(
-        [
+        assert re.search(
+            "Quota.*has been exceeded",
+            instance.query_and_get_error("SELECT * from test_table"),
+        )
+        system_quota_usage(
             [
-                "myQuota",
-                "default",
-                31556952,
-                1,
-                1,
-                1,
-                1,
-                0,
-                1,
-                1,
-                1,
-                0,
-                1,
-                0,
-                "\\N",
-                50,
-                1,
-                0,
-                "\\N",
-                "\\N",
-                "1",
+                [
+                    "myQuota",
+                    "default",
+                    31556952,
+                    1,
+                    1,
+                    1,
+                    1,
+                    0,
+                    1,
+                    1,
+                    1,
+                    0,
+                    1,
+                    0,
+                    "\\N",
+                    50,
+                    1,
+                    0,
+                    "\\N",
+                    "\\N",
+                    "1",
+                ]
             ]
-        ]
-    )
+        )
+    finally:
+        # Change quota, now the limits are enough to execute queries.
+        copy_quota_xml("normal_limits.xml")
 
-    # Change quota, now the limits are enough to execute queries.
-    copy_quota_xml("normal_limits.xml")
     check_system_quotas(
         [
             [

--- a/tests/integration/test_quota/test.py
+++ b/tests/integration/test_quota/test.py
@@ -1437,12 +1437,17 @@ def test_reload_users_xml_by_timer():
                 "[]",
             ]
         ],
+        user="user_with_no_quota",
     )
     assert_eq_with_retry(
         instance,
         "SELECT quota_name, duration, is_randomized_interval, max_queries, max_query_selects, max_query_inserts, max_errors, max_result_rows, max_result_bytes, max_read_rows, max_read_bytes, max_execution_time, max_written_bytes, max_failed_sequential_authentications FROM system.quota_limits",
         [["myQuota", 31556952, 0, 1, 1, 1, 1, 1, "\\N", 1, "\\N", "\\N", "\\N", "1"]],
+        user="user_with_no_quota",
     )
+
+    # Restore a clean config so later periodic reloads do not fail.
+    copy_quota_xml("no_quotas.xml")
 
 
 def test_dcl_introspection():

--- a/tests/integration/test_quota/test.py
+++ b/tests/integration/test_quota/test.py
@@ -1422,32 +1422,35 @@ def test_reload_users_xml_by_timer():
     time.sleep(1)  # The modification time of the 'quota.xml' file should be different,
     # because config files are reload by timer only when the modification time is changed.
     copy_quota_xml("tiny_limits.xml", reload_immediately=False)
-    assert_eq_with_retry(
-        instance,
-        "SELECT name, id, storage, keys, durations, apply_to_all, apply_to_list, apply_to_except FROM system.quotas",
-        [
+    try:
+        assert_eq_with_retry(
+            instance,
+            "SELECT name, id, storage, keys, durations, apply_to_all, apply_to_list, apply_to_except FROM system.quotas",
             [
-                "myQuota",
-                "e651da9c-a748-8703-061a-7e5e5096dae7",
-                "users_xml",
-                ["user_name"],
-                "[31556952]",
-                0,
-                "['default']",
-                "[]",
-            ]
-        ],
-        user="user_with_no_quota",
-    )
-    assert_eq_with_retry(
-        instance,
-        "SELECT quota_name, duration, is_randomized_interval, max_queries, max_query_selects, max_query_inserts, max_errors, max_result_rows, max_result_bytes, max_read_rows, max_read_bytes, max_execution_time, max_written_bytes, max_failed_sequential_authentications FROM system.quota_limits",
-        [["myQuota", 31556952, 0, 1, 1, 1, 1, 1, "\\N", 1, "\\N", "\\N", "\\N", "1"]],
-        user="user_with_no_quota",
-    )
+                [
+                    "myQuota",
+                    "e651da9c-a748-8703-061a-7e5e5096dae7",
+                    "users_xml",
+                    ["user_name"],
+                    "[31556952]",
+                    0,
+                    "['default']",
+                    "[]",
+                ]
+            ],
+            user="user_with_no_quota",
+        )
+        assert_eq_with_retry(
+            instance,
+            "SELECT quota_name, duration, is_randomized_interval, max_queries, max_query_selects, max_query_inserts, max_errors, max_result_rows, max_result_bytes, max_read_rows, max_read_bytes, max_execution_time, max_written_bytes, max_failed_sequential_authentications FROM system.quota_limits",
+            [["myQuota", 31556952, 0, 1, 1, 1, 1, 1, "\\N", 1, "\\N", "\\N", "\\N", "1"]],
+            user="user_with_no_quota",
+        )
+    finally:
+        # Restore a clean config so later periodic reloads do not fail.
+        copy_quota_xml("no_quotas.xml")
 
-    # Restore a clean config so later periodic reloads do not fail.
-    copy_quota_xml("no_quotas.xml")
+    check_system_quotas("")
 
 
 def test_dcl_introspection():

--- a/tests/integration/test_quota/test.py
+++ b/tests/integration/test_quota/test.py
@@ -452,9 +452,9 @@ def test_tracking_quota():
 
 
 def test_exceed_quota():
-    # Change quota, now the limits are tiny so we will exceed the quota.
-    copy_quota_xml("tiny_limits.xml")
     try:
+        # Change quota, now the limits are tiny so we will exceed the quota.
+        copy_quota_xml("tiny_limits.xml")
         check_system_quotas(
             [
                 [
@@ -1423,8 +1423,8 @@ def test_reload_users_xml_by_timer():
 
     time.sleep(1)  # The modification time of the 'quota.xml' file should be different,
     # because config files are reload by timer only when the modification time is changed.
-    copy_quota_xml("tiny_limits.xml", reload_immediately=False)
     try:
+        copy_quota_xml("tiny_limits.xml", reload_immediately=False)
         assert_eq_with_retry(
             instance,
             "SELECT name, id, storage, keys, durations, apply_to_all, apply_to_list, apply_to_except FROM system.quotas",


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/101878


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`Integration tests (amd_msan, 6/8)` on `c14076c7b5a` lost 11 of the 18 `test_quota/test.py` cases:
everything from `test_dcl_introspection` onward errored at setup with `Quota for user default for
31556952s has been exceeded: failed_sequential_authentications = 11/1`. Reported by
@ alexey-milovidov at https://github.com/ClickHouse/ClickHouse/pull/101878#issuecomment-5538012688;
failing job https://github.com/ClickHouse/ClickHouse/actions/runs/32976486085/job/98246537291. No
open issue covers it.

Two tests install `tiny_limits.xml`, the only config here that sets every limit to 1 over a one-year
interval on `default`'s quota, and both could return with it live: `test_reload_users_xml_by_timer`
never restored, and `test_exceed_quota` restored only after four exact-match assertions, having
already charged `queries` to 1/1 itself. One counter at its maximum is unrecoverable for the module,
because the autouse `reset_quotas_and_usage_info` fixture runs `DROP QUOTA IF EXISTS qA, qB` as
`default` as its first statement and has no teardown, so it throws at setup for every remaining
test. For the counter CI hit, `AccessControl::authenticate` charges it before authenticating and
clears it only on success, so past the maximum no attempt reaches the reset.

Both now restore from a `finally`. The timer test restores `no_quotas.xml`, and
`check_system_quotas("")` after the block pins that; its two polls also run as `user_with_no_quota`,
which no quota governs, because authentication is charged outside the interpreter even though the
polled tables are quota-exempt. `test_exceed_quota` needs no new assertion: its own post-restore
checks already redden when the restore is dropped. `git diff -w` is 12 lines; the rest is
reindentation.

Both directions, full module, per site: forcing each failing path pre-fix leaves 11 and 14
following tests erroring from `test.py:96`, the reported shape; with the fix both runs are 18/18.
The arms use `queries`, since no test can arm `failed_sequential_authentications` (`default` is
`no_password`); the cascade follows from a 1-unit quota being live, not from which counter tripped.

One residual stays: the fixture's first statement still runs as the quota-limited user.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118174&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118174](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118174+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.803` (included in `26.9` and later)
<!-- ch-version-info:end -->