### PR TITLE
Preview the lldb backtraces in the hung check instead of lldb's attach output

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1446,10 +1446,12 @@ def print_c_stacktraces(
             backtraces = lldb_backtraces_only(block)
             print(trim_for_log(backtraces, 100))
             # Distinct numbers over the whole dump: the two sections share one
-            # numbering, and either alone can be short (the summary skips threads
-            # with no stop reason, the timeout truncates the backtraces).
+            # numbering, and either alone can be short (the summary omits threads
+            # with no stop reason, the timeout truncates the backtraces), so the
+            # total is exact only while lldb ran to completion.
+            named = len(set(LLDB_THREAD_HEADER_RE.findall(block)))
             threads = (
-                f" for {len(set(LLDB_THREAD_HEADER_RE.findall(block)))} threads"
+                f" for {'at least ' if truncated else ''}{named} threads"
                 if LLDB_BACKTRACE_MARKER in block
                 else ""
             )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1446,12 +1446,12 @@ def print_c_stacktraces(
             backtraces = lldb_backtraces_only(block)
             print(trim_for_log(backtraces, 100))
             # Distinct numbers over the whole dump: the two sections share one
-            # numbering, and either alone can be short (the summary omits threads
-            # with no stop reason, the timeout truncates the backtraces), so the
-            # total is exact only while lldb ran to completion.
+            # numbering, and neither is a census on its own (the summary omits
+            # threads with no stop reason, and lldb can stop printing backtraces
+            # early), so the total is a lower bound and not an exact count.
             named = len(set(LLDB_THREAD_HEADER_RE.findall(block)))
             threads = (
-                f" for {'at least ' if truncated else ''}{named} threads"
+                f" for at least {named} threads"
                 if LLDB_BACKTRACE_MARKER in block
                 else ""
             )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1090,24 +1090,18 @@ LLDB_TIMEOUT = 30
 LLDB_SLOW_BUILD_TIMEOUT = 120
 
 LLDB_BACKTRACE_MARKER = "(lldb) thread backtrace all"
-LLDB_THREAD_HEADER_RE = re.compile(r"^[* ] *thread #\d+", re.M)
+LLDB_THREAD_HEADER_RE = re.compile(r"^[* ] *thread #(\d+)", re.M)
 
 
-def split_lldb_dump(dump: str) -> tuple[str, str]:
-    """Split an lldb --batch dump into the attach summary and the backtraces.
+def lldb_backtraces_only(dump: str) -> str:
+    """The part of an lldb --batch dump from the backtraces on.
 
     Attaching prints a stop summary before lldb echoes the first command: a
-    `thread #N` header and `frame #0` for every thread, plus a few lines of
-    disassembly wherever lldb has no source line for that frame. So the summary
-    enumerates every thread and the echo after it means the summary is
-    complete, while the backtraces that follow can be cut short by the lldb
-    timeout.
-
-    The summary is empty when the echo is absent, so an attach-only dump is
-    never taken for a thread census.
+    `thread #N` header and `frame #0` for each thread it reports, plus a few
+    lines of disassembly wherever lldb has no source line for that frame.
     """
-    summary, marker, rest = dump.partition(LLDB_BACKTRACE_MARKER)
-    return (summary, marker + rest) if marker else ("", dump)
+    _, marker, rest = dump.partition(LLDB_BACKTRACE_MARKER)
+    return marker + rest if marker else dump
 
 
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)
@@ -1449,11 +1443,14 @@ def print_c_stacktraces(
             truncated = TRUNCATED_ON_TIMEOUT_MARKER in bt
             block = f"=== PID {pid} ({label}) ===\n{bt}"
             _append_stacktrace_log(C_STACKTRACES_LOG, block)
-            attach_summary, backtraces = split_lldb_dump(block)
+            backtraces = lldb_backtraces_only(block)
             print(trim_for_log(backtraces, 100))
+            # Distinct numbers over the whole dump: the two sections share one
+            # numbering, and either alone can be short (the summary skips threads
+            # with no stop reason, the timeout truncates the backtraces).
             threads = (
-                f" for {len(LLDB_THREAD_HEADER_RE.findall(attach_summary))} threads"
-                if attach_summary
+                f" for {len(set(LLDB_THREAD_HEADER_RE.findall(block)))} threads"
+                if LLDB_BACKTRACE_MARKER in block
                 else ""
             )
             print(

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1090,13 +1090,15 @@ LLDB_TIMEOUT = 30
 LLDB_SLOW_BUILD_TIMEOUT = 120
 
 LLDB_BACKTRACE_MARKER = "(lldb) thread backtrace all"
+LLDB_THREAD_HEADER_RE = re.compile(r"^[* ] *thread #\d+", re.M)
 
 
 def lldb_backtraces_only(dump: str) -> str:
     """The part of an lldb --batch dump from the backtraces on.
 
-    Attaching prints a stop summary with frame #0 and disassembly for every
-    thread before lldb echoes the first command.
+    Attaching prints a stop summary before lldb echoes the first command: a
+    `thread #N` header and `frame #0` for every thread, plus a few lines of
+    disassembly wherever lldb has no source line for that frame.
     """
     _, marker, rest = dump.partition(LLDB_BACKTRACE_MARKER)
     return marker + rest if marker else dump
@@ -1446,7 +1448,7 @@ def print_c_stacktraces(
             # The attach summary lists every thread too, so a dump that stopped
             # before the marker holds thread headers but no backtrace to count.
             threads = (
-                f" for {len(re.findall(r'^[* ] *thread #\d+', backtraces, re.M))} threads"
+                f" for {len(LLDB_THREAD_HEADER_RE.findall(backtraces))} threads"
                 if LLDB_BACKTRACE_MARKER in block
                 else ""
             )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1446,7 +1446,7 @@ def print_c_stacktraces(
             # The attach summary lists every thread too, so a dump that stopped
             # before the marker holds thread headers but no backtrace to count.
             threads = (
-                f" for {len(re.findall(r'^[* ] *thread #', backtraces, re.M))} threads"
+                f" for {len(re.findall(r'^[* ] *thread #\d+', backtraces, re.M))} threads"
                 if LLDB_BACKTRACE_MARKER in block
                 else ""
             )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1089,6 +1089,18 @@ def get_transactions_list(args):
 LLDB_TIMEOUT = 30
 LLDB_SLOW_BUILD_TIMEOUT = 120
 
+LLDB_BACKTRACE_MARKER = "(lldb) thread backtrace all"
+
+
+def lldb_backtraces_only(dump: str) -> str:
+    """The part of an lldb --batch dump from the backtraces on.
+
+    Attaching prints a stop summary with frame #0 and disassembly for every
+    thread before lldb echoes the first command.
+    """
+    _, marker, rest = dump.partition(LLDB_BACKTRACE_MARKER)
+    return marker + rest if marker else dump
+
 
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)
 def get_stacktraces_from_lldb(pid, timeout: float = LLDB_TIMEOUT):
@@ -1429,10 +1441,18 @@ def print_c_stacktraces(
             truncated = TRUNCATED_ON_TIMEOUT_MARKER in bt
             block = f"=== PID {pid} ({label}) ===\n{bt}"
             _append_stacktrace_log(C_STACKTRACES_LOG, block)
-            print(trim_for_log(block, 100))
+            backtraces = lldb_backtraces_only(block)
+            print(trim_for_log(backtraces, 100))
+            # The attach summary lists every thread too, so a dump that stopped
+            # before the marker holds thread headers but no backtrace to count.
+            threads = (
+                f" for {len(re.findall(r'^[* ] *thread #', backtraces, re.M))} threads"
+                if LLDB_BACKTRACE_MARKER in block
+                else ""
+            )
             print(
-                f"({'partial' if truncated else 'full'} lldb backtrace saved to "
-                f"{C_STACKTRACES_LOG})"
+                f"({'partial' if truncated else 'full'} lldb backtrace{threads} "
+                f"saved to {C_STACKTRACES_LOG})"
             )
         else:
             print(f"Got suspiciously small stacktraces from {pid}: {bt}")

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1093,15 +1093,21 @@ LLDB_BACKTRACE_MARKER = "(lldb) thread backtrace all"
 LLDB_THREAD_HEADER_RE = re.compile(r"^[* ] *thread #\d+", re.M)
 
 
-def lldb_backtraces_only(dump: str) -> str:
-    """The part of an lldb --batch dump from the backtraces on.
+def split_lldb_dump(dump: str) -> tuple[str, str]:
+    """Split an lldb --batch dump into the attach summary and the backtraces.
 
     Attaching prints a stop summary before lldb echoes the first command: a
     `thread #N` header and `frame #0` for every thread, plus a few lines of
-    disassembly wherever lldb has no source line for that frame.
+    disassembly wherever lldb has no source line for that frame. So the summary
+    enumerates every thread and the echo after it means the summary is
+    complete, while the backtraces that follow can be cut short by the lldb
+    timeout.
+
+    The summary is empty when the echo is absent, so an attach-only dump is
+    never taken for a thread census.
     """
-    _, marker, rest = dump.partition(LLDB_BACKTRACE_MARKER)
-    return marker + rest if marker else dump
+    summary, marker, rest = dump.partition(LLDB_BACKTRACE_MARKER)
+    return (summary, marker + rest) if marker else ("", dump)
 
 
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)
@@ -1443,13 +1449,11 @@ def print_c_stacktraces(
             truncated = TRUNCATED_ON_TIMEOUT_MARKER in bt
             block = f"=== PID {pid} ({label}) ===\n{bt}"
             _append_stacktrace_log(C_STACKTRACES_LOG, block)
-            backtraces = lldb_backtraces_only(block)
+            attach_summary, backtraces = split_lldb_dump(block)
             print(trim_for_log(backtraces, 100))
-            # The attach summary lists every thread too, so a dump that stopped
-            # before the marker holds thread headers but no backtrace to count.
             threads = (
-                f" for {len(LLDB_THREAD_HEADER_RE.findall(backtraces))} threads"
-                if LLDB_BACKTRACE_MARKER in block
+                f" for {len(LLDB_THREAD_HEADER_RE.findall(attach_summary))} threads"
+                if attach_summary
                 else ""
             )
             print(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/117278


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Requested by @ alexey-milovidov in
https://github.com/ClickHouse/ClickHouse/pull/117278#issuecomment-5543965919 while
investigating a `Stress test (arm_tsan)` hung check. CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=117278&sha=a3aa22f344d4e8e0eb0adda4ecb56f3a2347d47e&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29
My analysis of the hang itself:
https://github.com/ClickHouse/ClickHouse/pull/117278#issuecomment-5544982995

That job's `hung_check.log` describes a process that does not exist. Its lldb window
reads as 9 threads, all in the sanitizer runtime, no ClickHouse frames. The dump it
previews holds **730 threads**, 505 of them blocked in `__tsan::SlotAttachAndLock`
under ordinary ClickHouse frames.

`lldb --batch -p <pid>` attaches before running any command, and on attach prints a
stop summary for each thread it reports: a `thread #N` header and `frame #0`, plus a few
of disassembly where lldb has no source line for that frame (522 of the 730 here).
That averages about 7 lines per thread, so past about 8 threads it fills the entire
50-line head window `trim_for_log` keeps; here `(lldb) thread backtrace all` is line
5,094. The head half reaches no backtrace, the tail half lands on the last two threads
lldb enumerated, and the hidden-lines marker counts lines, not threads.

This previews the dump from the `thread backtrace all` marker on and puts the thread
count on the existing saved-to line. `c_stacktraces.log` is unchanged, and a dump
without the marker is previewed as before. On that dump the wasted head half
becomes backtraces: `frame #N` lines with N > 0 in the head 50 go from 0 to 41,
disassembly from 18 to 0, `SlotAttachAndLock` becomes visible, and the line reads
`for at least 730 threads`. `hung_check.log` grows about 3.5 KB from 15,402 bytes. It remains a
window onto six threads.

The slot starvation behind the hang is not addressed here: 255 usable TSan slots for
730 threads, 392 of the blocked threads arriving through a signal handler. I have no
validated fix for it and am not guessing at one.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118183&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118183](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118183+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1359` (included in `26.9` and later)
<!-- ch-version-info:end -->