### PR TITLE
Docs: fix the "Permissions for queries" page (HTTP readonly default, lightweight UPDATE and DELETE, mutations, RBAC)

### DIFF
--- a/docs/concepts/features/configuration/settings/constraints-on-settings.mdx
+++ b/docs/concepts/features/configuration/settings/constraints-on-settings.mdx
@@ -106,13 +106,12 @@ The Merge process depends on `settings_constraints_replace_previous`:
 
 ## Read-only mode {#read-only}
 
-Read-only mode is enabled by the `readonly` setting which is not to be confused
-with the `readonly` constraint type:
-- `readonly=0`: No read-only restrictions.
-- `readonly=1`: Only read queries are allowed and settings cannot be changed 
-   unless `changeable_in_readonly` is set.
-- `readonly=2`: Only read queries are allowed, but settings can be changed, 
-  except for `readonly` setting itself.
+Read-only mode is enabled by the `readonly` setting, which is not to be confused with the `readonly`
+constraint type. When `readonly = 1`, a setting that would otherwise be refused can still be changed if
+a `changeable_in_readonly` constraint allows it. For what the values of the setting mean, see the
+[settings reference](/reference/settings/session-settings/other#readonly); for which classes of query
+each value permits, and for how the HTTP interface sets it, see
+[permissions for queries](/concepts/features/configuration/settings/permissions-for-queries#readonly).
 
 ### Example {#example-read-only}
 

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -53,7 +53,8 @@ Granting a privilege with `GRANT` is refused too, but not every access managemen
 a privilege it holds with grant option and propagate its own grants to another user.
 `REVOKE ... ON CLUSTER` is refused.
 
-Temporary tables are exempt: a session that may create one may also insert into it and drop it.
+Temporary tables are exempt from both settings: a session that may create one may also `ALTER` it,
+insert into it and drop it.
 
 <Note>
 
@@ -78,27 +79,31 @@ tables, views, dictionaries, user-defined functions, workloads, resources and SQ
 
 Possible values:
 
-- 0 — Executing a query that needs any of the following privileges is blocked: `CREATE DATABASE`,
-  `DROP DATABASE`, `CREATE TABLE`, `CREATE VIEW`, `ALTER TABLE`, `ALTER VIEW`, `DROP TABLE`,
-  `DROP VIEW`, `TRUNCATE`, `CREATE DICTIONARY`, `DROP DICTIONARY`, `CREATE FUNCTION`, `DROP FUNCTION`,
-  `CREATE WORKLOAD`, `DROP WORKLOAD`, `CREATE RESOURCE`, `DROP RESOURCE`, `CREATE HANDLER`,
-  `ALTER HANDLER`, `DROP HANDLER`. `RENAME`, `EXCHANGE`, `ATTACH` and `DETACH` need these privileges
-  too, so they are blocked as well, except that `ALTER TABLE ... ATTACH PARTITION` and `ATTACH PART`
-  need only `INSERT` and are not blocked by this setting, although `readonly` blocks them.
-  `ATTACH PARTITION ... FROM` needs `ALTER DELETE` as well and is blocked. Granting and revoking these
-  privileges is not blocked.
+- 0 — Executing a query on a persistent object that needs any of the following privileges is
+  blocked: `CREATE DATABASE`, `DROP DATABASE`, `CREATE TABLE`, `CREATE VIEW`, `ALTER TABLE`,
+  `ALTER VIEW`, `DROP TABLE`, `DROP VIEW`, `TRUNCATE`, `CREATE DICTIONARY`, `DROP DICTIONARY`,
+  `CREATE FUNCTION`, `DROP FUNCTION`, `CREATE WORKLOAD`, `DROP WORKLOAD`, `CREATE RESOURCE`,
+  `DROP RESOURCE`, `CREATE HANDLER`, `ALTER HANDLER`, `DROP HANDLER`. `RENAME`, `EXCHANGE`,
+  `ATTACH` and `DETACH` need these privileges too, so they are blocked as well, except that
+  `ALTER TABLE ... ATTACH PARTITION` and `ATTACH PART` need only `INSERT` and are not blocked by
+  this setting, although `readonly` blocks them on a persistent table.
+  `ATTACH PARTITION ... FROM` needs `ALTER DELETE` as well and is blocked. Granting and revoking
+  these privileges is not blocked.
 - 1 — Nothing is blocked by this setting.
 
 Default value: 1
 
 <Note>
+
 You cannot run `SET allow_ddl = 1` if `allow_ddl = 0` for the current session.
 
 `allow_ddl` does not restrict access management queries: `GRANT`, `REVOKE` and `CREATE`, `ALTER` and
 `DROP` of users, roles, row policies, masking policies, quotas and settings profiles are unaffected by
 it. `CREATE TEMPORARY TABLE` and named collection management are unaffected too, as are
 `ALTER DATABASE ... MODIFY SETTING` and `ALTER DATABASE ... MODIFY COMMENT`, which `readonly` does not
-restrict either.
+restrict either. A `SETTINGS allow_ddl` clause inside a `CREATE` or `ALTER` of a user, a role or a
+settings profile is refused when it changes the value, for the same reason `SET allow_ddl` is: an
+embedded setting is checked against the session's own settings constraints.
 </Note>
 
 <Info>

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -48,15 +48,22 @@ queries (`CREATE`, `ALTER`, `RENAME`, `EXCHANGE`, `ATTACH`, `DETACH`, `DROP`, `T
 statements that require a privilege from the `SYSTEM` group, and `CREATE`, `ALTER` and `DROP` of users,
 roles, row policies, masking policies, quotas and settings profiles are not permitted either.
 
+Granting a privilege with `GRANT` is refused too, but not every access management statement is: `REVOKE`
+and `GRANT CURRENT GRANTS` are not gated by `readonly`, so a read-only session can still revoke a
+privilege it holds with grant option and propagate its own grants to another user.
+
 Temporary tables are exempt: a session that may create one may also insert into it and drop it.
 
 <Note>
-Any HTTP method other than `POST` implies read-only: when the effective value of `readonly` is 0, the
-[HTTP interface](/concepts/features/interfaces/http) raises it to 2 for that request. (`PUT` and
-`DELETE` are mutating only for SQL-defined handlers created with `CREATE HANDLER` that accept them.)
-A value already set by a settings profile or by the user's settings is applied first and is kept, so a
-stricter value stays in force. A `readonly` parameter in the query string is applied after this and
-cannot lower the value. To modify data, use the `POST` method.
+
+Over the [HTTP interface](/concepts/features/interfaces/http), a request whose method is not `POST` runs
+with `readonly = 2` if the effective value would otherwise be 0. A stricter value already set by the
+user's settings or by a settings profile is kept. `PUT` and `DELETE` are exempt when they reach a
+SQL-defined handler created with `CREATE HANDLER` that accepts them, and such a handler can modify data;
+otherwise use the `POST` method to modify data.
+
+On a request raised this way, a `readonly` parameter in the query string is refused with
+`Cannot modify 'readonly' setting in readonly mode` unless it names the value the request already has.
 
 There is a way to prohibit the user from changing only specific settings, and a way to allow changing
 only specific settings under `readonly = 1` restrictions. For details see
@@ -75,7 +82,9 @@ Possible values:
   `DROP VIEW`, `TRUNCATE`, `CREATE DICTIONARY`, `DROP DICTIONARY`, `CREATE FUNCTION`, `DROP FUNCTION`,
   `CREATE WORKLOAD`, `DROP WORKLOAD`, `CREATE RESOURCE`, `DROP RESOURCE`, `CREATE HANDLER`,
   `ALTER HANDLER`, `DROP HANDLER`. `RENAME`, `EXCHANGE`, `ATTACH` and `DETACH` need these privileges
-  too, so they are blocked as well. Granting and revoking these privileges is not blocked.
+  too, so they are blocked as well, except that `ALTER TABLE ... ATTACH PARTITION` needs only `INSERT`
+  and is not blocked by this setting, although `readonly` blocks it. Granting and revoking these
+  privileges is not blocked.
 - 1 — Nothing is blocked by this setting.
 
 Default value: 1
@@ -92,9 +101,10 @@ unaffected too.
 <Info>
 **KILL QUERY**
 
-Killing your own queries needs no privilege, so it works with any combination of `readonly` and
-`allow_ddl`. Killing a query that belongs to another user, and any `KILL QUERY ... ON CLUSTER`, require
-the `KILL QUERY` privilege, which `readonly = 1` and `readonly = 2` refuse.
+Killing your own queries does not require the `KILL QUERY` privilege, so it works with any combination
+of `readonly` and `allow_ddl`. It does require `SELECT` on `system.processes`. Killing a query that
+belongs to another user, and any `KILL QUERY ... ON CLUSTER`, require the `KILL QUERY` privilege, which
+`readonly = 1` and `readonly = 2` refuse.
 </Info>
 
 ## Other relevant settings {#other-relevant-settings}

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -51,7 +51,7 @@ permitted either. Named collection management is an exception: `readonly` does n
 Granting a privilege with `GRANT` is refused too, but not every access management statement is: a local
 `REVOKE` and `GRANT CURRENT GRANTS` are not gated by `readonly`, so a read-only session can still revoke
 a privilege it holds with grant option and propagate its own grants to another user.
-`REVOKE ... ON CLUSTER` is refused.
+Revoking a privilege `ON CLUSTER` is refused.
 
 Temporary tables are exempt from both settings: a session that may create one may also `ALTER` it,
 insert into it and drop it.
@@ -61,8 +61,8 @@ insert into it and drop it.
 Over the [HTTP interface](/concepts/features/interfaces/http), a request whose method is not `POST` runs
 with `readonly = 2` if the effective value would otherwise be 0. A stricter value already set by the
 user's settings or by a settings profile is kept. `PUT` and `DELETE` are exempt when they reach a
-SQL-defined handler created with `CREATE HANDLER` that accepts them, and such a handler can modify data;
-otherwise use the `POST` method to modify data.
+SQL-defined [handler](/reference/statements/create/handler) that accepts them, so such a request can
+modify data when the effective `readonly` is 0; otherwise use the `POST` method to modify data.
 
 On a request raised this way, a `readonly` parameter in the query string is refused with
 `Cannot modify 'readonly' setting in readonly mode` unless it names the value the request already has.
@@ -100,10 +100,11 @@ You cannot run `SET allow_ddl = 1` if `allow_ddl = 0` for the current session.
 `allow_ddl` does not restrict access management queries: `GRANT`, `REVOKE` and `CREATE`, `ALTER` and
 `DROP` of users, roles, row policies, masking policies, quotas and settings profiles are unaffected by
 it. `CREATE TEMPORARY TABLE` and named collection management are unaffected too, as are
-`ALTER DATABASE ... MODIFY SETTING` and `ALTER DATABASE ... MODIFY COMMENT`, which `readonly` does not
-restrict either. A `SETTINGS allow_ddl` clause inside a `CREATE` or `ALTER` of a user, a role or a
-settings profile is refused when it changes the value, for the same reason `SET allow_ddl` is: an
-embedded setting is checked against the session's own settings constraints.
+`ALTER DATABASE ... MODIFY SETTING`, `ALTER DATABASE ... MODIFY COMMENT` and `UNDROP TABLE`, which
+`readonly` does not restrict either. Inside a `CREATE` or `ALTER` of a user, a role or a settings
+profile, a `SETTINGS allow_ddl = 1` clause is refused while the current session has `allow_ddl = 0`,
+and a `SETTINGS allow_ddl = 0` clause is accepted. An embedded setting is checked against the
+session's own settings constraints, which is also why `SET allow_ddl = 1` is refused.
 </Note>
 
 <Info>

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -34,7 +34,9 @@ When set to 1, allows queries such as:
 - Read queries (like `SELECT` and equivalent queries).
 - Queries that modify only session context (like `USE`).
 
-When set to 2, allows the above plus `SET` and `CREATE TEMPORARY TABLE`.
+When set to 2, allows the above plus `SET`, `CREATE TEMPORARY TABLE` and `RESTORE`. A `RESTORE` can
+create a table and load data into it, so `readonly = 2` does not by itself stop a session from
+writing; `readonly = 1` refuses it.
 
 Most table functions need the `CREATE TEMPORARY TABLE` privilege, so a `SELECT` that reads from one is
 refused at `readonly = 1` but not at `readonly = 2`. Some, such as `numbers`, are allowed in read-only
@@ -123,6 +125,8 @@ belongs to another user, and any `KILL QUERY ... ON CLUSTER`, require the `KILL 
   `allow_ddl`. When it is disabled, executing an introspection function is blocked. Granting the
   `INTROSPECTION` privilege is not blocked.
 - [`allow_non_metadata_alters`](/reference/settings/session-settings/allow#allow_non_metadata_alters)
-  is not a permission setting, but it restricts `ALTER` further: when it is disabled, an `ALTER` that
-  changes table metadata in a way that would also rewrite data on disk is refused on
-  `MergeTree`-family tables.
+  is not a permission setting, but it restricts `ALTER` further: when it is disabled, a command that
+  changes the columns, indexes, projections or TTL of a `MergeTree`-family table is refused if
+  applying it would rewrite data on disk (`DROP COLUMN`, `RENAME COLUMN`, a `MODIFY COLUMN` type
+  change, `MODIFY TTL`). `CLEAR COLUMN`, `CLEAR INDEX` and `CLEAR PROJECTION` are refused too,
+  although they change no metadata.

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -38,6 +38,9 @@ When set to 2, allows the above plus `SET`, `CREATE TEMPORARY TABLE` and `RESTOR
 create a table and load data into it, so `readonly = 2` does not by itself stop a session from
 writing; `readonly = 1` refuses it.
 
+`BACKUP` is not restricted by `readonly` at any value: a session that has the privileges to back a
+table up can write a backup even at `readonly = 1`. Do not rely on `readonly` to prevent backups.
+
 Most table functions need the `CREATE TEMPORARY TABLE` privilege, so a `SELECT` that reads from one is
 refused at `readonly = 1` but not at `readonly = 2`. Some, such as `numbers`, are allowed in read-only
 mode.

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -36,21 +36,22 @@ When set to 1, allows queries such as:
 
 When set to 2, allows the above plus `SET` and `CREATE TEMPORARY TABLE`.
 
-Default value: 0
-
 Most table functions need the `CREATE TEMPORARY TABLE` privilege, so a `SELECT` that reads from one is
-refused at `readonly = 1` but not at `readonly = 2`. A few, such as `numbers`, are allowed in read-only
+refused at `readonly = 1` but not at `readonly = 2`. Some, such as `numbers`, are allowed in read-only
 mode.
 
 For any value above 0, none of the following is permitted on a persistent table: write data queries
 (`INSERT`, `OPTIMIZE`, `DELETE`, `UPDATE`, `ALTER TABLE ... DELETE`, `ALTER TABLE ... UPDATE`) or DDL
-queries (`CREATE`, `ALTER`, `RENAME`, `EXCHANGE`, `ATTACH`, `DETACH`, `DROP`, `TRUNCATE`). `SYSTEM`
-statements that require a privilege from the `SYSTEM` group, and `CREATE`, `ALTER` and `DROP` of users,
-roles, row policies, masking policies, quotas and settings profiles are not permitted either.
+queries (`CREATE`, `ALTER TABLE`, `ALTER VIEW`, `RENAME`, `EXCHANGE`, `ATTACH`, `DETACH`, `DROP`,
+`TRUNCATE`). `SYSTEM` statements that require a privilege from the `SYSTEM` group, and `CREATE`, `ALTER`
+and `DROP` of users, roles, row policies, masking policies, quotas and settings profiles are not
+permitted either. Named collection management is an exception: `readonly` does not restrict
+`CREATE NAMED COLLECTION`, `ALTER NAMED COLLECTION` or `DROP NAMED COLLECTION`.
 
-Granting a privilege with `GRANT` is refused too, but not every access management statement is: `REVOKE`
-and `GRANT CURRENT GRANTS` are not gated by `readonly`, so a read-only session can still revoke a
-privilege it holds with grant option and propagate its own grants to another user.
+Granting a privilege with `GRANT` is refused too, but not every access management statement is: a local
+`REVOKE` and `GRANT CURRENT GRANTS` are not gated by `readonly`, so a read-only session can still revoke
+a privilege it holds with grant option and propagate its own grants to another user.
+`REVOKE ... ON CLUSTER` is refused.
 
 Temporary tables are exempt: a session that may create one may also insert into it and drop it.
 
@@ -82,8 +83,9 @@ Possible values:
   `DROP VIEW`, `TRUNCATE`, `CREATE DICTIONARY`, `DROP DICTIONARY`, `CREATE FUNCTION`, `DROP FUNCTION`,
   `CREATE WORKLOAD`, `DROP WORKLOAD`, `CREATE RESOURCE`, `DROP RESOURCE`, `CREATE HANDLER`,
   `ALTER HANDLER`, `DROP HANDLER`. `RENAME`, `EXCHANGE`, `ATTACH` and `DETACH` need these privileges
-  too, so they are blocked as well, except that `ALTER TABLE ... ATTACH PARTITION` needs only `INSERT`
-  and is not blocked by this setting, although `readonly` blocks it. Granting and revoking these
+  too, so they are blocked as well, except that `ALTER TABLE ... ATTACH PARTITION` and `ATTACH PART`
+  need only `INSERT` and are not blocked by this setting, although `readonly` blocks them.
+  `ATTACH PARTITION ... FROM` needs `ALTER DELETE` as well and is blocked. Granting and revoking these
   privileges is not blocked.
 - 1 — Nothing is blocked by this setting.
 
@@ -94,8 +96,9 @@ You cannot run `SET allow_ddl = 1` if `allow_ddl = 0` for the current session.
 
 `allow_ddl` does not restrict access management queries: `GRANT`, `REVOKE` and `CREATE`, `ALTER` and
 `DROP` of users, roles, row policies, masking policies, quotas and settings profiles are unaffected by
-it. `CREATE TEMPORARY TABLE`, named collection management and `ALTER DATABASE ... MODIFY SETTING` are
-unaffected too.
+it. `CREATE TEMPORARY TABLE` and named collection management are unaffected too, as are
+`ALTER DATABASE ... MODIFY SETTING` and `ALTER DATABASE ... MODIFY COMMENT`, which `readonly` does not
+restrict either.
 </Note>
 
 <Info>

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -43,7 +43,7 @@ mode.
 For any value above 0, none of the following is permitted on a persistent table: write data queries
 (`INSERT`, `OPTIMIZE`, `DELETE`, `UPDATE`, `ALTER TABLE ... DELETE`, `ALTER TABLE ... UPDATE`) or DDL
 queries (`CREATE`, `ALTER TABLE`, `ALTER VIEW`, `RENAME`, `EXCHANGE`, `ATTACH`, `DETACH`, `DROP`,
-`TRUNCATE`). `SYSTEM` statements that require a privilege from the `SYSTEM` group, and `CREATE`, `ALTER`
+`TRUNCATE TABLE`). `SYSTEM` statements that require a privilege from the `SYSTEM` group, and `CREATE`, `ALTER`
 and `DROP` of users, roles, row policies, masking policies, quotas and settings profiles are not
 permitted either. Named collection management is an exception: `readonly` does not restrict
 `CREATE NAMED COLLECTION`, `ALTER NAMED COLLECTION` or `DROP NAMED COLLECTION`.

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -125,8 +125,9 @@ belongs to another user, and any `KILL QUERY ... ON CLUSTER`, require the `KILL 
   `allow_ddl`. When it is disabled, executing an introspection function is blocked. Granting the
   `INTROSPECTION` privilege is not blocked.
 - [`allow_non_metadata_alters`](/reference/settings/session-settings/allow#allow_non_metadata_alters)
-  is not a permission setting, but it restricts `ALTER` further: when it is disabled, a command that
-  changes the columns, indexes, projections or TTL of a `MergeTree`-family table is refused if
-  applying it would rewrite data on disk (`DROP COLUMN`, `RENAME COLUMN`, a `MODIFY COLUMN` type
-  change, `MODIFY TTL`). `CLEAR COLUMN`, `CLEAR INDEX` and `CLEAR PROJECTION` are refused too,
-  although they change no metadata.
+  is not a permission setting, but it restricts `ALTER TABLE` further: when it is disabled, a command
+  that alters the table definition is refused on `MergeTree`-family tables if applying it would
+  rewrite data on disk (`DROP COLUMN`, `RENAME COLUMN`, a `MODIFY COLUMN` type change, `MODIFY TTL`).
+  `CLEAR COLUMN`, `CLEAR INDEX` and `CLEAR PROJECTION` are refused too, although they leave the
+  definition unchanged. Statements that are themselves mutations, such as `ALTER TABLE ... DELETE`,
+  `ALTER TABLE ... UPDATE` and `ALTER TABLE ... MATERIALIZE INDEX`, are not affected.

--- a/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
+++ b/docs/concepts/features/configuration/settings/permissions-for-queries.mdx
@@ -9,61 +9,101 @@ doc_type: 'reference'
 Queries in ClickHouse can be divided into several types:
 
 1.  Read data queries: `SELECT`, `SHOW`, `DESCRIBE`, `EXISTS`.
-2.  Write data queries: `INSERT`, `OPTIMIZE`.
+2.  Write data queries: `INSERT`, `OPTIMIZE`, [`DELETE`](/reference/statements/delete), [`UPDATE`](/reference/statements/update), `ALTER TABLE ... DELETE`, `ALTER TABLE ... UPDATE`.
 3.  Change settings query: `SET`, `USE`.
-4.  [DDL](https://en.wikipedia.org/wiki/Data_definition_language) queries: `CREATE`, `ALTER`, `RENAME`, `ATTACH`, `DETACH`, `DROP` `TRUNCATE`.
-5.  `KILL QUERY`.
+4.  [DDL](https://en.wikipedia.org/wiki/Data_definition_language) queries: `CREATE`, `ALTER`, `RENAME`, `EXCHANGE`, `ATTACH`, `DETACH`, `DROP`, `TRUNCATE`.
+5.  Access management queries: [`GRANT`](/reference/statements/grant), [`REVOKE`](/reference/statements/revoke), and `CREATE`, `ALTER` and `DROP` of users, roles, row policies, masking policies, quotas and settings profiles. See [access control and account management](/concepts/features/security/access-rights).
+6.  `KILL QUERY`.
+
+`ALTER TABLE ... DELETE` and `ALTER TABLE ... UPDATE` change data rather than table metadata, which
+is why they are listed above as write data queries. They require the `ALTER DELETE` and
+`ALTER UPDATE` privileges, which are also the privileges the standalone `DELETE` and `UPDATE`
+statements require. Those privileges belong to the `ALTER TABLE` privilege group, so `allow_ddl = 0`
+refuses all four statements on a persistent table.
 
 The following settings regulate user permissions by the type of query:
 
 ## readonly {#readonly}
-Restricts permissions for read data, write data, and change settings queries.
+Restricts which queries a session may run. The values of the setting, its default, and which settings
+each value lets you change are described in the
+[settings reference](/reference/settings/session-settings/other#readonly); this section describes which
+classes of query each value permits.
 
-When set to 1, allows:
+When set to 1, allows queries such as:
 
-- All types of read queries (like SELECT and equivalent queries).
-- Queries that modify only session context (like USE).
+- Read queries (like `SELECT` and equivalent queries).
+- Queries that modify only session context (like `USE`).
 
-When set to 2, allows the above plus:
-- SET and CREATE TEMPORARY TABLE
-
-<Tip>
-  Queries like EXISTS, DESCRIBE, EXPLAIN, SHOW PROCESSLIST, etc are equivalent to SELECT, because they just do select from system tables.
-</Tip>
-
-Possible values:
-
-- 0 — Read, Write, and Change settings queries are allowed.
-- 1 — Only Read data queries are allowed.
-- 2 — Read data and Change settings queries are allowed.
+When set to 2, allows the above plus `SET` and `CREATE TEMPORARY TABLE`.
 
 Default value: 0
 
+Most table functions need the `CREATE TEMPORARY TABLE` privilege, so a `SELECT` that reads from one is
+refused at `readonly = 1` but not at `readonly = 2`. A few, such as `numbers`, are allowed in read-only
+mode.
+
+For any value above 0, none of the following is permitted on a persistent table: write data queries
+(`INSERT`, `OPTIMIZE`, `DELETE`, `UPDATE`, `ALTER TABLE ... DELETE`, `ALTER TABLE ... UPDATE`) or DDL
+queries (`CREATE`, `ALTER`, `RENAME`, `EXCHANGE`, `ATTACH`, `DETACH`, `DROP`, `TRUNCATE`). `SYSTEM`
+statements that require a privilege from the `SYSTEM` group, and `CREATE`, `ALTER` and `DROP` of users,
+roles, row policies, masking policies, quotas and settings profiles are not permitted either.
+
+Temporary tables are exempt: a session that may create one may also insert into it and drop it.
+
 <Note>
-After setting `readonly = 1`, the user can't change `readonly` and `allow_ddl` settings in the current session.
+Any HTTP method other than `POST` implies read-only: when the effective value of `readonly` is 0, the
+[HTTP interface](/concepts/features/interfaces/http) raises it to 2 for that request. (`PUT` and
+`DELETE` are mutating only for SQL-defined handlers created with `CREATE HANDLER` that accept them.)
+A value already set by a settings profile or by the user's settings is applied first and is kept, so a
+stricter value stays in force. A `readonly` parameter in the query string is applied after this and
+cannot lower the value. To modify data, use the `POST` method.
 
-When using the `GET` method in the [HTTP interface](/concepts/features/interfaces/http), `readonly = 1` is set automatically. To modify data, use the `POST` method.
-
-Setting `readonly = 1` prohibits the user from changing settings. There is a way to prohibit the user from changing only specific settings. Also there is a way to allow changing only specific settings under `readonly = 1` restrictions. For details see [constraints on settings](/concepts/features/configuration/settings/constraints-on-settings).
+There is a way to prohibit the user from changing only specific settings, and a way to allow changing
+only specific settings under `readonly = 1` restrictions. For details see
+[constraints on settings](/concepts/features/configuration/settings/constraints-on-settings).
 </Note>
 
 ## allow_ddl {#allow_ddl}
 
-Allows or denies [DDL](https://en.wikipedia.org/wiki/Data_definition_language) queries.
+Allows or denies [DDL](https://en.wikipedia.org/wiki/Data_definition_language) queries on databases,
+tables, views, dictionaries, user-defined functions, workloads, resources and SQL-defined handlers.
 
 Possible values:
 
-- 0 — DDL queries are not allowed.
-- 1 — DDL queries are allowed.
+- 0 — Executing a query that needs any of the following privileges is blocked: `CREATE DATABASE`,
+  `DROP DATABASE`, `CREATE TABLE`, `CREATE VIEW`, `ALTER TABLE`, `ALTER VIEW`, `DROP TABLE`,
+  `DROP VIEW`, `TRUNCATE`, `CREATE DICTIONARY`, `DROP DICTIONARY`, `CREATE FUNCTION`, `DROP FUNCTION`,
+  `CREATE WORKLOAD`, `DROP WORKLOAD`, `CREATE RESOURCE`, `DROP RESOURCE`, `CREATE HANDLER`,
+  `ALTER HANDLER`, `DROP HANDLER`. `RENAME`, `EXCHANGE`, `ATTACH` and `DETACH` need these privileges
+  too, so they are blocked as well. Granting and revoking these privileges is not blocked.
+- 1 — Nothing is blocked by this setting.
 
 Default value: 1
 
 <Note>
 You cannot run `SET allow_ddl = 1` if `allow_ddl = 0` for the current session.
+
+`allow_ddl` does not restrict access management queries: `GRANT`, `REVOKE` and `CREATE`, `ALTER` and
+`DROP` of users, roles, row policies, masking policies, quotas and settings profiles are unaffected by
+it. `CREATE TEMPORARY TABLE`, named collection management and `ALTER DATABASE ... MODIFY SETTING` are
+unaffected too.
 </Note>
 
 <Info>
 **KILL QUERY**
 
-`KILL QUERY` can be performed with any combination of readonly and allow_ddl settings.
+Killing your own queries needs no privilege, so it works with any combination of `readonly` and
+`allow_ddl`. Killing a query that belongs to another user, and any `KILL QUERY ... ON CLUSTER`, require
+the `KILL QUERY` privilege, which `readonly = 1` and `readonly = 2` refuse.
 </Info>
+
+## Other relevant settings {#other-relevant-settings}
+
+- [`allow_introspection_functions`](/reference/settings/session-settings/allow#allow_introspection_functions)
+  is the third setting that takes part in the permission decision itself, together with `readonly` and
+  `allow_ddl`. When it is disabled, executing an introspection function is blocked. Granting the
+  `INTROSPECTION` privilege is not blocked.
+- [`allow_non_metadata_alters`](/reference/settings/session-settings/allow#allow_non_metadata_alters)
+  is not a permission setting, but it restricts `ALTER` further: when it is disabled, an `ALTER` that
+  changes table metadata in a way that would also rewrite data on disk is refused on
+  `MergeTree`-family tables.

--- a/docs/reference/functions/table-functions/index.mdx
+++ b/docs/reference/functions/table-functions/index.mdx
@@ -84,6 +84,7 @@ cat numbers.csv
 ```
 
 <Note>
+
 Most table functions need the `CREATE TEMPORARY TABLE` privilege, so you can't use them when
-[readonly](/concepts/features/configuration/settings/permissions-for-queries#readonly) is set to 1.
+[`readonly`](/concepts/features/configuration/settings/permissions-for-queries#readonly) is set to 1.
 </Note>

--- a/docs/reference/functions/table-functions/index.mdx
+++ b/docs/reference/functions/table-functions/index.mdx
@@ -85,6 +85,7 @@ cat numbers.csv
 
 <Note>
 
-Most table functions need the `CREATE TEMPORARY TABLE` privilege, so you can't use them when
+Most table functions need the `CREATE TEMPORARY TABLE` privilege to run, so a `SELECT` or `INSERT`
+that executes one is refused when
 [`readonly`](/concepts/features/configuration/settings/permissions-for-queries#readonly) is set to 1.
 </Note>

--- a/docs/reference/functions/table-functions/index.mdx
+++ b/docs/reference/functions/table-functions/index.mdx
@@ -84,5 +84,6 @@ cat numbers.csv
 ```
 
 <Note>
-You can't use table functions if the [allow_ddl](/reference/settings/session-settings/allow#allow_ddl) setting is disabled.
+Most table functions need the `CREATE TEMPORARY TABLE` privilege, so you can't use them when
+[readonly](/concepts/features/configuration/settings/permissions-for-queries#readonly) is set to 1.
 </Note>


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/115699
Related: https://github.com/ClickHouse/ClickHouse/issues/115697
Related: https://github.com/ClickHouse/ClickHouse/pull/115287

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Corrected and completed the "Permissions for queries" documentation page.

### Description

`permissions-for-queries`:

- lightweight `DELETE`/`UPDATE` and `ALTER TABLE ... DELETE`/`UPDATE` added to "Write data queries",
  plus an "Access management queries" category linking to the RBAC docs;
- `readonly`: over HTTP, any method other than `POST` runs with **2**, not 1, and only from an effective
  0, so a stricter profile value survives but an explicit 0 does not; `PUT`/`DELETE` at a SQL-defined
  handler skip the bump but still obey the effective value; a query-string `readonly` is refused, not
  clamped; `GRANT` is refused, while a local `REVOKE` and `GRANT CURRENT GRANTS` are not gated;
- deleted the `<Tip>` calling `EXISTS`/`DESCRIBE`/`EXPLAIN`/`SHOW PROCESSLIST` "equivalent to `SELECT`";
- `allow_ddl = 0` lists the privileges it blocks; it blocks neither `CREATE TEMPORARY TABLE`, granting,
  nor `ATTACH PARTITION`/`ATTACH PART`, which need only `INSERT`; the `... FROM` form is blocked.
  Neither setting restricts `ALTER DATABASE`, `UNDROP TABLE` or named collection management;
- `KILL QUERY`: your own needs no `KILL QUERY` privilege but does need `SELECT` on `system.processes`;
  another user's, and any `ON CLUSTER`, need the privilege, which `readonly` refuses;
- new section for `allow_introspection_functions` and `allow_non_metadata_alters`.

`table-functions/index.mdx` said the opposite: they need `CREATE TEMPORARY TABLE`, so
`readonly = 1` blocks them, not `allow_ddl`.

**Duplicate `readonly` docs**: of three copies, the `DECLARE` keeps the value semantics,
`permissions-for-queries#readonly` owns the query classes (losing `Possible values:`), and
`constraints-on-settings#read-only` keeps only the constraint-type disambiguation.

**#115697**: the wrong HTTP default is fixed here and `00305_http_and_readonly.sh` already asserts it,
so no test is added. The `readonly = 2` transition table is deferred to #115695, per @ ringerc.

Left undocumented on purpose: `readonly` versus `SET ROLE` and role grants (#115691 contests it), and
the `BACKUP`/`RESTORE` and SQL-defined handler policies themselves; what `readonly` does to each is
stated. The autogenerated `DECLARE` summary still calls values 1 and 2 read-only (fix belongs in
`src/Core/Settings.cpp`).

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118184&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118184](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118184+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->




<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1358` (included in `26.9` and later)
<!-- ch-version-info:end -->