### PR TITLE
Perf(TimeSeries): Keep sparse time series buckets inline

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -9,6 +9,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <absl/container/inlined_vector.h>
+
 #include <base/sort.h>
 
 #include <libdivide-config.h>
@@ -24,9 +26,9 @@
 
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h>
+#include <Common/AllocatorWithMemoryTracking.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/TargetSpecific.h>
-#include <Common/VectorWithMemoryTracking.h>
 
 
 namespace DB
@@ -426,7 +428,12 @@ protected:
         }
         else
         {
-            VectorWithMemoryTracking<std::pair<size_t, const Bucket *>> ordered_buckets;
+            /// Most sparse states contain only a handful of populated buckets. Keep those entries inline and
+            /// retain memory tracking when the sparse state grows beyond the inline capacity.
+            absl::InlinedVector<
+                std::pair<size_t, const Bucket *>,
+                /* N = */ 8,
+                AllocatorWithMemoryTracking<std::pair<size_t, const Bucket *>>> ordered_buckets;
             ordered_buckets.reserve(buckets.size());
             for (const auto & entry : buckets)
                 ordered_buckets.emplace_back(entry.getKey(), &entry.getMapped());

--- a/tests/performance/timeseries_to_grid_aggregation_functions.xml
+++ b/tests/performance/timeseries_to_grid_aggregation_functions.xml
@@ -44,6 +44,9 @@
     <create_query>
         CREATE TABLE ts_grid_ingest (id UInt64, timestamp DateTime64(3), value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
     </create_query>
+    <create_query>
+        CREATE TABLE ts_grid_tiny_sparse (id UInt32, bucket_index UInt8, timestamp DateTime, value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
+    </create_query>
 
     <!-- 400 series, one sample every 10s over [0, 100000) -> 10000 samples/series, 4M rows total.
          The value is a sawtooth counter (0..999) so rate/changes/resets have transitions and resets to count. -->
@@ -57,7 +60,7 @@
     </fill_query>
 
     <!-- Sparse counterpart: ~1 sample per 100s (10x fewer) while step stays 10, so only ~1 in 10 buckets is
-         populated -> density ~0.1 < BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN=0.4 -> exercises the collect-and-sort
+         populated -> density ~0.1 < BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN=0.35 -> exercises the collect-and-sort
          bucket iteration in doInsertResultInto (the dense fill above always range-scans). 400 series, 1000
          samples/series, 400K rows. -->
     <fill_query>
@@ -77,6 +80,18 @@
             toDateTime64(intDiv(number, 10000) * 15, 3) AS timestamp,
             (intDiv(number, 10000) % 1000)::Float64 AS value
         FROM numbers_mt(10000 * 5000)
+    </fill_query>
+
+    <!-- 10000 series with up to 32 populated buckets each. The grid has 1001 bucket slots, so all of these
+         queries use the collect-and-sort path while sweeping the inline-capacity boundary. -->
+    <fill_query>
+        INSERT INTO ts_grid_tiny_sparse
+        SELECT
+            number % 10000 AS id,
+            intDiv(number, 10000) AS bucket_index,
+            toDateTime(intDiv(number, 10000) * 10) AS timestamp,
+            number::Float64 AS value
+        FROM numbers_mt(10000 * 32)
     </fill_query>
 
     <!-- step = 10 over [0, 100000] -> 10001 grid points, ~1 populated bucket per step, window/10 buckets per window. -->
@@ -101,7 +116,16 @@
     <query>SELECT id, timeSeriesRateToGrid(0, 75000, 60, 300)(timestamp, value) FROM ts_grid_ingest GROUP BY id FORMAT Null</query>
     <query>SELECT id, timeSeriesDerivToGrid(0, 75000, 60, 300)(timestamp, value) FROM ts_grid_ingest GROUP BY id FORMAT Null</query>
 
+    <!-- Small sparse states: one query per populated-bucket count makes the inline-capacity effect visible. -->
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 1 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 2 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 4 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 8 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 16 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 32 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+
     <drop_query>DROP TABLE IF EXISTS ts_grid</drop_query>
     <drop_query>DROP TABLE IF EXISTS ts_grid_sparse</drop_query>
     <drop_query>DROP TABLE IF EXISTS ts_grid_ingest</drop_query>
+    <drop_query>DROP TABLE IF EXISTS ts_grid_tiny_sparse</drop_query>
 </test>

--- a/tests/performance/timeseries_to_grid_aggregation_functions.xml
+++ b/tests/performance/timeseries_to_grid_aggregation_functions.xml
@@ -44,9 +44,6 @@
     <create_query>
         CREATE TABLE ts_grid_ingest (id UInt64, timestamp DateTime64(3), value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
     </create_query>
-    <create_query>
-        CREATE TABLE ts_grid_tiny_sparse (id UInt32, bucket_index UInt8, timestamp DateTime, value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
-    </create_query>
 
     <!-- 400 series, one sample every 10s over [0, 100000) -> 10000 samples/series, 4M rows total.
          The value is a sawtooth counter (0..999) so rate/changes/resets have transitions and resets to count. -->
@@ -82,18 +79,6 @@
         FROM numbers_mt(10000 * 5000)
     </fill_query>
 
-    <!-- 10000 series with up to 32 populated buckets each. The grid has 1001 bucket slots, so all of these
-         queries use the collect-and-sort path while sweeping the inline-capacity boundary. -->
-    <fill_query>
-        INSERT INTO ts_grid_tiny_sparse
-        SELECT
-            number % 10000 AS id,
-            intDiv(number, 10000) AS bucket_index,
-            toDateTime(intDiv(number, 10000) * 10) AS timestamp,
-            number::Float64 AS value
-        FROM numbers_mt(10000 * 32)
-    </fill_query>
-
     <!-- step = 10 over [0, 100000] -> 10001 grid points, ~1 populated bucket per step, window/10 buckets per window. -->
     <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 100000, 10, {window})(timestamp, value) FROM ts_grid GROUP BY id FORMAT Null</query>
     <query>SELECT id, timeSeriesInstantRateToGrid(0, 100000, 10, {window})(timestamp, value) FROM ts_grid GROUP BY id FORMAT Null</query>
@@ -116,16 +101,7 @@
     <query>SELECT id, timeSeriesRateToGrid(0, 75000, 60, 300)(timestamp, value) FROM ts_grid_ingest GROUP BY id FORMAT Null</query>
     <query>SELECT id, timeSeriesDerivToGrid(0, 75000, 60, 300)(timestamp, value) FROM ts_grid_ingest GROUP BY id FORMAT Null</query>
 
-    <!-- Small sparse states: one query per populated-bucket count makes the inline-capacity effect visible. -->
-    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 1 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
-    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 2 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
-    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 4 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
-    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 8 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
-    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 16 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
-    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 10000, 10, 10)(timestamp, value) FROM ts_grid_tiny_sparse WHERE bucket_index &lt; 32 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
-
     <drop_query>DROP TABLE IF EXISTS ts_grid</drop_query>
     <drop_query>DROP TABLE IF EXISTS ts_grid_sparse</drop_query>
     <drop_query>DROP TABLE IF EXISTS ts_grid_ingest</drop_query>
-    <drop_query>DROP TABLE IF EXISTS ts_grid_tiny_sparse</drop_query>
 </test>

--- a/tests/performance/timeseries_to_grid_sparse_buckets.xml
+++ b/tests/performance/timeseries_to_grid_sparse_buckets.xml
@@ -1,0 +1,37 @@
+<test>
+    <settings>
+        <allow_experimental_time_series_aggregate_functions>1</allow_experimental_time_series_aggregate_functions>
+        <max_insert_threads>8</max_insert_threads>
+    </settings>
+
+    <!--
+        Focused benchmark for the sparse collect-and-sort path in doInsertResultInto.
+        There are 50,000 series with up to 32 populated buckets each, while the grid has
+        201 bucket slots. Even the largest case has density 32 / 201 < 0.35, so every
+        query stays on the sparse path. The 1/2/4/8/16/32 cases sweep across the inline
+        capacity boundary. With 50,000 states and 201 output points, each query still
+        materializes about 10M output values, while making the per-state setup visible.
+    -->
+    <create_query>
+        CREATE TABLE ts_grid_sparse_buckets (id UInt32, bucket_index UInt8, timestamp DateTime, value Float64) ENGINE = MergeTree ORDER BY (id, timestamp)
+    </create_query>
+    <fill_query>
+        INSERT INTO ts_grid_sparse_buckets
+        SELECT
+            number % 50000 AS id,
+            intDiv(number, 50000) AS bucket_index,
+            toDateTime(intDiv(number, 50000) * 10) AS timestamp,
+            number::Float64 AS value
+        FROM numbers_mt(50000 * 32)
+    </fill_query>
+
+    <!-- window = step, so there is one bucket per grid step. The maximum density is 32 / 201 < 0.35. -->
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 2000, 10, 10)(timestamp, value) FROM ts_grid_sparse_buckets WHERE bucket_index &lt; 1 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 2000, 10, 10)(timestamp, value) FROM ts_grid_sparse_buckets WHERE bucket_index &lt; 2 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 2000, 10, 10)(timestamp, value) FROM ts_grid_sparse_buckets WHERE bucket_index &lt; 4 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 2000, 10, 10)(timestamp, value) FROM ts_grid_sparse_buckets WHERE bucket_index &lt; 8 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 2000, 10, 10)(timestamp, value) FROM ts_grid_sparse_buckets WHERE bucket_index &lt; 16 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+    <query>SELECT id, timeSeriesResampleToGridWithStaleness(0, 2000, 10, 10)(timestamp, value) FROM ts_grid_sparse_buckets WHERE bucket_index &lt; 32 GROUP BY id SETTINGS max_threads = 1 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS ts_grid_sparse_buckets</drop_query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Avoid a heap allocation when finalizing sparse `timeSeries*ToGrid` states with a small number of populated buckets.

## What does this PR do?

The sparse finalization path collects populated buckets into an index/pointer list and sorts it before producing the grid. The list currently uses a memory-tracked vector and calls `reserve(buckets.size())`, which allocates even when a state has only a few populated buckets.

This change uses `absl::InlinedVector` with room for 8 entries and keeps the existing memory-tracking allocator for overflow. The ordering, bucket processing, serialized state format, and result values are unchanged.

## Why?

Small sparse states are common for high-cardinality time-series queries. Keeping the temporary list inside the aggregate function state removes one allocation for states with up to 8 populated buckets. Larger states still use the tracked heap allocation.

## Performance coverage

The existing `tests/performance/timeseries_to_grid_aggregation_functions.xml` fixture now includes:

- 10,000 independent series.
- A 1,001-slot grid that stays on the sparse collect-and-sort path.
- Queries with 1, 2, 4, 8, 16, and 32 populated buckets.
- `max_threads = 1` to keep finalization cost easy to compare.

The sweep crosses the inline capacity and measures both the no-allocation and overflow cases with the normal performance harness.

## Related work

- [#110875](https://github.com/ClickHouse/ClickHouse/pull/110875) introduced the current `HashMap` plus `::sort` sparse finalization path.
- [#115041](https://github.com/ClickHouse/ClickHouse/pull/115041) improves sample ingestion in the same aggregate functions.
- [#118163](https://github.com/ClickHouse/ClickHouse/pull/118163) fuses the `addMany()` copy and ordering check.

Those changes target ingestion or the bucket map itself. This PR only changes the temporary ordered-bucket list used during result finalization.

## Validation

- `git diff --check`
- XML parsing for the performance fixture

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118182&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118182](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118182+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
