### PR TITLE
Isolate 04326_json_advanced_shared_data_file_open and stop it misreporting a missing measurement

### DIFF
--- a/tests/queries/0_stateless/04326_json_advanced_shared_data_file_open.sh
+++ b/tests/queries/0_stateless/04326_json_advanced_shared_data_file_open.sh
@@ -77,7 +77,7 @@ MARK_CACHE_MISSES=$(${CLICKHOUSE_CLIENT} -q "
 # below that the query did not perform the read this test measures.
 MIN_MARKS=3
 if [ -z "${MARK_CACHE_MISSES}" ]; then
-    echo "FAIL: no query_log row for the measured query"
+    echo "FAIL: no QueryFinish row for the measured query"
 elif [ "${MARK_CACHE_MISSES}" -lt "${MIN_MARKS}" ]; then
     echo "FAIL: MarkCacheMisses (${MARK_CACHE_MISSES}) < ${MIN_MARKS}, the read was not measured"
 elif [ "${MARK_CACHE_MISSES}" -gt "${EXPECTED_MARKS}" ]; then

--- a/tests/queries/0_stateless/04326_json_advanced_shared_data_file_open.sh
+++ b/tests/queries/0_stateless/04326_json_advanced_shared_data_file_open.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: asserts an exact miss count on the process-wide mark cache, which it also clears.
 # Test that reading the whole JSON column with ADVANCED shared data serialization
 # does not open per-bucket data/marks/substreams files that are not needed for reading.
 # When reading the whole JSON column, only Structure (per bucket) and Copy streams are used;
@@ -70,13 +72,18 @@ MARK_CACHE_MISSES=$(${CLICKHOUSE_CLIENT} -q "
         AND current_database = currentDatabase()
 ")
 
-# MarkCacheMisses should be at most EXPECTED_MARKS.
-# It can be lower if some marks were already cached, but must not be higher —
-# that would mean unnecessary per-bucket data streams were loaded.
-if [ "${MARK_CACHE_MISSES}" -le "${EXPECTED_MARKS}" ]; then
-    echo "OK"
-else
+# MarkCacheMisses must not exceed EXPECTED_MARKS: a higher count means unnecessary per-bucket data
+# streams were loaded. It must also not fall below the three Copy streams, which are always read:
+# below that the query did not perform the read this test measures.
+MIN_MARKS=3
+if [ -z "${MARK_CACHE_MISSES}" ]; then
+    echo "FAIL: no query_log row for the measured query"
+elif [ "${MARK_CACHE_MISSES}" -lt "${MIN_MARKS}" ]; then
+    echo "FAIL: MarkCacheMisses (${MARK_CACHE_MISSES}) < ${MIN_MARKS}, the read was not measured"
+elif [ "${MARK_CACHE_MISSES}" -gt "${EXPECTED_MARKS}" ]; then
     echo "FAIL: MarkCacheMisses (${MARK_CACHE_MISSES}) > expected (${EXPECTED_MARKS})"
+else
+    echo "OK"
 fi
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${TABLE_NAME}"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107051
Related: https://github.com/ClickHouse/ClickHouse/pull/110015

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Isolate a stateless test that asserts a mark-cache miss count, and make it report a missing measurement instead of blaming the mark cache.


### Description

`04326_json_advanced_shared_data_file_open` asserts `MarkCacheMisses <= 6` for one `SELECT json`, on a process-wide cache. In 120 days CIDB records one `MarkCacheMisses (7) > expected (6)` red (2026-09-03, in `MergeQueueCI`, ejecting its PR from the queue) and two empty measurements after a memory-limit kill (2026-07-15), all on unrelated PRs. Both are fixed here.

The query makes seven mark-cache lookups over six mark files: prefix deserialization releases the `json.object_structure` stream (`SerializationObject.cpp:827-830` -> `MergeTreeReaderWide.cpp:437-441`) and the next `prefetchForColumn` re-creates it, because the registering callback fires only for dynamic-path substreams and this column has none. The seventh is normally a hit, so the count is 6; evict that entry in between and it is 7. Only a concurrent writer can evict between adjacent lookups. Measured: with a second connection loading marks, the unmodified test fails in 6 of 12 runs; 0 of 100 without.

Hence `# Tags: no-parallel`, bound unchanged. `various_checks.sh:212-226` mandates the tag for `SYSTEM DROP ... CACHE` but greps `system\s+drop`, and this test spells the same statement `SYSTEM CLEAR MARK CACHE`. 23 of the 26 stateless tests clearing this cache already carry it; the two that do not never execute it.

Second, a floor of 3 (the Copy streams) and an explicit empty-measurement branch: an OOM-killed `SELECT` leaves the value empty, and `[ "" -le 6 ]` then raises a bash error and blames the mark cache. Reverting #107051's skip still reddens the test at 16.

Cost: the flaky check runs it 25x not 50x (`functional_tests.py:709-712`), plus ~1.5 s serial. Left alone: the double lookup (no reproduced defect), the skip missing `prefetchBeginOfRange` (unmeasured), and that grep gap.

PR 110015 adds the same tag here, so its hunk becomes redundant; author's call.

To keep it parallel instead, I can assert the set of loaded mark paths from `--send_logs_level=test`; say so and I will switch.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=118185&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/118185](https://github.com/search?q=head%3Async-upstream%2Fpr%2F118185+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
